### PR TITLE
🐛 Add known deployment URLs to agent allowed origins

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -27,6 +27,9 @@ var defaultAllowedOrigins = []string{
 	"https://localhost",
 	"http://127.0.0.1",
 	"https://127.0.0.1",
+	// Known deployment URLs
+	"https://kubestellarklaudeconsole.netlify.app",
+	"https://kkc.apps.fmaas-vllm-d.fmaas.res.ibm.com",
 }
 
 // Server is the local agent WebSocket server


### PR DESCRIPTION
## Summary
- Add Netlify and vllm-d production URLs to agent's default allowed origins
- Fixes agent connection failures after security fix for Origin validation

The security fix that added Origin header validation broke connections from known deployment URLs. This adds them to the default allowed list.

**URLs added:**
- `https://kubestellarklaudeconsole.netlify.app`
- `https://kkc.apps.fmaas-vllm-d.fmaas.res.ibm.com`

Users can still add custom origins via `KKC_ALLOWED_ORIGINS` environment variable.

## Test plan
- [ ] Verify Netlify site can connect to local agent
- [ ] Verify vllm-d deployment can connect to local agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)