### PR TITLE
✨ Add live preview and AI assist to Card & Stat Block factories

### DIFF
--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -59,12 +59,12 @@ export function DynamicCard({ config }: CardComponentProps) {
 // Tier 1: Declarative Card Runtime
 // ============================================================================
 
-interface Tier1Props {
+export interface Tier1Props {
   definition: DynamicCardDefinition
   cardDefinition: DynamicCardDefinition_T1
 }
 
-function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
+export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
   const [apiData, setApiData] = useState<Record<string, unknown>[]>([])
   const [apiLoading, setApiLoading] = useState(false)
   const [apiError, setApiError] = useState<string | null>(null)
@@ -272,12 +272,12 @@ function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
 // Tier 2: Custom Code Runtime
 // ============================================================================
 
-interface Tier2Props {
+export interface Tier2Props {
   definition: DynamicCardDefinition
   config?: Record<string, unknown>
 }
 
-function Tier2CardRuntime({ definition, config }: Tier2Props) {
+export function Tier2CardRuntime({ definition, config }: Tier2Props) {
   const [CardComponent, setCardComponent] = useState<CardComponent | null>(null)
   const [compiling, setCompiling] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/web/src/components/dashboard/InlineAIAssist.tsx
+++ b/web/src/components/dashboard/InlineAIAssist.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Sparkles, Loader2, ChevronDown, ChevronUp, CheckCircle, AlertTriangle } from 'lucide-react'
+import { useMissions } from '../../hooks/useMissions'
+import { useApiKeyCheck, ApiKeyPromptModal } from '../cards/console-missions/shared'
+import { useAIMode } from '../../hooks/useAIMode'
+import { extractJsonFromMarkdown } from '../../lib/ai/extractJson'
+import { cn } from '../../lib/cn'
+
+interface InlineAIAssistProps<T> {
+  systemPrompt: string
+  placeholder: string
+  onResult: (result: T) => void
+  validateResult?: (data: unknown) => { valid: true; result: T } | { valid: false; error: string }
+}
+
+type Phase = 'collapsed' | 'idle' | 'generating' | 'success' | 'error'
+
+export function InlineAIAssist<T>({
+  systemPrompt,
+  placeholder,
+  onResult,
+  validateResult,
+}: InlineAIAssistProps<T>) {
+  const { mode, isFeatureEnabled } = useAIMode()
+  const { startMission, missions, closeSidebar } = useMissions()
+  const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
+
+  const [phase, setPhase] = useState<Phase>(() =>
+    mode === 'high' ? 'idle' : 'collapsed'
+  )
+  const [input, setInput] = useState('')
+  const [missionId, setMissionId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const enabled = isFeatureEnabled('naturalLanguage')
+  const trackedMission = missionId ? missions.find(m => m.id === missionId) : null
+
+  // Watch mission completion
+  useEffect(() => {
+    if (!trackedMission || phase !== 'generating') return
+
+    const assistantMessages = trackedMission.messages.filter(m => m.role === 'assistant')
+    const lastMsg = assistantMessages[assistantMessages.length - 1]
+
+    if (
+      (trackedMission.status === 'waiting_input' || trackedMission.status === 'completed') &&
+      lastMsg
+    ) {
+      const { data, error: parseErr } = extractJsonFromMarkdown<unknown>(lastMsg.content)
+      if (data) {
+        if (validateResult) {
+          const validation = validateResult(data)
+          if (validation.valid) {
+            onResult(validation.result)
+            setPhase('success')
+            setTimeout(() => {
+              setPhase('collapsed')
+              setInput('')
+            }, 1500)
+          } else {
+            setError(validation.error)
+            setPhase('error')
+          }
+        } else {
+          onResult(data as T)
+          setPhase('success')
+          setTimeout(() => {
+            setPhase('collapsed')
+            setInput('')
+          }, 1500)
+        }
+      } else {
+        setError(parseErr || 'Failed to parse AI response')
+        setPhase('error')
+      }
+    }
+
+    if (trackedMission.status === 'failed') {
+      setError('AI generation failed. Check your agent connection.')
+      setPhase('error')
+    }
+  }, [trackedMission, phase, validateResult, onResult])
+
+  const handleGenerate = useCallback(() => {
+    if (!input.trim()) return
+
+    checkKeyAndRun(() => {
+      const fullPrompt = `${systemPrompt}\n\nUser request: ${input}`
+      const id = startMission({
+        title: 'Inline AI Assist',
+        description: input.substring(0, 200),
+        type: 'custom',
+        initialPrompt: fullPrompt,
+      })
+      setMissionId(id)
+      setPhase('generating')
+      setError(null)
+      setTimeout(() => closeSidebar(), 150)
+    })
+  }, [input, systemPrompt, startMission, closeSidebar, checkKeyAndRun])
+
+  // Don't show at all in low mode
+  if (!enabled) return null
+
+  if (phase === 'collapsed') {
+    return (
+      <button
+        onClick={() => setPhase('idle')}
+        className="w-full flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs bg-purple-500/5 border border-purple-500/10 text-purple-400/70 hover:bg-purple-500/10 hover:text-purple-400 transition-colors"
+      >
+        <Sparkles className="w-3 h-3" />
+        <span>AI Assist — describe what you want</span>
+        <ChevronDown className="w-3 h-3 ml-auto" />
+      </button>
+    )
+  }
+
+  return (
+    <div className="rounded-md border border-purple-500/20 bg-purple-500/5 p-2 space-y-2">
+      <ApiKeyPromptModal isOpen={showKeyPrompt} onDismiss={dismissPrompt} onGoToSettings={goToSettings} />
+
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <Sparkles className="w-3 h-3 text-purple-400" />
+          <span className="text-[10px] font-medium text-purple-400 uppercase tracking-wide">AI Assist</span>
+        </div>
+        <button
+          onClick={() => { setPhase('collapsed'); setError(null) }}
+          className="p-0.5 text-muted-foreground/50 hover:text-foreground transition-colors"
+        >
+          <ChevronUp className="w-3 h-3" />
+        </button>
+      </div>
+
+      {/* Input + button */}
+      {(phase === 'idle' || phase === 'error') && (
+        <div className="flex gap-1.5">
+          <input
+            type="text"
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') handleGenerate()
+            }}
+            placeholder={placeholder}
+            className="flex-1 text-xs px-2.5 py-1.5 rounded-md bg-secondary/50 border border-border text-foreground placeholder:text-muted-foreground/40 focus:outline-none focus:ring-1 focus:ring-purple-500/50"
+          />
+          <button
+            onClick={handleGenerate}
+            disabled={!input.trim()}
+            className={cn(
+              'px-3 py-1.5 rounded-md text-xs font-medium transition-colors shrink-0',
+              input.trim()
+                ? 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30'
+                : 'bg-secondary text-muted-foreground cursor-not-allowed',
+            )}
+          >
+            Generate
+          </button>
+        </div>
+      )}
+
+      {/* Error */}
+      {phase === 'error' && error && (
+        <div className="flex items-center gap-1.5 text-[10px] text-red-400">
+          <AlertTriangle className="w-3 h-3 shrink-0" />
+          <span className="truncate">{error}</span>
+        </div>
+      )}
+
+      {/* Generating */}
+      {phase === 'generating' && (
+        <div className="flex items-center gap-2 py-1">
+          <Loader2 className="w-3.5 h-3.5 text-purple-400 animate-spin" />
+          <span className="text-xs text-purple-400">Generating...</span>
+        </div>
+      )}
+
+      {/* Success */}
+      {phase === 'success' && (
+        <div className="flex items-center gap-2 py-1">
+          <CheckCircle className="w-3.5 h-3.5 text-green-400" />
+          <span className="text-xs text-green-400">Applied!</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/dashboard/LivePreviewPanel.tsx
+++ b/web/src/components/dashboard/LivePreviewPanel.tsx
@@ -1,0 +1,248 @@
+import { useState, useEffect, useRef, useMemo } from 'react'
+import { Eye, EyeOff, Maximize2, Minimize2, AlertTriangle, Loader2, Database } from 'lucide-react'
+import { Tier1CardRuntime } from '../cards/DynamicCard'
+import { compileCardCode, createCardComponent } from '../../lib/dynamic-cards/compiler'
+import { DynamicCardErrorBoundary } from '../cards/DynamicCardErrorBoundary'
+import { cn } from '../../lib/cn'
+import type { DynamicCardDefinition, DynamicCardDefinition_T1 } from '../../lib/dynamic-cards/types'
+import type { CardComponent } from '../cards/cardRegistry'
+
+interface LivePreviewPanelProps {
+  tier: 'tier1' | 'tier2'
+  t1Config?: {
+    layout: 'list' | 'stats' | 'stats-and-list'
+    columns: DynamicCardDefinition_T1['columns']
+    staticData: Record<string, unknown>[]
+    stats?: DynamicCardDefinition_T1['stats']
+    searchFields?: string[]
+    defaultLimit?: number
+  }
+  t2Source?: string
+  title?: string
+  width?: number
+}
+
+const DEBOUNCE_T1 = 300
+const DEBOUNCE_T2 = 800
+
+export function LivePreviewPanel({ tier, t1Config, t2Source, title, width = 6 }: LivePreviewPanelProps) {
+  const [collapsed, setCollapsed] = useState(false)
+  const [sizeMode, setSizeMode] = useState<'card' | 'full'>('card')
+
+  if (collapsed) {
+    return (
+      <div className="flex items-center justify-center border-l border-border/50 bg-secondary/10 w-10 shrink-0">
+        <button
+          onClick={() => setCollapsed(false)}
+          className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+          title="Show preview"
+        >
+          <Eye className="w-4 h-4" />
+        </button>
+      </div>
+    )
+  }
+
+  const maxWidth = sizeMode === 'card'
+    ? `${Math.round((width / 12) * 400)}px`
+    : undefined
+
+  return (
+    <div className="border-l border-border/50 bg-secondary/10 flex flex-col w-[45%] shrink-0">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-1.5 border-b border-border/30">
+        <div className="flex items-center gap-1.5">
+          <Eye className="w-3 h-3 text-muted-foreground" />
+          <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide">Preview</span>
+          <span className="text-[9px] px-1 py-0.5 rounded bg-purple-500/10 text-purple-400/70">
+            Sample data
+          </span>
+        </div>
+        <div className="flex items-center gap-0.5">
+          <button
+            onClick={() => setSizeMode(sizeMode === 'card' ? 'full' : 'card')}
+            className="p-1 rounded text-muted-foreground/60 hover:text-foreground transition-colors"
+            title={sizeMode === 'card' ? 'Full width' : 'Card width'}
+          >
+            {sizeMode === 'card' ? <Maximize2 className="w-3 h-3" /> : <Minimize2 className="w-3 h-3" />}
+          </button>
+          <button
+            onClick={() => setCollapsed(true)}
+            className="p-1 rounded text-muted-foreground/60 hover:text-foreground transition-colors"
+            title="Hide preview"
+          >
+            <EyeOff className="w-3 h-3" />
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto p-3">
+        <div
+          className={cn(
+            'rounded-lg border border-border/50 bg-card/30 p-3 mx-auto transition-all',
+            sizeMode === 'card' && 'max-w-full',
+          )}
+          style={maxWidth ? { maxWidth } : undefined}
+        >
+          {title && (
+            <p className="text-xs font-medium text-muted-foreground mb-2 truncate">{title}</p>
+          )}
+          {tier === 'tier1' ? (
+            <T1Preview config={t1Config} />
+          ) : (
+            <T2Preview source={t2Source} />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Tier 1 Preview (debounced)
+// ============================================================================
+
+function T1Preview({ config }: { config?: LivePreviewPanelProps['t1Config'] }) {
+  const [debouncedConfig, setDebouncedConfig] = useState(config)
+  const timerRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => setDebouncedConfig(config), DEBOUNCE_T1)
+    return () => clearTimeout(timerRef.current)
+  }, [config])
+
+  if (!debouncedConfig || !debouncedConfig.columns || debouncedConfig.columns.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-center">
+        <Database className="w-6 h-6 text-muted-foreground/30 mb-2" />
+        <p className="text-xs text-muted-foreground/50">Add columns to see preview</p>
+      </div>
+    )
+  }
+
+  const cardDef: DynamicCardDefinition_T1 = {
+    dataSource: 'static',
+    staticData: debouncedConfig.staticData || [],
+    columns: debouncedConfig.columns,
+    layout: debouncedConfig.layout,
+    stats: debouncedConfig.stats,
+    searchFields: debouncedConfig.searchFields || debouncedConfig.columns.map(c => c.field),
+    defaultLimit: debouncedConfig.defaultLimit || 5,
+  }
+
+  const ephemeralDef: DynamicCardDefinition = {
+    id: '__preview__',
+    title: 'Preview',
+    tier: 'tier1',
+    createdAt: '',
+    updatedAt: '',
+    cardDefinition: cardDef,
+  }
+
+  return (
+    <DynamicCardErrorBoundary cardId="__preview__">
+      <Tier1CardRuntime definition={ephemeralDef} cardDefinition={cardDef} />
+    </DynamicCardErrorBoundary>
+  )
+}
+
+// ============================================================================
+// Tier 2 Preview (debounced compilation)
+// ============================================================================
+
+function T2Preview({ source }: { source?: string }) {
+  const [debouncedSource, setDebouncedSource] = useState(source)
+  const [compiling, setCompiling] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [CardComponent, setCardComponent] = useState<CardComponent | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout>>()
+
+  // Debounce source changes
+  useEffect(() => {
+    clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => setDebouncedSource(source), DEBOUNCE_T2)
+    return () => clearTimeout(timerRef.current)
+  }, [source])
+
+  // Compile when debounced source updates
+  const compiledKey = useMemo(() => debouncedSource, [debouncedSource])
+
+  useEffect(() => {
+    if (!compiledKey) {
+      setCardComponent(null)
+      setError(null)
+      return
+    }
+
+    let cancelled = false
+    setCompiling(true)
+    setError(null)
+
+    compileCardCode(compiledKey).then(result => {
+      if (cancelled) return
+      if (result.error) {
+        setError(result.error)
+        setCompiling(false)
+        setCardComponent(null)
+        return
+      }
+      const componentResult = createCardComponent(result.code!)
+      if (cancelled) return
+      if (componentResult.error) {
+        setError(componentResult.error)
+        setCompiling(false)
+        setCardComponent(null)
+        return
+      }
+      setCardComponent(() => componentResult.component)
+      setCompiling(false)
+    })
+
+    return () => { cancelled = true }
+  }, [compiledKey])
+
+  if (!source) {
+    return (
+      <div className="flex flex-col items-center justify-center py-6 text-center">
+        <Database className="w-6 h-6 text-muted-foreground/30 mb-2" />
+        <p className="text-xs text-muted-foreground/50">Write code to see preview</p>
+      </div>
+    )
+  }
+
+  if (compiling) {
+    return (
+      <div className="flex items-center justify-center py-6 gap-2">
+        <Loader2 className="w-4 h-4 text-purple-400 animate-spin" />
+        <span className="text-xs text-muted-foreground">Compiling...</span>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-4 px-2 text-center">
+        <AlertTriangle className="w-5 h-5 text-red-400 mb-1.5" />
+        <p className="text-[10px] text-red-400 font-mono break-all max-h-20 overflow-y-auto">{error}</p>
+      </div>
+    )
+  }
+
+  if (!CardComponent) {
+    return (
+      <div className="flex items-center justify-center py-6">
+        <p className="text-xs text-muted-foreground/50">No component produced</p>
+      </div>
+    )
+  }
+
+  return (
+    <DynamicCardErrorBoundary cardId="__preview_t2__">
+      <div className="min-h-[120px]">
+        <CardComponent config={{}} />
+      </div>
+    </DynamicCardErrorBoundary>
+  )
+}

--- a/web/src/lib/ai/prompts.ts
+++ b/web/src/lib/ai/prompts.ts
@@ -96,6 +96,77 @@ EXAMPLE:
 }
 \`\`\``
 
+export const CARD_INLINE_ASSIST_PROMPT = `You are an assistant that populates a declarative dashboard card form for a Kubernetes management console.
+
+The user will describe what they want briefly. Respond with a JSON object to populate the card form.
+
+{
+  "title": "string",
+  "description": "string",
+  "layout": "list" | "stats" | "stats-and-list",
+  "width": 3 | 4 | 6 | 8 | 12,
+  "columns": [
+    {
+      "field": "string (camelCase)",
+      "label": "string",
+      "format": "text" | "badge" | "number",
+      "badgeColors": { "value": "bg-COLOR-500/20 text-COLOR-400" }
+    }
+  ],
+  "data": [{ "field1": "value1" }]
+}
+
+RULES:
+- Keep it concise. 2-5 columns, 3-5 data rows.
+- Use realistic Kubernetes data.
+- Badge colors: green for healthy/running, red for failed/error, yellow for pending/warning.
+- Return ONLY JSON in a \`\`\`json fence.`
+
+export const CODE_INLINE_ASSIST_PROMPT = `You are an assistant that generates TSX source code for a custom dashboard card in a Kubernetes management console.
+
+The user will describe what they want. Generate a default-exported React component.
+
+Available in scope (DO NOT import): React, useState, useEffect, useMemo, useCallback, useRef, cn, useCardData, Skeleton, Pagination, all lucide-react icons.
+
+Return a JSON object:
+{
+  "title": "string",
+  "description": "string",
+  "width": 3 | 4 | 6 | 8 | 12,
+  "sourceCode": "export default function MyCard({ config }) { ... }"
+}
+
+RULES:
+- Use Tailwind CSS, dark theme: bg-secondary, text-foreground, text-muted-foreground, border-border
+- Purple accent: bg-purple-500/20, text-purple-400
+- h-full on root container
+- Include demo data/state so the card renders immediately
+- No import statements
+- Return ONLY JSON in a \`\`\`json fence.`
+
+export const STAT_INLINE_ASSIST_PROMPT = `You are an assistant that populates a stat block form for a Kubernetes management console.
+
+The user will describe what stat blocks they want. Respond with a JSON object:
+
+{
+  "title": "string",
+  "blocks": [
+    {
+      "label": "string",
+      "icon": "PascalCase lucide icon name",
+      "color": "purple" | "blue" | "green" | "yellow" | "orange" | "red" | "cyan" | "gray" | "indigo",
+      "field": "camelCase field name",
+      "format": "" | "number" | "percent" | "bytes",
+      "tooltip": "string"
+    }
+  ]
+}
+
+RULES:
+- 3-6 blocks. Green for healthy, red for errors, yellow for warnings, blue for info, purple for totals.
+- Available icons: Server, Database, Cpu, MemoryStick, CheckCircle2, XCircle, AlertTriangle, Activity, Layers, Shield, Globe, Cloud, Gauge, TrendingUp
+- Return ONLY JSON in a \`\`\`json fence.`
+
 export const STAT_BLOCK_SYSTEM_PROMPT = `You are an expert at creating dashboard stat block definitions for a Kubernetes management console.
 
 The user will describe the stat blocks they want. You must generate a valid JSON definition that matches this exact schema:

--- a/web/src/lib/ai/sampleData.ts
+++ b/web/src/lib/ai/sampleData.ts
@@ -1,0 +1,129 @@
+/**
+ * Heuristic sample data generator for live preview auto-population.
+ * Detects field semantics from column names and generates realistic Kubernetes-themed data.
+ */
+
+import type { DynamicCardColumn } from '../dynamic-cards/types'
+
+const K8S_NAMES = [
+  'api-server-1', 'worker-node-3', 'etcd-backup-2', 'ingress-ctrl-1',
+  'scheduler-main', 'coredns-7f9c', 'kube-proxy-4b2', 'metrics-srv-1',
+  'cert-manager-5a', 'redis-cache-2',
+]
+
+const NAMESPACES = [
+  'default', 'kube-system', 'production', 'staging', 'monitoring',
+  'istio-system', 'cert-manager', 'logging', 'ingress-nginx', 'argocd',
+]
+
+const CLUSTERS = [
+  'us-east-prod', 'eu-west-staging', 'ap-south-dev', 'us-west-dr',
+  'eu-central-prod',
+]
+
+const STATUS_VALUES = ['Running', 'Pending', 'Failed', 'Succeeded', 'Unknown']
+const HEALTH_VALUES = ['Healthy', 'Degraded', 'Critical', 'Unknown']
+const PHASE_VALUES = ['Active', 'Terminating', 'Pending']
+const BOOLEAN_VALUES = ['true', 'false']
+
+interface FieldSemantics {
+  pattern: RegExp
+  generate: (rowIdx: number) => unknown
+}
+
+const FIELD_HEURISTICS: FieldSemantics[] = [
+  { pattern: /^(pod_?)?name$|^resource$/i, generate: (i) => K8S_NAMES[i % K8S_NAMES.length] },
+  { pattern: /^namespace$/i, generate: (i) => NAMESPACES[i % NAMESPACES.length] },
+  { pattern: /^cluster$/i, generate: (i) => CLUSTERS[i % CLUSTERS.length] },
+  { pattern: /^status$/i, generate: (i) => STATUS_VALUES[i % STATUS_VALUES.length] },
+  { pattern: /^health$/i, generate: (i) => HEALTH_VALUES[i % HEALTH_VALUES.length] },
+  { pattern: /^phase$/i, generate: (i) => PHASE_VALUES[i % PHASE_VALUES.length] },
+  { pattern: /^ready$/i, generate: (i) => BOOLEAN_VALUES[i % 2] },
+  { pattern: /^restarts?$/i, generate: (i) => [0, 0, 2, 5, 0][i % 5] },
+  { pattern: /^(replicas?|count|total|instances?)$/i, generate: (i) => [3, 1, 5, 2, 4][i % 5] },
+  { pattern: /^(desired|available|ready_?replicas)$/i, generate: (i) => [3, 1, 5, 2, 4][i % 5] },
+  { pattern: /^cpu$/i, generate: (i) => ['250m', '500m', '1', '100m', '2'][i % 5] },
+  { pattern: /^memory$/i, generate: (i) => ['256Mi', '512Mi', '1Gi', '128Mi', '2Gi'][i % 5] },
+  { pattern: /^age$/i, generate: (i) => ['5d', '12h', '3d', '1h', '30d'][i % 5] },
+  { pattern: /^version$/i, generate: (i) => ['v1.28.3', 'v1.27.8', 'v1.29.0', 'v1.28.1', 'v1.27.5'][i % 5] },
+  { pattern: /^type$/i, generate: (i) => ['Deployment', 'StatefulSet', 'DaemonSet', 'Job', 'CronJob'][i % 5] },
+  { pattern: /^node$/i, generate: (i) => [`node-${i + 1}`, `worker-${i + 1}`][i % 2] },
+  { pattern: /^ip$|^address$/i, generate: (i) => `10.0.${i}.${100 + i}` },
+  { pattern: /^port$/i, generate: (i) => [80, 443, 8080, 3000, 6379][i % 5] },
+  { pattern: /^(image|container)$/i, generate: (i) => [`nginx:1.${25 + i}`, `redis:7.${i}`, `postgres:16.${i}`][i % 3] },
+  { pattern: /^(created|updated|timestamp|time|date)$/i, generate: (i) => {
+    const d = new Date(); d.setDate(d.getDate() - i * 3); return d.toISOString().split('T')[0]
+  }},
+  { pattern: /^(label|tag)s?$/i, generate: (i) => [`app=web`, `env=prod`, `team=platform`, `tier=backend`, `app=api`][i % 5] },
+  { pattern: /^(percent|pct|usage|utilization)$/i, generate: (i) => [45, 72, 18, 91, 33][i % 5] },
+]
+
+const ROW_COUNT = 5
+
+function generateFieldValue(fieldName: string, rowIdx: number): unknown {
+  for (const heuristic of FIELD_HEURISTICS) {
+    if (heuristic.pattern.test(fieldName)) {
+      return heuristic.generate(rowIdx)
+    }
+  }
+  return `value-${rowIdx + 1}`
+}
+
+export function generateSampleData(columns: DynamicCardColumn[]): Record<string, unknown>[] {
+  if (columns.length === 0) return []
+
+  const rows: Record<string, unknown>[] = []
+  for (let i = 0; i < ROW_COUNT; i++) {
+    const row: Record<string, unknown> = {}
+    for (const col of columns) {
+      if (col.field) {
+        row[col.field] = generateFieldValue(col.field, i)
+      }
+    }
+    rows.push(row)
+  }
+  return rows
+}
+
+export function detectFieldFormat(
+  fieldName: string,
+  sampleValues: unknown[],
+): { format: 'text' | 'badge' | 'number'; badgeColors?: Record<string, string> } {
+  const lowerField = fieldName.toLowerCase()
+
+  if (/^(status|health|phase|state|ready)$/.test(lowerField)) {
+    const uniqueVals = [...new Set(sampleValues.map(String))]
+    if (uniqueVals.length <= 6) {
+      const COLOR_MAP: Record<string, string> = {
+        running: 'bg-green-500/20 text-green-400',
+        healthy: 'bg-green-500/20 text-green-400',
+        active: 'bg-green-500/20 text-green-400',
+        succeeded: 'bg-green-500/20 text-green-400',
+        true: 'bg-green-500/20 text-green-400',
+        pending: 'bg-yellow-500/20 text-yellow-400',
+        degraded: 'bg-yellow-500/20 text-yellow-400',
+        terminating: 'bg-yellow-500/20 text-yellow-400',
+        failed: 'bg-red-500/20 text-red-400',
+        critical: 'bg-red-500/20 text-red-400',
+        error: 'bg-red-500/20 text-red-400',
+        false: 'bg-red-500/20 text-red-400',
+        unknown: 'bg-gray-500/20 text-gray-400',
+      }
+      const badgeColors: Record<string, string> = {}
+      for (const v of uniqueVals) {
+        badgeColors[v] = COLOR_MAP[v.toLowerCase()] || 'bg-blue-500/20 text-blue-400'
+      }
+      return { format: 'badge', badgeColors }
+    }
+  }
+
+  if (/^(restarts?|count|total|replicas?|port|instances?|desired|available|percent|pct|usage)$/.test(lowerField)) {
+    return { format: 'number' }
+  }
+
+  if (sampleValues.length > 0 && sampleValues.every(v => typeof v === 'number')) {
+    return { format: 'number' }
+  }
+
+  return { format: 'text' }
+}


### PR DESCRIPTION
## Summary
- **Live Preview Panel**: Split-pane layout in Card Factory (Declarative & Code tabs) with debounced real-time preview (300ms for declarative, 800ms for code compilation). Includes card/full-width size toggle and collapse/expand.
- **Inline AI Assist**: Natural language input bar for generating card configs, code, and stat blocks. Gated by AI mode (hidden on low, collapsed on medium, expanded on high). Uses missions API for generation.
- **Templates**: 5 declarative templates (Pod Status, Deployment Health, Node Resources, Service Status, Namespace Summary) and 5 code templates (Animated Gauge, Status Heatmap, Live Counter, Donut Chart, Activity Timeline).
- **Field Auto-Suggest**: Parses JSON data to suggest missing columns as clickable chips with auto-detected format (badge/number/text).
- **Smart Defaults**: Pattern-matching on stat block labels to auto-suggest icon and color (15 patterns covering common K8s metrics).
- **StatBlockFactory Enhancement**: Always-on split-pane preview replacing the old toggle button.

## Test plan
- [ ] Open Card Factory → Declarative tab: verify preview panel shows and updates on field changes
- [ ] Open Card Factory → Code tab: verify preview compiles and renders TSX
- [ ] Test AI assist bar visibility at low/medium/high AI modes
- [ ] Test template dropdown populates form fields and preview
- [ ] Open Stat Block Factory → verify split-pane preview, smart defaults, AI assist
- [ ] Verify no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)