### PR TITLE
🌱 Add 5 more unified card configs for resource types

### DIFF
--- a/web/src/config/cards/configmap-status.ts
+++ b/web/src/config/cards/configmap-status.ts
@@ -1,0 +1,103 @@
+/**
+ * ConfigMap Status Card Configuration
+ *
+ * Displays Kubernetes ConfigMaps using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const configMapStatusConfig: UnifiedCardConfig = {
+  type: 'configmap_status',
+  title: 'ConfigMaps',
+  category: 'workloads',
+  description: 'Kubernetes ConfigMaps across clusters',
+
+  // Appearance
+  icon: 'FileText',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useConfigMaps',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search configmaps...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'configmap-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'configmap-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'dataKeys',
+        header: 'Keys',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'creationTimestamp',
+        header: 'Age',
+        render: 'relative-time',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'FileText',
+    title: 'No ConfigMaps',
+    message: 'No ConfigMaps found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default configMapStatusConfig

--- a/web/src/config/cards/helm-release-status.ts
+++ b/web/src/config/cards/helm-release-status.ts
@@ -1,0 +1,120 @@
+/**
+ * Helm Release Status Card Configuration
+ *
+ * Displays Helm releases across clusters using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const helmReleaseStatusConfig: UnifiedCardConfig = {
+  type: 'helm_release_status',
+  title: 'Helm Release Status',
+  category: 'gitops',
+  description: 'Helm releases across clusters',
+
+  // Appearance
+  icon: 'Package',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useHelmReleases',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search releases...',
+      searchFields: ['name', 'namespace', 'chart', 'cluster'],
+      storageKey: 'helm-release-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'helm-release-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 5,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Release',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'chart',
+        header: 'Chart',
+        render: 'text',
+        width: 100,
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 90,
+      },
+      {
+        field: 'revision',
+        header: 'Rev',
+        render: 'number',
+        align: 'right',
+        width: 50,
+      },
+    ],
+  },
+
+  // Drill-down configuration
+  drillDown: {
+    action: 'drillToHelm',
+    params: ['cluster', 'namespace', 'name'],
+    context: {
+      chart: 'chart',
+      status: 'status',
+      revision: 'revision',
+    },
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Package',
+    title: 'No Helm releases',
+    message: 'No Helm releases found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 3,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default helmReleaseStatusConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -32,6 +32,12 @@ import { serviceStatusConfig } from './service-status'
 // Workload & Operator cards (PR 9)
 import { deploymentIssuesConfig } from './deployment-issues'
 import { operatorStatusConfig } from './operator-status'
+// Additional resource cards (PR 10)
+import { helmReleaseStatusConfig } from './helm-release-status'
+import { configMapStatusConfig } from './configmap-status'
+import { secretStatusConfig } from './secret-status'
+import { ingressStatusConfig } from './ingress-status'
+import { nodeStatusConfig } from './node-status'
 
 /**
  * Registry of all unified card configurations
@@ -63,6 +69,12 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   // Workload & Operator cards (PR 9)
   deployment_issues: deploymentIssuesConfig,
   operator_status: operatorStatusConfig,
+  // Additional resource cards (PR 10)
+  helm_release_status: helmReleaseStatusConfig,
+  configmap_status: configMapStatusConfig,
+  secret_status: secretStatusConfig,
+  ingress_status: ingressStatusConfig,
+  node_status: nodeStatusConfig,
 }
 
 /**
@@ -112,4 +124,10 @@ export {
   // Workload & Operator cards (PR 9)
   deploymentIssuesConfig,
   operatorStatusConfig,
+  // Additional resource cards (PR 10)
+  helmReleaseStatusConfig,
+  configMapStatusConfig,
+  secretStatusConfig,
+  ingressStatusConfig,
+  nodeStatusConfig,
 }

--- a/web/src/config/cards/ingress-status.ts
+++ b/web/src/config/cards/ingress-status.ts
@@ -1,0 +1,102 @@
+/**
+ * Ingress Status Card Configuration
+ *
+ * Displays Kubernetes Ingresses using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const ingressStatusConfig: UnifiedCardConfig = {
+  type: 'ingress_status',
+  title: 'Ingress Status',
+  category: 'network',
+  description: 'Kubernetes Ingresses across clusters',
+
+  // Appearance
+  icon: 'Globe',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useIngresses',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search ingresses...',
+      searchFields: ['name', 'namespace', 'cluster', 'host'],
+      storageKey: 'ingress-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'ingress-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'host',
+        header: 'Host',
+        render: 'text',
+        width: 150,
+      },
+      {
+        field: 'class',
+        header: 'Class',
+        render: 'text',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Globe',
+    title: 'No Ingresses',
+    message: 'No Ingresses found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default ingressStatusConfig

--- a/web/src/config/cards/node-status.ts
+++ b/web/src/config/cards/node-status.ts
@@ -1,0 +1,110 @@
+/**
+ * Node Status Card Configuration
+ *
+ * Displays Kubernetes Nodes using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const nodeStatusConfig: UnifiedCardConfig = {
+  type: 'node_status',
+  title: 'Node Status',
+  category: 'compute',
+  description: 'Kubernetes Nodes across clusters',
+
+  // Appearance
+  icon: 'Server',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useNodes',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search nodes...',
+      searchFields: ['name', 'cluster', 'status'],
+      storageKey: 'node-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'node-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 80,
+      },
+      {
+        field: 'roles',
+        header: 'Roles',
+        render: 'text',
+        width: 100,
+      },
+      {
+        field: 'cpuCapacity',
+        header: 'CPU',
+        render: 'text',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'memoryCapacity',
+        header: 'Memory',
+        render: 'text',
+        align: 'right',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Server',
+    title: 'No Nodes',
+    message: 'No Nodes found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default nodeStatusConfig

--- a/web/src/config/cards/secret-status.ts
+++ b/web/src/config/cards/secret-status.ts
@@ -1,0 +1,103 @@
+/**
+ * Secret Status Card Configuration
+ *
+ * Displays Kubernetes Secrets using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const secretStatusConfig: UnifiedCardConfig = {
+  type: 'secret_status',
+  title: 'Secrets',
+  category: 'security',
+  description: 'Kubernetes Secrets across clusters',
+
+  // Appearance
+  icon: 'Key',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useSecrets',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search secrets...',
+      searchFields: ['name', 'namespace', 'cluster', 'type'],
+      storageKey: 'secret-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'secret-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'type',
+        header: 'Type',
+        render: 'text',
+        width: 120,
+      },
+      {
+        field: 'dataKeys',
+        header: 'Keys',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Key',
+    title: 'No Secrets',
+    message: 'No Secrets found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default secretStatusConfig

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -18,7 +18,17 @@ import {
   useCachedDeployments,
   useCachedDeploymentIssues,
 } from '../../hooks/useCachedData'
-import { useClusters, usePVCs, useServices, useOperators } from '../../hooks/mcp'
+import {
+  useClusters,
+  usePVCs,
+  useServices,
+  useOperators,
+  useHelmReleases,
+  useConfigMaps,
+  useSecrets,
+  useIngresses,
+  useNodes,
+} from '../../hooks/mcp'
 
 // ============================================================================
 // Wrapper hooks that convert params object to positional args
@@ -112,6 +122,64 @@ function useUnifiedOperators(params?: Record<string, unknown>) {
   const result = useOperators(cluster)
   return {
     data: result.operators,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedHelmReleases(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const result = useHelmReleases(cluster)
+  return {
+    data: result.releases,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedConfigMaps(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useConfigMaps(cluster, namespace)
+  return {
+    data: result.configmaps,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedSecrets(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useSecrets(cluster, namespace)
+  return {
+    data: result.secrets,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedIngresses(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useIngresses(cluster, namespace)
+  return {
+    data: result.ingresses,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedNodes(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const result = useNodes(cluster)
+  return {
+    data: result.nodes,
     isLoading: result.isLoading,
     error: result.error ? new Error(result.error) : null,
     refetch: result.refetch,
@@ -308,6 +376,11 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useServices', useUnifiedServices)
   registerDataHook('useCachedDeploymentIssues', useUnifiedDeploymentIssues)
   registerDataHook('useOperators', useUnifiedOperators)
+  registerDataHook('useHelmReleases', useUnifiedHelmReleases)
+  registerDataHook('useConfigMaps', useUnifiedConfigMaps)
+  registerDataHook('useSecrets', useUnifiedSecrets)
+  registerDataHook('useIngresses', useUnifiedIngresses)
+  registerDataHook('useNodes', useUnifiedNodes)
 
   // Filtered event hooks
   registerDataHook('useWarningEvents', useWarningEvents)


### PR DESCRIPTION
## Summary
- Add `helm-release-status.ts` unified card config using `useHelmReleases` hook
- Add `configmap-status.ts` unified card config using `useConfigMaps` hook
- Add `secret-status.ts` unified card config using `useSecrets` hook
- Add `ingress-status.ts` unified card config using `useIngresses` hook
- Add `node-status.ts` unified card config using `useNodes` hook
- Register wrapper hooks for all new data sources in `registerHooks.ts`

This is part of PR 10 in the unified component architecture migration, adding 5 more cards to the unified system.

**Unified cards total: 24** (19 previous + 5 new)

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (no new errors)
- [x] Cards registered in CARD_CONFIGS registry
- [x] Hooks wrapped and registered in registerHooks.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)