### PR TITLE
✨ Rename Clusters dashboard to My Clusters

### DIFF
--- a/web/src/components/layout/SidebarCustomizer.tsx
+++ b/web/src/components/layout/SidebarCustomizer.tsx
@@ -113,7 +113,7 @@ interface KnownRoute {
 const KNOWN_ROUTES: KnownRoute[] = [
   // Core Dashboards
   { href: '/', name: 'Main Dashboard', description: 'Customizable overview with cluster health, workloads, and events', icon: 'LayoutDashboard', category: 'Core Dashboards' },
-  { href: '/clusters', name: 'Clusters', description: 'Detailed cluster management, health monitoring, and node status', icon: 'Server', category: 'Core Dashboards' },
+  { href: '/clusters', name: 'My Clusters', description: 'Detailed cluster management, health monitoring, and node status', icon: 'Server', category: 'Core Dashboards' },
   { href: '/workloads', name: 'Workloads', description: 'Deployments, pods, services, and application status across clusters', icon: 'Box', category: 'Core Dashboards' },
   { href: '/compute', name: 'Compute', description: 'CPU, memory, and GPU resource utilization and capacity', icon: 'Cpu', category: 'Core Dashboards' },
   { href: '/events', name: 'Events', description: 'Real-time cluster events, warnings, and audit logs', icon: 'Activity', category: 'Core Dashboards' },

--- a/web/src/config/dashboards/clusters.ts
+++ b/web/src/config/dashboards/clusters.ts
@@ -5,7 +5,7 @@ import type { UnifiedDashboardConfig } from '../../lib/unified/types'
 
 export const clustersDashboardConfig: UnifiedDashboardConfig = {
   id: 'clusters',
-  name: 'Clusters',
+  name: 'My Clusters',
   subtitle: 'Multi-cluster overview and management',
   route: '/clusters',
   statsType: 'clusters',

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -105,7 +105,7 @@ const ALL_STATS_DASHBOARD_TYPES: DashboardStatsType[] = [
 
 const DASHBOARD_STORAGE: { key: string; route: string; name: string }[] = [
   { key: 'kubestellar-main-dashboard-cards', route: '/', name: 'Main' },
-  { key: 'kubestellar-clusters-cards', route: '/clusters', name: 'Clusters' },
+  { key: 'kubestellar-clusters-cards', route: '/clusters', name: 'My Clusters' },
   { key: 'kubestellar-workloads-cards', route: '/workloads', name: 'Workloads' },
   { key: 'kubestellar-deployments-cards', route: '/deployments', name: 'Deployments' },
   { key: 'kubestellar-pods-cards', route: '/pods', name: 'Pods' },
@@ -240,7 +240,7 @@ function scanPlacedStats(): SearchItem[] {
 
 const PAGE_ITEMS: SearchItem[] = [
   { id: 'page-dashboard', name: 'Dashboard', description: 'Main dashboard with overview cards', category: 'page', href: '/', keywords: ['home', 'overview', 'main'] },
-  { id: 'page-clusters', name: 'Clusters', description: 'Manage Kubernetes clusters', category: 'page', href: '/clusters', keywords: ['kubernetes', 'k8s'] },
+  { id: 'page-clusters', name: 'My Clusters', description: 'Manage Kubernetes clusters', category: 'page', href: '/clusters', keywords: ['kubernetes', 'k8s', 'clusters'] },
   { id: 'page-workloads', name: 'Workloads', description: 'View deployments, pods, and workloads', category: 'page', href: '/workloads', keywords: ['deployment', 'pod', 'replica'] },
   { id: 'page-compute', name: 'Compute', description: 'Nodes, CPUs, GPUs, and compute resources', category: 'page', href: '/compute', keywords: ['node', 'cpu', 'gpu', 'tpu'] },
   { id: 'page-storage', name: 'Storage', description: 'Persistent volumes and storage classes', category: 'page', href: '/storage', keywords: ['pvc', 'volume', 'disk'] },

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -42,7 +42,7 @@ function subscribe(listener: () => void): () => void {
 const DEFAULT_PRIMARY_NAV: SidebarItem[] = [
   // Priority dashboards at the top
   { id: 'dashboard', name: 'Dashboard', icon: 'LayoutDashboard', href: '/', type: 'link', order: 0 },
-  { id: 'clusters', name: 'Clusters', icon: 'Server', href: '/clusters', type: 'link', order: 1 },
+  { id: 'clusters', name: 'My Clusters', icon: 'Server', href: '/clusters', type: 'link', order: 1 },
   { id: 'deploy', name: 'Deploy', icon: 'Rocket', href: '/deploy', type: 'link', order: 2 },
   { id: 'ai-ml', name: 'AI/ML', icon: 'Sparkles', href: '/ai-ml', type: 'link', order: 3 },
   { id: 'ci-cd', name: 'CI/CD', icon: 'GitMerge', href: '/ci-cd', type: 'link', order: 4 },

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1,7 +1,7 @@
 {
   "navigation": {
     "dashboard": "Dashboard",
-    "clusters": "Clusters",
+    "clusters": "My Clusters",
     "applications": "Applications",
     "events": "Events",
     "security": "Security",


### PR DESCRIPTION
## Summary
- Renamed "Clusters" dashboard to "My Clusters" for a more personalized feel
- Updated in sidebar navigation, search index, dashboard config, and locale

## Changes
- `clusters.ts` - Dashboard name
- `useSidebarConfig.ts` - Sidebar nav item
- `useSearchIndex.ts` - Search results
- `SidebarCustomizer.tsx` - Route listing
- `common.json` - Locale string

Note: Stats labels (e.g., "Clusters: 5") remain as "Clusters" since they describe counts.

## Test plan
- [ ] Sidebar shows "My Clusters" instead of "Clusters"
- [ ] Search for "clusters" still finds the page
- [ ] Dashboard title shows "My Clusters"

🤖 Generated with [Claude Code](https://claude.com/claude-code)