### PR TITLE
🐛 Fix demo mode: enable MSW for localStorage toggle

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -40,6 +40,19 @@ try {
 }
 
 /**
+ * Reset the backend availability cache (used when enabling demo mode with MSW)
+ * This clears both in-memory state and localStorage to force a fresh check
+ */
+export function resetBackendAvailabilityCache(): void {
+  backendAvailable = null
+  backendLastCheckTime = 0
+  backendCheckPromise = null
+  try {
+    localStorage.removeItem(BACKEND_STATUS_KEY)
+  } catch { /* ignore */ }
+}
+
+/**
  * Check backend availability - only makes ONE request, all others wait
  * Caches result in localStorage to avoid repeated checks across page loads
  * @param forceCheck - If true, ignores cache and always checks (used by login)

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -229,6 +229,40 @@ export const handlers = [
     })
   }),
 
+  // Health check
+  http.get('/api/health', async () => {
+    await delay(50)
+    return HttpResponse.json({ status: 'ok', version: 'demo' })
+  }),
+
+  // Active users (for presence tracking)
+  http.get('/api/active-users', async () => {
+    await delay(50)
+    return HttpResponse.json({ activeUsers: 1, totalConnections: 1 })
+  }),
+
+  http.post('/api/active-users', async () => {
+    await delay(50)
+    return HttpResponse.json({ success: true })
+  }),
+
+  // Permissions
+  http.get('/api/permissions/summary', async () => {
+    await delay(50)
+    return HttpResponse.json({
+      isAdmin: true,
+      canManageUsers: true,
+      canManageClusters: true,
+      canViewAllNamespaces: true,
+    })
+  }),
+
+  // Notifications
+  http.get('/api/notifications/unread-count', async () => {
+    await delay(50)
+    return HttpResponse.json({ count: 0 })
+  }),
+
   // MCP Status
   http.get('/api/mcp/status', async () => {
     await delay(100)
@@ -267,6 +301,30 @@ export const handlers = [
   http.get('/api/mcp/deployment-issues', async () => {
     await delay(150)
     return HttpResponse.json({ issues: demoDeploymentIssues })
+  }),
+
+  // Pods list (for cluster-specific queries)
+  http.get('/api/mcp/pods', async () => {
+    await delay(100)
+    return HttpResponse.json({
+      pods: [
+        { name: 'nginx-abc123', namespace: 'default', status: 'Running', cluster: 'kind-local' },
+        { name: 'redis-xyz789', namespace: 'cache', status: 'Running', cluster: 'kind-local' },
+        { name: 'api-server-456', namespace: 'backend', status: 'Running', cluster: 'kind-local' },
+      ],
+    })
+  }),
+
+  // Deployments list (for cluster-specific queries)
+  http.get('/api/mcp/deployments', async () => {
+    await delay(100)
+    return HttpResponse.json({
+      deployments: [
+        { name: 'nginx', namespace: 'default', replicas: 3, ready: 3, cluster: 'kind-local' },
+        { name: 'redis', namespace: 'cache', replicas: 2, ready: 2, cluster: 'kind-local' },
+        { name: 'api-server', namespace: 'backend', replicas: 5, ready: 5, cluster: 'kind-local' },
+      ],
+    })
   }),
 
   // Events
@@ -349,6 +407,12 @@ export const handlers = [
       return HttpResponse.json({ card })
     }
     return HttpResponse.json({ error: 'Card not found' }, { status: 404 })
+  }),
+
+  // List dashboards
+  http.get('/api/dashboards', async () => {
+    await delay(100)
+    return HttpResponse.json([])
   }),
 
   // Save dashboard configuration


### PR DESCRIPTION
## Summary
- Enable MSW (Mock Service Worker) when demo mode is toggled via localStorage `kc-demo-mode`, not just when set via env var or on Netlify
- Fix "Backend unreachable, using cached user data" warnings by resetting backend availability cache when MSW starts
- Add missing mock handlers that were causing 500 errors and console warnings in demo mode

## Changes
- **main.tsx**: Check `localStorage.getItem('kc-demo-mode')` to enable MSW, call `resetBackendAvailabilityCache()` after MSW starts
- **api.ts**: Add `resetBackendAvailabilityCache()` function to clear stale cache when switching to demo mode
- **handlers.ts**: Add missing mock handlers:
  - `/api/health` - health check endpoint
  - `/api/active-users` (GET/POST) - presence tracking
  - `/api/permissions/summary` - user permissions
  - `/api/notifications/unread-count` - notification badge
  - `/api/dashboards` - dashboard list (returns empty array)
  - `/api/mcp/pods` - pod list for cluster queries
  - `/api/mcp/deployments` - deployment list for cluster queries

## Test plan
- [x] Enable demo mode via UI toggle in settings
- [x] Verify MSW initializes (console shows "[MSW] Mocking enabled")
- [x] Verify no "Backend unreachable" warnings in console
- [x] Verify no 500 errors for API requests
- [x] Navigate between dashboards without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)