### PR TITLE
🐛 Fix GPU count showing 0 on cluster cards

### DIFF
--- a/web/src/hooks/useDemoMode.ts
+++ b/web/src/hooks/useDemoMode.ts
@@ -64,20 +64,18 @@ export function useDemoMode() {
   const toggleDemoMode = useCallback(() => {
     globalDemoMode = !globalDemoMode
     localStorage.setItem(DEMO_MODE_KEY, String(globalDemoMode))
-    // Clear GPU cache when turning off demo mode to prevent stale demo data
-    if (!globalDemoMode) {
-      localStorage.removeItem(GPU_CACHE_KEY)
-    }
+    // NOTE: We no longer clear GPU cache here - the fetch logic handles
+    // transitioning from demo to real data, and clearing here causes
+    // loss of GPU data if the subsequent fetch fails.
     notifyListeners()
   }, [])
 
   const setDemoMode = useCallback((value: boolean) => {
     globalDemoMode = value
     localStorage.setItem(DEMO_MODE_KEY, String(value))
-    // Clear GPU cache when turning off demo mode to prevent stale demo data
-    if (!value) {
-      localStorage.removeItem(GPU_CACHE_KEY)
-    }
+    // NOTE: We no longer clear GPU cache here - the fetch logic handles
+    // transitioning from demo to real data, and clearing here causes
+    // loss of GPU data if the subsequent fetch fails.
     notifyListeners()
   }, [])
 


### PR DESCRIPTION
## Summary
- Fix GPU count displaying 0 on cluster dashboard cards when fetch fails
- Add retry logic and localStorage cache recovery for resilience
- Remove premature cache clearing that caused data loss

## Problem
GPU counts showed 0 on all cluster cards while other metrics (nodes, CPUs, pods) displayed correctly. Root cause: localStorage cache was cleared BEFORE the fetch attempt, so when the fetch failed/aborted, there was no data to display.

## Changes
1. **Remove premature cache clearing** - Cache is now only updated after successful fetch
2. **Add retry logic** - 2 retries with 2s/5s delays on fetch failure  
3. **Add localStorage recovery** - Restore from localStorage when memory cache is empty
4. **Remove demo mode cache clearing** - Prevents losing GPU data during mode toggle

## Test plan
- [x] Toggle demo mode OFF → GPU counts persist (not reset to 0)
- [x] Navigate away during fetch → Navigate back → GPUs display from cache
- [x] Verify platform-eval shows ~10 GPUs, vllm-d shows ~42 GPUs (58 expected but 2 nodes have broken NVIDIA drivers)

🤖 Generated with [Claude Code](https://claude.ai/code)