### PR TITLE
✨ Add List & Table visualizations with renderer registry

### DIFF
--- a/web/src/lib/unified/card/UnifiedCard.tsx
+++ b/web/src/lib/unified/card/UnifiedCard.tsx
@@ -19,12 +19,10 @@ import type {
 } from '../types'
 import { useDataSource } from './hooks/useDataSource'
 import { useCardFiltering } from './hooks/useCardFiltering'
-
-// Visualization components (to be implemented in PR 2)
-// import { ListVisualization } from './visualizations/ListVisualization'
-// import { TableVisualization } from './visualizations/TableVisualization'
+import { ListVisualization } from './visualizations/ListVisualization'
+import { TableVisualization } from './visualizations/TableVisualization'
+// Chart visualization will be added in PR 4
 // import { ChartVisualization } from './visualizations/ChartVisualization'
-// import { StatusGridVisualization } from './visualizations/StatusGridVisualization'
 
 /**
  * UnifiedCard - Renders any card type from config
@@ -107,26 +105,24 @@ export function UnifiedCard({
 function renderContent(
   content: CardContent,
   data: unknown[],
-  _config: UnifiedCardConfig
+  config: UnifiedCardConfig
 ): ReactNode {
   switch (content.type) {
     case 'list':
-      // TODO: Implement in PR 2
       return (
-        <PlaceholderVisualization
-          type="list"
-          itemCount={data.length}
-          columns={content.columns.length}
+        <ListVisualization
+          content={content}
+          data={data}
+          drillDown={config.drillDown}
         />
       )
 
     case 'table':
-      // TODO: Implement in PR 2
       return (
-        <PlaceholderVisualization
-          type="table"
-          itemCount={data.length}
-          columns={content.columns.length}
+        <TableVisualization
+          content={content}
+          data={data}
+          drillDown={config.drillDown}
         />
       )
 
@@ -140,7 +136,7 @@ function renderContent(
       )
 
     case 'status-grid':
-      // TODO: Implement in PR 2
+      // TODO: Implement in PR 4
       return (
         <PlaceholderVisualization
           type="status-grid"

--- a/web/src/lib/unified/card/index.ts
+++ b/web/src/lib/unified/card/index.ts
@@ -15,3 +15,13 @@ export {
 } from './hooks'
 
 export type { UseDataSourceResult, UseCardFilteringResult } from './hooks'
+
+export {
+  registerRenderer,
+  getRenderer,
+  getRegisteredRenderers,
+  renderCell,
+} from './renderers'
+
+export { ListVisualization, TableVisualization } from './visualizations'
+export type { ListVisualizationProps, TableVisualizationProps } from './visualizations'

--- a/web/src/lib/unified/card/renderers/index.ts
+++ b/web/src/lib/unified/card/renderers/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Unified Card Renderers
+ */
+
+export {
+  registerRenderer,
+  getRenderer,
+  getRegisteredRenderers,
+  renderCell,
+} from './registry'
+
+export type { RendererFunction } from '../../types'

--- a/web/src/lib/unified/card/renderers/registry.ts
+++ b/web/src/lib/unified/card/renderers/registry.ts
@@ -1,0 +1,553 @@
+/**
+ * Renderer Registry - Centralized cell rendering for unified cards
+ *
+ * Provides built-in renderers for common data types and allows
+ * registering custom renderers for specialized display.
+ */
+
+import { ReactNode, createElement } from 'react'
+import type { CardColumnConfig, RendererFunction } from '../../types'
+import { getStatusColors } from '../../../cards/statusColors'
+import {
+  formatStatNumber,
+  formatBytes,
+  formatPercent,
+  formatDuration,
+} from '../../../stats/types'
+
+// ============================================================================
+// Renderer Registry
+// ============================================================================
+
+const rendererRegistry: Record<string, RendererFunction> = {}
+
+/**
+ * Register a custom renderer
+ *
+ * @example
+ * registerRenderer('custom-badge', (value, item) => (
+ *   <CustomBadge value={value} item={item} />
+ * ))
+ */
+export function registerRenderer(name: string, renderer: RendererFunction): void {
+  rendererRegistry[name] = renderer
+}
+
+/**
+ * Get a renderer by name
+ */
+export function getRenderer(name: string): RendererFunction | undefined {
+  // Check custom registry first
+  if (rendererRegistry[name]) {
+    return rendererRegistry[name]
+  }
+  // Fall back to built-in renderers
+  return BUILT_IN_RENDERERS[name]
+}
+
+/**
+ * List all registered renderers
+ */
+export function getRegisteredRenderers(): string[] {
+  return [...Object.keys(BUILT_IN_RENDERERS), ...Object.keys(rendererRegistry)]
+}
+
+/**
+ * Render a cell value using the appropriate renderer
+ */
+export function renderCell(
+  value: unknown,
+  item: Record<string, unknown>,
+  column: CardColumnConfig
+): ReactNode {
+  // Get renderer name from column config, default to 'text'
+  const rendererName = column.render ?? 'text'
+
+  // Get the renderer function
+  const renderer = getRenderer(rendererName)
+  if (!renderer) {
+    // Fallback to text if renderer not found
+    console.warn(`Renderer not found: ${rendererName}, falling back to text`)
+    return renderText(value, item, column)
+  }
+
+  return renderer(value, item, column)
+}
+
+// ============================================================================
+// Built-in Renderers
+// ============================================================================
+
+/**
+ * Text renderer - displays value as-is with optional prefix/suffix
+ */
+function renderText(
+  value: unknown,
+  _item: Record<string, unknown>,
+  column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const text = String(value)
+  const prefix = column.prefix ?? ''
+  const suffix = column.suffix ?? ''
+
+  return `${prefix}${text}${suffix}`
+}
+
+/**
+ * Number renderer - formats with K/M suffix
+ */
+function renderNumber(
+  value: unknown,
+  _item: Record<string, unknown>,
+  column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const num = typeof value === 'number' ? value : parseFloat(String(value))
+  if (isNaN(num)) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const prefix = column.prefix ?? ''
+  const suffix = column.suffix ?? ''
+
+  return createElement(
+    'span',
+    { className: 'font-mono tabular-nums' },
+    `${prefix}${formatStatNumber(num)}${suffix}`
+  )
+}
+
+/**
+ * Percentage renderer - formats as X%
+ */
+function renderPercentage(
+  value: unknown,
+  _item: Record<string, unknown>,
+  column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const num = typeof value === 'number' ? value : parseFloat(String(value))
+  if (isNaN(num)) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const prefix = column.prefix ?? ''
+  const suffix = column.suffix ?? ''
+
+  return createElement(
+    'span',
+    { className: 'font-mono tabular-nums' },
+    `${prefix}${formatPercent(num)}${suffix}`
+  )
+}
+
+/**
+ * Bytes renderer - formats as KB/MB/GB/TB
+ */
+function renderBytes(
+  value: unknown,
+  _item: Record<string, unknown>,
+  column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const num = typeof value === 'number' ? value : parseFloat(String(value))
+  if (isNaN(num)) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const prefix = column.prefix ?? ''
+  const suffix = column.suffix ?? ''
+
+  return createElement(
+    'span',
+    { className: 'font-mono tabular-nums' },
+    `${prefix}${formatBytes(num)}${suffix}`
+  )
+}
+
+/**
+ * Duration renderer - formats seconds as Xd Xh Xm Xs
+ */
+function renderDuration(
+  value: unknown,
+  _item: Record<string, unknown>,
+  column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const num = typeof value === 'number' ? value : parseFloat(String(value))
+  if (isNaN(num)) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const prefix = column.prefix ?? ''
+  const suffix = column.suffix ?? ''
+
+  return createElement(
+    'span',
+    { className: 'font-mono tabular-nums' },
+    `${prefix}${formatDuration(num)}${suffix}`
+  )
+}
+
+/**
+ * Date renderer - formats as date string
+ */
+function renderDate(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  try {
+    const date = value instanceof Date ? value : new Date(String(value))
+    return createElement(
+      'span',
+      { className: 'text-gray-300' },
+      date.toLocaleDateString()
+    )
+  } catch {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+}
+
+/**
+ * DateTime renderer - formats as date + time string
+ */
+function renderDateTime(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  try {
+    const date = value instanceof Date ? value : new Date(String(value))
+    return createElement(
+      'span',
+      { className: 'text-gray-300' },
+      date.toLocaleString()
+    )
+  } catch {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+}
+
+/**
+ * Relative time renderer - formats as "X minutes ago"
+ */
+function renderRelativeTime(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  try {
+    const date = value instanceof Date ? value : new Date(String(value))
+    const now = Date.now()
+    const diff = now - date.getTime()
+
+    // Format relative time
+    const seconds = Math.floor(diff / 1000)
+    if (seconds < 60) return 'just now'
+
+    const minutes = Math.floor(seconds / 60)
+    if (minutes < 60) return `${minutes}m ago`
+
+    const hours = Math.floor(minutes / 60)
+    if (hours < 24) return `${hours}h ago`
+
+    const days = Math.floor(hours / 24)
+    if (days < 30) return `${days}d ago`
+
+    const months = Math.floor(days / 30)
+    if (months < 12) return `${months}mo ago`
+
+    const years = Math.floor(days / 365)
+    return `${years}y ago`
+  } catch {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+}
+
+/**
+ * Status badge renderer - displays status with color coding
+ */
+function renderStatusBadge(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const status = String(value)
+  const colors = getStatusColors(status)
+
+  return createElement(
+    'span',
+    {
+      className: `inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${colors.bg} ${colors.text}`,
+    },
+    status
+  )
+}
+
+/**
+ * Cluster badge renderer - displays cluster name with icon
+ */
+function renderClusterBadge(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const cluster = String(value)
+
+  return createElement(
+    'span',
+    {
+      className: 'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-purple-500/20 text-purple-400',
+    },
+    cluster
+  )
+}
+
+/**
+ * Namespace badge renderer - displays namespace name
+ */
+function renderNamespaceBadge(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const namespace = String(value)
+
+  return createElement(
+    'span',
+    {
+      className: 'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-500/20 text-blue-400',
+    },
+    namespace
+  )
+}
+
+/**
+ * Progress bar renderer - displays value as a progress bar
+ */
+function renderProgressBar(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const num = typeof value === 'number' ? value : parseFloat(String(value))
+  if (isNaN(num)) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  // Clamp to 0-100
+  const percent = Math.min(100, Math.max(0, num))
+
+  // Determine color based on value
+  const severity = percent >= 90 ? 'error' : percent >= 70 ? 'warning' : 'success'
+  const colors = getStatusColors(
+    severity === 'error' ? 'failed' : severity === 'warning' ? 'pending' : 'running'
+  )
+
+  return createElement(
+    'div',
+    { className: 'flex items-center gap-2 w-full' },
+    createElement(
+      'div',
+      { className: 'flex-1 h-1.5 bg-gray-700 rounded-full overflow-hidden' },
+      createElement('div', {
+        className: `h-full ${colors.barColor} transition-all duration-300`,
+        style: { width: `${percent}%` },
+      })
+    ),
+    createElement(
+      'span',
+      { className: 'text-xs font-mono tabular-nums text-gray-400 w-10 text-right' },
+      `${Math.round(percent)}%`
+    )
+  )
+}
+
+/**
+ * Boolean renderer - displays checkmark or X
+ */
+function renderBoolean(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  const bool = Boolean(value)
+
+  return createElement(
+    'span',
+    {
+      className: bool ? 'text-green-400' : 'text-gray-500',
+    },
+    bool ? '✓' : '✗'
+  )
+}
+
+/**
+ * Icon renderer - displays an icon based on value
+ */
+function renderIcon(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  // For now, just render the value - icon lookup can be added later
+  return createElement(
+    'span',
+    { className: 'text-gray-400' },
+    String(value)
+  )
+}
+
+/**
+ * JSON renderer - displays JSON as formatted code
+ */
+function renderJson(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, 'null')
+  }
+
+  try {
+    const json = typeof value === 'string' ? value : JSON.stringify(value, null, 2)
+    return createElement(
+      'pre',
+      { className: 'text-xs text-gray-300 font-mono overflow-x-auto max-w-xs' },
+      json
+    )
+  } catch {
+    return createElement('span', { className: 'text-gray-500' }, '[Object]')
+  }
+}
+
+/**
+ * Truncate renderer - truncates long text with ellipsis
+ */
+function renderTruncate(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const text = String(value)
+
+  return createElement(
+    'span',
+    {
+      className: 'truncate max-w-[200px] block',
+      title: text,
+    },
+    text
+  )
+}
+
+/**
+ * Link renderer - displays as a clickable link
+ */
+function renderLink(
+  value: unknown,
+  _item: Record<string, unknown>,
+  _column: CardColumnConfig
+): ReactNode {
+  if (value === null || value === undefined) {
+    return createElement('span', { className: 'text-gray-500' }, '—')
+  }
+
+  const url = String(value)
+
+  return createElement(
+    'a',
+    {
+      href: url,
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      className: 'text-blue-400 hover:text-blue-300 hover:underline truncate max-w-[200px] block',
+    },
+    url
+  )
+}
+
+// ============================================================================
+// Built-in Renderer Map
+// ============================================================================
+
+const BUILT_IN_RENDERERS: Record<string, RendererFunction> = {
+  text: renderText,
+  number: renderNumber,
+  percentage: renderPercentage,
+  bytes: renderBytes,
+  duration: renderDuration,
+  date: renderDate,
+  datetime: renderDateTime,
+  'relative-time': renderRelativeTime,
+  'status-badge': renderStatusBadge,
+  'cluster-badge': renderClusterBadge,
+  'namespace-badge': renderNamespaceBadge,
+  'progress-bar': renderProgressBar,
+  boolean: renderBoolean,
+  icon: renderIcon,
+  json: renderJson,
+  truncate: renderTruncate,
+  link: renderLink,
+}
+
+export default {
+  registerRenderer,
+  getRenderer,
+  getRegisteredRenderers,
+  renderCell,
+}

--- a/web/src/lib/unified/card/visualizations/ListVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/ListVisualization.tsx
@@ -1,0 +1,195 @@
+/**
+ * ListVisualization - Renders data as a scrollable list
+ *
+ * Used for card content type 'list'. Displays data items in rows
+ * with configurable columns and cell renderers.
+ */
+
+import { useMemo, useState, useCallback } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+import type { CardContentList, CardColumnConfig, CardDrillDownConfig } from '../../types'
+import { renderCell } from '../renderers'
+
+export interface ListVisualizationProps {
+  /** Content configuration */
+  content: CardContentList
+  /** Data to display */
+  data: unknown[]
+  /** Drill-down configuration */
+  drillDown?: CardDrillDownConfig
+  /** Drill-down handler */
+  onDrillDown?: (item: Record<string, unknown>) => void
+}
+
+/**
+ * ListVisualization - Renders data as a list
+ */
+export function ListVisualization({
+  content,
+  data,
+  drillDown,
+  onDrillDown,
+}: ListVisualizationProps) {
+  const { columns, pageSize = 10, itemClick = 'none', showRowNumbers = false } = content
+
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(0)
+
+  // Calculate pagination
+  const totalPages = Math.ceil(data.length / pageSize)
+  const paginatedData = useMemo(() => {
+    if (!pageSize || pageSize <= 0) return data
+    const start = currentPage * pageSize
+    return data.slice(start, start + pageSize)
+  }, [data, currentPage, pageSize])
+
+  // Handle item click
+  const handleItemClick = useCallback(
+    (item: Record<string, unknown>) => {
+      if (itemClick === 'none') return
+      if (itemClick === 'drill' && onDrillDown) {
+        onDrillDown(item)
+      }
+      // 'expand' and 'select' can be implemented later
+    },
+    [itemClick, onDrillDown]
+  )
+
+  // Get visible columns (filter out hidden)
+  const visibleColumns = useMemo(
+    () => columns.filter((col) => !col.hidden),
+    [columns]
+  )
+
+  // Find primary column for styling
+  const primaryColumn = useMemo(
+    () => columns.find((col) => col.primary),
+    [columns]
+  )
+
+  const isClickable = itemClick !== 'none' && !!(drillDown || onDrillDown)
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* List content */}
+      <div className="flex-1 overflow-y-auto">
+        {paginatedData.length === 0 ? (
+          <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+            No items to display
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-800">
+            {paginatedData.map((item, index) => (
+              <ListItem
+                key={index}
+                item={item as Record<string, unknown>}
+                columns={visibleColumns}
+                primaryColumn={primaryColumn}
+                rowNumber={showRowNumbers ? currentPage * pageSize + index + 1 : undefined}
+                isClickable={isClickable}
+                onClick={() => handleItemClick(item as Record<string, unknown>)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Pagination footer */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between px-3 py-2 border-t border-gray-800 text-xs text-gray-400">
+          <span>
+            {currentPage * pageSize + 1}–{Math.min((currentPage + 1) * pageSize, data.length)} of {data.length}
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setCurrentPage((p) => Math.max(0, p - 1))}
+              disabled={currentPage === 0}
+              className="p-1 rounded hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <span className="px-2">
+              {currentPage + 1} / {totalPages}
+            </span>
+            <button
+              onClick={() => setCurrentPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={currentPage >= totalPages - 1}
+              className="p-1 rounded hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Individual list item row
+ */
+function ListItem({
+  item,
+  columns,
+  primaryColumn,
+  rowNumber,
+  isClickable,
+  onClick,
+}: {
+  item: Record<string, unknown>
+  columns: CardColumnConfig[]
+  primaryColumn?: CardColumnConfig
+  rowNumber?: number
+  isClickable: boolean
+  onClick: () => void
+}) {
+  return (
+    <div
+      className={`flex items-center gap-3 px-3 py-2 ${
+        isClickable
+          ? 'cursor-pointer hover:bg-gray-800/50 transition-colors'
+          : ''
+      }`}
+      onClick={isClickable ? onClick : undefined}
+    >
+      {/* Row number */}
+      {rowNumber !== undefined && (
+        <span className="text-xs text-gray-600 w-6 text-right shrink-0">
+          {rowNumber}
+        </span>
+      )}
+
+      {/* Columns */}
+      {columns.map((column, colIndex) => {
+        const value = item[column.field]
+        const isPrimary = column === primaryColumn
+
+        return (
+          <div
+            key={column.field}
+            className={`
+              ${column.width ? '' : 'flex-1'}
+              ${column.align === 'center' ? 'text-center' : ''}
+              ${column.align === 'right' ? 'text-right' : ''}
+              ${isPrimary ? 'font-medium text-gray-200' : 'text-gray-400'}
+              ${colIndex === 0 && !rowNumber ? 'flex-1' : ''}
+              truncate
+            `}
+            style={
+              column.width
+                ? {
+                    width: typeof column.width === 'number' ? `${column.width}px` : column.width,
+                    flexShrink: 0,
+                  }
+                : undefined
+            }
+          >
+            {renderCell(value, item, column)}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default ListVisualization

--- a/web/src/lib/unified/card/visualizations/TableVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/TableVisualization.tsx
@@ -1,0 +1,244 @@
+/**
+ * TableVisualization - Renders data as a table with headers
+ *
+ * Used for card content type 'table'. Displays data in a traditional
+ * table layout with sortable columns and pagination.
+ */
+
+import { useMemo, useState, useCallback } from 'react'
+import { ChevronLeft, ChevronRight, ChevronUp, ChevronDown } from 'lucide-react'
+import type { CardContentTable, CardDrillDownConfig } from '../../types'
+import { renderCell } from '../renderers'
+
+export interface TableVisualizationProps {
+  /** Content configuration */
+  content: CardContentTable
+  /** Data to display */
+  data: unknown[]
+  /** Drill-down configuration */
+  drillDown?: CardDrillDownConfig
+  /** Drill-down handler */
+  onDrillDown?: (item: Record<string, unknown>) => void
+}
+
+type SortDirection = 'asc' | 'desc'
+
+/**
+ * TableVisualization - Renders data as a table
+ */
+export function TableVisualization({
+  content,
+  data,
+  drillDown,
+  onDrillDown,
+}: TableVisualizationProps) {
+  const {
+    columns,
+    sortable = true,
+    defaultSort,
+    defaultDirection = 'asc',
+    pageSize = 10,
+  } = content
+
+  // Sort state
+  const [sortField, setSortField] = useState<string | undefined>(defaultSort)
+  const [sortDirection, setSortDirection] = useState<SortDirection>(defaultDirection)
+
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(0)
+
+  // Get visible columns
+  const visibleColumns = useMemo(
+    () => columns.filter((col) => !col.hidden),
+    [columns]
+  )
+
+  // Sort data
+  const sortedData = useMemo(() => {
+    if (!sortField) return data
+
+    return [...data].sort((a, b) => {
+      const aVal = (a as Record<string, unknown>)[sortField]
+      const bVal = (b as Record<string, unknown>)[sortField]
+
+      // Handle nullish values
+      if (aVal === null || aVal === undefined) return sortDirection === 'asc' ? 1 : -1
+      if (bVal === null || bVal === undefined) return sortDirection === 'asc' ? -1 : 1
+
+      // Compare values
+      let comparison = 0
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        comparison = aVal - bVal
+      } else if (typeof aVal === 'string' && typeof bVal === 'string') {
+        comparison = aVal.localeCompare(bVal)
+      } else {
+        comparison = String(aVal).localeCompare(String(bVal))
+      }
+
+      return sortDirection === 'asc' ? comparison : -comparison
+    })
+  }, [data, sortField, sortDirection])
+
+  // Paginate data
+  const totalPages = Math.ceil(sortedData.length / pageSize)
+  const paginatedData = useMemo(() => {
+    if (!pageSize || pageSize <= 0) return sortedData
+    const start = currentPage * pageSize
+    return sortedData.slice(start, start + pageSize)
+  }, [sortedData, currentPage, pageSize])
+
+  // Handle sort click
+  const handleSort = useCallback(
+    (field: string) => {
+      if (!sortable) return
+      if (sortField === field) {
+        // Toggle direction
+        setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc'))
+      } else {
+        // New field, default to ascending
+        setSortField(field)
+        setSortDirection('asc')
+      }
+      // Reset to first page on sort change
+      setCurrentPage(0)
+    },
+    [sortable, sortField]
+  )
+
+  // Handle row click
+  const handleRowClick = useCallback(
+    (item: Record<string, unknown>) => {
+      if (onDrillDown) {
+        onDrillDown(item)
+      }
+    },
+    [onDrillDown]
+  )
+
+  const isClickable = !!(drillDown || onDrillDown)
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Table */}
+      <div className="flex-1 overflow-auto">
+        <table className="w-full text-sm">
+          {/* Header */}
+          <thead className="sticky top-0 bg-gray-900/95 backdrop-blur-sm">
+            <tr className="border-b border-gray-800">
+              {visibleColumns.map((column) => (
+                <th
+                  key={column.field}
+                  className={`
+                    px-3 py-2 text-xs font-medium text-gray-400 uppercase tracking-wider
+                    ${column.align === 'center' ? 'text-center' : ''}
+                    ${column.align === 'right' ? 'text-right' : 'text-left'}
+                    ${sortable && column.sortable !== false ? 'cursor-pointer hover:text-gray-200 select-none' : ''}
+                  `}
+                  style={
+                    column.width
+                      ? {
+                          width: typeof column.width === 'number' ? `${column.width}px` : column.width,
+                        }
+                      : undefined
+                  }
+                  onClick={
+                    sortable && column.sortable !== false
+                      ? () => handleSort(column.field)
+                      : undefined
+                  }
+                >
+                  <div className="flex items-center gap-1">
+                    <span>{column.header ?? column.field}</span>
+                    {sortable && column.sortable !== false && sortField === column.field && (
+                      sortDirection === 'asc' ? (
+                        <ChevronUp className="w-3 h-3" />
+                      ) : (
+                        <ChevronDown className="w-3 h-3" />
+                      )
+                    )}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+
+          {/* Body */}
+          <tbody className="divide-y divide-gray-800">
+            {paginatedData.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={visibleColumns.length}
+                  className="px-3 py-8 text-center text-gray-500"
+                >
+                  No data to display
+                </td>
+              </tr>
+            ) : (
+              paginatedData.map((item, rowIndex) => (
+                <tr
+                  key={rowIndex}
+                  className={`
+                    ${isClickable ? 'cursor-pointer hover:bg-gray-800/50' : ''}
+                    transition-colors
+                  `}
+                  onClick={
+                    isClickable
+                      ? () => handleRowClick(item as Record<string, unknown>)
+                      : undefined
+                  }
+                >
+                  {visibleColumns.map((column) => {
+                    const value = (item as Record<string, unknown>)[column.field]
+                    return (
+                      <td
+                        key={column.field}
+                        className={`
+                          px-3 py-2
+                          ${column.align === 'center' ? 'text-center' : ''}
+                          ${column.align === 'right' ? 'text-right' : ''}
+                          ${column.primary ? 'font-medium text-gray-200' : 'text-gray-400'}
+                        `}
+                      >
+                        {renderCell(value, item as Record<string, unknown>, column)}
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination footer */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between px-3 py-2 border-t border-gray-800 text-xs text-gray-400">
+          <span>
+            {currentPage * pageSize + 1}–{Math.min((currentPage + 1) * pageSize, sortedData.length)} of {sortedData.length}
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setCurrentPage((p) => Math.max(0, p - 1))}
+              disabled={currentPage === 0}
+              className="p-1 rounded hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <span className="px-2">
+              {currentPage + 1} / {totalPages}
+            </span>
+            <button
+              onClick={() => setCurrentPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={currentPage >= totalPages - 1}
+              className="p-1 rounded hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default TableVisualization

--- a/web/src/lib/unified/card/visualizations/index.ts
+++ b/web/src/lib/unified/card/visualizations/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Unified Card Visualizations
+ */
+
+export { ListVisualization } from './ListVisualization'
+export type { ListVisualizationProps } from './ListVisualization'
+
+export { TableVisualization } from './TableVisualization'
+export type { TableVisualizationProps } from './TableVisualization'
+
+// Future exports (PR 4)
+// export { ChartVisualization } from './ChartVisualization'
+// export { StatusGridVisualization } from './StatusGridVisualization'

--- a/web/src/lib/unified/index.ts
+++ b/web/src/lib/unified/index.ts
@@ -106,6 +106,17 @@ export {
   getDataHook,
   getRegisteredDataHooks,
   useCardFiltering,
+  registerRenderer,
+  getRenderer,
+  getRegisteredRenderers,
+  renderCell,
+  ListVisualization,
+  TableVisualization,
+} from './card'
+
+export type {
+  ListVisualizationProps,
+  TableVisualizationProps,
 } from './card'
 
 // Future exports (PR 5 & 6)


### PR DESCRIPTION
## Summary
- Adds `ListVisualization` component for displaying data as scrollable lists with pagination
- Adds `TableVisualization` component for sortable data tables with column headers
- Creates renderer registry with 16 built-in renderers:
  - Basic: text, number, percentage, bytes, duration
  - Time: date, datetime, relative-time  
  - Badges: status-badge, cluster-badge, namespace-badge
  - Other: progress-bar, boolean, icon, json, truncate, link
- Updated `UnifiedCard` to use real visualizations for list/table content types
- Uses existing `statusColors` system for consistent status badge coloring

This is PR 2 of the unified component architecture plan.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (no errors in unified module)
- [ ] Visual verification of list and table rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)