### PR TITLE
🐛 Fix dynamic cards and stat blocks not persisting across page refresh

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,9 @@ import './index.css'
 import './lib/i18n'
 // Import cache migration utility
 import { migrateFromLocalStorage } from './lib/cache'
+// Import dynamic card/stats persistence loaders
+import { loadDynamicCards, getAllDynamicCards, loadDynamicStats } from './lib/dynamic-cards'
+import { registerDynamicCardType } from './components/cards/cardRegistry'
 
 // Suppress recharts dimension warnings (these occur when charts render before container is sized)
 const originalWarn = console.warn
@@ -57,6 +60,13 @@ enableMocking()
     } catch (e) {
       console.warn('[Cache] Migration failed:', e)
     }
+
+    // Restore dynamic cards and stat blocks from localStorage
+    loadDynamicCards()
+    getAllDynamicCards().forEach(card => {
+      registerDynamicCardType(card.id, card.defaultWidth ?? 6)
+    })
+    loadDynamicStats()
 
     ReactDOM.createRoot(document.getElementById('root')!).render(
       <React.StrictMode>


### PR DESCRIPTION
## Summary
- `loadDynamicCards()` and `loadDynamicStats()` were defined but never called on app startup
- Dynamic cards/stat blocks would work during the session but disappear after page refresh
- Add initialization calls in `main.tsx` before React renders to restore definitions from localStorage and register card grid widths

## Test plan
- [ ] Create a dynamic card via Card Factory → refresh page → card still renders
- [ ] Create a stat block via Stat Block Factory → refresh page → stat block still renders
- [ ] Verify `npx tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)