### PR TITLE
⚡ Improve dashboard data loading performance

### DIFF
--- a/web/src/components/cards/ClusterDropZone.tsx
+++ b/web/src/components/cards/ClusterDropZone.tsx
@@ -3,6 +3,7 @@ import { Server, Check, Cpu, HardDrive, Layers, Loader2 } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useClusterCapabilities, ClusterCapability } from '../../hooks/useWorkloads'
+import { getDemoMode } from '../../hooks/useDemoMode'
 
 // Demo cluster data (fallback when no real clusters)
 const DEMO_CLUSTERS: ClusterCapability[] = [
@@ -61,9 +62,9 @@ export function ClusterDropZone({
 
   if (!isDragging || !draggedWorkload) return null
 
-  // Use real clusters if available, otherwise demo data
-  const clusters = realClusters && realClusters.length > 0 ? realClusters : DEMO_CLUSTERS
-  const isDemo = !realClusters || realClusters.length === 0
+  // Use demo data only in demo mode
+  const isDemo = getDemoMode()
+  const clusters = isDemo ? DEMO_CLUSTERS : (realClusters || [])
 
   // Filter out clusters where workload is already deployed and unavailable clusters
   const availableClusters = clusters.filter(

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -11,6 +11,7 @@ import { cn } from '../../../lib/cn'
 import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
 import { WorkloadMonitorDiagnose } from './WorkloadMonitorDiagnose'
 import type { MonitorIssue, MonitoredResource } from '../../../types/workloadMonitor'
+import { getDemoMode } from '../../../hooks/useDemoMode'
 
 interface GitHubCIMonitorProps {
   config?: Record<string, unknown>
@@ -129,7 +130,8 @@ export function GitHubCIMonitor({ config }: GitHubCIMonitorProps) {
         }))
         allRuns.push(...runs)
       }
-      setWorkflows(allRuns.length > 0 ? allRuns : DEMO_WORKFLOWS)
+      // Only use demo data in demo mode
+      setWorkflows(allRuns.length > 0 ? allRuns : (getDemoMode() ? DEMO_WORKFLOWS : []))
     } catch (err) {
       console.error('[GitHubCIMonitor] fetch error:', err)
       setError(err instanceof Error ? err.message : 'Failed to fetch workflows')

--- a/web/src/components/compute/Compute.tsx
+++ b/web/src/components/compute/Compute.tsx
@@ -382,8 +382,8 @@ export function Compute() {
         lastUpdated={lastUpdated}
       />
 
-      {/* Error Display */}
-      {error && (
+      {/* Error Display - only show when no data is available */}
+      {error && !hasDataToShow && (
         <div className="mb-4 p-4 rounded-lg bg-red-500/10 border border-red-500/20 flex items-start gap-3">
           <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
           <div className="flex-1">

--- a/web/src/hooks/mcp/config.ts
+++ b/web/src/hooks/mcp/config.ts
@@ -55,9 +55,12 @@ export function useConfigMaps(cluster?: string, namespace?: string) {
       setError(null)
     } catch {
       setError('Failed to fetch ConfigMaps')
-      setConfigMaps(getDemoConfigMaps().filter(cm =>
-        (!cluster || cm.cluster === cluster) && (!namespace || cm.namespace === namespace)
-      ))
+      // Only fall back to demo data if in demo mode
+      if (getDemoMode()) {
+        setConfigMaps(getDemoConfigMaps().filter(cm =>
+          (!cluster || cm.cluster === cluster) && (!namespace || cm.namespace === namespace)
+        ))
+      }
     } finally {
       setIsLoading(false)
     }
@@ -120,9 +123,12 @@ export function useSecrets(cluster?: string, namespace?: string) {
       setError(null)
     } catch {
       setError('Failed to fetch Secrets')
-      setSecrets(getDemoSecrets().filter(s =>
-        (!cluster || s.cluster === cluster) && (!namespace || s.namespace === namespace)
-      ))
+      // Only fall back to demo data if in demo mode
+      if (getDemoMode()) {
+        setSecrets(getDemoSecrets().filter(s =>
+          (!cluster || s.cluster === cluster) && (!namespace || s.namespace === namespace)
+        ))
+      }
     } finally {
       setIsLoading(false)
     }
@@ -185,9 +191,12 @@ export function useServiceAccounts(cluster?: string, namespace?: string) {
       setError(null)
     } catch {
       setError('Failed to fetch ServiceAccounts')
-      setServiceAccounts(getDemoServiceAccounts().filter(sa =>
-        (!cluster || sa.cluster === cluster) && (!namespace || sa.namespace === namespace)
-      ))
+      // Only fall back to demo data if in demo mode
+      if (getDemoMode()) {
+        setServiceAccounts(getDemoServiceAccounts().filter(sa =>
+          (!cluster || sa.cluster === cluster) && (!namespace || sa.namespace === namespace)
+        ))
+      }
     } finally {
       setIsLoading(false)
     }

--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -148,12 +148,16 @@ export function useEvents(cluster?: string, namespace?: string, limit = 20) {
         return
       }
       console.error('[useEvents] Failed to fetch events:', err)
-      // Keep stale data, only use demo if no cached data
+      // Keep stale data, only use demo if no cached data AND in demo mode
       setConsecutiveFailures(prev => prev + 1)
       setLastRefresh(new Date())
       if (!silent && !eventsCache) {
         setError('Failed to fetch events')
-        setEvents(getDemoEvents())
+        // Only fall back to demo data if in demo mode
+        const token = localStorage.getItem('token')
+        if (!token || token === 'demo-token') {
+          setEvents(getDemoEvents())
+        }
       }
     } finally {
       // console.log('[useEvents] Finally block started')
@@ -287,10 +291,14 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
       setError(null)
       setLastUpdated(now)
     } catch (err) {
-      // Keep stale data, only use demo if no cached data
+      // Keep stale data, only use demo if no cached data AND in demo mode
       if (!silent && !warningEventsCache) {
         setError('Failed to fetch warning events')
-        setEvents(getDemoEvents().filter(e => e.type === 'Warning'))
+        // Only fall back to demo data if in demo mode
+        const token = localStorage.getItem('token')
+        if (!token || token === 'demo-token') {
+          setEvents(getDemoEvents().filter(e => e.type === 'Warning'))
+        }
       }
     } finally {
       setIsLoading(false)

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -232,8 +232,8 @@ export function useServices(cluster?: string, namespace?: string) {
       setLastRefresh(new Date())
       if (!silent) {
         setError('Failed to fetch services')
-        // Fall back to demo data on error if no cached data
-        if (services.length === 0) {
+        // Only fall back to demo data on error if in demo mode and no cached data
+        if (services.length === 0 && getDemoMode()) {
           setServices(getDemoServices().filter(s =>
             (!cluster || s.cluster === cluster) && (!namespace || s.namespace === namespace)
           ))
@@ -326,10 +326,12 @@ export function useIngresses(cluster?: string, namespace?: string) {
       setError(null)
     } catch {
       setError('Failed to fetch Ingresses')
-      // Fall back to demo data on error
-      setIngresses(getDemoIngresses().filter(i =>
-        (!cluster || i.cluster === cluster) && (!namespace || i.namespace === namespace)
-      ))
+      // Only fall back to demo data on error if in demo mode
+      if (getDemoMode()) {
+        setIngresses(getDemoIngresses().filter(i =>
+          (!cluster || i.cluster === cluster) && (!namespace || i.namespace === namespace)
+        ))
+      }
     } finally {
       setIsLoading(false)
     }
@@ -390,10 +392,12 @@ export function useNetworkPolicies(cluster?: string, namespace?: string) {
       setError(null)
     } catch {
       setError('Failed to fetch NetworkPolicies')
-      // Fall back to demo data on error
-      setNetworkPolicies(getDemoNetworkPolicies().filter(np =>
-        (!cluster || np.cluster === cluster) && (!namespace || np.namespace === namespace)
-      ))
+      // Only fall back to demo data on error if in demo mode
+      if (getDemoMode()) {
+        setNetworkPolicies(getDemoNetworkPolicies().filter(np =>
+          (!cluster || np.cluster === cluster) && (!namespace || np.namespace === namespace)
+        ))
+      }
     } finally {
       setIsLoading(false)
     }

--- a/web/src/hooks/mcp/security.ts
+++ b/web/src/hooks/mcp/security.ts
@@ -77,13 +77,17 @@ export function useSecurityIssues(cluster?: string, namespace?: string) {
       setLastRefresh(now)
       setIsUsingDemoData(false)
     } catch (err) {
-      // Only set demo data if we don't have existing data and not silent
+      // Only set demo data if we're in demo mode AND don't have existing data AND not silent
+      // In live mode, show error state instead of falling back to demo data
       setConsecutiveFailures(prev => prev + 1)
       setLastRefresh(new Date())
       if (!silent && hadNoData) {
         setError('Failed to fetch security issues')
-        setIssues(getDemoSecurityIssues())
-        setIsUsingDemoData(true)
+        // Only fall back to demo data if in demo mode
+        if (isDemoMode()) {
+          setIssues(getDemoSecurityIssues())
+          setIsUsingDemoData(true)
+        }
       }
     } finally {
       if (!silent) {
@@ -187,7 +191,10 @@ export function useGitOpsDrifts(cluster?: string, namespace?: string) {
       setLastRefresh(new Date())
       if (!silent) {
         setError('Failed to fetch GitOps drifts')
-        setDrifts(getDemoGitOpsDrifts())
+        // Only fall back to demo data if in demo mode
+        if (isDemoMode()) {
+          setDrifts(getDemoGitOpsDrifts())
+        }
       }
     } finally {
       if (!silent) {

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -312,12 +312,14 @@ export function usePods(cluster?: string, namespace?: string, sortBy: 'restarts'
       setConsecutiveFailures(0)
       setLastRefresh(now)
     } catch (err) {
-      // Keep stale data on error - don't fall back to demo
+      // Keep stale data on error - only fall back to demo if in demo mode
       setConsecutiveFailures(prev => prev + 1)
       setLastRefresh(new Date())
       if (!silent && !podsCache) {
         setError('Failed to fetch pods')
-        setPods(getDemoPods())
+        if (getDemoMode()) {
+          setPods(getDemoPods())
+        }
       }
     } finally {
       setIsLoading(false)
@@ -410,12 +412,14 @@ export function useAllPods(cluster?: string, namespace?: string) {
       setError(null)
       setLastUpdated(now)
     } catch (err) {
-      // Keep stale data on error, fallback to demo data if no cache
+      // Keep stale data on error, only fallback to demo data if in demo mode
       if (!silent && !podsCache) {
         setError('Failed to fetch pods')
-        setPods(getDemoAllPods().filter(p =>
-          (!cluster || p.cluster === cluster) && (!namespace || p.namespace === namespace)
-        ))
+        if (getDemoMode()) {
+          setPods(getDemoAllPods().filter(p =>
+            (!cluster || p.cluster === cluster) && (!namespace || p.namespace === namespace)
+          ))
+        }
       }
     } finally {
       if (!silent) {
@@ -676,12 +680,14 @@ export function useDeploymentIssues(cluster?: string, namespace?: string) {
       setConsecutiveFailures(0)
       setLastRefresh(now)
     } catch (err) {
-      // Keep stale data, only use demo if no cached data
+      // Keep stale data, only use demo if in demo mode and no cached data
       setConsecutiveFailures(prev => prev + 1)
       setLastRefresh(new Date())
       if (!silent && !deploymentIssuesCache) {
         setError('Failed to fetch deployment issues')
-        setIssues(getDemoDeploymentIssues())
+        if (getDemoMode()) {
+          setIssues(getDemoDeploymentIssues())
+        }
       }
     } finally {
       setIsLoading(false)

--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -53,7 +53,7 @@ class KubectlProxy {
   // Request queue to prevent overwhelming the WebSocket
   private requestQueue: QueuedRequest[] = []
   private activeRequests = 0
-  private readonly maxConcurrentRequests = 2 // Limit concurrent requests to local agent
+  private readonly maxConcurrentRequests = 4 // Increased from 2 for faster parallel operations
 
   /**
    * Ensure WebSocket is connected


### PR DESCRIPTION
## Summary
- Increase health check concurrency from 2 to 6 (~3x faster cluster health population)
- Increase kubectlProxy max concurrent requests from 2 to 4
- Add debounced localStorage writes to prevent main thread blocking
- Simplify distribution detection (remove slow sequential backend fallbacks)
- Add centralized TIMEOUT_CONFIG for consistent timeout behavior
- Mark timeout errors as definitive for immediate offline status
- Show loading indicator in Workloads card during data fetch
- Only show Compute error when no data is available

## Test plan
- [ ] Navigate between dashboards and verify data loads faster
- [ ] Check cluster health status updates within ~20s (vs previous 50s+)
- [ ] Verify offline clusters show as "offline" not "unhealthy"
- [ ] Confirm demo mode fallbacks only apply in demo mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)