### PR TITLE
🐛 Add failure badge propagation and fix deployment cluster data

### DIFF
--- a/web/src/components/cards/AppStatus.tsx
+++ b/web/src/components/cards/AppStatus.tsx
@@ -4,6 +4,7 @@ import { ClusterBadge } from '../ui/ClusterBadge'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCachedDeployments } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
+import { useReportCardDataState } from './CardDataContext'
 import {
   useCardData,
   commonComparators,
@@ -43,7 +44,11 @@ interface AppData {
 
 export function AppStatus(_props: AppStatusProps) {
   const { drillToDeployment } = useDrillDownActions()
-  const { deployments, isLoading } = useCachedDeployments()
+  const { deployments, isLoading, isFailed, consecutiveFailures } = useCachedDeployments()
+
+  // Report data state to CardWrapper for failure badge rendering
+  useReportCardDataState({ isFailed, consecutiveFailures })
+
   const {
     selectedClusters: globalSelectedClusters,
     isAllClustersSelected,

--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -1,0 +1,40 @@
+/**
+ * CardDataContext — allows card child components to report their cache/data
+ * state (isFailed, consecutiveFailures) up to the parent CardWrapper, which
+ * renders the appropriate status badges (failure, demo fallback, etc.).
+ *
+ * Usage inside a card component:
+ *
+ *   const { isFailed, consecutiveFailures } = useCachedPodIssues()
+ *   useReportCardDataState({ isFailed, consecutiveFailures })
+ */
+
+import { createContext, useContext, useEffect } from 'react'
+
+export interface CardDataState {
+  /** Whether 3+ consecutive fetch failures have occurred */
+  isFailed: boolean
+  /** Number of consecutive fetch failures */
+  consecutiveFailures: number
+}
+
+interface CardDataReportContextValue {
+  report: (state: CardDataState) => void
+}
+
+const NOOP_REPORT: CardDataReportContextValue = { report: () => {} }
+
+export const CardDataReportContext = createContext<CardDataReportContextValue>(NOOP_REPORT)
+
+/**
+ * Hook for card components to report their data/cache state to the parent
+ * CardWrapper. Call this with the isFailed/consecutiveFailures values from
+ * your cached data hook (e.g. useCachedPodIssues, useCachedDeployments).
+ */
+export function useReportCardDataState(state: CardDataState) {
+  const { isFailed, consecutiveFailures } = state
+  const ctx = useContext(CardDataReportContext)
+  useEffect(() => {
+    ctx.report({ isFailed, consecutiveFailures })
+  }, [ctx, isFailed, consecutiveFailures])
+}

--- a/web/src/components/cards/DeploymentStatus.tsx
+++ b/web/src/components/cards/DeploymentStatus.tsx
@@ -7,6 +7,7 @@ import { Pagination } from '../ui/Pagination'
 import { CardControls } from '../ui/CardControls'
 import { Skeleton } from '../ui/Skeleton'
 import type { Deployment } from '../../hooks/useMCP'
+import { useReportCardDataState } from './CardDataContext'
 import {
   useCardData,
   useCardFilters,
@@ -75,7 +76,12 @@ export function DeploymentStatus() {
   const {
     deployments: allDeployments,
     isLoading: hookLoading,
+    isFailed,
+    consecutiveFailures,
   } = useCachedDeployments()
+
+  // Report data state to CardWrapper for failure badge rendering
+  useReportCardDataState({ isFailed, consecutiveFailures })
 
   // Only show skeleton when no cached data exists
   const isLoading = hookLoading && allDeployments.length === 0

--- a/web/src/components/cards/PodIssues.tsx
+++ b/web/src/components/cards/PodIssues.tsx
@@ -4,6 +4,7 @@ import type { PodIssue } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { LimitedAccessWarning } from '../ui/LimitedAccessWarning'
+import { useReportCardDataState } from './CardDataContext'
 import {
   useCardData, commonComparators, getStatusColors,
   CardSkeleton, CardEmptyState, CardSearchInput,
@@ -30,8 +31,13 @@ export function PodIssues() {
   const {
     issues: rawIssues,
     isLoading: hookLoading,
+    isFailed,
+    consecutiveFailures,
     error
   } = useCachedPodIssues()
+
+  // Report data state to CardWrapper for failure badge rendering
+  useReportCardDataState({ isFailed, consecutiveFailures })
 
   // Only show skeleton when no cached data exists
   const isLoading = hookLoading && rawIssues.length === 0

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -362,13 +362,14 @@ export function useCachedDeployments(
     initialData: getDemoDeployments(),
     enabled: !isDemoMode(),
     fetcher: async () => {
-      const data = await fetchAPI<{ deployments: Deployment[] }>('deployments', { cluster, namespace })
-      const deployments = data.deployments || []
-      // Ensure each deployment has cluster set when fetching for a specific cluster
       if (cluster) {
+        // Fetch from specific cluster
+        const data = await fetchAPI<{ deployments: Deployment[] }>('deployments', { cluster, namespace })
+        const deployments = data.deployments || []
         return deployments.map(d => ({ ...d, cluster: d.cluster || cluster }))
       }
-      return deployments
+      // Fetch from all clusters so each deployment gets a cluster field
+      return fetchFromAllClusters<Deployment>('deployments', 'deployments', { namespace })
     },
   })
 


### PR DESCRIPTION
## Summary
- **Failure badge propagation**: Cards that use cached data hooks (PodIssues, DeploymentStatus, AppStatus) now report their `isFailed`/`consecutiveFailures` state to the parent CardWrapper via a new `CardDataContext`. When data fetch fails 3+ times consecutively, a red "Refresh failed" badge appears in the card header automatically.
- **Deployment cluster data fix**: `useCachedDeployments` now uses `fetchFromAllClusters` when no specific cluster is specified, ensuring each deployment gets a `cluster` field. This fixes missing cluster badges in Deployment Status and Workload Status cards.
- **Extensible pattern**: Any card component can adopt `useReportCardDataState` to propagate its cache state to CardWrapper — no changes needed to SharedSortableCard or DashboardCards.

## Changes
- **NEW** `web/src/components/cards/CardDataContext.tsx` — React context + `useReportCardDataState` hook for child-to-parent data state reporting
- **EDIT** `web/src/components/cards/CardWrapper.tsx` — Provides context, merges child state with props for badge rendering
- **EDIT** `web/src/components/cards/PodIssues.tsx` — Reports cache failure state via context
- **EDIT** `web/src/components/cards/DeploymentStatus.tsx` — Reports cache failure state via context
- **EDIT** `web/src/components/cards/AppStatus.tsx` — Reports cache failure state via context
- **EDIT** `web/src/hooks/useCachedData.ts` — `useCachedDeployments` uses `fetchFromAllClusters` when no cluster specified

## Test plan
- [ ] Verify PodIssues, DeploymentStatus, AppStatus cards show "Refresh failed" badge when API is unreachable
- [ ] Verify Deployment Status and Workload Status cards show correct cluster badges on each item
- [ ] Verify no regression when cards are in demo mode (demo badge still appears)
- [ ] Verify TypeScript compilation passes (`tsc -b --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)