### PR TITLE
🐛 Fix agent-first data fetching and cluster name deduplication

### DIFF
--- a/web/src/components/cards/DeploymentProgress.tsx
+++ b/web/src/components/cards/DeploymentProgress.tsx
@@ -135,7 +135,7 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
   }
 
   const handleDeploymentClick = (deployment: typeof deployments[0]) => {
-    const clusterName = deployment.cluster?.split('/').pop() || deployment.cluster || 'unknown'
+    const clusterName = deployment.cluster || 'unknown'
     drillToDeployment(clusterName, deployment.namespace, deployment.name, {
       status: deployment.status,
       version: extractVersion(deployment.image),
@@ -304,7 +304,7 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
           paginatedDeployments.map((deployment) => {
             const statusStyle = statusConfig[deployment.status]
             const StatusIcon = statusStyle.icon
-            const clusterName = deployment.cluster?.split('/').pop() || deployment.cluster || 'unknown'
+            const clusterName = deployment.cluster || 'unknown'
             const version = extractVersion(deployment.image)
 
             return (

--- a/web/src/components/cards/DeploymentStatus.tsx
+++ b/web/src/components/cards/DeploymentStatus.tsx
@@ -172,7 +172,7 @@ export function DeploymentStatus() {
   }
 
   const handleDeploymentClick = (deployment: Deployment) => {
-    const clusterName = deployment.cluster?.split('/').pop() || deployment.cluster || 'unknown'
+    const clusterName = deployment.cluster || 'unknown'
     drillToDeployment(clusterName, deployment.namespace, deployment.name, {
       status: deployment.status,
       version: extractVersion(deployment.image),
@@ -335,7 +335,7 @@ export function DeploymentStatus() {
           paginatedDeployments.map((deployment) => {
             const config = statusConfig[deployment.status as keyof typeof statusConfig] || statusConfig.running
             const StatusIcon = config.icon
-            const clusterName = deployment.cluster?.split('/').pop() || deployment.cluster || 'unknown'
+            const clusterName = deployment.cluster || 'unknown'
             const version = extractVersion(deployment.image)
 
             return (

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -43,22 +43,6 @@ export function ResourceUsage() {
     const usedCPUs = clusters.reduce((sum, c) => sum + (c.cpuRequestsCores || 0), 0)
     const usedMemoryGB = clusters.reduce((sum, c) => sum + (c.memoryRequestsGB || 0), 0)
 
-    // Debug: log cluster data to understand why values might be 0
-    if (clusters.length > 0) {
-      console.log('[ResourceUsage] Cluster data sample:', {
-        clusterCount: clusters.length,
-        firstCluster: clusters[0]?.name,
-        cpuCores: clusters[0]?.cpuCores,
-        cpuRequestsCores: clusters[0]?.cpuRequestsCores,
-        memoryGB: clusters[0]?.memoryGB,
-        memoryRequestsGB: clusters[0]?.memoryRequestsGB,
-        totalCPUs,
-        usedCPUs,
-        totalMemoryGB,
-        usedMemoryGB,
-      })
-    }
-
     // GPU data from GPU nodes
     const totalGPUs = gpuNodes.reduce((sum, n) => sum + n.gpuCount, 0)
     const allocatedGPUs = gpuNodes.reduce((sum, n) => sum + n.gpuAllocated, 0)

--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -78,12 +78,10 @@ export function useClusters() {
   // Re-fetch when demo mode changes (not on initial mount)
   const initialMountRef = useRef(true)
   useEffect(() => {
-    console.log('[GPU] isDemoMode effect:', { isDemoMode, isInitialMount: initialMountRef.current })
     if (initialMountRef.current) {
       initialMountRef.current = false
       return
     }
-    console.log('[GPU] isDemoMode changed, refetching')
     // Reset fetch flag and failure tracking to allow re-fetching
     setInitialFetchStarted(false)
     setHealthCheckFailures(0)
@@ -148,21 +146,6 @@ export function useClusters() {
     // First share metrics between clusters with same server (so short names get metrics from long names)
     const sharedMetricsClusters = shareMetricsBetweenSameServerClusters(localState.clusters)
     const result = deduplicateClustersByServer(sharedMetricsClusters)
-
-    // Debug: log what deduplication produced
-    if (result.length > 0) {
-      const sample = result.find(c => c.cpuCores && c.cpuCores > 100) || result[0]
-      console.log('[Dedup] Result sample:', {
-        name: sample?.name,
-        cpuCores: sample?.cpuCores,
-        cpuRequestsCores: sample?.cpuRequestsCores,
-        memoryGB: sample?.memoryGB,
-        memoryRequestsGB: sample?.memoryRequestsGB,
-        aliases: sample?.aliases?.length,
-        totalClusters: result.length,
-        withRequests: result.filter(c => c.cpuRequestsCores).length,
-      })
-    }
 
     return result
   }, [localState.clusters])

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -29,7 +29,7 @@ import { useEffect, useCallback, useRef, useSyncExternalStore } from 'react'
 // ============================================================================
 
 /** Cache version - increment when cache structure changes to invalidate old caches */
-const CACHE_VERSION = 3
+const CACHE_VERSION = 4
 
 /** IndexedDB configuration */
 const DB_NAME = 'kc_cache'


### PR DESCRIPTION
## Summary
- Restructure all data hooks (pod issues, deployments, deployment issues, workloads) to try the local agent **first** before falling back to REST API — fixes dashboard cards showing demo data when backend is down but agent is connected
- Fix cluster name deduplication: filter out long kubectl context paths (containing `/`) and force short names in all agent response mappings
- Remove all debug console.log statements and bump cache version to invalidate stale IndexedDB entries

## Test plan
- [ ] Start frontend with agent connected but no backend
- [ ] Verify Pod Issues, Deployment Status, Deployment Progress, Deployment Issues, and Workloads cards show live agent data
- [ ] Verify cluster badges show short names (e.g., `vllm-d`) not long context paths
- [ ] Verify no debug console.log messages in browser console
- [ ] Toggle demo mode on/off and verify cards switch between demo and live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)