### PR TITLE
🐛 Fix Copilot coding agent assignment with GraphQL header

### DIFF
--- a/.github/workflows/implement-fix.lock.yml
+++ b/.github/workflows/implement-fix.lock.yml
@@ -6682,7 +6682,7 @@ jobs:
             `;
           
             try {
-              const response = await github.graphql(query, { owner, repo });
+              const response = await github.graphql(query, { owner, repo, headers: { 'GraphQL-Features': 'issues_copilot_assignment_api_support' } });
               const actors = response.repository.suggestedActors.nodes;
           
               const loginName = AGENT_LOGIN_NAMES[agentName];
@@ -6796,6 +6796,7 @@ jobs:
               const response = await github.graphql(mutation, {
                 assignableId: issueId,
                 actorIds: actorIds,
+                headers: { 'GraphQL-Features': 'issues_copilot_assignment_api_support' },
               });
           
               if (response && response.replaceActorsForAssignable && response.replaceActorsForAssignable.__typename) {
@@ -6837,8 +6838,8 @@ jobs:
                 core.debug(`Failed to serialize GraphQL error details: ${loggingErr instanceof Error ? loggingErr.message : String(loggingErr)}`);
               }
           
-              // Check for permission-related errors
-              if (errorMessage.includes("Resource not accessible by personal access token") || errorMessage.includes("Resource not accessible by integration") || errorMessage.includes("Insufficient permissions to assign")) {
+              // Check for permission-related errors (including Copilot bot access)
+              if (errorMessage.includes("Resource not accessible by personal access token") || errorMessage.includes("Resource not accessible by integration") || errorMessage.includes("Insufficient permissions to assign") || errorMessage.includes("Bot does not have access")) {
                 // Attempt fallback mutation addAssigneesToAssignable when replaceActorsForAssignable is forbidden
                 core.info("Primary mutation replaceActorsForAssignable forbidden. Attempting fallback addAssigneesToAssignable...");
                 try {
@@ -6857,6 +6858,7 @@ jobs:
                   const fallbackResp = await github.graphql(fallbackMutation, {
                     assignableId: issueId,
                     assigneeIds: [agentId],
+                    headers: { 'GraphQL-Features': 'issues_copilot_assignment_api_support' },
                   });
                   if (fallbackResp && fallbackResp.addAssigneesToAssignable) {
                     core.info(`Fallback succeeded: agent '${agentName}' added via addAssigneesToAssignable.`);


### PR DESCRIPTION
## Summary
- Add required `GraphQL-Features: issues_copilot_assignment_api_support` header to all GraphQL mutations in the `Assign To Agent` step
- Expand fallback trigger to include "Bot does not have access" error (previously only triggered on "Resource not accessible" errors)
- The `replaceActorsForAssignable` mutation fails without this header, but the fallback `addAssigneesToAssignable` succeeds with it

## Root Cause
GitHub's Copilot coding agent assignment API requires a special GraphQL feature flag header. Without it, the mutation returns `FORBIDDEN: "Bot does not have access to the repository."` The gh-aw framework's generated lock.yml doesn't include this header.

## Test plan
- [ ] Re-trigger the implement-fix workflow on issue #205 via `workflow_dispatch`
- [ ] Verify the `safe_outputs` → `Assign To Agent` step succeeds
- [ ] Verify Copilot gets assigned to the issue and starts working

🤖 Generated with [Claude Code](https://claude.com/claude-code)