### PR TITLE
✨ Add CRD and webhook resolution to dependency walker

### DIFF
--- a/web/src/components/cards/ResourceMarshall.tsx
+++ b/web/src/components/cards/ResourceMarshall.tsx
@@ -16,6 +16,8 @@ import {
   ShieldCheck,
   Server,
   Search,
+  Blocks,
+  ShieldAlert,
 } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
 import { useNamespaces } from '../../hooks/useMCP'
@@ -30,6 +32,8 @@ const DEP_CATEGORIES: { label: string; kinds: string[]; icon: typeof Shield }[] 
   { label: 'Networking', kinds: ['Service', 'Ingress', 'NetworkPolicy'], icon: Network },
   { label: 'Scaling & Availability', kinds: ['HorizontalPodAutoscaler', 'PodDisruptionBudget'], icon: Gauge },
   { label: 'Storage', kinds: ['PersistentVolumeClaim'], icon: HardDrive },
+  { label: 'Custom Resources', kinds: ['CustomResourceDefinition'], icon: Blocks },
+  { label: 'Admission Control', kinds: ['ValidatingWebhookConfiguration', 'MutatingWebhookConfiguration'], icon: ShieldAlert },
 ]
 
 // Icon per dependency kind
@@ -47,6 +51,9 @@ const KIND_ICONS: Record<string, typeof Shield> = {
   HorizontalPodAutoscaler: Gauge,
   PodDisruptionBudget: Shield,
   PersistentVolumeClaim: HardDrive,
+  CustomResourceDefinition: Blocks,
+  ValidatingWebhookConfiguration: ShieldAlert,
+  MutatingWebhookConfiguration: ShieldAlert,
 }
 
 function groupDependencies(deps: ResolvedDependency[]) {

--- a/web/src/components/deploy/DeployConfirmDialog.tsx
+++ b/web/src/components/deploy/DeployConfirmDialog.tsx
@@ -15,6 +15,8 @@ import {
   Gauge,
   ShieldCheck,
   Server,
+  Blocks,
+  ShieldAlert,
 } from 'lucide-react'
 import { BaseModal } from '../../lib/modals/BaseModal'
 import { ClusterBadge } from '../ui/ClusterBadge'
@@ -39,6 +41,8 @@ const DEP_CATEGORIES: { label: string; kinds: string[]; icon: typeof Shield }[] 
   { label: 'Networking', kinds: ['Service', 'Ingress', 'NetworkPolicy'], icon: Network },
   { label: 'Scaling & Availability', kinds: ['HorizontalPodAutoscaler', 'PodDisruptionBudget'], icon: Gauge },
   { label: 'Storage', kinds: ['PersistentVolumeClaim'], icon: HardDrive },
+  { label: 'Custom Resources', kinds: ['CustomResourceDefinition'], icon: Blocks },
+  { label: 'Admission Control', kinds: ['ValidatingWebhookConfiguration', 'MutatingWebhookConfiguration'], icon: ShieldAlert },
 ]
 
 // Icon per dependency kind
@@ -56,6 +60,9 @@ const KIND_ICONS: Record<string, typeof Shield> = {
   HorizontalPodAutoscaler: Gauge,
   PodDisruptionBudget: Shield,
   PersistentVolumeClaim: HardDrive,
+  CustomResourceDefinition: Blocks,
+  ValidatingWebhookConfiguration: ShieldAlert,
+  MutatingWebhookConfiguration: ShieldAlert,
 }
 
 function groupDependencies(deps: ResolvedDependency[]) {


### PR DESCRIPTION
## Summary
- Added CRD resolution: finds CustomResourceDefinitions whose conversion webhook service matches the workload's services
- Added ValidatingWebhookConfiguration and MutatingWebhookConfiguration resolution: finds webhook configs whose clientConfig.service matches the workload's services
- Frontend: new "Custom Resources" and "Admission Control" categories in ResourceMarshall card and DeployConfirmDialog
- New dependency kinds: `CustomResourceDefinition`, `ValidatingWebhookConfiguration`, `MutatingWebhookConfiguration`

## Test plan
- [x] Go build passes
- [x] TypeScript check passes
- [x] Frontend build passes
- [ ] Select an operator workload with CRDs → CRDs appear in "Custom Resources" category
- [ ] Select a workload with admission webhooks → webhooks appear in "Admission Control" category

🤖 Generated with [Claude Code](https://claude.com/claude-code)