### PR TITLE
🐛 Fix isChecking flag not reset on stop

### DIFF
--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -77,6 +77,7 @@ class AgentManager {
       this.pollInterval = null
     }
     this.isStarted = false
+    this.isChecking = false // Reset so next start can check immediately
     console.log('[AgentManager] Stopped polling')
   }
 


### PR DESCRIPTION
## Summary
Reset `isChecking` to false in `stop()` method so that when polling restarts after page navigation, `checkAgent()` can run immediately instead of being skipped.

## Problem
When navigating between pages, the singleton AgentManager's `stop()` was called but `isChecking` wasn't reset. When returning to a page with agent status, `start()` called `checkAgent()` but it immediately returned because `isChecking` was still `true` from the previous interrupted check.

## Fix
Add `this.isChecking = false` to the `stop()` method.

🤖 Generated with [Claude Code](https://claude.ai/code)