### PR TITLE
🐛 Fix viewer count always 0 and demo mode not persisting across refresh

### DIFF
--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -189,8 +189,13 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 		return
 	}
 
-	// Validate JWT token
-	if h.jwtSecret != "" {
+	// Validate token
+	if authMsg.Token == "demo-token" {
+		// Demo mode: accept connection for presence tracking (count only, no user data)
+		userID = uuid.Nil
+		authenticated = true
+		log.Printf("Demo-mode WebSocket connection for presence tracking")
+	} else if h.jwtSecret != "" {
 		claims, err := middleware.ValidateJWT(authMsg.Token, h.jwtSecret)
 		if err != nil {
 			log.Printf("SECURITY: Rejected WebSocket - invalid token: %v", err)

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useState, useEffect } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { Sun, Moon, Monitor, User, Cast } from 'lucide-react'
 import { useAuth } from '../../../lib/auth'
 import { useTheme } from '../../../hooks/useTheme'
@@ -22,8 +22,14 @@ export function Navbar() {
   const navigate = useNavigate()
   const { theme, toggleTheme } = useTheme()
   const { isPresentationMode, togglePresentationMode } = usePresentationMode()
-  const { viewerCount } = useActiveUsers()
+  const { viewerCount, refetch } = useActiveUsers()
+  const location = useLocation()
   const [showFeedback, setShowFeedback] = useState(false)
+
+  // Refetch viewer count on page navigation
+  useEffect(() => {
+    refetch()
+  }, [location.pathname, refetch])
 
   return (
     <nav data-tour="navbar" className="fixed top-0 left-0 right-0 h-16 glass z-50 px-6 flex items-center justify-between">

--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback } from 'react'
-import { api } from '../lib/api'
 import { getDemoMode } from './useDemoMode'
 
 export interface ActiveUsersInfo {
@@ -28,10 +27,12 @@ let presencePingInterval: ReturnType<typeof setInterval> | null = null
 
 function startPresenceConnection() {
   if (presenceStarted) return
-  presenceStarted = true
 
   const token = localStorage.getItem('token')
   if (!token) return
+
+  // Set flag AFTER token check so a missing token doesn't permanently block
+  presenceStarted = true
 
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
   const wsUrl = `${protocol}//${window.location.hostname}:${window.location.port || (protocol === 'wss:' ? '443' : '80')}/ws`
@@ -53,6 +54,18 @@ function startPresenceConnection() {
           presenceWs.send(JSON.stringify({ type: 'ping' }))
         }
       }, 30000)
+    }
+
+    presenceWs.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data)
+        if (msg.type === 'authenticated') {
+          // Connection registered with hub — refetch so our own connection is counted
+          fetchActiveUsers()
+        }
+      } catch {
+        // Ignore parse errors
+      }
     }
 
     presenceWs.onclose = () => {
@@ -89,7 +102,9 @@ async function fetchActiveUsers() {
   }
 
   try {
-    const { data } = await api.get<ActiveUsersInfo>('/api/active-users')
+    const resp = await fetch('/api/active-users', { signal: AbortSignal.timeout(5000) })
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    const data: ActiveUsersInfo = await resp.json()
     consecutiveFailures = 0 // Reset on success
     if (data.activeUsers !== sharedInfo.activeUsers ||
         data.totalConnections !== sharedInfo.totalConnections) {
@@ -116,10 +131,13 @@ function startPolling() {
 }
 
 /**
- * Hook for tracking active users connected via WebSocket
+ * Hook for tracking active users connected via WebSocket.
+ * Returns viewerCount: totalConnections in demo mode, activeUsers in OAuth mode.
  */
 export function useActiveUsers() {
   const [info, setInfo] = useState<ActiveUsersInfo>(sharedInfo)
+  // Tick counter to force re-render when demo mode changes (so viewerCount recalculates)
+  const [, setDemoTick] = useState(0)
 
   useEffect(() => {
     // Start presence WebSocket + polling (singletons, only happen once)
@@ -135,8 +153,16 @@ export function useActiveUsers() {
     // Set initial state
     setInfo(sharedInfo)
 
+    // Re-render + refetch when demo mode toggles (viewerCount switches metric)
+    const handleDemoChange = () => {
+      setDemoTick(t => t + 1)
+      fetchActiveUsers()
+    }
+    window.addEventListener('kc-demo-mode-change', handleDemoChange)
+
     return () => {
       subscribers.delete(handleUpdate)
+      window.removeEventListener('kc-demo-mode-change', handleDemoChange)
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- **Viewer count fix**: `/api/active-users` was JWT-protected and the `api` client blocked requests with `demo-token` or cached backend-unavailable status. Moved endpoint to public, switched to raw `fetch`, and added WebSocket `onmessage` handler to refetch after auth.
- **Demo mode persistence**: `setGlobalDemoMode(false)` from `shared.ts` was overriding the user's explicit choice on every page load. Now reads localStorage directly to guard against auto-disable.
- **Cross-tab sync**: Demo mode changes in one tab now propagate to all other tabs via `storage` event.
- **Navigation refetch**: Viewer count updates immediately when switching pages.

## Test plan
- [ ] Enable demo mode, refresh — should stay in demo mode
- [ ] Open multiple tabs — viewer count should show total connections in demo mode
- [ ] Toggle demo mode — viewer count should refresh immediately
- [ ] Switch pages — viewer count should update

🤖 Generated with [Claude Code](https://claude.com/claude-code)