### PR TITLE
🌱 Add 5 workload unified card configs

### DIFF
--- a/web/src/config/cards/cronjob-status.ts
+++ b/web/src/config/cards/cronjob-status.ts
@@ -1,0 +1,108 @@
+/**
+ * CronJob Status Card Configuration
+ *
+ * Displays Kubernetes CronJobs using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const cronJobStatusConfig: UnifiedCardConfig = {
+  type: 'cronjob_status',
+  title: 'CronJobs',
+  category: 'workloads',
+  description: 'Kubernetes CronJobs across clusters',
+
+  // Appearance
+  icon: 'Clock',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useCronJobs',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search cronjobs...',
+      searchFields: ['name', 'namespace', 'cluster', 'schedule'],
+      storageKey: 'cronjob-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'cronjob-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'schedule',
+        header: 'Schedule',
+        render: 'text',
+        width: 100,
+      },
+      {
+        field: 'suspend',
+        header: 'Suspended',
+        render: 'status-badge',
+        width: 80,
+      },
+      {
+        field: 'lastSchedule',
+        header: 'Last Run',
+        render: 'relative-time',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Clock',
+    title: 'No CronJobs',
+    message: 'No CronJobs found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default cronJobStatusConfig

--- a/web/src/config/cards/daemonset-status.ts
+++ b/web/src/config/cards/daemonset-status.ts
@@ -1,0 +1,111 @@
+/**
+ * DaemonSet Status Card Configuration
+ *
+ * Displays Kubernetes DaemonSets using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const daemonSetStatusConfig: UnifiedCardConfig = {
+  type: 'daemonset_status',
+  title: 'DaemonSets',
+  category: 'workloads',
+  description: 'Kubernetes DaemonSets across clusters',
+
+  // Appearance
+  icon: 'Layers',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useDaemonSets',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search daemonsets...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'daemonset-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'daemonset-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'numberReady',
+        header: 'Ready',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'desiredNumberScheduled',
+        header: 'Desired',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'numberAvailable',
+        header: 'Available',
+        render: 'number',
+        align: 'right',
+        width: 70,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Layers',
+    title: 'No DaemonSets',
+    message: 'No DaemonSets found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default daemonSetStatusConfig

--- a/web/src/config/cards/hpa-status.ts
+++ b/web/src/config/cards/hpa-status.ts
@@ -1,0 +1,117 @@
+/**
+ * HPA Status Card Configuration
+ *
+ * Displays Kubernetes HorizontalPodAutoscalers using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const hpaStatusConfig: UnifiedCardConfig = {
+  type: 'hpa_status',
+  title: 'Autoscalers',
+  category: 'workloads',
+  description: 'Kubernetes HorizontalPodAutoscalers across clusters',
+
+  // Appearance
+  icon: 'TrendingUp',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useHPAs',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search HPAs...',
+      searchFields: ['name', 'namespace', 'cluster', 'targetRef'],
+      storageKey: 'hpa-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'hpa-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'targetRef',
+        header: 'Target',
+        render: 'text',
+        width: 100,
+      },
+      {
+        field: 'currentReplicas',
+        header: 'Current',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'minReplicas',
+        header: 'Min',
+        render: 'number',
+        align: 'right',
+        width: 50,
+      },
+      {
+        field: 'maxReplicas',
+        header: 'Max',
+        render: 'number',
+        align: 'right',
+        width: 50,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'TrendingUp',
+    title: 'No Autoscalers',
+    message: 'No HPAs found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default hpaStatusConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -38,6 +38,12 @@ import { configMapStatusConfig } from './configmap-status'
 import { secretStatusConfig } from './secret-status'
 import { ingressStatusConfig } from './ingress-status'
 import { nodeStatusConfig } from './node-status'
+// Workload resource cards (PR 11)
+import { jobStatusConfig } from './job-status'
+import { cronJobStatusConfig } from './cronjob-status'
+import { statefulSetStatusConfig } from './statefulset-status'
+import { daemonSetStatusConfig } from './daemonset-status'
+import { hpaStatusConfig } from './hpa-status'
 
 /**
  * Registry of all unified card configurations
@@ -75,6 +81,12 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   secret_status: secretStatusConfig,
   ingress_status: ingressStatusConfig,
   node_status: nodeStatusConfig,
+  // Workload resource cards (PR 11)
+  job_status: jobStatusConfig,
+  cronjob_status: cronJobStatusConfig,
+  statefulset_status: statefulSetStatusConfig,
+  daemonset_status: daemonSetStatusConfig,
+  hpa_status: hpaStatusConfig,
 }
 
 /**
@@ -130,4 +142,10 @@ export {
   secretStatusConfig,
   ingressStatusConfig,
   nodeStatusConfig,
+  // Workload resource cards (PR 11)
+  jobStatusConfig,
+  cronJobStatusConfig,
+  statefulSetStatusConfig,
+  daemonSetStatusConfig,
+  hpaStatusConfig,
 }

--- a/web/src/config/cards/job-status.ts
+++ b/web/src/config/cards/job-status.ts
@@ -1,0 +1,109 @@
+/**
+ * Job Status Card Configuration
+ *
+ * Displays Kubernetes Jobs using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const jobStatusConfig: UnifiedCardConfig = {
+  type: 'job_status',
+  title: 'Jobs',
+  category: 'workloads',
+  description: 'Kubernetes Jobs across clusters',
+
+  // Appearance
+  icon: 'Play',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useJobs',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search jobs...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'job-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'job-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 90,
+      },
+      {
+        field: 'completions',
+        header: 'Done',
+        render: 'text',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'duration',
+        header: 'Duration',
+        render: 'text',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Play',
+    title: 'No Jobs',
+    message: 'No Jobs found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default jobStatusConfig

--- a/web/src/config/cards/statefulset-status.ts
+++ b/web/src/config/cards/statefulset-status.ts
@@ -1,0 +1,109 @@
+/**
+ * StatefulSet Status Card Configuration
+ *
+ * Displays Kubernetes StatefulSets using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const statefulSetStatusConfig: UnifiedCardConfig = {
+  type: 'statefulset_status',
+  title: 'StatefulSets',
+  category: 'workloads',
+  description: 'Kubernetes StatefulSets across clusters',
+
+  // Appearance
+  icon: 'Database',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useStatefulSets',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search statefulsets...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'statefulset-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'statefulset-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'readyReplicas',
+        header: 'Ready',
+        render: 'replica-count',
+        width: 70,
+      },
+      {
+        field: 'replicas',
+        header: 'Desired',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'creationTimestamp',
+        header: 'Age',
+        render: 'relative-time',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Database',
+    title: 'No StatefulSets',
+    message: 'No StatefulSets found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default statefulSetStatusConfig

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -28,6 +28,11 @@ import {
   useSecrets,
   useIngresses,
   useNodes,
+  useJobs,
+  useCronJobs,
+  useStatefulSets,
+  useDaemonSets,
+  useHPAs,
 } from '../../hooks/mcp'
 
 // ============================================================================
@@ -180,6 +185,66 @@ function useUnifiedNodes(params?: Record<string, unknown>) {
   const result = useNodes(cluster)
   return {
     data: result.nodes,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedJobs(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useJobs(cluster, namespace)
+  return {
+    data: result.jobs,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedCronJobs(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useCronJobs(cluster, namespace)
+  return {
+    data: result.cronjobs,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedStatefulSets(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useStatefulSets(cluster, namespace)
+  return {
+    data: result.statefulsets,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedDaemonSets(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useDaemonSets(cluster, namespace)
+  return {
+    data: result.daemonsets,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedHPAs(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useHPAs(cluster, namespace)
+  return {
+    data: result.hpas,
     isLoading: result.isLoading,
     error: result.error ? new Error(result.error) : null,
     refetch: result.refetch,
@@ -381,6 +446,11 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useSecrets', useUnifiedSecrets)
   registerDataHook('useIngresses', useUnifiedIngresses)
   registerDataHook('useNodes', useUnifiedNodes)
+  registerDataHook('useJobs', useUnifiedJobs)
+  registerDataHook('useCronJobs', useUnifiedCronJobs)
+  registerDataHook('useStatefulSets', useUnifiedStatefulSets)
+  registerDataHook('useDaemonSets', useUnifiedDaemonSets)
+  registerDataHook('useHPAs', useUnifiedHPAs)
 
   // Filtered event hooks
   registerDataHook('useWarningEvents', useWarningEvents)


### PR DESCRIPTION
## Summary
- Add `job-status.ts` unified card config using `useJobs` hook
- Add `cronjob-status.ts` unified card config using `useCronJobs` hook
- Add `statefulset-status.ts` unified card config using `useStatefulSets` hook
- Add `daemonset-status.ts` unified card config using `useDaemonSets` hook
- Add `hpa-status.ts` unified card config using `useHPAs` hook
- Register wrapper hooks for all new data sources in `registerHooks.ts`

This is part of PR 11 in the unified component architecture migration, adding 5 more cards to the unified system.

**Unified cards total: 29** (24 previous + 5 new)

## Test plan
- [x] Build passes (`npm run build`)
- [x] Cards registered in CARD_CONFIGS registry
- [x] Hooks wrapped and registered in registerHooks.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)