### PR TITLE
🐛 Add explicit console.kubestellar.io to forced demo mode check

### DIFF
--- a/web/src/hooks/useDemoMode.ts
+++ b/web/src/hooks/useDemoMode.ts
@@ -11,7 +11,8 @@ const listeners = new Set<(value: boolean) => void>()
 const isNetlifyPreview = typeof window !== 'undefined' && (
   import.meta.env.VITE_DEMO_MODE === 'true' ||
   window.location.hostname.includes('netlify.app') ||
-  window.location.hostname.includes('deploy-preview-')
+  window.location.hostname.includes('deploy-preview-') ||
+  window.location.hostname === 'console.kubestellar.io'
 )
 
 /**


### PR DESCRIPTION
## Summary
- Add `console.kubestellar.io` hostname to the `isNetlifyPreview` check so demo mode is forced on the production Netlify domain
- `VITE_DEMO_MODE=true` is already baked in at build time, but this is a safety net for the custom domain

## Test plan
- [ ] Verify demo mode cannot be toggled off on console.kubestellar.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)