### PR TITLE
🐛 Include 'connecting' state in offline detection for skeleton

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -724,9 +724,10 @@ export function CardWrapper({
   const isDemoExempt = DEMO_EXEMPT_CARDS.has(cardType)
   const isDemoMode = globalDemoMode && !isDemoExempt
 
-  // When demo mode is OFF and agent is offline, force skeleton display
+  // When demo mode is OFF and agent is not connected, force skeleton display
   // This prevents showing stale/cached data when user expects live data
-  const isAgentOffline = agentStatus !== 'connected' && agentStatus !== 'connecting'
+  // Include 'connecting' state because it may take time before we know agent is truly offline
+  const isAgentOffline = agentStatus !== 'connected'
   const menuContainerRef = useRef<HTMLDivElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
 


### PR DESCRIPTION
## Summary
- Includes the 'connecting' agent status in offline detection
- Fixes the race condition where demo data flashes briefly before skeleton shows
- Now any agent status other than 'connected' triggers skeleton when demo mode is OFF

## Problem
When the app starts, the agent status is 'connecting' (not 'disconnected'). My previous fix excluded 'connecting' from offline detection, causing:
1. App starts → agent status is 'connecting'
2. `isAgentOffline = false` (because 'connecting' was excluded)
3. Demo data shows for cards like WorkloadDeployment
4. Agent timeout occurs → status changes to 'disconnected'
5. `isAgentOffline = true` → skeleton finally shows

## Solution
Changed from:
```typescript
const isAgentOffline = agentStatus !== 'connected' && agentStatus !== 'connecting'
```
To:
```typescript
const isAgentOffline = agentStatus !== 'connected'
```

## Test plan
- [x] Turn off demo mode
- [x] Ensure agent is not running
- [x] Navigate to Deploy dashboard
- [x] Verify skeleton shows immediately (no demo data flash)
- [x] Navigate away and back - verify skeleton still shows immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)