### PR TITLE
✨ Add unified configs for cards and dashboards (PR 7)

### DIFF
--- a/web/src/config/cards/active-alerts.ts
+++ b/web/src/config/cards/active-alerts.ts
@@ -1,0 +1,78 @@
+/**
+ * Active Alerts Card Configuration
+ *
+ * Displays currently firing alerts from Prometheus/Alertmanager.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const activeAlertsConfig: UnifiedCardConfig = {
+  type: 'active_alerts',
+  title: 'Active Alerts',
+  category: 'alerting',
+  description: 'Currently firing alerts across clusters',
+  icon: 'Bell',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+
+  dataSource: {
+    type: 'hook',
+    hook: 'useActiveAlerts',
+  },
+
+  stats: [
+    {
+      id: 'critical',
+      icon: 'AlertTriangle',
+      color: 'red',
+      label: 'Critical',
+      bgColor: 'bg-red-500',
+      valueSource: { type: 'count', filter: 'severity=critical' },
+    },
+    {
+      id: 'warning',
+      icon: 'AlertCircle',
+      color: 'yellow',
+      label: 'Warning',
+      bgColor: 'bg-yellow-500',
+      valueSource: { type: 'count', filter: 'severity=warning' },
+    },
+  ],
+
+  content: {
+    type: 'list',
+    columns: [
+      {
+        field: 'severity',
+        header: '',
+        width: 32,
+        render: 'status-badge',
+      },
+      {
+        field: 'alertname',
+        header: 'Alert',
+        primary: true,
+      },
+      {
+        field: 'duration',
+        header: 'Duration',
+        width: 80,
+        render: 'relative-time',
+      },
+    ],
+    pageSize: 6,
+  },
+
+  emptyState: {
+    icon: 'BellOff',
+    title: 'No active alerts',
+    message: 'All systems operating normally',
+    variant: 'success',
+  },
+
+  footer: {
+    showTotal: true,
+    text: 'alerts firing',
+  },
+}

--- a/web/src/config/cards/gitops-drift.ts
+++ b/web/src/config/cards/gitops-drift.ts
@@ -1,0 +1,77 @@
+/**
+ * GitOps Drift Card Configuration
+ *
+ * Displays resources that have drifted from their Git source.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gitopsDriftConfig: UnifiedCardConfig = {
+  type: 'gitops_drift',
+  title: 'GitOps Drift',
+  category: 'gitops',
+  description: 'Resources that have drifted from their declared state',
+  icon: 'GitBranch',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  dataSource: {
+    type: 'hook',
+    hook: 'useGitOpsDrift',
+  },
+
+  stats: [
+    {
+      id: 'drifted',
+      icon: 'AlertTriangle',
+      color: 'yellow',
+      label: 'Drifted',
+      bgColor: 'bg-yellow-500',
+      valueSource: { type: 'count' },
+    },
+  ],
+
+  content: {
+    type: 'list',
+    columns: [
+      {
+        field: 'status',
+        header: '',
+        width: 32,
+        render: 'status-badge',
+      },
+      {
+        field: 'resource',
+        header: 'Resource',
+        primary: true,
+      },
+      {
+        field: 'kind',
+        header: 'Kind',
+        width: 100,
+      },
+      {
+        field: 'lastSync',
+        header: 'Last Sync',
+        width: 100,
+        render: 'relative-time',
+      },
+    ],
+    pageSize: 6,
+  },
+
+  emptyState: {
+    icon: 'GitMerge',
+    title: 'No drift detected',
+    message: 'All resources are in sync',
+    variant: 'success',
+  },
+
+  drillDown: {
+    action: 'showGitOpsDrift',
+    params: ['resource', 'kind', 'namespace'],
+  },
+
+  isDemoData: true,
+}

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -16,6 +16,13 @@ import { resourceUsageConfig } from './resource-usage'
 // Chart cards (PR 4)
 import { clusterMetricsConfig } from './cluster-metrics'
 import { eventsTimelineConfig } from './events-timeline'
+// Additional cards (PR 7)
+import { securityIssuesConfig } from './security-issues'
+import { activeAlertsConfig } from './active-alerts'
+import { storageOverviewConfig } from './storage-overview'
+import { networkOverviewConfig } from './network-overview'
+import { topPodsConfig } from './top-pods'
+import { gitopsDriftConfig } from './gitops-drift'
 
 /**
  * Registry of all unified card configurations
@@ -31,6 +38,13 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   // Chart cards (PR 4)
   cluster_metrics: clusterMetricsConfig,
   events_timeline: eventsTimelineConfig,
+  // Additional cards (PR 7)
+  security_issues: securityIssuesConfig,
+  active_alerts: activeAlertsConfig,
+  storage_overview: storageOverviewConfig,
+  network_overview: networkOverviewConfig,
+  top_pods: topPodsConfig,
+  gitops_drift: gitopsDriftConfig,
 }
 
 /**
@@ -64,4 +78,11 @@ export {
   // Chart cards (PR 4)
   clusterMetricsConfig,
   eventsTimelineConfig,
+  // Additional cards (PR 7)
+  securityIssuesConfig,
+  activeAlertsConfig,
+  storageOverviewConfig,
+  networkOverviewConfig,
+  topPodsConfig,
+  gitopsDriftConfig,
 }

--- a/web/src/config/cards/network-overview.ts
+++ b/web/src/config/cards/network-overview.ts
@@ -1,0 +1,67 @@
+/**
+ * Network Overview Card Configuration
+ *
+ * Displays network status and connectivity summary.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const networkOverviewConfig: UnifiedCardConfig = {
+  type: 'network_overview',
+  title: 'Network Overview',
+  category: 'network',
+  description: 'Network connectivity and service status',
+  icon: 'Network',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+
+  dataSource: {
+    type: 'hook',
+    hook: 'useNetworkOverview',
+  },
+
+  content: {
+    type: 'status-grid',
+    columns: 2,
+    items: [
+      {
+        id: 'services',
+        label: 'Services',
+        valueSource: { type: 'field', path: 'serviceCount' },
+        icon: 'Globe',
+        color: 'blue',
+      },
+      {
+        id: 'ingresses',
+        label: 'Ingresses',
+        valueSource: { type: 'field', path: 'ingressCount' },
+        icon: 'ArrowRightLeft',
+        color: 'purple',
+      },
+      {
+        id: 'endpoints',
+        label: 'Endpoints',
+        valueSource: { type: 'field', path: 'endpointCount' },
+        icon: 'Link',
+        color: 'cyan',
+      },
+      {
+        id: 'policies',
+        label: 'Net Policies',
+        valueSource: { type: 'field', path: 'networkPolicyCount' },
+        icon: 'Shield',
+        color: 'green',
+      },
+    ],
+  },
+
+  emptyState: {
+    icon: 'Network',
+    title: 'No network data',
+    message: 'Network metrics not available',
+    variant: 'neutral',
+  },
+
+  isLive: true,
+}

--- a/web/src/config/cards/security-issues.ts
+++ b/web/src/config/cards/security-issues.ts
@@ -1,0 +1,79 @@
+/**
+ * Security Issues Card Configuration
+ *
+ * Displays security vulnerabilities and issues across clusters.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const securityIssuesConfig: UnifiedCardConfig = {
+  type: 'security_issues',
+  title: 'Security Issues',
+  category: 'security',
+  description: 'Security vulnerabilities and issues detected across clusters',
+  icon: 'Shield',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  dataSource: {
+    type: 'hook',
+    hook: 'useSecurityIssues',
+  },
+
+  content: {
+    type: 'list',
+    columns: [
+      {
+        field: 'severity',
+        header: 'Severity',
+        width: 80,
+        render: 'status-badge',
+      },
+      {
+        field: 'type',
+        header: 'Type',
+        width: 120,
+      },
+      {
+        field: 'resource',
+        header: 'Resource',
+        primary: true,
+      },
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        width: 100,
+        render: 'cluster-badge',
+      },
+    ],
+    pageSize: 8,
+  },
+
+  filters: [
+    {
+      field: 'severity',
+      label: 'Severity',
+      type: 'select',
+      options: [
+        { value: 'all', label: 'All' },
+        { value: 'critical', label: 'Critical' },
+        { value: 'high', label: 'High' },
+        { value: 'medium', label: 'Medium' },
+        { value: 'low', label: 'Low' },
+      ],
+    },
+  ],
+
+  emptyState: {
+    icon: 'ShieldCheck',
+    title: 'No security issues',
+    message: 'All resources are secure',
+    variant: 'success',
+  },
+
+  drillDown: {
+    action: 'showSecurityIssue',
+    params: ['resource', 'type', 'severity'],
+  },
+}

--- a/web/src/config/cards/storage-overview.ts
+++ b/web/src/config/cards/storage-overview.ts
@@ -1,0 +1,67 @@
+/**
+ * Storage Overview Card Configuration
+ *
+ * Displays storage usage and PVC status summary.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const storageOverviewConfig: UnifiedCardConfig = {
+  type: 'storage_overview',
+  title: 'Storage Overview',
+  category: 'storage',
+  description: 'Storage capacity and usage across clusters',
+  icon: 'HardDrive',
+  iconColor: 'text-purple-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+
+  dataSource: {
+    type: 'hook',
+    hook: 'useStorageOverview',
+  },
+
+  content: {
+    type: 'status-grid',
+    columns: 2,
+    items: [
+      {
+        id: 'total-capacity',
+        label: 'Total Capacity',
+        valueSource: { type: 'field', path: 'totalCapacity' },
+        icon: 'Database',
+        color: 'purple',
+      },
+      {
+        id: 'used',
+        label: 'Used',
+        valueSource: { type: 'field', path: 'usedStorage' },
+        icon: 'HardDrive',
+        color: 'blue',
+      },
+      {
+        id: 'pvcs',
+        label: 'PVCs',
+        valueSource: { type: 'field', path: 'pvcCount' },
+        icon: 'Layers',
+        color: 'cyan',
+      },
+      {
+        id: 'unbound',
+        label: 'Unbound',
+        valueSource: { type: 'field', path: 'unboundCount' },
+        icon: 'AlertCircle',
+        color: 'yellow',
+      },
+    ],
+  },
+
+  emptyState: {
+    icon: 'HardDrive',
+    title: 'No storage data',
+    message: 'Storage metrics not available',
+    variant: 'neutral',
+  },
+
+  isLive: true,
+}

--- a/web/src/config/cards/top-pods.ts
+++ b/web/src/config/cards/top-pods.ts
@@ -1,0 +1,82 @@
+/**
+ * Top Pods Card Configuration
+ *
+ * Displays pods with highest resource consumption.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const topPodsConfig: UnifiedCardConfig = {
+  type: 'top_pods',
+  title: 'Top Pods',
+  category: 'workloads',
+  description: 'Pods consuming the most resources',
+  icon: 'TrendingUp',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  dataSource: {
+    type: 'hook',
+    hook: 'useTopPods',
+  },
+
+  filters: [
+    {
+      field: 'metric',
+      label: 'Sort By',
+      type: 'select',
+      options: [
+        { value: 'cpu', label: 'CPU' },
+        { value: 'memory', label: 'Memory' },
+      ],
+    },
+  ],
+
+  content: {
+    type: 'table',
+    columns: [
+      {
+        field: 'name',
+        header: 'Pod',
+        primary: true,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        width: 120,
+      },
+      {
+        field: 'cpu',
+        header: 'CPU',
+        width: 80,
+        render: 'percentage',
+      },
+      {
+        field: 'memory',
+        header: 'Memory',
+        width: 80,
+        render: 'percentage',
+      },
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        width: 100,
+        render: 'cluster-badge',
+      },
+    ],
+    sortable: true,
+  },
+
+  emptyState: {
+    icon: 'Box',
+    title: 'No pod data',
+    message: 'Pod metrics not available',
+    variant: 'neutral',
+  },
+
+  drillDown: {
+    action: 'showPodDetails',
+    params: ['name', 'namespace', 'cluster'],
+  },
+}

--- a/web/src/config/dashboards/compute.ts
+++ b/web/src/config/dashboards/compute.ts
@@ -1,0 +1,114 @@
+/**
+ * Compute Dashboard Configuration
+ *
+ * Dashboard focused on compute resources: clusters, nodes, pods.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const computeDashboardConfig: UnifiedDashboardConfig = {
+  id: 'compute',
+  name: 'Compute',
+  subtitle: 'Cluster and node resources',
+  route: '/compute',
+
+  statsType: 'compute',
+  stats: {
+    type: 'compute',
+    title: 'Compute Resources',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'clusters',
+        name: 'Clusters',
+        icon: 'Server',
+        color: 'purple',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalClusters' },
+      },
+      {
+        id: 'nodes',
+        name: 'Nodes',
+        icon: 'Box',
+        color: 'cyan',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalNodes' },
+      },
+      {
+        id: 'pods',
+        name: 'Pods',
+        icon: 'Layers',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalPods' },
+      },
+      {
+        id: 'cpu-usage',
+        name: 'CPU Usage',
+        icon: 'Cpu',
+        color: 'orange',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.cpuUsagePercent' },
+        format: 'percentage',
+      },
+      {
+        id: 'memory-usage',
+        name: 'Memory',
+        icon: 'MemoryStick',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.memoryUsagePercent' },
+        format: 'percentage',
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'compute-1',
+      cardType: 'cluster_health',
+      position: { w: 4, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'compute-2',
+      cardType: 'resource_usage',
+      position: { w: 4, h: 3, x: 4, y: 0 },
+    },
+    {
+      id: 'compute-3',
+      cardType: 'top_pods',
+      position: { w: 4, h: 3, x: 8, y: 0 },
+    },
+    {
+      id: 'compute-4',
+      cardType: 'cluster_metrics',
+      position: { w: 6, h: 3, x: 0, y: 3 },
+    },
+    {
+      id: 'compute-5',
+      cardType: 'pod_issues',
+      position: { w: 6, h: 3, x: 6, y: 3 },
+    },
+  ],
+
+  availableCardTypes: [
+    'cluster_health',
+    'resource_usage',
+    'top_pods',
+    'pod_issues',
+    'cluster_metrics',
+    'deployment_status',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-compute-dashboard',
+}
+
+export default computeDashboardConfig

--- a/web/src/config/dashboards/gitops.ts
+++ b/web/src/config/dashboards/gitops.ts
@@ -1,0 +1,97 @@
+/**
+ * GitOps Dashboard Configuration
+ *
+ * Dashboard focused on GitOps sync status and deployments.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const gitopsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'gitops',
+  name: 'GitOps',
+  subtitle: 'Deployment and sync status',
+  route: '/gitops',
+
+  statsType: 'gitops',
+  stats: {
+    type: 'gitops',
+    title: 'GitOps Status',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'deployments',
+        name: 'Deployments',
+        icon: 'Rocket',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalDeployments' },
+      },
+      {
+        id: 'synced',
+        name: 'Synced',
+        icon: 'CheckCircle2',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.syncedCount' },
+      },
+      {
+        id: 'drifted',
+        name: 'Drifted',
+        icon: 'AlertTriangle',
+        color: 'yellow',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.driftedCount' },
+      },
+      {
+        id: 'failed',
+        name: 'Failed',
+        icon: 'XCircle',
+        color: 'red',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.failedCount' },
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'gitops-1',
+      cardType: 'deployment_status',
+      position: { w: 6, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'gitops-2',
+      cardType: 'gitops_drift',
+      position: { w: 6, h: 3, x: 6, y: 0 },
+    },
+    {
+      id: 'gitops-3',
+      cardType: 'event_stream',
+      position: { w: 6, h: 4, x: 0, y: 3 },
+    },
+    {
+      id: 'gitops-4',
+      cardType: 'events_timeline',
+      position: { w: 6, h: 3, x: 6, y: 3 },
+    },
+  ],
+
+  availableCardTypes: [
+    'deployment_status',
+    'gitops_drift',
+    'event_stream',
+    'events_timeline',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-gitops-dashboard',
+}
+
+export default gitopsDashboardConfig

--- a/web/src/config/dashboards/index.ts
+++ b/web/src/config/dashboards/index.ts
@@ -6,12 +6,18 @@
 
 import type { UnifiedDashboardConfig, DashboardConfigRegistry } from '../../lib/unified/types'
 import { mainDashboardConfig } from './main'
+import { computeDashboardConfig } from './compute'
+import { securityDashboardConfig } from './security'
+import { gitopsDashboardConfig } from './gitops'
 
 /**
  * Registry of all unified dashboard configurations
  */
 export const DASHBOARD_CONFIGS: DashboardConfigRegistry = {
   main: mainDashboardConfig,
+  compute: computeDashboardConfig,
+  security: securityDashboardConfig,
+  gitops: gitopsDashboardConfig,
 }
 
 /**
@@ -36,4 +42,9 @@ export function getUnifiedDashboardIds(): string[] {
 }
 
 // Re-export individual configs
-export { mainDashboardConfig }
+export {
+  mainDashboardConfig,
+  computeDashboardConfig,
+  securityDashboardConfig,
+  gitopsDashboardConfig,
+}

--- a/web/src/config/dashboards/security.ts
+++ b/web/src/config/dashboards/security.ts
@@ -1,0 +1,95 @@
+/**
+ * Security Dashboard Configuration
+ *
+ * Dashboard focused on security posture and compliance.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const securityDashboardConfig: UnifiedDashboardConfig = {
+  id: 'security',
+  name: 'Security',
+  subtitle: 'Security posture overview',
+  route: '/security',
+
+  statsType: 'security',
+  stats: {
+    type: 'security',
+    title: 'Security Status',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'critical',
+        name: 'Critical',
+        icon: 'AlertTriangle',
+        color: 'red',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.criticalIssues' },
+      },
+      {
+        id: 'high',
+        name: 'High',
+        icon: 'AlertCircle',
+        color: 'orange',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.highIssues' },
+      },
+      {
+        id: 'medium',
+        name: 'Medium',
+        icon: 'Info',
+        color: 'yellow',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.mediumIssues' },
+      },
+      {
+        id: 'policies',
+        name: 'Policies',
+        icon: 'Shield',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalPolicies' },
+      },
+      {
+        id: 'compliant',
+        name: 'Compliant',
+        icon: 'CheckCircle2',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.compliancePercent' },
+        format: 'percentage',
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'security-1',
+      cardType: 'security_issues',
+      position: { w: 6, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'security-2',
+      cardType: 'active_alerts',
+      position: { w: 6, h: 3, x: 6, y: 0 },
+    },
+  ],
+
+  availableCardTypes: [
+    'security_issues',
+    'active_alerts',
+    'pod_issues',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 60000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-security-dashboard',
+}
+
+export default securityDashboardConfig

--- a/web/src/lib/unified/card/UnifiedCard.tsx
+++ b/web/src/lib/unified/card/UnifiedCard.tsx
@@ -31,6 +31,7 @@ export function UnifiedCard({
   instanceConfig,
   title: _titleOverride,
   className,
+  overrideData,
 }: UnifiedCardProps) {
   // Merge instance config with base config
   const mergedConfig = useMemo(() => {
@@ -42,8 +43,14 @@ export function UnifiedCard({
     } as UnifiedCardConfig
   }, [config, instanceConfig])
 
-  // Fetch data using the configured data source
-  const { data, isLoading, error, refetch } = useDataSource(mergedConfig.dataSource)
+  // Fetch data using the configured data source (skipped if overrideData provided)
+  const { data: fetchedData, isLoading, error, refetch } = useDataSource(
+    mergedConfig.dataSource,
+    { skip: !!overrideData }
+  )
+
+  // Use override data if provided, otherwise use fetched data
+  const data = overrideData ?? fetchedData
 
   // Apply filtering if configured
   const { filteredData, filterControls } = useCardFiltering(

--- a/web/src/lib/unified/types.ts
+++ b/web/src/lib/unified/types.ts
@@ -679,6 +679,8 @@ export interface UnifiedCardProps {
   title?: string
   /** Additional className */
   className?: string
+  /** Override data for demo/testing purposes (bypasses data source) */
+  overrideData?: unknown[]
 }
 
 /**


### PR DESCRIPTION
## Summary

Migrate additional cards to unified config system and add new dashboard configurations:

### New Card Configs (6 cards)
- `security_issues` - Security vulnerabilities list
- `active_alerts` - Alerting card with stats
- `storage_overview` - Storage status grid
- `network_overview` - Network status grid
- `top_pods` - Resource consumption table
- `gitops_drift` - GitOps sync status list

### New Dashboard Configs (3 dashboards)
- `compute` - Cluster and node resources dashboard
- `security` - Security posture dashboard
- `gitops` - Deployment and sync status dashboard

### Other Changes
- Add `overrideData` prop to UnifiedCard for testing/demo purposes
- Add `skip` option to useDataSource hook
- Export new configs from registries

## Progress Summary

| PR | Status | Cards/Components |
|----|--------|------------------|
| #419 | ✅ Merged | Foundation Types |
| #420 | ✅ Merged | List & Table Visualizations |
| #421 | ✅ Merged | 5 Card Configs |
| #422 | ✅ Merged | Chart Visualizations |
| #423 | ✅ Merged | Stats Components |
| #424 | ✅ Merged | Dashboard Components |
| **This PR** | 🔄 | 6 Cards + 3 Dashboards |

**Total Cards Configured**: 13 of 120+

## Test plan
- [x] `npm run build` passes
- [ ] Cards render correctly when USE_UNIFIED_CARDS is enabled
- [ ] Dashboard configs can be loaded from registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)