### PR TITLE
✨ Implement AI/ML and CI/CD dashboard data hooks

### DIFF
--- a/web/src/components/aiml/AIML.tsx
+++ b/web/src/components/aiml/AIML.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react'
-import { useClusters } from '../../hooks/useMCP'
+import { useClusters, useGPUNodes } from '../../hooks/useMCP'
+import { useCachedLLMdModels } from '../../hooks/useCachedData'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
 import { StatBlockValue } from '../ui/StatsOverview'
 import { DashboardPage } from '../../lib/dashboards'
@@ -10,12 +11,27 @@ const AIML_CARDS_KEY = 'kubestellar-aiml-cards'
 // Default cards for AI/ML dashboard
 const DEFAULT_AIML_CARDS = getDefaultCards('ai-ml')
 
+// LLM-d clusters to monitor
+const LLMD_CLUSTERS = ['vllm-d', 'platform-eval']
+
 export function AIML() {
   const { clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error } = useClusters()
+  const { nodes: gpuNodes, isLoading: gpuLoading } = useGPUNodes()
+  const { models: llmModels, isLoading: llmLoading } = useCachedLLMdModels(LLMD_CLUSTERS)
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
 
   // Filter reachable clusters
   const reachableClusters = clusters.filter(c => c.reachable !== false)
+
+  // Calculate total GPUs
+  const totalGPUs = gpuNodes.reduce((sum, n) => sum + n.gpuCount, 0)
+
+  // Calculate ML workload count (LLM models + other ML deployments)
+  const mlWorkloadCount = llmModels.length
+
+  // Determine if we have real data (not just loading or error states)
+  const hasRealData = gpuNodes.length > 0 || llmModels.length > 0
+  const isDemoData = !hasRealData && !gpuLoading && !llmLoading
 
   // Stats value getter for the configurable StatsOverview component
   const getDashboardStatValue = useCallback((blockId: string): StatBlockValue => {
@@ -23,13 +39,31 @@ export function AIML() {
       case 'clusters':
         return { value: reachableClusters.length, sublabel: 'clusters', isClickable: false }
       case 'gpu_nodes':
-        return { value: 0, sublabel: 'GPU nodes', isClickable: false, isDemo: true }
+        return {
+          value: gpuNodes.length,
+          sublabel: `${totalGPUs} GPUs total`,
+          isClickable: false,
+          isDemo: gpuNodes.length === 0 && !gpuLoading
+        }
       case 'ml_workloads':
-        return { value: 0, sublabel: 'ML workloads', isClickable: false, isDemo: true }
+        return {
+          value: mlWorkloadCount,
+          sublabel: 'ML workloads',
+          isClickable: false,
+          isDemo: mlWorkloadCount === 0 && !llmLoading
+        }
+      case 'loaded_models':
+        const loadedCount = llmModels.filter(m => m.status === 'loaded').length
+        return {
+          value: loadedCount,
+          sublabel: 'models loaded',
+          isClickable: false,
+          isDemo: llmModels.length === 0 && !llmLoading
+        }
       default:
         return { value: '-' }
     }
-  }, [reachableClusters])
+  }, [reachableClusters, gpuNodes, totalGPUs, mlWorkloadCount, llmModels, gpuLoading, llmLoading])
 
   const getStatValue = useCallback(
     (blockId: string) => createMergedStatValueGetter(getDashboardStatValue, getUniversalStatValue)(blockId),
@@ -46,11 +80,11 @@ export function AIML() {
       statsType="compute"
       getStatValue={getStatValue}
       onRefresh={refetch}
-      isLoading={isLoading}
+      isLoading={isLoading || gpuLoading || llmLoading}
       isRefreshing={dataRefreshing}
       lastUpdated={lastUpdated}
-      hasData={reachableClusters.length > 0}
-      isDemoData={true}
+      hasData={reachableClusters.length > 0 || hasRealData}
+      isDemoData={isDemoData}
       emptyState={{
         title: 'AI/ML Dashboard',
         description: 'Add cards to monitor GPU utilization, ML workloads, and model training across your clusters.',

--- a/web/src/config/dashboards/ai-ml.ts
+++ b/web/src/config/dashboards/ai-ml.ts
@@ -10,12 +10,12 @@ export const aiMlDashboardConfig: UnifiedDashboardConfig = {
   route: '/ai-ml',
   statsType: 'ai-ml',
   cards: [
-    { id: 'llm-models-1', cardType: 'llm_models', position: { w: 6, h: 4 } },
-    { id: 'llm-inference-1', cardType: 'llm_inference', position: { w: 6, h: 4 } },
-    { id: 'llmd-stack-monitor-1', cardType: 'llmd_stack_monitor', position: { w: 6, h: 3 } },
-    { id: 'ml-jobs-1', cardType: 'ml_jobs', position: { w: 6, h: 3 } },
-    { id: 'ml-notebooks-1', cardType: 'ml_notebooks', position: { w: 6, h: 3 } },
-    { id: 'gpu-overview-1', cardType: 'gpu_overview', position: { w: 6, h: 3 } },
+    { id: 'llm-models-1', cardType: 'llm_models', position: { w: 4, h: 3 } },
+    { id: 'llm-inference-1', cardType: 'llm_inference', position: { w: 4, h: 3 } },
+    { id: 'llmd-stack-monitor-1', cardType: 'llmd_stack_monitor', position: { w: 4, h: 3 } },
+    { id: 'ml-jobs-1', cardType: 'ml_jobs', position: { w: 4, h: 3 } },
+    { id: 'ml-notebooks-1', cardType: 'ml_notebooks', position: { w: 4, h: 3 } },
+    { id: 'gpu-overview-1', cardType: 'gpu_overview', position: { w: 4, h: 3 } },
   ],
   features: {
     dragDrop: true,

--- a/web/src/config/dashboards/ci-cd.ts
+++ b/web/src/config/dashboards/ci-cd.ts
@@ -10,12 +10,12 @@ export const ciCdDashboardConfig: UnifiedDashboardConfig = {
   route: '/ci-cd',
   statsType: 'ci-cd',
   cards: [
-    { id: 'github-ci-monitor-1', cardType: 'github_ci_monitor', position: { w: 6, h: 4 } },
-    { id: 'github-activity-1', cardType: 'github_activity', position: { w: 6, h: 4 } },
-    { id: 'prow-status-1', cardType: 'prow_status', position: { w: 6, h: 3 } },
-    { id: 'prow-jobs-1', cardType: 'prow_jobs', position: { w: 6, h: 3 } },
-    { id: 'prow-ci-monitor-1', cardType: 'prow_ci_monitor', position: { w: 6, h: 3 } },
-    { id: 'prow-history-1', cardType: 'prow_history', position: { w: 6, h: 3 } },
+    { id: 'prow-status-1', cardType: 'prow_status', position: { w: 4, h: 3 } },
+    { id: 'prow-jobs-1', cardType: 'prow_jobs', position: { w: 4, h: 3 } },
+    { id: 'prow-ci-monitor-1', cardType: 'prow_ci_monitor', position: { w: 4, h: 3 } },
+    { id: 'prow-history-1', cardType: 'prow_history', position: { w: 4, h: 3 } },
+    { id: 'github-ci-monitor-1', cardType: 'github_ci_monitor', position: { w: 4, h: 3 } },
+    { id: 'github-activity-1', cardType: 'github_activity', position: { w: 4, h: 3 } },
   ],
   features: {
     dragDrop: true,


### PR DESCRIPTION
## Summary
- Add real data hooks to AI/ML dashboard (AIML.tsx) using `useClusters`, `useGPUNodes`, and `useCachedLLMdModels`
- Add real data hooks to CI/CD dashboard (CICD.tsx) using `useClusters`, `useDeployments`, and `useCachedProwJobs`
- Fix TypeScript errors: use `state` instead of `status` for ProwJob, remove non-existent `lastUpdated` from Deployment
- Reduce card sizes to minimal (w=4, h=3) in both dashboard configs
- Calculate real stats: GPU nodes, total GPUs, ML workloads, running/failed jobs, success rate

## Test plan
- [ ] Navigate to AI/ML dashboard and verify real data is shown when available
- [ ] Navigate to CI/CD dashboard and verify Prow job data is shown when available
- [ ] Verify cards display correctly at minimal sizes (4x3)
- [ ] Verify demo data indicator appears only when no real data is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)