### PR TITLE
🐛 fix: Add auth header to cluster health fetch

### DIFF
--- a/web/src/hooks/useMCP.ts
+++ b/web/src/hooks/useMCP.ts
@@ -161,8 +161,10 @@ async function fetchClustersFromAgent(): Promise<ClusterInfo[] | null> {
 
       // Try to fetch health data from backend to enrich clusters
       try {
+        const token = localStorage.getItem('token')
         const healthResponse = await fetch('http://localhost:8080/api/mcp/clusters/health', {
           signal: AbortSignal.timeout(10000),
+          headers: token ? { 'Authorization': `Bearer ${token}` } : {},
         })
         if (healthResponse.ok) {
           const healthData = await healthResponse.json()


### PR DESCRIPTION
## Summary
The cluster health enrichment fetch was failing with 401 Unauthorized because it wasn't including the Authorization header.

## Changes
- Added auth token to the health fetch request headers in `useMCP.ts`

## Test plan
- [x] Verified locally - `/api/mcp/clusters/health` now returns 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)