### PR TITLE
🐛 Sync demo mode detection with auth demo-token

### DIFF
--- a/web/src/hooks/useDemoMode.ts
+++ b/web/src/hooks/useDemoMode.ts
@@ -20,10 +20,12 @@ const isNetlifyPreview = typeof window !== 'undefined' && (
  */
 export const isDemoModeForced = isNetlifyPreview
 
-// Initialize from localStorage, or auto-enable on Netlify previews
+// Initialize from localStorage, auto-enable on Netlify previews, or when auth
+// has set a demo-token (backend unavailable / no real JWT)
 if (typeof window !== 'undefined') {
   const stored = localStorage.getItem(DEMO_MODE_KEY)
-  globalDemoMode = isNetlifyPreview || stored === 'true'
+  const hasDemoToken = localStorage.getItem('token') === 'demo-token'
+  globalDemoMode = isNetlifyPreview || stored === 'true' || hasDemoToken
 
   // Clear any stale demo GPU data if demo mode is off
   // This handles the case where demo data was incorrectly cached


### PR DESCRIPTION
## Summary
- The UI demo mode flag (`kc-demo-mode`) and auth `demo-token` were independent systems
- When auth auto-set `demo-token` (backend unavailable), `useDemoMode()` returned `false` because it only checked the `kc-demo-mode` localStorage flag
- Cards showed demo data without the Demo badge or yellow border
- Now `useDemoMode` initialization also checks `token === 'demo-token'`

## Test plan
- [x] Build passes
- [x] TypeScript check passes
- [ ] Visual: cards show Demo badge and yellow border when using demo-token

🤖 Generated with [Claude Code](https://claude.com/claude-code)