### PR TITLE
🐛 Fix KubeCraft array bounds, remove ProwJobs debug logging, add search spacing

### DIFF
--- a/web/src/components/cards/KubeCraft.tsx
+++ b/web/src/components/cards/KubeCraft.tsx
@@ -84,7 +84,7 @@ export function KubeCraft() {
 
     for (let x = 0; x < GRID_SIZE; x++) {
       height += Math.floor(Math.random() * 3) - 1
-      height = Math.max(GRID_SIZE / 3, Math.min(GRID_SIZE - 3, height))
+      height = Math.max(Math.floor(GRID_SIZE / 3), Math.min(GRID_SIZE - 3, height))
       heights.push(height)
     }
 

--- a/web/src/components/cards/workload-detection/ProwJobs.tsx
+++ b/web/src/components/cards/workload-detection/ProwJobs.tsx
@@ -25,11 +25,9 @@ export function ProwJobs({ config: _config }: ProwJobsProps) {
   const {
     jobs,
     isLoading,
-    isRefreshing,
     isFailed,
     consecutiveFailures,
     formatTimeAgo,
-    error,
   } = useCachedProwJobs('prow', 'prow')
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
@@ -40,9 +38,6 @@ export function ProwJobs({ config: _config }: ProwJobsProps) {
     consecutiveFailures: consecutiveFailures ?? 0,
     isDemoData: shouldUseDemoData,
   })
-
-  // Debug logging
-  console.log('[ProwJobs] render:', { jobsCount: jobs.length, isLoading, isRefreshing, isFailed, error, shouldUseDemoData })
 
   const [typeFilter, setTypeFilter] = useState<ProwJob['type'] | 'all'>('all')
   const [stateFilter, setStateFilter] = useState<ProwJob['state'] | 'all'>('all')

--- a/web/src/lib/cards/CardComponents.tsx
+++ b/web/src/lib/cards/CardComponents.tsx
@@ -234,7 +234,7 @@ export function CardSearchInput({
   useEffect(() => () => clearTimeout(timerRef.current), [])
 
   return (
-    <div className={`relative ${className}`}>
+    <div className={`relative mb-4 ${className}`}>
       <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
       <input
         type="text"


### PR DESCRIPTION
## Summary
- Fix KubeCraft.tsx array bounds error by using Math.floor(GRID_SIZE / 3) to prevent float indices
- Remove excessive ProwJobs debug console.log and unused variables
- Add mb-4 spacing to CardSearchInput for consistent visual gap below search inputs

## Test plan
- [x] Build passes
- [ ] KubeCraft game works without console errors
- [ ] No ProwJobs debug logging in console
- [ ] Search inputs have proper spacing from content below

🤖 Generated with [Claude Code](https://claude.com/claude-code)