### PR TITLE
🐛 Unify demo mode implementation across all hooks and cards

### DIFF
--- a/web/src/components/cards/workload-detection/ProwHistory.tsx
+++ b/web/src/components/cards/workload-detection/ProwHistory.tsx
@@ -9,7 +9,7 @@ import { Pagination } from '../../ui/Pagination'
 import { useCachedProwJobs } from '../../../hooks/useCachedData'
 import { useCardData } from '../../../lib/cards/cardHooks'
 import type { ProwJob } from '../../../hooks/useProw'
-import { useCardLoadingState } from '../CardDataContext'
+import { useCardLoadingState, useCardDemoState } from '../CardDataContext'
 
 interface ProwHistoryProps {
   config?: Record<string, unknown>
@@ -32,12 +32,18 @@ const STATE_ORDER: Record<string, number> = {
 }
 
 export function ProwHistory({ config: _config }: ProwHistoryProps) {
-  const { jobs, isLoading, formatTimeAgo } = useCachedProwJobs('prow', 'prow')
+  // Check if we should use demo data
+  const { shouldUseDemoData } = useCardDemoState({ requires: 'agent' })
+
+  const { jobs, isLoading, isFailed, consecutiveFailures, formatTimeAgo } = useCachedProwJobs('prow', 'prow')
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
     hasAnyData: jobs.length > 0,
+    isFailed,
+    consecutiveFailures: consecutiveFailures ?? 0,
+    isDemoData: shouldUseDemoData,
   })
 
   // Pre-filter to only completed jobs

--- a/web/src/components/cards/workload-detection/ProwJobs.tsx
+++ b/web/src/components/cards/workload-detection/ProwJobs.tsx
@@ -11,14 +11,17 @@ import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import type { SortDirection } from '../../../lib/cards/cardHooks'
 import { useCachedProwJobs } from '../../../hooks/useCachedData'
 import type { ProwJob } from '../../../hooks/useProw'
-import { useCardLoadingState } from '../CardDataContext'
+import { useCardLoadingState, useCardDemoState } from '../CardDataContext'
 
 interface ProwJobsProps {
   config?: Record<string, unknown>
 }
 
 export function ProwJobs({ config: _config }: ProwJobsProps) {
-  // Fetch real ProwJobs from the prow cluster with caching
+  // Check if we should use demo data
+  const { shouldUseDemoData } = useCardDemoState({ requires: 'agent' })
+
+  // Fetch ProwJobs from the prow cluster with caching (returns demo data in demo mode)
   const {
     jobs,
     isLoading,
@@ -35,10 +38,11 @@ export function ProwJobs({ config: _config }: ProwJobsProps) {
     hasAnyData: jobs.length > 0,
     isFailed,
     consecutiveFailures: consecutiveFailures ?? 0,
+    isDemoData: shouldUseDemoData,
   })
 
   // Debug logging
-  console.log('[ProwJobs] render:', { jobsCount: jobs.length, isLoading, isRefreshing, isFailed, error })
+  console.log('[ProwJobs] render:', { jobsCount: jobs.length, isLoading, isRefreshing, isFailed, error, shouldUseDemoData })
 
   const [typeFilter, setTypeFilter] = useState<ProwJob['type'] | 'all'>('all')
   const [stateFilter, setStateFilter] = useState<ProwJob['state'] | 'all'>('all')

--- a/web/src/components/cards/workload-detection/ProwStatus.tsx
+++ b/web/src/components/cards/workload-detection/ProwStatus.tsx
@@ -1,13 +1,26 @@
 import { ExternalLink } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { useCachedProwJobs } from '../../../hooks/useCachedData'
+import { useCardLoadingState, useCardDemoState } from '../CardDataContext'
 
 interface ProwStatusProps {
   config?: Record<string, unknown>
 }
 
 export function ProwStatus({ config: _config }: ProwStatusProps) {
-  const { status, isLoading } = useCachedProwJobs('prow', 'prow')
+  // Check if we should use demo data
+  const { shouldUseDemoData } = useCardDemoState({ requires: 'agent' })
+
+  const { status, jobs, isLoading, isFailed, consecutiveFailures } = useCachedProwJobs('prow', 'prow')
+
+  // Report loading state to CardWrapper
+  useCardLoadingState({
+    isLoading,
+    hasAnyData: jobs.length > 0,
+    isFailed,
+    consecutiveFailures: consecutiveFailures ?? 0,
+    isDemoData: shouldUseDemoData,
+  })
 
   if (isLoading) {
     return (

--- a/web/src/components/cards/workload-monitor/ProwCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/ProwCIMonitor.tsx
@@ -14,6 +14,7 @@ import { cn } from '../../../lib/cn'
 import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
 import { WorkloadMonitorDiagnose } from './WorkloadMonitorDiagnose'
 import type { MonitorIssue, MonitoredResource } from '../../../types/workloadMonitor'
+import { useCardLoadingState, useCardDemoState } from '../../cards/CardDataContext'
 
 const SORT_OPTIONS = [
   { value: 'state', label: 'State' },
@@ -66,7 +67,19 @@ const TYPE_BADGE: Record<string, string> = {
 }
 
 export function ProwCIMonitor({ config: _config }: ProwCIMonitorProps) {
-  const { jobs, status: prowStatus, isLoading, isRefreshing, refetch, formatTimeAgo } = useCachedProwJobs()
+  // Check if we should use demo data
+  const { shouldUseDemoData } = useCardDemoState({ requires: 'agent' })
+
+  const { jobs, status: prowStatus, isLoading, isRefreshing, isFailed, consecutiveFailures, refetch, formatTimeAgo } = useCachedProwJobs()
+
+  // Report loading state to CardWrapper
+  useCardLoadingState({
+    isLoading,
+    hasAnyData: jobs.length > 0,
+    isFailed,
+    consecutiveFailures: consecutiveFailures ?? 0,
+    isDemoData: shouldUseDemoData,
+  })
 
   // Stats
   const stats = useMemo(() => {

--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { api } from '../../lib/api'
-import { useDemoMode, getDemoMode } from '../useDemoMode'
+import { useDemoMode } from '../useDemoMode'
+import { isDemoMode } from '../../lib/demoMode'
 import { triggerAggressiveDetection } from '../useLocalAgent'
 import type { ClusterHealth, MCPStatus } from './types'
 import {
@@ -206,7 +207,7 @@ export function useClusterHealth(cluster?: string) {
 
   const refetch = useCallback(async () => {
     // If demo mode is enabled, use demo data
-    if (getDemoMode()) {
+    if (isDemoMode()) {
       const demoHealth = getDemoHealth(cluster)
       prevHealthRef.current = demoHealth
       setHealth(demoHealth)

--- a/web/src/hooks/mcp/config.ts
+++ b/web/src/hooks/mcp/config.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { api } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
-import { getDemoMode } from '../useDemoMode'
+import { isDemoMode } from '../../lib/demoMode'
 import { LOCAL_AGENT_URL } from './shared'
 import type { ConfigMap, Secret, ServiceAccount } from './types'
 
@@ -12,7 +12,7 @@ export function useConfigMaps(cluster?: string, namespace?: string) {
 
   const refetch = useCallback(async () => {
     // If demo mode is enabled, use demo data
-    if (getDemoMode()) {
+    if (isDemoMode()) {
       const demoConfigMaps = getDemoConfigMaps().filter(cm =>
         (!cluster || cm.cluster === cluster) && (!namespace || cm.namespace === namespace)
       )
@@ -78,7 +78,7 @@ export function useSecrets(cluster?: string, namespace?: string) {
   const [error, setError] = useState<string | null>(null)
 
   const refetch = useCallback(async () => {
-    if (getDemoMode()) {
+    if (isDemoMode()) {
       const demoSecrets = getDemoSecrets().filter(s =>
         (!cluster || s.cluster === cluster) && (!namespace || s.namespace === namespace)
       )
@@ -144,7 +144,7 @@ export function useServiceAccounts(cluster?: string, namespace?: string) {
   const [error, setError] = useState<string | null>(null)
 
   const refetch = useCallback(async () => {
-    if (getDemoMode()) {
+    if (isDemoMode()) {
       const demoSAs = getDemoServiceAccounts().filter(sa =>
         (!cluster || sa.cluster === cluster) && (!namespace || sa.namespace === namespace)
       )

--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { isDemoModeForced } from '../useDemoMode'
+import { isNetlifyDeployment, isDemoMode } from '../../lib/demoMode'
 import { MIN_REFRESH_INDICATOR_MS, getEffectiveInterval } from './shared'
 import type { HelmRelease, HelmHistoryEntry } from './types'
 
@@ -95,7 +95,7 @@ export function useHelmReleases(cluster?: string) {
 
   const refetch = useCallback(async (silent = false) => {
     // Skip fetching entirely in forced demo mode (Netlify) — no backend
-    if (isDemoModeForced) {
+    if (isNetlifyDeployment) {
       setIsLoading(false)
       setIsRefreshing(false)
       notifyListeners(false)
@@ -115,7 +115,7 @@ export function useHelmReleases(cluster?: string) {
 
       // Skip API calls when using demo token
       const token = localStorage.getItem('token')
-      if (!token || token === 'demo-token') {
+      if (isDemoMode()) {
         setLastRefresh(Date.now())
         setIsLoading(false)
         if (!silent) {
@@ -273,7 +273,7 @@ export function useHelmHistory(cluster?: string, release?: string, namespace?: s
 
       // Skip API calls when using demo token
       const token = localStorage.getItem('token')
-      if (!token || token === 'demo-token') {
+      if (isDemoMode()) {
         setIsLoading(false)
         setTimeout(() => setIsRefreshing(false), MIN_REFRESH_INDICATOR_MS)
         return
@@ -405,7 +405,7 @@ export function useHelmValues(cluster?: string, release?: string, namespace?: st
 
       // Skip API calls when using demo token
       const token = localStorage.getItem('token')
-      if (!token || token === 'demo-token') {
+      if (isDemoMode()) {
         setIsLoading(false)
         setTimeout(() => setIsRefreshing(false), MIN_REFRESH_INDICATOR_MS)
         return
@@ -505,7 +505,7 @@ export function useHelmValues(cluster?: string, release?: string, namespace?: st
       const doFetch = async () => {
         // Skip API calls when using demo token
         const token = localStorage.getItem('token')
-        if (!token || token === 'demo-token') {
+        if (isDemoMode()) {
           setIsLoading(false)
           setTimeout(() => setIsRefreshing(false), MIN_REFRESH_INDICATOR_MS)
           return

--- a/web/src/hooks/mcp/kagenti.ts
+++ b/web/src/hooks/mcp/kagenti.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { isAgentUnavailable, reportAgentDataSuccess, reportAgentDataError } from '../useLocalAgent'
 import { clusterCacheRef, LOCAL_AGENT_URL, getEffectiveInterval } from './shared'
-import { getDemoMode, isDemoModeForced } from '../useDemoMode'
+import { isDemoMode, isNetlifyDeployment } from '../../lib/demoMode'
 
 // ─── Types ─────────────────────────────────────────────────────────
 
@@ -117,7 +117,7 @@ const AGENT_TIMEOUT = 15000
 const POLL_INTERVAL = 60000
 
 function shouldUseDemoData(): boolean {
-  return getDemoMode() || isDemoModeForced
+  return isDemoMode() || isNetlifyDeployment
 }
 
 async function agentFetch<T>(path: string, cluster: string, namespace?: string): Promise<T | null> {

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { api } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
-import { getDemoMode } from '../useDemoMode'
+import { isDemoMode } from '../../lib/demoMode'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef } from './shared'
 import type { Service, Ingress, NetworkPolicy } from './types'
@@ -185,7 +185,7 @@ export function useServices(cluster?: string, namespace?: string) {
 
     try {
       // If demo mode is enabled, use demo data
-      if (getDemoMode()) {
+      if (isDemoMode()) {
         const demoServices = getDemoServices().filter(s =>
           (!cluster || s.cluster === cluster) && (!namespace || s.namespace === namespace)
         )
@@ -203,7 +203,7 @@ export function useServices(cluster?: string, namespace?: string) {
 
       // Skip API calls when using demo token
       const token = localStorage.getItem('token')
-      if (!token || token === 'demo-token') {
+      if (isDemoMode()) {
         const demoServices = getDemoServices().filter(s =>
           (!cluster || s.cluster === cluster) && (!namespace || s.namespace === namespace)
         )

--- a/web/src/hooks/mcp/operators.ts
+++ b/web/src/hooks/mcp/operators.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { api } from '../../lib/api'
-import { getDemoMode } from '../useDemoMode'
+import { isDemoMode } from '../../lib/demoMode'
 import { clusterCacheRef, subscribeClusterCache } from './shared'
 import type { Operator, OperatorSubscription } from './types'
 
@@ -24,7 +24,7 @@ function loadOperatorsCacheFromStorage(cacheKey: string): { data: Operator[], ti
 
 function saveOperatorsCacheToStorage(data: Operator[], key: string) {
   try {
-    if (data.length > 0 && !getDemoMode()) {
+    if (data.length > 0 && !isDemoMode()) {
       localStorage.setItem(OPERATORS_CACHE_KEY, JSON.stringify({ data, timestamp: Date.now(), key }))
     }
   } catch { /* ignore */ }
@@ -46,7 +46,7 @@ function loadSubscriptionsCacheFromStorage(cacheKey: string): { data: OperatorSu
 
 function saveSubscriptionsCacheToStorage(data: OperatorSubscription[], key: string) {
   try {
-    if (data.length > 0 && !getDemoMode()) {
+    if (data.length > 0 && !isDemoMode()) {
       localStorage.setItem(SUBSCRIPTIONS_CACHE_KEY, JSON.stringify({ data, timestamp: Date.now(), key }))
     }
   } catch { /* ignore */ }
@@ -81,7 +81,7 @@ export function useOperators(cluster?: string) {
 
     const doFetch = async () => {
       // If demo mode is enabled, use demo data directly
-      if (getDemoMode()) {
+      if (isDemoMode()) {
         if (!cancelled) {
           const clusters = cluster ? [cluster] : clusterCacheRef.clusters.map(c => c.name)
           const allOperators = clusters.flatMap(c => getDemoOperators(c))
@@ -200,7 +200,7 @@ export function useOperatorSubscriptions(cluster?: string) {
 
     const doFetch = async () => {
       // If demo mode is enabled, use demo data directly
-      if (getDemoMode()) {
+      if (isDemoMode()) {
         if (!cancelled) {
           const clusters = cluster ? [cluster] : clusterCacheRef.clusters.map(c => c.name)
           const allSubscriptions = clusters.flatMap(c => getDemoOperatorSubscriptions(c))

--- a/web/src/hooks/mcp/rbac.ts
+++ b/web/src/hooks/mcp/rbac.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { api } from '../../lib/api'
-import { getDemoMode } from '../useDemoMode'
+import { isDemoMode } from '../../lib/demoMode'
 import type { K8sRole, K8sRoleBinding, K8sServiceAccountInfo } from './types'
 
 // Demo RBAC data for when demo mode is enabled
@@ -99,7 +99,7 @@ export function useK8sRoles(cluster?: string, namespace?: string, includeSystem 
 
   const refetch = useCallback(async () => {
     // Demo mode returns demo data
-    if (getDemoMode()) {
+    if (isDemoMode()) {
       setRoles(getDemoK8sRoles(cluster))
       setIsLoading(false)
       setError(null)
@@ -147,7 +147,7 @@ export function useK8sRoleBindings(cluster?: string, namespace?: string, include
 
   const refetch = useCallback(async () => {
     // Demo mode returns demo data
-    if (getDemoMode()) {
+    if (isDemoMode()) {
       setBindings(getDemoK8sRoleBindings(cluster, namespace))
       setIsLoading(false)
       setError(null)
@@ -195,7 +195,7 @@ export function useK8sServiceAccounts(cluster?: string, namespace?: string) {
 
   const refetch = useCallback(async () => {
     // Demo mode returns demo data
-    if (getDemoMode()) {
+    if (isDemoMode()) {
       setServiceAccounts(getDemoK8sServiceAccounts(cluster, namespace))
       setIsLoading(false)
       setError(null)

--- a/web/src/hooks/mcp/security.ts
+++ b/web/src/hooks/mcp/security.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { isDemoMode } from '../../lib/demoMode'
 import { MIN_REFRESH_INDICATOR_MS, REFRESH_INTERVAL_MS, getEffectiveInterval } from './shared'
 import type { SecurityIssue, GitOpsDrift } from './types'
 
@@ -63,7 +64,7 @@ export function useSecurityIssues(cluster?: string, namespace?: string) {
 
       // Skip API calls when using demo token
       const token = localStorage.getItem('token')
-      if (!token || token === 'demo-token') {
+      if (isDemoMode()) {
         setIssues(getDemoSecurityIssues())
         const now = new Date()
         setLastUpdated(now)
@@ -162,7 +163,7 @@ export function useGitOpsDrifts(cluster?: string, namespace?: string) {
 
       // Skip API calls when using demo token
       const token = localStorage.getItem('token')
-      if (!token || token === 'demo-token') {
+      if (isDemoMode()) {
         const demoData = getDemoGitOpsDrifts()
         setDrifts(demoData)
         const now = Date.now()

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { api } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
-import { getDemoMode } from '../useDemoMode'
+import { isDemoMode } from '../../lib/demoMode'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { REFRESH_INTERVAL_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef } from './shared'
 import type { PVC, PV, ResourceQuota, LimitRange, ResourceQuotaSpec } from './types'
@@ -96,7 +96,7 @@ export function usePVCs(cluster?: string, namespace?: string) {
       setIsRefreshing(true)
     }
     // If demo mode is enabled, use demo data
-    if (getDemoMode()) {
+    if (isDemoMode()) {
       const demoPVCs = getDemoPVCs().filter(p =>
         (!cluster || p.cluster === cluster) && (!namespace || p.namespace === namespace)
       )
@@ -366,7 +366,7 @@ export function useResourceQuotas(cluster?: string, namespace?: string) {
 
   const refetch = useCallback(async () => {
     // If demo mode is enabled, use demo data
-    if (getDemoMode()) {
+    if (isDemoMode()) {
       const demoQuotas = getDemoResourceQuotas().filter(q =>
         (!cluster || q.cluster === cluster) && (!namespace || q.namespace === namespace)
       )
@@ -410,7 +410,7 @@ export function useLimitRanges(cluster?: string, namespace?: string) {
 
   const refetch = useCallback(async () => {
     // If demo mode is enabled, use demo data
-    if (getDemoMode()) {
+    if (isDemoMode()) {
       const demoRanges = getDemoLimitRanges().filter(lr =>
         (!cluster || lr.cluster === cluster) && (!namespace || lr.namespace === namespace)
       )

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -18,7 +18,7 @@
 import { useCache, type RefreshCategory } from '../lib/cache'
 import { isBackendUnavailable } from '../lib/api'
 import { kubectlProxy } from '../lib/kubectlProxy'
-import { isDemoModeForced } from './useDemoMode'
+import { isDemoMode } from '../lib/demoMode'
 import { clusterCacheRef } from './mcp/shared'
 import type {
   PodInfo,
@@ -40,15 +40,7 @@ const getToken = () => localStorage.getItem('token')
 
 const LOCAL_AGENT_URL = 'http://127.0.0.1:8585'
 
-const isDemoMode = () => {
-  // Netlify deployments are always demo mode — no local agent or backend
-  if (isDemoModeForced) return true
-  // If we have cluster data from the agent, we have a real data source
-  if (clusterCacheRef.clusters.length > 0) return false
-  const token = getToken()
-  if (!token || token === 'demo-token') return true
-  return isBackendUnavailable()
-}
+// Note: isDemoMode() is imported from '../lib/demoMode' - single source of truth
 
 async function fetchAPI<T>(
   endpoint: string,
@@ -395,7 +387,7 @@ export function useCachedPodIssues(
     key,
     category,
     initialData: getDemoPodIssues(),
-    enabled: true,
+    enabled: !isDemoMode(),
     fetcher: async () => {
       let issues: PodIssue[]
 
@@ -458,7 +450,7 @@ export function useCachedDeploymentIssues(
     key,
     category,
     initialData: getDemoDeploymentIssues(),
-    enabled: true,
+    enabled: !isDemoMode(),
     fetcher: async () => {
       // Try agent first — derive deployment issues from deployment data
       if (clusterCacheRef.clusters.length > 0) {
@@ -533,7 +525,7 @@ export function useCachedDeployments(
     key,
     category,
     initialData: getDemoDeployments(),
-    enabled: true,
+    enabled: !isDemoMode(),
     fetcher: async () => {
       // Try agent first (fast, no backend needed)
       if (clusterCacheRef.clusters.length > 0) {
@@ -765,7 +757,7 @@ export function useCachedProwJobs(
     key,
     category: 'gitops',
     initialData: getDemoProwJobs(),
-    enabled: true,
+    enabled: !isDemoMode(),
     fetcher: () => fetchProwJobs(prowCluster, namespace),
   })
 
@@ -1074,7 +1066,7 @@ export function useCachedLLMdServers(
     key,
     category: 'gitops',
     initialData: getDemoLLMdServers(),
-    enabled: true,
+    enabled: !isDemoMode(),
     fetcher: () => fetchLLMdServers(clusters),
   })
 
@@ -1138,7 +1130,7 @@ export function useCachedLLMdModels(
     key,
     category: 'gitops',
     initialData: getDemoLLMdModels(),
-    enabled: true,
+    enabled: !isDemoMode(),
     fetcher: () => fetchLLMdModels(clusters),
   })
 
@@ -1264,7 +1256,7 @@ export function useCachedSecurityIssues(
     key,
     category,
     initialData: getDemoSecurityIssues(),
-    enabled: true,
+    enabled: !isDemoMode(),
     fetcher: async () => {
       // Try kubectl proxy first (uses agent to run kubectl commands)
       if (clusterCacheRef.clusters.length > 0) {

--- a/web/src/hooks/useDemoMode.ts
+++ b/web/src/hooks/useDemoMode.ts
@@ -1,137 +1,66 @@
-import { useState, useEffect, useCallback } from 'react'
-
-const DEMO_MODE_KEY = 'kc-demo-mode'
-const GPU_CACHE_KEY = 'kubestellar-gpu-cache'
-
-// Global state for demo mode to ensure consistency across components
-let globalDemoMode = false
-const listeners = new Set<(value: boolean) => void>()
-
-// Auto-enable demo mode on Netlify builds (VITE_DEMO_MODE=true in netlify.toml)
-const isNetlifyPreview = typeof window !== 'undefined' && (
-  import.meta.env.VITE_DEMO_MODE === 'true' ||
-  window.location.hostname.includes('netlify.app') ||
-  window.location.hostname.includes('deploy-preview-') ||
-  window.location.hostname === 'console.kubestellar.io'
-)
-
 /**
- * Whether demo mode is forced on and cannot be toggled off.
- * True on Netlify deployments (console.kubestellar.io, preview deploys).
+ * React hook for demo mode state management.
+ *
+ * This hook provides automatic re-renders when demo mode changes.
+ * For non-React code, import directly from '../lib/demoMode'.
  */
-export const isDemoModeForced = isNetlifyPreview
 
-// Initialize from localStorage, auto-enable on Netlify previews, or when auth
-// has set a demo-token (backend unavailable / no real JWT).
-// IMPORTANT: If the user has explicitly toggled demo mode off (stored === 'false'),
-// respect that choice — don't let a stale demo-token override it.
-if (typeof window !== 'undefined') {
-  const stored = localStorage.getItem(DEMO_MODE_KEY)
-  const hasDemoToken = localStorage.getItem('token') === 'demo-token'
-  const userExplicitlyDisabled = stored === 'false'
-  globalDemoMode = isNetlifyPreview || stored === 'true' || (hasDemoToken && !userExplicitlyDisabled)
+import { useState, useEffect, useCallback } from 'react'
+import {
+  isDemoMode as _isDemoMode,
+  setDemoMode as _setDemoMode,
+  toggleDemoMode as _toggleDemoMode,
+  subscribeDemoMode,
+  isNetlifyDeployment,
+  isDemoModeForced,
+  canToggleDemoMode,
+  isDemoToken,
+  hasRealToken,
+  setDemoToken,
+  getDemoMode,
+  setGlobalDemoMode,
+} from '../lib/demoMode'
 
-  // Clear any stale demo GPU data if demo mode is off
-  if (!globalDemoMode) {
-    try {
-      const gpuCache = localStorage.getItem(GPU_CACHE_KEY)
-      if (gpuCache) {
-        const parsed = JSON.parse(gpuCache)
-        const demoClusterNames = ['vllm-gpu-cluster', 'eks-prod-us-east-1', 'gke-staging', 'aks-dev-westeu', 'openshift-prod', 'oci-oke-phoenix', 'alibaba-ack-shanghai', 'rancher-mgmt']
-        const hasDemoData = parsed.nodes?.some((node: { cluster: string }) =>
-          demoClusterNames.includes(node.cluster)
-        )
-        if (hasDemoData) {
-          localStorage.removeItem(GPU_CACHE_KEY)
-        }
-      }
-    } catch {
-      // Ignore parse errors
-    }
-  }
-
-  // Cross-tab sync: when another tab changes demo mode, update this tab
-  window.addEventListener('storage', (e) => {
-    if (e.key === DEMO_MODE_KEY) {
-      const newValue = e.newValue === 'true'
-      if (globalDemoMode !== newValue) {
-        globalDemoMode = newValue
-        notifyListeners()
-      }
-    }
-  })
-}
-
-function notifyListeners() {
-  listeners.forEach(listener => listener(globalDemoMode))
-  // Dispatch custom event so non-React subscribers (e.g. useActiveUsers) can react
-  window.dispatchEvent(new CustomEvent('kc-demo-mode-change', { detail: globalDemoMode }))
+// Re-export all utilities from the unified module for convenience
+export {
+  isNetlifyDeployment,
+  isDemoModeForced,
+  canToggleDemoMode,
+  isDemoToken,
+  hasRealToken,
+  setDemoToken,
+  getDemoMode,
+  setGlobalDemoMode,
 }
 
 /**
- * Hook to manage demo mode state with localStorage persistence.
+ * Hook to manage demo mode state with automatic re-renders on changes.
  * When demo mode is enabled, the app shows demo/mock data instead of
  * connecting to the real MCP agent.
+ *
+ * Usage:
+ * ```tsx
+ * const { isDemoMode, toggleDemoMode, setDemoMode } = useDemoMode()
+ * ```
  */
 export function useDemoMode() {
-  const [isDemoMode, setIsDemoMode] = useState(globalDemoMode)
+  const [isDemoMode, setIsDemoModeState] = useState(_isDemoMode())
 
   useEffect(() => {
-    const handleChange = (value: boolean) => {
-      setIsDemoMode(value)
-    }
-    listeners.add(handleChange)
-    setIsDemoMode(globalDemoMode)
-
-    return () => {
-      listeners.delete(handleChange)
-    }
+    const unsubscribe = subscribeDemoMode((value) => {
+      setIsDemoModeState(value)
+    })
+    // Sync in case state changed between render and effect
+    setIsDemoModeState(_isDemoMode())
+    return unsubscribe
   }, [])
 
-  const toggleDemoMode = useCallback(() => {
-    // Never allow disabling demo mode on Netlify deployments
-    if (isNetlifyPreview && globalDemoMode) return
-    globalDemoMode = !globalDemoMode
-    localStorage.setItem(DEMO_MODE_KEY, String(globalDemoMode))
-    notifyListeners()
-  }, [])
-
-  const setDemoMode = useCallback((value: boolean) => {
-    // Never allow disabling demo mode on Netlify deployments
-    if (isNetlifyPreview && !value) return
-    globalDemoMode = value
-    localStorage.setItem(DEMO_MODE_KEY, String(value))
-    notifyListeners()
-  }, [])
+  const toggleDemoMode = useCallback(_toggleDemoMode, [])
+  const setDemoMode = useCallback(_setDemoMode, [])
 
   return {
     isDemoMode,
     toggleDemoMode,
     setDemoMode,
   }
-}
-
-/**
- * Get current demo mode state without subscribing to changes.
- * Useful for one-time checks in non-React code.
- */
-export function getDemoMode(): boolean {
-  return globalDemoMode
-}
-
-/**
- * Set global demo mode from non-React code (e.g., when agent provides real data).
- * Notifies all subscribed components so they re-render.
- * Will NOT auto-disable demo mode if the user explicitly toggled it ON.
- */
-export function setGlobalDemoMode(value: boolean) {
-  // Never allow disabling demo mode on Netlify deployments
-  if (isNetlifyPreview && !value) return
-  // Don't auto-disable if user explicitly enabled demo mode.
-  // Read localStorage directly — survives module reloads, no stale variable.
-  if (!value && localStorage.getItem(DEMO_MODE_KEY) === 'true') return
-  if (globalDemoMode === value) return // no-op
-  globalDemoMode = value
-  localStorage.setItem(DEMO_MODE_KEY, String(value))
-  notifyListeners()
 }

--- a/web/src/lib/demoMode.ts
+++ b/web/src/lib/demoMode.ts
@@ -1,0 +1,203 @@
+/**
+ * Unified Demo Mode Utility
+ *
+ * This is the single source of truth for all demo mode checks in the application.
+ * All code should import from this module instead of checking tokens, environment
+ * variables, or other conditions directly.
+ *
+ * Demo mode is enabled when ANY of these conditions are true (in priority order):
+ * 1. Running on Netlify (console.kubestellar.io, deploy previews) - FORCED, cannot toggle off
+ * 2. User explicitly enabled via toggle (localStorage 'kc-demo-mode' === 'true')
+ * 3. Using demo token (!token || token === 'demo-token') AND user hasn't explicitly disabled
+ *
+ * Usage:
+ * - React components: use useDemoMode() hook from '../hooks/useDemoMode'
+ * - Non-React code: use isDemoMode() from this module
+ * - Cache hooks: use enabled: !isDemoMode() pattern
+ */
+
+const DEMO_MODE_KEY = 'kc-demo-mode'
+const DEMO_TOKEN = 'demo-token'
+const GPU_CACHE_KEY = 'kubestellar-gpu-cache'
+
+// ============================================================================
+// Environment Detection (computed once at module load, never changes)
+// ============================================================================
+
+/**
+ * Whether running on a Netlify deployment (console.kubestellar.io, preview deploys).
+ * These environments have no backend/agent access, so demo mode is forced.
+ */
+export const isNetlifyDeployment = typeof window !== 'undefined' && (
+  import.meta.env.VITE_DEMO_MODE === 'true' ||
+  window.location.hostname.includes('netlify.app') ||
+  window.location.hostname.includes('deploy-preview-') ||
+  window.location.hostname === 'console.kubestellar.io'
+)
+
+/**
+ * Whether demo mode is forced ON and cannot be toggled off.
+ * True on Netlify deployments.
+ * @deprecated Use isNetlifyDeployment instead for clarity
+ */
+export const isDemoModeForced = isNetlifyDeployment
+
+/**
+ * Whether the user can toggle demo mode on/off.
+ * False on Netlify deployments (demo mode is forced).
+ */
+export function canToggleDemoMode(): boolean {
+  return !isNetlifyDeployment
+}
+
+// ============================================================================
+// State Management (global singleton with subscribers)
+// ============================================================================
+
+let globalDemoMode = false
+const listeners = new Set<(value: boolean) => void>()
+
+// Initialize from localStorage or environment
+if (typeof window !== 'undefined') {
+  const stored = localStorage.getItem(DEMO_MODE_KEY)
+  const hasDemoToken = localStorage.getItem('token') === DEMO_TOKEN
+  const userExplicitlyDisabled = stored === 'false'
+
+  // Priority: Netlify > explicit preference > demo token fallback
+  globalDemoMode = isNetlifyDeployment ||
+                   stored === 'true' ||
+                   (hasDemoToken && !userExplicitlyDisabled)
+
+  // Clear any stale demo GPU data if demo mode is off
+  if (!globalDemoMode) {
+    try {
+      const gpuCache = localStorage.getItem(GPU_CACHE_KEY)
+      if (gpuCache) {
+        const parsed = JSON.parse(gpuCache)
+        const demoClusterNames = ['vllm-gpu-cluster', 'eks-prod-us-east-1', 'gke-staging', 'aks-dev-westeu', 'openshift-prod', 'oci-oke-phoenix', 'alibaba-ack-shanghai', 'rancher-mgmt']
+        const hasDemoData = parsed.nodes?.some((node: { cluster: string }) =>
+          demoClusterNames.includes(node.cluster)
+        )
+        if (hasDemoData) {
+          localStorage.removeItem(GPU_CACHE_KEY)
+        }
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  // Cross-tab sync: when another tab changes demo mode, update this tab
+  window.addEventListener('storage', (e) => {
+    if (e.key === DEMO_MODE_KEY) {
+      const newValue = e.newValue === 'true'
+      if (globalDemoMode !== newValue) {
+        globalDemoMode = newValue
+        notifyListeners()
+      }
+    }
+  })
+}
+
+function notifyListeners() {
+  listeners.forEach(listener => listener(globalDemoMode))
+  // Dispatch custom event so non-React subscribers can react
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('kc-demo-mode-change', { detail: globalDemoMode }))
+  }
+}
+
+// ============================================================================
+// Public API - Demo Mode State
+// ============================================================================
+
+/**
+ * Get current demo mode state (synchronous).
+ * Use this in non-React code or when you just need a one-time check.
+ *
+ * For React components, prefer useDemoMode() hook for automatic re-renders.
+ */
+export function isDemoMode(): boolean {
+  return globalDemoMode
+}
+
+/**
+ * Set demo mode state. Respects forced demo mode on Netlify.
+ * Notifies all subscribers (React hooks, event listeners).
+ *
+ * Will NOT auto-disable demo mode if the user explicitly toggled it ON.
+ */
+export function setDemoMode(value: boolean): void {
+  // Never allow disabling on Netlify
+  if (isNetlifyDeployment && !value) return
+  // Don't auto-disable if user explicitly enabled demo mode
+  if (!value && localStorage.getItem(DEMO_MODE_KEY) === 'true') return
+  if (globalDemoMode === value) return
+
+  globalDemoMode = value
+  localStorage.setItem(DEMO_MODE_KEY, String(value))
+  notifyListeners()
+}
+
+/**
+ * Toggle demo mode. No-op if demo mode is forced (Netlify).
+ */
+export function toggleDemoMode(): void {
+  if (isNetlifyDeployment && globalDemoMode) return
+  setDemoMode(!globalDemoMode)
+}
+
+/**
+ * Subscribe to demo mode changes.
+ * Returns unsubscribe function.
+ *
+ * Used internally by useDemoMode() hook.
+ */
+export function subscribeDemoMode(callback: (value: boolean) => void): () => void {
+  listeners.add(callback)
+  return () => listeners.delete(callback)
+}
+
+// ============================================================================
+// Token Helpers - Consolidated demo-token checks
+// ============================================================================
+
+/**
+ * Check if the current token is a demo token or missing.
+ * This is THE canonical way to check for demo token.
+ *
+ * Replaces all `!token || token === 'demo-token'` patterns.
+ */
+export function isDemoToken(): boolean {
+  const token = localStorage.getItem('token')
+  return !token || token === DEMO_TOKEN
+}
+
+/**
+ * Check if we have a real (non-demo) authentication token.
+ */
+export function hasRealToken(): boolean {
+  const token = localStorage.getItem('token')
+  return !!token && token !== DEMO_TOKEN
+}
+
+/**
+ * Set the demo token (used when falling back to demo mode).
+ */
+export function setDemoToken(): void {
+  localStorage.setItem('token', DEMO_TOKEN)
+}
+
+// ============================================================================
+// Legacy Exports - For backwards compatibility during migration
+// ============================================================================
+
+/**
+ * @deprecated Use isDemoMode() instead
+ */
+export const getDemoMode = isDemoMode
+
+/**
+ * @deprecated Use setDemoMode() instead
+ */
+export const setGlobalDemoMode = setDemoMode


### PR DESCRIPTION
## Summary
- Consolidates 6+ different demo mode patterns into a single source of truth at `lib/demoMode.ts`
- Ensures consistent behavior between localhost and console.kubestellar.io (Netlify) deployments
- Fixes Prow cards showing empty state on Netlify instead of demo data

## Changes
- Create unified `lib/demoMode.ts` with `isDemoMode()`, `isNetlifyDeployment`, and `isDemoToken()` functions
- Update all MCP hooks to use unified demo mode utility
- Update `useCachedData.ts` to use unified `isDemoMode()` instead of local function
- Fix Prow cards (ProwJobs, ProwStatus, ProwHistory, ProwCIMonitor) to properly report demo data state via `useCardDemoState` and `useCardLoadingState`
- Remove duplicate demo mode logic from individual hooks

## Test plan
- [ ] Verify Prow cards show demo data on console.kubestellar.io
- [ ] Verify demo mode toggle works on localhost
- [ ] Verify all cards transition consistently: skeleton → demo data
- [ ] Run `npm run lint` and `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)