### PR TITLE
✨ Convert cards to unified CardClusterFilter and CardSearchInput

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -9,7 +9,6 @@ import {
   Eye,
   EyeOff,
   ExternalLink,
-  Search,
 } from 'lucide-react'
 import { useAlerts } from '../../hooks/useAlerts'
 import { useGlobalFilters, type SeverityLevel } from '../../hooks/useGlobalFilters'
@@ -19,7 +18,7 @@ import { getSeverityIcon } from '../../types/alerts'
 import type { Alert, AlertSeverity } from '../../types/alerts'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
-import { useCardData, CardClusterFilter } from '../../lib/cards'
+import { useCardData, CardClusterFilter, CardSearchInput } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
 
 // Format relative time
@@ -261,16 +260,11 @@ export function ActiveAlerts() {
       </div>
 
       {/* Local Search */}
-      <div className="relative mb-3">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={localSearch}
-          onChange={(e) => setLocalSearch(e.target.value)}
-          placeholder="Search alerts..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={localSearch}
+        onChange={setLocalSearch}
+        placeholder="Search alerts..."
+      />
 
       {/* Stats Row */}
       <div className="grid grid-cols-3 gap-2 mb-3">

--- a/web/src/components/cards/ArgoCDSyncStatus.tsx
+++ b/web/src/components/cards/ArgoCDSyncStatus.tsx
@@ -1,7 +1,6 @@
-import { createPortal } from 'react-dom'
-import { CheckCircle, RefreshCw, AlertTriangle, ExternalLink, AlertCircle, Filter, ChevronDown, Server } from 'lucide-react'
+import { CheckCircle, RefreshCw, AlertTriangle, ExternalLink, AlertCircle, Server } from 'lucide-react'
 import { Skeleton } from '../ui/Skeleton'
-import { useChartFilters } from '../../lib/cards'
+import { useChartFilters, CardClusterFilter } from '../../lib/cards'
 import { useArgoCDSyncStatus } from '../../hooks/useArgoCD'
 import { useCardLoadingState } from './CardDataContext'
 
@@ -19,10 +18,6 @@ export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
     showClusterFilter,
     setShowClusterFilter,
     clusterFilterRef,
-
-    clusterFilterBtnRef,
-
-    dropdownStyle,
   } = useChartFilters({
     storageKey: 'argocd-sync-status',
   })
@@ -84,52 +79,16 @@ export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
           )}
 
           {/* Cluster filter dropdown */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClusters}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={clearClusterFilter}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
 
           <a
             href="https://argo-cd.readthedocs.io/"

--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -1,9 +1,8 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
-import { createPortal } from 'react-dom'
 import { TimeSeriesChart, MultiSeriesChart } from '../charts'
 import { useClusters } from '../../hooks/useMCP'
-import { Server, Clock, Filter, ChevronDown, Layers, TrendingUp } from 'lucide-react'
-import { useChartFilters } from '../../lib/cards'
+import { Server, Clock, Layers, TrendingUp } from 'lucide-react'
+import { useChartFilters, CardClusterFilter } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
 
 type TimeRange = '15m' | '1h' | '6h' | '24h'
@@ -69,8 +68,6 @@ export function ClusterMetrics() {
     showClusterFilter,
     setShowClusterFilter,
     clusterFilterRef,
-    clusterFilterBtnRef,
-    dropdownStyle,
   } = useChartFilters({ storageKey: 'cluster-metrics' })
 
   // Load history from localStorage
@@ -288,54 +285,16 @@ export function ClusterMetrics() {
         </div>
 
         {/* Cluster Filter */}
-        {availableClustersForFilter.length >= 1 && (
-          <div ref={clusterFilterRef} className="relative">
-            <button
-              ref={clusterFilterBtnRef}
-              onClick={() => setShowClusterFilter(!showClusterFilter)}
-              className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                localClusterFilter.length > 0
-                  ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                  : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-              }`}
-              title="Filter by cluster"
-            >
-              <Filter className="w-3 h-3" />
-              <ChevronDown className="w-3 h-3" />
-            </button>
-
-            {showClusterFilter && dropdownStyle && createPortal(
-              <div
-                className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                onMouseDown={e => e.stopPropagation()}
-              >
-                <div className="p-1">
-                  <button
-                    onClick={clearClusterFilter}
-                    className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                      localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                    }`}
-                  >
-                    All clusters
-                  </button>
-                  {availableClustersForFilter.map(cluster => (
-                    <button
-                      key={cluster.name}
-                      onClick={() => toggleClusterFilter(cluster.name)}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      {cluster.name}
-                    </button>
-                  ))}
-                </div>
-              </div>,
-              document.body
-            )}
-          </div>
-        )}
+        <CardClusterFilter
+          availableClusters={availableClustersForFilter}
+          selectedClusters={localClusterFilter}
+          onToggle={toggleClusterFilter}
+          onClear={clearClusterFilter}
+          isOpen={showClusterFilter}
+          setIsOpen={setShowClusterFilter}
+          containerRef={clusterFilterRef}
+          minClusters={1}
+        />
 
         {/* Chart Mode Toggle */}
         {clusters.length >= 1 && (

--- a/web/src/components/cards/ComputeOverview.tsx
+++ b/web/src/components/cards/ComputeOverview.tsx
@@ -1,11 +1,10 @@
 import { useMemo } from 'react'
-import { createPortal } from 'react-dom'
-import { Cpu, MemoryStick, Zap, Server, Box, Filter, ChevronDown, Activity } from 'lucide-react'
+import { Cpu, MemoryStick, Zap, Server, Box, Activity } from 'lucide-react'
 import { useClusters, useGPUNodes } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { formatStat, formatMemoryStat } from '../../lib/formatStats'
-import { useChartFilters } from '../../lib/cards'
+import { useChartFilters, CardClusterFilter } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
 import { ClusterStatusDot } from '../ui/ClusterStatusBadge'
 
@@ -24,10 +23,6 @@ export function ComputeOverview() {
     showClusterFilter,
     setShowClusterFilter,
     clusterFilterRef,
-
-    clusterFilterBtnRef,
-
-    dropdownStyle,
   } = useChartFilters({
     storageKey: 'compute-overview',
   })
@@ -164,52 +159,16 @@ export function ComputeOverview() {
           )}
 
           {/* Cluster filter dropdown */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClusters}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={clearClusterFilter}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
 
         </div>
       </div>

--- a/web/src/components/cards/DeploymentProgress.tsx
+++ b/web/src/components/cards/DeploymentProgress.tsx
@@ -1,9 +1,8 @@
 import { useState, useMemo } from 'react'
-import { createPortal } from 'react-dom'
-import { CheckCircle, Clock, XCircle, Loader2, Search, Filter, ChevronRight, ChevronDown, Server } from 'lucide-react'
+import { CheckCircle, Clock, XCircle, Loader2, Filter, ChevronRight, Server } from 'lucide-react'
 import { useCachedDeployments } from '../../hooks/useCachedData'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { ClusterStatusDot, getClusterState } from '../ui/ClusterStatusBadge'
+import { CardClusterFilter, CardSearchInput } from '../../lib/cards'
 import { Pagination } from '../ui/Pagination'
 import { CardControls } from '../ui/CardControls'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -211,70 +210,16 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
         </div>
         <div className="flex items-center gap-2">
           {/* Cluster Filter */}
-          {filters.availableClusters.length >= 1 && (
-            <div ref={filters.clusterFilterRef} className="relative">
-              <button
-                ref={filters.clusterFilterBtnRef}
-                onClick={() => filters.setShowClusterFilter(!filters.showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  filters.localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {filters.showClusterFilter && filters.dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: filters.dropdownStyle.top, left: filters.dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={filters.clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        filters.localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {filters.availableClusters.map(cluster => {
-                      const clusterState = getClusterState(
-                        cluster.healthy ?? true,
-                        cluster.reachable,
-                        cluster.nodeCount,
-                        undefined,
-                        cluster.errorType
-                      )
-                      const stateLabel = clusterState === 'healthy' ? '' :
-                        clusterState === 'degraded' ? 'degraded' :
-                        clusterState === 'unreachable-auth' ? 'needs auth' :
-                        clusterState.startsWith('unreachable') ? 'offline' : ''
-                      return (
-                        <button
-                          key={cluster.name}
-                          onClick={() => filters.toggleClusterFilter(cluster.name)}
-                          className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors flex items-center gap-2 ${
-                            filters.localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                          }`}
-                          title={stateLabel ? `${cluster.name} (${stateLabel})` : cluster.name}
-                        >
-                          <ClusterStatusDot state={clusterState} size="sm" />
-                          <span className="flex-1 truncate">{cluster.name}</span>
-                          {stateLabel && (
-                            <span className="text-[10px] text-muted-foreground shrink-0">{stateLabel}</span>
-                          )}
-                        </button>
-                      )
-                    })}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={filters.availableClusters}
+            selectedClusters={filters.localClusterFilter}
+            onToggle={filters.toggleClusterFilter}
+            onClear={filters.clearClusterFilter}
+            isOpen={filters.showClusterFilter}
+            setIsOpen={filters.setShowClusterFilter}
+            containerRef={filters.clusterFilterRef}
+            minClusters={1}
+          />
           <CardControls
             limit={itemsPerPage}
             onLimitChange={setItemsPerPage}
@@ -289,16 +234,11 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
 
       {/* Search and Status Filter Pills */}
       <div className="flex flex-col gap-2 mb-3 flex-shrink-0">
-        <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-          <input
-            type="text"
-            value={filters.search}
-            onChange={(e) => handleSearchChange(e.target.value)}
-            placeholder="Search deployments..."
-            className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-          />
-        </div>
+        <CardSearchInput
+          value={filters.search}
+          onChange={handleSearchChange}
+          placeholder="Search deployments..."
+        />
 
         <div className="flex items-center gap-1 flex-wrap">
           <Filter className="w-3.5 h-3.5 text-muted-foreground mr-1" />

--- a/web/src/components/cards/DeploymentStatus.tsx
+++ b/web/src/components/cards/DeploymentStatus.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { CheckCircle, Clock, XCircle, ChevronRight, Search, Filter, Server } from 'lucide-react'
+import { CheckCircle, Clock, XCircle, ChevronRight, Filter, Server } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCachedDeployments } from '../../hooks/useCachedData'
@@ -14,6 +14,7 @@ import {
   useStatusFilter,
   commonComparators,
   CardClusterFilter,
+  CardSearchInput,
   type SortDirection,
 } from '../../lib/cards'
 
@@ -249,16 +250,11 @@ export function DeploymentStatus() {
 
       {/* Search and Status Filter Pills */}
       <div className="flex flex-col gap-2 mb-3 flex-shrink-0">
-        <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => handleSearchChange(e.target.value)}
-            placeholder="Search deployments..."
-            className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-          />
-        </div>
+        <CardSearchInput
+          value={searchQuery}
+          onChange={handleSearchChange}
+          placeholder="Search deployments..."
+        />
 
         <div className="flex items-center gap-1 flex-wrap">
           <Filter className="w-3.5 h-3.5 text-muted-foreground mr-1" />

--- a/web/src/components/cards/EventsTimeline.tsx
+++ b/web/src/components/cards/EventsTimeline.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState, useEffect, useRef } from 'react'
-import { createPortal } from 'react-dom'
-import { Activity, AlertTriangle, CheckCircle, Clock, Filter, ChevronDown, Server } from 'lucide-react'
+import { Activity, AlertTriangle, CheckCircle, Clock, Server } from 'lucide-react'
 import {
   AreaChart,
   Area,
@@ -15,6 +14,7 @@ import { useCachedEvents } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { Skeleton, SkeletonStats } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
+import { CardClusterFilter } from '../../lib/cards'
 
 interface TimePoint {
   time: string
@@ -95,8 +95,6 @@ export function EventsTimeline() {
   const [localClusterFilter, setLocalClusterFilter] = useState<string[]>([])
   const [showClusterFilter, setShowClusterFilter] = useState(false)
   const clusterFilterRef = useRef<HTMLDivElement>(null)
-  const clusterFilterBtnRef = useRef<HTMLButtonElement>(null)
-  const [dropdownStyle, setDropdownStyle] = useState<{ top: number; left: number } | null>(null)
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -108,19 +106,6 @@ export function EventsTimeline() {
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
-
-  // Compute fixed position for portaled cluster dropdown
-  useEffect(() => {
-    if (showClusterFilter && clusterFilterBtnRef.current) {
-      const rect = clusterFilterBtnRef.current.getBoundingClientRect()
-      setDropdownStyle({
-        top: rect.bottom + 4,
-        left: Math.max(8, rect.right - 192),
-      })
-    } else {
-      setDropdownStyle(null)
-    }
-  }, [showClusterFilter])
 
   // Get reachable clusters
   const reachableClusters = useMemo(() => {
@@ -230,52 +215,16 @@ export function EventsTimeline() {
           </div>
 
           {/* Cluster Filter */}
-          {availableClustersForFilter.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={() => setLocalClusterFilter([])}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClustersForFilter.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClustersForFilter}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={() => setLocalClusterFilter([])}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
 
         </div>
       </div>

--- a/web/src/components/cards/GPUInventory.tsx
+++ b/web/src/components/cards/GPUInventory.tsx
@@ -1,10 +1,9 @@
 import { useMemo } from 'react'
-import { createPortal } from 'react-dom'
-import { Cpu, Server, ChevronRight, Filter, ChevronDown } from 'lucide-react'
+import { Cpu, Server, ChevronRight } from 'lucide-react'
 import { useGPUNodes } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { ClusterStatusDot, getClusterState } from '../ui/ClusterStatusBadge'
+import { CardClusterFilter } from '../../lib/cards'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { Skeleton } from '../ui/Skeleton'
@@ -161,70 +160,16 @@ export function GPUInventory({ config }: GPUInventoryProps) {
           )}
 
           {/* Cluster filter dropdown */}
-          {filters.availableClusters.length >= 1 && (
-            <div ref={filters.clusterFilterRef} className="relative">
-              <button
-                ref={filters.clusterFilterBtnRef}
-                onClick={() => filters.setShowClusterFilter(!filters.showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  filters.localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {filters.showClusterFilter && filters.dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: filters.dropdownStyle.top, left: filters.dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={filters.clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        filters.localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {filters.availableClusters.map(cluster => {
-                      const clusterState = getClusterState(
-                        cluster.healthy ?? true,
-                        cluster.reachable,
-                        cluster.nodeCount,
-                        undefined,
-                        cluster.errorType
-                      )
-                      const stateLabel = clusterState === 'healthy' ? '' :
-                        clusterState === 'degraded' ? 'degraded' :
-                        clusterState === 'unreachable-auth' ? 'needs auth' :
-                        clusterState.startsWith('unreachable') ? 'offline' : ''
-                      return (
-                        <button
-                          key={cluster.name}
-                          onClick={() => filters.toggleClusterFilter(cluster.name)}
-                          className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors flex items-center gap-2 ${
-                            filters.localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                          }`}
-                          title={stateLabel ? `${cluster.name} (${stateLabel})` : cluster.name}
-                        >
-                          <ClusterStatusDot state={clusterState} size="sm" />
-                          <span className="flex-1 truncate">{cluster.name}</span>
-                          {stateLabel && (
-                            <span className="text-[10px] text-muted-foreground shrink-0">{stateLabel}</span>
-                          )}
-                        </button>
-                      )
-                    })}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={filters.availableClusters}
+            selectedClusters={filters.localClusterFilter}
+            onToggle={filters.toggleClusterFilter}
+            onClear={filters.clearClusterFilter}
+            isOpen={filters.showClusterFilter}
+            setIsOpen={filters.setShowClusterFilter}
+            containerRef={filters.clusterFilterRef}
+            minClusters={1}
+          />
 
           <CardControls
             limit={itemsPerPage}

--- a/web/src/components/cards/GPUUtilization.tsx
+++ b/web/src/components/cards/GPUUtilization.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useEffect, useRef } from 'react'
-import { createPortal } from 'react-dom'
-import { TrendingUp, Clock, Filter, ChevronDown, Server } from 'lucide-react'
+import { TrendingUp, Clock, Server } from 'lucide-react'
+import { CardClusterFilter } from '../../lib/cards'
 import { Skeleton, SkeletonStats } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 import {
@@ -55,31 +55,6 @@ export function GPUUtilization() {
   const [localClusterFilter, setLocalClusterFilter] = useState<string[]>([])
   const [showClusterFilter, setShowClusterFilter] = useState(false)
   const clusterFilterRef = useRef<HTMLDivElement>(null)
-  const clusterFilterBtnRef = useRef<HTMLButtonElement>(null)
-  const [dropdownStyle, setDropdownStyle] = useState<{ top: number; left: number } | null>(null)
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (clusterFilterRef.current && !clusterFilterRef.current.contains(event.target as Node)) {
-        setShowClusterFilter(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
-
-  useEffect(() => {
-    if (showClusterFilter && clusterFilterBtnRef.current) {
-      const rect = clusterFilterBtnRef.current.getBoundingClientRect()
-      setDropdownStyle({
-        top: rect.bottom + 4,
-        left: Math.max(8, rect.right - 192),
-      })
-    } else {
-      setDropdownStyle(null)
-    }
-  }, [showClusterFilter])
 
   // Get reachable clusters
   const reachableClusters = useMemo(() => {
@@ -251,52 +226,16 @@ export function GPUUtilization() {
             </div>
 
             {/* Cluster Filter */}
-            {availableClustersForFilter.length >= 1 && (
-              <div ref={clusterFilterRef} className="relative">
-                <button
-                  ref={clusterFilterBtnRef}
-                  onClick={() => setShowClusterFilter(!showClusterFilter)}
-                  className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                    localClusterFilter.length > 0
-                      ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                      : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                  }`}
-                  title="Filter by cluster"
-                >
-                  <Filter className="w-3 h-3" />
-                  <ChevronDown className="w-3 h-3" />
-                </button>
-
-                {showClusterFilter && dropdownStyle && createPortal(
-                  <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                    <div className="p-1">
-                      <button
-                        onClick={() => setLocalClusterFilter([])}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        All clusters
-                      </button>
-                      {availableClustersForFilter.map(cluster => (
-                        <button
-                          key={cluster.name}
-                          onClick={() => toggleClusterFilter(cluster.name)}
-                          className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                            localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                          }`}
-                        >
-                          {cluster.name}
-                        </button>
-                      ))}
-                    </div>
-                  </div>,
-                document.body
-                )}
-              </div>
-            )}
+            <CardClusterFilter
+              availableClusters={availableClustersForFilter}
+              selectedClusters={localClusterFilter}
+              onToggle={toggleClusterFilter}
+              onClear={() => setLocalClusterFilter([])}
+              isOpen={showClusterFilter}
+              setIsOpen={setShowClusterFilter}
+              containerRef={clusterFilterRef}
+              minClusters={1}
+            />
 
           </div>
         </div>
@@ -338,52 +277,16 @@ export function GPUUtilization() {
           </div>
 
           {/* Cluster Filter */}
-          {availableClustersForFilter.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={() => setLocalClusterFilter([])}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClustersForFilter.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClustersForFilter}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={() => setLocalClusterFilter([])}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
 
         </div>
       </div>

--- a/web/src/components/cards/GitOpsDrift.tsx
+++ b/web/src/components/cards/GitOpsDrift.tsx
@@ -1,13 +1,12 @@
 import { useMemo } from 'react'
-import { createPortal } from 'react-dom'
-import { GitBranch, AlertTriangle, Plus, Minus, RefreshCw, Loader2, Search, ChevronRight, Filter, ChevronDown, Server } from 'lucide-react'
+import { GitBranch, AlertTriangle, Plus, Minus, RefreshCw, Loader2, ChevronRight, Server } from 'lucide-react'
 import { useGitOpsDrifts, GitOpsDrift as GitOpsDriftType } from '../../hooks/useMCP'
 import { useGlobalFilters, type SeverityLevel } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
-import { useCardData } from '../../lib/cards'
+import { useCardData, CardClusterFilter, CardSearchInput } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
 
 type SortByOption = 'severity' | 'type' | 'resource' | 'cluster'
@@ -133,9 +132,6 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
       setShowClusterFilter,
       clusterFilterRef,
 
-      clusterFilterBtnRef,
-
-      dropdownStyle,
     },
     sorting: {
       sortBy,
@@ -218,52 +214,16 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
         </div>
         <div className="flex items-center gap-2">
           {/* Cluster Filter */}
-          {availableClustersForFilter.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClustersForFilter.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClustersForFilter}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={clearClusterFilter}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
           <CardControls
             limit={itemsPerPage}
             onLimitChange={setItemsPerPage}
@@ -277,16 +237,11 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
       </div>
 
       {/* Local Search */}
-      <div className="relative mb-4">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={localSearch}
-          onChange={(e) => setLocalSearch(e.target.value)}
-          placeholder="Search drifts..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={localSearch}
+        onChange={setLocalSearch}
+        placeholder="Search drifts..."
+      />
 
       {/* Drifts list */}
       {totalItems === 0 ? (

--- a/web/src/components/cards/KyvernoPolicies.tsx
+++ b/web/src/components/cards/KyvernoPolicies.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react'
-import { AlertTriangle, CheckCircle, ExternalLink, AlertCircle, FileCheck, Search } from 'lucide-react'
+import { AlertTriangle, CheckCircle, ExternalLink, AlertCircle, FileCheck } from 'lucide-react'
+import { CardSearchInput } from '../../lib/cards'
 
 interface KyvernoPoliciesProps {
   config?: Record<string, unknown>
@@ -144,16 +145,11 @@ export function KyvernoPolicies({ config: _config }: KyvernoPoliciesProps) {
       </div>
 
       {/* Local Search */}
-      <div className="relative mb-3">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={localSearch}
-          onChange={(e) => setLocalSearch(e.target.value)}
-          placeholder="Search policies..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={localSearch}
+        onChange={setLocalSearch}
+        placeholder="Search policies..."
+      />
 
       {/* Policies list */}
       <div className="flex-1 overflow-y-auto space-y-2">

--- a/web/src/components/cards/NamespaceMonitor.tsx
+++ b/web/src/components/cards/NamespaceMonitor.tsx
@@ -1,9 +1,10 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import {
   Layers, ChevronRight, ChevronDown, Server, Box, Network, HardDrive,
-  FileText, FileKey, Clock, Container, Search, RefreshCw, Plus, Minus,
+  FileText, FileKey, Clock, Container, RefreshCw, Plus, Minus,
   AlertTriangle, Eye, X, Activity
 } from 'lucide-react'
+import { CardSearchInput } from '../../lib/cards'
 import {
   useClusters, useNamespaces, useDeployments, useServices, usePVCs,
   usePods, useConfigMaps, useSecrets, useJobs
@@ -601,16 +602,12 @@ export function NamespaceMonitor({ config: _config }: CardComponentProps) {
       <ChangesPanel />
 
       {/* Search */}
-      <div className="relative mb-3 flex-shrink-0">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-        <input
-          type="text"
-          value={searchFilter}
-          onChange={(e) => setSearchFilter(e.target.value)}
-          placeholder="Search clusters, namespaces..."
-          className="w-full pl-10 pr-4 py-2 text-sm bg-secondary rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={searchFilter}
+        onChange={setSearchFilter}
+        placeholder="Search clusters, namespaces..."
+        className="mb-3 flex-shrink-0"
+      />
 
       {/* Resource type filters */}
       <div className="flex flex-wrap gap-1.5 mb-3 flex-shrink-0">

--- a/web/src/components/cards/NetworkOverview.tsx
+++ b/web/src/components/cards/NetworkOverview.tsx
@@ -1,12 +1,11 @@
 import { useMemo } from 'react'
-import { createPortal } from 'react-dom'
-import { Globe, Server, Layers, ExternalLink, Filter, ChevronDown, Activity } from 'lucide-react'
+import { Globe, Server, Layers, ExternalLink, Activity } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedServices } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCardLoadingState } from './CardDataContext'
-import { useChartFilters } from '../../lib/cards'
+import { useChartFilters, CardClusterFilter } from '../../lib/cards'
 import { ClusterStatusDot } from '../ui/ClusterStatusBadge'
 
 export function NetworkOverview() {
@@ -34,10 +33,6 @@ export function NetworkOverview() {
     showClusterFilter,
     setShowClusterFilter,
     clusterFilterRef,
-
-    clusterFilterBtnRef,
-
-    dropdownStyle,
   } = useChartFilters({
     storageKey: 'network-overview',
   })
@@ -158,52 +153,16 @@ export function NetworkOverview() {
           )}
 
           {/* Cluster filter dropdown */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClusters}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={clearClusterFilter}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
 
         </div>
       </div>

--- a/web/src/components/cards/PodHealthTrend.tsx
+++ b/web/src/components/cards/PodHealthTrend.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState, useEffect, useRef } from 'react'
-import { createPortal } from 'react-dom'
-import { CheckCircle, AlertTriangle, Clock, Filter, ChevronDown, Server } from 'lucide-react'
+import { CheckCircle, AlertTriangle, Clock, Server } from 'lucide-react'
 import {
   AreaChart,
   Area,
@@ -15,6 +14,7 @@ import { useClusters } from '../../hooks/useMCP'
 import { useCachedPodIssues } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useCardLoadingState } from './CardDataContext'
+import { CardClusterFilter } from '../../lib/cards'
 
 interface HealthPoint {
   time: string
@@ -50,8 +50,6 @@ export function PodHealthTrend() {
   const [localClusterFilter, setLocalClusterFilter] = useState<string[]>([])
   const [showClusterFilter, setShowClusterFilter] = useState(false)
   const clusterFilterRef = useRef<HTMLDivElement>(null)
-  const clusterFilterBtnRef = useRef<HTMLButtonElement>(null)
-  const [dropdownStyle, setDropdownStyle] = useState<{ top: number; left: number } | null>(null)
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -63,19 +61,6 @@ export function PodHealthTrend() {
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
-
-  // Compute fixed position for portaled cluster dropdown
-  useEffect(() => {
-    if (showClusterFilter && clusterFilterBtnRef.current) {
-      const rect = clusterFilterBtnRef.current.getBoundingClientRect()
-      setDropdownStyle({
-        top: rect.bottom + 4,
-        left: Math.max(8, rect.right - 192),
-      })
-    } else {
-      setDropdownStyle(null)
-    }
-  }, [showClusterFilter])
 
   // Track historical data points with persistence
   const STORAGE_KEY = 'pod-health-trend-history'
@@ -267,52 +252,16 @@ export function PodHealthTrend() {
           </div>
 
           {/* Cluster Filter */}
-          {availableClustersForFilter.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={() => setLocalClusterFilter([])}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClustersForFilter.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClustersForFilter}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={() => setLocalClusterFilter([])}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
 
         </div>
       </div>

--- a/web/src/components/cards/ResourceTrend.tsx
+++ b/web/src/components/cards/ResourceTrend.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
-import { createPortal } from 'react-dom'
-import { TrendingUp, Cpu, MemoryStick, Box, Server, Clock, Filter, ChevronDown } from 'lucide-react'
+import { TrendingUp, Cpu, MemoryStick, Box, Server, Clock } from 'lucide-react'
 import {
   LineChart,
   Line,
@@ -14,6 +13,7 @@ import {
 import { useClusters } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useCardLoadingState } from './CardDataContext'
+import { CardClusterFilter } from '../../lib/cards'
 
 interface ResourcePoint {
   time: string
@@ -41,8 +41,6 @@ export function ResourceTrend() {
   const [localClusterFilter, setLocalClusterFilter] = useState<string[]>([])
   const [showClusterFilter, setShowClusterFilter] = useState(false)
   const clusterFilterRef = useRef<HTMLDivElement>(null)
-  const clusterFilterBtnRef = useRef<HTMLButtonElement>(null)
-  const [dropdownStyle, setDropdownStyle] = useState<{ top: number; left: number } | null>(null)
 
   // Report state to CardWrapper for refresh animation
   useCardLoadingState({
@@ -60,19 +58,6 @@ export function ResourceTrend() {
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
-
-  // Compute fixed position for portaled cluster dropdown
-  useEffect(() => {
-    if (showClusterFilter && clusterFilterBtnRef.current) {
-      const rect = clusterFilterBtnRef.current.getBoundingClientRect()
-      setDropdownStyle({
-        top: rect.bottom + 4,
-        left: Math.max(8, rect.right - 192),
-      })
-    } else {
-      setDropdownStyle(null)
-    }
-  }, [showClusterFilter])
 
   // Track historical data points with persistence
   const STORAGE_KEY = 'resource-trend-history'
@@ -261,52 +246,16 @@ export function ResourceTrend() {
           </div>
 
           {/* Cluster Filter */}
-          {availableClustersForFilter.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={() => setLocalClusterFilter([])}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClustersForFilter.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClustersForFilter}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={() => setLocalClusterFilter([])}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
 
         </div>
       </div>

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -1,10 +1,9 @@
 import { useMemo } from 'react'
-import { createPortal } from 'react-dom'
 import { Gauge } from '../charts'
-import { Cpu, MemoryStick, Filter, ChevronDown, Server } from 'lucide-react'
+import { Cpu, MemoryStick, Server } from 'lucide-react'
 import { useClusters, useGPUNodes } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { useChartFilters } from '../../lib/cards'
+import { useChartFilters, CardClusterFilter } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
 import { Skeleton } from '../ui/Skeleton'
 
@@ -23,10 +22,6 @@ export function ResourceUsage() {
     showClusterFilter,
     setShowClusterFilter,
     clusterFilterRef,
-
-    clusterFilterBtnRef,
-
-    dropdownStyle,
   } = useChartFilters({ storageKey: 'resource-usage' })
 
   // Filter GPU nodes to match the currently displayed clusters
@@ -125,52 +120,16 @@ export function ResourceUsage() {
 
         <div className="flex items-center gap-2">
           {/* Cluster Filter */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClusters}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={clearClusterFilter}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
 
         </div>
       </div>

--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -1,5 +1,4 @@
-import { Shield, AlertTriangle, User, Network, Server, ChevronRight, Search, Filter, ChevronDown } from 'lucide-react'
-import { createPortal } from 'react-dom'
+import { Shield, AlertTriangle, User, Network, Server, ChevronRight } from 'lucide-react'
 import { useMemo } from 'react'
 import type { SecurityIssue } from '../../hooks/useMCP'
 import { useCachedSecurityIssues } from '../../hooks/useCachedData'
@@ -8,7 +7,7 @@ import { ClusterBadge } from '../ui/ClusterBadge'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { LimitedAccessWarning } from '../ui/LimitedAccessWarning'
-import { useCardData } from '../../lib/cards'
+import { useCardData, CardClusterFilter, CardSearchInput } from '../../lib/cards'
 import { SEVERITY_COLORS, SeverityLevel } from '../../lib/accessibility'
 import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 
@@ -140,10 +139,6 @@ export function SecurityIssues({ config }: SecurityIssuesProps) {
       showClusterFilter,
       setShowClusterFilter,
       clusterFilterRef,
-
-      clusterFilterBtnRef,
-
-      dropdownStyle,
     },
     sorting: {
       sortBy,
@@ -254,52 +249,16 @@ export function SecurityIssues({ config }: SecurityIssuesProps) {
         </div>
         <div className="flex items-center gap-2">
           {/* Cluster Filter */}
-          {availableClustersForFilter.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClustersForFilter.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClustersForFilter}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={clearClusterFilter}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
           <CardControls
             limit={itemsPerPage}
             onLimitChange={setItemsPerPage}
@@ -313,16 +272,12 @@ export function SecurityIssues({ config }: SecurityIssuesProps) {
       </div>
 
       {/* Local Search */}
-      <div className="relative mb-3">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={localSearch}
-          onChange={(e) => setLocalSearch(e.target.value)}
-          placeholder="Search issues..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={localSearch}
+        onChange={setLocalSearch}
+        placeholder="Search issues..."
+        className="mb-3"
+      />
 
       {/* Issues list */}
       <div className="flex-1 space-y-3 overflow-y-auto min-h-card-content">

--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -1,12 +1,11 @@
 import { useMemo } from 'react'
-import { createPortal } from 'react-dom'
-import { HardDrive, Database, CheckCircle, AlertTriangle, Clock, Filter, ChevronDown, Server } from 'lucide-react'
+import { HardDrive, Database, CheckCircle, AlertTriangle, Clock, Server } from 'lucide-react'
 import { useClusters, usePVCs } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCardLoadingState } from './CardDataContext'
 import { formatStat, formatStorageStat } from '../../lib/formatStats'
-import { useChartFilters } from '../../lib/cards'
+import { useChartFilters, CardClusterFilter } from '../../lib/cards'
 
 export function StorageOverview() {
   const { deduplicatedClusters: clusters, isLoading } = useClusters()
@@ -33,10 +32,6 @@ export function StorageOverview() {
     showClusterFilter,
     setShowClusterFilter,
     clusterFilterRef,
-
-    clusterFilterBtnRef,
-
-    dropdownStyle,
   } = useChartFilters({
     storageKey: 'storage-overview',
   })
@@ -127,52 +122,16 @@ export function StorageOverview() {
           )}
 
           {/* Cluster filter dropdown */}
-          {availableClusters.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClusters.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClusters}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={clearClusterFilter}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
 
         </div>
       </div>

--- a/web/src/components/cards/TopPods.tsx
+++ b/web/src/components/cards/TopPods.tsx
@@ -1,12 +1,11 @@
-import { Loader2, AlertTriangle, ChevronRight, Search, Filter, ChevronDown, Server, Cpu, MemoryStick, Zap } from 'lucide-react'
-import { createPortal } from 'react-dom'
+import { Loader2, AlertTriangle, ChevronRight, Server, Cpu, MemoryStick, Zap } from 'lucide-react'
 import { useCachedPods } from '../../hooks/useCachedData'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCardLoadingState } from './CardDataContext'
-import { useCardData, commonComparators } from '../../lib/cards'
+import { useCardData, commonComparators, CardClusterFilter, CardSearchInput } from '../../lib/cards'
 
 type SortByOption = 'restarts' | 'name' | 'cpu' | 'memory' | 'gpu'
 
@@ -102,10 +101,6 @@ export function TopPods({ config }: TopPodsProps) {
       showClusterFilter,
       setShowClusterFilter,
       clusterFilterRef,
-
-      clusterFilterBtnRef,
-
-      dropdownStyle,
     },
     sorting: {
       sortBy,
@@ -178,52 +173,16 @@ export function TopPods({ config }: TopPodsProps) {
         </div>
         <div className="flex items-center gap-2">
           {/* Cluster Filter */}
-          {availableClustersForFilter.length >= 1 && (
-            <div ref={clusterFilterRef} className="relative">
-              <button
-                ref={clusterFilterBtnRef}
-                onClick={() => setShowClusterFilter(!showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-
-              {showClusterFilter && dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: dropdownStyle.top, left: dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button
-                      onClick={clearClusterFilter}
-                      className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                        localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                      }`}
-                    >
-                      All clusters
-                    </button>
-                    {availableClustersForFilter.map(cluster => (
-                      <button
-                        key={cluster.name}
-                        onClick={() => toggleClusterFilter(cluster.name)}
-                        className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                          localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                        }`}
-                      >
-                        {cluster.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={availableClustersForFilter}
+            selectedClusters={localClusterFilter}
+            onToggle={toggleClusterFilter}
+            onClear={clearClusterFilter}
+            isOpen={showClusterFilter}
+            setIsOpen={setShowClusterFilter}
+            containerRef={clusterFilterRef}
+            minClusters={1}
+          />
           <CardControls
             limit={itemsPerPage}
             onLimitChange={setItemsPerPage}
@@ -237,16 +196,12 @@ export function TopPods({ config }: TopPodsProps) {
       </div>
 
       {/* Local Search */}
-      <div className="relative mb-3">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={localSearch}
-          onChange={(e) => setLocalSearch(e.target.value)}
-          placeholder="Search pods..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={localSearch}
+        onChange={setLocalSearch}
+        placeholder="Search pods..."
+        className="mb-3"
+      />
 
       {/* Pods list */}
       {pods.length === 0 ? (

--- a/web/src/components/cards/workload-detection/LLMInference.tsx
+++ b/web/src/components/cards/workload-detection/LLMInference.tsx
@@ -1,9 +1,9 @@
 import { useState, useMemo, useRef, useEffect } from 'react'
-import { createPortal } from 'react-dom'
 import {
   ExternalLink, Cpu, Layers, AlertCircle, Play, Pause, RefreshCw,
-  Filter, ChevronDown, Server, Activity, Network, Box, Search
+  ChevronDown, Server, Activity, Network, Box
 } from 'lucide-react'
+import { CardClusterFilter, CardSearchInput } from '../../../lib/cards'
 import { Skeleton } from '../../ui/Skeleton'
 import { CardControls } from '../../ui/CardControls'
 import { Pagination } from '../../ui/Pagination'
@@ -13,7 +13,6 @@ import { useCachedLLMdServers } from '../../../hooks/useCachedData'
 import type { LLMdServer, LLMdComponentType } from '../../../hooks/useLLMd'
 import { LLMD_CLUSTERS } from './shared'
 import { useCardLoadingState } from '../CardDataContext'
-import { ClusterStatusDot, getClusterState } from '../../ui/ClusterStatusBadge'
 
 interface LLMInferenceProps {
   config?: Record<string, unknown>
@@ -216,62 +215,16 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
             )}
           </div>
           {/* Cluster filter */}
-          {filters.availableClusters.length >= 1 && (
-            <div ref={filters.clusterFilterRef} className="relative">
-              <button
-                ref={filters.clusterFilterBtnRef}
-                onClick={() => filters.setShowClusterFilter(!filters.showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  filters.localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-              {filters.showClusterFilter && filters.dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: filters.dropdownStyle.top, left: filters.dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button onClick={filters.clearClusterFilter} className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${filters.localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'}`}>All clusters</button>
-                    {filters.availableClusters.map(cluster => {
-                      const clusterState = getClusterState(
-                        cluster.healthy ?? true,
-                        cluster.reachable,
-                        cluster.nodeCount,
-                        undefined,
-                        cluster.errorType
-                      )
-                      const stateLabel = clusterState === 'healthy' ? '' :
-                        clusterState === 'degraded' ? 'degraded' :
-                        clusterState === 'unreachable-auth' ? 'needs auth' :
-                        clusterState.startsWith('unreachable') ? 'offline' : ''
-                      return (
-                        <button
-                          key={cluster.name}
-                          onClick={() => filters.toggleClusterFilter(cluster.name)}
-                          className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors flex items-center gap-2 ${
-                            filters.localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                          }`}
-                          title={stateLabel ? `${cluster.name} (${stateLabel})` : cluster.name}
-                        >
-                          <ClusterStatusDot state={clusterState} size="sm" />
-                          <span className="flex-1 truncate">{cluster.name}</span>
-                          {stateLabel && (
-                            <span className="text-[10px] text-muted-foreground shrink-0">{stateLabel}</span>
-                          )}
-                        </button>
-                      )
-                    })}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={filters.availableClusters}
+            selectedClusters={filters.localClusterFilter}
+            onToggle={filters.toggleClusterFilter}
+            onClear={filters.clearClusterFilter}
+            isOpen={filters.showClusterFilter}
+            setIsOpen={filters.setShowClusterFilter}
+            containerRef={filters.clusterFilterRef}
+            minClusters={1}
+          />
           <CardControls
             limit={itemsPerPage}
             onLimitChange={setItemsPerPage}
@@ -285,16 +238,12 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
       </div>
 
       {/* Search input */}
-      <div className="relative mb-2">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={filters.search}
-          onChange={(e) => filters.setSearch(e.target.value)}
-          placeholder="Search servers..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={filters.search}
+        onChange={filters.setSearch}
+        placeholder="Search servers..."
+        className="mb-2"
+      />
 
       {/* Integration notice */}
       <div className="flex items-start gap-2 p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 text-xs mb-4">

--- a/web/src/components/cards/workload-detection/MLJobs.tsx
+++ b/web/src/components/cards/workload-detection/MLJobs.tsx
@@ -1,10 +1,9 @@
 import {
   CheckCircle, XCircle, Clock, ExternalLink, Cpu,
-  AlertCircle, Play, Filter, ChevronDown, Server, Search
+  AlertCircle, Play, Server
 } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
-import { ClusterStatusDot, getClusterState } from '../../ui/ClusterStatusBadge'
-import { createPortal } from 'react-dom'
+import { CardClusterFilter, CardSearchInput } from '../../../lib/cards'
 import { Pagination } from '../../ui/Pagination'
 import { CardControls } from '../../ui/CardControls'
 import { useCardData } from '../../../lib/cards/cardHooks'
@@ -90,62 +89,16 @@ export function MLJobs({ config: _config }: MLJobsProps) {
           </span>
         </div>
         <div className="flex items-center gap-2">
-          {filters.availableClusters.length >= 1 && (
-            <div ref={filters.clusterFilterRef} className="relative">
-              <button
-                ref={filters.clusterFilterBtnRef}
-                onClick={() => filters.setShowClusterFilter(!filters.showClusterFilter)}
-                className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
-                  filters.localClusterFilter.length > 0
-                    ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                    : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                }`}
-                title="Filter by cluster"
-              >
-                <Filter className="w-3 h-3" />
-                <ChevronDown className="w-3 h-3" />
-              </button>
-              {filters.showClusterFilter && filters.dropdownStyle && createPortal(
-                <div className="fixed w-48 max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
-                  style={{ top: filters.dropdownStyle.top, left: filters.dropdownStyle.left }}
-                  onMouseDown={e => e.stopPropagation()}>
-                  <div className="p-1">
-                    <button onClick={filters.clearClusterFilter} className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${filters.localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'}`}>All clusters</button>
-                    {filters.availableClusters.map(cluster => {
-                      const clusterState = getClusterState(
-                        cluster.healthy ?? true,
-                        cluster.reachable,
-                        cluster.nodeCount,
-                        undefined,
-                        cluster.errorType
-                      )
-                      const stateLabel = clusterState === 'healthy' ? '' :
-                        clusterState === 'degraded' ? 'degraded' :
-                        clusterState === 'unreachable-auth' ? 'needs auth' :
-                        clusterState.startsWith('unreachable') ? 'offline' : ''
-                      return (
-                        <button
-                          key={cluster.name}
-                          onClick={() => filters.toggleClusterFilter(cluster.name)}
-                          className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors flex items-center gap-2 ${
-                            filters.localClusterFilter.includes(cluster.name) ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
-                          }`}
-                          title={stateLabel ? `${cluster.name} (${stateLabel})` : cluster.name}
-                        >
-                          <ClusterStatusDot state={clusterState} size="sm" />
-                          <span className="flex-1 truncate">{cluster.name}</span>
-                          {stateLabel && (
-                            <span className="text-[10px] text-muted-foreground shrink-0">{stateLabel}</span>
-                          )}
-                        </button>
-                      )
-                    })}
-                  </div>
-                </div>,
-              document.body
-              )}
-            </div>
-          )}
+          <CardClusterFilter
+            availableClusters={filters.availableClusters}
+            selectedClusters={filters.localClusterFilter}
+            onToggle={filters.toggleClusterFilter}
+            onClear={filters.clearClusterFilter}
+            isOpen={filters.showClusterFilter}
+            setIsOpen={filters.setShowClusterFilter}
+            containerRef={filters.clusterFilterRef}
+            minClusters={1}
+          />
           <CardControls
             limit={itemsPerPage}
             onLimitChange={setItemsPerPage}
@@ -159,16 +112,12 @@ export function MLJobs({ config: _config }: MLJobsProps) {
       </div>
 
       {/* Search input */}
-      <div className="relative mb-2">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={filters.search}
-          onChange={(e) => filters.setSearch(e.target.value)}
-          placeholder="Search jobs..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={filters.search}
+        onChange={filters.setSearch}
+        placeholder="Search jobs..."
+        className="mb-2"
+      />
 
       {/* Integration notice */}
       <div className="flex items-start gap-2 p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-xs mb-4">

--- a/web/src/components/cards/workload-detection/ProwHistory.tsx
+++ b/web/src/components/cards/workload-detection/ProwHistory.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react'
 import {
-  CheckCircle, XCircle, AlertTriangle, ExternalLink, Search
+  CheckCircle, XCircle, AlertTriangle, ExternalLink
 } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { CardControls } from '../../ui/CardControls'
+import { CardSearchInput } from '../../../lib/cards'
 import { Pagination } from '../../ui/Pagination'
 import { useCachedProwJobs } from '../../../hooks/useCachedData'
 import { useCardData } from '../../../lib/cards/cardHooks'
@@ -93,16 +94,12 @@ export function ProwHistory({ config: _config }: ProwHistoryProps) {
       </div>
 
       {/* Search input */}
-      <div className="relative mb-2">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={filters.search}
-          onChange={(e) => filters.setSearch(e.target.value)}
-          placeholder="Search history..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={filters.search}
+        onChange={filters.setSearch}
+        placeholder="Search history..."
+        className="mb-2"
+      />
 
       {/* Timeline */}
       <div className="flex-1 overflow-y-auto relative">

--- a/web/src/components/cards/workload-detection/ProwJobs.tsx
+++ b/web/src/components/cards/workload-detection/ProwJobs.tsx
@@ -1,10 +1,11 @@
 import { useState, useMemo } from 'react'
 import {
   CheckCircle, XCircle, Clock, AlertTriangle, ExternalLink,
-  Play, Search
+  Play
 } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { CardControls } from '../../ui/CardControls'
+import { CardSearchInput } from '../../../lib/cards'
 import { Pagination } from '../../ui/Pagination'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import type { SortDirection } from '../../../lib/cards/cardHooks'
@@ -174,16 +175,12 @@ export function ProwJobs({ config: _config }: ProwJobsProps) {
       </div>
 
       {/* Search input */}
-      <div className="relative mb-2">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={filters.search}
-          onChange={(e) => filters.setSearch(e.target.value)}
-          placeholder="Search jobs..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={filters.search}
+        onChange={filters.setSearch}
+        placeholder="Search jobs..."
+        className="mb-2"
+      />
 
       {/* Jobs list */}
       <div className="flex-1 overflow-y-auto space-y-2">

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -1,12 +1,13 @@
 import { useState, useMemo, useCallback, useEffect } from 'react'
 import {
   GitBranch, AlertTriangle, CheckCircle, XCircle,
-  Clock, RefreshCw, Loader2, ExternalLink, Search,
+  Clock, RefreshCw, Loader2, ExternalLink,
 } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
 import { CardControls } from '../../ui/CardControls'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
+import { CardSearchInput } from '../../../lib/cards'
 import type { SortDirection } from '../../../lib/cards/cardHooks'
 import { cn } from '../../../lib/cn'
 import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
@@ -333,18 +334,11 @@ export function GitHubCIMonitor({ config }: GitHubCIMonitorProps) {
       </div>
 
       {/* Search */}
-      <div className="mb-2">
-        <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-          <input
-            type="text"
-            value={filters.search}
-            onChange={(e) => filters.setSearch(e.target.value)}
-            placeholder="Search workflows..."
-            className="w-full pl-8 pr-3 py-1.5 text-xs rounded-md bg-secondary/50 border border-border text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-          />
-        </div>
-      </div>
+      <CardSearchInput
+        value={filters.search}
+        onChange={filters.setSearch}
+        placeholder="Search workflows..."
+      />
 
       {/* Workflow runs */}
       <div className="flex-1 overflow-y-auto space-y-0.5">

--- a/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
@@ -2,12 +2,13 @@ import { useMemo, useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import {
   Cpu, Network, Activity, Layers, Server,
-  RefreshCw, Loader2, ChevronDown, ChevronRight, Filter, Search,
+  RefreshCw, Loader2, ChevronDown, ChevronRight, Filter,
   Stethoscope, Wrench
 } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
 import { CardControls } from '../../ui/CardControls'
+import { CardSearchInput } from '../../../lib/cards'
 import { useCachedLLMdServers } from '../../../hooks/useCachedData'
 import { useWorkloadMonitor } from '../../../hooks/useWorkloadMonitor'
 import { useDiagnoseRepairLoop } from '../../../hooks/useDiagnoseRepairLoop'
@@ -538,16 +539,12 @@ export function LLMdStackMonitor({ config: _config }: LLMdStackMonitorProps) {
       </div>
 
       {/* Search */}
-      <div className="relative mb-3">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => { setSearch(e.target.value); setCurrentPage(1) }}
-          placeholder="Search components..."
-          className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
-        />
-      </div>
+      <CardSearchInput
+        value={search}
+        onChange={(v) => { setSearch(v); setCurrentPage(1) }}
+        placeholder="Search components..."
+        className="mb-3"
+      />
 
       {/* Component sections */}
       <div className="flex-1 overflow-y-auto space-y-0.5">

--- a/web/src/components/cards/workload-monitor/ProwCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/ProwCIMonitor.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from 'react'
 import {
   Activity, AlertTriangle, CheckCircle, XCircle,
-  Clock, RefreshCw, Loader2, Play, Pause, Search,
+  Clock, RefreshCw, Loader2, Play, Pause,
 } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
 import { CardControls } from '../../ui/CardControls'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
+import { CardSearchInput } from '../../../lib/cards'
 import type { SortDirection } from '../../../lib/cards/cardHooks'
 import { useCachedProwJobs } from '../../../hooks/useCachedData'
 import { cn } from '../../../lib/cn'
@@ -244,18 +245,12 @@ export function ProwCIMonitor({ config: _config }: ProwCIMonitorProps) {
       </div>
 
       {/* Search */}
-      <div className="mb-2">
-        <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-          <input
-            type="text"
-            value={filters.search}
-            onChange={(e) => filters.setSearch(e.target.value)}
-            placeholder="Search jobs..."
-            className="w-full pl-8 pr-3 py-1.5 text-xs rounded-md bg-secondary/50 border border-border text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-blue-500/50"
-          />
-        </div>
-      </div>
+      <CardSearchInput
+        value={filters.search}
+        onChange={filters.setSearch}
+        placeholder="Search jobs..."
+        className="mb-2"
+      />
 
       {/* Job list */}
       <div className="flex-1 overflow-y-auto space-y-0.5">


### PR DESCRIPTION
## Summary
- Convert 29 cards to use unified control components
- Net reduction of 1,052 lines of code through deduplication
- All cluster dropdowns now show health status indicators

## Cluster Filter conversions (20 cards)
ArgoCDSyncStatus, ClusterMetrics, ClusterResourceTree, ComputeOverview, DeploymentProgress, EventsTimeline, GitOpsDrift, GPUInventory, GPUUsageTrend, GPUUtilization, GPUWorkloads, LLMInference, MLJobs, NetworkOverview, PodHealthTrend, ResourceTrend, ResourceUsage, SecurityIssues, StorageOverview, TopPods

## Search Input conversions (17 cards)
ActiveAlerts, ClusterResourceTree, DeploymentProgress, DeploymentStatus, GitHubCIMonitor, GitOpsDrift, GPUWorkloads, KyvernoPolicies, LLMdStackMonitor, LLMInference, MLJobs, NamespaceMonitor, ProwCIMonitor, ProwHistory, ProwJobs, SecurityIssues, TopPods

## Benefits
- Consistent cluster health status indicators (green/yellow/orange/red) in all dropdowns
- Unified search input styling and behavior
- Reduced code duplication (~50 lines per card)
- Easier maintenance - changes only need to be made in one place

## Test plan
- [ ] Verify cluster dropdowns show status indicators
- [ ] Test search functionality in converted cards
- [ ] Confirm UI consistency across all cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)