### PR TITLE
🐛 Add Resource Marshall to deploy dashboard default cards

### DIFF
--- a/web/src/components/deploy/Deploy.tsx
+++ b/web/src/components/deploy/Deploy.tsx
@@ -57,6 +57,8 @@ const DEFAULT_DEPLOY_CARDS = [
   // Cross-card deploy
   { type: 'cluster_groups', title: 'Cluster Groups', position: { w: 4, h: 4 } },
   { type: 'deployment_missions', title: 'Deployment Missions', position: { w: 5, h: 4 } },
+  // Dependency explorer
+  { type: 'resource_marshall', title: 'Resource Marshall', position: { w: 6, h: 4 } },
   // Upgrade tracking
   { type: 'upgrade_status', title: 'Upgrade Status', position: { w: 4, h: 4 } },
 ]


### PR DESCRIPTION
## Summary
- Added `resource_marshall` card to `DEFAULT_DEPLOY_CARDS` in `Deploy.tsx`
- Without this, resetting the deploy dashboard would not include the Resource Marshall card

## Test plan
- [x] Reset deploy dashboard → Resource Marshall card appears
- [x] Select cluster → namespace → workload → dependency tree renders
- [x] TypeScript check passes (`npx tsc --noEmit`)
- [x] Frontend build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)