### PR TITLE
✨ Add deploy endpoint to kkc-agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ vendor/
 
 # Coordination file (local only)
 .claude-coord.md
-kkc-agent
+/kkc-agent

--- a/cmd/kkc-agent/main.go
+++ b/cmd/kkc-agent/main.go
@@ -14,6 +14,7 @@ import (
 func main() {
 	port := flag.Int("port", 8585, "Port to listen on")
 	kubeconfig := flag.String("kubeconfig", "", "Path to kubeconfig file")
+	deployToken := flag.String("deploy-token", os.Getenv("KKC_DEPLOY_TOKEN"), "Authorization token for deploy endpoint (or KKC_DEPLOY_TOKEN env)")
 	version := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
@@ -32,7 +33,7 @@ func main() {
 KubeStellar Klaude Console - Local Agent
 `)
 
-	server, err := agent.NewServer(agent.Config{Port: *port, Kubeconfig: *kubeconfig})
+	server, err := agent.NewServer(agent.Config{Port: *port, Kubeconfig: *kubeconfig, DeployToken: *deployToken})
 	if err != nil {
 		log.Fatalf("Failed to create server: %v", err)
 	}

--- a/pkg/agent/protocol/messages.go
+++ b/pkg/agent/protocol/messages.go
@@ -10,6 +10,7 @@ const (
 	TypeKubectl       MessageType = "kubectl"
 	TypeClaude        MessageType = "claude"
 	TypeRenameContext MessageType = "rename_context"
+	TypeDeploy        MessageType = "deploy"
 
 	// Response types
 	TypeResult MessageType = "result"
@@ -113,4 +114,27 @@ type RenameContextResponse struct {
 	Success bool   `json:"success"`
 	OldName string `json:"oldName"`
 	NewName string `json:"newName"`
+}
+
+// DeployRequest is the payload for helm deploy commands
+type DeployRequest struct {
+	Context     string            `json:"context,omitempty"`     // kubeconfig context to use
+	Namespace   string            `json:"namespace"`             // target namespace
+	ReleaseName string            `json:"releaseName"`           // helm release name
+	ChartPath   string            `json:"chartPath"`             // path to helm chart
+	ImageRepo   string            `json:"imageRepo,omitempty"`   // image repository
+	ImageTag    string            `json:"imageTag,omitempty"`    // image tag
+	Values      map[string]string `json:"values,omitempty"`      // additional --set values
+	Wait        bool              `json:"wait,omitempty"`        // wait for deployment
+	Timeout     string            `json:"timeout,omitempty"`     // timeout duration
+	AuthToken   string            `json:"authToken,omitempty"`   // authorization token
+}
+
+// DeployResponse is the response from a helm deploy command
+type DeployResponse struct {
+	Success     bool   `json:"success"`
+	ReleaseName string `json:"releaseName"`
+	Namespace   string `json:"namespace"`
+	Output      string `json:"output"`
+	Error       string `json:"error,omitempty"`
 }


### PR DESCRIPTION
## Summary
- Adds `/deploy` HTTP endpoint to kkc-agent for helm deployments
- Supports Bearer token authentication for secure deployments
- Enables CI/CD deployments without storing kubeconfig secrets

## Usage
```bash
# Start agent with deploy token
kkc-agent --deploy-token=mysecrettoken
# or
export KKC_DEPLOY_TOKEN=mysecrettoken
kkc-agent

# Trigger deployment
curl -X POST http://localhost:8585/deploy \
  -H "Authorization: Bearer mysecrettoken" \
  -H "Content-Type: application/json" \
  -d '{
    "namespace": "kkc",
    "releaseName": "kkc",
    "chartPath": "./deploy/helm/kubestellar-console",
    "imageTag": "latest",
    "wait": true,
    "timeout": "5m"
  }'
```

## Test plan
- [ ] Build agent: `go build ./cmd/kkc-agent/`
- [ ] Run agent with deploy token
- [ ] Test unauthenticated request (should fail)
- [ ] Test authenticated deploy request

🤖 Generated with [Claude Code](https://claude.ai/code)