### PR TITLE
🐛 Fix race condition where demo data flashes before skeleton

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -724,9 +724,8 @@ export function CardWrapper({
   const isDemoExempt = DEMO_EXEMPT_CARDS.has(cardType)
   const isDemoMode = globalDemoMode && !isDemoExempt
 
-  // When demo mode is OFF and agent is offline, force skeleton display for LIVE cards
-  // This prevents showing stale/cached demo data when user expects live data
-  // Cards that only support demo data (don't use useCardLoadingState) are not affected
+  // When demo mode is OFF and agent is offline, force skeleton display
+  // This prevents showing stale/cached data when user expects live data
   const isAgentOffline = agentStatus !== 'connected' && agentStatus !== 'connecting'
   const menuContainerRef = useRef<HTMLDivElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
@@ -750,11 +749,10 @@ export function CardWrapper({
 
   // Determine if we should show skeleton: loading with no cached data
   // OR when demo mode is OFF and agent is offline (prevents showing stale demo data)
-  // Only force skeleton for "live" cards that are NOT showing demo data
-  // Cards that only support demo data should still show their demo content
-  const isLiveCard = childDataState !== null
-  const isShowingDemoData = isDemoData || isDemoMode // Card is showing demo data
-  const forceSkeletonForOffline = !globalDemoMode && isAgentOffline && !isDemoExempt && isLiveCard && !isShowingDemoData
+  // Force skeleton immediately when offline + demo OFF, without waiting for childDataState
+  // This fixes the race condition where demo data briefly shows before skeleton
+  // Cards with isDemoData=true (explicitly showing demo) or demo-exempt cards are excluded
+  const forceSkeletonForOffline = !globalDemoMode && isAgentOffline && !isDemoExempt && !isDemoData && !isDemoMode
 
   // Default to 'list' skeleton type if not specified, enabling automatic skeleton display
   const effectiveSkeletonType = skeletonType || 'list'


### PR DESCRIPTION
## Summary
- Fixes issue where demo/cached data briefly flashes before skeleton appears
- Removes dependency on `childDataState` for `forceSkeletonForOffline` calculation  
- Skeleton now displays immediately when agent is offline and demo mode is OFF

## Problem
When navigating to a dashboard with agent offline and demo mode OFF:
1. Card mounts → `childDataState` is initially `null`
2. Since `childDataState === null`, `isLiveCard` was `false`
3. `forceSkeletonForOffline` required `isLiveCard` to be `true`, so it was `false`
4. Children rendered immediately (showing demo/cached data)
5. Then child called `useCardLoadingState`, setting `childDataState`
6. NOW `isLiveCard` became `true`, triggering skeleton

## Solution
Calculate `forceSkeletonForOffline` immediately from props/context, without waiting for `childDataState`:
- Force skeleton when: `!globalDemoMode && isAgentOffline && !isDemoExempt && !isDemoData && !isDemoMode`

## Test plan
- [ ] Turn off demo mode
- [ ] Disconnect agent
- [ ] Navigate between dashboards
- [ ] Verify skeleton shows immediately without demo data flash
- [ ] Verify demo-only cards still show demo data (when isDemoData prop is true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)