### PR TITLE
🐛 Fix token subcategory tracking for result and stream messages

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -494,6 +494,16 @@ The AI missions feature requires the local agent to be running.
           // Stream complete - mark as unread
           pendingRequests.current.delete(message.id)
           markMissionAsUnread(missionId)
+
+          // Track token delta for category usage when stream completes with usage data
+          if (payload.usage?.totalTokens) {
+            const previousTotal = m.tokenUsage?.total ?? 0
+            const delta = payload.usage.totalTokens - previousTotal
+            if (delta > 0) {
+              addCategoryTokens(delta, 'missions')
+            }
+          }
+
           // Clear active token tracking
           setActiveTokenCategory(null)
           return {
@@ -516,6 +526,15 @@ The AI missions feature requires the local agent to be running.
           output: chatPayload.usage.outputTokens,
           total: chatPayload.usage.totalTokens,
         } : m.tokenUsage
+
+        // Track token delta for category usage
+        if (chatPayload.usage?.totalTokens) {
+          const previousTotal = m.tokenUsage?.total ?? 0
+          const delta = chatPayload.usage.totalTokens - previousTotal
+          if (delta > 0) {
+            addCategoryTokens(delta, 'missions')
+          }
+        }
 
         return {
           ...m,


### PR DESCRIPTION
## Summary
Token subcategories were showing 0 even when missions consumed tokens. This was because `addCategoryTokens()` was only being called for `progress` messages, but the agent primarily reports token usage in `result` and `stream` messages.

## Changes
Added `addCategoryTokens()` calls to:
- `result` message handler (complete response with usage data)
- `stream` message handler (when `done=true` with usage data)

## Test plan
- [ ] Run a mission
- [ ] Open the token usage dropdown in navbar
- [ ] Verify "AI Missions" subcategory shows non-zero token count
- [ ] Refresh page and verify subcategory persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)