### PR TITLE
🐛 fix: Correct deployment name in verify step

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -132,6 +132,6 @@ jobs:
 
       - name: Verify deployment
         run: |
-          kubectl rollout status deployment/kkc -n kkc --timeout=3m
+          kubectl rollout status deployment/kkc-kubestellar-klaude-console -n kkc --timeout=3m
           echo "Deployment successful!"
           echo "Access KKC at: https://kkc.apps.fmaas-vllm-d.fmaas.res.ibm.com"


### PR DESCRIPTION
## Summary
- Fixed wrong deployment name in verify step
- Was checking `deployment/kkc` but should be `deployment/kkc-kubestellar-klaude-console`

🤖 Generated with [Claude Code](https://claude.com/claude-code)