### PR TITLE
⚠️ Rename agent binary: ksc-agent → kc-agent

### DIFF
--- a/.claude-coord.md
+++ b/.claude-coord.md
@@ -115,7 +115,7 @@ See `PLAN-local-agent.md` for full details.
 **Goal**: Bridge cluster Console UI with local kubeconfig + Claude Code
 
 **Split**:
-- **infra**: Backend agent (`cmd/ksc-agent/`, `pkg/agent/`)
+- **infra**: Backend agent (`cmd/kc-agent/`, `pkg/agent/`)
 - **ksc**: Frontend client (`web/src/lib/local-agent.ts`, UI indicators)
 
 **Cluster URL**: https://ksc-kubestellar-console-ksc.apps.fmaas-vllm-d.fmaas.res.ibm.com
@@ -174,7 +174,7 @@ I've completed:
 Now starting **Local Agent** to bridge cluster UI with local kubeconfig + Claude Code.
 
 **Proposed split:**
-- **Me (infra)**: Backend - `cmd/ksc-agent/`, `pkg/agent/` (Go WebSocket server, kubectl proxy, Claude integration)
+- **Me (infra)**: Backend - `cmd/kc-agent/`, `pkg/agent/` (Go WebSocket server, kubectl proxy, Claude integration)
 - **You (ksc)**: Frontend - `web/src/lib/local-agent.ts` (agent detection, WebSocket client, UI status indicators)
 
 See `PLAN-local-agent.md` for full architecture.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
           fi
 
           # Check for changes in agent-related paths
-          AGENT_PATHS="pkg/agent cmd/ksc-agent go.mod go.sum"
+          AGENT_PATHS="pkg/agent cmd/kc-agent go.mod go.sum"
           AGENT_CHANGED="false"
 
           for path in $AGENT_PATHS; do
@@ -295,7 +295,7 @@ jobs:
           body: |
             ## Changes
 
-            This release contains web/console updates only. No changes to ksc-agent binary.
+            This release contains web/console updates only. No changes to kc-agent binary.
 
             The Homebrew formula was not updated as there are no agent changes.
 
@@ -336,7 +336,7 @@ jobs:
             echo "- GitHub Release: https://github.com/${{ github.repository }}/releases/tag/${{ needs.determine-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
             echo "- Docker Image: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
             if [ "${{ needs.determine-version.outputs.agent_changed }}" = "true" ]; then
-              echo "- Homebrew: \`brew upgrade ksc-agent\` (formula updated)" >> $GITHUB_STEP_SUMMARY
+              echo "- Homebrew: \`brew upgrade kc-agent\` (formula updated)" >> $GITHUB_STEP_SUMMARY
             else
               echo "- Homebrew: No update (no agent changes)" >> $GITHUB_STEP_SUMMARY
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ vendor/
 
 # Coordination file (local only)
 .claude-coord.md
+/kc-agent
+/ksc-agent
 /kkc-agent
 
 # Claude Code local files

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,19 +1,19 @@
-# GoReleaser config for ksc-agent
+# GoReleaser config for kc-agent
 # Run: goreleaser release --clean
 # Test: goreleaser build --snapshot --clean
 
 version: 2
 
-project_name: ksc-agent
+project_name: kc-agent
 
 before:
   hooks:
     - go mod tidy
 
 builds:
-  - id: ksc-agent
-    main: ./cmd/ksc-agent
-    binary: ksc-agent
+  - id: kc-agent
+    main: ./cmd/kc-agent
+    binary: kc-agent
     env:
       - CGO_ENABLED=0
     goos:
@@ -27,9 +27,9 @@ builds:
       - -X github.com/kubestellar/console/pkg/agent.Version={{.Version}}
 
 archives:
-  - id: ksc-agent
+  - id: kc-agent
     builds:
-      - ksc-agent
+      - kc-agent
     formats:
       - tar.gz
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
@@ -47,7 +47,7 @@ changelog:
 
 # Homebrew tap - only runs if HOMEBREW_TAP_TOKEN is set
 brews:
-  - name: ksc-agent
+  - name: kc-agent
     # Skip if token is not set
     skip_upload: '{{ if .Env.HOMEBREW_TAP_TOKEN }}false{{ else }}true{{ end }}'
     repository:
@@ -59,9 +59,9 @@ brews:
     description: "Local agent for KubeStellar Console - bridges browser to kubeconfig and Claude Code"
     license: "Apache-2.0"
     test: |
-      system "#{bin}/ksc-agent", "--version"
+      system "#{bin}/kc-agent", "--version"
     install: |
-      bin.install "ksc-agent"
+      bin.install "kc-agent"
 
 release:
   github:

--- a/PLAN-local-agent.md
+++ b/PLAN-local-agent.md
@@ -8,7 +8,7 @@ Build a local agent that runs on the user's laptop to bridge the cluster-hosted 
 
 ```
 ┌─────────────────────────┐      ┌─────────────────────┐      ┌─────────────────────┐
-│  Cluster Console        │ ←──  │  Browser            │ ←──  │  ksc-agent          │
+│  Cluster Console        │ ←──  │  Browser            │ ←──  │  kc-agent          │
 │  (UI + GitHub Auth)     │      │  (WebSocket bridge) │      │  (localhost:8585)   │
 │  - Dashboard UI         │      │                     │      │  - kubeconfig proxy │
 │  - User session/JWT     │      │                     │      │  - claude-code proxy│
@@ -18,7 +18,7 @@ Build a local agent that runs on the user's laptop to bridge the cluster-hosted 
 
 ## Components
 
-### 1. Local Agent (`cmd/ksc-agent/`)
+### 1. Local Agent (`cmd/kc-agent/`)
 - **Language**: Go
 - **Distribution**: brew, binary releases
 - **Port**: 8585 (configurable)
@@ -46,7 +46,7 @@ Build a local agent that runs on the user's laptop to bridge the cluster-hosted 
 ## Implementation Phases
 
 ### Phase 1: Basic Agent Infrastructure
-- [ ] Create `cmd/ksc-agent/main.go`
+- [ ] Create `cmd/kc-agent/main.go`
 - [ ] WebSocket server setup
 - [ ] Health endpoint
 - [ ] Browser detection logic in frontend
@@ -74,7 +74,7 @@ Build a local agent that runs on the user's laptop to bridge the cluster-hosted 
 console/
 ├── cmd/
 │   ├── console/          # Existing server
-│   └── ksc-agent/        # NEW: Local agent
+│   └── kc-agent/        # NEW: Local agent
 │       └── main.go
 ├── pkg/
 │   ├── agent/            # NEW: Agent package
@@ -88,7 +88,7 @@ console/
 │       └── lib/
 │           └── local-agent.ts  # NEW: Browser client
 └── Formula/
-    └── ksc-agent.rb      # NEW: Homebrew formula
+    └── kc-agent.rb      # NEW: Homebrew formula
 ```
 
 ## Security Considerations

--- a/README.md
+++ b/README.md
@@ -98,23 +98,23 @@ Console uses the `kubestellar-ops` and `kubestellar-deploy` MCP servers to fetch
 
 ## KSC Agent (Local Agent)
 
-The **ksc-agent** is a local agent that runs on your machine and bridges the browser-based console to your local kubeconfig and Claude Code CLI. This allows the hosted console to access your clusters without exposing your kubeconfig over the internet.
+The **kc-agent** is a local agent that runs on your machine and bridges the browser-based console to your local kubeconfig and Claude Code CLI. This allows the hosted console to access your clusters without exposing your kubeconfig over the internet.
 
 ### Installation
 
 ```bash
 brew tap kubestellar/tap
-brew install --head ksc-agent
+brew install --head kc-agent
 ```
 
 ### Running the Agent
 
 ```bash
 # Start the agent (runs on localhost:8585)
-ksc-agent
+kc-agent
 
 # Or run as a background service
-brew services start kubestellar/tap/ksc-agent
+brew services start kubestellar/tap/kc-agent
 ```
 
 ### Configuration
@@ -123,8 +123,8 @@ The agent supports the following environment variables:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `KSC_ALLOWED_ORIGINS` | Comma-separated list of allowed origins for CORS | localhost only |
-| `KSC_AGENT_TOKEN` | Optional shared secret for authentication | (none) |
+| `KC_ALLOWED_ORIGINS` | Comma-separated list of allowed origins for CORS | localhost only |
+| `KC_AGENT_TOKEN` | Optional shared secret for authentication | (none) |
 
 #### Adding Custom Origins
 
@@ -132,10 +132,10 @@ If you're running the console on a custom domain, add it to the allowed origins:
 
 ```bash
 # Single origin
-KSC_ALLOWED_ORIGINS="https://my-console.example.com" ksc-agent
+KC_ALLOWED_ORIGINS="https://my-console.example.com" kc-agent
 
 # Multiple origins
-KSC_ALLOWED_ORIGINS="https://console1.example.com,https://console2.example.com" ksc-agent
+KC_ALLOWED_ORIGINS="https://console1.example.com,https://console2.example.com" kc-agent
 ```
 
 #### Running as a Service with Custom Origins
@@ -143,13 +143,13 @@ KSC_ALLOWED_ORIGINS="https://console1.example.com,https://console2.example.com" 
 To persist the configuration when running as a brew service, add to your shell profile (`~/.zshrc` or `~/.bashrc`):
 
 ```bash
-export KSC_ALLOWED_ORIGINS="https://my-console.example.com"
+export KC_ALLOWED_ORIGINS="https://my-console.example.com"
 ```
 
 Then restart the service:
 
 ```bash
-brew services restart kubestellar/tap/ksc-agent
+brew services restart kubestellar/tap/kc-agent
 ```
 
 ### Security
@@ -158,7 +158,7 @@ The agent implements several security measures:
 
 - **Origin Validation**: Only allows connections from configured origins (localhost by default)
 - **Localhost Only**: Binds to `127.0.0.1` - not accessible from other machines
-- **Optional Token Auth**: Can require a shared secret via `KSC_AGENT_TOKEN`
+- **Optional Token Auth**: Can require a shared secret via `KC_AGENT_TOKEN`
 - **Command Allowlist**: Only permits safe kubectl commands (get, describe, logs, etc.)
 
 ## Available Card Types

--- a/cmd/kc-agent/main.go
+++ b/cmd/kc-agent/main.go
@@ -18,7 +18,7 @@ func main() {
 	flag.Parse()
 
 	if *version {
-		fmt.Printf("ksc-agent version %s\n", agent.Version)
+		fmt.Printf("kc-agent version %s\n", agent.Version)
 		os.Exit(0)
 	}
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -87,7 +87,7 @@ The Homebrew formula is automatically updated in the [kubestellar/homebrew-tap](
 Installation:
 ```bash
 brew tap kubestellar/tap
-brew install ksc-agent
+brew install kc-agent
 ```
 
 ### Helm Charts

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -84,7 +84,7 @@ func NewServer(cfg Config) (*Server, error) {
 	allowedOrigins := append([]string{}, defaultAllowedOrigins...)
 
 	// Add custom origins from environment variable (comma-separated)
-	if extraOrigins := os.Getenv("KSC_ALLOWED_ORIGINS"); extraOrigins != "" {
+	if extraOrigins := os.Getenv("KC_ALLOWED_ORIGINS"); extraOrigins != "" {
 		for _, origin := range strings.Split(extraOrigins, ",") {
 			origin = strings.TrimSpace(origin)
 			if origin != "" {
@@ -94,7 +94,7 @@ func NewServer(cfg Config) (*Server, error) {
 	}
 
 	// Optional shared secret for authentication
-	agentToken := os.Getenv("KSC_AGENT_TOKEN")
+	agentToken := os.Getenv("KC_AGENT_TOKEN")
 	if agentToken != "" {
 		log.Println("Agent token authentication enabled")
 	}

--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -4,9 +4,9 @@ import { cn } from '../../lib/cn'
 import { AgentIcon } from './AgentIcon'
 import { BaseModal } from '../../lib/modals'
 
-const INSTALL_COMMAND = 'brew install kubestellar/tap/ksc-agent && ksc-agent'
+const INSTALL_COMMAND = 'brew install kubestellar/tap/kc-agent && kc-agent'
 
-const KSC_AGENT_URL = 'http://127.0.0.1:8585'
+const KC_AGENT_URL = 'http://127.0.0.1:8585'
 
 interface KeyStatus {
   provider: string
@@ -63,7 +63,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
     try {
       setLoading(true)
       setError(null)
-      const response = await fetch(`${KSC_AGENT_URL}/settings/keys`)
+      const response = await fetch(`${KC_AGENT_URL}/settings/keys`)
       if (!response.ok) {
         throw new Error('Failed to fetch key status')
       }
@@ -88,7 +88,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
 
     try {
       setSaving(true)
-      const response = await fetch(`${KSC_AGENT_URL}/settings/keys`, {
+      const response = await fetch(`${KC_AGENT_URL}/settings/keys`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ provider, apiKey: newKeyValue }),
@@ -114,7 +114,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
   const handleDeleteKey = async (provider: string) => {
     try {
       setSaving(true)
-      const response = await fetch(`${KSC_AGENT_URL}/settings/keys/${provider}`, {
+      const response = await fetch(`${KC_AGENT_URL}/settings/keys/${provider}`, {
         method: 'DELETE',
       })
 

--- a/web/src/components/agent/AgentSetupDialog.tsx
+++ b/web/src/components/agent/AgentSetupDialog.tsx
@@ -5,8 +5,8 @@ import { Download } from 'lucide-react'
 import { useLocalAgent } from '@/hooks/useLocalAgent'
 import { BaseModal } from '../../lib/modals'
 
-const DISMISSED_KEY = 'ksc-agent-setup-dismissed'
-const SNOOZED_KEY = 'ksc-agent-setup-snoozed'
+const DISMISSED_KEY = 'kc-agent-setup-dismissed'
+const SNOOZED_KEY = 'kc-agent-setup-snoozed'
 const SNOOZE_DURATION = 24 * 60 * 60 * 1000 // 24 hours
 
 export function AgentSetupDialog() {
@@ -14,7 +14,7 @@ export function AgentSetupDialog() {
   const [show, setShow] = useState(false)
   const [copied, setCopied] = useState(false)
 
-  const installCommand = 'brew install kubestellar/tap/ksc-agent && ksc-agent'
+  const installCommand = 'brew install kubestellar/tap/kc-agent && kc-agent'
 
   useEffect(() => {
     // Only show after initial connection check completes

--- a/web/src/components/agent/AgentStatus.tsx
+++ b/web/src/components/agent/AgentStatus.tsx
@@ -47,7 +47,7 @@ export function AgentInstallBanner() {
     navigator.clipboard.writeText(text)
   }
 
-  const installCommand = 'brew install kubestellar/tap/ksc-agent && ksc-agent'
+  const installCommand = 'brew install kubestellar/tap/kc-agent && kc-agent'
 
   return (
     <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-6">

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -96,7 +96,7 @@ export function Layout({ children }: LayoutProps) {
               <WifiOff className="w-4 h-4 text-orange-400 shrink-0" />
               <span className="text-sm text-orange-400 font-medium shrink-0">Offline</span>
               <span className="text-xs text-orange-400/70 truncate">
-                — Install: <code className="bg-orange-500/20 px-1 rounded">brew install kubestellar/tap/ksc-agent</code> → run <code className="bg-orange-500/20 px-1 rounded">ksc-agent</code> → configure your AI agent API keys in Settings
+                — Install: <code className="bg-orange-500/20 px-1 rounded">brew install kubestellar/tap/kc-agent</code> → run <code className="bg-orange-500/20 px-1 rounded">kc-agent</code> → configure your AI agent API keys in Settings
               </span>
             </div>
             <div className="flex items-center gap-2 shrink-0 ml-2">

--- a/web/src/components/layout/Navbar.tsx
+++ b/web/src/components/layout/Navbar.tsx
@@ -837,7 +837,7 @@ export function Navbar() {
                 <div className="bg-black/50 rounded p-2 font-mono text-[11px] text-green-400 mb-2 space-y-1">
                   <div className="text-muted-foreground"># Install via Homebrew</div>
                   <code className="block">brew tap kubestellar/tap</code>
-                  <code className="block">brew install ksc-agent</code>
+                  <code className="block">brew install kc-agent</code>
                 </div>
                 <p className="text-[10px] text-muted-foreground">
                   Visit{' '}

--- a/web/src/components/settings/Settings.tsx
+++ b/web/src/components/settings/Settings.tsx
@@ -121,7 +121,7 @@ export function Settings() {
   const [profileSaved, setProfileSaved] = useState(false)
   const [showAPIKeySettings, setShowAPIKeySettings] = useState(false)
 
-  const installCommand = 'brew install kubestellar/tap/ksc-agent && ksc-agent'
+  const installCommand = 'brew install kubestellar/tap/kc-agent && kc-agent'
 
   const copyInstallCommand = async () => {
     await navigator.clipboard.writeText(installCommand)

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -70,7 +70,7 @@ export function UpdateSettings() {
     ? `helm upgrade ksc kubestellar-console/kubestellar-console --version ${latestRelease.tag.replace(/^v/, '')} -n ksc`
     : 'helm upgrade ksc kubestellar-console/kubestellar-console -n ksc'
 
-  const brewCommand = 'brew upgrade kubestellar/tap/ksc-agent'
+  const brewCommand = 'brew upgrade kubestellar/tap/kc-agent'
 
   return (
     <div className="glass rounded-xl p-6">

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -336,15 +336,15 @@ export function useLocalAgent() {
   const installInstructions = {
     title: 'Install Local Agent',
     description:
-      'To connect to your local kubeconfig and Claude Code, install the ksc-agent on your machine.',
+      'To connect to your local kubeconfig and Claude Code, install the kc-agent on your machine.',
     steps: [
       {
         title: 'Install via Homebrew (macOS)',
-        command: 'brew install kubestellar/tap/ksc-agent && ksc-agent',
+        command: 'brew install kubestellar/tap/kc-agent && kc-agent',
       },
       {
         title: 'Or build from source',
-        command: 'go install github.com/kubestellar/console/cmd/ksc-agent@latest && ksc-agent',
+        command: 'go install github.com/kubestellar/console/cmd/kc-agent@latest && kc-agent',
       },
     ],
     benefits: [

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -87,7 +87,7 @@ interface StartMissionParams {
 
 const MissionContext = createContext<MissionContextValue | null>(null)
 
-const KSC_AGENT_WS_URL = 'ws://127.0.0.1:8585/ws'
+const KC_AGENT_WS_URL = 'ws://127.0.0.1:8585/ws'
 const MISSIONS_STORAGE_KEY = 'ksc_missions'
 const UNREAD_MISSIONS_KEY = 'ksc_unread_missions'
 
@@ -215,7 +215,7 @@ export function MissionProvider({ children }: { children: ReactNode }) {
       }, 5000)
 
       try {
-        wsRef.current = new WebSocket(KSC_AGENT_WS_URL)
+        wsRef.current = new WebSocket(KC_AGENT_WS_URL)
 
         wsRef.current.onopen = () => {
           clearTimeout(timeout)
@@ -310,8 +310,8 @@ export function MissionProvider({ children }: { children: ReactNode }) {
 The AI missions feature requires the local agent to be running.
 
 **To get started:**
-1. Install the agent: \`brew install kubestellar/tap/ksc-agent\`
-2. Start the agent: \`ksc-agent\`
+1. Install the agent: \`brew install kubestellar/tap/kc-agent\`
+2. Start the agent: \`kc-agent\`
 3. [Configure API Keys →](/settings) for Claude, OpenAI, or Gemini`
 
             const pendingMissionIds = new Set(pendingRequests.current.values())
@@ -585,8 +585,8 @@ The AI missions feature requires the local agent to be running.
 The AI missions feature requires the local agent to be running.
 
 **To get started:**
-1. Install the agent: \`brew install kubestellar/tap/ksc-agent\`
-2. Start the agent: \`ksc-agent\`
+1. Install the agent: \`brew install kubestellar/tap/kc-agent\`
+2. Start the agent: \`kc-agent\`
 3. [Configure API Keys →](/settings) for Claude, OpenAI, or Gemini`
 
       setMissions(prev => prev.map(m =>

--- a/web/src/lib/iconSuggester.ts
+++ b/web/src/lib/iconSuggester.ts
@@ -5,7 +5,7 @@
  * is unavailable, then to a random generic icon.
  */
 
-const KSC_AGENT_WS_URL = 'ws://127.0.0.1:8585/ws'
+const KC_AGENT_WS_URL = 'ws://127.0.0.1:8585/ws'
 
 // All Lucide icons available in the sidebar
 const ICON_POOL = [
@@ -91,7 +91,7 @@ function askAgentForIcon(name: string): Promise<string | null> {
     }, 5000)
 
     try {
-      const ws = new WebSocket(KSC_AGENT_WS_URL)
+      const ws = new WebSocket(KC_AGENT_WS_URL)
       let response = ''
       const requestId = `icon-suggest-${Date.now()}`
 

--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -5,7 +5,7 @@
  * which has access to the user's kubeconfig.
  */
 
-const KSC_AGENT_WS_URL = 'ws://127.0.0.1:8585/ws'
+const KC_AGENT_WS_URL = 'ws://127.0.0.1:8585/ws'
 
 type MessageType = 'kubectl' | 'health' | 'clusters' | 'result' | 'error'
 
@@ -74,7 +74,7 @@ class KubectlProxy {
     this.isConnecting = true
     this.connectPromise = new Promise((resolve, reject) => {
       try {
-        this.ws = new WebSocket(KSC_AGENT_WS_URL)
+        this.ws = new WebSocket(KC_AGENT_WS_URL)
 
         this.ws.onopen = () => {
           console.log('[KubectlProxy] Connected to local agent')


### PR DESCRIPTION
## Summary
- Renames the local agent binary from `ksc-agent` to `kc-agent` (shorter, cleaner name)
- Updates `cmd/ksc-agent/` → `cmd/kc-agent/` directory and main.go
- Updates GoReleaser config (project name, binary, brew formula)
- Renames environment variables: `KSC_AGENT_*` → `KC_AGENT_*`
- Updates all frontend references (brew install commands, localStorage keys, WebSocket URL constants)
- Updates CI/CD release workflow
- Updates documentation (README, RELEASING, PLAN-local-agent)

## Breaking Changes
- Agent binary renamed: `ksc-agent` → `kc-agent`
- Environment variables renamed: `KSC_ALLOWED_ORIGINS` → `KC_ALLOWED_ORIGINS`, `KSC_AGENT_TOKEN` → `KC_AGENT_TOKEN`
- localStorage keys updated: `ksc-agent-setup-*` → `kc-agent-setup-*`

## Test plan
- [ ] `go build ./cmd/kc-agent/` compiles
- [ ] Frontend builds without errors (`npm run build`)
- [ ] Agent connects successfully with new binary name
- [ ] Homebrew formula updated in companion PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)