### PR TITLE
🐛 Skip onboarding wizard on Netlify preview builds

### DIFF
--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -42,7 +42,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const setDemoMode = useCallback(() => {
-    const demoOnboarded = localStorage.getItem('demo-user-onboarded') === 'true'
+    const isNetlifyPreview = import.meta.env.VITE_DEMO_MODE === 'true' ||
+      window.location.hostname.includes('netlify.app') ||
+      window.location.hostname.includes('deploy-preview-')
+    const demoOnboarded = isNetlifyPreview || localStorage.getItem('demo-user-onboarded') === 'true'
     localStorage.setItem('token', 'demo-token')
     setTokenState('demo-token')
     setUser({


### PR DESCRIPTION
## Summary
- Skips the 7-step onboarding questionnaire on Netlify deploy previews and demo mode builds
- Preview visitors go straight to the dashboard instead of seeing "What's your primary role?"
- Local development still respects the localStorage toggle for testing onboarding

## Change
In `web/src/lib/auth.tsx`, when `VITE_DEMO_MODE=true` or hostname matches Netlify patterns, demo users are set to `onboarded: true` by default.

## Test plan
- [ ] Verify Netlify deploy preview shows dashboard directly (no onboarding)
- [ ] Verify local dev with `localStorage.removeItem('demo-user-onboarded')` still shows onboarding
- [ ] Verify local dev with `localStorage.setItem('demo-user-onboarded', 'true')` skips onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)