### PR TITLE
✨ Add Diagnose and Repair action buttons to failed items in dashboard cards

### DIFF
--- a/web/src/components/cards/DeploymentIssues.tsx
+++ b/web/src/components/cards/DeploymentIssues.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, AlertCircle, Clock, Scale, CheckCircle } from 'lucide-react'
+import { AlertTriangle, AlertCircle, Clock, Scale, CheckCircle, RotateCw, ArrowUpCircle, FileText } from 'lucide-react'
 import { useCachedDeploymentIssues } from '../../hooks/useCachedData'
 import type { DeploymentIssue } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -9,6 +9,7 @@ import {
   useCardData, commonComparators,
   CardSkeleton, CardEmptyState, CardSearchInput,
   CardControlsRow, CardListItem, CardPaginationFooter,
+  CardActionButtons,
 } from '../../lib/cards'
 
 type SortByOption = 'status' | 'name' | 'cluster'
@@ -41,7 +42,7 @@ export function DeploymentIssues({ config }: DeploymentIssuesProps) {
     error
   } = useCachedDeploymentIssues(clusterConfig, namespaceConfig)
 
-  const { drillToDeployment } = useDrillDownActions()
+  const { drillToDeployment, drillToEvents, drillToLogs } = useDrillDownActions()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton, showEmptyState } = useCardLoadingState({
@@ -213,6 +214,37 @@ export function DeploymentIssues({ config }: DeploymentIssuesProps) {
                       {issue.message}
                     </p>
                   )}
+                  {/* Diagnose & Repair actions */}
+                  <CardActionButtons
+                    className="mt-2"
+                    onDiagnose={() => drillToEvents(issue.cluster || 'default', issue.namespace, issue.name)}
+                    repairOptions={[
+                      {
+                        label: 'Rollout Restart',
+                        icon: RotateCw,
+                        description: 'Restart all pods in this deployment',
+                        onClick: () => drillToDeployment(issue.cluster || 'default', issue.namespace, issue.name, {
+                          reason: issue.reason,
+                          action: 'rollout-restart',
+                        }),
+                      },
+                      {
+                        label: 'Scale Up Replicas',
+                        icon: ArrowUpCircle,
+                        description: 'Increase replica count',
+                        onClick: () => drillToDeployment(issue.cluster || 'default', issue.namespace, issue.name, {
+                          reason: issue.reason,
+                          action: 'scale',
+                        }),
+                      },
+                      {
+                        label: 'View Logs',
+                        icon: FileText,
+                        description: 'Check container logs for errors',
+                        onClick: () => drillToLogs(issue.cluster || 'default', issue.namespace, issue.name),
+                      },
+                    ]}
+                  />
                 </div>
               </div>
             </CardListItem>

--- a/web/src/components/cards/DeploymentStatus.tsx
+++ b/web/src/components/cards/DeploymentStatus.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { CheckCircle, Clock, XCircle, ChevronRight, Filter, Server } from 'lucide-react'
+import { CheckCircle, Clock, XCircle, ChevronRight, Filter, Server, RotateCw, ArrowUpCircle, FileText } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCachedDeployments } from '../../hooks/useCachedData'
@@ -15,6 +15,7 @@ import {
   commonComparators,
   CardClusterFilter,
   CardSearchInput,
+  CardActionButtons,
   type SortDirection,
 } from '../../lib/cards'
 
@@ -74,7 +75,7 @@ const FILTER_CONFIG = {
 }
 
 export function DeploymentStatus() {
-  const { drillToDeployment } = useDrillDownActions()
+  const { drillToDeployment, drillToEvents, drillToLogs } = useDrillDownActions()
   const {
     deployments: allDeployments,
     isLoading: hookLoading,
@@ -335,6 +336,40 @@ export function DeploymentStatus() {
                     style={{ width: `${deployment.progress}%` }}
                   />
                 </div>
+
+                {/* Diagnose & Repair for failed deployments */}
+                {deployment.status === 'failed' && (
+                  <CardActionButtons
+                    className="mt-2"
+                    onDiagnose={() => drillToEvents(clusterName, deployment.namespace, deployment.name)}
+                    repairOptions={[
+                      {
+                        label: 'Rollout Restart',
+                        icon: RotateCw,
+                        description: 'Restart all pods in this deployment',
+                        onClick: () => drillToDeployment(clusterName, deployment.namespace, deployment.name, {
+                          status: deployment.status,
+                          action: 'rollout-restart',
+                        }),
+                      },
+                      {
+                        label: 'Scale Up Replicas',
+                        icon: ArrowUpCircle,
+                        description: 'Increase replica count',
+                        onClick: () => drillToDeployment(clusterName, deployment.namespace, deployment.name, {
+                          status: deployment.status,
+                          action: 'scale',
+                        }),
+                      },
+                      {
+                        label: 'View Logs',
+                        icon: FileText,
+                        description: 'Check container logs for errors',
+                        onClick: () => drillToLogs(clusterName, deployment.namespace, deployment.name),
+                      },
+                    ]}
+                  />
+                )}
               </div>
             )
           })

--- a/web/src/components/cards/PodIssues.tsx
+++ b/web/src/components/cards/PodIssues.tsx
@@ -1,4 +1,4 @@
-import { MemoryStick, ImageOff, Clock, RefreshCw, CheckCircle } from 'lucide-react'
+import { MemoryStick, ImageOff, Clock, RefreshCw, CheckCircle, RotateCw, FileText, Calendar } from 'lucide-react'
 import { useCachedPodIssues } from '../../hooks/useCachedData'
 import type { PodIssue } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -9,6 +9,7 @@ import {
   useCardData, commonComparators, getStatusColors,
   CardSkeleton, CardEmptyState, CardSearchInput,
   CardControlsRow, CardListItem, CardPaginationFooter,
+  CardActionButtons,
 } from '../../lib/cards'
 
 type SortByOption = 'status' | 'name' | 'restarts' | 'cluster'
@@ -43,7 +44,7 @@ export function PodIssues() {
     isFailed,
     consecutiveFailures,
   })
-  const { drillToPod } = useDrillDownActions()
+  const { drillToPod, drillToEvents, drillToLogs } = useDrillDownActions()
 
   // Use shared card data hook for filtering, sorting, and pagination
   const {
@@ -204,6 +205,34 @@ export function PodIssues() {
                       {issue.issues.join(', ')}
                     </p>
                   )}
+                  {/* Diagnose & Repair actions */}
+                  <CardActionButtons
+                    className="mt-2"
+                    onDiagnose={() => drillToEvents(issue.cluster || 'default', issue.namespace, issue.name)}
+                    repairOptions={[
+                      {
+                        label: 'Restart Pod',
+                        icon: RotateCw,
+                        description: 'Delete pod to let controller recreate it',
+                        onClick: () => drillToPod(issue.cluster || 'default', issue.namespace, issue.name, {
+                          status: issue.status,
+                          action: 'restart',
+                        }),
+                      },
+                      {
+                        label: 'View Logs',
+                        icon: FileText,
+                        description: 'Check container logs for errors',
+                        onClick: () => drillToLogs(issue.cluster || 'default', issue.namespace, issue.name),
+                      },
+                      {
+                        label: 'View Events',
+                        icon: Calendar,
+                        description: 'See recent events for this pod',
+                        onClick: () => drillToEvents(issue.cluster || 'default', issue.namespace, issue.name),
+                      },
+                    ]}
+                  />
                 </div>
               </div>
             </CardListItem>

--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -1,4 +1,4 @@
-import { Shield, AlertTriangle, User, Network, Server, ChevronRight } from 'lucide-react'
+import { Shield, AlertTriangle, User, Network, Server, ChevronRight, FileCode, Calendar, Eye } from 'lucide-react'
 import { useMemo } from 'react'
 import type { SecurityIssue } from '../../hooks/useMCP'
 import { useCachedSecurityIssues } from '../../hooks/useCachedData'
@@ -7,7 +7,7 @@ import { ClusterBadge } from '../ui/ClusterBadge'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { LimitedAccessWarning } from '../ui/LimitedAccessWarning'
-import { useCardData, CardClusterFilter, CardSearchInput } from '../../lib/cards'
+import { useCardData, CardClusterFilter, CardSearchInput, CardActionButtons } from '../../lib/cards'
 import { SEVERITY_COLORS, SeverityLevel } from '../../lib/accessibility'
 import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 
@@ -107,7 +107,7 @@ export function SecurityIssues({ config }: SecurityIssuesProps) {
   const isFailed = isDemoMode ? false : cachedFailed
   const consecutiveFailures = isDemoMode ? 0 : cachedFailures
 
-  const { drillToPod } = useDrillDownActions()
+  const { drillToPod, drillToEvents, drillToYAML } = useDrillDownActions()
 
   // Report card data state to parent CardWrapper for automatic skeleton/refresh handling
   const { showSkeleton, showEmptyState } = useCardLoadingState({
@@ -319,6 +319,37 @@ export function SecurityIssues({ config }: SecurityIssuesProps) {
                       {issue.details}
                     </p>
                   )}
+                  {/* Diagnose & Repair actions */}
+                  <CardActionButtons
+                    className="mt-2"
+                    onDiagnose={() => drillToPod(issue.cluster || 'default', issue.namespace, issue.name, {
+                      securityIssue: issue.issue,
+                      severity: issue.severity,
+                    })}
+                    repairOptions={[
+                      {
+                        label: 'View Pod Details',
+                        icon: Eye,
+                        description: 'Inspect pod configuration',
+                        onClick: () => drillToPod(issue.cluster || 'default', issue.namespace, issue.name, {
+                          securityIssue: issue.issue,
+                          severity: issue.severity,
+                        }),
+                      },
+                      {
+                        label: 'Edit YAML',
+                        icon: FileCode,
+                        description: 'View and fix pod security context',
+                        onClick: () => drillToYAML(issue.cluster || 'default', issue.namespace, 'Pod', issue.name),
+                      },
+                      {
+                        label: 'View Events',
+                        icon: Calendar,
+                        description: 'See recent pod events',
+                        onClick: () => drillToEvents(issue.cluster || 'default', issue.namespace, issue.name),
+                      },
+                    ]}
+                  />
                 </div>
                 <span title="Click to view details"><ChevronRight className="w-4 h-4 text-muted-foreground flex-shrink-0 mt-1" /></span>
               </div>

--- a/web/src/lib/cards/index.ts
+++ b/web/src/lib/cards/index.ts
@@ -64,6 +64,7 @@ export {
   CardFilterChips,
   CardControlsRow,
   CardPaginationFooter,
+  CardActionButtons,
   type CardSkeletonProps,
   type CardEmptyStateProps,
   type CardErrorStateProps,
@@ -77,6 +78,8 @@ export {
   type CardFilterChipsProps,
   type CardControlsRowProps,
   type CardPaginationFooterProps,
+  type RepairOption,
+  type CardActionButtonsProps,
   useDropdownPortal,
 } from './CardComponents'
 


### PR DESCRIPTION
## Summary
- Adds per-item **Diagnose** and **Repair** action buttons to failed/unhealthy items across 6 dashboard cards (ClusterHealth, SecurityIssues, PodIssues, DeploymentIssues, DeploymentStatus, AppStatus)
- **Diagnose** button (amber) opens events/details view for the specific failed item
- **Repair** button (blue dropdown) offers contextual repair actions based on failure type (restart pod, rollout restart, scale up, view logs, view events, edit YAML, retry connection, etc.)
- New reusable `CardActionButtons` component in the shared card library with portal-based dropdown menu

## Test plan
- [x] TypeScript build passes (`tsc -b` clean)
- [x] Lint passes (no new errors)
- [x] Verified buttons render on failed items in demo mode via Chrome DevTools
- [x] Verified Repair dropdown menu opens with contextual options
- [x] Verified buttons don't appear on healthy items
- [ ] Manual test: Click Diagnose button triggers drill-down to events view
- [ ] Manual test: Click Repair option triggers appropriate action

🤖 Generated with [Claude Code](https://claude.com/claude-code)