### PR TITLE
✨ Add AI-assisted creation to Card Factory and Stat Block Factory

### DIFF
--- a/web/src/components/dashboard/AiGenerationPanel.tsx
+++ b/web/src/components/dashboard/AiGenerationPanel.tsx
@@ -1,0 +1,248 @@
+import { useState, useEffect, useCallback, type ReactNode } from 'react'
+import { Sparkles, Loader2, CheckCircle, AlertTriangle, RotateCw, Save } from 'lucide-react'
+import { useMissions } from '../../hooks/useMissions'
+import { useApiKeyCheck, ApiKeyPromptModal } from '../cards/console-missions/shared'
+import { extractJsonFromMarkdown } from '../../lib/ai/extractJson'
+import { cn } from '../../lib/cn'
+
+type Phase = 'idle' | 'generating' | 'parsed' | 'error'
+
+interface AiGenerationPanelProps<T> {
+  systemPrompt: string
+  placeholder: string
+  missionTitle: string
+  validateResult: (data: unknown) => { valid: true; result: T } | { valid: false; error: string }
+  renderPreview: (result: T) => ReactNode
+  onSave: (result: T) => void
+  saveLabel?: string
+}
+
+export function AiGenerationPanel<T>({
+  systemPrompt,
+  placeholder,
+  missionTitle,
+  validateResult,
+  renderPreview,
+  onSave,
+  saveLabel = 'Save',
+}: AiGenerationPanelProps<T>) {
+  const [userPrompt, setUserPrompt] = useState('')
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [missionId, setMissionId] = useState<string | null>(null)
+  const [streamingText, setStreamingText] = useState('')
+  const [parsedResult, setParsedResult] = useState<T | null>(null)
+  const [parseError, setParseError] = useState<string | null>(null)
+
+  const { startMission, missions, closeSidebar } = useMissions()
+  const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
+
+  // Track the active mission
+  const trackedMission = missionId ? missions.find(m => m.id === missionId) : null
+
+  // Update streaming text from mission messages
+  useEffect(() => {
+    if (!trackedMission || phase !== 'generating') return
+
+    const assistantMessages = trackedMission.messages.filter(m => m.role === 'assistant')
+    const lastMsg = assistantMessages[assistantMessages.length - 1]
+    if (lastMsg) {
+      setStreamingText(lastMsg.content)
+    }
+
+    // Check for completion
+    if (
+      (trackedMission.status === 'waiting_input' || trackedMission.status === 'completed') &&
+      lastMsg
+    ) {
+      const { data, error } = extractJsonFromMarkdown<unknown>(lastMsg.content)
+      if (data) {
+        const validation = validateResult(data)
+        if (validation.valid) {
+          setParsedResult(validation.result)
+          setPhase('parsed')
+        } else {
+          setParseError(validation.error)
+          setPhase('error')
+        }
+      } else {
+        setParseError(error || 'Failed to parse AI response')
+        setPhase('error')
+      }
+    }
+
+    if (trackedMission.status === 'failed') {
+      setParseError('AI generation failed. Please check your agent connection and try again.')
+      setPhase('error')
+    }
+  }, [trackedMission?.status, trackedMission?.messages.length, phase, validateResult])
+
+  const handleGenerate = useCallback(() => {
+    if (!userPrompt.trim()) return
+
+    checkKeyAndRun(() => {
+      const fullPrompt = `${systemPrompt}\n\nUser request: ${userPrompt}`
+      const id = startMission({
+        title: missionTitle,
+        description: userPrompt.substring(0, 200),
+        type: 'custom',
+        initialPrompt: fullPrompt,
+      })
+      setMissionId(id)
+      setPhase('generating')
+      setStreamingText('')
+      setParsedResult(null)
+      setParseError(null)
+      // Close sidebar so modal stays focused
+      setTimeout(() => closeSidebar(), 150)
+    })
+  }, [userPrompt, systemPrompt, missionTitle, startMission, closeSidebar, checkKeyAndRun])
+
+  const handleRetry = useCallback(() => {
+    setPhase('idle')
+    setStreamingText('')
+    setParsedResult(null)
+    setParseError(null)
+    setMissionId(null)
+  }, [])
+
+  const handleSave = useCallback(() => {
+    if (parsedResult) {
+      onSave(parsedResult)
+      handleRetry()
+      setUserPrompt('')
+    }
+  }, [parsedResult, onSave, handleRetry])
+
+  return (
+    <div className="space-y-4 relative">
+      {/* API Key Modal */}
+      <ApiKeyPromptModal isOpen={showKeyPrompt} onDismiss={dismissPrompt} onGoToSettings={goToSettings} />
+
+      {/* Prompt input (idle and error phases) */}
+      {(phase === 'idle' || phase === 'error') && (
+        <>
+          <div>
+            <label className="text-xs text-muted-foreground block mb-1">
+              Describe what you want
+            </label>
+            <textarea
+              value={userPrompt}
+              onChange={e => setUserPrompt(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleGenerate()
+              }}
+              placeholder={placeholder}
+              rows={4}
+              className="w-full text-sm px-3 py-2 rounded-md bg-secondary/50 border border-border text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-purple-500/50"
+            />
+            <p className="text-[10px] text-muted-foreground/50 mt-1">
+              Press Cmd+Enter to generate
+            </p>
+          </div>
+
+          {/* Error display */}
+          {phase === 'error' && parseError && (
+            <div className="flex items-start gap-2 p-3 rounded-md bg-red-500/10 border border-red-500/20">
+              <AlertTriangle className="w-4 h-4 text-red-400 mt-0.5 shrink-0" />
+              <div className="flex-1 min-w-0">
+                <span className="text-xs text-red-400 break-words">{parseError}</span>
+                {streamingText && (
+                  <details className="mt-2 text-xs">
+                    <summary className="text-muted-foreground cursor-pointer hover:text-foreground">
+                      View raw AI output
+                    </summary>
+                    <pre className="mt-1 p-2 bg-secondary/50 rounded text-[10px] text-muted-foreground overflow-x-auto max-h-40 whitespace-pre-wrap">
+                      {streamingText}
+                    </pre>
+                  </details>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Generate button */}
+          <button
+            onClick={handleGenerate}
+            disabled={!userPrompt.trim()}
+            className={cn(
+              'w-full flex items-center justify-center gap-2 py-2.5 rounded-md text-sm font-medium transition-colors',
+              userPrompt.trim()
+                ? 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30'
+                : 'bg-secondary text-muted-foreground cursor-not-allowed',
+            )}
+          >
+            <Sparkles className="w-4 h-4" />
+            Generate with AI
+          </button>
+        </>
+      )}
+
+      {/* Generating — streaming view */}
+      {phase === 'generating' && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <Loader2 className="w-4 h-4 text-purple-400 animate-spin" />
+            <span className="text-sm text-purple-400">
+              {trackedMission?.currentStep || 'Generating...'}
+            </span>
+          </div>
+          <textarea
+            readOnly
+            value={streamingText || 'Waiting for AI response...'}
+            rows={12}
+            className="w-full text-xs px-3 py-2 rounded-md bg-secondary/50 border border-border text-foreground font-mono focus:outline-none leading-relaxed"
+          />
+          <p className="text-[10px] text-muted-foreground/50 text-center">
+            The AI is generating your definition. This may take a moment.
+          </p>
+        </div>
+      )}
+
+      {/* Parsed result — preview + save */}
+      {phase === 'parsed' && parsedResult && (
+        <div className="space-y-4">
+          <div className="flex items-center gap-2">
+            <CheckCircle className="w-4 h-4 text-green-400" />
+            <span className="text-sm text-green-400">Generation complete!</span>
+          </div>
+
+          {/* Preview */}
+          <div className="rounded-lg border border-border/50 bg-secondary/20 p-4">
+            {renderPreview(parsedResult)}
+          </div>
+
+          {/* Raw output toggle */}
+          <details className="text-xs">
+            <summary className="text-muted-foreground cursor-pointer hover:text-foreground">
+              View raw AI output
+            </summary>
+            <textarea
+              readOnly
+              value={streamingText}
+              rows={8}
+              className="w-full mt-2 text-xs px-3 py-2 rounded-md bg-secondary/50 border border-border text-foreground font-mono"
+            />
+          </details>
+
+          {/* Action buttons */}
+          <div className="flex gap-2">
+            <button
+              onClick={handleSave}
+              className="flex-1 flex items-center justify-center gap-2 py-2 rounded-md text-sm font-medium bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 transition-colors"
+            >
+              <Save className="w-4 h-4" />
+              {saveLabel}
+            </button>
+            <button
+              onClick={handleRetry}
+              className="flex items-center gap-2 px-4 py-2 rounded-md text-sm bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <RotateCw className="w-4 h-4" />
+              Regenerate
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/lib/ai/extractJson.ts
+++ b/web/src/lib/ai/extractJson.ts
@@ -1,0 +1,87 @@
+/**
+ * Extract JSON from AI markdown responses.
+ *
+ * AI models typically return JSON inside ```json fences with
+ * surrounding explanatory text. This utility extracts and parses
+ * the JSON using multiple strategies.
+ */
+
+export interface ExtractResult<T> {
+  data: T | null
+  error: string | null
+}
+
+export function extractJsonFromMarkdown<T = unknown>(text: string): ExtractResult<T> {
+  // Strategy 1: Look for ```json ... ``` fenced blocks
+  const jsonBlockRegex = /```json\s*\n?([\s\S]*?)```/g
+  const matches: string[] = []
+  let match: RegExpExecArray | null
+
+  while ((match = jsonBlockRegex.exec(text)) !== null) {
+    matches.push(match[1].trim())
+  }
+
+  // Try parsing each match (last match is often the final/correct one)
+  for (let i = matches.length - 1; i >= 0; i--) {
+    try {
+      const parsed = JSON.parse(matches[i]) as T
+      return { data: parsed, error: null }
+    } catch {
+      // continue to next match
+    }
+  }
+
+  // Strategy 2: Find raw JSON object/array in text via brace depth matching
+  const firstBrace = text.indexOf('{')
+  const firstBracket = text.indexOf('[')
+  const startIdx = Math.min(
+    firstBrace >= 0 ? firstBrace : Infinity,
+    firstBracket >= 0 ? firstBracket : Infinity,
+  )
+
+  if (startIdx < Infinity) {
+    const openChar = text[startIdx]
+    const closeChar = openChar === '{' ? '}' : ']'
+    let depth = 0
+    let inString = false
+    let escaped = false
+
+    for (let i = startIdx; i < text.length; i++) {
+      const ch = text[i]
+
+      if (escaped) {
+        escaped = false
+        continue
+      }
+      if (ch === '\\') {
+        escaped = true
+        continue
+      }
+      if (ch === '"') {
+        inString = !inString
+        continue
+      }
+      if (inString) continue
+
+      if (ch === openChar) depth++
+      if (ch === closeChar) depth--
+
+      if (depth === 0) {
+        try {
+          const parsed = JSON.parse(text.substring(startIdx, i + 1)) as T
+          return { data: parsed, error: null }
+        } catch {
+          break
+        }
+      }
+    }
+  }
+
+  // Strategy 3: Try parsing the entire text as JSON
+  try {
+    const parsed = JSON.parse(text.trim()) as T
+    return { data: parsed, error: null }
+  } catch {
+    return { data: null, error: 'Could not extract valid JSON from AI response.' }
+  }
+}

--- a/web/src/lib/ai/prompts.ts
+++ b/web/src/lib/ai/prompts.ts
@@ -1,0 +1,157 @@
+/**
+ * System prompt templates for AI-assisted card and stat block generation.
+ */
+
+export const CARD_T1_SYSTEM_PROMPT = `You are an expert at creating dashboard card definitions for a Kubernetes management console.
+
+The user will describe a card they want. You must generate a valid JSON definition that matches this exact schema:
+
+{
+  "title": "string - Card display title",
+  "description": "string - Brief description of the card",
+  "layout": "list" | "stats" | "stats-and-list",
+  "defaultWidth": 3 | 4 | 6 | 8 | 12,
+  "defaultLimit": number (items per page, typically 5-10),
+  "columns": [
+    {
+      "field": "string - data field name (camelCase)",
+      "label": "string - display label",
+      "format": "text" | "badge" | "number" | "date",
+      "badgeColors": { "value": "bg-COLOR-500/20 text-COLOR-400" }
+    }
+  ],
+  "searchFields": ["field1", "field2"],
+  "staticData": [
+    { "field1": "value1", "field2": "value2" }
+  ]
+}
+
+RULES:
+- Always include at least 2 columns
+- Always include 3-5 rows of realistic sample staticData
+- For badge columns, always include badgeColors with appropriate Tailwind classes
+- Available badge colors: green, red, yellow, orange, blue, purple, cyan, gray
+- Badge color format: "bg-{color}-500/20 text-{color}-400"
+- searchFields should include all text/badge columns
+- layout should match the content: use "list" for tabular data, "stats" for summary numbers, "stats-and-list" for both
+- defaultWidth: 6 for standard cards, 8 for wide, 4 for narrow, 12 for full-width
+- Return ONLY the JSON object inside a \`\`\`json code fence
+- Do NOT include any fields not in the schema above
+
+EXAMPLE:
+\`\`\`json
+{
+  "title": "Pod Status",
+  "description": "Overview of pod health across clusters",
+  "layout": "list",
+  "defaultWidth": 6,
+  "defaultLimit": 5,
+  "columns": [
+    { "field": "name", "label": "Pod Name", "format": "text" },
+    { "field": "namespace", "label": "Namespace", "format": "text" },
+    { "field": "status", "label": "Status", "format": "badge", "badgeColors": { "Running": "bg-green-500/20 text-green-400", "Pending": "bg-yellow-500/20 text-yellow-400", "Failed": "bg-red-500/20 text-red-400" } },
+    { "field": "restarts", "label": "Restarts", "format": "number" }
+  ],
+  "searchFields": ["name", "namespace", "status"],
+  "staticData": [
+    { "name": "api-server-1", "namespace": "default", "status": "Running", "restarts": 0 },
+    { "name": "worker-2", "namespace": "production", "status": "Running", "restarts": 2 },
+    { "name": "cache-1", "namespace": "default", "status": "Pending", "restarts": 0 }
+  ]
+}
+\`\`\``
+
+export const CARD_T2_SYSTEM_PROMPT = `You are an expert React developer creating custom dashboard cards for a Kubernetes management console.
+
+The user will describe a card. You must generate valid TSX source code that exports a default React component.
+
+Available in scope (DO NOT import these — they are globally available):
+- React, useState, useEffect, useMemo, useCallback, useRef, useReducer
+- cn (classnames utility)
+- useCardData (hook for filtering/sorting/pagination)
+- commonComparators (sorting utilities)
+- Skeleton (loading placeholder component)
+- Pagination (pagination component: <Pagination currentPage totalPages totalItems itemsPerPage onPageChange />)
+- All lucide-react icons (e.g. Server, Database, CheckCircle2, AlertTriangle, Activity, Cpu, etc.)
+
+RULES:
+- Export a default function component: export default function MyCard({ config }) { ... }
+- Use Tailwind CSS classes for styling
+- Use dark theme colors: bg-secondary, bg-card, text-foreground, text-muted-foreground, border-border
+- Use purple accent: bg-purple-500/20, text-purple-400
+- The card fills its container (use h-full)
+- Keep code concise but functional
+- Include meaningful sample data or demo state
+- Do NOT include any import statements
+- Return the response as a JSON object with title, description, defaultWidth, and sourceCode
+- Return ONLY the JSON inside a \`\`\`json code fence
+
+EXAMPLE:
+\`\`\`json
+{
+  "title": "Resource Counter",
+  "description": "Shows resource counts with animated counters",
+  "defaultWidth": 4,
+  "sourceCode": "export default function ResourceCounter({ config }) {\\n  const [count, setCount] = useState(42)\\n\\n  return (\\n    <div className=\\"h-full flex flex-col items-center justify-center gap-4\\">\\n      <Server className=\\"w-8 h-8 text-purple-400\\" />\\n      <p className=\\"text-3xl font-bold text-foreground\\">{count}</p>\\n      <p className=\\"text-sm text-muted-foreground\\">Total Resources</p>\\n    </div>\\n  )\\n}"
+}
+\`\`\``
+
+export const STAT_BLOCK_SYSTEM_PROMPT = `You are an expert at creating dashboard stat block definitions for a Kubernetes management console.
+
+The user will describe the stat blocks they want. You must generate a valid JSON definition that matches this exact schema:
+
+{
+  "title": "string - Section title",
+  "type": "string - unique type identifier (lowercase_with_underscores)",
+  "blocks": [
+    {
+      "id": "string - unique block ID (lowercase_underscores)",
+      "label": "string - display label",
+      "icon": "string - lucide-react icon name (PascalCase)",
+      "color": "purple" | "blue" | "green" | "yellow" | "orange" | "red" | "cyan" | "gray" | "indigo",
+      "field": "string - data field name (camelCase)",
+      "format": "" | "number" | "percent" | "bytes" | "currency" | "duration",
+      "tooltip": "string - tooltip text"
+    }
+  ]
+}
+
+AVAILABLE ICONS (use PascalCase names exactly):
+Server, Database, Cpu, MemoryStick, HardDrive, Zap, CheckCircle2, XCircle,
+AlertTriangle, Activity, BarChart3, Layers, Box, Shield, Lock, Globe, Cloud,
+GitBranch, Terminal, Code, Wifi, WifiOff, Clock, Users, Gauge, TrendingUp,
+TrendingDown, ArrowUpRight, Flame, Heart, Eye, FileText, Settings, Package
+
+AVAILABLE COLORS: purple, blue, green, yellow, orange, red, cyan, gray, indigo
+
+FORMAT OPTIONS:
+- "" (empty string): raw value, no formatting
+- "number": formats with K/M suffixes (1000 → "1K")
+- "percent": formats as percentage (87 → "87%")
+- "bytes": formats as KB/MB/GB/TB
+- "currency": formats with $ prefix
+- "duration": formats as seconds/minutes/hours/days
+
+RULES:
+- Generate 3-8 stat blocks depending on the request
+- Choose icons that semantically match the stat meaning
+- Choose colors that convey meaning: green=healthy/passing, red=errors/critical, yellow=warning/pending, blue=info, purple=totals
+- The "type" field should be a meaningful lowercase identifier with underscores
+- format should match the value type
+- Always include tooltips
+- Return ONLY the JSON object inside a \`\`\`json code fence
+
+EXAMPLE:
+\`\`\`json
+{
+  "title": "Cluster Overview",
+  "type": "cluster_overview",
+  "blocks": [
+    { "id": "total_clusters", "label": "Clusters", "icon": "Server", "color": "purple", "field": "totalClusters", "format": "number", "tooltip": "Total number of managed clusters" },
+    { "id": "healthy", "label": "Healthy", "icon": "CheckCircle2", "color": "green", "field": "healthyCount", "format": "number", "tooltip": "Clusters in healthy state" },
+    { "id": "unhealthy", "label": "Issues", "icon": "AlertTriangle", "color": "red", "field": "issueCount", "format": "number", "tooltip": "Clusters with detected issues" },
+    { "id": "cpu_usage", "label": "CPU", "icon": "Cpu", "color": "blue", "field": "cpuUsage", "format": "percent", "tooltip": "Average CPU utilization across all clusters" },
+    { "id": "memory_usage", "label": "Memory", "icon": "MemoryStick", "color": "cyan", "field": "memoryUsage", "format": "bytes", "tooltip": "Total memory usage across all clusters" }
+  ]
+}
+\`\`\``


### PR DESCRIPTION
## Summary
- Add **AI Create** tab to Card Factory modal with T1 (declarative) and T2 (custom code) mode toggle
- Add **AI Generate** tab to Stat Block Factory modal for AI-generated stat block definitions
- Create shared `AiGenerationPanel<T>` component with prompt → streaming → parse → preview → save workflow
- Create `extractJsonFromMarkdown` utility with 3-strategy JSON extraction from AI markdown responses
- Create system prompt templates for card T1, card T2, and stat block generation

## Test plan
- [ ] Open Card Factory → switch to "AI Create" tab → describe a card → verify streaming + preview + save
- [ ] Test both T1 (Declarative) and T2 (Custom Code) modes in AI Create
- [ ] Open Stat Block Factory → switch to "AI Generate" tab → describe stat blocks → verify streaming + preview + save
- [ ] Verify `npx tsc --noEmit` passes clean
- [ ] Verify error states: no API key, invalid AI response, failed validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)