### PR TITLE
🐛 Fix RBAC N+1 query and increase frontend timeout

### DIFF
--- a/web/src/hooks/useMCP.ts
+++ b/web/src/hooks/useMCP.ts
@@ -5710,7 +5710,7 @@ export function useK8sRoles(cluster?: string, namespace?: string, includeSystem 
       if (namespace) params.append('namespace', namespace)
       if (includeSystem) params.append('includeSystem', 'true')
 
-      const { data } = await api.get<K8sRole[]>(`/api/rbac/roles?${params}`)
+      const { data } = await api.get<K8sRole[]>(`/api/rbac/roles?${params}`, { timeout: 60000 })
       setRoles(data || [])
       setError(null)
     } catch (err) {
@@ -5757,7 +5757,7 @@ export function useK8sRoleBindings(cluster?: string, namespace?: string, include
       if (namespace) params.append('namespace', namespace)
       if (includeSystem) params.append('includeSystem', 'true')
 
-      const { data } = await api.get<K8sRoleBinding[]>(`/api/rbac/bindings?${params}`)
+      const { data } = await api.get<K8sRoleBinding[]>(`/api/rbac/bindings?${params}`, { timeout: 60000 })
       setBindings(data || [])
       setError(null)
     } catch (err) {
@@ -5797,7 +5797,7 @@ export function useK8sServiceAccounts(cluster?: string, namespace?: string) {
       if (cluster) params.append('cluster', cluster)
       if (namespace) params.append('namespace', namespace)
 
-      const { data } = await api.get<K8sServiceAccountInfo[]>(`/api/rbac/service-accounts?${params}`)
+      const { data } = await api.get<K8sServiceAccountInfo[]>(`/api/rbac/service-accounts?${params}`, { timeout: 60000 })
       setServiceAccounts(data || [])
       setError(null)
     } catch (err) {

--- a/web/src/hooks/useUsers.ts
+++ b/web/src/hooks/useUsers.ts
@@ -480,7 +480,7 @@ export function useK8sServiceAccounts(cluster?: string, namespace?: string) {
       const params = new URLSearchParams()
       params.set('cluster', cluster)
       if (namespace) params.set('namespace', namespace)
-      const { data } = await api.get<K8sServiceAccount[]>(`/api/rbac/service-accounts?${params}`)
+      const { data } = await api.get<K8sServiceAccount[]>(`/api/rbac/service-accounts?${params}`, { timeout: 60000 })
       setServiceAccounts(data || [])
       setError(null)
     } catch (err) {
@@ -557,7 +557,7 @@ export function useAllK8sServiceAccounts(clusters: Array<{ name: string }>) {
     const results = await Promise.allSettled(
       clusters.map(async (cluster) => {
         try {
-          const { data } = await api.get<K8sServiceAccount[]>(`/api/rbac/service-accounts?cluster=${cluster.name}`)
+          const { data } = await api.get<K8sServiceAccount[]>(`/api/rbac/service-accounts?cluster=${cluster.name}`, { timeout: 60000 })
           return { cluster: cluster.name, sas: data || [] }
         } catch {
           // Mark cluster as failed but don't break the whole fetch
@@ -609,7 +609,7 @@ export function useK8sRoles(cluster: string, namespace?: string, includeSystem?:
       const params = new URLSearchParams({ cluster })
       if (namespace) params.set('namespace', namespace)
       if (includeSystem) params.set('includeSystem', 'true')
-      const { data } = await api.get<K8sRole[]>(`/api/rbac/roles?${params}`)
+      const { data } = await api.get<K8sRole[]>(`/api/rbac/roles?${params}`, { timeout: 60000 })
       setRoles(data || [])
     } catch {
       // Silently fail - backend may be unavailable
@@ -642,7 +642,7 @@ export function useK8sRoleBindings(cluster: string, namespace?: string, includeS
       const params = new URLSearchParams({ cluster })
       if (namespace) params.set('namespace', namespace)
       if (includeSystem) params.set('includeSystem', 'true')
-      const { data } = await api.get<K8sRoleBinding[]>(`/api/rbac/bindings?${params}`)
+      const { data } = await api.get<K8sRoleBinding[]>(`/api/rbac/bindings?${params}`, { timeout: 60000 })
       setBindings(data || [])
     } catch {
       // Silently fail - backend may be unavailable


### PR DESCRIPTION
## Summary
- **Backend**: Replace per-ServiceAccount role lookups with a single batch fetch of all RoleBindings and ClusterRoleBindings, eliminating N+1 query pattern (reduced response from ~44s to <1s for clusters with many SAs)
- **Frontend**: Increase RBAC API call timeout from 5s to 60s in `useMCP.ts` and `useUsers.ts` to handle larger clusters

## Test plan
- [x] Verified SA endpoint response time dropped from 43.8s to 0.8s
- [x] Verified Namespace RBAC card loads roles, bindings, and SAs correctly
- [x] Verified namespace switching works without timeout errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)