### PR TITLE
⚡ Reduce skeleton flicker when navigating between dashboards

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -663,6 +663,14 @@ export function CardWrapper({
     return () => clearTimeout(timer)
   }, []) // Empty deps - only run on mount
 
+  // Skeleton delay: don't show skeleton immediately, wait a brief moment
+  // This prevents flicker when cache loads quickly from IndexedDB
+  const [skeletonDelayPassed, setSkeletonDelayPassed] = useState(false)
+  useEffect(() => {
+    const timer = setTimeout(() => setSkeletonDelayPassed(true), 100)
+    return () => clearTimeout(timer)
+  }, []) // Empty deps - only run on mount
+
   // Handle minimum spin duration for refresh button
   // Include both prop and context-reported refresh state
   const contextIsRefreshing = childDataState?.isRefreshing || false
@@ -778,7 +786,9 @@ export function CardWrapper({
   // Default to 'list' skeleton type if not specified, enabling automatic skeleton display
   const effectiveSkeletonType = skeletonType || 'list'
   // Demo data cards should NEVER show skeleton - they always have hardcoded data ready to display
-  const shouldShowSkeleton = !isDemoData && ((effectiveIsLoading && !effectiveHasData && !effectiveIsRefreshing) || forceSkeletonForOffline)
+  // Also delay skeleton display by 100ms to prevent flicker when cache loads quickly
+  const wantsToShowSkeleton = !isDemoData && ((effectiveIsLoading && !effectiveHasData && !effectiveIsRefreshing) || forceSkeletonForOffline)
+  const shouldShowSkeleton = wantsToShowSkeleton && skeletonDelayPassed
 
   // Use external messages if provided, otherwise use local state
   const messages = externalMessages ?? localMessages

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -762,8 +762,20 @@ export async function preloadCacheFromStorage(): Promise<void> {
         // Pre-populate the registry with loaded data
         // This creates a CacheStore with data already loaded
         const store = getOrCreateCache(key, entry.data, true)
-        // Mark as loaded so it doesn't try to load again
-        ;(store as unknown as { initialDataLoaded: boolean }).initialDataLoaded = true
+        // Mark as loaded and set proper state so it shows cached data immediately
+        const storeWithState = store as unknown as {
+          initialDataLoaded: boolean
+          state: CacheState<unknown>
+          notify: () => void
+        }
+        storeWithState.initialDataLoaded = true
+        storeWithState.state = {
+          ...storeWithState.state,
+          data: entry.data,
+          isLoading: false,
+          isRefreshing: true, // Will fetch fresh data in background
+          lastRefresh: entry.timestamp,
+        }
         loadedCount++
       }
     } catch {


### PR DESCRIPTION
## Summary
- Added 100ms delay before showing skeleton to prevent brief flash when cache loads quickly
- Fixed preloaded cache entries to have correct state (isLoading=false, isRefreshing=true)
- This reduces visual flicker when navigating between dashboards

## Changes

### CardWrapper.tsx
- Added `skeletonDelayPassed` state with 100ms timer
- Only show skeleton after delay passes, giving cache time to load

### cache/index.ts  
- Fixed `preloadCacheFromStorage()` to set proper state for preloaded entries
- Preloaded data now shows immediately without skeleton flash

## Test plan
- [ ] Navigate between dashboards - verify reduced flicker
- [ ] Clear IndexedDB, refresh page - skeleton should still show after 100ms
- [ ] With cached data, navigate - should show data immediately without skeleton flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)