### PR TITLE
✨ Add chart visualizations (PR 4)

### DIFF
--- a/web/src/config/cards/cluster-metrics.ts
+++ b/web/src/config/cards/cluster-metrics.ts
@@ -1,0 +1,94 @@
+/**
+ * Cluster Metrics Card Configuration
+ *
+ * Shows cluster performance metrics over time using line/area charts.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterMetricsConfig: UnifiedCardConfig = {
+  type: 'cluster_metrics',
+  title: 'Cluster Metrics',
+  category: 'compute',
+  description: 'CPU and memory metrics over time',
+
+  // Appearance
+  icon: 'Activity',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedClusterMetrics',
+  },
+
+  // Inline stats
+  stats: [
+    {
+      id: 'currentCpu',
+      icon: 'Cpu',
+      color: 'text-cyan-400',
+      bgColor: 'bg-cyan-500/10',
+      label: 'CPU',
+      valueSource: { type: 'computed', expression: 'latest:cpu' },
+    },
+    {
+      id: 'currentMemory',
+      icon: 'MemoryStick',
+      color: 'text-purple-400',
+      bgColor: 'bg-purple-500/10',
+      label: 'Memory',
+      valueSource: { type: 'computed', expression: 'latest:memory' },
+    },
+  ],
+
+  // Content - Line chart visualization
+  content: {
+    type: 'chart',
+    chartType: 'area',
+    height: 250,
+    showLegend: true,
+    xAxis: {
+      field: 'time',
+      label: 'Time',
+    },
+    yAxis: {
+      label: 'Usage %',
+    },
+    series: [
+      {
+        field: 'cpu',
+        label: 'CPU Usage',
+        color: '#06b6d4', // cyan
+      },
+      {
+        field: 'memory',
+        label: 'Memory Usage',
+        color: '#a855f7', // purple
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Activity',
+    title: 'No metrics data',
+    message: 'Cluster metrics will appear here once data is available',
+    variant: 'neutral',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'chart',
+    rows: 1,
+    showSearch: false,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default clusterMetricsConfig

--- a/web/src/config/cards/events-timeline.ts
+++ b/web/src/config/cards/events-timeline.ts
@@ -1,0 +1,107 @@
+/**
+ * Events Timeline Card Configuration
+ *
+ * Shows event counts over time using a bar chart.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const eventsTimelineConfig: UnifiedCardConfig = {
+  type: 'events_timeline',
+  title: 'Events Timeline',
+  category: 'alerting',
+  description: 'Event frequency over time',
+
+  // Appearance
+  icon: 'Clock',
+  iconColor: 'text-amber-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedEventsTimeline',
+  },
+
+  // Inline stats
+  stats: [
+    {
+      id: 'totalEvents',
+      icon: 'Bell',
+      color: 'text-amber-400',
+      bgColor: 'bg-amber-500/10',
+      label: 'Total',
+      valueSource: { type: 'computed', expression: 'sum:count' },
+    },
+    {
+      id: 'warningEvents',
+      icon: 'AlertTriangle',
+      color: 'text-orange-400',
+      bgColor: 'bg-orange-500/10',
+      label: 'Warnings',
+      valueSource: { type: 'computed', expression: 'sum:warnings' },
+    },
+    {
+      id: 'errorEvents',
+      icon: 'AlertCircle',
+      color: 'text-red-400',
+      bgColor: 'bg-red-500/10',
+      label: 'Errors',
+      valueSource: { type: 'computed', expression: 'sum:errors' },
+    },
+  ],
+
+  // Content - Bar chart visualization
+  content: {
+    type: 'chart',
+    chartType: 'bar',
+    height: 180,
+    showLegend: true,
+    xAxis: {
+      field: 'time',
+      label: 'Time',
+    },
+    yAxis: {
+      label: 'Events',
+    },
+    series: [
+      {
+        field: 'normal',
+        label: 'Normal',
+        color: '#22c55e', // green
+      },
+      {
+        field: 'warnings',
+        label: 'Warning',
+        color: '#f59e0b', // amber
+      },
+      {
+        field: 'errors',
+        label: 'Error',
+        color: '#ef4444', // red
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Clock',
+    title: 'No events',
+    message: 'Event history will appear here',
+    variant: 'neutral',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'chart',
+    rows: 1,
+    showSearch: false,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default eventsTimelineConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -13,6 +13,9 @@ import { clusterHealthConfig } from './cluster-health'
 import { deploymentStatusConfig } from './deployment-status'
 import { eventStreamConfig } from './event-stream'
 import { resourceUsageConfig } from './resource-usage'
+// Chart cards (PR 4)
+import { clusterMetricsConfig } from './cluster-metrics'
+import { eventsTimelineConfig } from './events-timeline'
 
 /**
  * Registry of all unified card configurations
@@ -25,6 +28,9 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   deployment_status: deploymentStatusConfig,
   event_stream: eventStreamConfig,
   resource_usage: resourceUsageConfig,
+  // Chart cards (PR 4)
+  cluster_metrics: clusterMetricsConfig,
+  events_timeline: eventsTimelineConfig,
 }
 
 /**
@@ -55,4 +61,7 @@ export {
   deploymentStatusConfig,
   eventStreamConfig,
   resourceUsageConfig,
+  // Chart cards (PR 4)
+  clusterMetricsConfig,
+  eventsTimelineConfig,
 }

--- a/web/src/lib/unified/card/UnifiedCard.tsx
+++ b/web/src/lib/unified/card/UnifiedCard.tsx
@@ -21,8 +21,7 @@ import { useDataSource } from './hooks/useDataSource'
 import { useCardFiltering } from './hooks/useCardFiltering'
 import { ListVisualization } from './visualizations/ListVisualization'
 import { TableVisualization } from './visualizations/TableVisualization'
-// Chart visualization will be added in PR 4
-// import { ChartVisualization } from './visualizations/ChartVisualization'
+import { ChartVisualization } from './visualizations/ChartVisualization'
 
 /**
  * UnifiedCard - Renders any card type from config
@@ -127,11 +126,10 @@ function renderContent(
       )
 
     case 'chart':
-      // TODO: Implement in PR 4
       return (
-        <PlaceholderVisualization
-          type={`chart (${content.chartType})`}
-          itemCount={data.length}
+        <ChartVisualization
+          content={content}
+          data={data}
         />
       )
 

--- a/web/src/lib/unified/card/visualizations/ChartVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/ChartVisualization.tsx
@@ -1,0 +1,495 @@
+/**
+ * ChartVisualization - Renders data as various chart types
+ *
+ * Supports: line, bar, donut, gauge, sparkline, area
+ * Uses Recharts library for rendering.
+ */
+
+import { useMemo } from 'react'
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  AreaChart,
+  Area,
+  PieChart,
+  Pie,
+  Cell,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts'
+import type { CardContentChart, CardChartSeries, CardAxisConfig } from '../../types'
+
+export interface ChartVisualizationProps {
+  /** Content configuration */
+  content: CardContentChart
+  /** Data to display */
+  data: unknown[]
+}
+
+// Default color palette for series
+const DEFAULT_COLORS = [
+  '#3b82f6', // blue
+  '#22c55e', // green
+  '#f59e0b', // amber
+  '#ef4444', // red
+  '#8b5cf6', // violet
+  '#06b6d4', // cyan
+  '#f97316', // orange
+  '#ec4899', // pink
+]
+
+/**
+ * ChartVisualization - Renders charts from config
+ */
+export function ChartVisualization({ content, data }: ChartVisualizationProps) {
+  const {
+    chartType,
+    series,
+    xAxis,
+    yAxis,
+    showLegend = true,
+    height = 200,
+  } = content
+
+  // Render the appropriate chart type
+  switch (chartType) {
+    case 'line':
+      return (
+        <LineChartRenderer
+          data={data}
+          series={series}
+          xAxis={xAxis}
+          yAxis={yAxis}
+          showLegend={showLegend}
+          height={height}
+        />
+      )
+
+    case 'area':
+      return (
+        <AreaChartRenderer
+          data={data}
+          series={series}
+          xAxis={xAxis}
+          yAxis={yAxis}
+          showLegend={showLegend}
+          height={height}
+        />
+      )
+
+    case 'bar':
+      return (
+        <BarChartRenderer
+          data={data}
+          series={series}
+          xAxis={xAxis}
+          yAxis={yAxis}
+          showLegend={showLegend}
+          height={height}
+        />
+      )
+
+    case 'donut':
+      return (
+        <DonutChartRenderer
+          data={data}
+          series={series}
+          showLegend={showLegend}
+          height={height}
+        />
+      )
+
+    case 'gauge':
+      return (
+        <GaugeChartRenderer
+          data={data}
+          series={series}
+          height={height}
+        />
+      )
+
+    case 'sparkline':
+      return (
+        <SparklineRenderer
+          data={data}
+          series={series}
+          height={height}
+        />
+      )
+
+    default:
+      return (
+        <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+          Unknown chart type: {chartType}
+        </div>
+      )
+  }
+}
+
+interface ChartRendererProps {
+  data: unknown[]
+  series: CardChartSeries[]
+  xAxis?: CardAxisConfig
+  yAxis?: CardAxisConfig
+  showLegend?: boolean
+  height: number
+}
+
+/**
+ * Line Chart Renderer
+ */
+function LineChartRenderer({
+  data,
+  series,
+  xAxis,
+  yAxis,
+  showLegend,
+  height,
+}: ChartRendererProps) {
+  const xField = xAxis?.field ?? 'time'
+
+  return (
+    <div style={{ width: '100%', height }}>
+      <ResponsiveContainer>
+        <LineChart data={data as Record<string, unknown>[]}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+          <XAxis
+            dataKey={xField}
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            axisLine={{ stroke: '#4b5563' }}
+            tickLine={{ stroke: '#4b5563' }}
+          />
+          <YAxis
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            axisLine={{ stroke: '#4b5563' }}
+            tickLine={{ stroke: '#4b5563' }}
+            label={
+              yAxis?.label
+                ? { value: yAxis.label, angle: -90, position: 'insideLeft', fill: '#9ca3af' }
+                : undefined
+            }
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#1f2937',
+              border: '1px solid #374151',
+              borderRadius: '0.375rem',
+            }}
+            labelStyle={{ color: '#e5e7eb' }}
+            itemStyle={{ color: '#e5e7eb' }}
+          />
+          {showLegend && (
+            <Legend
+              wrapperStyle={{ paddingTop: 10 }}
+              formatter={(value) => <span className="text-gray-300 text-xs">{value}</span>}
+            />
+          )}
+          {series.map((s, i) => (
+            <Line
+              key={s.field}
+              type="monotone"
+              dataKey={s.field}
+              name={s.label ?? s.field}
+              stroke={s.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length]}
+              strokeWidth={2}
+              strokeDasharray={s.style === 'dashed' ? '5 5' : s.style === 'dotted' ? '2 2' : undefined}
+              dot={false}
+              activeDot={{ r: 4 }}
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+/**
+ * Area Chart Renderer
+ */
+function AreaChartRenderer({
+  data,
+  series,
+  xAxis,
+  yAxis,
+  showLegend,
+  height,
+}: ChartRendererProps) {
+  const xField = xAxis?.field ?? 'time'
+
+  return (
+    <div style={{ width: '100%', height }}>
+      <ResponsiveContainer>
+        <AreaChart data={data as Record<string, unknown>[]}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+          <XAxis
+            dataKey={xField}
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            axisLine={{ stroke: '#4b5563' }}
+            tickLine={{ stroke: '#4b5563' }}
+          />
+          <YAxis
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            axisLine={{ stroke: '#4b5563' }}
+            tickLine={{ stroke: '#4b5563' }}
+            label={
+              yAxis?.label
+                ? { value: yAxis.label, angle: -90, position: 'insideLeft', fill: '#9ca3af' }
+                : undefined
+            }
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#1f2937',
+              border: '1px solid #374151',
+              borderRadius: '0.375rem',
+            }}
+            labelStyle={{ color: '#e5e7eb' }}
+            itemStyle={{ color: '#e5e7eb' }}
+          />
+          {showLegend && (
+            <Legend
+              wrapperStyle={{ paddingTop: 10 }}
+              formatter={(value) => <span className="text-gray-300 text-xs">{value}</span>}
+            />
+          )}
+          {series.map((s, i) => {
+            const color = s.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length]
+            return (
+              <Area
+                key={s.field}
+                type="monotone"
+                dataKey={s.field}
+                name={s.label ?? s.field}
+                stroke={color}
+                fill={color}
+                fillOpacity={0.3}
+                strokeWidth={2}
+              />
+            )
+          })}
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+/**
+ * Bar Chart Renderer
+ */
+function BarChartRenderer({
+  data,
+  series,
+  xAxis,
+  yAxis,
+  showLegend,
+  height,
+}: ChartRendererProps) {
+  const xField = xAxis?.field ?? 'name'
+
+  return (
+    <div style={{ width: '100%', height }}>
+      <ResponsiveContainer>
+        <BarChart data={data as Record<string, unknown>[]}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+          <XAxis
+            dataKey={xField}
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            axisLine={{ stroke: '#4b5563' }}
+            tickLine={{ stroke: '#4b5563' }}
+          />
+          <YAxis
+            tick={{ fill: '#9ca3af', fontSize: 11 }}
+            axisLine={{ stroke: '#4b5563' }}
+            tickLine={{ stroke: '#4b5563' }}
+            label={
+              yAxis?.label
+                ? { value: yAxis.label, angle: -90, position: 'insideLeft', fill: '#9ca3af' }
+                : undefined
+            }
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#1f2937',
+              border: '1px solid #374151',
+              borderRadius: '0.375rem',
+            }}
+            labelStyle={{ color: '#e5e7eb' }}
+            itemStyle={{ color: '#e5e7eb' }}
+          />
+          {showLegend && (
+            <Legend
+              wrapperStyle={{ paddingTop: 10 }}
+              formatter={(value) => <span className="text-gray-300 text-xs">{value}</span>}
+            />
+          )}
+          {series.map((s, i) => (
+            <Bar
+              key={s.field}
+              dataKey={s.field}
+              name={s.label ?? s.field}
+              fill={s.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length]}
+              radius={[4, 4, 0, 0]}
+            />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+/**
+ * Donut Chart Renderer
+ */
+function DonutChartRenderer({
+  data,
+  series,
+  showLegend,
+  height,
+}: Omit<ChartRendererProps, 'xAxis' | 'yAxis'>) {
+  // For donut charts, we expect data to be an array of { name, value } objects
+  // or we extract from the first series field
+  const chartData = useMemo(() => {
+    if (series.length === 0) return data
+
+    // If data has the series fields, transform to pie format
+    const primarySeries = series.find((s) => s.primary) ?? series[0]
+    if (!primarySeries) return data
+
+    return (data as Record<string, unknown>[]).map((item, i) => ({
+      name: String(item.name ?? item.label ?? `Item ${i + 1}`),
+      value: Number(item[primarySeries.field] ?? 0),
+      color: series[i]?.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length],
+    }))
+  }, [data, series])
+
+  return (
+    <div style={{ width: '100%', height }}>
+      <ResponsiveContainer>
+        <PieChart>
+          <Pie
+            data={chartData as Array<{ name: string; value: number; color?: string }>}
+            cx="50%"
+            cy="50%"
+            innerRadius="60%"
+            outerRadius="80%"
+            paddingAngle={2}
+            dataKey="value"
+            nameKey="name"
+          >
+            {(chartData as Array<{ color?: string }>).map((entry, i) => (
+              <Cell
+                key={`cell-${i}`}
+                fill={entry.color ?? DEFAULT_COLORS[i % DEFAULT_COLORS.length]}
+              />
+            ))}
+          </Pie>
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#1f2937',
+              border: '1px solid #374151',
+              borderRadius: '0.375rem',
+            }}
+            labelStyle={{ color: '#e5e7eb' }}
+            itemStyle={{ color: '#e5e7eb' }}
+          />
+          {showLegend && (
+            <Legend
+              formatter={(value) => <span className="text-gray-300 text-xs">{value}</span>}
+            />
+          )}
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+/**
+ * Gauge Chart Renderer (simplified as a half-donut)
+ */
+function GaugeChartRenderer({
+  data,
+  series,
+  height,
+}: Omit<ChartRendererProps, 'xAxis' | 'yAxis' | 'showLegend'>) {
+  // Extract value from first data item and first series
+  const value = useMemo(() => {
+    if (data.length === 0 || series.length === 0) return 0
+    const firstItem = data[0] as Record<string, unknown>
+    return Number(firstItem[series[0].field] ?? 0)
+  }, [data, series])
+
+  // Create gauge data (value vs remaining to 100)
+  const gaugeData = [
+    { name: 'value', value: Math.min(100, Math.max(0, value)) },
+    { name: 'remaining', value: Math.max(0, 100 - value) },
+  ]
+
+  // Color based on value
+  const color = value >= 90 ? '#ef4444' : value >= 70 ? '#f59e0b' : '#22c55e'
+
+  return (
+    <div style={{ width: '100%', height }} className="relative">
+      <ResponsiveContainer>
+        <PieChart>
+          <Pie
+            data={gaugeData}
+            cx="50%"
+            cy="70%"
+            startAngle={180}
+            endAngle={0}
+            innerRadius="60%"
+            outerRadius="80%"
+            dataKey="value"
+            stroke="none"
+          >
+            <Cell fill={color} />
+            <Cell fill="#374151" />
+          </Pie>
+        </PieChart>
+      </ResponsiveContainer>
+      {/* Center label */}
+      <div className="absolute inset-0 flex items-center justify-center pt-4">
+        <span className="text-2xl font-bold text-gray-200">{Math.round(value)}%</span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Sparkline Renderer (minimal line chart)
+ */
+function SparklineRenderer({
+  data,
+  series,
+  height,
+}: Omit<ChartRendererProps, 'xAxis' | 'yAxis' | 'showLegend'>) {
+  if (series.length === 0) {
+    return <div className="text-gray-500 text-sm">No series configured</div>
+  }
+
+  const primarySeries = series[0]
+
+  return (
+    <div style={{ width: '100%', height }}>
+      <ResponsiveContainer>
+        <LineChart data={data as Record<string, unknown>[]}>
+          <Line
+            type="monotone"
+            dataKey={primarySeries.field}
+            stroke={primarySeries.color ?? DEFAULT_COLORS[0]}
+            strokeWidth={2}
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+export default ChartVisualization

--- a/web/src/lib/unified/card/visualizations/index.ts
+++ b/web/src/lib/unified/card/visualizations/index.ts
@@ -8,6 +8,8 @@ export type { ListVisualizationProps } from './ListVisualization'
 export { TableVisualization } from './TableVisualization'
 export type { TableVisualizationProps } from './TableVisualization'
 
-// Future exports (PR 4)
-// export { ChartVisualization } from './ChartVisualization'
+export { ChartVisualization } from './ChartVisualization'
+export type { ChartVisualizationProps } from './ChartVisualization'
+
+// Future exports
 // export { StatusGridVisualization } from './StatusGridVisualization'


### PR DESCRIPTION
## Summary
- Add `ChartVisualization` component supporting line, area, bar, donut, gauge, and sparkline chart types
- Uses Recharts library with consistent dark theme styling
- Add `cluster_metrics` card config for CPU/memory trends
- Add `events_timeline` card config for event frequency histogram
- Update UnifiedCard to route chart content types to ChartVisualization

## Chart Types Supported
| Type | Use Case |
|------|----------|
| line | Time series data |
| area | Cumulative metrics with fill |
| bar | Categorical comparisons |
| donut | Proportional data |
| gauge | Single percentage values |
| sparkline | Compact inline trends |

## Files Changed
- `src/lib/unified/card/visualizations/ChartVisualization.tsx` - New chart renderer
- `src/lib/unified/card/visualizations/index.ts` - Export chart visualization
- `src/lib/unified/card/UnifiedCard.tsx` - Route chart content type
- `src/config/cards/cluster-metrics.ts` - Area chart config
- `src/config/cards/events-timeline.ts` - Bar chart config
- `src/config/cards/index.ts` - Register new configs

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] Chart configs export correctly from card registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)