### PR TITLE
✨ Unified CardAIActions for Diagnose/Repair/Ask buttons

### DIFF
--- a/web/src/components/cards/DeploymentStatus.tsx
+++ b/web/src/components/cards/DeploymentStatus.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { CheckCircle, Clock, XCircle, ChevronRight, Filter, Server, RotateCw, ArrowUpCircle, FileText } from 'lucide-react'
+import { CheckCircle, Clock, XCircle, ChevronRight, Filter, Server } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCachedDeployments } from '../../hooks/useCachedData'
@@ -15,7 +15,7 @@ import {
   commonComparators,
   CardClusterFilter,
   CardSearchInput,
-  CardActionButtons,
+  CardAIActions,
   type SortDirection,
 } from '../../lib/cards'
 
@@ -75,7 +75,7 @@ const FILTER_CONFIG = {
 }
 
 export function DeploymentStatus() {
-  const { drillToDeployment, drillToEvents, drillToLogs } = useDrillDownActions()
+  const { drillToDeployment } = useDrillDownActions()
   const {
     deployments: allDeployments,
     isLoading: hookLoading,
@@ -337,37 +337,19 @@ export function DeploymentStatus() {
                   />
                 </div>
 
-                {/* Diagnose & Repair for failed deployments */}
+                {/* AI Diagnose, Repair & Ask for failed deployments */}
                 {deployment.status === 'failed' && (
-                  <CardActionButtons
+                  <CardAIActions
                     className="mt-2"
-                    onDiagnose={() => drillToEvents(clusterName, deployment.namespace, deployment.name)}
-                    repairOptions={[
-                      {
-                        label: 'Rollout Restart',
-                        icon: RotateCw,
-                        description: 'Restart all pods in this deployment',
-                        onClick: () => drillToDeployment(clusterName, deployment.namespace, deployment.name, {
-                          status: deployment.status,
-                          action: 'rollout-restart',
-                        }),
-                      },
-                      {
-                        label: 'Scale Up Replicas',
-                        icon: ArrowUpCircle,
-                        description: 'Increase replica count',
-                        onClick: () => drillToDeployment(clusterName, deployment.namespace, deployment.name, {
-                          status: deployment.status,
-                          action: 'scale',
-                        }),
-                      },
-                      {
-                        label: 'View Logs',
-                        icon: FileText,
-                        description: 'Check container logs for errors',
-                        onClick: () => drillToLogs(clusterName, deployment.namespace, deployment.name),
-                      },
-                    ]}
+                    resource={{
+                      kind: 'Deployment',
+                      name: deployment.name,
+                      namespace: deployment.namespace,
+                      cluster: clusterName,
+                      status: deployment.status,
+                    }}
+                    issues={[{ name: 'Failed', message: `${deployment.readyReplicas}/${deployment.replicas} replicas ready` }]}
+                    additionalContext={{ image: deployment.image, progress: deployment.progress }}
                   />
                 )}
               </div>

--- a/web/src/components/cards/PodIssues.tsx
+++ b/web/src/components/cards/PodIssues.tsx
@@ -1,4 +1,4 @@
-import { MemoryStick, ImageOff, Clock, RefreshCw, CheckCircle, RotateCw, FileText, Calendar } from 'lucide-react'
+import { MemoryStick, ImageOff, Clock, RefreshCw, CheckCircle } from 'lucide-react'
 import { useCachedPodIssues } from '../../hooks/useCachedData'
 import type { PodIssue } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -9,7 +9,7 @@ import {
   useCardData, commonComparators, getStatusColors,
   CardSkeleton, CardEmptyState, CardSearchInput,
   CardControlsRow, CardListItem, CardPaginationFooter,
-  CardActionButtons,
+  CardAIActions,
 } from '../../lib/cards'
 
 type SortByOption = 'status' | 'name' | 'restarts' | 'cluster'
@@ -44,7 +44,7 @@ export function PodIssues() {
     isFailed,
     consecutiveFailures,
   })
-  const { drillToPod, drillToEvents, drillToLogs } = useDrillDownActions()
+  const { drillToPod } = useDrillDownActions()
 
   // Use shared card data hook for filtering, sorting, and pagination
   const {
@@ -205,33 +205,18 @@ export function PodIssues() {
                       {issue.issues.join(', ')}
                     </p>
                   )}
-                  {/* Diagnose & Repair actions */}
-                  <CardActionButtons
+                  {/* AI Diagnose, Repair & Ask actions */}
+                  <CardAIActions
                     className="mt-2"
-                    onDiagnose={() => drillToEvents(issue.cluster || 'default', issue.namespace, issue.name)}
-                    repairOptions={[
-                      {
-                        label: 'Restart Pod',
-                        icon: RotateCw,
-                        description: 'Delete pod to let controller recreate it',
-                        onClick: () => drillToPod(issue.cluster || 'default', issue.namespace, issue.name, {
-                          status: issue.status,
-                          action: 'restart',
-                        }),
-                      },
-                      {
-                        label: 'View Logs',
-                        icon: FileText,
-                        description: 'Check container logs for errors',
-                        onClick: () => drillToLogs(issue.cluster || 'default', issue.namespace, issue.name),
-                      },
-                      {
-                        label: 'View Events',
-                        icon: Calendar,
-                        description: 'See recent events for this pod',
-                        onClick: () => drillToEvents(issue.cluster || 'default', issue.namespace, issue.name),
-                      },
-                    ]}
+                    resource={{
+                      kind: 'Pod',
+                      name: issue.name,
+                      namespace: issue.namespace,
+                      cluster: issue.cluster || 'default',
+                      status: issue.status,
+                    }}
+                    issues={issue.issues.map(msg => ({ name: issue.status, message: msg }))}
+                    additionalContext={{ restarts: issue.restarts }}
                   />
                 </div>
               </div>

--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -1,4 +1,4 @@
-import { Shield, AlertTriangle, User, Network, Server, ChevronRight, FileCode, Calendar, Eye } from 'lucide-react'
+import { Shield, AlertTriangle, User, Network, Server, ChevronRight } from 'lucide-react'
 import { useMemo } from 'react'
 import type { SecurityIssue } from '../../hooks/useMCP'
 import { useCachedSecurityIssues } from '../../hooks/useCachedData'
@@ -7,7 +7,7 @@ import { ClusterBadge } from '../ui/ClusterBadge'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { LimitedAccessWarning } from '../ui/LimitedAccessWarning'
-import { useCardData, CardClusterFilter, CardSearchInput, CardActionButtons } from '../../lib/cards'
+import { useCardData, CardClusterFilter, CardSearchInput, CardAIActions } from '../../lib/cards'
 import { SEVERITY_COLORS, SeverityLevel } from '../../lib/accessibility'
 import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 
@@ -107,7 +107,7 @@ export function SecurityIssues({ config }: SecurityIssuesProps) {
   const isFailed = isDemoMode ? false : cachedFailed
   const consecutiveFailures = isDemoMode ? 0 : cachedFailures
 
-  const { drillToPod, drillToEvents, drillToYAML } = useDrillDownActions()
+  const { drillToPod } = useDrillDownActions()
 
   // Report card data state to parent CardWrapper for automatic skeleton/refresh handling
   const { showSkeleton, showEmptyState } = useCardLoadingState({
@@ -319,36 +319,18 @@ export function SecurityIssues({ config }: SecurityIssuesProps) {
                       {issue.details}
                     </p>
                   )}
-                  {/* Diagnose & Repair actions */}
-                  <CardActionButtons
+                  {/* AI Diagnose, Repair & Ask actions */}
+                  <CardAIActions
                     className="mt-2"
-                    onDiagnose={() => drillToPod(issue.cluster || 'default', issue.namespace, issue.name, {
-                      securityIssue: issue.issue,
-                      severity: issue.severity,
-                    })}
-                    repairOptions={[
-                      {
-                        label: 'View Pod Details',
-                        icon: Eye,
-                        description: 'Inspect pod configuration',
-                        onClick: () => drillToPod(issue.cluster || 'default', issue.namespace, issue.name, {
-                          securityIssue: issue.issue,
-                          severity: issue.severity,
-                        }),
-                      },
-                      {
-                        label: 'Edit YAML',
-                        icon: FileCode,
-                        description: 'View and fix pod security context',
-                        onClick: () => drillToYAML(issue.cluster || 'default', issue.namespace, 'Pod', issue.name),
-                      },
-                      {
-                        label: 'View Events',
-                        icon: Calendar,
-                        description: 'See recent pod events',
-                        onClick: () => drillToEvents(issue.cluster || 'default', issue.namespace, issue.name),
-                      },
-                    ]}
+                    resource={{
+                      kind: 'Pod',
+                      name: issue.name,
+                      namespace: issue.namespace,
+                      cluster: issue.cluster || 'default',
+                      status: issue.severity,
+                    }}
+                    issues={[{ name: issue.issue, message: issue.details || issue.issue }]}
+                    additionalContext={{ severity: issue.severity, securityIssue: issue.issue }}
                   />
                 </div>
                 <span title="Click to view details"><ChevronRight className="w-4 h-4 text-muted-foreground flex-shrink-0 mt-1" /></span>

--- a/web/src/lib/cards/index.ts
+++ b/web/src/lib/cards/index.ts
@@ -65,6 +65,7 @@ export {
   CardControlsRow,
   CardPaginationFooter,
   CardActionButtons,
+  CardAIActions,
   type CardSkeletonProps,
   type CardEmptyStateProps,
   type CardErrorStateProps,
@@ -80,6 +81,8 @@ export {
   type CardPaginationFooterProps,
   type RepairOption,
   type CardActionButtonsProps,
+  type CardAIActionsProps,
+  type CardAIResource,
   useDropdownPortal,
 } from './CardComponents'
 


### PR DESCRIPTION
## Summary
- Replace `CardActionButtons` (which opened drilldown modals) with new `CardAIActions` component (which opens the AI missions sidebar) in all 6 affected cards
- New `CardAIActions` component internally manages `useMissions` + `useApiKeyCheck`, so cards only pass resource context — no callbacks
- Affected cards: PodIssues, DeploymentStatus, DeploymentIssues, ClusterHealth, SecurityIssues, AppStatus
- Adds "Ask" button alongside Diagnose and Repair for freeform AI queries

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Diagnose/Repair/Ask buttons render correctly on Workloads dashboard
- [x] Clicking Diagnose shows AI Agent Required prompt (when no agent configured)
- [x] Parent row click (drilldown) not triggered when AI buttons are clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)