### PR TITLE
🐛 Fix LLM-d stack discovery to find all stacks via Deployment-based detection

### DIFF
--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -31,7 +31,7 @@ const LOCAL_AGENT_URL = 'http://127.0.0.1:8585'
 const POLL_INTERVAL = 30000 // Poll every 30 seconds
 
 const DEFAULT_SETTINGS = {
-  limit: 5000000, // 5M tokens (realistic for Claude usage)
+  limit: 500000000, // 500M tokens monthly default
   warningThreshold: 0.7, // 70%
   criticalThreshold: 0.9, // 90%
   stopThreshold: 1.0, // 100%


### PR DESCRIPTION
## Summary
- Added Deployment-based broad discovery to `useStackDiscovery` using name/namespace/label patterns (matching the same approach as `useLLMdServers`) to find LLM-d workloads that lack explicit `llm-d.ai/role` pod labels
- Increased kubectl timeouts from 15s to 30s to prevent timeout cascades when 8 parallel requests compete for 2 concurrent WebSocket slots
- Updated default monthly token limit to 500M

## Test plan
- [ ] Stack selector ("Focus on a Stack") should show significantly more than 13 stacks
- [ ] Stacks from Deployments without `llm-d.ai/role` labels should appear with correct replica counts
- [ ] Previously discovered stacks (pods with labels + InferencePools) should still work identically
- [ ] No timeout errors in console for stack discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)