### PR TITLE
🐛 Kill existing backend before starting in start-dev.sh

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -36,6 +36,14 @@ fi
 export DEV_MODE=${DEV_MODE:-true}
 export FRONTEND_URL=${FRONTEND_URL:-http://localhost:5174}
 
+# Kill any existing instance on port 8080
+EXISTING_PID=$(lsof -ti :8080 2>/dev/null)
+if [ -n "$EXISTING_PID" ]; then
+    echo "Killing existing backend on port 8080 (PID: $EXISTING_PID)..."
+    kill -9 $EXISTING_PID 2>/dev/null
+    sleep 1
+fi
+
 echo "Starting KubeStellar Console..."
 echo "  GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:0:10}..."
 echo "  Frontend: $FRONTEND_URL"


### PR DESCRIPTION
## Summary
- Start script now kills any existing process on port 8080 before launching
- Prevents "address already in use" errors when restarting

## Test plan
- [ ] Run `./start-dev.sh` twice — second run should kill first and start cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)