### PR TITLE
🐛 fix: Use full SHA for image tags in workflow

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -71,7 +71,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix=
+            type=sha,prefix=,format=long
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Summary
- Fixed image tag mismatch causing deployment failures
- The docker/metadata-action was creating short SHA tags (7 chars) but the deploy step was using full SHA (40 chars)
- Changed `type=sha,prefix=` to `type=sha,prefix=,format=long` to create full SHA tags

## Test plan
- [ ] Verify workflow creates image with full SHA tag
- [ ] Verify deployment uses matching tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)