### PR TITLE
✨ Add unified dashboard configs for all 21 dashboards

### DIFF
--- a/web/src/config/dashboards/ai-ml.ts
+++ b/web/src/config/dashboards/ai-ml.ts
@@ -1,0 +1,29 @@
+/**
+ * AI/ML Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const aiMlDashboardConfig: UnifiedDashboardConfig = {
+  id: 'ai-ml',
+  name: 'AI/ML Workloads',
+  subtitle: 'LLM inference, ML jobs, and notebooks',
+  route: '/ai-ml',
+  statsType: 'ai-ml',
+  cards: [
+    { id: 'llm-models-1', cardType: 'llm_models', position: { w: 6, h: 4 } },
+    { id: 'llm-inference-1', cardType: 'llm_inference', position: { w: 6, h: 4 } },
+    { id: 'llmd-stack-monitor-1', cardType: 'llmd_stack_monitor', position: { w: 6, h: 3 } },
+    { id: 'ml-jobs-1', cardType: 'ml_jobs', position: { w: 6, h: 3 } },
+    { id: 'ml-notebooks-1', cardType: 'ml_notebooks', position: { w: 6, h: 3 } },
+    { id: 'gpu-overview-1', cardType: 'gpu_overview', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'ai-ml-dashboard-cards',
+}
+
+export default aiMlDashboardConfig

--- a/web/src/config/dashboards/alerts.ts
+++ b/web/src/config/dashboards/alerts.ts
@@ -1,0 +1,28 @@
+/**
+ * Alerts Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const alertsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'alerts',
+  name: 'Alerts',
+  subtitle: 'Alert management and configuration',
+  route: '/alerts',
+  statsType: 'alerts',
+  cards: [
+    { id: 'active-alerts-1', cardType: 'active_alerts', position: { w: 8, h: 4 } },
+    { id: 'alert-rules-1', cardType: 'alert_rules', position: { w: 4, h: 3 } },
+    { id: 'falco-alerts-1', cardType: 'falco_alerts', position: { w: 6, h: 3 } },
+    { id: 'warning-events-1', cardType: 'warning_events', position: { w: 6, h: 3 } },
+    { id: 'event-summary-1', cardType: 'event_summary', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 15000,
+  },
+  storageKey: 'alerts-dashboard-cards',
+}
+
+export default alertsDashboardConfig

--- a/web/src/config/dashboards/ci-cd.ts
+++ b/web/src/config/dashboards/ci-cd.ts
@@ -1,0 +1,29 @@
+/**
+ * CI/CD Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const ciCdDashboardConfig: UnifiedDashboardConfig = {
+  id: 'ci-cd',
+  name: 'CI/CD',
+  subtitle: 'Continuous integration and deployment pipelines',
+  route: '/ci-cd',
+  statsType: 'ci-cd',
+  cards: [
+    { id: 'github-ci-monitor-1', cardType: 'github_ci_monitor', position: { w: 6, h: 4 } },
+    { id: 'github-activity-1', cardType: 'github_activity', position: { w: 6, h: 4 } },
+    { id: 'prow-status-1', cardType: 'prow_status', position: { w: 6, h: 3 } },
+    { id: 'prow-jobs-1', cardType: 'prow_jobs', position: { w: 6, h: 3 } },
+    { id: 'prow-ci-monitor-1', cardType: 'prow_ci_monitor', position: { w: 6, h: 3 } },
+    { id: 'prow-history-1', cardType: 'prow_history', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 60000,
+  },
+  storageKey: 'ci-cd-dashboard-cards',
+}
+
+export default ciCdDashboardConfig

--- a/web/src/config/dashboards/clusters.ts
+++ b/web/src/config/dashboards/clusters.ts
@@ -1,0 +1,29 @@
+/**
+ * Clusters Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const clustersDashboardConfig: UnifiedDashboardConfig = {
+  id: 'clusters',
+  name: 'Clusters',
+  subtitle: 'Multi-cluster overview and management',
+  route: '/clusters',
+  statsType: 'clusters',
+  cards: [
+    { id: 'cluster-health-1', cardType: 'cluster_health', position: { w: 8, h: 4 } },
+    { id: 'cluster-groups-1', cardType: 'cluster_groups', position: { w: 4, h: 4 } },
+    { id: 'cluster-metrics-1', cardType: 'cluster_metrics', position: { w: 6, h: 3 } },
+    { id: 'cluster-comparison-1', cardType: 'cluster_comparison', position: { w: 6, h: 3 } },
+    { id: 'provider-health-1', cardType: 'provider_health', position: { w: 4, h: 3 } },
+    { id: 'cluster-locations-1', cardType: 'cluster_locations', position: { w: 8, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'clusters-dashboard-cards',
+}
+
+export default clustersDashboardConfig

--- a/web/src/config/dashboards/compliance.ts
+++ b/web/src/config/dashboards/compliance.ts
@@ -1,0 +1,29 @@
+/**
+ * Compliance Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const complianceDashboardConfig: UnifiedDashboardConfig = {
+  id: 'compliance',
+  name: 'Compliance',
+  subtitle: 'Security posture and compliance metrics',
+  route: '/compliance',
+  statsType: 'compliance',
+  cards: [
+    { id: 'compliance-score-1', cardType: 'compliance_score', position: { w: 4, h: 3 } },
+    { id: 'policy-violations-1', cardType: 'policy_violations', position: { w: 8, h: 4 } },
+    { id: 'opa-policies-1', cardType: 'opa_policies', position: { w: 6, h: 3 } },
+    { id: 'kyverno-policies-1', cardType: 'kyverno_policies', position: { w: 6, h: 3 } },
+    { id: 'kubescape-scan-1', cardType: 'kubescape_scan', position: { w: 6, h: 3 } },
+    { id: 'trivy-scan-1', cardType: 'trivy_scan', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 60000,
+  },
+  storageKey: 'compliance-dashboard-cards',
+}
+
+export default complianceDashboardConfig

--- a/web/src/config/dashboards/cost.ts
+++ b/web/src/config/dashboards/cost.ts
@@ -1,0 +1,28 @@
+/**
+ * Cost Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const costDashboardConfig: UnifiedDashboardConfig = {
+  id: 'cost',
+  name: 'Cost Management',
+  subtitle: 'Cluster cost analysis and optimization',
+  route: '/cost',
+  statsType: 'cost',
+  cards: [
+    { id: 'cluster-costs-1', cardType: 'cluster_costs', position: { w: 8, h: 4 } },
+    { id: 'kubecost-overview-1', cardType: 'kubecost_overview', position: { w: 4, h: 3 } },
+    { id: 'opencost-overview-1', cardType: 'opencost_overview', position: { w: 4, h: 3 } },
+    { id: 'resource-capacity-1', cardType: 'resource_capacity', position: { w: 6, h: 3 } },
+    { id: 'resource-trend-1', cardType: 'resource_trend', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 300000, // 5 minutes
+  },
+  storageKey: 'cost-dashboard-cards',
+}
+
+export default costDashboardConfig

--- a/web/src/config/dashboards/deployments.ts
+++ b/web/src/config/dashboards/deployments.ts
@@ -1,0 +1,29 @@
+/**
+ * Deployments Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const deploymentsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'deployments',
+  name: 'Deployments',
+  subtitle: 'Deployment status and rollout management',
+  route: '/deployments',
+  statsType: 'deployments',
+  cards: [
+    { id: 'deployment-status-1', cardType: 'deployment_status', position: { w: 8, h: 4 } },
+    { id: 'deployment-issues-1', cardType: 'deployment_issues', position: { w: 4, h: 3 } },
+    { id: 'deployment-progress-1', cardType: 'deployment_progress', position: { w: 6, h: 3 } },
+    { id: 'replicaset-status-1', cardType: 'replicaset_status', position: { w: 6, h: 3 } },
+    { id: 'hpa-status-1', cardType: 'hpa_status', position: { w: 6, h: 3 } },
+    { id: 'workload-deployment-1', cardType: 'workload_deployment', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 15000,
+  },
+  storageKey: 'deployments-dashboard-cards',
+}
+
+export default deploymentsDashboardConfig

--- a/web/src/config/dashboards/gpu.ts
+++ b/web/src/config/dashboards/gpu.ts
@@ -1,0 +1,29 @@
+/**
+ * GPU Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const gpuDashboardConfig: UnifiedDashboardConfig = {
+  id: 'gpu',
+  name: 'GPU Reservations',
+  subtitle: 'GPU resource allocation and utilization',
+  route: '/gpu-reservations',
+  statsType: 'gpu',
+  cards: [
+    { id: 'gpu-overview-1', cardType: 'gpu_overview', position: { w: 4, h: 3 } },
+    { id: 'gpu-status-1', cardType: 'gpu_status', position: { w: 8, h: 4 } },
+    { id: 'gpu-inventory-1', cardType: 'gpu_inventory', position: { w: 6, h: 3 } },
+    { id: 'gpu-utilization-1', cardType: 'gpu_utilization', position: { w: 6, h: 3 } },
+    { id: 'gpu-usage-trend-1', cardType: 'gpu_usage_trend', position: { w: 6, h: 3 } },
+    { id: 'gpu-workloads-1', cardType: 'gpu_workloads', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'gpu-dashboard-cards',
+}
+
+export default gpuDashboardConfig

--- a/web/src/config/dashboards/helm.ts
+++ b/web/src/config/dashboards/helm.ts
@@ -1,0 +1,27 @@
+/**
+ * Helm Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const helmDashboardConfig: UnifiedDashboardConfig = {
+  id: 'helm',
+  name: 'Helm Releases',
+  subtitle: 'Helm chart versions, releases, and values',
+  route: '/helm',
+  statsType: 'helm',
+  cards: [
+    { id: 'helm-release-status-1', cardType: 'helm_release_status', position: { w: 8, h: 4 } },
+    { id: 'chart-versions-1', cardType: 'chart_versions', position: { w: 4, h: 3 } },
+    { id: 'helm-history-1', cardType: 'helm_history', position: { w: 6, h: 3 } },
+    { id: 'helm-values-diff-1', cardType: 'helm_values_diff', position: { w: 6, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 60000,
+  },
+  storageKey: 'helm-dashboard-cards',
+}
+
+export default helmDashboardConfig

--- a/web/src/config/dashboards/index.ts
+++ b/web/src/config/dashboards/index.ts
@@ -14,6 +14,18 @@ import { networkDashboardConfig } from './network'
 import { eventsDashboardConfig } from './events'
 import { workloadsDashboardConfig } from './workloads'
 import { operatorsDashboardConfig } from './operators'
+import { clustersDashboardConfig } from './clusters'
+import { complianceDashboardConfig } from './compliance'
+import { costDashboardConfig } from './cost'
+import { gpuDashboardConfig } from './gpu'
+import { nodesDashboardConfig } from './nodes'
+import { deploymentsDashboardConfig } from './deployments'
+import { podsDashboardConfig } from './pods'
+import { servicesDashboardConfig } from './services'
+import { helmDashboardConfig } from './helm'
+import { alertsDashboardConfig } from './alerts'
+import { aiMlDashboardConfig } from './ai-ml'
+import { ciCdDashboardConfig } from './ci-cd'
 
 /**
  * Registry of all unified dashboard configurations
@@ -28,6 +40,18 @@ export const DASHBOARD_CONFIGS: DashboardConfigRegistry = {
   events: eventsDashboardConfig,
   workloads: workloadsDashboardConfig,
   operators: operatorsDashboardConfig,
+  clusters: clustersDashboardConfig,
+  compliance: complianceDashboardConfig,
+  cost: costDashboardConfig,
+  gpu: gpuDashboardConfig,
+  nodes: nodesDashboardConfig,
+  deployments: deploymentsDashboardConfig,
+  pods: podsDashboardConfig,
+  services: servicesDashboardConfig,
+  helm: helmDashboardConfig,
+  alerts: alertsDashboardConfig,
+  'ai-ml': aiMlDashboardConfig,
+  'ci-cd': ciCdDashboardConfig,
 }
 
 /**
@@ -62,4 +86,16 @@ export {
   eventsDashboardConfig,
   workloadsDashboardConfig,
   operatorsDashboardConfig,
+  clustersDashboardConfig,
+  complianceDashboardConfig,
+  costDashboardConfig,
+  gpuDashboardConfig,
+  nodesDashboardConfig,
+  deploymentsDashboardConfig,
+  podsDashboardConfig,
+  servicesDashboardConfig,
+  helmDashboardConfig,
+  alertsDashboardConfig,
+  aiMlDashboardConfig,
+  ciCdDashboardConfig,
 }

--- a/web/src/config/dashboards/nodes.ts
+++ b/web/src/config/dashboards/nodes.ts
@@ -1,0 +1,28 @@
+/**
+ * Nodes Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const nodesDashboardConfig: UnifiedDashboardConfig = {
+  id: 'nodes',
+  name: 'Nodes',
+  subtitle: 'Node status, capacity, and management',
+  route: '/nodes',
+  statsType: 'nodes',
+  cards: [
+    { id: 'node-status-1', cardType: 'node_status', position: { w: 12, h: 4 } },
+    { id: 'resource-usage-1', cardType: 'resource_usage', position: { w: 6, h: 3 } },
+    { id: 'resource-capacity-1', cardType: 'resource_capacity', position: { w: 6, h: 3 } },
+    { id: 'top-pods-1', cardType: 'top_pods', position: { w: 6, h: 3 } },
+    { id: 'upgrade-status-1', cardType: 'upgrade_status', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'nodes-dashboard-cards',
+}
+
+export default nodesDashboardConfig

--- a/web/src/config/dashboards/pods.ts
+++ b/web/src/config/dashboards/pods.ts
@@ -1,0 +1,29 @@
+/**
+ * Pods Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const podsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'pods',
+  name: 'Pods',
+  subtitle: 'Pod status, logs, and troubleshooting',
+  route: '/pods',
+  statsType: 'pods',
+  cards: [
+    { id: 'pod-issues-1', cardType: 'pod_issues', position: { w: 8, h: 4 } },
+    { id: 'pod-health-trend-1', cardType: 'pod_health_trend', position: { w: 4, h: 3 } },
+    { id: 'top-pods-1', cardType: 'top_pods', position: { w: 6, h: 3 } },
+    { id: 'warning-events-1', cardType: 'warning_events', position: { w: 6, h: 3 } },
+    { id: 'resource-usage-1', cardType: 'resource_usage', position: { w: 6, h: 3 } },
+    { id: 'namespace-overview-1', cardType: 'namespace_overview', position: { w: 6, h: 3 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 15000,
+  },
+  storageKey: 'pods-dashboard-cards',
+}
+
+export default podsDashboardConfig

--- a/web/src/config/dashboards/services.ts
+++ b/web/src/config/dashboards/services.ts
@@ -1,0 +1,29 @@
+/**
+ * Services Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const servicesDashboardConfig: UnifiedDashboardConfig = {
+  id: 'services',
+  name: 'Services',
+  subtitle: 'Service status and configuration',
+  route: '/services',
+  statsType: 'services',
+  cards: [
+    { id: 'service-status-1', cardType: 'service_status', position: { w: 8, h: 4 } },
+    { id: 'ingress-status-1', cardType: 'ingress_status', position: { w: 4, h: 3 } },
+    { id: 'gateway-status-1', cardType: 'gateway_status', position: { w: 6, h: 3 } },
+    { id: 'service-exports-1', cardType: 'service_exports', position: { w: 6, h: 3 } },
+    { id: 'service-imports-1', cardType: 'service_imports', position: { w: 6, h: 3 } },
+    { id: 'service-topology-1', cardType: 'service_topology', position: { w: 6, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'services-dashboard-cards',
+}
+
+export default servicesDashboardConfig


### PR DESCRIPTION
## Summary

Completes the dashboard unification by adding config-driven configurations for all 21 dashboard pages.

### New Dashboard Configs

| Dashboard | Route | Description |
|-----------|-------|-------------|
| clusters | /clusters | Multi-cluster overview |
| compliance | /compliance | Security posture |
| cost | /cost | Cost analysis |
| gpu | /gpu-reservations | GPU utilization |
| nodes | /nodes | Node management |
| deployments | /deployments | Deployment rollouts |
| pods | /pods | Pod troubleshooting |
| services | /services | Service configuration |
| helm | /helm | Helm releases |
| alerts | /alerts | Alert management |
| ai-ml | /ai-ml | ML workloads |
| ci-cd | /ci-cd | CI/CD pipelines |

Each config defines:
- Default card placements with grid positions
- Stats section type for dashboard metrics
- Feature flags (drag-drop, auto-refresh intervals)
- Storage key for user customizations

## Test plan

- [x] Build passes with all 21 dashboard configs
- [x] Type checking validates all configs
- [ ] Visual verification of dashboard rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)