### PR TITLE
🐛 Fix login landing on Dashboard instead of first sidebar item

### DIFF
--- a/web/src/hooks/useLastRoute.ts
+++ b/web/src/hooks/useLastRoute.ts
@@ -78,10 +78,11 @@ export function useLastRoute() {
 
   // Save last route on path change
   useEffect(() => {
-    // Don't track auth-related pages
+    // Don't track auth-related pages or the root path (which is a redirect target)
     if (location.pathname.startsWith('/auth') ||
         location.pathname === '/login' ||
-        location.pathname === '/onboarding') {
+        location.pathname === '/onboarding' ||
+        location.pathname === '/') {
       return
     }
 
@@ -102,19 +103,19 @@ export function useLastRoute() {
 
     try {
       const lastRoute = localStorage.getItem(LAST_ROUTE_KEY)
+      // Always check for a first-sidebar-item override first
+      const firstSidebarRoute = getFirstDashboardRoute()
+
       if (lastRoute && lastRoute !== '/' && lastRoute !== location.pathname) {
-        // Navigate to last route and restore scroll after navigation
+        // Navigate to last visited route and restore scroll after navigation
         navigate(lastRoute, { replace: true })
         // Restore scroll position after a short delay to allow page to render
         setTimeout(() => {
           restoreScrollPosition(lastRoute)
         }, 100)
-      } else {
-        // No saved route or it's root - navigate to first dashboard in sidebar
-        const firstDashboard = getFirstDashboardRoute()
-        if (firstDashboard && firstDashboard !== '/') {
-          navigate(firstDashboard, { replace: true })
-        }
+      } else if (firstSidebarRoute && firstSidebarRoute !== '/') {
+        // No saved route or it's root — navigate to first sidebar item
+        navigate(firstSidebarRoute, { replace: true })
       }
     } catch {
       // Ignore localStorage errors


### PR DESCRIPTION
## Summary
- On login, the app now redirects to the first item in the user's sidebar (e.g., /clusters) instead of always landing on Dashboard
- Stopped persisting "/" as the last route, so the first-sidebar fallback always triggers on fresh login
- Simplified restore logic to always compute the first sidebar route upfront

## Test plan
- [ ] Clear localStorage, login → should land on first sidebar item, not Dashboard
- [ ] Navigate to /workloads, reload → should restore /workloads (saved route)
- [ ] Reorder sidebar to put a different page first, reload → should land there

🤖 Generated with [Claude Code](https://claude.com/claude-code)