### PR TITLE
🐛 Fix Auto-QA octal bug in day-of-year calculation

### DIFF
--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -77,7 +77,7 @@ jobs:
             echo "Focus override: $OVERRIDE"
           else
             DOY=$(date -u +%j)  # Day of year (1-366)
-            SLOT=$(( DOY % 8 ))
+            SLOT=$(( 10#$DOY % 8 ))  # 10# forces base-10 (date +%j zero-pads, which bash reads as octal)
             case $SLOT in
               0) FOCUS="performance" ;;
               1) FOCUS="security" ;;


### PR DESCRIPTION
## Summary
- `date +%j` returns zero-padded day-of-year (e.g., `029`). Bash arithmetic interprets leading zeros as octal, and digits 8/9 are invalid in octal, causing every hourly run to fail with: `029: value too great for base`
- Fix: `10#$DOY` forces base-10 interpretation

## Test plan
- [ ] Trigger workflow manually and verify "Determine daily focus" step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)