### PR TITLE
🐛 Clear demo data and show loading skeletons when switching to live mode

### DIFF
--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -179,6 +179,22 @@ export function useEvents(cluster?: string, namespace?: string, limit = 20) {
     return () => clearInterval(interval)
   }, [refetch, cacheKey])
 
+  // Listen for demo data clear event (when switching from demo to live mode)
+  useEffect(() => {
+    const handleClearDemoData = () => {
+      // Clear module-level cache
+      eventsCache = null
+      // Reset to loading state
+      setEvents([])
+      setIsLoading(true)
+      setLastUpdated(null)
+      setLastRefresh(null)
+    }
+
+    window.addEventListener('kc-clear-demo-data', handleClearDemoData)
+    return () => window.removeEventListener('kc-clear-demo-data', handleClearDemoData)
+  }, [])
+
   return {
     events,
     isLoading,
@@ -296,6 +312,21 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
     const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
     return () => clearInterval(interval)
   }, [refetch, cacheKey])
+
+  // Listen for demo data clear event (when switching from demo to live mode)
+  useEffect(() => {
+    const handleClearDemoData = () => {
+      // Clear module-level cache
+      warningEventsCache = null
+      // Reset to loading state
+      setEvents([])
+      setIsLoading(true)
+      setLastUpdated(null)
+    }
+
+    window.addEventListener('kc-clear-demo-data', handleClearDemoData)
+    return () => window.removeEventListener('kc-clear-demo-data', handleClearDemoData)
+  }, [])
 
   return { events, isLoading, isRefreshing, lastUpdated, error, refetch: () => refetch(false) }
 }

--- a/web/src/hooks/mcp/security.ts
+++ b/web/src/hooks/mcp/security.ts
@@ -97,6 +97,22 @@ export function useSecurityIssues(cluster?: string, namespace?: string) {
     refetch()
   }, [cluster, namespace]) // Only refetch on parameter changes, not on refetch function change
 
+  // Listen for demo data clear event (when switching from demo to live mode)
+  useEffect(() => {
+    const handleClearDemoData = () => {
+      // Reset to loading state and clear data
+      setIssues([])
+      setIsLoading(true)
+      setIsUsingDemoData(false)
+      setLastUpdated(null)
+      setLastRefresh(null)
+      // Refetch will be triggered by the mode change
+    }
+
+    window.addEventListener('kc-clear-demo-data', handleClearDemoData)
+    return () => window.removeEventListener('kc-clear-demo-data', handleClearDemoData)
+  }, [])
+
   return {
     issues,
     isLoading,
@@ -187,6 +203,20 @@ export function useGitOpsDrifts(cluster?: string, namespace?: string) {
     const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
     return () => clearInterval(interval)
   }, [refetch])
+
+  // Listen for demo data clear event (when switching from demo to live mode)
+  useEffect(() => {
+    const handleClearDemoData = () => {
+      // Reset to loading state and clear data
+      setDrifts([])
+      setIsLoading(true)
+      setLastRefresh(null)
+      // Refetch will be triggered by the mode change
+    }
+
+    window.addEventListener('kc-clear-demo-data', handleClearDemoData)
+    return () => window.removeEventListener('kc-clear-demo-data', handleClearDemoData)
+  }, [])
 
   return {
     drifts,


### PR DESCRIPTION
## Summary
When switching from demo mode to live mode, clear all demo data and show loading skeletons until real data loads.

## Problem
Previously, when switching from demo to live mode, demo data remained visible while live data was being fetched. This was confusing because users would see demo cluster names while waiting for real clusters to load.

## Solution
- Add `clearDemoDataAndResetLoading()` function in `shared.ts` that:
  - Clears all localStorage caches (kubestellar-*, console_cache_*, kc-cache-*)
  - Clears IndexedDB caches via the cache library
  - Resets cluster cache to loading state
  - Dispatches `kc-clear-demo-data` custom event
- Add event listeners to data hooks (security, events) to reset their state on this event
- Listen for `kc-demo-mode-change` event and trigger clear when switching FROM demo TO live

## Test plan
- [x] Build passes
- [ ] In demo mode, switch to live mode
- [ ] All cards should show loading skeletons immediately
- [ ] Real data should load and replace skeletons

🤖 Generated with [Claude Code](https://claude.com/claude-code)