### PR TITLE
🐛 Fix event dedup and add missing event card components

### DIFF
--- a/pkg/api/handlers/gateway.go
+++ b/pkg/api/handlers/gateway.go
@@ -92,7 +92,7 @@ func (h *GatewayHandlers) GetGatewayAPIStatus(c *fiber.Ctx) error {
 		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
 	}
 
-	clusters, err := h.k8sClient.ListClusters(c.Context())
+	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 	}

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -163,7 +163,7 @@ func (h *GitOpsHandlers) ListHelmReleases(c *fiber.Ctx) error {
 
 	// Query all clusters in parallel with timeout
 	if h.k8sClient != nil {
-		clusters, err := h.k8sClient.ListClusters(c.Context())
+		clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 		if err != nil {
 			return c.Status(500).JSON(fiber.Map{"error": err.Error(), "releases": []HelmRelease{}})
 		}
@@ -246,7 +246,7 @@ func (h *GitOpsHandlers) ListKustomizations(c *fiber.Ctx) error {
 
 	// Query all clusters in parallel with timeout
 	if h.k8sClient != nil {
-		clusters, err := h.k8sClient.ListClusters(c.Context())
+		clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 		if err != nil {
 			return c.Status(500).JSON(fiber.Map{"error": err.Error(), "kustomizations": []Kustomization{}})
 		}
@@ -367,7 +367,7 @@ func (h *GitOpsHandlers) ListOperators(c *fiber.Ctx) error {
 
 	// Query all clusters in parallel with timeout
 	if h.k8sClient != nil {
-		clusters, err := h.k8sClient.ListClusters(c.Context())
+		clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 		if err != nil {
 			return c.Status(500).JSON(fiber.Map{"error": err.Error(), "operators": []Operator{}})
 		}

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -159,7 +159,7 @@ func (h *MCPHandlers) GetPods(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -217,7 +217,7 @@ func (h *MCPHandlers) FindPodIssues(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -264,7 +264,7 @@ func (h *MCPHandlers) GetGPUNodes(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -311,7 +311,7 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatus(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -358,7 +358,7 @@ func (h *MCPHandlers) GetNodes(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -407,7 +407,7 @@ func (h *MCPHandlers) FindDeploymentIssues(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -455,7 +455,7 @@ func (h *MCPHandlers) GetDeployments(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -502,7 +502,7 @@ func (h *MCPHandlers) GetServices(c *fiber.Ctx) error {
 
 	if h.k8sClient != nil {
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -549,7 +549,7 @@ func (h *MCPHandlers) GetJobs(c *fiber.Ctx) error {
 
 	if h.k8sClient != nil {
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -596,7 +596,7 @@ func (h *MCPHandlers) GetHPAs(c *fiber.Ctx) error {
 
 	if h.k8sClient != nil {
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -643,7 +643,7 @@ func (h *MCPHandlers) GetConfigMaps(c *fiber.Ctx) error {
 
 	if h.k8sClient != nil {
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -690,7 +690,7 @@ func (h *MCPHandlers) GetSecrets(c *fiber.Ctx) error {
 
 	if h.k8sClient != nil {
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -737,7 +737,7 @@ func (h *MCPHandlers) GetServiceAccounts(c *fiber.Ctx) error {
 
 	if h.k8sClient != nil {
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -784,7 +784,7 @@ func (h *MCPHandlers) GetPVCs(c *fiber.Ctx) error {
 
 	if h.k8sClient != nil {
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -830,7 +830,7 @@ func (h *MCPHandlers) GetPVs(c *fiber.Ctx) error {
 
 	if h.k8sClient != nil {
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -877,7 +877,7 @@ func (h *MCPHandlers) GetResourceQuotas(c *fiber.Ctx) error {
 
 	if h.k8sClient != nil {
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -924,7 +924,7 @@ func (h *MCPHandlers) GetLimitRanges(c *fiber.Ctx) error {
 
 	if h.k8sClient != nil {
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -1067,9 +1067,11 @@ func (h *MCPHandlers) GetEvents(c *fiber.Ctx) error {
 
 	// Fall back to direct k8s client
 	if h.k8sClient != nil {
-		// If no cluster specified, query all clusters in parallel with timeout
+		// If no cluster specified, query deduplicated clusters in parallel with timeout
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			// Use deduplicated clusters to avoid querying the same physical cluster
+			// via multiple kubeconfig contexts (e.g. "vllm-d" and its long OpenShift name)
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -1137,9 +1139,9 @@ func (h *MCPHandlers) GetWarningEvents(c *fiber.Ctx) error {
 
 	// Fall back to direct k8s client
 	if h.k8sClient != nil {
-		// If no cluster specified, query all clusters in parallel
+		// If no cluster specified, query deduplicated clusters in parallel
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}
@@ -1198,7 +1200,7 @@ func (h *MCPHandlers) CheckSecurityIssues(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
 		if cluster == "" {
-			clusters, err := h.k8sClient.ListClusters(c.Context())
+			clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 			if err != nil {
 				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 			}

--- a/pkg/api/handlers/mcs.go
+++ b/pkg/api/handlers/mcs.go
@@ -92,7 +92,7 @@ func (h *MCSHandlers) GetMCSStatus(c *fiber.Ctx) error {
 		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
 	}
 
-	clusters, err := h.k8sClient.ListClusters(c.Context())
+	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 	}

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -171,7 +171,7 @@ func (h *RBACHandler) ListK8sServiceAccounts(c *fiber.Ctx) error {
 	}
 
 	// Get SAs from all clusters
-	clusters, err := h.k8sClient.ListClusters(ctx)
+	clusters, err := h.k8sClient.DeduplicatedClusters(ctx)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list clusters")
 	}

--- a/web/src/components/cards/EventSummary.tsx
+++ b/web/src/components/cards/EventSummary.tsx
@@ -1,0 +1,198 @@
+import { useMemo } from 'react'
+import { AlertTriangle, CheckCircle2, Activity, Server, ChevronDown } from 'lucide-react'
+import { useCachedEvents } from '../../hooks/useCachedData'
+import { useGlobalFilters } from '../../hooks/useGlobalFilters'
+import { RefreshButton } from '../ui/RefreshIndicator'
+import { Skeleton } from '../ui/Skeleton'
+import { useChartFilters } from '../../lib/cards'
+
+export function EventSummary() {
+  const {
+    events,
+    isLoading,
+    isRefreshing,
+    refetch,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  } = useCachedEvents(undefined, undefined, { limit: 100, category: 'realtime' })
+  const { filterByCluster } = useGlobalFilters()
+
+  const {
+    localClusterFilter,
+    toggleClusterFilter,
+    clearClusterFilter,
+    availableClusters,
+    showClusterFilter,
+    setShowClusterFilter,
+    clusterFilterRef,
+  } = useChartFilters({
+    storageKey: 'event-summary',
+  })
+
+  const filteredEvents = useMemo(() => {
+    let result = filterByCluster(events)
+    if (localClusterFilter.length > 0) {
+      result = result.filter(e => e.cluster && localClusterFilter.includes(e.cluster))
+    }
+    return result
+  }, [events, filterByCluster, localClusterFilter])
+
+  const summary = useMemo(() => {
+    const warnings = filteredEvents.filter(e => e.type === 'Warning').length
+    const normal = filteredEvents.filter(e => e.type === 'Normal').length
+
+    const reasonCounts: Record<string, number> = {}
+    filteredEvents.forEach(e => {
+      reasonCounts[e.reason] = (reasonCounts[e.reason] || 0) + 1
+    })
+    const topReasons = Object.entries(reasonCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+
+    const clusterCounts: Record<string, number> = {}
+    filteredEvents.forEach(e => {
+      if (e.cluster) {
+        const name = e.cluster.split('/').pop() || e.cluster
+        clusterCounts[name] = (clusterCounts[name] || 0) + 1
+      }
+    })
+    const topClusters = Object.entries(clusterCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+
+    return { warnings, normal, topReasons, topClusters }
+  }, [filteredEvents])
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3 p-1">
+        <Skeleton className="h-16 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+      </div>
+    )
+  }
+
+  const total = filteredEvents.length
+
+  return (
+    <div className="space-y-4">
+      {/* Header controls */}
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">
+          {total} event{total !== 1 ? 's' : ''}
+        </span>
+        <div className="flex items-center gap-2">
+          {/* Cluster filter */}
+          {availableClusters.length > 1 && (
+            <div className="relative" ref={clusterFilterRef}>
+              <button
+                onClick={() => setShowClusterFilter(!showClusterFilter)}
+                className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 transition-colors"
+              >
+                <Server className="w-3 h-3" />
+                {localClusterFilter.length > 0 ? `${localClusterFilter.length} cluster${localClusterFilter.length > 1 ? 's' : ''}` : 'All'}
+                <ChevronDown className="w-3 h-3" />
+              </button>
+              {showClusterFilter && (
+                <div className="absolute right-0 top-full mt-1 z-50 bg-card border border-border rounded-lg shadow-lg p-2 min-w-[160px]">
+                  <button onClick={clearClusterFilter} className="w-full text-left text-xs px-2 py-1 rounded hover:bg-secondary text-muted-foreground">
+                    All Clusters
+                  </button>
+                  {availableClusters.map(cluster => (
+                    <button
+                      key={cluster.name}
+                      onClick={() => toggleClusterFilter(cluster.name)}
+                      className={`w-full text-left text-xs px-2 py-1 rounded hover:bg-secondary ${localClusterFilter.includes(cluster.name) ? 'text-foreground font-medium' : 'text-muted-foreground'}`}
+                    >
+                      {localClusterFilter.includes(cluster.name) ? '✓ ' : ''}{cluster.name}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+          <RefreshButton
+            isRefreshing={isRefreshing}
+            onRefresh={refetch}
+            lastRefresh={lastRefresh ?? undefined}
+            isFailed={isFailed}
+            consecutiveFailures={consecutiveFailures}
+          />
+        </div>
+      </div>
+
+      {/* Type breakdown */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex items-center gap-2 p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+          <AlertTriangle className="w-4 h-4 text-yellow-400" />
+          <div>
+            <div className="text-lg font-bold text-yellow-400">{summary.warnings}</div>
+            <div className="text-xs text-muted-foreground">Warnings</div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 p-2 rounded-lg bg-green-500/10 border border-green-500/20">
+          <CheckCircle2 className="w-4 h-4 text-green-400" />
+          <div>
+            <div className="text-lg font-bold text-green-400">{summary.normal}</div>
+            <div className="text-xs text-muted-foreground">Normal</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Top reasons */}
+      {summary.topReasons.length > 0 && (
+        <div>
+          <div className="text-xs font-medium text-muted-foreground mb-2">Top Reasons</div>
+          <div className="space-y-1">
+            {summary.topReasons.map(([reason, count]) => (
+              <div key={reason} className="flex items-center justify-between text-xs">
+                <span className="text-foreground truncate mr-2">{reason}</span>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <div className="w-16 h-1.5 rounded-full bg-secondary overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-purple-500"
+                      style={{ width: `${Math.min(100, (count / total) * 100)}%` }}
+                    />
+                  </div>
+                  <span className="text-muted-foreground w-6 text-right">{count}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Cluster distribution */}
+      {summary.topClusters.length > 1 && (
+        <div>
+          <div className="text-xs font-medium text-muted-foreground mb-2">By Cluster</div>
+          <div className="space-y-1">
+            {summary.topClusters.map(([cluster, count]) => (
+              <div key={cluster} className="flex items-center justify-between text-xs">
+                <span className="text-foreground truncate mr-2">{cluster}</span>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <div className="w-16 h-1.5 rounded-full bg-secondary overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-blue-500"
+                      style={{ width: `${Math.min(100, (count / total) * 100)}%` }}
+                    />
+                  </div>
+                  <span className="text-muted-foreground w-6 text-right">{count}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {total === 0 && (
+        <div className="text-center py-4">
+          <Activity className="w-8 h-8 mx-auto mb-2 text-muted-foreground opacity-50" />
+          <p className="text-sm text-muted-foreground">No events</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/RecentEvents.tsx
+++ b/web/src/components/cards/RecentEvents.tsx
@@ -1,0 +1,191 @@
+import { useMemo } from 'react'
+import { Clock, AlertTriangle, CheckCircle2, Activity, Server, ChevronDown } from 'lucide-react'
+import { useCachedEvents } from '../../hooks/useCachedData'
+import { useGlobalFilters } from '../../hooks/useGlobalFilters'
+import { ClusterBadge } from '../ui/ClusterBadge'
+import { Pagination, usePagination } from '../ui/Pagination'
+import { RefreshButton } from '../ui/RefreshIndicator'
+import { Skeleton } from '../ui/Skeleton'
+import { useChartFilters } from '../../lib/cards'
+
+const ONE_HOUR_MS = 60 * 60 * 1000
+
+function getMinutesAgo(timestamp: string | undefined): string {
+  if (!timestamp) return 'Unknown'
+  const diffMs = Date.now() - new Date(timestamp).getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  if (diffMins < 1) return 'Just now'
+  if (diffMins < 60) return `${diffMins}m ago`
+  return `${Math.floor(diffMins / 60)}h ago`
+}
+
+export function RecentEvents() {
+  const {
+    events,
+    isLoading,
+    isRefreshing,
+    refetch,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  } = useCachedEvents(undefined, undefined, { limit: 100, category: 'realtime' })
+  const { filterByCluster } = useGlobalFilters()
+
+  const {
+    localClusterFilter,
+    toggleClusterFilter,
+    clearClusterFilter,
+    availableClusters,
+    showClusterFilter,
+    setShowClusterFilter,
+    clusterFilterRef,
+  } = useChartFilters({
+    storageKey: 'recent-events',
+  })
+
+  const recentEvents = useMemo(() => {
+    const cutoff = Date.now() - ONE_HOUR_MS
+    let result = filterByCluster(events).filter(e => {
+      if (!e.lastSeen) return false
+      return new Date(e.lastSeen).getTime() >= cutoff
+    })
+    if (localClusterFilter.length > 0) {
+      result = result.filter(e => e.cluster && localClusterFilter.includes(e.cluster))
+    }
+    return result
+  }, [events, filterByCluster, localClusterFilter])
+
+  const { paginatedItems, currentPage, totalPages, goToPage, needsPagination, itemsPerPage, setPerPage } = usePagination(recentEvents, 5)
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3 p-1">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    )
+  }
+
+  const warningCount = recentEvents.filter(e => e.type === 'Warning').length
+
+  return (
+    <div className="space-y-3">
+      {/* Header controls */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Clock className="w-3.5 h-3.5 text-blue-400" />
+          <span className="text-xs text-muted-foreground">
+            {recentEvents.length} event{recentEvents.length !== 1 ? 's' : ''} in last hour
+            {warningCount > 0 && (
+              <span className="text-yellow-400 ml-1">({warningCount} warning{warningCount !== 1 ? 's' : ''})</span>
+            )}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {availableClusters.length > 1 && (
+            <div className="relative" ref={clusterFilterRef}>
+              <button
+                onClick={() => setShowClusterFilter(!showClusterFilter)}
+                className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 transition-colors"
+              >
+                <Server className="w-3 h-3" />
+                {localClusterFilter.length > 0 ? `${localClusterFilter.length} cluster${localClusterFilter.length > 1 ? 's' : ''}` : 'All'}
+                <ChevronDown className="w-3 h-3" />
+              </button>
+              {showClusterFilter && (
+                <div className="absolute right-0 top-full mt-1 z-50 bg-card border border-border rounded-lg shadow-lg p-2 min-w-[160px]">
+                  <button onClick={clearClusterFilter} className="w-full text-left text-xs px-2 py-1 rounded hover:bg-secondary text-muted-foreground">
+                    All Clusters
+                  </button>
+                  {availableClusters.map(cluster => (
+                    <button
+                      key={cluster.name}
+                      onClick={() => toggleClusterFilter(cluster.name)}
+                      className={`w-full text-left text-xs px-2 py-1 rounded hover:bg-secondary ${localClusterFilter.includes(cluster.name) ? 'text-foreground font-medium' : 'text-muted-foreground'}`}
+                    >
+                      {localClusterFilter.includes(cluster.name) ? '✓ ' : ''}{cluster.name}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+          <RefreshButton
+            isRefreshing={isRefreshing}
+            onRefresh={refetch}
+            lastRefresh={lastRefresh ?? undefined}
+            isFailed={isFailed}
+            consecutiveFailures={consecutiveFailures}
+          />
+        </div>
+      </div>
+
+      {/* Recent events list */}
+      {recentEvents.length === 0 ? (
+        <div className="text-center py-6">
+          <Activity className="w-8 h-8 mx-auto mb-2 text-muted-foreground opacity-50" />
+          <p className="text-sm text-muted-foreground">No events in the last hour</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {paginatedItems.map((event, i) => (
+            <div
+              key={`${event.object}-${event.reason}-${i}`}
+              className={`p-2 rounded-lg border ${
+                event.type === 'Warning'
+                  ? 'bg-yellow-500/5 border-yellow-500/20'
+                  : 'bg-green-500/5 border-green-500/20'
+              }`}
+            >
+              <div className="flex items-start gap-2">
+                {event.type === 'Warning' ? (
+                  <AlertTriangle className="w-3.5 h-3.5 text-yellow-400 mt-0.5 flex-shrink-0" />
+                ) : (
+                  <CheckCircle2 className="w-3.5 h-3.5 text-green-400 mt-0.5 flex-shrink-0" />
+                )}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    <span className={`text-xs px-1.5 py-0.5 rounded font-medium ${
+                      event.type === 'Warning'
+                        ? 'bg-yellow-500/20 text-yellow-400'
+                        : 'bg-green-500/20 text-green-400'
+                    }`}>
+                      {event.reason}
+                    </span>
+                    <span className="text-xs text-foreground truncate">{event.object}</span>
+                    {event.count > 1 && (
+                      <span className="text-xs px-1 py-0.5 rounded bg-card text-muted-foreground">
+                        ×{event.count}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground truncate mt-0.5">{event.message}</p>
+                  <div className="flex items-center gap-2 mt-1">
+                    <span className="text-xs text-muted-foreground">{event.namespace}</span>
+                    {event.cluster && (
+                      <ClusterBadge cluster={event.cluster.split('/').pop() || event.cluster} size="sm" />
+                    )}
+                    <span className="text-xs text-muted-foreground ml-auto">{getMinutesAgo(event.lastSeen)}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {needsPagination && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalItems={recentEvents.length}
+          itemsPerPage={itemsPerPage}
+          onPageChange={goToPage}
+          onItemsPerPageChange={setPerPage}
+        />
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/WarningEvents.tsx
+++ b/web/src/components/cards/WarningEvents.tsx
@@ -1,0 +1,171 @@
+import { useMemo } from 'react'
+import { AlertTriangle, CheckCircle2, Server, ChevronDown } from 'lucide-react'
+import { useCachedEvents } from '../../hooks/useCachedData'
+import { useGlobalFilters } from '../../hooks/useGlobalFilters'
+import { ClusterBadge } from '../ui/ClusterBadge'
+import { Pagination, usePagination } from '../ui/Pagination'
+import { RefreshButton } from '../ui/RefreshIndicator'
+import { Skeleton } from '../ui/Skeleton'
+import { useChartFilters } from '../../lib/cards'
+
+function getTimeAgo(timestamp: string | undefined): string {
+  if (!timestamp) return 'Unknown'
+  const now = new Date()
+  const then = new Date(timestamp)
+  const diffMs = now.getTime() - then.getTime()
+  const diffMins = Math.floor(diffMs / 60000)
+  const diffHours = Math.floor(diffMins / 60)
+  const diffDays = Math.floor(diffHours / 24)
+
+  if (diffDays > 0) return `${diffDays}d ago`
+  if (diffHours > 0) return `${diffHours}h ago`
+  if (diffMins > 0) return `${diffMins}m ago`
+  return 'Just now'
+}
+
+export function WarningEvents() {
+  const {
+    events,
+    isLoading,
+    isRefreshing,
+    refetch,
+    isFailed,
+    consecutiveFailures,
+    lastRefresh,
+  } = useCachedEvents(undefined, undefined, { limit: 100, category: 'realtime' })
+  const { filterByCluster } = useGlobalFilters()
+
+  const {
+    localClusterFilter,
+    toggleClusterFilter,
+    clearClusterFilter,
+    availableClusters,
+    showClusterFilter,
+    setShowClusterFilter,
+    clusterFilterRef,
+  } = useChartFilters({
+    storageKey: 'warning-events',
+  })
+
+  const warningEvents = useMemo(() => {
+    let result = filterByCluster(events).filter(e => e.type === 'Warning')
+    if (localClusterFilter.length > 0) {
+      result = result.filter(e => e.cluster && localClusterFilter.includes(e.cluster))
+    }
+    return result
+  }, [events, filterByCluster, localClusterFilter])
+
+  const { paginatedItems, currentPage, totalPages, goToPage, needsPagination, itemsPerPage, setPerPage } = usePagination(warningEvents, 5)
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3 p-1">
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-10 w-full" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Header controls */}
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">
+          {warningEvents.length} warning{warningEvents.length !== 1 ? 's' : ''}
+        </span>
+        <div className="flex items-center gap-2">
+          {availableClusters.length > 1 && (
+            <div className="relative" ref={clusterFilterRef}>
+              <button
+                onClick={() => setShowClusterFilter(!showClusterFilter)}
+                className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 transition-colors"
+              >
+                <Server className="w-3 h-3" />
+                {localClusterFilter.length > 0 ? `${localClusterFilter.length} cluster${localClusterFilter.length > 1 ? 's' : ''}` : 'All'}
+                <ChevronDown className="w-3 h-3" />
+              </button>
+              {showClusterFilter && (
+                <div className="absolute right-0 top-full mt-1 z-50 bg-card border border-border rounded-lg shadow-lg p-2 min-w-[160px]">
+                  <button onClick={clearClusterFilter} className="w-full text-left text-xs px-2 py-1 rounded hover:bg-secondary text-muted-foreground">
+                    All Clusters
+                  </button>
+                  {availableClusters.map(cluster => (
+                    <button
+                      key={cluster.name}
+                      onClick={() => toggleClusterFilter(cluster.name)}
+                      className={`w-full text-left text-xs px-2 py-1 rounded hover:bg-secondary ${localClusterFilter.includes(cluster.name) ? 'text-foreground font-medium' : 'text-muted-foreground'}`}
+                    >
+                      {localClusterFilter.includes(cluster.name) ? '✓ ' : ''}{cluster.name}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+          <RefreshButton
+            isRefreshing={isRefreshing}
+            onRefresh={refetch}
+            lastRefresh={lastRefresh ?? undefined}
+            isFailed={isFailed}
+            consecutiveFailures={consecutiveFailures}
+          />
+        </div>
+      </div>
+
+      {/* Warning events list */}
+      {warningEvents.length === 0 ? (
+        <div className="text-center py-6">
+          <CheckCircle2 className="w-8 h-8 mx-auto mb-2 text-green-400 opacity-50" />
+          <p className="text-sm text-muted-foreground">No warnings</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {paginatedItems.map((event, i) => (
+            <div
+              key={`${event.object}-${event.reason}-${i}`}
+              className="p-2 rounded-lg bg-yellow-500/5 border border-yellow-500/20"
+            >
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="w-3.5 h-3.5 text-yellow-400 mt-0.5 flex-shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5 flex-wrap">
+                    <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400 font-medium">
+                      {event.reason}
+                    </span>
+                    <span className="text-xs text-foreground truncate">{event.object}</span>
+                    {event.count > 1 && (
+                      <span className="text-xs px-1 py-0.5 rounded bg-card text-muted-foreground">
+                        ×{event.count}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground truncate mt-0.5">{event.message}</p>
+                  <div className="flex items-center gap-2 mt-1">
+                    <span className="text-xs text-muted-foreground">{event.namespace}</span>
+                    {event.cluster && (
+                      <ClusterBadge cluster={event.cluster.split('/').pop() || event.cluster} size="sm" />
+                    )}
+                    <span className="text-xs text-muted-foreground ml-auto">{getTimeAgo(event.lastSeen)}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      {needsPagination && (
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalItems={warningEvents.length}
+          itemsPerPage={itemsPerPage}
+          onPageChange={goToPage}
+          onItemsPerPageChange={setPerPage}
+        />
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -17,6 +17,10 @@ import { GPUStatus } from './GPUStatus'
 import { GPUOverview } from './GPUOverview'
 import { GPUWorkloads } from './GPUWorkloads'
 import { SecurityIssues } from './SecurityIssues'
+// Event dashboard cards
+import { EventSummary } from './EventSummary'
+import { WarningEvents } from './WarningEvents'
+import { RecentEvents } from './RecentEvents'
 // Live data trend cards
 import { EventsTimeline } from './EventsTimeline'
 import { PodHealthTrend } from './PodHealthTrend'
@@ -163,6 +167,9 @@ export const CARD_COMPONENTS: Record<string, CardComponent> = {
   // Core cards
   cluster_health: ClusterHealth,
   event_stream: EventStream,
+  event_summary: EventSummary,
+  warning_events: WarningEvents,
+  recent_events: RecentEvents,
   pod_issues: PodIssues,
   top_pods: TopPods,
   app_status: AppStatus,
@@ -387,6 +394,9 @@ export const LIVE_DATA_CARDS = new Set([
   // Real-time status cards
   'cluster_metrics',
   'events_timeline',
+  'event_summary',
+  'warning_events',
+  'recent_events',
   'gpu_utilization',
   // Overview cards with live data
   'service_status',
@@ -434,6 +444,11 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
 
   // Workload Deployment - wide for workload list
   workload_deployment: 6,
+
+  // Event dashboard cards
+  event_summary: 6,
+  warning_events: 6,
+  recent_events: 6,
 
   // Medium cards (5-6 columns) - lists and tables
   event_stream: 6,


### PR DESCRIPTION
## Summary
- **Backend cluster deduplication**: Add `DeduplicatedClusters()` method to k8s client that groups kubeconfig contexts by server URL and picks the shortest name. This prevents duplicate queries and ensures events/resources from long-named contexts (e.g. `default/api-fmaas-vllm-d-...`) are correctly attributed to their short-name cluster (e.g. `vllm-d`). Applied to all ~23 parallel-query API handlers across `mcp.go`, `gitops.go`, `mcs.go`, `gateway.go`, and `rbac.go`.
- **Missing event card components**: Add three card components (`EventSummary`, `WarningEvents`, `RecentEvents`) referenced by `DEFAULT_EVENTS_CARDS` in the Events dashboard, fixing console warnings about unknown card types. Registered with proper widths and live-data badges.

## Test plan
- [ ] Build backend: `go build ./...`
- [ ] Build frontend: `cd web && npm run build`
- [ ] Navigate to Events dashboard — no console warnings about unknown card types
- [ ] Verify event summary card shows warning/normal breakdown
- [ ] Verify warning events card shows filtered warning events
- [ ] Verify recent events card shows events from the last hour
- [ ] Check Events dashboard shows events from ALL clusters (including platform-eval, vllm-d)
- [ ] Check global cluster filter works correctly with deduplicated names

🤖 Generated with [Claude Code](https://claude.com/claude-code)