### PR TITLE
🐛 Fix cluster selector dropdown cut off in Cluster Metrics card

### DIFF
--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
+import { createPortal } from 'react-dom'
 import { TimeSeriesChart, MultiSeriesChart } from '../charts'
 import { useClusters } from '../../hooks/useMCP'
 import { Server, Clock, Filter, ChevronDown, Layers, TrendingUp } from 'lucide-react'
@@ -62,6 +63,22 @@ export function ClusterMetrics() {
     setShowClusterFilter,
     clusterFilterRef,
   } = useChartFilters({ storageKey: 'cluster-metrics' })
+
+  const filterButtonRef = useRef<HTMLButtonElement>(null)
+  const [filterDropdownPos, setFilterDropdownPos] = useState<{ top: number; left: number } | null>(null)
+
+  // Compute dropdown position when filter opens
+  useEffect(() => {
+    if (showClusterFilter && filterButtonRef.current) {
+      const rect = filterButtonRef.current.getBoundingClientRect()
+      setFilterDropdownPos({
+        top: rect.bottom + 4,
+        left: Math.max(8, rect.right - 192), // 192px = w-48; keep on screen
+      })
+    } else {
+      setFilterDropdownPos(null)
+    }
+  }, [showClusterFilter])
 
   // Load history from localStorage
   const loadSavedHistory = useCallback((): MetricPoint[] => {
@@ -281,6 +298,7 @@ export function ClusterMetrics() {
         {availableClustersForFilter.length >= 1 && (
           <div ref={clusterFilterRef} className="relative">
             <button
+              ref={filterButtonRef}
               onClick={() => setShowClusterFilter(!showClusterFilter)}
               className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
                 localClusterFilter.length > 0
@@ -293,8 +311,11 @@ export function ClusterMetrics() {
               <ChevronDown className="w-3 h-3" />
             </button>
 
-            {showClusterFilter && (
-              <div className="absolute top-full right-0 mt-1 w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50">
+            {showClusterFilter && filterDropdownPos && createPortal(
+              <div
+                className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
+                style={{ top: filterDropdownPos.top, left: filterDropdownPos.left }}
+              >
                 <div className="p-1">
                   <button
                     onClick={clearClusterFilter}
@@ -316,7 +337,8 @@ export function ClusterMetrics() {
                     </button>
                   ))}
                 </div>
-              </div>
+              </div>,
+              document.body
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- The cluster filter dropdown in Cluster Metrics was clipped by the card's `overflow-auto` container
- Uses `createPortal` to render the dropdown in `document.body` with fixed positioning
- Dropdown position is calculated from the filter button's bounding rect and clamped to stay on-screen (left edge minimum of 8px)

## Test plan
- [ ] Open Cluster Metrics card and click the cluster filter dropdown
- [ ] Verify dropdown is fully visible and not cut off on any edge
- [ ] Verify clicking cluster options still works correctly
- [ ] Verify clicking outside the dropdown closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)