### PR TITLE
⚡ Progressive stack discovery: per-namespace deployment queries

### DIFF
--- a/web/src/hooks/useStackDiscovery.ts
+++ b/web/src/hooks/useStackDiscovery.ts
@@ -123,6 +123,30 @@ interface DeploymentResource {
   status: { replicas?: number; readyReplicas?: number; availableReplicas?: number }
 }
 
+interface HPAResource {
+  metadata: { name: string; namespace: string }
+  spec?: { minReplicas?: number; maxReplicas?: number }
+  status?: { currentReplicas?: number; desiredReplicas?: number }
+}
+
+interface WVAResource {
+  metadata: { name: string; namespace: string }
+  spec?: {
+    minReplicas?: number
+    maxReplicas?: number
+    scaleTargetRef?: { namespace?: string }
+  }
+  status?: {
+    currentReplicas?: number
+    desiredReplicas?: number
+    desiredOptimizedAlloc?: { numReplicas?: number }
+  }
+}
+
+interface VPAResource {
+  metadata: { name: string; namespace: string }
+}
+
 // Namespace heuristics for LLM-d workloads (mirrors useLLMdServers patterns)
 function isLlmdNamespace(ns: string): boolean {
   const n = ns.toLowerCase()
@@ -155,6 +179,67 @@ function isLlmdDeployment(d: DeploymentResource): boolean {
     name.includes('scheduling') || name.includes('inference-pool') ||
     (nsMatch && (name.includes('gateway') || name.includes('ingress')))
   )
+}
+
+// Number of namespaces to query per batch in Phase 2 deployment discovery
+const DEPLOYMENT_BATCH_SIZE = 3
+
+// Sort stacks: healthy first, then by name
+function sortStacks(a: LLMdStack, b: LLMdStack): number {
+  if (a.status === 'healthy' && b.status !== 'healthy') return -1
+  if (a.status !== 'healthy' && b.status === 'healthy') return 1
+  return a.name.localeCompare(b.name)
+}
+
+// Build components from Deployments (used by Phase 2 namespace-level discovery)
+function buildComponentsFromDeployments(
+  deployments: DeploymentResource[],
+  namespace: string,
+  cluster: string,
+  fallbackModel?: string,
+): {
+  prefill: LLMdStackComponent[]
+  decode: LLMdStackComponent[]
+  both: LLMdStackComponent[]
+  epp: LLMdStackComponent | null
+  model: string | undefined
+} {
+  const prefill: LLMdStackComponent[] = []
+  const decode: LLMdStackComponent[] = []
+  const both: LLMdStackComponent[] = []
+  let epp: LLMdStackComponent | null = null
+  let model = fallbackModel
+
+  for (const dep of deployments) {
+    const depName = dep.metadata.name.toLowerCase()
+    const depLabels = dep.spec.template?.metadata?.labels || {}
+    const role = depLabels['llm-d.ai/role']?.toLowerCase()
+    const replicas = dep.spec.replicas ?? dep.status.replicas ?? 0
+    const ready = dep.status.readyReplicas ?? 0
+    const depModel = depLabels['llmd.org/model'] || model
+    const depStatus: LLMdStackComponent['status'] =
+      ready === replicas && replicas > 0 ? 'running' : ready > 0 ? 'running' : 'error'
+
+    const isEpp = depName.includes('-epp') || depName.endsWith('epp') ||
+      depName.includes('scheduling') || depName.includes('inference-pool')
+
+    if (isEpp && !epp) {
+      epp = { name: dep.metadata.name, namespace, cluster, type: 'epp', status: ready > 0 ? 'running' : 'pending', replicas, readyReplicas: ready }
+    } else if (role === 'prefill' || depName.includes('prefill')) {
+      prefill.push({ name: dep.metadata.name, namespace, cluster, type: 'prefill', status: depStatus, replicas, readyReplicas: ready, model: depModel })
+    } else if (role === 'decode' || depName.includes('decode')) {
+      decode.push({ name: dep.metadata.name, namespace, cluster, type: 'decode', status: depStatus, replicas, readyReplicas: ready, model: depModel })
+    } else {
+      both.push({ name: dep.metadata.name, namespace, cluster, type: 'both', status: depStatus, replicas, readyReplicas: ready, model: depModel })
+    }
+
+    // Pick up model from first deployment with a label
+    if (!model && depLabels['llmd.org/model']) {
+      model = depLabels['llmd.org/model']
+    }
+  }
+
+  return { prefill, decode, both, epp, model }
 }
 
 /**
@@ -304,13 +389,50 @@ export function useStackDiscovery(clusters: string[]) {
     }
 
     try {
-      // Progressive discovery: process clusters sequentially, update UI after each completes
-      for (const cluster of clusters) {
-        const clusterStacks: LLMdStack[] = []
+      // ── Helper: merge new stacks into state (used by both Phase 1 and Phase 2) ──
+      const mergeIntoState = (cluster: string, newStacks: LLMdStack[], replace: boolean) => {
+        if (newStacks.length === 0) return
 
+        setStacks(prev => {
+          if (replace) {
+            // Phase 1: replace all stacks for this cluster
+            const cachedById = new Map(
+              prev.filter(s => s.cluster === cluster).map(s => [s.id, s])
+            )
+            const filtered = prev.filter(s => s.cluster !== cluster)
+            const mergedStacks = newStacks.map(freshStack => {
+              const cachedStack = cachedById.get(freshStack.id)
+              if (!cachedStack) return freshStack
+              return mergeStackWithCached(freshStack, cachedStack)
+            })
+            const merged = [...filtered, ...mergedStacks]
+            merged.sort(sortStacks)
+            saveCachedStacks(merged)
+            hasStacksRef.current = merged.length > 0
+            return merged
+          } else {
+            // Phase 2: add stacks that don't already exist (progressive enrichment)
+            const existingIds = new Set(prev.map(s => s.id))
+            const trulyNew = newStacks.filter(s => !existingIds.has(s.id))
+            if (trulyNew.length === 0) return prev
+            const merged = [...prev, ...trulyNew]
+            merged.sort(sortStacks)
+            saveCachedStacks(merged)
+            hasStacksRef.current = true
+            return merged
+          }
+        })
+      }
+
+      // Progressive discovery: process clusters sequentially, update UI after each phase
+      for (const cluster of clusters) {
         try {
-          // Run all kubectl calls in parallel for speed
-          const [podsResponse, poolsResponse, svcResponse, gwResponse, hpaResponse, wvaResponse, vpaResponse, deploymentsResponse] = await Promise.all([
+          // ════════════════════════════════════════════════════════════════
+          // Phase 1: Fast discovery — labeled pods, InferencePools, and
+          //          shared resources (services, gateways, autoscalers).
+          //          NO bulk deployment query — that's Phase 2.
+          // ════════════════════════════════════════════════════════════════
+          const [podsResponse, poolsResponse, svcResponse, gwResponse, hpaResponse, wvaResponse, vpaResponse] = await Promise.all([
             kubectlProxy.exec(['get', 'pods', '-A', '-l', 'llm-d.ai/role', '-o', 'json'], { context: cluster, timeout: 30000 }),
             kubectlProxy.exec(['get', 'inferencepools', '-A', '-o', 'json'], { context: cluster, timeout: 30000 }),
             kubectlProxy.exec(['get', 'services', '-A', '-o', 'json'], { context: cluster, timeout: 30000 }),
@@ -318,7 +440,6 @@ export function useStackDiscovery(clusters: string[]) {
             kubectlProxy.exec(['get', 'hpa', '-A', '-o', 'json'], { context: cluster, timeout: 30000 }),
             kubectlProxy.exec(['get', 'variantautoscalings', '-A', '-o', 'json'], { context: cluster, timeout: 30000 }),
             kubectlProxy.exec(['get', 'vpa', '-A', '-o', 'json'], { context: cluster, timeout: 30000 }),
-            kubectlProxy.exec(['get', 'deployments', '-A', '-o', 'json'], { context: cluster, timeout: 30000 }),
           ])
 
           // Skip cluster entirely if it's unreachable (connection error or timeout)
@@ -337,9 +458,7 @@ export function useStackDiscovery(clusters: string[]) {
           const podsByNamespace = new Map<string, PodResource[]>()
           for (const pod of pods) {
             const ns = pod.metadata.namespace
-            if (!podsByNamespace.has(ns)) {
-              podsByNamespace.set(ns, [])
-            }
+            if (!podsByNamespace.has(ns)) podsByNamespace.set(ns, [])
             podsByNamespace.get(ns)!.push(pod)
           }
 
@@ -348,37 +467,11 @@ export function useStackDiscovery(clusters: string[]) {
           const pools = (poolsData.items || []) as InferencePoolResource[]
           const poolsByNamespace = new Map(pools.map(p => [p.metadata.namespace, p]))
 
-          // Parse and filter Deployments for LLM-d workloads (broad discovery)
-          const depsData = deploymentsResponse.exitCode === 0 ? JSON.parse(deploymentsResponse.output) : { items: [] }
-          const allDeployments = (depsData.items || []) as DeploymentResource[]
-          const llmdDeployments = allDeployments.filter(isLlmdDeployment)
-          const deploymentsByNamespace = new Map<string, DeploymentResource[]>()
-          for (const dep of llmdDeployments) {
-            const ns = dep.metadata.namespace
-            if (!deploymentsByNamespace.has(ns)) deploymentsByNamespace.set(ns, [])
-            deploymentsByNamespace.get(ns)!.push(dep)
-          }
-
-          // DEBUG: Log discovery counts
-          console.log(`[useStackDiscovery] Cluster ${cluster}: pods=${pods.length}, pools=${pools.length}, llmdDeployments=${llmdDeployments.length}, totalDeployments=${allDeployments.length}`)
-          console.log(`[useStackDiscovery] Cluster ${cluster}: deployment namespaces:`, [...deploymentsByNamespace.keys()])
-          console.log(`[useStackDiscovery] Cluster ${cluster}: deploymentsResponse.exitCode=${deploymentsResponse.exitCode}`)
-
-          // Skip cluster early if no labeled pods, InferencePools, or LLM-d Deployments
-          if (pods.length === 0 && pools.length === 0 && llmdDeployments.length === 0) {
-            console.log(`[useStackDiscovery] SKIPPING cluster ${cluster}: no pods, pools, or llmd deployments`)
-            continue
-          }
-
           // Parse services for EPP
           let svcData = { items: [] as ServiceResource[] }
           try {
-            if (svcResponse.exitCode === 0) {
-              svcData = JSON.parse(svcResponse.output)
-            }
-          } catch (e) {
-            console.error(`[useStackDiscovery] Error parsing services on ${cluster}:`, e)
-          }
+            if (svcResponse.exitCode === 0) svcData = JSON.parse(svcResponse.output)
+          } catch { /* ignore */ }
           const services = (svcData.items || []) as ServiceResource[]
           const eppByNamespace = new Map<string, ServiceResource>()
           for (const svc of services) {
@@ -394,38 +487,14 @@ export function useStackDiscovery(clusters: string[]) {
 
           // Parse HPAs
           const hpaData = hpaResponse.exitCode === 0 ? JSON.parse(hpaResponse.output) : { items: [] }
-          interface HPAResource {
-            metadata: { name: string; namespace: string }
-            spec?: { minReplicas?: number; maxReplicas?: number }
-            status?: { currentReplicas?: number; desiredReplicas?: number }
-          }
           const hpas = (hpaData.items || []) as HPAResource[]
           const hpaByNamespace = new Map<string, HPAResource>()
           for (const hpa of hpas) {
-            if (!hpaByNamespace.has(hpa.metadata.namespace)) {
-              hpaByNamespace.set(hpa.metadata.namespace, hpa)
-            }
+            if (!hpaByNamespace.has(hpa.metadata.namespace)) hpaByNamespace.set(hpa.metadata.namespace, hpa)
           }
 
           // Parse WVA (VariantAutoscaling)
           const wvaData = wvaResponse.exitCode === 0 ? JSON.parse(wvaResponse.output) : { items: [] }
-          interface WVAResource {
-            metadata: { name: string; namespace: string }
-            spec?: {
-              minReplicas?: number
-              maxReplicas?: number
-              scaleTargetRef?: {
-                namespace?: string
-              }
-            }
-            status?: {
-              currentReplicas?: number
-              desiredReplicas?: number
-              desiredOptimizedAlloc?: {
-                numReplicas?: number
-              }
-            }
-          }
           const wvas = (wvaData.items || []) as WVAResource[]
           const wvaByNamespace = new Map<string, WVAResource>()
           const wvaByTargetNamespace = new Map<string, WVAResource>()
@@ -439,25 +508,59 @@ export function useStackDiscovery(clusters: string[]) {
 
           // Parse VPA
           const vpaData = vpaResponse.exitCode === 0 ? JSON.parse(vpaResponse.output) : { items: [] }
-          interface VPAResource {
-            metadata: { name: string; namespace: string }
-          }
           const vpas = (vpaData.items || []) as VPAResource[]
           const vpaByNamespace = new Map<string, VPAResource>()
-          for (const vpa of vpas) {
-            vpaByNamespace.set(vpa.metadata.namespace, vpa)
+          for (const vpa of vpas) { vpaByNamespace.set(vpa.metadata.namespace, vpa) }
+
+          // ── Helper: detect autoscaler for a namespace ──
+          const detectAutoscaler = (namespace: string): AutoscalerInfo | undefined => {
+            const wva = wvaByNamespace.get(namespace) || wvaByTargetNamespace.get(namespace)
+            const hpa = hpaByNamespace.get(namespace)
+            const vpa = vpaByNamespace.get(namespace)
+            if (wva) {
+              return {
+                type: 'WVA', name: wva.metadata.name,
+                minReplicas: wva.spec?.minReplicas, maxReplicas: wva.spec?.maxReplicas,
+                currentReplicas: wva.status?.currentReplicas,
+                desiredReplicas: wva.status?.desiredOptimizedAlloc?.numReplicas ?? wva.status?.desiredReplicas,
+              }
+            }
+            if (hpa) {
+              return {
+                type: 'HPA', name: hpa.metadata.name,
+                minReplicas: hpa.spec?.minReplicas, maxReplicas: hpa.spec?.maxReplicas,
+                currentReplicas: hpa.status?.currentReplicas, desiredReplicas: hpa.status?.desiredReplicas,
+              }
+            }
+            if (vpa) return { type: 'VPA', name: vpa.metadata.name }
+            return undefined
           }
 
-          // Collect all namespaces that have pods, InferencePools, or LLM-d Deployments
-          const allStackNamespaces = new Set<string>([
+          // ── Helper: build EPP and Gateway components for a namespace ──
+          const buildInfraComponents = (namespace: string, eppOverride: LLMdStackComponent | null = null) => {
+            const eppService = eppByNamespace.get(namespace)
+            const eppComponent: LLMdStackComponent | null = eppOverride || (eppService ? {
+              name: eppService.metadata.name, namespace, cluster, type: 'epp',
+              status: 'running', replicas: 1, readyReplicas: 1,
+            } : null)
+            const gw = gatewayByNamespace.get(namespace)
+            const gatewayComponent: LLMdStackComponent | null = gw ? {
+              name: gw.metadata.name, namespace, cluster, type: 'gateway',
+              status: gw.status?.addresses?.length ? 'running' : 'pending',
+              replicas: 1, readyReplicas: gw.status?.addresses?.length ? 1 : 0,
+            } : null
+            return { epp: eppComponent, gateway: gatewayComponent }
+          }
+
+          // Collect Phase 1 namespaces from labeled pods and InferencePools
+          const phase1Namespaces = new Set<string>([
             ...podsByNamespace.keys(),
             ...poolsByNamespace.keys(),
-            ...deploymentsByNamespace.keys(),
           ])
-          console.log(`[useStackDiscovery] Cluster ${cluster}: allStackNamespaces (${allStackNamespaces.size}):`, [...allStackNamespaces])
 
-          // Build stacks from namespaces
-          for (const namespace of allStackNamespaces) {
+          // Build Phase 1 stacks from labeled pods
+          const phase1Stacks: LLMdStack[] = []
+          for (const namespace of phase1Namespaces) {
             const nsPods = podsByNamespace.get(namespace) || []
             const prefillPods: PodResource[] = []
             const decodePods: PodResource[] = []
@@ -466,232 +569,128 @@ export function useStackDiscovery(clusters: string[]) {
             for (const pod of nsPods) {
               const role = pod.metadata.labels?.['llm-d.ai/role']?.toLowerCase()
               const podName = pod.metadata.name.toLowerCase()
-
-              // Match by explicit role label first
-              if (role === 'prefill' || role === 'prefill-server') {
-                prefillPods.push(pod)
-              } else if (role === 'decode' || role === 'decode-server') {
-                decodePods.push(pod)
-              } else if (role === 'both' || role === 'unified' || role === 'model' || role === 'server' || role === 'vllm') {
-                bothPods.push(pod)
-              }
-              // Infer from pod name patterns if role is unrecognized
-              else if (podName.includes('prefill')) {
-                prefillPods.push(pod)
-              } else if (podName.includes('decode')) {
-                decodePods.push(pod)
-              }
-              // Default: treat as unified server
-              else {
-                bothPods.push(pod)
-              }
+              if (role === 'prefill' || role === 'prefill-server') prefillPods.push(pod)
+              else if (role === 'decode' || role === 'decode-server') decodePods.push(pod)
+              else if (role === 'both' || role === 'unified' || role === 'model' || role === 'server' || role === 'vllm') bothPods.push(pod)
+              else if (podName.includes('prefill')) prefillPods.push(pod)
+              else if (podName.includes('decode')) decodePods.push(pod)
+              else bothPods.push(pod)
             }
 
-            // Get model name from first pod (mutable - may be enriched from Deployments)
-            const firstPod = nsPods[0]
-            let model = firstPod?.metadata.labels?.['llm-d.ai/model']
+            const model = nsPods[0]?.metadata.labels?.['llm-d.ai/model']
 
-            // Build components
-            const buildComponent = (pods: PodResource[], type: LLMdStackComponent['type']): LLMdStackComponent[] => {
+            // Build components from pods grouped by deployment (pod-template-hash)
+            const buildFromPods = (pods: PodResource[], type: LLMdStackComponent['type']): LLMdStackComponent[] => {
               if (pods.length === 0) return []
-
-              // Group by deployment (using pod-template-hash)
-              const byDeployment = new Map<string, PodResource[]>()
+              const byHash = new Map<string, PodResource[]>()
               for (const pod of pods) {
                 const hash = pod.metadata.labels?.['pod-template-hash'] || 'default'
-                if (!byDeployment.has(hash)) {
-                  byDeployment.set(hash, [])
-                }
-                byDeployment.get(hash)!.push(pod)
+                if (!byHash.has(hash)) byHash.set(hash, [])
+                byHash.get(hash)!.push(pod)
               }
-
-              return Array.from(byDeployment.entries()).map(([, deploymentPods]) => {
-                const ready = deploymentPods.filter(p =>
-                  p.status.phase === 'Running' &&
-                  p.status.containerStatuses?.every(c => c.ready)
+              return Array.from(byHash.values()).map(group => {
+                const ready = group.filter(p =>
+                  p.status.phase === 'Running' && p.status.containerStatuses?.every(c => c.ready)
                 ).length
-
                 return {
-                  name: deploymentPods[0].metadata.name.replace(/-[a-z0-9]+$/, ''),
-                  namespace,
-                  cluster,
-                  type,
-                  status: ready === deploymentPods.length ? 'running' : ready > 0 ? 'running' : 'error',
-                  replicas: deploymentPods.length,
-                  readyReplicas: ready,
-                  model,
-                  podNames: deploymentPods.map(p => p.metadata.name),
+                  name: group[0].metadata.name.replace(/-[a-z0-9]+$/, ''),
+                  namespace, cluster, type,
+                  status: ready === group.length ? 'running' : ready > 0 ? 'running' : 'error',
+                  replicas: group.length, readyReplicas: ready, model,
+                  podNames: group.map(p => p.metadata.name),
                 }
               })
             }
 
-            const prefillComponents = buildComponent(prefillPods, 'prefill')
-            const decodeComponents = buildComponent(decodePods, 'decode')
-            const bothComponents = buildComponent(bothPods, 'both')
-
-            // Fall back to Deployment-based discovery when no labeled pods exist
-            const nsDeployments = deploymentsByNamespace.get(namespace) || []
-            let eppFromDeployment: LLMdStackComponent | null = null
-
-            if (prefillPods.length === 0 && decodePods.length === 0 && bothPods.length === 0 && nsDeployments.length > 0) {
-              for (const dep of nsDeployments) {
-                const depName = dep.metadata.name.toLowerCase()
-                const depLabels = dep.spec.template?.metadata?.labels || {}
-                const role = depLabels['llm-d.ai/role']?.toLowerCase()
-                const replicas = dep.spec.replicas ?? dep.status.replicas ?? 0
-                const ready = dep.status.readyReplicas ?? 0
-                const depModel = depLabels['llmd.org/model'] || model
-                const depStatus: LLMdStackComponent['status'] = ready === replicas && replicas > 0 ? 'running' : ready > 0 ? 'running' : 'error'
-
-                const isEpp = depName.includes('-epp') || depName.endsWith('epp') || depName.includes('scheduling') || depName.includes('inference-pool')
-
-                if (isEpp && !eppFromDeployment) {
-                  eppFromDeployment = { name: dep.metadata.name, namespace, cluster, type: 'epp', status: ready > 0 ? 'running' : 'pending', replicas, readyReplicas: ready }
-                } else if (role === 'prefill' || depName.includes('prefill')) {
-                  prefillComponents.push({ name: dep.metadata.name, namespace, cluster, type: 'prefill', status: depStatus, replicas, readyReplicas: ready, model: depModel })
-                } else if (role === 'decode' || depName.includes('decode')) {
-                  decodeComponents.push({ name: dep.metadata.name, namespace, cluster, type: 'decode', status: depStatus, replicas, readyReplicas: ready, model: depModel })
-                } else {
-                  bothComponents.push({ name: dep.metadata.name, namespace, cluster, type: 'both', status: depStatus, replicas, readyReplicas: ready, model: depModel })
-                }
-              }
-            }
-
-            // Extract model name from Deployments when pods don't provide it
-            if (!model && nsDeployments.length > 0) {
-              model = nsDeployments[0].spec.template?.metadata?.labels?.['llmd.org/model']
-            }
-
-            // EPP component
-            const eppService = eppByNamespace.get(namespace)
-            const eppComponent: LLMdStackComponent | null = eppFromDeployment || (eppService ? {
-              name: eppService.metadata.name,
-              namespace,
-              cluster,
-              type: 'epp',
-              status: 'running', // Assume running if service exists
-              replicas: 1,
-              readyReplicas: 1,
-            } : null)
-
-            // Gateway component
-            const gateway = gatewayByNamespace.get(namespace)
-            const gatewayComponent: LLMdStackComponent | null = gateway ? {
-              name: gateway.metadata.name,
-              namespace,
-              cluster,
-              type: 'gateway',
-              status: gateway.status?.addresses?.length ? 'running' : 'pending',
-              replicas: 1,
-              readyReplicas: gateway.status?.addresses?.length ? 1 : 0,
-            } : null
-
-            const components = {
-              prefill: prefillComponents,
-              decode: decodeComponents,
-              both: bothComponents,
-              epp: eppComponent,
-              gateway: gatewayComponent,
-            }
+            const prefillComponents = buildFromPods(prefillPods, 'prefill')
+            const decodeComponents = buildFromPods(decodePods, 'decode')
+            const bothComponents = buildFromPods(bothPods, 'both')
+            const { epp, gateway } = buildInfraComponents(namespace)
+            const components = { prefill: prefillComponents, decode: decodeComponents, both: bothComponents, epp, gateway }
 
             const pool = poolsByNamespace.get(namespace)
-            const totalReplicas =
-              prefillComponents.reduce((sum, c) => sum + c.replicas, 0) +
-              decodeComponents.reduce((sum, c) => sum + c.replicas, 0) +
-              bothComponents.reduce((sum, c) => sum + c.replicas, 0)
-            const readyReplicas =
-              prefillComponents.reduce((sum, c) => sum + c.readyReplicas, 0) +
-              decodeComponents.reduce((sum, c) => sum + c.readyReplicas, 0) +
-              bothComponents.reduce((sum, c) => sum + c.readyReplicas, 0)
+            const totalReplicas = [...prefillComponents, ...decodeComponents, ...bothComponents].reduce((s, c) => s + c.replicas, 0)
+            const readyReplicas = [...prefillComponents, ...decodeComponents, ...bothComponents].reduce((s, c) => s + c.readyReplicas, 0)
 
-            // Detect autoscaler - WVA takes precedence, then HPA, then VPA
-            // Check both same-namespace and cross-namespace WVA targeting
-            let autoscaler: AutoscalerInfo | undefined
-            const wva = wvaByNamespace.get(namespace) || wvaByTargetNamespace.get(namespace)
-            const hpa = hpaByNamespace.get(namespace)
-            const vpa = vpaByNamespace.get(namespace)
-
-            if (wva) {
-              // Use desiredOptimizedAlloc.numReplicas if available (WVA status field)
-              const desiredReplicas = wva.status?.desiredOptimizedAlloc?.numReplicas ?? wva.status?.desiredReplicas
-              autoscaler = {
-                type: 'WVA',
-                name: wva.metadata.name,
-                minReplicas: wva.spec?.minReplicas,
-                maxReplicas: wva.spec?.maxReplicas,
-                currentReplicas: wva.status?.currentReplicas,
-                desiredReplicas,
-              }
-            } else if (hpa) {
-              autoscaler = {
-                type: 'HPA',
-                name: hpa.metadata.name,
-                minReplicas: hpa.spec?.minReplicas,
-                maxReplicas: hpa.spec?.maxReplicas,
-                currentReplicas: hpa.status?.currentReplicas,
-                desiredReplicas: hpa.status?.desiredReplicas,
-              }
-            } else if (vpa) {
-              autoscaler = {
-                type: 'VPA',
-                name: vpa.metadata.name,
-              }
-            }
-
-            const stack = {
-              id: `${namespace}@${cluster}`,
-              name: pool?.metadata.name || namespace,
-              namespace,
-              cluster,
-              inferencePool: pool?.metadata.name,
-              components,
-              status: getStackStatus(components),
+            phase1Stacks.push({
+              id: `${namespace}@${cluster}`, name: pool?.metadata.name || namespace,
+              namespace, cluster, inferencePool: pool?.metadata.name,
+              components, status: getStackStatus(components),
               hasDisaggregation: prefillComponents.length > 0 && decodeComponents.length > 0,
-              model,
-              totalReplicas,
-              readyReplicas,
-              autoscaler,
-            }
-            console.log(`[useStackDiscovery] Created stack: ${stack.id} (${stack.name}) - P:${prefillComponents.length} D:${decodeComponents.length} B:${bothComponents.length} nsDeployments:${nsDeployments.length}`)
-            clusterStacks.push(stack)
-          }
-
-          // Progressive update: add this cluster's stacks immediately
-          // Only update if we got results - preserve cached data when cluster is unreachable
-          if (clusterStacks.length > 0) {
-            setStacks(prev => {
-              // Build lookup of cached stacks for this cluster
-              const cachedById = new Map(
-                prev.filter(s => s.cluster === cluster).map(s => [s.id, s])
-              )
-              const filtered = prev.filter(s => s.cluster !== cluster)
-
-              // Merge each fresh stack with its cached counterpart to preserve
-              // P/D/WVA details that may be missing due to partial API failures
-              const mergedStacks = clusterStacks.map(freshStack => {
-                const cachedStack = cachedById.get(freshStack.id)
-                if (!cachedStack) return freshStack
-                return mergeStackWithCached(freshStack, cachedStack)
-              })
-
-              const merged = [...filtered, ...mergedStacks]
-              // Sort: healthy first, then by name
-              merged.sort((a, b) => {
-                if (a.status === 'healthy' && b.status !== 'healthy') return -1
-                if (a.status !== 'healthy' && b.status === 'healthy') return 1
-                return a.name.localeCompare(b.name)
-              })
-              saveCachedStacks(merged) // Cache progressively too
-              hasStacksRef.current = merged.length > 0
-              return merged
+              model, totalReplicas, readyReplicas, autoscaler: detectAutoscaler(namespace),
             })
           }
-          // Note: If clusterStacks is empty but we had cached data for this cluster,
-          // we intentionally preserve the cached data to avoid losing P/D/WVA details
-          // when the cluster is temporarily unreachable
+
+          // ── Phase 1 UI update: show pod/pool stacks immediately ──
+          mergeIntoState(cluster, phase1Stacks, true)
+
+          // ════════════════════════════════════════════════════════════════
+          // Phase 2: Progressive deployment discovery — query candidate
+          //          namespaces one batch at a time, adding new stacks as
+          //          they're found. This avoids the 4+ MB bulk query.
+          // ════════════════════════════════════════════════════════════════
+
+          // Get all namespaces in the cluster (lightweight query)
+          const nsResponse = await kubectlProxy.exec(
+            ['get', 'namespaces', '-o', 'jsonpath={.items[*].metadata.name}'],
+            { context: cluster, timeout: 15000 },
+          )
+          const allClusterNamespaces = nsResponse.exitCode === 0
+            ? nsResponse.output.split(/\s+/).filter(Boolean)
+            : []
+
+          // Filter to candidate namespaces not already discovered in Phase 1
+          const candidateNamespaces = allClusterNamespaces
+            .filter(isLlmdNamespace)
+            .filter(ns => !phase1Namespaces.has(ns))
+
+          if (candidateNamespaces.length > 0) {
+            console.log(`[useStackDiscovery] Phase 2 for ${cluster}: ${candidateNamespaces.length} candidate namespaces`)
+          }
+
+          // Query deployments per namespace in small batches
+          for (let i = 0; i < candidateNamespaces.length; i += DEPLOYMENT_BATCH_SIZE) {
+            const batch = candidateNamespaces.slice(i, i + DEPLOYMENT_BATCH_SIZE)
+            const batchResults = await Promise.all(
+              batch.map(ns =>
+                kubectlProxy.exec(['get', 'deployments', '-n', ns, '-o', 'json'], { context: cluster, timeout: 15000 })
+              ),
+            )
+
+            const batchStacks: LLMdStack[] = []
+            for (let j = 0; j < batch.length; j++) {
+              const ns = batch[j]
+              const depResponse = batchResults[j]
+              if (depResponse.exitCode !== 0) continue
+
+              let depsData: { items?: DeploymentResource[] }
+              try { depsData = JSON.parse(depResponse.output) } catch { continue }
+              const deps = (depsData.items || []) as DeploymentResource[]
+              const llmdDeps = deps.filter(isLlmdDeployment)
+              if (llmdDeps.length === 0) continue
+
+              // Build stack from deployments
+              const { prefill, decode, both, epp: depEpp, model } = buildComponentsFromDeployments(llmdDeps, ns, cluster)
+              const { epp, gateway } = buildInfraComponents(ns, depEpp)
+              const components = { prefill, decode, both, epp, gateway }
+              const pool = poolsByNamespace.get(ns)
+              const totalReplicas = [...prefill, ...decode, ...both].reduce((s, c) => s + c.replicas, 0)
+              const readyReplicas = [...prefill, ...decode, ...both].reduce((s, c) => s + c.readyReplicas, 0)
+
+              batchStacks.push({
+                id: `${ns}@${cluster}`, name: pool?.metadata.name || ns,
+                namespace: ns, cluster, inferencePool: pool?.metadata.name,
+                components, status: getStackStatus(components),
+                hasDisaggregation: prefill.length > 0 && decode.length > 0,
+                model, totalReplicas, readyReplicas, autoscaler: detectAutoscaler(ns),
+              })
+            }
+
+            // Progressive UI update after each batch
+            mergeIntoState(cluster, batchStacks, false)
+          }
 
         } catch (err) {
-          // Suppress demo mode errors - they're expected when agent is unavailable
           const errMsg = err instanceof Error ? err.message : String(err)
           if (!errMsg.includes('demo mode') && !errMsg.includes('timed out')) {
             console.error(`[useStackDiscovery] Error fetching from ${cluster}:`, err)


### PR DESCRIPTION
## Summary
- Replaces bulk `kubectl get deployments -A -o json` (4+ MB on large clusters) with per-namespace queries in batches of 3
- Two-phase discovery: Phase 1 (fast: labeled pods + InferencePools) → immediate UI update, Phase 2 (progressive: deployment queries per candidate namespace) → stacks appear as batches complete
- Combined with localStorage cache, gives instant display + progressive enrichment
- Extracted helper functions to reduce duplication (buildComponentsFromDeployments, sortStacks, detectAutoscaler, buildInfraComponents)

## Test plan
- [ ] With agent connected: stack selector should show significantly more than 13 stacks
- [ ] Stacks should appear progressively (Phase 1 instantly, Phase 2 batches fill in)
- [ ] Previously discovered stacks (pods with labels + InferencePools) still work
- [ ] Cached stacks display instantly on page load
- [ ] `npm run build` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)