### PR TITLE
🐛 Fix Copilot agent assignment in auto-qa

### DIFF
--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -1291,13 +1291,18 @@ jobs:
 
               core.info(`Created issue #${issue.number}: ${check.title}`);
 
-              // Auto-assign Copilot so no human triage is needed
+              // Auto-assign Copilot coding agent so no human triage is needed
+              const repo = `${context.repo.owner}/${context.repo.repo}`;
               try {
-                await github.rest.issues.addAssignees({
+                await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issue.number,
-                  assignees: ['Copilot'],
+                  assignees: ['copilot-swe-agent[bot]'],
+                  agent_assignment: {
+                    target_repo: repo,
+                    base_branch: 'main',
+                  },
                 });
                 core.info(`Assigned Copilot to #${issue.number}`);
               } catch (e) {


### PR DESCRIPTION
## Summary
- Fix Copilot assignment to use `copilot-swe-agent[bot]` instead of `Copilot`
- Include `agent_assignment` payload with `target_repo` and `base_branch` required by the GitHub Copilot coding agent API

## Test plan
- [ ] Verify next auto-qa issue creation assigns Copilot correctly
- [ ] Monitor for Copilot responding (no permissions error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)