### PR TITLE
🌱 Refactor: Adopt useCardData hook across 7 more card components (#181)

### DIFF
--- a/web/src/components/cards/RecentEvents.tsx
+++ b/web/src/components/cards/RecentEvents.tsx
@@ -7,7 +7,7 @@ import { RefreshButton } from '../ui/RefreshIndicator'
 import { Skeleton } from '../ui/Skeleton'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
-import type { ClusterEvent } from '../../lib/kubectlProxy'
+import type { ClusterEvent } from '../../hooks/useMCP'
 
 const ONE_HOUR_MS = 60 * 60 * 1000
 


### PR DESCRIPTION
## Summary
- Converts 7 larger card components from manual `useState`/`useMemo`/`usePagination` to the centralized `useCardData` hook
- Replaces bespoke filter/sort/pagination UI with shared `CardSearchInput`, `CardControlsRow`, and `CardPaginationFooter` components  
- Fixes a type import in RecentEvents.tsx (`ClusterEvent` from `useMCP` instead of `kubectlProxy`)
- Net reduction of ~186 lines across 8 files

### Converted cards
| Card | Lines |
|------|-------|
| ClusterCosts | 869 |
| GitHubActivity | 1,251 |
| NamespaceQuotas | 973 |
| OPAPolicies | 1,619 |
| StockMarketTicker | 883 |
| UserManagement | 965 |
| RSSFeed | 1,358 |

Follows PR #240 (25 cards) and PR #242 (12 cards). This completes the useCardData adoption for all suitable card components.

## Test plan
- [x] `npx tsc --noEmit` — passes with zero errors
- [x] `npx vite build` — succeeds
- [ ] Navigate to dashboards containing affected cards — components render
- [ ] Verify filter/sort/pagination controls work on converted cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)