### PR TITLE
✨ Consolidate dashboard actions into FAB and fix mission sidebar overlap

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -91,7 +91,7 @@ export function Layout({ children }: LayoutProps) {
           "fixed top-16 z-30 bg-orange-500/10 border-b border-orange-500/20 transition-[right] duration-300",
           config.collapsed ? "left-20" : "left-64",
           // Adjust right edge when mission sidebar is open
-          isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen ? "right-96" : "right-0",
+          isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen ? "right-[500px]" : "right-0",
           isMissionSidebarOpen && isMissionSidebarMinimized && !isMissionFullScreen && "right-12"
         )}>
           <div className="flex items-center justify-between py-1.5 px-4">
@@ -134,7 +134,7 @@ export function Layout({ children }: LayoutProps) {
           'flex-1 p-6 transition-all duration-300 overflow-y-auto',
           config.collapsed ? 'ml-20' : 'ml-64',
           // Don't apply margin when fullscreen is active - sidebar covers everything
-          isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen && 'mr-96',
+          isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen && 'mr-[500px]',
           isMissionSidebarOpen && isMissionSidebarMinimized && !isMissionFullScreen && 'mr-12'
         )}>
           {children}

--- a/web/src/components/layout/MissionSidebar.tsx
+++ b/web/src/components/layout/MissionSidebar.tsx
@@ -1112,7 +1112,7 @@ export function MissionSidebar() {
         "transition-[width,top,border,transform] duration-300 ease-in-out",
         isFullScreen
           ? "inset-0 top-16 border-l-0 rounded-none"
-          : "top-16 right-0 bottom-0 w-[520px] border-l shadow-xl",
+          : "top-16 right-0 bottom-0 w-[500px] border-l shadow-xl",
         !isSidebarOpen && "translate-x-full pointer-events-none"
       )}
     >


### PR DESCRIPTION
## Summary
- Replace three separate floating buttons (Add Card, Templates, Reset) with a single "+" FAB that expands into a menu on click with click-outside-to-close behavior
- Fix mission sidebar overlapping dashboard content by synchronizing sidebar width (500px) with Layout `margin-right` and offline banner `right` positioning
- FAB shifts left when mission sidebar is open to avoid overlap

## Test plan
- [ ] Verify "+" FAB appears at bottom-right of dashboard
- [ ] Click FAB to expand menu showing Add Card, Templates, and Reset options
- [ ] Click outside menu to close it
- [ ] Open AI Missions sidebar — dashboard content shrinks, FAB shifts left
- [ ] No overlap between sidebar and dashboard cards/buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)