### PR TITLE
🐛 Fix feedback UI for demo/auth'd users and enhance webhook pipeline

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -259,9 +259,16 @@ export function FeatureRequestModal({ isOpen, onClose }: FeatureRequestModalProp
 
       {/* Header */}
       <div className="p-4 border-b border-border flex items-center justify-between flex-shrink-0">
-        <h2 className="text-lg font-semibold text-foreground">
-          Feedback
-        </h2>
+        <div className="flex items-center gap-2">
+          <h2 className="text-lg font-semibold text-foreground">
+            Feedback
+          </h2>
+          {!canPerformActions && (
+            <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-amber-500/20 text-amber-400 uppercase tracking-wider">
+              Demo
+            </span>
+          )}
+        </div>
         <button
           onClick={handleClose}
           disabled={isSubmitting}
@@ -462,6 +469,11 @@ export function FeatureRequestModal({ isOpen, onClose }: FeatureRequestModalProp
                                     <span className={`px-1.5 py-0.5 text-[10px] font-medium rounded ${statusInfo.bgColor} ${statusInfo.color}`}>
                                       {statusInfo.label}
                                     </span>
+                                    {request.status === 'fix_complete' && (
+                                      <span className="px-1.5 py-0.5 text-[10px] font-medium rounded bg-gray-500/20 text-gray-400">
+                                        Closed
+                                      </span>
+                                    )}
                                     {getStatusDescription(request.status, request.closed_by_user) && (
                                       <span className={`text-xs text-muted-foreground ${shouldBlur ? 'blur-sm select-none' : ''}`}>
                                         {getStatusDescription(request.status, request.closed_by_user)}

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -1,10 +1,10 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { api } from '../lib/api'
 
-// Check if user is in demo mode (demo-token)
+// Check if user is in demo mode — no token or explicit demo-token
 function isDemoUser(): boolean {
   const token = localStorage.getItem('token')
-  return token === 'demo-token'
+  return !token || token === 'demo-token'
 }
 
 // Types


### PR DESCRIPTION
## Summary
- **Fix demo mode fallback**: `isDemoUser()` now handles missing token gracefully — users without a token see demo data instead of an empty queue
- **Fix auth session recovery**: When a stored JWT is invalid/expired, `refreshUser()` falls back to demo mode instead of logging out to a broken state
- **Add "Demo" badge**: Non-authenticated users see a "Demo" indicator in the feedback dialog header
- **Add "Closed" badge**: Items with `fix_complete` status now show a "Closed" pill alongside "Fix Complete" to indicate the issue is merged and closed
- **Enhance webhook pipeline**: `ensureFeatureRequestExists()` auto-creates DB records for externally-created GitHub issues, and `pipelineLabels` map handles all pipeline label transitions with notifications

## Test plan
- [ ] Start backend in dev mode, verify demo users see demo data with "Demo" badge
- [ ] Login as authenticated user, verify real GitHub data appears in queue
- [ ] Navigate away and back, verify session recovers to demo mode gracefully (not empty queue)
- [ ] Verify fix_complete items show both "Fix Complete" and "Closed" badges
- [ ] Verify webhook creates DB records for externally-created issues with `ai-fix-requested` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)