### PR TITLE
🐛 Add gate job to prevent 'no jobs were run' failure notifications

### DIFF
--- a/.github/workflows/copilot-recovery.yml
+++ b/.github/workflows/copilot-recovery.yml
@@ -35,7 +35,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Override DCO for bot PRs automatically (handles both Check Runs and Status API)
+  # Gate job ensures the workflow always has at least one job that runs,
+  # preventing GitHub from reporting "No jobs were run" as a failure
+  # and sending noisy email notifications.
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Event ${{ github.event_name }} received"
+
+  # Override DCO for bot PRs automatically
   override-dco-for-bots:
     if: |
       github.event_name == 'check_run' &&


### PR DESCRIPTION
## Summary
- When copilot-recovery triggers on events where no job `if:` conditions match, GitHub reports "No jobs were run" as a failure and sends an email notification
- Add a lightweight `gate` job that always succeeds, preventing the false-failure notification

## Test plan
- [ ] Merge and verify no more "Run failed: No jobs were run" emails
- [ ] Verify actual recovery jobs still trigger correctly on relevant events

🤖 Generated with [Claude Code](https://claude.com/claude-code)