### PR TITLE
🐛 Fix Resource Marshall workload resolution errors

### DIFF
--- a/web/src/components/cards/ResourceMarshall.tsx
+++ b/web/src/components/cards/ResourceMarshall.tsx
@@ -80,12 +80,14 @@ export function ResourceMarshall() {
   // Fetch namespaces for selected cluster
   const { namespaces, isLoading: nsLoading } = useNamespaces(selectedCluster || undefined)
 
-  // Fetch workloads for selected cluster + namespace
+  // Fetch workloads only when both cluster and namespace are selected.
+  // Passing enabled=false prevents fetching all workloads across clusters.
+  const hasSelection = !!selectedCluster && !!selectedNamespace
   const workloadOpts = useMemo(() => {
     if (!selectedCluster || !selectedNamespace) return undefined
     return { cluster: selectedCluster, namespace: selectedNamespace }
   }, [selectedCluster, selectedNamespace])
-  const { data: workloads, isLoading: wlLoading } = useWorkloads(workloadOpts)
+  const { data: workloads, isLoading: wlLoading } = useWorkloads(workloadOpts, hasSelection)
 
   // Dependency resolution
   const { data: depData, isLoading: depLoading, error: depError, resolve, reset } = useResolveDependencies()


### PR DESCRIPTION
## Summary
- **Root cause**: `useWorkloads(undefined)` fetched all 678 workloads across all clusters when no cluster/namespace was selected. The workload dropdown showed stale data from other clusters, allowing users to select workloads that didn't exist in the chosen cluster/namespace — causing "not found" errors from the resolve endpoint.
- Added `enabled` parameter to `useWorkloads` hook; ResourceMarshall passes `enabled=false` until both cluster and namespace are selected
- Clear stale data in `useWorkloads` when options change (prevents stale dropdown between cluster/namespace switches)
- Backend: distinguish "not found" from connectivity/RBAC errors using `apierrors.IsNotFound` in `ResolveWorkloadDependencies`

## Test plan
- [x] Workload dropdown shows 1 option (placeholder) when no cluster/namespace selected (was 678)
- [x] Select cluster → namespace → workload → dependency tree resolves correctly
- [x] Switching clusters properly clears workload dropdown
- [x] TypeScript check passes
- [x] Frontend build passes
- [x] Go build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)