### PR TITLE
✨ Add automatic polling for GPU and cluster data

### DIFF
--- a/web/src/hooks/useMCP.ts
+++ b/web/src/hooks/useMCP.ts
@@ -1659,6 +1659,15 @@ export function useClusters() {
         connectSharedWebSocket()
       }
     }
+
+    // Set up periodic polling every 60 seconds for dynamic cluster updates
+    const pollInterval = setInterval(() => {
+      fullFetchClusters()
+    }, 60000)
+
+    return () => {
+      clearInterval(pollInterval)
+    }
   }, [])
 
   // Refetch function that consumers can call
@@ -3603,8 +3612,14 @@ export function useGPUNodes(cluster?: string) {
       fetchGPUNodes(cluster)
     }
 
+    // Set up periodic polling every 30 seconds for dynamic updates
+    const pollInterval = setInterval(() => {
+      fetchGPUNodes(cluster, 'poll')
+    }, 30000)
+
     return () => {
       gpuNodeSubscribers.delete(handleUpdate)
+      clearInterval(pollInterval)
     }
   }, [cluster])
 


### PR DESCRIPTION
## Summary
- Add automatic polling so dashboard updates dynamically without manual refresh
- GPU data refreshes every 30 seconds
- Cluster data refreshes every 60 seconds

## Problem
User had to manually refresh the page to see updated GPU counts after nodes came back online.

## Solution
Added `setInterval` polling in both `useGPUNodes` and `useClusters` hooks with proper cleanup on unmount.

🤖 Generated with [Claude Code](https://claude.ai/code)