### PR TITLE
✨ Add Provider Health dashboard card

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -392,6 +392,9 @@ const CARD_TITLES: Record<string, string> = {
   kube_doom: 'Kube Doom',
   kube_craft: 'Kube Craft',
   kube_chess: 'Kube Chess',
+
+  // Provider health
+  provider_health: 'Provider Health',
 }
 
 // Short descriptions shown via info icon tooltip in the card header
@@ -500,6 +503,7 @@ const CARD_DESCRIPTIONS: Record<string, string> = {
   llm_models: 'LLM models deployed via llm-d with version info.',
   ml_jobs: 'Machine learning training and batch job status.',
   ml_notebooks: 'Jupyter notebook server status and resource usage.',
+  provider_health: 'Health and status of AI and cloud infrastructure providers.',
 }
 
 // Card icons with their colors - displayed in the card header next to the title
@@ -640,6 +644,9 @@ const CARD_ICONS: Record<string, { icon: ComponentType<{ className?: string }>, 
   prow_ci_monitor: { icon: Activity, color: 'text-blue-400' },
   github_ci_monitor: { icon: GitBranch, color: 'text-purple-400' },
   cluster_health_monitor: { icon: Server, color: 'text-green-400' },
+
+  // Provider health
+  provider_health: { icon: Activity, color: 'text-emerald-400' },
 
   // Games
   sudoku_game: { icon: Puzzle, color: 'text-purple-400' },

--- a/web/src/components/cards/ProviderHealth.tsx
+++ b/web/src/components/cards/ProviderHealth.tsx
@@ -1,0 +1,117 @@
+import { ExternalLink } from 'lucide-react'
+import { useProviderHealth, ProviderHealthInfo } from '../../hooks/useProviderHealth'
+import { SkeletonList } from '../ui/Skeleton'
+import { AgentIcon } from '../agent/AgentIcon'
+import { CloudProviderIcon } from '../ui/CloudProviderIcon'
+import type { CloudProvider } from '../ui/CloudProviderIcon'
+import { cn } from '../../lib/cn'
+
+const STATUS_COLORS: Record<ProviderHealthInfo['status'], string> = {
+  operational: 'bg-green-500',
+  degraded: 'bg-yellow-500',
+  down: 'bg-red-500',
+  unknown: 'bg-gray-400',
+  not_configured: 'bg-gray-400',
+}
+
+const STATUS_LABELS: Record<ProviderHealthInfo['status'], string> = {
+  operational: 'Operational',
+  degraded: 'Degraded',
+  down: 'Down',
+  unknown: 'Unknown',
+  not_configured: 'Not Configured',
+}
+
+function ProviderRow({ provider }: { provider: ProviderHealthInfo }) {
+  return (
+    <div className="flex items-center gap-3 py-2 px-1 rounded-lg hover:bg-secondary/30 transition-colors">
+      {/* Icon */}
+      <div className="shrink-0">
+        {provider.category === 'ai' ? (
+          <AgentIcon provider={provider.id} className="w-5 h-5" />
+        ) : (
+          <CloudProviderIcon provider={provider.id as CloudProvider} size={20} />
+        )}
+      </div>
+
+      {/* Name & detail */}
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-foreground truncate">{provider.name}</div>
+        {provider.detail && (
+          <div className="text-xs text-muted-foreground truncate">{provider.detail}</div>
+        )}
+      </div>
+
+      {/* Status dot + label */}
+      <div className="flex items-center gap-1.5 shrink-0">
+        <div className={cn('w-2 h-2 rounded-full', STATUS_COLORS[provider.status])} />
+        <span className="text-xs text-muted-foreground">{STATUS_LABELS[provider.status]}</span>
+      </div>
+
+      {/* Status page link */}
+      {provider.statusUrl && (
+        <a
+          href={provider.statusUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 p-1 hover:bg-secondary/50 rounded transition-colors text-muted-foreground hover:text-foreground"
+          title="View status page"
+          onClick={e => e.stopPropagation()}
+        >
+          <ExternalLink className="w-3.5 h-3.5" />
+        </a>
+      )}
+    </div>
+  )
+}
+
+export function ProviderHealth() {
+  const { aiProviders, cloudProviders, isLoading } = useProviderHealth()
+
+  if (isLoading) {
+    return <SkeletonList items={5} />
+  }
+
+  const hasAny = aiProviders.length > 0 || cloudProviders.length > 0
+
+  if (!hasAny) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
+        <p className="text-sm">No providers detected</p>
+        <p className="text-xs mt-1">Configure AI keys or connect clusters to see provider health</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* AI Providers */}
+      {aiProviders.length > 0 && (
+        <div>
+          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+            AI Providers
+          </h4>
+          <div className="space-y-0.5">
+            {aiProviders.map(p => (
+              <ProviderRow key={p.id} provider={p} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Cloud Providers */}
+      {cloudProviders.length > 0 && (
+        <div>
+          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+            Cloud Providers
+          </h4>
+          <div className="space-y-0.5">
+            {cloudProviders.map(p => (
+              <ProviderRow key={p.id} provider={p} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -126,6 +126,7 @@ const LLMdStackMonitor = lazy(() => import('./workload-monitor/LLMdStackMonitor'
 const ProwCIMonitor = lazy(() => import('./workload-monitor/ProwCIMonitor').then(m => ({ default: m.ProwCIMonitor })))
 const GitHubCIMonitor = lazy(() => import('./workload-monitor/GitHubCIMonitor').then(m => ({ default: m.GitHubCIMonitor })))
 const ClusterHealthMonitor = lazy(() => import('./workload-monitor/ClusterHealthMonitor').then(m => ({ default: m.ClusterHealthMonitor })))
+const ProviderHealth = lazy(() => import('./ProviderHealth').then(m => ({ default: m.ProviderHealth })))
 
 // Type for card component props
 export type CardComponentProps = { config?: Record<string, unknown> }
@@ -309,6 +310,8 @@ export const CARD_COMPONENTS: Record<string, CardComponent> = {
   prow_ci_monitor: ProwCIMonitor,
   github_ci_monitor: GitHubCIMonitor,
   cluster_health_monitor: ClusterHealthMonitor,
+  // Provider Health card (AI + Cloud provider status)
+  provider_health: ProviderHealth,
 
   // Aliases - map catalog types to existing components with similar functionality
   gpu_list: GPUInventory,
@@ -366,6 +369,8 @@ export const DEMO_DATA_CARDS = new Set([
   // Note: llm_inference, llm_models now use real data via useLLMd hook
   'ml_jobs',
   'ml_notebooks',
+  // Provider health card - shows demo providers in demo mode
+  'provider_health',
 ])
 
 /**
@@ -454,6 +459,8 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   prow_ci_monitor: 6,
   github_ci_monitor: 8,
   cluster_health_monitor: 6,
+  // Provider Health card
+  provider_health: 6,
 
   // Event dashboard cards
   event_summary: 6,

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -69,6 +69,7 @@ const DEFAULT_DASHBOARD_CARDS: Card[] = [
   { id: 'default-5', card_type: 'event_stream', config: {}, position: { x: 6, y: 3, w: 6, h: 4 } },
   { id: 'default-6', card_type: 'deployment_status', config: {}, position: { x: 0, y: 6, w: 6, h: 3 } },
   { id: 'default-7', card_type: 'pod_issues', config: {}, position: { x: 6, y: 7, w: 6, h: 3 } },
+  { id: 'default-8', card_type: 'provider_health', config: {}, position: { x: 0, y: 10, w: 6, h: 3 } },
 ]
 
 

--- a/web/src/components/dashboard/templates.ts
+++ b/web/src/components/dashboard/templates.ts
@@ -23,6 +23,7 @@ export const DASHBOARD_TEMPLATES: DashboardTemplate[] = [
     icon: '🌐',
     category: 'cluster',
     cards: [
+      { card_type: 'provider_health', position: { w: 4, h: 3 } },
       { card_type: 'cluster_health', position: { w: 4, h: 2 } },
       { card_type: 'compute_overview', position: { w: 4, h: 3 } },
       { card_type: 'storage_overview', position: { w: 4, h: 3 } },
@@ -67,6 +68,20 @@ export const DASHBOARD_TEMPLATES: DashboardTemplate[] = [
       { card_type: 'event_stream', position: { w: 4, h: 2 } },
       { card_type: 'deployment_status', position: { w: 4, h: 2 } },
       { card_type: 'upgrade_status', position: { w: 4, h: 2 } },
+    ],
+  },
+
+  {
+    id: 'provider-status',
+    name: 'Provider Status',
+    description: 'Health and connectivity status of AI and cloud infrastructure providers',
+    icon: '🏥',
+    category: 'cluster',
+    cards: [
+      { card_type: 'provider_health', position: { w: 6, h: 3 } },
+      { card_type: 'cluster_health', position: { w: 6, h: 3 } },
+      { card_type: 'active_alerts', position: { w: 6, h: 2 } },
+      { card_type: 'event_stream', position: { w: 6, h: 2 } },
     ],
   },
 
@@ -276,6 +291,7 @@ export const DASHBOARD_TEMPLATES: DashboardTemplate[] = [
     icon: '🤖',
     category: 'ai',
     cards: [
+      { card_type: 'provider_health', position: { w: 4, h: 3 } },
       { card_type: 'console_ai_issues', title: 'AI Issues', position: { w: 4, h: 3 } },
       { card_type: 'console_ai_kubeconfig_audit', title: 'Kubeconfig Audit', position: { w: 4, h: 3 } },
       { card_type: 'console_ai_health_check', title: 'Health Check', position: { w: 4, h: 3 } },

--- a/web/src/hooks/useProviderHealth.ts
+++ b/web/src/hooks/useProviderHealth.ts
@@ -1,0 +1,195 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { getDemoMode } from './useDemoMode'
+import { useClusters } from './mcp/clusters'
+import { detectCloudProvider, getProviderLabel } from '../components/ui/CloudProviderIcon'
+import type { CloudProvider } from '../components/ui/CloudProviderIcon'
+
+const KC_AGENT_URL = 'http://127.0.0.1:8585'
+const REFRESH_INTERVAL = 60_000 // 60 seconds
+
+/** Health status of a single provider */
+export interface ProviderHealthInfo {
+  id: string
+  name: string
+  category: 'ai' | 'cloud'
+  status: 'operational' | 'degraded' | 'down' | 'unknown' | 'not_configured'
+  statusUrl?: string
+  detail?: string
+}
+
+/** Status page URLs for known providers — extensible */
+const STATUS_PAGES: Record<string, string> = {
+  // AI providers
+  anthropic: 'https://status.anthropic.com',
+  openai: 'https://status.openai.com',
+  google: 'https://status.cloud.google.com',
+  // Cloud providers
+  eks: 'https://health.aws.amazon.com/health/status',
+  gke: 'https://status.cloud.google.com',
+  aks: 'https://status.azure.com/en-us/status',
+  openshift: 'https://status.redhat.com',
+  oci: 'https://ocistatus.oraclecloud.com',
+  alibaba: 'https://status.alibabacloud.com',
+  digitalocean: 'https://status.digitalocean.com',
+  rancher: 'https://status.rancher.com',
+}
+
+/** Display name mapping for AI providers */
+const AI_PROVIDER_NAMES: Record<string, string> = {
+  anthropic: 'Anthropic (Claude)',
+  claude: 'Anthropic (Claude)',
+  openai: 'OpenAI',
+  google: 'Google (Gemini)',
+  gemini: 'Google (Gemini)',
+  bob: 'Bob (Built-in)',
+  'anthropic-local': 'Claude Code (Local)',
+}
+
+/** Normalize AI provider ID for dedup and status lookup */
+function normalizeAIProvider(provider: string): string {
+  if (provider === 'claude') return 'anthropic'
+  if (provider === 'gemini') return 'google'
+  if (provider === 'anthropic-local') return 'anthropic-local'
+  return provider
+}
+
+interface KeyStatus {
+  provider: string
+  displayName: string
+  configured: boolean
+  source?: 'env' | 'config'
+  valid?: boolean
+  error?: string
+}
+
+interface KeysStatusResponse {
+  keys: KeyStatus[]
+  configPath: string
+}
+
+/** Demo data — shows a realistic set of providers all operational */
+function getDemoProviders(): ProviderHealthInfo[] {
+  return [
+    { id: 'anthropic', name: 'Anthropic (Claude)', category: 'ai', status: 'operational', statusUrl: STATUS_PAGES.anthropic, detail: 'API key configured' },
+    { id: 'openai', name: 'OpenAI', category: 'ai', status: 'operational', statusUrl: STATUS_PAGES.openai, detail: 'API key configured' },
+    { id: 'google', name: 'Google (Gemini)', category: 'ai', status: 'operational', statusUrl: STATUS_PAGES.google, detail: 'API key configured' },
+    { id: 'eks', name: 'AWS EKS', category: 'cloud', status: 'operational', statusUrl: STATUS_PAGES.eks, detail: '3 clusters' },
+    { id: 'gke', name: 'Google GKE', category: 'cloud', status: 'operational', statusUrl: STATUS_PAGES.gke, detail: '2 clusters' },
+    { id: 'aks', name: 'Azure AKS', category: 'cloud', status: 'operational', statusUrl: STATUS_PAGES.aks, detail: '1 cluster' },
+    { id: 'openshift', name: 'OpenShift', category: 'cloud', status: 'operational', statusUrl: STATUS_PAGES.openshift, detail: '1 cluster' },
+    { id: 'oci', name: 'Oracle OKE', category: 'cloud', status: 'operational', statusUrl: STATUS_PAGES.oci, detail: '1 cluster' },
+  ]
+}
+
+/**
+ * Hook that discovers AI + Cloud providers and reports their health.
+ * AI providers come from the backend /settings/keys endpoint.
+ * Cloud providers are detected from cluster distributions.
+ * Auto-refreshes every 60 seconds.
+ */
+export function useProviderHealth() {
+  const [providers, setProviders] = useState<ProviderHealthInfo[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const intervalRef = useRef<ReturnType<typeof setInterval>>()
+  const { clusters } = useClusters()
+
+  const fetchProviders = useCallback(async () => {
+    if (getDemoMode()) {
+      setProviders(getDemoProviders())
+      setIsLoading(false)
+      return
+    }
+
+    const result: ProviderHealthInfo[] = []
+
+    // --- AI Providers from /settings/keys ---
+    try {
+      const response = await fetch(`${KC_AGENT_URL}/settings/keys`)
+      if (response.ok) {
+        const data: KeysStatusResponse = await response.json()
+        const seen = new Set<string>()
+        for (const key of data.keys) {
+          const normalized = normalizeAIProvider(key.provider)
+          if (seen.has(normalized)) continue
+          seen.add(normalized)
+
+          const name = AI_PROVIDER_NAMES[key.provider] || key.displayName || key.provider
+          let status: ProviderHealthInfo['status'] = 'unknown'
+          let detail: string | undefined
+
+          if (key.configured) {
+            if (key.valid === true) {
+              status = 'operational'
+              detail = 'API key configured and valid'
+            } else if (key.valid === false) {
+              status = 'down'
+              detail = key.error || 'API key invalid'
+            } else {
+              status = 'operational'
+              detail = 'API key configured'
+            }
+          } else {
+            status = 'not_configured'
+            detail = 'API key not configured'
+          }
+
+          result.push({
+            id: normalized,
+            name,
+            category: 'ai',
+            status,
+            statusUrl: STATUS_PAGES[normalized],
+            detail,
+          })
+        }
+      }
+    } catch {
+      // Agent unreachable — no AI providers to show
+    }
+
+    // --- Cloud Providers from cluster distributions ---
+    if (clusters.length > 0) {
+      const providerCounts = new Map<CloudProvider, number>()
+      for (const cluster of clusters) {
+        const provider = detectCloudProvider(
+          cluster.name,
+          cluster.server,
+          cluster.namespaces,
+          cluster.user,
+        )
+        // Skip generic/local providers — only show real cloud platforms
+        if (provider === 'kubernetes' || provider === 'kind' || provider === 'minikube' || provider === 'k3s') {
+          continue
+        }
+        providerCounts.set(provider, (providerCounts.get(provider) || 0) + 1)
+      }
+
+      for (const [provider, count] of providerCounts) {
+        result.push({
+          id: provider,
+          name: getProviderLabel(provider),
+          category: 'cloud',
+          status: 'operational',
+          statusUrl: STATUS_PAGES[provider],
+          detail: `${count} cluster${count !== 1 ? 's' : ''} detected`,
+        })
+      }
+    }
+
+    setProviders(result)
+    setIsLoading(false)
+  }, [clusters])
+
+  useEffect(() => {
+    fetchProviders()
+    intervalRef.current = setInterval(fetchProviders, REFRESH_INTERVAL)
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [fetchProviders])
+
+  const aiProviders = providers.filter(p => p.category === 'ai')
+  const cloudProviders = providers.filter(p => p.category === 'cloud')
+
+  return { providers, aiProviders, cloudProviders, isLoading, refetch: fetchProviders }
+}


### PR DESCRIPTION
## Summary
- New **Provider Health** dashboard card showing health/connectivity of external services
- **AI Providers** (Claude, OpenAI, Gemini) dynamically discovered from backend `/settings/keys` endpoint
- **Cloud Providers** (AWS EKS, GKE, AKS, etc.) auto-detected from cluster distributions
- Flexible design — new providers automatically appear when added to the system
- Each provider shows: icon, name, status dot (green/yellow/red/gray), detail text, and clickable status page link
- Demo mode shows all providers as operational

## Changes
- `web/src/hooks/useProviderHealth.ts` — New hook for dynamic provider discovery + health (60s auto-refresh)
- `web/src/components/cards/ProviderHealth.tsx` — New card component with AI + Cloud sections
- `web/src/components/cards/cardRegistry.ts` — Registered card, demo set, default width
- `web/src/components/cards/CardWrapper.tsx` — Added title, description, icon
- `web/src/components/dashboard/templates.ts` — Added to Cluster Overview, AI Dashboard templates; new Provider Status template
- `web/src/components/dashboard/Dashboard.tsx` — Added to main dashboard defaults

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (no new errors from new files)
- [ ] Card appears on main dashboard in demo mode
- [ ] AI + Cloud provider sections render with proper icons and status dots
- [ ] Status page links open in new tabs
- [ ] Templates modal shows provider_health in Cluster Overview, AI Dashboard, and Provider Status

🤖 Generated with [Claude Code](https://claude.com/claude-code)