### PR TITLE
✨ Add setup instructions dialog and startup scripts for demo mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,8 @@ GITHUB_CLIENT_SECRET=
 # Dev mode settings (optional, defaults shown)
 DEV_MODE=true
 FRONTEND_URL=http://localhost:5174
+# Skip the onboarding questionnaire for new users (default: false)
+SKIP_ONBOARDING=false
 
 # Feature request / AI automation settings (optional)
 # GitHub PAT for creating issues (needs 'repo' scope)

--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -30,6 +30,7 @@ type AuthConfig struct {
 	DevUserAvatar    string
 	GitHubToken      string // Personal access token for dev mode profile lookup
 	DevMode          bool   // Force dev mode bypass even if OAuth credentials present
+	SkipOnboarding   bool   // Skip onboarding questionnaire for new users
 }
 
 // AuthHandler handles authentication
@@ -41,8 +42,9 @@ type AuthHandler struct {
 	devUserLogin  string
 	devUserEmail  string
 	devUserAvatar string
-	githubToken   string
-	devMode       bool
+	githubToken      string
+	devMode          bool
+	skipOnboarding   bool
 }
 
 // NewAuthHandler creates a new auth handler
@@ -67,8 +69,9 @@ func NewAuthHandler(s store.Store, cfg AuthConfig) *AuthHandler {
 		devUserLogin:  cfg.DevUserLogin,
 		devUserEmail:  cfg.DevUserEmail,
 		devUserAvatar: cfg.DevUserAvatar,
-		githubToken:   cfg.GitHubToken,
-		devMode:       cfg.DevMode,
+		githubToken:      cfg.GitHubToken,
+		devMode:          cfg.DevMode,
+		skipOnboarding:   cfg.SkipOnboarding,
 	}
 }
 
@@ -240,6 +243,7 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 			GitHubLogin: ghUser.Login,
 			Email:       ghUser.Email,
 			AvatarURL:   ghUser.AvatarURL,
+			Onboarded:   h.skipOnboarding, // Skip questionnaire if SKIP_ONBOARDING=true
 		}
 		if err := h.store.CreateUser(user); err != nil {
 			return c.Redirect(h.frontendURL+"/login?error=create_user_failed", fiber.StatusTemporaryRedirect)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -25,6 +25,7 @@ import (
 type Config struct {
 	Port             int
 	DevMode          bool
+	SkipOnboarding   bool
 	DatabasePath     string
 	GitHubClientID   string
 	GitHubSecret     string
@@ -206,6 +207,7 @@ func (s *Server) setupRoutes() {
 		DevUserAvatar:    s.config.DevUserAvatar,
 		GitHubToken:      s.config.GitHubToken,
 		DevMode:          s.config.DevMode,
+		SkipOnboarding:   s.config.SkipOnboarding,
 	})
 	s.app.Get("/auth/github", auth.GitHubLogin)
 	s.app.Get("/auth/github/callback", auth.GitHubCallback)
@@ -526,6 +528,8 @@ func LoadConfigFromEnv() Config {
 		GitHubWebhookSecret: os.Getenv("GITHUB_WEBHOOK_SECRET"),
 		FeedbackRepoOwner:   getEnvOrDefault("FEEDBACK_REPO_OWNER", "kubestellar"),
 		FeedbackRepoName:    getEnvOrDefault("FEEDBACK_REPO_NAME", "console"),
+		// Skip onboarding questionnaire for new users
+		SkipOnboarding: os.Getenv("SKIP_ONBOARDING") == "true",
 	}
 }
 

--- a/startup-demo.sh
+++ b/startup-demo.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# KubeStellar Console - Demo Mode Startup
+# No credentials needed - runs with demo data and dev-user auto-login
+#
+# Usage:
+#   ./startup-demo.sh       # run in foreground
+#   ./startup-demo.sh &     # run in background
+
+set -e
+cd "$(dirname "$0")"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+echo -e "${GREEN}=== KubeStellar Console - Demo Mode ===${NC}"
+echo ""
+
+# Environment
+export DEV_MODE=true
+export SKIP_ONBOARDING=true
+export FRONTEND_URL=http://localhost:5174
+
+# Create data directory
+mkdir -p ./data
+
+# Port cleanup
+for p in 8080 5174; do
+    if lsof -Pi :$p -sTCP:LISTEN -t >/dev/null 2>&1; then
+        echo -e "${YELLOW}Port $p is in use, killing existing process...${NC}"
+        lsof -ti:$p | xargs kill -9 2>/dev/null || true
+        sleep 1
+    fi
+done
+
+# Cleanup on exit
+cleanup() {
+    echo -e "\n${YELLOW}Shutting down...${NC}"
+    kill $BACKEND_PID 2>/dev/null || true
+    kill $FRONTEND_PID 2>/dev/null || true
+    exit 0
+}
+trap cleanup SIGINT SIGTERM
+
+# Start backend (dev mode, no OAuth needed)
+echo -e "${GREEN}Starting backend (demo mode)...${NC}"
+GOWORK=off go run ./cmd/console --dev &
+BACKEND_PID=$!
+sleep 2
+
+# Start frontend
+echo -e "${GREEN}Starting frontend...${NC}"
+(cd web && npm run dev -- --port 5174) &
+FRONTEND_PID=$!
+
+echo ""
+echo -e "${GREEN}=== Console is running in DEMO mode ===${NC}"
+echo ""
+echo -e "  Frontend: ${CYAN}http://localhost:5174${NC}"
+echo -e "  Backend:  ${CYAN}http://localhost:8080${NC}"
+echo ""
+echo -e "  No login required - auto-signed in as dev-user"
+echo -e "  Demo data is shown by default"
+echo ""
+echo "Press Ctrl+C to stop"
+
+wait

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# KubeStellar Console - OAuth Mode Startup
+# Requires GitHub OAuth credentials in .env or environment
+#
+# Setup:
+#   1. Create a GitHub OAuth App at https://github.com/settings/developers
+#      - Homepage URL: http://localhost:5174
+#      - Callback URL: http://localhost:5174/auth/github/callback
+#   2. Create a .env file:
+#      GITHUB_CLIENT_ID=<your-client-id>
+#      GITHUB_CLIENT_SECRET=<your-client-secret>
+#   3. Run: ./startup-oauth.sh
+
+set -e
+cd "$(dirname "$0")"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+echo -e "${GREEN}=== KubeStellar Console - OAuth Mode ===${NC}"
+echo ""
+
+# Load .env file if it exists
+if [ -f .env ]; then
+    echo -e "${GREEN}Loading .env file...${NC}"
+    while IFS='=' read -r key value; do
+        [[ $key =~ ^#.*$ ]] && continue
+        [[ -z "$key" ]] && continue
+        value="${value%\"}"
+        value="${value#\"}"
+        value="${value%\'}"
+        value="${value#\'}"
+        export "$key=$value"
+    done < .env
+fi
+
+# Check required OAuth credentials
+if [ -z "$GITHUB_CLIENT_ID" ]; then
+    echo -e "${RED}Error: GITHUB_CLIENT_ID is not set${NC}"
+    echo ""
+    echo "Create a .env file with:"
+    echo "  GITHUB_CLIENT_ID=<your-client-id>"
+    echo "  GITHUB_CLIENT_SECRET=<your-client-secret>"
+    echo ""
+    echo "Or create a GitHub OAuth App at:"
+    echo "  https://github.com/settings/developers"
+    echo "  Homepage URL: http://localhost:5174"
+    echo "  Callback URL: http://localhost:5174/auth/github/callback"
+    exit 1
+fi
+
+if [ -z "$GITHUB_CLIENT_SECRET" ]; then
+    echo -e "${RED}Error: GITHUB_CLIENT_SECRET is not set${NC}"
+    exit 1
+fi
+
+# Generate JWT_SECRET if not set (production mode requires it)
+if [ -z "$JWT_SECRET" ]; then
+    export JWT_SECRET=$(openssl rand -hex 32)
+    echo -e "${YELLOW}Generated random JWT_SECRET (set JWT_SECRET in .env to persist across restarts)${NC}"
+fi
+
+# Environment
+export DEV_MODE=false
+export SKIP_ONBOARDING=true
+export FRONTEND_URL=http://localhost:5174
+
+# Create data directory
+mkdir -p ./data
+
+echo -e "${GREEN}Configuration:${NC}"
+echo "  Mode: OAuth (real GitHub login)"
+echo "  GitHub Client ID: ${GITHUB_CLIENT_ID:0:8}..."
+echo "  Backend Port: 8080"
+echo "  Frontend URL: $FRONTEND_URL"
+echo ""
+
+# Port cleanup
+for p in 8080 5174; do
+    if lsof -Pi :$p -sTCP:LISTEN -t >/dev/null 2>&1; then
+        echo -e "${YELLOW}Port $p is in use, killing existing process...${NC}"
+        lsof -ti:$p | xargs kill -9 2>/dev/null || true
+        sleep 1
+    fi
+done
+
+# Cleanup on exit
+cleanup() {
+    echo -e "\n${YELLOW}Shutting down...${NC}"
+    kill $BACKEND_PID 2>/dev/null || true
+    kill $FRONTEND_PID 2>/dev/null || true
+    exit 0
+}
+trap cleanup SIGINT SIGTERM
+
+# Start backend (NO --dev flag, uses real OAuth)
+echo -e "${GREEN}Starting backend (OAuth mode)...${NC}"
+GOWORK=off go run ./cmd/console &
+BACKEND_PID=$!
+sleep 2
+
+# Start frontend
+echo -e "${GREEN}Starting frontend...${NC}"
+(cd web && npm run dev -- --port 5174) &
+FRONTEND_PID=$!
+
+echo ""
+echo -e "${GREEN}=== Console is running in OAUTH mode ===${NC}"
+echo ""
+echo -e "  Frontend: ${CYAN}http://localhost:5174${NC}"
+echo -e "  Backend:  ${CYAN}http://localhost:8080${NC}"
+echo -e "  Auth:     GitHub OAuth (real login)"
+echo ""
+echo "Press Ctrl+C to stop"
+
+wait

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Box, WifiOff, X, Settings } from 'lucide-react'
+import { Box, WifiOff, X, Settings, Rocket } from 'lucide-react'
 import { Navbar } from './navbar/index'
 import { Sidebar } from './Sidebar'
 import { MissionSidebar, MissionSidebarToggle } from './mission-sidebar'
@@ -13,6 +13,7 @@ import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { cn } from '../../lib/cn'
 import { TourOverlay, TourPrompt } from '../onboarding/Tour'
 import { TourProvider } from '../../hooks/useTour'
+import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
 
 interface LayoutProps {
   children: ReactNode
@@ -24,6 +25,7 @@ export function Layout({ children }: LayoutProps) {
   const { isDemoMode, toggleDemoMode } = useDemoMode()
   const { status: agentStatus } = useLocalAgent()
   const [offlineBannerDismissed, setOfflineBannerDismissed] = useState(false)
+  const [showSetupDialog, setShowSetupDialog] = useState(false)
 
   // Show offline banner when agent is disconnected (not demo mode, not connecting)
   const showOfflineBanner = !isDemoMode && agentStatus === 'disconnected' && !offlineBannerDismissed
@@ -74,6 +76,13 @@ export function Layout({ children }: LayoutProps) {
             <span className="text-xs text-yellow-400/70">
               Showing sample data from all cloud providers
             </span>
+            <button
+              onClick={() => setShowSetupDialog(true)}
+              className="ml-2 flex items-center gap-1.5 px-3 py-1 bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 rounded-full text-xs font-medium transition-colors"
+            >
+              <Rocket className="w-3.5 h-3.5" />
+              Want your own local KubeStellar Console?
+            </button>
             <button
               onClick={toggleDemoMode}
               className="ml-2 p-1 hover:bg-yellow-500/20 rounded transition-colors"
@@ -144,6 +153,12 @@ export function Layout({ children }: LayoutProps) {
       {/* AI Mission sidebar */}
       <MissionSidebar />
       <MissionSidebarToggle />
+
+      {/* Setup Instructions Dialog */}
+      <SetupInstructionsDialog
+        isOpen={showSetupDialog}
+        onClose={() => setShowSetupDialog(false)}
+      />
     </div>
     </TourProvider>
   )

--- a/web/src/components/setup/SetupInstructionsDialog.tsx
+++ b/web/src/components/setup/SetupInstructionsDialog.tsx
@@ -1,0 +1,256 @@
+'use client'
+
+import { useState } from 'react'
+import { Rocket, Copy, Check, Terminal, Globe, Download, ExternalLink, ChevronDown, ChevronRight, KeyRound } from 'lucide-react'
+import { BaseModal } from '../../lib/modals'
+
+interface SetupInstructionsDialogProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const REPO_URL = 'https://github.com/kubestellar/console'
+const DOCS_URL = 'https://console-docs.kubestellar.io'
+
+const STEPS = [
+  {
+    number: 1,
+    title: 'Clone the repository',
+    description: 'Get the KubeStellar Console source code',
+    command: 'git clone https://github.com/kubestellar/console.git',
+    icon: Download,
+  },
+  {
+    number: 2,
+    title: 'Navigate to the project',
+    description: 'Change into the project directory',
+    command: 'cd console',
+    icon: Terminal,
+  },
+  {
+    number: 3,
+    title: 'Start the console',
+    description: 'Run the startup script in the background',
+    command: './startup-demo.sh &',
+    altCommand: './startup-oauth.sh &',
+    altLabel: 'With GitHub OAuth login',
+    icon: Rocket,
+    hasOAuthGuide: true,
+  },
+  {
+    number: 4,
+    title: 'Install the local agent',
+    description: 'Connect your kubeconfig clusters',
+    command: 'brew install kubestellar/tap/kc-agent && kc-agent',
+    icon: Download,
+  },
+  {
+    number: 5,
+    title: 'Open the console',
+    description: 'Access your local KubeStellar Console',
+    command: 'open http://localhost:5174',
+    icon: Globe,
+  },
+] as const
+
+const OAUTH_STEPS = [
+  { label: 'Go to', link: 'https://github.com/settings/developers', linkText: 'GitHub Developer Settings' },
+  { label: 'Click "New OAuth App" and fill in:' },
+  { label: 'Application name:', value: 'KubeStellar Console' },
+  { label: 'Homepage URL:', value: 'http://localhost:5174' },
+  { label: 'Callback URL:', value: 'http://localhost:5174/auth/github/callback' },
+  { label: 'Click "Register application", then copy the Client ID and generate a Client Secret' },
+  { label: 'Create a .env file in the project root:', command: 'GITHUB_CLIENT_ID=<your-client-id>\nGITHUB_CLIENT_SECRET=<your-client-secret>' },
+]
+
+export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDialogProps) {
+  const [copiedStep, setCopiedStep] = useState<number | null>(null)
+  const [showOAuthGuide, setShowOAuthGuide] = useState(false)
+
+  const copyToClipboard = async (text: string, stepKey: number) => {
+    await navigator.clipboard.writeText(text)
+    setCopiedStep(stepKey)
+    setTimeout(() => setCopiedStep(null), 2000)
+  }
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="md">
+      <BaseModal.Header
+        title="Run KubeStellar Console Locally"
+        description="Connect your own clusters in 5 steps"
+        icon={Rocket}
+        onClose={onClose}
+        showBack={false}
+      />
+
+      <BaseModal.Content>
+        <div className="space-y-3">
+          {STEPS.map((step) => {
+            const Icon = step.icon
+            return (
+              <div
+                key={step.number}
+                className="rounded-lg border border-border/50 bg-secondary/30 p-3"
+              >
+                <div className="flex items-start gap-3">
+                  <div className="flex-shrink-0 w-7 h-7 rounded-full bg-purple-500/20 flex items-center justify-center">
+                    <span className="text-sm font-bold text-purple-400">{step.number}</span>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-0.5">
+                      <Icon className="w-4 h-4 text-muted-foreground" />
+                      <span className="font-medium text-sm text-foreground">{step.title}</span>
+                    </div>
+                    <p className="text-xs text-muted-foreground mb-2">{step.description}</p>
+                    <div className="flex items-center gap-2">
+                      <code className="flex-1 rounded bg-muted px-3 py-1.5 text-xs font-mono text-foreground select-all overflow-x-auto">
+                        {step.command}
+                      </code>
+                      <button
+                        onClick={() => copyToClipboard(step.command, step.number)}
+                        className="shrink-0 p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                        title="Copy command"
+                      >
+                        {copiedStep === step.number ? (
+                          <Check className="w-3.5 h-3.5 text-green-400" />
+                        ) : (
+                          <Copy className="w-3.5 h-3.5" />
+                        )}
+                      </button>
+                    </div>
+                    {'altCommand' in step && step.altCommand && (
+                      <div className="mt-2">
+                        <span className="text-xs text-muted-foreground">
+                          {'altLabel' in step ? step.altLabel : 'Alternative'}:
+                        </span>
+                        <div className="flex items-center gap-2 mt-1">
+                          <code className="flex-1 rounded bg-muted px-3 py-1.5 text-xs font-mono text-foreground select-all overflow-x-auto">
+                            {step.altCommand}
+                          </code>
+                          <button
+                            onClick={() => copyToClipboard(step.altCommand, step.number + 100)}
+                            className="shrink-0 p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                            title="Copy command"
+                          >
+                            {copiedStep === step.number + 100 ? (
+                              <Check className="w-3.5 h-3.5 text-green-400" />
+                            ) : (
+                              <Copy className="w-3.5 h-3.5" />
+                            )}
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                    {'hasOAuthGuide' in step && step.hasOAuthGuide && (
+                      <div className="mt-2">
+                        <button
+                          onClick={() => setShowOAuthGuide(!showOAuthGuide)}
+                          className="flex items-center gap-1.5 text-xs text-purple-400 hover:text-purple-300 transition-colors"
+                        >
+                          {showOAuthGuide ? (
+                            <ChevronDown className="w-3.5 h-3.5" />
+                          ) : (
+                            <ChevronRight className="w-3.5 h-3.5" />
+                          )}
+                          <KeyRound className="w-3.5 h-3.5" />
+                          How to set up GitHub OAuth
+                        </button>
+                        {showOAuthGuide && (
+                          <div className="mt-2 rounded-lg border border-purple-500/20 bg-purple-500/5 p-3 space-y-2">
+                            {OAUTH_STEPS.map((oStep, idx) => (
+                              <div key={idx} className="text-xs">
+                                {oStep.link ? (
+                                  <span className="text-muted-foreground">
+                                    {idx + 1}. {oStep.label}{' '}
+                                    <a
+                                      href={oStep.link}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="text-purple-400 hover:text-purple-300 underline"
+                                    >
+                                      {oStep.linkText}
+                                    </a>
+                                  </span>
+                                ) : oStep.value ? (
+                                  <div className="flex items-center gap-2 ml-4">
+                                    <span className="text-muted-foreground shrink-0">{oStep.label}</span>
+                                    <code className="rounded bg-muted px-2 py-0.5 font-mono text-foreground select-all">
+                                      {oStep.value}
+                                    </code>
+                                  </div>
+                                ) : oStep.command ? (
+                                  <div className="ml-4 mt-1">
+                                    <span className="text-muted-foreground">{idx + 1}. {oStep.label}</span>
+                                    <div className="flex items-center gap-2 mt-1">
+                                      <pre className="flex-1 rounded bg-muted px-3 py-1.5 font-mono text-foreground select-all overflow-x-auto whitespace-pre">
+                                        {oStep.command}
+                                      </pre>
+                                      <button
+                                        onClick={() => copyToClipboard(oStep.command, 200 + idx)}
+                                        className="shrink-0 p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors self-start"
+                                        title="Copy"
+                                      >
+                                        {copiedStep === 200 + idx ? (
+                                          <Check className="w-3.5 h-3.5 text-green-400" />
+                                        ) : (
+                                          <Copy className="w-3.5 h-3.5" />
+                                        )}
+                                      </button>
+                                    </div>
+                                  </div>
+                                ) : (
+                                  <span className="text-muted-foreground">
+                                    {idx + 1}. {oStep.label}
+                                  </span>
+                                )}
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        <div className="mt-4 flex items-center justify-center gap-4">
+          <a
+            href={DOCS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 text-sm text-purple-400 hover:text-purple-300 transition-colors"
+          >
+            <ExternalLink className="w-4 h-4" />
+            Documentation
+          </a>
+          <span className="text-muted-foreground/30">|</span>
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1.5 text-sm text-purple-400 hover:text-purple-300 transition-colors"
+          >
+            <ExternalLink className="w-4 h-4" />
+            GitHub
+          </a>
+        </div>
+      </BaseModal.Content>
+
+      <BaseModal.Footer showKeyboardHints={false}>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          Prerequisites: Go 1.21+, Node.js 18+, Homebrew
+        </div>
+        <div className="flex-1" />
+        <button
+          onClick={onClose}
+          className="rounded border px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+        >
+          Close
+        </button>
+      </BaseModal.Footer>
+    </BaseModal>
+  )
+}


### PR DESCRIPTION
## Summary
- Add **"Want your own local KubeStellar Console?"** CTA button to the demo mode banner
- New **SetupInstructionsDialog** modal with 5-step guide: clone → cd → startup → agent install → open browser
- Inline **OAuth setup guide** (expandable) with GitHub Developer Settings link, field values, and .env template
- **Documentation** and **GitHub** links at the bottom of the dialog
- Two new root-level startup scripts: `startup-demo.sh` (no creds needed) and `startup-oauth.sh` (GitHub OAuth)
- Backend `SKIP_ONBOARDING` env var to bypass the onboarding questionnaire in both modes

## Test plan
- [x] Go backend compiles cleanly
- [x] TypeScript has no new errors (pre-existing error in RecentEvents.tsx unrelated)
- [x] ESLint has no new errors
- [x] Demo mode banner shows purple "Want your own local KubeStellar Console?" pill button
- [x] Clicking button opens the setup instructions dialog with all 5 steps
- [x] "How to set up GitHub OAuth" expander reveals inline OAuth guide
- [x] Copy buttons work for all commands
- [x] Documentation and GitHub links render at bottom
- [x] Dialog closes with Close button and Esc key

🤖 Generated with [Claude Code](https://claude.com/claude-code)