### PR TITLE
🐛 Fix card type mapping, offline cluster filtering, and card persistence

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -832,6 +832,12 @@ function DragPreviewCard({ card }: { card: Card }) {
 }
 
 function mapVisualizationToCardType(visualization: string, type: string): string {
+  // First, check if the type is a valid registered card - if so, use it directly
+  if (type && CARD_COMPONENTS[type]) {
+    return type
+  }
+
+  // Fall back to visualization mapping for AI-generated or unknown types
   const mapping: Record<string, string> = {
     gauge: 'resource_usage',
     timeseries: 'cluster_metrics',


### PR DESCRIPTION
## Summary

- Fix `mapVisualizationToCardType` to use actual card type when valid (fixes all timeseries cards becoming `cluster_metrics`)
- Exclude offline/unreachable clusters from all graph calculations (ResourceTrend, PodHealthTrend, EventsTimeline, GPUUtilization, ClusterMetrics, GPUWorkloads)
- Fix duplicate cards when adding from catalog (removed duplicates, added deduplication logic)
- Fix cards disappearing after background refresh (preserve local-only cards)
- Add new GPUWorkloads card for pods on GPU nodes
- Fix theme toggle to return to user's selected dark theme
- Fix namespace resources progressive loading with timeout
- Lock body scroll when Add Card modal is open

## Test plan

- [ ] Add cards from "Live Trends" category - each should render its own unique content
- [ ] Events Timeline should show warning/normal events
- [ ] Pod Health Trend should show healthy/unhealthy/pending pods
- [ ] Resource Trend should show CPU/memory/pods/nodes selector
- [ ] GPU Utilization should show GPU allocation (if GPUs present)
- [ ] Verify offline clusters don't affect graph data
- [ ] Verify newly added cards persist after page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)