### PR TITLE
🌱 Use self-hosted runner for vllm-d deployment

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -88,24 +88,14 @@ jobs:
   deploy-vllm-d:
     needs: build
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, kkc]
     environment: vllm-d
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up kubectl
-        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3.2
-
-      - name: Set up Helm
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
-
-      - name: Configure kubeconfig
-        run: |
-          mkdir -p $HOME/.kube
-          echo "${{ secrets.VLLM_D_KUBECONFIG }}" | base64 -d > $HOME/.kube/config
-          chmod 600 $HOME/.kube/config
+      # Runner already has cluster access via service account - no kubeconfig needed
 
       - name: Create namespace if not exists
         run: |

--- a/deploy/arc/kubestellar-console-runner.yaml
+++ b/deploy/arc/kubestellar-console-runner.yaml
@@ -1,0 +1,41 @@
+---
+# Secret for GitHub API credentials
+# You need to create this with a PAT that has 'repo' scope
+# kubectl create secret generic arc-github-secret-kubestellar \
+#   --namespace arc-systems \
+#   --from-literal=github_token=ghp_xxxxxxxxxxxx
+apiVersion: v1
+kind: Secret
+metadata:
+  name: arc-github-secret-kubestellar
+  namespace: arc-systems
+type: Opaque
+stringData:
+  github_token: "REPLACE_WITH_PAT"  # PAT with 'repo' scope
+
+---
+apiVersion: actions.summerwind.dev/v1alpha1
+kind: RunnerDeployment
+metadata:
+  name: kubestellar-console-runners
+  namespace: arc-systems
+spec:
+  replicas: 2
+  template:
+    spec:
+      repository: kubestellar/console
+      githubAPICredentialsFrom:
+        secretRef:
+          name: arc-github-secret-kubestellar
+      labels:
+        - self-hosted
+        - linux
+        - openshift
+        - kkc
+      resources:
+        limits:
+          cpu: "2"
+          memory: "4Gi"
+        requests:
+          cpu: "500m"
+          memory: "1Gi"


### PR DESCRIPTION
## Summary
- Use self-hosted ARC runner in vllm-d cluster instead of kubeconfig secrets
- Runner has direct cluster access via service account
- Eliminates need for VLLM_D_KUBECONFIG secret

## Changes
- `runs-on: ubuntu-latest` → `runs-on: [self-hosted, kkc]`
- Removed kubeconfig secret configuration step
- Added ARC RunnerDeployment manifest in `deploy/arc/`

## Setup completed
- [x] Created `arc-github-secret-kubestellar` secret
- [x] Deployed `kubestellar-console-runners` (2 replicas)
- [x] Created RBAC rolebinding for kkc namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)