### PR TITLE
🐛 Remove redundant demo install banner

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -13,7 +13,6 @@ import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { useNetworkStatus } from '../../hooks/useNetworkStatus'
 import { cn } from '../../lib/cn'
 import { TourOverlay, TourPrompt } from '../onboarding/Tour'
-import { DemoInstallBanner } from '../onboarding/DemoInstallGuide'
 import { TourProvider } from '../../hooks/useTour'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
 
@@ -130,9 +129,6 @@ export function Layout({ children }: LayoutProps) {
           </div>
         </div>
       )}
-
-      {/* Demo Install Guide Banner - positioned under demo banner */}
-      {isDemoMode && <DemoInstallBanner collapsed={config.collapsed} />}
 
       {/* Offline Mode Banner - positioned in main content area only */}
       {showOfflineBanner && (


### PR DESCRIPTION
## Summary
- Remove the `DemoInstallBanner` from Layout — it stacked a second "Want to use your own clusters?" banner directly below the existing "Demo Mode Active" banner which already has a "Want your own local KubeStellar Console?" CTA
- Single banner with one clear CTA is cleaner than two overlapping prompts

## Test plan
- [x] Build passes
- [x] TypeScript type check passes
- [x] No lint errors in changed file
- [ ] Visual: demo mode shows only one banner with the install CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)