### PR TITLE
🐛 Fix Safari PWA Add to Dock support

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -194,15 +194,8 @@ function App() {
       <Routes>
         <Route path="/login" element={<Login />} />
         <Route path="/auth/callback" element={<AuthCallback />} />
-        {/* PWA Mini Dashboard - lightweight widget mode */}
-        <Route
-          path="/widget"
-          element={
-            <ProtectedRoute>
-              <MiniDashboard />
-            </ProtectedRoute>
-          }
-        />
+        {/* PWA Mini Dashboard - lightweight widget mode (no auth required for local monitoring) */}
+        <Route path="/widget" element={<MiniDashboard />} />
         <Route
           path="/onboarding"
           element={


### PR DESCRIPTION
## Summary
Fix Safari's "Add to Dock" feature for the PWA mini-dashboard.

## Problem
Safari's "Add to Dock" creates a standalone app that doesn't share cookies/localStorage with Safari browser. This caused the widget to show the login page instead of the dashboard.

## Fix
- Remove auth requirement from `/widget` route (appropriate for local monitoring)
- Add Safari detection to show specific instructions: **File → Add to Dock**
- Properly detect standalone mode including Safari's `navigator.standalone`

## Test plan
1. Open http://localhost:5174/widget in Safari
2. See "Safari: File → Add to Dock to install" instruction
3. Use File → Add to Dock
4. Click dock icon - should show mini-dashboard directly (no login)

🤖 Generated with [Claude Code](https://claude.com/claude-code)