### PR TITLE
⏪ Revert cluster cache initialization change

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -198,39 +198,19 @@ function mergeWithStoredClusters(newClusters: ClusterInfo[]): ClusterInfo[] {
   })
 }
 
-// Demo clusters - defined early so they can be used in cache initialization
-// One cluster for each provider type to showcase all icons
-const DEMO_CLUSTERS: ClusterInfo[] = [
-  { name: 'kind-local', context: 'kind-local', healthy: true, source: 'kubeconfig', nodeCount: 1, podCount: 15, cpuCores: 4, memoryGB: 8, storageGB: 50, distribution: 'kind' },
-  { name: 'minikube', context: 'minikube', healthy: true, source: 'kubeconfig', nodeCount: 1, podCount: 12, cpuCores: 2, memoryGB: 4, storageGB: 20, distribution: 'minikube' },
-  { name: 'k3s-edge', context: 'k3s-edge', healthy: true, source: 'kubeconfig', nodeCount: 3, podCount: 28, cpuCores: 6, memoryGB: 12, storageGB: 100, distribution: 'k3s' },
-  { name: 'eks-prod-us-east-1', context: 'eks-prod', healthy: true, source: 'kubeconfig', nodeCount: 12, podCount: 156, cpuCores: 96, memoryGB: 384, storageGB: 2000, server: 'https://ABC123.gr7.us-east-1.eks.amazonaws.com', distribution: 'eks' },
-  { name: 'gke-staging', context: 'gke-staging', healthy: true, source: 'kubeconfig', nodeCount: 6, podCount: 78, cpuCores: 48, memoryGB: 192, storageGB: 1000, distribution: 'gke' },
-  { name: 'aks-dev-westeu', context: 'aks-dev', healthy: true, source: 'kubeconfig', nodeCount: 4, podCount: 45, cpuCores: 32, memoryGB: 128, storageGB: 500, server: 'https://aks-dev-dns-abc123.hcp.westeurope.azmk8s.io:443', distribution: 'aks' },
-  { name: 'openshift-prod', context: 'ocp-prod', healthy: true, source: 'kubeconfig', nodeCount: 9, podCount: 234, cpuCores: 72, memoryGB: 288, storageGB: 1500, server: 'api.openshift-prod.example.com:6443', distribution: 'openshift', namespaces: ['openshift-operators', 'openshift-monitoring'] },
-  { name: 'oci-oke-phoenix', context: 'oke-phoenix', healthy: true, source: 'kubeconfig', nodeCount: 5, podCount: 67, cpuCores: 40, memoryGB: 160, storageGB: 800, server: 'https://abc123.us-phoenix-1.clusters.oci.oraclecloud.com:6443', distribution: 'oci' },
-  { name: 'alibaba-ack-shanghai', context: 'ack-shanghai', healthy: false, source: 'kubeconfig', nodeCount: 8, podCount: 112, cpuCores: 64, memoryGB: 256, storageGB: 1200, distribution: 'alibaba' },
-  { name: 'do-nyc1-prod', context: 'do-nyc1', healthy: true, source: 'kubeconfig', nodeCount: 3, podCount: 34, cpuCores: 12, memoryGB: 48, storageGB: 300, distribution: 'digitalocean' },
-  { name: 'rancher-mgmt', context: 'rancher-mgmt', healthy: true, source: 'kubeconfig', nodeCount: 3, podCount: 89, cpuCores: 24, memoryGB: 96, storageGB: 400, distribution: 'rancher' },
-  { name: 'vllm-gpu-cluster', context: 'vllm-d', healthy: true, source: 'kubeconfig', nodeCount: 8, podCount: 124, cpuCores: 256, memoryGB: 2048, storageGB: 8000, distribution: 'kubernetes' },
-]
-
 // Module-level shared state - initialize from localStorage if available
 const storedClusters = loadClusterCacheFromStorage()
-// In forced demo mode (Netlify), use demo clusters if no localStorage data
-const initialClusters = storedClusters.length > 0
-  ? storedClusters
-  : (isDemoModeForced ? DEMO_CLUSTERS : [])
-const hasInitialData = initialClusters.length > 0
+// In forced demo mode (Netlify), don't show loading - demo data will be set synchronously
+const hasInitialData = storedClusters.length > 0 || isDemoModeForced
 export let clusterCache: ClusterCache = {
-  clusters: initialClusters,
-  lastUpdated: hasInitialData ? new Date() : null,
-  isLoading: !hasInitialData, // Don't show loading if we have cached data or demo data
+  clusters: storedClusters,
+  lastUpdated: storedClusters.length > 0 ? new Date() : null,
+  isLoading: !hasInitialData, // Don't show loading if we have cached data or are in forced demo mode
   isRefreshing: false,
   error: null,
   consecutiveFailures: 0,
   isFailed: false,
-  lastRefresh: hasInitialData ? new Date() : null,
+  lastRefresh: storedClusters.length > 0 ? new Date() : null,
 }
 
 // Subscribers that get notified when cluster data changes
@@ -1407,9 +1387,23 @@ export async function refreshSingleCluster(clusterName: string): Promise<void> {
   }
 }
 
-// Demo data fallbacks - returns the shared DEMO_CLUSTERS constant
+// Demo data fallbacks
 function getDemoClusters(): ClusterInfo[] {
-  return DEMO_CLUSTERS
+  return [
+    // One cluster for each provider type to showcase all icons
+    { name: 'kind-local', context: 'kind-local', healthy: true, source: 'kubeconfig', nodeCount: 1, podCount: 15, cpuCores: 4, memoryGB: 8, storageGB: 50, distribution: 'kind' },
+    { name: 'minikube', context: 'minikube', healthy: true, source: 'kubeconfig', nodeCount: 1, podCount: 12, cpuCores: 2, memoryGB: 4, storageGB: 20, distribution: 'minikube' },
+    { name: 'k3s-edge', context: 'k3s-edge', healthy: true, source: 'kubeconfig', nodeCount: 3, podCount: 28, cpuCores: 6, memoryGB: 12, storageGB: 100, distribution: 'k3s' },
+    { name: 'eks-prod-us-east-1', context: 'eks-prod', healthy: true, source: 'kubeconfig', nodeCount: 12, podCount: 156, cpuCores: 96, memoryGB: 384, storageGB: 2000, server: 'https://ABC123.gr7.us-east-1.eks.amazonaws.com', distribution: 'eks' },
+    { name: 'gke-staging', context: 'gke-staging', healthy: true, source: 'kubeconfig', nodeCount: 6, podCount: 78, cpuCores: 48, memoryGB: 192, storageGB: 1000, distribution: 'gke' },
+    { name: 'aks-dev-westeu', context: 'aks-dev', healthy: true, source: 'kubeconfig', nodeCount: 4, podCount: 45, cpuCores: 32, memoryGB: 128, storageGB: 500, server: 'https://aks-dev-dns-abc123.hcp.westeurope.azmk8s.io:443', distribution: 'aks' },
+    { name: 'openshift-prod', context: 'ocp-prod', healthy: true, source: 'kubeconfig', nodeCount: 9, podCount: 234, cpuCores: 72, memoryGB: 288, storageGB: 1500, server: 'api.openshift-prod.example.com:6443', distribution: 'openshift', namespaces: ['openshift-operators', 'openshift-monitoring'] },
+    { name: 'oci-oke-phoenix', context: 'oke-phoenix', healthy: true, source: 'kubeconfig', nodeCount: 5, podCount: 67, cpuCores: 40, memoryGB: 160, storageGB: 800, server: 'https://abc123.us-phoenix-1.clusters.oci.oraclecloud.com:6443', distribution: 'oci' },
+    { name: 'alibaba-ack-shanghai', context: 'ack-shanghai', healthy: false, source: 'kubeconfig', nodeCount: 8, podCount: 112, cpuCores: 64, memoryGB: 256, storageGB: 1200, distribution: 'alibaba' },
+    { name: 'do-nyc1-prod', context: 'do-nyc1', healthy: true, source: 'kubeconfig', nodeCount: 3, podCount: 34, cpuCores: 12, memoryGB: 48, storageGB: 300, distribution: 'digitalocean' },
+    { name: 'rancher-mgmt', context: 'rancher-mgmt', healthy: true, source: 'kubeconfig', nodeCount: 3, podCount: 89, cpuCores: 24, memoryGB: 96, storageGB: 400, distribution: 'rancher' },
+    { name: 'vllm-gpu-cluster', context: 'vllm-d', healthy: true, source: 'kubeconfig', nodeCount: 8, podCount: 124, cpuCores: 256, memoryGB: 2048, storageGB: 8000, distribution: 'kubernetes' },
+  ]
 }
 
 // Lightweight reference to cluster cache for domain modules


### PR DESCRIPTION
## Summary

Reverts PR #677 which caused flicker on all dashboards except Clusters.

The issue was that initializing `clusterCache.clusters` with `DEMO_CLUSTERS` instead of an empty array caused `fullFetchClusters()` to skip the `updateClusterCache()` call (because `clusters.length !== 0`), which meant `notifyClusterSubscribers()` wasn't called. This broke the notification chain that other hooks depended on.

## What was broken

- All dashboards (except Clusters) were flickering on console.kubestellar.io
- The cache initialization with demo clusters prevented the notification chain from running

## Fix

Keeping the original behavior:
- `clusters`: empty array initially
- `isLoading`: false when `isDemoModeForced`
- `fullFetchClusters()` populates demo data and notifies subscribers

🤖 Generated with [Claude Code](https://claude.com/claude-code)