### PR TITLE
✨ Make dynamic cards re-addable from Add Card modal

### DIFF
--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -425,7 +425,12 @@ export function CustomDashboard() {
   }, [])
 
   // Current card types for recommendations
-  const currentCardTypes = useMemo(() => cards.map(c => c.card_type), [cards])
+  const currentCardTypes = useMemo(() => cards.map(c => {
+    if (c.card_type === 'dynamic_card' && c.config?.dynamicCardId) {
+      return `dynamic_card::${c.config.dynamicCardId as string}`
+    }
+    return c.card_type
+  }), [cards])
 
   // Loading skeleton
   if (isLoading && cards.length === 0) {

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -769,7 +769,12 @@ export function Dashboard() {
     showToast(`Applied "${template.name}" template with ${newCards.length} cards`, 'success')
   }, [dashboard, recordCardAdded, showToast])
 
-  const currentCardTypes = localCards.map(c => c.card_type)
+  const currentCardTypes = localCards.map(c => {
+    if (c.card_type === 'dynamic_card' && c.config?.dynamicCardId) {
+      return `dynamic_card::${c.config.dynamicCardId as string}`
+    }
+    return c.card_type
+  })
 
   // Check if any cards are using demo data
   const hasDemoDataCards = localCards.some(c => DEMO_DATA_CARDS.has(c.card_type))


### PR DESCRIPTION
## Summary
- Dynamic cards now appear in a **"Custom Cards"** category in the Add Card modal's Browse tab
- Users can re-add a dynamic card to the dashboard after removing it, without losing the card definition
- The "(Added)" badge correctly tracks individual dynamic cards on the dashboard
- Listing is reactive — creating/deleting cards via Card Factory updates the list immediately

## Test plan
- [ ] Create a dynamic card via Card Factory → confirm it appears on the dashboard
- [ ] Reopen Add Card modal → "Custom Cards" category shows the card with "(Added)" badge
- [ ] Remove card from dashboard → reopen modal → card is now selectable
- [ ] Select and add it → card reappears on dashboard
- [ ] Refresh page → open modal → custom card still in catalog
- [ ] `npx tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)