### PR TITLE
🐛 fix: Use Recreate strategy for deployment with PVC

### DIFF
--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -9,6 +9,10 @@ spec:
   selector:
     matchLabels:
       {{- include "kubestellar-console.selectorLabels" . | nindent 6 }}
+  {{- if .Values.persistence.enabled }}
+  strategy:
+    type: Recreate
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
## Summary
- When persistence is enabled, use `Recreate` deployment strategy instead of `RollingUpdate`
- This prevents Multi-Attach errors with ReadWriteOnce PVCs
- The old pod is terminated before the new one starts, releasing the PVC

## Problem
With RollingUpdate strategy, the new pod tries to attach to the PVC while the old pod still has it mounted, causing:
```
Multi-Attach error for volume "pvc-xxx": Volume is already used by pod(s) kkc-xxx
```

## Solution
When `persistence.enabled=true`, set `strategy.type: Recreate` which ensures clean handoff of the PVC.

## Test plan
- [ ] Deploy with persistence enabled
- [ ] Trigger a new deployment
- [ ] Verify no Multi-Attach errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)