### PR TITLE
✨ Add Node Offline Detection to PWA mini-dashboard

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#7c3aed" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="KC Widget" />
+    <meta name="apple-mobile-web-app-title" content="KubeStellar" />
     <link rel="apple-touch-icon" href="/kubestellar.png" />
     <title>KubeStellar Console</title>
   </head>

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "KC Console Widget",
-  "short_name": "KC Widget",
+  "name": "KubeStellar Console Widget",
+  "short_name": "KubeStellar",
   "description": "KubeStellar Console mini-dashboard widget",
   "start_url": "/widget",
   "display": "standalone",
@@ -25,7 +25,7 @@
     {
       "name": "Full Dashboard",
       "url": "/dashboard",
-      "description": "Open full KC Console dashboard"
+      "description": "Open full KubeStellar Console dashboard"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Add Node Offline Detection to the PWA mini-dashboard widget, along with several UX improvements.

## Changes

### Node Offline Detection
- Fetches nodes from local agent (`http://127.0.0.1:8585/nodes`)
- Displays offline node count (nodes not Ready or unschedulable)
- Red indicator when nodes are offline, green when all online
- Affects overall health status indicator

### Stats Grid (6 items in 3x2 layout)
| Stat | Description |
|------|-------------|
| Clusters | Total count + healthy count |
| GPUs | Allocated/Total format (e.g., "2/8") |
| Nodes Offline | Offline count + "needs attention" or "all online" |
| Pod Issues | Issue count + critical count |
| Nodes | Total nodes + ready count |
| Status | Overall health (OK/Warn/Alert) |

### UX Improvements
- Renamed to "KubeStellar Console" throughout
- Replaced Settings link with "Open Full Dashboard" button
- GPU display now shows "allocated/total" format

## Test plan
- [ ] Open /widget - see 6 stats in 3x2 grid
- [ ] Nodes Offline shows 0 (green) when all nodes ready
- [ ] GPU shows allocated/total format
- [ ] Footer shows "Open Full Dashboard" instead of Settings
- [ ] Title shows "KubeStellar Console"

🤖 Generated with [Claude Code](https://claude.com/claude-code)