### PR TITLE
🐛 Add missing cards to CARD_CATALOG in AddCardModal

### DIFF
--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -14,6 +14,7 @@ const CARD_CATALOG = {
     { type: 'cluster_costs', title: 'Cluster Costs', description: 'Resource cost estimation', visualization: 'bar' },
     { type: 'upgrade_status', title: 'Cluster Upgrade Status', description: 'Available cluster upgrades', visualization: 'status' },
     { type: 'cluster_resource_tree', title: 'Cluster Resource Tree', description: 'Hierarchical view of cluster resources with search and filters', visualization: 'table' },
+    { type: 'provider_health', title: 'Provider Health', description: 'Health and status of AI and cloud infrastructure providers', visualization: 'status' },
   ],
   'Workloads': [
     { type: 'deployment_status', title: 'Deployment Status', description: 'Deployment health across clusters', visualization: 'donut' },
@@ -80,6 +81,9 @@ const CARD_CATALOG = {
   'Security & Events': [
     { type: 'security_issues', title: 'Security Issues', description: 'Security findings and vulnerabilities', visualization: 'table' },
     { type: 'event_stream', title: 'Event Stream', description: 'Live Kubernetes event feed', visualization: 'events' },
+    { type: 'event_summary', title: 'Event Summary', description: 'Aggregated event counts grouped by type and reason', visualization: 'status' },
+    { type: 'warning_events', title: 'Warning Events', description: 'Warning-level events that may need attention', visualization: 'events' },
+    { type: 'recent_events', title: 'Recent Events', description: 'Most recent events across all clusters', visualization: 'events' },
     { type: 'user_management', title: 'User Management', description: 'Console users and Kubernetes RBAC', visualization: 'table' },
   ],
   'Live Trends': [
@@ -154,6 +158,7 @@ const CARD_CATALOG = {
     { type: 'kube_craft', title: 'KubeCraft 2D', description: '2D Minecraft-style block builder with terrain generation', visualization: 'status' },
     { type: 'kube_craft_3d', title: 'KubeCraft 3D', description: 'Full 3D Minecraft-style game with first-person controls', visualization: 'status' },
     { type: 'kube_doom', title: 'Kube Doom', description: 'Raycasting FPS - eliminate rogue CrashPods, OOMKillers, and ZombieDeploys', visualization: 'status' },
+    { type: 'pod_crosser', title: 'Pod Crosser', description: 'Frogger-style game - guide your pod across traffic and rivers', visualization: 'status' },
   ],
   'Utilities': [
     { type: 'network_utils', title: 'Network Utils', description: 'Ping hosts, check ports, and view network information', visualization: 'status' },
@@ -187,6 +192,33 @@ interface AddCardModalProps {
 // Simulated AI response - in production this would call Claude API
 function generateCardSuggestions(query: string): CardSuggestion[] {
   const lowerQuery = query.toLowerCase()
+
+  // Provider/health-related queries
+  if (lowerQuery.includes('provider') || lowerQuery.includes('ai provider') || lowerQuery.includes('cloud provider') || lowerQuery.includes('infrastructure health')) {
+    return [
+      {
+        type: 'provider_health',
+        title: 'Provider Health',
+        description: 'Health and status of AI and cloud infrastructure providers',
+        visualization: 'status',
+        config: {},
+      },
+      {
+        type: 'cluster_health',
+        title: 'Cluster Health',
+        description: 'Health status of all clusters',
+        visualization: 'status',
+        config: {},
+      },
+      {
+        type: 'active_alerts',
+        title: 'Active Alerts',
+        description: 'Firing alerts with severity',
+        visualization: 'status',
+        config: {},
+      },
+    ]
+  }
 
   // GPU-related queries
   if (lowerQuery.includes('gpu')) {


### PR DESCRIPTION
## Summary
- Added 5 registered cards that were missing from the `CARD_CATALOG` in `AddCardModal.tsx`
- The `CARD_CATALOG` is a separate hardcoded list independent of `cardRegistry.ts` — cards must be added to both
- Missing cards: `provider_health`, `event_summary`, `warning_events`, `recent_events`, `pod_crosser`
- Also added provider health to AI suggestion queries (matches "provider", "ai provider", "cloud provider", "infrastructure health")

## Cards Added
| Card | Category |
|------|----------|
| `provider_health` | Cluster Health |
| `event_summary` | Security & Events |
| `warning_events` | Security & Events |
| `recent_events` | Security & Events |
| `pod_crosser` | Arcade |

## Test plan
- [ ] Open Add Card modal → Browse tab → verify Provider Health appears in Cluster Health category
- [ ] Verify event_summary, warning_events, recent_events appear in Security & Events
- [ ] Verify pod_crosser appears in Arcade
- [ ] Search "provider" in AI tab → returns Provider Health suggestion
- [ ] Build passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)