### PR TITLE
🐛 Fix Pod Issues card missing cluster badges and sparse demo data

### DIFF
--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -133,7 +133,11 @@ const getDemoEvents = (): ClusterEvent[] => [
 ]
 
 const getDemoPodIssues = (): PodIssue[] => [
-  { name: 'failing-pod', namespace: 'default', status: 'CrashLoopBackOff', issues: ['Container crashing'], restarts: 5 },
+  { name: 'api-server-7d8f9c6b5-x2k4m', namespace: 'production', cluster: 'prod-east', status: 'CrashLoopBackOff', issues: ['Container restarting', 'OOMKilled'], restarts: 15 },
+  { name: 'worker-5c6d7e8f9-n3p2q', namespace: 'batch', cluster: 'vllm-d', status: 'ImagePullBackOff', issues: ['Failed to pull image'], restarts: 0 },
+  { name: 'cache-redis-0', namespace: 'data', cluster: 'staging', status: 'Pending', issues: ['Insufficient memory'], restarts: 0 },
+  { name: 'metrics-collector-2b4c6-j8k9l', namespace: 'monitoring', cluster: 'prod-west', status: 'CrashLoopBackOff', issues: ['Exit code 137'], restarts: 8 },
+  { name: 'gpu-scheduler-0', namespace: 'ml-ops', cluster: 'vllm-d', status: 'Pending', issues: ['Insufficient nvidia.com/gpu'], restarts: 0 },
 ]
 
 const getDemoDeploymentIssues = (): DeploymentIssue[] => [


### PR DESCRIPTION
## Summary
- Demo fallback data in `getDemoPodIssues()` had a single entry with no `cluster` field — cluster badges never rendered
- Replaced with 5 realistic pod issues across `prod-east`, `prod-west`, `vllm-d`, and `staging` clusters
- Each entry now includes the `cluster` field so `ClusterBadge` renders properly

## Test plan
- [x] Build passes
- [x] TypeScript type check passes
- [ ] Visual: Pod Issues card shows cluster badges on each item in demo mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)