### PR TITLE
🐛 Skip fetching in demo mode to prevent console errors

### DIFF
--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
+import { isDemoModeForced } from '../useDemoMode'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL } from './shared'
 import type { ClusterEvent } from './types'
 
@@ -35,6 +36,16 @@ export function useEvents(cluster?: string, namespace?: string, limit = 20) {
   const [lastRefresh, setLastRefresh] = useState<Date | null>(cached?.timestamp || null)
 
   const refetch = useCallback(async (silent = false) => {
+    // Skip fetching entirely in forced demo mode (Netlify) — no backend or agent
+    if (isDemoModeForced) {
+      if (!eventsCache) {
+        setEvents(getDemoEvents())
+      }
+      setIsLoading(false)
+      setIsRefreshing(false)
+      return
+    }
+
     // Skip backend fetch in demo mode - use cached or demo data
     const token = localStorage.getItem('token')
     if (!token || token === 'demo-token') {

--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { isDemoModeForced } from '../useDemoMode'
 import { MIN_REFRESH_INDICATOR_MS, getEffectiveInterval } from './shared'
 import type { HelmRelease, HelmHistoryEntry } from './types'
 
@@ -93,6 +94,14 @@ export function useHelmReleases(cluster?: string) {
   }, [])
 
   const refetch = useCallback(async (silent = false) => {
+    // Skip fetching entirely in forced demo mode (Netlify) — no backend
+    if (isDemoModeForced) {
+      setIsLoading(false)
+      setIsRefreshing(false)
+      notifyListeners(false)
+      return
+    }
+
     if (!silent) {
       setIsLoading(true)
     } else {

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { api, isBackendUnavailable } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
-import { getDemoMode } from '../useDemoMode'
+import { getDemoMode, isDemoModeForced } from '../useDemoMode'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef } from './shared'
 import type { PodInfo, PodIssue, Deployment, DeploymentIssue, Job, HPA, ReplicaSet, StatefulSet, DaemonSet, CronJob } from './types'
@@ -720,6 +720,14 @@ export function useDeployments(cluster?: string, namespace?: string) {
   }, [cluster, namespace])
 
   const refetch = useCallback(async (silent = false) => {
+    // Skip fetching entirely in demo mode — no backend or agent available
+    if (isDemoModeForced) {
+      setDeployments([])
+      setIsLoading(false)
+      setIsRefreshing(false)
+      return
+    }
+
     // For silent (background) refreshes, don't update loading states - prevents UI flashing
     if (!silent) {
       // Always set isRefreshing first so indicator shows

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -691,6 +691,9 @@ function formatTimeAgo(timestamp: string): string {
 }
 
 async function fetchProwJobs(prowCluster: string, namespace: string): Promise<ProwJob[]> {
+  // Skip fetching in demo mode — no agent available
+  if (isDemoModeForced) return []
+
   const response = await kubectlProxy.exec(
     ['get', 'prowjobs', '-n', namespace, '-o', 'json', '--sort-by=.metadata.creationTimestamp'],
     { context: prowCluster, timeout: 30000 }
@@ -881,6 +884,9 @@ function extractGPUInfo(deployment: DeploymentResource): { gpu?: string; gpuCoun
 }
 
 async function fetchLLMdServers(clusters: string[]): Promise<LLMdServer[]> {
+  // Skip fetching in demo mode — no agent available
+  if (isDemoModeForced) return []
+
   const allServers: LLMdServer[] = []
   const keyNamespaces = ['b2', 'e2e-helm', 'e2e-solution', 'e2e-pd', 'effi', 'effi2', 'guygir',
     'llm-d', 'aibrix-system', 'hc4ai-operator', 'hc4ai-operator-dev', 'e2e-solution-platform-eval', 'inference-router-test']
@@ -1027,6 +1033,9 @@ export function useCachedLLMdServers(
 }
 
 async function fetchLLMdModels(clusters: string[]): Promise<LLMdModel[]> {
+  // Skip fetching in demo mode — no agent available
+  if (isDemoModeForced) return []
+
   const allModels: LLMdModel[] = []
   for (const cluster of clusters) {
     try {


### PR DESCRIPTION
## Summary
Add `isDemoModeForced` guards to all data fetching functions that use kubectl proxy or REST API endpoints. This prevents console errors when running on the Netlify demo site.

## Problem
When running in demo mode (especially forced demo mode on Netlify), the console was spamming errors:
- `Error: Agent unavailable in demo mode` from kubectlProxy
- `net::ERR_CONNECTION_REFUSED` for `/api/mcp/deployments`, `/api/mcp/events`, `/api/gitops/helm-releases`
- WebSocket connection failures

## Solution
Added early-return guards that check `isDemoModeForced` at the start of fetch functions:

**useCachedData.ts:**
- `fetchLLMdModels` - skip kubectl proxy calls
- `fetchLLMdServers` - skip kubectl proxy calls  
- `fetchProwJobs` - skip kubectl proxy calls

**workloads.ts:**
- `useDeployments.refetch` - skip all API/agent calls

**events.ts:**
- `useEvents.refetch` - skip all API/agent calls

**helm.ts:**
- `useHelmReleases.refetch` - skip all API calls

## Test plan
- [ ] Load console.kubestellar.io (Netlify demo)
- [ ] Open browser console
- [ ] Verify no "Agent unavailable" or "ERR_CONNECTION_REFUSED" errors
- [ ] Navigate to different dashboards, verify no fetch errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)