### PR TITLE
🐛 Fix main build - add missing Reload method and GitOps handlers

### DIFF
--- a/pkg/agent/kubectl.go
+++ b/pkg/agent/kubectl.go
@@ -107,6 +107,14 @@ func (k *KubectlProxy) validateArgs(args []string) bool {
 
 func (k *KubectlProxy) GetCurrentContext() string { return k.config.CurrentContext }
 
+// Reload reloads the kubeconfig from disk
+func (k *KubectlProxy) Reload() {
+	config, err := clientcmd.LoadFromFile(k.kubeconfig)
+	if err == nil {
+		k.config = config
+	}
+}
+
 // RenameContext renames a kubeconfig context
 func (k *KubectlProxy) RenameContext(oldName, newName string) error {
 	cmdArgs := []string{"config", "rename-context", oldName, newName}

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/k8s"
+	"github.com/kubestellar/console/pkg/mcp"
+)
+
+// GitOpsHandlers handles GitOps-related requests
+type GitOpsHandlers struct {
+	bridge    *mcp.Bridge
+	k8sClient *k8s.MultiClusterClient
+}
+
+// NewGitOpsHandlers creates new GitOps handlers
+func NewGitOpsHandlers(bridge *mcp.Bridge, k8sClient *k8s.MultiClusterClient) *GitOpsHandlers {
+	return &GitOpsHandlers{
+		bridge:    bridge,
+		k8sClient: k8sClient,
+	}
+}
+
+// DetectDrift detects configuration drift
+func (h *GitOpsHandlers) DetectDrift(c *fiber.Ctx) error {
+	// TODO: Implement drift detection
+	return c.JSON(fiber.Map{
+		"drifts": []interface{}{},
+		"status": "not_implemented",
+	})
+}
+
+// Sync synchronizes configuration
+func (h *GitOpsHandlers) Sync(c *fiber.Ctx) error {
+	// TODO: Implement sync
+	return c.JSON(fiber.Map{
+		"status": "not_implemented",
+	})
+}


### PR DESCRIPTION
## Summary
- Add missing `Reload()` method to `KubectlProxy` that reloads kubeconfig from disk
- Add `GitOpsHandlers` stub with `DetectDrift` and `Sync` methods (TODO implementation)

These are referenced in `server.go` but were missing, causing main to fail to build.

## Test plan
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)