### PR TITLE
🐛 Remove status trigger from Copilot Error Recovery

### DIFF
--- a/.github/workflows/copilot-recovery.yml
+++ b/.github/workflows/copilot-recovery.yml
@@ -3,7 +3,6 @@ name: Copilot Error Recovery
 on:
   check_run:
     types: [completed]
-  status:  # Prow uses Status API, not Check Runs
   workflow_run:
     workflows: ["Build and Deploy KSC"]
     types: [completed]
@@ -31,16 +30,17 @@ permissions:
   pull-requests: write
   statuses: write
 
+concurrency:
+  group: copilot-recovery-${{ github.event.check_run.pull_requests[0].number || github.event.pull_request.number || github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   # Override DCO for bot PRs automatically (handles both Check Runs and Status API)
   override-dco-for-bots:
     if: |
-      (github.event_name == 'check_run' &&
-       github.event.check_run.name == 'dco' &&
-       github.event.check_run.conclusion == 'failure') ||
-      (github.event_name == 'status' &&
-       github.event.context == 'dco' &&
-       github.event.state == 'failure')
+      github.event_name == 'check_run' &&
+      github.event.check_run.name == 'dco' &&
+      github.event.check_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     steps:
       - name: Check if PR is from a bot
@@ -48,19 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Handle both check_run and status events
-          if [ "${{ github.event_name }}" == "status" ]; then
-            SHA="${{ github.event.sha }}"
-            # Find PR for this commit
-            PR_DATA=$(gh api repos/${{ github.repository }}/commits/$SHA/pulls --jq '.[0]' 2>/dev/null || echo "")
-            if [ -z "$PR_DATA" ] || [ "$PR_DATA" == "null" ]; then
-              echo "No PR found for commit $SHA"
-              exit 0
-            fi
-            PR_NUM=$(echo "$PR_DATA" | jq -r '.number')
-          else
-            PR_NUM=$(echo '${{ toJson(github.event.check_run.pull_requests) }}' | jq -r '.[0].number')
-          fi
+          PR_NUM=$(echo '${{ toJson(github.event.check_run.pull_requests) }}' | jq -r '.[0].number')
 
           if [ -z "$PR_NUM" ] || [ "$PR_NUM" == "null" ]; then
             echo "No PR found"
@@ -73,7 +61,7 @@ jobs:
           if [[ "$PR_AUTHOR" == *"[bot]"* ]] || [[ "$PR_AUTHOR" == "Copilot" ]] || [[ "$PR_AUTHOR" == "copilot-swe-agent" ]] || [[ "$PR_AUTHOR" == "dependabot"* ]]; then
             echo "is_bot=true" >> $GITHUB_OUTPUT
             echo "pr_number=$PR_NUM" >> $GITHUB_OUTPUT
-            echo "sha=${{ github.event.sha || github.event.check_run.head_sha }}" >> $GITHUB_OUTPUT
+            echo "sha=${{ github.event.check_run.head_sha }}" >> $GITHUB_OUTPUT
           else
             echo "is_bot=false" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary
- Remove `status:` trigger — same feedback loop issue as PR #198 (copilot-automation)
- Simplify DCO override job to only handle `check_run` events (no longer needs `status` event path)
- Add `concurrency` group with `cancel-in-progress: true`
- This should also reduce notification noise since the workflow was posting preview status comments on every status event

## Test plan
- [ ] Verify DCO override still works when DCO check_run fails on a Copilot PR
- [ ] Verify build failure notifications still fire on check_run failure
- [ ] Confirm no more `status`-triggered runs in Actions tab
- [ ] Confirm reduced notification frequency

🤖 Generated with [Claude Code](https://claude.com/claude-code)