### PR TITLE
✨ Add standard card controls to Deployment Missions card

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -179,6 +179,7 @@ const CARD_TITLES: Record<string, string> = {
   // Workload and deployment cards
   app_status: 'Workload Status',
   workload_deployment: 'Workloads',
+  deployment_missions: 'Deployment Missions',
   deployment_progress: 'Deployment Progress',
   deployment_status: 'Deployment Status',
   deployment_issues: 'Deployment Issues',
@@ -284,6 +285,7 @@ const CARD_ICONS: Record<string, { icon: ComponentType<{ className?: string }>, 
 
   // Workload and deployment cards
   app_status: { icon: Box, color: 'text-purple-400' },
+  deployment_missions: { icon: Rocket, color: 'text-blue-400' },
   deployment_progress: { icon: Clock, color: 'text-blue-400' },
   deployment_status: { icon: Box, color: 'text-purple-400' },
   deployment_issues: { icon: AlertTriangle, color: 'text-orange-400' },

--- a/web/src/lib/formatCardTitle.ts
+++ b/web/src/lib/formatCardTitle.ts
@@ -2,6 +2,7 @@
 const CUSTOM_TITLES: Record<string, string> = {
   app_status: 'Workload Status',
   chart_versions: 'Helm Chart Versions',
+  deployment_missions: 'Deployment Missions',
   helm_release_status: 'Helm Release Status',
   helm_history: 'Helm History',
   helm_values_diff: 'Helm Values Diff',


### PR DESCRIPTION
## Summary
- Register `deployment_missions` in `CARD_TITLES` and `CARD_ICONS` in CardWrapper
- Rewrite Missions card to use `useCardData` hook for search, sort, and pagination
- Add manual cluster filter (filters by target clusters, bypasses broken global `filterByCluster`)
- Add `CardControlsRow`, `CardSearchInput`, `CardPaginationFooter`, `CardEmptyState`
- Add `deployment_missions` to `formatCardTitle` CUSTOM_TITLES

## Test plan
- [ ] Missions card renders with standard card header (Rocket icon, "Deployment Missions" title)
- [ ] Cluster filter dropdown shows available clusters, filters missions by target clusters
- [ ] Search filters missions by workload name, namespace, source cluster, group name, and target clusters
- [ ] Sort by status/workload/time/clusters works correctly
- [ ] Pagination footer shows correct counts and page controls
- [ ] Empty state displays when no missions match filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)