### PR TITLE
🐛 Fix mobile responsive cards - single column on mobile, stats 2 per row

### DIFF
--- a/web/src/components/alerts/Alerts.tsx
+++ b/web/src/components/alerts/Alerts.tsx
@@ -269,7 +269,7 @@ export function Alerts() {
         onDragEnd={handleDragEnd}
       >
         <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-          <div className="grid grid-cols-12 gap-4 pb-32 auto-rows-[minmax(180px,auto)]">
+          <div className="grid grid-cols-1 md:grid-cols-12 gap-4 pb-32 auto-rows-[minmax(180px,auto)]">
             {cards.map(card => (
               <SortableCard
                 key={card.id}

--- a/web/src/components/arcade/Arcade.tsx
+++ b/web/src/components/arcade/Arcade.tsx
@@ -22,6 +22,7 @@ import { DashboardTemplate } from '../dashboard/templates'
 import { formatCardTitle } from '../../lib/formatCardTitle'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
 import { getRememberPosition, setRememberPosition } from '../../hooks/useLastRoute'
+import { useMobile } from '../../hooks/useMobile'
 
 const ARCADE_CARDS_KEY = 'kubestellar-arcade-cards'
 
@@ -82,11 +83,13 @@ const SortableArcadeCard = memo(function SortableArcadeCard({
     transition,
   } = useSortable({ id: card.id })
 
+  const { isMobile } = useMobile()
   const cardWidth = card.position?.w || 4
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    // Only apply multi-column span on desktop; mobile uses single column
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     opacity: isDragging ? 0.5 : 1,
   }
 
@@ -335,7 +338,7 @@ export function Arcade() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableArcadeCard
                         key={card.id}

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -1960,7 +1960,7 @@ export function Clusters() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
                     {cards.map(card => (
                       <SortableClusterCard
                         key={card.id}

--- a/web/src/components/clusters/components/SortableClusterCard.tsx
+++ b/web/src/components/clusters/components/SortableClusterCard.tsx
@@ -6,6 +6,7 @@ import { CardWrapper } from '../../cards/CardWrapper'
 import { CARD_COMPONENTS, DEMO_DATA_CARDS } from '../../cards/cardRegistry'
 import { DashboardCard } from '../../../lib/dashboards'
 import { formatCardTitle } from '../../../lib/formatCardTitle'
+import { useMobile } from '../../../hooks/useMobile'
 
 export interface SortableClusterCardProps {
   card: DashboardCard
@@ -36,11 +37,13 @@ export const SortableClusterCard = memo(function SortableClusterCard({
     transition,
   } = useSortable({ id: card.id })
 
+  const { isMobile } = useMobile()
   const cardWidth = card.position?.w || 4
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    // Only apply multi-column span on desktop; mobile uses single column
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     opacity: isDragging ? 0.5 : 1,
   }
 

--- a/web/src/components/compliance/Compliance.tsx
+++ b/web/src/components/compliance/Compliance.tsx
@@ -356,7 +356,7 @@ export function Compliance() {
           onDragEnd={handleDragEnd}
         >
           <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-            <div className="grid grid-cols-12 gap-4 pb-32">
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-4 pb-32">
               {cards.map(card => (
                 <SortableCard
                   key={card.id}

--- a/web/src/components/compute/Compute.tsx
+++ b/web/src/components/compute/Compute.tsx
@@ -28,6 +28,7 @@ import { formatCardTitle } from '../../lib/formatCardTitle'
 import { StatsOverview, StatBlockValue } from '../ui/StatsOverview'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
+import { useMobile } from '../../hooks/useMobile'
 
 const COMPUTE_CARDS_KEY = 'kubestellar-compute-cards'
 
@@ -69,12 +70,13 @@ const SortableComputeCard = memo(function SortableComputeCard({
     transform,
     transition,
   } = useSortable({ id: card.id })
+  const { isMobile } = useMobile()
 
   const cardWidth = card.position?.w || 4
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     opacity: isDragging ? 0.5 : 1,
   }
 
@@ -532,7 +534,7 @@ export function Compute() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableComputeCard
                         key={card.id}

--- a/web/src/components/cost/Cost.tsx
+++ b/web/src/components/cost/Cost.tsx
@@ -409,7 +409,7 @@ export function Cost() {
           onDragEnd={handleDragEnd}
         >
           <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-            <div className="grid grid-cols-12 gap-4 pb-32">
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-4 pb-32">
               {cards.map(card => (
                 <SortableCard
                   key={card.id}

--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -439,7 +439,7 @@ export function CustomDashboard() {
         <div className="animate-pulse space-y-6">
           <div className="h-8 w-64 bg-secondary/50 rounded" />
           <div className="h-4 w-96 bg-secondary/30 rounded" />
-          <div className="grid grid-cols-12 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
             {[...Array(3)].map((_, i) => (
               <div key={i} className="col-span-4 h-48 bg-secondary/30 rounded-lg" />
             ))}
@@ -529,7 +529,7 @@ export function CustomDashboard() {
           onDragEnd={handleDragEnd}
         >
           <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-            <div className="grid grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
               {cards.map((card) => (
                 <SortableCard
                   key={card.id}

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -891,7 +891,7 @@ export function Dashboard() {
         onDragCancel={handleDragCancel}
       >
         <SortableContext items={localCards.map(c => c.id)} strategy={rectSortingStrategy}>
-          <div data-tour="dashboard" className="grid grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
+          <div data-tour="dashboard" className="grid grid-cols-1 md:grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
             {localCards.map((card) => (
               <SortableCard
                 key={card.id}

--- a/web/src/components/data-compliance/DataCompliance.tsx
+++ b/web/src/components/data-compliance/DataCompliance.tsx
@@ -340,7 +340,7 @@ export function DataCompliance() {
           onDragEnd={handleDragEnd}
         >
           <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-            <div className="grid grid-cols-12 gap-4 pb-32">
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-4 pb-32">
               {cards.map(card => (
                 <SortableCard
                   key={card.id}

--- a/web/src/components/deploy/Deploy.tsx
+++ b/web/src/components/deploy/Deploy.tsx
@@ -4,6 +4,7 @@ import { Rocket, Plus, LayoutGrid, ChevronDown, ChevronRight, GripVertical } fro
 import { DashboardHeader } from '../shared/DashboardHeader'
 import { StatsOverview, StatBlockValue } from '../ui/StatsOverview'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
+import { useMobile } from '../../hooks/useMobile'
 import {
   DndContext,
   closestCenter,
@@ -84,6 +85,7 @@ const SortableDeployCard = memo(function SortableDeployCard({
   onRefresh,
   lastUpdated,
 }: SortableDeployCardProps) {
+  const { isMobile } = useMobile()
   const {
     attributes,
     listeners,
@@ -96,7 +98,8 @@ const SortableDeployCard = memo(function SortableDeployCard({
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    // Only apply multi-column span on desktop; mobile uses single column
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     opacity: isDragging ? 0.5 : 1,
   }
 
@@ -458,7 +461,7 @@ export function Deploy() {
                 onDragEnd={handleDeployDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableDeployCard
                         key={card.id}

--- a/web/src/components/deployments/Deployments.tsx
+++ b/web/src/components/deployments/Deployments.tsx
@@ -28,6 +28,7 @@ import { FloatingDashboardActions } from '../dashboard/FloatingDashboardActions'
 import { DashboardTemplate } from '../dashboard/templates'
 import { formatCardTitle } from '../../lib/formatCardTitle'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
+import { useMobile } from '../../hooks/useMobile'
 
 const DEPLOYMENTS_CARDS_KEY = 'kubestellar-deployments-cards'
 
@@ -68,12 +69,13 @@ const SortableDeploymentsCard = memo(function SortableDeploymentsCard({
     transform,
     transition,
   } = useSortable({ id: card.id })
+  const { isMobile } = useMobile()
 
   const cardWidth = card.position?.w || 6
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     opacity: isDragging ? 0.5 : 1,
   }
 
@@ -352,7 +354,7 @@ export function Deployments() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableDeploymentsCard
                         key={card.id}

--- a/web/src/components/events/Events.tsx
+++ b/web/src/components/events/Events.tsx
@@ -33,6 +33,7 @@ import { formatCardTitle } from '../../lib/formatCardTitle'
 import { StatsOverview, StatBlockValue } from '../ui/StatsOverview'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
+import { useMobile } from '../../hooks/useMobile'
 
 const EVENTS_CARDS_KEY = 'kubestellar-events-cards'
 
@@ -73,13 +74,14 @@ const SortableEventCard = memo(function SortableEventCard({
     transform,
     transition,
   } = useSortable({ id: card.id })
+  const { isMobile } = useMobile()
 
   const cardWidth = card.position?.w || 4
   const cardHeight = card.position?.h || 3
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     gridRow: `span ${cardHeight}`,
     opacity: isDragging ? 0.5 : 1,
   }
@@ -691,7 +693,7 @@ export function Events() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableEventCard
                         key={card.id}

--- a/web/src/components/gitops/GitOps.tsx
+++ b/web/src/components/gitops/GitOps.tsx
@@ -711,7 +711,7 @@ export function GitOps() {
           onDragEnd={handleDragEnd}
         >
           <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-            <div className="grid grid-cols-12 gap-4 pb-32">
+            <div className="grid grid-cols-1 md:grid-cols-12 gap-4 pb-32">
               {cards.map(card => (
                 <SortableCard
                   key={card.id}

--- a/web/src/components/helm/HelmReleases.tsx
+++ b/web/src/components/helm/HelmReleases.tsx
@@ -28,6 +28,7 @@ import { formatCardTitle } from '../../lib/formatCardTitle'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
 import { DashboardHeader } from '../shared/DashboardHeader'
+import { useMobile } from '../../hooks/useMobile'
 
 const HELM_CARDS_KEY = 'kubestellar-helm-cards'
 
@@ -68,12 +69,13 @@ const SortableHelmCard = memo(function SortableHelmCard({
     transform,
     transition,
   } = useSortable({ id: card.id })
+  const { isMobile } = useMobile()
 
   const cardWidth = card.position?.w || 6
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     opacity: isDragging ? 0.5 : 1,
   }
 
@@ -309,7 +311,7 @@ export function HelmReleases() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableHelmCard
                         key={card.id}

--- a/web/src/components/logs/Logs.tsx
+++ b/web/src/components/logs/Logs.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, memo, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { ScrollText, GripVertical, ChevronDown, ChevronRight, Plus, LayoutGrid } from 'lucide-react'
+import { useMobile } from '../../hooks/useMobile'
 import {
   DndContext,
   closestCenter,
@@ -68,11 +69,13 @@ const SortableLogsCard = memo(function SortableLogsCard({
     transition,
   } = useSortable({ id: card.id })
 
+  const { isMobile } = useMobile()
   const cardWidth = card.position?.w || 6
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    // Only apply multi-column span on desktop; mobile uses single column
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     opacity: isDragging ? 0.5 : 1,
   }
 
@@ -369,7 +372,7 @@ export function Logs() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableLogsCard
                         key={card.id}

--- a/web/src/components/network/Network.tsx
+++ b/web/src/components/network/Network.tsx
@@ -28,6 +28,7 @@ import { DashboardTemplate } from '../dashboard/templates'
 import { formatCardTitle } from '../../lib/formatCardTitle'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
+import { useMobile } from '../../hooks/useMobile'
 
 const NETWORK_CARDS_KEY = 'kubestellar-network-cards'
 
@@ -67,13 +68,14 @@ const SortableNetworkCard = memo(function SortableNetworkCard({
     transform,
     transition,
   } = useSortable({ id: card.id })
+  const { isMobile } = useMobile()
 
   const cardWidth = card.position?.w || 4
   const cardHeight = card.position?.h || 3
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     gridRow: `span ${cardHeight}`,
     opacity: isDragging ? 0.5 : 1,
   }
@@ -350,7 +352,7 @@ export function Network() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableNetworkCard
                         key={card.id}

--- a/web/src/components/nodes/Nodes.tsx
+++ b/web/src/components/nodes/Nodes.tsx
@@ -28,6 +28,7 @@ import { formatCardTitle } from '../../lib/formatCardTitle'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
 import { DashboardHeader } from '../shared/DashboardHeader'
+import { useMobile } from '../../hooks/useMobile'
 
 const NODES_CARDS_KEY = 'kubestellar-nodes-cards'
 
@@ -69,12 +70,13 @@ const SortableNodesCard = memo(function SortableNodesCard({
     transform,
     transition,
   } = useSortable({ id: card.id })
+  const { isMobile } = useMobile()
 
   const cardWidth = card.position?.w || 4
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     opacity: isDragging ? 0.5 : 1,
   }
 
@@ -358,7 +360,7 @@ export function Nodes() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableNodesCard
                         key={card.id}

--- a/web/src/components/operators/Operators.tsx
+++ b/web/src/components/operators/Operators.tsx
@@ -28,6 +28,7 @@ import { FloatingDashboardActions } from '../dashboard/FloatingDashboardActions'
 import { DashboardTemplate } from '../dashboard/templates'
 import { formatCardTitle } from '../../lib/formatCardTitle'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
+import { useMobile } from '../../hooks/useMobile'
 
 const OPERATORS_CARDS_KEY = 'kubestellar-operators-cards'
 
@@ -68,12 +69,13 @@ const SortableOperatorsCard = memo(function SortableOperatorsCard({
     transform,
     transition,
   } = useSortable({ id: card.id })
+  const { isMobile } = useMobile()
 
   const cardWidth = card.position?.w || 4
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     opacity: isDragging ? 0.5 : 1,
   }
 
@@ -387,7 +389,7 @@ export function Operators() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableOperatorsCard
                         key={card.id}

--- a/web/src/components/pods/Pods.tsx
+++ b/web/src/components/pods/Pods.tsx
@@ -31,6 +31,7 @@ import { formatCardTitle } from '../../lib/formatCardTitle'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
 import { DashboardHeader } from '../shared/DashboardHeader'
+import { useMobile } from '../../hooks/useMobile'
 
 const PODS_CARDS_KEY = 'kubestellar-pods-cards'
 
@@ -71,13 +72,14 @@ const SortablePodCard = memo(function SortablePodCard({
     transform,
     transition,
   } = useSortable({ id: card.id })
+  const { isMobile } = useMobile()
 
   const cardWidth = card.position?.w || 4
   const cardHeight = card.position?.h || 3
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     gridRow: `span ${cardHeight}`,
     opacity: isDragging ? 0.5 : 1,
   }
@@ -373,7 +375,7 @@ export function Pods() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortablePodCard
                         key={card.id}

--- a/web/src/components/security/Security.tsx
+++ b/web/src/components/security/Security.tsx
@@ -31,6 +31,7 @@ import { DashboardTemplate } from '../dashboard/templates'
 import { formatCardTitle } from '../../lib/formatCardTitle'
 import { StatsOverview, StatBlockValue } from '../ui/StatsOverview'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
+import { useMobile } from '../../hooks/useMobile'
 import {
   getMockSecurityData,
   getMockRBACData,
@@ -77,13 +78,14 @@ const SortableSecurityCard = memo(function SortableSecurityCard({
     transform,
     transition,
   } = useSortable({ id: card.id })
+  const { isMobile } = useMobile()
 
   const cardWidth = card.position?.w || 4
   const cardHeight = card.position?.h || 3
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     gridRow: `span ${cardHeight}`,
     opacity: isDragging ? 0.5 : 1,
   }
@@ -565,7 +567,7 @@ export function Security() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableSecurityCard
                         key={card.id}

--- a/web/src/components/services/Services.tsx
+++ b/web/src/components/services/Services.tsx
@@ -28,6 +28,7 @@ import { formatCardTitle } from '../../lib/formatCardTitle'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
 import { DashboardHeader } from '../shared/DashboardHeader'
+import { useMobile } from '../../hooks/useMobile'
 
 const SERVICES_CARDS_KEY = 'kubestellar-services-cards'
 
@@ -68,12 +69,13 @@ const SortableServicesCard = memo(function SortableServicesCard({
     transform,
     transition,
   } = useSortable({ id: card.id })
+  const { isMobile } = useMobile()
 
   const cardWidth = card.position?.w || 6
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     opacity: isDragging ? 0.5 : 1,
   }
 
@@ -335,7 +337,7 @@ export function Services() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableServicesCard
                         key={card.id}

--- a/web/src/components/storage/Storage.tsx
+++ b/web/src/components/storage/Storage.tsx
@@ -30,6 +30,7 @@ import { ClusterBadge } from '../ui/ClusterBadge'
 import { formatCardTitle } from '../../lib/formatCardTitle'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
+import { useMobile } from '../../hooks/useMobile'
 
 // PVC List Modal
 interface PVCListModalProps {
@@ -170,13 +171,14 @@ const SortableStorageCard = memo(function SortableStorageCard({
     transform,
     transition,
   } = useSortable({ id: card.id })
+  const { isMobile } = useMobile()
 
   const cardWidth = card.position?.w || 4
   const cardHeight = card.position?.h || 3
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     gridRow: `span ${cardHeight}`,
     opacity: isDragging ? 0.5 : 1,
   }
@@ -528,7 +530,7 @@ export function Storage() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableStorageCard
                         key={card.id}

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -173,11 +173,12 @@ export function StatsOverview({
   }
 
   // Dynamic grid columns based on visible blocks
+  // Mobile: max 2 columns, tablet+: responsive based on count
   const gridCols = visibleBlocks.length <= 4 ? 'grid-cols-2 md:grid-cols-4' :
-    visibleBlocks.length <= 5 ? 'grid-cols-5' :
-    visibleBlocks.length <= 6 ? 'grid-cols-3 md:grid-cols-6' :
-    visibleBlocks.length <= 8 ? 'grid-cols-4 lg:grid-cols-8' :
-    'grid-cols-5 lg:grid-cols-10'
+    visibleBlocks.length <= 5 ? 'grid-cols-2 md:grid-cols-5' :
+    visibleBlocks.length <= 6 ? 'grid-cols-2 md:grid-cols-3 lg:grid-cols-6' :
+    visibleBlocks.length <= 8 ? 'grid-cols-2 md:grid-cols-4 lg:grid-cols-8' :
+    'grid-cols-2 md:grid-cols-5 lg:grid-cols-10'
 
   return (
     <div className={`mb-6 ${className}`}>

--- a/web/src/components/workloads/Workloads.tsx
+++ b/web/src/components/workloads/Workloads.tsx
@@ -31,6 +31,7 @@ import { formatCardTitle } from '../../lib/formatCardTitle'
 import { useDashboard, DashboardCard } from '../../lib/dashboards'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
 import { DashboardHeader } from '../shared/DashboardHeader'
+import { useMobile } from '../../hooks/useMobile'
 
 const WORKLOADS_CARDS_KEY = 'kubestellar-workloads-cards'
 
@@ -72,13 +73,14 @@ const SortableWorkloadCard = memo(function SortableWorkloadCard({
     transform,
     transition,
   } = useSortable({ id: card.id })
+  const { isMobile } = useMobile()
 
   const cardWidth = card.position?.w || 4
   const cardHeight = card.position?.h || 3
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
     gridRow: `span ${cardHeight}`,
     opacity: isDragging ? 0.5 : 1,
   }
@@ -472,7 +474,7 @@ export function Workloads() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
-                  <div className="grid grid-cols-12 gap-4">
+                  <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
                     {cards.map(card => (
                       <SortableWorkloadCard
                         key={card.id}

--- a/web/src/lib/dashboards/DashboardComponents.tsx
+++ b/web/src/lib/dashboards/DashboardComponents.tsx
@@ -8,6 +8,7 @@ import { DashboardCard } from './types'
 import { CardWrapper } from '../../components/cards/CardWrapper'
 import { CARD_COMPONENTS, DEMO_DATA_CARDS } from '../../components/cards/cardRegistry'
 import { formatCardTitle } from '../../lib/formatCardTitle'
+import { useMobile } from '../../hooks/useMobile'
 
 // ============================================================================
 // Icon Resolver
@@ -44,14 +45,16 @@ export const SortableDashboardCard = memo(function SortableDashboardCard({
     transition,
   } = useSortable({ id: card.id })
 
+  const { isMobile } = useMobile()
   const cardWidth = card.position?.w || 4
   const cardHeight = card.position?.h || 2
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    gridColumn: `span ${cardWidth}`,
-    gridRow: `span ${cardHeight}`,
+    // Only apply multi-column span on desktop; mobile uses single column
+    gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
+    gridRow: isMobile ? undefined : `span ${cardHeight}`,
     opacity: isDragging ? 0.5 : 1,
   }
 

--- a/web/src/lib/stats/StatsRuntime.tsx
+++ b/web/src/lib/stats/StatsRuntime.tsx
@@ -239,17 +239,18 @@ export function StatsRuntime({
   }, [customGetStatValue, type, data, blocks])
 
   // Dynamic grid columns based on visible blocks
+  // Mobile: max 2 columns, tablet+: responsive based on count
   const gridCols = useMemo(() => {
     if (grid?.columns) {
-      return `grid-cols-${grid.columns}`
+      return `grid-cols-2 md:grid-cols-${grid.columns}`
     }
 
     const count = visibleBlocks.length
     if (count <= 4) return 'grid-cols-2 md:grid-cols-4'
-    if (count <= 5) return 'grid-cols-5'
-    if (count <= 6) return 'grid-cols-3 md:grid-cols-6'
-    if (count <= 8) return 'grid-cols-4 lg:grid-cols-8'
-    return 'grid-cols-5 lg:grid-cols-10'
+    if (count <= 5) return 'grid-cols-2 md:grid-cols-5'
+    if (count <= 6) return 'grid-cols-2 md:grid-cols-3 lg:grid-cols-6'
+    if (count <= 8) return 'grid-cols-2 md:grid-cols-4 lg:grid-cols-8'
+    return 'grid-cols-2 md:grid-cols-5 lg:grid-cols-10'
   }, [visibleBlocks.length, grid?.columns])
 
   return (


### PR DESCRIPTION
## Summary
- Cards display in single column on mobile devices (< 768px)
- Stats overview blocks show max 2 per row on mobile
- Desktop behavior unchanged

## Changes
- Update all 22 dashboard grids: `grid-cols-1 md:grid-cols-12`
- Add `useMobile` hook to SortableCard components for conditional column span
- Update StatsOverview and StatsRuntime for mobile-friendly 2-column stats

## Test plan
- [x] Build passes
- [x] Tested on iPhone SE viewport (375px) using Chrome DevTools
- [x] Cards display single column on mobile
- [x] Stats display 2 per row on mobile
- [x] Desktop behavior unchanged (12-column grid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)