### PR TITLE
✨ Add all available dashboards to sidebar

### DIFF
--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -46,19 +46,28 @@ const DEFAULT_PRIMARY_NAV: SidebarItem[] = [
   { id: 'deploy', name: 'Deploy', icon: 'Rocket', href: '/deploy', type: 'link', order: 2 },
   { id: 'ai-ml', name: 'AI/ML', icon: 'Sparkles', href: '/ai-ml', type: 'link', order: 3 },
   { id: 'ci-cd', name: 'CI/CD', icon: 'GitMerge', href: '/ci-cd', type: 'link', order: 4 },
-  // All other dashboards
-  { id: 'gpu-reservations', name: 'GPU Reservations', icon: 'Cpu', href: '/gpu-reservations', type: 'link', order: 5 },
-  { id: 'workloads', name: 'Workloads', icon: 'Box', href: '/workloads', type: 'link', order: 6 },
-  { id: 'compute', name: 'Compute', icon: 'Monitor', href: '/compute', type: 'link', order: 7 },
-  { id: 'storage', name: 'Storage', icon: 'HardDrive', href: '/storage', type: 'link', order: 8 },
-  { id: 'network', name: 'Network', icon: 'Globe', href: '/network', type: 'link', order: 9 },
-  { id: 'events', name: 'Events', icon: 'Activity', href: '/events', type: 'link', order: 10 },
-  { id: 'security', name: 'Security', icon: 'Shield', href: '/security', type: 'link', order: 11 },
-  { id: 'security-posture', name: 'Security Posture', icon: 'ShieldCheck', href: '/security-posture', type: 'link', order: 12 },
-  { id: 'data-compliance', name: 'Data Compliance', icon: 'Database', href: '/data-compliance', type: 'link', order: 13 },
-  { id: 'gitops', name: 'GitOps', icon: 'GitBranch', href: '/gitops', type: 'link', order: 14 },
-  { id: 'alerts', name: 'Alerts', icon: 'Bell', href: '/alerts', type: 'link', order: 15 },
-  { id: 'arcade', name: 'Arcade', icon: 'Gamepad2', href: '/arcade', type: 'link', order: 16 },
+  // All other dashboards (alphabetical)
+  { id: 'alerts', name: 'Alerts', icon: 'Bell', href: '/alerts', type: 'link', order: 5 },
+  { id: 'arcade', name: 'Arcade', icon: 'Gamepad2', href: '/arcade', type: 'link', order: 6 },
+  { id: 'compliance', name: 'Compliance', icon: 'ClipboardCheck', href: '/compliance', type: 'link', order: 7 },
+  { id: 'compute', name: 'Compute', icon: 'Monitor', href: '/compute', type: 'link', order: 8 },
+  { id: 'cost', name: 'Cost', icon: 'DollarSign', href: '/cost', type: 'link', order: 9 },
+  { id: 'data-compliance', name: 'Data Compliance', icon: 'Database', href: '/data-compliance', type: 'link', order: 10 },
+  { id: 'deployments', name: 'Deployments', icon: 'Layers', href: '/deployments', type: 'link', order: 11 },
+  { id: 'events', name: 'Events', icon: 'Activity', href: '/events', type: 'link', order: 12 },
+  { id: 'gitops', name: 'GitOps', icon: 'GitBranch', href: '/gitops', type: 'link', order: 13 },
+  { id: 'gpu-reservations', name: 'GPU Reservations', icon: 'Cpu', href: '/gpu-reservations', type: 'link', order: 14 },
+  { id: 'helm', name: 'Helm', icon: 'Package', href: '/helm', type: 'link', order: 15 },
+  { id: 'logs', name: 'Logs', icon: 'FileText', href: '/logs', type: 'link', order: 16 },
+  { id: 'network', name: 'Network', icon: 'Globe', href: '/network', type: 'link', order: 17 },
+  { id: 'nodes', name: 'Nodes', icon: 'CircuitBoard', href: '/nodes', type: 'link', order: 18 },
+  { id: 'operators', name: 'Operators', icon: 'Cog', href: '/operators', type: 'link', order: 19 },
+  { id: 'pods', name: 'Pods', icon: 'Hexagon', href: '/pods', type: 'link', order: 20 },
+  { id: 'security', name: 'Security', icon: 'Shield', href: '/security', type: 'link', order: 21 },
+  { id: 'security-posture', name: 'Security Posture', icon: 'ShieldCheck', href: '/security-posture', type: 'link', order: 22 },
+  { id: 'services', name: 'Services', icon: 'Network', href: '/services', type: 'link', order: 23 },
+  { id: 'storage', name: 'Storage', icon: 'HardDrive', href: '/storage', type: 'link', order: 24 },
+  { id: 'workloads', name: 'Workloads', icon: 'Box', href: '/workloads', type: 'link', order: 25 },
 ]
 
 const DEFAULT_SECONDARY_NAV: SidebarItem[] = [
@@ -77,8 +86,8 @@ const DEFAULT_CONFIG: SidebarConfig = {
   isMobileOpen: false,
 }
 
-const STORAGE_KEY = 'kubestellar-sidebar-config-v7'
-const OLD_STORAGE_KEY = 'kubestellar-sidebar-config-v6'
+const STORAGE_KEY = 'kubestellar-sidebar-config-v8'
+const OLD_STORAGE_KEY = 'kubestellar-sidebar-config-v7'
 
 // Routes to remove during migration (deprecated/removed routes)
 const DEPRECATED_ROUTES = ['/apps']
@@ -373,5 +382,6 @@ export const AVAILABLE_ICONS = [
   'Key', 'Users', 'Bell', 'AlertTriangle', 'CheckCircle', 'XCircle',
   'RefreshCw', 'Search', 'Filter', 'Layers', 'Globe', 'Terminal',
   'Code', 'Cpu', 'HardDrive', 'Wifi', 'Monitor', 'Folder', 'Gamepad2',
-  'Sparkles', 'GitMerge', 'Rocket', 'ShieldCheck',
+  'Sparkles', 'GitMerge', 'Rocket', 'ShieldCheck', 'ClipboardCheck',
+  'DollarSign', 'Package', 'FileText', 'CircuitBoard', 'Cog', 'Hexagon', 'Network',
 ]


### PR DESCRIPTION
## Summary
Add all dashboard routes to the default sidebar navigation for console.kubestellar.io

**Priority (top 5):**
1. Dashboard
2. Clusters
3. Deploy
4. AI/ML
5. CI/CD

**All other dashboards (alphabetical):**
- Alerts
- Arcade
- Compliance
- Compute
- Cost
- Data Compliance
- Deployments
- Events
- GitOps
- GPU Reservations
- Helm
- Logs
- Network
- Nodes
- Operators
- Pods
- Security
- Security Posture
- Services
- Storage
- Workloads

## Test plan
- [ ] Verify all 26 dashboards appear in sidebar on console.kubestellar.io
- [ ] Verify priority dashboards are at the top
- [ ] Clear localStorage to test fresh user experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)