### PR TITLE
✨ Add dynamic LLM-d cluster discovery for AI/ML dashboard

### DIFF
--- a/web/src/components/cards/workload-detection/shared.ts
+++ b/web/src/components/cards/workload-detection/shared.ts
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
+import type { ClusterInfo } from '../../../hooks/mcp/types'
 
 export interface DemoState {
   isLoading: boolean
@@ -11,8 +12,44 @@ export function useDemoData<T>(data: T): DemoState & { data: T } {
   return { data, isLoading, lastUpdated }
 }
 
-// Clusters known to have llm-d stacks
+// Keywords that indicate a cluster may have LLM-d or AI/ML workloads
+const LLMD_CLUSTER_KEYWORDS = [
+  'vllm', 'llm', 'inference', 'model', 'eval', 'gpu', 'ai', 'ml',
+  'tgi', 'triton', 'serving', 'aibrix', 'hc4ai'
+]
+
+// Default clusters known to have llm-d stacks (fallback)
 export const LLMD_CLUSTERS = ['vllm-d', 'platform-eval']
+
+/**
+ * Dynamically discover clusters that likely have LLM-d stacks
+ * based on cluster name patterns and GPU availability
+ */
+export function useLLMdClusters(
+  clusters: ClusterInfo[],
+  gpuClusterNames: Set<string> = new Set()
+): string[] {
+  return useMemo(() => {
+    const reachable = clusters.filter(c => c.reachable !== false)
+
+    // Find clusters that likely have LLM workloads based on:
+    // 1. Clusters with GPU nodes
+    // 2. Cluster names containing AI/ML keywords
+    const candidates = reachable.filter(c => {
+      const nameLower = c.name.toLowerCase()
+      return gpuClusterNames.has(c.name) ||
+        LLMD_CLUSTER_KEYWORDS.some(kw => nameLower.includes(kw))
+    }).map(c => c.name)
+
+    // If no candidates found, return all reachable clusters (the useCachedLLMdServers
+    // will scan them for llm-d namespaces)
+    if (candidates.length === 0) {
+      return reachable.slice(0, 10).map(c => c.name)
+    }
+
+    return candidates
+  }, [clusters, gpuClusterNames])
+}
 
 export const DEMO_ML_JOBS = [
   { name: 'train-gpt-finetune', framework: 'PyTorch', status: 'running', gpus: 8, progress: 67, eta: '2h 15m', cluster: 'gpu-cluster-1' },

--- a/web/src/config/dashboards/ci-cd.ts
+++ b/web/src/config/dashboards/ci-cd.ts
@@ -10,12 +10,14 @@ export const ciCdDashboardConfig: UnifiedDashboardConfig = {
   route: '/ci-cd',
   statsType: 'ci-cd',
   cards: [
-    { id: 'prow-status-1', cardType: 'prow_status', position: { w: 4, h: 3 } },
-    { id: 'prow-jobs-1', cardType: 'prow_jobs', position: { w: 4, h: 3 } },
-    { id: 'prow-ci-monitor-1', cardType: 'prow_ci_monitor', position: { w: 4, h: 3 } },
-    { id: 'prow-history-1', cardType: 'prow_history', position: { w: 4, h: 3 } },
-    { id: 'github-ci-monitor-1', cardType: 'github_ci_monitor', position: { w: 4, h: 3 } },
-    { id: 'github-activity-1', cardType: 'github_activity', position: { w: 4, h: 3 } },
+    // Top row: Prow overview cards
+    { id: 'prow-status-1', cardType: 'prow_status', title: 'Prow Status', position: { w: 4, h: 3 } },
+    { id: 'prow-jobs-1', cardType: 'prow_jobs', title: 'Prow Jobs', position: { w: 5, h: 4 } },
+    { id: 'prow-ci-monitor-1', cardType: 'prow_ci_monitor', title: 'Prow CI Monitor', position: { w: 6, h: 4 } },
+    // Second row: History and GitHub integration
+    { id: 'prow-history-1', cardType: 'prow_history', title: 'Prow History', position: { w: 4, h: 3 } },
+    { id: 'github-ci-monitor-1', cardType: 'github_ci_monitor', title: 'GitHub CI Monitor', position: { w: 6, h: 4 } },
+    { id: 'github-activity-1', cardType: 'github_activity', title: 'GitHub Activity', position: { w: 5, h: 4 } },
   ],
   features: {
     dragDrop: true,


### PR DESCRIPTION
## Summary
- Implement intelligent LLM-d cluster detection based on GPU nodes and AI/ML naming patterns
- Add `useLLMdClusters` hook that dynamically discovers clusters likely to have LLM-d stacks
- Keywords detected: vllm, llm, inference, model, eval, gpu, ai, ml, tgi, triton, serving, aibrix, hc4ai
- Falls back to scanning reachable clusters when dedicated clusters (vllm-d, platform-eval) are offline
- Tune CI/CD dashboard card sizes for better Prow data display

## Test plan
- [ ] Verify AI/ML dashboard detects clusters with GPU nodes
- [ ] Verify AI/ML dashboard detects clusters with AI/ML naming patterns
- [ ] Verify fallback behavior when vllm-d/platform-eval are offline
- [ ] Verify CI/CD dashboard cards display properly with Prow data

🤖 Generated with [Claude Code](https://claude.com/claude-code)