### PR TITLE
🐛 fix: search card results add card to dashboard instead of empty navigation

### DIFF
--- a/web/src/components/layout/navbar/SearchDropdown.tsx
+++ b/web/src/components/layout/navbar/SearchDropdown.tsx
@@ -18,6 +18,8 @@ import {
 } from 'lucide-react'
 import { useSearchIndex, CATEGORY_ORDER, type SearchCategory, type SearchItem } from '../../../hooks/useSearchIndex'
 import { useMissions } from '../../../hooks/useMissions'
+import { useDashboardContext } from '../../../hooks/useDashboardContext'
+import { CARD_TITLES } from '../../cards/CardWrapper'
 
 const CATEGORY_CONFIG: Record<SearchCategory, { label: string; icon: typeof Server }> = {
   page: { label: 'Pages', icon: LayoutDashboard },
@@ -38,6 +40,7 @@ const CATEGORY_CONFIG: Record<SearchCategory, { label: string; icon: typeof Serv
 export function SearchDropdown() {
   const navigate = useNavigate()
   const { openSidebar, setActiveMission } = useMissions()
+  const { setPendingRestoreCard } = useDashboardContext()
   const [searchQuery, setSearchQuery] = useState('')
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const [selectedIndex, setSelectedIndex] = useState(0)
@@ -63,12 +66,21 @@ export function SearchDropdown() {
       const missionId = item.href.replace('#mission:', '')
       setActiveMission(missionId)
       openSidebar()
+    } else if (item.href?.startsWith('#addCard:')) {
+      // Card items: add the card to the dashboard and navigate there
+      const cardType = item.href.replace('#addCard:', '')
+      setPendingRestoreCard({
+        cardType,
+        cardTitle: CARD_TITLES[cardType] || item.name,
+        config: {},
+      })
+      navigate('/')
     } else if (item.href) {
       navigate(item.href)
     }
     setSearchQuery('')
     setIsSearchOpen(false)
-  }, [navigate, setActiveMission, openSidebar])
+  }, [navigate, setActiveMission, openSidebar, setPendingRestoreCard])
 
   // Close dropdown when clicking outside
   useEffect(() => {

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -87,12 +87,14 @@ const PAGE_ITEMS: SearchItem[] = [
 ]
 
 // Build card items from CARD_TITLES
+// href uses #addCard:<type> so SearchDropdown can detect card actions
+// and add the card to the dashboard instead of just navigating
 const CARD_ITEMS: SearchItem[] = Object.entries(CARD_TITLES).map(([id, title]) => ({
   id: `card-${id}`,
   name: title,
   description: CARD_DESCRIPTIONS[id],
   category: 'card' as const,
-  href: '/',
+  href: `#addCard:${id}`,
   keywords: [id, id.replace(/_/g, ' ')],
 }))
 


### PR DESCRIPTION
## Summary
- Clicking a card in search results now **adds the card to the top of the main dashboard** and shows a success toast
- Previously, clicking a card result just navigated to `/` — the card wasn't there, so the user saw nothing useful
- Uses the existing `pendingRestoreCard` mechanism from `useDashboardContext` (same flow as card history restore)

## How it works
1. Card search items use `#addCard:<type>` href markers (e.g., `#addCard:console_ai_offline_detection`)
2. `SearchDropdown` detects the marker, calls `setPendingRestoreCard({ cardType, cardTitle, config: {} })`
3. Navigates to `/` (main dashboard)
4. `Dashboard.tsx` already handles `pendingRestoreCard`: adds card at top, records in history, shows success toast

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` — zero warnings on changed files
- [ ] Search "offline" → click "AI Offline Detection" → card appears at top of dashboard with toast
- [ ] Search "gpu" → click any GPU card → card added to dashboard
- [ ] Non-card results (pages, clusters, pods) still navigate normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)