### PR TITLE
🌱 Bump agent version to 0.3.0

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kubestellar/console/pkg/agent/protocol"
 )
 
-const Version = "0.2.0"
+const Version = "0.3.0"
 
 // Config holds agent configuration
 type Config struct {


### PR DESCRIPTION
## Summary
- Bump agent version from 0.2.0 to 0.3.0

Security improvements in this release:
- Origin header validation for WebSocket connections
- Known deployment URLs added to allowed origins
- Optional token authentication support

## Test plan
- [ ] Verify agent reports version 0.3.0 at /health endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)