### PR TITLE
✨ Self-managed DashboardHeader timestamp and Deploy StatsOverview

### DIFF
--- a/web/src/components/ui/StatsBlockDefinitions.ts
+++ b/web/src/components/ui/StatsBlockDefinitions.ts
@@ -33,6 +33,7 @@ export type DashboardStatsType =
   | 'alerts'
   | 'dashboard'
   | 'operators'
+  | 'deploy'
 
 /**
  * Default stat blocks for the Clusters dashboard
@@ -254,6 +255,20 @@ export const OPERATORS_STAT_BLOCKS: StatBlockConfig[] = [
 ]
 
 /**
+ * Default stat blocks for the Deploy dashboard
+ */
+export const DEPLOY_STAT_BLOCKS: StatBlockConfig[] = [
+  { id: 'deployments', name: 'Deployments', icon: 'Ship', visible: true, color: 'blue' },
+  { id: 'healthy', name: 'Healthy', icon: 'CheckCircle2', visible: true, color: 'green' },
+  { id: 'progressing', name: 'Progressing', icon: 'Clock', visible: true, color: 'cyan' },
+  { id: 'failed', name: 'Failed', icon: 'XCircle', visible: true, color: 'red' },
+  { id: 'helm', name: 'Helm Releases', icon: 'Package', visible: true, color: 'purple' },
+  { id: 'argocd', name: 'ArgoCD Apps', icon: 'Workflow', visible: true, color: 'orange' },
+  { id: 'namespaces', name: 'Namespaces', icon: 'FolderOpen', visible: true, color: 'cyan' },
+  { id: 'clusters', name: 'Clusters', icon: 'Server', visible: true, color: 'purple' },
+]
+
+/**
  * Get all stat blocks across all dashboard types
  */
 export const ALL_STAT_BLOCKS: StatBlockConfig[] = (() => {
@@ -273,6 +288,7 @@ export const ALL_STAT_BLOCKS: StatBlockConfig[] = (() => {
     ...ALERTS_STAT_BLOCKS,
     ...DASHBOARD_STAT_BLOCKS,
     ...OPERATORS_STAT_BLOCKS,
+    ...DEPLOY_STAT_BLOCKS,
   ]
 
   // Deduplicate by ID
@@ -321,6 +337,8 @@ export function getDefaultStatBlocks(dashboardType: DashboardStatsType): StatBlo
       return DASHBOARD_STAT_BLOCKS
     case 'operators':
       return OPERATORS_STAT_BLOCKS
+    case 'deploy':
+      return DEPLOY_STAT_BLOCKS
     default:
       return []
   }


### PR DESCRIPTION
## Summary
- **DashboardHeader** now self-manages its "Updated" timestamp internally — no dashboard needs to pass `lastUpdated` as a prop anymore. Timestamp initializes on mount and updates when `isFetching` transitions true→false. Layout changed to flex-col so timestamp renders below refresh controls.
- **Deploy dashboard**: replaced static banner with `StatsOverview` component using real data from `useCachedDeployments` (deployments, healthy, progressing, failed, helm, argocd, namespaces, clusters).
- Added `deploy` stat block definitions to `StatsBlockDefinitions.ts`.

## Test plan
- [x] Deploy page shows stat blocks with real data (529 deployments, 526 healthy, 3 failed, 5 clusters, 241 namespaces)
- [x] "Updated" timestamp appears on all dashboards without any per-page changes
- [x] Timestamp updates after refresh completes
- [x] ArgoCD Apps shows demo beaker icon
- [x] TypeScript and production build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)