### PR TITLE
✨ Add AI/ML, GPU Reservations, and CI/CD to default sidebar

### DIFF
--- a/web/src/components/cards/workload-detection/shared.ts
+++ b/web/src/components/cards/workload-detection/shared.ts
@@ -15,11 +15,19 @@ export function useDemoData<T>(data: T): DemoState & { data: T } {
 // Keywords that indicate a cluster may have LLM-d or AI/ML workloads
 const LLMD_CLUSTER_KEYWORDS = [
   'vllm', 'llm', 'inference', 'model', 'eval', 'gpu', 'ai', 'ml',
-  'tgi', 'triton', 'serving', 'aibrix', 'hc4ai'
+  'tgi', 'triton', 'serving', 'aibrix', 'hc4ai', 'pok', 'prod',
 ]
 
 // Default clusters known to have llm-d stacks (fallback)
-export const LLMD_CLUSTERS = ['vllm-d', 'platform-eval']
+// pok-prod-* clusters often have production LLM workloads
+export const LLMD_CLUSTERS = [
+  'vllm-d',
+  'platform-eval',
+  'pok-prod-0001',
+  'pok-prod-0002',
+  'pokprod001',
+  'pokprod002',
+]
 
 /**
  * Dynamically discover clusters that likely have LLM-d stacks

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -43,17 +43,20 @@ const DEFAULT_PRIMARY_NAV: SidebarItem[] = [
   { id: 'dashboard', name: 'Dashboard', icon: 'LayoutDashboard', href: '/', type: 'link', order: 0 },
   { id: 'clusters', name: 'Clusters', icon: 'Server', href: '/clusters', type: 'link', order: 1 },
   { id: 'workloads', name: 'Workloads', icon: 'Box', href: '/workloads', type: 'link', order: 2 },
-  { id: 'compute', name: 'Compute', icon: 'Cpu', href: '/compute', type: 'link', order: 3 },
-  { id: 'storage', name: 'Storage', icon: 'HardDrive', href: '/storage', type: 'link', order: 4 },
-  { id: 'network', name: 'Network', icon: 'Globe', href: '/network', type: 'link', order: 5 },
-  { id: 'events', name: 'Events', icon: 'Activity', href: '/events', type: 'link', order: 6 },
-  { id: 'security', name: 'Security', icon: 'Shield', href: '/security', type: 'link', order: 7 },
-  { id: 'security-posture', name: 'Security Posture', icon: 'ShieldCheck', href: '/security-posture', type: 'link', order: 8 },
-  { id: 'data-compliance', name: 'Data Compliance', icon: 'Database', href: '/data-compliance', type: 'link', order: 9 },
-  { id: 'gitops', name: 'GitOps', icon: 'GitBranch', href: '/gitops', type: 'link', order: 10 },
-  { id: 'alerts', name: 'Alerts', icon: 'Bell', href: '/alerts', type: 'link', order: 11 },
-  { id: 'arcade', name: 'Arcade', icon: 'Gamepad2', href: '/arcade', type: 'link', order: 12 },
-  { id: 'deploy', name: 'Deploy', icon: 'Rocket', href: '/deploy', type: 'link', order: 13 },
+  { id: 'ai-ml', name: 'AI/ML', icon: 'Sparkles', href: '/ai-ml', type: 'link', order: 3 },
+  { id: 'gpu-reservations', name: 'GPU Reservations', icon: 'Cpu', href: '/gpu-reservations', type: 'link', order: 4 },
+  { id: 'ci-cd', name: 'CI/CD', icon: 'GitMerge', href: '/ci-cd', type: 'link', order: 5 },
+  { id: 'compute', name: 'Compute', icon: 'Monitor', href: '/compute', type: 'link', order: 6 },
+  { id: 'storage', name: 'Storage', icon: 'HardDrive', href: '/storage', type: 'link', order: 7 },
+  { id: 'network', name: 'Network', icon: 'Globe', href: '/network', type: 'link', order: 8 },
+  { id: 'events', name: 'Events', icon: 'Activity', href: '/events', type: 'link', order: 9 },
+  { id: 'security', name: 'Security', icon: 'Shield', href: '/security', type: 'link', order: 10 },
+  { id: 'security-posture', name: 'Security Posture', icon: 'ShieldCheck', href: '/security-posture', type: 'link', order: 11 },
+  { id: 'data-compliance', name: 'Data Compliance', icon: 'Database', href: '/data-compliance', type: 'link', order: 12 },
+  { id: 'gitops', name: 'GitOps', icon: 'GitBranch', href: '/gitops', type: 'link', order: 13 },
+  { id: 'alerts', name: 'Alerts', icon: 'Bell', href: '/alerts', type: 'link', order: 14 },
+  { id: 'arcade', name: 'Arcade', icon: 'Gamepad2', href: '/arcade', type: 'link', order: 15 },
+  { id: 'deploy', name: 'Deploy', icon: 'Rocket', href: '/deploy', type: 'link', order: 16 },
 ]
 
 const DEFAULT_SECONDARY_NAV: SidebarItem[] = [
@@ -72,8 +75,8 @@ const DEFAULT_CONFIG: SidebarConfig = {
   isMobileOpen: false,
 }
 
-const STORAGE_KEY = 'kubestellar-sidebar-config-v5'
-const OLD_STORAGE_KEY = 'kubestellar-sidebar-config-v4'
+const STORAGE_KEY = 'kubestellar-sidebar-config-v6'
+const OLD_STORAGE_KEY = 'kubestellar-sidebar-config-v5'
 
 // Routes to remove during migration (deprecated/removed routes)
 const DEPRECATED_ROUTES = ['/apps']
@@ -368,4 +371,5 @@ export const AVAILABLE_ICONS = [
   'Key', 'Users', 'Bell', 'AlertTriangle', 'CheckCircle', 'XCircle',
   'RefreshCw', 'Search', 'Filter', 'Layers', 'Globe', 'Terminal',
   'Code', 'Cpu', 'HardDrive', 'Wifi', 'Monitor', 'Folder', 'Gamepad2',
+  'Sparkles', 'GitMerge', 'Rocket', 'ShieldCheck',
 ]


### PR DESCRIPTION
## Summary
- Add AI/ML, GPU Reservations, and CI/CD dashboards to default sidebar navigation
- Add pok-prod clusters to LLMD_CLUSTERS for scanning production LLM workloads
- Add 'pok' and 'prod' to cluster discovery keywords for dynamic detection
- Bump sidebar config version to v6 to migrate existing users
- Add Sparkles, GitMerge, Rocket, ShieldCheck to available sidebar icons

This makes the AI-ML infrastructure dashboards more visible in the sidebar and ensures production clusters with LLM-d stacks (like pok-prod-0001) are scanned by default.

## Test plan
- [ ] Verify AI/ML, GPU Reservations, and CI/CD appear in sidebar after clearing localStorage (or for new users)
- [ ] Verify LLM Inference card scans pok-prod clusters
- [ ] Verify sidebar migration works for existing users

🤖 Generated with [Claude Code](https://claude.com/claude-code)