### PR TITLE
🐛 Fix dashboard blinking on first navigation between pages

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,6 +48,47 @@ const NamespaceManager = lazy(() => import('./components/namespaces/NamespaceMan
 const Arcade = lazy(() => import('./components/arcade/Arcade').then(m => ({ default: m.Arcade })))
 const Deploy = lazy(() => import('./components/deploy/Deploy').then(m => ({ default: m.Deploy })))
 
+// Prefetch all lazy route chunks after initial page load.
+// This runs during idle time so by the time the user navigates,
+// the target chunk is already cached and loads instantly.
+if (typeof window !== 'undefined') {
+  const prefetchRoutes = () => {
+    const chunks = [
+      () => import('./components/dashboard/Dashboard'),
+      () => import('./components/clusters/Clusters'),
+      () => import('./components/workloads/Workloads'),
+      () => import('./components/compute/Compute'),
+      () => import('./components/events/Events'),
+      () => import('./components/nodes/Nodes'),
+      () => import('./components/deployments/Deployments'),
+      () => import('./components/pods/Pods'),
+      () => import('./components/services/Services'),
+      () => import('./components/storage/Storage'),
+      () => import('./components/network/Network'),
+      () => import('./components/security/Security'),
+      () => import('./components/gitops/GitOps'),
+      () => import('./components/alerts/Alerts'),
+      () => import('./components/cost/Cost'),
+      () => import('./components/compliance/Compliance'),
+      () => import('./components/operators/Operators'),
+      () => import('./components/helm/HelmReleases'),
+      () => import('./components/settings/Settings'),
+      () => import('./components/gpu/GPUReservations'),
+    ]
+    // Stagger imports to avoid blocking the main thread
+    chunks.forEach((load, i) => {
+      setTimeout(() => load().catch(() => {}), i * 100)
+    })
+  }
+
+  // Use requestIdleCallback if available, otherwise setTimeout
+  if ('requestIdleCallback' in window) {
+    requestIdleCallback(prefetchRoutes, { timeout: 5000 })
+  } else {
+    setTimeout(prefetchRoutes, 2000)
+  }
+}
+
 // Loading fallback component with delay to prevent flash on fast navigation
 function LoadingFallback() {
   const [showLoading, setShowLoading] = useState(false)

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react'
+import { ReactNode, useState, Suspense } from 'react'
 import { Link } from 'react-router-dom'
 import { Box, WifiOff, X, Settings, Rocket } from 'lucide-react'
 import { Navbar } from './navbar/index'
@@ -15,6 +15,41 @@ import { TourOverlay, TourPrompt } from '../onboarding/Tour'
 import { DemoInstallBanner } from '../onboarding/DemoInstallGuide'
 import { TourProvider } from '../../hooks/useTour'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
+
+// Content-area loading skeleton shown during lazy route transitions.
+// Keeps the Layout shell (navbar + sidebar) visible while the page chunk loads.
+function ContentFallback() {
+  return (
+    <div className="pt-16 animate-pulse">
+      {/* Header skeleton */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <div className="h-7 w-44 bg-secondary/60 rounded mb-2" />
+          <div className="h-4 w-64 bg-secondary/40 rounded" />
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-9 w-24 bg-secondary/40 rounded" />
+        </div>
+      </div>
+      {/* Card grid skeleton */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {[1, 2, 3, 4, 5, 6].map(i => (
+          <div key={i} className="rounded-xl border border-border/30 bg-secondary/10 p-4">
+            <div className="flex items-center gap-2 mb-4">
+              <div className="h-4 w-4 bg-secondary/50 rounded" />
+              <div className="h-4 w-28 bg-secondary/50 rounded" />
+            </div>
+            <div className="space-y-3">
+              <div className="h-3 w-full bg-secondary/30 rounded" />
+              <div className="h-3 w-3/4 bg-secondary/30 rounded" />
+              <div className="h-20 w-full bg-secondary/20 rounded" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
 
 interface LayoutProps {
   children: ReactNode
@@ -150,7 +185,9 @@ export function Layout({ children }: LayoutProps) {
           isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen && 'mr-[500px]',
           isMissionSidebarOpen && isMissionSidebarMinimized && !isMissionFullScreen && 'mr-12'
         )}>
-          {children}
+          <Suspense fallback={<ContentFallback />}>
+            {children}
+          </Suspense>
         </main>
       </div>
 


### PR DESCRIPTION
## Summary
- Add a `Suspense` boundary inside `Layout` around `{children}` with a content-area skeleton fallback, so the navbar and sidebar stay visible during lazy route transitions instead of the entire page going blank
- Prefetch all 20 main route chunks during browser idle time (`requestIdleCallback`) after initial page load, so subsequent navigations load instantly from cache

## Root Cause
The single `<Suspense>` in `App.tsx` wrapped the entire `<Routes>` tree including `<Layout>`. When navigating to a lazy-loaded page for the first time, React replaced the full page (sidebar, navbar, content) with `LoadingFallback` which rendered `null` for 200ms — causing a visible blink/flash.

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes
- [x] Navigation between dashboards shows content skeleton instead of blank page
- [x] Sidebar and navbar remain visible during route transitions
- [x] Screenshot verified via CDP after navigating through multiple dashboards

🤖 Generated with [Claude Code](https://claude.com/claude-code)