### PR TITLE
🐛 Use CONSOLE_AUTO PAT to mark Copilot draft PRs as ready

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -406,17 +406,17 @@ jobs:
       - name: Mark PR ready if build passes and PR is draft
         if: steps.wait_netlify.outputs.netlify_conclusion == 'success'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CONSOLE_AUTO || secrets.GITHUB_TOKEN }}
         run: |
           PR_NUM="${{ github.event.pull_request.number }}"
           REPO="${{ github.repository }}"
 
-          # Check if PR is still a draft
+          # Check if PR is still a draft — use CONSOLE_AUTO PAT for Copilot-created PRs
           IS_DRAFT=$(gh pr view "$PR_NUM" --repo "$REPO" --json isDraft --jq '.isDraft')
 
           if [ "$IS_DRAFT" = "true" ]; then
             echo "PR #$PR_NUM is a draft with passing build, marking as ready..."
-            gh pr ready "$PR_NUM" --repo "$REPO"
+            gh pr ready "$PR_NUM" --repo "$REPO" || echo "Warning: failed to mark ready"
 
             # Also clean up labels
             gh pr edit "$PR_NUM" --repo "$REPO" --remove-label "do-not-merge/work-in-progress" 2>/dev/null || true

--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Process Copilot PR
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.CONSOLE_AUTO || secrets.GITHUB_TOKEN }}
           script: |
             // Get PR info based on event type
             let prNumber, pr;

--- a/.github/workflows/copilot-build-check.yml
+++ b/.github/workflows/copilot-build-check.yml
@@ -111,14 +111,14 @@ jobs:
       - name: Mark PR ready when build and lint pass
         if: steps.build.outcome == 'success' && steps.lint.outcome == 'success' && steps.find_pr.outputs.pr_number != ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CONSOLE_AUTO || secrets.GITHUB_TOKEN }}
         run: |
           PR_NUM="${{ steps.find_pr.outputs.pr_number }}"
 
-          # Check if PR is draft
+          # Check if PR is draft — use CONSOLE_AUTO PAT to modify Copilot-created PRs
           IS_DRAFT=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json isDraft --jq '.isDraft')
           if [ "$IS_DRAFT" = "true" ]; then
-            gh pr ready "$PR_NUM" --repo "${{ github.repository }}"
+            gh pr ready "$PR_NUM" --repo "${{ github.repository }}" || echo "Warning: failed to mark ready with primary token"
             echo "Marked PR #$PR_NUM as ready for review"
           fi
 

--- a/.github/workflows/copilot-pr-monitor.yml
+++ b/.github/workflows/copilot-pr-monitor.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Check Copilot PRs (3x with 20s intervals)
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.CONSOLE_AUTO || secrets.GITHUB_TOKEN }}
           script: |
             const sleep = ms => new Promise(r => setTimeout(r, ms));
 

--- a/.github/workflows/copilot-recovery.yml
+++ b/.github/workflows/copilot-recovery.yml
@@ -371,7 +371,7 @@ jobs:
       - name: Auto-mark PR ready for review
         if: steps.pr_info.outputs.is_copilot == 'true' && steps.pr_info.outputs.is_draft == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CONSOLE_AUTO || secrets.GITHUB_TOKEN }}
         run: |
           PR_NUM="${{ steps.pr_info.outputs.pr_number }}"
 


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` from workflows lacks permission to change draft status on PRs created by the Copilot bot
- Switches all 5 workflows that mark PRs ready to use `CONSOLE_AUTO` PAT (with `GITHUB_TOKEN` fallback)
- This ensures the full Auto-QA pipeline (issue -> Copilot PR -> ready -> merge) runs without manual intervention

## Affected Workflows
- `copilot-build-check.yml` — `gh pr ready` after build+lint pass
- `copilot-pr-monitor.yml` — GraphQL `markPullRequestReadyForReview` (runs every minute)
- `copilot-automation.yml` — GraphQL `markPullRequestReadyForReview`
- `copilot-recovery.yml` — GraphQL `markPullRequestReadyForReview`
- `ai-fix.yml` — `gh pr ready` after Netlify preview passes

## Test plan
- [ ] Trigger Auto-QA with `auto_triage=true` → verify Copilot PR gets marked ready automatically
- [ ] Verify `CONSOLE_AUTO` secret exists in repo settings
- [ ] Verify fallback to `GITHUB_TOKEN` if `CONSOLE_AUTO` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)