### PR TITLE
✨ Fix fullscreen mode for arcade games and AI-ML dashboard cards

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -54,10 +54,7 @@ const WIDTH_OPTIONS = [
 const LARGE_EXPANDED_CARDS = new Set([
   'cluster_comparison',
   'cluster_resource_tree',
-  'match_game',
   // AI-ML cards that need more space when expanded
-  'llmd_flow',
-  'epp_routing',
   'kvcache_monitor',
   'pd_disaggregation',
   'llmd_benchmarks',
@@ -67,8 +64,15 @@ const LARGE_EXPANDED_CARDS = new Set([
 // Cards that should be nearly fullscreen when expanded (maps, large visualizations, games)
 const FULLSCREEN_EXPANDED_CARDS = new Set([
   'cluster_locations',
-  'sudoku_game', // Games need fullscreen for the grid to fill properly
   'mobile_browser', // Shows iPad view when expanded
+  // AI-ML visualization cards benefit from full viewport
+  'llmd_flow', 'epp_routing',
+  // All arcade games need fullscreen to fill the entire screen
+  'sudoku_game', 'container_tetris', 'node_invaders', 'kube_snake',
+  'flappy_pod', 'kube_pong', 'kube_kong', 'game_2048', 'kube_man',
+  'kube_galaga', 'kube_chess', 'checkers', 'pod_crosser', 'pod_brothers',
+  'pod_pitfall', 'match_game', 'solitaire', 'kubedle', 'pod_sweeper',
+  'kube_craft', 'kube_doom', 'kube_kart',
 ])
 
 // Context to expose card expanded state to children

--- a/web/src/components/cards/FlappyPod.tsx
+++ b/web/src/components/cards/FlappyPod.tsx
@@ -253,7 +253,7 @@ export function FlappyPod(_props: CardComponentProps) {
 
       {/* Game area - relative container for overlays */}
       <div
-        className="flex-1 flex items-center justify-center relative"
+        className={`flex-1 flex items-center justify-center relative ${isExpanded ? 'min-h-0' : ''}`}
         onClick={handleClick}
       >
         <canvas
@@ -261,6 +261,7 @@ export function FlappyPod(_props: CardComponentProps) {
           width={gameWidth}
           height={gameHeight}
           className="border border-border rounded cursor-pointer"
+          style={isExpanded ? { width: '100%', height: '100%', objectFit: 'contain' } : undefined}
         />
 
         {/* Start overlay - only covers game area */}

--- a/web/src/components/cards/KubeCraft.tsx
+++ b/web/src/components/cards/KubeCraft.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 
 import { Save, Download, Trash2, Grid, Sun, Moon } from 'lucide-react'
 
+import { useCardExpanded } from './CardWrapper'
+
 // Game constants
 const CANVAS_WIDTH = 400
 const CANVAS_HEIGHT = 400
@@ -32,6 +34,7 @@ const BLOCKS: Record<BlockType, { color: string; secondary?: string; transparent
 const BLOCK_TYPES: BlockType[] = ['dirt', 'grass', 'stone', 'wood', 'leaves', 'water', 'sand', 'brick', 'glass']
 
 export function KubeCraft() {
+  const { isExpanded } = useCardExpanded()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [selectedBlock, setSelectedBlock] = useState<BlockType>('grass')
   const [isErasing, setIsErasing] = useState(false)
@@ -326,7 +329,7 @@ export function KubeCraft() {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex flex-col items-center gap-3">
+      <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Block palette */}
         <div className="flex flex-wrap gap-1 justify-center">
           {BLOCK_TYPES.map(type => (
@@ -359,12 +362,13 @@ export function KubeCraft() {
         </div>
 
         {/* Canvas */}
-        <div className="relative">
+        <div className={`relative ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
           <canvas
             ref={canvasRef}
             width={CANVAS_WIDTH}
             height={CANVAS_HEIGHT}
             className="border border-border rounded cursor-crosshair"
+            style={isExpanded ? { width: '100%', height: '100%', objectFit: 'contain' } : undefined}
             onMouseDown={handleMouseDown}
             onMouseUp={handleMouseUp}
             onMouseMove={handleMouseMove}

--- a/web/src/components/cards/KubeDoom.tsx
+++ b/web/src/components/cards/KubeDoom.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { Play, RotateCcw, Pause, Trophy, Target, Heart, Crosshair } from 'lucide-react'
+import { useCardExpanded } from './CardWrapper'
 
 // Canvas dimensions
 const CANVAS_WIDTH = 480
@@ -85,6 +86,7 @@ function spawnEnemies(level: number): Enemy[] {
 }
 
 export function KubeDoom() {
+  const { isExpanded } = useCardExpanded()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'gameover' | 'levelcomplete'>('idle')
   const [score, setScore] = useState(0)
@@ -554,7 +556,7 @@ export function KubeDoom() {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex flex-col items-center gap-3">
+      <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
         <div className="flex items-center justify-between w-full max-w-[480px] text-sm">
           <div className="flex items-center gap-4">
@@ -588,12 +590,13 @@ export function KubeDoom() {
         </div>
 
         {/* Game canvas */}
-        <div className="relative">
+        <div className={`relative ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
           <canvas
             ref={canvasRef}
             width={CANVAS_WIDTH}
             height={CANVAS_HEIGHT}
             className="border border-border rounded"
+            style={isExpanded ? { width: '100%', height: '100%', objectFit: 'contain' } : undefined}
             tabIndex={0}
           />
 

--- a/web/src/components/cards/KubeGalaga.tsx
+++ b/web/src/components/cards/KubeGalaga.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 
 import { Play, RotateCcw, Pause, Trophy, Target, Heart, Zap } from 'lucide-react'
 
+import { useCardExpanded } from './CardWrapper'
+
 // Game constants
 const CANVAS_WIDTH = 400
 const CANVAS_HEIGHT = 500
@@ -55,6 +57,7 @@ interface Star {
 }
 
 export function KubeGalaga() {
+  const { isExpanded } = useCardExpanded()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'gameover' | 'levelcomplete'>('idle')
   const [score, setScore] = useState(0)
@@ -488,7 +491,7 @@ export function KubeGalaga() {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex flex-col items-center gap-3">
+      <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
         <div className="flex items-center justify-between w-full max-w-[400px] text-sm">
           <div className="flex items-center gap-4">
@@ -515,13 +518,14 @@ export function KubeGalaga() {
         </div>
 
         {/* Game canvas */}
-        <div className="relative">
+        <div className={`relative ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
           <canvas
             ref={canvasRef}
             width={CANVAS_WIDTH}
             height={CANVAS_HEIGHT}
             className="border border-border rounded"
             tabIndex={0}
+            style={isExpanded ? { width: '100%', height: '100%', objectFit: 'contain' } : undefined}
           />
 
           {/* Overlays */}

--- a/web/src/components/cards/KubeKart.tsx
+++ b/web/src/components/cards/KubeKart.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 
 import { Play, RotateCcw, Pause, Trophy, Flag, Timer, Gauge } from 'lucide-react'
 
+import { useCardExpanded } from './CardWrapper'
+
 // Game constants
 const CANVAS_WIDTH = 400
 const CANVAS_HEIGHT = 500
@@ -58,6 +60,7 @@ const COLORS = {
 const KART_NAMES = ['Pod Racer', 'Node Runner', 'Cluster Cruiser', 'Service Sprinter']
 
 export function KubeKart() {
+  const { isExpanded } = useCardExpanded()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'countdown' | 'playing' | 'paused' | 'finished'>('idle')
   const [countdown, setCountdown] = useState(3)
@@ -533,7 +536,7 @@ export function KubeKart() {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex flex-col items-center gap-3">
+      <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
         <div className="flex items-center justify-between w-full max-w-[400px] text-sm">
           <div className="flex items-center gap-4">
@@ -561,13 +564,14 @@ export function KubeKart() {
         </div>
 
         {/* Game canvas */}
-        <div className="relative">
+        <div className={`relative ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
           <canvas
             ref={canvasRef}
             width={CANVAS_WIDTH}
             height={CANVAS_HEIGHT}
             className="border border-border rounded"
             tabIndex={0}
+            style={isExpanded ? { width: '100%', height: '100%', objectFit: 'contain' } : undefined}
           />
 
           {/* Overlays */}

--- a/web/src/components/cards/KubePong.tsx
+++ b/web/src/components/cards/KubePong.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 
 import { Play, RotateCcw, Pause, Trophy, Cpu, User } from 'lucide-react'
+import { useCardExpanded } from './CardWrapper'
 
 // Game constants
 const CANVAS_WIDTH = 400
@@ -37,6 +38,7 @@ interface Paddle {
 }
 
 export function KubePong() {
+  const { isExpanded } = useCardExpanded()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'finished'>('idle')
   const [playerScore, setPlayerScore] = useState(0)
@@ -307,7 +309,7 @@ export function KubePong() {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex flex-col items-center gap-3">
+      <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
         <div className="flex items-center justify-between w-full max-w-[400px] text-sm">
           <div className="flex items-center gap-2">
@@ -325,12 +327,13 @@ export function KubePong() {
         </div>
 
         {/* Game canvas */}
-        <div className="relative">
+        <div className={`relative ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
           <canvas
             ref={canvasRef}
             width={CANVAS_WIDTH}
             height={CANVAS_HEIGHT}
             className="border border-border rounded"
+            style={isExpanded ? { width: '100%', height: '100%', objectFit: 'contain' } : undefined}
             tabIndex={0}
           />
 

--- a/web/src/components/cards/KubeSnake.tsx
+++ b/web/src/components/cards/KubeSnake.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 
 import { Play, RotateCcw, Pause, Trophy, Apple, Zap } from 'lucide-react'
+import { useCardExpanded } from './CardWrapper'
 
 // Game constants
 const CANVAS_WIDTH = 400
@@ -29,6 +30,7 @@ interface Point {
 type Direction = 'up' | 'down' | 'left' | 'right'
 
 export function KubeSnake() {
+  const { isExpanded } = useCardExpanded()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'gameover'>('idle')
   const [score, setScore] = useState(0)
@@ -298,7 +300,7 @@ export function KubeSnake() {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex flex-col items-center gap-3">
+      <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
         <div className="flex items-center justify-between w-full max-w-[400px] text-sm">
           <div className="flex items-center gap-2">
@@ -316,12 +318,13 @@ export function KubeSnake() {
         </div>
 
         {/* Game canvas */}
-        <div className="relative">
+        <div className={`relative ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
           <canvas
             ref={canvasRef}
             width={CANVAS_WIDTH}
             height={CANVAS_HEIGHT}
             className="border border-border rounded"
+            style={isExpanded ? { width: '100%', height: '100%', objectFit: 'contain' } : undefined}
             tabIndex={0}
           />
 

--- a/web/src/components/cards/MatchGame.tsx
+++ b/web/src/components/cards/MatchGame.tsx
@@ -5,6 +5,7 @@ import {
   Play, Pause, RotateCcw, Trophy, Clock, Hash
 } from 'lucide-react'
 import { CardComponentProps } from './cardRegistry'
+import { useCardExpanded } from './CardWrapper'
 
 // Kubernetes/Cloud themed icons for matching
 const CARD_ICONS = [
@@ -44,6 +45,7 @@ const DIFFICULTY_CONFIG = {
 }
 
 export function MatchGame(_props: CardComponentProps) {
+  const { isExpanded } = useCardExpanded()
   const [difficulty, setDifficulty] = useState<Difficulty>('easy')
   const [cards, setCards] = useState<GameCard[]>([])
   const [flippedCards, setFlippedCards] = useState<string[]>([])
@@ -272,7 +274,7 @@ export function MatchGame(_props: CardComponentProps) {
   const { rows, cols } = DIFFICULTY_CONFIG[difficulty]
 
   return (
-    <div className="flex flex-col gap-2 h-full relative">
+    <div className={`flex flex-col gap-2 h-full relative ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
       {/* Canvas for confetti */}
       <canvas
         ref={canvasRef}

--- a/web/src/components/cards/PodBrothers.tsx
+++ b/web/src/components/cards/PodBrothers.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 
 import { Play, RotateCcw, Pause, Trophy, Heart, Star } from 'lucide-react'
 
+import { useCardExpanded } from './CardWrapper'
+
 // Game constants
 const CANVAS_WIDTH = 480
 const CANVAS_HEIGHT = 320
@@ -72,6 +74,7 @@ interface Coin {
 }
 
 export function PodBrothers() {
+  const { isExpanded } = useCardExpanded()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'won' | 'lost'>('idle')
   const [score, setScore] = useState(0)
@@ -481,7 +484,7 @@ export function PodBrothers() {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex flex-col items-center gap-3">
+      <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
         <div className="flex items-center justify-between w-full max-w-[480px] text-sm">
           <div className="flex items-center gap-4">
@@ -501,12 +504,13 @@ export function PodBrothers() {
         </div>
 
         {/* Game canvas */}
-        <div className="relative">
+        <div className={`relative ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
           <canvas
             ref={canvasRef}
             width={CANVAS_WIDTH}
             height={CANVAS_HEIGHT}
             className="border border-border rounded bg-[#5c94fc]"
+            style={isExpanded ? { width: '100%', height: '100%', objectFit: 'contain' } : undefined}
             tabIndex={0}
           />
 

--- a/web/src/components/cards/llmd/EPPRouting.tsx
+++ b/web/src/components/cards/llmd/EPPRouting.tsx
@@ -901,7 +901,7 @@ export function EPPRouting() {
       </div>
 
       {/* Main visualization area */}
-      <div className={`flex-1 relative ${isExpanded ? 'min-h-[500px]' : 'min-h-[200px]'}`}>
+      <div className={`flex-1 relative ${isExpanded ? 'min-h-0' : 'min-h-[200px]'}`}>
         <svg
           viewBox="-5 -5 120 120"
           className="w-full h-full overflow-visible"

--- a/web/src/components/cards/llmd/LLMdFlow.tsx
+++ b/web/src/components/cards/llmd/LLMdFlow.tsx
@@ -932,7 +932,7 @@ export function LLMdFlow() {
   const showEmptyState = !selectedStack && !isDemoMode
 
   return (
-    <div className={`relative w-full h-full flex-1 bg-gradient-to-br from-slate-900/50 to-slate-800/30 rounded-lg overflow-hidden ${isExpanded ? 'min-h-[600px]' : 'min-h-[300px]'}`}>
+    <div className={`relative w-full h-full flex-1 bg-gradient-to-br from-slate-900/50 to-slate-800/30 rounded-lg overflow-hidden ${isExpanded ? 'min-h-0' : 'min-h-[300px]'}`}>
       {/* Empty state overlay */}
       {showEmptyState && (
         <div className="absolute inset-0 flex flex-col items-center justify-center z-20 bg-slate-900/60 backdrop-blur-sm">


### PR DESCRIPTION
## Summary
- Add all 21 arcade games + LLMdFlow + EPPRouting to `FULLSCREEN_EXPANDED_CARDS` for 98vh/95vw modal sizing
- Fix 9 canvas-based games to scale properly in fullscreen using CSS `objectFit: contain` with `flex-1 min-h-0` wrappers
- Fix EPPRouting and LLMdFlow SVG cards to use `min-h-0` when expanded, allowing flex-1 to fill the fullscreen modal

## Test plan
- [x] All 21 arcade games tested in fullscreen via Chrome DevTools Protocol
- [x] EPPRouting card verified in both card view and fullscreen
- [x] LLMdFlow card verified in both card view and fullscreen
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)