### PR TITLE
🌱 Exempt arcade cards from demo badge and yellow border

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -10,6 +10,7 @@ import { cn } from '../../lib/cn'
 import { useCardCollapse } from '../../lib/cards'
 import { useSnoozedCards } from '../../hooks/useSnoozedCards'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import { DEMO_EXEMPT_CARDS } from './cardRegistry'
 import { ChatMessage } from './CardChat'
 
 // Minimum duration to show spin animation (ensures at least one full rotation)
@@ -784,7 +785,9 @@ export function CardWrapper({
   const [localMessages, setLocalMessages] = useState<ChatMessage[]>([])
   const [menuPosition, setMenuPosition] = useState<{ top: number; right: number } | null>(null)
   const { snoozeSwap } = useSnoozedCards()
-  const { isDemoMode } = useDemoMode()
+  const { isDemoMode: globalDemoMode } = useDemoMode()
+  const isDemoExempt = DEMO_EXEMPT_CARDS.has(cardType)
+  const isDemoMode = globalDemoMode && !isDemoExempt
   const menuContainerRef = useRef<HTMLDivElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
 

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -379,6 +379,21 @@ export const DEMO_DATA_CARDS = new Set([
 ])
 
 /**
+ * Cards that should never show demo indicators (badge/yellow border).
+ * Arcade/game cards don't have "demo data" — they're always just games.
+ */
+export const DEMO_EXEMPT_CARDS = new Set([
+  'sudoku_game',
+  'checkers',
+  'container_tetris',
+  'kube_kong',
+  'pod_crosser',
+  'kube_kart',
+  'kube_snake',
+  'kube_chess',
+])
+
+/**
  * Cards that display live/real-time data streams.
  * These show a "Live" badge in the title when showing real data (not demo).
  * Primarily time-series, trend, and event streaming cards.


### PR DESCRIPTION
## Summary
- Added `DEMO_EXEMPT_CARDS` set in cardRegistry for game cards
- CardWrapper overrides `isDemoMode` to `false` for exempt cards
- Arcade cards (sudoku, checkers, tetris, kube-kong, pod-crosser, kube-kart, kube-snake, kube-chess) no longer show "Demo" badge or yellow border

## Test plan
- [x] Build passes
- [x] TypeScript check passes
- [ ] Visual: arcade cards have no Demo badge or yellow border in demo mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)