### PR TITLE
✨ Unify all 144 card configs with config-driven architecture

### DIFF
--- a/web/src/config/cards/alert-rules.ts
+++ b/web/src/config/cards/alert-rules.ts
@@ -1,0 +1,34 @@
+/**
+ * Alert Rules Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const alertRulesConfig: UnifiedCardConfig = {
+  type: 'alert_rules',
+  title: 'Alert Rules',
+  category: 'alerts',
+  description: 'Prometheus/Alertmanager alert rules',
+  icon: 'Bell',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useAlertRules' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search rules...', searchFields: ['name', 'severity'], storageKey: 'alert-rules' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Rule', primary: true, render: 'truncate' },
+      { field: 'severity', header: 'Severity', render: 'status-badge', width: 80 },
+      { field: 'state', header: 'State', render: 'status-badge', width: 80 },
+      { field: 'alertsCount', header: 'Alerts', render: 'number', width: 60 },
+    ],
+  },
+  emptyState: { icon: 'Bell', title: 'No Alert Rules', message: 'No alert rules configured', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default alertRulesConfig

--- a/web/src/config/cards/app-status.ts
+++ b/web/src/config/cards/app-status.ts
@@ -1,0 +1,29 @@
+/**
+ * App Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const appStatusConfig: UnifiedCardConfig = {
+  type: 'app_status',
+  title: 'Application Status',
+  category: 'workloads',
+  description: 'Application deployment status overview',
+  icon: 'Package',
+  iconColor: 'text-blue-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useAppStatus' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'running', label: 'Running', color: 'green' },
+      { field: 'pending', label: 'Pending', color: 'yellow' },
+      { field: 'failed', label: 'Failed', color: 'red' },
+    ],
+  },
+  emptyState: { icon: 'Package', title: 'No Apps', message: 'No applications found', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: false,
+  isLive: true,
+}
+export default appStatusConfig

--- a/web/src/config/cards/argocd-applications.ts
+++ b/web/src/config/cards/argocd-applications.ts
@@ -1,0 +1,34 @@
+/**
+ * ArgoCD Applications Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const argocdApplicationsConfig: UnifiedCardConfig = {
+  type: 'argocd_applications',
+  title: 'ArgoCD Applications',
+  category: 'gitops',
+  description: 'ArgoCD managed applications',
+  icon: 'GitBranch',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useArgoCDApplications' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search apps...', searchFields: ['name', 'namespace', 'project'], storageKey: 'argocd-apps' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Application', primary: true, render: 'truncate' },
+      { field: 'project', header: 'Project', render: 'text', width: 100 },
+      { field: 'syncStatus', header: 'Sync', render: 'status-badge', width: 80 },
+      { field: 'healthStatus', header: 'Health', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'GitBranch', title: 'No Applications', message: 'No ArgoCD applications found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default argocdApplicationsConfig

--- a/web/src/config/cards/argocd-health.ts
+++ b/web/src/config/cards/argocd-health.ts
@@ -1,0 +1,30 @@
+/**
+ * ArgoCD Health Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const argocdHealthConfig: UnifiedCardConfig = {
+  type: 'argocd_health',
+  title: 'ArgoCD Health',
+  category: 'gitops',
+  description: 'Health status of ArgoCD applications',
+  icon: 'HeartPulse',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useArgoCDHealth' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'healthy', label: 'Healthy', color: 'green' },
+      { field: 'degraded', label: 'Degraded', color: 'yellow' },
+      { field: 'progressing', label: 'Progressing', color: 'blue' },
+      { field: 'missing', label: 'Missing', color: 'red' },
+    ],
+  },
+  emptyState: { icon: 'HeartPulse', title: 'No Health Data', message: 'No ArgoCD health data available', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: true,
+  isLive: false,
+}
+export default argocdHealthConfig

--- a/web/src/config/cards/argocd-sync-status.ts
+++ b/web/src/config/cards/argocd-sync-status.ts
@@ -1,0 +1,29 @@
+/**
+ * ArgoCD Sync Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const argocdSyncStatusConfig: UnifiedCardConfig = {
+  type: 'argocd_sync_status',
+  title: 'ArgoCD Sync Status',
+  category: 'gitops',
+  description: 'Sync status of ArgoCD applications',
+  icon: 'RefreshCw',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useArgoCDSyncStatus' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'synced', label: 'Synced', color: 'green' },
+      { field: 'outOfSync', label: 'Out of Sync', color: 'yellow' },
+      { field: 'unknown', label: 'Unknown', color: 'gray' },
+    ],
+  },
+  emptyState: { icon: 'RefreshCw', title: 'No Status', message: 'No sync status available', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: true,
+  isLive: false,
+}
+export default argocdSyncStatusConfig

--- a/web/src/config/cards/cert-manager.ts
+++ b/web/src/config/cards/cert-manager.ts
@@ -1,0 +1,29 @@
+/**
+ * Cert Manager Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const certManagerConfig: UnifiedCardConfig = {
+  type: 'cert_manager',
+  title: 'Certificates',
+  category: 'security',
+  description: 'cert-manager certificate status',
+  icon: 'FileKey',
+  iconColor: 'text-green-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useCertManager' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'total', label: 'Total', color: 'blue' },
+      { field: 'ready', label: 'Ready', color: 'green' },
+      { field: 'expiringSoon', label: 'Expiring', color: 'yellow' },
+    ],
+  },
+  emptyState: { icon: 'FileKey', title: 'No Certs', message: 'No certificates found', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: false,
+  isLive: true,
+}
+export default certManagerConfig

--- a/web/src/config/cards/chart-versions.ts
+++ b/web/src/config/cards/chart-versions.ts
@@ -1,0 +1,31 @@
+/**
+ * Chart Versions Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const chartVersionsConfig: UnifiedCardConfig = {
+  type: 'chart_versions',
+  title: 'Chart Versions',
+  category: 'gitops',
+  description: 'Available Helm chart versions',
+  icon: 'Package',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useChartVersions' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Chart', primary: true, render: 'truncate' },
+      { field: 'version', header: 'Version', render: 'text', width: 80 },
+      { field: 'appVersion', header: 'App Ver', render: 'text', width: 80 },
+      { field: 'created', header: 'Created', render: 'relative-time', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'Package', title: 'No Charts', message: 'No chart versions found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default chartVersionsConfig

--- a/web/src/config/cards/checkers.ts
+++ b/web/src/config/cards/checkers.ts
@@ -1,0 +1,22 @@
+/**
+ * Checkers Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const checkersConfig: UnifiedCardConfig = {
+  type: 'checkers',
+  title: 'AI Checkers',
+  category: 'games',
+  description: 'Play checkers against AI',
+  icon: 'Circle',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'Checkers' },
+  emptyState: { icon: 'Circle', title: 'Checkers', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default checkersConfig

--- a/web/src/config/cards/cluster-comparison.ts
+++ b/web/src/config/cards/cluster-comparison.ts
@@ -1,0 +1,32 @@
+/**
+ * Cluster Comparison Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterComparisonConfig: UnifiedCardConfig = {
+  type: 'cluster_comparison',
+  title: 'Cluster Comparison',
+  category: 'cluster-health',
+  description: 'Compare metrics across clusters',
+  icon: 'GitCompare',
+  iconColor: 'text-blue-400',
+  defaultWidth: 12,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useClusterComparison' },
+  content: {
+    type: 'table',
+    columns: [
+      { field: 'cluster', header: 'Cluster', primary: true, render: 'cluster-badge' },
+      { field: 'nodes', header: 'Nodes', render: 'number', align: 'right' },
+      { field: 'pods', header: 'Pods', render: 'number', align: 'right' },
+      { field: 'cpu', header: 'CPU %', render: 'percentage', align: 'right' },
+      { field: 'memory', header: 'Memory %', render: 'percentage', align: 'right' },
+      { field: 'status', header: 'Status', render: 'status-badge' },
+    ],
+  },
+  emptyState: { icon: 'GitCompare', title: 'No Clusters', message: 'No clusters to compare', variant: 'info' },
+  loadingState: { type: 'table', rows: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default clusterComparisonConfig

--- a/web/src/config/cards/cluster-costs.ts
+++ b/web/src/config/cards/cluster-costs.ts
@@ -1,0 +1,29 @@
+/**
+ * Cluster Costs Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterCostsConfig: UnifiedCardConfig = {
+  type: 'cluster_costs',
+  title: 'Cluster Costs',
+  category: 'cost',
+  description: 'Cost allocation by cluster',
+  icon: 'DollarSign',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useClusterCosts' },
+  content: {
+    type: 'chart',
+    chartType: 'bar',
+    dataKey: 'clusters',
+    xAxis: 'cluster',
+    yAxis: ['compute', 'storage', 'network'],
+    colors: ['#3b82f6', '#10b981', '#f59e0b'],
+  },
+  emptyState: { icon: 'DollarSign', title: 'No Cost Data', message: 'Cost data not available', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: true,
+  isLive: false,
+}
+export default clusterCostsConfig

--- a/web/src/config/cards/cluster-focus.ts
+++ b/web/src/config/cards/cluster-focus.ts
@@ -1,0 +1,30 @@
+/**
+ * Cluster Focus Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterFocusConfig: UnifiedCardConfig = {
+  type: 'cluster_focus',
+  title: 'Cluster Focus',
+  category: 'cluster-health',
+  description: 'Focused view of selected cluster',
+  icon: 'Target',
+  iconColor: 'text-purple-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useClusterFocus' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'nodes', label: 'Nodes', color: 'blue' },
+      { field: 'pods', label: 'Pods', color: 'green' },
+      { field: 'cpu', label: 'CPU %', color: 'orange', format: 'percentage' },
+      { field: 'memory', label: 'Memory %', color: 'purple', format: 'percentage' },
+    ],
+  },
+  emptyState: { icon: 'Target', title: 'Select Cluster', message: 'Select a cluster to view details', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default clusterFocusConfig

--- a/web/src/config/cards/cluster-groups.ts
+++ b/web/src/config/cards/cluster-groups.ts
@@ -1,0 +1,30 @@
+/**
+ * Cluster Groups Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterGroupsConfig: UnifiedCardConfig = {
+  type: 'cluster_groups',
+  title: 'Cluster Groups',
+  category: 'cluster-health',
+  description: 'Manage cluster groupings',
+  icon: 'Layers',
+  iconColor: 'text-indigo-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useClusterGroups' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'name', header: 'Group', primary: true, render: 'truncate' },
+      { field: 'clusterCount', header: 'Clusters', render: 'number', width: 70 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Layers', title: 'No Groups', message: 'No cluster groups defined', variant: 'info' },
+  loadingState: { type: 'list', rows: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default clusterGroupsConfig

--- a/web/src/config/cards/cluster-health-monitor.ts
+++ b/web/src/config/cards/cluster-health-monitor.ts
@@ -1,0 +1,22 @@
+/**
+ * Cluster Health Monitor Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterHealthMonitorConfig: UnifiedCardConfig = {
+  type: 'cluster_health_monitor',
+  title: 'Cluster Monitor',
+  category: 'cluster-health',
+  description: 'Comprehensive cluster health',
+  icon: 'HeartPulse',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useClusterHealthMonitor' },
+  content: { type: 'custom', component: 'ClusterHealthView' },
+  emptyState: { icon: 'HeartPulse', title: 'No Clusters', message: 'No clusters to monitor', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default clusterHealthMonitorConfig

--- a/web/src/config/cards/cluster-locations.ts
+++ b/web/src/config/cards/cluster-locations.ts
@@ -1,0 +1,25 @@
+/**
+ * Cluster Locations Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterLocationsConfig: UnifiedCardConfig = {
+  type: 'cluster_locations',
+  title: 'Cluster Locations',
+  category: 'cluster-health',
+  description: 'Geographic distribution of clusters',
+  icon: 'MapPin',
+  iconColor: 'text-red-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useClusterLocations' },
+  content: {
+    type: 'custom',
+    component: 'ClusterMap',
+  },
+  emptyState: { icon: 'MapPin', title: 'No Location Data', message: 'Cluster location data not available', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: true,
+  isLive: false,
+}
+export default clusterLocationsConfig

--- a/web/src/config/cards/cluster-network.ts
+++ b/web/src/config/cards/cluster-network.ts
@@ -1,0 +1,25 @@
+/**
+ * Cluster Network Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterNetworkConfig: UnifiedCardConfig = {
+  type: 'cluster_network',
+  title: 'Cluster Network',
+  category: 'network',
+  description: 'Network topology visualization',
+  icon: 'Network',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useClusterNetwork' },
+  content: {
+    type: 'custom',
+    component: 'NetworkTopology',
+  },
+  emptyState: { icon: 'Network', title: 'No Network Data', message: 'Network data not available', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: true,
+  isLive: false,
+}
+export default clusterNetworkConfig

--- a/web/src/config/cards/cluster-resource-tree.ts
+++ b/web/src/config/cards/cluster-resource-tree.ts
@@ -1,0 +1,25 @@
+/**
+ * Cluster Resource Tree Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterResourceTreeConfig: UnifiedCardConfig = {
+  type: 'cluster_resource_tree',
+  title: 'Resource Tree',
+  category: 'cluster-health',
+  description: 'Hierarchical view of cluster resources',
+  icon: 'GitBranch',
+  iconColor: 'text-purple-400',
+  defaultWidth: 12,
+  defaultHeight: 5,
+  dataSource: { type: 'hook', hook: 'useClusterResourceTree' },
+  content: {
+    type: 'custom',
+    component: 'ResourceTree',
+  },
+  emptyState: { icon: 'GitBranch', title: 'No Resources', message: 'Select a cluster to view resources', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default clusterResourceTreeConfig

--- a/web/src/config/cards/compliance-score.ts
+++ b/web/src/config/cards/compliance-score.ts
@@ -1,0 +1,29 @@
+/**
+ * Compliance Score Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const complianceScoreConfig: UnifiedCardConfig = {
+  type: 'compliance_score',
+  title: 'Compliance Score',
+  category: 'security',
+  description: 'Overall compliance posture score',
+  icon: 'Award',
+  iconColor: 'text-green-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useComplianceScore' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'overall', label: 'Overall', color: 'blue', format: 'percentage' },
+      { field: 'security', label: 'Security', color: 'red', format: 'percentage' },
+      { field: 'reliability', label: 'Reliability', color: 'green', format: 'percentage' },
+    ],
+  },
+  emptyState: { icon: 'Award', title: 'No Score', message: 'Compliance data not available', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: true,
+  isLive: false,
+}
+export default complianceScoreConfig

--- a/web/src/config/cards/compute-overview.ts
+++ b/web/src/config/cards/compute-overview.ts
@@ -1,0 +1,29 @@
+/**
+ * Compute Overview Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const computeOverviewConfig: UnifiedCardConfig = {
+  type: 'compute_overview',
+  title: 'Compute Overview',
+  category: 'compute',
+  description: 'Compute resource summary',
+  icon: 'Cpu',
+  iconColor: 'text-blue-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useComputeOverview' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'nodes', label: 'Nodes', color: 'blue' },
+      { field: 'cpuUsage', label: 'CPU %', color: 'orange', format: 'percentage' },
+      { field: 'memoryUsage', label: 'Memory %', color: 'green', format: 'percentage' },
+    ],
+  },
+  emptyState: { icon: 'Cpu', title: 'No Data', message: 'No compute data available', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: false,
+  isLive: true,
+}
+export default computeOverviewConfig

--- a/web/src/config/cards/console-ai-health-check.ts
+++ b/web/src/config/cards/console-ai-health-check.ts
@@ -1,0 +1,22 @@
+/**
+ * Console AI Health Check Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const consoleAiHealthCheckConfig: UnifiedCardConfig = {
+  type: 'console_ai_health_check',
+  title: 'AI Health Check',
+  category: 'ai-ml',
+  description: 'AI-powered cluster health check',
+  icon: 'Stethoscope',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useConsoleAIHealthCheck' },
+  content: { type: 'custom', component: 'AIHealthCheckView' },
+  emptyState: { icon: 'Stethoscope', title: 'No Check', message: 'Run AI health check', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default consoleAiHealthCheckConfig

--- a/web/src/config/cards/console-ai-issues.ts
+++ b/web/src/config/cards/console-ai-issues.ts
@@ -1,0 +1,31 @@
+/**
+ * Console AI Issues Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const consoleAiIssuesConfig: UnifiedCardConfig = {
+  type: 'console_ai_issues',
+  title: 'AI Issues',
+  category: 'ai-ml',
+  description: 'AI-detected cluster issues',
+  icon: 'Bot',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useConsoleAIIssues' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'severity', header: 'Sev', render: 'status-badge', width: 60 },
+      { field: 'issue', header: 'Issue', primary: true, render: 'truncate' },
+      { field: 'cluster', header: 'Cluster', render: 'cluster-badge', width: 100 },
+      { field: 'confidence', header: 'Conf', render: 'percentage', width: 60 },
+    ],
+  },
+  emptyState: { icon: 'Bot', title: 'No Issues', message: 'No AI-detected issues', variant: 'success' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default consoleAiIssuesConfig

--- a/web/src/config/cards/console-ai-kubeconfig-audit.ts
+++ b/web/src/config/cards/console-ai-kubeconfig-audit.ts
@@ -1,0 +1,22 @@
+/**
+ * Console AI Kubeconfig Audit Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const consoleAiKubeconfigAuditConfig: UnifiedCardConfig = {
+  type: 'console_ai_kubeconfig_audit',
+  title: 'Kubeconfig Audit',
+  category: 'security',
+  description: 'AI kubeconfig security audit',
+  icon: 'FileKey',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useConsoleAIKubeconfigAudit' },
+  content: { type: 'custom', component: 'KubeconfigAuditView' },
+  emptyState: { icon: 'FileKey', title: 'No Audit', message: 'Run kubeconfig audit', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default consoleAiKubeconfigAuditConfig

--- a/web/src/config/cards/console-ai-offline-detection.ts
+++ b/web/src/config/cards/console-ai-offline-detection.ts
@@ -1,0 +1,30 @@
+/**
+ * Console AI Offline Detection Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const consoleAiOfflineDetectionConfig: UnifiedCardConfig = {
+  type: 'console_ai_offline_detection',
+  title: 'Offline Detection',
+  category: 'cluster-health',
+  description: 'AI-detected offline clusters',
+  icon: 'WifiOff',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useConsoleAIOfflineDetection' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'cluster', header: 'Cluster', primary: true, render: 'cluster-badge' },
+      { field: 'lastSeen', header: 'Last Seen', render: 'relative-time', width: 100 },
+      { field: 'reason', header: 'Reason', render: 'truncate', width: 150 },
+    ],
+  },
+  emptyState: { icon: 'WifiOff', title: 'All Online', message: 'All clusters are online', variant: 'success' },
+  loadingState: { type: 'list', rows: 3 },
+  isDemoData: false,
+  isLive: true,
+}
+export default consoleAiOfflineDetectionConfig

--- a/web/src/config/cards/container-tetris.ts
+++ b/web/src/config/cards/container-tetris.ts
@@ -1,0 +1,22 @@
+/**
+ * Container Tetris Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const containerTetrisConfig: UnifiedCardConfig = {
+  type: 'container_tetris',
+  title: 'Container Tetris',
+  category: 'games',
+  description: 'Container-themed Tetris game',
+  icon: 'Box',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 5,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'ContainerTetris' },
+  emptyState: { icon: 'Box', title: 'Tetris', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default containerTetrisConfig

--- a/web/src/config/cards/crd-health.ts
+++ b/web/src/config/cards/crd-health.ts
@@ -1,0 +1,34 @@
+/**
+ * CRD Health Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const crdHealthConfig: UnifiedCardConfig = {
+  type: 'crd_health',
+  title: 'CRD Health',
+  category: 'operators',
+  description: 'Custom Resource Definition health status',
+  icon: 'FileCode',
+  iconColor: 'text-purple-400',
+  defaultWidth: 5,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useCRDHealth' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search CRDs...', searchFields: ['name', 'group'], storageKey: 'crd-health' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Name', primary: true, render: 'truncate' },
+      { field: 'group', header: 'Group', render: 'text', width: 120 },
+      { field: 'version', header: 'Version', render: 'text', width: 80 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'FileCode', title: 'No CRDs', message: 'No Custom Resource Definitions found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default crdHealthConfig

--- a/web/src/config/cards/deployment-missions.ts
+++ b/web/src/config/cards/deployment-missions.ts
@@ -1,0 +1,30 @@
+/**
+ * Deployment Missions Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const deploymentMissionsConfig: UnifiedCardConfig = {
+  type: 'deployment_missions',
+  title: 'Deployment Missions',
+  category: 'workloads',
+  description: 'Track deployment progress',
+  icon: 'Target',
+  iconColor: 'text-purple-400',
+  defaultWidth: 5,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useDeploymentMissions' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'name', header: 'Mission', primary: true, render: 'truncate' },
+      { field: 'progress', header: 'Progress', render: 'progress-bar', width: 100 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Target', title: 'No Missions', message: 'No active deployment missions', variant: 'info' },
+  loadingState: { type: 'list', rows: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default deploymentMissionsConfig

--- a/web/src/config/cards/deployment-progress.ts
+++ b/web/src/config/cards/deployment-progress.ts
@@ -1,0 +1,31 @@
+/**
+ * Deployment Progress Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const deploymentProgressConfig: UnifiedCardConfig = {
+  type: 'deployment_progress',
+  title: 'Deployment Progress',
+  category: 'workloads',
+  description: 'Track deployment rollout progress',
+  icon: 'RefreshCw',
+  iconColor: 'text-blue-400',
+  defaultWidth: 5,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useDeploymentProgress' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'name', header: 'Deployment', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'progress', header: 'Progress', render: 'progress-bar', width: 120 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'RefreshCw', title: 'No Rollouts', message: 'No deployments in progress', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default deploymentProgressConfig

--- a/web/src/config/cards/dynamic-card.ts
+++ b/web/src/config/cards/dynamic-card.ts
@@ -1,0 +1,22 @@
+/**
+ * Dynamic Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const dynamicCardConfig: UnifiedCardConfig = {
+  type: 'dynamic_card',
+  title: 'Dynamic Card',
+  category: 'utility',
+  description: 'User-defined dynamic card',
+  icon: 'Sparkles',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'DynamicCardRenderer' },
+  emptyState: { icon: 'Sparkles', title: 'Dynamic', message: 'Configure card', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default dynamicCardConfig

--- a/web/src/config/cards/event-summary.ts
+++ b/web/src/config/cards/event-summary.ts
@@ -1,0 +1,30 @@
+/**
+ * Event Summary Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const eventSummaryConfig: UnifiedCardConfig = {
+  type: 'event_summary',
+  title: 'Event Summary',
+  category: 'events',
+  description: 'Summary of Kubernetes events',
+  icon: 'Activity',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useEventSummary' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'total', label: 'Total', color: 'blue' },
+      { field: 'normal', label: 'Normal', color: 'green' },
+      { field: 'warning', label: 'Warning', color: 'yellow' },
+      { field: 'error', label: 'Error', color: 'red' },
+    ],
+  },
+  emptyState: { icon: 'Activity', title: 'No Events', message: 'No events recorded', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default eventSummaryConfig

--- a/web/src/config/cards/external-secrets.ts
+++ b/web/src/config/cards/external-secrets.ts
@@ -1,0 +1,29 @@
+/**
+ * External Secrets Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const externalSecretsConfig: UnifiedCardConfig = {
+  type: 'external_secrets',
+  title: 'External Secrets',
+  category: 'security',
+  description: 'External Secrets Operator status',
+  icon: 'Key',
+  iconColor: 'text-purple-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useExternalSecrets' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'total', label: 'Total', color: 'blue' },
+      { field: 'ready', label: 'Ready', color: 'green' },
+      { field: 'failed', label: 'Failed', color: 'red' },
+    ],
+  },
+  emptyState: { icon: 'Key', title: 'No ESO', message: 'External Secrets not configured', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: true,
+  isLive: false,
+}
+export default externalSecretsConfig

--- a/web/src/config/cards/falco-alerts.ts
+++ b/web/src/config/cards/falco-alerts.ts
@@ -1,0 +1,29 @@
+/**
+ * Falco Alerts Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const falcoAlertsConfig: UnifiedCardConfig = {
+  type: 'falco_alerts',
+  title: 'Falco Alerts',
+  category: 'security',
+  description: 'Runtime security alerts from Falco',
+  icon: 'AlertTriangle',
+  iconColor: 'text-red-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useFalcoAlerts' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'critical', label: 'Critical', color: 'red' },
+      { field: 'warning', label: 'Warning', color: 'yellow' },
+      { field: 'notice', label: 'Notice', color: 'blue' },
+    ],
+  },
+  emptyState: { icon: 'AlertTriangle', title: 'No Alerts', message: 'No Falco alerts', variant: 'success' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: true,
+  isLive: false,
+}
+export default falcoAlertsConfig

--- a/web/src/config/cards/flappy-pod.ts
+++ b/web/src/config/cards/flappy-pod.ts
@@ -1,0 +1,22 @@
+/**
+ * Flappy Pod Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const flappyPodConfig: UnifiedCardConfig = {
+  type: 'flappy_pod',
+  title: 'Flappy Pod',
+  category: 'games',
+  description: 'Flappy bird with pods',
+  icon: 'Bird',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'FlappyPod' },
+  emptyState: { icon: 'Bird', title: 'Flappy Pod', message: 'Press space to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default flappyPodConfig

--- a/web/src/config/cards/game-2048.ts
+++ b/web/src/config/cards/game-2048.ts
@@ -1,0 +1,22 @@
+/**
+ * 2048 Game Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const game2048Config: UnifiedCardConfig = {
+  type: 'game_2048',
+  title: 'Kube 2048',
+  category: 'games',
+  description: 'Classic 2048 sliding puzzle',
+  icon: 'Grid2X2',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'Game2048' },
+  emptyState: { icon: 'Grid2X2', title: '2048', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default game2048Config

--- a/web/src/config/cards/gateway-status.ts
+++ b/web/src/config/cards/gateway-status.ts
@@ -1,0 +1,31 @@
+/**
+ * Gateway Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gatewayStatusConfig: UnifiedCardConfig = {
+  type: 'gateway_status',
+  title: 'Gateway Status',
+  category: 'network',
+  description: 'Gateway API resources',
+  icon: 'Router',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGatewayStatus' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Gateway', primary: true, render: 'truncate' },
+      { field: 'class', header: 'Class', render: 'text', width: 100 },
+      { field: 'addresses', header: 'Addresses', render: 'number', width: 80 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Router', title: 'No Gateways', message: 'No Gateway API resources', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default gatewayStatusConfig

--- a/web/src/config/cards/github-activity.ts
+++ b/web/src/config/cards/github-activity.ts
@@ -1,0 +1,31 @@
+/**
+ * GitHub Activity Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const githubActivityConfig: UnifiedCardConfig = {
+  type: 'github_activity',
+  title: 'GitHub Activity',
+  category: 'ci-cd',
+  description: 'Recent GitHub repository activity',
+  icon: 'Github',
+  iconColor: 'text-gray-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGithubActivity' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'type', header: 'Event', render: 'text', width: 80 },
+      { field: 'repo', header: 'Repository', primary: true, render: 'truncate' },
+      { field: 'actor', header: 'Actor', render: 'text', width: 100 },
+      { field: 'timestamp', header: 'Time', render: 'relative-time', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Github', title: 'No Activity', message: 'No recent GitHub activity', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default githubActivityConfig

--- a/web/src/config/cards/github-ci-monitor.ts
+++ b/web/src/config/cards/github-ci-monitor.ts
@@ -1,0 +1,22 @@
+/**
+ * GitHub CI Monitor Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const githubCiMonitorConfig: UnifiedCardConfig = {
+  type: 'github_ci_monitor',
+  title: 'GitHub Actions',
+  category: 'ci-cd',
+  description: 'GitHub Actions monitoring',
+  icon: 'Github',
+  iconColor: 'text-gray-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGitHubCIMonitor' },
+  content: { type: 'custom', component: 'GitHubCIView' },
+  emptyState: { icon: 'Github', title: 'No Actions', message: 'GitHub Actions not configured', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default githubCiMonitorConfig

--- a/web/src/config/cards/gpu-inventory.ts
+++ b/web/src/config/cards/gpu-inventory.ts
@@ -1,0 +1,35 @@
+/**
+ * GPU Inventory Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gpuInventoryConfig: UnifiedCardConfig = {
+  type: 'gpu_inventory',
+  title: 'GPU Inventory',
+  category: 'compute',
+  description: 'Available GPU resources',
+  icon: 'Cpu',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGPUInventory' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search GPUs...', searchFields: ['name', 'model', 'cluster'], storageKey: 'gpu-inventory' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'cluster', header: 'Cluster', render: 'cluster-badge', width: 100 },
+      { field: 'node', header: 'Node', render: 'text', width: 120 },
+      { field: 'model', header: 'Model', primary: true, render: 'truncate' },
+      { field: 'memory', header: 'Memory', render: 'bytes', width: 80 },
+      { field: 'utilization', header: 'Util %', render: 'percentage', width: 70 },
+    ],
+  },
+  emptyState: { icon: 'Cpu', title: 'No GPUs', message: 'No GPU resources found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default gpuInventoryConfig

--- a/web/src/config/cards/gpu-overview.ts
+++ b/web/src/config/cards/gpu-overview.ts
@@ -1,0 +1,30 @@
+/**
+ * GPU Overview Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gpuOverviewConfig: UnifiedCardConfig = {
+  type: 'gpu_overview',
+  title: 'GPU Overview',
+  category: 'compute',
+  description: 'GPU resource summary',
+  icon: 'Cpu',
+  iconColor: 'text-green-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGPUOverview' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'total', label: 'Total GPUs', color: 'blue' },
+      { field: 'available', label: 'Available', color: 'green' },
+      { field: 'inUse', label: 'In Use', color: 'orange' },
+      { field: 'avgUtilization', label: 'Avg Util %', color: 'purple', format: 'percentage' },
+    ],
+  },
+  emptyState: { icon: 'Cpu', title: 'No GPUs', message: 'No GPU data available', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: true,
+  isLive: false,
+}
+export default gpuOverviewConfig

--- a/web/src/config/cards/gpu-status.ts
+++ b/web/src/config/cards/gpu-status.ts
@@ -1,0 +1,31 @@
+/**
+ * GPU Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gpuStatusConfig: UnifiedCardConfig = {
+  type: 'gpu_status',
+  title: 'GPU Status',
+  category: 'compute',
+  description: 'GPU health and status',
+  icon: 'Activity',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGPUStatus' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'GPU', primary: true, render: 'truncate' },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+      { field: 'temperature', header: 'Temp', render: 'text', width: 60, suffix: '°C' },
+      { field: 'power', header: 'Power', render: 'text', width: 60, suffix: 'W' },
+    ],
+  },
+  emptyState: { icon: 'Activity', title: 'No GPUs', message: 'No GPU status available', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default gpuStatusConfig

--- a/web/src/config/cards/gpu-usage-trend.ts
+++ b/web/src/config/cards/gpu-usage-trend.ts
@@ -1,0 +1,29 @@
+/**
+ * GPU Usage Trend Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gpuUsageTrendConfig: UnifiedCardConfig = {
+  type: 'gpu_usage_trend',
+  title: 'GPU Usage Trend',
+  category: 'live-trends',
+  description: 'Historical GPU usage over time',
+  icon: 'BarChart2',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGPUUsageTrend' },
+  content: {
+    type: 'chart',
+    chartType: 'area',
+    dataKey: 'timeseries',
+    xAxis: 'timestamp',
+    yAxis: ['memory', 'compute'],
+    colors: ['#10b981', '#3b82f6'],
+  },
+  emptyState: { icon: 'BarChart2', title: 'No Data', message: 'No GPU trend data', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: true,
+  isLive: true,
+}
+export default gpuUsageTrendConfig

--- a/web/src/config/cards/gpu-utilization.ts
+++ b/web/src/config/cards/gpu-utilization.ts
@@ -1,0 +1,29 @@
+/**
+ * GPU Utilization Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gpuUtilizationConfig: UnifiedCardConfig = {
+  type: 'gpu_utilization',
+  title: 'GPU Utilization',
+  category: 'live-trends',
+  description: 'Real-time GPU utilization chart',
+  icon: 'TrendingUp',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGPUUtilization' },
+  content: {
+    type: 'chart',
+    chartType: 'line',
+    dataKey: 'timeseries',
+    xAxis: 'timestamp',
+    yAxis: ['utilization'],
+    colors: ['#10b981'],
+  },
+  emptyState: { icon: 'TrendingUp', title: 'No Data', message: 'No GPU utilization data', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: true,
+  isLive: true,
+}
+export default gpuUtilizationConfig

--- a/web/src/config/cards/gpu-workloads.ts
+++ b/web/src/config/cards/gpu-workloads.ts
@@ -1,0 +1,31 @@
+/**
+ * GPU Workloads Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const gpuWorkloadsConfig: UnifiedCardConfig = {
+  type: 'gpu_workloads',
+  title: 'GPU Workloads',
+  category: 'compute',
+  description: 'Workloads using GPU resources',
+  icon: 'Zap',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useGPUWorkloads' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Workload', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'gpuCount', header: 'GPUs', render: 'number', width: 60 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Zap', title: 'No Workloads', message: 'No GPU workloads found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default gpuWorkloadsConfig

--- a/web/src/config/cards/helm-history.ts
+++ b/web/src/config/cards/helm-history.ts
@@ -1,0 +1,32 @@
+/**
+ * Helm History Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const helmHistoryConfig: UnifiedCardConfig = {
+  type: 'helm_history',
+  title: 'Helm History',
+  category: 'gitops',
+  description: 'Helm release revision history',
+  icon: 'History',
+  iconColor: 'text-blue-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useHelmHistory' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'revision', header: 'Rev', render: 'number', width: 50 },
+      { field: 'chart', header: 'Chart', primary: true, render: 'truncate' },
+      { field: 'appVersion', header: 'App Ver', render: 'text', width: 80 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+      { field: 'updated', header: 'Updated', render: 'relative-time', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'History', title: 'No History', message: 'No release history available', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: false,
+}
+export default helmHistoryConfig

--- a/web/src/config/cards/helm-values-diff.ts
+++ b/web/src/config/cards/helm-values-diff.ts
@@ -1,0 +1,25 @@
+/**
+ * Helm Values Diff Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const helmValuesDiffConfig: UnifiedCardConfig = {
+  type: 'helm_values_diff',
+  title: 'Helm Values Diff',
+  category: 'gitops',
+  description: 'Compare Helm values between revisions',
+  icon: 'FileDiff',
+  iconColor: 'text-purple-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useHelmValuesDiff' },
+  content: {
+    type: 'custom',
+    component: 'DiffViewer',
+  },
+  emptyState: { icon: 'FileDiff', title: 'No Diff', message: 'Select revisions to compare', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default helmValuesDiffConfig

--- a/web/src/config/cards/iframe-embed.ts
+++ b/web/src/config/cards/iframe-embed.ts
@@ -1,0 +1,22 @@
+/**
+ * Iframe Embed Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const iframeEmbedConfig: UnifiedCardConfig = {
+  type: 'iframe_embed',
+  title: 'Embed',
+  category: 'utility',
+  description: 'Embed external content',
+  icon: 'Globe',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'IframeEmbed' },
+  emptyState: { icon: 'Globe', title: 'Embed', message: 'Configure URL to embed', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default iframeEmbedConfig

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -1,187 +1,457 @@
 /**
- * Card Configuration Registry
- *
- * Central registry for all unified card configurations.
- * Add new card configs here as they are migrated.
+ * Card Configuration Registry - Auto-generated
  */
 
 import type { UnifiedCardConfig, CardConfigRegistry } from '../../lib/unified/types'
 
-// Import card configurations
-import { podIssuesConfig } from './pod-issues'
-import { clusterHealthConfig } from './cluster-health'
-import { deploymentStatusConfig } from './deployment-status'
-import { eventStreamConfig } from './event-stream'
-import { resourceUsageConfig } from './resource-usage'
-// Chart cards (PR 4)
-import { clusterMetricsConfig } from './cluster-metrics'
-import { eventsTimelineConfig } from './events-timeline'
-// Additional cards (PR 7)
-import { securityIssuesConfig } from './security-issues'
 import { activeAlertsConfig } from './active-alerts'
-import { storageOverviewConfig } from './storage-overview'
-import { networkOverviewConfig } from './network-overview'
-import { topPodsConfig } from './top-pods'
-import { gitopsDriftConfig } from './gitops-drift'
-// Event cards (PR 8)
-import { warningEventsConfig } from './warning-events'
-import { recentEventsConfig } from './recent-events'
-// Storage & Networking cards (PR 8)
-import { pvcStatusConfig } from './pvc-status'
-import { serviceStatusConfig } from './service-status'
-// Workload & Operator cards (PR 9)
-import { deploymentIssuesConfig } from './deployment-issues'
-import { operatorStatusConfig } from './operator-status'
-// Additional resource cards (PR 10)
-import { helmReleaseStatusConfig } from './helm-release-status'
+import { alertRulesConfig } from './alert-rules'
+import { appStatusConfig } from './app-status'
+import { argocdApplicationsConfig } from './argocd-applications'
+import { argocdHealthConfig } from './argocd-health'
+import { argocdSyncStatusConfig } from './argocd-sync-status'
+import { certManagerConfig } from './cert-manager'
+import { chartVersionsConfig } from './chart-versions'
+import { checkersConfig } from './checkers'
+import { clusterComparisonConfig } from './cluster-comparison'
+import { clusterCostsConfig } from './cluster-costs'
+import { clusterFocusConfig } from './cluster-focus'
+import { clusterGroupsConfig } from './cluster-groups'
+import { clusterHealthConfig } from './cluster-health'
+import { clusterHealthMonitorConfig } from './cluster-health-monitor'
+import { clusterLocationsConfig } from './cluster-locations'
+import { clusterMetricsConfig } from './cluster-metrics'
+import { clusterNetworkConfig } from './cluster-network'
+import { clusterResourceTreeConfig } from './cluster-resource-tree'
+import { complianceScoreConfig } from './compliance-score'
+import { computeOverviewConfig } from './compute-overview'
 import { configMapStatusConfig } from './configmap-status'
-import { secretStatusConfig } from './secret-status'
-import { ingressStatusConfig } from './ingress-status'
-import { nodeStatusConfig } from './node-status'
-// Workload resource cards (PR 11)
-import { jobStatusConfig } from './job-status'
+import { consoleAiHealthCheckConfig } from './console-ai-health-check'
+import { consoleAiIssuesConfig } from './console-ai-issues'
+import { consoleAiKubeconfigAuditConfig } from './console-ai-kubeconfig-audit'
+import { consoleAiOfflineDetectionConfig } from './console-ai-offline-detection'
+import { containerTetrisConfig } from './container-tetris'
+import { crdHealthConfig } from './crd-health'
 import { cronJobStatusConfig } from './cronjob-status'
-import { statefulSetStatusConfig } from './statefulset-status'
 import { daemonSetStatusConfig } from './daemonset-status'
+import { deploymentIssuesConfig } from './deployment-issues'
+import { deploymentMissionsConfig } from './deployment-missions'
+import { deploymentProgressConfig } from './deployment-progress'
+import { deploymentStatusConfig } from './deployment-status'
+import { dynamicCardConfig } from './dynamic-card'
+import { eventStreamConfig } from './event-stream'
+import { eventSummaryConfig } from './event-summary'
+import { eventsTimelineConfig } from './events-timeline'
+import { externalSecretsConfig } from './external-secrets'
+import { falcoAlertsConfig } from './falco-alerts'
+import { flappyPodConfig } from './flappy-pod'
+import { game2048Config } from './game-2048'
+import { gatewayStatusConfig } from './gateway-status'
+import { githubActivityConfig } from './github-activity'
+import { githubCiMonitorConfig } from './github-ci-monitor'
+import { gitopsDriftConfig } from './gitops-drift'
+import { gpuInventoryConfig } from './gpu-inventory'
+import { gpuOverviewConfig } from './gpu-overview'
+import { gpuStatusConfig } from './gpu-status'
+import { gpuUsageTrendConfig } from './gpu-usage-trend'
+import { gpuUtilizationConfig } from './gpu-utilization'
+import { gpuWorkloadsConfig } from './gpu-workloads'
+import { helmHistoryConfig } from './helm-history'
+import { helmReleaseStatusConfig } from './helm-release-status'
+import { helmValuesDiffConfig } from './helm-values-diff'
 import { hpaStatusConfig } from './hpa-status'
-// Additional resource cards (PR 12)
-import { replicaSetStatusConfig } from './replicaset-status'
-import { pvStatusConfig } from './pv-status'
-import { resourceQuotaStatusConfig } from './resource-quota-status'
+import { iframeEmbedConfig } from './iframe-embed'
+import { ingressStatusConfig } from './ingress-status'
+import { jobStatusConfig } from './job-status'
+import { kubeChessConfig } from './kube-chess'
+import { kubeCraftConfig } from './kube-craft'
+import { kubeDoomConfig } from './kube-doom'
+import { kubeGalagaConfig } from './kube-galaga'
+import { kubeKartConfig } from './kube-kart'
+import { kubeKongConfig } from './kube-kong'
+import { kubeManConfig } from './kube-man'
+import { kubePongConfig } from './kube-pong'
+import { kubeSnakeConfig } from './kube-snake'
+import { kubecostOverviewConfig } from './kubecost-overview'
+import { kubectlConfig } from './kubectl'
+import { kubedleConfig } from './kubedle'
+import { kubescapeScanConfig } from './kubescape-scan'
+import { kustomizationStatusConfig } from './kustomization-status'
+import { kyvernoPoliciesConfig } from './kyverno-policies'
 import { limitRangeStatusConfig } from './limit-range-status'
-import { networkPolicyStatusConfig } from './network-policy-status'
+import { llmInferenceConfig } from './llm-inference'
+import { llmModelsConfig } from './llm-models'
+import { llmdStackMonitorConfig } from './llmd-stack-monitor'
+import { matchGameConfig } from './match-game'
+import { mlJobsConfig } from './ml-jobs'
+import { mlNotebooksConfig } from './ml-notebooks'
+import { mobileBrowserConfig } from './mobile-browser'
+import { namespaceEventsConfig } from './namespace-events'
+import { namespaceMonitorConfig } from './namespace-monitor'
+import { namespaceOverviewConfig } from './namespace-overview'
+import { namespaceQuotasConfig } from './namespace-quotas'
+import { namespaceRbacConfig } from './namespace-rbac'
 import { namespaceStatusConfig } from './namespace-status'
+import { networkOverviewConfig } from './network-overview'
+import { networkPolicyStatusConfig } from './network-policy-status'
+import { networkUtilsConfig } from './network-utils'
+import { nodeInvadersConfig } from './node-invaders'
+import { nodeStatusConfig } from './node-status'
+import { opaPoliciesConfig } from './opa-policies'
+import { opencostOverviewConfig } from './opencost-overview'
+import { operatorStatusConfig } from './operator-status'
 import { operatorSubscriptionStatusConfig } from './operator-subscription-status'
-import { serviceAccountStatusConfig } from './service-account-status'
-// RBAC cards (PR 13)
-import { roleStatusConfig } from './role-status'
+import { operatorSubscriptionsConfig } from './operator-subscriptions'
+import { overlayComparisonConfig } from './overlay-comparison'
+import { podBrothersConfig } from './pod-brothers'
+import { podCrosserConfig } from './pod-crosser'
+import { podHealthTrendConfig } from './pod-health-trend'
+import { podIssuesConfig } from './pod-issues'
+import { podPitfallConfig } from './pod-pitfall'
+import { podSweeperConfig } from './pod-sweeper'
+import { policyViolationsConfig } from './policy-violations'
+import { providerHealthConfig } from './provider-health'
+import { prowCiMonitorConfig } from './prow-ci-monitor'
+import { prowHistoryConfig } from './prow-history'
+import { prowJobsConfig } from './prow-jobs'
+import { prowStatusConfig } from './prow-status'
+import { pvStatusConfig } from './pv-status'
+import { pvcStatusConfig } from './pvc-status'
+import { recentEventsConfig } from './recent-events'
+import { replicaSetStatusConfig } from './replicaset-status'
+import { resourceCapacityConfig } from './resource-capacity'
+import { resourceMarshallConfig } from './resource-marshall'
+import { resourceQuotaStatusConfig } from './resource-quota-status'
+import { resourceTrendConfig } from './resource-trend'
+import { resourceUsageConfig } from './resource-usage'
 import { roleBindingStatusConfig } from './role-binding-status'
+import { roleStatusConfig } from './role-status'
+import { rssFeedConfig } from './rss-feed'
+import { secretStatusConfig } from './secret-status'
+import { securityIssuesConfig } from './security-issues'
+import { serviceAccountStatusConfig } from './service-account-status'
+import { serviceExportsConfig } from './service-exports'
+import { serviceImportsConfig } from './service-imports'
+import { serviceStatusConfig } from './service-status'
+import { serviceTopologyConfig } from './service-topology'
+import { solitaireConfig } from './solitaire'
+import { statefulSetStatusConfig } from './statefulset-status'
+import { stockMarketTickerConfig } from './stock-market-ticker'
+import { storageOverviewConfig } from './storage-overview'
+import { sudokuGameConfig } from './sudoku-game'
+import { topPodsConfig } from './top-pods'
+import { trivyScanConfig } from './trivy-scan'
+import { upgradeStatusConfig } from './upgrade-status'
+import { userManagementConfig } from './user-management'
+import { vaultSecretsConfig } from './vault-secrets'
+import { warningEventsConfig } from './warning-events'
+import { weatherConfig } from './weather'
+import { workloadDeploymentConfig } from './workload-deployment'
+import { workloadMonitorConfig } from './workload-monitor'
 
-/**
- * Registry of all unified card configurations
- * Key is the card type, value is the configuration
- */
 export const CARD_CONFIGS: CardConfigRegistry = {
-  // Migrated cards (PR 3)
-  pod_issues: podIssuesConfig,
-  cluster_health: clusterHealthConfig,
-  deployment_status: deploymentStatusConfig,
-  event_stream: eventStreamConfig,
-  resource_usage: resourceUsageConfig,
-  // Chart cards (PR 4)
-  cluster_metrics: clusterMetricsConfig,
-  events_timeline: eventsTimelineConfig,
-  // Additional cards (PR 7)
-  security_issues: securityIssuesConfig,
   active_alerts: activeAlertsConfig,
-  storage_overview: storageOverviewConfig,
-  network_overview: networkOverviewConfig,
-  top_pods: topPodsConfig,
-  gitops_drift: gitopsDriftConfig,
-  // Event cards (PR 8)
-  warning_events: warningEventsConfig,
-  recent_events: recentEventsConfig,
-  // Storage & Networking cards (PR 8)
-  pvc_status: pvcStatusConfig,
-  service_status: serviceStatusConfig,
-  // Workload & Operator cards (PR 9)
-  deployment_issues: deploymentIssuesConfig,
-  operator_status: operatorStatusConfig,
-  // Additional resource cards (PR 10)
-  helm_release_status: helmReleaseStatusConfig,
+  alert_rules: alertRulesConfig,
+  app_status: appStatusConfig,
+  argocd_applications: argocdApplicationsConfig,
+  argocd_health: argocdHealthConfig,
+  argocd_sync_status: argocdSyncStatusConfig,
+  cert_manager: certManagerConfig,
+  chart_versions: chartVersionsConfig,
+  checkers: checkersConfig,
+  cluster_comparison: clusterComparisonConfig,
+  cluster_costs: clusterCostsConfig,
+  cluster_focus: clusterFocusConfig,
+  cluster_groups: clusterGroupsConfig,
+  cluster_health: clusterHealthConfig,
+  cluster_health_monitor: clusterHealthMonitorConfig,
+  cluster_locations: clusterLocationsConfig,
+  cluster_metrics: clusterMetricsConfig,
+  cluster_network: clusterNetworkConfig,
+  cluster_resource_tree: clusterResourceTreeConfig,
+  compliance_score: complianceScoreConfig,
+  compute_overview: computeOverviewConfig,
   configmap_status: configMapStatusConfig,
-  secret_status: secretStatusConfig,
-  ingress_status: ingressStatusConfig,
-  node_status: nodeStatusConfig,
-  // Workload resource cards (PR 11)
-  job_status: jobStatusConfig,
+  console_ai_health_check: consoleAiHealthCheckConfig,
+  console_ai_issues: consoleAiIssuesConfig,
+  console_ai_kubeconfig_audit: consoleAiKubeconfigAuditConfig,
+  console_ai_offline_detection: consoleAiOfflineDetectionConfig,
+  container_tetris: containerTetrisConfig,
+  crd_health: crdHealthConfig,
   cronjob_status: cronJobStatusConfig,
-  statefulset_status: statefulSetStatusConfig,
   daemonset_status: daemonSetStatusConfig,
+  deployment_issues: deploymentIssuesConfig,
+  deployment_missions: deploymentMissionsConfig,
+  deployment_progress: deploymentProgressConfig,
+  deployment_status: deploymentStatusConfig,
+  dynamic_card: dynamicCardConfig,
+  event_stream: eventStreamConfig,
+  event_summary: eventSummaryConfig,
+  events_timeline: eventsTimelineConfig,
+  external_secrets: externalSecretsConfig,
+  falco_alerts: falcoAlertsConfig,
+  flappy_pod: flappyPodConfig,
+  game_2048: game2048Config,
+  gateway_status: gatewayStatusConfig,
+  github_activity: githubActivityConfig,
+  github_ci_monitor: githubCiMonitorConfig,
+  gitops_drift: gitopsDriftConfig,
+  gpu_inventory: gpuInventoryConfig,
+  gpu_overview: gpuOverviewConfig,
+  gpu_status: gpuStatusConfig,
+  gpu_usage_trend: gpuUsageTrendConfig,
+  gpu_utilization: gpuUtilizationConfig,
+  gpu_workloads: gpuWorkloadsConfig,
+  helm_history: helmHistoryConfig,
+  helm_release_status: helmReleaseStatusConfig,
+  helm_values_diff: helmValuesDiffConfig,
   hpa_status: hpaStatusConfig,
-  // Additional resource cards (PR 12)
-  replicaset_status: replicaSetStatusConfig,
-  pv_status: pvStatusConfig,
-  resource_quota_status: resourceQuotaStatusConfig,
+  iframe_embed: iframeEmbedConfig,
+  ingress_status: ingressStatusConfig,
+  job_status: jobStatusConfig,
+  kube_chess: kubeChessConfig,
+  kube_craft: kubeCraftConfig,
+  kube_doom: kubeDoomConfig,
+  kube_galaga: kubeGalagaConfig,
+  kube_kart: kubeKartConfig,
+  kube_kong: kubeKongConfig,
+  kube_man: kubeManConfig,
+  kube_pong: kubePongConfig,
+  kube_snake: kubeSnakeConfig,
+  kubecost_overview: kubecostOverviewConfig,
+  kubectl: kubectlConfig,
+  kubedle: kubedleConfig,
+  kubescape_scan: kubescapeScanConfig,
+  kustomization_status: kustomizationStatusConfig,
+  kyverno_policies: kyvernoPoliciesConfig,
   limit_range_status: limitRangeStatusConfig,
-  network_policy_status: networkPolicyStatusConfig,
+  llm_inference: llmInferenceConfig,
+  llm_models: llmModelsConfig,
+  llmd_stack_monitor: llmdStackMonitorConfig,
+  match_game: matchGameConfig,
+  ml_jobs: mlJobsConfig,
+  ml_notebooks: mlNotebooksConfig,
+  mobile_browser: mobileBrowserConfig,
+  namespace_events: namespaceEventsConfig,
+  namespace_monitor: namespaceMonitorConfig,
+  namespace_overview: namespaceOverviewConfig,
+  namespace_quotas: namespaceQuotasConfig,
+  namespace_rbac: namespaceRbacConfig,
   namespace_status: namespaceStatusConfig,
+  network_overview: networkOverviewConfig,
+  network_policy_status: networkPolicyStatusConfig,
+  network_utils: networkUtilsConfig,
+  node_invaders: nodeInvadersConfig,
+  node_status: nodeStatusConfig,
+  opa_policies: opaPoliciesConfig,
+  opencost_overview: opencostOverviewConfig,
+  operator_status: operatorStatusConfig,
   operator_subscription_status: operatorSubscriptionStatusConfig,
-  service_account_status: serviceAccountStatusConfig,
-  // RBAC cards (PR 13)
-  role_status: roleStatusConfig,
+  operator_subscriptions: operatorSubscriptionsConfig,
+  overlay_comparison: overlayComparisonConfig,
+  pod_brothers: podBrothersConfig,
+  pod_crosser: podCrosserConfig,
+  pod_health_trend: podHealthTrendConfig,
+  pod_issues: podIssuesConfig,
+  pod_pitfall: podPitfallConfig,
+  pod_sweeper: podSweeperConfig,
+  policy_violations: policyViolationsConfig,
+  provider_health: providerHealthConfig,
+  prow_ci_monitor: prowCiMonitorConfig,
+  prow_history: prowHistoryConfig,
+  prow_jobs: prowJobsConfig,
+  prow_status: prowStatusConfig,
+  pv_status: pvStatusConfig,
+  pvc_status: pvcStatusConfig,
+  recent_events: recentEventsConfig,
+  replicaset_status: replicaSetStatusConfig,
+  resource_capacity: resourceCapacityConfig,
+  resource_marshall: resourceMarshallConfig,
+  resource_quota_status: resourceQuotaStatusConfig,
+  resource_trend: resourceTrendConfig,
+  resource_usage: resourceUsageConfig,
   role_binding_status: roleBindingStatusConfig,
+  role_status: roleStatusConfig,
+  rss_feed: rssFeedConfig,
+  secret_status: secretStatusConfig,
+  security_issues: securityIssuesConfig,
+  service_account_status: serviceAccountStatusConfig,
+  service_exports: serviceExportsConfig,
+  service_imports: serviceImportsConfig,
+  service_status: serviceStatusConfig,
+  service_topology: serviceTopologyConfig,
+  solitaire: solitaireConfig,
+  statefulset_status: statefulSetStatusConfig,
+  stock_market_ticker: stockMarketTickerConfig,
+  storage_overview: storageOverviewConfig,
+  sudoku_game: sudokuGameConfig,
+  top_pods: topPodsConfig,
+  trivy_scan: trivyScanConfig,
+  upgrade_status: upgradeStatusConfig,
+  user_management: userManagementConfig,
+  vault_secrets: vaultSecretsConfig,
+  warning_events: warningEventsConfig,
+  weather: weatherConfig,
+  workload_deployment: workloadDeploymentConfig,
+  workload_monitor: workloadMonitorConfig,
 }
 
-/**
- * Get a card configuration by type
- */
 export function getCardConfig(cardType: string): UnifiedCardConfig | undefined {
   return CARD_CONFIGS[cardType]
 }
 
-/**
- * Check if a card type has a unified configuration
- */
 export function hasUnifiedConfig(cardType: string): boolean {
   return cardType in CARD_CONFIGS
 }
 
-/**
- * Get all registered unified card types
- */
 export function getUnifiedCardTypes(): string[] {
   return Object.keys(CARD_CONFIGS)
 }
 
-// Re-export individual configs for direct imports
+// Re-export configs
 export {
-  podIssuesConfig,
-  clusterHealthConfig,
-  deploymentStatusConfig,
-  eventStreamConfig,
-  resourceUsageConfig,
-  // Chart cards (PR 4)
-  clusterMetricsConfig,
-  eventsTimelineConfig,
-  // Additional cards (PR 7)
-  securityIssuesConfig,
   activeAlertsConfig,
-  storageOverviewConfig,
-  networkOverviewConfig,
-  topPodsConfig,
-  gitopsDriftConfig,
-  // Event cards (PR 8)
-  warningEventsConfig,
-  recentEventsConfig,
-  // Storage & Networking cards (PR 8)
-  pvcStatusConfig,
-  serviceStatusConfig,
-  // Workload & Operator cards (PR 9)
-  deploymentIssuesConfig,
-  operatorStatusConfig,
-  // Additional resource cards (PR 10)
-  helmReleaseStatusConfig,
+  alertRulesConfig,
+  appStatusConfig,
+  argocdApplicationsConfig,
+  argocdHealthConfig,
+  argocdSyncStatusConfig,
+  certManagerConfig,
+  chartVersionsConfig,
+  checkersConfig,
+  clusterComparisonConfig,
+  clusterCostsConfig,
+  clusterFocusConfig,
+  clusterGroupsConfig,
+  clusterHealthConfig,
+  clusterHealthMonitorConfig,
+  clusterLocationsConfig,
+  clusterMetricsConfig,
+  clusterNetworkConfig,
+  clusterResourceTreeConfig,
+  complianceScoreConfig,
+  computeOverviewConfig,
   configMapStatusConfig,
-  secretStatusConfig,
-  ingressStatusConfig,
-  nodeStatusConfig,
-  // Workload resource cards (PR 11)
-  jobStatusConfig,
+  consoleAiHealthCheckConfig,
+  consoleAiIssuesConfig,
+  consoleAiKubeconfigAuditConfig,
+  consoleAiOfflineDetectionConfig,
+  containerTetrisConfig,
+  crdHealthConfig,
   cronJobStatusConfig,
-  statefulSetStatusConfig,
   daemonSetStatusConfig,
+  deploymentIssuesConfig,
+  deploymentMissionsConfig,
+  deploymentProgressConfig,
+  deploymentStatusConfig,
+  dynamicCardConfig,
+  eventStreamConfig,
+  eventSummaryConfig,
+  eventsTimelineConfig,
+  externalSecretsConfig,
+  falcoAlertsConfig,
+  flappyPodConfig,
+  game2048Config,
+  gatewayStatusConfig,
+  githubActivityConfig,
+  githubCiMonitorConfig,
+  gitopsDriftConfig,
+  gpuInventoryConfig,
+  gpuOverviewConfig,
+  gpuStatusConfig,
+  gpuUsageTrendConfig,
+  gpuUtilizationConfig,
+  gpuWorkloadsConfig,
+  helmHistoryConfig,
+  helmReleaseStatusConfig,
+  helmValuesDiffConfig,
   hpaStatusConfig,
-  // Additional resource cards (PR 12)
-  replicaSetStatusConfig,
-  pvStatusConfig,
-  resourceQuotaStatusConfig,
+  iframeEmbedConfig,
+  ingressStatusConfig,
+  jobStatusConfig,
+  kubeChessConfig,
+  kubeCraftConfig,
+  kubeDoomConfig,
+  kubeGalagaConfig,
+  kubeKartConfig,
+  kubeKongConfig,
+  kubeManConfig,
+  kubePongConfig,
+  kubeSnakeConfig,
+  kubecostOverviewConfig,
+  kubectlConfig,
+  kubedleConfig,
+  kubescapeScanConfig,
+  kustomizationStatusConfig,
+  kyvernoPoliciesConfig,
   limitRangeStatusConfig,
-  networkPolicyStatusConfig,
+  llmInferenceConfig,
+  llmModelsConfig,
+  llmdStackMonitorConfig,
+  matchGameConfig,
+  mlJobsConfig,
+  mlNotebooksConfig,
+  mobileBrowserConfig,
+  namespaceEventsConfig,
+  namespaceMonitorConfig,
+  namespaceOverviewConfig,
+  namespaceQuotasConfig,
+  namespaceRbacConfig,
   namespaceStatusConfig,
+  networkOverviewConfig,
+  networkPolicyStatusConfig,
+  networkUtilsConfig,
+  nodeInvadersConfig,
+  nodeStatusConfig,
+  opaPoliciesConfig,
+  opencostOverviewConfig,
+  operatorStatusConfig,
   operatorSubscriptionStatusConfig,
-  serviceAccountStatusConfig,
-  // RBAC cards (PR 13)
-  roleStatusConfig,
+  operatorSubscriptionsConfig,
+  overlayComparisonConfig,
+  podBrothersConfig,
+  podCrosserConfig,
+  podHealthTrendConfig,
+  podIssuesConfig,
+  podPitfallConfig,
+  podSweeperConfig,
+  policyViolationsConfig,
+  providerHealthConfig,
+  prowCiMonitorConfig,
+  prowHistoryConfig,
+  prowJobsConfig,
+  prowStatusConfig,
+  pvStatusConfig,
+  pvcStatusConfig,
+  recentEventsConfig,
+  replicaSetStatusConfig,
+  resourceCapacityConfig,
+  resourceMarshallConfig,
+  resourceQuotaStatusConfig,
+  resourceTrendConfig,
+  resourceUsageConfig,
   roleBindingStatusConfig,
+  roleStatusConfig,
+  rssFeedConfig,
+  secretStatusConfig,
+  securityIssuesConfig,
+  serviceAccountStatusConfig,
+  serviceExportsConfig,
+  serviceImportsConfig,
+  serviceStatusConfig,
+  serviceTopologyConfig,
+  solitaireConfig,
+  statefulSetStatusConfig,
+  stockMarketTickerConfig,
+  storageOverviewConfig,
+  sudokuGameConfig,
+  topPodsConfig,
+  trivyScanConfig,
+  upgradeStatusConfig,
+  userManagementConfig,
+  vaultSecretsConfig,
+  warningEventsConfig,
+  weatherConfig,
+  workloadDeploymentConfig,
+  workloadMonitorConfig,
 }

--- a/web/src/config/cards/kube-chess.ts
+++ b/web/src/config/cards/kube-chess.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Chess Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeChessConfig: UnifiedCardConfig = {
+  type: 'kube_chess',
+  title: 'Kube Chess',
+  category: 'games',
+  description: 'Play chess against AI',
+  icon: 'Crown',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeChess' },
+  emptyState: { icon: 'Crown', title: 'Kube Chess', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeChessConfig

--- a/web/src/config/cards/kube-craft.ts
+++ b/web/src/config/cards/kube-craft.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Craft Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeCraftConfig: UnifiedCardConfig = {
+  type: 'kube_craft',
+  title: 'Kube Craft',
+  category: 'games',
+  description: 'Minecraft-style building',
+  icon: 'Hammer',
+  iconColor: 'text-brown-400',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeCraft' },
+  emptyState: { icon: 'Hammer', title: 'Kube Craft', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeCraftConfig

--- a/web/src/config/cards/kube-doom.ts
+++ b/web/src/config/cards/kube-doom.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Doom Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeDoomConfig: UnifiedCardConfig = {
+  type: 'kube_doom',
+  title: 'Kube Doom',
+  category: 'games',
+  description: 'Doom-style FPS',
+  icon: 'Skull',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeDoom' },
+  emptyState: { icon: 'Skull', title: 'Kube Doom', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeDoomConfig

--- a/web/src/config/cards/kube-galaga.ts
+++ b/web/src/config/cards/kube-galaga.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Galaga Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeGalagaConfig: UnifiedCardConfig = {
+  type: 'kube_galaga',
+  title: 'Kube Galaga',
+  category: 'games',
+  description: 'Galaga-style shooter',
+  icon: 'Crosshair',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeGalaga' },
+  emptyState: { icon: 'Crosshair', title: 'Kube Galaga', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeGalagaConfig

--- a/web/src/config/cards/kube-kart.ts
+++ b/web/src/config/cards/kube-kart.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Kart Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeKartConfig: UnifiedCardConfig = {
+  type: 'kube_kart',
+  title: 'Kube Kart',
+  category: 'games',
+  description: 'Racing game',
+  icon: 'Car',
+  iconColor: 'text-red-400',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeKart' },
+  emptyState: { icon: 'Car', title: 'Kube Kart', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeKartConfig

--- a/web/src/config/cards/kube-kong.ts
+++ b/web/src/config/cards/kube-kong.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Kong Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeKongConfig: UnifiedCardConfig = {
+  type: 'kube_kong',
+  title: 'Kube Kong',
+  category: 'games',
+  description: 'Donkey Kong inspired game',
+  icon: 'Banana',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeKong' },
+  emptyState: { icon: 'Banana', title: 'Kube Kong', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeKongConfig

--- a/web/src/config/cards/kube-man.ts
+++ b/web/src/config/cards/kube-man.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube-Man Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeManConfig: UnifiedCardConfig = {
+  type: 'kube_man',
+  title: 'Kube-Man',
+  category: 'games',
+  description: 'Kubernetes Pac-Man clone',
+  icon: 'Ghost',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeMan' },
+  emptyState: { icon: 'Ghost', title: 'Kube-Man', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeManConfig

--- a/web/src/config/cards/kube-pong.ts
+++ b/web/src/config/cards/kube-pong.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Pong Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubePongConfig: UnifiedCardConfig = {
+  type: 'kube_pong',
+  title: 'Kube Pong',
+  category: 'games',
+  description: 'Classic Pong game',
+  icon: 'Minus',
+  iconColor: 'text-white',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubePong' },
+  emptyState: { icon: 'Minus', title: 'Kube Pong', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubePongConfig

--- a/web/src/config/cards/kube-snake.ts
+++ b/web/src/config/cards/kube-snake.ts
@@ -1,0 +1,22 @@
+/**
+ * Kube Snake Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubeSnakeConfig: UnifiedCardConfig = {
+  type: 'kube_snake',
+  title: 'Kube Snake',
+  category: 'games',
+  description: 'Classic Snake game',
+  icon: 'Waves',
+  iconColor: 'text-green-400',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'KubeSnake' },
+  emptyState: { icon: 'Waves', title: 'Kube Snake', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubeSnakeConfig

--- a/web/src/config/cards/kubecost-overview.ts
+++ b/web/src/config/cards/kubecost-overview.ts
@@ -1,0 +1,29 @@
+/**
+ * Kubecost Overview Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubecostOverviewConfig: UnifiedCardConfig = {
+  type: 'kubecost_overview',
+  title: 'Kubecost',
+  category: 'cost',
+  description: 'Kubecost cost allocation',
+  icon: 'Wallet',
+  iconColor: 'text-blue-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useKubecostOverview' },
+  content: {
+    type: 'chart',
+    chartType: 'donut',
+    dataKey: 'breakdown',
+    valueKey: 'cost',
+    labelKey: 'category',
+    colors: ['#3b82f6', '#10b981', '#f59e0b', '#ef4444'],
+  },
+  emptyState: { icon: 'Wallet', title: 'No Cost Data', message: 'Kubecost not configured', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: true,
+  isLive: false,
+}
+export default kubecostOverviewConfig

--- a/web/src/config/cards/kubectl.ts
+++ b/web/src/config/cards/kubectl.ts
@@ -1,0 +1,25 @@
+/**
+ * Kubectl Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubectlConfig: UnifiedCardConfig = {
+  type: 'kubectl',
+  title: 'Kubectl',
+  category: 'utility',
+  description: 'Interactive kubectl terminal',
+  icon: 'Terminal',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useKubectl' },
+  content: {
+    type: 'custom',
+    component: 'KubectlTerminal',
+  },
+  emptyState: { icon: 'Terminal', title: 'Terminal', message: 'Enter kubectl commands', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default kubectlConfig

--- a/web/src/config/cards/kubedle.ts
+++ b/web/src/config/cards/kubedle.ts
@@ -1,0 +1,22 @@
+/**
+ * Kubedle Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubedleConfig: UnifiedCardConfig = {
+  type: 'kubedle',
+  title: 'Kubedle',
+  category: 'games',
+  description: 'Kubernetes word guessing game',
+  icon: 'Type',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'Kubedle' },
+  emptyState: { icon: 'Type', title: 'Kubedle', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default kubedleConfig

--- a/web/src/config/cards/kubescape-scan.ts
+++ b/web/src/config/cards/kubescape-scan.ts
@@ -1,0 +1,29 @@
+/**
+ * Kubescape Scan Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kubescapeScanConfig: UnifiedCardConfig = {
+  type: 'kubescape_scan',
+  title: 'Kubescape Scan',
+  category: 'security',
+  description: 'Kubernetes security posture scan',
+  icon: 'ShieldAlert',
+  iconColor: 'text-purple-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useKubescapeScan' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'score', label: 'Score', color: 'blue', format: 'percentage' },
+      { field: 'passed', label: 'Passed', color: 'green' },
+      { field: 'failed', label: 'Failed', color: 'red' },
+    ],
+  },
+  emptyState: { icon: 'ShieldAlert', title: 'No Scans', message: 'No Kubescape scan data', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: true,
+  isLive: false,
+}
+export default kubescapeScanConfig

--- a/web/src/config/cards/kustomization-status.ts
+++ b/web/src/config/cards/kustomization-status.ts
@@ -1,0 +1,31 @@
+/**
+ * Kustomization Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kustomizationStatusConfig: UnifiedCardConfig = {
+  type: 'kustomization_status',
+  title: 'Kustomizations',
+  category: 'gitops',
+  description: 'Flux Kustomization resources',
+  icon: 'Layers',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useKustomizationStatus' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Name', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'ready', header: 'Ready', render: 'status-badge', width: 70 },
+      { field: 'lastApplied', header: 'Applied', render: 'relative-time', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'Layers', title: 'No Kustomizations', message: 'No Kustomization resources found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default kustomizationStatusConfig

--- a/web/src/config/cards/kyverno-policies.ts
+++ b/web/src/config/cards/kyverno-policies.ts
@@ -1,0 +1,34 @@
+/**
+ * Kyverno Policies Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const kyvernoPoliciesConfig: UnifiedCardConfig = {
+  type: 'kyverno_policies',
+  title: 'Kyverno Policies',
+  category: 'security',
+  description: 'Kyverno policy resources',
+  icon: 'ShieldCheck',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useKyvernoPolicies' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search policies...', searchFields: ['name', 'category'], storageKey: 'kyverno-policies' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Policy', primary: true, render: 'truncate' },
+      { field: 'category', header: 'Category', render: 'text', width: 100 },
+      { field: 'validationFailures', header: 'Failures', render: 'number', width: 70 },
+      { field: 'background', header: 'Background', render: 'text', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'ShieldCheck', title: 'No Policies', message: 'No Kyverno policies found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default kyvernoPoliciesConfig

--- a/web/src/config/cards/llm-inference.ts
+++ b/web/src/config/cards/llm-inference.ts
@@ -1,0 +1,31 @@
+/**
+ * LLM Inference Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const llmInferenceConfig: UnifiedCardConfig = {
+  type: 'llm_inference',
+  title: 'LLM Inference',
+  category: 'ai-ml',
+  description: 'LLM inference endpoint status',
+  icon: 'Bot',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useLLMInference' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'model', header: 'Model', primary: true, render: 'truncate' },
+      { field: 'endpoint', header: 'Endpoint', render: 'text', width: 120 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+      { field: 'latency', header: 'Latency', render: 'text', width: 70, suffix: 'ms' },
+    ],
+  },
+  emptyState: { icon: 'Bot', title: 'No Endpoints', message: 'No LLM inference endpoints', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default llmInferenceConfig

--- a/web/src/config/cards/llm-models.ts
+++ b/web/src/config/cards/llm-models.ts
@@ -1,0 +1,31 @@
+/**
+ * LLM Models Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const llmModelsConfig: UnifiedCardConfig = {
+  type: 'llm_models',
+  title: 'LLM Models',
+  category: 'ai-ml',
+  description: 'Deployed LLM models',
+  icon: 'Brain',
+  iconColor: 'text-pink-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useLLMModels' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Model', primary: true, render: 'truncate' },
+      { field: 'version', header: 'Version', render: 'text', width: 80 },
+      { field: 'replicas', header: 'Replicas', render: 'number', width: 70 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Brain', title: 'No Models', message: 'No LLM models deployed', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default llmModelsConfig

--- a/web/src/config/cards/llmd-stack-monitor.ts
+++ b/web/src/config/cards/llmd-stack-monitor.ts
@@ -1,0 +1,22 @@
+/**
+ * LLMd Stack Monitor Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const llmdStackMonitorConfig: UnifiedCardConfig = {
+  type: 'llmd_stack_monitor',
+  title: 'LLMd Stack',
+  category: 'ai-ml',
+  description: 'LLM-d stack health monitoring',
+  icon: 'Layers',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useLLMdStackMonitor' },
+  content: { type: 'custom', component: 'LLMdStackView' },
+  emptyState: { icon: 'Layers', title: 'No Stack', message: 'LLM-d stack not detected', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default llmdStackMonitorConfig

--- a/web/src/config/cards/match-game.ts
+++ b/web/src/config/cards/match-game.ts
@@ -1,0 +1,22 @@
+/**
+ * Match Game Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const matchGameConfig: UnifiedCardConfig = {
+  type: 'match_game',
+  title: 'Kube Match',
+  category: 'games',
+  description: 'Memory matching game',
+  icon: 'Puzzle',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'MatchGame' },
+  emptyState: { icon: 'Puzzle', title: 'Match', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default matchGameConfig

--- a/web/src/config/cards/ml-jobs.ts
+++ b/web/src/config/cards/ml-jobs.ts
@@ -1,0 +1,31 @@
+/**
+ * ML Jobs Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const mlJobsConfig: UnifiedCardConfig = {
+  type: 'ml_jobs',
+  title: 'ML Jobs',
+  category: 'ai-ml',
+  description: 'Machine learning training jobs',
+  icon: 'Sparkles',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useMLJobs' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Job', primary: true, render: 'truncate' },
+      { field: 'type', header: 'Type', render: 'text', width: 80 },
+      { field: 'progress', header: 'Progress', render: 'progress-bar', width: 100 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Sparkles', title: 'No Jobs', message: 'No ML jobs found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default mlJobsConfig

--- a/web/src/config/cards/ml-notebooks.ts
+++ b/web/src/config/cards/ml-notebooks.ts
@@ -1,0 +1,31 @@
+/**
+ * ML Notebooks Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const mlNotebooksConfig: UnifiedCardConfig = {
+  type: 'ml_notebooks',
+  title: 'ML Notebooks',
+  category: 'ai-ml',
+  description: 'Jupyter notebook instances',
+  icon: 'BookOpen',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useMLNotebooks' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Notebook', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'image', header: 'Image', render: 'truncate', width: 120 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'BookOpen', title: 'No Notebooks', message: 'No ML notebooks found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default mlNotebooksConfig

--- a/web/src/config/cards/mobile-browser.ts
+++ b/web/src/config/cards/mobile-browser.ts
@@ -1,0 +1,22 @@
+/**
+ * Mobile Browser Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const mobileBrowserConfig: UnifiedCardConfig = {
+  type: 'mobile_browser',
+  title: 'Mobile Browser',
+  category: 'utility',
+  description: 'Mobile web browser emulator',
+  icon: 'Smartphone',
+  iconColor: 'text-gray-400',
+  defaultWidth: 5,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'MobileBrowser' },
+  emptyState: { icon: 'Smartphone', title: 'Browser', message: 'Enter URL to browse', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default mobileBrowserConfig

--- a/web/src/config/cards/namespace-events.ts
+++ b/web/src/config/cards/namespace-events.ts
@@ -1,0 +1,31 @@
+/**
+ * Namespace Events Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const namespaceEventsConfig: UnifiedCardConfig = {
+  type: 'namespace_events',
+  title: 'Namespace Events',
+  category: 'events',
+  description: 'Events in selected namespace',
+  icon: 'Activity',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useNamespaceEvents' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'type', header: 'Type', render: 'status-badge', width: 80 },
+      { field: 'reason', header: 'Reason', render: 'text', width: 100 },
+      { field: 'message', header: 'Message', primary: true, render: 'truncate' },
+      { field: 'lastTimestamp', header: 'Time', render: 'relative-time', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Activity', title: 'No Events', message: 'No events in namespace', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default namespaceEventsConfig

--- a/web/src/config/cards/namespace-monitor.ts
+++ b/web/src/config/cards/namespace-monitor.ts
@@ -1,0 +1,30 @@
+/**
+ * Namespace Monitor Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const namespaceMonitorConfig: UnifiedCardConfig = {
+  type: 'namespace_monitor',
+  title: 'Namespace Monitor',
+  category: 'namespaces',
+  description: 'Real-time namespace health monitoring',
+  icon: 'Monitor',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useNamespaceMonitor' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'healthy', label: 'Healthy', color: 'green' },
+      { field: 'warning', label: 'Warning', color: 'yellow' },
+      { field: 'critical', label: 'Critical', color: 'red' },
+      { field: 'unknown', label: 'Unknown', color: 'gray' },
+    ],
+  },
+  emptyState: { icon: 'Monitor', title: 'No Data', message: 'Select a namespace to monitor', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default namespaceMonitorConfig

--- a/web/src/config/cards/namespace-overview.ts
+++ b/web/src/config/cards/namespace-overview.ts
@@ -1,0 +1,30 @@
+/**
+ * Namespace Overview Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const namespaceOverviewConfig: UnifiedCardConfig = {
+  type: 'namespace_overview',
+  title: 'Namespace Overview',
+  category: 'namespaces',
+  description: 'Namespace resource summary',
+  icon: 'FolderOpen',
+  iconColor: 'text-sky-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useNamespaceOverview' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'pods', label: 'Pods', color: 'blue' },
+      { field: 'deployments', label: 'Deployments', color: 'purple' },
+      { field: 'services', label: 'Services', color: 'green' },
+      { field: 'configmaps', label: 'ConfigMaps', color: 'orange' },
+    ],
+  },
+  emptyState: { icon: 'FolderOpen', title: 'Select Namespace', message: 'Select a namespace to view details', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default namespaceOverviewConfig

--- a/web/src/config/cards/namespace-quotas.ts
+++ b/web/src/config/cards/namespace-quotas.ts
@@ -1,0 +1,31 @@
+/**
+ * Namespace Quotas Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const namespaceQuotasConfig: UnifiedCardConfig = {
+  type: 'namespace_quotas',
+  title: 'Namespace Quotas',
+  category: 'namespaces',
+  description: 'Resource quota usage by namespace',
+  icon: 'Gauge',
+  iconColor: 'text-amber-400',
+  defaultWidth: 5,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useNamespaceQuotas' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'resource', header: 'Resource', primary: true, render: 'text' },
+      { field: 'used', header: 'Used', render: 'text', width: 80 },
+      { field: 'hard', header: 'Limit', render: 'text', width: 80 },
+      { field: 'percentage', header: 'Usage', render: 'progress-bar', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'Gauge', title: 'No Quotas', message: 'No resource quotas defined', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default namespaceQuotasConfig

--- a/web/src/config/cards/namespace-rbac.ts
+++ b/web/src/config/cards/namespace-rbac.ts
@@ -1,0 +1,31 @@
+/**
+ * Namespace RBAC Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const namespaceRbacConfig: UnifiedCardConfig = {
+  type: 'namespace_rbac',
+  title: 'Namespace RBAC',
+  category: 'security',
+  description: 'RBAC permissions in namespace',
+  icon: 'Shield',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useNamespaceRBAC' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'subject', header: 'Subject', primary: true, render: 'truncate' },
+      { field: 'type', header: 'Type', render: 'text', width: 80 },
+      { field: 'role', header: 'Role', render: 'text', width: 100 },
+      { field: 'scope', header: 'Scope', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Shield', title: 'No RBAC', message: 'No RBAC bindings found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default namespaceRbacConfig

--- a/web/src/config/cards/network-utils.ts
+++ b/web/src/config/cards/network-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Network Utils Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const networkUtilsConfig: UnifiedCardConfig = {
+  type: 'network_utils',
+  title: 'Network Utils',
+  category: 'utility',
+  description: 'Network diagnostic tools',
+  icon: 'Wifi',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 5,
+  defaultHeight: 3,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'NetworkUtils' },
+  emptyState: { icon: 'Wifi', title: 'Network Utils', message: 'Run network diagnostics', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default networkUtilsConfig

--- a/web/src/config/cards/node-invaders.ts
+++ b/web/src/config/cards/node-invaders.ts
@@ -1,0 +1,22 @@
+/**
+ * Node Invaders Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const nodeInvadersConfig: UnifiedCardConfig = {
+  type: 'node_invaders',
+  title: 'Node Invaders',
+  category: 'games',
+  description: 'Space Invaders with nodes',
+  icon: 'Rocket',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'NodeInvaders' },
+  emptyState: { icon: 'Rocket', title: 'Node Invaders', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default nodeInvadersConfig

--- a/web/src/config/cards/opa-policies.ts
+++ b/web/src/config/cards/opa-policies.ts
@@ -1,0 +1,34 @@
+/**
+ * OPA Policies Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const opaPoliciesConfig: UnifiedCardConfig = {
+  type: 'opa_policies',
+  title: 'OPA/Gatekeeper Policies',
+  category: 'security',
+  description: 'OPA Gatekeeper constraint templates',
+  icon: 'Shield',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useOPAPolicies' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search policies...', searchFields: ['name', 'kind'], storageKey: 'opa-policies' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Policy', primary: true, render: 'truncate' },
+      { field: 'kind', header: 'Kind', render: 'text', width: 120 },
+      { field: 'violations', header: 'Violations', render: 'number', width: 80 },
+      { field: 'enforcement', header: 'Mode', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'Shield', title: 'No Policies', message: 'No OPA policies found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default opaPoliciesConfig

--- a/web/src/config/cards/opencost-overview.ts
+++ b/web/src/config/cards/opencost-overview.ts
@@ -1,0 +1,29 @@
+/**
+ * OpenCost Overview Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const opencostOverviewConfig: UnifiedCardConfig = {
+  type: 'opencost_overview',
+  title: 'OpenCost',
+  category: 'cost',
+  description: 'OpenCost cost allocation',
+  icon: 'DollarSign',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useOpenCostOverview' },
+  content: {
+    type: 'chart',
+    chartType: 'bar',
+    dataKey: 'namespaces',
+    xAxis: 'namespace',
+    yAxis: ['cpu', 'memory', 'storage'],
+    colors: ['#3b82f6', '#10b981', '#f59e0b'],
+  },
+  emptyState: { icon: 'DollarSign', title: 'No Cost Data', message: 'OpenCost not configured', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: true,
+  isLive: false,
+}
+export default opencostOverviewConfig

--- a/web/src/config/cards/operator-subscriptions.ts
+++ b/web/src/config/cards/operator-subscriptions.ts
@@ -1,0 +1,34 @@
+/**
+ * Operator Subscriptions Card Configuration (legacy name)
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const operatorSubscriptionsConfig: UnifiedCardConfig = {
+  type: 'operator_subscriptions',
+  title: 'Operator Subscriptions',
+  category: 'operators',
+  description: 'OLM Operator Subscriptions',
+  icon: 'RefreshCw',
+  iconColor: 'text-violet-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useOperatorSubscriptions' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search subscriptions...', searchFields: ['name', 'namespace', 'channel'], storageKey: 'operator-subs' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Name', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'channel', header: 'Channel', render: 'text', width: 80 },
+      { field: 'installPlanApproval', header: 'Approval', render: 'status-badge', width: 90 },
+    ],
+  },
+  emptyState: { icon: 'RefreshCw', title: 'No Subscriptions', message: 'No Operator Subscriptions found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5, showSearch: true },
+  isDemoData: false,
+  isLive: true,
+}
+export default operatorSubscriptionsConfig

--- a/web/src/config/cards/overlay-comparison.ts
+++ b/web/src/config/cards/overlay-comparison.ts
@@ -1,0 +1,25 @@
+/**
+ * Overlay Comparison Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const overlayComparisonConfig: UnifiedCardConfig = {
+  type: 'overlay_comparison',
+  title: 'Overlay Comparison',
+  category: 'gitops',
+  description: 'Compare Kustomize overlays',
+  icon: 'GitCompare',
+  iconColor: 'text-blue-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useOverlayComparison' },
+  content: {
+    type: 'custom',
+    component: 'OverlayDiff',
+  },
+  emptyState: { icon: 'GitCompare', title: 'No Overlays', message: 'Select overlays to compare', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: true,
+  isLive: false,
+}
+export default overlayComparisonConfig

--- a/web/src/config/cards/pod-brothers.ts
+++ b/web/src/config/cards/pod-brothers.ts
@@ -1,0 +1,22 @@
+/**
+ * Pod Brothers Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const podBrothersConfig: UnifiedCardConfig = {
+  type: 'pod_brothers',
+  title: 'Pod Brothers',
+  category: 'games',
+  description: 'Mario Bros-style game',
+  icon: 'Users',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'PodBrothers' },
+  emptyState: { icon: 'Users', title: 'Pod Brothers', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default podBrothersConfig

--- a/web/src/config/cards/pod-crosser.ts
+++ b/web/src/config/cards/pod-crosser.ts
@@ -1,0 +1,22 @@
+/**
+ * Pod Crosser Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const podCrosserConfig: UnifiedCardConfig = {
+  type: 'pod_crosser',
+  title: 'Pod Crosser',
+  category: 'games',
+  description: 'Frogger-style game',
+  icon: 'Car',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'PodCrosser' },
+  emptyState: { icon: 'Car', title: 'Pod Crosser', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default podCrosserConfig

--- a/web/src/config/cards/pod-health-trend.ts
+++ b/web/src/config/cards/pod-health-trend.ts
@@ -1,0 +1,29 @@
+/**
+ * Pod Health Trend Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const podHealthTrendConfig: UnifiedCardConfig = {
+  type: 'pod_health_trend',
+  title: 'Pod Health Trend',
+  category: 'live-trends',
+  description: 'Pod health over time',
+  icon: 'HeartPulse',
+  iconColor: 'text-red-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'usePodHealthTrend' },
+  content: {
+    type: 'chart',
+    chartType: 'area',
+    dataKey: 'timeseries',
+    xAxis: 'timestamp',
+    yAxis: ['healthy', 'unhealthy'],
+    colors: ['#10b981', '#ef4444'],
+  },
+  emptyState: { icon: 'HeartPulse', title: 'No Data', message: 'No pod health data', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: false,
+  isLive: true,
+}
+export default podHealthTrendConfig

--- a/web/src/config/cards/pod-pitfall.ts
+++ b/web/src/config/cards/pod-pitfall.ts
@@ -1,0 +1,22 @@
+/**
+ * Pod Pitfall Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const podPitfallConfig: UnifiedCardConfig = {
+  type: 'pod_pitfall',
+  title: 'Pod Pitfall',
+  category: 'games',
+  description: 'Pitfall-style adventure',
+  icon: 'TreePine',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'PodPitfall' },
+  emptyState: { icon: 'TreePine', title: 'Pod Pitfall', message: 'Press to start', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default podPitfallConfig

--- a/web/src/config/cards/pod-sweeper.ts
+++ b/web/src/config/cards/pod-sweeper.ts
@@ -1,0 +1,22 @@
+/**
+ * Pod Sweeper Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const podSweeperConfig: UnifiedCardConfig = {
+  type: 'pod_sweeper',
+  title: 'Pod Sweeper',
+  category: 'games',
+  description: 'Kubernetes-themed minesweeper',
+  icon: 'Bomb',
+  iconColor: 'text-gray-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'PodSweeper' },
+  emptyState: { icon: 'Bomb', title: 'Pod Sweeper', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default podSweeperConfig

--- a/web/src/config/cards/policy-violations.ts
+++ b/web/src/config/cards/policy-violations.ts
@@ -1,0 +1,31 @@
+/**
+ * Policy Violations Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const policyViolationsConfig: UnifiedCardConfig = {
+  type: 'policy_violations',
+  title: 'Policy Violations',
+  category: 'security',
+  description: 'Security policy violation summary',
+  icon: 'AlertOctagon',
+  iconColor: 'text-red-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'usePolicyViolations' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'resource', header: 'Resource', primary: true, render: 'truncate' },
+      { field: 'policy', header: 'Policy', render: 'text', width: 120 },
+      { field: 'severity', header: 'Severity', render: 'status-badge', width: 80 },
+      { field: 'timestamp', header: 'Time', render: 'relative-time', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'AlertOctagon', title: 'No Violations', message: 'No policy violations found', variant: 'success' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default policyViolationsConfig

--- a/web/src/config/cards/provider-health.ts
+++ b/web/src/config/cards/provider-health.ts
@@ -1,0 +1,31 @@
+/**
+ * Provider Health Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const providerHealthConfig: UnifiedCardConfig = {
+  type: 'provider_health',
+  title: 'Provider Health',
+  category: 'cluster-health',
+  description: 'Cloud and AI provider status',
+  icon: 'Cloud',
+  iconColor: 'text-sky-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useProviderHealth' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'provider', header: 'Provider', primary: true, render: 'truncate' },
+      { field: 'type', header: 'Type', render: 'text', width: 80 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+      { field: 'latency', header: 'Latency', render: 'text', width: 70, suffix: 'ms' },
+    ],
+  },
+  emptyState: { icon: 'Cloud', title: 'No Providers', message: 'No providers configured', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default providerHealthConfig

--- a/web/src/config/cards/prow-ci-monitor.ts
+++ b/web/src/config/cards/prow-ci-monitor.ts
@@ -1,0 +1,22 @@
+/**
+ * Prow CI Monitor Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const prowCiMonitorConfig: UnifiedCardConfig = {
+  type: 'prow_ci_monitor',
+  title: 'Prow CI',
+  category: 'ci-cd',
+  description: 'Prow CI system monitoring',
+  icon: 'GitBranch',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useProwCIMonitor' },
+  content: { type: 'custom', component: 'ProwCIView' },
+  emptyState: { icon: 'GitBranch', title: 'No Prow', message: 'Prow CI not detected', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default prowCiMonitorConfig

--- a/web/src/config/cards/prow-history.ts
+++ b/web/src/config/cards/prow-history.ts
@@ -1,0 +1,31 @@
+/**
+ * Prow History Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const prowHistoryConfig: UnifiedCardConfig = {
+  type: 'prow_history',
+  title: 'Prow History',
+  category: 'ci-cd',
+  description: 'Prow job execution history',
+  icon: 'History',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useProwHistory' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'job', header: 'Job', primary: true, render: 'truncate' },
+      { field: 'result', header: 'Result', render: 'status-badge', width: 80 },
+      { field: 'duration', header: 'Duration', render: 'duration', width: 80 },
+      { field: 'finished', header: 'Finished', render: 'relative-time', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'History', title: 'No History', message: 'No Prow history available', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default prowHistoryConfig

--- a/web/src/config/cards/prow-jobs.ts
+++ b/web/src/config/cards/prow-jobs.ts
@@ -1,0 +1,34 @@
+/**
+ * Prow Jobs Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const prowJobsConfig: UnifiedCardConfig = {
+  type: 'prow_jobs',
+  title: 'Prow Jobs',
+  category: 'ci-cd',
+  description: 'Prow CI job status',
+  icon: 'GitPullRequest',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useProwJobs' },
+  filters: [
+    { field: 'search', type: 'text', placeholder: 'Search jobs...', searchFields: ['name', 'type'], storageKey: 'prow-jobs' },
+  ],
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Job', primary: true, render: 'truncate' },
+      { field: 'type', header: 'Type', render: 'text', width: 80 },
+      { field: 'state', header: 'State', render: 'status-badge', width: 80 },
+      { field: 'startTime', header: 'Started', render: 'relative-time', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'GitPullRequest', title: 'No Jobs', message: 'No Prow jobs found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default prowJobsConfig

--- a/web/src/config/cards/prow-status.ts
+++ b/web/src/config/cards/prow-status.ts
@@ -1,0 +1,30 @@
+/**
+ * Prow Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const prowStatusConfig: UnifiedCardConfig = {
+  type: 'prow_status',
+  title: 'Prow Status',
+  category: 'ci-cd',
+  description: 'Prow CI system status',
+  icon: 'Activity',
+  iconColor: 'text-green-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useProwStatus' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'running', label: 'Running', color: 'blue' },
+      { field: 'passed', label: 'Passed', color: 'green' },
+      { field: 'failed', label: 'Failed', color: 'red' },
+      { field: 'pending', label: 'Pending', color: 'yellow' },
+    ],
+  },
+  emptyState: { icon: 'Activity', title: 'No Status', message: 'Prow status unavailable', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: false,
+  isLive: true,
+}
+export default prowStatusConfig

--- a/web/src/config/cards/resource-capacity.ts
+++ b/web/src/config/cards/resource-capacity.ts
@@ -1,0 +1,29 @@
+/**
+ * Resource Capacity Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const resourceCapacityConfig: UnifiedCardConfig = {
+  type: 'resource_capacity',
+  title: 'Resource Capacity',
+  category: 'compute',
+  description: 'Cluster resource capacity overview',
+  icon: 'BarChart3',
+  iconColor: 'text-blue-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useResourceCapacity' },
+  content: {
+    type: 'chart',
+    chartType: 'bar',
+    dataKey: 'clusters',
+    xAxis: 'cluster',
+    yAxis: ['cpu', 'memory', 'storage'],
+    colors: ['#3b82f6', '#10b981', '#f59e0b'],
+  },
+  emptyState: { icon: 'BarChart3', title: 'No Data', message: 'No capacity data available', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: true,
+  isLive: false,
+}
+export default resourceCapacityConfig

--- a/web/src/config/cards/resource-marshall.ts
+++ b/web/src/config/cards/resource-marshall.ts
@@ -1,0 +1,22 @@
+/**
+ * Resource Marshall Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const resourceMarshallConfig: UnifiedCardConfig = {
+  type: 'resource_marshall',
+  title: 'Resource Marshall',
+  category: 'workloads',
+  description: 'Dependency tree explorer',
+  icon: 'GitBranch',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useResourceMarshall' },
+  content: { type: 'custom', component: 'ResourceMarshallTree' },
+  emptyState: { icon: 'GitBranch', title: 'No Resources', message: 'Select a resource to explore', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default resourceMarshallConfig

--- a/web/src/config/cards/resource-trend.ts
+++ b/web/src/config/cards/resource-trend.ts
@@ -1,0 +1,29 @@
+/**
+ * Resource Trend Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const resourceTrendConfig: UnifiedCardConfig = {
+  type: 'resource_trend',
+  title: 'Resource Trend',
+  category: 'live-trends',
+  description: 'Resource usage over time',
+  icon: 'TrendingUp',
+  iconColor: 'text-blue-400',
+  defaultWidth: 8,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useResourceTrend' },
+  content: {
+    type: 'chart',
+    chartType: 'line',
+    dataKey: 'timeseries',
+    xAxis: 'timestamp',
+    yAxis: ['cpu', 'memory'],
+    colors: ['#f59e0b', '#3b82f6'],
+  },
+  emptyState: { icon: 'TrendingUp', title: 'No Data', message: 'No resource trend data', variant: 'info' },
+  loadingState: { type: 'chart' },
+  isDemoData: false,
+  isLive: true,
+}
+export default resourceTrendConfig

--- a/web/src/config/cards/rss-feed.ts
+++ b/web/src/config/cards/rss-feed.ts
@@ -1,0 +1,30 @@
+/**
+ * RSS Feed Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const rssFeedConfig: UnifiedCardConfig = {
+  type: 'rss_feed',
+  title: 'RSS Feed',
+  category: 'utility',
+  description: 'RSS/Atom feed reader',
+  icon: 'Rss',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useRSSFeed' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'title', header: 'Title', primary: true, render: 'truncate' },
+      { field: 'source', header: 'Source', render: 'text', width: 100 },
+      { field: 'pubDate', header: 'Published', render: 'relative-time', width: 100 },
+    ],
+  },
+  emptyState: { icon: 'Rss', title: 'No Feed', message: 'No RSS feed configured', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: false,
+  isLive: true,
+}
+export default rssFeedConfig

--- a/web/src/config/cards/service-exports.ts
+++ b/web/src/config/cards/service-exports.ts
@@ -1,0 +1,31 @@
+/**
+ * Service Exports Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const serviceExportsConfig: UnifiedCardConfig = {
+  type: 'service_exports',
+  title: 'Service Exports',
+  category: 'network',
+  description: 'Multi-cluster service exports',
+  icon: 'ArrowUpFromLine',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useServiceExports' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Service', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'cluster', header: 'Cluster', render: 'cluster-badge', width: 100 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'ArrowUpFromLine', title: 'No Exports', message: 'No service exports found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default serviceExportsConfig

--- a/web/src/config/cards/service-imports.ts
+++ b/web/src/config/cards/service-imports.ts
@@ -1,0 +1,31 @@
+/**
+ * Service Imports Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const serviceImportsConfig: UnifiedCardConfig = {
+  type: 'service_imports',
+  title: 'Service Imports',
+  category: 'network',
+  description: 'Multi-cluster service imports',
+  icon: 'ArrowDownToLine',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useServiceImports' },
+  content: {
+    type: 'list',
+    pageSize: 10,
+    columns: [
+      { field: 'name', header: 'Service', primary: true, render: 'truncate' },
+      { field: 'namespace', header: 'Namespace', render: 'namespace-badge', width: 100 },
+      { field: 'sourceCluster', header: 'Source', render: 'cluster-badge', width: 100 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'ArrowDownToLine', title: 'No Imports', message: 'No service imports found', variant: 'info' },
+  loadingState: { type: 'list', rows: 5 },
+  isDemoData: true,
+  isLive: false,
+}
+export default serviceImportsConfig

--- a/web/src/config/cards/service-topology.ts
+++ b/web/src/config/cards/service-topology.ts
@@ -1,0 +1,22 @@
+/**
+ * Service Topology Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const serviceTopologyConfig: UnifiedCardConfig = {
+  type: 'service_topology',
+  title: 'Service Topology',
+  category: 'network',
+  description: 'Service connectivity visualization',
+  icon: 'Network',
+  iconColor: 'text-cyan-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useServiceTopology' },
+  content: { type: 'custom', component: 'ServiceTopologyGraph' },
+  emptyState: { icon: 'Network', title: 'No Topology', message: 'Service topology data unavailable', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: true,
+  isLive: false,
+}
+export default serviceTopologyConfig

--- a/web/src/config/cards/solitaire.ts
+++ b/web/src/config/cards/solitaire.ts
@@ -1,0 +1,22 @@
+/**
+ * Solitaire Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const solitaireConfig: UnifiedCardConfig = {
+  type: 'solitaire',
+  title: 'Solitaire',
+  category: 'games',
+  description: 'Classic card solitaire',
+  icon: 'Club',
+  iconColor: 'text-red-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'Solitaire' },
+  emptyState: { icon: 'Club', title: 'Solitaire', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default solitaireConfig

--- a/web/src/config/cards/stock-market-ticker.ts
+++ b/web/src/config/cards/stock-market-ticker.ts
@@ -1,0 +1,25 @@
+/**
+ * Stock Market Ticker Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const stockMarketTickerConfig: UnifiedCardConfig = {
+  type: 'stock_market_ticker',
+  title: 'Stock Ticker',
+  category: 'utility',
+  description: 'Live stock market data',
+  icon: 'TrendingUp',
+  iconColor: 'text-green-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useStockMarketTicker' },
+  content: {
+    type: 'custom',
+    component: 'StockTicker',
+  },
+  emptyState: { icon: 'TrendingUp', title: 'No Data', message: 'Stock data unavailable', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default stockMarketTickerConfig

--- a/web/src/config/cards/sudoku-game.ts
+++ b/web/src/config/cards/sudoku-game.ts
@@ -1,0 +1,22 @@
+/**
+ * Sudoku Game Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const sudokuGameConfig: UnifiedCardConfig = {
+  type: 'sudoku_game',
+  title: 'Sudoku',
+  category: 'games',
+  description: 'Classic Sudoku puzzle game',
+  icon: 'Grid3X3',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'static' },
+  content: { type: 'custom', component: 'SudokuGame' },
+  emptyState: { icon: 'Grid3X3', title: 'Sudoku', message: 'Start a new game', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default sudokuGameConfig

--- a/web/src/config/cards/trivy-scan.ts
+++ b/web/src/config/cards/trivy-scan.ts
@@ -1,0 +1,30 @@
+/**
+ * Trivy Scan Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const trivyScanConfig: UnifiedCardConfig = {
+  type: 'trivy_scan',
+  title: 'Trivy Vulnerabilities',
+  category: 'security',
+  description: 'Container vulnerability scan results',
+  icon: 'Bug',
+  iconColor: 'text-orange-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useTrivyScan' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'critical', label: 'Critical', color: 'red' },
+      { field: 'high', label: 'High', color: 'orange' },
+      { field: 'medium', label: 'Medium', color: 'yellow' },
+      { field: 'low', label: 'Low', color: 'blue' },
+    ],
+  },
+  emptyState: { icon: 'Bug', title: 'No Scans', message: 'No vulnerability scan data', variant: 'info' },
+  loadingState: { type: 'stats', count: 4 },
+  isDemoData: true,
+  isLive: false,
+}
+export default trivyScanConfig

--- a/web/src/config/cards/upgrade-status.ts
+++ b/web/src/config/cards/upgrade-status.ts
@@ -1,0 +1,31 @@
+/**
+ * Upgrade Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const upgradeStatusConfig: UnifiedCardConfig = {
+  type: 'upgrade_status',
+  title: 'Upgrade Status',
+  category: 'cluster-health',
+  description: 'Cluster upgrade availability',
+  icon: 'ArrowUpCircle',
+  iconColor: 'text-green-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useUpgradeStatus' },
+  content: {
+    type: 'list',
+    pageSize: 8,
+    columns: [
+      { field: 'cluster', header: 'Cluster', render: 'cluster-badge', width: 100 },
+      { field: 'currentVersion', header: 'Current', render: 'text', width: 80 },
+      { field: 'availableVersion', header: 'Available', render: 'text', width: 80 },
+      { field: 'status', header: 'Status', render: 'status-badge', width: 80 },
+    ],
+  },
+  emptyState: { icon: 'ArrowUpCircle', title: 'All Current', message: 'All clusters are up to date', variant: 'success' },
+  loadingState: { type: 'list', rows: 4 },
+  isDemoData: true,
+  isLive: false,
+}
+export default upgradeStatusConfig

--- a/web/src/config/cards/user-management.ts
+++ b/web/src/config/cards/user-management.ts
@@ -1,0 +1,22 @@
+/**
+ * User Management Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const userManagementConfig: UnifiedCardConfig = {
+  type: 'user_management',
+  title: 'User Management',
+  category: 'security',
+  description: 'Manage console users',
+  icon: 'Users',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useUserManagement' },
+  content: { type: 'custom', component: 'UserManagementUI' },
+  emptyState: { icon: 'Users', title: 'No Users', message: 'No users configured', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: false,
+}
+export default userManagementConfig

--- a/web/src/config/cards/vault-secrets.ts
+++ b/web/src/config/cards/vault-secrets.ts
@@ -1,0 +1,29 @@
+/**
+ * Vault Secrets Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const vaultSecretsConfig: UnifiedCardConfig = {
+  type: 'vault_secrets',
+  title: 'Vault Secrets',
+  category: 'security',
+  description: 'HashiCorp Vault secret status',
+  icon: 'Lock',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 4,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useVaultSecrets' },
+  content: {
+    type: 'stats-grid',
+    stats: [
+      { field: 'total', label: 'Total', color: 'blue' },
+      { field: 'synced', label: 'Synced', color: 'green' },
+      { field: 'failed', label: 'Failed', color: 'red' },
+    ],
+  },
+  emptyState: { icon: 'Lock', title: 'No Vault', message: 'Vault not configured', variant: 'info' },
+  loadingState: { type: 'stats', count: 3 },
+  isDemoData: true,
+  isLive: false,
+}
+export default vaultSecretsConfig

--- a/web/src/config/cards/weather.ts
+++ b/web/src/config/cards/weather.ts
@@ -1,0 +1,25 @@
+/**
+ * Weather Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const weatherConfig: UnifiedCardConfig = {
+  type: 'weather',
+  title: 'Weather',
+  category: 'utility',
+  description: 'Current weather conditions',
+  icon: 'Cloud',
+  iconColor: 'text-sky-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useWeather' },
+  content: {
+    type: 'custom',
+    component: 'WeatherDisplay',
+  },
+  emptyState: { icon: 'Cloud', title: 'No Weather', message: 'Weather data unavailable', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default weatherConfig

--- a/web/src/config/cards/workload-deployment.ts
+++ b/web/src/config/cards/workload-deployment.ts
@@ -1,0 +1,22 @@
+/**
+ * Workload Deployment Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const workloadDeploymentConfig: UnifiedCardConfig = {
+  type: 'workload_deployment',
+  title: 'Workload Deployment',
+  category: 'workloads',
+  description: 'Deploy workloads to clusters',
+  icon: 'Upload',
+  iconColor: 'text-blue-400',
+  defaultWidth: 6,
+  defaultHeight: 3,
+  dataSource: { type: 'hook', hook: 'useWorkloadDeployment' },
+  content: { type: 'custom', component: 'WorkloadDeploymentUI' },
+  emptyState: { icon: 'Upload', title: 'Deploy', message: 'Select workload to deploy', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default workloadDeploymentConfig

--- a/web/src/config/cards/workload-monitor.ts
+++ b/web/src/config/cards/workload-monitor.ts
@@ -1,0 +1,22 @@
+/**
+ * Workload Monitor Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const workloadMonitorConfig: UnifiedCardConfig = {
+  type: 'workload_monitor',
+  title: 'Workload Monitor',
+  category: 'workloads',
+  description: 'Live workload health monitoring',
+  icon: 'Monitor',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useWorkloadMonitor' },
+  content: { type: 'custom', component: 'WorkloadMonitorView' },
+  emptyState: { icon: 'Monitor', title: 'No Workloads', message: 'No workloads to monitor', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default workloadMonitorConfig

--- a/web/src/lib/cards/types.ts
+++ b/web/src/lib/cards/types.ts
@@ -28,11 +28,17 @@ export type CardCategory =
   | 'security'
   | 'live-trends'
   | 'ai'
+  | 'ai-ml'
   | 'alerting'
+  | 'alerts'
   | 'cost'
   | 'policy'
   | 'external'
   | 'utilities'
+  | 'utility'
+  | 'games'
+  | 'events'
+  | 'ci-cd'
 
 export interface CardDefinition {
   /** Unique card type identifier */

--- a/web/src/lib/unified/card/hooks/useDataSource.ts
+++ b/web/src/lib/unified/card/hooks/useDataSource.ts
@@ -103,7 +103,7 @@ export function useDataSource(
   )
 
   const staticResult = useStaticDataSourceInternal(
-    !skip && config.type === 'static' ? config.data : null
+    !skip && config.type === 'static' ? (config.data ?? null) : null
   )
 
   const contextResult = useContextDataSourceInternal(

--- a/web/src/lib/unified/card/visualizations/ChartVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/ChartVisualization.tsx
@@ -50,12 +50,21 @@ const DEFAULT_COLORS = [
 export function ChartVisualization({ content, data }: ChartVisualizationProps) {
   const {
     chartType,
-    series,
+    series: rawSeries,
     xAxis,
     yAxis,
     showLegend = true,
     height = 200,
   } = content
+
+  // Derive series from yAxis if not explicitly provided
+  const series: CardChartSeries[] = rawSeries ?? (
+    Array.isArray(yAxis)
+      ? yAxis.map(field => ({ field }))
+      : yAxis && typeof yAxis === 'string'
+        ? [{ field: yAxis }]
+        : []
+  )
 
   // Render the appropriate chart type
   switch (chartType) {
@@ -135,10 +144,24 @@ export function ChartVisualization({ content, data }: ChartVisualizationProps) {
 interface ChartRendererProps {
   data: unknown[]
   series: CardChartSeries[]
-  xAxis?: CardAxisConfig
-  yAxis?: CardAxisConfig
+  xAxis?: CardAxisConfig | string
+  yAxis?: CardAxisConfig | string | string[]
   showLegend?: boolean
   height: number
+}
+
+/**
+ * Normalize axis config to full CardAxisConfig object
+ */
+function normalizeAxisConfig(axis?: CardAxisConfig | string | string[]): CardAxisConfig | undefined {
+  if (!axis) return undefined
+  if (typeof axis === 'string') {
+    return { field: axis }
+  }
+  if (Array.isArray(axis)) {
+    return { field: axis[0] }
+  }
+  return axis
 }
 
 /**
@@ -147,11 +170,13 @@ interface ChartRendererProps {
 function LineChartRenderer({
   data,
   series,
-  xAxis,
-  yAxis,
+  xAxis: xAxisProp,
+  yAxis: yAxisProp,
   showLegend,
   height,
 }: ChartRendererProps) {
+  const xAxis = normalizeAxisConfig(xAxisProp)
+  const yAxis = normalizeAxisConfig(yAxisProp)
   const xField = xAxis?.field ?? 'time'
 
   return (
@@ -215,11 +240,13 @@ function LineChartRenderer({
 function AreaChartRenderer({
   data,
   series,
-  xAxis,
-  yAxis,
+  xAxis: xAxisProp,
+  yAxis: yAxisProp,
   showLegend,
   height,
 }: ChartRendererProps) {
+  const xAxis = normalizeAxisConfig(xAxisProp)
+  const yAxis = normalizeAxisConfig(yAxisProp)
   const xField = xAxis?.field ?? 'time'
 
   return (
@@ -285,11 +312,13 @@ function AreaChartRenderer({
 function BarChartRenderer({
   data,
   series,
-  xAxis,
-  yAxis,
+  xAxis: xAxisProp,
+  yAxis: yAxisProp,
   showLegend,
   height,
 }: ChartRendererProps) {
+  const xAxis = normalizeAxisConfig(xAxisProp)
+  const yAxis = normalizeAxisConfig(yAxisProp)
   const xField = xAxis?.field ?? 'name'
 
   return (

--- a/web/src/lib/unified/types.ts
+++ b/web/src/lib/unified/types.ts
@@ -81,7 +81,7 @@ export interface UnifiedCardConfig {
   isLive?: boolean
 }
 
-export type CardWidth = 3 | 4 | 6 | 8 | 12
+export type CardWidth = 3 | 4 | 5 | 6 | 8 | 12
 
 // ============================================================================
 // Data Source Types (discriminated union)
@@ -115,8 +115,8 @@ export interface CardDataSourceApi {
 
 export interface CardDataSourceStatic {
   type: 'static'
-  /** Static data array */
-  data: unknown[]
+  /** Static data array (optional for custom components that don't need data) */
+  data?: unknown[]
 }
 
 export interface CardDataSourceContext {
@@ -141,6 +141,7 @@ export type CardContent =
   | CardContentTable
   | CardContentChart
   | CardContentStatusGrid
+  | CardContentStatsGrid
   | CardContentCustom
 
 export interface CardContentList {
@@ -173,16 +174,24 @@ export interface CardContentChart {
   type: 'chart'
   /** Chart type */
   chartType: 'line' | 'bar' | 'donut' | 'gauge' | 'sparkline' | 'area'
-  /** Data series configuration */
-  series: CardChartSeries[]
-  /** X-axis configuration */
-  xAxis?: CardAxisConfig
-  /** Y-axis configuration */
-  yAxis?: CardAxisConfig
+  /** Data series configuration (optional - can derive from yAxis) */
+  series?: CardChartSeries[]
+  /** X-axis configuration (string field name or full config) */
+  xAxis?: CardAxisConfig | string
+  /** Y-axis configuration (string field name, array of fields, or full config) */
+  yAxis?: CardAxisConfig | string | string[]
   /** Show legend */
   showLegend?: boolean
   /** Chart height in pixels */
   height?: number
+  /** Data key field (for donut/pie charts) */
+  dataKey?: string
+  /** Value key field (alias for dataKey) */
+  valueKey?: string
+  /** Label key field (for donut/pie charts) */
+  labelKey?: string
+  /** Color palette for chart series */
+  colors?: string[]
 }
 
 export interface CardContentStatusGrid {
@@ -198,9 +207,32 @@ export interface CardContentStatusGrid {
 export interface CardContentCustom {
   type: 'custom'
   /** Component name from registry */
-  componentName: string
+  componentName?: string
+  /** Component name (alias for componentName) */
+  component?: string
   /** Props to pass to component */
   props?: Record<string, unknown>
+}
+
+export interface CardContentStatsGrid {
+  type: 'stats-grid'
+  /** Stat items to display */
+  stats: CardStatsGridItem[]
+  /** Grid columns */
+  columns?: number
+}
+
+export interface CardStatsGridItem {
+  /** Field name from data */
+  field: string
+  /** Label to display */
+  label: string
+  /** Color for the stat */
+  color?: string
+  /** Icon name */
+  icon?: string
+  /** Value format */
+  format?: 'number' | 'percentage' | 'bytes' | 'currency'
 }
 
 // ============================================================================
@@ -408,11 +440,13 @@ export interface CardLoadingStateConfig {
   /** Number of skeleton rows */
   rows?: number
   /** Skeleton type */
-  type?: 'table' | 'list' | 'chart' | 'status'
+  type?: 'table' | 'list' | 'chart' | 'status' | 'stats' | 'custom'
   /** Show header skeleton */
   showHeader?: boolean
   /** Show search skeleton */
   showSearch?: boolean
+  /** Number of items for stats type */
+  count?: number
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

This massive migration moves **all 144 card types** to the unified config-driven architecture, replacing 120+ individual component implementations with declarative configuration files.

- Add 105 new card config files covering all remaining card types
- Update types to support stats-grid content, flexible chart configs
- Add missing CardCategory values (games, alerts, events, ci-cd, etc.)
- Make chart series optional (can derive from yAxis)
- Support string/array axis configs for simpler chart definitions
- Update ChartVisualization to normalize axis configs
- Fix CardDataSourceStatic to allow optional data for custom components

### Card Categories Unified

| Category | Cards | Examples |
|----------|-------|----------|
| Cluster Health | 15 | ClusterHealth, ClusterMetrics, ClusterComparison |
| Workloads | 20 | DeploymentStatus, PodIssues, ReplicaSetStatus |
| Storage/Network | 12 | PVStatus, PVCStatus, IngressStatus, ServiceStatus |
| GitOps/ArgoCD | 10 | ArgoCDHealth, KustomizationStatus, GitopsDrift |
| Security | 15 | FalcoAlerts, TrivyScan, KubescapeScan, OPAPolicies |
| Operators | 8 | OperatorStatus, CRDHealth, OperatorSubscriptions |
| Events/Alerts | 10 | EventStream, WarningEvents, ActiveAlerts |
| Cost Management | 6 | ClusterCosts, KubecostOverview, OpenCostOverview |
| AI/ML | 8 | LLMModels, MLJobs, MLNotebooks, GPUOverview |
| Games/Utilities | 25 | KubeSnake, FlappyPod, Checkers, Weather |
| CI/CD | 15 | GithubCIMonitor, ProwStatus, ProwJobs |

## Test plan

- [x] Build passes with all 144 card configs
- [x] Type checking validates all configs
- [ ] Visual verification of card rendering (sample)
- [ ] No console errors in demo mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)