### PR TITLE
🐛 Show service health indicator for unconfigured providers

### DIFF
--- a/web/src/components/cards/ProviderHealth.tsx
+++ b/web/src/components/cards/ProviderHealth.tsx
@@ -12,7 +12,6 @@ const STATUS_COLORS: Record<ProviderHealthInfo['status'], string> = {
   degraded: 'bg-yellow-500',
   down: 'bg-red-500',
   unknown: 'bg-gray-400',
-  not_configured: 'bg-gray-400',
 }
 
 const STATUS_LABELS: Record<ProviderHealthInfo['status'], string> = {
@@ -20,7 +19,6 @@ const STATUS_LABELS: Record<ProviderHealthInfo['status'], string> = {
   degraded: 'Degraded',
   down: 'Down',
   unknown: 'Unknown',
-  not_configured: 'Not Configured',
 }
 
 function ProviderRow({ provider, onConfigure }: { provider: ProviderHealthInfo; onConfigure?: () => void }) {
@@ -47,10 +45,15 @@ function ProviderRow({ provider, onConfigure }: { provider: ProviderHealthInfo; 
       <div className="flex items-center gap-1.5 shrink-0">
         <div className={cn('w-2 h-2 rounded-full', STATUS_COLORS[provider.status])} />
         <span className="text-xs text-muted-foreground">{STATUS_LABELS[provider.status]}</span>
+        {!provider.configured && (
+          <span className="text-[10px] text-yellow-500 bg-yellow-500/10 px-1.5 py-0.5 rounded-full font-medium">
+            No Key
+          </span>
+        )}
       </div>
 
       {/* Configure link for unconfigured providers */}
-      {provider.status === 'not_configured' && onConfigure && (
+      {!provider.configured && onConfigure && (
         <button
           onClick={(e) => { e.stopPropagation(); onConfigure() }}
           className="shrink-0 p-1 hover:bg-purple-500/20 rounded transition-colors text-muted-foreground hover:text-purple-400"


### PR DESCRIPTION
## Summary
- Separated configuration status from service health in the Provider Health card
- Unconfigured AI providers now check actual service health via Statuspage.io JSON API (`/api/v2/status.json`)
- Health dot shows green/yellow/red based on real service status, even when API key is not configured
- Added a "No Key" badge next to the health label for unconfigured providers
- Added `configured: boolean` field to `ProviderHealthInfo` interface

## Test plan
- [ ] Provider Health card shows service health dots for unconfigured providers
- [ ] Configured providers still show operational/degraded/down correctly
- [ ] "No Key" badge appears next to unconfigured providers
- [ ] Gear icon still shows for unconfigured providers to navigate to settings
- [ ] Demo mode still shows all providers as operational

🤖 Generated with [Claude Code](https://claude.com/claude-code)