### PR TITLE
🐛 Skip agent connections in demo mode to eliminate console errors

### DIFF
--- a/web/src/hooks/useKubectl.ts
+++ b/web/src/hooks/useKubectl.ts
@@ -8,6 +8,8 @@
  * - Cleans up on unmount
  */
 
+import { getDemoMode } from './useDemoMode'
+
 const AGENT_WS_URL = 'ws://127.0.0.1:8585/ws'
 const RECONNECT_DELAY = 1000
 const REQUEST_TIMEOUT = 30000
@@ -41,6 +43,11 @@ class KubectlService {
 
   private connect() {
     if (this.ws?.readyState === WebSocket.OPEN || this.isConnecting) {
+      return
+    }
+
+    // In demo mode, skip WebSocket connection to avoid console errors
+    if (getDemoMode()) {
       return
     }
 

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { getDemoMode } from './useDemoMode'
 
 export interface AgentHealth {
   status: string
@@ -62,7 +63,14 @@ interface AgentState {
 type Listener = (state: AgentState) => void
 
 class AgentManager {
-  private state: AgentState = {
+  private state: AgentState = getDemoMode() ? {
+    status: 'disconnected',
+    health: DEMO_DATA,
+    error: 'Demo mode - agent connection skipped',
+    connectionEvents: [],
+    dataErrorCount: 0,
+    lastDataError: null,
+  } : {
     status: 'connecting',
     health: null,
     error: null,
@@ -85,6 +93,17 @@ class AgentManager {
   start() {
     if (this.isStarted) return
     this.isStarted = true
+
+    // In demo mode, skip agent connection entirely to avoid console errors
+    if (getDemoMode()) {
+      this.setState({
+        status: 'disconnected',
+        health: DEMO_DATA,
+        error: 'Demo mode - agent connection skipped',
+      })
+      return
+    }
+
     this.addEvent('connecting', 'Attempting to connect to local agent...')
     this.checkAgent()
     this.currentPollInterval = POLL_INTERVAL

--- a/web/src/hooks/useMCP.ts
+++ b/web/src/hooks/useMCP.ts
@@ -1857,21 +1857,6 @@ export function useClusters() {
     const sharedMetricsClusters = shareMetricsBetweenSameServerClusters(localState.clusters)
     const result = deduplicateClustersByServer(sharedMetricsClusters)
 
-    // Debug: log what deduplication produced
-    if (result.length > 0) {
-      const sample = result.find(c => c.cpuCores && c.cpuCores > 100) || result[0]
-      console.log('[Dedup] Result sample:', {
-        name: sample?.name,
-        cpuCores: sample?.cpuCores,
-        cpuRequestsCores: sample?.cpuRequestsCores,
-        memoryGB: sample?.memoryGB,
-        memoryRequestsGB: sample?.memoryRequestsGB,
-        aliases: sample?.aliases?.length,
-        totalClusters: result.length,
-        withRequests: result.filter(c => c.cpuRequestsCores).length,
-      })
-    }
-
     return result
   }, [localState.clusters])
 

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useCallback, useRef, useEffect, ReactNode } from 'react'
 import type { AgentInfo, AgentsListPayload, AgentSelectedPayload, ChatStreamPayload } from '../types/agent'
+import { getDemoMode } from './useDemoMode'
 
 export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed'
 
@@ -196,6 +197,11 @@ export function MissionProvider({ children }: { children: ReactNode }) {
 
   // Connect to local agent WebSocket
   const ensureConnection = useCallback(() => {
+    // In demo mode, skip WebSocket connection to avoid console errors
+    if (getDemoMode()) {
+      return Promise.reject(new Error('Agent unavailable in demo mode'))
+    }
+
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       return Promise.resolve()
     }

--- a/web/src/lib/iconSuggester.ts
+++ b/web/src/lib/iconSuggester.ts
@@ -5,6 +5,8 @@
  * is unavailable, then to a random generic icon.
  */
 
+import { getDemoMode } from '../hooks/useDemoMode'
+
 const KC_AGENT_WS_URL = 'ws://127.0.0.1:8585/ws'
 
 // All Lucide icons available in the sidebar
@@ -85,6 +87,11 @@ const KEYWORD_MAP: Record<string, string> = {
  * Times out after 5 seconds.
  */
 function askAgentForIcon(name: string): Promise<string | null> {
+  // In demo mode, skip WebSocket connection to avoid console errors
+  if (getDemoMode()) {
+    return Promise.resolve(null)
+  }
+
   return new Promise((resolve) => {
     const timeout = setTimeout(() => {
       resolve(null)

--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -5,6 +5,8 @@
  * which has access to the user's kubeconfig.
  */
 
+import { getDemoMode } from '../hooks/useDemoMode'
+
 const KC_AGENT_WS_URL = 'ws://127.0.0.1:8585/ws'
 
 type MessageType = 'kubectl' | 'health' | 'clusters' | 'result' | 'error'
@@ -57,6 +59,11 @@ class KubectlProxy {
    * Ensure WebSocket is connected
    */
   private async ensureConnected(): Promise<void> {
+    // In demo mode, skip WebSocket connection to avoid console errors
+    if (getDemoMode()) {
+      throw new Error('Agent unavailable in demo mode')
+    }
+
     if (this.ws?.readyState === WebSocket.OPEN) {
       return
     }


### PR DESCRIPTION
## Summary
- Remove `[Dedup] Result sample:` debug logging from `useMCP.ts`
- Guard all agent connection points (health polling, WebSocket, fetch) with `getDemoMode()` checks so demo mode (console.kubestellar.io) never attempts to reach `127.0.0.1:8585`
- Eliminates ~91 console errors per page load across all dashboards in demo mode

## Files changed
- `useLocalAgent.ts` — Initialize AgentManager as disconnected in demo mode; skip health polling
- `kubectlProxy.ts` — Reject immediately in `ensureConnected()` in demo mode
- `useMissions.tsx` — Reject immediately in `ensureConnection()` in demo mode
- `useKubectl.ts` — Return early from `connect()` in demo mode
- `iconSuggester.ts` — Return null immediately in demo mode (falls back to keyword matching)
- `useMCP.ts` — Remove `[Dedup]` debug console.log block

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm run build` — builds successfully
- [x] `npm run lint` — no new lint errors (pre-existing only)
- [x] `npx vite preview` — serves 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)