### PR TITLE
✨ Unified demo mode switching with Mode Transition Coordinator

### DIFF
--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode } from '../../lib/demoMode'
+import { registerCacheReset } from '../../lib/modeTransition'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL } from './shared'
 import type { ClusterEvent } from './types'
 
@@ -369,4 +370,13 @@ function getDemoEvents(): ClusterEvent[] {
       count: 8,
     },
   ]
+}
+
+// Register with mode transition coordinator for unified cache clearing
+if (typeof window !== 'undefined') {
+  registerCacheReset('events', () => {
+    eventsCache = null
+    warningEventsCache = null
+    console.log('[Events] Caches cleared for mode transition')
+  })
 }

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { api } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode } from '../../lib/demoMode'
+import { registerCacheReset } from '../../lib/modeTransition'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef } from './shared'
 import type { Service, Ingress, NetworkPolicy } from './types'
@@ -421,4 +422,17 @@ function getDemoServices(): Service[] {
     { name: 'grafana', namespace: 'monitoring', cluster: 'staging', type: 'NodePort', clusterIP: '10.96.40.20', ports: ['3000:30300/TCP'], age: '20d' },
     { name: 'ml-inference', namespace: 'ml', cluster: 'vllm-d', type: 'LoadBalancer', clusterIP: '10.96.50.10', externalIP: '34.56.78.90', ports: ['8080/TCP'], age: '15d' },
   ]
+}
+
+// Register with mode transition coordinator for unified cache clearing
+if (typeof window !== 'undefined') {
+  registerCacheReset('services', () => {
+    try {
+      localStorage.removeItem(SERVICES_CACHE_KEY)
+    } catch {
+      // Ignore storage errors
+    }
+    servicesCache = null
+    console.log('[Networking] Cache cleared for mode transition')
+  })
 }

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { api } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode } from '../../lib/demoMode'
+import { registerCacheReset } from '../../lib/modeTransition'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { REFRESH_INTERVAL_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef } from './shared'
 import type { PVC, PV, ResourceQuota, LimitRange, ResourceQuotaSpec } from './types'
@@ -579,4 +580,17 @@ function getDemoLimitRanges(): LimitRange[] {
       age: '40d'
     },
   ]
+}
+
+// Register with mode transition coordinator for unified cache clearing
+if (typeof window !== 'undefined') {
+  registerCacheReset('storage', () => {
+    try {
+      localStorage.removeItem(PVCS_CACHE_KEY)
+    } catch {
+      // Ignore storage errors
+    }
+    pvcsCache = null
+    console.log('[Storage] Cache cleared for mode transition')
+  })
 }

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { api, isBackendUnavailable } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode, isNetlifyDeployment } from '../../lib/demoMode'
+import { registerCacheReset } from '../../lib/modeTransition'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef } from './shared'
 import type { PodInfo, PodIssue, Deployment, DeploymentIssue, Job, HPA, ReplicaSet, StatefulSet, DaemonSet, CronJob } from './types'
@@ -1245,4 +1246,27 @@ export function usePodLogs(cluster: string, namespace: string, pod: string, cont
   }, [refetch])
 
   return { logs, isLoading, error, refetch }
+}
+
+// ============================================================================
+// Mode Transition Registration - Clear all workload caches for unified demo switching
+// ============================================================================
+
+if (typeof window !== 'undefined') {
+  registerCacheReset('workloads', () => {
+    // Clear pods cache
+    try {
+      localStorage.removeItem(PODS_CACHE_KEY)
+    } catch {
+      // Ignore storage errors
+    }
+    podsCache = null
+
+    // Clear other module-level caches
+    podIssuesCache = null
+    deploymentIssuesCache = null
+    deploymentsCache = null
+
+    console.log('[Workloads] All caches cleared for mode transition')
+  })
 }

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -24,6 +24,7 @@
 
 import { useEffect, useCallback, useRef, useSyncExternalStore } from 'react'
 import { isDemoMode, subscribeDemoMode } from '../demoMode'
+import { registerCacheReset } from '../modeTransition'
 
 // ============================================================================
 // Configuration
@@ -332,6 +333,9 @@ if (typeof window !== 'undefined') {
 
   // Subscribe to demo mode changes
   subscribeDemoMode(checkDemoModeChange)
+
+  // Register with mode transition coordinator
+  registerCacheReset('unified-cache', clearAllInMemoryCaches)
 }
 
 // ============================================================================

--- a/web/src/lib/demoMode.ts
+++ b/web/src/lib/demoMode.ts
@@ -16,6 +16,8 @@
  * - Cache hooks: use enabled: !isDemoMode() pattern
  */
 
+import { clearAllRegisteredCaches } from './modeTransition'
+
 const DEMO_MODE_KEY = 'kc-demo-mode'
 const DEMO_TOKEN = 'demo-token'
 const GPU_CACHE_KEY = 'kubestellar-gpu-cache'
@@ -143,9 +145,19 @@ export function setDemoMode(value: boolean, userInitiated = false): void {
 /**
  * Toggle demo mode. No-op if demo mode is forced (Netlify).
  * This is a user-initiated action, so it can turn off demo mode.
+ *
+ * Clears all registered caches BEFORE toggling, which:
+ * 1. Sets isLoading: true on all caches
+ * 2. Triggers skeleton loading states in all cards simultaneously
+ * 3. Cards then fetch appropriate data (demo or live) based on new mode
  */
 export function toggleDemoMode(): void {
   if (isNetlifyDeployment && globalDemoMode) return
+
+  // Clear all caches FIRST - this sets isLoading: true, showing skeletons
+  clearAllRegisteredCaches()
+
+  // Then toggle demo mode - this triggers data fetching
   setDemoMode(!globalDemoMode, true) // userInitiated=true allows turning off
 }
 

--- a/web/src/lib/modeTransition.ts
+++ b/web/src/lib/modeTransition.ts
@@ -1,0 +1,66 @@
+/**
+ * Mode Transition Coordinator
+ *
+ * Central registry for cache reset functions. When demo mode is toggled,
+ * all registered caches are cleared synchronously, triggering skeleton
+ * loading states in all cards simultaneously.
+ *
+ * Each cache system registers its reset function at module initialization.
+ * The reset function should:
+ * 1. Clear stored data (localStorage, module variables)
+ * 2. Set isLoading: true and data: [] or null
+ * 3. Notify subscribers so React components re-render with skeletons
+ */
+
+// Registry of cache reset functions
+const cacheResetRegistry = new Map<string, () => void | Promise<void>>()
+
+/**
+ * Register a cache reset function.
+ * Called by cache systems at module initialization.
+ *
+ * @param key - Unique identifier for the cache (e.g., 'clusters', 'gpu-nodes')
+ * @param resetFn - Function that clears the cache and sets loading state
+ */
+export function registerCacheReset(
+  key: string,
+  resetFn: () => void | Promise<void>
+): void {
+  cacheResetRegistry.set(key, resetFn)
+}
+
+/**
+ * Unregister a cache reset function.
+ * Called on module cleanup if needed.
+ */
+export function unregisterCacheReset(key: string): void {
+  cacheResetRegistry.delete(key)
+}
+
+/**
+ * Clear all registered caches.
+ * Called by toggleDemoMode() before changing the demo mode state.
+ *
+ * Each reset function should set isLoading: true, triggering skeletons.
+ * Cards will then fetch appropriate data (demo or live) based on the new mode.
+ */
+export function clearAllRegisteredCaches(): void {
+  console.log(
+    `[ModeTransition] Clearing ${cacheResetRegistry.size} registered caches`
+  )
+
+  cacheResetRegistry.forEach((resetFn, key) => {
+    try {
+      resetFn()
+    } catch (e) {
+      console.error(`[ModeTransition] Failed to reset cache '${key}':`, e)
+    }
+  })
+}
+
+/**
+ * Get the number of registered caches (for debugging).
+ */
+export function getRegisteredCacheCount(): number {
+  return cacheResetRegistry.size
+}


### PR DESCRIPTION
## Summary

- Adds Mode Transition Coordinator (`modeTransition.ts`) for unified cache clearing on demo mode toggle
- Registers all 9 cache systems with the coordinator for synchronized reset
- Ensures skeletons display immediately when switching between live and demo modes
- Each card independently transitions from skeleton to data when its data is ready

## Changes

### New File
- `web/src/lib/modeTransition.ts` - Cache reset registry with `registerCacheReset()` and `clearAllRegisteredCaches()`

### Modified Files
- `web/src/lib/demoMode.ts` - Calls `clearAllRegisteredCaches()` before toggling demo mode
- `web/src/hooks/mcp/shared.ts` - Registers clusters cache reset
- `web/src/hooks/mcp/compute.ts` - Registers GPU nodes cache reset
- `web/src/hooks/mcp/workloads.ts` - Registers workloads cache reset (pods, deployments, issues)
- `web/src/hooks/mcp/events.ts` - Registers events cache reset
- `web/src/hooks/mcp/storage.ts` - Registers storage/PVC cache reset
- `web/src/hooks/mcp/networking.ts` - Registers services cache reset
- `web/src/hooks/mcp/helm.ts` - Registers Helm cache reset
- `web/src/lib/cache/index.ts` - Registers unified cache reset

## Test plan

- [ ] Toggle demo mode ON: All cards show skeleton immediately, then reveal demo data
- [ ] Toggle demo mode OFF: All cards show skeleton immediately, then reveal live data
- [ ] Verify no stale data persists after mode switch
- [ ] Verify fast cards reveal data before slow cards (independent timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)