### PR TITLE
✨ Add CardAIActions and sorting to UnifiedCard framework

### DIFF
--- a/web/src/config/cards/pod-issues.ts
+++ b/web/src/config/cards/pod-issues.ts
@@ -47,6 +47,16 @@ export const podIssuesConfig: UnifiedCardConfig = {
     type: 'list',
     pageSize: 5,
     itemClick: 'drill',
+    // Sorting configuration
+    sortable: true,
+    defaultSort: 'status',
+    defaultDirection: 'asc',
+    sortOptions: [
+      { field: 'status', label: 'Status' },
+      { field: 'name', label: 'Name' },
+      { field: 'restarts', label: 'Restarts' },
+      { field: 'cluster', label: 'Cluster' },
+    ],
     columns: [
       {
         field: 'cluster',

--- a/web/src/lib/unified/card/visualizations/ListVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/ListVisualization.tsx
@@ -6,10 +6,12 @@
  */
 
 import { useMemo, useState, useCallback } from 'react'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ChevronLeft, ChevronRight, ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react'
 import type { CardContentList, CardColumnConfig, CardDrillDownConfig, CardAIActionsConfig } from '../../types'
 import { renderCell } from '../renderers'
 import { CardAIActions } from '../../../cards/CardComponents'
+
+type SortDirection = 'asc' | 'desc'
 
 export interface ListVisualizationProps {
   /** Content configuration */
@@ -31,18 +33,72 @@ export function ListVisualization({
   drillDown,
   onDrillDown,
 }: ListVisualizationProps) {
-  const { columns, pageSize = 10, itemClick = 'none', showRowNumbers = false, aiActions } = content
+  const {
+    columns,
+    pageSize = 10,
+    itemClick = 'none',
+    showRowNumbers = false,
+    aiActions,
+    sortable = false,
+    defaultSort,
+    defaultDirection = 'asc',
+    sortOptions,
+  } = content
 
   // Pagination state
   const [currentPage, setCurrentPage] = useState(0)
 
-  // Calculate pagination
-  const totalPages = Math.ceil(data.length / pageSize)
+  // Sorting state
+  const [sortBy, setSortBy] = useState<string | undefined>(defaultSort)
+  const [sortDirection, setSortDirection] = useState<SortDirection>(defaultDirection)
+
+  // Build sort options from config or columns
+  const availableSortOptions = useMemo(() => {
+    if (sortOptions) return sortOptions
+    // Default: use all columns with headers as sortable options
+    return columns
+      .filter((col) => !col.hidden && col.header)
+      .map((col) => ({
+        field: col.field,
+        label: col.header || col.field,
+      }))
+  }, [sortOptions, columns])
+
+  // Sort data
+  const sortedData = useMemo(() => {
+    if (!sortable || !sortBy) return data
+
+    return [...data].sort((a, b) => {
+      const aRecord = a as Record<string, unknown>
+      const bRecord = b as Record<string, unknown>
+      const aVal = aRecord[sortBy]
+      const bVal = bRecord[sortBy]
+
+      // Handle null/undefined
+      if (aVal == null && bVal == null) return 0
+      if (aVal == null) return sortDirection === 'asc' ? 1 : -1
+      if (bVal == null) return sortDirection === 'asc' ? -1 : 1
+
+      // Handle numbers
+      if (typeof aVal === 'number' && typeof bVal === 'number') {
+        return sortDirection === 'asc' ? aVal - bVal : bVal - aVal
+      }
+
+      // Handle strings
+      const aStr = String(aVal).toLowerCase()
+      const bStr = String(bVal).toLowerCase()
+      const comparison = aStr.localeCompare(bStr)
+      return sortDirection === 'asc' ? comparison : -comparison
+    })
+  }, [data, sortable, sortBy, sortDirection])
+
+  // Calculate pagination (on sorted data)
+  const totalPages = Math.ceil(sortedData.length / pageSize)
   const paginatedData = useMemo(() => {
-    if (!pageSize || pageSize <= 0) return data
+    if (!pageSize || pageSize <= 0) return sortedData
     const start = currentPage * pageSize
-    return data.slice(start, start + pageSize)
-  }, [data, currentPage, pageSize])
+    return sortedData.slice(start, start + pageSize)
+  }, [sortedData, currentPage, pageSize])
 
   // Handle item click
   const handleItemClick = useCallback(
@@ -70,8 +126,54 @@ export function ListVisualization({
 
   const isClickable = itemClick !== 'none' && !!(drillDown || onDrillDown)
 
+  // Toggle sort direction
+  const toggleSortDirection = useCallback(() => {
+    setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'))
+  }, [])
+
   return (
     <div className="flex flex-col h-full">
+      {/* Sort controls */}
+      {sortable && availableSortOptions.length > 0 && (
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-800">
+          <ArrowUpDown className="w-3.5 h-3.5 text-gray-500" />
+          <select
+            value={sortBy || ''}
+            onChange={(e) => {
+              setSortBy(e.target.value || undefined)
+              setCurrentPage(0) // Reset to first page on sort change
+            }}
+            className="px-2 py-1 text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500"
+          >
+            <option value="">Sort by...</option>
+            {availableSortOptions.map((opt) => (
+              <option key={opt.field} value={opt.field}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          {sortBy && (
+            <button
+              onClick={toggleSortDirection}
+              className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 hover:bg-gray-700 transition-colors"
+              title={sortDirection === 'asc' ? 'Ascending (click to reverse)' : 'Descending (click to reverse)'}
+            >
+              {sortDirection === 'asc' ? (
+                <>
+                  <ArrowUp className="w-3 h-3" />
+                  <span>Asc</span>
+                </>
+              ) : (
+                <>
+                  <ArrowDown className="w-3 h-3" />
+                  <span>Desc</span>
+                </>
+              )}
+            </button>
+          )}
+        </div>
+      )}
+
       {/* List content */}
       <div className="flex-1 overflow-y-auto">
         {paginatedData.length === 0 ? (

--- a/web/src/lib/unified/types.ts
+++ b/web/src/lib/unified/types.ts
@@ -156,6 +156,14 @@ export interface CardContentList {
   showRowNumbers?: boolean
   /** AI actions configuration for list items */
   aiActions?: CardAIActionsConfig
+  /** Enable sorting controls */
+  sortable?: boolean
+  /** Default sort field (column field name) */
+  defaultSort?: string
+  /** Default sort direction */
+  defaultDirection?: 'asc' | 'desc'
+  /** Sort options to show in dropdown (defaults to all sortable columns) */
+  sortOptions?: Array<{ field: string; label: string }>
 }
 
 /**

--- a/web/src/pages/UnifiedCardTest.tsx
+++ b/web/src/pages/UnifiedCardTest.tsx
@@ -43,7 +43,6 @@ export function UnifiedCardTest() {
       <div className="mt-8 p-4 bg-secondary/50 rounded-lg">
         <h3 className="font-semibold mb-3">Framework Gaps to Fix (Phase 4)</h3>
         <ul className="list-disc list-inside text-sm text-muted-foreground space-y-1">
-          <li>❌ <strong>Sorting</strong> - No sort controls (Sort: Status, Ascending buttons)</li>
           <li>❌ <strong>Header stats badge</strong> - Legacy shows "168 issues" count badge</li>
           <li>❌ <strong>Restart count format</strong> - Shows "6.3K" vs legacy "6260 restarts"</li>
           <li>❌ <strong>Multi-status display</strong> - Shows single status vs "CrashLoopBackOff, OOMKilled"</li>
@@ -58,6 +57,7 @@ export function UnifiedCardTest() {
           <li>✅ <strong>Cluster filter</strong> - Dropdown filters by cluster</li>
           <li>✅ <strong>Renderers</strong> - cluster-badge, status-badge, number renderers work</li>
           <li>✅ <strong>CardAIActions</strong> - Diagnose/Repair buttons on each list item (hover to reveal)</li>
+          <li>✅ <strong>Sorting</strong> - Sort by field with ascending/descending toggle</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add CardAIActions (Diagnose/Repair buttons) to UnifiedCard list items
- Add sorting controls to UnifiedCard list visualization
- Enable AI actions and sorting in pod-issues config as example
- Update test page to show working features

## Details

### CardAIActions Integration
- Added `CardAIActionsConfig` type to configure AI actions per card
- ListVisualization now renders Diagnose/Repair buttons on hover
- Buttons extract resource context from list items via field mapping

### Sorting Controls
- Added `sortable`, `defaultSort`, `defaultDirection`, `sortOptions` to CardContentList
- ListVisualization now shows sort dropdown and direction toggle
- Data is sorted before pagination

## Test plan
- [x] Build passes
- [x] Visit /test/unified-card to see side-by-side comparison
- [x] Verify Diagnose/Repair buttons appear on hover
- [x] Verify sorting dropdown and direction toggle work

🤖 Generated with [Claude Code](https://claude.com/claude-code)