### PR TITLE
🐛 Fix Netlify SPA routing breaking asset loading

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -18,11 +18,12 @@
   to = "/.netlify/functions/presence"
   status = 200
 
-# SPA routing - redirect all routes to index.html
+# SPA routing - redirect all routes to index.html (only if file doesn't exist)
 [[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200
+  force = false
 
 # Headers for security and caching
 [[headers]]


### PR DESCRIPTION
## Summary
**CRITICAL FIX** - console.kubestellar.io is broken because JavaScript assets are being served as HTML.

## Problem
The SPA redirect rule in `netlify.toml`:
```toml
[[redirects]]
  from = "/*"
  to = "/index.html"
  status = 200
```

This wildcard catches ALL requests including `/assets/*` and serves `index.html` instead of the actual JavaScript/CSS files. The browser receives HTML when expecting JavaScript, causing the entire app to fail to load.

## Fix
Add `force = false` to the redirect rule:
```toml
[[redirects]]
  from = "/*"
  to = "/index.html"
  status = 200
  force = false
```

With `force = false`, Netlify only applies the redirect when no matching file exists, allowing static assets to be served correctly.

## Test plan
- [ ] After deploy, verify https://console.kubestellar.io loads correctly
- [ ] Verify `/assets/*.js` returns JavaScript (not HTML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)