### PR TITLE
🐛 Fix agent status pill jumping size between Demo/AI states

### DIFF
--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -28,7 +28,7 @@ export function AgentStatusIndicator() {
       <button
         onClick={() => setShowAgentStatus(!showAgentStatus)}
         className={cn(
-          'flex items-center gap-2 px-2 py-1.5 rounded-lg transition-colors',
+          'flex items-center justify-center gap-2 w-[5.5rem] py-1.5 rounded-lg transition-colors',
           isDemoMode
             ? 'bg-purple-500/10 text-purple-400 hover:bg-purple-500/20'
             : isDegraded


### PR DESCRIPTION
## Summary
- Give the agent status indicator button a fixed width (`w-[5.5rem]`) with centered content
- Both "Demo" and "AI" states now render at exactly 88px — no size jump when toggling

## Test plan
- [ ] Toggle demo mode — pill stays same width, no layout shift
- [ ] Pill shows centered content in all states: Demo, AI, Degraded, Offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)