### PR TITLE
🌱 Mode-aware viewer count: connections in demo, users in OAuth

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -22,7 +22,7 @@ export function Navbar() {
   const navigate = useNavigate()
   const { theme, toggleTheme } = useTheme()
   const { isPresentationMode, togglePresentationMode } = usePresentationMode()
-  const { totalConnections } = useActiveUsers()
+  const { viewerCount } = useActiveUsers()
   const [showFeedback, setShowFeedback] = useState(false)
 
   return (
@@ -91,7 +91,7 @@ export function Navbar() {
         {/* Active Viewers */}
         <div className="flex items-center gap-1 px-1.5 py-1.5 text-muted-foreground">
           <User className="w-4 h-4" />
-          <span className="text-xs tabular-nums">{totalConnections}</span>
+          <span className="text-xs tabular-nums">{viewerCount}</span>
         </div>
 
         {/* Feature Request (includes notifications) */}

--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { api } from '../lib/api'
+import { getDemoMode } from './useDemoMode'
 
 export interface ActiveUsersInfo {
   activeUsers: number
@@ -91,11 +92,13 @@ export function useActiveUsers() {
     fetchActiveUsers()
   }, [])
 
+  // Demo mode: show total connections (sessions). OAuth mode: show unique users.
+  const viewerCount = getDemoMode() ? info.totalConnections : info.activeUsers
+
   return {
     activeUsers: info.activeUsers,
     totalConnections: info.totalConnections,
-    // Show badge if any users are connected (including yourself)
-    showBadge: info.activeUsers >= 1 || info.totalConnections >= 1,
+    viewerCount,
     refetch,
   }
 }


### PR DESCRIPTION
## Summary
- Demo mode: show `totalConnections` (simultaneous sessions/logins)
- OAuth mode: show `activeUsers` (unique GitHub users logged in)
- Hook exposes `viewerCount` that picks the right metric based on mode

## Test plan
- [ ] Dev mode (localhost:5174): open 2+ tabs, count should reflect connections
- [ ] Test on console.kubestellar.io after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)