### PR TITLE
🌱 Add 4 specialized monitoring cards: llm-d, Prow CI, GitHub CI, Cluster Health

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -244,6 +244,11 @@ const CARD_TITLES: Record<string, string> = {
   deployment_issues: 'Deployment Issues',
   cluster_groups: 'Cluster Groups',
   resource_marshall: 'Resource Marshall',
+  workload_monitor: 'Workload Monitor',
+  llmd_stack_monitor: 'llm-d Stack Monitor',
+  prow_ci_monitor: 'Prow CI Monitor',
+  github_ci_monitor: 'GitHub CI Monitor',
+  cluster_health_monitor: 'Cluster Health Monitor',
 
   // Pod and resource cards
   pod_issues: 'Pod Issues',
@@ -407,6 +412,11 @@ const CARD_DESCRIPTIONS: Record<string, string> = {
   deployment_issues: 'Active deployment problems such as failed rollouts or image pull errors.',
   cluster_groups: 'Organize clusters into logical groups for targeted deployments.',
   resource_marshall: 'Explore resource dependency trees and ownership chains.',
+  workload_monitor: 'Monitor all resources for a workload with health status, alerts, and AI diagnose/repair.',
+  llmd_stack_monitor: 'Monitor the llm-d inference stack: model serving, EPP, gateways, and autoscalers.',
+  prow_ci_monitor: 'Monitor Prow CI jobs with success rates, failure analysis, and AI repair.',
+  github_ci_monitor: 'Monitor GitHub Actions workflows across repos with pass rates and alerts.',
+  cluster_health_monitor: 'Monitor cluster health across all connected clusters with pod and deployment issues.',
   pod_issues: 'Pods with errors, restarts, or scheduling problems.',
   top_pods: 'Top resource-consuming pods ranked by CPU or memory usage.',
   resource_capacity: 'Cluster resource capacity vs. current allocation.',
@@ -623,6 +633,13 @@ const CARD_ICONS: Record<string, { icon: ComponentType<{ className?: string }>, 
 
   // Workload deployment
   workload_deployment: { icon: Box, color: 'text-blue-400' },
+
+  // Workload Monitor cards
+  workload_monitor: { icon: Package, color: 'text-purple-400' },
+  llmd_stack_monitor: { icon: Cpu, color: 'text-purple-400' },
+  prow_ci_monitor: { icon: Activity, color: 'text-blue-400' },
+  github_ci_monitor: { icon: GitBranch, color: 'text-purple-400' },
+  cluster_health_monitor: { icon: Server, color: 'text-green-400' },
 
   // Games
   sudoku_game: { icon: Puzzle, color: 'text-purple-400' },

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -122,6 +122,10 @@ const ClusterGroups = lazy(() => import('./ClusterGroups').then(m => ({ default:
 const Missions = lazy(() => import('./Missions').then(m => ({ default: m.Missions })))
 const ResourceMarshall = lazy(() => import('./ResourceMarshall').then(m => ({ default: m.ResourceMarshall })))
 const WorkloadMonitor = lazy(() => import('./workload-monitor/WorkloadMonitor').then(m => ({ default: m.WorkloadMonitor })))
+const LLMdStackMonitor = lazy(() => import('./workload-monitor/LLMdStackMonitor').then(m => ({ default: m.LLMdStackMonitor })))
+const ProwCIMonitor = lazy(() => import('./workload-monitor/ProwCIMonitor').then(m => ({ default: m.ProwCIMonitor })))
+const GitHubCIMonitor = lazy(() => import('./workload-monitor/GitHubCIMonitor').then(m => ({ default: m.GitHubCIMonitor })))
+const ClusterHealthMonitor = lazy(() => import('./workload-monitor/ClusterHealthMonitor').then(m => ({ default: m.ClusterHealthMonitor })))
 
 // Type for card component props
 export type CardComponentProps = { config?: Record<string, unknown> }
@@ -300,6 +304,11 @@ export const CARD_COMPONENTS: Record<string, CardComponent> = {
   resource_marshall: ResourceMarshall,
   // Workload Monitor card (health monitoring with tree/list views)
   workload_monitor: WorkloadMonitor,
+  // Specialized monitoring cards
+  llmd_stack_monitor: LLMdStackMonitor,
+  prow_ci_monitor: ProwCIMonitor,
+  github_ci_monitor: GitHubCIMonitor,
+  cluster_health_monitor: ClusterHealthMonitor,
 
   // Aliases - map catalog types to existing components with similar functionality
   gpu_list: GPUInventory,
@@ -395,6 +404,11 @@ export const LIVE_DATA_CARDS = new Set([
   'deployment_missions',
   // Workload Monitor - live health monitoring
   'workload_monitor',
+  // Specialized monitoring cards
+  'llmd_stack_monitor',
+  'prow_ci_monitor',
+  'github_ci_monitor',
+  'cluster_health_monitor',
 ])
 
 /**
@@ -435,6 +449,11 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   resource_marshall: 6,
   // Workload Monitor card
   workload_monitor: 8,
+  // Specialized monitoring cards
+  llmd_stack_monitor: 6,
+  prow_ci_monitor: 6,
+  github_ci_monitor: 8,
+  cluster_health_monitor: 6,
 
   // Event dashboard cards
   event_summary: 6,

--- a/web/src/components/cards/workload-monitor/ClusterHealthMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/ClusterHealthMonitor.tsx
@@ -1,0 +1,385 @@
+import { useMemo, useState } from 'react'
+import {
+  Server, AlertTriangle, CheckCircle, XCircle,
+  RefreshCw, Loader2, ChevronDown, ChevronRight,
+  Box, Activity,
+} from 'lucide-react'
+import { Skeleton } from '../../ui/Skeleton'
+import { useClusters } from '../../../hooks/useMCP'
+import { useCachedPodIssues, useCachedDeploymentIssues } from '../../../hooks/useCachedData'
+import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
+import { cn } from '../../../lib/cn'
+import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
+import { WorkloadMonitorDiagnose } from './WorkloadMonitorDiagnose'
+import type { MonitorIssue, MonitoredResource, ResourceHealthStatus } from '../../../types/workloadMonitor'
+
+interface ClusterHealthMonitorProps {
+  config?: Record<string, unknown>
+}
+
+interface ClusterHealthSummary {
+  name: string
+  status: ResourceHealthStatus
+  nodes: number
+  podIssueCount: number
+  deployIssueCount: number
+  totalIssues: number
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  healthy: 'bg-green-500/20 text-green-400',
+  degraded: 'bg-yellow-500/20 text-yellow-400',
+  unhealthy: 'bg-red-500/20 text-red-400',
+  unknown: 'bg-gray-500/20 text-gray-400',
+}
+
+const STATUS_DOT: Record<string, string> = {
+  healthy: 'bg-green-400',
+  degraded: 'bg-yellow-400',
+  unhealthy: 'bg-red-400',
+  unknown: 'bg-gray-400',
+}
+
+export function ClusterHealthMonitor({ config: _config }: ClusterHealthMonitorProps) {
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading, refetch: refetchClusters } = useClusters()
+  const { issues: allPodIssues, isLoading: podsLoading, refetch: refetchPods } = useCachedPodIssues()
+  const { issues: allDeployIssues, isLoading: deploysLoading, refetch: refetchDeploys } = useCachedDeploymentIssues()
+  const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
+  const [expandedClusters, setExpandedClusters] = useState<Set<string>>(new Set())
+  const [isRefreshing, setIsRefreshing] = useState(false)
+
+  const isLoading = clustersLoading || podsLoading || deploysLoading
+
+  // Filter clusters by global filter
+  const clusters = useMemo(() => {
+    if (isAllClustersSelected) return allClusters
+    return allClusters.filter(c => selectedClusters.includes(c.name))
+  }, [allClusters, selectedClusters, isAllClustersSelected])
+
+  // Build per-cluster health summaries
+  const clusterSummaries = useMemo<ClusterHealthSummary[]>(() => {
+    return clusters.map(cluster => {
+      const podIssues = allPodIssues.filter(p => p.cluster === cluster.name)
+      const deployIssues = allDeployIssues.filter(d => d.cluster === cluster.name)
+      const totalIssues = podIssues.length + deployIssues.length
+
+      let status: ResourceHealthStatus = 'healthy'
+      if (totalIssues > 5) status = 'unhealthy'
+      else if (totalIssues > 0) status = 'degraded'
+
+      return {
+        name: cluster.name,
+        status,
+        nodes: cluster.nodeCount || 0,
+        podIssueCount: podIssues.length,
+        deployIssueCount: deployIssues.length,
+        totalIssues,
+      }
+    }).sort((a, b) => {
+      const order: Record<string, number> = { unhealthy: 0, degraded: 1, unknown: 2, healthy: 3 }
+      return (order[a.status] ?? 2) - (order[b.status] ?? 2)
+    })
+  }, [clusters, allPodIssues, allDeployIssues])
+
+  // Overall stats
+  const stats = useMemo(() => {
+    const total = clusterSummaries.length
+    const healthy = clusterSummaries.filter(c => c.status === 'healthy').length
+    const degraded = clusterSummaries.filter(c => c.status === 'degraded').length
+    const unhealthy = clusterSummaries.filter(c => c.status === 'unhealthy').length
+    const totalPodIssues = allPodIssues.length
+    const totalDeployIssues = allDeployIssues.length
+    const totalNodes = clusterSummaries.reduce((sum, c) => sum + c.nodes, 0)
+    return { total, healthy, degraded, unhealthy, totalPodIssues, totalDeployIssues, totalNodes }
+  }, [clusterSummaries, allPodIssues, allDeployIssues])
+
+  const overallHealth = useMemo<ResourceHealthStatus>(() => {
+    if (stats.unhealthy > 0) return 'unhealthy'
+    if (stats.degraded > 0) return 'degraded'
+    if (stats.total === 0) return 'unknown'
+    return 'healthy'
+  }, [stats])
+
+  // Synthesize issues
+  const issues = useMemo<MonitorIssue[]>(() => {
+    const result: MonitorIssue[] = []
+
+    // Pod issues
+    allPodIssues.forEach((p, idx) => {
+      const clusterMatch = isAllClustersSelected || selectedClusters.includes(p.cluster || '')
+      if (!clusterMatch) return
+      result.push({
+        id: `pod-${p.name}-${idx}`,
+        resource: {
+          id: `Pod/${p.namespace}/${p.name}`,
+          kind: 'Pod',
+          name: p.name || 'unknown',
+          namespace: p.namespace || 'default',
+          cluster: p.cluster || 'unknown',
+          status: 'unhealthy',
+          category: 'workload',
+          lastChecked: new Date().toISOString(),
+          optional: false,
+          order: idx,
+        },
+        severity: p.restarts > 10 ? 'critical' : 'warning',
+        title: `Pod ${p.name} issue`,
+        description: p.reason || `Pod in ${p.status} state with ${p.restarts || 0} restarts`,
+        detectedAt: new Date().toISOString(),
+      })
+    })
+
+    // Deployment issues
+    allDeployIssues.forEach((d, idx) => {
+      const clusterMatch = isAllClustersSelected || selectedClusters.includes(d.cluster || '')
+      if (!clusterMatch) return
+      result.push({
+        id: `deploy-${d.name}-${idx}`,
+        resource: {
+          id: `Deployment/${d.namespace}/${d.name}`,
+          kind: 'Deployment',
+          name: d.name || 'unknown',
+          namespace: d.namespace || 'default',
+          cluster: d.cluster || 'unknown',
+          status: 'unhealthy',
+          category: 'workload',
+          lastChecked: new Date().toISOString(),
+          optional: false,
+          order: idx,
+        },
+        severity: 'warning',
+        title: `Deployment ${d.name} issue`,
+        description: d.reason || `Deployment has ${d.readyReplicas || 0}/${d.replicas || 0} ready replicas`,
+        detectedAt: new Date().toISOString(),
+      })
+    })
+
+    return result.slice(0, 50)
+  }, [allPodIssues, allDeployIssues, selectedClusters, isAllClustersSelected])
+
+  // Synthesize resources for diagnose
+  const monitorResources = useMemo<MonitoredResource[]>(() => {
+    return clusterSummaries.map((c, idx) => ({
+      id: `Cluster/${c.name}`,
+      kind: 'Cluster',
+      name: c.name,
+      namespace: '',
+      cluster: c.name,
+      status: c.status,
+      category: 'workload' as const,
+      lastChecked: new Date().toISOString(),
+      optional: false,
+      order: idx,
+    }))
+  }, [clusterSummaries])
+
+  const toggleCluster = (name: string) => {
+    setExpandedClusters(prev => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name)
+      else next.add(name)
+      return next
+    })
+  }
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true)
+    try {
+      await Promise.all([
+        refetchClusters?.(),
+        refetchPods?.(),
+        refetchDeploys?.(),
+      ])
+    } finally {
+      setIsRefreshing(false)
+    }
+  }
+
+  if (isLoading && clusters.length === 0) {
+    return (
+      <div className="space-y-3">
+        <Skeleton variant="text" width={160} height={20} />
+        <div className="grid grid-cols-3 gap-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" height={48} />
+          ))}
+        </div>
+        <Skeleton variant="rounded" height={40} />
+        <Skeleton variant="rounded" height={40} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card">
+      {/* Header */}
+      <div className="rounded-lg bg-card/50 border border-border p-2.5 mb-3 flex items-center gap-2">
+        <Server className="w-4 h-4 text-green-400 shrink-0" />
+        <span className="text-sm font-medium text-foreground">Cluster Health</span>
+        <span className="text-xs text-muted-foreground">{stats.total} clusters</span>
+        <span className={cn('text-xs px-1.5 py-0.5 rounded ml-auto', STATUS_BADGE[overallHealth] || STATUS_BADGE.unknown)}>
+          {overallHealth}
+        </span>
+        <button
+          onClick={handleRefresh}
+          disabled={isRefreshing}
+          className="p-1 rounded hover:bg-secondary transition-colors"
+          title="Refresh"
+        >
+          {isRefreshing
+            ? <Loader2 className="w-3.5 h-3.5 text-green-400 animate-spin" />
+            : <RefreshCw className="w-3.5 h-3.5 text-muted-foreground" />}
+        </button>
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-3 gap-2 mb-3">
+        <div className="rounded-md bg-card/50 border border-border p-2 text-center">
+          <p className="text-lg font-semibold text-foreground">{stats.totalNodes}</p>
+          <p className="text-[10px] text-muted-foreground">Nodes</p>
+        </div>
+        <div className="rounded-md bg-card/50 border border-border p-2 text-center">
+          <p className="text-lg font-semibold text-red-400">{stats.totalPodIssues}</p>
+          <p className="text-[10px] text-muted-foreground">Pod Issues</p>
+        </div>
+        <div className="rounded-md bg-card/50 border border-border p-2 text-center">
+          <p className="text-lg font-semibold text-orange-400">{stats.totalDeployIssues}</p>
+          <p className="text-[10px] text-muted-foreground">Deploy Issues</p>
+        </div>
+      </div>
+
+      {/* Cluster list */}
+      <div className="flex-1 overflow-y-auto space-y-0.5">
+        {clusterSummaries.map(cluster => {
+          const isExpanded = expandedClusters.has(cluster.name)
+          const clusterPodIssues = allPodIssues.filter(p => p.cluster === cluster.name)
+          const clusterDeployIssues = allDeployIssues.filter(d => d.cluster === cluster.name)
+
+          return (
+            <div key={cluster.name} className="border-b border-border/30 last:border-0">
+              <button
+                onClick={() => toggleCluster(cluster.name)}
+                className="w-full flex items-center gap-2 py-1.5 px-1 text-left hover:bg-card/30 rounded transition-colors"
+              >
+                {isExpanded
+                  ? <ChevronDown className="w-3 h-3 text-muted-foreground shrink-0" />
+                  : <ChevronRight className="w-3 h-3 text-muted-foreground shrink-0" />}
+                <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', STATUS_DOT[cluster.status] || 'bg-gray-400')} />
+                <Server className="w-3.5 h-3.5 text-purple-400 shrink-0" />
+                <span className="text-sm text-foreground flex-1 truncate">{cluster.name}</span>
+                {cluster.nodes > 0 && (
+                  <span className="text-[10px] text-muted-foreground shrink-0">
+                    {cluster.nodes} nodes
+                  </span>
+                )}
+                <span className={cn('text-xs px-1.5 py-0.5 rounded shrink-0', STATUS_BADGE[cluster.status])}>
+                  {cluster.totalIssues > 0 ? `${cluster.totalIssues} issues` : 'healthy'}
+                </span>
+              </button>
+
+              {isExpanded && (
+                <div className="ml-8 mb-1.5 space-y-0.5">
+                  {/* Pod issues for this cluster */}
+                  {clusterPodIssues.length > 0 && (
+                    <div className="space-y-0.5">
+                      <div className="flex items-center gap-1.5 py-0.5 px-1">
+                        <Box className="w-3 h-3 text-orange-400" />
+                        <span className="text-[10px] font-medium text-muted-foreground">
+                          Pod Issues ({clusterPodIssues.length})
+                        </span>
+                      </div>
+                      {clusterPodIssues.slice(0, 5).map((p, i) => (
+                        <div key={`pod-${i}`} className="flex items-center gap-2 py-0.5 px-1 ml-4 rounded hover:bg-card/30 transition-colors">
+                          <XCircle className="w-3 h-3 text-red-400 shrink-0" />
+                          <span className="text-xs text-foreground truncate flex-1">{p.name}</span>
+                          <span className="text-[10px] text-muted-foreground shrink-0">{p.namespace}</span>
+                          <span className="text-[10px] px-1 py-0.5 rounded bg-red-500/20 text-red-400 shrink-0">
+                            {p.status || 'error'}
+                          </span>
+                        </div>
+                      ))}
+                      {clusterPodIssues.length > 5 && (
+                        <p className="text-[10px] text-muted-foreground ml-4 px-1">
+                          +{clusterPodIssues.length - 5} more
+                        </p>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Deploy issues for this cluster */}
+                  {clusterDeployIssues.length > 0 && (
+                    <div className="space-y-0.5">
+                      <div className="flex items-center gap-1.5 py-0.5 px-1">
+                        <Activity className="w-3 h-3 text-yellow-400" />
+                        <span className="text-[10px] font-medium text-muted-foreground">
+                          Deployment Issues ({clusterDeployIssues.length})
+                        </span>
+                      </div>
+                      {clusterDeployIssues.slice(0, 5).map((d, i) => (
+                        <div key={`deploy-${i}`} className="flex items-center gap-2 py-0.5 px-1 ml-4 rounded hover:bg-card/30 transition-colors">
+                          <AlertTriangle className="w-3 h-3 text-yellow-400 shrink-0" />
+                          <span className="text-xs text-foreground truncate flex-1">{d.name}</span>
+                          <span className="text-[10px] text-muted-foreground shrink-0">{d.namespace}</span>
+                          <span className="text-[10px] px-1 py-0.5 rounded bg-yellow-500/20 text-yellow-400 shrink-0">
+                            {d.readyReplicas ?? 0}/{d.replicas ?? 0}
+                          </span>
+                        </div>
+                      ))}
+                      {clusterDeployIssues.length > 5 && (
+                        <p className="text-[10px] text-muted-foreground ml-4 px-1">
+                          +{clusterDeployIssues.length - 5} more
+                        </p>
+                      )}
+                    </div>
+                  )}
+
+                  {/* Healthy state */}
+                  {clusterPodIssues.length === 0 && clusterDeployIssues.length === 0 && (
+                    <div className="flex items-center gap-2 py-1 px-1">
+                      <CheckCircle className="w-3 h-3 text-green-400" />
+                      <span className="text-xs text-green-400">All workloads healthy</span>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )
+        })}
+
+        {clusterSummaries.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <Server className="w-8 h-8 text-muted-foreground/40 mb-2" />
+            <p className="text-sm text-muted-foreground">No clusters available.</p>
+          </div>
+        )}
+      </div>
+
+      {/* Alerts */}
+      <WorkloadMonitorAlerts issues={issues.slice(0, 10)} />
+
+      {/* AI Diagnose & Repair */}
+      <WorkloadMonitorDiagnose
+        resources={monitorResources}
+        issues={issues.slice(0, 20)}
+        monitorType="cluster-health"
+        diagnosable={true}
+        repairable={true}
+        workloadContext={{
+          totalClusters: stats.total,
+          healthyClusters: stats.healthy,
+          degradedClusters: stats.degraded,
+          unhealthyClusters: stats.unhealthy,
+          totalNodes: stats.totalNodes,
+          totalPodIssues: stats.totalPodIssues,
+          totalDeployIssues: stats.totalDeployIssues,
+          clusterSummaries: clusterSummaries.map(c => ({
+            name: c.name,
+            status: c.status,
+            nodes: c.nodes,
+            issues: c.totalIssues,
+          })),
+        }}
+      />
+    </div>
+  )
+}

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -1,0 +1,411 @@
+import { useState, useMemo, useCallback, useEffect } from 'react'
+import {
+  GitBranch, AlertTriangle, CheckCircle, XCircle,
+  Clock, RefreshCw, Loader2, ExternalLink,
+} from 'lucide-react'
+import { Skeleton } from '../../ui/Skeleton'
+import { Pagination } from '../../ui/Pagination'
+import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
+import type { SortDirection } from '../../../lib/cards/cardHooks'
+import { cn } from '../../../lib/cn'
+import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
+import { WorkloadMonitorDiagnose } from './WorkloadMonitorDiagnose'
+import type { MonitorIssue, MonitoredResource } from '../../../types/workloadMonitor'
+
+interface GitHubCIMonitorProps {
+  config?: Record<string, unknown>
+}
+
+interface GitHubCIConfig {
+  repos?: string[]
+  token?: string
+}
+
+interface WorkflowRun {
+  id: string
+  name: string
+  repo: string
+  status: 'completed' | 'in_progress' | 'queued' | 'waiting'
+  conclusion: 'success' | 'failure' | 'cancelled' | 'skipped' | 'timed_out' | 'action_required' | null
+  branch: string
+  event: string
+  runNumber: number
+  createdAt: string
+  updatedAt: string
+  url: string
+}
+
+type SortField = 'name' | 'status' | 'repo' | 'branch'
+
+const CONCLUSION_BADGE: Record<string, string> = {
+  success: 'bg-green-500/20 text-green-400',
+  failure: 'bg-red-500/20 text-red-400',
+  cancelled: 'bg-gray-500/20 text-gray-400',
+  skipped: 'bg-gray-500/20 text-gray-400',
+  timed_out: 'bg-orange-500/20 text-orange-400',
+  action_required: 'bg-yellow-500/20 text-yellow-400',
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  completed: 'bg-green-500/20 text-green-400',
+  in_progress: 'bg-blue-500/20 text-blue-400',
+  queued: 'bg-yellow-500/20 text-yellow-400',
+  waiting: 'bg-purple-500/20 text-purple-400',
+}
+
+const CONCLUSION_ORDER: Record<string, number> = {
+  failure: 0,
+  timed_out: 1,
+  action_required: 2,
+  cancelled: 3,
+  skipped: 4,
+  success: 5,
+}
+
+// Demo data for when GitHub API is not available
+const DEMO_WORKFLOWS: WorkflowRun[] = [
+  { id: '1', name: 'CI / Build & Test', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'success', branch: 'main', event: 'push', runNumber: 1234, createdAt: new Date(Date.now() - 300000).toISOString(), updatedAt: new Date(Date.now() - 60000).toISOString(), url: '#' },
+  { id: '2', name: 'CI / Lint', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'failure', branch: 'feat/new-feature', event: 'pull_request', runNumber: 1233, createdAt: new Date(Date.now() - 600000).toISOString(), updatedAt: new Date(Date.now() - 300000).toISOString(), url: '#' },
+  { id: '3', name: 'Release / Publish', repo: 'kubestellar/kubestellar', status: 'in_progress', conclusion: null, branch: 'main', event: 'workflow_dispatch', runNumber: 1232, createdAt: new Date(Date.now() - 120000).toISOString(), updatedAt: new Date(Date.now() - 30000).toISOString(), url: '#' },
+  { id: '4', name: 'E2E Tests', repo: 'kubestellar/console', status: 'completed', conclusion: 'success', branch: 'main', event: 'push', runNumber: 567, createdAt: new Date(Date.now() - 900000).toISOString(), updatedAt: new Date(Date.now() - 600000).toISOString(), url: '#' },
+  { id: '5', name: 'CI / Build & Test', repo: 'kubestellar/console', status: 'completed', conclusion: 'success', branch: 'feat/workload-monitor', event: 'pull_request', runNumber: 566, createdAt: new Date(Date.now() - 1200000).toISOString(), updatedAt: new Date(Date.now() - 900000).toISOString(), url: '#' },
+  { id: '6', name: 'Deploy Preview', repo: 'kubestellar/console', status: 'queued', conclusion: null, branch: 'feat/card-factory', event: 'pull_request', runNumber: 565, createdAt: new Date(Date.now() - 60000).toISOString(), updatedAt: new Date(Date.now() - 30000).toISOString(), url: '#' },
+  { id: '7', name: 'Security Scan', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'timed_out', branch: 'main', event: 'schedule', runNumber: 1231, createdAt: new Date(Date.now() - 3600000).toISOString(), updatedAt: new Date(Date.now() - 1800000).toISOString(), url: '#' },
+  { id: '8', name: 'Dependabot', repo: 'kubestellar/kubestellar', status: 'completed', conclusion: 'success', branch: 'dependabot/npm/react-19', event: 'pull_request', runNumber: 1230, createdAt: new Date(Date.now() - 7200000).toISOString(), updatedAt: new Date(Date.now() - 3600000).toISOString(), url: '#' },
+]
+
+function formatTimeAgo(iso: string): string {
+  const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+export function GitHubCIMonitor({ config }: GitHubCIMonitorProps) {
+  const ghConfig = config as GitHubCIConfig | undefined
+  const [workflows, setWorkflows] = useState<WorkflowRun[]>(DEMO_WORKFLOWS)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const repos = ghConfig?.repos || ['kubestellar/kubestellar', 'kubestellar/console']
+
+  const fetchWorkflows = useCallback(async (isRefresh = false) => {
+    const token = ghConfig?.token || localStorage.getItem('github_token')
+    if (!token) {
+      // Use demo data
+      setWorkflows(DEMO_WORKFLOWS)
+      return
+    }
+
+    if (isRefresh) setIsRefreshing(true)
+    else setIsLoading(true)
+    setError(null)
+
+    try {
+      const allRuns: WorkflowRun[] = []
+      for (const repo of repos) {
+        const response = await fetch(`https://api.github.com/repos/${repo}/actions/runs?per_page=10`, {
+          headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github.v3+json' },
+        })
+        if (!response.ok) throw new Error(`GitHub API error: ${response.status}`)
+        const data = await response.json()
+        const runs = (data.workflow_runs || []).map((run: Record<string, unknown>) => ({
+          id: String(run.id),
+          name: run.name as string,
+          repo,
+          status: run.status as WorkflowRun['status'],
+          conclusion: run.conclusion as WorkflowRun['conclusion'],
+          branch: (run.head_branch || 'unknown') as string,
+          event: (run.event || 'unknown') as string,
+          runNumber: run.run_number as number,
+          createdAt: run.created_at as string,
+          updatedAt: run.updated_at as string,
+          url: (run.html_url || '#') as string,
+        }))
+        allRuns.push(...runs)
+      }
+      setWorkflows(allRuns.length > 0 ? allRuns : DEMO_WORKFLOWS)
+    } catch (err) {
+      console.error('[GitHubCIMonitor] fetch error:', err)
+      setError(err instanceof Error ? err.message : 'Failed to fetch workflows')
+      // Keep demo data on error
+    } finally {
+      setIsLoading(false)
+      setIsRefreshing(false)
+    }
+  }, [repos, ghConfig?.token])
+
+  useEffect(() => {
+    fetchWorkflows()
+    const interval = setInterval(() => fetchWorkflows(true), 60_000)
+    return () => clearInterval(interval)
+  }, [fetchWorkflows])
+
+  // Stats
+  const stats = useMemo(() => {
+    const total = workflows.length
+    const failed = workflows.filter(w => w.conclusion === 'failure' || w.conclusion === 'timed_out').length
+    const inProgress = workflows.filter(w => w.status === 'in_progress').length
+    const queued = workflows.filter(w => w.status === 'queued' || w.status === 'waiting').length
+    const passed = workflows.filter(w => w.conclusion === 'success').length
+    const successRate = total > 0 ? Math.round((passed / total) * 100) : 0
+    return { total, failed, inProgress, queued, passed, successRate }
+  }, [workflows])
+
+  const effectiveStatus = (w: WorkflowRun): string => {
+    if (w.status !== 'completed') return w.status
+    return w.conclusion || 'unknown'
+  }
+
+  const {
+    items,
+    totalItems,
+    currentPage,
+    totalPages,
+    goToPage,
+    needsPagination,
+    itemsPerPage,
+    filters,
+  } = useCardData(workflows, {
+    filter: {
+      searchFields: ['name', 'repo', 'branch', 'event'] as (keyof WorkflowRun)[],
+    },
+    sort: {
+      defaultField: 'status' as SortField,
+      defaultDirection: 'asc' as SortDirection,
+      comparators: {
+        name: commonComparators.string('name'),
+        status: (a, b) => {
+          const aOrder = a.conclusion ? (CONCLUSION_ORDER[a.conclusion] ?? 5) : -1
+          const bOrder = b.conclusion ? (CONCLUSION_ORDER[b.conclusion] ?? 5) : -1
+          return aOrder - bOrder
+        },
+        repo: commonComparators.string('repo'),
+        branch: commonComparators.string('branch'),
+      },
+    },
+    defaultLimit: 8,
+  })
+
+  // Synthesize issues
+  const issues = useMemo<MonitorIssue[]>(() => {
+    return workflows
+      .filter(w => w.conclusion === 'failure' || w.conclusion === 'timed_out')
+      .map(w => ({
+        id: `gh-${w.id}`,
+        resource: {
+          id: `WorkflowRun/${w.repo}/${w.name}`,
+          kind: 'WorkflowRun',
+          name: w.name,
+          namespace: w.repo,
+          cluster: 'github',
+          status: 'unhealthy' as const,
+          category: 'workload' as const,
+          lastChecked: w.updatedAt,
+          optional: false,
+          order: 0,
+        },
+        severity: w.conclusion === 'failure' ? 'critical' as const : 'warning' as const,
+        title: `${w.name} ${w.conclusion} on ${w.branch}`,
+        description: `Workflow run #${w.runNumber} in ${w.repo} ${w.conclusion}. Event: ${w.event}. Updated ${formatTimeAgo(w.updatedAt)}.`,
+        detectedAt: w.updatedAt,
+      }))
+  }, [workflows])
+
+  const monitorResources = useMemo<MonitoredResource[]>(() => {
+    return workflows.slice(0, 20).map((w, idx) => ({
+      id: `WorkflowRun/${w.repo}/${w.id}`,
+      kind: 'WorkflowRun',
+      name: w.name,
+      namespace: w.repo,
+      cluster: 'github',
+      status: w.conclusion === 'success' ? 'healthy' as const :
+              (w.conclusion === 'failure' || w.conclusion === 'timed_out') ? 'unhealthy' as const :
+              w.status === 'in_progress' ? 'degraded' as const : 'unknown' as const,
+      category: 'workload' as const,
+      lastChecked: w.updatedAt,
+      optional: false,
+      order: idx,
+    }))
+  }, [workflows])
+
+  const overallHealth = useMemo(() => {
+    if (stats.failed > 0) return 'degraded'
+    if (stats.total === 0) return 'unknown'
+    return 'healthy'
+  }, [stats])
+
+  if (isLoading && workflows.length === 0) {
+    return (
+      <div className="space-y-3">
+        <Skeleton variant="text" width={160} height={20} />
+        <div className="grid grid-cols-4 gap-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" height={48} />
+          ))}
+        </div>
+        <Skeleton variant="rounded" height={40} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card">
+      {/* Header */}
+      <div className="rounded-lg bg-card/50 border border-border p-2.5 mb-3 flex items-center gap-2">
+        <GitBranch className="w-4 h-4 text-purple-400 shrink-0" />
+        <span className="text-sm font-medium text-foreground">GitHub CI</span>
+        <span className="text-xs text-muted-foreground">{repos.length} repos</span>
+        <span className={cn(
+          'text-xs px-1.5 py-0.5 rounded ml-auto',
+          overallHealth === 'healthy' ? 'bg-green-500/20 text-green-400' :
+          overallHealth === 'degraded' ? 'bg-yellow-500/20 text-yellow-400' :
+          'bg-gray-500/20 text-gray-400',
+        )}>
+          {overallHealth}
+        </span>
+        <button
+          onClick={() => fetchWorkflows(true)}
+          disabled={isRefreshing}
+          className="p-1 rounded hover:bg-secondary transition-colors"
+          title="Refresh"
+        >
+          {isRefreshing
+            ? <Loader2 className="w-3.5 h-3.5 text-purple-400 animate-spin" />
+            : <RefreshCw className="w-3.5 h-3.5 text-muted-foreground" />}
+        </button>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-lg bg-yellow-500/10 border border-yellow-500/20 p-2 flex items-start gap-2 mb-2">
+          <AlertTriangle className="w-3.5 h-3.5 text-yellow-400 mt-0.5 shrink-0" />
+          <p className="text-xs text-yellow-400/70">{error}</p>
+        </div>
+      )}
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-4 gap-2 mb-3">
+        <div className="rounded-md bg-card/50 border border-border p-2 text-center">
+          <p className="text-lg font-semibold text-green-400">{stats.successRate}%</p>
+          <p className="text-[10px] text-muted-foreground">Pass Rate</p>
+        </div>
+        <div className="rounded-md bg-card/50 border border-border p-2 text-center">
+          <p className="text-lg font-semibold text-red-400">{stats.failed}</p>
+          <p className="text-[10px] text-muted-foreground">Failed</p>
+        </div>
+        <div className="rounded-md bg-card/50 border border-border p-2 text-center">
+          <p className="text-lg font-semibold text-blue-400">{stats.inProgress}</p>
+          <p className="text-[10px] text-muted-foreground">Running</p>
+        </div>
+        <div className="rounded-md bg-card/50 border border-border p-2 text-center">
+          <p className="text-lg font-semibold text-yellow-400">{stats.queued}</p>
+          <p className="text-[10px] text-muted-foreground">Queued</p>
+        </div>
+      </div>
+
+      {/* Search */}
+      <div className="mb-2">
+        <input
+          type="text"
+          value={filters.search}
+          onChange={(e) => filters.setSearch(e.target.value)}
+          placeholder="Search workflows..."
+          className="w-full text-xs px-2.5 py-1.5 rounded-md bg-secondary/50 border border-border text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-purple-500/50"
+        />
+      </div>
+
+      {/* Workflow runs */}
+      <div className="flex-1 overflow-y-auto space-y-0.5">
+        {items.map(w => {
+          const status = effectiveStatus(w)
+          const badgeClass = w.status === 'completed'
+            ? (CONCLUSION_BADGE[w.conclusion || ''] || 'bg-gray-500/20 text-gray-400')
+            : (STATUS_BADGE[w.status] || 'bg-gray-500/20 text-gray-400')
+          const StatusIcon = w.conclusion === 'success' ? CheckCircle :
+                             w.conclusion === 'failure' ? XCircle :
+                             w.status === 'in_progress' ? Loader2 :
+                             w.status === 'queued' ? Clock : AlertTriangle
+
+          return (
+            <div
+              key={w.id}
+              className="flex items-center gap-2 py-1 px-1.5 rounded hover:bg-card/30 transition-colors"
+            >
+              <StatusIcon className={cn(
+                'w-3.5 h-3.5 shrink-0',
+                w.conclusion === 'success' ? 'text-green-400' :
+                w.conclusion === 'failure' ? 'text-red-400' :
+                w.status === 'in_progress' ? 'text-blue-400 animate-spin' :
+                'text-muted-foreground',
+              )} />
+              <div className="flex-1 min-w-0">
+                <span className="text-xs text-foreground truncate block">{w.name}</span>
+                <span className="text-[10px] text-muted-foreground truncate block">
+                  {w.repo.split('/')[1]} · {w.branch}
+                </span>
+              </div>
+              <span className={cn('text-[10px] px-1 py-0.5 rounded shrink-0', badgeClass)}>
+                {status}
+              </span>
+              <span className="text-[10px] text-muted-foreground shrink-0">
+                {formatTimeAgo(w.updatedAt)}
+              </span>
+              {w.url !== '#' && (
+                <a
+                  href={w.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="shrink-0 p-0.5 rounded hover:bg-secondary transition-colors"
+                  onClick={e => e.stopPropagation()}
+                >
+                  <ExternalLink className="w-3 h-3 text-muted-foreground" />
+                </a>
+              )}
+            </div>
+          )
+        })}
+        {items.length === 0 && (
+          <p className="text-sm text-muted-foreground text-center py-4">No matching workflows.</p>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {needsPagination && (
+        <div className="mt-2 pt-2 border-t border-border/50">
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalItems={totalItems}
+            itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : totalItems}
+            onPageChange={goToPage}
+          />
+        </div>
+      )}
+
+      {/* Alerts */}
+      <WorkloadMonitorAlerts issues={issues} />
+
+      {/* AI Diagnose (no repair for GitHub) */}
+      <WorkloadMonitorDiagnose
+        resources={monitorResources}
+        issues={issues}
+        monitorType="github"
+        diagnosable={true}
+        repairable={false}
+        workloadContext={{
+          repos,
+          totalWorkflows: stats.total,
+          failedWorkflows: stats.failed,
+          successRate: stats.successRate,
+          inProgress: stats.inProgress,
+        }}
+      />
+    </div>
+  )
+}

--- a/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
@@ -1,0 +1,350 @@
+import { useMemo, useState } from 'react'
+import {
+  Cpu, Network, Activity, Layers, Server,
+  RefreshCw, Loader2, ChevronDown, ChevronRight,
+} from 'lucide-react'
+import { Skeleton } from '../../ui/Skeleton'
+import { useCachedLLMdServers } from '../../../hooks/useCachedData'
+import { useWorkloadMonitor } from '../../../hooks/useWorkloadMonitor'
+import { cn } from '../../../lib/cn'
+import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
+import { WorkloadMonitorDiagnose } from './WorkloadMonitorDiagnose'
+import { LLMD_CLUSTERS } from '../workload-detection/shared'
+import type { MonitorIssue, MonitoredResource } from '../../../types/workloadMonitor'
+
+interface LLMdStackMonitorProps {
+  config?: Record<string, unknown>
+}
+
+interface ComponentSection {
+  label: string
+  icon: typeof Cpu
+  color: string
+  items: ComponentItem[]
+}
+
+interface ComponentItem {
+  name: string
+  status: 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
+  detail?: string
+  cluster?: string
+}
+
+const STATUS_DOT: Record<string, string> = {
+  healthy: 'bg-green-400',
+  degraded: 'bg-yellow-400',
+  unhealthy: 'bg-red-400',
+  unknown: 'bg-gray-400',
+  running: 'bg-green-400',
+  scaling: 'bg-yellow-400',
+  stopped: 'bg-red-400',
+  error: 'bg-red-400',
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  healthy: 'bg-green-500/20 text-green-400',
+  degraded: 'bg-yellow-500/20 text-yellow-400',
+  unhealthy: 'bg-red-500/20 text-red-400',
+  unknown: 'bg-gray-500/20 text-gray-400',
+}
+
+export function LLMdStackMonitor({ config: _config }: LLMdStackMonitorProps) {
+  const { servers, isLoading: serversLoading, isRefreshing: serversRefreshing, refetch: refetchServers } = useCachedLLMdServers(LLMD_CLUSTERS)
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(['Model Serving', 'EPP', 'Gateway']))
+
+  // Use workload monitor for the primary llm-d namespace
+  const llmdCluster = LLMD_CLUSTERS[0] || ''
+  const {
+    resources,
+    issues,
+    overallStatus,
+    isLoading: monitorLoading,
+    isRefreshing: monitorRefreshing,
+    refetch: refetchMonitor,
+  } = useWorkloadMonitor(llmdCluster, 'llm-d', '', {
+    autoRefreshMs: 30_000,
+  })
+
+  const isLoading = serversLoading || monitorLoading
+  const isRefreshing = serversRefreshing || monitorRefreshing
+
+  // Build component sections from llm-d server data
+  const sections = useMemo<ComponentSection[]>(() => {
+    const modelServers = servers.filter(s => s.componentType === 'model')
+    const eppServers = servers.filter(s => s.componentType === 'epp')
+    const gateways = servers.filter(s => s.componentType === 'gateway')
+    const prometheus = servers.filter(s => s.componentType === 'prometheus')
+    const autoscalers = servers.filter(s => s.componentType === 'autoscaler')
+
+    const mapStatus = (s: string): ComponentItem['status'] => {
+      if (s === 'running') return 'healthy'
+      if (s === 'scaling') return 'degraded'
+      if (s === 'stopped' || s === 'error') return 'unhealthy'
+      return 'unknown'
+    }
+
+    return [
+      {
+        label: 'Model Serving',
+        icon: Cpu,
+        color: 'text-purple-400',
+        items: modelServers.map(s => ({
+          name: s.name,
+          status: mapStatus(s.status),
+          detail: `${s.type || 'vLLM'} · ${s.model || 'unknown'} · ${s.readyReplicas ?? 0}/${s.replicas ?? 0} replicas`,
+          cluster: s.cluster,
+        })),
+      },
+      {
+        label: 'EPP',
+        icon: Layers,
+        color: 'text-blue-400',
+        items: eppServers.map(s => ({
+          name: s.name,
+          status: mapStatus(s.status),
+          detail: `${s.readyReplicas ?? 0}/${s.replicas ?? 0} replicas`,
+          cluster: s.cluster,
+        })),
+      },
+      {
+        label: 'Gateway',
+        icon: Network,
+        color: 'text-cyan-400',
+        items: gateways.map(s => ({
+          name: s.name,
+          status: mapStatus(s.status),
+          detail: s.namespace,
+          cluster: s.cluster,
+        })),
+      },
+      {
+        label: 'Prometheus',
+        icon: Activity,
+        color: 'text-orange-400',
+        items: prometheus.map(s => ({
+          name: s.name,
+          status: mapStatus(s.status),
+          detail: s.namespace,
+          cluster: s.cluster,
+        })),
+      },
+      {
+        label: 'Autoscaler',
+        icon: Server,
+        color: 'text-green-400',
+        items: autoscalers.map(s => ({
+          name: s.name,
+          status: mapStatus(s.status),
+          detail: s.autoscalerType || 'HPA',
+          cluster: s.cluster,
+        })),
+      },
+    ].filter(s => s.items.length > 0)
+  }, [servers])
+
+  // Combine issues from monitor and synthesized from llm-d
+  const allIssues = useMemo<MonitorIssue[]>(() => {
+    const monitorIssues = [...issues]
+    // Add synthetic issues from unhealthy llm-d servers
+    servers.forEach((s) => {
+      if (s.status === 'error' || s.status === 'stopped') {
+        monitorIssues.push({
+          id: `llmd-${s.name}-${s.status}`,
+          resource: {
+            id: `${'Deployment'}/${s.namespace}/${s.name}`,
+            kind: 'Deployment',
+            name: s.name,
+            namespace: s.namespace,
+            cluster: s.cluster,
+            status: s.status === 'error' ? 'unhealthy' : 'degraded',
+            category: 'workload',
+            lastChecked: new Date().toISOString(),
+            optional: false,
+            order: 0,
+          },
+          severity: s.status === 'error' ? 'critical' : 'warning',
+          title: `${s.componentType} ${s.name} is ${s.status}`,
+          description: `Server ${s.name} in namespace ${s.namespace} is ${s.status}`,
+          detectedAt: new Date().toISOString(),
+        })
+      }
+    })
+    return monitorIssues
+  }, [issues, servers])
+
+  // Combine resources
+  const allResources = useMemo<MonitoredResource[]>(() => {
+    if (resources.length > 0) return resources
+    // Synthesize from servers if no monitor resources
+    return servers.map((s, idx) => ({
+      id: `${'Deployment'}/${s.namespace}/${s.name}`,
+      kind: 'Deployment',
+      name: s.name,
+      namespace: s.namespace,
+      cluster: s.cluster,
+      status: s.status === 'running' ? 'healthy' as const :
+              s.status === 'scaling' ? 'degraded' as const :
+              s.status === 'error' ? 'unhealthy' as const : 'unknown' as const,
+      category: 'workload' as const,
+      lastChecked: new Date().toISOString(),
+      optional: false,
+      order: idx,
+    }))
+  }, [resources, servers])
+
+  // Calculate overall health
+  const stackHealth = useMemo(() => {
+    if (overallStatus !== 'unknown') return overallStatus
+    const statuses = sections.flatMap(s => s.items.map(i => i.status))
+    if (statuses.some(s => s === 'unhealthy')) return 'unhealthy'
+    if (statuses.some(s => s === 'degraded')) return 'degraded'
+    if (statuses.every(s => s === 'healthy')) return 'healthy'
+    return 'unknown'
+  }, [overallStatus, sections])
+
+  const toggleSection = (label: string) => {
+    setExpandedSections(prev => {
+      const next = new Set(prev)
+      if (next.has(label)) next.delete(label)
+      else next.add(label)
+      return next
+    })
+  }
+
+  const handleRefresh = () => {
+    refetchServers()
+    refetchMonitor()
+  }
+
+  if (isLoading && servers.length === 0) {
+    return (
+      <div className="space-y-3">
+        <Skeleton variant="text" width={180} height={20} />
+        <Skeleton variant="rounded" height={40} />
+        <Skeleton variant="rounded" height={40} />
+        <Skeleton variant="rounded" height={40} />
+      </div>
+    )
+  }
+
+  // Empty state
+  if (servers.length === 0 && !isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <Cpu className="w-8 h-8 text-muted-foreground/40 mb-2" />
+        <p className="text-sm text-muted-foreground">
+          No llm-d stack detected. Deploy llm-d to see monitoring data.
+        </p>
+        <p className="text-xs text-muted-foreground/70 mt-1">
+          Looking in clusters: {LLMD_CLUSTERS.join(', ')}
+        </p>
+      </div>
+    )
+  }
+
+  const totalComponents = sections.reduce((acc, s) => acc + s.items.length, 0)
+  const healthyComponents = sections.reduce(
+    (acc, s) => acc + s.items.filter(i => i.status === 'healthy').length,
+    0,
+  )
+
+  return (
+    <div className="h-full flex flex-col min-h-card">
+      {/* Header */}
+      <div className="rounded-lg bg-card/50 border border-border p-2.5 mb-3 flex items-center gap-2">
+        <Cpu className="w-4 h-4 text-purple-400 shrink-0" />
+        <span className="text-sm font-medium text-foreground">llm-d Stack</span>
+        <span className="text-xs text-muted-foreground">
+          {healthyComponents}/{totalComponents} components
+        </span>
+        <span className={cn('text-xs px-1.5 py-0.5 rounded ml-auto', STATUS_BADGE[stackHealth] || STATUS_BADGE.unknown)}>
+          {stackHealth}
+        </span>
+        <button
+          onClick={handleRefresh}
+          disabled={isRefreshing}
+          className="p-1 rounded hover:bg-secondary transition-colors"
+          title="Refresh"
+        >
+          {isRefreshing
+            ? <Loader2 className="w-3.5 h-3.5 text-purple-400 animate-spin" />
+            : <RefreshCw className="w-3.5 h-3.5 text-muted-foreground" />}
+        </button>
+      </div>
+
+      {/* Component sections */}
+      <div className="flex-1 overflow-y-auto space-y-0.5">
+        {sections.map(section => {
+          const SectionIcon = section.icon
+          const isExpanded = expandedSections.has(section.label)
+          const sectionHealthy = section.items.filter(i => i.status === 'healthy').length
+          const allHealthy = sectionHealthy === section.items.length
+
+          return (
+            <div key={section.label} className="border-b border-border/30 last:border-0">
+              <button
+                onClick={() => toggleSection(section.label)}
+                className="w-full flex items-center gap-2 py-1.5 px-1 text-left hover:bg-card/30 rounded transition-colors"
+              >
+                {isExpanded
+                  ? <ChevronDown className="w-3 h-3 text-muted-foreground shrink-0" />
+                  : <ChevronRight className="w-3 h-3 text-muted-foreground shrink-0" />}
+                <SectionIcon className={cn('w-3.5 h-3.5 shrink-0', section.color)} />
+                <span className="text-sm text-foreground flex-1">{section.label}</span>
+                <span className={cn(
+                  'text-xs px-1.5 py-0.5 rounded',
+                  allHealthy ? 'bg-green-500/20 text-green-400' : 'bg-yellow-500/20 text-yellow-400',
+                )}>
+                  {sectionHealthy}/{section.items.length}
+                </span>
+              </button>
+              {isExpanded && (
+                <div className="ml-8 mb-1.5 space-y-0.5">
+                  {section.items.map(item => (
+                    <div key={item.name} className="flex items-center gap-2 py-0.5 px-1 rounded hover:bg-card/30 transition-colors">
+                      <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', STATUS_DOT[item.status] || 'bg-gray-400')} />
+                      <span className="text-xs text-foreground truncate flex-1">{item.name}</span>
+                      {item.detail && (
+                        <span className="text-[10px] text-muted-foreground shrink-0 truncate max-w-[200px]">
+                          {item.detail}
+                        </span>
+                      )}
+                      {item.cluster && (
+                        <span className="text-[10px] px-1 py-0.5 rounded bg-secondary text-muted-foreground shrink-0">
+                          {item.cluster}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Alerts */}
+      <WorkloadMonitorAlerts issues={allIssues} />
+
+      {/* AI Diagnose (no repair for llm-d) */}
+      <WorkloadMonitorDiagnose
+        resources={allResources}
+        issues={allIssues}
+        monitorType="llmd"
+        diagnosable={true}
+        repairable={false}
+        workloadContext={{
+          clusters: LLMD_CLUSTERS,
+          stackHealth,
+          totalComponents,
+          healthyComponents,
+          sections: sections.map(s => ({
+            label: s.label,
+            total: s.items.length,
+            healthy: s.items.filter(i => i.status === 'healthy').length,
+          })),
+        }}
+      />
+    </div>
+  )
+}

--- a/web/src/components/cards/workload-monitor/ProwCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/ProwCIMonitor.tsx
@@ -1,0 +1,306 @@
+import { useMemo } from 'react'
+import {
+  Activity, AlertTriangle, CheckCircle, XCircle,
+  Clock, RefreshCw, Loader2, Play, Pause,
+} from 'lucide-react'
+import { Skeleton } from '../../ui/Skeleton'
+import { Pagination } from '../../ui/Pagination'
+import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
+import type { SortDirection } from '../../../lib/cards/cardHooks'
+import { useCachedProwJobs } from '../../../hooks/useCachedData'
+import { cn } from '../../../lib/cn'
+import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
+import { WorkloadMonitorDiagnose } from './WorkloadMonitorDiagnose'
+import type { MonitorIssue, MonitoredResource } from '../../../types/workloadMonitor'
+
+interface ProwCIMonitorProps {
+  config?: Record<string, unknown>
+}
+
+type SortField = 'name' | 'state' | 'type' | 'duration'
+
+const STATE_ORDER: Record<string, number> = {
+  failure: 0,
+  error: 1,
+  aborted: 2,
+  running: 3,
+  pending: 4,
+  triggered: 5,
+  success: 6,
+}
+
+const STATE_BADGE: Record<string, string> = {
+  success: 'bg-green-500/20 text-green-400',
+  failure: 'bg-red-500/20 text-red-400',
+  error: 'bg-red-500/20 text-red-400',
+  running: 'bg-blue-500/20 text-blue-400',
+  pending: 'bg-yellow-500/20 text-yellow-400',
+  triggered: 'bg-purple-500/20 text-purple-400',
+  aborted: 'bg-gray-500/20 text-gray-400',
+}
+
+const STATE_ICON: Record<string, typeof CheckCircle> = {
+  success: CheckCircle,
+  failure: XCircle,
+  error: AlertTriangle,
+  running: Play,
+  pending: Clock,
+  triggered: Activity,
+  aborted: Pause,
+}
+
+const TYPE_BADGE: Record<string, string> = {
+  presubmit: 'bg-blue-500/20 text-blue-400',
+  postsubmit: 'bg-green-500/20 text-green-400',
+  periodic: 'bg-purple-500/20 text-purple-400',
+  batch: 'bg-cyan-500/20 text-cyan-400',
+}
+
+export function ProwCIMonitor({ config: _config }: ProwCIMonitorProps) {
+  const { jobs, status: prowStatus, isLoading, isRefreshing, refetch, formatTimeAgo } = useCachedProwJobs()
+
+  // Stats
+  const stats = useMemo(() => {
+    const total = jobs.length
+    const failed = jobs.filter(j => j.state === 'failure' || j.state === 'error').length
+    const running = jobs.filter(j => j.state === 'running').length
+    const pending = jobs.filter(j => j.state === 'pending' || j.state === 'triggered').length
+    const succeeded = jobs.filter(j => j.state === 'success').length
+    const successRate = total > 0 ? Math.round((succeeded / total) * 100) : 0
+    return { total, failed, running, pending, succeeded, successRate }
+  }, [jobs])
+
+  // useCardData for search, sort, pagination
+  const {
+    items,
+    totalItems,
+    currentPage,
+    totalPages,
+    goToPage,
+    needsPagination,
+    itemsPerPage,
+    filters,
+  } = useCardData(jobs, {
+    filter: {
+      searchFields: ['name', 'state', 'type', 'cluster'] as (keyof typeof jobs[0])[],
+    },
+    sort: {
+      defaultField: 'state' as SortField,
+      defaultDirection: 'asc' as SortDirection,
+      comparators: {
+        name: commonComparators.string('name'),
+        state: (a, b) => (STATE_ORDER[a.state] ?? 5) - (STATE_ORDER[b.state] ?? 5),
+        type: commonComparators.string('type'),
+        duration: commonComparators.string('duration'),
+      },
+    },
+    defaultLimit: 8,
+  })
+
+  // Synthesize monitor issues from failed jobs
+  const issues = useMemo<MonitorIssue[]>(() => {
+    return jobs
+      .filter(j => j.state === 'failure' || j.state === 'error')
+      .map(j => ({
+        id: `prow-${j.id}`,
+        resource: {
+          id: `ProwJob/${j.name}`,
+          kind: 'ProwJob',
+          name: j.name,
+          namespace: 'prow',
+          cluster: j.cluster || 'prow',
+          status: 'unhealthy' as const,
+          category: 'workload' as const,
+          lastChecked: j.startTime,
+          optional: false,
+          order: 0,
+        },
+        severity: j.state === 'error' ? 'critical' as const : 'warning' as const,
+        title: `${j.type} job "${j.name}" ${j.state}`,
+        description: `Job started ${formatTimeAgo(j.startTime)}${j.pr ? ` for PR #${j.pr}` : ''}. Duration: ${j.duration}`,
+        detectedAt: j.startTime,
+      }))
+  }, [jobs, formatTimeAgo])
+
+  // Synthesize resources for diagnose
+  const monitorResources = useMemo<MonitoredResource[]>(() => {
+    return jobs.slice(0, 20).map((j, idx) => ({
+      id: `ProwJob/${j.name}/${j.id}`,
+      kind: 'ProwJob',
+      name: j.name,
+      namespace: 'prow',
+      cluster: j.cluster || 'prow',
+      status: j.state === 'success' ? 'healthy' as const :
+              (j.state === 'failure' || j.state === 'error') ? 'unhealthy' as const :
+              j.state === 'running' ? 'degraded' as const : 'unknown' as const,
+      category: 'workload' as const,
+      lastChecked: j.startTime,
+      optional: false,
+      order: idx,
+    }))
+  }, [jobs])
+
+  // Overall health
+  const overallHealth = useMemo(() => {
+    if (prowStatus.healthy === false) return 'unhealthy'
+    if (stats.failed > 0) return 'degraded'
+    return 'healthy'
+  }, [prowStatus.healthy, stats.failed])
+
+  if (isLoading && jobs.length === 0) {
+    return (
+      <div className="space-y-3">
+        <Skeleton variant="text" width={140} height={20} />
+        <div className="grid grid-cols-4 gap-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" height={48} />
+          ))}
+        </div>
+        <Skeleton variant="rounded" height={40} />
+        <Skeleton variant="rounded" height={40} />
+      </div>
+    )
+  }
+
+  if (jobs.length === 0 && !isLoading) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <Activity className="w-8 h-8 text-muted-foreground/40 mb-2" />
+        <p className="text-sm text-muted-foreground">
+          No Prow jobs detected. Deploy Prow to see CI monitoring data.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card">
+      {/* Header */}
+      <div className="rounded-lg bg-card/50 border border-border p-2.5 mb-3 flex items-center gap-2">
+        <Activity className="w-4 h-4 text-blue-400 shrink-0" />
+        <span className="text-sm font-medium text-foreground">Prow CI</span>
+        <span className="text-xs text-muted-foreground">{stats.total} jobs</span>
+        <span className={cn(
+          'text-xs px-1.5 py-0.5 rounded ml-auto',
+          overallHealth === 'healthy' ? 'bg-green-500/20 text-green-400' :
+          overallHealth === 'degraded' ? 'bg-yellow-500/20 text-yellow-400' :
+          'bg-red-500/20 text-red-400',
+        )}>
+          {overallHealth}
+        </span>
+        <button
+          onClick={refetch}
+          disabled={isRefreshing}
+          className="p-1 rounded hover:bg-secondary transition-colors"
+          title="Refresh"
+        >
+          {isRefreshing
+            ? <Loader2 className="w-3.5 h-3.5 text-blue-400 animate-spin" />
+            : <RefreshCw className="w-3.5 h-3.5 text-muted-foreground" />}
+        </button>
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-4 gap-2 mb-3">
+        <div className="rounded-md bg-card/50 border border-border p-2 text-center">
+          <p className="text-lg font-semibold text-green-400">{stats.successRate}%</p>
+          <p className="text-[10px] text-muted-foreground">Success Rate</p>
+        </div>
+        <div className="rounded-md bg-card/50 border border-border p-2 text-center">
+          <p className="text-lg font-semibold text-red-400">{stats.failed}</p>
+          <p className="text-[10px] text-muted-foreground">Failed</p>
+        </div>
+        <div className="rounded-md bg-card/50 border border-border p-2 text-center">
+          <p className="text-lg font-semibold text-blue-400">{stats.running}</p>
+          <p className="text-[10px] text-muted-foreground">Running</p>
+        </div>
+        <div className="rounded-md bg-card/50 border border-border p-2 text-center">
+          <p className="text-lg font-semibold text-yellow-400">{stats.pending}</p>
+          <p className="text-[10px] text-muted-foreground">Pending</p>
+        </div>
+      </div>
+
+      {/* Search */}
+      <div className="mb-2">
+        <input
+          type="text"
+          value={filters.search}
+          onChange={(e) => filters.setSearch(e.target.value)}
+          placeholder="Search jobs..."
+          className="w-full text-xs px-2.5 py-1.5 rounded-md bg-secondary/50 border border-border text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-blue-500/50"
+        />
+      </div>
+
+      {/* Job list */}
+      <div className="flex-1 overflow-y-auto space-y-0.5">
+        {items.map(job => {
+          const StateIcon = STATE_ICON[job.state] || Activity
+          return (
+            <div
+              key={job.id}
+              className="flex items-center gap-2 py-1 px-1.5 rounded hover:bg-card/30 transition-colors"
+            >
+              <StateIcon className={cn(
+                'w-3.5 h-3.5 shrink-0',
+                job.state === 'success' ? 'text-green-400' :
+                job.state === 'failure' || job.state === 'error' ? 'text-red-400' :
+                job.state === 'running' ? 'text-blue-400' : 'text-muted-foreground',
+              )} />
+              <span className="text-xs text-foreground truncate flex-1">{job.name}</span>
+              <span className={cn('text-[10px] px-1 py-0.5 rounded shrink-0', TYPE_BADGE[job.type] || 'bg-gray-500/20 text-gray-400')}>
+                {job.type}
+              </span>
+              <span className={cn('text-[10px] px-1 py-0.5 rounded shrink-0', STATE_BADGE[job.state] || 'bg-gray-500/20 text-gray-400')}>
+                {job.state}
+              </span>
+              {job.pr && (
+                <span className="text-[10px] text-muted-foreground shrink-0">
+                  #{job.pr}
+                </span>
+              )}
+              <span className="text-[10px] text-muted-foreground shrink-0">
+                {job.duration}
+              </span>
+            </div>
+          )
+        })}
+        {items.length === 0 && (
+          <p className="text-sm text-muted-foreground text-center py-4">No matching jobs.</p>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {needsPagination && (
+        <div className="mt-2 pt-2 border-t border-border/50">
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalItems={totalItems}
+            itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : totalItems}
+            onPageChange={goToPage}
+          />
+        </div>
+      )}
+
+      {/* Alerts */}
+      <WorkloadMonitorAlerts issues={issues} />
+
+      {/* AI Diagnose & Repair */}
+      <WorkloadMonitorDiagnose
+        resources={monitorResources}
+        issues={issues}
+        monitorType="prow"
+        diagnosable={true}
+        repairable={true}
+        workloadContext={{
+          prowCluster: 'prow',
+          totalJobs: stats.total,
+          failedJobs: stats.failed,
+          successRate: stats.successRate,
+          runningJobs: stats.running,
+          pendingJobs: stats.pending,
+        }}
+      />
+    </div>
+  )
+}

--- a/web/src/components/cards/workload-monitor/index.ts
+++ b/web/src/components/cards/workload-monitor/index.ts
@@ -1,1 +1,5 @@
 export { WorkloadMonitor } from './WorkloadMonitor'
+export { LLMdStackMonitor } from './LLMdStackMonitor'
+export { ProwCIMonitor } from './ProwCIMonitor'
+export { GitHubCIMonitor } from './GitHubCIMonitor'
+export { ClusterHealthMonitor } from './ClusterHealthMonitor'


### PR DESCRIPTION
## Summary
- **LLMdStackMonitor**: Monitors llm-d inference stack (model serving, EPP, gateways, Prometheus, autoscalers) with diagnose-only AI support
- **ProwCIMonitor**: Monitors Prow CI jobs with stats grid, search, pagination, and full AI diagnose/repair loop
- **GitHubCIMonitor**: Monitors GitHub Actions workflows across repos with pass rates, demo fallback, and AI diagnosis
- **ClusterHealthMonitor**: Monitors all clusters with per-cluster drill-down showing pod/deployment issues and full AI diagnose/repair loop

## Test plan
- [ ] Add `llmd_stack_monitor` card to dashboard, verify llm-d component sections render
- [ ] Add `prow_ci_monitor` card, verify stats grid, job list, search, and pagination work
- [ ] Add `github_ci_monitor` card, verify demo workflows display, stats grid renders
- [ ] Add `cluster_health_monitor` card, verify per-cluster health summaries and drill-downs
- [ ] Verify AI Diagnose button works on each card type (llm-d = diagnose only, Prow/Cluster = diagnose + repair)
- [ ] Verify all 4 cards appear in card catalog with correct titles and icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)