### PR TITLE
🐛 Fix mission chat appending all responses into one bubble

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -408,8 +408,8 @@ The AI missions feature requires the local agent to be running.
         const payload = message.payload as ChatStreamPayload
         const lastMsg = m.messages[m.messages.length - 1]
 
-        if (lastMsg?.role === 'assistant' && !payload.done) {
-          // Append to existing assistant message, preserve agent
+        if (lastMsg?.role === 'assistant' && !payload.done && m.status === 'running') {
+          // Append to existing assistant message mid-stream, preserve agent
           return {
             ...m,
             status: 'running' as MissionStatus,


### PR DESCRIPTION
## Summary
- Each agent response in a mission now renders as a separate chat bubble instead of being concatenated into one
- Root cause: the streaming handler checked `lastMsg?.role === 'assistant' && !payload.done` which was true even for NEW responses after a previous one completed
- Fix: add `&& m.status === 'running'` so only mid-stream chunks append; new responses (when status is `waiting_input`) create a new message

## Test plan
- [ ] Start a mission that triggers multi-turn agent responses
- [ ] Verify each response appears as a separate bubble
- [ ] Verify streaming within a single response still works (chunks append correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)