### PR TITLE
🐛 Fix GET /api/gitops/drifts endpoint

### DIFF
--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -90,6 +90,19 @@ type SyncResponse struct {
 	TokensUsed int      `json:"tokensUsed,omitempty"`
 }
 
+// ListDrifts returns a list of detected drifts (for GET endpoint)
+func (h *GitOpsHandlers) ListDrifts(c *fiber.Ctx) error {
+	// Optional query params for filtering
+	// cluster := c.Query("cluster")
+	// namespace := c.Query("namespace")
+
+	// Return empty list - actual drift detection requires specific repo/path
+	// which should be done via POST /api/gitops/detect-drift
+	return c.JSON(fiber.Map{
+		"drifts": []GitOpsDrift{},
+	})
+}
+
 // DetectDrift detects drift between git and cluster state
 func (h *GitOpsHandlers) DetectDrift(c *fiber.Ctx) error {
 	var req DetectDriftRequest

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -291,12 +291,12 @@ func (s *Server) setupRoutes() {
 	gitopsHandlers := handlers.NewGitOpsHandlers(s.bridge, s.k8sClient)
 	if s.config.DevMode {
 		// Dev mode: unprotected for testing
-		s.app.Get("/api/gitops/drifts", gitopsHandlers.DetectDrift)
+		s.app.Get("/api/gitops/drifts", gitopsHandlers.ListDrifts)
 		s.app.Post("/api/gitops/detect-drift", gitopsHandlers.DetectDrift)
 		s.app.Post("/api/gitops/sync", gitopsHandlers.Sync)
 	} else {
 		// Production: protected
-		api.Get("/gitops/drifts", gitopsHandlers.DetectDrift)
+		api.Get("/gitops/drifts", gitopsHandlers.ListDrifts)
 		api.Post("/gitops/detect-drift", gitopsHandlers.DetectDrift)
 		api.Post("/gitops/sync", gitopsHandlers.Sync)
 	}


### PR DESCRIPTION
## Summary
Add `ListDrifts` handler for the GET `/api/gitops/drifts` endpoint.

## Problem
The GET endpoint was using `DetectDrift` handler which expects a POST body with `repoUrl`, causing 400 errors on GET requests.

## Fix
- Add new `ListDrifts` handler that returns an empty array (actual drift detection should use POST)
- Update routes to use `ListDrifts` for GET endpoint

🤖 Generated with [Claude Code](https://claude.ai/code)