### PR TITLE
🐛 Scroll to top when navigating between dashboards

### DIFF
--- a/web/src/hooks/useLastRoute.ts
+++ b/web/src/hooks/useLastRoute.ts
@@ -265,16 +265,15 @@ export function useLastRoute() {
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
   }, [saveScrollPositionNow])
 
-  // Restore scroll when navigating to a previously visited page
+  // Scroll to top when navigating between dashboards (not on initial app load)
   useEffect(() => {
     if (!hasRestoredRef.current) return
 
-    const timeoutId = setTimeout(() => {
-      restoreScrollPosition(location.pathname)
-    }, 50)
-
-    return () => clearTimeout(timeoutId)
-  }, [location.pathname, restoreScrollPosition])
+    const container = getScrollContainer()
+    if (container) {
+      container.scrollTo({ top: 0, behavior: 'instant' })
+    }
+  }, [location.pathname])
 
   return {
     lastRoute: localStorage.getItem(LAST_ROUTE_KEY),


### PR DESCRIPTION
## Summary
- Navigate between dashboards now always scrolls to top
- Scroll position is still saved to localStorage and restored on app load (login/session restore)
- Only the in-session scroll restoration between route changes is removed

## Test plan
- [ ] Click between Dashboard, Events, Clusters, etc. — each page starts at the top
- [ ] Scroll down on a dashboard, navigate away, come back — starts at top
- [ ] Refresh the browser (F5) — scroll position is restored from localStorage
- [ ] Close and reopen the app — scroll position is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)