### PR TITLE
✨ Add missing dashboards to sidebar customizer

### DIFF
--- a/web/src/components/layout/SidebarCustomizer.tsx
+++ b/web/src/components/layout/SidebarCustomizer.tsx
@@ -128,6 +128,10 @@ const KNOWN_ROUTES: KnownRoute[] = [
   { href: '/network', name: 'Network', description: 'Network policies, ingress, and service mesh configuration', icon: 'Network', category: 'Core Dashboards' },
   { href: '/arcade', name: 'Arcade', description: 'Kubernetes-themed arcade games for taking a break', icon: 'Gamepad2', category: 'Core Dashboards' },
   { href: '/deploy', name: 'KubeStellar Deploy', description: 'Deployment monitoring, GitOps, Helm releases, and ArgoCD', icon: 'Rocket', category: 'Core Dashboards' },
+  { href: '/ai-ml', name: 'AI/ML', description: 'AI and machine learning workloads, GPU utilization, and model serving', icon: 'Brain', category: 'Core Dashboards' },
+  { href: '/ci-cd', name: 'CI/CD', description: 'Continuous integration and deployment pipelines, Prow jobs, and GitHub workflows', icon: 'GitPullRequest', category: 'Core Dashboards' },
+  { href: '/compliance', name: 'Compliance', description: 'Regulatory compliance, audit logs, and policy enforcement', icon: 'ClipboardCheck', category: 'Core Dashboards' },
+  { href: '/gpu', name: 'GPU', description: 'GPU monitoring, utilization, and workload management', icon: 'Cpu', category: 'Core Dashboards' },
   // Resource Pages
   { href: '/namespaces', name: 'Namespaces', description: 'Namespace management and resource allocation', icon: 'FolderTree', category: 'Resources' },
   { href: '/nodes', name: 'Nodes', description: 'Cluster node health and resource usage', icon: 'HardDrive', category: 'Resources' },


### PR DESCRIPTION
## Summary
- Add AI/ML, CI/CD, Compliance, and GPU dashboards to KNOWN_ROUTES
- These dashboards were registered in DASHBOARD_CONFIGS but missing from the sidebar add dialog

## Test plan
- [ ] Open sidebar customizer
- [ ] Click "Add Dashboard"
- [ ] Verify AI/ML, CI/CD, Compliance, and GPU appear in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)