### PR TITLE
✨ Redesign Demo Install Guide as banner + modal

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -12,7 +12,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { cn } from '../../lib/cn'
 import { TourOverlay, TourPrompt } from '../onboarding/Tour'
-import { DemoInstallGuide } from '../onboarding/DemoInstallGuide'
+import { DemoInstallBanner } from '../onboarding/DemoInstallGuide'
 import { TourProvider } from '../../hooks/useTour'
 
 interface LayoutProps {
@@ -86,6 +86,9 @@ export function Layout({ children }: LayoutProps) {
         </div>
       )}
 
+      {/* Demo Install Guide Banner - positioned under demo banner */}
+      {isDemoMode && <DemoInstallBanner collapsed={config.collapsed} />}
+
       {/* Offline Mode Banner - positioned in main content area only */}
       {showOfflineBanner && (
         <div className={cn(
@@ -141,9 +144,6 @@ export function Layout({ children }: LayoutProps) {
           {children}
         </main>
       </div>
-
-      {/* Demo install guide floater */}
-      {isDemoMode && <DemoInstallGuide />}
 
       {/* AI Mission sidebar */}
       <MissionSidebar />

--- a/web/src/components/onboarding/DemoInstallGuide.tsx
+++ b/web/src/components/onboarding/DemoInstallGuide.tsx
@@ -1,11 +1,12 @@
 import { useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
-import { X, Copy, Check, ExternalLink, Settings, Rocket, Terminal, Key } from 'lucide-react'
+import { X, Copy, Check, ExternalLink, Settings, Rocket, Terminal, Key, Download, ChevronRight } from 'lucide-react'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import { cn } from '../../lib/cn'
 
 const DISMISSED_KEY = 'kc-demo-install-dismissed'
 
-function CopyCommand({ command }: { command: string }) {
+function CopyCommand({ command, label }: { command: string; label?: string }) {
   const [copied, setCopied] = useState(false)
 
   const handleCopy = useCallback(async () => {
@@ -21,24 +22,161 @@ function CopyCommand({ command }: { command: string }) {
   return (
     <button
       onClick={handleCopy}
-      className="flex items-center gap-2 w-full text-left font-mono text-xs bg-gray-900/80 border border-gray-700/50 rounded px-2.5 py-1.5 hover:border-purple-500/40 hover:bg-gray-800/80 transition-colors group/copy"
+      className="flex items-center gap-2 w-full text-left font-mono text-sm bg-black/40 border border-gray-700/50 rounded-lg px-3 py-2 hover:border-purple-500/40 hover:bg-black/60 transition-colors group/copy"
       title={copied ? 'Copied!' : 'Click to copy'}
     >
-      <span className="flex-1 text-gray-300">{command}</span>
+      <span className="text-gray-400 select-none">$</span>
+      <span className="flex-1 text-gray-200">{command}</span>
       {copied ? (
-        <Check className="w-3.5 h-3.5 text-green-400 shrink-0" />
+        <span className="flex items-center gap-1 text-green-400 text-xs shrink-0">
+          <Check className="w-3.5 h-3.5" />
+          {label || 'Copied'}
+        </span>
       ) : (
-        <Copy className="w-3.5 h-3.5 text-gray-500 group-hover/copy:text-gray-300 shrink-0 transition-colors" />
+        <Copy className="w-4 h-4 text-gray-600 group-hover/copy:text-gray-300 shrink-0 transition-colors" />
       )}
     </button>
   )
 }
 
-export function DemoInstallGuide() {
+function StepNumber({ n }: { n: number }) {
+  return (
+    <div className="flex items-center justify-center w-8 h-8 rounded-full bg-gradient-to-br from-purple-500 to-blue-500 text-white text-sm font-bold shrink-0 shadow-lg shadow-purple-500/20">
+      {n}
+    </div>
+  )
+}
+
+// The modal with full install instructions
+function InstallModal({ onClose }: { onClose: () => void }) {
   const { toggleDemoMode } = useDemoMode()
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[9999] p-4 overflow-y-auto"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div
+        className="min-h-full flex items-center justify-center"
+        onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+      >
+        <div
+          className="glass w-full max-w-lg rounded-2xl overflow-hidden animate-fade-in-up"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Header */}
+          <div className="relative px-6 pt-6 pb-4">
+            <button
+              onClick={onClose}
+              className="absolute top-4 right-4 p-1.5 rounded-lg hover:bg-white/10 transition-colors"
+            >
+              <X className="w-4 h-4 text-muted-foreground" />
+            </button>
+            <div className="flex items-center gap-3 mb-1">
+              <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-gradient-to-br from-purple-500 to-blue-500 shadow-lg shadow-purple-500/20">
+                <Rocket className="w-5 h-5 text-white" />
+              </div>
+              <div>
+                <h2 className="text-lg font-bold text-foreground">Set Up Your Console</h2>
+                <p className="text-sm text-muted-foreground">Easy as 1-2-3</p>
+              </div>
+            </div>
+          </div>
+
+          {/* Steps */}
+          <div className="px-6 space-y-5 pb-2">
+            {/* Step 1 */}
+            <div className="flex gap-3">
+              <StepNumber n={1} />
+              <div className="flex-1 min-w-0 pt-0.5">
+                <div className="flex items-center gap-2 mb-2">
+                  <Download className="w-4 h-4 text-purple-400" />
+                  <h3 className="text-sm font-semibold text-foreground">Install</h3>
+                </div>
+                <p className="text-xs text-muted-foreground mb-2">
+                  Installs the console backend, frontend, and local agent:
+                </p>
+                <CopyCommand command="brew install kubestellar/tap/kc" />
+              </div>
+            </div>
+
+            {/* Step 2 */}
+            <div className="flex gap-3">
+              <StepNumber n={2} />
+              <div className="flex-1 min-w-0 pt-0.5">
+                <div className="flex items-center gap-2 mb-2">
+                  <Terminal className="w-4 h-4 text-blue-400" />
+                  <h3 className="text-sm font-semibold text-foreground">Run</h3>
+                </div>
+                <p className="text-xs text-muted-foreground mb-2">
+                  Starts the backend, frontend, and connects your clusters:
+                </p>
+                <CopyCommand command="kc" />
+              </div>
+            </div>
+
+            {/* Step 3 */}
+            <div className="flex gap-3">
+              <StepNumber n={3} />
+              <div className="flex-1 min-w-0 pt-0.5">
+                <div className="flex items-center gap-2 mb-2">
+                  <Key className="w-4 h-4 text-emerald-400" />
+                  <h3 className="text-sm font-semibold text-foreground">Configure AI Keys</h3>
+                </div>
+                <p className="text-xs text-muted-foreground mb-2">
+                  Add your OpenAI, Anthropic, or other LLM API keys in Settings to enable AI features.
+                </p>
+                <Link
+                  to="/settings"
+                  onClick={onClose}
+                  className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-emerald-500/10 border border-emerald-500/20 hover:bg-emerald-500/20 text-emerald-400 transition-colors"
+                >
+                  <Settings className="w-3.5 h-3.5" />
+                  Open Settings
+                  <ChevronRight className="w-3 h-3" />
+                </Link>
+              </div>
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-between px-6 py-4 mt-3 border-t border-border/50">
+            <a
+              href="https://kubestellar.io/docs/console"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Read the full docs
+              <ExternalLink className="w-3 h-3" />
+            </a>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => { toggleDemoMode(); onClose() }}
+                className="text-xs px-3 py-1.5 rounded-lg bg-yellow-500/10 border border-yellow-500/20 hover:bg-yellow-500/20 text-yellow-400 transition-colors"
+              >
+                Exit Demo
+              </button>
+              <button
+                onClick={onClose}
+                className="text-xs px-4 py-1.5 rounded-lg bg-purple-500/20 border border-purple-500/30 hover:bg-purple-500/30 text-purple-300 font-medium transition-colors"
+              >
+                Got it
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Banner that sits under the demo mode banner
+export function DemoInstallBanner({ collapsed }: { collapsed: boolean }) {
   const [dismissed, setDismissed] = useState(() => {
     return localStorage.getItem(DISMISSED_KEY) === 'true'
   })
+  const [modalOpen, setModalOpen] = useState(false)
 
   const handleDismiss = useCallback(() => {
     setDismissed(true)
@@ -48,85 +186,40 @@ export function DemoInstallGuide() {
   if (dismissed) return null
 
   return (
-    <div className="fixed bottom-5 left-72 z-40 w-[340px] glass rounded-xl border border-purple-500/20 shadow-2xl shadow-purple-900/20 animate-fade-in-up">
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 pt-3.5 pb-0">
-        <div className="flex items-center gap-2">
-          <Rocket className="w-4 h-4 text-purple-400" />
-          <h3 className="text-sm font-semibold text-foreground">Get Started with Your Own Clusters</h3>
-        </div>
-        <button
-          onClick={handleDismiss}
-          className="p-1 -mr-1 rounded hover:bg-white/10 transition-colors"
-          title="Dismiss"
-        >
-          <X className="w-3.5 h-3.5 text-muted-foreground" />
-        </button>
-      </div>
-
-      {/* Steps */}
-      <div className="px-4 pt-3 pb-3 space-y-3">
-        {/* Step 1 */}
-        <div className="flex gap-2.5">
-          <div className="flex items-center justify-center w-5 h-5 rounded-full bg-purple-500/20 text-purple-400 text-[10px] font-bold shrink-0 mt-0.5">1</div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1.5 mb-1">
-              <Terminal className="w-3.5 h-3.5 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground">Install the agent</span>
-            </div>
-            <CopyCommand command="brew install kubestellar/tap/kc-agent" />
-          </div>
-        </div>
-
-        {/* Step 2 */}
-        <div className="flex gap-2.5">
-          <div className="flex items-center justify-center w-5 h-5 rounded-full bg-purple-500/20 text-purple-400 text-[10px] font-bold shrink-0 mt-0.5">2</div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1.5 mb-1">
-              <Terminal className="w-3.5 h-3.5 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground">Run it</span>
-            </div>
-            <CopyCommand command="kc-agent" />
-          </div>
-        </div>
-
-        {/* Step 3 */}
-        <div className="flex gap-2.5">
-          <div className="flex items-center justify-center w-5 h-5 rounded-full bg-purple-500/20 text-purple-400 text-[10px] font-bold shrink-0 mt-0.5">3</div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1.5">
-              <Key className="w-3.5 h-3.5 text-muted-foreground" />
-              <span className="text-xs text-muted-foreground">Configure AI keys in Settings</span>
-            </div>
-          </div>
+    <>
+      <div className={cn(
+        "fixed top-[calc(4rem+36px)] right-0 z-40 transition-[left] duration-300",
+        "bg-gradient-to-r from-purple-500/10 via-blue-500/10 to-purple-500/10 border-b border-purple-500/20",
+        collapsed ? "left-20" : "left-64",
+      )}>
+        <div className="flex items-center justify-center gap-3 py-1.5 px-4">
+          <Rocket className="w-4 h-4 text-purple-400 animate-pulse" />
+          <span className="text-sm text-purple-300">
+            Want to use your <span className="font-semibold text-purple-200">own clusters</span>?
+          </span>
+          <button
+            onClick={() => setModalOpen(true)}
+            className="text-xs px-3 py-1 rounded-full bg-purple-500/20 border border-purple-500/30 hover:bg-purple-500/30 text-purple-300 font-medium transition-colors"
+          >
+            Install Guide
+            <ChevronRight className="w-3 h-3 inline ml-0.5 -mr-0.5" />
+          </button>
+          <button
+            onClick={handleDismiss}
+            className="ml-1 p-1 hover:bg-purple-500/20 rounded transition-colors"
+            title="Dismiss"
+          >
+            <X className="w-3.5 h-3.5 text-purple-400/70" />
+          </button>
         </div>
       </div>
 
-      {/* Actions */}
-      <div className="flex items-center gap-2 px-4 pb-3.5 pt-0.5">
-        <a
-          href="https://kubestellar.io/docs/console"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1 text-xs px-2.5 py-1.5 rounded-md bg-secondary/50 hover:bg-secondary/80 text-muted-foreground hover:text-foreground transition-colors"
-        >
-          Docs
-          <ExternalLink className="w-3 h-3" />
-        </a>
-        <Link
-          to="/settings"
-          className="flex items-center gap-1 text-xs px-2.5 py-1.5 rounded-md bg-secondary/50 hover:bg-secondary/80 text-muted-foreground hover:text-foreground transition-colors"
-        >
-          <Settings className="w-3 h-3" />
-          Settings
-        </Link>
-        <button
-          onClick={toggleDemoMode}
-          className="text-xs px-2.5 py-1.5 rounded-md bg-yellow-500/10 hover:bg-yellow-500/20 text-yellow-400 transition-colors ml-auto"
-        >
-          Exit Demo
-        </button>
-      </div>
-    </div>
+      {modalOpen && <InstallModal onClose={() => setModalOpen(false)} />}
+    </>
   )
+}
+
+// Keep the old export name for backward compat, but it's now unused in Layout
+export function DemoInstallGuide() {
+  return null
 }


### PR DESCRIPTION
## Summary
- Replaces the floating card with a **purple gradient banner** directly under the demo mode banner — much more visible
- Clicking "Install Guide" opens a **modal** with clear 1-2-3 steps:
  1. `brew install kubestellar/tap/kc` — installs backend, frontend, and agent
  2. `kc` — starts everything
  3. Configure AI keys in Settings
- Banner is dismissible with localStorage persistence
- Modal includes click-to-copy commands, Settings link, docs link, Exit Demo, and "Got it" button

## Test plan
- [ ] Enable demo mode → purple install banner visible under yellow demo banner
- [ ] Click "Install Guide" → modal opens with 3 steps
- [ ] Copy commands work (click-to-copy)
- [ ] "Open Settings" link navigates to /settings
- [ ] "Exit Demo" turns off demo mode
- [ ] "Got it" closes modal
- [ ] X on banner dismisses it, persists on reload
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)