### PR TITLE
🎨 Use solid dark background for card info tooltips

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1012,7 +1012,7 @@ export function CardWrapper({
             {description && (
               <span className="relative group/info">
                 <Info className="w-3.5 h-3.5 text-muted-foreground/50 hover:text-muted-foreground cursor-help transition-colors" />
-                <span className="absolute left-1/2 -translate-x-1/2 top-full mt-1.5 w-56 px-2.5 py-1.5 rounded-md bg-popover border border-border text-xs text-muted-foreground shadow-lg opacity-0 pointer-events-none group-hover/info:opacity-100 group-hover/info:pointer-events-auto transition-opacity z-50 leading-relaxed">
+                <span className="absolute left-1/2 -translate-x-1/2 top-full mt-1.5 w-56 px-2.5 py-1.5 rounded-md bg-zinc-900 border border-zinc-700 text-xs text-zinc-300 shadow-lg opacity-0 pointer-events-none group-hover/info:opacity-100 group-hover/info:pointer-events-auto transition-opacity z-50 leading-relaxed">
                   {description}
                 </span>
               </span>


### PR DESCRIPTION
## Summary
Change card info tooltip background from transparent `bg-popover` to solid `bg-zinc-900` for better readability.

Before: Transparent background showing content behind
After: Solid dark background with visible text

## Test plan
- [ ] Hover over (i) icon on any card
- [ ] Verify tooltip has solid dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)