### PR TITLE
🐛 Fix NetworkUtils crash when latest ping result is undefined

### DIFF
--- a/web/src/components/cards/NetworkUtils.tsx
+++ b/web/src/components/cards/NetworkUtils.tsx
@@ -389,7 +389,7 @@ export function NetworkUtils() {
                           <AlertTriangle className="w-3 h-3 text-muted-foreground" />
                         )}
                         <span className={getStatusColor(latest?.latency ?? null, latest?.status || '')}>
-                          {latest?.latency !== null ? `${latest.latency}ms` : latest?.status || 'Not tested'}
+                          {latest?.latency != null ? `${latest.latency}ms` : latest?.status || 'Not tested'}
                         </span>
                       </div>
                       {avg !== null && (


### PR DESCRIPTION
## Summary
- Fix crash when adding all cards from catalog
- Use `!= null` instead of `!== null` to check for both undefined and null
- `undefined !== null` is true, causing `latest.latency` access on undefined

## Test plan
- [ ] Open Add Cards modal
- [ ] Click "Select All" to select all cards
- [ ] Click "Add Cards" - should not crash
- [ ] NetworkUtils card should render without error

🤖 Generated with [Claude Code](https://claude.ai/claude-code)