### PR TITLE
🌱 Fix last klaude reference in netlify.toml comment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
-# Netlify configuration for KubeStellar Klaude Console
+# Netlify configuration for KubeStellar Console
 # Enables PR preview deployments with mock data (no backend required)
 
 [build]


### PR DESCRIPTION
## Summary
- Fix the last remaining `Klaude` reference: a comment in `netlify.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)