### PR TITLE
🐛 Fix react-is version mismatch causing site crash

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,7 +20,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-i18next": "^16.5.3",
-        "react-is": "^19.2.3",
+        "react-is": "^18.3.1",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.1.1",
         "recharts": "^3.6.0",
@@ -7571,9 +7571,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
-      "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
     "node_modules/react-markdown": {

--- a/web/package.json
+++ b/web/package.json
@@ -34,7 +34,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^16.5.3",
-    "react-is": "^19.2.3",
+    "react-is": "^18.3.1",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.1.1",
     "recharts": "^3.6.0",


### PR DESCRIPTION
## Summary
- Downgrade `react-is` from `^19.2.3` to `^18.3.1` to match React 18.x
- Fixes `Cannot read properties of undefined (reading 'useLayoutEffect')` error in @dnd-kit

## Problem
The production site (console.kubestellar.io) is crashing with:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'useLayoutEffect')
    at dnd-BREMTJ0Z.js:1:699
```

This is caused by a version mismatch between `react-is@19.x` and `react@18.x`.

## Test plan
- [ ] Build succeeds
- [ ] Site loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)