### PR TITLE
🐛 Slow down prediction analysis to default 1 hour

### DIFF
--- a/web/src/components/settings/sections/PredictionSettingsSection.tsx
+++ b/web/src/components/settings/sections/PredictionSettingsSection.tsx
@@ -35,7 +35,7 @@ export function PredictionSettingsSection({
   }
 
   const handleIntervalChange = (value: number) => {
-    updateSettings({ interval: Math.min(Math.max(value, 5), 30) })
+    updateSettings({ interval: Math.min(Math.max(value, 15), 120) })
   }
 
   const handleConfidenceChange = (value: number) => {
@@ -119,8 +119,9 @@ export function PredictionSettingsSection({
               </div>
               <input
                 type="range"
-                min="5"
-                max="30"
+                min="15"
+                max="120"
+                step="15"
                 value={settings.interval}
                 onChange={(e) => handleIntervalChange(parseInt(e.target.value))}
                 className="w-full h-2 bg-secondary rounded-full appearance-none cursor-pointer
@@ -132,8 +133,8 @@ export function PredictionSettingsSection({
                   [&::-webkit-slider-thumb]:cursor-pointer"
               />
               <div className="flex justify-between text-xs text-muted-foreground mt-1">
-                <span>5 min (more updates)</span>
-                <span>30 min (fewer API calls)</span>
+                <span>15 min</span>
+                <span>2 hours</span>
               </div>
             </div>
 

--- a/web/src/types/predictions.ts
+++ b/web/src/types/predictions.ts
@@ -164,7 +164,7 @@ export interface MetricsSnapshot {
 export interface PredictionSettings {
   /** Enable/disable AI predictions */
   aiEnabled: boolean
-  /** Minutes between AI analysis runs (5-30) */
+  /** Minutes between AI analysis runs (15-120) */
   interval: number
   /** Minimum confidence threshold (50-90) */
   minConfidence: number
@@ -210,7 +210,7 @@ export interface PredictionSettingsMessage {
  */
 export const DEFAULT_PREDICTION_SETTINGS: PredictionSettings = {
   aiEnabled: true,
-  interval: 10,
+  interval: 60,
   minConfidence: 60,
   maxPredictions: 10,
   consensusMode: false,


### PR DESCRIPTION
## Summary
- Change default AI prediction interval from 10 minutes to 60 minutes (1 hour)
- Extend slider range from 5-30 to 15-120 minutes
- Add 15-minute step for cleaner interval selection

This reduces API calls and resource usage while still allowing users to configure more frequent analysis if needed.

## Test plan
- [ ] Open Settings > Predictive Failure Detection
- [ ] Verify slider shows 15 min to 2 hours range
- [ ] Verify default value is 60 minutes
- [ ] Verify slider steps in 15 minute increments

🤖 Generated with [Claude Code](https://claude.com/claude-code)