### PR TITLE
🐛 Persist demo mode & agent selection across browser refresh

### DIFF
--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -92,16 +92,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     // Demo token — check if the backend has come online since the token was issued.
-    // If so, clear the stale demo token so the login screen appears and the user
-    // can authenticate with a real JWT via GitHub OAuth.
+    // If the user explicitly enabled demo mode (via the toggle), keep it even if
+    // the backend is available. Otherwise, clear the stale demo token so the login
+    // screen appears and the user can authenticate with a real JWT via GitHub OAuth.
     if (effectiveToken === 'demo-token') {
-      const backendUp = await checkBackendAvailability(true)
-      if (backendUp) {
-        localStorage.removeItem('token')
-        cacheUser(null)
-        setTokenState(null)
-        setUser(null)
-        return
+      const userExplicitlyEnabledDemo = localStorage.getItem('kc-demo-mode') === 'true'
+      if (!userExplicitlyEnabledDemo) {
+        const backendUp = await checkBackendAvailability(true)
+        if (backendUp) {
+          localStorage.removeItem('token')
+          cacheUser(null)
+          setTokenState(null)
+          setUser(null)
+          return
+        }
       }
       setDemoMode()
       return


### PR DESCRIPTION
## Summary
- **Demo mode persistence**: When a user explicitly enables demo mode via the toggle (`kc-demo-mode=true`), the auth layer no longer clears the demo-token on page refresh when the backend is available. Previously, `refreshUser()` would detect the backend, destroy the demo session, and show the login screen — undoing the user's explicit choice.
- **Agent selection persistence**: The selected AI agent (Claude, OpenAI, Gemini) is now saved to `localStorage` (`kc_selected_agent`). On page refresh, the persisted selection is restored and synced back to the WebSocket server. Previously, the selection was only held in WebSocket state and lost on every refresh.

## Test plan
- [ ] Toggle demo mode ON, refresh browser → demo mode stays ON
- [ ] Toggle demo mode OFF, refresh browser → demo mode stays OFF
- [ ] Select a non-default AI agent, refresh browser → same agent remains selected
- [ ] On Netlify preview: demo mode cannot be disabled (existing guard unchanged)
- [ ] With no backend running: demo mode fallback still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)