### PR TITLE
🐛 fix: replace dashboard blackout with loading skeleton

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -137,9 +137,13 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth()
 
   if (isLoading) {
-    // Return null instead of a spinner to avoid flashing a bare loading screen.
-    // Auth resolves almost instantly from localStorage cache; the top-level
-    // Suspense/LoadingFallback handles the rare uncached case after 200ms.
+    // If we have a token (likely authenticated), render children optimistically
+    // to avoid a blank flash. Auth resolves almost instantly from localStorage
+    // cache. The stale-while-revalidate pattern in AuthProvider means isLoading
+    // is only true when there's no cached user, so this is safe.
+    if (localStorage.getItem('token')) {
+      return <>{children}</>
+    }
     return null
   }
 

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -194,13 +194,39 @@ export function Layout({ children }: LayoutProps) {
       <div className="flex flex-1 overflow-hidden" style={{ paddingTop: NAVBAR_HEIGHT + totalBannerHeight }}>
         <Sidebar />
         <main className={cn(
-          'flex-1 p-6 transition-all duration-300 overflow-y-auto',
+          'flex-1 p-6 transition-[margin] duration-300 overflow-y-auto',
           config.collapsed ? 'ml-20' : 'ml-64',
           // Don't apply margin when fullscreen is active - sidebar covers everything
           isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen && 'mr-[500px]',
           isMissionSidebarOpen && isMissionSidebarMinimized && !isMissionFullScreen && 'mr-12'
         )}>
-          <Suspense fallback={null}>
+          <Suspense fallback={
+            <div className="pt-16 animate-in fade-in duration-300">
+              {/* Header skeleton */}
+              <div className="flex items-center justify-between mb-6">
+                <div>
+                  <div className="h-8 w-48 bg-secondary rounded animate-pulse mb-2" />
+                  <div className="h-4 w-64 bg-secondary/50 rounded animate-pulse" />
+                </div>
+              </div>
+              {/* Card grid skeleton */}
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {[1, 2, 3, 4, 5, 6].map(i => (
+                  <div key={i} className="glass rounded-lg p-4">
+                    <div className="flex items-center justify-between mb-4">
+                      <div className="h-5 w-32 bg-secondary rounded animate-pulse" />
+                      <div className="h-5 w-8 bg-secondary rounded animate-pulse" />
+                    </div>
+                    <div className="space-y-3">
+                      <div className="h-4 w-full bg-secondary/50 rounded animate-pulse" />
+                      <div className="h-4 w-3/4 bg-secondary/50 rounded animate-pulse" />
+                      <div className="h-20 w-full bg-secondary/30 rounded animate-pulse" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          }>
             {children}
           </Suspense>
         </main>


### PR DESCRIPTION
## Summary
- Replace `Suspense fallback={null}` in Layout.tsx with a card grid skeleton, fixing a ~4 second black void during initial page loads when lazy chunks are loading
- Fix `ProtectedRoute` to render children optimistically when a token exists, preventing a blank flash during auth revalidation
- Narrow `transition-all` to `transition-[margin]` on the main content area to prevent animating unrelated CSS properties during layout changes

## Test plan
- [x] Type check passes (zero errors)
- [x] Build succeeds
- [x] Verified on localhost:5174 — skeleton shows during lazy chunk loading instead of black void
- [x] Verified SPA navigation remains instant (no skeleton flash for cached chunks)
- [x] Verified on console.kubestellar.io — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)