### PR TITLE
🐛 Fix operator dashboard stats and cluster switching

### DIFF
--- a/web/src/components/ui/StatsConfig.tsx
+++ b/web/src/components/ui/StatsConfig.tsx
@@ -47,6 +47,7 @@ export type DashboardStatsType =
   | 'cost'
   | 'alerts'
   | 'dashboard'
+  | 'operators'
 
 /**
  * Default stat blocks for the Clusters dashboard
@@ -212,6 +213,20 @@ export const DASHBOARD_STAT_BLOCKS: StatBlockConfig[] = [
 ]
 
 /**
+ * Default stat blocks for the Operators dashboard
+ */
+export const OPERATORS_STAT_BLOCKS: StatBlockConfig[] = [
+  { id: 'operators', name: 'Total', icon: 'Package', visible: true, color: 'purple' },
+  { id: 'installed', name: 'Installed', icon: 'CheckCircle2', visible: true, color: 'green' },
+  { id: 'installing', name: 'Installing', icon: 'RefreshCw', visible: true, color: 'blue' },
+  { id: 'failing', name: 'Failing', icon: 'XCircle', visible: true, color: 'red' },
+  { id: 'upgrades', name: 'Upgrades', icon: 'ArrowUpCircle', visible: true, color: 'orange' },
+  { id: 'subscriptions', name: 'Subscriptions', icon: 'Newspaper', visible: true, color: 'indigo' },
+  { id: 'crds', name: 'CRDs', icon: 'FileCode', visible: true, color: 'cyan' },
+  { id: 'clusters', name: 'Clusters', icon: 'Server', visible: true, color: 'blue' },
+]
+
+/**
  * Get default stat blocks for a dashboard type
  */
 export function getDefaultStatBlocks(dashboardType: DashboardStatsType): StatBlockConfig[] {
@@ -242,6 +257,8 @@ export function getDefaultStatBlocks(dashboardType: DashboardStatsType): StatBlo
       return ALERTS_STAT_BLOCKS
     case 'dashboard':
       return DASHBOARD_STAT_BLOCKS
+    case 'operators':
+      return OPERATORS_STAT_BLOCKS
     default:
       return []
   }
@@ -264,6 +281,8 @@ const colorClasses: Record<string, string> = {
   blue: 'text-blue-400',
   red: 'text-red-400',
   gray: 'text-gray-400',
+  indigo: 'text-indigo-400',
+  teal: 'text-teal-400',
 }
 
 // Icon emoji mapping for the config modal
@@ -303,6 +322,10 @@ const iconEmojis: Record<string, string> = {
   Activity: '📈',
   List: '📜',
   DollarSign: '💵',
+  Newspaper: '📰',
+  RefreshCw: '🔄',
+  ArrowUpCircle: '⬆️',
+  FileCode: '📄',
 }
 
 interface SortableItemProps {

--- a/web/src/hooks/useMCP.ts
+++ b/web/src/hooks/useMCP.ts
@@ -3586,96 +3586,224 @@ export interface OperatorSubscription {
   cluster?: string
 }
 
-// Hook to get operators for a cluster
+// Hook to get operators for a cluster (or all clusters if undefined)
 export function useOperators(cluster?: string) {
   const [operators, setOperators] = useState<Operator[]>([])
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Track cluster count to re-fetch when clusters become available
+  const [clusterCount, setClusterCount] = useState(clusterCache.clusters.length)
+  // Version counter to force refetch
+  const [fetchVersion, setFetchVersion] = useState(0)
 
-  const refetch = useCallback(async () => {
-    if (!cluster) {
-      setOperators([])
-      return
-    }
-
-    setIsRefreshing(true)
-    if (operators.length === 0) {
-      setIsLoading(true)
-    }
-    try {
-      // Try to fetch from API - will fall back to demo data if not available
-      const { data } = await api.get<{ operators: Operator[] }>(`/api/mcp/operators?cluster=${encodeURIComponent(cluster)}`)
-      setOperators(data.operators || [])
-      setError(null)
-    } catch (err) {
-      setError('Failed to fetch operators')
-      // Use demo data with cluster-specific variation
-      setOperators(getDemoOperators(cluster))
-    } finally {
-      setIsLoading(false)
-      setIsRefreshing(false)
-    }
-  }, [cluster, operators.length])
-
+  // Subscribe to cluster cache updates for "all clusters" mode
   useEffect(() => {
-    refetch()
-  }, [refetch])
+    const handleUpdate = (cache: ClusterCache) => {
+      setClusterCount(cache.clusters.length)
+    }
+    clusterSubscribers.add(handleUpdate)
+    return () => {
+      clusterSubscribers.delete(handleUpdate)
+    }
+  }, [])
+
+  // Refetch when cluster, clusterCount, or fetchVersion changes
+  useEffect(() => {
+    let cancelled = false
+
+    const doFetch = async () => {
+      setIsRefreshing(true)
+
+      // If no cluster specified, fetch from all clusters
+      if (!cluster) {
+        const allClusters = clusterCache.clusters
+        if (allClusters.length === 0) {
+          // No clusters available yet, use empty array
+          if (!cancelled) {
+            setOperators([])
+            setIsLoading(false)
+            setIsRefreshing(false)
+          }
+          return
+        }
+
+        // Aggregate operators from all clusters
+        const allOperators: Operator[] = []
+        for (const c of allClusters) {
+          try {
+            const { data } = await api.get<{ operators: Operator[] }>(`/api/mcp/operators?cluster=${encodeURIComponent(c.name)}`)
+            allOperators.push(...(data.operators || []).map(op => ({ ...op, cluster: c.name })))
+          } catch {
+            // Use demo data for this cluster
+            allOperators.push(...getDemoOperators(c.name))
+          }
+        }
+        if (!cancelled) {
+          setOperators(allOperators)
+          setError(null)
+          setIsLoading(false)
+          setIsRefreshing(false)
+        }
+        return
+      }
+
+      try {
+        // Try to fetch from API - will fall back to demo data if not available
+        const { data } = await api.get<{ operators: Operator[] }>(`/api/mcp/operators?cluster=${encodeURIComponent(cluster)}`)
+        if (!cancelled) {
+          // Ensure each operator has the cluster property set
+          setOperators((data.operators || []).map(op => ({ ...op, cluster })))
+          setError(null)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError('Failed to fetch operators')
+          // Use demo data with cluster-specific variation
+          setOperators(getDemoOperators(cluster))
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false)
+          setIsRefreshing(false)
+        }
+      }
+    }
+
+    doFetch()
+
+    return () => {
+      cancelled = true
+    }
+  }, [cluster, clusterCount, fetchVersion])
+
+  const refetch = useCallback(() => {
+    setFetchVersion(v => v + 1)
+  }, [])
 
   return { operators, isLoading, isRefreshing, error, refetch }
 }
 
-// Hook to get operator subscriptions for a cluster
+// Hook to get operator subscriptions for a cluster (or all clusters if undefined)
 export function useOperatorSubscriptions(cluster?: string) {
   const [subscriptions, setSubscriptions] = useState<OperatorSubscription[]>([])
-  const [isLoading, setIsLoading] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  // Track cluster count to re-fetch when clusters become available
+  const [clusterCount, setClusterCount] = useState(clusterCache.clusters.length)
+  // Version counter to force refetch
+  const [fetchVersion, setFetchVersion] = useState(0)
 
-  const refetch = useCallback(async () => {
-    if (!cluster) {
-      setSubscriptions([])
-      return
-    }
-
-    setIsRefreshing(true)
-    if (subscriptions.length === 0) {
-      setIsLoading(true)
-    }
-    try {
-      const { data } = await api.get<{ subscriptions: OperatorSubscription[] }>(`/api/mcp/operator-subscriptions?cluster=${encodeURIComponent(cluster)}`)
-      setSubscriptions(data.subscriptions || [])
-      setError(null)
-    } catch (err) {
-      setError('Failed to fetch subscriptions')
-      setSubscriptions(getDemoOperatorSubscriptions(cluster))
-    } finally {
-      setIsLoading(false)
-      setIsRefreshing(false)
-    }
-  }, [cluster, subscriptions.length])
-
+  // Subscribe to cluster cache updates for "all clusters" mode
   useEffect(() => {
-    refetch()
-  }, [refetch])
+    const handleUpdate = (cache: ClusterCache) => {
+      setClusterCount(cache.clusters.length)
+    }
+    clusterSubscribers.add(handleUpdate)
+    return () => {
+      clusterSubscribers.delete(handleUpdate)
+    }
+  }, [])
+
+  // Refetch when cluster, clusterCount, or fetchVersion changes
+  useEffect(() => {
+    let cancelled = false
+
+    const doFetch = async () => {
+      setIsRefreshing(true)
+
+      // If no cluster specified, fetch from all clusters
+      if (!cluster) {
+        const allClusters = clusterCache.clusters
+        if (allClusters.length === 0) {
+          // No clusters available yet, use empty array
+          if (!cancelled) {
+            setSubscriptions([])
+            setIsLoading(false)
+            setIsRefreshing(false)
+          }
+          return
+        }
+
+        // Aggregate subscriptions from all clusters
+        const allSubscriptions: OperatorSubscription[] = []
+        for (const c of allClusters) {
+          try {
+            const { data } = await api.get<{ subscriptions: OperatorSubscription[] }>(`/api/mcp/operator-subscriptions?cluster=${encodeURIComponent(c.name)}`)
+            allSubscriptions.push(...(data.subscriptions || []).map(sub => ({ ...sub, cluster: c.name })))
+          } catch {
+            // Use demo data for this cluster
+            allSubscriptions.push(...getDemoOperatorSubscriptions(c.name))
+          }
+        }
+        if (!cancelled) {
+          setSubscriptions(allSubscriptions)
+          setError(null)
+          setIsLoading(false)
+          setIsRefreshing(false)
+        }
+        return
+      }
+
+      try {
+        const { data } = await api.get<{ subscriptions: OperatorSubscription[] }>(`/api/mcp/operator-subscriptions?cluster=${encodeURIComponent(cluster)}`)
+        if (!cancelled) {
+          // Ensure each subscription has the cluster property set
+          setSubscriptions((data.subscriptions || []).map(sub => ({ ...sub, cluster })))
+          setError(null)
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError('Failed to fetch subscriptions')
+          setSubscriptions(getDemoOperatorSubscriptions(cluster))
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false)
+          setIsRefreshing(false)
+        }
+      }
+    }
+
+    doFetch()
+
+    return () => {
+      cancelled = true
+    }
+  }, [cluster, clusterCount, fetchVersion])
+
+  const refetch = useCallback(() => {
+    setFetchVersion(v => v + 1)
+  }, [])
 
   return { subscriptions, isLoading, isRefreshing, error, refetch }
 }
 
 function getDemoOperators(cluster: string): Operator[] {
-  // Vary demo data slightly based on cluster name
-  const suffix = cluster.includes('prod') ? '-prod' : cluster.includes('staging') ? '-staging' : ''
-  return [
+  // Generate cluster-specific demo data using hash of cluster name
+  const hash = cluster.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+  const operatorCount = 3 + (hash % 5) // 3-7 operators per cluster
+
+  const baseOperators: Operator[] = [
     { name: 'prometheus-operator', namespace: 'monitoring', version: 'v0.65.1', status: 'Succeeded', cluster },
     { name: 'cert-manager', namespace: 'cert-manager', version: 'v1.12.0', status: 'Succeeded', upgradeAvailable: 'v1.13.0', cluster },
-    { name: `elasticsearch-operator${suffix}`, namespace: 'elastic-system', version: 'v2.8.0', status: 'Succeeded', cluster },
-    { name: 'strimzi-kafka-operator', namespace: 'kafka', version: 'v0.35.0', status: cluster.includes('staging') ? 'Installing' : 'Succeeded', cluster },
-    { name: 'argocd-operator', namespace: 'argocd', version: 'v0.6.0', status: cluster.includes('prod') ? 'Succeeded' : 'Failed', cluster },
+    { name: 'elasticsearch-operator', namespace: 'elastic-system', version: 'v2.8.0', status: hash % 3 === 0 ? 'Failed' : 'Succeeded', cluster },
+    { name: 'strimzi-kafka-operator', namespace: 'kafka', version: 'v0.35.0', status: hash % 4 === 0 ? 'Installing' : 'Succeeded', cluster },
+    { name: 'argocd-operator', namespace: 'argocd', version: 'v0.6.0', status: hash % 5 === 0 ? 'Failed' : 'Succeeded', cluster },
+    { name: 'jaeger-operator', namespace: 'observability', version: 'v1.47.0', status: 'Succeeded', cluster },
+    { name: 'kiali-operator', namespace: 'istio-system', version: 'v1.72.0', status: hash % 2 === 0 ? 'Upgrading' : 'Succeeded', upgradeAvailable: hash % 2 === 0 ? 'v1.73.0' : undefined, cluster },
   ]
+
+  return baseOperators.slice(0, operatorCount)
 }
 
 function getDemoOperatorSubscriptions(cluster: string): OperatorSubscription[] {
-  return [
+  // Generate cluster-specific demo data using hash of cluster name
+  const hash = cluster.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+  const subCount = 2 + (hash % 4) // 2-5 subscriptions per cluster
+
+  const baseSubscriptions: OperatorSubscription[] = [
     {
       name: 'prometheus-operator',
       namespace: 'monitoring',
@@ -3692,7 +3820,7 @@ function getDemoOperatorSubscriptions(cluster: string): OperatorSubscription[] {
       source: 'operatorhubio-catalog',
       installPlanApproval: 'Manual',
       currentCSV: 'cert-manager.v1.12.0',
-      pendingUpgrade: 'cert-manager.v1.13.0',
+      pendingUpgrade: hash % 2 === 0 ? 'cert-manager.v1.13.0' : undefined,
       cluster,
     },
     {
@@ -3700,8 +3828,9 @@ function getDemoOperatorSubscriptions(cluster: string): OperatorSubscription[] {
       namespace: 'kafka',
       channel: 'stable',
       source: 'operatorhubio-catalog',
-      installPlanApproval: 'Automatic',
+      installPlanApproval: hash % 3 === 0 ? 'Manual' : 'Automatic',
       currentCSV: 'strimzi-cluster-operator.v0.35.0',
+      pendingUpgrade: hash % 4 === 0 ? 'strimzi-cluster-operator.v0.36.0' : undefined,
       cluster,
     },
     {
@@ -3711,10 +3840,21 @@ function getDemoOperatorSubscriptions(cluster: string): OperatorSubscription[] {
       source: 'operatorhubio-catalog',
       installPlanApproval: 'Manual',
       currentCSV: 'argocd-operator.v0.6.0',
-      pendingUpgrade: cluster.includes('staging') ? 'argocd-operator.v0.7.0' : undefined,
+      pendingUpgrade: hash % 5 === 0 ? 'argocd-operator.v0.7.0' : undefined,
+      cluster,
+    },
+    {
+      name: 'jaeger-operator',
+      namespace: 'observability',
+      channel: 'stable',
+      source: 'operatorhubio-catalog',
+      installPlanApproval: 'Automatic',
+      currentCSV: 'jaeger-operator.v1.47.0',
       cluster,
     },
   ]
+
+  return baseSubscriptions.slice(0, subCount)
 }
 
 function getDemoEvents(): ClusterEvent[] {


### PR DESCRIPTION
## Summary

- Add 'operators' dashboard type to StatsConfig with proper stat blocks (total, installed, installing, failing, upgrades, subscriptions, crds, clusters)
- Fix operator hooks (useOperators, useOperatorSubscriptions) to aggregate data from all clusters when "All Clusters" is selected
- Generate cluster-specific demo data (different counts per cluster based on name hash)
- Fix CRD Health card to generate cluster-specific data that changes when switching clusters
- Add ClusterBadge to all list items in OperatorStatus, OperatorSubscriptions, and CRDHealth cards
- Fix flickering by only showing skeleton when loading AND no data exists
- Update footers to show current cluster context
- Fix stats counts to use filtered data instead of paginated/raw data

## Test plan

- [ ] Navigate to Operators page
- [ ] Verify stats overview shows correct values (not zero)
- [ ] Switch cluster dropdown - verify list items change
- [ ] Verify stats update when switching clusters
- [ ] Verify ClusterBadge appears on each list item
- [ ] Verify no flickering when switching clusters
- [ ] Verify "All Clusters" option is available in all dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)