### PR TITLE
✨ Always show info icon on all cards

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1009,14 +1009,12 @@ export function CardWrapper({
             {dragHandle}
             {ResolvedIcon && <ResolvedIcon className={cn('w-4 h-4', resolvedIconColor)} />}
             <h3 className="text-sm font-medium text-foreground">{title}</h3>
-            {description && (
-              <span className="relative group/info">
-                <Info className="w-3.5 h-3.5 text-muted-foreground/50 hover:text-muted-foreground cursor-help transition-colors" />
-                <span className="absolute left-1/2 -translate-x-1/2 top-full mt-1.5 w-56 px-2.5 py-1.5 rounded-md bg-zinc-900 border border-zinc-700 text-xs text-zinc-300 shadow-lg opacity-0 pointer-events-none group-hover/info:opacity-100 group-hover/info:pointer-events-auto transition-opacity z-50 leading-relaxed">
-                  {description}
-                </span>
+            <span className="relative group/info">
+              <Info className="w-3.5 h-3.5 text-muted-foreground/50 hover:text-muted-foreground cursor-help transition-colors" />
+              <span className="absolute left-1/2 -translate-x-1/2 top-full mt-1.5 w-56 px-2.5 py-1.5 rounded-md bg-zinc-900 border border-zinc-700 text-xs text-zinc-300 shadow-lg opacity-0 pointer-events-none group-hover/info:opacity-100 group-hover/info:pointer-events-auto transition-opacity z-50 leading-relaxed">
+                {description || `${title} card. Description coming soon.`}
               </span>
-            )}
+            </span>
             {/* Demo data indicator - shows if global demo mode is on OR card uses demo data */}
             {(isDemoMode || isDemoData) && (
               <span


### PR DESCRIPTION
## Summary
Part of unified card framework - info icon now appears on every card header, not just cards with descriptions.

- Cards with `CARD_DESCRIPTIONS` entry: Shows the description
- Cards without description: Shows fallback "{title} card. Description coming soon."

## Test plan
- [ ] Verify info (i) icon appears on all cards
- [ ] Cards with descriptions show proper text
- [ ] Cards without descriptions show fallback text

🤖 Generated with [Claude Code](https://claude.com/claude-code)