### PR TITLE
🐛 Fix extractHostname reference error in HardwareHealthCard

### DIFF
--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -184,14 +184,6 @@ export function HardwareHealthCard() {
     hasAnyData: alerts.length > 0 || inventory.length > 0 || nodeCount > 0,
   })
 
-  // Node count should use deduplicated inventory (same logic as deduplicatedInventory)
-  // This is computed before deduplicatedInventory but uses the same extractHostname logic
-  const deduplicatedNodeCount = useMemo(() => {
-    const uniqueHostnames = new Set<string>()
-    inventory.forEach(node => uniqueHostnames.add(extractHostname(node.nodeName)))
-    return uniqueHostnames.size || nodeCount
-  }, [inventory, nodeCount])
-
   // Fetch device alerts and inventory
   useEffect(() => {
     if (getDemoMode()) {
@@ -323,6 +315,9 @@ export function HardwareHealthCard() {
     })
     return Array.from(byHostname.values())
   }, [inventory])
+
+  // Node count should use deduplicated inventory count for consistency
+  const deduplicatedNodeCount = deduplicatedInventory.length || nodeCount
 
   // Available clusters for filtering (from deduplicated data)
   const availableClustersForFilter = useMemo(() => {


### PR DESCRIPTION
## Summary
- Fix runtime error: "Cannot access 'extractHostname' before initialization"
- Move `deduplicatedNodeCount` to be defined after `extractHostname`
- Simplify to use `deduplicatedInventory.length` directly

## Root Cause
PR #562 added `extractHostname` usage in `deduplicatedNodeCount`, but the variable order caused a temporal dead zone error.

## Test plan
- [ ] Clusters dashboard loads without error
- [ ] Hardware Health card displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)