### PR TITLE
✨ Add unified dashboard configs (batch 1)

### DIFF
--- a/web/src/config/dashboards/events.ts
+++ b/web/src/config/dashboards/events.ts
@@ -1,0 +1,97 @@
+/**
+ * Events Dashboard Configuration
+ *
+ * Dashboard focused on Kubernetes events monitoring.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const eventsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'events',
+  name: 'Events',
+  subtitle: 'Kubernetes events monitoring',
+  route: '/events',
+
+  statsType: 'events',
+  stats: {
+    type: 'events',
+    title: 'Event Activity',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'total-events',
+        name: 'Total',
+        icon: 'Activity',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalEvents' },
+      },
+      {
+        id: 'warning-events',
+        name: 'Warnings',
+        icon: 'AlertTriangle',
+        color: 'yellow',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.warningCount' },
+      },
+      {
+        id: 'error-events',
+        name: 'Errors',
+        icon: 'AlertCircle',
+        color: 'red',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.errorCount' },
+      },
+      {
+        id: 'normal-events',
+        name: 'Normal',
+        icon: 'CheckCircle2',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.normalCount' },
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'events-1',
+      cardType: 'event_stream',
+      position: { w: 6, h: 4, x: 0, y: 0 },
+    },
+    {
+      id: 'events-2',
+      cardType: 'warning_events',
+      position: { w: 6, h: 4, x: 6, y: 0 },
+    },
+    {
+      id: 'events-3',
+      cardType: 'recent_events',
+      position: { w: 6, h: 3, x: 0, y: 4 },
+    },
+    {
+      id: 'events-4',
+      cardType: 'events_timeline',
+      position: { w: 6, h: 3, x: 6, y: 4 },
+    },
+  ],
+
+  availableCardTypes: [
+    'event_stream',
+    'warning_events',
+    'recent_events',
+    'events_timeline',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 10000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-events-dashboard',
+}
+
+export default eventsDashboardConfig

--- a/web/src/config/dashboards/index.ts
+++ b/web/src/config/dashboards/index.ts
@@ -9,6 +9,11 @@ import { mainDashboardConfig } from './main'
 import { computeDashboardConfig } from './compute'
 import { securityDashboardConfig } from './security'
 import { gitopsDashboardConfig } from './gitops'
+import { storageDashboardConfig } from './storage'
+import { networkDashboardConfig } from './network'
+import { eventsDashboardConfig } from './events'
+import { workloadsDashboardConfig } from './workloads'
+import { operatorsDashboardConfig } from './operators'
 
 /**
  * Registry of all unified dashboard configurations
@@ -18,6 +23,11 @@ export const DASHBOARD_CONFIGS: DashboardConfigRegistry = {
   compute: computeDashboardConfig,
   security: securityDashboardConfig,
   gitops: gitopsDashboardConfig,
+  storage: storageDashboardConfig,
+  network: networkDashboardConfig,
+  events: eventsDashboardConfig,
+  workloads: workloadsDashboardConfig,
+  operators: operatorsDashboardConfig,
 }
 
 /**
@@ -47,4 +57,9 @@ export {
   computeDashboardConfig,
   securityDashboardConfig,
   gitopsDashboardConfig,
+  storageDashboardConfig,
+  networkDashboardConfig,
+  eventsDashboardConfig,
+  workloadsDashboardConfig,
+  operatorsDashboardConfig,
 }

--- a/web/src/config/dashboards/network.ts
+++ b/web/src/config/dashboards/network.ts
@@ -1,0 +1,97 @@
+/**
+ * Network Dashboard Configuration
+ *
+ * Dashboard focused on networking resources: Services, Ingresses, NetworkPolicies.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const networkDashboardConfig: UnifiedDashboardConfig = {
+  id: 'network',
+  name: 'Network',
+  subtitle: 'Networking resources',
+  route: '/network',
+
+  statsType: 'network',
+  stats: {
+    type: 'network',
+    title: 'Network Resources',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'services',
+        name: 'Services',
+        icon: 'Globe',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalServices' },
+      },
+      {
+        id: 'ingresses',
+        name: 'Ingresses',
+        icon: 'ArrowRightLeft',
+        color: 'purple',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalIngresses' },
+      },
+      {
+        id: 'network-policies',
+        name: 'Policies',
+        icon: 'Shield',
+        color: 'orange',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalNetworkPolicies' },
+      },
+      {
+        id: 'endpoints',
+        name: 'Endpoints',
+        icon: 'CircleDot',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalEndpoints' },
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'network-1',
+      cardType: 'network_overview',
+      position: { w: 4, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'network-2',
+      cardType: 'service_status',
+      position: { w: 8, h: 3, x: 4, y: 0 },
+    },
+    {
+      id: 'network-3',
+      cardType: 'ingress_status',
+      position: { w: 6, h: 3, x: 0, y: 3 },
+    },
+    {
+      id: 'network-4',
+      cardType: 'network_policy_status',
+      position: { w: 6, h: 3, x: 6, y: 3 },
+    },
+  ],
+
+  availableCardTypes: [
+    'network_overview',
+    'service_status',
+    'ingress_status',
+    'network_policy_status',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-network-dashboard',
+}
+
+export default networkDashboardConfig

--- a/web/src/config/dashboards/operators.ts
+++ b/web/src/config/dashboards/operators.ts
@@ -1,0 +1,98 @@
+/**
+ * Operators Dashboard Configuration
+ *
+ * Dashboard focused on operator resources: Operators, Subscriptions, CRDs.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const operatorsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'operators',
+  name: 'Operators',
+  subtitle: 'Operator lifecycle management',
+  route: '/operators',
+
+  statsType: 'operators',
+  stats: {
+    type: 'operators',
+    title: 'Operator Resources',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'operators',
+        name: 'Operators',
+        icon: 'Settings',
+        color: 'purple',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalOperators' },
+      },
+      {
+        id: 'subscriptions',
+        name: 'Subscriptions',
+        icon: 'RefreshCw',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalSubscriptions' },
+      },
+      {
+        id: 'healthy',
+        name: 'Healthy',
+        icon: 'CheckCircle2',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.healthyCount' },
+      },
+      {
+        id: 'degraded',
+        name: 'Degraded',
+        icon: 'AlertTriangle',
+        color: 'yellow',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.degradedCount' },
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'operators-1',
+      cardType: 'operator_status',
+      position: { w: 6, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'operators-2',
+      cardType: 'operator_subscription_status',
+      position: { w: 6, h: 3, x: 6, y: 0 },
+    },
+    {
+      id: 'operators-3',
+      cardType: 'helm_release_status',
+      position: { w: 6, h: 3, x: 0, y: 3 },
+    },
+    {
+      id: 'operators-4',
+      cardType: 'configmap_status',
+      position: { w: 6, h: 3, x: 6, y: 3 },
+    },
+  ],
+
+  availableCardTypes: [
+    'operator_status',
+    'operator_subscription_status',
+    'helm_release_status',
+    'configmap_status',
+    'secret_status',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-operators-dashboard',
+}
+
+export default operatorsDashboardConfig

--- a/web/src/config/dashboards/storage.ts
+++ b/web/src/config/dashboards/storage.ts
@@ -1,0 +1,107 @@
+/**
+ * Storage Dashboard Configuration
+ *
+ * Dashboard focused on storage resources: PVCs, PVs, StorageClasses.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const storageDashboardConfig: UnifiedDashboardConfig = {
+  id: 'storage',
+  name: 'Storage',
+  subtitle: 'Persistent storage resources',
+  route: '/storage',
+
+  statsType: 'storage',
+  stats: {
+    type: 'storage',
+    title: 'Storage Resources',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'pvcs',
+        name: 'PVCs',
+        icon: 'Database',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalPVCs' },
+      },
+      {
+        id: 'pvs',
+        name: 'PVs',
+        icon: 'HardDrive',
+        color: 'purple',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalPVs' },
+      },
+      {
+        id: 'bound',
+        name: 'Bound',
+        icon: 'CheckCircle2',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.boundCount' },
+      },
+      {
+        id: 'pending',
+        name: 'Pending',
+        icon: 'Clock',
+        color: 'yellow',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.pendingCount' },
+      },
+      {
+        id: 'storage-usage',
+        name: 'Usage',
+        icon: 'Percent',
+        color: 'orange',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.storageUsagePercent' },
+        format: 'percentage',
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'storage-1',
+      cardType: 'storage_overview',
+      position: { w: 4, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'storage-2',
+      cardType: 'pvc_status',
+      position: { w: 8, h: 3, x: 4, y: 0 },
+    },
+    {
+      id: 'storage-3',
+      cardType: 'pv_status',
+      position: { w: 6, h: 3, x: 0, y: 3 },
+    },
+    {
+      id: 'storage-4',
+      cardType: 'resource_quota_status',
+      position: { w: 6, h: 3, x: 6, y: 3 },
+    },
+  ],
+
+  availableCardTypes: [
+    'storage_overview',
+    'pvc_status',
+    'pv_status',
+    'resource_quota_status',
+    'limit_range_status',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-storage-dashboard',
+}
+
+export default storageDashboardConfig

--- a/web/src/config/dashboards/workloads.ts
+++ b/web/src/config/dashboards/workloads.ts
@@ -1,0 +1,119 @@
+/**
+ * Workloads Dashboard Configuration
+ *
+ * Dashboard focused on workload resources: Deployments, StatefulSets, DaemonSets, Jobs.
+ */
+
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const workloadsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'workloads',
+  name: 'Workloads',
+  subtitle: 'Application workloads',
+  route: '/workloads',
+
+  statsType: 'workloads',
+  stats: {
+    type: 'workloads',
+    title: 'Workload Resources',
+    collapsible: true,
+    showConfigButton: true,
+    blocks: [
+      {
+        id: 'deployments',
+        name: 'Deployments',
+        icon: 'Package',
+        color: 'blue',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalDeployments' },
+      },
+      {
+        id: 'statefulsets',
+        name: 'StatefulSets',
+        icon: 'Database',
+        color: 'purple',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalStatefulSets' },
+      },
+      {
+        id: 'daemonsets',
+        name: 'DaemonSets',
+        icon: 'Layers',
+        color: 'cyan',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalDaemonSets' },
+      },
+      {
+        id: 'jobs',
+        name: 'Jobs',
+        icon: 'Zap',
+        color: 'orange',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalJobs' },
+      },
+      {
+        id: 'cronjobs',
+        name: 'CronJobs',
+        icon: 'Clock',
+        color: 'green',
+        visible: true,
+        valueSource: { type: 'field', path: 'summary.totalCronJobs' },
+      },
+    ],
+  },
+
+  cards: [
+    {
+      id: 'workloads-1',
+      cardType: 'deployment_status',
+      position: { w: 6, h: 3, x: 0, y: 0 },
+    },
+    {
+      id: 'workloads-2',
+      cardType: 'deployment_issues',
+      position: { w: 6, h: 3, x: 6, y: 0 },
+    },
+    {
+      id: 'workloads-3',
+      cardType: 'statefulset_status',
+      position: { w: 6, h: 3, x: 0, y: 3 },
+    },
+    {
+      id: 'workloads-4',
+      cardType: 'daemonset_status',
+      position: { w: 6, h: 3, x: 6, y: 3 },
+    },
+    {
+      id: 'workloads-5',
+      cardType: 'job_status',
+      position: { w: 6, h: 3, x: 0, y: 6 },
+    },
+    {
+      id: 'workloads-6',
+      cardType: 'cronjob_status',
+      position: { w: 6, h: 3, x: 6, y: 6 },
+    },
+  ],
+
+  availableCardTypes: [
+    'deployment_status',
+    'deployment_issues',
+    'statefulset_status',
+    'daemonset_status',
+    'job_status',
+    'cronjob_status',
+    'replicaset_status',
+    'hpa_status',
+  ],
+
+  features: {
+    dragDrop: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+    addCard: true,
+  },
+
+  storageKey: 'kubestellar-unified-workloads-dashboard',
+}
+
+export default workloadsDashboardConfig


### PR DESCRIPTION
## Summary
- Add Storage dashboard config (PVCs, PVs, quotas)
- Add Network dashboard config (Services, Ingresses, NetworkPolicies)
- Add Events dashboard config (event stream, timeline, warnings)
- Add Workloads dashboard config (Deployments, StatefulSets, DaemonSets, Jobs)
- Add Operators dashboard config (OLM, Subscriptions, Helm)
- Total unified dashboards: 9

## Test plan
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)