### PR TITLE
🐛 Fix demo mode persistence across browser refreshes

### DIFF
--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -114,7 +114,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUser(response.data)
       cacheUser(response.data)
     } catch (error) {
-      console.error('Failed to fetch user, falling back to demo mode:', error)
+      // If the backend is temporarily unreachable but we have a real token,
+      // keep the token and use cached user data instead of destroying the
+      // session by falling back to demo mode.
+      const cachedUser = getCachedUser()
+      if (cachedUser) {
+        console.warn('Backend unreachable, using cached user data')
+        setUser(cachedUser)
+        return
+      }
+      // No cached user — fall back to demo mode as last resort
+      console.error('Failed to fetch user and no cache, falling back to demo mode:', error)
       setDemoMode()
     }
   }, [setDemoMode])


### PR DESCRIPTION
## Summary
- Fixed auth.tsx: backend unreachable no longer destroys real JWT token by falling back to demo mode — uses cached user data instead
- Fixed useDemoMode.ts: user's explicit demo mode preference (stored in localStorage) is now respected over stale demo-token
- Added guards in toggleDemoMode/setDemoMode to prevent disabling demo mode on Netlify — Netlify always stays in demo mode

## Behavior
| Scenario | Before | After |
|----------|--------|-------|
| Non-Netlify: refresh with real token, backend down | Token destroyed → demo mode | Cached user used → stays live |
| Non-Netlify: toggle demo off, refresh | demo-token overrides → demo on | Stored preference respected → stays off |
| Netlify: try to disable demo mode | Prevented by UI | Prevented by UI + function guards |

## Test plan
- [ ] Non-Netlify: authenticate, toggle demo mode off, refresh → stays off
- [ ] Non-Netlify: authenticate, stop backend, refresh → stays authenticated with cached user
- [ ] Netlify: demo mode always on, toggle shows install dialog
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)