### PR TITLE
🐛 Fix AI-ML cards missing demo badge in demo mode

### DIFF
--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -206,6 +206,12 @@ export interface CardDemoStateResult {
   shouldUseDemoData: boolean
   /** Why the card is using demo data (null if not using demo) */
   reason: DemoReason
+  /**
+   * Whether to show the demo badge/indicator in CardWrapper.
+   * This is usually the same as shouldUseDemoData, but for stack-dependent cards
+   * it's true when global demo mode is on (even if a stack is selected).
+   */
+  showDemoBadge: boolean
 }
 
 /**
@@ -247,7 +253,7 @@ export function useCardDemoState(options: CardDemoStateOptions = {}): CardDemoSt
 
     // 1. Demo-only card (requires: 'none')
     if (requires === 'none') {
-      return { shouldUseDemoData: true, reason: 'demo-only-card' as DemoReason }
+      return { shouldUseDemoData: true, reason: 'demo-only-card' as DemoReason, showDemoBadge: true }
     }
 
     // 2. Stack-dependent cards: use stack data if a stack is selected
@@ -256,29 +262,31 @@ export function useCardDemoState(options: CardDemoStateOptions = {}): CardDemoSt
       // Check if we're in a StackProvider and have a selected stack
       // If a stack is selected (real or demo), use its data - not generic demo data
       if (stackContext?.selectedStack) {
-        return { shouldUseDemoData: false, reason: null }
+        // Stack is selected - use its data (even if it's demo data)
+        // But still show demo badge if global demo mode is on
+        return { shouldUseDemoData: false, reason: null, showDemoBadge: isDemoMode }
       }
       // No stack selected - use demo data
-      return { shouldUseDemoData: true, reason: 'stack-not-selected' as DemoReason }
+      return { shouldUseDemoData: true, reason: 'stack-not-selected' as DemoReason, showDemoBadge: true }
     }
 
     // 3. Global demo mode is ON - use demo data for non-stack cards
     if (isDemoMode) {
-      return { shouldUseDemoData: true, reason: 'global-demo-mode' as DemoReason }
+      return { shouldUseDemoData: true, reason: 'global-demo-mode' as DemoReason, showDemoBadge: true }
     }
 
     // 4. Agent-dependent card but agent is offline
     if (requires === 'agent' && isAgentUnavailable()) {
-      return { shouldUseDemoData: true, reason: 'agent-offline' as DemoReason }
+      return { shouldUseDemoData: true, reason: 'agent-offline' as DemoReason, showDemoBadge: true }
     }
 
     // 5. Specific endpoint returned 404/error
     if (!isLiveDataAvailable) {
-      return { shouldUseDemoData: true, reason: 'endpoint-missing' as DemoReason }
+      return { shouldUseDemoData: true, reason: 'endpoint-missing' as DemoReason, showDemoBadge: true }
     }
 
     // All checks passed - use live data
-    return { shouldUseDemoData: false, reason: null }
+    return { shouldUseDemoData: false, reason: null, showDemoBadge: false }
   }, [isDemoMode, requires, isLiveDataAvailable, stackContext?.selectedStack])
 }
 

--- a/web/src/components/cards/llmd/EPPRouting.tsx
+++ b/web/src/components/cards/llmd/EPPRouting.tsx
@@ -512,10 +512,11 @@ export function EPPRouting() {
 
   // Get stack context and centralized demo state
   const selectedStack = stackContext?.selectedStack
-  const { shouldUseDemoData: isDemoMode } = useCardDemoState({ requires: 'stack' })
+  const { shouldUseDemoData: isDemoMode, showDemoBadge } = useCardDemoState({ requires: 'stack' })
 
   // Report demo state to CardWrapper so it can show demo badge and yellow outline
-  useReportCardDataState({ isDemoData: isDemoMode, isFailed: false, consecutiveFailures: 0 })
+  // Use showDemoBadge (true when global demo mode) rather than isDemoMode (false when stack selected)
+  useReportCardDataState({ isDemoData: showDemoBadge, isFailed: false, consecutiveFailures: 0 })
 
   // Build dynamic nodes from stack topology
   const dynamicNodes = useMemo((): FlowNode[] => {

--- a/web/src/components/cards/llmd/KVCacheMonitor.tsx
+++ b/web/src/components/cards/llmd/KVCacheMonitor.tsx
@@ -259,10 +259,10 @@ export function KVCacheMonitor() {
 
   // Get stack context and centralized demo state
   const selectedStack = stackContext?.selectedStack
-  const { shouldUseDemoData: isDemoMode } = useCardDemoState({ requires: 'stack' })
+  const { shouldUseDemoData: isDemoMode, showDemoBadge } = useCardDemoState({ requires: 'stack' })
 
   // Report demo state to CardWrapper so it can show demo badge and yellow outline
-  useReportCardDataState({ isDemoData: isDemoMode, isFailed: false, consecutiveFailures: 0 })
+  useReportCardDataState({ isDemoData: showDemoBadge, isFailed: false, consecutiveFailures: 0 })
 
   // Generate stats from stack data or demo
   const generateStats = useCallback((): KVCacheStats[] => {

--- a/web/src/components/cards/llmd/LLMdAIInsights.tsx
+++ b/web/src/components/cards/llmd/LLMdAIInsights.tsx
@@ -316,10 +316,11 @@ function generateStackInsights(stack: LLMdStack): AIInsight[] {
 
 export function LLMdAIInsights() {
   const stackContext = useOptionalStack()
-  const { shouldUseDemoData, reason } = useCardDemoState({ requires: 'stack' })
+  const { shouldUseDemoData, showDemoBadge, reason } = useCardDemoState({ requires: 'stack' })
 
   // Report demo state to CardWrapper so it can show demo badge and yellow outline
-  useReportCardDataState({ isDemoData: shouldUseDemoData, isFailed: false, consecutiveFailures: 0 })
+  // Use showDemoBadge (true when global demo mode) rather than shouldUseDemoData (false when stack selected)
+  useReportCardDataState({ isDemoData: showDemoBadge, isFailed: false, consecutiveFailures: 0 })
 
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [chatInput, setChatInput] = useState('')
@@ -400,7 +401,6 @@ export function LLMdAIInsights() {
     critical: insights.filter(i => i.severity === 'critical').length,
   }
 
-  const showDemoBadge = shouldUseDemoData
   const selectedStack = stackContext?.selectedStack
 
   return (

--- a/web/src/components/cards/llmd/LLMdBenchmarks.tsx
+++ b/web/src/components/cards/llmd/LLMdBenchmarks.tsx
@@ -62,10 +62,11 @@ function getStackComparisonData(stacks: LLMdStack[]): StackComparisonData[] {
 
 export function LLMdBenchmarks() {
   const stackContext = useOptionalStack()
-  const { shouldUseDemoData } = useCardDemoState({ requires: 'stack' })
+  const { shouldUseDemoData, showDemoBadge } = useCardDemoState({ requires: 'stack' })
 
   // Report demo state to CardWrapper so it can show demo badge and yellow outline
-  useReportCardDataState({ isDemoData: shouldUseDemoData, isFailed: false, consecutiveFailures: 0 })
+  // Use showDemoBadge (true when global demo mode) rather than shouldUseDemoData (false when stack selected)
+  useReportCardDataState({ isDemoData: showDemoBadge, isFailed: false, consecutiveFailures: 0 })
 
   const [viewMode, setViewMode] = useState<ViewMode>(shouldUseDemoData ? 'comparison' : 'stacks')
   const [modelFilter, setModelFilter] = useState<ModelFilter>('all')
@@ -154,7 +155,6 @@ export function LLMdBenchmarks() {
     return { totalReplicas, healthyStacks, disaggStacks, autoscaledStacks, total: stackComparison.length }
   }, [stackComparison])
 
-  const showDemoBadge = shouldUseDemoData
   const availableViews: ViewMode[] = shouldUseDemoData
     ? ['comparison', 'latency']
     : ['stacks', 'comparison', 'latency']

--- a/web/src/components/cards/llmd/LLMdFlow.tsx
+++ b/web/src/components/cards/llmd/LLMdFlow.tsx
@@ -577,10 +577,11 @@ export function LLMdFlow() {
 
   // Get selected stack from context and centralized demo state
   const selectedStack = stackContext?.selectedStack
-  const { shouldUseDemoData: isDemoMode } = useCardDemoState({ requires: 'stack' })
+  const { shouldUseDemoData: isDemoMode, showDemoBadge } = useCardDemoState({ requires: 'stack' })
 
   // Report demo state to CardWrapper so it can show demo badge and yellow outline
-  useReportCardDataState({ isDemoData: isDemoMode, isFailed: false, consecutiveFailures: 0 })
+  // Use showDemoBadge (true when global demo mode) rather than isDemoMode (false when stack selected)
+  useReportCardDataState({ isDemoData: showDemoBadge, isFailed: false, consecutiveFailures: 0 })
 
   // Build dynamic node positions based on actual stack topology
   const { nodePositions, connections, nodeLabels } = useMemo(() => {

--- a/web/src/components/cards/llmd/PDDisaggregation.tsx
+++ b/web/src/components/cards/llmd/PDDisaggregation.tsx
@@ -176,13 +176,14 @@ function ServerCard({ server, isHighlighted }: ServerCardProps) {
 export function PDDisaggregation() {
   const stackContext = useOptionalStack()
   const selectedStack = stackContext?.selectedStack
-  const { shouldUseDemoData: isDemoMode } = useCardDemoState({ requires: 'stack' })
+  const { shouldUseDemoData: isDemoMode, showDemoBadge } = useCardDemoState({ requires: 'stack' })
 
   // Detect if card is in expanded/fullscreen mode
   const { isExpanded } = useCardExpanded()
 
   // Report demo state to CardWrapper so it can show demo badge and yellow outline
-  useReportCardDataState({ isDemoData: isDemoMode, isFailed: false, consecutiveFailures: 0 })
+  // Use showDemoBadge (true when global demo mode) rather than isDemoMode (false when stack selected)
+  useReportCardDataState({ isDemoData: showDemoBadge, isFailed: false, consecutiveFailures: 0 })
 
   const [servers, setServers] = useState<ServerStats[]>([])
   const [packets, setPackets] = useState<TransferPacket[]>([])


### PR DESCRIPTION
## Summary

- Add `showDemoBadge` field to `CardDemoStateResult` interface to separate "which data to use" from "show demo indicator"
- For stack-dependent cards, `shouldUseDemoData` is false when a stack is selected (even if demo stack), but `showDemoBadge` is true when global demo mode is active
- Updated all 6 LLM-d cards to report `showDemoBadge` to `useReportCardDataState`

## Test plan
- [ ] Navigate to console.kubestellar.io (demo mode only deployment)
- [ ] Select any stack from the dropdown on AI-ML dashboard
- [ ] Verify all AI-ML cards show the "Demo" badge and yellow outline

🤖 Generated with [Claude Code](https://claude.com/claude-code)