### PR TITLE
🐛 Fix offline banner flashing and page skeleton behavior

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -34,8 +34,9 @@ export function Layout({ children }: LayoutProps) {
 
   // Show network banner when browser detects no network, or briefly after reconnecting
   const showNetworkBanner = !isOnline || wasOffline
-  // Show offline banner when agent is disconnected (not demo mode, not connecting)
-  const showOfflineBanner = !isDemoMode && agentStatus === 'disconnected' && !offlineBannerDismissed
+  // Show offline banner when agent is not connected (includes 'connecting', 'disconnected', 'degraded')
+  // Keep banner visible until agent is actually connected
+  const showOfflineBanner = !isDemoMode && agentStatus !== 'connected' && !offlineBannerDismissed
 
   // Banner stacking: each banner's top offset depends on how many banners above it are visible.
   // Navbar is 64px (top-16). Each banner is ~36px tall.

--- a/web/src/components/workloads/Workloads.tsx
+++ b/web/src/components/workloads/Workloads.tsx
@@ -3,6 +3,8 @@ import { ChevronRight } from 'lucide-react'
 import { useDeploymentIssues, usePodIssues, useClusters, useDeployments } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
+import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { useDemoMode } from '../../hooks/useDemoMode'
 import { StatusIndicator } from '../charts/StatusIndicator'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { Skeleton } from '../ui/Skeleton'
@@ -35,13 +37,18 @@ export function Workloads() {
   const { issues: deploymentIssues, isLoading: deploymentIssuesLoading, isRefreshing: deploymentIssuesRefreshing, refetch: refetchDeploymentIssues } = useDeploymentIssues()
   const { deployments: allDeployments, isLoading: deploymentsLoading, isRefreshing: deploymentsRefreshing, refetch: refetchDeployments } = useDeployments()
   const { clusters, isLoading: clustersLoading, refetch: refetchClusters } = useClusters()
+  const { status: agentStatus } = useLocalAgent()
+  const { isDemoMode } = useDemoMode()
 
   const { drillToNamespace, drillToAllNamespaces, drillToAllDeployments, drillToAllPods } = useDrillDownActions()
 
   // Combined states
   const isLoading = podIssuesLoading || deploymentIssuesLoading || deploymentsLoading || clustersLoading
   const isRefreshing = podIssuesRefreshing || deploymentIssuesRefreshing || deploymentsRefreshing
-  const showSkeletons = (allDeployments.length === 0 && podIssues.length === 0 && deploymentIssues.length === 0) && isLoading
+  // Show skeletons when loading with no data OR when agent is offline and demo mode is OFF
+  const isAgentOffline = agentStatus !== 'connected'
+  const forceSkeletonForOffline = !isDemoMode && isAgentOffline
+  const showSkeletons = ((allDeployments.length === 0 && podIssues.length === 0 && deploymentIssues.length === 0) && isLoading) || forceSkeletonForOffline
 
   // Combined refresh
   const handleRefresh = useCallback(() => {


### PR DESCRIPTION
## Summary
- Fixes offline banner disappearing/reappearing when switching dashboards
- Adds skeleton display to Workloads page when agent is offline + demo mode OFF

## Changes

### 1. Layout.tsx - Offline Banner
**Before:** `showOfflineBanner = agentStatus === 'disconnected'`
**After:** `showOfflineBanner = agentStatus !== 'connected'`

This keeps the banner visible during the 'connecting' state, preventing flashing.

### 2. Workloads.tsx - Page Skeleton
Added agent offline check so the page shows skeleton (not cached data) when:
- Demo mode is OFF
- Agent is not connected

## Test plan
- [x] Navigate between dashboards - offline banner should stay visible
- [x] Workloads page should show skeleton when agent offline + demo OFF

🤖 Generated with [Claude Code](https://claude.com/claude-code)