### PR TITLE
✨ Migrate Batch 3 chart/overview cards to UnifiedCard

### DIFF
--- a/web/src/lib/unified/card/UnifiedCardAdapter.tsx
+++ b/web/src/lib/unified/card/UnifiedCardAdapter.tsx
@@ -82,6 +82,28 @@ export const UNIFIED_READY_CARDS = new Set<string>([
 
   // Service account
   'service_account_status', // useServiceAccounts
+
+  // =====================================================================
+  // Phase 6 Batch 3 - Chart and overview cards
+  // =====================================================================
+
+  // Chart cards (demo data)
+  'cluster_metrics',        // useCachedClusterMetrics
+  'events_timeline',        // useCachedEventsTimeline
+  'pod_health_trend',       // usePodHealthTrend
+  'resource_trend',         // useResourceTrend
+
+  // Table/list cards with demo data
+  'resource_usage',         // useCachedResourceUsage
+  'top_pods',               // useTopPods
+  'security_issues',        // useSecurityIssues
+  'active_alerts',          // useActiveAlerts
+  'gitops_drift',           // useGitOpsDrift
+
+  // Status grid/overview cards (demo data)
+  'storage_overview',       // useStorageOverview
+  'network_overview',       // useNetworkOverview
+  'compute_overview',       // useComputeOverview
 ])
 
 /**

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -497,6 +497,34 @@ const DEMO_GITOPS_DRIFT = [
   { app: 'monitoring', status: 'synced', cluster: 'dev', lastSync: Date.now() - 120000 },
 ]
 
+// Pod health trend demo data
+const DEMO_POD_HEALTH_TREND = [
+  { timestamp: Date.now() - 300000, healthy: 145, unhealthy: 3 },
+  { timestamp: Date.now() - 240000, healthy: 148, unhealthy: 2 },
+  { timestamp: Date.now() - 180000, healthy: 142, unhealthy: 5 },
+  { timestamp: Date.now() - 120000, healthy: 150, unhealthy: 1 },
+  { timestamp: Date.now() - 60000, healthy: 147, unhealthy: 4 },
+  { timestamp: Date.now(), healthy: 149, unhealthy: 2 },
+]
+
+// Resource trend demo data
+const DEMO_RESOURCE_TREND = [
+  { timestamp: Date.now() - 300000, cpu: 45, memory: 62 },
+  { timestamp: Date.now() - 240000, cpu: 52, memory: 65 },
+  { timestamp: Date.now() - 180000, cpu: 48, memory: 58 },
+  { timestamp: Date.now() - 120000, cpu: 55, memory: 70 },
+  { timestamp: Date.now() - 60000, cpu: 50, memory: 67 },
+  { timestamp: Date.now(), cpu: 53, memory: 64 },
+]
+
+// Compute overview demo data
+const DEMO_COMPUTE_OVERVIEW = {
+  nodes: 12,
+  cpuUsage: 48,
+  memoryUsage: 62,
+  podCount: 156,
+}
+
 // ============================================================================
 // Filtered event hooks
 // These provide pre-filtered event data for specific card types
@@ -581,6 +609,18 @@ function useGitOpsDrift() {
   return useDemoDataHook(DEMO_GITOPS_DRIFT)
 }
 
+function usePodHealthTrend() {
+  return useDemoDataHook(DEMO_POD_HEALTH_TREND)
+}
+
+function useResourceTrend() {
+  return useDemoDataHook(DEMO_RESOURCE_TREND)
+}
+
+function useComputeOverview() {
+  return useDemoDataHook([DEMO_COMPUTE_OVERVIEW])
+}
+
 // ============================================================================
 // Register all data hooks for use in unified cards
 // Call this once at application startup
@@ -633,6 +673,9 @@ export function registerUnifiedHooks(): void {
   registerDataHook('useNetworkOverview', useNetworkOverview)
   registerDataHook('useTopPods', useTopPods)
   registerDataHook('useGitOpsDrift', useGitOpsDrift)
+  registerDataHook('usePodHealthTrend', usePodHealthTrend)
+  registerDataHook('useResourceTrend', useResourceTrend)
+  registerDataHook('useComputeOverview', useComputeOverview)
 }
 
 // Auto-register when this module is imported


### PR DESCRIPTION
## Summary
- Add 12 more cards to UNIFIED_READY_CARDS (Batch 3)
- Add missing demo hooks (usePodHealthTrend, useResourceTrend, useComputeOverview)
- Total cards migrated: 42 cards

### Cards Added

**Chart cards:**
- `cluster_metrics`, `events_timeline`, `pod_health_trend`, `resource_trend`

**Table/list cards (demo data):**
- `resource_usage`, `top_pods`, `security_issues`, `active_alerts`, `gitops_drift`

**Status grid/overview cards:**
- `storage_overview`, `network_overview`, `compute_overview`

## Test plan
- [ ] Build passes
- [ ] Navigate to /unified-test page
- [ ] Select chart cards from dropdown
- [ ] Verify chart rendering works

🤖 Generated with [Claude Code](https://claude.com/claude-code)