### PR TITLE
🌱 Add WorkloadMonitor card with tree/list views and alerts

### DIFF
--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -121,6 +121,7 @@ const WorkloadDeployment = lazy(() => import('./WorkloadDeployment').then(m => (
 const ClusterGroups = lazy(() => import('./ClusterGroups').then(m => ({ default: m.ClusterGroups })))
 const Missions = lazy(() => import('./Missions').then(m => ({ default: m.Missions })))
 const ResourceMarshall = lazy(() => import('./ResourceMarshall').then(m => ({ default: m.ResourceMarshall })))
+const WorkloadMonitor = lazy(() => import('./workload-monitor/WorkloadMonitor').then(m => ({ default: m.WorkloadMonitor })))
 
 // Type for card component props
 export type CardComponentProps = { config?: Record<string, unknown> }
@@ -297,6 +298,8 @@ export const CARD_COMPONENTS: Record<string, CardComponent> = {
   deployment_missions: Missions,
   // Resource Marshall card (dependency tree explorer)
   resource_marshall: ResourceMarshall,
+  // Workload Monitor card (health monitoring with tree/list views)
+  workload_monitor: WorkloadMonitor,
 
   // Aliases - map catalog types to existing components with similar functionality
   gpu_list: GPUInventory,
@@ -390,6 +393,8 @@ export const LIVE_DATA_CARDS = new Set([
   'cert_manager',
   // Deployment Missions card - polls deploy status in real time
   'deployment_missions',
+  // Workload Monitor - live health monitoring
+  'workload_monitor',
 ])
 
 /**
@@ -428,6 +433,8 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   deployment_missions: 5,
   // Resource Marshall card
   resource_marshall: 6,
+  // Workload Monitor card
+  workload_monitor: 8,
 
   // Event dashboard cards
   event_summary: 6,

--- a/web/src/components/cards/workload-monitor/WorkloadMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitor.tsx
@@ -1,0 +1,309 @@
+import { useState, useMemo, useCallback } from 'react'
+import { Package, RefreshCw, Loader2, AlertTriangle, Search } from 'lucide-react'
+import { Skeleton } from '../../ui/Skeleton'
+import { Pagination } from '../../ui/Pagination'
+import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
+import type { SortDirection } from '../../../lib/cards/cardHooks'
+import { useClusters, useNamespaces } from '../../../hooks/useMCP'
+import { useWorkloads } from '../../../hooks/useWorkloads'
+import { useWorkloadMonitor } from '../../../hooks/useWorkloadMonitor'
+import { cn } from '../../../lib/cn'
+import type {
+  MonitoredResource,
+  MonitorViewMode,
+  ResourceCategory,
+  ResourceHealthStatus,
+  WorkloadMonitorConfig,
+} from '../../../types/workloadMonitor'
+import { WorkloadMonitorToolbar } from './WorkloadMonitorToolbar'
+import { WorkloadMonitorTree } from './WorkloadMonitorTree'
+import { WorkloadMonitorList } from './WorkloadMonitorList'
+import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
+
+interface WorkloadMonitorProps {
+  config?: Record<string, unknown>
+}
+
+type SortField = 'name' | 'kind' | 'status' | 'category' | 'order'
+
+const STATUS_ORDER: Record<string, number> = { unhealthy: 0, missing: 1, degraded: 2, unknown: 3, healthy: 4 }
+
+export function WorkloadMonitor({ config }: WorkloadMonitorProps) {
+  const monitorConfig = config as WorkloadMonitorConfig | undefined
+
+  // Cascading selectors (used when config doesn't pre-specify the workload)
+  const { deduplicatedClusters: clusters } = useClusters()
+  const [selectedCluster, setSelectedCluster] = useState(monitorConfig?.cluster || '')
+  const [selectedNamespace, setSelectedNamespace] = useState(monitorConfig?.namespace || '')
+  const [selectedWorkload, setSelectedWorkload] = useState(monitorConfig?.workload || '')
+
+  const isPreConfigured = !!(monitorConfig?.cluster && monitorConfig?.namespace && monitorConfig?.workload)
+  const activeCluster = isPreConfigured ? monitorConfig!.cluster! : selectedCluster
+  const activeNamespace = isPreConfigured ? monitorConfig!.namespace! : selectedNamespace
+  const activeWorkload = isPreConfigured ? monitorConfig!.workload! : selectedWorkload
+
+  // Fetch namespaces/workloads for selectors
+  const { namespaces, isLoading: nsLoading } = useNamespaces(selectedCluster || undefined)
+  const hasSelection = !!selectedCluster && !!selectedNamespace
+  const workloadOpts = useMemo(() => {
+    if (!selectedCluster || !selectedNamespace) return undefined
+    return { cluster: selectedCluster, namespace: selectedNamespace }
+  }, [selectedCluster, selectedNamespace])
+  const { data: workloads, isLoading: wlLoading } = useWorkloads(workloadOpts, hasSelection)
+
+  // Monitor data
+  const {
+    resources,
+    issues,
+    overallStatus,
+    workloadKind,
+    isLoading,
+    isRefreshing,
+    error,
+    refetch,
+  } = useWorkloadMonitor(activeCluster, activeNamespace, activeWorkload, {
+    autoRefreshMs: monitorConfig?.autoRefreshMs,
+  })
+
+  // View mode and filters
+  const [viewMode, setViewMode] = useState<MonitorViewMode>('tree')
+  const [categoryFilter, setCategoryFilter] = useState<ResourceCategory | 'all'>('all')
+  const [statusFilter, setStatusFilter] = useState<ResourceHealthStatus | 'all'>('all')
+
+  // Pre-filter by category and status before useCardData
+  const preFiltered = useMemo(() => {
+    let filtered = resources
+    if (categoryFilter !== 'all') {
+      filtered = filtered.filter(r => r.category === categoryFilter)
+    }
+    if (statusFilter !== 'all') {
+      filtered = filtered.filter(r => r.status === statusFilter)
+    }
+    return filtered
+  }, [resources, categoryFilter, statusFilter])
+
+  const {
+    items,
+    totalItems,
+    currentPage,
+    totalPages,
+    goToPage,
+    needsPagination,
+    itemsPerPage,
+    setItemsPerPage,
+    filters,
+    sorting,
+  } = useCardData<MonitoredResource, SortField>(preFiltered, {
+    filter: {
+      searchFields: ['name', 'kind', 'status', 'category', 'message'] as (keyof MonitoredResource)[],
+    },
+    sort: {
+      defaultField: 'status',
+      defaultDirection: 'asc' as SortDirection,
+      comparators: {
+        name: commonComparators.string<MonitoredResource>('name'),
+        kind: commonComparators.string<MonitoredResource>('kind'),
+        status: (a, b) => (STATUS_ORDER[a.status] ?? 3) - (STATUS_ORDER[b.status] ?? 3),
+        category: commonComparators.string<MonitoredResource>('category'),
+        order: (a, b) => a.order - b.order,
+      },
+    },
+    defaultLimit: 10,
+  })
+
+  // Handlers for selectors
+  const handleClusterChange = useCallback((cluster: string) => {
+    setSelectedCluster(cluster)
+    setSelectedNamespace('')
+    setSelectedWorkload('')
+  }, [])
+
+  const handleNamespaceChange = useCallback((ns: string) => {
+    setSelectedNamespace(ns)
+    setSelectedWorkload('')
+  }, [])
+
+  const handleWorkloadChange = useCallback((name: string) => {
+    setSelectedWorkload(name)
+  }, [])
+
+  const handleResourceClick = useCallback((_resource: MonitoredResource) => {
+    // DrillDown integration will be added in Phase 3
+    // For now, this is a placeholder for click-through navigation
+  }, [])
+
+  const clusterNames = useMemo(() => clusters.map(c => c.name).sort(), [clusters])
+
+  // Loading state
+  if (isLoading && !resources.length) {
+    return (
+      <div className="space-y-3">
+        <Skeleton variant="text" width={120} height={20} />
+        <Skeleton variant="rounded" height={40} />
+        <Skeleton variant="rounded" height={40} />
+        <Skeleton variant="rounded" height={40} />
+      </div>
+    )
+  }
+
+  const statusColors: Record<string, string> = {
+    healthy: 'bg-green-500/20 text-green-400',
+    degraded: 'bg-yellow-500/20 text-yellow-400',
+    unhealthy: 'bg-red-500/20 text-red-400',
+    unknown: 'bg-gray-500/20 text-gray-400',
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card">
+      {/* Cascading selectors (only when not pre-configured) */}
+      {!isPreConfigured && (
+        <div className="space-y-2 mb-3">
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-muted-foreground w-20 shrink-0">Cluster</label>
+            <select
+              value={selectedCluster}
+              onChange={(e) => handleClusterChange(e.target.value)}
+              className="flex-1 text-sm rounded-md bg-secondary/50 border border-border px-2 py-1.5 text-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
+            >
+              <option value="">Select cluster...</option>
+              {clusterNames.map(c => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-muted-foreground w-20 shrink-0">Namespace</label>
+            <select
+              value={selectedNamespace}
+              onChange={(e) => handleNamespaceChange(e.target.value)}
+              disabled={!selectedCluster || nsLoading}
+              className={cn(
+                'flex-1 text-sm rounded-md bg-secondary/50 border border-border px-2 py-1.5 text-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50',
+                (!selectedCluster || nsLoading) && 'opacity-50 cursor-not-allowed',
+              )}
+            >
+              <option value="">{nsLoading ? 'Loading...' : 'Select namespace...'}</option>
+              {namespaces.map(ns => (
+                <option key={ns} value={ns}>{ns}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-muted-foreground w-20 shrink-0">Workload</label>
+            <select
+              value={selectedWorkload}
+              onChange={(e) => handleWorkloadChange(e.target.value)}
+              disabled={!selectedNamespace || wlLoading}
+              className={cn(
+                'flex-1 text-sm rounded-md bg-secondary/50 border border-border px-2 py-1.5 text-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50',
+                (!selectedNamespace || wlLoading) && 'opacity-50 cursor-not-allowed',
+              )}
+            >
+              <option value="">{wlLoading ? 'Loading...' : 'Select workload...'}</option>
+              {workloads?.map(w => (
+                <option key={`${w.type}-${w.name}`} value={w.name}>
+                  {w.name} ({w.type})
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!activeWorkload && (
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <Search className="w-8 h-8 text-muted-foreground/40 mb-2" />
+          <p className="text-sm text-muted-foreground">
+            Select a cluster, namespace, and workload to monitor.
+          </p>
+        </div>
+      )}
+
+      {/* Error state */}
+      {error && !isLoading && activeWorkload && (
+        <div className="rounded-lg bg-yellow-500/10 border border-yellow-500/20 p-3 flex items-start gap-2 mb-3">
+          <AlertTriangle className="w-4 h-4 text-yellow-400 mt-0.5 shrink-0" />
+          <div>
+            <p className="text-sm text-yellow-400 font-medium">Monitor error</p>
+            <p className="text-xs text-yellow-400/70 mt-0.5">{error.message}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Main content (only when workload is selected and data is available) */}
+      {activeWorkload && resources.length > 0 && (
+        <>
+          {/* Workload header */}
+          <div className="rounded-lg bg-card/50 border border-border p-2.5 mb-3 flex items-center gap-2">
+            <Package className="w-4 h-4 text-purple-400 shrink-0" />
+            <span className="text-sm font-medium text-foreground">{activeWorkload}</span>
+            {workloadKind && (
+              <span className="text-xs px-1.5 py-0.5 rounded bg-secondary text-muted-foreground">
+                {workloadKind}
+              </span>
+            )}
+            <span className={`text-xs px-1.5 py-0.5 rounded ml-auto ${statusColors[overallStatus] || statusColors.unknown}`}>
+              {overallStatus}
+            </span>
+            <button
+              onClick={refetch}
+              disabled={isRefreshing}
+              className="p-1 rounded hover:bg-secondary transition-colors"
+              title="Refresh"
+            >
+              {isRefreshing
+                ? <Loader2 className="w-3.5 h-3.5 text-purple-400 animate-spin" />
+                : <RefreshCw className="w-3.5 h-3.5 text-muted-foreground" />}
+            </button>
+          </div>
+
+          {/* Toolbar */}
+          <WorkloadMonitorToolbar
+            search={filters.search}
+            onSearchChange={filters.setSearch}
+            viewMode={viewMode}
+            onViewModeChange={setViewMode}
+            categoryFilter={categoryFilter}
+            onCategoryFilterChange={setCategoryFilter}
+            statusFilter={statusFilter}
+            onStatusFilterChange={setStatusFilter}
+            totalItems={totalItems}
+            issueCount={issues.length}
+            sortBy={sorting.sortBy}
+            onSortChange={(v) => sorting.setSortBy(v as SortField)}
+            sortDirection={sorting.sortDirection}
+            onSortDirectionChange={sorting.setSortDirection}
+            limit={itemsPerPage}
+            onLimitChange={setItemsPerPage}
+          />
+
+          {/* View */}
+          <div className="flex-1 overflow-y-auto">
+            {viewMode === 'tree' ? (
+              <WorkloadMonitorTree resources={items} onResourceClick={handleResourceClick} />
+            ) : (
+              <WorkloadMonitorList resources={items} onResourceClick={handleResourceClick} />
+            )}
+          </div>
+
+          {/* Pagination */}
+          {needsPagination && (
+            <div className="mt-2 pt-2 border-t border-border/50">
+              <Pagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                totalItems={totalItems}
+                itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : totalItems}
+                onPageChange={goToPage}
+              />
+            </div>
+          )}
+
+          {/* Alerts */}
+          <WorkloadMonitorAlerts issues={issues} />
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/workload-monitor/WorkloadMonitorAlerts.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitorAlerts.tsx
@@ -1,0 +1,71 @@
+import { AlertTriangle, AlertCircle, Info, ChevronDown, ChevronRight } from 'lucide-react'
+import { useState } from 'react'
+import type { MonitorIssue } from '../../../types/workloadMonitor'
+
+interface AlertsProps {
+  issues: MonitorIssue[]
+}
+
+const SEVERITY_CONFIG = {
+  critical: { icon: AlertCircle, bg: 'bg-red-500/10', border: 'border-red-500/20', text: 'text-red-400', badge: 'bg-red-500/20 text-red-400' },
+  warning: { icon: AlertTriangle, bg: 'bg-yellow-500/10', border: 'border-yellow-500/20', text: 'text-yellow-400', badge: 'bg-yellow-500/20 text-yellow-400' },
+  info: { icon: Info, bg: 'bg-blue-500/10', border: 'border-blue-500/20', text: 'text-blue-400', badge: 'bg-blue-500/20 text-blue-400' },
+}
+
+export function WorkloadMonitorAlerts({ issues }: AlertsProps) {
+  const [expanded, setExpanded] = useState(true)
+
+  if (issues.length === 0) return null
+
+  const criticalCount = issues.filter(i => i.severity === 'critical').length
+  const warningCount = issues.filter(i => i.severity === 'warning').length
+  const infoCount = issues.filter(i => i.severity === 'info').length
+
+  return (
+    <div className="mt-3">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors mb-2"
+      >
+        {expanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+        <AlertTriangle className="w-3.5 h-3.5 text-yellow-400" />
+        <span>Issues ({issues.length})</span>
+        {criticalCount > 0 && (
+          <span className="text-[10px] px-1 py-0.5 rounded bg-red-500/20 text-red-400">{criticalCount} critical</span>
+        )}
+        {warningCount > 0 && (
+          <span className="text-[10px] px-1 py-0.5 rounded bg-yellow-500/20 text-yellow-400">{warningCount} warning</span>
+        )}
+        {infoCount > 0 && (
+          <span className="text-[10px] px-1 py-0.5 rounded bg-blue-500/20 text-blue-400">{infoCount} info</span>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="space-y-1.5">
+          {issues.map(issue => {
+            const config = SEVERITY_CONFIG[issue.severity as keyof typeof SEVERITY_CONFIG] || SEVERITY_CONFIG.info
+            const SeverityIcon = config.icon
+            return (
+              <div
+                key={issue.id}
+                className={`rounded-md ${config.bg} border ${config.border} p-2 flex items-start gap-2`}
+              >
+                <SeverityIcon className={`w-3.5 h-3.5 ${config.text} mt-0.5 shrink-0`} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className={`text-xs font-medium ${config.text}`}>{issue.title}</span>
+                    <span className={`text-[10px] px-1 py-0.5 rounded ${config.badge}`}>{issue.severity}</span>
+                  </div>
+                  {issue.description && (
+                    <p className={`text-[10px] ${config.text} opacity-70 mt-0.5`}>{issue.description}</p>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/workload-monitor/WorkloadMonitorList.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitorList.tsx
@@ -1,0 +1,78 @@
+import { CheckCircle, XCircle, AlertTriangle, HelpCircle, MinusCircle } from 'lucide-react'
+import { getIconForKind } from '../../../lib/resourceCategories'
+import type { MonitoredResource, ResourceHealthStatus } from '../../../types/workloadMonitor'
+
+interface ListProps {
+  resources: MonitoredResource[]
+  onResourceClick?: (resource: MonitoredResource) => void
+}
+
+const STATUS_ICON: Record<ResourceHealthStatus, JSX.Element> = {
+  healthy: <CheckCircle className="w-3.5 h-3.5 text-green-400" />,
+  degraded: <AlertTriangle className="w-3.5 h-3.5 text-yellow-400" />,
+  unhealthy: <XCircle className="w-3.5 h-3.5 text-red-400" />,
+  unknown: <HelpCircle className="w-3.5 h-3.5 text-gray-400" />,
+  missing: <MinusCircle className="w-3.5 h-3.5 text-red-400" />,
+}
+
+const STATUS_BADGE: Record<ResourceHealthStatus, string> = {
+  healthy: 'bg-green-500/20 text-green-400',
+  degraded: 'bg-yellow-500/20 text-yellow-400',
+  unhealthy: 'bg-red-500/20 text-red-400',
+  unknown: 'bg-gray-500/20 text-gray-400',
+  missing: 'bg-red-500/20 text-red-400',
+}
+
+const CATEGORY_BADGE: Record<string, string> = {
+  rbac: 'bg-blue-500/20 text-blue-400',
+  config: 'bg-cyan-500/20 text-cyan-400',
+  networking: 'bg-indigo-500/20 text-indigo-400',
+  scaling: 'bg-orange-500/20 text-orange-400',
+  storage: 'bg-amber-500/20 text-amber-400',
+  crd: 'bg-violet-500/20 text-violet-400',
+  admission: 'bg-rose-500/20 text-rose-400',
+  workload: 'bg-purple-500/20 text-purple-400',
+  other: 'bg-gray-500/20 text-gray-400',
+}
+
+export function WorkloadMonitorList({ resources, onResourceClick }: ListProps) {
+  if (resources.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground text-center py-4">
+        No resources found.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-1">
+      {resources.map(resource => {
+        const ResourceIcon = getIconForKind(resource.kind)
+        return (
+          <div
+            key={resource.id}
+            className="flex items-center gap-2 py-1.5 px-2 rounded-md hover:bg-card/50 cursor-pointer transition-colors border border-transparent hover:border-border/50"
+            onClick={() => onResourceClick?.(resource)}
+          >
+            {STATUS_ICON[resource.status]}
+            <ResourceIcon className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            <span className="text-xs font-medium text-foreground truncate min-w-0 flex-1">
+              {resource.name}
+            </span>
+            <span className={`text-[10px] px-1.5 py-0.5 rounded shrink-0 ${CATEGORY_BADGE[resource.category] || CATEGORY_BADGE.other}`}>
+              {resource.kind}
+            </span>
+            <span className={`text-[10px] px-1.5 py-0.5 rounded shrink-0 ${STATUS_BADGE[resource.status]}`}>
+              {resource.status}
+            </span>
+            {resource.message && (
+              <span className="text-[10px] text-muted-foreground truncate max-w-[120px] shrink-0">
+                {resource.message}
+              </span>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/components/cards/workload-monitor/WorkloadMonitorToolbar.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitorToolbar.tsx
@@ -1,0 +1,133 @@
+import { Search, List, GitBranch } from 'lucide-react'
+import { CardControls } from '../../ui/CardControls'
+import type { MonitorViewMode, ResourceCategory, ResourceHealthStatus } from '../../../types/workloadMonitor'
+
+interface ToolbarProps {
+  search: string
+  onSearchChange: (v: string) => void
+  viewMode: MonitorViewMode
+  onViewModeChange: (v: MonitorViewMode) => void
+  categoryFilter: ResourceCategory | 'all'
+  onCategoryFilterChange: (v: ResourceCategory | 'all') => void
+  statusFilter: ResourceHealthStatus | 'all'
+  onStatusFilterChange: (v: ResourceHealthStatus | 'all') => void
+  totalItems: number
+  issueCount: number
+  sortBy: string
+  onSortChange: (v: string) => void
+  sortDirection: 'asc' | 'desc'
+  onSortDirectionChange: (v: 'asc' | 'desc') => void
+  limit: number | 'unlimited'
+  onLimitChange: (v: number | 'unlimited') => void
+}
+
+const SORT_OPTIONS = [
+  { value: 'name', label: 'Name' },
+  { value: 'kind', label: 'Kind' },
+  { value: 'status', label: 'Status' },
+  { value: 'category', label: 'Category' },
+  { value: 'order', label: 'Apply Order' },
+]
+
+export function WorkloadMonitorToolbar({
+  search,
+  onSearchChange,
+  viewMode,
+  onViewModeChange,
+  categoryFilter,
+  onCategoryFilterChange,
+  statusFilter,
+  onStatusFilterChange,
+  totalItems,
+  issueCount,
+  sortBy,
+  onSortChange,
+  sortDirection,
+  onSortDirectionChange,
+  limit,
+  onLimitChange,
+}: ToolbarProps) {
+  return (
+    <div className="space-y-2 mb-3">
+      {/* Top row: summary + controls */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+            {totalItems} resources
+          </span>
+          {issueCount > 0 && (
+            <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400">
+              {issueCount} issue{issueCount !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {/* View mode toggle */}
+          <div className="flex rounded-md border border-border overflow-hidden">
+            <button
+              onClick={() => onViewModeChange('tree')}
+              className={`p-1 ${viewMode === 'tree' ? 'bg-purple-500/20 text-purple-400' : 'text-muted-foreground hover:text-foreground'}`}
+              title="Tree view"
+            >
+              <GitBranch className="w-3.5 h-3.5" />
+            </button>
+            <button
+              onClick={() => onViewModeChange('list')}
+              className={`p-1 ${viewMode === 'list' ? 'bg-purple-500/20 text-purple-400' : 'text-muted-foreground hover:text-foreground'}`}
+              title="List view"
+            >
+              <List className="w-3.5 h-3.5" />
+            </button>
+          </div>
+          {/* Category filter */}
+          <select
+            value={categoryFilter}
+            onChange={(e) => onCategoryFilterChange(e.target.value as ResourceCategory | 'all')}
+            className="px-2 py-1 text-xs rounded-lg bg-secondary border border-border text-foreground"
+          >
+            <option value="all">All Categories</option>
+            <option value="rbac">RBAC</option>
+            <option value="config">Config</option>
+            <option value="networking">Networking</option>
+            <option value="scaling">Scaling</option>
+            <option value="storage">Storage</option>
+            <option value="crd">CRDs</option>
+            <option value="admission">Admission</option>
+          </select>
+          {/* Status filter */}
+          <select
+            value={statusFilter}
+            onChange={(e) => onStatusFilterChange(e.target.value as ResourceHealthStatus | 'all')}
+            className="px-2 py-1 text-xs rounded-lg bg-secondary border border-border text-foreground"
+          >
+            <option value="all">All Status</option>
+            <option value="healthy">Healthy</option>
+            <option value="degraded">Degraded</option>
+            <option value="unhealthy">Unhealthy</option>
+            <option value="missing">Missing</option>
+          </select>
+          <CardControls
+            limit={limit}
+            onLimitChange={onLimitChange}
+            sortBy={sortBy}
+            sortOptions={SORT_OPTIONS}
+            onSortChange={onSortChange}
+            sortDirection={sortDirection}
+            onSortDirectionChange={onSortDirectionChange}
+          />
+        </div>
+      </div>
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="Search resources..."
+          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
+        />
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/cards/workload-monitor/WorkloadMonitorTree.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitorTree.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { DEP_CATEGORIES, getIconForKind } from '../../../lib/resourceCategories'
+import type { MonitoredResource, ResourceCategory } from '../../../types/workloadMonitor'
+
+interface TreeProps {
+  resources: MonitoredResource[]
+  onResourceClick?: (resource: MonitoredResource) => void
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  healthy: 'text-green-400',
+  degraded: 'text-yellow-400',
+  unhealthy: 'text-red-400',
+  unknown: 'text-gray-400',
+  missing: 'text-red-400',
+}
+
+const STATUS_DOT: Record<string, string> = {
+  healthy: 'bg-green-400',
+  degraded: 'bg-yellow-400',
+  unhealthy: 'bg-red-400',
+  unknown: 'bg-gray-400',
+  missing: 'bg-red-400',
+}
+
+function groupByCategory(resources: MonitoredResource[]) {
+  const groups: { label: string; category: ResourceCategory; icon: typeof ChevronDown; resources: MonitoredResource[] }[] = []
+
+  for (const cat of DEP_CATEGORIES) {
+    const matching = resources.filter(r => r.category === cat.category)
+    if (matching.length > 0) {
+      groups.push({ label: cat.label, category: cat.category, icon: cat.icon, resources: matching })
+    }
+  }
+
+  // Catch-all for 'other'
+  const other = resources.filter(r => r.category === 'other')
+  if (other.length > 0) {
+    groups.push({ label: 'Other', category: 'other', icon: ChevronDown, resources: other })
+  }
+
+  return groups
+}
+
+export function WorkloadMonitorTree({ resources, onResourceClick }: TreeProps) {
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => new Set(DEP_CATEGORIES.map(c => c.label)))
+  const groups = groupByCategory(resources)
+
+  const toggleGroup = (label: string) => {
+    setExpandedGroups(prev => {
+      const next = new Set(prev)
+      if (next.has(label)) next.delete(label)
+      else next.add(label)
+      return next
+    })
+  }
+
+  if (resources.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground text-center py-4">
+        No resources found.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-0.5">
+      {groups.map(group => {
+        const GroupIcon = group.icon
+        const isExpanded = expandedGroups.has(group.label)
+        const healthyCount = group.resources.filter(r => r.status === 'healthy').length
+        const totalCount = group.resources.length
+        const allHealthy = healthyCount === totalCount
+
+        return (
+          <div key={group.label} className="border-b border-border/30 last:border-0">
+            <button
+              onClick={() => toggleGroup(group.label)}
+              className="w-full flex items-center gap-2 py-1.5 px-1 text-left hover:bg-card/30 rounded transition-colors"
+            >
+              {isExpanded
+                ? <ChevronDown className="w-3 h-3 text-muted-foreground shrink-0" />
+                : <ChevronRight className="w-3 h-3 text-muted-foreground shrink-0" />}
+              <GroupIcon className="w-3.5 h-3.5 text-purple-400 shrink-0" />
+              <span className="text-sm text-foreground flex-1">{group.label}</span>
+              <span className={`text-xs px-1.5 py-0.5 rounded ${allHealthy ? 'bg-green-500/20 text-green-400' : 'bg-yellow-500/20 text-yellow-400'}`}>
+                {healthyCount}/{totalCount}
+              </span>
+            </button>
+
+            {isExpanded && (
+              <div className="ml-8 mb-1.5 space-y-0.5">
+                {group.resources.map(resource => {
+                  const ResourceIcon = getIconForKind(resource.kind)
+                  return (
+                    <div
+                      key={resource.id}
+                      className="flex items-center gap-2 py-0.5 px-1 rounded hover:bg-card/30 cursor-pointer transition-colors"
+                      onClick={() => onResourceClick?.(resource)}
+                    >
+                      <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${STATUS_DOT[resource.status] || 'bg-gray-400'}`} />
+                      <ResourceIcon className="w-3 h-3 text-muted-foreground shrink-0" />
+                      <span className="text-xs text-muted-foreground w-24 truncate shrink-0">{resource.kind}</span>
+                      <span className="text-xs text-foreground truncate flex-1">{resource.name}</span>
+                      {resource.message && (
+                        <span className={`text-[10px] shrink-0 ${STATUS_COLORS[resource.status] || 'text-gray-400'}`}>
+                          {resource.message}
+                        </span>
+                      )}
+                      {resource.optional && (
+                        <span className="text-[10px] text-muted-foreground/50 shrink-0">opt</span>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/src/components/cards/workload-monitor/index.ts
+++ b/web/src/components/cards/workload-monitor/index.ts
@@ -1,0 +1,1 @@
+export { WorkloadMonitor } from './WorkloadMonitor'


### PR DESCRIPTION
## Summary
- New `workload_monitor` card type with cascading cluster/namespace/workload selectors
- Tree view groups resources by category (RBAC, Config, Networking, etc.) with health status badges
- List view with sortable columns, status and category badges
- Inline alerts panel showing detected issues by severity
- Full `useCardData` integration (search, sort, paginate, filter by category/status)
- View mode toggle (tree/list), auto-refresh, manual refresh
- Registered in `CARD_COMPONENTS`, `LIVE_DATA_CARDS`, `CARD_DEFAULT_WIDTHS`

## Test plan
- [ ] `cd web && npx tsc --noEmit` passes (only pre-existing RecentEvents error)
- [ ] Add `workload_monitor` card to dashboard
- [ ] Select a workload and verify tree/list views render

🤖 Generated with [Claude Code](https://claude.com/claude-code)