### PR TITLE
✨ Add PWA mini-dashboard and rename to Node Offline Detection

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#7c3aed" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="KC Widget" />
+    <link rel="apple-touch-icon" href="/kubestellar.png" />
     <title>KubeStellar Console</title>
   </head>
   <body>

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,0 +1,31 @@
+{
+  "name": "KC Console Widget",
+  "short_name": "KC Widget",
+  "description": "KubeStellar Console mini-dashboard widget",
+  "start_url": "/widget",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#7c3aed",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "64x64",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "/kubestellar.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ],
+  "categories": ["utilities", "productivity"],
+  "shortcuts": [
+    {
+      "name": "Full Dashboard",
+      "url": "/dashboard",
+      "description": "Open full KC Console dashboard"
+    }
+  ]
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -50,6 +50,7 @@ const Arcade = lazy(() => import('./components/arcade/Arcade').then(m => ({ defa
 const Deploy = lazy(() => import('./components/deploy/Deploy').then(m => ({ default: m.Deploy })))
 const AIML = lazy(() => import('./components/aiml/AIML').then(m => ({ default: m.AIML })))
 const CICD = lazy(() => import('./components/cicd/CICD').then(m => ({ default: m.CICD })))
+const MiniDashboard = lazy(() => import('./components/widget/MiniDashboard').then(m => ({ default: m.MiniDashboard })))
 
 // Prefetch all lazy route chunks after initial page load.
 // This runs during idle time so by the time the user navigates,
@@ -193,6 +194,15 @@ function App() {
       <Routes>
         <Route path="/login" element={<Login />} />
         <Route path="/auth/callback" element={<AuthCallback />} />
+        {/* PWA Mini Dashboard - lightweight widget mode */}
+        <Route
+          path="/widget"
+          element={
+            <ProtectedRoute>
+              <MiniDashboard />
+            </ProtectedRoute>
+          }
+        />
         <Route
           path="/onboarding"
           element={

--- a/web/src/components/widget/MiniDashboard.tsx
+++ b/web/src/components/widget/MiniDashboard.tsx
@@ -1,0 +1,271 @@
+/**
+ * Mini Dashboard - PWA Widget Mode
+ *
+ * A compact, always-refreshing dashboard designed to be installed as a
+ * Progressive Web App (PWA) for desktop monitoring.
+ *
+ * Install: Click browser menu → "Install app" or "Add to Desktop"
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { RefreshCw, Maximize2, Settings, Download } from 'lucide-react'
+import { useClusters, useGPUNodes, usePodIssues } from '../../hooks/useMCP'
+import { cn } from '../../lib/cn'
+
+// Stat card component
+function StatCard({
+  label,
+  value,
+  color,
+  subValue,
+  onClick,
+}: {
+  label: string
+  value: string | number
+  color: string
+  subValue?: string
+  onClick?: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={!onClick}
+      className={cn(
+        'flex flex-col items-center justify-center p-3 rounded-lg',
+        'bg-gray-800/50 border border-gray-700/50',
+        'transition-all duration-200',
+        onClick && 'hover:bg-gray-700/50 hover:border-gray-600 cursor-pointer'
+      )}
+    >
+      <span className={cn('text-2xl font-bold', color)}>{value}</span>
+      <span className="text-xs text-gray-400 mt-1">{label}</span>
+      {subValue && <span className="text-[10px] text-gray-500">{subValue}</span>}
+    </button>
+  )
+}
+
+// Status indicator
+function StatusDot({ status }: { status: 'healthy' | 'warning' | 'error' }) {
+  const colors = {
+    healthy: 'bg-green-500',
+    warning: 'bg-yellow-500',
+    error: 'bg-red-500',
+  }
+  return (
+    <span className={cn('w-2 h-2 rounded-full inline-block animate-pulse', colors[status])} />
+  )
+}
+
+export function MiniDashboard() {
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+  const [installPrompt, setInstallPrompt] = useState<BeforeInstallPromptEvent | null>(null)
+  const [isInstalled, setIsInstalled] = useState(false)
+
+  // Fetch data
+  const { clusters, isLoading: clustersLoading, refetch: refetchClusters } = useClusters()
+  const { nodes: gpuNodes, isLoading: gpuLoading, refetch: refetchGPU } = useGPUNodes()
+  const { issues: podIssues, isLoading: issuesLoading, refetch: refetchIssues } = usePodIssues()
+
+  const isLoading = clustersLoading || gpuLoading || issuesLoading
+
+  // Calculate stats
+  const totalClusters = clusters?.length || 0
+  const healthyClusters = clusters?.filter((c) => c.healthy).length || 0
+  const totalGPUs = gpuNodes?.reduce((sum, n) => sum + (n.gpuCount || 0), 0) || 0
+  const allocatedGPUs = gpuNodes?.reduce((sum, n) => sum + (n.gpuAllocated || 0), 0) || 0
+  const totalIssues = podIssues?.length || 0
+  // Critical issues are those with CrashLoopBackOff, OOMKilled, or Error status
+  const criticalIssues = podIssues?.filter((i) =>
+    i.status === 'CrashLoopBackOff' || i.status === 'OOMKilled' || i.status === 'Error'
+  ).length || 0
+
+  // Overall health status
+  const overallStatus: 'healthy' | 'warning' | 'error' =
+    criticalIssues > 0 ? 'error' : totalIssues > 3 ? 'warning' : 'healthy'
+
+  // Manual refresh
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true)
+    await Promise.all([refetchClusters?.(), refetchGPU?.(), refetchIssues?.()])
+    setLastUpdated(new Date())
+    setIsRefreshing(false)
+  }, [refetchClusters, refetchGPU, refetchIssues])
+
+  // Auto-refresh every 30 seconds
+  useEffect(() => {
+    const interval = setInterval(handleRefresh, 30000)
+    return () => clearInterval(interval)
+  }, [handleRefresh])
+
+  // Update lastUpdated when data loads
+  useEffect(() => {
+    if (!isLoading && !lastUpdated) {
+      setLastUpdated(new Date())
+    }
+  }, [isLoading, lastUpdated])
+
+  // PWA install prompt
+  useEffect(() => {
+    const handler = (e: BeforeInstallPromptEvent) => {
+      e.preventDefault()
+      setInstallPrompt(e)
+    }
+    window.addEventListener('beforeinstallprompt', handler as EventListener)
+
+    // Check if already installed
+    if (window.matchMedia('(display-mode: standalone)').matches) {
+      setIsInstalled(true)
+    }
+
+    return () => window.removeEventListener('beforeinstallprompt', handler as EventListener)
+  }, [])
+
+  const handleInstall = async () => {
+    if (!installPrompt) return
+    await installPrompt.prompt()
+    const result = await installPrompt.userChoice
+    if (result.outcome === 'accepted') {
+      setIsInstalled(true)
+      setInstallPrompt(null)
+    }
+  }
+
+  // Open full dashboard in new window
+  const openFullDashboard = () => {
+    window.open('/dashboard', '_blank')
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-900 to-gray-800 text-white p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <StatusDot status={overallStatus} />
+          <h1 className="text-lg font-semibold">KC Console</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          {lastUpdated && (
+            <span className="text-xs text-gray-500">
+              {lastUpdated.toLocaleTimeString()}
+            </span>
+          )}
+          <button
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+            className="p-1.5 rounded-lg hover:bg-gray-700/50 text-gray-400 hover:text-white transition-colors disabled:opacity-50"
+            title="Refresh"
+          >
+            <RefreshCw className={cn('w-4 h-4', isRefreshing && 'animate-spin')} />
+          </button>
+          <button
+            onClick={openFullDashboard}
+            className="p-1.5 rounded-lg hover:bg-gray-700/50 text-gray-400 hover:text-white transition-colors"
+            title="Open full dashboard"
+          >
+            <Maximize2 className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Stats Grid */}
+      <div className="grid grid-cols-2 gap-3 mb-4">
+        <StatCard
+          label="Clusters"
+          value={totalClusters}
+          color="text-purple-400"
+          subValue={`${healthyClusters} healthy`}
+        />
+        <StatCard
+          label="GPUs"
+          value={totalGPUs}
+          color="text-green-400"
+          subValue={`${allocatedGPUs} allocated`}
+        />
+        <StatCard
+          label="Pod Issues"
+          value={totalIssues}
+          color={totalIssues > 0 ? 'text-orange-400' : 'text-gray-400'}
+          subValue={criticalIssues > 0 ? `${criticalIssues} critical` : undefined}
+        />
+        <StatCard
+          label="Status"
+          value={overallStatus === 'healthy' ? 'OK' : overallStatus === 'warning' ? 'Warn' : 'Alert'}
+          color={
+            overallStatus === 'healthy'
+              ? 'text-green-400'
+              : overallStatus === 'warning'
+              ? 'text-yellow-400'
+              : 'text-red-400'
+          }
+        />
+      </div>
+
+      {/* Issues List (if any) */}
+      {totalIssues > 0 && (
+        <div className="mb-4">
+          <h2 className="text-xs font-medium text-gray-400 mb-2">Recent Issues</h2>
+          <div className="space-y-1 max-h-32 overflow-y-auto">
+            {podIssues?.slice(0, 5).map((issue, i) => {
+              const isCritical = issue.status === 'CrashLoopBackOff' || issue.status === 'OOMKilled' || issue.status === 'Error'
+              return (
+                <div
+                  key={i}
+                  className="flex items-center gap-2 text-xs p-2 rounded bg-gray-800/50 border border-gray-700/30"
+                >
+                  <span
+                    className={cn(
+                      'w-1.5 h-1.5 rounded-full flex-shrink-0',
+                      isCritical ? 'bg-red-500' : 'bg-orange-500'
+                    )}
+                  />
+                  <span className="truncate text-gray-300">{issue.name}</span>
+                  <span className="text-gray-500 ml-auto flex-shrink-0">{issue.reason || issue.status}</span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Footer / Install Prompt */}
+      <div className="fixed bottom-0 left-0 right-0 p-3 bg-gray-900/90 border-t border-gray-800">
+        {!isInstalled && installPrompt ? (
+          <button
+            onClick={handleInstall}
+            className="w-full py-2 px-4 rounded-lg bg-purple-600 hover:bg-purple-700 text-white text-sm font-medium flex items-center justify-center gap-2 transition-colors"
+          >
+            <Download className="w-4 h-4" />
+            Install as Desktop Widget
+          </button>
+        ) : !isInstalled ? (
+          <div className="text-center text-xs text-gray-500">
+            <p>Use browser menu → "Install app" to add to desktop</p>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between text-xs text-gray-500">
+            <span>KC Console Widget</span>
+            <a
+              href="/settings"
+              className="flex items-center gap-1 hover:text-gray-400 transition-colors"
+            >
+              <Settings className="w-3 h-3" />
+              Settings
+            </a>
+          </div>
+        )}
+      </div>
+
+      {/* Padding for fixed footer */}
+      <div className="h-16" />
+    </div>
+  )
+}
+
+// TypeScript type for the install prompt event
+interface BeforeInstallPromptEvent extends Event {
+  prompt(): Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
+export default MiniDashboard

--- a/web/src/lib/widgets/widgetRegistry.ts
+++ b/web/src/lib/widgets/widgetRegistry.ts
@@ -125,7 +125,7 @@ export const WIDGET_CARDS: Record<string, WidgetCardDefinition> = {
   // AI/Console cards
   console_ai_offline_detection: {
     cardType: 'console_ai_offline_detection',
-    displayName: 'AI Offline Detection',
+    displayName: 'Node Offline Detection',
     description: 'Detects offline nodes and unavailable GPUs',
     apiEndpoints: ['/nodes', '/api/mcp/gpu-nodes'],
     supportsTheme: true,


### PR DESCRIPTION
## Summary
- Add Progressive Web App (PWA) mini-dashboard that can be installed as a desktop widget
- Rename "AI Offline Detection" → "Node Offline Detection" in widget registry

## PWA Mini-Dashboard

Users can now install KC Console as a desktop widget app. Navigate to `/widget` for a compact, auto-refreshing monitoring view.

### Features
- **Compact Stats Grid**: Clusters, GPUs, Pod Issues, Status at a glance
- **Auto-Refresh**: Updates every 30 seconds automatically
- **Issues List**: Shows recent pod issues when problems are detected
- **Install Prompt**: One-click "Install as Desktop Widget" for Chrome/Edge
- **Standalone Mode**: Runs without browser chrome when installed
- **Quick Access**: Open full dashboard with single click

### Installation
1. Navigate to `http://localhost:5174/widget`
2. Click "Install as Desktop Widget" or use browser menu → "Install app"
3. App appears in dock/taskbar and runs as standalone window

### Files Added
- `web/public/manifest.json` - PWA manifest with standalone display mode
- `web/src/components/widget/MiniDashboard.tsx` - Compact dashboard component
- Updated `web/index.html` with PWA meta tags
- Added `/widget` route to `App.tsx`

## Test plan
- [ ] Navigate to /widget - compact dashboard loads
- [ ] Stats show Clusters, GPUs, Pod Issues, Status
- [ ] Auto-refresh updates data every 30 seconds
- [ ] "Install as Desktop Widget" button appears in Chrome/Edge
- [ ] After install, app runs as standalone window
- [ ] "Node Offline Detection" shows in widget export modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)