### PR TITLE
✨ Add unified component architecture foundation

### DIFF
--- a/web/src/lib/unified/card/UnifiedCard.tsx
+++ b/web/src/lib/unified/card/UnifiedCard.tsx
@@ -1,0 +1,329 @@
+/**
+ * UnifiedCard - Single component that renders any card type from configuration
+ *
+ * This component accepts a UnifiedCardConfig and renders the appropriate
+ * visualization based on the content.type field. All variations come from
+ * configuration, not code branches.
+ *
+ * Usage:
+ *   <UnifiedCard config={podIssuesConfig} />
+ *   <UnifiedCard config={clusterHealthConfig} title="Custom Title" />
+ */
+
+import { useMemo, ReactNode } from 'react'
+import { AlertTriangle, Info } from 'lucide-react'
+import type {
+  UnifiedCardConfig,
+  UnifiedCardProps,
+  CardContent,
+} from '../types'
+import { useDataSource } from './hooks/useDataSource'
+import { useCardFiltering } from './hooks/useCardFiltering'
+
+// Visualization components (to be implemented in PR 2)
+// import { ListVisualization } from './visualizations/ListVisualization'
+// import { TableVisualization } from './visualizations/TableVisualization'
+// import { ChartVisualization } from './visualizations/ChartVisualization'
+// import { StatusGridVisualization } from './visualizations/StatusGridVisualization'
+
+/**
+ * UnifiedCard - Renders any card type from config
+ */
+export function UnifiedCard({
+  config,
+  instanceConfig,
+  title: _titleOverride,
+  className,
+}: UnifiedCardProps) {
+  // Merge instance config with base config
+  const mergedConfig = useMemo(() => {
+    if (!instanceConfig) return config
+    return {
+      ...config,
+      // Instance config can override certain fields
+      ...instanceConfig,
+    } as UnifiedCardConfig
+  }, [config, instanceConfig])
+
+  // Fetch data using the configured data source
+  const { data, isLoading, error, refetch } = useDataSource(mergedConfig.dataSource)
+
+  // Apply filtering if configured
+  const { filteredData, filterControls } = useCardFiltering(
+    data,
+    mergedConfig.filters
+  )
+
+  // Determine what to render
+  const content = useMemo(() => {
+    // Error state
+    if (error) {
+      return (
+        <ErrorState
+          message={error.message}
+          onRetry={refetch}
+        />
+      )
+    }
+
+    // Loading state
+    if (isLoading) {
+      return <LoadingState config={mergedConfig.loadingState} />
+    }
+
+    // Empty state
+    if (!filteredData || filteredData.length === 0) {
+      return <EmptyState config={mergedConfig.emptyState} />
+    }
+
+    // Render the appropriate visualization based on content type
+    return renderContent(mergedConfig.content, filteredData, mergedConfig)
+  }, [error, isLoading, filteredData, mergedConfig, refetch])
+
+  return (
+    <div className={className}>
+      {/* Filter controls (if any) */}
+      {filterControls}
+
+      {/* Inline stats (if configured) */}
+      {mergedConfig.stats && mergedConfig.stats.length > 0 && (
+        <InlineStats stats={mergedConfig.stats} data={filteredData} />
+      )}
+
+      {/* Main content */}
+      {content}
+
+      {/* Footer (if configured) */}
+      {mergedConfig.footer && (
+        <CardFooter config={mergedConfig.footer} data={filteredData} />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Render the appropriate visualization based on content.type
+ */
+function renderContent(
+  content: CardContent,
+  data: unknown[],
+  _config: UnifiedCardConfig
+): ReactNode {
+  switch (content.type) {
+    case 'list':
+      // TODO: Implement in PR 2
+      return (
+        <PlaceholderVisualization
+          type="list"
+          itemCount={data.length}
+          columns={content.columns.length}
+        />
+      )
+
+    case 'table':
+      // TODO: Implement in PR 2
+      return (
+        <PlaceholderVisualization
+          type="table"
+          itemCount={data.length}
+          columns={content.columns.length}
+        />
+      )
+
+    case 'chart':
+      // TODO: Implement in PR 4
+      return (
+        <PlaceholderVisualization
+          type={`chart (${content.chartType})`}
+          itemCount={data.length}
+        />
+      )
+
+    case 'status-grid':
+      // TODO: Implement in PR 2
+      return (
+        <PlaceholderVisualization
+          type="status-grid"
+          itemCount={content.items.length}
+        />
+      )
+
+    case 'custom':
+      // TODO: Load from component registry
+      return (
+        <PlaceholderVisualization
+          type={`custom: ${content.componentName}`}
+          itemCount={data.length}
+        />
+      )
+
+    default:
+      return (
+        <div className="text-gray-400 text-sm p-4">
+          Unknown content type: {(content as { type: string }).type}
+        </div>
+      )
+  }
+}
+
+/**
+ * Placeholder visualization while actual implementations are built
+ */
+function PlaceholderVisualization({
+  type,
+  itemCount,
+  columns,
+}: {
+  type: string
+  itemCount: number
+  columns?: number
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center p-6 text-gray-500 border border-dashed border-gray-700 rounded-lg m-2">
+      <Info className="w-8 h-8 mb-2 text-blue-400" />
+      <div className="text-sm font-medium">Visualization: {type}</div>
+      <div className="text-xs mt-1">
+        {itemCount} items{columns ? `, ${columns} columns` : ''}
+      </div>
+      <div className="text-xs mt-2 text-gray-600">
+        (Implementation pending - PR 2/4)
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Loading state component
+ */
+function LoadingState({
+  config,
+}: {
+  config?: UnifiedCardConfig['loadingState']
+}) {
+  const rows = config?.rows ?? 3
+  const showSearch = config?.showSearch ?? true
+
+  return (
+    <div className="p-2 space-y-2 animate-pulse">
+      {showSearch && (
+        <div className="h-8 bg-gray-800 rounded w-full" />
+      )}
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <div className="h-4 bg-gray-800 rounded w-16" />
+          <div className="h-4 bg-gray-800 rounded flex-1" />
+          <div className="h-4 bg-gray-800 rounded w-20" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Empty state component
+ */
+function EmptyState({
+  config,
+}: {
+  config?: UnifiedCardConfig['emptyState']
+}) {
+  // TODO: Use dynamic icon lookup based on config?.icon (using Info for now)
+  const title = config?.title ?? 'No data'
+  const message = config?.message
+  const variant = config?.variant ?? 'neutral'
+
+  const variantColors = {
+    success: 'text-green-400',
+    info: 'text-blue-400',
+    warning: 'text-yellow-400',
+    neutral: 'text-gray-400',
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center p-6 text-center">
+      <div className={`mb-2 ${variantColors[variant]}`}>
+        <Info className="w-8 h-8" />
+      </div>
+      <div className="text-sm font-medium text-gray-300">{title}</div>
+      {message && (
+        <div className="text-xs text-gray-500 mt-1">{message}</div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Error state component
+ */
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string
+  onRetry?: () => void
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center p-6 text-center">
+      <AlertTriangle className="w-8 h-8 text-red-400 mb-2" />
+      <div className="text-sm font-medium text-gray-300">Error loading data</div>
+      <div className="text-xs text-gray-500 mt-1">{message}</div>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="mt-3 px-3 py-1 text-xs bg-gray-800 hover:bg-gray-700 rounded transition-colors"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Inline stats displayed at top of card
+ */
+function InlineStats({
+  stats,
+  data: _data,
+}: {
+  stats: NonNullable<UnifiedCardConfig['stats']>
+  data: unknown[] | undefined
+}) {
+  // TODO: Implement value resolution from stats config
+  return (
+    <div className="flex items-center gap-3 px-2 py-1.5 border-b border-gray-800">
+      {stats.map((stat) => (
+        <div key={stat.id} className="flex items-center gap-1.5 text-xs">
+          <div className={`w-2 h-2 rounded-full ${stat.bgColor ?? 'bg-gray-600'}`} />
+          <span className="text-gray-400">{stat.label}:</span>
+          <span className="font-medium text-gray-200">--</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Card footer component
+ */
+function CardFooter({
+  config,
+  data,
+}: {
+  config: NonNullable<UnifiedCardConfig['footer']>
+  data: unknown[] | undefined
+}) {
+  return (
+    <div className="flex items-center justify-between px-2 py-1.5 text-xs text-gray-500 border-t border-gray-800">
+      {config.showTotal && data && (
+        <span>{data.length} items</span>
+      )}
+      {config.text && <span>{config.text}</span>}
+      {config.pagination && (
+        <span className="text-gray-600">Pagination placeholder</span>
+      )}
+    </div>
+  )
+}
+
+export default UnifiedCard

--- a/web/src/lib/unified/card/hooks/index.ts
+++ b/web/src/lib/unified/card/hooks/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Unified Card Hooks
+ */
+
+export { useDataSource, registerDataHook, getDataHook, getRegisteredDataHooks } from './useDataSource'
+export type { UseDataSourceResult } from './useDataSource'
+
+export { useCardFiltering } from './useCardFiltering'
+export type { UseCardFilteringResult } from './useCardFiltering'

--- a/web/src/lib/unified/card/hooks/useCardFiltering.ts
+++ b/web/src/lib/unified/card/hooks/useCardFiltering.ts
@@ -1,0 +1,209 @@
+/**
+ * useCardFiltering - Unified filtering hook for cards
+ *
+ * Applies filters based on card configuration and provides
+ * filter control components for the UI.
+ */
+
+import { useState, useMemo, useCallback, ReactNode, createElement } from 'react'
+import type { CardFilterConfig } from '../../types'
+
+export interface UseCardFilteringResult {
+  /** Filtered data */
+  filteredData: unknown[] | undefined
+  /** Filter control components to render */
+  filterControls: ReactNode
+  /** Current filter state */
+  filterState: Record<string, unknown>
+  /** Update a filter value */
+  setFilter: (field: string, value: unknown) => void
+  /** Clear all filters */
+  clearFilters: () => void
+}
+
+/**
+ * useCardFiltering - Apply configured filters to data
+ */
+export function useCardFiltering(
+  data: unknown[] | undefined,
+  filters?: CardFilterConfig[]
+): UseCardFilteringResult {
+  // Filter state - keyed by field name
+  const [filterState, setFilterState] = useState<Record<string, unknown>>({})
+
+  // Update a single filter
+  const setFilter = useCallback((field: string, value: unknown) => {
+    setFilterState((prev) => ({
+      ...prev,
+      [field]: value,
+    }))
+  }, [])
+
+  // Clear all filters
+  const clearFilters = useCallback(() => {
+    setFilterState({})
+  }, [])
+
+  // Apply filters to data
+  const filteredData = useMemo(() => {
+    if (!data) return undefined
+    if (!filters || filters.length === 0) return data
+
+    let result = [...data]
+
+    for (const filter of filters) {
+      const filterValue = filterState[filter.field]
+
+      // Skip if no value set
+      if (filterValue === undefined || filterValue === null || filterValue === '') {
+        continue
+      }
+
+      switch (filter.type) {
+        case 'text': {
+          const query = String(filterValue).toLowerCase()
+          const searchFields = filter.searchFields ?? [filter.field]
+          result = result.filter((item) => {
+            const record = item as Record<string, unknown>
+            return searchFields.some((field) => {
+              const value = record[field]
+              return value && String(value).toLowerCase().includes(query)
+            })
+          })
+          break
+        }
+
+        case 'select':
+        case 'cluster-select': {
+          const selected = filterValue as string
+          result = result.filter((item) => {
+            const record = item as Record<string, unknown>
+            return record[filter.field] === selected
+          })
+          break
+        }
+
+        case 'multi-select':
+        case 'chips': {
+          const selected = filterValue as string[]
+          if (selected.length > 0) {
+            result = result.filter((item) => {
+              const record = item as Record<string, unknown>
+              return selected.includes(String(record[filter.field]))
+            })
+          }
+          break
+        }
+
+        case 'toggle': {
+          const enabled = filterValue as boolean
+          if (enabled) {
+            result = result.filter((item) => {
+              const record = item as Record<string, unknown>
+              return Boolean(record[filter.field])
+            })
+          }
+          break
+        }
+      }
+    }
+
+    return result
+  }, [data, filters, filterState])
+
+  // Generate filter control components
+  const filterControls = useMemo(() => {
+    if (!filters || filters.length === 0) return null
+
+    return createElement(
+      'div',
+      { className: 'flex items-center gap-2 p-2 border-b border-gray-800' },
+      filters.map((filter) =>
+        createElement(FilterControl, {
+          key: filter.field,
+          config: filter,
+          value: filterState[filter.field],
+          onChange: (value: unknown) => setFilter(filter.field, value),
+        })
+      )
+    )
+  }, [filters, filterState, setFilter])
+
+  return {
+    filteredData,
+    filterControls,
+    filterState,
+    setFilter,
+    clearFilters,
+  }
+}
+
+/**
+ * Individual filter control component
+ */
+function FilterControl({
+  config,
+  value,
+  onChange,
+}: {
+  config: CardFilterConfig
+  value: unknown
+  onChange: (value: unknown) => void
+}) {
+  switch (config.type) {
+    case 'text':
+      return createElement('input', {
+        type: 'text',
+        placeholder: config.placeholder ?? `Search ${config.label ?? config.field}...`,
+        value: (value as string) ?? '',
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
+        className:
+          'flex-1 px-3 py-1.5 text-sm bg-gray-800 border border-gray-700 rounded focus:outline-none focus:border-blue-500 text-gray-200 placeholder-gray-500',
+      })
+
+    case 'select':
+    case 'cluster-select':
+      return createElement(
+        'select',
+        {
+          value: (value as string) ?? '',
+          onChange: (e: React.ChangeEvent<HTMLSelectElement>) =>
+            onChange(e.target.value || undefined),
+          className:
+            'px-3 py-1.5 text-sm bg-gray-800 border border-gray-700 rounded focus:outline-none focus:border-blue-500 text-gray-200',
+        },
+        createElement('option', { value: '' }, config.placeholder ?? 'All'),
+        config.options?.map((opt) =>
+          createElement('option', { key: opt.value, value: opt.value }, opt.label)
+        )
+      )
+
+    case 'toggle':
+      return createElement(
+        'label',
+        { className: 'flex items-center gap-2 text-sm text-gray-400 cursor-pointer' },
+        createElement('input', {
+          type: 'checkbox',
+          checked: (value as boolean) ?? false,
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.checked),
+          className: 'rounded border-gray-700 bg-gray-800',
+        }),
+        config.label ?? config.field
+      )
+
+    case 'chips':
+    case 'multi-select':
+      // Simplified chip display - full implementation in PR 2
+      return createElement(
+        'div',
+        { className: 'flex items-center gap-1 text-xs' },
+        createElement('span', { className: 'text-gray-400' }, config.label ?? config.field),
+        createElement('span', { className: 'text-gray-500' }, '(multi-select)')
+      )
+
+    default:
+      return null
+  }
+}
+
+export default useCardFiltering

--- a/web/src/lib/unified/card/hooks/useDataSource.ts
+++ b/web/src/lib/unified/card/hooks/useDataSource.ts
@@ -1,0 +1,288 @@
+/**
+ * useDataSource - Unified data fetching hook for cards
+ *
+ * Supports multiple data source types:
+ * - hook: Use a registered data hook (e.g., useClusters, usePods)
+ * - api: Direct API fetch with optional polling
+ * - static: Static data array
+ * - context: Read from React context
+ */
+
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import type { CardDataSource } from '../../types'
+
+// Hook registry - populated by registerDataHook
+const dataHookRegistry: Record<
+  string,
+  (params?: Record<string, unknown>) => {
+    data: unknown[] | undefined
+    isLoading: boolean
+    error: Error | null
+    refetch?: () => void
+  }
+> = {}
+
+/**
+ * Register a data hook for use in card configs
+ *
+ * @example
+ * registerDataHook('useCachedPodIssues', useCachedPodIssues)
+ */
+export function registerDataHook(
+  name: string,
+  hook: (params?: Record<string, unknown>) => {
+    data: unknown[] | undefined
+    isLoading: boolean
+    error: Error | null
+    refetch?: () => void
+  }
+) {
+  dataHookRegistry[name] = hook
+}
+
+/**
+ * Get a registered data hook
+ */
+export function getDataHook(name: string) {
+  return dataHookRegistry[name]
+}
+
+/**
+ * List all registered data hooks
+ */
+export function getRegisteredDataHooks(): string[] {
+  return Object.keys(dataHookRegistry)
+}
+
+export interface UseDataSourceResult {
+  data: unknown[] | undefined
+  isLoading: boolean
+  error: Error | null
+  refetch: () => void
+}
+
+const EMPTY_RESULT: UseDataSourceResult = {
+  data: undefined,
+  isLoading: false,
+  error: null,
+  refetch: () => {},
+}
+
+/**
+ * Unified data source hook
+ *
+ * IMPORTANT: This hook must be used with a stable config reference.
+ * Changing config.type between renders will cause issues due to React's
+ * rules of hooks. Each data source type has its own component wrapper
+ * that should be used instead if dynamic switching is needed.
+ */
+export function useDataSource(config: CardDataSource): UseDataSourceResult {
+  // Call ALL hooks unconditionally - they check internally if they should be active
+  // This satisfies React's rules of hooks
+  const hookResult = useHookDataSourceInternal(
+    config.type === 'hook' ? config.hook : null,
+    config.type === 'hook' ? config.params : undefined
+  )
+
+  const apiResult = useApiDataSourceInternal(
+    config.type === 'api' ? config.endpoint : null,
+    config.type === 'api' ? config.method : 'GET',
+    config.type === 'api' ? config.params : undefined,
+    config.type === 'api' ? config.pollInterval : undefined
+  )
+
+  const staticResult = useStaticDataSourceInternal(
+    config.type === 'static' ? config.data : null
+  )
+
+  const contextResult = useContextDataSourceInternal(
+    config.type === 'context' ? config.contextKey : null
+  )
+
+  // Return the appropriate result based on config type
+  switch (config.type) {
+    case 'hook':
+      return hookResult
+    case 'api':
+      return apiResult
+    case 'static':
+      return staticResult
+    case 'context':
+      return contextResult
+    default: {
+      // Exhaustive check
+      const _exhaustiveCheck: never = config
+      return {
+        data: undefined,
+        isLoading: false,
+        error: new Error(`Unknown data source type: ${(_exhaustiveCheck as CardDataSource).type}`),
+        refetch: () => {},
+      }
+    }
+  }
+}
+
+/**
+ * Hook-based data source (internal - always runs but skips if hookName is null)
+ */
+function useHookDataSourceInternal(
+  hookName: string | null,
+  params?: Record<string, unknown>
+): UseDataSourceResult {
+  // Memoize error result
+  const errorResult = useMemo<UseDataSourceResult>(
+    () => {
+      if (!hookName) return EMPTY_RESULT
+      return {
+        data: undefined,
+        isLoading: false,
+        error: new Error(
+          `Data hook not registered: ${hookName}. Register it with registerDataHook().`
+        ),
+        refetch: () => {},
+      }
+    },
+    [hookName]
+  )
+
+  // Get the hook from registry
+  const registeredHook = hookName ? dataHookRegistry[hookName] : null
+
+  // Call the hook if it exists, otherwise use a stable empty result
+  // Note: We can't conditionally call hooks, but we CAN conditionally
+  // pass null to a function that returns stable results
+  const hookResult = registeredHook ? registeredHook(params) : null
+
+  // Return appropriate result
+  if (!hookName) {
+    return EMPTY_RESULT
+  }
+
+  if (!hookResult) {
+    return errorResult
+  }
+
+  return {
+    data: hookResult.data,
+    isLoading: hookResult.isLoading,
+    error: hookResult.error,
+    refetch: hookResult.refetch ?? (() => {}),
+  }
+}
+
+/**
+ * API-based data source (internal - always runs but skips if endpoint is null)
+ */
+function useApiDataSourceInternal(
+  endpoint: string | null,
+  method: 'GET' | 'POST' = 'GET',
+  params?: Record<string, unknown>,
+  pollInterval?: number
+): UseDataSourceResult {
+  const [data, setData] = useState<unknown[] | undefined>(undefined)
+  const [isLoading, setIsLoading] = useState(!!endpoint)
+  const [error, setError] = useState<Error | null>(null)
+
+  // Stringify params for stable dependency comparison
+  const paramsKey = useMemo(() => (params ? JSON.stringify(params) : ''), [params])
+
+  const fetchData = useCallback(async () => {
+    if (!endpoint) return
+
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      let url = endpoint
+      if (method === 'GET' && params) {
+        const searchParams = new URLSearchParams()
+        Object.entries(params).forEach(([key, value]) => {
+          if (value !== undefined && value !== null) {
+            searchParams.set(key, String(value))
+          }
+        })
+        url = `${endpoint}?${searchParams.toString()}`
+      }
+
+      const response = await fetch(url, {
+        method,
+        headers: method === 'POST' ? { 'Content-Type': 'application/json' } : undefined,
+        body: method === 'POST' && params ? JSON.stringify(params) : undefined,
+      })
+
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status} ${response.statusText}`)
+      }
+
+      const json = await response.json()
+      // Assume response is array or has data array property
+      const resultData = Array.isArray(json) ? json : json.data ?? json.items ?? []
+      setData(resultData)
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [endpoint, method, paramsKey]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Initial fetch (only if endpoint is provided)
+  useEffect(() => {
+    if (endpoint) {
+      fetchData()
+    }
+  }, [endpoint, fetchData])
+
+  // Polling (only if endpoint and pollInterval are provided)
+  useEffect(() => {
+    if (!endpoint || !pollInterval || pollInterval <= 0) return
+
+    const interval = setInterval(fetchData, pollInterval)
+    return () => clearInterval(interval)
+  }, [endpoint, fetchData, pollInterval])
+
+  // Return empty result if no endpoint
+  if (!endpoint) {
+    return EMPTY_RESULT
+  }
+
+  return { data, isLoading, error, refetch: fetchData }
+}
+
+/**
+ * Static data source (internal - always runs but skips if data is null)
+ */
+function useStaticDataSourceInternal(staticData: unknown[] | null): UseDataSourceResult {
+  return useMemo(
+    () => {
+      if (!staticData) return EMPTY_RESULT
+      return {
+        data: staticData,
+        isLoading: false,
+        error: null,
+        refetch: () => {},
+      }
+    },
+    [staticData]
+  )
+}
+
+/**
+ * Context-based data source (internal - always runs but skips if contextKey is null)
+ */
+function useContextDataSourceInternal(contextKey: string | null): UseDataSourceResult {
+  return useMemo(
+    () => {
+      if (!contextKey) return EMPTY_RESULT
+      // TODO: Implement context registry similar to hook registry
+      return {
+        data: undefined,
+        isLoading: false,
+        error: new Error(`Context data source not yet implemented: ${contextKey}`),
+        refetch: () => {},
+      }
+    },
+    [contextKey]
+  )
+}
+
+export default useDataSource

--- a/web/src/lib/unified/card/index.ts
+++ b/web/src/lib/unified/card/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Unified Card Module
+ *
+ * Exports the UnifiedCard component and supporting utilities.
+ */
+
+export { UnifiedCard, default as UnifiedCardDefault } from './UnifiedCard'
+
+export {
+  useDataSource,
+  registerDataHook,
+  getDataHook,
+  getRegisteredDataHooks,
+  useCardFiltering,
+} from './hooks'
+
+export type { UseDataSourceResult, UseCardFilteringResult } from './hooks'

--- a/web/src/lib/unified/index.ts
+++ b/web/src/lib/unified/index.ts
@@ -1,0 +1,113 @@
+/**
+ * Unified Component Architecture
+ *
+ * This module provides the unified component system:
+ * - UnifiedCard: Single component that renders any card type from config
+ * - UnifiedStatBlock: Single component that renders any stat block from config (PR 5)
+ * - UnifiedDashboard: Single component that renders any dashboard from config (PR 6)
+ *
+ * All variations come from configuration, not code branches.
+ *
+ * @example
+ * ```tsx
+ * import { UnifiedCard, registerDataHook } from '@/lib/unified'
+ *
+ * // Register data hooks at app startup
+ * registerDataHook('useCachedPodIssues', useCachedPodIssues)
+ *
+ * // Use in component
+ * <UnifiedCard config={podIssuesConfig} />
+ * ```
+ */
+
+// Types
+export type {
+  // Card types
+  UnifiedCardConfig,
+  UnifiedCardProps,
+  CardDataSource,
+  CardDataSourceHook,
+  CardDataSourceApi,
+  CardDataSourceStatic,
+  CardDataSourceContext,
+  CardDataTransform,
+  CardContent,
+  CardContentList,
+  CardContentTable,
+  CardContentChart,
+  CardContentStatusGrid,
+  CardContentCustom,
+  CardColumnConfig,
+  CardRenderer,
+  CardChartSeries,
+  CardAxisConfig,
+  CardStatusItem,
+  CardValueSource,
+  CardFilterConfig,
+  CardFilterOption,
+  CardStatConfig,
+  CardStatAction,
+  CardFooterConfig,
+  CardDrillDownConfig,
+  CardEmptyStateConfig,
+  CardLoadingStateConfig,
+  CardWidth,
+
+  // Stat block types
+  UnifiedStatBlockConfig,
+  UnifiedStatBlockProps,
+  StatValueSource,
+  StatValueSourceField,
+  StatValueSourceComputed,
+  StatValueSourceHook,
+  StatValueSourceAggregate,
+  StatValueFormat,
+  StatBlockAction,
+
+  // Stats section types
+  UnifiedStatsSectionConfig,
+  UnifiedStatsSectionProps,
+
+  // Dashboard types
+  UnifiedDashboardConfig,
+  UnifiedDashboardProps,
+  DashboardCardPlacement,
+  DashboardFeatures,
+
+  // Registry types
+  CardConfigRegistry,
+  StatsConfigRegistry,
+  DashboardConfigRegistry,
+  RendererFunction,
+  RendererRegistry,
+  DataHookFunction,
+  DataHookRegistry,
+} from './types'
+
+// Re-export from existing modules
+export type {
+  CardCategory,
+  CardVisualization,
+  CardPlacement,
+  CardStatus,
+} from '../cards/types'
+
+export type {
+  StatBlockColor,
+  StatBlockValue,
+  StatBlockConfig,
+} from '../stats/types'
+
+// Components
+export {
+  UnifiedCard,
+  useDataSource,
+  registerDataHook,
+  getDataHook,
+  getRegisteredDataHooks,
+  useCardFiltering,
+} from './card'
+
+// Future exports (PR 5 & 6)
+// export { UnifiedStatBlock, UnifiedStatsSection } from './stats'
+// export { UnifiedDashboard } from './dashboard'

--- a/web/src/lib/unified/types.ts
+++ b/web/src/lib/unified/types.ts
@@ -1,0 +1,732 @@
+/**
+ * Unified Component Types
+ *
+ * This module provides type definitions for the unified component architecture:
+ * - UnifiedCard: Single component that renders any card type from config
+ * - UnifiedStatBlock: Single component that renders any stat block from config
+ * - UnifiedDashboard: Single component that renders any dashboard from config
+ *
+ * All variations come from configuration, not code branches.
+ */
+
+// Re-export existing types that we're extending
+export type {
+  CardCategory,
+  CardVisualization,
+  CardPlacement,
+  CardStatus,
+} from '../cards/types'
+
+export type {
+  StatBlockColor,
+  StatBlockValue,
+  StatBlockConfig,
+} from '../stats/types'
+
+// ============================================================================
+// UnifiedCard Types
+// ============================================================================
+
+/**
+ * Complete card configuration - drives all card rendering
+ */
+export interface UnifiedCardConfig {
+  /** Unique card type identifier */
+  type: string
+  /** Display title */
+  title: string
+  /** Card category for organization */
+  category: CardCategory
+  /** Description shown in info tooltip */
+  description?: string
+
+  // Appearance
+  /** Icon name from lucide-react */
+  icon?: string
+  /** Icon color class (e.g., 'text-green-400') */
+  iconColor?: string
+  /** Default grid width (3-12 columns) */
+  defaultWidth?: CardWidth
+  /** Default grid height (in rows) */
+  defaultHeight?: number
+
+  // Data
+  /** Data source configuration */
+  dataSource: CardDataSource
+  /** Data transformation after fetching */
+  transform?: CardDataTransform
+
+  // Layout sections
+  /** Inline stats shown at top of card */
+  stats?: CardStatConfig[]
+  /** Filter controls */
+  filters?: CardFilterConfig[]
+  /** Main content area */
+  content: CardContent
+  /** Footer configuration */
+  footer?: CardFooterConfig
+
+  // Interaction
+  /** Drill-down configuration */
+  drillDown?: CardDrillDownConfig
+  /** Empty state configuration */
+  emptyState?: CardEmptyStateConfig
+  /** Loading state configuration */
+  loadingState?: CardLoadingStateConfig
+
+  // Metadata
+  /** Whether card uses demo/mock data */
+  isDemoData?: boolean
+  /** Whether card has live/real-time data */
+  isLive?: boolean
+}
+
+export type CardWidth = 3 | 4 | 6 | 8 | 12
+
+// ============================================================================
+// Data Source Types (discriminated union)
+// ============================================================================
+
+export type CardDataSource =
+  | CardDataSourceHook
+  | CardDataSourceApi
+  | CardDataSourceStatic
+  | CardDataSourceContext
+
+export interface CardDataSourceHook {
+  type: 'hook'
+  /** Hook name from the hook registry */
+  hook: string
+  /** Parameters to pass to the hook */
+  params?: Record<string, unknown>
+}
+
+export interface CardDataSourceApi {
+  type: 'api'
+  /** API endpoint path */
+  endpoint: string
+  /** HTTP method */
+  method?: 'GET' | 'POST'
+  /** Query parameters */
+  params?: Record<string, unknown>
+  /** Polling interval in ms (0 = no polling) */
+  pollInterval?: number
+}
+
+export interface CardDataSourceStatic {
+  type: 'static'
+  /** Static data array */
+  data: unknown[]
+}
+
+export interface CardDataSourceContext {
+  type: 'context'
+  /** Key in React context to read data from */
+  contextKey: string
+}
+
+export interface CardDataTransform {
+  /** Transform function name from registry */
+  fn: string
+  /** Additional parameters */
+  params?: Record<string, unknown>
+}
+
+// ============================================================================
+// Content Types (discriminated union)
+// ============================================================================
+
+export type CardContent =
+  | CardContentList
+  | CardContentTable
+  | CardContentChart
+  | CardContentStatusGrid
+  | CardContentCustom
+
+export interface CardContentList {
+  type: 'list'
+  /** Column definitions */
+  columns: CardColumnConfig[]
+  /** Item click behavior */
+  itemClick?: 'drill' | 'expand' | 'select' | 'none'
+  /** Max items per page (enables pagination) */
+  pageSize?: number
+  /** Show row numbers */
+  showRowNumbers?: boolean
+}
+
+export interface CardContentTable {
+  type: 'table'
+  /** Column definitions */
+  columns: CardColumnConfig[]
+  /** Enable column sorting */
+  sortable?: boolean
+  /** Default sort field */
+  defaultSort?: string
+  /** Default sort direction */
+  defaultDirection?: 'asc' | 'desc'
+  /** Max items per page */
+  pageSize?: number
+}
+
+export interface CardContentChart {
+  type: 'chart'
+  /** Chart type */
+  chartType: 'line' | 'bar' | 'donut' | 'gauge' | 'sparkline' | 'area'
+  /** Data series configuration */
+  series: CardChartSeries[]
+  /** X-axis configuration */
+  xAxis?: CardAxisConfig
+  /** Y-axis configuration */
+  yAxis?: CardAxisConfig
+  /** Show legend */
+  showLegend?: boolean
+  /** Chart height in pixels */
+  height?: number
+}
+
+export interface CardContentStatusGrid {
+  type: 'status-grid'
+  /** Status items to display */
+  items: CardStatusItem[]
+  /** Grid columns */
+  columns?: number
+  /** Show counts */
+  showCounts?: boolean
+}
+
+export interface CardContentCustom {
+  type: 'custom'
+  /** Component name from registry */
+  componentName: string
+  /** Props to pass to component */
+  props?: Record<string, unknown>
+}
+
+// ============================================================================
+// Column & Renderer Types
+// ============================================================================
+
+export interface CardColumnConfig {
+  /** Field name from data item */
+  field: string
+  /** Column header text */
+  header?: string
+  /** Column width (px, %, or 'auto') */
+  width?: number | string
+  /** Text alignment */
+  align?: 'left' | 'center' | 'right'
+  /** Renderer name from registry, or built-in type */
+  render?: CardRenderer
+  /** Whether this is the primary field (bold, clickable) */
+  primary?: boolean
+  /** Whether column is sortable */
+  sortable?: boolean
+  /** Whether column is hidden by default */
+  hidden?: boolean
+  /** Suffix to append to value */
+  suffix?: string
+  /** Prefix to prepend to value */
+  prefix?: string
+}
+
+export type CardRenderer =
+  | 'text'
+  | 'number'
+  | 'percentage'
+  | 'bytes'
+  | 'duration'
+  | 'date'
+  | 'datetime'
+  | 'relative-time'
+  | 'status-badge'
+  | 'cluster-badge'
+  | 'namespace-badge'
+  | 'progress-bar'
+  | 'icon'
+  | 'boolean'
+  | 'json'
+  | 'truncate'
+  | 'link'
+  | string // Custom renderer name
+
+// ============================================================================
+// Chart Types
+// ============================================================================
+
+export interface CardChartSeries {
+  /** Field name for values */
+  field: string
+  /** Series label */
+  label?: string
+  /** Series color */
+  color?: string
+  /** Line/bar style */
+  style?: 'solid' | 'dashed' | 'dotted'
+  /** For donut: whether this is the main value */
+  primary?: boolean
+}
+
+export interface CardAxisConfig {
+  /** Field for axis values */
+  field?: string
+  /** Axis label */
+  label?: string
+  /** Axis type */
+  type?: 'linear' | 'time' | 'category'
+  /** Value format */
+  format?: 'number' | 'percentage' | 'bytes' | 'currency' | 'time'
+  /** Min value */
+  min?: number
+  /** Max value */
+  max?: number
+}
+
+// ============================================================================
+// Status Grid Types
+// ============================================================================
+
+export interface CardStatusItem {
+  /** Item ID */
+  id: string
+  /** Item label */
+  label: string
+  /** Icon name */
+  icon: string
+  /** Icon color */
+  color: string
+  /** Background color */
+  bgColor?: string
+  /** Value source configuration */
+  valueSource: CardValueSource
+}
+
+export type CardValueSource =
+  | { type: 'field'; path: string }
+  | { type: 'computed'; expression: string }
+  | { type: 'count'; filter?: string }
+
+// ============================================================================
+// Filter Types
+// ============================================================================
+
+export interface CardFilterConfig {
+  /** Field to filter on */
+  field: string
+  /** Filter type */
+  type: 'text' | 'select' | 'multi-select' | 'cluster-select' | 'chips' | 'toggle'
+  /** Filter label */
+  label?: string
+  /** Placeholder text */
+  placeholder?: string
+  /** For text: fields to search across */
+  searchFields?: string[]
+  /** For select/chips: static options */
+  options?: CardFilterOption[]
+  /** For select/chips: data source for options */
+  optionsSource?: string
+  /** Storage key for persistence */
+  storageKey?: string
+}
+
+export interface CardFilterOption {
+  value: string
+  label: string
+  icon?: string
+  color?: string
+}
+
+// ============================================================================
+// Inline Stats Types
+// ============================================================================
+
+export interface CardStatConfig {
+  /** Stat ID */
+  id: string
+  /** Icon name */
+  icon: string
+  /** Icon color class */
+  color: string
+  /** Background color class */
+  bgColor?: string
+  /** Stat label */
+  label: string
+  /** Value source */
+  valueSource: CardValueSource
+  /** Click action */
+  onClick?: CardStatAction
+}
+
+export interface CardStatAction {
+  type: 'filter' | 'drill' | 'navigate'
+  target: string
+  params?: Record<string, string>
+}
+
+// ============================================================================
+// Footer Types
+// ============================================================================
+
+export interface CardFooterConfig {
+  /** Show pagination */
+  pagination?: boolean
+  /** Show total count */
+  showTotal?: boolean
+  /** Custom footer text */
+  text?: string
+}
+
+// ============================================================================
+// Drill-Down Types
+// ============================================================================
+
+export interface CardDrillDownConfig {
+  /** Action name from useDrillDownActions */
+  action: string
+  /** Fields from data item to pass as params */
+  params: string[]
+  /** Additional context to include */
+  context?: Record<string, string>
+}
+
+// ============================================================================
+// Empty & Loading States
+// ============================================================================
+
+export interface CardEmptyStateConfig {
+  /** Icon name */
+  icon: string
+  /** Main message */
+  title: string
+  /** Secondary message */
+  message?: string
+  /** Variant for styling */
+  variant: 'success' | 'info' | 'warning' | 'neutral'
+}
+
+export interface CardLoadingStateConfig {
+  /** Number of skeleton rows */
+  rows?: number
+  /** Skeleton type */
+  type?: 'table' | 'list' | 'chart' | 'status'
+  /** Show header skeleton */
+  showHeader?: boolean
+  /** Show search skeleton */
+  showSearch?: boolean
+}
+
+// ============================================================================
+// UnifiedStatBlock Types
+// ============================================================================
+
+/**
+ * Complete stat block configuration
+ */
+export interface UnifiedStatBlockConfig {
+  /** Unique block ID */
+  id: string
+  /** Display name */
+  name: string
+  /** Icon name from lucide-react */
+  icon: string
+  /** Color variant */
+  color: StatBlockColor
+  /** Whether visible by default */
+  visible?: boolean
+  /** Display order */
+  order?: number
+
+  // Value resolution
+  /** How to get the value */
+  valueSource: StatValueSource
+  /** Value format */
+  format?: StatValueFormat
+  /** Sublabel field */
+  sublabelField?: string
+
+  // Interaction
+  /** Click action */
+  onClick?: StatBlockAction
+  /** Tooltip text */
+  tooltip?: string
+}
+
+export type StatValueSource =
+  | StatValueSourceField
+  | StatValueSourceComputed
+  | StatValueSourceHook
+  | StatValueSourceAggregate
+
+export interface StatValueSourceField {
+  type: 'field'
+  /** Dot-notation path to value (e.g., 'summary.healthyCount') */
+  path: string
+}
+
+export interface StatValueSourceComputed {
+  type: 'computed'
+  /** Expression (e.g., 'filter:healthy|count', 'sum:pods') */
+  expression: string
+}
+
+export interface StatValueSourceHook {
+  type: 'hook'
+  /** Hook name */
+  hookName: string
+  /** Field from hook result */
+  field: string
+}
+
+export interface StatValueSourceAggregate {
+  type: 'aggregate'
+  /** Aggregation type */
+  aggregation: 'sum' | 'count' | 'avg' | 'min' | 'max'
+  /** Field to aggregate */
+  field: string
+  /** Filter before aggregating */
+  filter?: string
+}
+
+export type StatValueFormat = 'number' | 'percentage' | 'bytes' | 'currency' | 'duration'
+
+export interface StatBlockAction {
+  /** Action type */
+  type: 'drill' | 'filter' | 'navigate' | 'callback'
+  /** Target (action name, filter field, or route) */
+  target: string
+  /** Parameters */
+  params?: Record<string, string>
+}
+
+// ============================================================================
+// UnifiedStatsSection Types
+// ============================================================================
+
+/**
+ * Complete stats section configuration
+ */
+export interface UnifiedStatsSectionConfig {
+  /** Section type identifier */
+  type: string
+  /** Section title */
+  title?: string
+  /** Stat blocks */
+  blocks: UnifiedStatBlockConfig[]
+  /** Default collapsed state */
+  defaultCollapsed?: boolean
+  /** Collapsible */
+  collapsible?: boolean
+  /** Storage key for collapsed state */
+  storageKey?: string
+  /** Show configure button */
+  showConfigButton?: boolean
+  /** Grid configuration */
+  grid?: {
+    columns?: number
+    responsive?: {
+      sm?: number
+      md?: number
+      lg?: number
+    }
+  }
+}
+
+// ============================================================================
+// UnifiedDashboard Types
+// ============================================================================
+
+/**
+ * Complete dashboard configuration
+ */
+export interface UnifiedDashboardConfig {
+  /** Unique dashboard ID */
+  id: string
+  /** Display name */
+  name: string
+  /** Subtitle/description */
+  subtitle?: string
+  /** Route path */
+  route?: string
+
+  // Stats configuration
+  /** Stats section type */
+  statsType?: string
+  /** Custom stats config */
+  stats?: UnifiedStatsSectionConfig
+  /** Custom value resolver function name */
+  statsValueResolver?: string
+
+  // Cards configuration
+  /** Default cards for this dashboard */
+  cards: DashboardCardPlacement[]
+  /** Available card types for add menu */
+  availableCardTypes?: string[]
+
+  // Features
+  features?: DashboardFeatures
+
+  // Persistence
+  /** Storage key for card positions */
+  storageKey?: string
+}
+
+export interface DashboardCardPlacement {
+  /** Unique placement ID */
+  id: string
+  /** Card type (references UnifiedCardConfig.type) */
+  cardType: string
+  /** Instance-specific config overrides */
+  config?: Record<string, unknown>
+  /** Title override */
+  title?: string
+  /** Grid position */
+  position: {
+    /** Width in grid columns (3-12) */
+    w: number
+    /** Height in grid rows */
+    h: number
+    /** X position (optional, for absolute positioning) */
+    x?: number
+    /** Y position (optional, for absolute positioning) */
+    y?: number
+  }
+}
+
+export interface DashboardFeatures {
+  /** Enable drag-and-drop */
+  dragDrop?: boolean
+  /** Enable auto-refresh */
+  autoRefresh?: boolean
+  /** Auto-refresh interval in ms */
+  autoRefreshInterval?: number
+  /** Show add card button */
+  addCard?: boolean
+  /** Show templates button */
+  templates?: boolean
+  /** Show recommendations */
+  recommendations?: boolean
+  /** Show AI mission suggestions */
+  missionSuggestions?: boolean
+  /** Show floating action buttons */
+  floatingActions?: boolean
+  /** Enable card sections */
+  cardSections?: boolean
+}
+
+// ============================================================================
+// Registry Types
+// ============================================================================
+
+/**
+ * Card configuration registry
+ */
+export type CardConfigRegistry = Record<string, UnifiedCardConfig>
+
+/**
+ * Stats configuration registry
+ */
+export type StatsConfigRegistry = Record<string, UnifiedStatsSectionConfig>
+
+/**
+ * Dashboard configuration registry
+ */
+export type DashboardConfigRegistry = Record<string, UnifiedDashboardConfig>
+
+/**
+ * Renderer function type
+ */
+export type RendererFunction<T = unknown> = (
+  value: T,
+  item: Record<string, unknown>,
+  column: CardColumnConfig
+) => React.ReactNode
+
+/**
+ * Renderer registry
+ */
+export type RendererRegistry = Record<string, RendererFunction>
+
+/**
+ * Data hook type
+ */
+export type DataHookFunction = (
+  params?: Record<string, unknown>
+) => {
+  data: unknown[] | undefined
+  isLoading: boolean
+  error: Error | null
+  refetch?: () => void
+}
+
+/**
+ * Data hook registry
+ */
+export type DataHookRegistry = Record<string, DataHookFunction>
+
+// ============================================================================
+// Component Props Types
+// ============================================================================
+
+/**
+ * Props for UnifiedCard component
+ */
+export interface UnifiedCardProps {
+  /** Card configuration */
+  config: UnifiedCardConfig
+  /** Instance-specific config overrides */
+  instanceConfig?: Record<string, unknown>
+  /** Title override */
+  title?: string
+  /** Additional className */
+  className?: string
+}
+
+/**
+ * Props for UnifiedStatBlock component
+ */
+export interface UnifiedStatBlockProps {
+  /** Stat block configuration */
+  config: UnifiedStatBlockConfig
+  /** Data object to resolve values from */
+  data?: unknown
+  /** Override value getter */
+  getValue?: () => StatBlockValue
+  /** Loading state */
+  isLoading?: boolean
+}
+
+/**
+ * Props for UnifiedStatsSection component
+ */
+export interface UnifiedStatsSectionProps {
+  /** Stats section configuration */
+  config: UnifiedStatsSectionConfig
+  /** Data to resolve values from */
+  data?: unknown
+  /** Custom value getter by block ID */
+  getStatValue?: (blockId: string) => StatBlockValue
+  /** Whether data is loaded */
+  hasData?: boolean
+  /** Loading state */
+  isLoading?: boolean
+  /** Last updated timestamp */
+  lastUpdated?: Date | null
+  /** Additional className */
+  className?: string
+}
+
+/**
+ * Props for UnifiedDashboard component
+ */
+export interface UnifiedDashboardProps {
+  /** Dashboard configuration */
+  config: UnifiedDashboardConfig
+  /** Stats data */
+  statsData?: unknown
+  /** Additional className */
+  className?: string
+}
+
+// Import CardCategory for the type alias
+import type { CardCategory } from '../cards/types'
+import type { StatBlockColor, StatBlockValue } from '../stats/types'


### PR DESCRIPTION
## Summary
- Introduces the unified component system to consolidate 120+ individual card implementations
- Adds `UnifiedCardConfig` type with discriminated unions for content types (list, table, chart, status-grid, custom)
- Adds `UnifiedStatBlockConfig` type with value source resolution patterns
- Adds `UnifiedDashboardConfig` type for dashboard layouts
- Creates `UnifiedCard` component shell with placeholder visualizations
- Implements `useDataSource` hook supporting hook/api/static/context data sources
- Implements `useCardFiltering` hook for filter control generation
- Adds data hook registry for registering existing hooks

This is PR 1 of the unified component architecture plan. Subsequent PRs will add:
- PR 2: List & table visualizations
- PR 3: First 5 card migrations
- PR 4: Chart visualizations
- PR 5: UnifiedStatBlock
- PR 6: UnifiedDashboard

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (no errors in unified module)
- [ ] Manual verification of component rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)