### PR TITLE
🐛 Remove status trigger from Copilot PR Automation

### DIFF
--- a/.github/workflows/copilot-automation.yml
+++ b/.github/workflows/copilot-automation.yml
@@ -11,13 +11,16 @@ on:
     types: [opened, synchronize, ready_for_review]
   check_run:
     types: [completed]
-  status: {}
 
 permissions:
   contents: write
   pull-requests: write
   issues: write
   statuses: write
+
+concurrency:
+  group: copilot-automation-${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.event.inputs.pr_number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   copilot-automation:
@@ -38,20 +41,6 @@ jobs:
               prNumber = parseInt(context.payload.inputs.pr_number, 10);
             } else if (context.eventName === 'pull_request_target') {
               prNumber = context.payload.pull_request.number;
-            } else if (context.eventName === 'status') {
-              // Status event (e.g., Prow setting DCO) — find associated PRs
-              const sha = context.payload.sha;
-              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: sha
-              });
-              const openPr = prs.find(p => p.state === 'open');
-              if (!openPr) {
-                core.info('No open PR for this status event');
-                return;
-              }
-              prNumber = openPr.number;
             } else if (context.eventName === 'check_run') {
               const checkRun = context.payload.check_run;
               const prs = checkRun.pull_requests;
@@ -168,7 +157,6 @@ jobs:
             if (pr.draft) {
               // Only auto-mark ready on check_run or status events (not on PR open)
               const shouldCheckReady = context.eventName === 'check_run' ||
-                                       context.eventName === 'status' ||
                                        context.eventName === 'workflow_dispatch';
               if (shouldCheckReady) {
                 // Check if Netlify deploy preview passed


### PR DESCRIPTION
## Summary
- Remove `status: {}` trigger that caused 60+ workflow runs in 7 minutes
- The workflow's own `createCommitStatus` call (DCO override) was generating new `status` events, creating a feedback loop
- `check_run: completed` already covers the same use cases (DCO check, Netlify build)
- Add `concurrency` group with `cancel-in-progress: true` to prevent duplicate runs for the same PR

## Test plan
- [ ] Merge and monitor Actions tab — Copilot PR Automation should no longer fire on `status` events
- [ ] Verify DCO override still works on new Copilot PRs (triggered by `check_run` or `pull_request_target`)
- [ ] Verify Netlify ready-for-review still works (triggered by `check_run: completed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)