### PR TITLE
🐛 fix: search navigates to existing cards instead of adding new ones

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -921,6 +921,8 @@ export function CardWrapper({
           ref={lazyRef}
           key={flashKey}
           data-tour="card"
+          data-card-type={cardType}
+          data-card-id={cardId}
           className={cn(
             'glass rounded-xl overflow-hidden card-hover',
             'flex flex-col transition-all duration-200',


### PR DESCRIPTION
## Summary

- Card search results now find cards **already placed on dashboards** by scanning localStorage instead of trying to add new cards
- Each result shows which dashboard the card is on (e.g. "On Deploy dashboard") and clicking navigates to that dashboard, scrolling the card into view with a brief purple highlight ring
- Cards on multiple dashboards appear as separate search results, so users can pick which dashboard to go to

## Changes

- **CardWrapper.tsx**: Add `data-card-type` and `data-card-id` attributes for DOM targeting
- **useSearchIndex.ts**: Replace static `CARD_TITLES` enumeration with localStorage scanning of all 22 dashboard storage keys + custom dashboards. Add `scrollTarget` field to `SearchItem`
- **SearchDropdown.tsx**: Remove `#addCard:` / `setPendingRestoreCard` approach. Add `scrollToCard()` that polls for the card element after navigation and smooth-scrolls into view with a 2s highlight

## Test plan

- [ ] Search for a card name (e.g. "offline") — results show which dashboard each card is on
- [ ] Click a card result — navigates to the correct dashboard and scrolls to the card
- [ ] If already on the dashboard, clicking scrolls without re-navigation
- [ ] Cards placed on multiple dashboards appear as separate results
- [ ] Purple ring highlight appears briefly then fades
- [ ] Non-card results (pages, clusters, missions, etc.) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)