### PR TITLE
✨ Add slide-out animation and Escape key to AI Missions panel

### DIFF
--- a/web/src/components/layout/MissionSidebar.tsx
+++ b/web/src/components/layout/MissionSidebar.tsx
@@ -1022,18 +1022,22 @@ export function MissionSidebar() {
   const [collapsedMissions, setCollapsedMissions] = useState<Set<string>>(new Set())
   const [fontSize, setFontSize] = useState<FontSize>('base')
 
-  // Exit fullscreen on Escape key
+  // Escape key: exit fullscreen first, then close sidebar
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isFullScreen) {
-        setFullScreen(false)
+      if (e.key === 'Escape') {
+        if (isFullScreen) {
+          setFullScreen(false)
+        } else if (isSidebarOpen) {
+          closeSidebar()
+        }
       }
     }
-    if (isFullScreen) {
+    if (isSidebarOpen) {
       document.addEventListener('keydown', handleEscape)
       return () => document.removeEventListener('keydown', handleEscape)
     }
-  }, [isFullScreen, setFullScreen])
+  }, [isSidebarOpen, isFullScreen, setFullScreen, closeSidebar])
 
   // Count missions needing attention
   const needsAttention = missions.filter(m =>
@@ -1066,14 +1070,14 @@ export function MissionSidebar() {
     }
   }
 
-  if (!isSidebarOpen) {
-    return null
-  }
-
   // Minimized sidebar view (thin strip)
   if (isSidebarMinimized) {
     return (
-      <div className="fixed top-20 right-4 bottom-4 w-12 bg-card/95 backdrop-blur-sm border border-border rounded-lg shadow-xl z-40 flex flex-col items-center py-4">
+      <div className={cn(
+        "fixed top-20 right-4 bottom-4 w-12 bg-card/95 backdrop-blur-sm border border-border rounded-lg shadow-xl z-40 flex flex-col items-center py-4",
+        "transition-transform duration-300 ease-in-out",
+        !isSidebarOpen && "translate-x-[calc(100%+2rem)] pointer-events-none"
+      )}>
         <button
           onClick={expandSidebar}
           className="p-2 hover:bg-secondary rounded transition-colors mb-4"
@@ -1105,11 +1109,11 @@ export function MissionSidebar() {
       data-tour="ai-missions"
       className={cn(
         "fixed bg-card/95 backdrop-blur-sm border-border z-40 flex flex-col overflow-hidden rounded-lg",
-        // Use separate transitions for smoother animation
-        "transition-[width,top,border] duration-300",
+        "transition-[width,top,border,transform] duration-300 ease-in-out",
         isFullScreen
           ? "inset-0 top-16 border-l-0 rounded-none"
-          : "top-20 right-4 bottom-4 w-[520px] border shadow-xl"
+          : "top-20 right-4 bottom-4 w-[520px] border shadow-xl",
+        !isSidebarOpen && "translate-x-[calc(100%+2rem)] pointer-events-none"
       )}
     >
       {/* Header */}


### PR DESCRIPTION
## Summary
- AI Missions panel now slides out to the right with a 300ms animation when closing, instead of disappearing instantly
- Escape key closes the sidebar (exits fullscreen first if in fullscreen mode)
- Both minimized strip and expanded panel views animate consistently

## Test plan
- [ ] Open AI Missions panel, close it — verify slide-out animation
- [ ] Open panel, press Escape — verify it closes with slide animation
- [ ] Enter fullscreen, press Escape — verify it exits fullscreen first
- [ ] Press Escape again — verify sidebar closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)