### PR TITLE
✨ Add card configurations and registry integration

### DIFF
--- a/web/src/config/cards/cluster-health.ts
+++ b/web/src/config/cards/cluster-health.ts
@@ -1,0 +1,127 @@
+/**
+ * Cluster Health Card Configuration
+ *
+ * Displays cluster health status across all connected clusters.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterHealthConfig: UnifiedCardConfig = {
+  type: 'cluster_health',
+  title: 'Cluster Health',
+  category: 'cluster-health',
+  description: 'Health status of all connected Kubernetes clusters',
+
+  // Appearance
+  icon: 'Activity',
+  iconColor: 'text-green-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useClusters',
+  },
+
+  // Inline stats at top of card
+  stats: [
+    {
+      id: 'healthy',
+      icon: 'CheckCircle',
+      color: 'text-green-400',
+      bgColor: 'bg-green-500/10',
+      label: 'Healthy',
+      valueSource: { type: 'computed', expression: 'filter:healthy|count' },
+    },
+    {
+      id: 'unhealthy',
+      icon: 'XCircle',
+      color: 'text-orange-400',
+      bgColor: 'bg-orange-500/10',
+      label: 'Unhealthy',
+      valueSource: { type: 'computed', expression: 'filter:!healthy&!unreachable|count' },
+    },
+    {
+      id: 'offline',
+      icon: 'WifiOff',
+      color: 'text-yellow-400',
+      bgColor: 'bg-yellow-500/10',
+      label: 'Offline',
+      valueSource: { type: 'computed', expression: 'filter:unreachable|count' },
+    },
+  ],
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search clusters...',
+      searchFields: ['name', 'context', 'server'],
+      storageKey: 'cluster-health',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    itemClick: 'drill',
+    columns: [
+      {
+        field: 'healthy',
+        header: 'Status',
+        render: 'status-badge',
+        width: 80,
+      },
+      {
+        field: 'name',
+        header: 'Cluster',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'nodeCount',
+        header: 'Nodes',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'podCount',
+        header: 'Pods',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+    ],
+  },
+
+  // Drill-down
+  drillDown: {
+    action: 'openClusterDetail',
+    params: ['name'],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Server',
+    title: 'No clusters connected',
+    message: 'Connect a cluster to get started',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default clusterHealthConfig

--- a/web/src/config/cards/deployment-status.ts
+++ b/web/src/config/cards/deployment-status.ts
@@ -1,0 +1,128 @@
+/**
+ * Deployment Status Card Configuration
+ *
+ * Shows deployment health and replica status across clusters.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const deploymentStatusConfig: UnifiedCardConfig = {
+  type: 'deployment_status',
+  title: 'Deployment Status',
+  category: 'workloads',
+  description: 'Status of deployments showing replica counts and health',
+
+  // Appearance
+  icon: 'Layers',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedDeployments',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search deployments...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'deployment-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'deployment-status-cluster',
+    },
+  ],
+
+  // Content - Table visualization
+  content: {
+    type: 'table',
+    pageSize: 10,
+    sortable: true,
+    defaultSort: 'name',
+    defaultDirection: 'asc',
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 120,
+        sortable: true,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 120,
+        sortable: true,
+      },
+      {
+        field: 'name',
+        header: 'Deployment',
+        primary: true,
+        sortable: true,
+      },
+      {
+        field: 'readyReplicas',
+        header: 'Ready',
+        render: 'number',
+        align: 'center',
+        width: 70,
+        sortable: true,
+      },
+      {
+        field: 'replicas',
+        header: 'Total',
+        render: 'number',
+        align: 'center',
+        width: 70,
+        sortable: true,
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 100,
+        sortable: true,
+      },
+    ],
+  },
+
+  // Drill-down
+  drillDown: {
+    action: 'drillToDeployment',
+    params: ['cluster', 'namespace', 'name'],
+    context: {
+      replicas: 'replicas',
+      readyReplicas: 'readyReplicas',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Layers',
+    title: 'No deployments found',
+    message: 'No deployments in selected clusters',
+    variant: 'neutral',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'table',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default deploymentStatusConfig

--- a/web/src/config/cards/event-stream.ts
+++ b/web/src/config/cards/event-stream.ts
@@ -1,0 +1,126 @@
+/**
+ * Event Stream Card Configuration
+ *
+ * Shows recent Kubernetes events across clusters.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const eventStreamConfig: UnifiedCardConfig = {
+  type: 'event_stream',
+  title: 'Event Stream',
+  category: 'live-trends',
+  description: 'Real-time stream of Kubernetes events across clusters',
+
+  // Appearance
+  icon: 'Activity',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedEvents',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search events...',
+      searchFields: ['reason', 'message', 'involvedObject.name', 'involvedObject.kind'],
+      storageKey: 'event-stream',
+    },
+    {
+      field: 'type',
+      type: 'chips',
+      label: 'Type',
+      options: [
+        { value: 'Warning', label: 'Warning', color: 'text-yellow-400' },
+        { value: 'Normal', label: 'Normal', color: 'text-blue-400' },
+      ],
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'event-stream-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    itemClick: 'drill',
+    columns: [
+      {
+        field: 'type',
+        header: 'Type',
+        render: 'status-badge',
+        width: 80,
+      },
+      {
+        field: 'lastTimestamp',
+        header: 'Time',
+        render: 'relative-time',
+        width: 80,
+      },
+      {
+        field: 'involvedObject.kind',
+        header: 'Kind',
+        width: 80,
+      },
+      {
+        field: 'involvedObject.name',
+        header: 'Object',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'reason',
+        header: 'Reason',
+        width: 120,
+      },
+      {
+        field: 'message',
+        header: 'Message',
+        render: 'truncate',
+      },
+    ],
+  },
+
+  // Drill-down
+  drillDown: {
+    action: 'drillToEvent',
+    params: ['cluster', 'namespace', 'involvedObject.name', 'involvedObject.kind'],
+    context: {
+      reason: 'reason',
+      message: 'message',
+      type: 'type',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Activity',
+    title: 'No recent events',
+    message: 'Cluster activity will appear here',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default eventStreamConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -1,0 +1,58 @@
+/**
+ * Card Configuration Registry
+ *
+ * Central registry for all unified card configurations.
+ * Add new card configs here as they are migrated.
+ */
+
+import type { UnifiedCardConfig, CardConfigRegistry } from '../../lib/unified/types'
+
+// Import card configurations
+import { podIssuesConfig } from './pod-issues'
+import { clusterHealthConfig } from './cluster-health'
+import { deploymentStatusConfig } from './deployment-status'
+import { eventStreamConfig } from './event-stream'
+import { resourceUsageConfig } from './resource-usage'
+
+/**
+ * Registry of all unified card configurations
+ * Key is the card type, value is the configuration
+ */
+export const CARD_CONFIGS: CardConfigRegistry = {
+  // Migrated cards (PR 3)
+  pod_issues: podIssuesConfig,
+  cluster_health: clusterHealthConfig,
+  deployment_status: deploymentStatusConfig,
+  event_stream: eventStreamConfig,
+  resource_usage: resourceUsageConfig,
+}
+
+/**
+ * Get a card configuration by type
+ */
+export function getCardConfig(cardType: string): UnifiedCardConfig | undefined {
+  return CARD_CONFIGS[cardType]
+}
+
+/**
+ * Check if a card type has a unified configuration
+ */
+export function hasUnifiedConfig(cardType: string): boolean {
+  return cardType in CARD_CONFIGS
+}
+
+/**
+ * Get all registered unified card types
+ */
+export function getUnifiedCardTypes(): string[] {
+  return Object.keys(CARD_CONFIGS)
+}
+
+// Re-export individual configs for direct imports
+export {
+  podIssuesConfig,
+  clusterHealthConfig,
+  deploymentStatusConfig,
+  eventStreamConfig,
+  resourceUsageConfig,
+}

--- a/web/src/config/cards/pod-issues.ts
+++ b/web/src/config/cards/pod-issues.ts
@@ -1,0 +1,116 @@
+/**
+ * Pod Issues Card Configuration
+ *
+ * Displays pods with issues (CrashLoopBackOff, OOMKilled, etc.)
+ * using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const podIssuesConfig: UnifiedCardConfig = {
+  type: 'pod_issues',
+  title: 'Pod Issues',
+  category: 'workloads',
+  description: 'Pods with errors, crashes, or other issues requiring attention',
+
+  // Appearance
+  icon: 'AlertTriangle',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedPodIssues',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search issues...',
+      searchFields: ['name', 'namespace', 'cluster', 'status'],
+      storageKey: 'pod-issues',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'pod-issues-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 5,
+    itemClick: 'drill',
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Pod',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 120,
+      },
+      {
+        field: 'restarts',
+        header: 'Restarts',
+        render: 'number',
+        align: 'right',
+        width: 80,
+      },
+    ],
+  },
+
+  // Drill-down
+  drillDown: {
+    action: 'drillToPod',
+    params: ['cluster', 'namespace', 'name'],
+    context: {
+      status: 'status',
+      restarts: 'restarts',
+      issues: 'issues',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'CheckCircle',
+    title: 'All pods healthy',
+    message: 'No issues detected',
+    variant: 'success',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 3,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default podIssuesConfig

--- a/web/src/config/cards/resource-usage.ts
+++ b/web/src/config/cards/resource-usage.ts
@@ -1,0 +1,122 @@
+/**
+ * Resource Usage Card Configuration
+ *
+ * Shows CPU and memory usage across clusters.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const resourceUsageConfig: UnifiedCardConfig = {
+  type: 'resource_usage',
+  title: 'Resource Usage',
+  category: 'compute',
+  description: 'CPU and memory utilization across clusters',
+
+  // Appearance
+  icon: 'Cpu',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedResourceUsage',
+  },
+
+  // Inline stats
+  stats: [
+    {
+      id: 'avgCpu',
+      icon: 'Cpu',
+      color: 'text-cyan-400',
+      bgColor: 'bg-cyan-500/10',
+      label: 'Avg CPU',
+      valueSource: { type: 'computed', expression: 'avg:cpuPercent' },
+    },
+    {
+      id: 'avgMemory',
+      icon: 'MemoryStick',
+      color: 'text-purple-400',
+      bgColor: 'bg-purple-500/10',
+      label: 'Avg Memory',
+      valueSource: { type: 'computed', expression: 'avg:memoryPercent' },
+    },
+  ],
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search...',
+      searchFields: ['cluster', 'nodeName'],
+      storageKey: 'resource-usage',
+    },
+  ],
+
+  // Content - Table visualization
+  content: {
+    type: 'table',
+    pageSize: 10,
+    sortable: true,
+    defaultSort: 'cpuPercent',
+    defaultDirection: 'desc',
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 120,
+        sortable: true,
+      },
+      {
+        field: 'nodeName',
+        header: 'Node',
+        primary: true,
+        sortable: true,
+      },
+      {
+        field: 'cpuPercent',
+        header: 'CPU',
+        render: 'progress-bar',
+        width: 150,
+        sortable: true,
+      },
+      {
+        field: 'memoryPercent',
+        header: 'Memory',
+        render: 'progress-bar',
+        width: 150,
+        sortable: true,
+      },
+    ],
+  },
+
+  // Drill-down
+  drillDown: {
+    action: 'drillToNode',
+    params: ['cluster', 'nodeName'],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Cpu',
+    title: 'No resource data',
+    message: 'Resource metrics will appear here',
+    variant: 'neutral',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'table',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default resourceUsageConfig


### PR DESCRIPTION
## Summary
- Creates declarative card configurations for 5 cards:
  - `pod_issues`: Pod health issues with status badges
  - `cluster_health`: Cluster health overview with inline stats
  - `deployment_status`: Deployment status table with sorting
  - `event_stream`: Real-time event feed with type filters
  - `resource_usage`: CPU/memory usage with progress bars
- Updates `cardRegistry.ts` to support unified cards:
  - Adds `USE_UNIFIED_CARDS` feature flag (disabled by default)
  - Checks for unified configs in `getCardComponent()`
  - Includes unified cards in registration checks

## How it works
When `USE_UNIFIED_CARDS` is enabled in cardRegistry.ts, cards with unified configurations will render using the `UnifiedCard` component instead of their legacy implementations. This allows gradual migration.

## Files created
```
src/config/cards/
├── index.ts
├── pod-issues.ts
├── cluster-health.ts
├── deployment-status.ts
├── event-stream.ts
└── resource-usage.ts
```

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (no new errors)
- [ ] Toggle `USE_UNIFIED_CARDS=true` and verify cards render

🤖 Generated with [Claude Code](https://claude.com/claude-code)