### PR TITLE
🐛 Fix demo mode data loading and remove redundant refresh icon

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -976,10 +976,6 @@ export function CardWrapper({
                 Refresh failed
               </span>
             )}
-            {/* Refresh indicator - shows when either isVisuallySpinning or child reports loading */}
-            {(isVisuallySpinning || effectiveIsLoading) && !effectiveIsFailed && (
-              <RefreshCw className="w-3 h-3 text-blue-400 animate-spin" />
-            )}
             {/* Last updated indicator */}
             {!isVisuallySpinning && !effectiveIsLoading && !effectiveIsFailed && lastUpdated && (
               <span className="text-[10px] text-muted-foreground" title={lastUpdated.toLocaleString()}>

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { api, isBackendUnavailable } from '../../lib/api'
+import { api } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { getDemoMode } from '../useDemoMode'
 import { kubectlProxy } from '../../lib/kubectlProxy'
@@ -189,9 +189,9 @@ export function usePods(cluster?: string, namespace?: string, sortBy: 'restarts'
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
 
   const refetch = useCallback(async (silent = false) => {
-    // Skip backend fetch in demo mode or when backend is unavailable
+    // Skip backend fetch only when not logged in at all
     const token = localStorage.getItem('token')
-    if (!token || token === 'demo-token' || isBackendUnavailable()) {
+    if (!token) {
       const now = new Date()
       setLastUpdated(now)
       setLastRefresh(now)
@@ -414,9 +414,9 @@ export function usePodIssues(cluster?: string, namespace?: string) {
   }, [cluster, namespace])
 
   const refetch = useCallback(async (silent = false) => {
-    // Skip backend fetch in demo mode
+    // Skip only if not logged in at all
     const token = localStorage.getItem('token')
-    if (!token || token === 'demo-token') {
+    if (!token) {
       const now = new Date()
       setLastUpdated(now)
       setLastRefresh(now)
@@ -566,9 +566,9 @@ export function useDeploymentIssues(cluster?: string, namespace?: string) {
   const [lastRefresh, setLastRefresh] = useState<Date | null>(cached?.timestamp || null)
 
   const refetch = useCallback(async (silent = false) => {
-    // Skip backend fetch in demo mode
+    // Skip only when not logged in at all - allow demo-token to proceed so MSW can handle it
     const token = localStorage.getItem('token')
-    if (!token || token === 'demo-token') {
+    if (!token) {
       if (!deploymentIssuesCache) {
         setIssues(getDemoDeploymentIssues())
       }
@@ -784,7 +784,8 @@ export function useDeployments(cluster?: string, namespace?: string) {
       const url = `/api/mcp/deployments?${params}`
 
       const token = localStorage.getItem('token')
-      if (!token || token === 'demo-token') {
+      // Skip only if no token at all (not logged in) - allow demo-token to proceed so MSW can handle it
+      if (!token) {
         setDeployments([])
         const now = new Date()
         setLastUpdated(now)


### PR DESCRIPTION
## Summary
- Fix `usePods`, `usePodIssues`, and `useDeploymentIssues` hooks to allow `demo-token` through to MSW interception instead of returning early with empty data
- Remove small refresh icon from card title area (redundant with refresh button spinner on right side of card header)

## Changes
1. **workloads.ts**: Changed `token === 'demo-token'` checks to allow API calls to proceed so MSW can intercept them in demo mode
2. **CardWrapper.tsx**: Removed the small spinning `RefreshCw` icon that appeared in the title area next to badges - the refresh button on the right already shows a spinner

## Test plan
- [x] Build passes
- [ ] Verify deployments dashboard stats load properly in demo mode
- [ ] Verify refresh button spins when clicked (no small icon in title)

🤖 Generated with [Claude Code](https://claude.com/claude-code)