### PR TITLE
🐛 Fix AI summary WebSocket and auto-match resolutions

### DIFF
--- a/web/src/components/missions/SaveResolutionDialog.tsx
+++ b/web/src/components/missions/SaveResolutionDialog.tsx
@@ -85,7 +85,8 @@ Return ONLY valid JSON, no markdown code blocks or explanation.`
         type: 'chat',
         id: `summary-${Date.now()}`,
         payload: {
-          content: prompt,
+          prompt: prompt,
+          sessionId: `resolution-${mission.id}`,
           agent: mission.agent || 'claude',
         }
       }))


### PR DESCRIPTION
## Summary
- Fixes the "Prompt cannot be empty" error in AI summary generation
- Enhances resolution matching to be automatic and visible

## Changes
### Bug Fix
- Use `prompt` field instead of `content` in WebSocket payload
- Add `sessionId` to match the expected message format

### Auto-Match Enhancements
- Match resolutions for ALL mission types (except deploy/upgrade)
- Store matched resolutions on mission object
- Show system message when resolutions are found:
  > 🔍 Found 2 similar resolutions from your knowledge base...
- Display match percentage and source (personal history/team knowledge)

## Test plan
- [ ] Click "Save Resolution" - AI summary should generate successfully
- [ ] Start a mission with a known issue type that has saved resolutions
- [ ] See system message showing matched resolutions were auto-injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)