### PR TITLE
🌱 Refactor: Adopt useCardData hook across 12 more card components (#181)

### DIFF
--- a/web/src/components/cards/ChartVersions.tsx
+++ b/web/src/components/cards/ChartVersions.tsx
@@ -1,11 +1,11 @@
-import { useState, useMemo, useRef, useEffect } from 'react'
-import { Search, Package, Filter, ChevronDown, Server } from 'lucide-react'
+import { useMemo } from 'react'
+import { Package } from 'lucide-react'
 import { useClusters, useHelmReleases } from '../../hooks/useMCP'
-import { useGlobalFilters } from '../../hooks/useGlobalFilters'
-import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { Pagination, usePagination } from '../ui/Pagination'
+import {
+  useCardData, commonComparators,
+  CardSkeleton, CardSearchInput, CardControlsRow, CardPaginationFooter,
+} from '../../lib/cards'
 
 interface ChartVersionsProps {
   config?: {
@@ -30,54 +30,7 @@ const SORT_OPTIONS = [
 ]
 
 export function ChartVersions({ config: _config }: ChartVersionsProps) {
-  const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
-  const [sortBy, setSortBy] = useState<SortByOption>('name')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-  const [limit, setLimit] = useState<number | 'unlimited'>(5)
-  const [localSearch, setLocalSearch] = useState('')
-  const [localClusterFilter, setLocalClusterFilter] = useState<string[]>(() => {
-    // Load from localStorage
-    try {
-      const saved = localStorage.getItem('kubestellar-card-filter:chart-versions')
-      return saved ? JSON.parse(saved) : []
-    } catch { return [] }
-  })
-  const [showClusterFilter, setShowClusterFilter] = useState(false)
-  const clusterFilterRef = useRef<HTMLDivElement>(null)
-  const {
-    selectedClusters: globalSelectedClusters,
-    isAllClustersSelected,
-    customFilter,
-  } = useGlobalFilters()
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (clusterFilterRef.current && !clusterFilterRef.current.contains(event.target as Node)) {
-        setShowClusterFilter(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
-
-  // Save cluster filter to localStorage
-  useEffect(() => {
-    localStorage.setItem('kubestellar-card-filter:chart-versions', JSON.stringify(localClusterFilter))
-  }, [localClusterFilter])
-
-  const toggleClusterFilter = (clusterName: string) => {
-    setLocalClusterFilter(prev => {
-      if (prev.includes(clusterName)) {
-        return prev.filter(c => c !== clusterName)
-      }
-      return [...prev, clusterName]
-    })
-  }
-
-  const clearClusterFilter = () => {
-    setLocalClusterFilter([])
-  }
+  const { isLoading: clustersLoading } = useClusters()
 
   // Fetch ALL Helm releases once - filter locally
   const {
@@ -88,39 +41,9 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
   // Only show skeleton when no cached data exists
   const isLoading = (clustersLoading || releasesLoading) && allHelmReleases.length === 0
 
-  // Filter by selected clusters locally (no API call)
-  const helmReleases = useMemo(() => {
-    if (localClusterFilter.length === 0) return allHelmReleases
-    return allHelmReleases.filter(r => r.cluster && localClusterFilter.includes(r.cluster))
-  }, [allHelmReleases, localClusterFilter])
-
-  // Get reachable clusters
-  const reachableClusters = useMemo(() => {
-    return allClusters.filter(c => c.reachable !== false)
-  }, [allClusters])
-
-  // Apply global filters to get available clusters
-  const availableClustersForFilter = useMemo(() => {
-    let result = reachableClusters
-
-    if (!isAllClustersSelected) {
-      result = result.filter(c => globalSelectedClusters.includes(c.name))
-    }
-
-    if (customFilter.trim()) {
-      const query = customFilter.toLowerCase()
-      result = result.filter(c =>
-        c.name.toLowerCase().includes(query) ||
-        c.context?.toLowerCase().includes(query)
-      )
-    }
-
-    return result
-  }, [reachableClusters, globalSelectedClusters, isAllClustersSelected, customFilter])
-
   // Transform Helm releases to chart info
   const allCharts: ChartInfo[] = useMemo(() => {
-    return helmReleases.map(r => {
+    return allHelmReleases.map(r => {
       // Parse chart name and version (e.g., "prometheus-25.8.0" -> chart: "prometheus", version: "25.8.0")
       const chartParts = r.chart.match(/^(.+)-(\d+\.\d+\.\d+.*)$/)
       const chartName = chartParts ? chartParts[1] : r.chart
@@ -134,151 +57,90 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
         cluster: r.cluster,
       }
     })
-  }, [helmReleases])
+  }, [allHelmReleases])
 
-  // Filter and sort
-  const filteredAndSorted = useMemo(() => {
-    let result = [...allCharts]
-
-    // Apply custom text filter (global)
-    if (customFilter.trim()) {
-      const query = customFilter.toLowerCase()
-      result = result.filter(c =>
-        c.name.toLowerCase().includes(query) ||
-        c.chart.toLowerCase().includes(query) ||
-        c.namespace.toLowerCase().includes(query) ||
-        c.version.toLowerCase().includes(query)
-      )
-    }
-
-    // Apply local search filter
-    if (localSearch.trim()) {
-      const query = localSearch.toLowerCase()
-      result = result.filter(c =>
-        c.name.toLowerCase().includes(query) ||
-        c.chart.toLowerCase().includes(query) ||
-        c.namespace.toLowerCase().includes(query) ||
-        c.version.toLowerCase().includes(query)
-      )
-    }
-
-    // Sort
-    result.sort((a, b) => {
-      let compare = 0
-      switch (sortBy) {
-        case 'name':
-          compare = a.name.localeCompare(b.name)
-          break
-        case 'chart':
-          compare = a.chart.localeCompare(b.chart)
-          break
-        case 'namespace':
-          compare = a.namespace.localeCompare(b.namespace)
-          break
-      }
-      return sortDirection === 'asc' ? compare : -compare
-    })
-
-    return result
-  }, [allCharts, customFilter, localSearch, sortBy, sortDirection])
-
-  // Use pagination hook
-  const effectivePerPage = limit === 'unlimited' ? 1000 : limit
+  // Use shared card data hook for filtering, sorting, and pagination
   const {
-    paginatedItems: charts,
+    items: charts,
+    totalItems,
     currentPage,
     totalPages,
-    totalItems,
-    itemsPerPage: perPage,
+    itemsPerPage,
     goToPage,
     needsPagination,
-  } = usePagination(filteredAndSorted, effectivePerPage)
+    setItemsPerPage,
+    filters: {
+      search: localSearch,
+      setSearch: setLocalSearch,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters: availableClustersForFilter,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+  } = useCardData<ChartInfo, SortByOption>(allCharts, {
+    filter: {
+      searchFields: ['name', 'chart', 'namespace', 'version'],
+      clusterField: 'cluster',
+      storageKey: 'chart-versions',
+    },
+    sort: {
+      defaultField: 'name',
+      defaultDirection: 'asc',
+      comparators: {
+        name: commonComparators.string('name'),
+        chart: commonComparators.string('chart'),
+        namespace: commonComparators.string('namespace'),
+      },
+    },
+    defaultLimit: 5,
+  })
 
   // Count unique charts
   const uniqueCharts = new Set(allCharts.map(c => c.chart)).size
 
   if (isLoading) {
-    return (
-      <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-4">
-          <Skeleton variant="text" width={130} height={20} />
-          <Skeleton variant="rounded" width={120} height={32} />
-        </div>
-        <div className="space-y-2">
-          <Skeleton variant="rounded" height={50} />
-          <Skeleton variant="rounded" height={50} />
-          <Skeleton variant="rounded" height={50} />
-        </div>
-      </div>
-    )
+    return <CardSkeleton type="list" rows={3} showHeader rowHeight={50} />
   }
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-2">
-          {localClusterFilter.length > 0 && (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
-              <Server className="w-3 h-3" />
-              {localClusterFilter.length}/{availableClustersForFilter.length}
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          {/* Cluster Filter */}
-          {availableClustersForFilter.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClustersForFilter.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-          <CardControls
-            limit={limit}
-            onLimitChange={setLimit}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
-        </div>
+        <div className="flex items-center gap-2" />
+        <CardControlsRow
+          clusterIndicator={{
+            selectedCount: localClusterFilter.length,
+            totalCount: availableClustersForFilter.length,
+          }}
+          clusterFilter={{
+            availableClusters: availableClustersForFilter,
+            selectedClusters: localClusterFilter,
+            onToggle: toggleClusterFilter,
+            onClear: clearClusterFilter,
+            isOpen: showClusterFilter,
+            setIsOpen: setShowClusterFilter,
+            containerRef: clusterFilterRef,
+            minClusters: 1,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => setSortBy(v as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+        />
       </div>
 
       {availableClustersForFilter.length === 0 ? (
@@ -288,16 +150,12 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
       ) : (
         <>
           {/* Local Search */}
-          <div className="relative mb-4">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-            <input
-              type="text"
-              value={localSearch}
-              onChange={(e) => setLocalSearch(e.target.value)}
-              placeholder="Search charts..."
-              className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-            />
-          </div>
+          <CardSearchInput
+            value={localSearch}
+            onChange={setLocalSearch}
+            placeholder="Search charts..."
+            className="mb-4"
+          />
 
           {/* Summary */}
           <div className="flex gap-2 mb-4">
@@ -341,18 +199,14 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
           </div>
 
           {/* Pagination */}
-          {needsPagination && limit !== 'unlimited' && (
-            <div className="pt-2 border-t border-border/50 mt-2">
-              <Pagination
-                currentPage={currentPage}
-                totalPages={totalPages}
-                totalItems={totalItems}
-                itemsPerPage={perPage}
-                onPageChange={goToPage}
-                showItemsPerPage={false}
-              />
-            </div>
-          )}
+          <CardPaginationFooter
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalItems={totalItems}
+            itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 5}
+            onPageChange={goToPage}
+            needsPagination={needsPagination && itemsPerPage !== 'unlimited'}
+          />
 
           {/* Footer */}
           <div className="mt-4 pt-3 border-t border-border/50 text-xs text-muted-foreground">

--- a/web/src/components/cards/EventStream.tsx
+++ b/web/src/components/cards/EventStream.tsx
@@ -1,14 +1,14 @@
-import { useState, useMemo } from 'react'
-import { AlertTriangle, Info, XCircle, ChevronRight, Search, Filter, ChevronDown, Server } from 'lucide-react'
+import { AlertTriangle, Info, XCircle, ChevronRight } from 'lucide-react'
 import { useCachedEvents } from '../../hooks/useCachedData'
+import type { ClusterEvent } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { Pagination, usePagination } from '../ui/Pagination'
 import { LimitedAccessWarning } from '../ui/LimitedAccessWarning'
-import { Skeleton } from '../ui/Skeleton'
-import { useChartFilters } from '../../lib/cards'
+import {
+  useCardData, commonComparators,
+  CardSkeleton, CardSearchInput,
+  CardControlsRow, CardPaginationFooter,
+} from '../../lib/cards'
 
 type SortByOption = 'time' | 'count' | 'type'
 
@@ -19,87 +19,66 @@ const SORT_OPTIONS = [
 ]
 
 export function EventStream() {
-  const [itemsPerPage, setItemsPerPage] = useState<number | 'unlimited'>(5)
-  const [sortBy, setSortBy] = useState<SortByOption>('time')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
-  const [searchQuery, setSearchQuery] = useState('')
   // Fetch more events from API to enable pagination (using cached data hook)
   const {
     events: rawEvents,
     isLoading: hookLoading,
     error,
   } = useCachedEvents(undefined, undefined, { limit: 100, category: 'realtime' })
-  const { filterByCluster } = useGlobalFilters()
-
-  // Local cluster filter
-  const {
-    localClusterFilter,
-    toggleClusterFilter,
-    clearClusterFilter,
-    availableClusters,
-    showClusterFilter,
-    setShowClusterFilter,
-    clusterFilterRef,
-  } = useChartFilters({
-    storageKey: 'event-stream',
-  })
 
   // Only show skeleton when no cached data exists
   const isLoading = hookLoading && rawEvents.length === 0
 
-  // Filter and sort events
-  const filteredAndSorted = useMemo(() => {
-    let filtered = filterByCluster(rawEvents)
-
-    // Apply local cluster filter
-    if (localClusterFilter.length > 0) {
-      filtered = filtered.filter(event => {
-        const clusterName = event.cluster || 'default'
-        return localClusterFilter.includes(clusterName)
-      })
-    }
-
-    // Apply search filter
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase()
-      filtered = filtered.filter(event =>
-        event.message.toLowerCase().includes(query) ||
-        event.object.toLowerCase().includes(query) ||
-        event.namespace.toLowerCase().includes(query) ||
-        event.type.toLowerCase().includes(query) ||
-        (event.cluster?.toLowerCase() || '').includes(query)
-      )
-    }
-
-    const sorted = [...filtered].sort((a, b) => {
-      let result = 0
-      if (sortBy === 'count') result = b.count - a.count
-      else if (sortBy === 'type') result = a.type.localeCompare(b.type)
-      // 'time' - keep original order (already sorted by time desc)
-      return sortDirection === 'asc' ? -result : result
-    })
-    return sorted
-  }, [rawEvents, sortBy, sortDirection, filterByCluster, searchQuery, localClusterFilter])
-
-  // Use pagination hook
-  const effectivePerPage = itemsPerPage === 'unlimited' ? 1000 : itemsPerPage
+  // Use shared card data hook for filtering, sorting, and pagination
   const {
-    paginatedItems: events,
+    items: events,
     currentPage,
     totalPages,
     totalItems,
-    itemsPerPage: perPage,
+    itemsPerPage,
     goToPage,
     needsPagination,
-  } = usePagination(filteredAndSorted, effectivePerPage)
+    setItemsPerPage,
+    filters: {
+      search: localSearch,
+      setSearch: setLocalSearch,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+  } = useCardData<ClusterEvent, SortByOption>(rawEvents, {
+    filter: {
+      searchFields: ['message', 'object', 'namespace', 'type'],
+      clusterField: 'cluster',
+      customPredicate: (event, query) =>
+        (event.cluster?.toLowerCase() || '').includes(query),
+      storageKey: 'event-stream',
+    },
+    sort: {
+      defaultField: 'time',
+      defaultDirection: 'desc',
+      comparators: {
+        time: () => 0, // Keep original order (already sorted by time desc)
+        count: commonComparators.number('count'),
+        type: commonComparators.string('type'),
+      },
+    },
+    defaultLimit: 5,
+  })
+
   const { drillToEvents, drillToPod, drillToDeployment } = useDrillDownActions()
 
-  const handleSearchChange = (query: string) => {
-    setSearchQuery(query)
-    goToPage(1)
-  }
-
-  const handleEventClick = (event: typeof events[0]) => {
+  const handleEventClick = (event: ClusterEvent) => {
     // Parse object to get resource type and name
     const [resourceType, resourceName] = event.object.split('/')
     const cluster = event.cluster || 'default'
@@ -125,100 +104,48 @@ export function EventStream() {
   }
 
   if (isLoading) {
-    return (
-      <div className="h-full flex flex-col min-h-card">
-        <div className="flex items-center justify-between mb-3">
-          <Skeleton variant="text" width={100} height={16} />
-          <Skeleton variant="rounded" width={80} height={28} />
-        </div>
-        <div className="space-y-2">
-          <Skeleton variant="rounded" height={60} />
-          <Skeleton variant="rounded" height={60} />
-          <Skeleton variant="rounded" height={60} />
-        </div>
-      </div>
-    )
+    return <CardSkeleton type="list" rows={3} showHeader rowHeight={60} />
   }
 
   return (
     <div className="h-full flex flex-col content-loaded">
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2">
-          {localClusterFilter.length > 0 && (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
-              <Server className="w-3 h-3" />
-              {localClusterFilter.length}/{availableClusters.length}
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          {/* Cluster Filter */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-          <CardControls
-            limit={itemsPerPage}
-            onLimitChange={setItemsPerPage}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
-        </div>
+        <div className="flex items-center gap-2" />
+        <CardControlsRow
+          clusterIndicator={{
+            selectedCount: localClusterFilter.length,
+            totalCount: availableClusters.length,
+          }}
+          clusterFilter={{
+            availableClusters,
+            selectedClusters: localClusterFilter,
+            onToggle: toggleClusterFilter,
+            onClear: clearClusterFilter,
+            isOpen: showClusterFilter,
+            setIsOpen: setShowClusterFilter,
+            containerRef: clusterFilterRef,
+            minClusters: 1,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => setSortBy(v as SortByOption),
+            sortDirection,
+            onSortDirectionChange: setSortDirection,
+          }}
+        />
       </div>
 
       {/* Search */}
-      <div className="relative mb-3">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={searchQuery}
-          onChange={(e) => handleSearchChange(e.target.value)}
-          placeholder="Search events..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={localSearch}
+        onChange={setLocalSearch}
+        placeholder="Search events..."
+        className="mb-3"
+      />
 
       {/* Event list */}
       <div className="flex-1 space-y-2 overflow-y-auto min-h-card-content">
@@ -266,18 +193,14 @@ export function EventStream() {
       </div>
 
       {/* Pagination */}
-      {needsPagination && itemsPerPage !== 'unlimited' && (
-        <div className="pt-2 border-t border-border/50 mt-2">
-          <Pagination
-            currentPage={currentPage}
-            totalPages={totalPages}
-            totalItems={totalItems}
-            itemsPerPage={perPage}
-            onPageChange={goToPage}
-            showItemsPerPage={false}
-          />
-        </div>
-      )}
+      <CardPaginationFooter
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 1000}
+        onPageChange={goToPage}
+        needsPagination={needsPagination}
+      />
 
       <LimitedAccessWarning hasError={!!error} className="mt-2" />
     </div>

--- a/web/src/components/cards/NamespaceRBAC.tsx
+++ b/web/src/components/cards/NamespaceRBAC.tsx
@@ -1,13 +1,12 @@
 import { useState, useMemo } from 'react'
-import { Users, Key, Lock, ChevronRight, Search, Server, Filter, ChevronDown } from 'lucide-react'
+import { Users, Key, Lock, ChevronRight } from 'lucide-react'
 import { useClusters, useNamespaces, useK8sRoles, useK8sRoleBindings, useK8sServiceAccounts } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { CardControls, SortDirection } from '../ui/CardControls'
-import { Pagination, usePagination } from '../ui/Pagination'
-import { useChartFilters } from '../../lib/cards'
+import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 
 interface NamespaceRBACProps {
   config?: {
@@ -38,16 +37,6 @@ export function NamespaceRBAC({ config }: NamespaceRBACProps) {
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const [selectedNamespace, setSelectedNamespace] = useState<string>(config?.namespace || '')
   const [activeTab, setActiveTab] = useState<'roles' | 'bindings' | 'serviceaccounts'>('roles')
-  const [sortBy, setSortBy] = useState<SortByOption>('name')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-  const [limit, setLimit] = useState<number | 'unlimited'>(5)
-  const [localSearch, setLocalSearch] = useState('')
-
-  // Local cluster filter
-  const {
-    localClusterFilter, toggleClusterFilter, clearClusterFilter,
-    availableClusters, showClusterFilter, setShowClusterFilter, clusterFilterRef,
-  } = useChartFilters({ storageKey: 'namespace-rbac' })
 
   // Fetch namespaces for the selected cluster (requires a cluster to be selected)
   const { namespaces } = useNamespaces(selectedCluster || undefined)
@@ -78,86 +67,83 @@ export function NamespaceRBAC({ config }: NamespaceRBACProps) {
   const isLoading = isInitialLoading
   const showSkeleton = isLoading && clusters.length === 0
 
-  // Transform RBAC data to the display format
-  const rbacData = useMemo(() => {
-    if (!selectedCluster || !selectedNamespace) {
-      return { roles: [], bindings: [], serviceaccounts: [] }
-    }
-
-    // Sort function
-    const sortItems = (items: RBACItem[]) => {
-      return [...items].sort((a, b) => {
-        let compare = 0
-        switch (sortBy) {
-          case 'name':
-            compare = a.name.localeCompare(b.name)
-            break
-          case 'rules':
-            compare = (a.rules || 0) - (b.rules || 0)
-            break
-        }
-        return sortDirection === 'asc' ? compare : -compare
-      })
-    }
-
-    // Filter function for local search
-    const filterItems = (items: RBACItem[]) => {
-      if (!localSearch.trim()) return items
-      const query = localSearch.toLowerCase()
-      return items.filter(item =>
-        item.name.toLowerCase().includes(query) ||
-        (item.subjects || []).some(s => s.toLowerCase().includes(query))
-      )
-    }
-
-    // Transform roles to RBACItem format
-    const roles: RBACItem[] = sortItems(filterItems(k8sRoles
+  // Transform raw RBAC data into RBACItem arrays (no filtering/sorting — that's handled by useCardData)
+  const rbacRoles: RBACItem[] = useMemo(() => {
+    if (!selectedCluster || !selectedNamespace) return []
+    return k8sRoles
       .filter(r => !r.namespace || r.namespace === selectedNamespace)
       .map(r => ({
         name: r.name,
         type: 'Role' as const,
         rules: r.ruleCount,
         cluster: r.cluster,
-      }))))
+      }))
+  }, [selectedCluster, selectedNamespace, k8sRoles])
 
-    // Transform bindings to RBACItem format
-    const bindings: RBACItem[] = sortItems(filterItems(k8sBindings
+  const rbacBindings: RBACItem[] = useMemo(() => {
+    if (!selectedCluster || !selectedNamespace) return []
+    return k8sBindings
       .filter(b => !b.namespace || b.namespace === selectedNamespace)
       .map(b => ({
         name: b.name,
         type: 'RoleBinding' as const,
         subjects: b.subjects.map(s => s.name),
         cluster: b.cluster,
-      }))))
+      }))
+  }, [selectedCluster, selectedNamespace, k8sBindings])
 
-    // Transform service accounts to RBACItem format
-    const serviceaccounts: RBACItem[] = sortItems(filterItems(k8sServiceAccounts
+  const rbacServiceAccounts: RBACItem[] = useMemo(() => {
+    if (!selectedCluster || !selectedNamespace) return []
+    return k8sServiceAccounts
       .filter(sa => sa.namespace === selectedNamespace)
       .map(sa => ({
         name: sa.name,
         type: 'ServiceAccount' as const,
         cluster: sa.cluster,
-      }))))
+      }))
+  }, [selectedCluster, selectedNamespace, k8sServiceAccounts])
 
-    return { roles, bindings, serviceaccounts }
-  }, [selectedCluster, selectedNamespace, k8sRoles, k8sBindings, k8sServiceAccounts, sortBy, sortDirection, localSearch])
+  // Select the active tab's data
+  const activeTabItems = activeTab === 'roles'
+    ? rbacRoles
+    : activeTab === 'bindings'
+      ? rbacBindings
+      : rbacServiceAccounts
 
-  // Pagination for current tab
-  const effectivePerPage = limit === 'unlimited' ? 1000 : limit
+  // Apply useCardData for filtering, sorting, and pagination on the active tab
   const {
-    paginatedItems: paginatedItems,
+    items: paginatedItems,
+    totalItems,
     currentPage,
     totalPages,
-    totalItems,
-    itemsPerPage: perPage,
+    itemsPerPage,
     goToPage,
     needsPagination,
-  } = usePagination(rbacData[activeTab], effectivePerPage)
+    setItemsPerPage,
+    filters,
+    sorting,
+  } = useCardData<RBACItem, SortByOption>(activeTabItems, {
+    filter: {
+      searchFields: ['name'] as (keyof RBACItem)[],
+      storageKey: 'namespace-rbac',
+      customPredicate: (item, query) =>
+        (item.subjects || []).some(s => s.toLowerCase().includes(query)),
+    },
+    sort: {
+      defaultField: 'name',
+      defaultDirection: 'asc',
+      comparators: {
+        name: commonComparators.string<RBACItem>('name'),
+        rules: commonComparators.number<RBACItem>('rules'),
+      },
+    },
+    defaultLimit: 5,
+  })
 
   const tabs = [
-    { key: 'roles' as const, label: 'Roles', icon: Key, count: rbacData.roles.length },
-    { key: 'bindings' as const, label: 'Bindings', icon: Lock, count: rbacData.bindings.length },
-    { key: 'serviceaccounts' as const, label: 'SAs', icon: Users, count: rbacData.serviceaccounts.length },
+    { key: 'roles' as const, label: 'Roles', icon: Key, count: rbacRoles.length },
+    { key: 'bindings' as const, label: 'Bindings', icon: Lock, count: rbacBindings.length },
+    { key: 'serviceaccounts' as const, label: 'SAs', icon: Users, count: rbacServiceAccounts.length },
   ]
 
   if (showSkeleton) {
@@ -183,72 +169,34 @@ export function NamespaceRBAC({ config }: NamespaceRBACProps) {
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
-            {activeTab === 'roles' ? `${rbacData.roles.length} roles` : activeTab === 'bindings' ? `${rbacData.bindings.length} bindings` : `${rbacData.serviceaccounts.length} service accounts`}
+            {activeTab === 'roles' ? `${rbacRoles.length} roles` : activeTab === 'bindings' ? `${rbacBindings.length} bindings` : `${rbacServiceAccounts.length} service accounts`}
           </span>
         </div>
-        <div className="flex items-center gap-2">
-          {/* Cluster count indicator */}
-          {localClusterFilter.length > 0 && (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
-              <Server className="w-3 h-3" />
-              {localClusterFilter.length}/{availableClusters.length}
-            </span>
-          )}
-
-          {/* Cluster filter dropdown */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && (
-                <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(c => (
-                      <button
-                        key={c.name}
-                        onClick={() => toggleClusterFilter(c.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(c.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {c.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
-          <CardControls
-            limit={limit}
-            onLimitChange={setLimit}
-            sortBy={sortBy}
-            sortOptions={SORT_OPTIONS}
-            onSortChange={setSortBy}
-            sortDirection={sortDirection}
-            onSortDirectionChange={setSortDirection}
-          />
-        </div>
+        <CardControlsRow
+          clusterIndicator={{
+            selectedCount: filters.localClusterFilter.length,
+            totalCount: filters.availableClusters.length,
+          }}
+          clusterFilter={{
+            availableClusters: filters.availableClusters,
+            selectedClusters: filters.localClusterFilter,
+            onToggle: filters.toggleClusterFilter,
+            onClear: filters.clearClusterFilter,
+            isOpen: filters.showClusterFilter,
+            setIsOpen: filters.setShowClusterFilter,
+            containerRef: filters.clusterFilterRef,
+          }}
+          cardControls={{
+            limit: itemsPerPage,
+            onLimitChange: setItemsPerPage,
+            sortBy: sorting.sortBy,
+            sortOptions: SORT_OPTIONS,
+            onSortChange: (v) => sorting.setSortBy(v as SortByOption),
+            sortDirection: sorting.sortDirection,
+            onSortDirectionChange: sorting.setSortDirection,
+          }}
+          className="mb-0"
+        />
       </div>
 
       {/* Selectors */}
@@ -286,16 +234,12 @@ export function NamespaceRBAC({ config }: NamespaceRBACProps) {
       ) : (
         <>
           {/* Local Search */}
-          <div className="relative mb-4">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-            <input
-              type="text"
-              value={localSearch}
-              onChange={(e) => setLocalSearch(e.target.value)}
-              placeholder="Search RBAC..."
-              className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-            />
-          </div>
+          <CardSearchInput
+            value={filters.search}
+            onChange={filters.setSearch}
+            placeholder="Search RBAC..."
+            className="mb-4"
+          />
 
           {/* Scope badge */}
           <div className="flex items-center gap-2 mb-4">
@@ -374,24 +318,20 @@ export function NamespaceRBAC({ config }: NamespaceRBACProps) {
           </div>
 
           {/* Pagination */}
-          {needsPagination && limit !== 'unlimited' && (
-            <div className="pt-2 border-t border-border/50 mt-2">
-              <Pagination
-                currentPage={currentPage}
-                totalPages={totalPages}
-                totalItems={totalItems}
-                itemsPerPage={perPage}
-                onPageChange={goToPage}
-                showItemsPerPage={false}
-              />
-            </div>
-          )}
+          <CardPaginationFooter
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalItems={totalItems}
+            itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : totalItems}
+            onPageChange={goToPage}
+            needsPagination={needsPagination}
+          />
 
           {/* Summary */}
           <div className="mt-4 pt-3 border-t border-border/50 flex items-center justify-between text-xs text-muted-foreground">
-            <span>{rbacData.roles.length} Roles</span>
-            <span>{rbacData.bindings.length} Bindings</span>
-            <span>{rbacData.serviceaccounts.length} ServiceAccounts</span>
+            <span>{rbacRoles.length} Roles</span>
+            <span>{rbacBindings.length} Bindings</span>
+            <span>{rbacServiceAccounts.length} ServiceAccounts</span>
           </div>
         </>
       )}

--- a/web/src/components/cards/RecentEvents.tsx
+++ b/web/src/components/cards/RecentEvents.tsx
@@ -1,14 +1,17 @@
 import { useMemo } from 'react'
-import { Clock, AlertTriangle, CheckCircle2, Activity, Server, ChevronDown } from 'lucide-react'
+import { Clock, AlertTriangle, CheckCircle2, Activity } from 'lucide-react'
 import { useCachedEvents } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { Pagination, usePagination } from '../ui/Pagination'
 import { RefreshButton } from '../ui/RefreshIndicator'
 import { Skeleton } from '../ui/Skeleton'
-import { useChartFilters } from '../../lib/cards'
+import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
+import { CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
+import type { ClusterEvent } from '../../lib/kubectlProxy'
 
 const ONE_HOUR_MS = 60 * 60 * 1000
+
+type SortByOption = 'time' | 'reason' | 'object'
 
 function getMinutesAgo(timestamp: string | undefined): string {
   if (!timestamp) return 'Unknown'
@@ -31,31 +34,43 @@ export function RecentEvents() {
   } = useCachedEvents(undefined, undefined, { limit: 100, category: 'realtime' })
   const { filterByCluster } = useGlobalFilters()
 
-  const {
-    localClusterFilter,
-    toggleClusterFilter,
-    clearClusterFilter,
-    availableClusters,
-    showClusterFilter,
-    setShowClusterFilter,
-    clusterFilterRef,
-  } = useChartFilters({
-    storageKey: 'recent-events',
-  })
-
-  const recentEvents = useMemo(() => {
+  // Pre-filter to events within the last hour (before handing to useCardData)
+  const recentEventsCandidates = useMemo(() => {
     const cutoff = Date.now() - ONE_HOUR_MS
-    let result = filterByCluster(events).filter(e => {
+    return filterByCluster(events).filter(e => {
       if (!e.lastSeen) return false
       return new Date(e.lastSeen).getTime() >= cutoff
     })
-    if (localClusterFilter.length > 0) {
-      result = result.filter(e => e.cluster && localClusterFilter.includes(e.cluster))
-    }
-    return result
-  }, [events, filterByCluster, localClusterFilter])
+  }, [events, filterByCluster])
 
-  const { paginatedItems, currentPage, totalPages, goToPage, needsPagination, itemsPerPage, setPerPage } = usePagination(recentEvents, 5)
+  const {
+    items: paginatedItems,
+    totalItems,
+    currentPage,
+    totalPages,
+    itemsPerPage,
+    goToPage,
+    needsPagination,
+    setItemsPerPage,
+    filters,
+    sorting,
+  } = useCardData<ClusterEvent, SortByOption>(recentEventsCandidates, {
+    filter: {
+      searchFields: ['reason', 'object', 'message', 'namespace'],
+      clusterField: 'cluster',
+      storageKey: 'recent-events',
+    },
+    sort: {
+      defaultField: 'time',
+      defaultDirection: 'desc',
+      comparators: {
+        time: commonComparators.date<ClusterEvent>('lastSeen'),
+        reason: commonComparators.string<ClusterEvent>('reason'),
+        object: commonComparators.string<ClusterEvent>('object'),
+      },
+    },
+    defaultLimit: 5,
+  })
 
   if (isLoading) {
     return (
@@ -67,7 +82,7 @@ export function RecentEvents() {
     )
   }
 
-  const warningCount = recentEvents.filter(e => e.type === 'Warning').length
+  const warningCount = recentEventsCandidates.filter(e => e.type === 'Warning').length
 
   return (
     <div className="space-y-3">
@@ -76,41 +91,37 @@ export function RecentEvents() {
         <div className="flex items-center gap-2">
           <Clock className="w-3.5 h-3.5 text-blue-400" />
           <span className="text-xs text-muted-foreground">
-            {recentEvents.length} event{recentEvents.length !== 1 ? 's' : ''} in last hour
+            {totalItems} event{totalItems !== 1 ? 's' : ''} in last hour
             {warningCount > 0 && (
               <span className="text-yellow-400 ml-1">({warningCount} warning{warningCount !== 1 ? 's' : ''})</span>
             )}
           </span>
         </div>
         <div className="flex items-center gap-2">
-          {availableClusters.length > 1 && (
-            <div className="relative" ref={clusterFilterRef}>
-              <button
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 transition-colors"
-              >
-                <Server className="w-3 h-3" />
-                {localClusterFilter.length > 0 ? `${localClusterFilter.length} cluster${localClusterFilter.length > 1 ? 's' : ''}` : 'All'}
-                <ChevronDown className="w-3 h-3" />
-              </button>
-              {showClusterFilter && (
-                <div className="absolute right-0 top-full mt-1 z-50 bg-card border border-border rounded-lg shadow-lg p-2 min-w-[160px]">
-                  <button onClick={clearClusterFilter} className="w-full text-left text-xs px-2 py-1 rounded hover:bg-secondary text-muted-foreground">
-                    All Clusters
-                  </button>
-                  {availableClusters.map(cluster => (
-                    <button
-                      key={cluster.name}
-                      onClick={() => toggleClusterFilter(cluster.name)}
-                      className={`w-full text-left text-xs px-2 py-1 rounded hover:bg-secondary ${localClusterFilter.includes(cluster.name) ? 'text-foreground font-medium' : 'text-muted-foreground'}`}
-                    >
-                      {localClusterFilter.includes(cluster.name) ? '✓ ' : ''}{cluster.name}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
+          <CardControlsRow
+            clusterFilter={{
+              availableClusters: filters.availableClusters,
+              selectedClusters: filters.localClusterFilter,
+              onToggle: filters.toggleClusterFilter,
+              onClear: filters.clearClusterFilter,
+              isOpen: filters.showClusterFilter,
+              setIsOpen: filters.setShowClusterFilter,
+              containerRef: filters.clusterFilterRef,
+            }}
+            cardControls={{
+              limit: itemsPerPage,
+              onLimitChange: setItemsPerPage,
+              sortBy: sorting.sortBy,
+              sortOptions: [
+                { value: 'time', label: 'Time' },
+                { value: 'reason', label: 'Reason' },
+                { value: 'object', label: 'Object' },
+              ],
+              onSortChange: (v) => sorting.setSortBy(v as SortByOption),
+              sortDirection: sorting.sortDirection,
+              onSortDirectionChange: sorting.setSortDirection,
+            }}
+          />
           <RefreshButton
             isRefreshing={isRefreshing}
             onRefresh={refetch}
@@ -122,7 +133,7 @@ export function RecentEvents() {
       </div>
 
       {/* Recent events list */}
-      {recentEvents.length === 0 ? (
+      {totalItems === 0 ? (
         <div className="text-center py-6">
           <Activity className="w-8 h-8 mx-auto mb-2 text-muted-foreground opacity-50" />
           <p className="text-sm text-muted-foreground">No events in the last hour</p>
@@ -156,7 +167,7 @@ export function RecentEvents() {
                     <span className="text-xs text-foreground truncate">{event.object}</span>
                     {event.count > 1 && (
                       <span className="text-xs px-1 py-0.5 rounded bg-card text-muted-foreground">
-                        ×{event.count}
+                        x{event.count}
                       </span>
                     )}
                   </div>
@@ -176,16 +187,14 @@ export function RecentEvents() {
       )}
 
       {/* Pagination */}
-      {needsPagination && (
-        <Pagination
-          currentPage={currentPage}
-          totalPages={totalPages}
-          totalItems={recentEvents.length}
-          itemsPerPage={itemsPerPage}
-          onPageChange={goToPage}
-          onItemsPerPageChange={setPerPage}
-        />
-      )}
+      <CardPaginationFooter
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 5}
+        onPageChange={goToPage}
+        needsPagination={needsPagination}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Converts 12 card components from manual `useState`/`useMemo`/`usePagination` patterns to the centralized `useCardData` hook
- Replaces bespoke filter/sort/pagination UI with shared `CardSearchInput`, `CardControlsRow`, and `CardPaginationFooter` components
- Net reduction of ~317 lines across 12 files (979 insertions, 1296 deletions)

### Converted cards
| Card | Before | After | Δ |
|------|--------|-------|---|
| ChartVersions | Manual state | useCardData | -115 |
| EventStream | Manual state | useCardData | -46 |
| GPUOverview | Manual state | useCardData | -43 |
| HelmHistory | Manual state | useCardData | -42 |
| HelmValuesDiff | Manual state | useCardData | +24* |
| NamespaceRBAC | Manual state | useCardData | -64 |
| OpenCostOverview | Manual state | useCardData | -17 |
| OperatorSubscriptions | Manual state | useCardData | -50 |
| RecentEvents | Manual state | useCardData | -24 |
| WarningEvents | Manual state | useCardData | -10 |
| LLMModels | Manual state | useCardData | -10 |
| MLNotebooks | Manual state | useCardData | -20 |

*HelmValuesDiff gained lines from adding proper search/pagination that was previously missing.

Follows PR #240 which converted the first 25 cards.

## Test plan
- [x] `npx tsc --noEmit` — passes with zero errors
- [x] `npx vite build` — succeeds
- [ ] Navigate to dashboards containing affected cards — components render
- [ ] Verify filter/sort/pagination controls work on converted cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)