### PR TITLE
🐛 Fix cards not showing refresh animation and stuck on skeleton

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -647,9 +647,15 @@ export function CardWrapper({
   const [isVisuallySpinning, setIsVisuallySpinning] = useState(false)
   const spinStartRef = useRef<number | null>(null)
 
+  // Child-reported data state (from card components via CardDataContext)
+  // Declared early so it can be used in the refresh animation effect below
+  const [childDataState, setChildDataState] = useState<CardDataState | null>(null)
+
   // Handle minimum spin duration for refresh button
+  // Include both prop and context-reported refresh state
+  const contextIsRefreshing = childDataState?.isRefreshing || false
   useEffect(() => {
-    if (isRefreshing) {
+    if (isRefreshing || contextIsRefreshing) {
       setIsVisuallySpinning(true)
       spinStartRef.current = Date.now()
     } else if (spinStartRef.current !== null) {
@@ -667,7 +673,7 @@ export function CardWrapper({
         spinStartRef.current = null
       }
     }
-  }, [isRefreshing])
+  }, [isRefreshing, contextIsRefreshing])
 
   // Re-trigger animation when flashType changes to a non-none value
   useEffect(() => {
@@ -718,8 +724,7 @@ export function CardWrapper({
   const menuContainerRef = useRef<HTMLDivElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
 
-  // Child-reported data state (from card components via CardDataContext)
-  const [childDataState, setChildDataState] = useState<CardDataState | null>(null)
+  // Report callback for CardDataContext (childDataState is declared earlier for refresh animation)
   const reportCallback = useCallback((state: CardDataState) => {
     setChildDataState(state)
   }, [])

--- a/web/src/components/cards/HelmHistory.tsx
+++ b/web/src/components/cards/HelmHistory.tsx
@@ -106,9 +106,10 @@ export function HelmHistory({ config }: HelmHistoryProps) {
   )
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
+  // Note: Consider "hasAnyData" true when no release selected - we want to show selectors, not empty state
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: historyLoading,
-    hasAnyData: rawHistory.length > 0,
+    hasAnyData: rawHistory.length > 0 || !selectedRelease,
     isFailed,
     consecutiveFailures,
   })

--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -332,6 +332,9 @@ export function useHelmHistory(cluster?: string, release?: string, namespace?: s
       }
     } else if (release) {
       refetch()
+    } else {
+      // No release selected - not loading, just waiting for user selection
+      setIsLoading(false)
     }
   }, [cluster, release, refetch])
 


### PR DESCRIPTION
## Summary
- CardWrapper now listens to context-reported `isRefreshing` state for refresh animation (cards report via `useCardLoadingState` → context)
- Fixed HelmHistory hook staying stuck at `isLoading: true` when no release selected
- Fixed HelmHistory card showing empty state instead of selectors when no release selected

## Test plan
- [ ] Verify Helm History card shows selectors when no release selected (not skeleton)
- [ ] Verify refresh animation shows in card header when data is refreshing
- [ ] Verify SecurityIssues card shows refresh animation during data refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)