### PR TITLE
✨ Auto-enable demo data mode on Netlify preview builds

### DIFF
--- a/web/src/hooks/useDemoMode.ts
+++ b/web/src/hooks/useDemoMode.ts
@@ -7,10 +7,17 @@ const GPU_CACHE_KEY = 'kubestellar-gpu-cache'
 let globalDemoMode = false
 const listeners = new Set<(value: boolean) => void>()
 
-// Initialize from localStorage
+// Auto-enable demo mode on Netlify preview builds (VITE_DEMO_MODE=true in netlify.toml)
+const isNetlifyPreview = typeof window !== 'undefined' && (
+  import.meta.env.VITE_DEMO_MODE === 'true' ||
+  window.location.hostname.includes('netlify.app') ||
+  window.location.hostname.includes('deploy-preview-')
+)
+
+// Initialize from localStorage, or auto-enable on Netlify previews
 if (typeof window !== 'undefined') {
   const stored = localStorage.getItem(DEMO_MODE_KEY)
-  globalDemoMode = stored === 'true'
+  globalDemoMode = isNetlifyPreview || stored === 'true'
 
   // Clear any stale demo GPU data if demo mode is off
   // This handles the case where demo data was incorrectly cached


### PR DESCRIPTION
## Summary
- Auto-enables demo data mode (`ksc-demo-mode`) on Netlify preview builds so cards show dummy clusters, pods, nodes, and other data instead of empty/zero values
- Detects Netlify via `VITE_DEMO_MODE=true` (set in `netlify.toml`) or hostname patterns (`netlify.app`, `deploy-preview-`)
- Complements the existing auth-level demo mode (login/onboarding skip from PR #170) with data-level demo mode

## Test plan
- [ ] Verify Netlify deploy preview shows populated dashboard with demo clusters and data
- [ ] Verify local dev without `VITE_DEMO_MODE` still defaults to localStorage-based toggle
- [ ] Verify the demo mode toggle in settings still works to override

🤖 Generated with [Claude Code](https://claude.com/claude-code)