### PR TITLE
🐛 Fix WebSocket connection attempts in local demo mode

### DIFF
--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -193,9 +193,9 @@ export function useActiveUsers() {
   const [, setDemoTick] = useState(0)
 
   useEffect(() => {
-    // On Netlify (no backend): use HTTP heartbeat for presence tracking
-    // With backend: use WebSocket presence connection
-    if (isDemoModeForced) {
+    // In demo mode (Netlify or user-enabled): use HTTP heartbeat for presence tracking
+    // With backend (non-demo): use WebSocket presence connection
+    if (isDemoModeForced || getDemoMode()) {
       startHeartbeat()
     } else {
       startPresenceConnection()


### PR DESCRIPTION
## Summary

Fixes console errors about WebSocket connection failures when running locally with demo mode enabled.

The `useActiveUsers` hook was using `isDemoModeForced` (true only on Netlify) instead of checking the actual demo mode state with `getDemoMode()`. This caused it to attempt WebSocket connections even when demo mode was manually enabled locally.

## Changes

- Check both `isDemoModeForced` and `getDemoMode()` to skip WebSocket connections in all demo mode scenarios

## Test plan

- [x] Build passes
- [ ] No WebSocket connection errors in Chrome console with local demo mode enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)