### PR TITLE
🐛 Fix agent selector missing after toggling demo mode off

### DIFF
--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -30,10 +30,12 @@ export function AgentSelector({ compact = false, className = '', showSettings = 
   const currentAgent = visibleAgents.find(a => a.name === selectedAgent) || visibleAgents[0]
   const hasAvailableAgents = visibleAgents.some(a => a.available)
 
-  // Connect to agent WebSocket on mount to load agents list
+  // Connect to agent WebSocket on mount and when leaving demo mode
   useEffect(() => {
-    connectToAgent()
-  }, [connectToAgent])
+    if (!isDemoMode) {
+      connectToAgent()
+    }
+  }, [connectToAgent, isDemoMode])
 
   // Close dropdown when clicking outside
   useEffect(() => {

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -48,9 +48,11 @@ export function Navbar() {
         {/* Update Indicator */}
         <UpdateIndicator />
 
-        {/* Agent Selector first — when it hides in demo mode, only space to the left shifts */}
-        <AgentSelector compact showSettings={true} />
-        <AgentStatusIndicator />
+        {/* Agent area — fixed-width wrapper prevents layout shift when selector toggles */}
+        <div className="flex items-center justify-end gap-1 shrink-0" style={{ minWidth: '10rem' }}>
+          <AgentSelector compact showSettings={true} />
+          <AgentStatusIndicator />
+        </div>
 
         {/* Language Selector */}
         <LanguageSelector />


### PR DESCRIPTION
## Summary
- **Agent selector reconnect**: `connectToAgent()` useEffect now depends on `isDemoMode` — when switching from demo to live mode, the WebSocket reconnects and fetches the agent list
- **Navbar wrapper**: AgentSelector + AgentStatusIndicator wrapped in a fixed `min-width: 10rem` container with `justify-end` to prevent layout shift

## Test plan
- [ ] Start in demo mode, toggle OFF → agent selector appears with available agents
- [ ] Start in non-demo mode → agent selector shows immediately
- [ ] Toggle demo ON → agent selector hides, no layout shift on items to the right
- [ ] Settings gear + agent dropdown both visible to left of status pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)