### PR TITLE
✨ Add per-dashboard Pin toggle to remember scroll position

### DIFF
--- a/web/src/components/shared/DashboardHeader.tsx
+++ b/web/src/components/shared/DashboardHeader.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
 import { RefreshCw, Hourglass } from 'lucide-react'
+import { getRememberPosition, setRememberPosition } from '../../hooks/useLastRoute'
 
 interface DashboardHeaderProps {
   /** Dashboard title text or ReactNode */
@@ -51,6 +53,9 @@ export function DashboardHeader({
   afterTitle,
   rightExtra,
 }: DashboardHeaderProps) {
+  const location = useLocation()
+  const [rememberPosition, setRememberPositionState] = useState(() => getRememberPosition(location.pathname))
+
   // Self-managed timestamp: updates when isFetching goes true → false
   const [internalLastUpdated, setInternalLastUpdated] = useState<Date>(() => new Date())
   const wasFetchingRef = useRef(isFetching)
@@ -92,6 +97,23 @@ export function DashboardHeader({
       <div className="flex flex-col items-end gap-0.5">
         <div className="flex items-center gap-3">
           {rightExtra}
+          <label
+            htmlFor={`remember-position-${autoRefreshId || 'default'}`}
+            className="flex items-center gap-1.5 cursor-pointer text-xs text-muted-foreground"
+            title="Remember scroll position when navigating away"
+          >
+            <input
+              type="checkbox"
+              id={`remember-position-${autoRefreshId || 'default'}`}
+              checked={rememberPosition}
+              onChange={(e) => {
+                setRememberPositionState(e.target.checked)
+                setRememberPosition(location.pathname, e.target.checked)
+              }}
+              className="rounded border-border w-3.5 h-3.5"
+            />
+            Pin
+          </label>
           {onAutoRefreshChange && (
             <label
               htmlFor={autoRefreshId || 'auto-refresh'}


### PR DESCRIPTION
## Summary
- Add a "Pin" checkbox to every dashboard header (next to Auto refresh) that controls scroll position restoration
- When Pin is on (default): navigating back restores scroll to where the user left off
- When Pin is off: navigating to the dashboard always starts at the top
- Preference stored per-path in localStorage, persists across sessions
- Scroll position is always saved regardless of toggle — toggle only affects restoration

## Test plan
- [ ] Navigate to Deploy, scroll to Workloads card, navigate away, come back → restores position (Pin on by default)
- [ ] Uncheck Pin, navigate away, come back → starts at top
- [ ] Re-check Pin, scroll down, navigate away, come back → restores position
- [ ] Refresh browser → Pin preference persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)