### PR TITLE
🌱 Refactor: Adopt useCardData hook across 25 card components (#181)

### DIFF
--- a/web/src/components/cards/CRDHealth.tsx
+++ b/web/src/components/cards/CRDHealth.tsx
@@ -1,11 +1,10 @@
 import { useState, useMemo, useCallback } from 'react'
-import { CheckCircle, AlertTriangle, XCircle, Database, Search, Filter, ChevronDown, Server } from 'lucide-react'
+import { CheckCircle, AlertTriangle, XCircle, Database } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
-import { useChartFilters } from '../../lib/cards'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { Pagination, usePagination } from '../ui/Pagination'
+import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 
 interface CRDHealthProps {
   config?: {
@@ -32,26 +31,12 @@ const SORT_OPTIONS = [
   { value: 'instances' as const, label: 'Instances' },
 ]
 
-export function CRDHealth({ config: _config }: CRDHealthProps) {
-  const { isLoading } = useClusters()
+const statusOrder: Record<string, number> = { NotEstablished: 0, Terminating: 1, Established: 2 }
 
-  // Use chart filters hook for cluster filtering
-  const {
-    localClusterFilter,
-    toggleClusterFilter,
-    clearClusterFilter,
-    availableClusters,
-    filteredClusters: clusters,
-    showClusterFilter,
-    setShowClusterFilter,
-    clusterFilterRef,
-  } = useChartFilters({ storageKey: 'crd-health' })
+export function CRDHealth({ config: _config }: CRDHealthProps) {
+  const { isLoading, deduplicatedClusters } = useClusters()
 
   const [filterGroup, setFilterGroup] = useState<string>('')
-  const [sortBy, setSortBy] = useState<SortByOption>('status')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-  const [limit, setLimit] = useState<number | 'unlimited'>(5)
-  const [localSearch, setLocalSearch] = useState('')
 
   // Generate cluster-specific CRD data
   const getClusterCRDs = useCallback((clusterName: string): CRD[] => {
@@ -75,72 +60,73 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
     return baseCRDs.slice(0, crdCount)
   }, [])
 
-  // Mock CRD data - generates CRDs for each cluster
+  // Generate CRDs for all reachable clusters (useCardData handles cluster filtering)
   const allCRDs: CRD[] = useMemo(() => {
+    const reachable = deduplicatedClusters.filter(c => c.reachable !== false)
     const crdsWithClusters: CRD[] = []
-    clusters.forEach(c => {
+    reachable.forEach(c => {
       crdsWithClusters.push(...getClusterCRDs(c.name))
     })
     return crdsWithClusters
-  }, [clusters, getClusterCRDs])
+  }, [deduplicatedClusters, getClusterCRDs])
 
-  // Get unique groups
+  // Apply group filter before passing to useCardData
+  const groupFilteredCRDs = useMemo(() => {
+    if (!filterGroup) return allCRDs
+    return allCRDs.filter(c => c.group === filterGroup)
+  }, [allCRDs, filterGroup])
+
+  // Use shared card data hook for filtering, sorting, and pagination
+  const {
+    items: crds,
+    totalItems,
+    currentPage,
+    totalPages,
+    itemsPerPage,
+    goToPage,
+    needsPagination,
+    setItemsPerPage,
+    filters: {
+      search: localSearch,
+      setSearch: setLocalSearch,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+  } = useCardData<CRD, SortByOption>(groupFilteredCRDs, {
+    filter: {
+      searchFields: ['name', 'group', 'cluster'] as (keyof CRD)[],
+      clusterField: 'cluster' as keyof CRD,
+      storageKey: 'crd-health',
+    },
+    sort: {
+      defaultField: 'status',
+      defaultDirection: 'asc',
+      comparators: {
+        status: (a, b) => statusOrder[a.status] - statusOrder[b.status],
+        name: commonComparators.string('name'),
+        group: commonComparators.string('group'),
+        instances: (a, b) => a.instances - b.instances,
+      },
+    },
+    defaultLimit: 5,
+  })
+
+  // Get unique groups (from all CRDs before useCardData filtering)
   const groups = useMemo(() => {
     const groupSet = new Set(allCRDs.map(c => c.group))
     return Array.from(groupSet).sort()
   }, [allCRDs])
-
-  // Filter and sort CRDs
-  const filteredAndSorted = useMemo(() => {
-    let result = filterGroup ? allCRDs.filter(c => c.group === filterGroup) : allCRDs
-
-    // Apply local search
-    if (localSearch.trim()) {
-      const query = localSearch.toLowerCase()
-      result = result.filter(crd =>
-        crd.name.toLowerCase().includes(query) ||
-        crd.group.toLowerCase().includes(query) ||
-        crd.version.toLowerCase().includes(query) ||
-        crd.scope.toLowerCase().includes(query) ||
-        crd.cluster.toLowerCase().includes(query)
-      )
-    }
-
-    // Sort
-    const statusOrder: Record<string, number> = { NotEstablished: 0, Terminating: 1, Established: 2 }
-    result = [...result].sort((a, b) => {
-      let compare = 0
-      switch (sortBy) {
-        case 'status':
-          compare = (statusOrder[a.status] ?? 5) - (statusOrder[b.status] ?? 5)
-          break
-        case 'name':
-          compare = a.name.localeCompare(b.name)
-          break
-        case 'group':
-          compare = a.group.localeCompare(b.group)
-          break
-        case 'instances':
-          compare = b.instances - a.instances
-          break
-      }
-      return sortDirection === 'asc' ? compare : -compare
-    })
-
-    return result
-  }, [allCRDs, filterGroup, sortBy, sortDirection, localSearch])
-
-  // Use pagination hook
-  const effectivePerPage = limit === 'unlimited' ? 1000 : limit
-  const {
-    paginatedItems: crds,
-    currentPage,
-    totalPages,
-    totalItems,
-    itemsPerPage: perPage,
-    goToPage,
-    needsPagination,
-  } = usePagination(filteredAndSorted, effectivePerPage)
 
   const getStatusIcon = (status: CRD['status']) => {
     switch (status) {
@@ -158,9 +144,33 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
     }
   }
 
-  const healthyCRDs = filteredAndSorted.filter(c => c.status === 'Established').length
-  const unhealthyCRDs = filteredAndSorted.filter(c => c.status !== 'Established').length
-  const totalInstances = filteredAndSorted.reduce((sum, c) => sum + c.instances, 0)
+  // Compute stats from the filtered set (pre-pagination) by approximating
+  // the same filters useCardData applies: cluster filter + search
+  const statsSource = useMemo(() => {
+    let result = groupFilteredCRDs
+
+    // Apply local cluster filter
+    if (localClusterFilter.length > 0) {
+      result = result.filter(c => localClusterFilter.includes(c.cluster))
+    }
+
+    // Apply local search
+    if (localSearch.trim()) {
+      const query = localSearch.toLowerCase()
+      result = result.filter(c =>
+        c.name.toLowerCase().includes(query) ||
+        c.group.toLowerCase().includes(query) ||
+        c.cluster.toLowerCase().includes(query)
+      )
+    }
+
+    return result
+  }, [groupFilteredCRDs, localClusterFilter, localSearch])
+
+  const healthyCount = statsSource.filter(c => c.status === 'Established').length
+  const unhealthyCount = statsSource.filter(c => c.status !== 'Established').length
+  const totalInstances = statsSource.reduce((sum, c) => sum + c.instances, 0)
+
   const showSkeleton = isLoading && allCRDs.length === 0
 
   if (showSkeleton) {
@@ -183,82 +193,41 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Controls - single row */}
       <div className="flex items-center justify-between gap-2 mb-4">
-        <div className="flex items-center gap-2">
-          {localClusterFilter.length > 0 && (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
-              <Server className="w-3 h-3" />
-              {clusters.length}/{availableClusters.length}
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          {/* Cluster Filter */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
-          <CardControls
-            limit={limit}
-            onLimitChange={setLimit}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
-        </div>
+        <div className="flex items-center gap-2" />
+        <CardControlsRow
+          clusterIndicator={{
+            selectedCount: localClusterFilter.length,
+            totalCount: availableClusters.length,
+          }}
+          clusterFilter={{
+            availableClusters,
+            selectedClusters: localClusterFilter,
+            onToggle: toggleClusterFilter,
+            onClear: clearClusterFilter,
+            isOpen: showClusterFilter,
+            setIsOpen: setShowClusterFilter,
+            containerRef: clusterFilterRef,
+            minClusters: 1,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => setSortBy(v as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+        />
       </div>
 
       {/* Local Search */}
-      <div className="relative mb-4">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={localSearch}
-          onChange={(e) => setLocalSearch(e.target.value)}
-          placeholder="Search CRDs..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={localSearch}
+        onChange={setLocalSearch}
+        placeholder="Search CRDs..."
+        className="mb-4"
+      />
 
       {availableClusters.length === 0 ? (
         <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
@@ -290,15 +259,15 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
           {/* Summary */}
           <div className="grid grid-cols-4 gap-2 mb-4">
             <div className="p-2 rounded-lg bg-teal-500/10 text-center">
-              <span className="text-lg font-bold text-teal-400">{filteredAndSorted.length}</span>
+              <span className="text-lg font-bold text-teal-400">{totalItems}</span>
               <p className="text-xs text-muted-foreground">CRDs</p>
             </div>
             <div className="p-2 rounded-lg bg-green-500/10 text-center">
-              <span className="text-lg font-bold text-green-400">{healthyCRDs}</span>
+              <span className="text-lg font-bold text-green-400">{healthyCount}</span>
               <p className="text-xs text-muted-foreground">Healthy</p>
             </div>
             <div className="p-2 rounded-lg bg-red-500/10 text-center">
-              <span className="text-lg font-bold text-red-400">{unhealthyCRDs}</span>
+              <span className="text-lg font-bold text-red-400">{unhealthyCount}</span>
               <p className="text-xs text-muted-foreground">Issues</p>
             </div>
             <div className="p-2 rounded-lg bg-blue-500/10 text-center">
@@ -342,22 +311,18 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
           </div>
 
           {/* Pagination */}
-          {needsPagination && limit !== 'unlimited' && (
-            <div className="pt-2 border-t border-border/50 mt-2">
-              <Pagination
-                currentPage={currentPage}
-                totalPages={totalPages}
-                totalItems={totalItems}
-                itemsPerPage={perPage}
-                onPageChange={goToPage}
-                showItemsPerPage={false}
-              />
-            </div>
-          )}
+          <CardPaginationFooter
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalItems={totalItems}
+            itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 10}
+            onPageChange={goToPage}
+            needsPagination={needsPagination && itemsPerPage !== 'unlimited'}
+          />
 
           {/* Footer */}
           <div className="mt-4 pt-3 border-t border-border/50 text-xs text-muted-foreground">
-            {groups.length} API groups {localClusterFilter.length === 1 ? `on ${localClusterFilter[0]}` : `across ${clusters.length} cluster${clusters.length !== 1 ? 's' : ''}`}
+            {groups.length} API groups {localClusterFilter.length === 1 ? `on ${localClusterFilter[0]}` : `across ${availableClusters.length} cluster${availableClusters.length !== 1 ? 's' : ''}`}
           </div>
         </>
       )}

--- a/web/src/components/cards/GPUStatus.tsx
+++ b/web/src/components/cards/GPUStatus.tsx
@@ -1,13 +1,11 @@
 import { useState, useMemo } from 'react'
-import { Activity, ChevronRight, Filter, ChevronDown, Server, Search } from 'lucide-react'
+import { Activity, ChevronRight } from 'lucide-react'
 import { useGPUNodes } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { Pagination, usePagination } from '../ui/Pagination'
 import { Skeleton } from '../ui/Skeleton'
-import { useChartFilters } from '../../lib/cards'
+import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 
 interface GPUStatusProps {
   config?: Record<string, unknown>
@@ -21,36 +19,27 @@ const SORT_OPTIONS = [
   { value: 'gpuCount' as const, label: 'GPU Count' },
 ]
 
+interface ClusterGPUStats {
+  clusterName: string
+  total: number
+  used: number
+  types: string[]
+  utilization: number
+}
+
 export function GPUStatus({ config }: GPUStatusProps) {
   const cluster = config?.cluster as string | undefined
   const {
     nodes: rawNodes,
     isLoading: hookLoading,
   } = useGPUNodes(cluster)
-  const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { drillToCluster } = useDrillDownActions()
-
-  // Local cluster filter
-  const {
-    localClusterFilter,
-    toggleClusterFilter,
-    clearClusterFilter,
-    availableClusters,
-    showClusterFilter,
-    setShowClusterFilter,
-    clusterFilterRef,
-  } = useChartFilters({
-    storageKey: 'gpu-status',
-  })
 
   // Only show skeleton when no cached data exists
   const isLoading = hookLoading && rawNodes.length === 0
 
-  const [sortBy, setSortBy] = useState<SortByOption>('utilization')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
-  const [limit, setLimit] = useState<number | 'unlimited'>(5)
+  // Card-specific GPU type filter (not handled by useCardData)
   const [selectedGpuType, setSelectedGpuType] = useState<string>('all')
-  const [searchQuery, setSearchQuery] = useState('')
 
   // Get all unique GPU types for filter dropdown
   const gpuTypes = useMemo(() => {
@@ -59,32 +48,16 @@ export function GPUStatus({ config }: GPUStatusProps) {
     return Array.from(types).sort()
   }, [rawNodes])
 
-  // Filter nodes by global cluster selection, local filter, and GPU type
-  const filteredNodes = useMemo(() => {
-    let result = rawNodes
-    if (!isAllClustersSelected) {
-      result = result.filter(n => selectedClusters.some(c => n.cluster.startsWith(c)))
-    }
-    if (localClusterFilter.length > 0) {
-      result = result.filter(n => localClusterFilter.some(c => n.cluster.startsWith(c)))
-    }
-    if (selectedGpuType !== 'all') {
-      result = result.filter(n => n.gpuType.toLowerCase().includes(selectedGpuType.toLowerCase()))
-    }
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase()
-      result = result.filter(n =>
-        n.cluster.toLowerCase().includes(query) ||
-        n.gpuType.toLowerCase().includes(query) ||
-        n.name.toLowerCase().includes(query)
-      )
-    }
-    return result
-  }, [rawNodes, selectedClusters, isAllClustersSelected, selectedGpuType, localClusterFilter, searchQuery])
+  // Step 1: Pre-filter nodes by GPU type (card-specific filter)
+  const preFilteredNodes = useMemo(() => {
+    if (selectedGpuType === 'all') return rawNodes
+    return rawNodes.filter(n => n.gpuType.toLowerCase().includes(selectedGpuType.toLowerCase()))
+  }, [rawNodes, selectedGpuType])
 
-  // Calculate cluster-level stats from filtered nodes
+  // Step 2: Aggregate to cluster-level stats
+  // Don't apply cluster/search filters here - useCardData handles that
   const clusterStatsList = useMemo(() => {
-    const clusterStats = filteredNodes.reduce((acc, node) => {
+    const clusterStats = preFilteredNodes.reduce((acc, node) => {
       if (!acc[node.cluster]) {
         acc[node.cluster] = { total: 0, used: 0, types: new Set<string>() }
       }
@@ -94,44 +67,59 @@ export function GPUStatus({ config }: GPUStatusProps) {
       return acc
     }, {} as Record<string, { total: number; used: number; types: Set<string> }>)
 
-    // Convert to array for sorting and pagination
-    const list = Object.entries(clusterStats).map(([clusterName, stats]) => ({
+    return Object.entries(clusterStats).map(([clusterName, stats]) => ({
       clusterName,
       total: stats.total,
       used: stats.used,
       types: Array.from(stats.types),
       utilization: stats.total > 0 ? (stats.used / stats.total) * 100 : 0,
     }))
+  }, [preFilteredNodes])
 
-    // Sort
-    return list.sort((a, b) => {
-      let compare = 0
-      switch (sortBy) {
-        case 'utilization':
-          compare = a.utilization - b.utilization
-          break
-        case 'cluster':
-          compare = a.clusterName.localeCompare(b.clusterName)
-          break
-        case 'gpuCount':
-          compare = a.total - b.total
-          break
-      }
-      return sortDirection === 'asc' ? compare : -compare
-    })
-  }, [filteredNodes, sortBy, sortDirection])
-
-  // Use pagination hook
-  const effectivePerPage = limit === 'unlimited' ? 1000 : limit
+  // Step 3: useCardData for search/cluster filter/sort/pagination
   const {
-    paginatedItems: displayStats,
+    items: displayStats,
+    totalItems,
     currentPage,
     totalPages,
-    totalItems,
-    itemsPerPage: perPage,
+    itemsPerPage,
     goToPage,
     needsPagination,
-  } = usePagination(clusterStatsList, effectivePerPage)
+    setItemsPerPage,
+    filters: {
+      search: localSearch,
+      setSearch: setLocalSearch,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters: availableClustersForFilter,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+  } = useCardData<ClusterGPUStats, SortByOption>(clusterStatsList, {
+    filter: {
+      searchFields: ['clusterName'],
+      clusterField: 'clusterName',
+      storageKey: 'gpu-status',
+    },
+    sort: {
+      defaultField: 'utilization',
+      defaultDirection: 'desc',
+      comparators: {
+        utilization: (a, b) => a.utilization - b.utilization,
+        cluster: commonComparators.string('clusterName'),
+        gpuCount: (a, b) => a.total - b.total,
+      },
+    },
+    defaultLimit: 5,
+  })
 
   if (isLoading) {
     return (
@@ -150,7 +138,7 @@ export function GPUStatus({ config }: GPUStatusProps) {
     )
   }
 
-  if (filteredNodes.length === 0) {
+  if (preFilteredNodes.length === 0) {
     return (
       <div className="h-full flex flex-col content-loaded">
         <div className="flex items-center justify-end mb-3">
@@ -175,82 +163,40 @@ export function GPUStatus({ config }: GPUStatusProps) {
             {totalItems} clusters
           </span>
         </div>
-        <div className="flex items-center gap-2">
-          {/* Cluster count indicator */}
-          {localClusterFilter.length > 0 && (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
-              <Server className="w-3 h-3" />
-              {localClusterFilter.length}/{availableClusters.length}
-            </span>
-          )}
-
-          {/* Cluster filter dropdown */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
-          <CardControls
-            limit={limit}
-            onLimitChange={setLimit}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
-        </div>
+        <CardControlsRow
+          clusterIndicator={{
+            selectedCount: localClusterFilter.length,
+            totalCount: availableClustersForFilter.length,
+          }}
+          clusterFilter={{
+            availableClusters: availableClustersForFilter,
+            selectedClusters: localClusterFilter,
+            onToggle: toggleClusterFilter,
+            onClear: clearClusterFilter,
+            isOpen: showClusterFilter,
+            setIsOpen: setShowClusterFilter,
+            containerRef: clusterFilterRef,
+            minClusters: 1,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => setSortBy(v as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+        />
       </div>
 
       {/* Search */}
-      <div className="relative mb-2">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={searchQuery}
-          onChange={(e) => { setSearchQuery(e.target.value); goToPage(1) }}
-          placeholder="Search GPU clusters..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={localSearch}
+        onChange={setLocalSearch}
+        placeholder="Search GPU clusters..."
+        className="mb-2"
+      />
 
       {/* GPU Type Filter */}
       {gpuTypes.length > 1 && (
@@ -313,18 +259,14 @@ export function GPUStatus({ config }: GPUStatusProps) {
       </div>
 
       {/* Pagination */}
-      {needsPagination && limit !== 'unlimited' && (
-        <div className="pt-2 border-t border-border/50 mt-2">
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            totalItems={totalItems}
-            itemsPerPage={perPage}
-            onPageChange={goToPage}
-            showItemsPerPage={false}
-          />
-        </div>
-      )}
+      <CardPaginationFooter
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 5}
+        onPageChange={goToPage}
+        needsPagination={needsPagination && itemsPerPage !== 'unlimited'}
+      />
     </div>
   )
 }

--- a/web/src/components/cards/GatewayStatus.tsx
+++ b/web/src/components/cards/GatewayStatus.tsx
@@ -1,8 +1,10 @@
-import { useState, useMemo } from 'react'
-import { CheckCircle2, Clock, XCircle, Search, Filter, ChevronDown, Server, AlertCircle, ExternalLink, Globe, ArrowRight } from 'lucide-react'
+import { CheckCircle2, Clock, XCircle, AlertCircle, ExternalLink, Globe, ArrowRight, Server } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { useChartFilters } from '../../lib/cards'
+import {
+  useCardData,
+  commonComparators,
+  CardSearchInput, CardControlsRow, CardPaginationFooter,
+} from '../../lib/cards'
 
 // Gateway status types
 type GatewayStatusType = 'Programmed' | 'Accepted' | 'Pending' | 'NotAccepted' | 'Unknown'
@@ -134,7 +136,7 @@ const getStatusColors = (status: GatewayStatusType) => {
   }
 }
 
-type SortField = 'name' | 'cluster' | 'status'
+type SortByOption = 'name' | 'cluster' | 'status'
 
 const SORT_OPTIONS = [
   { value: 'name' as const, label: 'Name' },
@@ -142,61 +144,56 @@ const SORT_OPTIONS = [
   { value: 'status' as const, label: 'Status' },
 ]
 
+const GATEWAY_SORT_COMPARATORS: Record<SortByOption, (a: Gateway, b: Gateway) => number> = {
+  name: commonComparators.string<Gateway>('name'),
+  cluster: commonComparators.string<Gateway>('cluster'),
+  status: commonComparators.string<Gateway>('status'),
+}
+
 interface GatewayStatusProps {
   config?: Record<string, unknown>
 }
 
 export function GatewayStatus({ config: _config }: GatewayStatusProps) {
-  const [localSearch, setLocalSearch] = useState('')
-  const [limit, setLimit] = useState<number | 'unlimited'>(5)
-  const [sortBy, setSortBy] = useState<SortField>('name')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-
-  // Local cluster filter
   const {
-    localClusterFilter,
-    toggleClusterFilter,
-    clearClusterFilter,
-    availableClusters,
-    showClusterFilter,
-    setShowClusterFilter,
-    clusterFilterRef,
-  } = useChartFilters({
-    storageKey: 'gateway-status',
+    items: paginatedGateways,
+    totalItems,
+    currentPage,
+    totalPages,
+    itemsPerPage,
+    goToPage,
+    needsPagination,
+    setItemsPerPage,
+    filters: {
+      search: localSearch,
+      setSearch: setLocalSearch,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+  } = useCardData<Gateway, SortByOption>(DEMO_GATEWAYS, {
+    filter: {
+      searchFields: ['name', 'namespace', 'cluster', 'gatewayClass', 'status'],
+      clusterField: 'cluster',
+      storageKey: 'gateway-status',
+    },
+    sort: {
+      defaultField: 'name',
+      defaultDirection: 'asc',
+      comparators: GATEWAY_SORT_COMPARATORS,
+    },
+    defaultLimit: 5,
   })
-
-  // Filter gateways by local search and cluster filter
-  const filteredGateways = useMemo(() => {
-    let result = [...DEMO_GATEWAYS]
-
-    // Apply local cluster filter
-    if (localClusterFilter.length > 0) {
-      result = result.filter(gw => localClusterFilter.includes(gw.cluster))
-    }
-
-    // Apply search
-    if (localSearch.trim()) {
-      const query = localSearch.toLowerCase()
-      result = result.filter(gw =>
-        gw.name.toLowerCase().includes(query) ||
-        gw.namespace.toLowerCase().includes(query) ||
-        gw.cluster.toLowerCase().includes(query) ||
-        gw.gatewayClass.toLowerCase().includes(query) ||
-        gw.status.toLowerCase().includes(query)
-      )
-    }
-
-    // Sort
-    const sorted = result.sort((a, b) => {
-      let cmp = 0
-      if (sortBy === 'name') cmp = a.name.localeCompare(b.name)
-      else if (sortBy === 'cluster') cmp = a.cluster.localeCompare(b.cluster)
-      else if (sortBy === 'status') cmp = a.status.localeCompare(b.status)
-      return sortDirection === 'asc' ? cmp : -cmp
-    })
-
-    return sorted
-  }, [localSearch, localClusterFilter, sortBy, sortDirection])
 
   return (
     <div className="h-full flex flex-col min-h-card">
@@ -204,7 +201,7 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
       <div className="flex items-center justify-between mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-muted-foreground">
-            {filteredGateways.length} gateways
+            {totalItems} gateways
           </span>
           <a
             href="https://gateway-api.sigs.k8s.io/"
@@ -215,83 +212,43 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
           >
             <ExternalLink className="w-4 h-4" />
           </a>
-        </div>
-        <div className="flex items-center gap-2">
-          {/* Cluster count indicator */}
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
               <Server className="w-3 h-3" />
               {localClusterFilter.length}/{availableClusters.length}
             </span>
           )}
-
-          {/* Cluster filter dropdown */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
-          <CardControls
-            limit={limit}
-            onLimitChange={setLimit}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
         </div>
+        <CardControlsRow
+          clusterFilter={{
+            availableClusters,
+            selectedClusters: localClusterFilter,
+            onToggle: toggleClusterFilter,
+            onClear: clearClusterFilter,
+            isOpen: showClusterFilter,
+            setIsOpen: setShowClusterFilter,
+            containerRef: clusterFilterRef,
+            minClusters: 1,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => setSortBy(v as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+        />
       </div>
 
       {/* Search */}
-      <div className="relative mb-3">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={localSearch}
-          onChange={(e) => setLocalSearch(e.target.value)}
-          placeholder="Search gateways..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={localSearch}
+        onChange={setLocalSearch}
+        placeholder="Search gateways..."
+        className="mb-3"
+      />
 
       {/* Gateway API Integration Notice */}
       <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-purple-500/10 border border-purple-500/20 text-xs">
@@ -330,7 +287,7 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
 
       {/* Gateways list */}
       <div className="flex-1 overflow-y-auto space-y-2">
-        {filteredGateways.map((gw, idx) => {
+        {paginatedGateways.map((gw, idx) => {
           const Icon = getStatusIcon(gw.status)
           const colors = getStatusColors(gw.status)
           return (
@@ -377,6 +334,16 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
           )
         })}
       </div>
+
+      {/* Pagination */}
+      <CardPaginationFooter
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 10}
+        onPageChange={goToPage}
+        needsPagination={needsPagination && itemsPerPage !== 'unlimited'}
+      />
 
       {/* Quick install command */}
       <div className="mt-3 pt-3 border-t border-border/50">

--- a/web/src/components/cards/HelmReleaseStatus.tsx
+++ b/web/src/components/cards/HelmReleaseStatus.tsx
@@ -1,13 +1,13 @@
 import { useState, useMemo } from 'react'
-import { CheckCircle, AlertTriangle, XCircle, Clock, Search, ChevronRight, Filter, ChevronDown, Server } from 'lucide-react'
+import { CheckCircle, AlertTriangle, XCircle, Clock, ChevronRight, Server } from 'lucide-react'
 import { useClusters, useHelmReleases } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { useGlobalFilters } from '../../hooks/useGlobalFilters'
-import { useChartFilters } from '../../lib/cards'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { Pagination, usePagination } from '../ui/Pagination'
+import {
+  useCardData,
+  CardSearchInput, CardControlsRow, CardPaginationFooter,
+} from '../../lib/cards'
 
 interface HelmReleaseStatusProps {
   config?: {
@@ -42,27 +42,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
   const { isLoading: clustersLoading } = useClusters()
   const { drillToHelm } = useDrillDownActions()
 
-  // Use chart filters hook for cluster filtering
-  const {
-    localClusterFilter,
-    toggleClusterFilter,
-    clearClusterFilter,
-    availableClusters,
-    filteredClusters: clusters,
-    showClusterFilter,
-    setShowClusterFilter,
-    clusterFilterRef,
-  } = useChartFilters({ storageKey: 'helm-release-status' })
-
   const [selectedNamespace, setSelectedNamespace] = useState<string>(config?.namespace || '')
-  const [sortBy, setSortBy] = useState<SortByOption>('status')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-  const [limit, setLimit] = useState<number | 'unlimited'>(5)
-  const [localSearch, setLocalSearch] = useState('')
-  const {
-    customFilter,
-    filterByStatus,
-  } = useGlobalFilters()
 
   // Fetch ALL Helm releases once (not per-cluster) - filter locally
   const {
@@ -73,15 +53,9 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
   // Only show loading skeleton when no data exists (not during refresh)
   const isLoading = (clustersLoading || releasesLoading) && allHelmReleases.length === 0
 
-  // Filter by selected clusters locally (no API call)
-  const helmReleases = useMemo(() => {
-    const clusterNames = new Set(clusters.map(c => c.name))
-    return allHelmReleases.filter(r => r.cluster && clusterNames.has(r.cluster))
-  }, [allHelmReleases, clusters])
-
   // Transform API data to display format
   const allReleases = useMemo(() => {
-    return helmReleases.map(r => {
+    return allHelmReleases.map(r => {
       // Parse chart name and version (e.g., "prometheus-25.8.0" -> chart: "prometheus", version: "25.8.0")
       const chartParts = r.chart.match(/^(.+)-(\d+\.\d+\.\d+.*)$/)
       const chartName = chartParts ? chartParts[1] : r.chart
@@ -99,83 +73,68 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
         cluster: r.cluster,
       }
     })
-  }, [helmReleases])
+  }, [allHelmReleases])
 
-  // Get unique namespaces
+  // Pre-filter by namespace before passing to useCardData
+  const namespacedReleases = useMemo(() => {
+    if (!selectedNamespace) return allReleases
+    return allReleases.filter(r => r.namespace === selectedNamespace)
+  }, [allReleases, selectedNamespace])
+
+  // Get unique namespaces (from full unfiltered set)
   const namespaces = useMemo(() => {
     const nsSet = new Set(allReleases.map(r => r.namespace))
     return Array.from(nsSet).sort()
   }, [allReleases])
 
-  // Filter and sort releases by namespace, status, and custom text
-  const filteredAndSorted = useMemo(() => {
-    let result = allReleases
+  const statusOrder: Record<string, number> = { failed: 0, pending: 1, uninstalling: 2, superseded: 3, deployed: 4 }
 
-    // Filter by namespace
-    if (selectedNamespace) {
-      result = result.filter(r => r.namespace === selectedNamespace)
-    }
-
-    // Apply status filter
-    result = filterByStatus(result)
-
-    // Apply custom text filter (global)
-    if (customFilter.trim()) {
-      const query = customFilter.toLowerCase()
-      result = result.filter(r =>
-        r.name.toLowerCase().includes(query) ||
-        r.namespace.toLowerCase().includes(query) ||
-        r.chart.toLowerCase().includes(query) ||
-        r.version.toLowerCase().includes(query)
-      )
-    }
-
-    // Apply local search filter
-    if (localSearch.trim()) {
-      const query = localSearch.toLowerCase()
-      result = result.filter(r =>
-        r.name.toLowerCase().includes(query) ||
-        r.namespace.toLowerCase().includes(query) ||
-        r.chart.toLowerCase().includes(query) ||
-        r.version.toLowerCase().includes(query)
-      )
-    }
-
-    // Sort
-    const statusOrder: Record<string, number> = { failed: 0, pending: 1, uninstalling: 2, superseded: 3, deployed: 4 }
-    result = [...result].sort((a, b) => {
-      let compare = 0
-      switch (sortBy) {
-        case 'status':
-          compare = (statusOrder[a.status] ?? 5) - (statusOrder[b.status] ?? 5)
-          break
-        case 'name':
-          compare = a.name.localeCompare(b.name)
-          break
-        case 'chart':
-          compare = a.chart.localeCompare(b.chart)
-          break
-        case 'updated':
-          compare = new Date(b.updated).getTime() - new Date(a.updated).getTime()
-          break
-      }
-      return sortDirection === 'asc' ? compare : -compare
-    })
-
-    return result
-  }, [allReleases, selectedNamespace, filterByStatus, customFilter, sortBy, sortDirection, localSearch])
-
-  // Use pagination hook
-  const effectivePerPage = limit === 'unlimited' ? 1000 : limit
+  // Use shared card data hook for filtering, sorting, and pagination
   const {
-    paginatedItems: releases,
+    items: releases,
+    totalItems,
     currentPage,
     totalPages,
-    totalItems,
-    itemsPerPage: perPage,
+    itemsPerPage,
     goToPage,
     needsPagination,
-  } = usePagination(filteredAndSorted, effectivePerPage)
+    setItemsPerPage,
+    filters: {
+      search: localSearch,
+      setSearch: setLocalSearch,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+  } = useCardData<HelmReleaseDisplay, SortByOption>(namespacedReleases, {
+    filter: {
+      searchFields: ['name', 'namespace', 'chart', 'version'] as (keyof HelmReleaseDisplay)[],
+      clusterField: 'cluster' as keyof HelmReleaseDisplay,
+      statusField: 'status' as keyof HelmReleaseDisplay,
+      storageKey: 'helm-release-status',
+    },
+    sort: {
+      defaultField: 'status',
+      defaultDirection: 'asc',
+      comparators: {
+        status: (a, b) => (statusOrder[a.status] ?? 5) - (statusOrder[b.status] ?? 5),
+        name: (a, b) => a.name.localeCompare(b.name),
+        chart: (a, b) => a.chart.localeCompare(b.chart),
+        updated: (a, b) => new Date(b.updated).getTime() - new Date(a.updated).getTime(),
+      },
+    },
+    defaultLimit: 5,
+  })
 
   const getStatusIcon = (status: HelmReleaseDisplay['status']) => {
     switch (status) {
@@ -204,9 +163,9 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
     return `${Math.floor(diff / 86400000)}d ago`
   }
 
-  // Use filteredAndSorted for total counts (not paginated releases)
-  const deployedCount = filteredAndSorted.filter(r => r.status === 'deployed').length
-  const failedCount = filteredAndSorted.filter(r => r.status === 'failed').length
+  // Counts from namespace-filtered releases (pre-pagination summary)
+  const deployedCount = namespacedReleases.filter(r => r.status === 'deployed').length
+  const failedCount = namespacedReleases.filter(r => r.status === 'failed').length
 
   if (isLoading) {
     return (
@@ -233,65 +192,31 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
               <Server className="w-3 h-3" />
-              {clusters.length}/{availableClusters.length}
+              {localClusterFilter.length}/{availableClusters.length}
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          {/* Cluster Filter */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
-          <CardControls
-            limit={limit}
-            onLimitChange={setLimit}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
-        </div>
+        <CardControlsRow
+          clusterFilter={{
+            availableClusters,
+            selectedClusters: localClusterFilter,
+            onToggle: toggleClusterFilter,
+            onClear: clearClusterFilter,
+            isOpen: showClusterFilter,
+            setIsOpen: setShowClusterFilter,
+            containerRef: clusterFilterRef,
+            minClusters: 1,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => setSortBy(v as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+        />
       </div>
 
       {/* Namespace selector */}
@@ -333,16 +258,12 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
           </div>
 
           {/* Local Search */}
-          <div className="relative mb-4">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-            <input
-              type="text"
-              value={localSearch}
-              onChange={(e) => setLocalSearch(e.target.value)}
-              placeholder="Search releases..."
-              className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-            />
-          </div>
+          <CardSearchInput
+            value={localSearch}
+            onChange={setLocalSearch}
+            placeholder="Search releases..."
+            className="mb-4"
+          />
 
           {/* Summary */}
           <div className="flex gap-2 mb-4">
@@ -404,22 +325,18 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
           </div>
 
           {/* Pagination */}
-          {needsPagination && limit !== 'unlimited' && (
-            <div className="pt-2 border-t border-border/50 mt-2">
-              <Pagination
-                currentPage={currentPage}
-                totalPages={totalPages}
-                totalItems={totalItems}
-                itemsPerPage={perPage}
-                onPageChange={goToPage}
-                showItemsPerPage={false}
-              />
-            </div>
-          )}
+          <CardPaginationFooter
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalItems={totalItems}
+            itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 10}
+            onPageChange={goToPage}
+            needsPagination={needsPagination && itemsPerPage !== 'unlimited'}
+          />
 
           {/* Footer */}
           <div className="mt-4 pt-3 border-t border-border/50 text-xs text-muted-foreground">
-            {totalItems} release{totalItems !== 1 ? 's' : ''}{localClusterFilter.length === 1 ? (selectedNamespace ? ` in ${localClusterFilter[0]}/${selectedNamespace}` : ` in ${localClusterFilter[0]}`) : ` across ${clusters.length} cluster${clusters.length !== 1 ? 's' : ''}`}
+            {totalItems} release{totalItems !== 1 ? 's' : ''}{localClusterFilter.length === 1 ? (selectedNamespace ? ` in ${localClusterFilter[0]}/${selectedNamespace}` : ` in ${localClusterFilter[0]}`) : ` across ${availableClusters.length} cluster${availableClusters.length !== 1 ? 's' : ''}`}
           </div>
         </>
       )}

--- a/web/src/components/cards/KustomizationStatus.tsx
+++ b/web/src/components/cards/KustomizationStatus.tsx
@@ -1,13 +1,14 @@
 import { useState, useMemo } from 'react'
-import { CheckCircle, AlertTriangle, XCircle, RefreshCw, Clock, GitBranch, Search, ChevronRight, Filter, ChevronDown, Server } from 'lucide-react'
+import { CheckCircle, AlertTriangle, XCircle, RefreshCw, Clock, GitBranch, ChevronRight } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { Pagination, usePagination } from '../ui/Pagination'
-import { useChartFilters } from '../../lib/cards'
+import {
+  useCardData,
+  CardSearchInput, CardControlsRow, CardPaginationFooter,
+} from '../../lib/cards'
 
 interface KustomizationStatusProps {
   config?: {
@@ -39,10 +40,6 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
   const { deduplicatedClusters: allClusters, isLoading } = useClusters()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const [selectedNamespace, setSelectedNamespace] = useState<string>(config?.namespace || '')
-  const [sortBy, setSortBy] = useState<SortByOption>('status')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-  const [limit, setLimit] = useState<number | 'unlimited'>(5)
-  const [localSearch, setLocalSearch] = useState('')
   const {
     selectedClusters: globalSelectedClusters,
     isAllClustersSelected,
@@ -50,20 +47,7 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
   } = useGlobalFilters()
   const { drillToKustomization } = useDrillDownActions()
 
-  // Local cluster filter
-  const {
-    localClusterFilter,
-    toggleClusterFilter,
-    clearClusterFilter,
-    availableClusters,
-    showClusterFilter,
-    setShowClusterFilter,
-    clusterFilterRef,
-  } = useChartFilters({
-    storageKey: 'kustomization-status',
-  })
-
-  // Apply global filters
+  // Apply global filters to cluster list for the dropdown
   const clusters = useMemo(() => {
     let result = allClusters
 
@@ -98,58 +82,58 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
     return Array.from(nsSet).sort()
   }, [allKustomizations])
 
-  // Filter and sort by namespace
-  const filteredAndSorted = useMemo(() => {
-    let result = selectedNamespace
-      ? allKustomizations.filter(k => k.namespace === selectedNamespace)
-      : allKustomizations
+  // Pre-filter by namespace before passing to useCardData
+  const namespacedKustomizations = useMemo(() => {
+    if (!selectedNamespace) return allKustomizations
+    return allKustomizations.filter(k => k.namespace === selectedNamespace)
+  }, [allKustomizations, selectedNamespace])
 
-    // Apply local search filter
-    if (localSearch.trim()) {
-      const query = localSearch.toLowerCase()
-      result = result.filter(k =>
-        k.name.toLowerCase().includes(query) ||
-        k.namespace.toLowerCase().includes(query) ||
-        k.path.toLowerCase().includes(query) ||
-        k.sourceRef.toLowerCase().includes(query)
-      )
-    }
+  const statusOrder: Record<string, number> = { NotReady: 0, Progressing: 1, Suspended: 2, Ready: 3 }
 
-    // Sort
-    const statusOrder: Record<string, number> = { NotReady: 0, Progressing: 1, Suspended: 2, Ready: 3 }
-    result = [...result].sort((a, b) => {
-      let compare = 0
-      switch (sortBy) {
-        case 'status':
-          compare = (statusOrder[a.status] ?? 5) - (statusOrder[b.status] ?? 5)
-          break
-        case 'name':
-          compare = a.name.localeCompare(b.name)
-          break
-        case 'namespace':
-          compare = a.namespace.localeCompare(b.namespace)
-          break
-        case 'lastApplied':
-          compare = new Date(b.lastApplied).getTime() - new Date(a.lastApplied).getTime()
-          break
-      }
-      return sortDirection === 'asc' ? compare : -compare
-    })
-
-    return result
-  }, [allKustomizations, selectedNamespace, localSearch, sortBy, sortDirection])
-
-  // Use pagination hook
-  const effectivePerPage = limit === 'unlimited' ? 1000 : limit
+  // Use shared card data hook for filtering, sorting, and pagination
   const {
-    paginatedItems: kustomizations,
+    items: kustomizations,
+    totalItems,
     currentPage,
     totalPages,
-    totalItems,
-    itemsPerPage: perPage,
+    itemsPerPage,
     goToPage,
     needsPagination,
-  } = usePagination(filteredAndSorted, effectivePerPage)
+    setItemsPerPage,
+    filters: {
+      search: localSearch,
+      setSearch: setLocalSearch,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+  } = useCardData<Kustomization, SortByOption>(namespacedKustomizations, {
+    filter: {
+      searchFields: ['name', 'namespace', 'path', 'sourceRef'] as (keyof Kustomization)[],
+      storageKey: 'kustomization-status',
+    },
+    sort: {
+      defaultField: 'status',
+      defaultDirection: 'asc',
+      comparators: {
+        status: (a, b) => (statusOrder[a.status] ?? 5) - (statusOrder[b.status] ?? 5),
+        name: (a, b) => a.name.localeCompare(b.name),
+        namespace: (a, b) => a.namespace.localeCompare(b.namespace),
+        lastApplied: (a, b) => new Date(b.lastApplied).getTime() - new Date(a.lastApplied).getTime(),
+      },
+    },
+    defaultLimit: 5,
+  })
 
   const getStatusIcon = (status: Kustomization['status']) => {
     switch (status) {
@@ -180,8 +164,8 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
     return `${Math.floor(diff / 86400000)}d ago`
   }
 
-  const readyCount = filteredAndSorted.filter(k => k.status === 'Ready').length
-  const notReadyCount = filteredAndSorted.filter(k => k.status === 'NotReady').length
+  const readyCount = namespacedKustomizations.filter(k => k.status === 'Ready').length
+  const notReadyCount = namespacedKustomizations.filter(k => k.status === 'NotReady').length
   const showSkeleton = isLoading && allKustomizations.length === 0
 
   if (showSkeleton) {
@@ -210,69 +194,27 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
             {totalItems} kustomizations
           </span>
         </div>
-        <div className="flex items-center gap-2">
-          {/* Cluster count indicator */}
-          {localClusterFilter.length > 0 && (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
-              <Server className="w-3 h-3" />
-              {localClusterFilter.length}/{availableClusters.length}
-            </span>
-          )}
-
-          {/* Cluster filter dropdown */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(c => (
-                      <button
-                        key={c.name}
-                        onClick={() => toggleClusterFilter(c.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(c.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {c.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
-          <CardControls
-            limit={limit}
-            onLimitChange={setLimit}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
-        </div>
+        <CardControlsRow
+          clusterFilter={{
+            availableClusters,
+            selectedClusters: localClusterFilter,
+            onToggle: toggleClusterFilter,
+            onClear: clearClusterFilter,
+            isOpen: showClusterFilter,
+            setIsOpen: setShowClusterFilter,
+            containerRef: clusterFilterRef,
+            minClusters: 1,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => setSortBy(v as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+        />
       </div>
 
       {/* Selectors */}
@@ -321,16 +263,12 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
           </div>
 
           {/* Local Search */}
-          <div className="relative mb-4">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-            <input
-              type="text"
-              value={localSearch}
-              onChange={(e) => setLocalSearch(e.target.value)}
-              placeholder="Search kustomizations..."
-              className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-            />
-          </div>
+          <CardSearchInput
+            value={localSearch}
+            onChange={setLocalSearch}
+            placeholder="Search kustomizations..."
+            className="mb-4"
+          />
 
           {/* Summary */}
           <div className="flex gap-2 mb-4">
@@ -395,18 +333,14 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
           </div>
 
           {/* Pagination */}
-          {needsPagination && limit !== 'unlimited' && (
-            <div className="pt-2 border-t border-border/50 mt-2">
-              <Pagination
-                currentPage={currentPage}
-                totalPages={totalPages}
-                totalItems={totalItems}
-                itemsPerPage={perPage}
-                onPageChange={goToPage}
-                showItemsPerPage={false}
-              />
-            </div>
-          )}
+          <CardPaginationFooter
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalItems={totalItems}
+            itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 10}
+            onPageChange={goToPage}
+            needsPagination={needsPagination && itemsPerPage !== 'unlimited'}
+          />
 
           {/* Footer */}
           <div className="mt-4 pt-3 border-t border-border/50 text-xs text-muted-foreground">

--- a/web/src/components/cards/OperatorStatus.tsx
+++ b/web/src/components/cards/OperatorStatus.tsx
@@ -1,13 +1,20 @@
-import { useState, useMemo } from 'react'
-import { CheckCircle, AlertTriangle, XCircle, RefreshCw, ArrowUpCircle, Search, ChevronRight, Filter, ChevronDown, Server } from 'lucide-react'
+import { useMemo } from 'react'
+import { CheckCircle, AlertTriangle, XCircle, RefreshCw, ArrowUpCircle, ChevronRight } from 'lucide-react'
 import { useClusters, useOperators, Operator } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { useGlobalFilters } from '../../hooks/useGlobalFilters'
-import { useChartFilters } from '../../lib/cards'
-import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { Pagination, usePagination } from '../ui/Pagination'
+import { Skeleton } from '../ui/Skeleton'
+import {
+  useCardData,
+  useCardFilters,
+  commonComparators,
+  type SortDirection,
+} from '../../lib/cards'
+import {
+  CardSearchInput,
+  CardControlsRow,
+  CardPaginationFooter,
+} from '../../lib/cards/CardComponents'
 
 interface OperatorStatusProps {
   config?: {
@@ -24,103 +31,74 @@ const SORT_OPTIONS = [
   { value: 'version' as const, label: 'Version' },
 ]
 
+const STATUS_ORDER: Record<string, number> = { Failed: 0, Installing: 1, Upgrading: 2, Succeeded: 3 }
+
+const OPERATOR_SORT_COMPARATORS = {
+  status: (a: Operator, b: Operator) => (STATUS_ORDER[a.status] ?? 5) - (STATUS_ORDER[b.status] ?? 5),
+  name: commonComparators.string<Operator>('name'),
+  namespace: commonComparators.string<Operator>('namespace'),
+  version: commonComparators.string<Operator>('version'),
+}
+
+// Shared filter config for counting and display
+const FILTER_CONFIG = {
+  searchFields: ['name', 'namespace', 'version'] as (keyof Operator)[],
+  clusterField: 'cluster' as keyof Operator,
+  statusField: 'status' as keyof Operator,
+  storageKey: 'operator-status',
+}
+
 export function OperatorStatus({ config: _config }: OperatorStatusProps) {
   const { isLoading: clustersLoading } = useClusters()
   const { drillToOperator } = useDrillDownActions()
 
-  // Use chart filters hook for cluster filtering
-  const {
-    localClusterFilter,
-    toggleClusterFilter,
-    clearClusterFilter,
-    availableClusters,
-    filteredClusters: clusters,
-    showClusterFilter,
-    setShowClusterFilter,
-    clusterFilterRef,
-  } = useChartFilters({ storageKey: 'operator-status' })
-
-  const [sortBy, setSortBy] = useState<SortByOption>('status')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-  const [limit, setLimit] = useState<number | 'unlimited'>(5)
-  const [localSearch, setLocalSearch] = useState('')
-  const {
-    customFilter,
-    filterByStatus,
-  } = useGlobalFilters()
-
   // Fetch operators - pass undefined to get all clusters
   const { operators: rawOperators, isLoading: operatorsLoading } = useOperators(undefined)
 
-  // Apply filters and sorting to operators
-  const filteredAndSorted = useMemo(() => {
-    let result = rawOperators
+  // Use useCardFilters for status counts (globally filtered, before local search/pagination)
+  const { filtered: globalFilteredOperators } = useCardFilters(rawOperators, FILTER_CONFIG)
 
-    // Apply cluster filter (from useChartFilters)
-    const clusterNames = new Set(clusters.map(c => c.name))
-    result = result.filter(op => {
-      const clusterName = op.cluster?.split('/')[0] || ''
-      return clusterNames.has(clusterName) || clusterNames.has(op.cluster || '')
-    })
-
-    // Apply status filter
-    result = filterByStatus(result)
-
-    // Apply custom text filter (global)
-    if (customFilter.trim()) {
-      const query = customFilter.toLowerCase()
-      result = result.filter(op =>
-        op.name.toLowerCase().includes(query) ||
-        op.namespace.toLowerCase().includes(query) ||
-        op.version.toLowerCase().includes(query)
-      )
-    }
-
-    // Apply local search filter
-    if (localSearch.trim()) {
-      const query = localSearch.toLowerCase()
-      result = result.filter(op =>
-        op.name.toLowerCase().includes(query) ||
-        op.namespace.toLowerCase().includes(query) ||
-        op.version.toLowerCase().includes(query)
-      )
-    }
-
-    // Sort
-    const statusOrder: Record<string, number> = { Failed: 0, Installing: 1, Upgrading: 2, Succeeded: 3 }
-    result = [...result].sort((a, b) => {
-      let compare = 0
-      switch (sortBy) {
-        case 'status':
-          compare = (statusOrder[a.status] ?? 5) - (statusOrder[b.status] ?? 5)
-          break
-        case 'name':
-          compare = a.name.localeCompare(b.name)
-          break
-        case 'namespace':
-          compare = a.namespace.localeCompare(b.namespace)
-          break
-        case 'version':
-          compare = a.version.localeCompare(b.version)
-          break
-      }
-      return sortDirection === 'asc' ? compare : -compare
-    })
-
-    return result
-  }, [rawOperators, clusters, filterByStatus, customFilter, localSearch, sortBy, sortDirection])
-
-  // Use pagination hook
-  const effectivePerPage = limit === 'unlimited' ? 1000 : limit
+  // Use shared card data hook for filtering, sorting, and pagination
   const {
-    paginatedItems: operators,
+    items: operators,
+    totalItems,
     currentPage,
     totalPages,
-    totalItems,
-    itemsPerPage: perPage,
+    itemsPerPage,
     goToPage,
     needsPagination,
-  } = usePagination(filteredAndSorted, effectivePerPage)
+    setItemsPerPage,
+    filters: {
+      search: searchQuery,
+      setSearch: setSearchQuery,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+  } = useCardData<Operator, SortByOption>(rawOperators, {
+    filter: {
+      searchFields: ['name', 'namespace', 'version'] as (keyof Operator)[],
+      clusterField: 'cluster',
+      statusField: 'status',
+      storageKey: 'operator-status',
+    },
+    sort: {
+      defaultField: 'status',
+      defaultDirection: 'asc' as SortDirection,
+      comparators: OPERATOR_SORT_COMPARATORS,
+    },
+    defaultLimit: 5,
+  })
 
   const isLoading = clustersLoading || operatorsLoading
   const showSkeleton = isLoading && rawOperators.length === 0
@@ -145,12 +123,12 @@ export function OperatorStatus({ config: _config }: OperatorStatusProps) {
     }
   }
 
-  // Use filteredAndSorted for total counts (not paginated 'operators')
-  const statusCounts = {
-    succeeded: filteredAndSorted.filter(o => o.status === 'Succeeded').length,
-    failed: filteredAndSorted.filter(o => o.status === 'Failed').length,
-    other: filteredAndSorted.filter(o => !['Succeeded', 'Failed'].includes(o.status)).length,
-  }
+  // Status counts from globally filtered data (before local search/pagination)
+  const statusCounts = useMemo(() => ({
+    succeeded: globalFilteredOperators.filter(o => o.status === 'Succeeded').length,
+    failed: globalFilteredOperators.filter(o => o.status === 'Failed').length,
+    other: globalFilteredOperators.filter(o => !['Succeeded', 'Failed'].includes(o.status)).length,
+  }), [globalFilteredOperators])
 
   if (showSkeleton) {
     return (
@@ -170,76 +148,40 @@ export function OperatorStatus({ config: _config }: OperatorStatusProps) {
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
-      {/* Controls - single row */}
+      {/* Controls row */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          {localClusterFilter.length > 0 && (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
-              <Server className="w-3 h-3" />
-              {clusters.length}/{availableClusters.length}
-            </span>
-          )}
           {totalItems > 0 && (
             <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
               {totalItems} operators
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          {/* Cluster Filter */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
-          <CardControls
-            limit={limit}
-            onLimitChange={setLimit}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
-        </div>
+        <CardControlsRow
+          clusterIndicator={localClusterFilter.length > 0 ? {
+            selectedCount: localClusterFilter.length,
+            totalCount: availableClusters.length,
+          } : undefined}
+          clusterFilter={{
+            availableClusters,
+            selectedClusters: localClusterFilter,
+            onToggle: toggleClusterFilter,
+            onClear: clearClusterFilter,
+            isOpen: showClusterFilter,
+            setIsOpen: setShowClusterFilter,
+            containerRef: clusterFilterRef,
+            minClusters: 1,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => setSortBy(v as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+        />
       </div>
 
       {availableClusters.length > 0 && (
@@ -254,22 +196,18 @@ export function OperatorStatus({ config: _config }: OperatorStatusProps) {
               </span>
             ) : (
               <span className="text-xs px-2 py-1 rounded-full bg-purple-500/20 text-purple-400">
-                All Clusters ({clusters.length})
+                All Clusters ({availableClusters.length})
               </span>
             )}
           </div>
 
           {/* Local Search */}
-          <div className="relative mb-4">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-            <input
-              type="text"
-              value={localSearch}
-              onChange={(e) => setLocalSearch(e.target.value)}
-              placeholder="Search operators..."
-              className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-            />
-          </div>
+          <CardSearchInput
+            value={searchQuery}
+            onChange={setSearchQuery}
+            placeholder="Search operators..."
+            className="mb-4"
+          />
 
           {/* Summary */}
           <div className="flex gap-2 mb-4">
@@ -334,22 +272,18 @@ export function OperatorStatus({ config: _config }: OperatorStatusProps) {
           </div>
 
           {/* Pagination */}
-          {needsPagination && limit !== 'unlimited' && (
-            <div className="pt-2 border-t border-border/50 mt-2">
-              <Pagination
-                currentPage={currentPage}
-                totalPages={totalPages}
-                totalItems={totalItems}
-                itemsPerPage={perPage}
-                onPageChange={goToPage}
-                showItemsPerPage={false}
-              />
-            </div>
-          )}
+          <CardPaginationFooter
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalItems={totalItems}
+            itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : totalItems}
+            onPageChange={goToPage}
+            needsPagination={needsPagination && itemsPerPage !== 'unlimited'}
+          />
 
           {/* Footer */}
           <div className="mt-4 pt-3 border-t border-border/50 text-xs text-muted-foreground">
-            {totalItems} operator{totalItems !== 1 ? 's' : ''} {localClusterFilter.length === 1 ? `on ${localClusterFilter[0]}` : `across ${clusters.length} cluster${clusters.length !== 1 ? 's' : ''}`}
+            {totalItems} operator{totalItems !== 1 ? 's' : ''} {localClusterFilter.length === 1 ? `on ${localClusterFilter[0]}` : `across ${availableClusters.length} cluster${availableClusters.length !== 1 ? 's' : ''}`}
           </div>
         </>
       )}

--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -1,10 +1,10 @@
-import { useMemo, useState } from 'react'
-import { CheckCircle, AlertTriangle, Clock, Search, ChevronRight, Filter, ChevronDown, Server } from 'lucide-react'
+import { useMemo } from 'react'
+import { CheckCircle, AlertTriangle, Clock, ChevronRight } from 'lucide-react'
 import { usePVCs } from '../../hooks/useMCP'
+import type { PVC } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { useChartFilters } from '../../lib/cards'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { Pagination, usePagination } from '../ui/Pagination'
+import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 import { ClusterBadge } from '../ui/ClusterBadge'
 
 type SortByOption = 'status' | 'name' | 'capacity' | 'age'
@@ -15,6 +15,8 @@ const SORT_OPTIONS = [
   { value: 'capacity' as const, label: 'Capacity' },
   { value: 'age' as const, label: 'Age' },
 ]
+
+const STATUS_ORDER: Record<string, number> = { failed: 0, lost: 0, pending: 1, bound: 2 }
 
 // Parse capacity string to bytes for sorting
 function parseCapacity(capacity?: string): number {
@@ -32,6 +34,13 @@ function parseCapacity(capacity?: string): number {
     'pi': 1024 * 1024 * 1024 * 1024 * 1024,
   }
   return value * (multipliers[unit] || 1)
+}
+
+const PVC_SORT_COMPARATORS = {
+  status: (a: PVC, b: PVC) => (STATUS_ORDER[a.status.toLowerCase()] ?? 1) - (STATUS_ORDER[b.status.toLowerCase()] ?? 1),
+  name: commonComparators.string<PVC>('name'),
+  capacity: (a: PVC, b: PVC) => parseCapacity(b.capacity) - parseCapacity(a.capacity),
+  age: (a: PVC, b: PVC) => (a.age || '').localeCompare(b.age || ''),
 }
 
 function getStatusIcon(status: string) {
@@ -60,26 +69,48 @@ export function PVCStatus() {
   const { pvcs, isLoading, error } = usePVCs()
   const { drillToPVC } = useDrillDownActions()
 
-  // Local cluster filter
   const {
-    localClusterFilter,
-    toggleClusterFilter,
-    clearClusterFilter,
-    availableClusters,
-    showClusterFilter,
-    setShowClusterFilter,
-    clusterFilterRef,
-  } = useChartFilters({
-    storageKey: 'pvc-status',
+    items: displayPVCs,
+    totalItems,
+    currentPage,
+    totalPages,
+    itemsPerPage,
+    goToPage,
+    needsPagination,
+    setItemsPerPage,
+    filters: {
+      search,
+      setSearch,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+  } = useCardData<PVC, SortByOption>(pvcs, {
+    filter: {
+      searchFields: ['name', 'namespace', 'cluster', 'storageClass'],
+      clusterField: 'cluster',
+      storageKey: 'pvc-status',
+    },
+    sort: {
+      defaultField: 'status',
+      defaultDirection: 'asc',
+      comparators: PVC_SORT_COMPARATORS,
+    },
+    defaultLimit: 10,
   })
 
-  const [localSearch, setLocalSearch] = useState('')
-  const [sortBy, setSortBy] = useState<SortByOption>('status')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-  const [limit, setLimit] = useState<number | 'unlimited'>(10)
-
-  // Filter PVCs
-  const filteredPVCs = useMemo(() => {
+  // Stats based on filtered data (approximate: apply local cluster filter + search to pvcs)
+  const stats = useMemo(() => {
     let result = pvcs
 
     // Apply local cluster filter
@@ -91,8 +122,8 @@ export function PVCStatus() {
     }
 
     // Apply search filter
-    if (localSearch.trim()) {
-      const query = localSearch.toLowerCase()
+    if (search.trim()) {
+      const query = search.toLowerCase()
       result = result.filter(pvc =>
         pvc.name.toLowerCase().includes(query) ||
         pvc.namespace.toLowerCase().includes(query) ||
@@ -101,53 +132,13 @@ export function PVCStatus() {
       )
     }
 
-    return result
-  }, [pvcs, localClusterFilter, localSearch])
-
-  // Sort PVCs
-  const sortedPVCs = useMemo(() => {
-    const sorted = [...filteredPVCs].sort((a, b) => {
-      let result = 0
-      switch (sortBy) {
-        case 'status':
-          // Order: Failed, Pending, Bound
-          const statusOrder: Record<string, number> = { 'failed': 0, 'lost': 0, 'pending': 1, 'bound': 2 }
-          result = (statusOrder[a.status.toLowerCase()] ?? 1) - (statusOrder[b.status.toLowerCase()] ?? 1)
-          break
-        case 'name':
-          result = a.name.localeCompare(b.name)
-          break
-        case 'capacity':
-          result = parseCapacity(b.capacity) - parseCapacity(a.capacity)
-          break
-        case 'age':
-          result = (a.age || '').localeCompare(b.age || '')
-          break
-      }
-      return sortDirection === 'asc' ? result : -result
-    })
-    return sorted
-  }, [filteredPVCs, sortBy, sortDirection])
-
-  // Use pagination hook
-  const effectivePerPage = limit === 'unlimited' ? 1000 : limit
-  const {
-    paginatedItems: displayPVCs,
-    currentPage,
-    totalPages,
-    totalItems,
-    itemsPerPage: perPage,
-    goToPage,
-    needsPagination,
-  } = usePagination(sortedPVCs, effectivePerPage)
-
-  // Stats
-  const stats = useMemo(() => ({
-    total: filteredPVCs.length,
-    bound: filteredPVCs.filter(p => p.status === 'Bound').length,
-    pending: filteredPVCs.filter(p => p.status === 'Pending').length,
-    failed: filteredPVCs.filter(p => !['Bound', 'Pending'].includes(p.status)).length,
-  }), [filteredPVCs])
+    return {
+      total: result.length,
+      bound: result.filter(p => p.status === 'Bound').length,
+      pending: result.filter(p => p.status === 'Pending').length,
+      failed: result.filter(p => !['Bound', 'Pending'].includes(p.status)).length,
+    }
+  }, [pvcs, localClusterFilter, search])
 
   const showSkeleton = isLoading && pvcs.length === 0
 
@@ -164,79 +155,40 @@ export function PVCStatus() {
       {/* Controls */}
       <div className="flex items-center justify-between mb-4">
         <span className="text-sm font-medium text-muted-foreground">{totalItems} PVCs</span>
-        <div className="flex items-center gap-2">
-          {localClusterFilter.length > 0 && (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
-              <Server className="w-3 h-3" />
-              {localClusterFilter.length}/{availableClusters.length}
-            </span>
-          )}
-          {/* Cluster Filter */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-          <CardControls
-            limit={limit}
-            onLimitChange={setLimit}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
-        </div>
+        <CardControlsRow
+          clusterIndicator={localClusterFilter.length > 0 ? {
+            selectedCount: localClusterFilter.length,
+            totalCount: availableClusters.length,
+          } : undefined}
+          clusterFilter={{
+            availableClusters,
+            selectedClusters: localClusterFilter,
+            onToggle: toggleClusterFilter,
+            onClear: clearClusterFilter,
+            isOpen: showClusterFilter,
+            setIsOpen: setShowClusterFilter,
+            containerRef: clusterFilterRef,
+            minClusters: 1,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (value: string) => setSortBy(value as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+        />
       </div>
 
       {/* Local Search */}
-      <div className="relative mb-4">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={localSearch}
-          onChange={(e) => setLocalSearch(e.target.value)}
-          placeholder="Search PVCs..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={search}
+        onChange={setSearch}
+        placeholder="Search PVCs..."
+        className="mb-4"
+      />
 
       {/* Stats row */}
       <div className="grid grid-cols-4 gap-2 mb-4">
@@ -302,18 +254,14 @@ export function PVCStatus() {
       </div>
 
       {/* Pagination */}
-      {needsPagination && limit !== 'unlimited' && (
-        <div className="pt-2 border-t border-border/50 mt-2">
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            totalItems={totalItems}
-            itemsPerPage={perPage}
-            onPageChange={goToPage}
-            showItemsPerPage={false}
-          />
-        </div>
-      )}
+      <CardPaginationFooter
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : totalItems}
+        onPageChange={goToPage}
+        needsPagination={needsPagination}
+      />
     </div>
   )
 }

--- a/web/src/components/cards/ServiceExports.tsx
+++ b/web/src/components/cards/ServiceExports.tsx
@@ -1,8 +1,10 @@
-import { useState, useMemo } from 'react'
-import { CheckCircle2, Clock, XCircle, HelpCircle, Search, AlertCircle, ExternalLink, Server, Filter, ChevronDown } from 'lucide-react'
+import { CheckCircle2, Clock, XCircle, HelpCircle, AlertCircle, ExternalLink, Server } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { useChartFilters } from '../../lib/cards'
+import {
+  useCardData,
+  commonComparators,
+  CardSearchInput, CardControlsRow, CardPaginationFooter,
+} from '../../lib/cards'
 import type { ServiceExport, ServiceExportStatus } from '../../types/mcs'
 
 // Demo data for MCS ServiceExports
@@ -99,65 +101,56 @@ const SORT_OPTIONS = [
 
 const statusOrder: Record<string, number> = { Failed: 0, Pending: 1, Ready: 2 }
 
+const EXPORT_SORT_COMPARATORS = {
+  name: commonComparators.string<ServiceExport>('name'),
+  status: (a: ServiceExport, b: ServiceExport) => (statusOrder[a.status] || 3) - (statusOrder[b.status] || 3),
+  cluster: commonComparators.string<ServiceExport>('cluster'),
+}
+
 interface ServiceExportsProps {
   config?: Record<string, unknown>
 }
 
 export function ServiceExports({ config: _config }: ServiceExportsProps) {
-  const [localSearch, setLocalSearch] = useState('')
-  const [limit, setLimit] = useState<number | 'unlimited'>(5)
-  const [sortBy, setSortBy] = useState<SortByOption>('status')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-
-  // Local cluster filter
   const {
-    localClusterFilter,
-    toggleClusterFilter,
-    clearClusterFilter,
-    availableClusters,
-    showClusterFilter,
-    setShowClusterFilter,
-    clusterFilterRef,
-  } = useChartFilters({
-    storageKey: 'service-exports',
+    items: filteredExports,
+    totalItems,
+    currentPage,
+    totalPages,
+    itemsPerPage,
+    goToPage,
+    needsPagination,
+    setItemsPerPage,
+    filters: {
+      search: localSearch,
+      setSearch: setLocalSearch,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+  } = useCardData<ServiceExport, SortByOption>(DEMO_EXPORTS, {
+    filter: {
+      searchFields: ['name', 'namespace', 'cluster', 'serviceName', 'status'],
+      clusterField: 'cluster',
+      storageKey: 'service-exports',
+    },
+    sort: {
+      defaultField: 'status',
+      defaultDirection: 'asc',
+      comparators: EXPORT_SORT_COMPARATORS,
+    },
+    defaultLimit: 5,
   })
-
-  // Filter exports by local search and cluster filter
-  const filteredExports = useMemo(() => {
-    let result = DEMO_EXPORTS
-
-    // Apply local cluster filter
-    if (localClusterFilter.length > 0) {
-      result = result.filter(exp => localClusterFilter.includes(exp.cluster))
-    }
-
-    // Apply search filter
-    if (localSearch.trim()) {
-      const query = localSearch.toLowerCase()
-      result = result.filter(exp =>
-        exp.name.toLowerCase().includes(query) ||
-        exp.namespace.toLowerCase().includes(query) ||
-        exp.cluster.toLowerCase().includes(query) ||
-        exp.serviceName?.toLowerCase().includes(query) ||
-        exp.status.toLowerCase().includes(query)
-      )
-    }
-
-    // Sort
-    const sorted = [...result].sort((a, b) => {
-      let cmp = 0
-      if (sortBy === 'status') cmp = (statusOrder[a.status] || 3) - (statusOrder[b.status] || 3)
-      else if (sortBy === 'name') cmp = a.name.localeCompare(b.name)
-      else if (sortBy === 'cluster') cmp = a.cluster.localeCompare(b.cluster)
-      return sortDirection === 'asc' ? cmp : -cmp
-    })
-
-    // Apply limit
-    if (limit !== 'unlimited') {
-      return sorted.slice(0, limit)
-    }
-    return sorted
-  }, [localSearch, localClusterFilter, sortBy, sortDirection, limit])
 
   return (
     <div className="h-full flex flex-col min-h-card">
@@ -183,61 +176,27 @@ export function ServiceExports({ config: _config }: ServiceExportsProps) {
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          {/* Cluster filter dropdown */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
-          <CardControls
-            limit={limit}
-            onLimitChange={setLimit}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
-        </div>
+        <CardControlsRow
+          clusterFilter={{
+            availableClusters,
+            selectedClusters: localClusterFilter,
+            onToggle: toggleClusterFilter,
+            onClear: clearClusterFilter,
+            isOpen: showClusterFilter,
+            setIsOpen: setShowClusterFilter,
+            containerRef: clusterFilterRef,
+            minClusters: 1,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => setSortBy(v as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+        />
       </div>
 
       {/* MCS Integration Notice */}
@@ -276,16 +235,12 @@ export function ServiceExports({ config: _config }: ServiceExportsProps) {
       </div>
 
       {/* Local Search */}
-      <div className="relative mb-3">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={localSearch}
-          onChange={(e) => setLocalSearch(e.target.value)}
-          placeholder="Search exports..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={localSearch}
+        onChange={setLocalSearch}
+        placeholder="Search exports..."
+        className="mb-3"
+      />
 
       {/* Exports list */}
       <div className="flex-1 overflow-y-auto space-y-2">
@@ -326,6 +281,16 @@ export function ServiceExports({ config: _config }: ServiceExportsProps) {
           )
         })}
       </div>
+
+      {/* Pagination */}
+      <CardPaginationFooter
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 10}
+        onPageChange={goToPage}
+        needsPagination={needsPagination && itemsPerPage !== 'unlimited'}
+      />
 
       {/* Quick install command */}
       <div className="mt-3 pt-3 border-t border-border/50">

--- a/web/src/components/cards/ServiceImports.tsx
+++ b/web/src/components/cards/ServiceImports.tsx
@@ -1,8 +1,7 @@
-import { useState, useMemo } from 'react'
-import { CheckCircle2, XCircle, Search, AlertCircle, ExternalLink, Globe, Server, Filter, ChevronDown } from 'lucide-react'
+import { CheckCircle2, XCircle, AlertCircle, ExternalLink, Globe } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { useChartFilters } from '../../lib/cards'
+import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 import type { ServiceImport, ServiceImportType } from '../../types/mcs'
 
 // Demo data for MCS ServiceImports
@@ -98,66 +97,41 @@ const SORT_OPTIONS = [
   { value: 'cluster' as const, label: 'Cluster' },
 ]
 
+const IMPORT_SORT_COMPARATORS: Record<SortByOption, (a: ServiceImport, b: ServiceImport) => number> = {
+  name: commonComparators.string<ServiceImport>('name'),
+  type: commonComparators.string<ServiceImport>('type'),
+  cluster: commonComparators.string<ServiceImport>('cluster'),
+}
+
 interface ServiceImportsProps {
   config?: Record<string, unknown>
 }
 
 export function ServiceImports({ config: _config }: ServiceImportsProps) {
-  const [localSearch, setLocalSearch] = useState('')
-  const [limit, setLimit] = useState<number | 'unlimited'>(5)
-  const [sortBy, setSortBy] = useState<SortByOption>('name')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-
-  // Local cluster filter
   const {
-    localClusterFilter,
-    toggleClusterFilter,
-    clearClusterFilter,
-    availableClusters,
-    showClusterFilter,
-    setShowClusterFilter,
-    clusterFilterRef,
-  } = useChartFilters({
-    storageKey: 'service-imports',
+    items: filteredImports,
+    totalItems,
+    currentPage,
+    totalPages,
+    itemsPerPage,
+    goToPage,
+    needsPagination,
+    setItemsPerPage,
+    filters,
+    sorting,
+  } = useCardData<ServiceImport, SortByOption>(DEMO_IMPORTS, {
+    filter: {
+      searchFields: ['name', 'namespace', 'cluster', 'sourceCluster', 'dnsName', 'type'],
+      clusterField: 'cluster',
+      storageKey: 'service-imports',
+    },
+    sort: {
+      defaultField: 'name',
+      defaultDirection: 'asc',
+      comparators: IMPORT_SORT_COMPARATORS,
+    },
+    defaultLimit: 5,
   })
-
-  // Filter imports by local search and cluster filter
-  const filteredImports = useMemo(() => {
-    let result = DEMO_IMPORTS
-
-    // Apply local cluster filter
-    if (localClusterFilter.length > 0) {
-      result = result.filter(imp => localClusterFilter.includes(imp.cluster))
-    }
-
-    // Apply search filter
-    if (localSearch.trim()) {
-      const query = localSearch.toLowerCase()
-      result = result.filter(imp =>
-        imp.name.toLowerCase().includes(query) ||
-        imp.namespace.toLowerCase().includes(query) ||
-        imp.cluster.toLowerCase().includes(query) ||
-        imp.sourceCluster?.toLowerCase().includes(query) ||
-        imp.dnsName?.toLowerCase().includes(query) ||
-        imp.type.toLowerCase().includes(query)
-      )
-    }
-
-    // Sort
-    const sorted = [...result].sort((a, b) => {
-      let cmp = 0
-      if (sortBy === 'name') cmp = a.name.localeCompare(b.name)
-      else if (sortBy === 'type') cmp = a.type.localeCompare(b.type)
-      else if (sortBy === 'cluster') cmp = a.cluster.localeCompare(b.cluster)
-      return sortDirection === 'asc' ? cmp : -cmp
-    })
-
-    // Apply limit
-    if (limit !== 'unlimited') {
-      return sorted.slice(0, limit)
-    }
-    return sorted
-  }, [localSearch, localClusterFilter, sortBy, sortDirection, limit])
 
   return (
     <div className="h-full flex flex-col min-h-card">
@@ -176,68 +150,32 @@ export function ServiceImports({ config: _config }: ServiceImportsProps) {
           <span className="text-sm font-medium text-muted-foreground">
             {DEMO_STATS.totalImports} imports
           </span>
-          {localClusterFilter.length > 0 && (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
-              <Server className="w-3 h-3" />
-              {localClusterFilter.length}/{availableClusters.length}
-            </span>
-          )}
         </div>
-        <div className="flex items-center gap-2">
-          {/* Cluster filter dropdown */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
-          <CardControls
-            limit={limit}
-            onLimitChange={setLimit}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
-        </div>
+        <CardControlsRow
+          clusterIndicator={{
+            selectedCount: filters.localClusterFilter.length,
+            totalCount: filters.availableClusters.length,
+          }}
+          clusterFilter={{
+            availableClusters: filters.availableClusters,
+            selectedClusters: filters.localClusterFilter,
+            onToggle: filters.toggleClusterFilter,
+            onClear: filters.clearClusterFilter,
+            isOpen: filters.showClusterFilter,
+            setIsOpen: filters.setShowClusterFilter,
+            containerRef: filters.clusterFilterRef,
+            minClusters: 1,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy: sorting.sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => sorting.setSortBy(v as SortByOption),
+            sortDirection: sorting.sortDirection,
+            onSortDirectionChange: sorting.setSortDirection,
+          }}
+        />
       </div>
 
       {/* MCS Integration Notice */}
@@ -276,16 +214,12 @@ export function ServiceImports({ config: _config }: ServiceImportsProps) {
       </div>
 
       {/* Local Search */}
-      <div className="relative mb-3">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={localSearch}
-          onChange={(e) => setLocalSearch(e.target.value)}
-          placeholder="Search imports..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={filters.search}
+        onChange={filters.setSearch}
+        placeholder="Search imports..."
+        className="mb-3"
+      />
 
       {/* Imports list */}
       <div className="flex-1 overflow-y-auto space-y-2">
@@ -324,6 +258,16 @@ export function ServiceImports({ config: _config }: ServiceImportsProps) {
           )
         })}
       </div>
+
+      {/* Pagination */}
+      <CardPaginationFooter
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : filteredImports.length}
+        onPageChange={goToPage}
+        needsPagination={needsPagination}
+      />
 
       {/* Usage example */}
       <div className="mt-3 pt-3 border-t border-border/50">

--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -1,13 +1,12 @@
 import { useMemo, useState, useEffect, useRef } from 'react'
-import { ArrowUp, CheckCircle, AlertTriangle, Rocket, WifiOff, Search, Loader2, Filter, ChevronDown, Server } from 'lucide-react'
+import { ArrowUp, CheckCircle, AlertTriangle, Rocket, WifiOff, Loader2 } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { Pagination, usePagination } from '../ui/Pagination'
-import { useChartFilters } from '../../lib/cards'
+import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 
 interface UpgradeStatusProps {
   config?: Record<string, unknown>
@@ -224,6 +223,24 @@ function getStatusIcon(status: string) {
   }
 }
 
+interface UpgradeItem {
+  name: string
+  currentVersion: string
+  targetVersion: string
+  status: 'unreachable' | 'loading' | 'available' | 'current'
+  progress: number
+  isUnreachable: boolean
+  isLoading: boolean
+}
+
+const STATUS_ORDER: Record<string, number> = { available: 0, loading: 1, unreachable: 2, current: 3 }
+
+const UPGRADE_SORT_COMPARATORS: Record<SortByOption, (a: UpgradeItem, b: UpgradeItem) => number> = {
+  status: commonComparators.statusOrder<UpgradeItem>('status', STATUS_ORDER),
+  version: commonComparators.string<UpgradeItem>('currentVersion'),
+  cluster: commonComparators.string<UpgradeItem>('name'),
+}
+
 export function UpgradeStatus({ config: _config }: UpgradeStatusProps) {
   const { deduplicatedClusters: allClusters, isLoading: isLoadingHook } = useClusters()
   const { drillToCluster } = useDrillDownActions()
@@ -231,31 +248,15 @@ export function UpgradeStatus({ config: _config }: UpgradeStatusProps) {
   const { isConnected: agentConnected } = useLocalAgent()
   const [clusterVersions, setClusterVersions] = useState<Record<string, string>>({})
   const [fetchCompleted, setFetchCompleted] = useState(false)
-  const [sortBy, setSortBy] = useState<SortByOption>('status')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-  const [limit, setLimit] = useState<number | 'unlimited'>(5)
-  const [localSearch, setLocalSearch] = useState('')
 
-  // Local cluster filter
-  const {
-    localClusterFilter,
-    toggleClusterFilter,
-    clearClusterFilter,
-    availableClusters,
-    showClusterFilter,
-    setShowClusterFilter,
-    clusterFilterRef,
-  } = useChartFilters({
-    storageKey: 'upgrade-status',
-  })
-
-  // Only show skeleton when no cached data exists - prevents flickering on refresh
-  const isLoading = isLoadingHook && allClusters.length === 0
   const {
     selectedClusters: globalSelectedClusters,
     isAllClustersSelected,
     customFilter,
   } = useGlobalFilters()
+
+  // Only show skeleton when no cached data exists - prevents flickering on refresh
+  const isLoading = isLoadingHook && allClusters.length === 0
 
   // Track previous agent connection state to detect reconnections
   const prevAgentConnectedRef = useRef(agentConnected)
@@ -367,8 +368,8 @@ Please proceed step by step and ask for confirmation before making any changes.`
     })
   }
 
-  // Apply global filters and local search
-  const clusters = useMemo(() => {
+  // Apply global filters to get clusters, then build version data
+  const globalFilteredClusters = useMemo(() => {
     let result = allClusters
 
     if (!isAllClustersSelected) {
@@ -383,34 +384,12 @@ Please proceed step by step and ask for confirmation before making any changes.`
       )
     }
 
-    // Apply local cluster filter
-    if (localClusterFilter.length > 0) {
-      result = result.filter(c => localClusterFilter.includes(c.name))
-    }
-
-    // Apply local search filter
-    if (localSearch.trim()) {
-      const query = localSearch.toLowerCase()
-      result = result.filter(c =>
-        c.name.toLowerCase().includes(query) ||
-        c.context?.toLowerCase().includes(query)
-      )
-    }
-
     return result
-  }, [allClusters, globalSelectedClusters, isAllClustersSelected, customFilter, localSearch, localClusterFilter])
-
-  if (isLoading) {
-    return (
-      <div className="h-full flex items-center justify-center">
-        <div className="spinner w-8 h-8" />
-      </div>
-    )
-  }
+  }, [allClusters, globalSelectedClusters, isAllClustersSelected, customFilter])
 
   // Build version data from real cluster versions
   const clusterVersionData = useMemo(() => {
-    const data = clusters.map((c) => {
+    return globalFilteredClusters.map((c) => {
       // A cluster is reachable if it has nodes (same logic as other components)
       const hasNodes = c.nodeCount && c.nodeCount > 0
       const isUnreachable = c.reachable === false || (!hasNodes && c.healthy === false)
@@ -437,39 +416,61 @@ Please proceed step by step and ask for confirmation before making any changes.`
         isLoading: isStillLoading,
       }
     })
+  }, [globalFilteredClusters, clusterVersions, agentConnected, fetchCompleted])
 
-    // Sort
-    const statusOrder: Record<string, number> = { available: 0, loading: 1, unreachable: 2, current: 3 }
-    return data.sort((a, b) => {
-      let compare = 0
-      switch (sortBy) {
-        case 'status':
-          compare = (statusOrder[a.status] ?? 3) - (statusOrder[b.status] ?? 3)
-          break
-        case 'version':
-          compare = a.currentVersion.localeCompare(b.currentVersion)
-          break
-        case 'cluster':
-          compare = a.name.localeCompare(b.name)
-          break
-      }
-      return sortDirection === 'asc' ? compare : -compare
-    })
-  }, [clusters, clusterVersions, agentConnected, fetchCompleted, sortBy, sortDirection])
-
-  // Use pagination hook
-  const effectivePerPage = limit === 'unlimited' ? 1000 : limit
+  // Use shared card data hook for filtering, sorting, and pagination
   const {
-    paginatedItems: displayClusters,
+    items: displayClusters,
+    totalItems,
     currentPage,
     totalPages,
-    totalItems,
-    itemsPerPage: perPage,
+    itemsPerPage,
     goToPage,
     needsPagination,
-  } = usePagination(clusterVersionData, effectivePerPage)
+    setItemsPerPage,
+    filters: {
+      search,
+      setSearch,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+  } = useCardData<UpgradeItem, SortByOption>(clusterVersionData, {
+    filter: {
+      searchFields: ['name', 'currentVersion'],
+      clusterField: 'name',
+      storageKey: 'upgrade-status',
+    },
+    sort: {
+      defaultField: 'status',
+      defaultDirection: 'asc',
+      comparators: UPGRADE_SORT_COMPARATORS,
+    },
+    defaultLimit: 5,
+  })
+
+  // Suppress unused variable warnings for values used indirectly
+  void totalItems
 
   const pendingUpgrades = clusterVersionData.filter((c) => c.status === 'available').length
+
+  if (isLoading) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <div className="spinner w-8 h-8" />
+      </div>
+    )
+  }
 
   return (
     <div className="h-full flex flex-col">
@@ -482,82 +483,42 @@ Please proceed step by step and ask for confirmation before making any changes.`
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2">
-          {/* Cluster count indicator */}
-          {localClusterFilter.length > 0 && (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
-              <Server className="w-3 h-3" />
-              {localClusterFilter.length}/{availableClusters.length}
-            </span>
-          )}
-
-          {/* Cluster filter dropdown */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
-          <CardControls
-            limit={limit}
-            onLimitChange={setLimit}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
-        </div>
+        <CardControlsRow
+          clusterIndicator={
+            localClusterFilter.length > 0
+              ? { selectedCount: localClusterFilter.length, totalCount: availableClusters.length }
+              : undefined
+          }
+          clusterFilter={{
+            availableClusters,
+            selectedClusters: localClusterFilter,
+            onToggle: toggleClusterFilter,
+            onClear: clearClusterFilter,
+            isOpen: showClusterFilter,
+            setIsOpen: setShowClusterFilter,
+            containerRef: clusterFilterRef,
+            minClusters: 1,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => setSortBy(v as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+          className="mb-0"
+        />
       </div>
 
       {/* Local Search */}
-      <div className="relative mb-3">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={localSearch}
-          onChange={(e) => setLocalSearch(e.target.value)}
-          placeholder="Search clusters..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={search}
+        onChange={setSearch}
+        placeholder="Search clusters..."
+        className="mb-3"
+      />
 
       {/* Clusters list */}
       <div className="flex-1 space-y-2 overflow-y-auto">
@@ -601,18 +562,14 @@ Please proceed step by step and ask for confirmation before making any changes.`
       </div>
 
       {/* Pagination */}
-      {needsPagination && limit !== 'unlimited' && (
-        <div className="pt-2 border-t border-border/50 mt-2">
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            totalItems={totalItems}
-            itemsPerPage={perPage}
-            onPageChange={goToPage}
-            showItemsPerPage={false}
-          />
-        </div>
-      )}
+      <CardPaginationFooter
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 10}
+        onPageChange={goToPage}
+        needsPagination={needsPagination}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Adopt centralized `useCardData` hook from `cardHooks.ts` across 25 card components, replacing manual `useState`/`useMemo`/`usePagination` filter/sort/pagination patterns
- Net reduction of **~1,150 lines** of duplicated state management code
- Replace `useChartFilters`, `CardControls`, `usePagination`, and manual search/sort `useMemo` blocks with unified `useCardData` + `CardSearchInput` + `CardControlsRow` + `CardPaginationFooter`

### Cards converted (25):
AlertRules, AppStatus, ArgoCDApplications, CRDHealth, ClusterHealth, DeploymentProgress, DeploymentStatus, GPUInventory, GPUStatus, GPUWorkloads, GatewayStatus, GitOpsDrift, HelmReleaseStatus, KustomizationStatus, NamespaceEvents, OperatorStatus, PVCStatus, ServiceExports, ServiceImports, UpgradeStatus, WorkloadDeployment, LLMInference, MLJobs, ProwHistory, ProwJobs

### Pattern applied (before → after):
```tsx
// BEFORE (~30 lines of manual state per card)
const [sortBy, setSortBy] = useState('name')
const [sortDir, setSortDir] = useState<'asc'|'desc'>('asc')
const [limit, setLimit] = useState(5)
const [search, setSearch] = useState('')
const { localClusterFilter, ... } = useChartFilters(...)
const filtered = useMemo(() => items.filter(...), [...])
const sorted = useMemo(() => filtered.sort(...), [...])
const { paginatedItems, ... } = usePagination(sorted, limit)

// AFTER (~10 lines with useCardData)
const { items, filters, sorting, ... } = useCardData(rawItems, {
  filter: { searchFields: [...], clusterField: 'cluster', storageKey: '...' },
  sort: { defaultField: '...', comparators: { ... } },
  defaultLimit: 5,
})
```

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds (16.98s)
- [ ] Navigate to dashboards with converted cards — verify rendering
- [ ] Verify search, sort, cluster filter, pagination still work on each card
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)