### PR TITLE
✨ Add RBAC unified card configs (batch 6)

### DIFF
--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -53,6 +53,9 @@ import { networkPolicyStatusConfig } from './network-policy-status'
 import { namespaceStatusConfig } from './namespace-status'
 import { operatorSubscriptionStatusConfig } from './operator-subscription-status'
 import { serviceAccountStatusConfig } from './service-account-status'
+// RBAC cards (PR 13)
+import { roleStatusConfig } from './role-status'
+import { roleBindingStatusConfig } from './role-binding-status'
 
 /**
  * Registry of all unified card configurations
@@ -105,6 +108,9 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   namespace_status: namespaceStatusConfig,
   operator_subscription_status: operatorSubscriptionStatusConfig,
   service_account_status: serviceAccountStatusConfig,
+  // RBAC cards (PR 13)
+  role_status: roleStatusConfig,
+  role_binding_status: roleBindingStatusConfig,
 }
 
 /**
@@ -175,4 +181,7 @@ export {
   namespaceStatusConfig,
   operatorSubscriptionStatusConfig,
   serviceAccountStatusConfig,
+  // RBAC cards (PR 13)
+  roleStatusConfig,
+  roleBindingStatusConfig,
 }

--- a/web/src/config/cards/role-binding-status.ts
+++ b/web/src/config/cards/role-binding-status.ts
@@ -1,0 +1,102 @@
+/**
+ * Role Binding Status Card Configuration
+ *
+ * Displays Kubernetes RoleBindings and ClusterRoleBindings using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const roleBindingStatusConfig: UnifiedCardConfig = {
+  type: 'role_binding_status',
+  title: 'Role Bindings',
+  category: 'security',
+  description: 'Kubernetes RoleBindings and ClusterRoleBindings across clusters',
+
+  // Appearance
+  icon: 'Link',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useK8sRoleBindings',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search bindings...',
+      searchFields: ['name', 'namespace', 'cluster', 'roleName'],
+      storageKey: 'role-binding-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'role-binding-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'roleName',
+        header: 'Role',
+        render: 'text',
+        width: 100,
+      },
+      {
+        field: 'isCluster',
+        header: 'Scope',
+        render: 'text',
+        width: 80,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Link',
+    title: 'No Role Bindings',
+    message: 'No RoleBindings found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default roleBindingStatusConfig

--- a/web/src/config/cards/role-status.ts
+++ b/web/src/config/cards/role-status.ts
@@ -1,0 +1,103 @@
+/**
+ * Role Status Card Configuration
+ *
+ * Displays Kubernetes Roles and ClusterRoles using the unified card system.
+ */
+
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const roleStatusConfig: UnifiedCardConfig = {
+  type: 'role_status',
+  title: 'Roles',
+  category: 'security',
+  description: 'Kubernetes Roles and ClusterRoles across clusters',
+
+  // Appearance
+  icon: 'Key',
+  iconColor: 'text-amber-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+
+  // Data source
+  dataSource: {
+    type: 'hook',
+    hook: 'useK8sRoles',
+  },
+
+  // Filters
+  filters: [
+    {
+      field: 'search',
+      type: 'text',
+      placeholder: 'Search roles...',
+      searchFields: ['name', 'namespace', 'cluster'],
+      storageKey: 'role-status',
+    },
+    {
+      field: 'cluster',
+      type: 'cluster-select',
+      label: 'Cluster',
+      storageKey: 'role-status-cluster',
+    },
+  ],
+
+  // Content - List visualization
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      {
+        field: 'cluster',
+        header: 'Cluster',
+        render: 'cluster-badge',
+        width: 100,
+      },
+      {
+        field: 'namespace',
+        header: 'Namespace',
+        render: 'namespace-badge',
+        width: 100,
+      },
+      {
+        field: 'name',
+        header: 'Name',
+        primary: true,
+        render: 'truncate',
+      },
+      {
+        field: 'isCluster',
+        header: 'Scope',
+        render: 'text',
+        width: 80,
+      },
+      {
+        field: 'ruleCount',
+        header: 'Rules',
+        render: 'number',
+        align: 'right',
+        width: 60,
+      },
+    ],
+  },
+
+  // Empty state
+  emptyState: {
+    icon: 'Key',
+    title: 'No Roles',
+    message: 'No Roles found in the selected clusters',
+    variant: 'info',
+  },
+
+  // Loading state
+  loadingState: {
+    type: 'list',
+    rows: 5,
+    showSearch: true,
+  },
+
+  // Metadata
+  isDemoData: false,
+  isLive: true,
+}
+
+export default roleStatusConfig

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -41,6 +41,8 @@ import {
   useNamespaces,
   useOperatorSubscriptions,
   useServiceAccounts,
+  useK8sRoles,
+  useK8sRoleBindings,
 } from '../../hooks/mcp'
 
 // ============================================================================
@@ -352,6 +354,30 @@ function useUnifiedServiceAccounts(params?: Record<string, unknown>) {
   }
 }
 
+function useUnifiedK8sRoles(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useK8sRoles(cluster, namespace)
+  return {
+    data: result.roles,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedK8sRoleBindings(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useK8sRoleBindings(cluster, namespace)
+  return {
+    data: result.bindings,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
 // ============================================================================
 // Demo data hooks for cards that don't have real data hooks yet
 // These return static demo data for visualization purposes
@@ -560,6 +586,8 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useNamespaces', useUnifiedNamespaces)
   registerDataHook('useOperatorSubscriptions', useUnifiedOperatorSubscriptions)
   registerDataHook('useServiceAccounts', useUnifiedServiceAccounts)
+  registerDataHook('useK8sRoles', useUnifiedK8sRoles)
+  registerDataHook('useK8sRoleBindings', useUnifiedK8sRoleBindings)
 
   // Filtered event hooks
   registerDataHook('useWarningEvents', useWarningEvents)


### PR DESCRIPTION
## Summary
- Add Role status card (K8s Roles and ClusterRoles)
- Add Role Binding status card (K8s RoleBindings and ClusterRoleBindings)
- Total unified cards: 39

## Test plan
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)