### PR TITLE
🐛 Eliminate pervasive UI flickering across all dashboards

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -116,7 +116,9 @@ function LoadingFallback() {
   }, [])
 
   if (!showLoading) {
-    return null
+    // Invisible placeholder maintains layout dimensions during route transitions,
+    // preventing the content area from collapsing to 0 height (blank flash).
+    return <div className="min-h-screen" />
   }
 
   return (

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -987,7 +987,8 @@ export function CardWrapper({
   // - Card explicitly reports isLoading: true, OR
   // - Card hasn't reported yet AND quick timeout hasn't passed (brief skeleton for reporting cards)
   // Static/demo cards that never report will stop showing as loading after 150ms
-  const effectiveIsLoading = isRefreshing || childDataState?.isLoading || (childDataState === null && !initialRenderTimedOut && !skeletonTimedOut)
+  // NOTE: isRefreshing is NOT included — background refreshes should be invisible to avoid flicker
+  const effectiveIsLoading = childDataState?.isLoading || (childDataState === null && !initialRenderTimedOut && !skeletonTimedOut)
   const effectiveIsRefreshing = childDataState?.isRefreshing || false
   // hasData logic:
   // - If card explicitly reports hasData, use it

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -19,6 +19,16 @@ import { TourProvider } from '../../hooks/useTour'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
 
 
+// Module-level constant — computed once, never changes on re-render.
+// Prevents star field from flickering when Layout re-renders due to hooks.
+const STAR_POSITIONS = Array.from({ length: 30 }, () => ({
+  width: Math.random() * 2 + 1 + 'px',
+  height: Math.random() * 2 + 1 + 'px',
+  left: Math.random() * 100 + '%',
+  top: Math.random() * 100 + '%',
+  animationDelay: Math.random() * 3 + 's',
+}))
+
 interface LayoutProps {
   children: ReactNode
 }
@@ -67,20 +77,10 @@ export function Layout({ children }: LayoutProps) {
       <TourOverlay />
       <TourPrompt />
 
-      {/* Star field background */}
+      {/* Star field background — positions are stable (module-level constant) */}
       <div className="star-field">
-        {Array.from({ length: 30 }).map((_, i) => (
-          <div
-            key={i}
-            className="star"
-            style={{
-              width: Math.random() * 2 + 1 + 'px',
-              height: Math.random() * 2 + 1 + 'px',
-              left: Math.random() * 100 + '%',
-              top: Math.random() * 100 + '%',
-              animationDelay: Math.random() * 3 + 's',
-            }}
-          />
+        {STAR_POSITIONS.map((style, i) => (
+          <div key={i} className="star" style={style} />
         ))}
       </div>
 
@@ -203,7 +203,7 @@ export function Layout({ children }: LayoutProps) {
         </div>
       )}
 
-      <div className="flex flex-1 overflow-hidden" style={{ paddingTop: NAVBAR_HEIGHT + totalBannerHeight }}>
+      <div className="flex flex-1 overflow-hidden transition-[padding-top] duration-300" style={{ paddingTop: NAVBAR_HEIGHT + totalBannerHeight }}>
         <Sidebar />
         <main className={cn(
           'flex-1 p-4 md:p-6 transition-[margin] duration-300 overflow-y-auto',

--- a/web/src/hooks/useRefreshIndicator.ts
+++ b/web/src/hooks/useRefreshIndicator.ts
@@ -1,58 +1,29 @@
-import { useState, useCallback, useRef, useEffect } from 'react'
+import { useState, useCallback, useRef } from 'react'
 
-// Minimum time to show the "Updating" hourglass indicator.
-// Ensures the hourglass is always visible even if data returns instantly.
-const MIN_REFRESH_INDICATOR_MS = 500
+// Minimum time to show the refresh indicator on user-triggered refreshes.
+// Kept short for snappy feedback without causing visible flicker.
+const MIN_REFRESH_INDICATOR_MS = 300
 
 /**
- * Hook that guarantees the refresh/hourglass indicator is visible for at least
- * MIN_REFRESH_INDICATOR_MS in two scenarios:
- *
- * 1. On mount — when a dashboard is first opened, the hourglass shows while
- *    the data hooks perform their initial (possibly silent/cached) fetch.
- * 2. On click — when the user clicks the refresh button.
+ * Hook that shows a brief refresh indicator when the user clicks the refresh
+ * button. Does NOT show on mount — cached data should render instantly.
  *
  * Usage:
  *   const { showIndicator, triggerRefresh } = useRefreshIndicator(refetch)
- *   const isRefreshVisible = isFetching  // use isFetching to sync hourglass with spin icon
- *
- * For components that are reused across route changes (e.g. CustomDashboard
- * rendered at /custom-dashboard/:id), pass a resetKey so the mount indicator
- * re-triggers when the key changes:
- *   const { showIndicator, triggerRefresh } = useRefreshIndicator(refetch, id)
  */
-export function useRefreshIndicator(refetchFn: () => void, resetKey?: string) {
-  // Start true so the hourglass shows immediately when a dashboard opens
-  const [showIndicator, setShowIndicator] = useState(true)
+export function useRefreshIndicator(refetchFn: () => void, _resetKey?: string) {
+  const [showIndicator, setShowIndicator] = useState(false)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Show the indicator on mount, and re-trigger when resetKey changes
-  // (handles route reuse where the component doesn't unmount/remount)
-  useEffect(() => {
-    setShowIndicator(true)
-    if (timerRef.current) clearTimeout(timerRef.current)
-    timerRef.current = setTimeout(() => {
-      setShowIndicator(false)
-      timerRef.current = null
-    }, MIN_REFRESH_INDICATOR_MS)
-    return () => {
-      if (timerRef.current) clearTimeout(timerRef.current)
-    }
-  }, [resetKey])
-
   const triggerRefresh = useCallback(() => {
-    // Always show the indicator immediately
     setShowIndicator(true)
 
-    // Clear any existing timer (e.g. rapid clicks)
     if (timerRef.current) {
       clearTimeout(timerRef.current)
     }
 
-    // Call the actual data refetch
     refetchFn()
 
-    // Ensure minimum visible duration
     timerRef.current = setTimeout(() => {
       setShowIndicator(false)
       timerRef.current = null


### PR DESCRIPTION
## Summary
- Remove forced 500ms `MIN_REFRESH_INDICATOR_MS` delay in cache layer that caused every background poll to show a visible refresh pulse
- Remove `simulateRefresh()` that forced 500ms loading flash on demo mount
- Remove 500ms mount-time indicator from `useRefreshIndicator` hook
- Preload ALL IndexedDB cache keys at startup (not just 6 hardcoded), eliminating skeleton flashes when cached data exists
- Memoize star field positions at module level to prevent background repositioning on Layout re-renders
- Add smooth transition for banner padding changes
- Replace `null` with invisible layout placeholder in `LoadingFallback` to prevent content collapse during route transitions
- Stop treating background `isRefreshing` as `isLoading` in `CardWrapper` so cards don't flash loading state on every poll
- Memoize `AlertsProvider` context value and stabilize evaluation interval with refs to prevent re-render cascades

## Files changed
| File | Change |
|------|--------|
| `lib/cache/index.ts` | Remove 500ms forced delay, remove `simulateRefresh()`, preload all IDB keys |
| `hooks/useRefreshIndicator.ts` | Remove mount flash, reduce to 300ms for user-triggered only |
| `components/layout/Layout.tsx` | Memoize star field, smooth banner transitions |
| `App.tsx` | Layout placeholder in route transitions |
| `components/cards/CardWrapper.tsx` | Don't treat refresh as loading |
| `contexts/AlertsContext.tsx` | Memoize context value, stabilize evaluation with refs |

## Test plan
- [ ] Open console in demo mode — Dashboard renders cached data immediately, no skeleton flash
- [ ] Navigate between pages (Dashboard → Clusters → Pods → back) — no blank flashes, no star repositioning
- [ ] Cards do NOT pulse every 15-30 seconds during background refresh
- [ ] Manual refresh button still shows a brief spin animation
- [ ] Banner slides smoothly when toggling demo mode
- [ ] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)