### PR TITLE
🐛 Fix OAuth redirect URL in production mode

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -368,7 +368,13 @@ func LoadConfigFromEnv() Config {
 		dbPath = p
 	}
 
-	frontendURL := "http://localhost:5174"
+	// Default frontend URL depends on mode:
+	// - Dev mode: Vite dev server on 5174
+	// - Production mode: Backend serves frontend on 8080
+	frontendURL := "http://localhost:8080"
+	if os.Getenv("DEV_MODE") == "true" {
+		frontendURL = "http://localhost:5174"
+	}
 	if u := os.Getenv("FRONTEND_URL"); u != "" {
 		frontendURL = u
 	}


### PR DESCRIPTION
## Summary
Default frontend URL to port 8080 in production mode since the backend serves the frontend. Only use port 5174 in dev mode where Vite runs separately.

## Problem
OAuth callback was redirecting to localhost:5174 even in production mode, causing login failures when only the backend on 8080 is running.

## Solution
- Change default frontendURL to 8080
- Only use 5174 when DEV_MODE=true

Generated with Claude Code