### PR TITLE
🐛 Fix skeleton flash on refresh for stat blocks

### DIFF
--- a/web/src/components/alerts/Alerts.tsx
+++ b/web/src/components/alerts/Alerts.tsx
@@ -257,7 +257,7 @@ export function Alerts() {
         dashboardType="alerts"
         getStatValue={getStatValue}
         hasData={stats.firing > 0 || enabledRulesCount > 0}
-        isLoading={isRefreshing}
+        isLoading={false}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-alerts-stats-collapsed"
       />

--- a/web/src/components/gitops/GitOps.tsx
+++ b/web/src/components/gitops/GitOps.tsx
@@ -562,7 +562,7 @@ export function GitOps() {
         dashboardType="gitops"
         getStatValue={getStatValue}
         hasData={stats.total > 0}
-        isLoading={isRefreshing}
+        isLoading={false}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-gitops-stats-collapsed"
       />

--- a/web/src/components/security/Security.tsx
+++ b/web/src/components/security/Security.tsx
@@ -616,7 +616,7 @@ export function Security() {
         dashboardType="security"
         getStatValue={getStatValue}
         hasData={stats.total > 0}
-        isLoading={isRefreshing}
+        isLoading={false}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-security-stats-collapsed"
       />


### PR DESCRIPTION
## Summary
- Fixed `StatsOverview` receiving `isLoading={isRefreshing}` in Security, GitOps, and Alerts dashboards
- This caused skeleton loaders to flash briefly during data refresh
- Changed to `isLoading={false}` since these dashboards always have data from universal stats

## Test plan
- [x] Verified Security dashboard stats render without skeleton flash on refresh
- [x] TypeScript check passes
- [x] Vite production build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)