### PR TITLE
🐛 Fix Playwright tests for Clusters, Events, and Settings pages

### DIFF
--- a/web/e2e/Clusters.spec.ts
+++ b/web/e2e/Clusters.spec.ts
@@ -1,307 +1,161 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
+
+/**
+ * Sets up authentication and MCP mocks for cluster tests
+ */
+async function setupClustersTest(page: Page) {
+  // Mock authentication
+  await page.route('**/api/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1',
+        github_id: '12345',
+        github_login: 'testuser',
+        email: 'test@example.com',
+        onboarded: true,
+      }),
+    })
+  )
+
+  // Mock MCP endpoints
+  await page.route('**/api/mcp/**', (route) => {
+    const url = route.request().url()
+    if (url.includes('/clusters')) {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          clusters: [
+            { name: 'prod-east', context: 'ctx-1', healthy: true, reachable: true, nodeCount: 5, podCount: 45, version: '1.28.0' },
+            { name: 'prod-west', context: 'ctx-2', healthy: true, reachable: true, nodeCount: 3, podCount: 32, version: '1.27.0' },
+            { name: 'staging', context: 'ctx-3', healthy: false, reachable: true, nodeCount: 2, podCount: 15, version: '1.28.0' },
+          ],
+        }),
+      })
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ issues: [], events: [], nodes: [] }),
+      })
+    }
+  })
+
+  // Set auth token
+  await page.goto('/login')
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'test-token')
+    localStorage.setItem('demo-user-onboarded', 'true')
+  })
+
+  await page.goto('/clusters')
+  await page.waitForLoadState('domcontentloaded')
+}
 
 test.describe('Clusters Page', () => {
   test.beforeEach(async ({ page }) => {
-    // Mock authentication
-    await page.route('**/api/me', (route) =>
-      route.fulfill({
-        status: 200,
-        json: {
-          id: '1',
-          github_id: '12345',
-          github_login: 'testuser',
-          email: 'test@example.com',
-          onboarded: true,
-        },
-      })
-    )
-
-    // Mock MCP endpoints - consolidated handler to avoid route conflicts
-    await page.route('**/api/mcp/**', (route) => {
-      const url = route.request().url()
-      if (url.includes('/clusters')) {
-        route.fulfill({
-          status: 200,
-          json: {
-            clusters: [
-              { name: 'prod-east', healthy: true, nodeCount: 5, version: '1.28.0', server: 'https://prod-east.k8s.example.com' },
-              { name: 'prod-west', healthy: true, nodeCount: 3, version: '1.27.0', server: 'https://prod-west.k8s.example.com' },
-              { name: 'staging', healthy: false, nodeCount: 2, version: '1.28.0', server: 'https://staging.k8s.example.com' },
-            ],
-          },
-        })
-      } else {
-        route.fulfill({
-          status: 200,
-          json: { issues: [], events: [], nodes: [] },
-        })
-      }
-    })
-
-    // Set auth token
-    await page.goto('/login')
-    await page.evaluate(() => {
-      localStorage.setItem('token', 'test-token')
-      localStorage.setItem('demo-user-onboarded', 'true')
-    })
-
-    // Wait for localStorage to persist before navigation
-    await page.waitForTimeout(500)
-
-    await page.goto('/clusters')
-    await page.waitForLoadState('domcontentloaded')
-    await page.waitForTimeout(500)
+    await setupClustersTest(page)
   })
 
   test.describe('Cluster List', () => {
-    test('displays cluster list', async ({ page }) => {
-      // Wait for clusters to load
-      await page.waitForTimeout(2000)
-
-      // Should show cluster cards - the component renders them as glass cards with cursor-pointer
-      // Also look for cluster name text like prod-east, prod-west, staging from our mock
-      const clusterCards = page.locator('.glass.cursor-pointer, div:has-text("prod-east"), div:has-text("prod-west")')
-      const clusterCount = await clusterCards.count()
-
-      // Page should have loaded - cluster count may vary
-      expect(clusterCount >= 0).toBeTruthy()
+    test('displays clusters page', async ({ page }) => {
+      // Clusters page should be visible
+      await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
     })
 
-    test('shows cluster health status', async ({ page }) => {
-      await page.waitForTimeout(1500)
+    test('shows cluster names from mock data', async ({ page }) => {
+      await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
 
-      // Look for health indicators
-      const healthIndicators = page.locator(
-        'text=/healthy|unhealthy|ready|not ready/i, [class*="status"], [data-status]'
-      )
-      const hasHealth = await healthIndicators.first().isVisible().catch(() => false)
-      expect(hasHealth || true).toBeTruthy()
+      // Should show cluster names from our mock data
+      await expect(page.getByText('prod-east')).toBeVisible({ timeout: 5000 })
+      await expect(page.getByText('prod-west')).toBeVisible()
+      await expect(page.getByText('staging')).toBeVisible()
     })
 
-    test('shows cluster node count', async ({ page }) => {
-      await page.waitForTimeout(1500)
+    test('shows cluster health status indicators', async ({ page }) => {
+      await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
 
-      // Look for node count
-      const nodeCounts = page.locator('text=/\\d+.*nodes?|nodes?.*\\d+/i')
-      const hasNodes = await nodeCounts.first().isVisible().catch(() => false)
-      expect(hasNodes || true).toBeTruthy()
-    })
-
-    test('shows cluster pod count', async ({ page }) => {
-      await page.waitForTimeout(1500)
-
-      // Look for pod count
-      const podCounts = page.locator('text=/\\d+.*pods?|pods?.*\\d+/i')
-      const hasPods = await podCounts.first().isVisible().catch(() => false)
-      expect(hasPods || true).toBeTruthy()
-    })
-  })
-
-  test.describe('Cluster Details', () => {
-    test('can open cluster detail modal', async ({ page }) => {
-      await page.waitForTimeout(2000)
-
-      // Click on a cluster
-      const firstCluster = page.locator(
-        '[data-testid*="cluster"], [class*="cluster-item"], .glass.cursor-pointer, tr'
-      ).first()
-      const hasCluster = await firstCluster.isVisible().catch(() => false)
-
-      if (hasCluster) {
-        await firstCluster.click()
-        await page.waitForTimeout(1000)
-
-        // Should open modal/detail view
-        const modal = page.locator('[role="dialog"], .modal, [data-testid="cluster-detail"]')
-        const hasModal = await modal.isVisible().catch(() => false)
-        // Modal may or may not appear depending on implementation
-        expect(hasModal || true).toBeTruthy()
-      }
-    })
-
-    test('cluster detail shows node information', async ({ page }) => {
-      await page.waitForTimeout(1500)
-
-      const firstCluster = page.locator('[data-testid*="cluster"], tr').first()
-      const hasCluster = await firstCluster.isVisible().catch(() => false)
-
-      if (hasCluster) {
-        await firstCluster.click()
-        await page.waitForTimeout(500)
-
-        // Look for node info in detail
-        const nodeInfo = page.locator('text=/nodes?|node.*list|node.*count/i')
-        const hasNodeInfo = await nodeInfo.first().isVisible().catch(() => false)
-        expect(hasNodeInfo || true).toBeTruthy()
-      }
-    })
-
-    test('cluster detail shows GPU information if available', async ({ page }) => {
-      await page.route('**/api/mcp/gpu-nodes*', (route) =>
-        route.fulfill({
-          status: 200,
-          json: {
-            nodes: [
-              { name: 'gpu-node-1', cluster: 'vllm-d', gpuType: 'A100', gpuCount: 8, gpuAllocated: 6 },
-            ],
-          },
-        })
-      )
-
-      await page.waitForTimeout(1500)
-
-      // Look for GPU info
-      const gpuInfo = page.locator('text=/gpu|a100|v100|nvidia/i')
-      const hasGpu = await gpuInfo.first().isVisible().catch(() => false)
-      expect(hasGpu || true).toBeTruthy()
-    })
-
-    test('cluster detail shows issues if present', async ({ page }) => {
-      await page.route('**/api/mcp/clusters/*/health', (route) =>
-        route.fulfill({
-          status: 200,
-          json: {
-            cluster: 'test',
-            healthy: false,
-            nodeCount: 3,
-            readyNodes: 2,
-            issues: ['Node not ready', 'High memory pressure'],
-          },
-        })
-      )
-
-      await page.waitForTimeout(1500)
-
-      // Look for issue indicators
-      const issues = page.locator('text=/issue|error|warning|not ready/i')
-      const hasIssues = await issues.first().isVisible().catch(() => false)
-      expect(hasIssues || true).toBeTruthy()
+      // Health status should be displayed - look for healthy/unhealthy text or status dots
+      // We have 2 healthy clusters and 1 unhealthy
+      const healthyIndicators = page.locator('.bg-green-400, .text-green-400, [class*="green"]')
+      const healthyCount = await healthyIndicators.count()
+      expect(healthyCount).toBeGreaterThan(0)
     })
   })
 
   test.describe('Cluster Actions', () => {
-    test('has refresh button', async ({ page }) => {
-      const refreshButton = page.getByRole('button', { name: /refresh/i }).first()
-      const hasRefresh = await refreshButton.isVisible().catch(() => false)
-      expect(hasRefresh || true).toBeTruthy()
+    test('has refresh button in header', async ({ page }) => {
+      await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
+      await expect(page.getByTestId('dashboard-refresh-button')).toBeVisible()
     })
 
-    test('refresh updates cluster data', async ({ page }) => {
-      await page.waitForTimeout(1000)
+    test('refresh button is clickable', async ({ page }) => {
+      await expect(page.getByTestId('dashboard-refresh-button')).toBeVisible({ timeout: 10000 })
 
       // Click refresh
-      const refreshButton = page.getByRole('button', { name: /refresh/i }).first()
-      const hasRefresh = await refreshButton.isVisible().catch(() => false)
+      await page.getByTestId('dashboard-refresh-button').click()
 
-      if (hasRefresh) {
-        await refreshButton.click()
-        await page.waitForTimeout(1000)
-      }
-
-      // Test passes if we got here - refresh may or may not be available
-      expect(true).toBeTruthy()
-    })
-
-    test('can filter clusters', async ({ page }) => {
-      // Look for filter input
-      const filterInput = page.locator(
-        'input[placeholder*="filter"], input[placeholder*="search"], [data-testid="cluster-filter"]'
-      ).first()
-      const hasFilter = await filterInput.isVisible().catch(() => false)
-
-      if (hasFilter) {
-        await filterInput.fill('vllm')
-        await page.waitForTimeout(500)
-
-        // Should filter clusters
-        const visibleClusters = page.locator('[data-testid*="cluster"]:visible')
-        const count = await visibleClusters.count()
-        // Filter should work
-      }
-    })
-  })
-
-  test.describe('Cluster Drilldown', () => {
-    test('can drilldown to pods', async ({ page }) => {
-      await page.waitForTimeout(1500)
-
-      // Look for pods drilldown option
-      const podsLink = page.locator('text=/view.*pods|pods.*list/i').first()
-      const hasPods = await podsLink.isVisible().catch(() => false)
-
-      if (hasPods) {
-        await podsLink.click()
-
-        // Should show pod list
-        const podList = page.locator('text=/pod.*name|container|ready/i')
-        const hasPodList = await podList.first().isVisible().catch(() => false)
-        expect(hasPodList || true).toBeTruthy()
-      }
-    })
-
-    test('can drilldown to events', async ({ page }) => {
-      await page.waitForTimeout(1500)
-
-      const eventsLink = page.locator('text=/view.*events|events.*list/i').first()
-      const hasEvents = await eventsLink.isVisible().catch(() => false)
-
-      if (hasEvents) {
-        await eventsLink.click()
-
-        // Should show events
-        const eventList = page.locator('text=/warning|normal|reason|message/i')
-        const hasEventList = await eventList.first().isVisible().catch(() => false)
-        expect(hasEventList || true).toBeTruthy()
-      }
+      // Button should remain visible after click
+      await expect(page.getByTestId('dashboard-refresh-button')).toBeVisible()
     })
   })
 
   test.describe('Empty States', () => {
     test('handles no clusters gracefully', async ({ page }) => {
+      // Override mock to return empty clusters
       await page.route('**/api/mcp/clusters', (route) =>
         route.fulfill({
           status: 200,
-          json: { clusters: [] },
+          contentType: 'application/json',
+          body: JSON.stringify({ clusters: [] }),
         })
       )
 
       await page.reload()
-      await page.waitForTimeout(1000)
+      await page.waitForLoadState('domcontentloaded')
 
-      // Should show empty state
-      const emptyState = page.locator('text=/no clusters|connect.*cluster|get started/i')
-      const hasEmpty = await emptyState.first().isVisible().catch(() => false)
-      expect(hasEmpty || true).toBeTruthy()
+      // Page should still render (not crash)
+      await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
+    })
+  })
+
+  test.describe('Responsive Design', () => {
+    test('adapts to mobile viewport', async ({ page }) => {
+      await page.setViewportSize({ width: 375, height: 667 })
+
+      // Page should still render at mobile size
+      await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
+    })
+
+    test('adapts to tablet viewport', async ({ page }) => {
+      await page.setViewportSize({ width: 768, height: 1024 })
+
+      // Content should still be accessible
+      await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
     })
   })
 
   test.describe('Accessibility', () => {
     test('cluster list is keyboard navigable', async ({ page }) => {
-      await page.waitForTimeout(2000)
+      await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
 
-      // Tab to cluster list
+      // Tab through elements
       for (let i = 0; i < 5; i++) {
         await page.keyboard.press('Tab')
-        await page.waitForTimeout(100)
       }
 
-      // Should have focused element
+      // Should have a focused element
       const focused = page.locator(':focus')
-      const hasFocus = await focused.isVisible().catch(() => false)
-
-      // Keyboard navigation may work differently
-      expect(hasFocus || true).toBeTruthy()
+      await expect(focused).toBeVisible()
     })
 
-    test('clusters have proper ARIA labels', async ({ page }) => {
-      await page.waitForTimeout(2000)
+    test('page has heading', async ({ page }) => {
+      await expect(page.getByTestId('clusters-page')).toBeVisible({ timeout: 10000 })
 
-      // Check for ARIA attributes or common accessibility patterns
-      // Include buttons (implicit role), links, and elements with explicit roles
-      const accessibleElements = page.locator('button, a[href], [role], [aria-label], nav, main, header')
-      const count = await accessibleElements.count()
-      // Firefox may have page loading issues in CI - use permissive check
-      expect(count > 0 || true).toBeTruthy()
+      // Should have a heading with "Clusters"
+      await expect(page.getByRole('heading', { name: /clusters/i })).toBeVisible()
     })
   })
 })

--- a/web/e2e/Events.spec.ts
+++ b/web/e2e/Events.spec.ts
@@ -1,353 +1,153 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
+
+/**
+ * Sets up authentication and MCP mocks for events tests
+ */
+async function setupEventsTest(page: Page) {
+  // Mock authentication
+  await page.route('**/api/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1',
+        github_id: '12345',
+        github_login: 'testuser',
+        email: 'test@example.com',
+        onboarded: true,
+      }),
+    })
+  )
+
+  // Mock MCP events endpoint with sample data
+  await page.route('**/api/mcp/events', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        events: [
+          { type: 'Warning', reason: 'BackOff', message: 'Back-off restarting failed container', namespace: 'default', involvedObject: 'pod-1', cluster: 'prod-east', age: '5m' },
+          { type: 'Normal', reason: 'Scheduled', message: 'Successfully assigned pod to node', namespace: 'default', involvedObject: 'pod-2', cluster: 'prod-west', age: '10m' },
+          { type: 'Warning', reason: 'FailedScheduling', message: 'Insufficient memory', namespace: 'kube-system', involvedObject: 'pod-3', cluster: 'staging', age: '1h' },
+        ],
+      }),
+    })
+  )
+
+  // Mock other MCP endpoints
+  await page.route('**/api/mcp/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ clusters: [], issues: [], nodes: [] }),
+    })
+  )
+
+  // Set auth token
+  await page.goto('/login')
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'test-token')
+    localStorage.setItem('demo-user-onboarded', 'true')
+  })
+
+  await page.goto('/events')
+  await page.waitForLoadState('domcontentloaded')
+}
 
 test.describe('Events Page', () => {
   test.beforeEach(async ({ page }) => {
-    // Mock authentication
-    await page.route('**/api/me', (route) =>
-      route.fulfill({
-        status: 200,
-        json: {
-          id: '1',
-          github_id: '12345',
-          github_login: 'testuser',
-          email: 'test@example.com',
-          onboarded: true,
-        },
-      })
-    )
-
-    // Mock MCP events endpoint with sample data
-    await page.route('**/api/mcp/events', (route) =>
-      route.fulfill({
-        status: 200,
-        json: {
-          events: [
-            { type: 'Warning', reason: 'BackOff', message: 'Back-off restarting failed container', namespace: 'default', involvedObject: 'pod-1', cluster: 'prod-east', age: '5m' },
-            { type: 'Normal', reason: 'Scheduled', message: 'Successfully assigned pod to node', namespace: 'default', involvedObject: 'pod-2', cluster: 'prod-west', age: '10m' },
-            { type: 'Warning', reason: 'FailedScheduling', message: 'Insufficient memory', namespace: 'kube-system', involvedObject: 'pod-3', cluster: 'staging', age: '1h' },
-          ],
-        },
-      })
-    )
-
-    await page.route('**/api/mcp/**', (route) =>
-      route.fulfill({
-        status: 200,
-        json: { clusters: [], issues: [], nodes: [] },
-      })
-    )
-
-    // Set auth token
-    await page.goto('/login')
-    await page.evaluate(() => {
-      localStorage.setItem('token', 'test-token')
-      localStorage.setItem('demo-user-onboarded', 'true')
-      localStorage.setItem('demo-user-onboarded', 'true')
-    })
-
-    await page.goto('/events')
-    await page.waitForLoadState('domcontentloaded')
-    await page.waitForTimeout(500)
+    await setupEventsTest(page)
   })
 
   test.describe('Event List', () => {
-    test('displays event list', async ({ page }) => {
-      // Should show events
-      const events = page.locator(
-        '[data-testid*="event"], [class*="event"], tr:has-text("Warning"), tr:has-text("Normal")'
-      )
-      const eventCount = await events.count()
-      expect(eventCount).toBeGreaterThanOrEqual(0)
+    test('displays events page', async ({ page }) => {
+      // Wait for dashboard header (Events uses DashboardPage)
+      await expect(page.getByTestId('dashboard-header')).toBeVisible({ timeout: 10000 })
+
+      // Should have Events title
+      await expect(page.getByRole('heading', { name: /events/i })).toBeVisible()
     })
 
-    test('shows event type (Warning/Normal)', async ({ page }) => {
-      const eventTypes = page.locator('text=/warning|normal/i')
-      const hasTypes = await eventTypes.first().isVisible().catch(() => false)
-      expect(hasTypes || true).toBeTruthy()
+    test('shows event types (Warning/Normal)', async ({ page }) => {
+      await expect(page.getByTestId('dashboard-header')).toBeVisible({ timeout: 10000 })
+
+      // Event types from our mock data
+      const warningText = page.getByText(/warning/i).first()
+      await expect(warningText).toBeVisible({ timeout: 5000 })
     })
 
-    test('shows event reason', async ({ page }) => {
-      const reasons = page.locator(
-        'text=/BackOff|FailedScheduling|Scheduled|Unhealthy|Pulled/i'
-      )
-      const hasReasons = await reasons.first().isVisible().catch(() => false)
-      expect(hasReasons || true).toBeTruthy()
-    })
+    test('shows event reasons from mock data', async ({ page }) => {
+      await expect(page.getByTestId('dashboard-header')).toBeVisible({ timeout: 10000 })
 
-    test('shows event message', async ({ page }) => {
-      // Events should have descriptive messages
-      const messages = page.locator('text=/container|pod|node|image|scheduled/i')
-      const hasMessages = await messages.first().isVisible().catch(() => false)
-      expect(hasMessages || true).toBeTruthy()
-    })
-
-    test('shows event count', async ({ page }) => {
-      // Events should show occurrence count
-      const counts = page.locator('text=/count|×\\d+|\\(\\d+\\)/i')
-      const hasCounts = await counts.first().isVisible().catch(() => false)
-      expect(hasCounts || true).toBeTruthy()
+      // Reasons from our mock data
+      const backoffText = page.getByText(/BackOff|FailedScheduling|Scheduled/i).first()
+      await expect(backoffText).toBeVisible({ timeout: 5000 })
     })
   })
 
-  test.describe('Event Filtering', () => {
-    test('can filter by event type', async ({ page }) => {
-      // Look for type filter
-      const typeFilter = page.locator(
-        'select:has(option:text("Warning")), button:has-text("Warning"), [data-testid="type-filter"]'
-      ).first()
-      const hasFilter = await typeFilter.isVisible().catch(() => false)
-
-      if (hasFilter) {
-        await typeFilter.click()
-
-        // Select warnings only
-        const warningOption = page.locator('text=Warning').first()
-        await warningOption.click()
-
-        await page.waitForTimeout(500)
-
-        // Should only show warnings
-        const normalEvents = page.locator('[data-type="Normal"]')
-        const normalCount = await normalEvents.count()
-        // Filter should reduce or eliminate normal events
-      }
+  test.describe('Refresh Controls', () => {
+    test('has refresh button', async ({ page }) => {
+      await expect(page.getByTestId('dashboard-refresh-button')).toBeVisible({ timeout: 10000 })
     })
 
-    test('can filter by cluster', async ({ page }) => {
-      await page.waitForTimeout(1000)
-
-      const clusterFilter = page.locator(
-        'select:has(option:text(/cluster/i)), [data-testid="cluster-filter"]'
-      ).first()
-      const hasFilter = await clusterFilter.isVisible().catch(() => false)
-
-      if (hasFilter) {
-        await clusterFilter.click()
-        await page.waitForTimeout(500)
-
-        // Should show cluster options
-        const clusterOptions = page.locator('option, [role="option"]')
-        const optionCount = await clusterOptions.count()
-        // Filter may or may not have options
-        expect(optionCount >= 0).toBeTruthy()
-      }
-    })
-
-    test('can filter by namespace', async ({ page }) => {
-      const namespaceFilter = page.locator(
-        'select:has(option:text(/namespace/i)), [data-testid="namespace-filter"], input[placeholder*="namespace"]'
-      ).first()
-      const hasFilter = await namespaceFilter.isVisible().catch(() => false)
-
-      if (hasFilter) {
-        await namespaceFilter.fill('production')
-        await page.waitForTimeout(500)
-
-        // Should filter events
-      }
-    })
-
-    test('can search events', async ({ page }) => {
-      const searchInput = page.locator(
-        'input[placeholder*="search"], input[type="search"], [data-testid="event-search"]'
-      ).first()
-      const hasSearch = await searchInput.isVisible().catch(() => false)
-
-      if (hasSearch) {
-        await searchInput.fill('BackOff')
-        await page.waitForTimeout(500)
-
-        // Should filter to matching events
-        const backoffEvents = page.locator('text=BackOff')
-        const count = await backoffEvents.count()
-        expect(count).toBeGreaterThanOrEqual(0)
-      }
-    })
-  })
-
-  test.describe('Auto-Refresh', () => {
-    test('has auto-refresh toggle', async ({ page }) => {
-      await page.waitForTimeout(1000)
-
-      const refreshToggle = page.locator(
-        '[data-testid="auto-refresh"], [aria-label*="auto"], text=/auto.*refresh/i'
-      ).first()
-      const hasToggle = await refreshToggle.isVisible().catch(() => false)
-      expect(hasToggle || true).toBeTruthy()
-    })
-
-    test('auto-refresh fetches new events', async ({ page }) => {
-      let apiCallCount = 0
-      await page.route('**/api/mcp/events**', async (route) => {
-        apiCallCount++
-        await route.continue()
-      })
-
-      // Wait for auto-refresh (typically 10 seconds)
-      await page.waitForTimeout(12000)
-
-      // Should have made multiple API calls - but may not if auto-refresh is off
-      expect(apiCallCount >= 0).toBeTruthy()
-    })
-
-    test('manual refresh button works', async ({ page }) => {
-      await page.waitForTimeout(1000)
+    test('refresh button is clickable', async ({ page }) => {
+      await expect(page.getByTestId('dashboard-refresh-button')).toBeVisible({ timeout: 10000 })
 
       // Click refresh
-      const refreshButton = page.getByRole('button', { name: /refresh/i }).first()
-      const hasRefresh = await refreshButton.isVisible().catch(() => false)
+      await page.getByTestId('dashboard-refresh-button').click()
 
-      if (hasRefresh) {
-        await refreshButton.click()
-        await page.waitForTimeout(1000)
-      }
-
-      // Test passes if we got here - refresh may or may not be available
-      expect(true).toBeTruthy()
-    })
-  })
-
-  test.describe('Event Details', () => {
-    test('can view event details', async ({ page }) => {
-      // Click on an event
-      const firstEvent = page.locator(
-        '[data-testid*="event"], tr:has-text("Warning"), tr:has-text("Normal")'
-      ).first()
-      const hasEvent = await firstEvent.isVisible().catch(() => false)
-
-      if (hasEvent) {
-        await firstEvent.click()
-
-        // Should show detail modal or expand
-        const detail = page.locator(
-          '[role="dialog"], [data-testid="event-detail"], [class*="expanded"]'
-        )
-        const hasDetail = await detail.isVisible({ timeout: 3000 }).catch(() => false)
-        expect(hasDetail || true).toBeTruthy()
-      }
-    })
-
-    test('event detail shows full message', async ({ page }) => {
-      const firstEvent = page.locator('[data-testid*="event"], tr').first()
-      const hasEvent = await firstEvent.isVisible().catch(() => false)
-
-      if (hasEvent) {
-        await firstEvent.click()
-        await page.waitForTimeout(500)
-
-        // Should show full message
-        const fullMessage = page.locator(
-          'text=/container|scheduling|node|back-off restarting/i'
-        )
-        const hasMessage = await fullMessage.first().isVisible().catch(() => false)
-        expect(hasMessage || true).toBeTruthy()
-      }
-    })
-
-    test('event detail shows timestamps', async ({ page }) => {
-      const timestamps = page.locator('text=/first.*seen|last.*seen|ago|\\d{4}-\\d{2}/i')
-      const hasTimestamps = await timestamps.first().isVisible().catch(() => false)
-      expect(hasTimestamps || true).toBeTruthy()
-    })
-  })
-
-  test.describe('Warnings Only View', () => {
-    test('can toggle warnings-only mode', async ({ page }) => {
-      await page.waitForTimeout(1000)
-
-      const warningsToggle = page.locator(
-        '[data-testid="warnings-only"], button:has-text("Warnings"), input[type="checkbox"]:near(:text("Warning"))'
-      ).first()
-      const hasToggle = await warningsToggle.isVisible().catch(() => false)
-
-      if (hasToggle) {
-        await warningsToggle.click()
-        await page.waitForTimeout(500)
-
-        // Should only show warning events - filtering may vary
-      }
-
-      // Test passes if we got here
-      expect(true).toBeTruthy()
-    })
-  })
-
-  test.describe('Pagination', () => {
-    test('handles large event lists', async ({ page }) => {
-      // Mock many events
-      await page.route('**/api/mcp/events**', (route) =>
-        route.fulfill({
-          status: 200,
-          json: {
-            events: Array(100).fill(null).map((_, i) => ({
-              type: i % 3 === 0 ? 'Warning' : 'Normal',
-              reason: 'Test',
-              message: `Event ${i}`,
-              object: `Pod/pod-${i}`,
-              namespace: 'default',
-              count: 1,
-            })),
-          },
-        })
-      )
-
-      await page.reload()
-      await page.waitForTimeout(1500)
-
-      // Should have pagination or virtual scrolling
-      const pagination = page.locator(
-        '[data-testid="pagination"], .pagination, button:has-text("Next"), button:has-text("Load more")'
-      )
-      const hasPagination = await pagination.first().isVisible().catch(() => false)
-      expect(hasPagination || true).toBeTruthy()
+      // Button should remain visible after click
+      await expect(page.getByTestId('dashboard-refresh-button')).toBeVisible()
     })
   })
 
   test.describe('Empty States', () => {
     test('handles no events gracefully', async ({ page }) => {
+      // Override mock to return empty events
       await page.route('**/api/mcp/events**', (route) =>
         route.fulfill({
           status: 200,
-          json: { events: [] },
+          contentType: 'application/json',
+          body: JSON.stringify({ events: [] }),
         })
       )
 
       await page.reload()
-      await page.waitForTimeout(1000)
+      await page.waitForLoadState('domcontentloaded')
 
-      // Should show empty state
-      const emptyState = page.locator('text=/no events|no activity|all clear/i')
-      const hasEmpty = await emptyState.first().isVisible().catch(() => false)
-      expect(hasEmpty || true).toBeTruthy()
+      // Page should still render (not crash)
+      await expect(page.getByTestId('dashboard-header')).toBeVisible({ timeout: 10000 })
     })
   })
 
   test.describe('Responsive Design', () => {
     test('adapts to mobile viewport', async ({ page }) => {
       await page.setViewportSize({ width: 375, height: 667 })
-      await page.waitForTimeout(500)
 
       // Content should still be accessible
-      const events = page.locator('[data-testid*="event"], tr')
-      const isVisible = await events.first().isVisible().catch(() => false)
-      expect(isVisible || true).toBeTruthy()
+      await expect(page.getByTestId('dashboard-header')).toBeVisible({ timeout: 10000 })
     })
   })
 
   test.describe('Accessibility', () => {
     test('event list is keyboard navigable', async ({ page }) => {
-      await page.waitForTimeout(1000)
+      await expect(page.getByTestId('dashboard-header')).toBeVisible({ timeout: 10000 })
 
+      // Tab through elements
       for (let i = 0; i < 5; i++) {
         await page.keyboard.press('Tab')
-        await page.waitForTimeout(100)
       }
 
+      // Should have a focused element
       const focused = page.locator(':focus')
-      const hasFocus = await focused.isVisible().catch(() => false)
+      await expect(focused).toBeVisible()
+    })
 
-      // Keyboard navigation may work differently
-      expect(hasFocus || true).toBeTruthy()
+    test('page has heading', async ({ page }) => {
+      await expect(page.getByTestId('dashboard-header')).toBeVisible({ timeout: 10000 })
+
+      // Should have Events heading
+      await expect(page.getByRole('heading', { name: /events/i })).toBeVisible()
     })
   })
 })

--- a/web/e2e/Settings.spec.ts
+++ b/web/e2e/Settings.spec.ts
@@ -1,90 +1,76 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
+
+/**
+ * Sets up authentication and MCP mocks for settings tests
+ */
+async function setupSettingsTest(page: Page) {
+  // Mock authentication
+  await page.route('**/api/me', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '1',
+        github_id: '12345',
+        github_login: 'testuser',
+        email: 'test@example.com',
+        onboarded: true,
+      }),
+    })
+  )
+
+  // Mock MCP endpoints
+  await page.route('**/api/mcp/**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ clusters: [], issues: [], events: [], nodes: [] }),
+    })
+  )
+
+  // Set auth token
+  await page.goto('/login')
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'test-token')
+    localStorage.setItem('demo-user-onboarded', 'true')
+  })
+
+  await page.goto('/settings')
+  await page.waitForLoadState('domcontentloaded')
+}
 
 test.describe('Settings Page', () => {
   test.beforeEach(async ({ page }) => {
-    // Mock authentication
-    await page.route('**/api/me', (route) =>
-      route.fulfill({
-        status: 200,
-        json: {
-          id: '1',
-          github_id: '12345',
-          github_login: 'testuser',
-          email: 'test@example.com',
-          onboarded: true,
-        },
-      })
-    )
-
-    // Mock MCP endpoints
-    await page.route('**/api/mcp/**', (route) =>
-      route.fulfill({
-        status: 200,
-        json: { clusters: [], issues: [], events: [], nodes: [] },
-      })
-    )
-
-    // Set auth token and demo mode flags
-    await page.goto('/login')
-    await page.evaluate(() => {
-      localStorage.setItem('token', 'test-token')
-      localStorage.setItem('demo-user-onboarded', 'true')
-    })
-
-    // Wait for localStorage to be persisted before navigating
-    await page.waitForTimeout(500)
-
-    await page.goto('/settings')
-    await page.waitForLoadState('domcontentloaded')
-    await page.waitForTimeout(500)
+    await setupSettingsTest(page)
   })
 
   test.describe('Page Layout', () => {
     test('displays settings page', async ({ page }) => {
-      await page.waitForTimeout(1000) // Give browsers extra time
-
-      // Should have settings heading or be on settings page
-      const heading = page.locator('h1, h2').filter({ hasText: /settings/i }).first()
-      const hasHeading = await heading.isVisible().catch(() => false)
-
-      // Fallback: check URL
-      const isSettingsPage = page.url().includes('/settings')
-
-      expect(hasHeading || isSettingsPage || true).toBeTruthy()
+      // Settings page should be visible
+      await expect(page.getByTestId('settings-page')).toBeVisible({ timeout: 10000 })
     })
 
-    test('has navigation back to dashboard', async ({ page }) => {
-      const backLink = page.getByRole('link', { name: /dashboard|home|back/i }).first()
-      const hasBack = await backLink.isVisible().catch(() => false)
-      expect(hasBack || true).toBeTruthy()
+    test('shows settings title', async ({ page }) => {
+      await expect(page.getByTestId('settings-page')).toBeVisible({ timeout: 10000 })
+
+      // Should have Settings heading
+      await expect(page.getByTestId('settings-title')).toBeVisible()
+      await expect(page.getByTestId('settings-title')).toHaveText('Settings')
+    })
+
+    test('has sidebar navigation', async ({ page }) => {
+      await expect(page.getByTestId('settings-page')).toBeVisible({ timeout: 10000 })
+
+      // Sidebar should be visible
+      await expect(page.getByTestId('sidebar')).toBeVisible()
     })
   })
 
   test.describe('Theme Settings', () => {
-    test('can toggle between dark and light theme', async ({ page }) => {
-      // Find theme toggle
-      const themeToggle = page.locator(
-        '[data-testid="theme-toggle"], [aria-label*="theme"], button:has-text("Theme")'
-      ).first()
-      const hasToggle = await themeToggle.isVisible().catch(() => false)
-
-      if (hasToggle) {
-        // Get initial theme
-        const htmlElement = page.locator('html')
-        const initialClass = await htmlElement.getAttribute('class')
-
-        // Toggle theme
-        await themeToggle.click()
-        await page.waitForTimeout(500)
-
-        // Theme class should change
-        const newClass = await htmlElement.getAttribute('class')
-        // Verify theme changed
-      }
-    })
-
     test('theme persists after reload', async ({ page }) => {
-      // Set theme
+      await expect(page.getByTestId('settings-page')).toBeVisible({ timeout: 10000 })
+
+      // Set theme in localStorage
       await page.evaluate(() => {
         localStorage.setItem('theme', 'light')
       })
@@ -98,201 +84,57 @@ test.describe('Settings Page', () => {
       )
       expect(storedTheme).toBe('light')
     })
-
-    test('supports system theme preference', async ({ page }) => {
-      // Look for system theme option
-      const systemOption = page.locator(
-        'button:has-text("System"), [data-value="system"], option:text("System")'
-      ).first()
-      const hasSystem = await systemOption.isVisible().catch(() => false)
-      expect(hasSystem || true).toBeTruthy()
-    })
   })
 
   test.describe('AI Mode Settings', () => {
     test('displays AI mode section', async ({ page }) => {
-      await page.waitForTimeout(1000) // Give browsers extra time
+      await expect(page.getByTestId('settings-page')).toBeVisible({ timeout: 10000 })
 
-      const aiSection = page.locator('text=/ai.*mode|intelligence/i').first()
+      // Look for AI mode section
+      const aiSection = page.getByText(/ai.*mode|intelligence/i).first()
       const hasAiSection = await aiSection.isVisible().catch(() => false)
 
-      // AI mode section may not exist in all configurations
-      expect(hasAiSection || true).toBeTruthy()
-    })
-
-    test('shows token limit configuration', async ({ page }) => {
-      const tokenLimit = page.locator('text=/token.*limit|limit.*tokens/i')
-      const hasLimit = await tokenLimit.first().isVisible().catch(() => false)
-      expect(hasLimit || true).toBeTruthy()
-    })
-
-    test('can adjust token limit', async ({ page }) => {
-      const tokenInput = page.locator(
-        'input[name*="token"], input[data-testid*="token-limit"]'
-      ).first()
-      const hasInput = await tokenInput.isVisible().catch(() => false)
-
-      if (hasInput) {
-        await tokenInput.clear()
-        await tokenInput.fill('20000')
-        await page.waitForTimeout(500)
-
-        // Value should update
-        const value = await tokenInput.inputValue()
-        expect(value).toBe('20000')
-      }
-    })
-  })
-
-  test.describe('User Preferences', () => {
-    test('displays user profile section', async ({ page }) => {
-      const profileSection = page.locator('text=/profile|account|user/i').first()
-      const hasProfile = await profileSection.isVisible().catch(() => false)
-      expect(hasProfile || true).toBeTruthy()
-    })
-
-    test('can update display name', async ({ page }) => {
-      const nameInput = page.locator(
-        'input[name*="name"], input[placeholder*="name"], input[data-testid*="display-name"]'
-      ).first()
-      const hasInput = await nameInput.isVisible().catch(() => false)
-
-      if (hasInput) {
-        await nameInput.clear()
-        await nameInput.fill('Test User')
-        await page.waitForTimeout(500)
-      }
-    })
-  })
-
-  test.describe('Dashboard Preferences', () => {
-    test('shows default card configuration', async ({ page }) => {
-      const cardConfig = page.locator('text=/default.*cards|card.*layout|dashboard.*config/i')
-      const hasConfig = await cardConfig.first().isVisible().catch(() => false)
-      expect(hasConfig || true).toBeTruthy()
-    })
-
-    test('can reset dashboard to default', async ({ page }) => {
-      const resetButton = page.getByRole('button', { name: /reset|default/i }).first()
-      const hasReset = await resetButton.isVisible().catch(() => false)
-
-      if (hasReset) {
-        await resetButton.click()
-
-        // Confirm if needed
-        const confirmButton = page.getByRole('button', { name: /confirm|yes/i })
-        const hasConfirm = await confirmButton.isVisible().catch(() => false)
-        if (hasConfirm) {
-          await confirmButton.click()
-        }
-      }
-    })
-  })
-
-  test.describe('Save/Cancel Actions', () => {
-    test('has save button', async ({ page }) => {
-      const saveButton = page.getByRole('button', { name: /save|apply/i }).first()
-      const hasSave = await saveButton.isVisible().catch(() => false)
-      expect(hasSave || true).toBeTruthy()
-    })
-
-    test('shows unsaved changes indicator', async ({ page }) => {
-      // Make a change
-      const input = page.locator('input').first()
-      const hasInput = await input.isVisible().catch(() => false)
-
-      if (hasInput) {
-        await input.fill('changed')
-        await page.waitForTimeout(500)
-
-        // Should show unsaved indicator
-        const unsavedIndicator = page.locator('text=/unsaved|changes/i')
-        const hasIndicator = await unsavedIndicator.first().isVisible().catch(() => false)
-        // May or may not have indicator depending on implementation
-      }
-    })
-
-    test('can discard changes', async ({ page }) => {
-      const discardButton = page.getByRole('button', { name: /cancel|discard|reset/i }).first()
-      const hasDiscard = await discardButton.isVisible().catch(() => false)
-      expect(hasDiscard || true).toBeTruthy()
-    })
-  })
-
-  test.describe('Logout', () => {
-    test('has logout option', async ({ page }) => {
-      const logoutButton = page.getByRole('button', { name: /logout|sign out/i }).first()
-      const hasLogout = await logoutButton.isVisible().catch(() => false)
-      expect(hasLogout || true).toBeTruthy()
-    })
-
-    test('logout redirects to login', async ({ page }) => {
-      const logoutButton = page.getByRole('button', { name: /logout|sign out/i }).first()
-      const hasLogout = await logoutButton.isVisible().catch(() => false)
-
-      if (hasLogout) {
-        await logoutButton.click()
-
-        // Should redirect to login
-        await page.waitForURL(/\/login/, { timeout: 5000 })
-        await expect(page).toHaveURL(/\/login/)
-      }
+      // AI mode section should be visible
+      expect(hasAiSection).toBe(true)
     })
   })
 
   test.describe('Accessibility', () => {
-    test('form elements have labels', async ({ page }) => {
-      // Wait for settings page to fully load
-      await page.waitForTimeout(1000)
+    test('settings page is keyboard navigable', async ({ page }) => {
+      await expect(page.getByTestId('settings-page')).toBeVisible({ timeout: 10000 })
 
-      // Verify we're on settings page
-      const isSettingsPage = page.url().includes('/settings')
-
-      // Check for form elements - inputs, textareas, selects, or elements with input roles
-      const formElements = page.locator('input, textarea, select, [role="textbox"], [role="slider"], [role="combobox"], [role="spinbutton"]')
-      const elementCount = await formElements.count()
-
-      // Check that at least some form elements have associated labels or accessible names
-      let labeledCount = 0
-      for (let i = 0; i < Math.min(elementCount, 10); i++) {
-        const element = formElements.nth(i)
-        const id = await element.getAttribute('id')
-        const ariaLabel = await element.getAttribute('aria-label')
-        const placeholder = await element.getAttribute('placeholder')
-        const type = await element.getAttribute('type')
-        const role = await element.getAttribute('role')
-        const name = await element.getAttribute('name')
-
-        // Should have some form of labeling, or be a commonly unlabeled type
-        if (id || ariaLabel || placeholder || name || type === 'range' || type === 'hidden' || role) {
-          labeledCount++
-        }
-      }
-
-      // If no form elements found, try checking for textboxes by accessible name
-      if (labeledCount === 0 && elementCount === 0) {
-        const textboxes = page.getByRole('textbox')
-        const textboxCount = await textboxes.count()
-        labeledCount = textboxCount
-      }
-
-      // Settings page should have form elements when loaded, but may vary in CI
-      // Firefox may have auth timing issues causing redirect to login
-      // Use permissive check - test validates accessibility when page loads correctly
-      expect(labeledCount > 0 || isSettingsPage || true).toBeTruthy()
-    })
-
-    test('keyboard navigation works', async ({ page }) => {
+      // Tab through elements
       for (let i = 0; i < 5; i++) {
         await page.keyboard.press('Tab')
-        await page.waitForTimeout(100)
       }
 
+      // Should have a focused element
       const focused = page.locator(':focus')
-      const hasFocus = await focused.isVisible().catch(() => false)
+      await expect(focused).toBeVisible()
+    })
 
-      // Keyboard navigation may work differently across browsers
-      expect(hasFocus || true).toBeTruthy()
+    test('page has proper heading hierarchy', async ({ page }) => {
+      await expect(page.getByTestId('settings-page')).toBeVisible({ timeout: 10000 })
+
+      // Should have h1 heading
+      const h1Count = await page.locator('h1').count()
+      expect(h1Count).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  test.describe('Responsive Design', () => {
+    test('adapts to mobile viewport', async ({ page }) => {
+      await page.setViewportSize({ width: 375, height: 667 })
+
+      // Page should still render at mobile size
+      await expect(page.getByTestId('settings-page')).toBeVisible({ timeout: 10000 })
+    })
+
+    test('adapts to tablet viewport', async ({ page }) => {
+      await page.setViewportSize({ width: 768, height: 1024 })
+
+      // Content should still be accessible
+      await expect(page.getByTestId('settings-page')).toBeVisible({ timeout: 10000 })
     })
   })
 })

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -1697,7 +1697,7 @@ export function Clusters() {
   // The error variable is kept for potential future use but UI always renders
 
   return (
-    <div className="pt-16">
+    <div data-testid="clusters-page" className="pt-16">
       {/* Header */}
       <DashboardHeader
         title="Clusters"

--- a/web/src/components/settings/Settings.tsx
+++ b/web/src/components/settings/Settings.tsx
@@ -28,9 +28,9 @@ export function Settings() {
   const { forceCheck: forceVersionCheck } = useVersionCheck()
 
   return (
-    <div className="pt-16 max-w-4xl mx-auto">
+    <div data-testid="settings-page" className="pt-16 max-w-4xl mx-auto">
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-foreground">Settings</h1>
+        <h1 data-testid="settings-title" className="text-2xl font-bold text-foreground">Settings</h1>
         <p className="text-muted-foreground">Configure console preferences and AI usage</p>
       </div>
 


### PR DESCRIPTION
## Summary
- Add `data-testid` attributes to `Clusters.tsx` and `Settings.tsx` components
- Rewrite `Clusters.spec.ts` with proper assertions (remove `|| true` patterns)
- Rewrite `Events.spec.ts` with proper assertions and API mocking
- Rewrite `Settings.spec.ts` with proper assertions and test structure
- All tests now use explicit waits instead of `waitForTimeout`
- Tests use `data-testid` selectors for stability

## Test plan
- [x] Build passes
- [x] Tests use proper Playwright assertions
- [x] No `|| true` patterns in modified test files

Continues the Playwright testing overhaul from PR #485.

🤖 Generated with [Claude Code](https://claude.com/claude-code)