### PR TITLE
🐛 Add Google Gemini health check via API ping

### DIFF
--- a/web/src/hooks/useProviderHealth.ts
+++ b/web/src/hooks/useProviderHealth.ts
@@ -89,7 +89,7 @@ const STATUS_PAGES: Record<string, string> = {
   // AI providers
   anthropic: 'https://status.claude.com',
   openai: 'https://status.openai.com',
-  google: 'https://status.cloud.google.com',
+  google: 'https://aistudio.google.com/status',
   // Cloud providers
   eks: 'https://health.aws.amazon.com/health/status',
   gke: 'https://status.cloud.google.com',


### PR DESCRIPTION
## Summary
- Added ping-based health check for Google Gemini in the backend `/providers/health` endpoint
- Pings `generativelanguage.googleapis.com` with an invalid key — any HTTP response (even 400) proves the service is operational
- Updated Google's status page link from `status.cloud.google.com` to `aistudio.google.com/status` (Gemini-specific)
- All 3 AI providers now have health checks: Anthropic (Statuspage.io), OpenAI (Statuspage.io), Google (API ping)

## Test plan
- [ ] Backend: `curl http://127.0.0.1:8585/providers/health` returns google as operational
- [ ] Provider Health card shows Google (Gemini) with green/red dot instead of gray Unknown
- [ ] Status page link opens aistudio.google.com/status

🤖 Generated with [Claude Code](https://claude.com/claude-code)