### PR TITLE
Refactor ActiveAlerts and DeploymentStatus to use CardClusterFilter

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -1,5 +1,4 @@
 import { useState, useMemo, useCallback } from 'react'
-import { createPortal } from 'react-dom'
 import {
   AlertTriangle,
   CheckCircle,
@@ -7,8 +6,6 @@ import {
   ChevronRight,
   Bot,
   Server,
-  Filter,
-  ChevronDown,
   Eye,
   EyeOff,
   ExternalLink,
@@ -22,7 +19,7 @@ import { getSeverityIcon } from '../../types/alerts'
 import type { Alert, AlertSeverity } from '../../types/alerts'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
-import { useCardData } from '../../lib/cards'
+import { useCardData, CardClusterFilter } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
 
 // Format relative time
@@ -121,10 +118,6 @@ export function ActiveAlerts() {
       showClusterFilter,
       setShowClusterFilter,
       clusterFilterRef,
-
-      clusterFilterBtnRef,
-
-      dropdownStyle,
     },
     sorting: {
       sortBy,
@@ -242,55 +235,16 @@ export function ActiveAlerts() {
             )}
           </button>
           {/* 2. Cluster Filter */}
-          {availableClustersForFilter.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0
-                          ? 'bg-purple-500/20 text-purple-400'
-                          : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClustersForFilter.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name)
-                            ? 'bg-purple-500/20 text-purple-400'
-                            : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClustersForFilter}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={clearClusterFilter}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
           {/* 3. CardControls */}
           <CardControls
             limit={itemsPerPage}

--- a/web/src/components/cards/DeploymentStatus.tsx
+++ b/web/src/components/cards/DeploymentStatus.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from 'react'
-import { createPortal } from 'react-dom'
-import { CheckCircle, Clock, XCircle, ChevronRight, Search, Filter, ChevronDown, Server } from 'lucide-react'
+import { CheckCircle, Clock, XCircle, ChevronRight, Search, Filter, Server } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCachedDeployments } from '../../hooks/useCachedData'
@@ -14,6 +13,7 @@ import {
   useCardFilters,
   useStatusFilter,
   commonComparators,
+  CardClusterFilter,
   type SortDirection,
 } from '../../lib/cards'
 
@@ -134,10 +134,6 @@ export function DeploymentStatus() {
       showClusterFilter,
       setShowClusterFilter,
       clusterFilterRef,
-
-      clusterFilterBtnRef,
-
-      dropdownStyle,
     },
     sorting: {
       sortBy,
@@ -228,52 +224,16 @@ export function DeploymentStatus() {
           )}
 
           {/* Cluster filter dropdown */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClusters}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={clearClusterFilter}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
 
           <CardControls
             limit={itemsPerPage}


### PR DESCRIPTION
## Summary
- Replace custom cluster filter dropdown implementations with the unified CardClusterFilter component
- Remove unused imports (createPortal, Filter, ChevronDown)
- Remove unused destructured variables (clusterFilterBtnRef, dropdownStyle)

This improves code consistency across cards and reduces duplication.

## Test plan
- [ ] Verify ActiveAlerts card cluster filter dropdown works correctly
- [ ] Verify DeploymentStatus card cluster filter dropdown works correctly
- [ ] Verify cluster status indicators appear in dropdowns (if clusters have health data)
- [ ] No visual changes to the filter dropdown behavior

Generated with [Claude Code](https://claude.com/claude-code)