### PR TITLE
✨ Unified CardAIActions for Diagnose/Repair buttons across all cards

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -18,7 +18,7 @@ import { getSeverityIcon } from '../../types/alerts'
 import type { Alert, AlertSeverity } from '../../types/alerts'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
-import { useCardData, CardClusterFilter, CardSearchInput } from '../../lib/cards'
+import { useCardData, CardClusterFilter, CardSearchInput, CardAIActions } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
 
 // Format relative time
@@ -367,13 +367,12 @@ export function ActiveAlerts() {
                     )
                   } else {
                     return (
-                      <button
-                        onClick={e => handleAIDiagnose(e, alert.id)}
-                        className="px-2 py-1 text-xs rounded bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 transition-colors flex items-center gap-1"
-                      >
-                        <Bot className="w-3 h-3" />
-                        AI Diagnose
-                      </button>
+                      <CardAIActions
+                        resource={{ kind: 'Alert', name: alert.ruleName, cluster: alert.cluster, status: alert.severity }}
+                        issues={[{ name: alert.ruleName, message: alert.message }]}
+                        showRepair={false}
+                        onDiagnose={e => handleAIDiagnose(e, alert.id)}
+                      />
                     )
                   }
                 })()}

--- a/web/src/components/cards/CRDHealth.tsx
+++ b/web/src/components/cards/CRDHealth.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
-import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
 
 interface CRDHealthProps {
   config?: {
@@ -319,6 +319,13 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
                     <span className="text-border">|</span>
                     <span>{crd.scope}</span>
                   </div>
+                  {crd.status !== 'Established' && (
+                    <CardAIActions
+                      resource={{ kind: 'CustomResourceDefinition', name: crd.name, cluster: crd.cluster, status: crd.status }}
+                      issues={[{ name: `CRD ${crd.status}`, message: `CRD "${crd.name}" (${crd.group}) is ${crd.status} on cluster ${crd.cluster}` }]}
+                      className="mt-1 ml-6"
+                    />
+                  )}
                 </div>
               )
             })}

--- a/web/src/components/cards/GPUWorkloads.tsx
+++ b/web/src/components/cards/GPUWorkloads.tsx
@@ -3,7 +3,7 @@ import { Cpu, Box, ChevronRight, AlertTriangle, CheckCircle, Loader2, Server } f
 import { useGPUNodes, useAllPods, useClusters } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
-import { CardClusterFilter, CardSearchInput } from '../../lib/cards'
+import { CardClusterFilter, CardSearchInput, CardAIActions } from '../../lib/cards'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { Skeleton } from '../ui/Skeleton'
@@ -322,6 +322,12 @@ export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
                       )}
                     </div>
                   </div>
+                  {pod.status !== 'Running' && pod.status !== 'Succeeded' && pod.status !== 'Completed' && (
+                    <CardAIActions
+                      resource={{ kind: 'Pod', name: pod.name, namespace: pod.namespace, cluster: pod.cluster, status: pod.status }}
+                      issues={[{ name: `Pod ${pod.status}`, message: `GPU workload pod is in ${pod.status} state` }]}
+                    />
+                  )}
                   <ChevronRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
                 </div>
               </div>

--- a/web/src/components/cards/GatewayStatus.tsx
+++ b/web/src/components/cards/GatewayStatus.tsx
@@ -5,6 +5,7 @@ import {
   useCardData,
   commonComparators,
   CardSearchInput, CardControlsRow, CardPaginationFooter,
+  CardAIActions,
 } from '../../lib/cards'
 import { K8S_DOCS } from '../../config/externalApis'
 import { useCardLoadingState } from './CardDataContext'
@@ -375,6 +376,13 @@ export function GatewayStatus({ config: _config }: GatewayStatusProps) {
                     </span>
                   ))}
                 </div>
+              )}
+              {(gw.status === 'NotAccepted' || gw.status === 'Pending') && (
+                <CardAIActions
+                  resource={{ kind: 'Gateway', name: gw.name, namespace: gw.namespace, cluster: gw.cluster, status: gw.status }}
+                  issues={[{ name: `Gateway ${gw.status}`, message: `Gateway "${gw.name}" (class: ${gw.gatewayClass}) is ${gw.status}` }]}
+                  className="mt-1"
+                />
               )}
             </div>
           )

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, useRef } from 'react'
 import { AlertTriangle, CheckCircle, Cpu, HardDrive, Wifi, Server, RefreshCw, XCircle, ChevronRight, List, AlertCircle, BellOff, Clock, MoreVertical } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { useCardDemoState, useCardLoadingState } from './CardDataContext'
-import { CardControlsRow, CardSearchInput, CardPaginationFooter } from '../../lib/cards/CardComponents'
+import { CardControlsRow, CardSearchInput, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useClusters } from '../../hooks/useMCP'
@@ -817,6 +817,10 @@ export function HardwareHealthCard() {
 
                   {/* Actions */}
                   <div className="flex items-center gap-1 flex-shrink-0 ml-2">
+                    <CardAIActions
+                      resource={{ kind: 'HardwareDevice', name: alert.nodeName, cluster: alert.cluster, status: alert.severity }}
+                      issues={[{ name: `${getDeviceLabel(alert.deviceType)} disappeared`, message: `${alert.previousCount} → ${alert.currentCount} (${alert.droppedCount} disappeared)` }]}
+                    />
                     {/* Snooze indicator or snooze button */}
                     {isSnoozed(alert.id) ? (
                       <button

--- a/web/src/components/cards/HelmReleaseStatus.tsx
+++ b/web/src/components/cards/HelmReleaseStatus.tsx
@@ -6,7 +6,7 @@ import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import {
   useCardData,
-  CardSearchInput, CardControlsRow, CardPaginationFooter,
+  CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions,
 } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
 
@@ -324,6 +324,12 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
                       <span className="text-sm text-foreground font-medium group-hover:text-purple-400" title={release.name}>{release.name}</span>
                     </div>
                     <div className="flex items-center gap-2">
+                      {release.status !== 'deployed' && release.status !== 'superseded' && (
+                        <CardAIActions
+                          resource={{ kind: 'HelmRelease', name: release.name, namespace: release.namespace, cluster: release.cluster, status: release.status }}
+                          issues={[{ name: `Release ${release.status}`, message: `Helm release ${release.name} (chart: ${release.chart}@${release.version}) is in ${release.status} state` }]}
+                        />
+                      )}
                       <span className={`text-xs px-1.5 py-0.5 rounded bg-${color}-500/20 text-${color}-400`} title={`Release status: ${release.status}`}>
                         {release.status}
                       </span>

--- a/web/src/components/cards/KustomizationStatus.tsx
+++ b/web/src/components/cards/KustomizationStatus.tsx
@@ -8,6 +8,7 @@ import { useDrillDownActions } from '../../hooks/useDrillDown'
 import {
   useCardData,
   CardSearchInput, CardControlsRow, CardPaginationFooter,
+  CardAIActions,
 } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
 
@@ -386,6 +387,13 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
                       <span>{formatTime(ks.lastApplied)}</span>
                     </div>
                   </div>
+                  {(ks.status === 'NotReady' || ks.status === 'Suspended') && (
+                    <CardAIActions
+                      resource={{ kind: 'Kustomization', name: ks.name, namespace: ks.namespace, cluster: selectedCluster, status: ks.status }}
+                      issues={[{ name: `Kustomization ${ks.status}`, message: `Kustomization "${ks.name}" in ${ks.namespace} is ${ks.status} (source: ${ks.sourceRef}, path: ${ks.path})` }]}
+                      className="mt-1 ml-6"
+                    />
+                  )}
                 </div>
               )
             })}

--- a/web/src/components/cards/OperatorStatus.tsx
+++ b/web/src/components/cards/OperatorStatus.tsx
@@ -15,6 +15,7 @@ import {
   CardSearchInput,
   CardControlsRow,
   CardPaginationFooter,
+  CardAIActions,
 } from '../../lib/cards/CardComponents'
 
 interface OperatorStatusProps {
@@ -265,6 +266,12 @@ export function OperatorStatus({ config: _config }: OperatorStatusProps) {
                       <span className="text-sm text-foreground group-hover:text-purple-400">{op.name}</span>
                     </div>
                     <div className="flex items-center gap-2">
+                      {op.status !== 'Succeeded' && (
+                        <CardAIActions
+                          resource={{ kind: 'Operator', name: op.name, namespace: op.namespace, cluster: op.cluster, status: op.status }}
+                          issues={[{ name: `Operator ${op.status}`, message: `Operator is in ${op.status} state${op.upgradeAvailable ? `, upgrade available: ${op.upgradeAvailable}` : ''}` }]}
+                        />
+                      )}
                       <span className={`text-xs px-1.5 py-0.5 rounded bg-${color}-500/20 text-${color}-400`}>
                         {op.status}
                       </span>

--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -5,7 +5,7 @@ import type { PVC } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCardLoadingState } from './CardDataContext'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
-import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
 import { ClusterBadge } from '../ui/ClusterBadge'
 
 type SortByOption = 'status' | 'name' | 'capacity' | 'age'
@@ -262,6 +262,12 @@ export function PVCStatus() {
                   </span>
                 )}
                 <span className={getStatusColor(pvc.status)}>{pvc.status}</span>
+                {pvc.status !== 'Bound' && (
+                  <CardAIActions
+                    resource={{ kind: 'PersistentVolumeClaim', name: pvc.name, namespace: pvc.namespace, cluster: pvc.cluster, status: pvc.status }}
+                    issues={[{ name: `PVC ${pvc.status}`, message: `PersistentVolumeClaim is in ${pvc.status} state${pvc.storageClass ? ` (storageClass: ${pvc.storageClass})` : ''}` }]}
+                  />
+                )}
                 <ChevronRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
               </div>
             </div>

--- a/web/src/components/cards/ServiceExports.tsx
+++ b/web/src/components/cards/ServiceExports.tsx
@@ -4,6 +4,7 @@ import {
   useCardData,
   commonComparators,
   CardSearchInput, CardControlsRow, CardPaginationFooter,
+  CardAIActions,
 } from '../../lib/cards'
 import { Skeleton } from '../ui/Skeleton'
 import { K8S_DOCS } from '../../config/externalApis'
@@ -323,6 +324,13 @@ export function ServiceExports({ config: _config }: ServiceExportsProps) {
                   </span>
                 )}
               </div>
+              {(exp.status === 'Pending' || exp.status === 'Failed') && (
+                <CardAIActions
+                  resource={{ kind: 'ServiceExport', name: exp.name, namespace: exp.namespace, cluster: exp.cluster, status: exp.status }}
+                  issues={[{ name: `Export ${exp.status}`, message: exp.message || `ServiceExport "${exp.name}" is ${exp.status}` }]}
+                  className="mt-1"
+                />
+              )}
             </div>
           )
         })}

--- a/web/src/components/cards/TopPods.tsx
+++ b/web/src/components/cards/TopPods.tsx
@@ -5,7 +5,7 @@ import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCardLoadingState } from './CardDataContext'
-import { useCardData, commonComparators, CardClusterFilter, CardSearchInput } from '../../lib/cards'
+import { useCardData, commonComparators, CardClusterFilter, CardSearchInput, CardAIActions } from '../../lib/cards'
 
 type SortByOption = 'restarts' | 'name' | 'cpu' | 'memory' | 'gpu'
 
@@ -379,7 +379,18 @@ export function TopPods({ config }: TopPodsProps) {
                   <span className="flex-shrink-0">{pod.ready}</span>
                   <span className="flex-shrink-0">{pod.age}</span>
                 </div>
-                <ChevronRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                <div className="flex items-center gap-1">
+                  {(pod.restarts >= 1 || (pod.status !== 'Running' && pod.status !== 'Succeeded' && pod.status !== 'Completed')) && (
+                    <CardAIActions
+                      resource={{ kind: 'Pod', name: pod.name, namespace: pod.namespace, cluster: pod.cluster, status: pod.status }}
+                      issues={[
+                        ...(pod.restarts >= 1 ? [{ name: 'High restarts', message: `Pod has restarted ${pod.restarts} time${pod.restarts !== 1 ? 's' : ''}` }] : []),
+                        ...(pod.status !== 'Running' && pod.status !== 'Succeeded' && pod.status !== 'Completed' ? [{ name: `Pod ${pod.status}`, message: `Pod is in ${pod.status} state` }] : []),
+                      ]}
+                    />
+                  )}
+                  <ChevronRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                </div>
               </div>
             </div>
           )})}

--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -6,7 +6,7 @@ import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
-import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
 import { useCardLoadingState } from './CardDataContext'
 
 interface UpgradeStatusProps {
@@ -563,6 +563,18 @@ Please proceed step by step and ask for confirmation before making any changes.`
                 <Rocket className="w-3 h-3" />
                 Start Upgrade to {cluster.targetVersion}
               </button>
+            )}
+            {(cluster.status === 'unreachable' || cluster.status === 'available') && (
+              <CardAIActions
+                resource={{ kind: 'Cluster', name: cluster.name, status: cluster.status }}
+                issues={[{
+                  name: cluster.status === 'unreachable' ? 'Cluster unreachable' : 'Upgrade available',
+                  message: cluster.status === 'unreachable'
+                    ? `Cluster ${cluster.name} is unreachable and cannot be queried for version info`
+                    : `Cluster ${cluster.name} can be upgraded from ${cluster.currentVersion} to ${cluster.targetVersion}`,
+                }]}
+                className="mt-2"
+              />
             )}
           </div>
         ))}

--- a/web/src/components/cards/WarningEvents.tsx
+++ b/web/src/components/cards/WarningEvents.tsx
@@ -6,7 +6,7 @@ import { RefreshButton } from '../ui/RefreshIndicator'
 import { Skeleton } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
-import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
 import type { ClusterEvent } from '../../hooks/useMCP'
 
 function getTimeAgo(timestamp: string | undefined): string {
@@ -205,6 +205,11 @@ export function WarningEvents() {
                     {event.cluster && (
                       <ClusterBadge cluster={event.cluster.split('/').pop() || event.cluster} size="sm" />
                     )}
+                    <CardAIActions
+                      resource={{ kind: 'Event', name: event.object, namespace: event.namespace, cluster: event.cluster, status: 'Warning' }}
+                      issues={[{ name: event.reason, message: event.message }]}
+                      showRepair={false}
+                    />
                     <span className="text-xs text-muted-foreground ml-auto">{getTimeAgo(event.lastSeen)}</span>
                   </div>
                 </div>

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useEffect, useRef } from 'react'
-import { AlertCircle, CheckCircle, Clock, ChevronRight, TrendingUp, TrendingDown, Minus, Cpu, HardDrive, RefreshCw, Info, Sparkles, ThumbsUp, ThumbsDown, Zap, Layers, List, Stethoscope, Wrench } from 'lucide-react'
+import { AlertCircle, CheckCircle, Clock, ChevronRight, TrendingUp, TrendingDown, Minus, Cpu, HardDrive, RefreshCw, Info, Sparkles, ThumbsUp, ThumbsDown, Zap, Layers, List } from 'lucide-react'
 import { useCardDemoState } from '../CardDataContext'
 import { useMissions } from '../../../hooks/useMissions'
 import { useGPUNodes, usePodIssues, useClusters } from '../../../hooks/useMCP'
@@ -14,7 +14,7 @@ import { useApiKeyCheck, ApiKeyPromptModal } from './shared'
 import type { ConsoleMissionCardProps } from './shared'
 import { useCardLoadingState } from '../CardDataContext'
 import type { PredictedRisk, TrendDirection } from '../../../types/predictions'
-import { CardControlsRow, CardSearchInput, CardPaginationFooter } from '../../../lib/cards/CardComponents'
+import { CardControlsRow, CardSearchInput, CardPaginationFooter, CardAIActions } from '../../../lib/cards/CardComponents'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 
 // ============================================================================
@@ -1152,62 +1152,11 @@ TASK:
                 </div>
                 {/* Item action buttons */}
                 <div className="flex items-center gap-1 flex-shrink-0 ml-2">
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      startMission({
-                        title: `Diagnose: ${node.name}`,
-                        description: `Diagnosing node ${node.name}`,
-                        type: 'troubleshoot',
-                        initialPrompt: `Diagnose this Kubernetes node issue:
-
-NODE: ${node.name}
-CLUSTER: ${node.cluster || 'unknown'}
-STATUS: ${node.unschedulable ? 'Cordoned' : node.status}
-ROOT CAUSE: ${rootCause?.cause || 'Unknown'}
-DETAILS: ${rootCause?.details || 'No details available'}
-
-Please:
-1. Explain what this issue means
-2. Identify the root cause
-3. List diagnostic commands to gather more info
-4. Provide the steps to fix this issue`,
-                        context: { node: node.name, cluster: node.cluster },
-                      })
-                    }}
-                    className="p-1 rounded text-muted-foreground hover:text-purple-400 hover:bg-purple-500/10 transition-colors opacity-0 group-hover:opacity-100"
-                    title={`Diagnose ${node.name}`}
-                  >
-                    <Stethoscope className="w-3 h-3" />
-                  </button>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      startMission({
-                        title: `Repair: ${node.name}`,
-                        description: `Repairing node ${node.name}`,
-                        type: 'troubleshoot',
-                        initialPrompt: `Repair this Kubernetes node:
-
-NODE: ${node.name}
-CLUSTER: ${node.cluster || 'unknown'}
-STATUS: ${node.unschedulable ? 'Cordoned' : node.status}
-ROOT CAUSE: ${rootCause?.cause || 'Unknown'}
-DETAILS: ${rootCause?.details || 'No details available'}
-
-Please provide:
-1. The exact commands to fix this issue
-2. Any prerequisites or safety checks
-3. How to verify the repair was successful
-4. Any follow-up actions needed`,
-                        context: { node: node.name, cluster: node.cluster },
-                      })
-                    }}
-                    className="p-1 rounded text-muted-foreground hover:text-orange-400 hover:bg-orange-500/10 transition-colors opacity-0 group-hover:opacity-100"
-                    title={`Repair ${node.name}`}
-                  >
-                    <Wrench className="w-3 h-3" />
-                  </button>
+                  <CardAIActions
+                    resource={{ kind: 'Node', name: node.name, cluster: node.cluster, status: node.unschedulable ? 'Cordoned' : node.status }}
+                    issues={rootCause ? [{ name: rootCause.cause, message: rootCause.details }] : []}
+                    className="opacity-0 group-hover:opacity-100"
+                  />
                   <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100" />
                 </div>
               </div>
@@ -1235,60 +1184,11 @@ Please provide:
                 </div>
                 {/* Item action buttons */}
                 <div className="flex items-center gap-1 flex-shrink-0 ml-2">
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      startMission({
-                        title: `Diagnose GPU: ${issue.nodeName}`,
-                        description: `Diagnosing GPU issue on ${issue.nodeName}`,
-                        type: 'troubleshoot',
-                        initialPrompt: `Diagnose this GPU issue:
-
-NODE: ${issue.nodeName}
-CLUSTER: ${issue.cluster}
-ISSUE: ${issue.reason}
-EXPECTED GPUs: ${issue.expected > 0 ? issue.expected : 'Unknown'}
-AVAILABLE GPUs: ${issue.available}
-
-Please:
-1. Explain what could cause GPUs to show as unavailable
-2. List diagnostic commands to check GPU status
-3. Check for driver issues, nvidia-smi output, device plugin status
-4. Identify the root cause`,
-                        context: { node: issue.nodeName, cluster: issue.cluster },
-                      })
-                    }}
-                    className="p-1 rounded text-muted-foreground hover:text-purple-400 hover:bg-purple-500/10 transition-colors opacity-0 group-hover:opacity-100"
-                    title={`Diagnose GPU on ${issue.nodeName}`}
-                  >
-                    <Stethoscope className="w-3 h-3" />
-                  </button>
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      startMission({
-                        title: `Repair GPU: ${issue.nodeName}`,
-                        description: `Repairing GPU on ${issue.nodeName}`,
-                        type: 'troubleshoot',
-                        initialPrompt: `Repair the GPU issue on this node:
-
-NODE: ${issue.nodeName}
-CLUSTER: ${issue.cluster}
-ISSUE: ${issue.reason}
-
-Please provide:
-1. Steps to restore GPU availability
-2. How to restart NVIDIA device plugin
-3. Driver-related fixes if applicable
-4. How to verify GPUs are working again`,
-                        context: { node: issue.nodeName, cluster: issue.cluster },
-                      })
-                    }}
-                    className="p-1 rounded text-muted-foreground hover:text-orange-400 hover:bg-orange-500/10 transition-colors opacity-0 group-hover:opacity-100"
-                    title={`Repair GPU on ${issue.nodeName}`}
-                  >
-                    <Wrench className="w-3 h-3" />
-                  </button>
+                  <CardAIActions
+                    resource={{ kind: 'GPU', name: issue.nodeName, cluster: issue.cluster, status: `${issue.available}/${issue.expected} GPUs available` }}
+                    issues={[{ name: 'GPU Unavailable', message: issue.reason }]}
+                    className="opacity-0 group-hover:opacity-100"
+                  />
                   <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100" />
                 </div>
               </div>
@@ -1361,71 +1261,14 @@ Please provide:
 
                   {/* Action Buttons + Feedback + Chevron */}
                   <div className="flex items-center gap-1 flex-shrink-0 ml-2">
-                    {/* Diagnose & Repair buttons */}
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        startMission({
-                          title: `Diagnose: ${risk.name}`,
-                          description: `Diagnosing predicted risk for ${risk.name}`,
-                          type: 'troubleshoot',
-                          initialPrompt: `Diagnose this predicted failure risk:
-
-RESOURCE: ${risk.name}
-CLUSTER: ${risk.cluster || 'unknown'}
-${risk.namespace ? `NAMESPACE: ${risk.namespace}` : ''}
-TYPE: ${risk.type}
-SEVERITY: ${risk.severity}
-PREDICTION SOURCE: ${risk.source === 'ai' ? `AI (${risk.confidence || 0}% confidence)` : 'Heuristic threshold'}
-${risk.trend ? `TREND: ${risk.trend}` : ''}
-
-SUMMARY: ${risk.reason}
-${risk.reasonDetailed ? `DETAILS: ${risk.reasonDetailed}` : ''}
-
-Please:
-1. Explain what this prediction means
-2. Assess the likelihood of this failure occurring
-3. List diagnostic commands to verify the risk
-4. Identify contributing factors`,
-                          context: { name: risk.name, cluster: risk.cluster, type: risk.type },
-                        })
-                      }}
-                      className="p-1 rounded text-muted-foreground hover:text-purple-400 hover:bg-purple-500/10 transition-colors opacity-0 group-hover:opacity-100"
-                      title={`Diagnose ${risk.name}`}
-                    >
-                      <Stethoscope className="w-3 h-3" />
-                    </button>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        startMission({
-                          title: `Prevent: ${risk.name}`,
-                          description: `Preventing predicted failure for ${risk.name}`,
-                          type: 'troubleshoot',
-                          initialPrompt: `Prevent this predicted failure:
-
-RESOURCE: ${risk.name}
-CLUSTER: ${risk.cluster || 'unknown'}
-${risk.namespace ? `NAMESPACE: ${risk.namespace}` : ''}
-TYPE: ${risk.type}
-SEVERITY: ${risk.severity}
-
-SUMMARY: ${risk.reason}
-${risk.reasonDetailed ? `DETAILS: ${risk.reasonDetailed}` : ''}
-
-Please provide:
-1. Preventive actions to avoid this failure
-2. Specific commands or configuration changes
-3. How to verify the risk has been mitigated
-4. Monitoring recommendations to catch this earlier`,
-                          context: { name: risk.name, cluster: risk.cluster, type: risk.type },
-                        })
-                      }}
-                      className="p-1 rounded text-muted-foreground hover:text-orange-400 hover:bg-orange-500/10 transition-colors opacity-0 group-hover:opacity-100"
-                      title={`Prevent failure for ${risk.name}`}
-                    >
-                      <Wrench className="w-3 h-3" />
-                    </button>
+                    {/* Diagnose & Prevent buttons */}
+                    <CardAIActions
+                      resource={{ kind: risk.type, name: risk.name, namespace: risk.namespace, cluster: risk.cluster, status: risk.severity }}
+                      issues={[{ name: risk.reason, message: risk.reasonDetailed || risk.reason }]}
+                      additionalContext={{ source: risk.source, confidence: risk.confidence, trend: risk.trend }}
+                      repairLabel="Prevent"
+                      className="opacity-0 group-hover:opacity-100"
+                    />
                     {/* AI feedback buttons */}
                     {risk.source === 'ai' && risk.id && (
                       <>

--- a/web/src/components/cards/workload-detection/ProwJobs.tsx
+++ b/web/src/components/cards/workload-detection/ProwJobs.tsx
@@ -5,7 +5,7 @@ import {
 } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { CardControls } from '../../ui/CardControls'
-import { CardSearchInput } from '../../../lib/cards'
+import { CardSearchInput, CardAIActions } from '../../../lib/cards'
 import { Pagination } from '../../ui/Pagination'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import type { SortDirection } from '../../../lib/cards/cardHooks'
@@ -205,6 +205,13 @@ export function ProwJobs({ config: _config }: ProwJobsProps) {
                 </a>
               )}
             </div>
+            {(job.state === 'failure' || job.state === 'error' || job.state === 'aborted') && (
+              <CardAIActions
+                resource={{ kind: 'ProwJob', name: job.name, status: job.state }}
+                issues={[{ name: `Job ${job.state}`, message: `PROW job "${job.name}" (${job.type}) ended with state: ${job.state}` }]}
+                className="mt-1"
+              />
+            )}
           </div>
         ))}
       </div>

--- a/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
@@ -3,12 +3,12 @@ import { createPortal } from 'react-dom'
 import {
   Cpu, Network, Activity, Layers, Server,
   RefreshCw, Loader2, ChevronDown, ChevronRight, Filter,
-  Stethoscope, Wrench, AlertTriangle
+  AlertTriangle
 } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
 import { CardControls } from '../../ui/CardControls'
-import { CardSearchInput } from '../../../lib/cards'
+import { CardSearchInput, CardAIActions } from '../../../lib/cards'
 import { useCachedLLMdServers } from '../../../hooks/useCachedData'
 import { useWorkloadMonitor } from '../../../hooks/useWorkloadMonitor'
 import { useDiagnoseRepairLoop } from '../../../hooks/useDiagnoseRepairLoop'
@@ -744,24 +744,14 @@ export function LLMdStackMonitor({ config: _config }: LLMdStackMonitorProps) {
                               {item.cluster}
                             </span>
                           )}
-                          {/* Diag/Repair icons - show always for non-healthy items */}
+                          {/* Diag icon - show for non-healthy items */}
                           {item.status !== 'healthy' && (
-                            <div className="flex items-center gap-0.5 shrink-0">
-                              <button
-                                className="p-0.5 rounded hover:bg-blue-500/20 text-blue-400/70 hover:text-blue-400 transition-colors"
-                                title={`Diagnose ${item.name}`}
-                                onClick={(e) => { e.stopPropagation(); handleItemDiagnose(item) }}
-                              >
-                                <Stethoscope className="w-3 h-3" />
-                              </button>
-                              <button
-                                className="p-0.5 rounded hover:bg-orange-500/20 text-orange-400/70 hover:text-orange-400 transition-colors"
-                                title={`Repair ${item.name}`}
-                                onClick={(e) => { e.stopPropagation(); handleItemDiagnose(item) }}
-                              >
-                                <Wrench className="w-3 h-3" />
-                              </button>
-                            </div>
+                            <CardAIActions
+                              resource={{ kind: 'Deployment', name: item.name, namespace: item.namespace, cluster: item.cluster, status: item.status }}
+                              issues={item.detail ? [{ name: item.status, message: item.detail }] : []}
+                              showRepair={false}
+                              onDiagnose={(e) => { e.stopPropagation(); handleItemDiagnose(item) }}
+                            />
                           )}
                         </div>
                       ))}
@@ -861,18 +851,17 @@ export function LLMdStackMonitor({ config: _config }: LLMdStackMonitorProps) {
                           )}
                         </div>
                       </div>
-                      <button
-                        onClick={() => handleItemDiagnose({
+                      <CardAIActions
+                        resource={{ kind: issue.resource?.kind || 'Resource', name: issue.resource?.name || issue.title, namespace: issue.resource?.namespace, cluster: issue.resource?.cluster, status: issue.severity }}
+                        issues={[{ name: issue.title, message: issue.description || '' }]}
+                        showRepair={false}
+                        onDiagnose={() => handleItemDiagnose({
                           name: issue.resource?.name || issue.title,
                           status: issue.severity === 'critical' ? 'unhealthy' : 'degraded',
                           namespace: issue.resource?.namespace,
                           cluster: issue.resource?.cluster,
                         })}
-                        className="shrink-0 p-1.5 rounded hover:bg-purple-500/20 transition-colors"
-                        title="Diagnose with AI"
-                      >
-                        <Stethoscope className="w-4 h-4 text-purple-400" />
-                      </button>
+                      />
                     </div>
                   </div>
                 )

--- a/web/src/components/cards/workload-monitor/WorkloadMonitorAlerts.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitorAlerts.tsx
@@ -1,7 +1,7 @@
-import { AlertTriangle, AlertCircle, Info, ChevronDown, ChevronRight, Stethoscope } from 'lucide-react'
+import { AlertTriangle, AlertCircle, Info, ChevronDown, ChevronRight } from 'lucide-react'
 import { useState } from 'react'
 import type { MonitorIssue } from '../../../types/workloadMonitor'
-import { useMissions } from '../../../hooks/useMissions'
+import { CardAIActions } from '../../../lib/cards/CardComponents'
 
 interface AlertsProps {
   issues: MonitorIssue[]
@@ -16,19 +16,9 @@ const SEVERITY_CONFIG = {
   info: { icon: Info, bg: 'bg-blue-500/10', border: 'border-blue-500/20', text: 'text-blue-400', badge: 'bg-blue-500/20 text-blue-400' },
 }
 
-export function WorkloadMonitorAlerts({ issues, monitorType, expanded: forcedExpanded }: AlertsProps) {
+export function WorkloadMonitorAlerts({ issues, monitorType: _monitorType, expanded: forcedExpanded }: AlertsProps) {
   const [localExpanded, setLocalExpanded] = useState(true)
   const isExpanded = forcedExpanded !== undefined ? forcedExpanded : localExpanded
-  const { startMission } = useMissions()
-
-  const handleDiagnose = (issue: MonitorIssue) => {
-    startMission({
-      title: `Diagnose: ${issue.title}`,
-      description: issue.description || `${issue.severity} issue`,
-      type: 'troubleshoot',
-      initialPrompt: `Diagnose this ${monitorType || 'workflow'} issue:\n\n**Issue:** ${issue.title}\n**Severity:** ${issue.severity}\n**Details:** ${issue.description || 'No additional details'}\n**Resource:** ${issue.resource?.name || 'Unknown'} (${issue.resource?.kind || 'Unknown'})\n\nPlease analyze the root cause and suggest fixes.`,
-    })
-  }
 
   const criticalCount = issues.filter(i => i.severity === 'critical').length
   const warningCount = issues.filter(i => i.severity === 'warning').length
@@ -106,13 +96,11 @@ export function WorkloadMonitorAlerts({ issues, monitorType, expanded: forcedExp
                     <p className={`text-[10px] ${config.text} opacity-70 mt-0.5`}>{issue.description}</p>
                   )}
                 </div>
-                <button
-                  onClick={() => handleDiagnose(issue)}
-                  className="shrink-0 p-1 rounded hover:bg-purple-500/20 transition-colors"
-                  title="Diagnose with AI"
-                >
-                  <Stethoscope className="w-3.5 h-3.5 text-purple-400" />
-                </button>
+                <CardAIActions
+                  resource={{ kind: issue.resource?.kind || 'Resource', name: issue.resource?.name || issue.title, namespace: issue.resource?.namespace, cluster: issue.resource?.cluster, status: issue.severity }}
+                  issues={[{ name: issue.title, message: issue.description || '' }]}
+                  showRepair={false}
+                />
               </div>
             )
           })}

--- a/web/src/components/ui/AlertBadge.tsx
+++ b/web/src/components/ui/AlertBadge.tsx
@@ -1,12 +1,13 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Bell, AlertTriangle, CheckCircle, Clock, ChevronRight, X, Bot, Server, Search, ExternalLink, CheckSquare, Square, MinusSquare } from 'lucide-react'
+import { Bell, AlertTriangle, CheckCircle, Clock, ChevronRight, X, Server, Search, ExternalLink, CheckSquare, Square, MinusSquare } from 'lucide-react'
 import { useAlerts } from '../../hooks/useAlerts'
 import { useDrillDown } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
 import { useMobile } from '../../hooks/useMobile'
 import { getSeverityIcon } from '../../types/alerts'
 import type { Alert, AlertSeverity } from '../../types/alerts'
+import { CardAIActions } from '../../lib/cards/CardComponents'
 
 // Animated counter component for the badge - exported for future use
 export function AnimatedCounter({ value, className }: { value: number; className?: string }) {
@@ -466,13 +467,12 @@ export function AlertBadge() {
                       } else {
                         // No mission or mission was deleted - show diagnose button
                         return (
-                          <button
-                            onClick={e => handleDiagnose(e, alert.id)}
-                            className="px-2 py-1 text-xs rounded bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 transition-colors flex items-center gap-1"
-                          >
-                            <Bot className="w-3 h-3" />
-                            Diagnose
-                          </button>
+                          <CardAIActions
+                            resource={{ kind: 'Alert', name: alert.ruleName, cluster: alert.cluster, status: alert.severity }}
+                            issues={[{ name: alert.ruleName, message: alert.message }]}
+                            showRepair={false}
+                            onDiagnose={e => handleDiagnose(e, alert.id)}
+                          />
                         )
                       }
                     })()}


### PR DESCRIPTION
## Summary
- Enhanced `CardAIActions` component with new props (`showRepair`, `repairLabel`, `diagnosePrompt`, `repairPrompt`, `onDiagnose`, `onRepair`) for flexible usage across all card types
- Replaced 6 old-style inline Diagnose/Repair button implementations with unified `CardAIActions` component
- Added `CardAIActions` to 13 additional cards for any list item with non-healthy/non-ready status
- Fixed bug in LLMdStackMonitor where both Diagnose and Repair buttons called the same handler
- Prediction items now show "Prevent" instead of "Repair" via `repairLabel` prop

## Cards Updated (20 files)

### Replaced old-style buttons (6 cards):
- ConsoleOfflineDetectionCard (3 locations: nodes, GPUs, predictions)
- WorkloadMonitorAlerts
- GitHubCIMonitor
- LLMdStackMonitor (2 locations + bug fix)
- ActiveAlerts
- AlertBadge

### Added new Diagnose/Repair buttons (13 cards):
- HardwareHealthCard, WarningEvents, GPUWorkloads, OperatorStatus
- HelmReleaseStatus, PVCStatus, TopPods, UpgradeStatus
- ProwJobs, ServiceExports, GatewayStatus, KustomizationStatus, CRDHealth

## Test plan
- [ ] Verify icon-only Diagnose/Repair buttons appear on non-healthy items across all 19 cards
- [ ] Click Diagnose opens AI Missions sidebar with contextual prompt
- [ ] Click Repair opens sidebar with repair-focused prompt
- [ ] Predictions show "Prevent" tooltip instead of "Repair"
- [ ] LLMdStackMonitor: Diagnose triggers diagnose-repair-loop correctly
- [ ] ActiveAlerts/AlertBadge: "View Diagnosis" still shows when mission exists
- [ ] Healthy items show NO buttons
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)