### PR TITLE
✨ Migrate Batch 2 cards to UnifiedCard framework

### DIFF
--- a/web/src/lib/unified/card/UnifiedCardAdapter.tsx
+++ b/web/src/lib/unified/card/UnifiedCardAdapter.tsx
@@ -29,8 +29,9 @@ import type { CardComponentProps } from '../../../components/cards/cardRegistry'
  * 4. Compare rendering with legacy component
  */
 export const UNIFIED_READY_CARDS = new Set<string>([
+  // =====================================================================
   // Phase 6 Batch 1 - Simple list cards with registered hooks
-  // These cards have complete configs and list visualization
+  // =====================================================================
 
   // Core workload cards
   'pod_issues',           // useCachedPodIssues
@@ -58,6 +59,29 @@ export const UNIFIED_READY_CARDS = new Set<string>([
   'replicaset_status',    // useReplicaSets
   'pv_status',            // usePVs
   'namespace_status',     // useNamespaces
+
+  // =====================================================================
+  // Phase 6 Batch 2 - Additional list/table cards
+  // =====================================================================
+
+  // RBAC cards
+  'role_status',          // useK8sRoles
+  'role_binding_status',  // useK8sRoleBindings
+
+  // Quota cards
+  'resource_quota_status', // useResourceQuotas
+  'limit_range_status',   // useLimitRanges
+
+  // Network cards
+  'network_policy_status', // useNetworkPolicies
+  'service_exports',      // useServiceExports
+  'service_imports',      // useServiceImports
+
+  // Operator cards
+  'operator_subscription_status', // useOperatorSubscriptions
+
+  // Service account
+  'service_account_status', // useServiceAccounts
 ])
 
 /**

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -44,6 +44,10 @@ import {
   useK8sRoles,
   useK8sRoleBindings,
 } from '../../hooks/mcp'
+import {
+  useServiceExports,
+  useServiceImports,
+} from '../../hooks/useMCS'
 
 // ============================================================================
 // Wrapper hooks that convert params object to positional args
@@ -378,6 +382,30 @@ function useUnifiedK8sRoleBindings(params?: Record<string, unknown>) {
   }
 }
 
+function useUnifiedServiceExports(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useServiceExports(cluster, namespace)
+  return {
+    data: result.exports,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
+function useUnifiedServiceImports(params?: Record<string, unknown>) {
+  const cluster = params?.cluster as string | undefined
+  const namespace = params?.namespace as string | undefined
+  const result = useServiceImports(cluster, namespace)
+  return {
+    data: result.imports,
+    isLoading: result.isLoading,
+    error: result.error ? new Error(result.error) : null,
+    refetch: result.refetch,
+  }
+}
+
 // ============================================================================
 // Demo data hooks for cards that don't have real data hooks yet
 // These return static demo data for visualization purposes
@@ -588,6 +616,8 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useServiceAccounts', useUnifiedServiceAccounts)
   registerDataHook('useK8sRoles', useUnifiedK8sRoles)
   registerDataHook('useK8sRoleBindings', useUnifiedK8sRoleBindings)
+  registerDataHook('useServiceExports', useUnifiedServiceExports)
+  registerDataHook('useServiceImports', useUnifiedServiceImports)
 
   // Filtered event hooks
   registerDataHook('useWarningEvents', useWarningEvents)


### PR DESCRIPTION
## Summary
- Add 9 more cards to UNIFIED_READY_CARDS (Batch 2)
- Register MCS hooks (useServiceExports, useServiceImports)
- Total cards migrated: 30 cards

### Cards Added
- RBAC: `role_status`, `role_binding_status`
- Quotas: `resource_quota_status`, `limit_range_status`
- Network: `network_policy_status`, `service_exports`, `service_imports`
- Operators: `operator_subscription_status`
- Security: `service_account_status`

## Test plan
- [ ] Build passes
- [ ] Navigate to /unified-test page
- [ ] Select migrated cards from dropdown
- [ ] Verify rendering works

🤖 Generated with [Claude Code](https://claude.com/claude-code)