### PR TITLE
🐛 Restore lost navbar fixes: agent dropdown, status pill, demo toggle

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -48,9 +48,9 @@ export function Navbar() {
         {/* Update Indicator */}
         <UpdateIndicator />
 
-        {/* Agent Selector + Status — grayed out in demo mode */}
-        <AgentSelector compact />
+        {/* Agent Status + Selector — status (Demo/AI pill) on left, selector on right */}
         <AgentStatusIndicator />
+        <AgentSelector compact />
 
         {/* Language Selector */}
         <LanguageSelector />


### PR DESCRIPTION
## Summary

PR #330 (e66092d) overwrote changes from commits e5f4587 and 6f4aabf. This restores all lost fixes:

- **AgentSelector**: Never show standalone gear — always show dropdown trigger with generic robot icon; settings gear inside dropdown only; grey-out in demo mode; sorted agents
- **AgentStatusIndicator**: 300ms debounce prevents yellow flash on navigation; sticky demo styling on toggle-off; fixed-width pill prevents navbar jump; version badge restored in dropdown
- **Navbar**: Swap order — Demo/AI pill before agent selector
- **useDemoMode**: `userExplicitlyEnabled` flag prevents `shared.ts` auto-disable from overriding user's deliberate demo toggle

## Test plan

- [ ] Toggle demo mode on/off — should stay on, not revert
- [ ] Navigate between dashboards — no yellow/offline flash on AI pill
- [ ] Agent selector shows generic robot icon (not gear) when no agents
- [ ] Agent selector greyed out in demo mode
- [ ] Pill width stays fixed when switching Demo↔AI
- [ ] Version badge visible in agent status dropdown next to "Connected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)