### PR TITLE
🌱 Skip build/deploy for documentation-only changes

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -3,8 +3,24 @@ name: Build and Deploy KKC
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/**'
+      - '!.github/workflows/build-deploy.yml'
+      - 'LICENSE'
+      - 'OWNERS'
+      - '.gitignore'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/**'
+      - '!.github/workflows/build-deploy.yml'
+      - 'LICENSE'
+      - 'OWNERS'
+      - '.gitignore'
   workflow_dispatch:
     inputs:
       deploy_target:


### PR DESCRIPTION
## Summary
Add paths-ignore to build-deploy workflow to skip builds when only documentation files are changed.

Files that skip build:
- `*.md` (README, docs)
- `docs/**`
- `.github/**` (except build-deploy.yml itself)
- `LICENSE`, `OWNERS`, `.gitignore`

## Test plan
- [x] Workflow syntax is valid
- [ ] Test with a docs-only PR (this one won't trigger build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)