### PR TITLE
🐛 Fix Resource Marshall card not loading workloads in demo mode

### DIFF
--- a/web/src/hooks/useDependencies.ts
+++ b/web/src/hooks/useDependencies.ts
@@ -1,4 +1,8 @@
 import { useState, useCallback } from 'react'
+import { isAgentUnavailable } from './useLocalAgent'
+import { clusterCacheRef } from './mcp/shared'
+
+const AGENT_URL = 'http://127.0.0.1:8585'
 
 export interface ResolvedDependency {
   kind: string
@@ -22,6 +26,92 @@ function authHeaders(): Record<string, string> {
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
+/** Fetch a JSON endpoint from the local agent with timeout. */
+async function agentFetch(path: string, timeout = 15000): Promise<Record<string, unknown>> {
+  const ctrl = new AbortController()
+  const tid = setTimeout(() => ctrl.abort(), timeout)
+  try {
+    const res = await fetch(`${AGENT_URL}${path}`, {
+      signal: ctrl.signal,
+      headers: { Accept: 'application/json' },
+    })
+    if (!res.ok) throw new Error(`Agent ${res.status}`)
+    return await res.json()
+  } finally {
+    clearTimeout(tid)
+  }
+}
+
+/**
+ * Resolve dependencies via the local agent by scanning namespace resources.
+ * This is a fallback when the backend REST API is unavailable.
+ */
+async function resolveViaAgent(
+  cluster: string,
+  namespace: string,
+  name: string,
+): Promise<DependencyResolution | null> {
+  if (isAgentUnavailable()) return null
+
+  // Map display cluster name to kubectl context
+  const clusterEntry = clusterCacheRef.clusters.find(
+    c => c.name === cluster && c.reachable !== false,
+  )
+  const context = clusterEntry?.context || cluster
+
+  const params = `cluster=${encodeURIComponent(context)}&namespace=${encodeURIComponent(namespace)}`
+
+  // Fetch namespace resources in parallel
+  const [configmaps, secrets, serviceaccounts, services, pvcs, hpas] = await Promise.allSettled([
+    agentFetch(`/configmaps?${params}`),
+    agentFetch(`/secrets?${params}`),
+    agentFetch(`/serviceaccounts?${params}`),
+    agentFetch(`/services?${params}`),
+    agentFetch(`/pvcs?${params}`),
+    agentFetch(`/hpas?${params}`),
+  ])
+
+  const deps: ResolvedDependency[] = []
+  let order = 0
+
+  // Extract resources from agent responses
+  const extract = (result: PromiseSettledResult<Record<string, unknown>>, key: string, kind: string) => {
+    if (result.status !== 'fulfilled') return
+    const items = result.value[key] as Array<{ name: string; namespace?: string }> | null
+    if (!items) return
+    for (const item of items) {
+      // Skip system resources
+      if (item.name.startsWith('kube-') && kind !== 'Service') continue
+      if (kind === 'ServiceAccount' && item.name === 'default') continue
+      deps.push({
+        kind,
+        name: item.name,
+        namespace: item.namespace || namespace,
+        optional: false,
+        order: order++,
+      })
+    }
+  }
+
+  extract(configmaps, 'configmaps', 'ConfigMap')
+  extract(secrets, 'secrets', 'Secret')
+  extract(serviceaccounts, 'serviceaccounts', 'ServiceAccount')
+  extract(services, 'services', 'Service')
+  extract(pvcs, 'pvcs', 'PersistentVolumeClaim')
+  extract(hpas, 'hpas', 'HorizontalPodAutoscaler')
+
+  return {
+    workload: name,
+    kind: 'Deployment',
+    namespace,
+    cluster,
+    dependencies: deps,
+    warnings: deps.length > 0
+      ? ['Showing all namespace resources (exact dependency tracing requires backend)']
+      : [],
+  }
+}
+
 /**
  * Hook to resolve dependencies for a workload (dry-run).
  * Used by the pre-deploy confirmation dialog and the Resource Marshall card.
@@ -41,20 +131,34 @@ export function useResolveDependencies() {
     setData(null)
 
     try {
-      const res = await fetch(
-        `/api/workloads/resolve-deps/${encodeURIComponent(cluster)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
-        { headers: authHeaders() },
-      )
-      if (!res.ok) {
-        const errorData = await res.json().catch(() => ({ error: res.statusText }))
-        throw new Error(errorData.error || `Failed to resolve dependencies: ${res.statusText}`)
+      // Try backend REST API first (works when JWT auth is available)
+      try {
+        const res = await fetch(
+          `/api/workloads/resolve-deps/${encodeURIComponent(cluster)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
+          { headers: authHeaders() },
+        )
+        if (!res.ok) {
+          throw new Error(`REST ${res.status}`)
+        }
+        const result: DependencyResolution = await res.json()
+        setData(result)
+        return result
+      } catch {
+        // REST API failed, try agent fallback
       }
-      const result: DependencyResolution = await res.json()
-      setData(result)
-      return result
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error('Unknown error')
-      setError(error)
+
+      // Fall back to agent-based namespace resource scan
+      try {
+        const agentResult = await resolveViaAgent(cluster, namespace, name)
+        if (agentResult) {
+          setData(agentResult)
+          return agentResult
+        }
+      } catch {
+        // Agent also failed
+      }
+
+      setError(new Error('No data source available for dependency resolution'))
       return null
     } finally {
       setIsLoading(false)

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { getDemoMode } from './useDemoMode'
+import { isDemoModeForced } from './useDemoMode'
 
 export interface AgentHealth {
   status: string
@@ -66,7 +66,7 @@ interface AgentState {
 type Listener = (state: AgentState) => void
 
 class AgentManager {
-  private state: AgentState = getDemoMode() ? {
+  private state: AgentState = isDemoModeForced ? {
     status: 'disconnected',
     health: DEMO_DATA,
     error: 'Demo mode - agent connection skipped',
@@ -99,8 +99,8 @@ class AgentManager {
     if (this.isStarted) return
     this.isStarted = true
 
-    // In demo mode, skip agent connection entirely to avoid console errors
-    if (getDemoMode()) {
+    // On Netlify deployments, skip agent connection entirely (no local agent available)
+    if (isDemoModeForced) {
       this.setState({
         status: 'disconnected',
         health: DEMO_DATA,

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { getDemoMode } from './useDemoMode'
+import { isAgentUnavailable } from './useLocalAgent'
 import { clusterCacheRef } from './mcp/shared'
 
 // Types
@@ -63,8 +63,8 @@ async function fetchWorkloadsViaAgent(opts?: {
   cluster?: string
   namespace?: string
 }): Promise<Workload[] | null> {
-  // Skip agent requests entirely in demo mode (no local agent on Netlify)
-  if (getDemoMode()) return null
+  // Skip agent requests when agent is unavailable (e.g. Netlify with no local agent)
+  if (isAgentUnavailable()) return null
 
   const clusters = clusterCacheRef.clusters
     .filter(c => c.reachable !== false && !c.name.includes('/'))


### PR DESCRIPTION
## Summary
- Fixed Resource Marshall card workload dropdown being empty when running in demo mode on localhost
- Root cause: `getDemoMode()` was used in three hooks to skip agent-based data fetching, but demo mode auto-activates with demo-token even on localhost where the agent is available
- Changed `AgentManager` in `useLocalAgent.ts` to use `isDemoModeForced` (Netlify-only) instead of `getDemoMode()`
- Changed `useWorkloads.ts` guard from `getDemoMode()` to `isAgentUnavailable()` for proper agent detection
- Added agent HTTP fallback in `useDependencies.ts` for dependency resolution when REST API is unavailable

## Test plan
- [x] Verified cluster dropdown populates with available clusters
- [x] Verified namespace dropdown populates after cluster selection
- [x] Verified workload dropdown shows "hello-multicluster (Deployment)" after selecting ks-docs-oci/default
- [x] Verified dependency tree shows networking dependencies (2 deps)
- [x] Build passes (`npm run build`)
- [x] Lint passes (no new errors introduced)
- [x] Screenshot captured showing working card

🤖 Generated with [Claude Code](https://claude.com/claude-code)