### PR TITLE
🐛 Fix hasData pattern causing cards stuck on skeleton

### DIFF
--- a/web/src/components/cards/ArgoCDApplications.tsx
+++ b/web/src/components/cards/ArgoCDApplications.tsx
@@ -66,13 +66,16 @@ export function ArgoCDApplications({ config }: ArgoCDApplicationsProps) {
   } = useArgoCDApplications()
   const { drillToArgoApp } = useDrillDownActions()
 
+  // hasData should be true once loading completes (even with empty data)
+  const hasData = !isLoading || allApps.length > 0
+
   // Report data state to CardWrapper
   useReportCardDataState({
     isFailed,
     consecutiveFailures,
-    isLoading,
-    isRefreshing,
-    hasData: allApps.length > 0,
+    isLoading: isLoading && allApps.length === 0,
+    isRefreshing: isRefreshing || (isLoading && allApps.length > 0),
+    hasData,
   })
 
   // Card-specific status filter

--- a/web/src/components/cards/ArgoCDHealth.tsx
+++ b/web/src/components/cards/ArgoCDHealth.tsx
@@ -26,13 +26,16 @@ export function ArgoCDHealth({ config: _config }: ArgoCDHealthProps) {
     consecutiveFailures,
   } = useArgoCDHealth()
 
+  // hasData should be true once loading completes (even with empty data)
+  const hasData = !isLoading || total > 0
+
   // Report data state to CardWrapper
   useReportCardDataState({
     isFailed,
     consecutiveFailures,
-    isLoading,
-    isRefreshing,
-    hasData: total > 0,
+    isLoading: isLoading && total === 0,
+    isRefreshing: isRefreshing || (isLoading && total > 0),
+    hasData,
   })
 
   const showSkeleton = isLoading && total === 0 && !isFailed

--- a/web/src/components/cards/ChartVersions.tsx
+++ b/web/src/components/cards/ChartVersions.tsx
@@ -45,13 +45,16 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
   // Only show skeleton when no cached data exists
   const isLoading = (clustersLoading || releasesLoading) && allHelmReleases.length === 0
 
+  // hasData should be true once loading completes (even with empty data)
+  const hasData = !isLoading || allHelmReleases.length > 0
+
   // Report card data state to parent CardWrapper for automatic skeleton/refresh handling
   useReportCardDataState({
     isFailed,
     consecutiveFailures,
     isLoading,
     isRefreshing,
-    hasData: allHelmReleases.length > 0,
+    hasData,
   })
 
   // Transform Helm releases to chart info

--- a/web/src/components/cards/DataComplianceCards.tsx
+++ b/web/src/components/cards/DataComplianceCards.tsx
@@ -166,14 +166,15 @@ export function ExternalSecrets({ config: _config }: CardConfig) {
 // Cert-Manager TLS Certificates Card
 export function CertManager({ config: _config }: CardConfig) {
   const { status, issuers, isLoading, isRefreshing, consecutiveFailures, isFailed } = useCertManager()
-  const hasData = issuers.length > 0 || status.installed
+  // hasData should be true once loading completes (even with empty data)
+  const hasData = !isLoading || issuers.length > 0 || status.installed
 
   // Report state to CardWrapper for refresh animation
   useReportCardDataState({
     isFailed,
     consecutiveFailures,
-    isLoading: isLoading && !hasData,
-    isRefreshing: isRefreshing || (isLoading && hasData),
+    isLoading: isLoading && issuers.length === 0 && !status.installed,
+    isRefreshing: isRefreshing || (isLoading && (issuers.length > 0 || status.installed)),
     hasData,
   })
 

--- a/web/src/components/cards/DeploymentIssues.tsx
+++ b/web/src/components/cards/DeploymentIssues.tsx
@@ -42,9 +42,10 @@ export function DeploymentIssues({ config }: DeploymentIssuesProps) {
     error
   } = useCachedDeploymentIssues(clusterConfig, namespaceConfig)
 
-  // Only show skeleton when no cached data exists
-  const hasData = rawIssues.length > 0
-  const isLoading = hookLoading && !hasData
+  // hasData should be true once loading completes (even with empty data)
+  // This prevents skeleton showing forever when API returns empty array
+  const hasData = !hookLoading || rawIssues.length > 0
+  const isLoading = hookLoading && rawIssues.length === 0
   const { drillToDeployment } = useDrillDownActions()
 
   // Report data state to CardWrapper for failure badge rendering

--- a/web/src/components/cards/GitOpsDrift.tsx
+++ b/web/src/components/cards/GitOpsDrift.tsx
@@ -72,13 +72,16 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
   // Only show skeleton when no cached data exists - prevents flickering
   const isLoading = isLoadingHook && drifts.length === 0
 
+  // hasData should be true once loading completes (even with empty data)
+  const hasData = !isLoading || drifts.length > 0
+
   // Report card data state to parent CardWrapper for automatic skeleton/refresh handling
   useReportCardDataState({
     isFailed,
     consecutiveFailures,
     isLoading,
     isRefreshing,
-    hasData: drifts.length > 0,
+    hasData,
   })
 
   // Map drift severity to global SeverityLevel

--- a/web/src/components/cards/HelmHistory.tsx
+++ b/web/src/components/cards/HelmHistory.tsx
@@ -108,13 +108,16 @@ export function HelmHistory({ config }: HelmHistoryProps) {
   // Only show skeleton when no cached data exists
   const isLoading = (clustersLoading || releasesLoading) && allHelmReleases.length === 0
 
+  // hasData should be true once loading completes (even with empty data)
+  const hasData = !historyLoading || rawHistory.length > 0
+
   // Report card data state to parent CardWrapper for automatic skeleton/refresh handling
   useReportCardDataState({
     isFailed,
     consecutiveFailures,
-    isLoading: historyLoading,
-    isRefreshing: historyRefreshing,
-    hasData: rawHistory.length > 0,
+    isLoading: historyLoading && rawHistory.length === 0,
+    isRefreshing: historyRefreshing || (historyLoading && rawHistory.length > 0),
+    hasData,
   })
 
   // Apply global filters to clusters

--- a/web/src/components/cards/HelmReleaseStatus.tsx
+++ b/web/src/components/cards/HelmReleaseStatus.tsx
@@ -57,13 +57,16 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
   // Only show loading skeleton when no data exists (not during refresh)
   const isLoading = (clustersLoading || releasesLoading) && allHelmReleases.length === 0
 
+  // hasData should be true once loading completes (even with empty data)
+  const hasData = !isLoading || allHelmReleases.length > 0
+
   // Report card data state to parent CardWrapper for automatic skeleton/refresh handling
   useReportCardDataState({
     isFailed,
     consecutiveFailures,
     isLoading,
     isRefreshing,
-    hasData: allHelmReleases.length > 0,
+    hasData,
   })
 
   // Transform API data to display format

--- a/web/src/components/cards/KustomizationStatus.tsx
+++ b/web/src/components/cards/KustomizationStatus.tsx
@@ -99,6 +99,9 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
     }
   }, [storedData.data.length])
 
+  // hasData should be true once loading completes (even with empty data)
+  const hasData = !isLoading || kustomizationData.length > 0
+
   // Report card data state to parent CardWrapper for automatic skeleton/refresh handling
   // Using demo data so isFailed is always false, isRefreshing is false
   useReportCardDataState({
@@ -106,7 +109,7 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
     consecutiveFailures: 0,
     isLoading,
     isRefreshing: false,
-    hasData: kustomizationData.length > 0,
+    hasData,
   })
 
   // Apply global filters to cluster list for the dropdown

--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -71,12 +71,13 @@ export function PVCStatus() {
   const { drillToPVC } = useDrillDownActions()
 
   // Report card data state
-  const hasData = pvcs.length > 0
+  // hasData should be true once loading completes (even with empty data)
+  const hasData = !isLoading || pvcs.length > 0
   useReportCardDataState({
     isFailed,
     consecutiveFailures,
-    isLoading: isLoading && !hasData,
-    isRefreshing: isRefreshing || (isLoading && hasData),
+    isLoading: isLoading && pvcs.length === 0,
+    isRefreshing: isRefreshing || (isLoading && pvcs.length > 0),
     hasData,
   })
 

--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -112,13 +112,16 @@ export function SecurityIssues({ config }: SecurityIssuesProps) {
 
   const { drillToPod } = useDrillDownActions()
 
+  // hasData should be true once loading completes (even with empty data)
+  const hasData = !isLoading || rawIssues.length > 0
+
   // Report card data state to parent CardWrapper for automatic skeleton/refresh handling
   useReportCardDataState({
     isFailed,
     consecutiveFailures,
     isLoading,
     isRefreshing,
-    hasData: rawIssues.length > 0,
+    hasData,
   })
 
   const severityOrder: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3, info: 4 }

--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -16,12 +16,14 @@ export function StorageOverview() {
   const { drillToPVC } = useDrillDownActions()
 
   // Report card data state
-  const hasData = pvcs.length > 0
+  // hasData should be true once loading completes (even with empty data)
+  const combinedLoading = isLoading || pvcsLoading
+  const hasData = !combinedLoading || pvcs.length > 0
   useReportCardDataState({
     isFailed,
     consecutiveFailures,
-    isLoading: (isLoading || pvcsLoading) && !hasData,
-    isRefreshing: isRefreshing || ((isLoading || pvcsLoading) && hasData),
+    isLoading: combinedLoading && pvcs.length === 0,
+    isRefreshing: isRefreshing || (combinedLoading && pvcs.length > 0),
     hasData,
   })
 

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -18,14 +18,15 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
   const { drillToCluster, drillToNode } = useDrillDownActions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
 
-  const hasData = gpuNodes.length > 0
+  // hasData should be true once loading completes (even with empty data)
+  const hasData = !isLoading || gpuNodes.length > 0
 
   // Report state to CardWrapper for refresh animation
   useReportCardDataState({
     isFailed: false,
     consecutiveFailures: 0,
-    isLoading: isLoading && !hasData,
-    isRefreshing: isLoading && hasData,
+    isLoading: isLoading && gpuNodes.length === 0,
+    isRefreshing: isLoading && gpuNodes.length > 0,
     hasData,
   })
 


### PR DESCRIPTION
## Summary
- Fix cards stuck showing skeleton forever when APIs returned empty arrays
- Changed `hasData = items.length > 0` to `hasData = !isLoading || items.length > 0`
- Once loading completes, hasData is true - empty array is a valid loaded state

## Fixed Cards (13 total)
- ArgoCDApplications, ArgoCDHealth
- ChartVersions, DataComplianceCards
- DeploymentIssues, GitOpsDrift
- HelmHistory, HelmReleaseStatus
- KustomizationStatus, PVCStatus
- SecurityIssues, StorageOverview
- ConsoleOfflineDetectionCard

## Test plan
- [x] Storage dashboard loads properly with 0 PVCs
- [x] GitOps Drift shows integration setup content
- [x] Data Compliance cards stable, no blinking
- [x] Helm History card not stuck on skeleton
- [x] Arcade loads with all 21 games

🤖 Generated with [Claude Code](https://claude.com/claude-code)