### PR TITLE
🐛 Use PAT for auto-qa issue creation to trigger Copilot assignment

### DIFF
--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -788,7 +788,7 @@ jobs:
 
       - name: Ensure labels exist
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CONSOLE_AUTO }}
         run: |
           LABELS=(
             "auto-qa:FF6B35:Issue detected by automated QA"
@@ -855,6 +855,7 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
+          github-token: ${{ secrets.CONSOLE_AUTO }}
           script: |
             const fs = require('fs');
             const prefix = process.env.ISSUE_PREFIX;


### PR DESCRIPTION
## Summary
- Switch `auto-qa.yml` from `GITHUB_TOKEN` to `CONSOLE_AUTO` PAT for issue creation
- GitHub's security model prevents `GITHUB_TOKEN`-generated events from triggering other workflows
- This caused auto-qa issues (#225, #226) to never trigger `implement-fix.lock.yml`, so Copilot was never auto-assigned

## Changes
- **Label creation step**: `GH_TOKEN: secrets.GITHUB_TOKEN` → `GH_TOKEN: secrets.CONSOLE_AUTO`
- **Issue creation step**: Added `github-token: ${{ secrets.CONSOLE_AUTO }}` to `actions/github-script@v7`

## Test plan
- [ ] Next auto-qa run creates issues that trigger implement-fix workflow
- [ ] Copilot gets auto-assigned to newly created issues
- [ ] Verify no permission errors with CONSOLE_AUTO PAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)