### PR TITLE
🐛 Add JWT_SECRET support to Helm deployment

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -115,6 +115,7 @@ jobs:
             --namespace kkc \
             --from-literal=github-client-id=${{ secrets.KKC_OAUTH_CLIENT_ID }} \
             --from-literal=github-client-secret=${{ secrets.KKC_OAUTH_CLIENT_SECRET }} \
+            --from-literal=jwt-secret=${{ secrets.KKC_JWT_SECRET }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy with Helm
@@ -125,6 +126,7 @@ jobs:
             --set image.tag=${{ github.sha }} \
             --set github.existingSecret=kkc-secrets \
             --set claude.existingSecret=kkc-secrets \
+            --set jwt.existingSecret=kkc-secrets \
             --set route.enabled=true \
             --set route.host=kkc.apps.fmaas-vllm-d.fmaas.res.ibm.com \
             --wait \

--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -98,6 +98,13 @@ spec:
                   name: {{ .Values.claude.existingSecret | default (include "kubestellar-console.fullname" .) }}
                   key: {{ .Values.claude.existingSecretKey | default "claude-api-key" }}
             {{- end }}
+            {{- if or .Values.jwt.existingSecret .Values.jwt.secret }}
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.jwt.existingSecret | default (include "kubestellar-console.fullname" .) }}
+                  key: {{ .Values.jwt.existingSecretKey | default "jwt-secret" }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
## Summary

Fixes the deployment failure caused by the security hardening in #51. The console now requires `JWT_SECRET` in production mode, but it wasn't configured in the Helm deployment.

**Changes:**
- Update `deployment.yaml` to read `JWT_SECRET` from existing secret via `jwt.existingSecret`
- Update `build-deploy.yml` workflow to include `jwt-secret` in the `kkc-secrets` secret

## Required GitHub Actions Secret

You need to add `KKC_JWT_SECRET` as a repository secret in GitHub:

1. Go to Settings > Secrets and variables > Actions
2. Add new repository secret: `KKC_JWT_SECRET`
3. Value: A cryptographically secure random string (at least 32 characters)
   - Generate one with: `openssl rand -base64 32`

## Test plan

- [ ] Add KKC_JWT_SECRET to GitHub Actions secrets
- [ ] Merge this PR
- [ ] Verify deployment succeeds on vllm-d cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)