### PR TITLE
🐛 Fix navbar layout shift when toggling demo mode / agent

### DIFF
--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react'
 import { ChevronDown, Check, Loader2, Settings } from 'lucide-react'
 import { useMissions } from '../../hooks/useMissions'
+import { useDemoMode } from '../../hooks/useDemoMode'
 import { AgentIcon } from './AgentIcon'
 import { APIKeySettings } from './APIKeySettings'
 import type { AgentInfo } from '../../types/agent'
@@ -14,6 +15,7 @@ interface AgentSelectorProps {
 
 export function AgentSelector({ compact = false, className = '', showSettings = true }: AgentSelectorProps) {
   const { agents, selectedAgent, agentsLoading, selectAgent, connectToAgent } = useMissions()
+  const { isDemoMode } = useDemoMode()
   const [isOpen, setIsOpen] = useState(false)
   const [showSettingsModal, setShowSettingsModal] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -56,6 +58,9 @@ export function AgentSelector({ compact = false, className = '', showSettings = 
       return () => document.removeEventListener('keydown', handleEscape)
     }
   }, [isOpen])
+
+  // In demo mode, agent selection is not applicable — render nothing
+  if (isDemoMode) return null
 
   if (agentsLoading) {
     return (

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -48,9 +48,9 @@ export function AgentStatusIndicator() {
         ) : (
           <WifiOff className="w-4 h-4" />
         )}
-        {isDemoMode && (
-          <span className="text-xs font-medium hidden sm:inline">Demo</span>
-        )}
+        <span className="text-xs font-medium hidden sm:inline">
+          {isDemoMode ? 'Demo' : isDegraded ? 'Degraded' : isConnected ? 'AI' : agentStatus === 'connecting' ? 'AI' : 'Offline'}
+        </span>
         <span className={cn(
           'w-2 h-2 rounded-full',
           isDemoMode ? 'bg-purple-400' : isDegraded ? 'bg-yellow-400 animate-pulse' : isConnected ? 'bg-green-400' : agentStatus === 'connecting' ? 'bg-yellow-400 animate-pulse' : 'bg-red-400'

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -3,9 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { Sun, Moon, Monitor, Users, Cast } from 'lucide-react'
 import { useAuth } from '../../../lib/auth'
 import { useTheme } from '../../../hooks/useTheme'
-import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { useActiveUsers } from '../../../hooks/useActiveUsers'
-import { useDemoMode } from '../../../hooks/useDemoMode'
 import { usePresentationMode } from '../../../hooks/usePresentationMode'
 import { TourTrigger } from '../../onboarding/Tour'
 import { UserProfileDropdown } from '../UserProfileDropdown'
@@ -23,8 +21,6 @@ export function Navbar() {
   const { user, logout } = useAuth()
   const navigate = useNavigate()
   const { theme, toggleTheme } = useTheme()
-  const { isConnected } = useLocalAgent()
-  const { isDemoMode } = useDemoMode()
   const { isPresentationMode, togglePresentationMode } = usePresentationMode()
   const { activeUsers, showBadge: showActiveUsersBadge } = useActiveUsers()
   const [showFeedback, setShowFeedback] = useState(false)
@@ -52,13 +48,9 @@ export function Navbar() {
         {/* Update Indicator */}
         <UpdateIndicator />
 
-        {/* Agent Status Indicator */}
+        {/* Agent Selector first — when it hides in demo mode, only space to the left shifts */}
+        <AgentSelector compact showSettings={true} />
         <AgentStatusIndicator />
-
-        {/* AI Agent Selector - shown when agent is connected */}
-        {isConnected && !isDemoMode && (
-          <AgentSelector compact showSettings={true} />
-        )}
 
         {/* Language Selector */}
         <LanguageSelector />


### PR DESCRIPTION
## Summary
- **Swap order**: AgentSelector now renders *before* AgentStatusIndicator in the navbar, so its appearance/disappearance only affects space to the left (search bar gap), not right-side items
- **Internal demo handling**: AgentSelector returns `null` when demo mode is active (instead of parent conditional rendering), keeping React hooks stable
- **Stable indicator width**: AgentStatusIndicator always shows a text label (Demo / AI / Degraded / Offline) instead of only showing text in demo mode

## Test plan
- [ ] Toggle demo mode ON/OFF — items from language selector rightward stay in place
- [ ] Refresh in both modes — no visible jump
- [ ] Agent selector dropdown still works when not in demo mode
- [ ] Agent status dropdown still works in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)