### PR TITLE
🐛 Enable automatic skeleton display for all cards

### DIFF
--- a/web/public/mockServiceWorker.js
+++ b/web/public/mockServiceWorker.js
@@ -1,4 +1,4 @@
-/* eslint-disable */
+ 
 /* tslint:disable */
 
 /**

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -733,7 +733,9 @@ export function CardWrapper({
   const effectiveHasData = childDataState?.hasData ?? true // Default to true if not reported
 
   // Determine if we should show skeleton: loading with no cached data
-  const shouldShowSkeleton = skeletonType && effectiveIsLoading && !effectiveHasData && !effectiveIsRefreshing
+  // Default to 'list' skeleton type if not specified, enabling automatic skeleton display
+  const effectiveSkeletonType = skeletonType || 'list'
+  const shouldShowSkeleton = effectiveIsLoading && !effectiveHasData && !effectiveIsRefreshing
 
   // Use external messages if provided, otherwise use local state
   const messages = externalMessages ?? localMessages
@@ -1062,14 +1064,14 @@ export function CardWrapper({
             {(isVisible || isExpanded) ? (
               // Show skeleton when loading with no cached data
               shouldShowSkeleton ? (
-                <CardSkeleton type={skeletonType} rows={skeletonRows} showHeader />
+                <CardSkeleton type={effectiveSkeletonType} rows={skeletonRows || 3} showHeader />
               ) : (
                 children
               )
             ) : (
               // Show skeleton during lazy mount (before IntersectionObserver fires)
               // This provides visual continuity instead of a tiny pulse loader
-              <CardSkeleton type={skeletonType || 'list'} rows={skeletonRows || 3} showHeader={false} />
+              <CardSkeleton type={effectiveSkeletonType} rows={skeletonRows || 3} showHeader={false} />
             )}
           </div>
         )}

--- a/web/src/components/cards/Checkers.tsx
+++ b/web/src/components/cards/Checkers.tsx
@@ -522,7 +522,7 @@ export function Checkers(_props: CardComponentProps) {
       if (result.move) {
         let newBoard = applyMove(board, result.move)
         let lastPos = result.move.to
-        let capturedAny = result.move.isJump
+        const capturedAny = result.move.isJump
 
         // Show combat animation for captures
         if (result.move.isJump && result.move.captures.length > 0) {

--- a/web/src/components/cards/ContainerTetris.tsx
+++ b/web/src/components/cards/ContainerTetris.tsx
@@ -231,7 +231,7 @@ export function ContainerTetris(_props: CardComponentProps) {
   const hardDrop = useCallback(() => {
     if (!piece || gameOver || isPaused) return
 
-    let newPiece = { ...piece }
+    const newPiece = { ...piece }
     while (isValidPosition(board, { ...newPiece, y: newPiece.y + 1 })) {
       newPiece.y++
     }

--- a/web/src/components/cards/Game2048.tsx
+++ b/web/src/components/cards/Game2048.tsx
@@ -96,7 +96,7 @@ function slideLine(line: (number | null)[]): [(number | null)[], number, boolean
 
 // Move grid in direction
 function moveGrid(grid: Grid, direction: 'up' | 'down' | 'left' | 'right'): { grid: Grid; score: number; moved: boolean } {
-  let newGrid = grid.map(row => [...row])
+  const newGrid = grid.map(row => [...row])
   let totalScore = 0
   let anyMoved = false
 
@@ -192,7 +192,7 @@ export function Game2048(_props: CardComponentProps) {
     const result = moveGrid(grid, direction)
 
     if (result.moved) {
-      let newGrid = addRandomTile(result.grid)
+      const newGrid = addRandomTile(result.grid)
       setGrid(newGrid)
       const newScore = score + result.score
       setScore(newScore)

--- a/web/src/components/cards/Kubectl.tsx
+++ b/web/src/components/cards/Kubectl.tsx
@@ -141,7 +141,7 @@ export function Kubectl() {
 
     try {
       // Parse command
-      let args = cmd.trim().split(/\s+/)
+      const args = cmd.trim().split(/\s+/)
       
       // Add output format if not specified
       if (!args.includes('-o') && !args.includes('--output') && outputFormat !== 'table') {

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -235,7 +235,7 @@ spec:
 // Module-level flag to prevent StrictMode double-checks
 // This persists across component mounts within the same page load
 let globalCheckInProgress = false
-let globalCheckedClusters = new Set<string>()
+const globalCheckedClusters = new Set<string>()
 
 async function checkGatekeeperStatus(clusterName: string): Promise<GatekeeperStatus> {
   try {

--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -41,7 +41,7 @@ function setCachedVersion(clusterName: string, version: string) {
 
 // Shared WebSocket for version fetching
 let versionWs: WebSocket | null = null
-let versionPendingRequests: Map<string, (version: string | null) => void> = new Map()
+const versionPendingRequests: Map<string, (version: string | null) => void> = new Map()
 let wsConnecting = false
 
 function ensureVersionWs(): Promise<WebSocket> {

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -797,14 +797,14 @@ function NamespaceResources({ clusterName, namespace }: NamespaceResourcesProps)
 }
 
 // Legacy ClusterDetail - kept for reference, using ClusterDetailModal instead
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+ 
 interface _ClusterDetailProps {
   clusterName: string
   onClose: () => void
   onRename?: (clusterName: string) => void
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+ 
 export function _ClusterDetail({ clusterName, onClose, onRename }: _ClusterDetailProps) {
   const { health, isLoading } = useClusterHealth(clusterName)
   const { issues: podIssues } = usePodIssues(clusterName)

--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -315,7 +315,7 @@ export function useHelmHistory(cluster?: string, release?: string, namespace?: s
       setIsRefreshing(false)
     }
     // Note: cachedEntry deliberately excluded to prevent infinite loops
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
   }, [cluster, release, namespace])
 
   useEffect(() => {

--- a/web/src/hooks/useProw.ts
+++ b/web/src/hooks/useProw.ts
@@ -171,7 +171,7 @@ export function useProwJobs(prowCluster = 'prow', namespace = 'prow') {
       }
       setIsRefreshing(false)
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+   
   }, [prowCluster, namespace])
 
   useEffect(() => {

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -81,8 +81,8 @@ const DEPRECATED_ROUTES = ['/apps']
 // Migrate config to ensure all default routes exist
 function migrateConfig(stored: SidebarConfig): SidebarConfig {
   // First, remove deprecated routes
-  let primaryNav = stored.primaryNav.filter(item => !DEPRECATED_ROUTES.includes(item.href))
-  let secondaryNav = stored.secondaryNav.filter(item => !DEPRECATED_ROUTES.includes(item.href))
+  const primaryNav = stored.primaryNav.filter(item => !DEPRECATED_ROUTES.includes(item.href))
+  const secondaryNav = stored.secondaryNav.filter(item => !DEPRECATED_ROUTES.includes(item.href))
 
   // Find default routes that are missing from the stored config
   const existingHrefs = new Set([

--- a/web/src/hooks/useSnoozedCards.ts
+++ b/web/src/hooks/useSnoozedCards.ts
@@ -14,7 +14,7 @@ export interface SnoozedSwap {
 
 // Simple in-memory store - in production this would sync with backend
 let snoozedSwaps: SnoozedSwap[] = []
-let listeners: Set<() => void> = new Set()
+const listeners: Set<() => void> = new Set()
 
 function notifyListeners() {
   listeners.forEach((listener) => listener())

--- a/web/src/hooks/useSnoozedMissions.ts
+++ b/web/src/hooks/useSnoozedMissions.ts
@@ -23,7 +23,7 @@ interface StoredState {
 
 // Module-level state for cross-component sharing
 let state: StoredState = { snoozed: [], dismissed: [] }
-let listeners: Set<() => void> = new Set()
+const listeners: Set<() => void> = new Set()
 
 function notifyListeners() {
   listeners.forEach((listener) => listener())

--- a/web/src/hooks/useSnoozedRecommendations.ts
+++ b/web/src/hooks/useSnoozedRecommendations.ts
@@ -9,8 +9,8 @@ export interface SnoozedRecommendation {
 
 // Simple in-memory store - in production this would sync with backend
 let snoozedRecs: SnoozedRecommendation[] = []
-let dismissedRecIds: Set<string> = new Set()
-let listeners: Set<() => void> = new Set()
+const dismissedRecIds: Set<string> = new Set()
+const listeners: Set<() => void> = new Set()
 
 function notifyListeners() {
   listeners.forEach((listener) => listener())

--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -35,7 +35,7 @@ let sharedUsage: TokenUsage = {
   resetDate: getNextResetDate(),
 }
 let pollStarted = false
-let subscribers = new Set<(usage: TokenUsage) => void>()
+const subscribers = new Set<(usage: TokenUsage) => void>()
 
 // Initialize from localStorage
 if (typeof window !== 'undefined') {

--- a/web/src/lib/dynamic-cards/compiler.ts
+++ b/web/src/lib/dynamic-cards/compiler.ts
@@ -47,7 +47,7 @@ export function createCardComponent(compiledCode: string): DynamicComponentResul
     const scopeKeys = Object.keys(scope)
     const scopeValues = scopeKeys.map(k => scope[k])
 
-    // eslint-disable-next-line no-new-func
+     
     const factory = new Function(...scopeKeys, moduleCode)
     const component = factory(...scopeValues) as ComponentType<CardComponentProps>
 

--- a/web/src/lib/unified/stats/UnifiedStatBlock.tsx
+++ b/web/src/lib/unified/stats/UnifiedStatBlock.tsx
@@ -93,7 +93,7 @@ export function UnifiedStatBlock({
       isDemo: resolved.isDemo,
       isClickable: !!config.onClick,
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
   }, [config, data, getValue])
 
   // Get components


### PR DESCRIPTION
## Summary
- Default skeleton type to 'list' when not specified in CardWrapper
- Cards now automatically show skeleton during loading when no cached data exists
- Removes requirement to explicitly pass skeletonType prop
- Includes lint fixes

## Test plan
- [x] Build passes
- [x] Security dashboard loads correctly with cached data
- [x] Skeleton displays automatically when loading with no cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)