### PR TITLE
✨ Add TopPods card showing pods sorted by restarts

### DIFF
--- a/web/src/components/cards/TopPods.tsx
+++ b/web/src/components/cards/TopPods.tsx
@@ -1,0 +1,125 @@
+import { RefreshCw, Loader2, AlertTriangle } from 'lucide-react'
+import { usePods } from '../../hooks/useMCP'
+
+interface TopPodsProps {
+  config?: {
+    cluster?: string
+    namespace?: string
+    sortBy?: 'restarts' | 'name'
+    limit?: number
+  }
+}
+
+export function TopPods({ config }: TopPodsProps) {
+  const cluster = config?.cluster
+  const namespace = config?.namespace
+  const sortBy = config?.sortBy || 'restarts'
+  const limit = config?.limit || 10
+
+  const { pods, isLoading, error, refetch } = usePods(cluster, namespace, sortBy, limit)
+
+  if (isLoading && pods.length === 0) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (error && pods.length === 0) {
+    return (
+      <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+        {error}
+      </div>
+    )
+  }
+
+  // Find the max restarts for visual scaling
+  const maxRestarts = Math.max(...pods.map(p => p.restarts), 1)
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-sm font-medium text-muted-foreground">
+          Top Pods by {sortBy === 'restarts' ? 'Restarts' : 'Name'}
+        </span>
+        <button
+          onClick={() => refetch()}
+          className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-white transition-colors"
+          title="Refresh"
+        >
+          <RefreshCw className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Pods list */}
+      {pods.length === 0 ? (
+        <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
+          No pods found
+        </div>
+      ) : (
+        <div className="flex-1 space-y-2 overflow-y-auto">
+          {pods.map((pod, index) => (
+            <div
+              key={`${pod.cluster}-${pod.namespace}-${pod.name}`}
+              className="group p-2 rounded-lg bg-secondary/30 border border-border/50 hover:border-border transition-colors"
+            >
+              <div className="flex items-center justify-between mb-1">
+                <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <span className="text-xs text-muted-foreground w-5">{index + 1}.</span>
+                  <span className="text-sm font-medium text-white truncate" title={pod.name}>
+                    {pod.name}
+                  </span>
+                </div>
+                {pod.restarts > 0 && (
+                  <div className="flex items-center gap-1 flex-shrink-0">
+                    <AlertTriangle className={`w-3 h-3 ${
+                      pod.restarts >= 10 ? 'text-red-400' :
+                      pod.restarts >= 5 ? 'text-orange-400' :
+                      'text-yellow-400'
+                    }`} />
+                    <span className={`text-xs font-medium ${
+                      pod.restarts >= 10 ? 'text-red-400' :
+                      pod.restarts >= 5 ? 'text-orange-400' :
+                      'text-yellow-400'
+                    }`}>
+                      {pod.restarts}
+                    </span>
+                  </div>
+                )}
+                {pod.restarts === 0 && (
+                  <span className="text-xs text-green-400 font-medium">0</span>
+                )}
+              </div>
+
+              {/* Progress bar for restarts visualization */}
+              {sortBy === 'restarts' && pod.restarts > 0 && (
+                <div className="h-1 bg-secondary rounded-full overflow-hidden mt-1">
+                  <div
+                    className={`h-full transition-all duration-300 ${
+                      pod.restarts >= 10 ? 'bg-red-500' :
+                      pod.restarts >= 5 ? 'bg-orange-500' :
+                      'bg-yellow-500'
+                    }`}
+                    style={{ width: `${(pod.restarts / maxRestarts) * 100}%` }}
+                  />
+                </div>
+              )}
+
+              {/* Details row */}
+              <div className="flex items-center gap-3 text-xs text-muted-foreground mt-1">
+                <span className="truncate" title={`${pod.cluster} / ${pod.namespace}`}>
+                  {pod.cluster} / {pod.namespace}
+                </span>
+                <span className="flex-shrink-0">{pod.status}</span>
+                <span className="flex-shrink-0">{pod.ready}</span>
+                <span className="flex-shrink-0">{pod.age}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -28,6 +28,7 @@ import { CardWrapper } from '../cards/CardWrapper'
 import { ClusterHealth } from '../cards/ClusterHealth'
 import { EventStream } from '../cards/EventStream'
 import { PodIssues } from '../cards/PodIssues'
+import { TopPods } from '../cards/TopPods'
 import { AppStatus } from '../cards/AppStatus'
 import { ResourceUsage } from '../cards/ResourceUsage'
 import { ClusterMetrics } from '../cards/ClusterMetrics'
@@ -63,6 +64,7 @@ const CARD_COMPONENTS: Record<string, React.ComponentType<{ config?: Record<stri
   cluster_health: ClusterHealth,
   event_stream: EventStream,
   pod_issues: PodIssues,
+  top_pods: TopPods,
   app_status: AppStatus,
   resource_usage: ResourceUsage,
   cluster_metrics: ClusterMetrics,

--- a/web/src/hooks/useMCP.ts
+++ b/web/src/hooks/useMCP.ts
@@ -169,6 +169,49 @@ export function useClusterHealth(cluster?: string) {
   return { health, isLoading, error, refetch }
 }
 
+// Hook to get pods
+export function usePods(cluster?: string, namespace?: string, sortBy: 'restarts' | 'name' = 'restarts', limit = 10) {
+  const [pods, setPods] = useState<PodInfo[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refetch = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const params = new URLSearchParams()
+      if (cluster) params.append('cluster', cluster)
+      if (namespace) params.append('namespace', namespace)
+      const { data } = await api.get<{ pods: PodInfo[] }>(`/api/mcp/pods?${params}`)
+      let sortedPods = data.pods || []
+
+      // Sort by restarts (descending) or name
+      if (sortBy === 'restarts') {
+        sortedPods = sortedPods.sort((a, b) => b.restarts - a.restarts)
+      } else {
+        sortedPods = sortedPods.sort((a, b) => a.name.localeCompare(b.name))
+      }
+
+      // Limit results
+      setPods(sortedPods.slice(0, limit))
+      setError(null)
+    } catch (err) {
+      setError('Failed to fetch pods')
+      setPods(getDemoPods())
+    } finally {
+      setIsLoading(false)
+    }
+  }, [cluster, namespace, sortBy, limit])
+
+  useEffect(() => {
+    refetch()
+    // Poll every 15 seconds for pod updates
+    const interval = setInterval(refetch, 15000)
+    return () => clearInterval(interval)
+  }, [refetch])
+
+  return { pods, isLoading, error, refetch }
+}
+
 // Hook to get pod issues
 export function usePodIssues(cluster?: string, namespace?: string) {
   const [issues, setIssues] = useState<PodIssue[]>([])
@@ -454,6 +497,21 @@ function getDemoPodIssues(): PodIssue[] {
       issues: ['Insufficient memory'],
       restarts: 0,
     },
+  ]
+}
+
+function getDemoPods(): PodInfo[] {
+  return [
+    { name: 'api-server-7d8f9c6b5-x2k4m', namespace: 'production', cluster: 'prod-east', status: 'Running', ready: '1/1', restarts: 15, age: '2d', node: 'node-1' },
+    { name: 'worker-5c6d7e8f9-n3p2q', namespace: 'batch', cluster: 'vllm-d', status: 'Running', ready: '1/1', restarts: 8, age: '5h', node: 'gpu-node-2' },
+    { name: 'cache-redis-0', namespace: 'data', cluster: 'staging', status: 'Running', ready: '1/1', restarts: 5, age: '14d', node: 'node-3' },
+    { name: 'frontend-8e9f0a1b2-def34', namespace: 'web', cluster: 'prod-west', status: 'Running', ready: '1/1', restarts: 3, age: '1d', node: 'node-2' },
+    { name: 'nginx-ingress-abc123', namespace: 'ingress', cluster: 'prod-east', status: 'Running', ready: '1/1', restarts: 2, age: '7d', node: 'node-1' },
+    { name: 'monitoring-agent-xyz', namespace: 'monitoring', cluster: 'staging', status: 'Running', ready: '1/1', restarts: 1, age: '30d', node: 'node-4' },
+    { name: 'api-gateway-pod-1', namespace: 'production', cluster: 'prod-east', status: 'Running', ready: '1/1', restarts: 0, age: '3d', node: 'node-2' },
+    { name: 'worker-processor-1', namespace: 'batch', cluster: 'vllm-d', status: 'Running', ready: '1/1', restarts: 0, age: '12h', node: 'gpu-node-1' },
+    { name: 'database-primary-0', namespace: 'data', cluster: 'staging', status: 'Running', ready: '1/1', restarts: 0, age: '60d', node: 'node-5' },
+    { name: 'scheduler-job-xyz', namespace: 'system', cluster: 'prod-east', status: 'Running', ready: '1/1', restarts: 0, age: '4h', node: 'node-1' },
   ]
 }
 


### PR DESCRIPTION
## Summary
- Add `usePods` hook with sorting and limit options
- Add `TopPods` card component with restart count visualization
- Add color-coded restart indicators (yellow/orange/red)
- Register card in Dashboard component

## Features
The card shows:
- Top 10 pods sorted by restarts (configurable)
- Visual progress bar for restart comparison
- Pod details: cluster, namespace, status, ready state, age
- Color coding: yellow (1-4), orange (5-9), red (10+) restarts

## Test plan
- [x] Backend `go build ./...` succeeds
- [x] Frontend `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)