### PR TITLE
🐛 Eliminate page flash on dashboard navigation

### DIFF
--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -1664,7 +1664,7 @@ export function Clusters() {
     }
   }, [globalFilteredClusters, gpuByCluster])
 
-  if (isLoading) {
+  if (isLoading && clusters.length === 0) {
     return (
       <div className="pt-16">
         <div className="mb-6">

--- a/web/src/components/compliance/Compliance.tsx
+++ b/web/src/components/compliance/Compliance.tsx
@@ -342,7 +342,7 @@ export function Compliance() {
         dashboardType="compliance"
         getStatValue={getStatValue}
         hasData={posture.totalChecks > 0}
-        isLoading={isLoading}
+        isLoading={isLoading && clusters.length === 0}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-compliance-stats-collapsed"
       />

--- a/web/src/components/compute/ClusterComparisonPage.tsx
+++ b/web/src/components/compute/ClusterComparisonPage.tsx
@@ -62,7 +62,7 @@ export function ClusterComparisonPage() {
     navigate('/compute')
   }
 
-  if (isLoading) {
+  if (isLoading && clusters.length === 0) {
     return (
       <div className="pt-16">
         <div className="mb-6">

--- a/web/src/components/cost/Cost.tsx
+++ b/web/src/components/cost/Cost.tsx
@@ -395,7 +395,7 @@ export function Cost() {
         dashboardType="cost"
         getStatValue={getStatValue}
         hasData={reachableClusters.length > 0}
-        isLoading={isLoading}
+        isLoading={isLoading && clusters.length === 0}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-cost-stats-collapsed"
       />

--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -474,7 +474,7 @@ export function CustomDashboard() {
         dashboardType="dashboard"
         getStatValue={getStatValue}
         hasData={deduplicatedClusters.length > 0}
-        isLoading={isClustersLoading}
+        isLoading={isClustersLoading && deduplicatedClusters.length === 0}
         lastUpdated={lastUpdated}
         collapsedStorageKey={`kubestellar-custom-${id}-stats-collapsed`}
       />

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -774,7 +774,7 @@ export function Dashboard() {
   const hasDemoDataCards = localCards.some(c => DEMO_DATA_CARDS.has(c.card_type))
   const demoDataCardCount = localCards.filter(c => DEMO_DATA_CARDS.has(c.card_type)).length
 
-  if (isLoading) {
+  if (isLoading && localCards.length === 0) {
     return (
       <div className="pt-16">
         {/* Header skeleton */}
@@ -830,7 +830,7 @@ export function Dashboard() {
         dashboardType="dashboard"
         getStatValue={getStatValue}
         hasData={clusters.length > 0}
-        isLoading={isClustersLoading}
+        isLoading={isClustersLoading && clusters.length === 0}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-dashboard-stats-collapsed"
       />

--- a/web/src/components/data-compliance/DataCompliance.tsx
+++ b/web/src/components/data-compliance/DataCompliance.tsx
@@ -169,7 +169,7 @@ const DEMO_POSTURE = {
 
 export function DataCompliance() {
   const location = useLocation()
-  const { isLoading, refetch, lastUpdated, isRefreshing: dataRefreshing } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, refetch, lastUpdated, isRefreshing: dataRefreshing } = useClusters()
   const { showIndicator, triggerRefresh } = useRefreshIndicator(refetch)
   const isRefreshing = dataRefreshing || showIndicator
   const isFetching = isLoading || isRefreshing || showIndicator
@@ -325,7 +325,7 @@ export function DataCompliance() {
         dashboardType="data-compliance"
         getStatValue={getStatValue}
         hasData={true}
-        isLoading={isLoading}
+        isLoading={isLoading && clusters.length === 0}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-data-compliance-stats-collapsed"
         isDemoData={true}

--- a/web/src/components/deploy/Deploy.tsx
+++ b/web/src/components/deploy/Deploy.tsx
@@ -412,8 +412,8 @@ export function Deploy() {
       <StatsOverview
         dashboardType="deploy"
         getStatValue={getStatValue}
-        hasData={!deploymentsLoading}
-        isLoading={deploymentsLoading}
+        hasData={cachedDeployments.length > 0}
+        isLoading={deploymentsLoading && cachedDeployments.length === 0}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-deploy-stats-collapsed"
       />

--- a/web/src/components/deployments/Deployments.tsx
+++ b/web/src/components/deployments/Deployments.tsx
@@ -307,8 +307,8 @@ export function Deployments() {
       <StatsOverview
         dashboardType="workloads"
         getStatValue={getStatValue}
-        hasData={!isLoading}
-        isLoading={isLoading}
+        hasData={deployments.length > 0}
+        isLoading={isLoading && deployments.length === 0}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-deployments-stats-collapsed"
       />

--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -227,7 +227,7 @@ export function GPUReservations() {
     setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1))
   }
 
-  if (isLoading) {
+  if (isLoading && nodes.length === 0) {
     return (
       <div className="pt-16 flex items-center justify-center min-h-[400px]">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />

--- a/web/src/components/helm/HelmReleases.tsx
+++ b/web/src/components/helm/HelmReleases.tsx
@@ -265,7 +265,7 @@ export function HelmReleases() {
         dashboardType="gitops"
         getStatValue={getStatValue}
         hasData={reachableClusters.length > 0}
-        isLoading={isLoading}
+        isLoading={isLoading && clusters.length === 0}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-helm-stats-collapsed"
       />

--- a/web/src/components/logs/Logs.tsx
+++ b/web/src/components/logs/Logs.tsx
@@ -325,7 +325,7 @@ export function Logs() {
         dashboardType="events"
         getStatValue={getStatValue}
         hasData={reachableClusters.length > 0}
-        isLoading={isLoading}
+        isLoading={isLoading && clusters.length === 0}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-logs-stats-collapsed"
       />

--- a/web/src/components/nodes/Nodes.tsx
+++ b/web/src/components/nodes/Nodes.tsx
@@ -314,7 +314,7 @@ export function Nodes() {
         dashboardType="compute"
         getStatValue={getStatValue}
         hasData={totalNodes > 0}
-        isLoading={isLoading}
+        isLoading={isLoading && clusters.length === 0}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-nodes-stats-collapsed"
       />

--- a/web/src/components/operators/Operators.tsx
+++ b/web/src/components/operators/Operators.tsx
@@ -343,7 +343,7 @@ export function Operators() {
         dashboardType="operators"
         getStatValue={getStatValue}
         hasData={totalOperators > 0 || reachableClusters.length > 0}
-        isLoading={isLoading}
+        isLoading={isLoading && clusters.length === 0}
         lastUpdated={lastUpdated}
         collapsedStorageKey="kubestellar-operators-stats-collapsed"
       />

--- a/web/src/hooks/useMCP.ts
+++ b/web/src/hooks/useMCP.ts
@@ -2773,12 +2773,16 @@ export function useDeployments(cluster?: string, namespace?: string) {
   const [consecutiveFailures, setConsecutiveFailures] = useState(0)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(cached?.timestamp || null)
 
-  // Reset state when cluster changes
+  // Reset state when cluster/namespace actually changes (not on initial mount)
+  const prevDeploymentsKeyRef = useRef(cacheKey)
   useEffect(() => {
-    setDeployments([])
-    setIsLoading(true)
-    setError(null)
-  }, [cluster, namespace])
+    if (prevDeploymentsKeyRef.current !== cacheKey) {
+      prevDeploymentsKeyRef.current = cacheKey
+      setDeployments([])
+      setIsLoading(true)
+      setError(null)
+    }
+  }, [cacheKey])
 
   const refetch = useCallback(async (silent = false) => {
     // For silent (background) refreshes, don't update loading states - prevents UI flashing
@@ -3007,12 +3011,16 @@ export function useServices(cluster?: string, namespace?: string) {
   const [consecutiveFailures, setConsecutiveFailures] = useState(0)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(cached?.timestamp || null)
 
-  // Reset state when cluster changes
+  // Reset state when cluster/namespace actually changes (not on initial mount)
+  const prevServicesKeyRef = useRef(cacheKey)
   useEffect(() => {
-    setServices([])
-    setIsLoading(true)
-    setError(null)
-  }, [cluster, namespace])
+    if (prevServicesKeyRef.current !== cacheKey) {
+      prevServicesKeyRef.current = cacheKey
+      setServices([])
+      setIsLoading(true)
+      setError(null)
+    }
+  }, [cacheKey])
 
   const refetch = useCallback(async (silent = false) => {
     // For silent (background) refreshes, don't update loading states - prevents UI flashing


### PR DESCRIPTION
## Summary
- Guard page-level skeletons with data emptiness checks so they only show on first load when no cached data exists
- Fix StatsOverview callers across 11 pages to pass `isLoading && data.length === 0` instead of raw `isLoading`
- Fix `useDeployments` and `useServices` hooks to not reset cached state on mount (useEffect was unconditionally clearing cached data on every mount, not just on parameter changes)

This matches the Events page behavior which never flashes because it uses localStorage-backed caching via `useCachedEvents`.

## Files Changed (15)
- `web/src/hooks/useMCP.ts` — Fix `useDeployments`/`useServices` reset effects with ref-based param change detection
- `web/src/components/dashboard/Dashboard.tsx` — Guard full-page skeleton and StatsOverview
- `web/src/components/dashboard/CustomDashboard.tsx` — Guard StatsOverview
- `web/src/components/clusters/Clusters.tsx` — Guard full-page skeleton
- `web/src/components/compute/ClusterComparisonPage.tsx` — Guard full-page skeleton
- `web/src/components/gpu/GPUReservations.tsx` — Guard full-page skeleton
- `web/src/components/logs/Logs.tsx` — Fix StatsOverview isLoading
- `web/src/components/deployments/Deployments.tsx` — Fix StatsOverview isLoading
- `web/src/components/operators/Operators.tsx` — Fix StatsOverview isLoading
- `web/src/components/nodes/Nodes.tsx` — Fix StatsOverview isLoading
- `web/src/components/deploy/Deploy.tsx` — Fix StatsOverview isLoading
- `web/src/components/helm/HelmReleases.tsx` — Fix StatsOverview isLoading
- `web/src/components/cost/Cost.tsx` — Fix StatsOverview isLoading
- `web/src/components/compliance/Compliance.tsx` — Fix StatsOverview isLoading
- `web/src/components/data-compliance/DataCompliance.tsx` — Fix StatsOverview isLoading

## Test plan
- [ ] Navigate to Dashboard → should not show full skeleton on return (cache exists after first load)
- [ ] Navigate to Events → no flash (baseline, unchanged)
- [ ] Navigate to Clusters, Nodes, Deployments, Helm, etc. → no flash on return
- [ ] Hard refresh (Ctrl+Shift+R) → skeleton OK on very first load (no cache yet)
- [ ] Navigate away and back → no flash on return
- [ ] Change cluster filter → skeleton shows briefly (correct for new data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)