### PR TITLE
✨ Add 8 unified card configs (batch 5)

### DIFF
--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -44,6 +44,15 @@ import { cronJobStatusConfig } from './cronjob-status'
 import { statefulSetStatusConfig } from './statefulset-status'
 import { daemonSetStatusConfig } from './daemonset-status'
 import { hpaStatusConfig } from './hpa-status'
+// Additional resource cards (PR 12)
+import { replicaSetStatusConfig } from './replicaset-status'
+import { pvStatusConfig } from './pv-status'
+import { resourceQuotaStatusConfig } from './resource-quota-status'
+import { limitRangeStatusConfig } from './limit-range-status'
+import { networkPolicyStatusConfig } from './network-policy-status'
+import { namespaceStatusConfig } from './namespace-status'
+import { operatorSubscriptionStatusConfig } from './operator-subscription-status'
+import { serviceAccountStatusConfig } from './service-account-status'
 
 /**
  * Registry of all unified card configurations
@@ -87,6 +96,15 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   statefulset_status: statefulSetStatusConfig,
   daemonset_status: daemonSetStatusConfig,
   hpa_status: hpaStatusConfig,
+  // Additional resource cards (PR 12)
+  replicaset_status: replicaSetStatusConfig,
+  pv_status: pvStatusConfig,
+  resource_quota_status: resourceQuotaStatusConfig,
+  limit_range_status: limitRangeStatusConfig,
+  network_policy_status: networkPolicyStatusConfig,
+  namespace_status: namespaceStatusConfig,
+  operator_subscription_status: operatorSubscriptionStatusConfig,
+  service_account_status: serviceAccountStatusConfig,
 }
 
 /**
@@ -148,4 +166,13 @@ export {
   statefulSetStatusConfig,
   daemonSetStatusConfig,
   hpaStatusConfig,
+  // Additional resource cards (PR 12)
+  replicaSetStatusConfig,
+  pvStatusConfig,
+  resourceQuotaStatusConfig,
+  limitRangeStatusConfig,
+  networkPolicyStatusConfig,
+  namespaceStatusConfig,
+  operatorSubscriptionStatusConfig,
+  serviceAccountStatusConfig,
 }

--- a/web/src/config/cards/limit-range-status.ts
+++ b/web/src/config/cards/limit-range-status.ts
@@ -1,0 +1,96 @@
+/**
+ * LimitRange Status Card Configuration
+ *
+ * Displays Kubernetes LimitRanges using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const limitRangeStatusConfig: UnifiedCardConfig = {
+  type: 'limit_range_status',
+  title: 'Limit Ranges',
+  category: 'namespaces',
+  description: 'Kubernetes LimitRanges across clusters',
+
+  // Appearance
+  icon: 'Sliders',
+  iconColor: 'text-teal-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useLimitRanges',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search limit ranges...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'limit-range-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'limit-range-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'type',
+        header: 'Type',
+        render: 'text',
+        width: 100,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Sliders',
+    title: 'No Limit Ranges',
+    message: 'No LimitRanges found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default limitRangeStatusConfig

--- a/web/src/config/cards/namespace-status.ts
+++ b/web/src/config/cards/namespace-status.ts
@@ -1,0 +1,96 @@
+/**
+ * Namespace Status Card Configuration
+ *
+ * Displays Kubernetes Namespaces using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const namespaceStatusConfig: UnifiedCardConfig = {
+  type: 'namespace_status',
+  title: 'Namespaces',
+  category: 'namespaces',
+  description: 'Kubernetes Namespaces across clusters',
+
+  // Appearance
+  icon: 'FolderOpen',
+  iconColor: 'text-sky-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useNamespaces',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search namespaces...',
+      searchFields: ['name', 'cluster', 'status'],
+      storageKey: 'namespace-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'namespace-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 80,
+      },
+      {
+        field: 'creationTimestamp',
+        header: 'Age',
+        render: 'relative-time',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'FolderOpen',
+    title: 'No Namespaces',
+    message: 'No Namespaces found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default namespaceStatusConfig

--- a/web/src/config/cards/network-policy-status.ts
+++ b/web/src/config/cards/network-policy-status.ts
@@ -1,0 +1,102 @@
+/**
+ * NetworkPolicy Status Card Configuration
+ *
+ * Displays Kubernetes NetworkPolicies using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const networkPolicyStatusConfig: UnifiedCardConfig = {
+  type: 'network_policy_status',
+  title: 'Network Policies',
+  category: 'network',
+  description: 'Kubernetes NetworkPolicies across clusters',
+
+  // Appearance
+  icon: 'Shield',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useNetworkPolicies',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search network policies...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'network-policy-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'network-policy-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'podSelector',
+        header: 'Pod Selector',
+        render: 'text',
+        width: 120,
+      },
+      {
+        field: 'policyTypes',
+        header: 'Types',
+        render: 'text',
+        width: 100,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Shield',
+    title: 'No Network Policies',
+    message: 'No NetworkPolicies found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default networkPolicyStatusConfig

--- a/web/src/config/cards/operator-subscription-status.ts
+++ b/web/src/config/cards/operator-subscription-status.ts
@@ -1,0 +1,102 @@
+/**
+ * Operator Subscription Status Card Configuration
+ *
+ * Displays OLM Operator Subscriptions using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const operatorSubscriptionStatusConfig: UnifiedCardConfig = {
+  type: 'operator_subscription_status',
+  title: 'Operator Subscriptions',
+  category: 'operators',
+  description: 'OLM Operator Subscriptions across clusters',
+
+  // Appearance
+  icon: 'RefreshCw',
+  iconColor: 'text-violet-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useOperatorSubscriptions',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search subscriptions...',
+      searchFields: ['name', 'namespace', 'cluster', 'channel'],
+      storageKey: 'operator-subscription-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'operator-subscription-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'channel',
+        header: 'Channel',
+        render: 'text',
+        width: 80,
+      },
+      {
+        field: 'installPlanApproval',
+        header: 'Approval',
+        render: 'status-badge',
+        width: 90,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'RefreshCw',
+    title: 'No Subscriptions',
+    message: 'No Operator Subscriptions found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default operatorSubscriptionStatusConfig

--- a/web/src/config/cards/pv-status.ts
+++ b/web/src/config/cards/pv-status.ts
@@ -1,0 +1,102 @@
+/**
+ * PersistentVolume Status Card Configuration
+ *
+ * Displays Kubernetes PersistentVolumes using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const pvStatusConfig: UnifiedCardConfig = {
+  type: 'pv_status',
+  title: 'Persistent Volumes',
+  category: 'storage',
+  description: 'Kubernetes PersistentVolumes across clusters',
+
+  // Appearance
+  icon: 'HardDrive',
+  iconColor: 'text-amber-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'usePVs',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search PVs...',
+      searchFields: ['name', 'cluster', 'storageClass', 'status'],
+      storageKey: 'pv-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'pv-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'capacity',
+        header: 'Capacity',
+        render: 'text',
+        width: 80,
+      },
+      {
+        field: 'status',
+        header: 'Status',
+        render: 'status-badge',
+        width: 90,
+      },
+      {
+        field: 'storageClass',
+        header: 'Storage Class',
+        render: 'text',
+        width: 120,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'HardDrive',
+    title: 'No Persistent Volumes',
+    message: 'No PVs found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default pvStatusConfig

--- a/web/src/config/cards/replicaset-status.ts
+++ b/web/src/config/cards/replicaset-status.ts
@@ -1,0 +1,104 @@
+/**
+ * ReplicaSet Status Card Configuration
+ *
+ * Displays Kubernetes ReplicaSets using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const replicaSetStatusConfig: UnifiedCardConfig = {
+  type: 'replicaset_status',
+  title: 'ReplicaSets',
+  category: 'workloads',
+  description: 'Kubernetes ReplicaSets across clusters',
+
+  // Appearance
+  icon: 'Copy',
+  iconColor: 'text-indigo-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useReplicaSets',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search replicasets...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'replicaset-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'replicaset-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'readyReplicas',
+        header: 'Ready',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+      {
+        field: 'replicas',
+        header: 'Desired',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Copy',
+    title: 'No ReplicaSets',
+    message: 'No ReplicaSets found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default replicaSetStatusConfig

--- a/web/src/config/cards/resource-quota-status.ts
+++ b/web/src/config/cards/resource-quota-status.ts
@@ -1,0 +1,102 @@
+/**
+ * ResourceQuota Status Card Configuration
+ *
+ * Displays Kubernetes ResourceQuotas using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const resourceQuotaStatusConfig: UnifiedCardConfig = {
+  type: 'resource_quota_status',
+  title: 'Resource Quotas',
+  category: 'namespaces',
+  description: 'Kubernetes ResourceQuotas across clusters',
+
+  // Appearance
+  icon: 'Gauge',
+  iconColor: 'text-rose-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useResourceQuotas',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search quotas...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'resource-quota-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'resource-quota-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'cpuUsed',
+        header: 'CPU Used',
+        render: 'text',
+        width: 80,
+      },
+      {
+        field: 'memoryUsed',
+        header: 'Memory Used',
+        render: 'text',
+        width: 100,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Gauge',
+    title: 'No Resource Quotas',
+    message: 'No ResourceQuotas found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default resourceQuotaStatusConfig

--- a/web/src/config/cards/service-account-status.ts
+++ b/web/src/config/cards/service-account-status.ts
@@ -1,0 +1,103 @@
+/**
+ * ServiceAccount Status Card Configuration
+ *
+ * Displays Kubernetes ServiceAccounts using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const serviceAccountStatusConfig: UnifiedCardConfig = {
+  type: 'service_account_status',
+  title: 'Service Accounts',
+  category: 'security',
+  description: 'Kubernetes ServiceAccounts across clusters',
+
+  // Appearance
+  icon: 'UserCircle',
+  iconColor: 'text-emerald-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useServiceAccounts',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search service accounts...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'service-account-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'service-account-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'secretCount',
+        header: 'Secrets',
+        render: 'number',
+        align: 'right',
+        width: 70,
+      },
+      {
+        field: 'creationTimestamp',
+        header: 'Age',
+        render: 'relative-time',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'UserCircle',
+    title: 'No Service Accounts',
+    message: 'No ServiceAccounts found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default serviceAccountStatusConfig

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -33,6 +33,14 @@ import {
   useStatefulSets,
   useDaemonSets,
   useHPAs,
+  useReplicaSets,
+  usePVs,
+  useResourceQuotas,
+  useLimitRanges,
+  useNetworkPolicies,
+  useNamespaces,
+  useOperatorSubscriptions,
+  useServiceAccounts,
 } from '../../hooks/mcp'
 
 // ============================================================================
@@ -251,6 +259,99 @@ function useUnifiedHPAs(params?: Record<string, unknown>) {
   }
 }
 
+function useUnifiedReplicaSets(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useReplicaSets(cluster, namespace)
+  return {
+    data: result.replicasets,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedPVs(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const result = usePVs(cluster)
+  return {
+    data: result.pvs,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedResourceQuotas(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useResourceQuotas(cluster, namespace)
+  return {
+    data: result.resourceQuotas,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedLimitRanges(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useLimitRanges(cluster, namespace)
+  return {
+    data: result.limitRanges,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedNetworkPolicies(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useNetworkPolicies(cluster, namespace)
+  return {
+    data: result.networkpolicies,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedNamespaces(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const result = useNamespaces(cluster)
+  return {
+    data: result.namespaces,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedOperatorSubscriptions(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const result = useOperatorSubscriptions(cluster)
+  return {
+    data: result.subscriptions,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedServiceAccounts(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useServiceAccounts(cluster, namespace)
+  return {
+    data: result.serviceAccounts,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
 // ============================================================================
 // Demo data hooks for cards that don't have real data hooks yet
 // These return static demo data for visualization purposes
@@ -451,6 +552,14 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useStatefulSets', useUnifiedStatefulSets)
   registerDataHook('useDaemonSets', useUnifiedDaemonSets)
   registerDataHook('useHPAs', useUnifiedHPAs)
+  registerDataHook('useReplicaSets', useUnifiedReplicaSets)
+  registerDataHook('usePVs', useUnifiedPVs)
+  registerDataHook('useResourceQuotas', useUnifiedResourceQuotas)
+  registerDataHook('useLimitRanges', useUnifiedLimitRanges)
+  registerDataHook('useNetworkPolicies', useUnifiedNetworkPolicies)
+  registerDataHook('useNamespaces', useUnifiedNamespaces)
+  registerDataHook('useOperatorSubscriptions', useUnifiedOperatorSubscriptions)
+  registerDataHook('useServiceAccounts', useUnifiedServiceAccounts)
 
   // Filtered event hooks
   registerDataHook('useWarningEvents', useWarningEvents)


### PR DESCRIPTION
## Summary
- Add ReplicaSet, PersistentVolume, ResourceQuota, LimitRange, NetworkPolicy, Namespace, OperatorSubscription, and ServiceAccount card configs
- Register 8 new wrapper hooks
- Total unified cards: 37

## Test plan
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)