### PR TITLE
✨ Add URL-based card anchoring with ?card= deep links

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useState, useEffect, useCallback, useRef, useMemo, createContext, useContext, ComponentType } from 'react'
 import { createPortal } from 'react-dom'
 import {
-  Maximize2, MoreVertical, Clock, Settings, Replace, Trash2, MessageCircle, RefreshCw, MoveHorizontal, ChevronRight, ChevronDown, Info, Download,
+  Maximize2, MoreVertical, Clock, Settings, Replace, Trash2, MessageCircle, RefreshCw, MoveHorizontal, ChevronRight, ChevronDown, Info, Download, Link2,
   // Card icons
   AlertTriangle, Box, Activity, Database, Server, Cpu, Network, Shield, Package, GitBranch, FileCode, Gauge, AlertCircle, Layers, HardDrive, Globe, Users, Terminal, TrendingUp, Gamepad2, Puzzle, Target, Zap, Crown, Ghost, Bird, Rocket, Wand2, Stethoscope, MonitorCheck, Workflow, Split, Router, BookOpen, Cloudy, Rss, Frame, Wrench, Phone,
 } from 'lucide-react'
@@ -1291,6 +1291,18 @@ export function CardWrapper({
                   >
                     <Settings className="w-4 h-4" />
                     Configure
+                  </button>
+                  <button
+                    onClick={() => {
+                      setShowMenu(false)
+                      const url = `${window.location.origin}${window.location.pathname}?card=${cardType}`
+                      navigator.clipboard.writeText(url)
+                    }}
+                    className="w-full px-4 py-2 text-left text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 flex items-center gap-2"
+                    title="Copy a direct URL to this card"
+                  >
+                    <Link2 className="w-4 h-4" />
+                    Copy Link
                   </button>
                   {/* Resize submenu */}
                   {onWidthChange && (

--- a/web/src/components/layout/navbar/SearchDropdown.tsx
+++ b/web/src/components/layout/navbar/SearchDropdown.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react'
 import { useSearchIndex, CATEGORY_ORDER, type SearchCategory, type SearchItem } from '../../../hooks/useSearchIndex'
 import { useMissions } from '../../../hooks/useMissions'
+import { scrollToCard } from '../../../lib/scrollToCard'
 
 const CATEGORY_CONFIG: Record<SearchCategory, { label: string; icon: typeof Server }> = {
   page: { label: 'Pages', icon: LayoutDashboard },
@@ -34,36 +35,6 @@ const CATEGORY_CONFIG: Record<SearchCategory, { label: string; icon: typeof Serv
   dashboard: { label: 'Dashboards', icon: LayoutDashboard },
   helm: { label: 'Helm Releases', icon: Package },
   node: { label: 'Nodes', icon: HardDrive },
-}
-
-const SCROLL_HIGHLIGHT_MS = 2000
-const SCROLL_POLL_INTERVAL_MS = 100
-const SCROLL_POLL_MAX_MS = 3000
-
-/**
- * After navigation, poll for a card element by data-card-type and scroll it into view
- * with a brief highlight ring.
- */
-function scrollToCard(cardType: string) {
-  const startTime = Date.now()
-
-  function poll() {
-    const el = document.querySelector(`[data-card-type="${cardType}"]`)
-    if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-      el.classList.add('ring-2', 'ring-purple-500', 'ring-offset-2', 'ring-offset-background')
-      setTimeout(() => {
-        el.classList.remove('ring-2', 'ring-purple-500', 'ring-offset-2', 'ring-offset-background')
-      }, SCROLL_HIGHLIGHT_MS)
-      return
-    }
-    if (Date.now() - startTime < SCROLL_POLL_MAX_MS) {
-      setTimeout(poll, SCROLL_POLL_INTERVAL_MS)
-    }
-  }
-
-  // Start polling after a frame so React can render the new route
-  requestAnimationFrame(() => setTimeout(poll, SCROLL_POLL_INTERVAL_MS))
 }
 
 export function SearchDropdown() {

--- a/web/src/hooks/useDeepLink.ts
+++ b/web/src/hooks/useDeepLink.ts
@@ -1,11 +1,13 @@
 import { useEffect, useCallback } from 'react'
 import { useSearchParams, useNavigate } from 'react-router-dom'
 import { useDrillDownActions } from './useDrillDown'
+import { scrollToCard } from '../lib/scrollToCard'
 
 /**
  * Deep linking support for notifications and external links.
  *
  * URL params supported:
+ * - ?card=cluster_health - Scrolls to and highlights a card by type
  * - ?drilldown=node&cluster=xyz&node=abc - Opens node drilldown
  * - ?drilldown=pod&cluster=xyz&namespace=abc&pod=def - Opens pod drilldown
  * - ?drilldown=cluster&cluster=xyz - Opens cluster drilldown
@@ -30,6 +32,7 @@ export type DeepLinkDrilldown =
 interface DeepLinkParams {
   drilldown?: DeepLinkDrilldown
   action?: DeepLinkAction
+  card?: string
   cluster?: string
   namespace?: string
   node?: string
@@ -48,6 +51,7 @@ export function buildDeepLinkURL(params: DeepLinkParams): string {
 
   if (params.drilldown) searchParams.set('drilldown', params.drilldown)
   if (params.action) searchParams.set('action', params.action)
+  if (params.card) searchParams.set('card', params.card)
   if (params.cluster) searchParams.set('cluster', params.cluster)
   if (params.namespace) searchParams.set('namespace', params.namespace)
   if (params.node) searchParams.set('node', params.node)
@@ -116,6 +120,7 @@ export function useDeepLink() {
       const newParams = new URLSearchParams(searchParams)
       newParams.delete('drilldown')
       newParams.delete('action')
+      newParams.delete('card')
       newParams.delete('cluster')
       newParams.delete('namespace')
       newParams.delete('node')
@@ -182,6 +187,13 @@ export function useDeepLink() {
       }, 500) // Wait for app to initialize
 
       return () => clearTimeout(timer)
+    }
+
+    // Handle card anchor - scroll to and highlight a specific card
+    const card = searchParams.get('card')
+    if (card) {
+      clearParams()
+      scrollToCard(card)
     }
   }, [searchParams, setSearchParams, navigate, drillToNode, drillToPod, drillToCluster, drillToDeployment, drillToNamespace])
 

--- a/web/src/hooks/useLastRoute.ts
+++ b/web/src/hooks/useLastRoute.ts
@@ -232,6 +232,11 @@ export function useLastRoute() {
 
     if (location.pathname !== '/') return
 
+    // Don't redirect away from '/' when deep link params are present —
+    // let useDeepLink handle them on the current route.
+    const params = new URLSearchParams(location.search)
+    if (params.has('card') || params.has('drilldown') || params.has('action')) return
+
     try {
       const lastRoute = localStorage.getItem(LAST_ROUTE_KEY)
       const firstSidebarRoute = getFirstDashboardRoute()

--- a/web/src/lib/scrollToCard.ts
+++ b/web/src/lib/scrollToCard.ts
@@ -1,0 +1,29 @@
+const SCROLL_HIGHLIGHT_MS = 2000
+const SCROLL_POLL_INTERVAL_MS = 100
+const SCROLL_POLL_MAX_MS = 3000
+
+/**
+ * Poll for a card element by data-card-type and scroll it into view
+ * with a brief highlight ring.
+ */
+export function scrollToCard(cardType: string) {
+  const startTime = Date.now()
+
+  function poll() {
+    const el = document.querySelector(`[data-card-type="${cardType}"]`)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      el.classList.add('ring-2', 'ring-purple-500', 'ring-offset-2', 'ring-offset-background')
+      setTimeout(() => {
+        el.classList.remove('ring-2', 'ring-purple-500', 'ring-offset-2', 'ring-offset-background')
+      }, SCROLL_HIGHLIGHT_MS)
+      return
+    }
+    if (Date.now() - startTime < SCROLL_POLL_MAX_MS) {
+      setTimeout(poll, SCROLL_POLL_INTERVAL_MS)
+    }
+  }
+
+  // Start polling after a frame so React can render the new route
+  requestAnimationFrame(() => setTimeout(poll, SCROLL_POLL_INTERVAL_MS))
+}


### PR DESCRIPTION
## Summary
- Add `?card=<card_type>` URL param support to navigate directly to any dashboard card
- Extract `scrollToCard` into shared utility (`web/src/lib/scrollToCard.ts`)
- Add "Copy Link" menu item to every card's dropdown menu
- Skip last-route redirect when deep link params are present in URL

Completes the half-built feature where `MiniDashboard.tsx` already generated `?card=` URLs (e.g., `/compute?card=gpu_overview`) but nothing consumed them.

## Test plan
- [ ] Navigate to `/?card=cluster_health` — card scrolls into view with purple highlight
- [ ] Navigate to `/?card=event_stream` — page scrolls down to Event Stream card
- [ ] Open any card's three-dot menu — "Copy Link" option copies direct URL to clipboard
- [ ] Paste copied URL in new tab — navigates to that card
- [ ] Search dropdown (Cmd+K) card navigation still works as before
- [ ] URL is cleaned up after scroll (no `?card=` in address bar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)