### PR TITLE
🐛 Show connection count for viewer icon, remove tooltip

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -22,7 +22,7 @@ export function Navbar() {
   const navigate = useNavigate()
   const { theme, toggleTheme } = useTheme()
   const { isPresentationMode, togglePresentationMode } = usePresentationMode()
-  const { activeUsers } = useActiveUsers()
+  const { totalConnections } = useActiveUsers()
   const [showFeedback, setShowFeedback] = useState(false)
 
   return (
@@ -89,12 +89,9 @@ export function Navbar() {
         <TourTrigger />
 
         {/* Active Viewers */}
-        <div
-          className="flex items-center gap-1 px-1.5 py-1.5 text-muted-foreground"
-          title={`${activeUsers} user${activeUsers !== 1 ? 's' : ''} viewing this console`}
-        >
+        <div className="flex items-center gap-1 px-1.5 py-1.5 text-muted-foreground">
           <User className="w-4 h-4" />
-          <span className="text-xs tabular-nums">{activeUsers}</span>
+          <span className="text-xs tabular-nums">{totalConnections}</span>
         </div>
 
         {/* Feature Request (includes notifications) */}


### PR DESCRIPTION
## Summary
- Show `totalConnections` instead of `activeUsers` so the count reflects active browser sessions
- Remove hover tooltip for subtlety
- Future: unique GitHub users count for OAuth mode (separate from this)

## Test plan
- [ ] Open 2+ tabs to localhost:5174 — count should increase
- [ ] No hover tooltip on icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)