### PR TITLE
🐛 Fix Provider Health demo badge and add Settings link

### DIFF
--- a/web/src/components/cards/ProviderHealth.tsx
+++ b/web/src/components/cards/ProviderHealth.tsx
@@ -1,4 +1,5 @@
-import { ExternalLink } from 'lucide-react'
+import { ExternalLink, Settings } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
 import { useProviderHealth, ProviderHealthInfo } from '../../hooks/useProviderHealth'
 import { SkeletonList } from '../ui/Skeleton'
 import { AgentIcon } from '../agent/AgentIcon'
@@ -22,7 +23,7 @@ const STATUS_LABELS: Record<ProviderHealthInfo['status'], string> = {
   not_configured: 'Not Configured',
 }
 
-function ProviderRow({ provider }: { provider: ProviderHealthInfo }) {
+function ProviderRow({ provider, onConfigure }: { provider: ProviderHealthInfo; onConfigure?: () => void }) {
   return (
     <div className="flex items-center gap-3 py-2 px-1 rounded-lg hover:bg-secondary/30 transition-colors">
       {/* Icon */}
@@ -48,6 +49,17 @@ function ProviderRow({ provider }: { provider: ProviderHealthInfo }) {
         <span className="text-xs text-muted-foreground">{STATUS_LABELS[provider.status]}</span>
       </div>
 
+      {/* Configure link for unconfigured providers */}
+      {provider.status === 'not_configured' && onConfigure && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onConfigure() }}
+          className="shrink-0 p-1 hover:bg-purple-500/20 rounded transition-colors text-muted-foreground hover:text-purple-400"
+          title="Configure in Settings"
+        >
+          <Settings className="w-3.5 h-3.5" />
+        </button>
+      )}
+
       {/* Status page link */}
       {provider.statusUrl && (
         <a
@@ -67,6 +79,9 @@ function ProviderRow({ provider }: { provider: ProviderHealthInfo }) {
 
 export function ProviderHealth() {
   const { aiProviders, cloudProviders, isLoading } = useProviderHealth()
+  const navigate = useNavigate()
+
+  const goToSettings = () => navigate('/settings')
 
   if (isLoading) {
     return <SkeletonList items={5} />
@@ -78,7 +93,12 @@ export function ProviderHealth() {
     return (
       <div className="flex flex-col items-center justify-center py-8 text-muted-foreground">
         <p className="text-sm">No providers detected</p>
-        <p className="text-xs mt-1">Configure AI keys or connect clusters to see provider health</p>
+        <p className="text-xs mt-1">
+          <button onClick={goToSettings} className="text-purple-400 hover:underline">
+            Configure AI keys
+          </button>
+          {' '}or connect clusters to see provider health
+        </p>
       </div>
     )
   }
@@ -93,7 +113,7 @@ export function ProviderHealth() {
           </h4>
           <div className="space-y-0.5">
             {aiProviders.map(p => (
-              <ProviderRow key={p.id} provider={p} />
+              <ProviderRow key={p.id} provider={p} onConfigure={goToSettings} />
             ))}
           </div>
         </div>

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -374,8 +374,8 @@ export const DEMO_DATA_CARDS = new Set([
   // Note: llm_inference, llm_models now use real data via useLLMd hook
   'ml_jobs',
   'ml_notebooks',
-  // Provider health card - shows demo providers in demo mode
-  'provider_health',
+  // Provider health card uses real data from /settings/keys + useClusters()
+  // Only shows demo data when getDemoMode() is true (handled inside the hook)
 ])
 
 /**


### PR DESCRIPTION
## Summary
- Removed `provider_health` from `DEMO_DATA_CARDS` — the card fetches real data from `/settings/keys` and `useClusters()`, only falling back to demo data when `getDemoMode()` is true (handled inside the hook). The "Demo" badge was incorrectly showing on live instances.
- Added a Settings gear icon for unconfigured AI providers that navigates to `/settings` to configure API keys
- Added "Configure AI keys" link in the empty state when no providers are detected

## Test plan
- [ ] Live instance: Provider Health card should NOT show "Demo" badge
- [ ] Live instance with unconfigured AI keys: shows gear icon next to "Not Configured" — clicking navigates to Settings
- [ ] Demo mode (Netlify): card should still work with demo data (no "Demo" badge since it's not in DEMO_DATA_CARDS, but demo mode is handled by the hook)
- [ ] Empty state shows "Configure AI keys" link → navigates to Settings
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)