### PR TITLE
✨ Integrate persistence into Deploy dashboard cards

### DIFF
--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -18,6 +18,7 @@ import {
   Search,
   Tag,
   Filter,
+  Database,
 } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { ClusterBadge } from '../ui/ClusterBadge'
@@ -103,7 +104,7 @@ function relativeTime(iso: string): string {
 // ============================================================================
 
 export function ClusterGroups(_props: ClusterGroupsProps) {
-  const { groups, createGroup, updateGroup, deleteGroup, evaluateGroup } = useClusterGroups()
+  const { groups, createGroup, updateGroup, deleteGroup, evaluateGroup, isPersisted } = useClusterGroups()
   const { deduplicatedClusters: clusters, isLoading } = useClusters()
   const [isCreating, setIsCreating] = useState(false)
 
@@ -146,6 +147,15 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
           <span className="text-sm font-medium text-gray-300">
             {groups.length} group{groups.length !== 1 ? 's' : ''}
           </span>
+          {isPersisted && (
+            <span
+              className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[9px] font-medium rounded bg-green-500/20 text-green-400 border border-green-500/30"
+              title="Groups are stored as Kubernetes CRs"
+            >
+              <Database className="w-2.5 h-2.5" />
+              CR
+            </span>
+          )}
         </div>
         <button
           onClick={() => setIsCreating(true)}


### PR DESCRIPTION
## Summary
Integrate CRD-based persistence into the Deploy dashboard cards.

- ClusterGroups card now stores groups as ClusterGroup CRs when persistence is enabled
- Deploy drag-and-drop creates ManagedWorkload and WorkloadDeployment CRs
- Visual "CR" badge shows when groups are persisted to Kubernetes

## Changes
- **useClusterGroups hook**: Automatically uses CRs or localStorage based on persistence config
- **Deploy.tsx**: Creates CRs when workloads are dragged to cluster groups
- **ClusterGroups card**: Shows green "CR" badge when persistence is active

## kubectl Experience
When persistence is enabled, users can interact with cluster groups via kubectl:
```bash
kubectl get clustergroups -n kubestellar-console
```

## Test plan
- [ ] Enable persistence in Settings > Integrations > Deploy Persistence
- [ ] Create a cluster group - verify CR is created via kubectl
- [ ] Drag a workload to a cluster group - verify CRs are created
- [ ] Verify "CR" badge appears on ClusterGroups card header
- [ ] Disable persistence - verify fallback to localStorage works

🤖 Generated with [Claude Code](https://claude.com/claude-code)