### PR TITLE
🌱 Add deployment-issues and operator-status unified card configs

### DIFF
--- a/web/src/config/cards/deployment-issues.ts
+++ b/web/src/config/cards/deployment-issues.ts
@@ -1,0 +1,114 @@
+/**
+ * Deployment Issues Card Configuration
+ *
+ * Displays Kubernetes Deployments with issues using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const deploymentIssuesConfig: UnifiedCardConfig = {
+  type: 'deployment_issues',
+  title: 'Deployment Issues',
+  category: 'workloads',
+  description: 'Kubernetes Deployments with replica or readiness issues',
+
+  // Appearance
+  icon: 'AlertTriangle',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCachedDeploymentIssues',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search deployments...',
+      searchFields: ['name', 'namespace', 'cluster', 'reason', 'message'],
+      storageKey: 'deployment-issues',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'deployment-issues-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 5,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Deployment',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'reason',
+        header: 'Reason',
+        render: 'status-badge',
+        width: 120,
+      },
+      {
+        field: 'readyReplicas',
+        header: 'Ready',
+        render: 'replica-count',
+        width: 80,
+      },
+    ],
+  },
+
+  // Drill-down configuration
+  drillDown: {
+    action: 'drillToDeployment',
+    params: ['cluster', 'namespace', 'name'],
+    context: {
+      replicas: 'replicas',
+      readyReplicas: 'readyReplicas',
+      reason: 'reason',
+      message: 'message',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'CheckCircle',
+    title: 'All deployments healthy',
+    message: 'No deployment issues detected',
+    variant: 'success',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 3,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default deploymentIssuesConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -29,6 +29,9 @@ import { recentEventsConfig } from './recent-events'
 // Storage & Networking cards (PR 8)
 import { pvcStatusConfig } from './pvc-status'
 import { serviceStatusConfig } from './service-status'
+// Workload & Operator cards (PR 9)
+import { deploymentIssuesConfig } from './deployment-issues'
+import { operatorStatusConfig } from './operator-status'
 
 /**
  * Registry of all unified card configurations
@@ -57,6 +60,9 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   // Storage & Networking cards (PR 8)
   pvc_status: pvcStatusConfig,
   service_status: serviceStatusConfig,
+  // Workload & Operator cards (PR 9)
+  deployment_issues: deploymentIssuesConfig,
+  operator_status: operatorStatusConfig,
 }
 
 /**
@@ -103,4 +109,7 @@ export {
   // Storage & Networking cards (PR 8)
   pvcStatusConfig,
   serviceStatusConfig,
+  // Workload & Operator cards (PR 9)
+  deploymentIssuesConfig,
+  operatorStatusConfig,
 }

--- a/web/src/config/cards/operator-status.ts
+++ b/web/src/config/cards/operator-status.ts
@@ -1,0 +1,113 @@
+/**
+ * Operator Status Card Configuration
+ *
+ * Displays Kubernetes Operators using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const operatorStatusConfig: UnifiedCardConfig = {
+  type: 'operator_status',
+  title: 'Operator Status',
+  category: 'operators',
+  description: 'OLM-managed Operators across clusters',
+
+  // Appearance
+  icon: 'Package',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useOperators',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search operators...',
+      searchFields: ['name', 'namespace', 'version', 'cluster'],
+      storageKey: 'operator-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'operator-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 5,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Operator',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 100,
+      },
+      {
+        field: 'version',
+        header: 'Version',
+        render: 'text',
+        width: 90,
+      },
+    ],
+  },
+
+  // Drill-down configuration
+  drillDown: {
+    action: 'drillToOperator',
+    params: ['cluster', 'namespace', 'name'],
+    context: {
+      status: 'status',
+      version: 'version',
+      upgradeAvailable: 'upgradeAvailable',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Package',
+    title: 'No operators found',
+    message: 'No OLM-managed Operators in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 3,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default operatorStatusConfig

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -16,8 +16,9 @@ import {
   useCachedPodIssues,
   useCachedEvents,
   useCachedDeployments,
+  useCachedDeploymentIssues,
 } from '../../hooks/useCachedData'
-import { useClusters, usePVCs, useServices } from '../../hooks/mcp'
+import { useClusters, usePVCs, useServices, useOperators } from '../../hooks/mcp'
 
 // ============================================================================
 // Wrapper hooks that convert params object to positional args
@@ -88,6 +89,29 @@ function useUnifiedServices(params?: Record<string, unknown>) {
   const result = useServices(cluster, namespace)
   return {
     data: result.services,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedDeploymentIssues(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useCachedDeploymentIssues(cluster, namespace)
+  return {
+    data: result.issues,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedOperators(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const result = useOperators(cluster)
+  return {
+    data: result.operators,
     isLoading: result.isLoading,
     error: result.error ? new Error(result.error) : null,
     refetch: result.refetch,
@@ -282,6 +306,8 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useClusters', useUnifiedClusters)
   registerDataHook('usePVCs', useUnifiedPVCs)
   registerDataHook('useServices', useUnifiedServices)
+  registerDataHook('useCachedDeploymentIssues', useUnifiedDeploymentIssues)
+  registerDataHook('useOperators', useUnifiedOperators)
 
   // Filtered event hooks
   registerDataHook('useWarningEvents', useWarningEvents)


### PR DESCRIPTION
## Summary
- Add `deployment-issues.ts` unified card config using `useCachedDeploymentIssues` hook
- Add `operator-status.ts` unified card config using `useOperators` hook
- Add wrapper hooks in `registerHooks.ts` (useUnifiedDeploymentIssues, useUnifiedOperators)
- Register new configs in card config registry

This is part of PR 9 in the unified component architecture migration, adding 2 more cards to the unified system.

**Unified cards total: 19** (17 previous + 2 new)

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (no new errors)
- [x] Dev server starts successfully
- [x] Cards registered in CARD_CONFIGS registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)