### PR TITLE
🐛 Add showEmptyState to prevent blank cards when data is empty

### DIFF
--- a/web/src/components/cards/AppStatus.tsx
+++ b/web/src/components/cards/AppStatus.tsx
@@ -47,7 +47,7 @@ export function AppStatus(_props: AppStatusProps) {
   const { deployments, isLoading, isFailed, consecutiveFailures } = useCachedDeployments()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: deployments.length > 0,
     isFailed,
@@ -173,6 +173,15 @@ export function AppStatus(_props: AppStatusProps) {
     return (
       <div className="h-full flex items-center justify-center">
         <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No applications found</p>
+        <p className="text-xs mt-1">Deploy applications to see their status</p>
       </div>
     )
   }

--- a/web/src/components/cards/ArgoCDApplications.tsx
+++ b/web/src/components/cards/ArgoCDApplications.tsx
@@ -66,7 +66,7 @@ export function ArgoCDApplications({ config }: ArgoCDApplicationsProps) {
   const { drillToArgoApp } = useDrillDownActions()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: allApps.length > 0,
     isFailed,
@@ -147,6 +147,15 @@ export function ArgoCDApplications({ config }: ArgoCDApplicationsProps) {
           <Skeleton variant="rounded" height={60} />
           <Skeleton variant="rounded" height={60} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No ArgoCD applications</p>
+        <p className="text-xs mt-1">Deploy applications with ArgoCD to see them here</p>
       </div>
     )
   }

--- a/web/src/components/cards/ArgoCDHealth.tsx
+++ b/web/src/components/cards/ArgoCDHealth.tsx
@@ -26,7 +26,7 @@ export function ArgoCDHealth({ config: _config }: ArgoCDHealthProps) {
   } = useArgoCDHealth()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: total > 0,
     isFailed,
@@ -45,6 +45,15 @@ export function ArgoCDHealth({ config: _config }: ArgoCDHealthProps) {
           <Skeleton variant="rounded" height={20} />
           <Skeleton variant="rounded" height={20} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No ArgoCD data</p>
+        <p className="text-xs mt-1">Connect ArgoCD to see health status</p>
       </div>
     )
   }

--- a/web/src/components/cards/ArgoCDSyncStatus.tsx
+++ b/web/src/components/cards/ArgoCDSyncStatus.tsx
@@ -38,7 +38,7 @@ export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
   } = useArgoCDSyncStatus(localClusterFilter)
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: total > 0,
     isFailed,
@@ -57,6 +57,15 @@ export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
           <Skeleton variant="rounded" height={20} />
           <Skeleton variant="rounded" height={20} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No ArgoCD data</p>
+        <p className="text-xs mt-1">Connect ArgoCD to see sync status</p>
       </div>
     )
   }

--- a/web/src/components/cards/CRDHealth.tsx
+++ b/web/src/components/cards/CRDHealth.tsx
@@ -72,7 +72,7 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
   }, [deduplicatedClusters, getClusterCRDs])
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: allCRDs.length > 0,
   })
@@ -190,6 +190,15 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
           <Skeleton variant="rounded" height={40} />
           <Skeleton variant="rounded" height={40} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No CRDs found</p>
+        <p className="text-xs mt-1">Custom Resource Definitions will appear here</p>
       </div>
     )
   }

--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -66,17 +66,22 @@ export interface CardLoadingStateOptions {
  * - `hasData` should be true once loading completes (even with empty data)
  * - `hasData` should be true if we have cached data (even while refreshing)
  * - Skeleton should only show when loading AND no cached data exists
+ * - Empty state should show when loading finishes but no data exists
  *
  * @example
  * ```tsx
  * const { clusters, isLoading } = useClusters()
- * const { showSkeleton } = useCardLoadingState({
+ * const { showSkeleton, showEmptyState } = useCardLoadingState({
  *   isLoading,
  *   hasAnyData: clusters.length > 0,
  * })
  *
  * if (showSkeleton) {
  *   return <CardSkeleton type="list" rows={3} />
+ * }
+ *
+ * if (showEmptyState) {
+ *   return <CardEmptyState message="No clusters found" />
  * }
  * ```
  */
@@ -106,6 +111,8 @@ export function useCardLoadingState(options: CardLoadingStateOptions) {
     hasData,
     /** Whether to show skeleton loading state (only when loading with no cached data) */
     showSkeleton: isLoading && !hasAnyData,
+    /** Whether to show empty state (loading finished but no data exists) */
+    showEmptyState: !isLoading && !hasAnyData,
     /** Whether data is being refreshed (has cache, fetching update) */
     isRefreshing: isLoading && hasData,
   }

--- a/web/src/components/cards/ChartVersions.tsx
+++ b/web/src/components/cards/ChartVersions.tsx
@@ -42,7 +42,7 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
   } = useHelmReleases()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading || releasesLoading,
     hasAnyData: allHelmReleases.length > 0,
     isFailed,
@@ -117,6 +117,15 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
 
   if (showSkeleton) {
     return <CardSkeleton type="list" rows={3} showHeader rowHeight={50} />
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No Helm charts</p>
+        <p className="text-xs mt-1">Install Helm charts to track versions</p>
+      </div>
+    )
   }
 
   return (

--- a/web/src/components/cards/ClusterComparison.tsx
+++ b/web/src/components/cards/ClusterComparison.tsx
@@ -18,7 +18,7 @@ export function ClusterComparison({ config }: ClusterComparisonProps) {
   const [selectedClusters, setSelectedClusters] = useState<string[]>(config?.clusters || [])
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading,
     hasAnyData: rawClusters.length > 0,
   })
@@ -94,6 +94,15 @@ export function ClusterComparison({ config }: ClusterComparisonProps) {
           <Skeleton variant="rounded" height={150} />
           <Skeleton variant="rounded" height={150} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No clusters to compare</p>
+        <p className="text-xs mt-1">Add clusters to compare their metrics</p>
       </div>
     )
   }

--- a/web/src/components/cards/ClusterFocus.tsx
+++ b/web/src/components/cards/ClusterFocus.tsx
@@ -23,7 +23,7 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
   const [internalCluster, setInternalCluster] = useState<string>('')
 
   // Report state to CardWrapper for refresh animation
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading,
     hasAnyData: allClusters.length > 0,
   })
@@ -81,6 +81,15 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
           <Skeleton variant="rounded" height={80} />
           <Skeleton variant="rounded" height={80} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No clusters available</p>
+        <p className="text-xs mt-1">Add clusters to your kubeconfig</p>
       </div>
     )
   }

--- a/web/src/components/cards/ClusterHealth.tsx
+++ b/web/src/components/cards/ClusterHealth.tsx
@@ -127,7 +127,7 @@ export function ClusterHealth() {
   })
 
   // Report state to CardWrapper for refresh animation
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isLoadingHook,
     hasAnyData: rawClusters.length > 0,
     isFailed: !!error && rawClusters.length === 0,
@@ -207,6 +207,15 @@ export function ClusterHealth() {
         <div className="mt-4 pt-3 border-t border-border/50">
           <Skeleton variant="text" width="60%" height={12} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No clusters configured</p>
+        <p className="text-xs mt-1">Add clusters to your kubeconfig to get started</p>
       </div>
     )
   }

--- a/web/src/components/cards/ClusterLocations.tsx
+++ b/web/src/components/cards/ClusterLocations.tsx
@@ -216,7 +216,7 @@ export function ClusterLocations({ config: _config }: ClusterLocationsProps) {
   const { drillToCluster } = useDrillDownActions()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: allClusters.length > 0,
   })
@@ -391,6 +391,15 @@ export function ClusterLocations({ config: _config }: ClusterLocationsProps) {
           <Skeleton variant="rounded" width={80} height={28} />
         </div>
         <Skeleton variant="rounded" className="flex-1" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No clusters available</p>
+        <p className="text-xs mt-1">Add clusters to see their locations</p>
       </div>
     )
   }

--- a/web/src/components/cards/ClusterNetwork.tsx
+++ b/web/src/components/cards/ClusterNetwork.tsx
@@ -16,7 +16,7 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
 
   // Report state to CardWrapper for refresh animation
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: allClusters.length > 0,
   })
@@ -74,6 +74,15 @@ export function ClusterNetwork({ config }: ClusterNetworkProps) {
         </div>
         <Skeleton variant="rounded" height={80} className="mb-3" />
         <Skeleton variant="rounded" height={60} />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No network data</p>
+        <p className="text-xs mt-1">Connect to clusters to see network status</p>
       </div>
     )
   }

--- a/web/src/components/cards/ComputeOverview.tsx
+++ b/web/src/components/cards/ComputeOverview.tsx
@@ -93,7 +93,7 @@ export function ComputeOverview() {
     filteredClusters.some(c => c.reachable !== false && c.cpuCores !== undefined && c.nodeCount !== undefined && c.nodeCount > 0)
 
   // Report state to CardWrapper for refresh animation
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isLoading || gpuLoading,
     hasAnyData: clusters.length > 0,
   })
@@ -102,6 +102,15 @@ export function ComputeOverview() {
     return (
       <div className="h-full flex items-center justify-center">
         <div className="animate-pulse text-muted-foreground">Loading compute data...</div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No compute data</p>
+        <p className="text-xs mt-1">Connect to clusters to see compute metrics</p>
       </div>
     )
   }

--- a/web/src/components/cards/DeploymentIssues.tsx
+++ b/web/src/components/cards/DeploymentIssues.tsx
@@ -44,7 +44,7 @@ export function DeploymentIssues({ config }: DeploymentIssuesProps) {
   const { drillToDeployment } = useDrillDownActions()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: hookLoading,
     hasAnyData: rawIssues.length > 0,
     isFailed,
@@ -117,6 +117,15 @@ export function DeploymentIssues({ config }: DeploymentIssuesProps) {
         message="No issues detected"
         variant="success"
       />
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No deployment issues</p>
+        <p className="text-xs mt-1">All deployments are healthy</p>
+      </div>
     )
   }
 

--- a/web/src/components/cards/EventStream.tsx
+++ b/web/src/components/cards/EventStream.tsx
@@ -28,7 +28,7 @@ export function EventStream() {
   } = useCachedEvents(undefined, undefined, { limit: 100, category: 'realtime' })
 
   // Report state to CardWrapper for refresh animation
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: hookLoading,
     hasAnyData: rawEvents.length > 0,
     isFailed: !!error && rawEvents.length === 0,
@@ -111,6 +111,15 @@ export function EventStream() {
 
   if (showSkeleton) {
     return <CardSkeleton type="list" rows={3} showHeader rowHeight={60} />
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No events</p>
+        <p className="text-xs mt-1">Cluster events will appear here</p>
+      </div>
+    )
   }
 
   return (

--- a/web/src/components/cards/EventSummary.tsx
+++ b/web/src/components/cards/EventSummary.tsx
@@ -20,7 +20,7 @@ export function EventSummary() {
   const { filterByCluster } = useGlobalFilters()
 
   // Report state to CardWrapper for refresh animation
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: events.length > 0,
     isFailed: isFailed && events.length === 0,
@@ -79,6 +79,15 @@ export function EventSummary() {
         <Skeleton className="h-16 w-full" />
         <Skeleton className="h-4 w-3/4" />
         <Skeleton className="h-4 w-1/2" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No events</p>
+        <p className="text-xs mt-1">Cluster events will appear here</p>
       </div>
     )
   }

--- a/web/src/components/cards/EventsTimeline.tsx
+++ b/web/src/components/cards/EventsTimeline.tsx
@@ -86,7 +86,7 @@ export function EventsTimeline() {
   const { deduplicatedClusters: clusters } = useClusters()
 
   // Report state to CardWrapper for refresh animation
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: hookLoading,
     hasAnyData: events.length > 0,
   })
@@ -188,6 +188,15 @@ export function EventsTimeline() {
         </div>
         <SkeletonStats className="mb-4" />
         <Skeleton variant="rounded" height={160} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No events</p>
+        <p className="text-xs mt-1">Cluster events will appear here</p>
       </div>
     )
   }

--- a/web/src/components/cards/GPUStatus.tsx
+++ b/web/src/components/cards/GPUStatus.tsx
@@ -37,7 +37,7 @@ export function GPUStatus({ config }: GPUStatusProps) {
   const { drillToCluster } = useDrillDownActions()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: hookLoading,
     hasAnyData: rawNodes.length > 0,
   })
@@ -142,7 +142,7 @@ export function GPUStatus({ config }: GPUStatusProps) {
     )
   }
 
-  if (preFilteredNodes.length === 0) {
+  if (showEmptyState || preFilteredNodes.length === 0) {
     return (
       <div className="h-full flex flex-col content-loaded">
         <div className="flex items-center justify-end mb-3">

--- a/web/src/components/cards/GitOpsDrift.tsx
+++ b/web/src/components/cards/GitOpsDrift.tsx
@@ -69,7 +69,7 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
   const { selectedSeverities, isAllSeveritiesSelected, customFilter } = useGlobalFilters()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isLoadingHook,
     hasAnyData: drifts.length > 0,
     isFailed,
@@ -169,6 +169,15 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
     return (
       <div className="h-full flex items-center justify-center">
         <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No drift detected</p>
+        <p className="text-xs mt-1">GitOps resources are in sync</p>
       </div>
     )
   }

--- a/web/src/components/cards/HelmHistory.tsx
+++ b/web/src/components/cards/HelmHistory.tsx
@@ -106,7 +106,7 @@ export function HelmHistory({ config }: HelmHistoryProps) {
   )
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: historyLoading,
     hasAnyData: rawHistory.length > 0,
     isFailed,
@@ -226,6 +226,15 @@ export function HelmHistory({ config }: HelmHistoryProps) {
           <Skeleton variant="rounded" height={50} />
           <Skeleton variant="rounded" height={50} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No Helm releases</p>
+        <p className="text-xs mt-1">Install Helm charts to see history</p>
       </div>
     )
   }

--- a/web/src/components/cards/HelmReleaseStatus.tsx
+++ b/web/src/components/cards/HelmReleaseStatus.tsx
@@ -54,7 +54,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
   } = useHelmReleases()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading || releasesLoading,
     hasAnyData: allHelmReleases.length > 0,
     isFailed,
@@ -188,6 +188,15 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
           <Skeleton variant="rounded" height={60} />
           <Skeleton variant="rounded" height={60} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No Helm releases</p>
+        <p className="text-xs mt-1">Install Helm charts to track releases</p>
       </div>
     )
   }

--- a/web/src/components/cards/KustomizationStatus.tsx
+++ b/web/src/components/cards/KustomizationStatus.tsx
@@ -100,7 +100,7 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
   }, [storedData.data.length])
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: kustomizationData.length > 0,
   })
@@ -231,6 +231,15 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
           <Skeleton variant="rounded" height={60} />
           <Skeleton variant="rounded" height={60} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No Kustomizations</p>
+        <p className="text-xs mt-1">Kustomizations will appear here</p>
       </div>
     )
   }

--- a/web/src/components/cards/NamespaceEvents.tsx
+++ b/web/src/components/cards/NamespaceEvents.tsx
@@ -44,13 +44,10 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
   const isLoading = clustersLoading || eventsLoading
 
   // Report state to CardWrapper for refresh animation
-  const { showSkeleton: _showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: allEvents.length > 0,
   })
-
-  // hasData should be true once loading completes (even with empty data)
-  const hasData = !isLoading || allEvents.length > 0
 
   // Use cascading selection hook for cluster -> namespace
   const {
@@ -131,8 +128,6 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
     defaultLimit: 5,
   })
 
-  const showSkeleton = isLoading && !hasData
-
   const getEventIcon = (type: string) => {
     if (type === 'Warning') return AlertTriangle
     if (type === 'Error') return AlertCircle
@@ -158,6 +153,15 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
 
   if (showSkeleton) {
     return <CardSkeleton type="list" rows={3} showHeader showSearch rowHeight={60} />
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No events</p>
+        <p className="text-xs mt-1">Namespace events will appear here</p>
+      </div>
+    )
   }
 
   return (

--- a/web/src/components/cards/NamespaceOverview.tsx
+++ b/web/src/components/cards/NamespaceOverview.tsx
@@ -65,7 +65,7 @@ export function NamespaceOverview({ config }: NamespaceOverviewProps) {
   const cluster = clusters.find(c => c.name === selectedCluster)
 
   // Report state to CardWrapper for refresh animation
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading,
     hasAnyData: allClusters.length > 0,
   })
@@ -81,6 +81,15 @@ export function NamespaceOverview({ config }: NamespaceOverviewProps) {
           <Skeleton variant="rounded" height={80} />
           <Skeleton variant="rounded" height={80} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No namespaces</p>
+        <p className="text-xs mt-1">Connect to clusters to see namespaces</p>
       </div>
     )
   }

--- a/web/src/components/cards/NamespaceRBAC.tsx
+++ b/web/src/components/cards/NamespaceRBAC.tsx
@@ -65,11 +65,9 @@ export function NamespaceRBAC({ config }: NamespaceRBACProps) {
   // Check if we're loading initial data or fetching RBAC data
   const isInitialLoading = clustersLoading
   const isFetchingRBAC = selectedCluster && selectedNamespace && (rolesLoading || bindingsLoading || sasLoading)
-  const isLoading = isInitialLoading
-  const showSkeleton = isLoading && clusters.length === 0
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isInitialLoading || !!isFetchingRBAC,
     hasAnyData: clusters.length > 0 || k8sRoles.length > 0 || k8sBindings.length > 0 || k8sServiceAccounts.length > 0,
   })
@@ -166,6 +164,15 @@ export function NamespaceRBAC({ config }: NamespaceRBACProps) {
           <Skeleton variant="rounded" height={40} />
           <Skeleton variant="rounded" height={40} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No RBAC data</p>
+        <p className="text-xs mt-1">RBAC roles and bindings will appear here</p>
       </div>
     )
   }

--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -17,7 +17,7 @@ export function NetworkOverview() {
 
   // Report card data state
   const combinedLoading = isLoading || servicesLoading
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: combinedLoading,
     hasAnyData: services.length > 0,
     isFailed,
@@ -95,6 +95,15 @@ export function NetworkOverview() {
     return (
       <div className="h-full flex items-center justify-center">
         <div className="animate-pulse text-muted-foreground">Loading network data...</div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No network services</p>
+        <p className="text-xs mt-1">Services will appear when deployed</p>
       </div>
     )
   }

--- a/web/src/components/cards/OperatorStatus.tsx
+++ b/web/src/components/cards/OperatorStatus.tsx
@@ -57,8 +57,8 @@ export function OperatorStatus({ config: _config }: OperatorStatusProps) {
   const { operators: rawOperators, isLoading: operatorsLoading, consecutiveFailures, isFailed } = useOperators(undefined)
 
   // Report card data state
-  useCardLoadingState({
-    isLoading: operatorsLoading,
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: clustersLoading || operatorsLoading,
     hasAnyData: rawOperators.length > 0,
     isFailed,
     consecutiveFailures,
@@ -109,9 +109,6 @@ export function OperatorStatus({ config: _config }: OperatorStatusProps) {
     defaultLimit: 5,
   })
 
-  const isLoading = clustersLoading || operatorsLoading
-  const showSkeleton = isLoading && rawOperators.length === 0
-
   const getStatusIcon = (status: Operator['status']) => {
     switch (status) {
       case 'Succeeded': return CheckCircle
@@ -151,6 +148,15 @@ export function OperatorStatus({ config: _config }: OperatorStatusProps) {
           <Skeleton variant="rounded" height={50} />
           <Skeleton variant="rounded" height={50} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No operators</p>
+        <p className="text-xs mt-1">Operators will appear when installed</p>
       </div>
     )
   }

--- a/web/src/components/cards/OperatorSubscriptions.tsx
+++ b/web/src/components/cards/OperatorSubscriptions.tsx
@@ -55,8 +55,8 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
   const { subscriptions: rawSubscriptions, isLoading: subscriptionsLoading, consecutiveFailures, isFailed } = useOperatorSubscriptions(undefined)
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  useCardLoadingState({
-    isLoading: subscriptionsLoading,
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: clustersLoading || subscriptionsLoading,
     hasAnyData: rawSubscriptions.length > 0,
     isFailed,
     consecutiveFailures,
@@ -106,9 +106,6 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
     defaultLimit: 5,
   })
 
-  const isLoading = clustersLoading || subscriptionsLoading
-  const showSkeleton = isLoading && rawSubscriptions.length === 0
-
   // Summary counts from globally filtered data (before local search/pagination)
   const { autoCount, manualCount, pendingCount } = useMemo(() => ({
     autoCount: globalFilteredSubscriptions.filter(s => s.installPlanApproval === 'Automatic').length,
@@ -128,6 +125,15 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
           <Skeleton variant="rounded" height={60} />
           <Skeleton variant="rounded" height={60} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No subscriptions</p>
+        <p className="text-xs mt-1">Operator subscriptions will appear here</p>
       </div>
     )
   }

--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -71,7 +71,7 @@ export function PVCStatus() {
   const { drillToPVC } = useDrillDownActions()
 
   // Report card data state
-  useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: pvcs.length > 0,
     isFailed,
@@ -149,12 +149,19 @@ export function PVCStatus() {
     }
   }, [pvcs, localClusterFilter, search])
 
-  const showSkeleton = isLoading && pvcs.length === 0
-
   if (showSkeleton) {
     return (
       <div className="h-full flex items-center justify-center">
         <div className="animate-pulse text-muted-foreground">Loading PVCs...</div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No PVCs</p>
+        <p className="text-xs mt-1">Persistent Volume Claims will appear here</p>
       </div>
     )
   }

--- a/web/src/components/cards/PodHealthTrend.tsx
+++ b/web/src/components/cards/PodHealthTrend.tsx
@@ -42,7 +42,7 @@ export function PodHealthTrend() {
   const isLoadingData = clustersLoading || issuesLoading
 
   // Report state to CardWrapper for refresh animation
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isLoadingData,
     hasAnyData: clusters.length > 0 || issues.length > 0,
   })
@@ -224,6 +224,15 @@ export function PodHealthTrend() {
     return (
       <div className="h-full flex items-center justify-center">
         <div className="animate-pulse text-muted-foreground">Loading pod health...</div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No pod data</p>
+        <p className="text-xs mt-1">Pod health trends will appear here</p>
       </div>
     )
   }

--- a/web/src/components/cards/PodIssues.tsx
+++ b/web/src/components/cards/PodIssues.tsx
@@ -37,7 +37,7 @@ export function PodIssues() {
   } = useCachedPodIssues()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: hookLoading,
     hasAnyData: rawIssues.length > 0,
     isFailed,
@@ -105,6 +105,15 @@ export function PodIssues() {
         message="No issues detected"
         variant="success"
       />
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No pod issues</p>
+        <p className="text-xs mt-1">All pods are healthy</p>
+      </div>
     )
   }
 

--- a/web/src/components/cards/RecentEvents.tsx
+++ b/web/src/components/cards/RecentEvents.tsx
@@ -36,7 +36,7 @@ export function RecentEvents() {
   const { filterByCluster } = useGlobalFilters()
 
   // Report data state to CardWrapper for failure badge rendering
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: events.length > 0,
     isFailed,
@@ -87,6 +87,15 @@ export function RecentEvents() {
         <Skeleton className="h-10 w-full" />
         <Skeleton className="h-10 w-full" />
         <Skeleton className="h-10 w-full" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No events</p>
+        <p className="text-xs mt-1">Recent events will appear here</p>
       </div>
     )
   }

--- a/web/src/components/cards/ResourceCapacity.tsx
+++ b/web/src/components/cards/ResourceCapacity.tsx
@@ -47,7 +47,7 @@ export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
   const [limit, setLimit] = useState<number | 'unlimited'>(10)
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: allClusters.length > 0,
   })
@@ -210,6 +210,15 @@ export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
           <Skeleton variant="rounded" height={56} />
           <Skeleton variant="rounded" height={56} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No clusters available</p>
+        <p className="text-xs mt-1">Connect to clusters to see resource capacity</p>
       </div>
     )
   }

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -62,13 +62,12 @@ export function ResourceUsage() {
   }
 
   // Report state to CardWrapper for refresh animation
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading,
     hasAnyData: clusters.length > 0,
   })
-  const isLoading = showSkeleton
 
-  if (isLoading) {
+  if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-[200px]">
         <div className="flex items-center justify-between mb-4">
@@ -89,6 +88,15 @@ export function ResourceUsage() {
           <Skeleton variant="rounded" height={40} />
           <Skeleton variant="rounded" height={40} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No clusters available</p>
+        <p className="text-xs mt-1">Connect to clusters to see resource usage</p>
       </div>
     )
   }

--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -112,7 +112,7 @@ export function SecurityIssues({ config }: SecurityIssuesProps) {
   const { drillToPod } = useDrillDownActions()
 
   // Report card data state to parent CardWrapper for automatic skeleton/refresh handling
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: rawIssues.length > 0,
     isFailed,
@@ -215,7 +215,7 @@ export function SecurityIssues({ config }: SecurityIssuesProps) {
     )
   }
 
-  if (issues.length === 0) {
+  if (showEmptyState || issues.length === 0) {
     return (
       <div className="h-full flex flex-col">
         <div className="flex items-center justify-end mb-3">

--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -17,7 +17,7 @@ export function StorageOverview() {
 
   // Report card data state
   const combinedLoading = isLoading || pvcsLoading
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: combinedLoading,
     hasAnyData: pvcs.length > 0,
     isFailed,
@@ -99,6 +99,15 @@ export function StorageOverview() {
     return (
       <div className="h-full flex items-center justify-center">
         <div className="animate-pulse text-muted-foreground">Loading storage data...</div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No storage data</p>
+        <p className="text-xs mt-1">Storage data will appear here</p>
       </div>
     )
   }

--- a/web/src/components/cards/TopPods.tsx
+++ b/web/src/components/cards/TopPods.tsx
@@ -75,7 +75,7 @@ export function TopPods({ config }: TopPodsProps) {
   } = useCachedPods(clusterConfig, namespaceConfig, { limit: 100, category: 'pods' })
 
   // Report data state to CardWrapper for failure badge rendering
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: rawPods.length > 0,
     isFailed,
@@ -137,6 +137,15 @@ export function TopPods({ config }: TopPodsProps) {
     return (
       <div className="h-full flex items-center justify-center">
         <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No pods</p>
+        <p className="text-xs mt-1">Pods will appear when running</p>
       </div>
     )
   }

--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -80,7 +80,7 @@ export function UserManagement({ config: _config }: UserManagementProps) {
   const openshiftUsersLoading = openshiftInitialLoading && allOpenshiftUsers.length === 0
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading || usersLoading || sasInitialLoading || openshiftInitialLoading,
     hasAnyData: allClusters.length > 0 || allUsers.length > 0 || allServiceAccounts.length > 0,
     isFailed: Boolean(usersError),
@@ -304,11 +304,6 @@ export function UserManagement({ config: _config }: UserManagementProps) {
     }
   }
 
-  // Only show skeleton during initial loading
-  const hasData = allUsers.length > 0 || currentUser !== null
-  const hasError = Boolean(usersError)
-  const showSkeleton = usersLoading && !hasData && !hasError
-
   if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
@@ -328,6 +323,15 @@ export function UserManagement({ config: _config }: UserManagementProps) {
           <Skeleton variant="rounded" height={56} />
           <Skeleton variant="rounded" height={56} />
         </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No users</p>
+        <p className="text-xs mt-1">Users and service accounts will appear here</p>
       </div>
     )
   }

--- a/web/src/components/cards/WarningEvents.tsx
+++ b/web/src/components/cards/WarningEvents.tsx
@@ -47,7 +47,7 @@ export function WarningEvents() {
   const warningOnly = useMemo(() => events.filter(e => e.type === 'Warning'), [events])
 
   // Report data state to CardWrapper for failure badge rendering
-  const { showSkeleton } = useCardLoadingState({
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: events.length > 0,
     isFailed,
@@ -103,6 +103,15 @@ export function WarningEvents() {
         <Skeleton className="h-10 w-full" />
         <Skeleton className="h-10 w-full" />
         <Skeleton className="h-10 w-full" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <p className="text-sm">No warnings</p>
+        <p className="text-xs mt-1">Warning events will appear here</p>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Added `showEmptyState` flag to `useCardLoadingState` hook
- Updated 38 cards to handle empty state when loading finishes with no data
- Prevents cards from showing blank content when data is legitimately empty

## Problem
When loading finishes but no data exists (`isLoading=false` and `hasAnyData=false`), `showSkeleton` is false but there's nothing to render, causing blank cards.

## Solution
Added `showEmptyState: !isLoading && !hasAnyData` to the hook. Cards now check this flag and show appropriate "No X found" messages.

## Test plan
- [x] Verified build passes
- [x] Tested Dashboard, Compute, Storage pages in browser
- [x] Confirmed cards show proper empty state messages instead of blank content

🤖 Generated with [Claude Code](https://claude.com/claude-code)