### PR TITLE
🐛 Fix OAuth redirect URL and add version info to login

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -82,6 +82,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            COMMIT_HASH=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ FROM node:20-alpine AS frontend-builder
 
 WORKDIR /app
 
+# Build arg for commit hash
+ARG COMMIT_HASH=unknown
+
 # Copy package files
 COPY web/package*.json ./
 RUN npm ci
@@ -28,7 +31,8 @@ RUN npm ci
 # Copy source
 COPY web/ ./
 
-# Build
+# Build with commit hash
+ENV VITE_COMMIT_HASH=${COMMIT_HASH}
 RUN npm run build
 
 # Final stage

--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -57,6 +57,13 @@ spec:
               value: "8080"
             - name: DATABASE_PATH
               value: {{ .Values.database.sqlitePath | quote }}
+            {{- if .Values.route.enabled }}
+            - name: FRONTEND_URL
+              value: "https://{{ .Values.route.host }}"
+            {{- else if .Values.ingress.enabled }}
+            - name: FRONTEND_URL
+              value: "https://{{ (index .Values.ingress.hosts 0).host }}"
+            {{- end }}
             {{- if .Values.github.existingSecret }}
             - name: GITHUB_CLIENT_ID
               valueFrom:

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -94,6 +94,13 @@ export function Login() {
           className="absolute inset-0"
         />
       </div>
+
+      {/* Version info - bottom right */}
+      <div className="absolute bottom-4 right-4 text-xs text-gray-600 font-mono z-10">
+        <span title={`Built: ${__BUILD_TIME__}`}>
+          v{__APP_VERSION__} ({__COMMIT_HASH__.substring(0, 7)})
+        </span>
+      </div>
     </div>
   )
 }

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,5 +1,10 @@
 /// <reference types="vite/client" />
 
+// Build-time constants injected by vite.config.ts
+declare const __APP_VERSION__: string;
+declare const __COMMIT_HASH__: string;
+declare const __BUILD_TIME__: string;
+
 declare module '*.css' {
   const content: string;
   export default content;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(process.env.npm_package_version || '0.1.0'),
+    __COMMIT_HASH__: JSON.stringify(process.env.VITE_COMMIT_HASH || 'dev'),
+    __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+  },
   plugins: [react()],
   server: {
     port: 5174,


### PR DESCRIPTION
## Summary
- Set `FRONTEND_URL` env var from route.host or ingress.host in Helm deployment - fixes OAuth redirect mismatch
- Add build-time version info (commit hash, version, build time) to login page
- Pass `COMMIT_HASH` build arg to Docker image for version display

## Changes
- `deploy/helm/.../deployment.yaml` - Add FRONTEND_URL from route/ingress host
- `web/vite.config.ts` - Add build-time constants
- `web/src/vite-env.d.ts` - Type declarations for build constants
- `web/src/components/auth/Login.tsx` - Display version in bottom right
- `Dockerfile` - Accept COMMIT_HASH build arg
- `.github/workflows/build-deploy.yml` - Pass commit SHA as build arg

## Test plan
- [x] Verify OAuth redirect now uses correct URL
- [x] Verify version info displays on login page
- [x] Verify deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)