### PR TITLE
✨ Move language selector and presentation mode to user dropdown

### DIFF
--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -1,6 +1,8 @@
 import { useState, useRef, useEffect } from 'react'
-import { User, Mail, MessageSquare, Shield, Settings, LogOut, ChevronDown, Coins, Lightbulb, Linkedin } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { User, Mail, MessageSquare, Shield, Settings, LogOut, ChevronDown, Coins, Lightbulb, Linkedin, Globe, Check, Cast } from 'lucide-react'
 import { useRewards, REWARD_ACTIONS } from '../../hooks/useRewards'
+import { languages } from '../../lib/i18n'
 
 interface UserProfileDropdownProps {
   user: {
@@ -13,12 +15,23 @@ interface UserProfileDropdownProps {
   onLogout: () => void
   onPreferences?: () => void
   onFeedback?: () => void
+  isPresentationMode?: boolean
+  onTogglePresentationMode?: () => void
 }
 
-export function UserProfileDropdown({ user, onLogout, onPreferences, onFeedback }: UserProfileDropdownProps) {
+export function UserProfileDropdown({ user, onLogout, onPreferences, onFeedback, isPresentationMode, onTogglePresentationMode }: UserProfileDropdownProps) {
   const [isOpen, setIsOpen] = useState(false)
+  const [showLanguageSubmenu, setShowLanguageSubmenu] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
   const { totalCoins, awardCoins } = useRewards()
+  const { i18n } = useTranslation()
+
+  const currentLanguage = languages.find(l => l.code === i18n.language) || languages[0]
+
+  const handleLanguageChange = (langCode: string) => {
+    i18n.changeLanguage(langCode)
+    setShowLanguageSubmenu(false)
+  }
 
   const handleLinkedInShare = () => {
     const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent('https://kubestellar.io')}`
@@ -129,6 +142,66 @@ export function UserProfileDropdown({ user, onLogout, onPreferences, onFeedback 
               <span className="text-muted-foreground">Coins:</span>
               <span className="text-yellow-400 font-medium">{totalCoins.toLocaleString()}</span>
             </div>
+            {/* Language selector */}
+            <div className="relative">
+              <button
+                onClick={() => setShowLanguageSubmenu(!showLanguageSubmenu)}
+                className="w-full flex items-center gap-3 px-2 py-1.5 text-sm hover:bg-secondary/50 rounded-lg transition-colors"
+              >
+                <Globe className="w-4 h-4 text-muted-foreground" />
+                <span className="text-muted-foreground">Language:</span>
+                <span className="text-foreground flex items-center gap-1.5">
+                  <span>{currentLanguage.flag}</span>
+                  <span>{currentLanguage.name}</span>
+                </span>
+                <ChevronDown className={`w-3 h-3 ml-auto text-muted-foreground transition-transform ${showLanguageSubmenu ? 'rotate-180' : ''}`} />
+              </button>
+              {showLanguageSubmenu && (
+                <div className="mt-1 ml-6 space-y-0.5 border-l-2 border-border pl-3">
+                  {languages.map((lang) => (
+                    <button
+                      key={lang.code}
+                      onClick={() => handleLanguageChange(lang.code)}
+                      className={`w-full flex items-center gap-2 px-2 py-1.5 text-sm rounded-lg transition-colors ${
+                        i18n.language === lang.code
+                          ? 'bg-purple-500/20 text-foreground'
+                          : 'text-muted-foreground hover:bg-secondary/50 hover:text-foreground'
+                      }`}
+                    >
+                      <span>{lang.flag}</span>
+                      <span>{lang.name}</span>
+                      {i18n.language === lang.code && (
+                        <Check className="w-3 h-3 ml-auto text-purple-400" />
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+            {/* Presentation Mode toggle */}
+            {onTogglePresentationMode && (
+              <button
+                onClick={onTogglePresentationMode}
+                className="w-full flex items-center gap-3 px-2 py-1.5 text-sm hover:bg-secondary/50 rounded-lg transition-colors"
+              >
+                <Cast className={`w-4 h-4 ${isPresentationMode ? 'text-blue-400' : 'text-muted-foreground'}`} />
+                <span className="text-muted-foreground">Presentation:</span>
+                <span className={isPresentationMode ? 'text-blue-400' : 'text-foreground'}>
+                  {isPresentationMode ? 'On' : 'Off'}
+                </span>
+                <div
+                  className={`ml-auto w-8 h-4 rounded-full transition-colors ${
+                    isPresentationMode ? 'bg-blue-500' : 'bg-secondary'
+                  }`}
+                >
+                  <div
+                    className={`w-3 h-3 rounded-full bg-white mt-0.5 transition-transform ${
+                      isPresentationMode ? 'ml-4' : 'ml-0.5'
+                    }`}
+                  />
+                </div>
+              </button>
+            )}
           </div>
 
           {/* Actions */}

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { Sun, Moon, Monitor, User, Cast, Menu, X, MoreVertical } from 'lucide-react'
+import { Sun, Moon, Monitor, User, Menu, X, MoreVertical } from 'lucide-react'
 import { useAuth } from '../../../lib/auth'
 import { useSidebarConfig } from '../../../hooks/useSidebarConfig'
 import { useTheme } from '../../../hooks/useTheme'
@@ -15,7 +15,6 @@ import { AgentSelector } from '../../agent/AgentSelector'
 import { SearchDropdown } from './SearchDropdown'
 import { TokenUsageWidget } from './TokenUsageWidget'
 import { ClusterFilterPanel } from './ClusterFilterPanel'
-import { LanguageSelector } from './LanguageSelector'
 import { AgentStatusIndicator } from './AgentStatusIndicator'
 import { UpdateIndicator } from './UpdateIndicator'
 
@@ -86,23 +85,8 @@ export function Navbar() {
           <AgentStatusIndicator />
           <AgentSelector compact />
 
-          {/* Language Selector */}
-          <LanguageSelector />
-
           {/* Token Usage */}
           <TokenUsageWidget />
-
-          {/* Presentation Mode toggle */}
-          <button
-            onClick={togglePresentationMode}
-            className={isPresentationMode
-              ? 'p-2 rounded-lg transition-colors bg-blue-500/20 text-blue-400'
-              : 'p-2 rounded-lg transition-colors hover:bg-secondary text-muted-foreground'
-            }
-            title={isPresentationMode ? 'Presentation Mode ON (click to disable)' : 'Enable Presentation Mode (reduces animations for screen sharing)'}
-          >
-            <Cast className="w-5 h-5" />
-          </button>
 
           {/* Tour trigger */}
           <TourTrigger />
@@ -175,11 +159,6 @@ export function Navbar() {
                     <AgentStatusIndicator />
                   </div>
                   <div className="px-3 py-2 flex items-center justify-between">
-                    <span className="text-sm text-muted-foreground">Language</span>
-                    <LanguageSelector />
-                  </div>
-                  <div className="border-t border-border my-2" />
-                  <div className="px-3 py-2 flex items-center justify-between">
                     <span className="text-sm text-muted-foreground">Viewers</span>
                     <div
                       className="flex items-center gap-1 text-muted-foreground"
@@ -205,6 +184,8 @@ export function Navbar() {
           onLogout={logout}
           onPreferences={() => navigate('/settings')}
           onFeedback={() => setShowFeedback(true)}
+          isPresentationMode={isPresentationMode}
+          onTogglePresentationMode={togglePresentationMode}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- Moved language selector from navbar to user profile dropdown
- Moved presentation mode toggle from navbar to user profile dropdown
- Reduces navbar clutter while keeping controls easily accessible

## Changes
- `UserProfileDropdown.tsx` - Added language selector with expandable submenu and presentation mode toggle
- `Navbar.tsx` - Removed language selector and presentation mode button, passing props to UserProfileDropdown

## Test plan
- [ ] Click user avatar to open dropdown
- [ ] Language selector shows current language, expands to show all options
- [ ] Changing language works correctly
- [ ] Presentation mode toggle works with visual feedback
- [ ] Navbar is cleaner with fewer buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)