### PR TITLE
🐛 Remove duplicate kagenti route registrations with undefined handlers

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -245,13 +245,6 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/predictions/feedback", s.handlePredictionsFeedback)
 	mux.HandleFunc("/predictions/stats", s.handlePredictionsStats)
 
-	// Kagenti AI agent platform endpoints
-	mux.HandleFunc("/kagenti/agents", s.handleKagentiAgentsHTTP)
-	mux.HandleFunc("/kagenti/cards", s.handleKagentiCardsHTTP)
-	mux.HandleFunc("/kagenti/builds", s.handleKagentiBuildsHTTP)
-	mux.HandleFunc("/kagenti/tools", s.handleKagentiToolsHTTP)
-	mux.HandleFunc("/kagenti/summary", s.handleKagentiSummaryHTTP)
-
 	// Device tracking endpoints
 	mux.HandleFunc("/devices/alerts", s.handleDeviceAlerts)
 	mux.HandleFunc("/devices/alerts/clear", s.handleDeviceAlertsClear)


### PR DESCRIPTION
## Summary

- Remove duplicate kagenti route registrations that referenced undefined `*HTTP` handlers
- The same routes were registered twice - once with broken handler names, once with correct ones
- This caused a compile error that prevented the backend from starting

## Test plan
- [x] `go build ./...` passes
- [ ] Start development environment with `./startup-oauth.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)