### PR TITLE
✨ Add anchor IDs and deep-link navigation to Settings sections

### DIFF
--- a/web/src/components/settings/Settings.tsx
+++ b/web/src/components/settings/Settings.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 import { useAuth } from '../../lib/auth'
 import { useTheme } from '../../hooks/useTheme'
 import { useTokenUsage } from '../../hooks/useTokenUsage'
@@ -23,6 +25,7 @@ PredictionSettingsSection,
 } from './sections'
 
 export function Settings() {
+  const location = useLocation()
   const { user, refreshUser } = useAuth()
   const { themeId, setTheme, themes, currentTheme } = useTheme()
   const { usage, updateSettings, resetUsage } = useTokenUsage()
@@ -31,6 +34,27 @@ export function Settings() {
   const { colorBlindMode, setColorBlindMode, reduceMotion, setReduceMotion, highContrast, setHighContrast } = useAccessibility()
   const { forceCheck: forceVersionCheck } = useVersionCheck()
   const { settings: predictionSettings, updateSettings: updatePredictionSettings, resetSettings: resetPredictionSettings } = usePredictionSettings()
+
+  // Handle deep linking - scroll to section based on URL hash
+  useEffect(() => {
+    const hash = location.hash.replace('#', '')
+    if (hash) {
+      // Small delay to ensure sections are rendered
+      const scrollToElement = () => {
+        const element = document.getElementById(hash)
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'start' })
+          // Add a brief highlight effect
+          element.classList.add('ring-2', 'ring-purple-500/50')
+          setTimeout(() => {
+            element.classList.remove('ring-2', 'ring-purple-500/50')
+          }, 2000)
+        }
+      }
+      // Wait for render
+      setTimeout(scrollToElement, 100)
+    }
+  }, [location.hash])
 
   return (
     <div data-testid="settings-page" className="pt-16 max-w-4xl mx-auto">

--- a/web/src/components/settings/sections/AISettingsSection.tsx
+++ b/web/src/components/settings/sections/AISettingsSection.tsx
@@ -9,7 +9,7 @@ interface AISettingsSectionProps {
 
 export function AISettingsSection({ mode, setMode, description }: AISettingsSectionProps) {
   return (
-    <div className="glass rounded-xl p-6">
+    <div id="ai-mode-settings" className="glass rounded-xl p-6">
       <div className="flex items-center gap-3 mb-4">
         <div className="p-2 rounded-lg bg-purple-500/20">
           <Cpu className="w-5 h-5 text-purple-400" />

--- a/web/src/components/settings/sections/APIKeysSection.tsx
+++ b/web/src/components/settings/sections/APIKeysSection.tsx
@@ -7,7 +7,7 @@ export function APIKeysSection() {
 
   return (
     <>
-      <div className="glass rounded-xl p-6">
+      <div id="api-keys-settings" className="glass rounded-xl p-6">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
             <div className="p-2 rounded-lg bg-amber-500/20">

--- a/web/src/components/settings/sections/AccessibilitySection.tsx
+++ b/web/src/components/settings/sections/AccessibilitySection.tsx
@@ -18,7 +18,7 @@ export function AccessibilitySection({
   setHighContrast,
 }: AccessibilitySectionProps) {
   return (
-    <div className="glass rounded-xl p-6 relative z-0">
+    <div id="accessibility-settings" className="glass rounded-xl p-6 relative z-0">
       <div className="flex items-center gap-3 mb-4">
         <div className="p-2 rounded-lg bg-teal-500/20">
           <Eye className="w-5 h-5 text-teal-400" />

--- a/web/src/components/settings/sections/AgentSection.tsx
+++ b/web/src/components/settings/sections/AgentSection.tsx
@@ -20,7 +20,7 @@ export function AgentSection({ isConnected, health, refresh }: AgentSectionProps
   }
 
   return (
-    <div className="glass rounded-xl p-6">
+    <div id="agent-settings" className="glass rounded-xl p-6">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
           <div className={`p-2 rounded-lg ${isConnected ? 'bg-green-500/20' : 'bg-orange-500/20'}`}>

--- a/web/src/components/settings/sections/NotificationSettingsSection.tsx
+++ b/web/src/components/settings/sections/NotificationSettingsSection.tsx
@@ -87,7 +87,7 @@ export function NotificationSettingsSection() {
   }
 
   return (
-    <div className="rounded-lg border border-border bg-card p-6">
+    <div id="notifications-settings" className="rounded-lg border border-border bg-card p-6">
       <div className="flex items-center gap-3 mb-4">
         <Bell className="w-5 h-5 text-primary" />
         <h2 className="text-lg font-semibold text-foreground">Alert Notifications</h2>

--- a/web/src/components/settings/sections/PermissionsSection.tsx
+++ b/web/src/components/settings/sections/PermissionsSection.tsx
@@ -3,7 +3,7 @@ import { CanIChecker } from '../../rbac/CanIChecker'
 
 export function PermissionsSection() {
   return (
-    <div className="glass rounded-xl p-6 relative z-0">
+    <div id="permissions-settings" className="glass rounded-xl p-6 relative z-0">
       <div className="flex items-center gap-3 mb-4">
         <div className="p-2 rounded-lg bg-emerald-500/20">
           <ShieldCheck className="w-5 h-5 text-emerald-400" />

--- a/web/src/components/settings/sections/PredictionSettingsSection.tsx
+++ b/web/src/components/settings/sections/PredictionSettingsSection.tsx
@@ -52,7 +52,7 @@ export function PredictionSettingsSection({
   }
 
   return (
-    <div className="glass rounded-xl p-6">
+    <div id="prediction-settings" className="glass rounded-xl p-6">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
           <div className="p-2 rounded-lg bg-blue-500/20">

--- a/web/src/components/settings/sections/ProfileSection.tsx
+++ b/web/src/components/settings/sections/ProfileSection.tsx
@@ -48,7 +48,7 @@ export function ProfileSection({ initialEmail, initialSlackId, refreshUser }: Pr
   }
 
   return (
-    <div className="glass rounded-xl p-6">
+    <div id="profile-settings" className="glass rounded-xl p-6">
       <div className="flex items-center gap-3 mb-4">
         <div className="p-2 rounded-lg bg-indigo-500/20">
           <User className="w-5 h-5 text-indigo-400" />

--- a/web/src/components/settings/sections/ThemeSection.tsx
+++ b/web/src/components/settings/sections/ThemeSection.tsx
@@ -14,7 +14,7 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
   const [themeDropdownOpen, setThemeDropdownOpen] = useState(false)
 
   return (
-    <div className="glass rounded-xl p-6 overflow-visible relative z-30" style={{ isolation: 'isolate' }}>
+    <div id="theme-settings" className="glass rounded-xl p-6 overflow-visible relative z-30" style={{ isolation: 'isolate' }}>
       <div className="flex items-center gap-3 mb-4">
         <div className="p-2 rounded-lg bg-gradient-to-br from-purple-500/20 to-pink-500/20">
           <Palette className="w-5 h-5 text-purple-400" />

--- a/web/src/components/settings/sections/TokenUsageSection.tsx
+++ b/web/src/components/settings/sections/TokenUsageSection.tsx
@@ -25,7 +25,7 @@ export function TokenUsageSection({ usage, updateSettings, resetUsage }: TokenUs
   }
 
   return (
-    <div className="glass rounded-xl p-6">
+    <div id="token-usage-settings" className="glass rounded-xl p-6">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-3">
           <div className="p-2 rounded-lg bg-yellow-500/20">

--- a/web/src/components/settings/sections/WidgetSettingsSection.tsx
+++ b/web/src/components/settings/sections/WidgetSettingsSection.tsx
@@ -321,7 +321,7 @@ export function WidgetSettingsSection() {
   const widgetPath = '~/Library/Application Support/Übersicht/widgets/'
 
   return (
-    <div className="glass rounded-xl p-6">
+    <div id="widget-settings" className="glass rounded-xl p-6">
       <div className="flex items-center gap-3 mb-4">
         <div className="p-2 rounded-lg bg-cyan-500/20">
           <Monitor className="w-5 h-5 text-cyan-400" />


### PR DESCRIPTION
## Summary
- Added `id` attributes to all Settings sections for deep-link navigation
- Added URL hash handler in Settings.tsx that scrolls to sections and highlights them
- Enables direct navigation like `/settings#theme-settings` or `/settings#notifications-settings`

## Sections with anchor IDs
- `profile-settings` - User profile
- `agent-settings` - Local agent connection
- `theme-settings` - Appearance/theme selection
- `accessibility-settings` - Accessibility options
- `permissions-settings` - RBAC permission checker
- `prediction-settings` - Predictive failure detection
- `widget-settings` - Desktop widget
- `notifications-settings` - Alert notification channels
- `api-keys-settings` - AI provider keys
- `token-usage-settings` - Token usage limits
- `ai-mode-settings` - AI usage mode slider
- `github-token-settings` - GitHub integration (already existed)

## Test plan
- [ ] Navigate to `/settings#theme-settings` - should scroll to theme section with highlight
- [ ] Navigate to `/settings#notifications-settings` - should scroll to notifications section
- [ ] Existing GitHub token deep linking continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)