### PR TITLE
✨ Add cache subscriber patterns for unified demo mode switching (Phase B)

### DIFF
--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -20,6 +20,7 @@ interface HelmReleasesCache {
 
 interface HelmReleasesCacheState {
   releases: HelmRelease[]
+  isLoading: boolean  // Added for unified demo mode switching
   isRefreshing: boolean
   consecutiveFailures: number
   lastError: string | null
@@ -74,6 +75,7 @@ export function useHelmReleases(cluster?: string) {
   useEffect(() => {
     const updateHandler = (state: HelmReleasesCacheState) => {
       setReleases(state.releases)
+      if (state.isLoading !== undefined) setIsLoading(state.isLoading)
       setIsRefreshing(state.isRefreshing)
       setConsecutiveFailures(state.consecutiveFailures)
       setError(state.lastError)
@@ -83,9 +85,10 @@ export function useHelmReleases(cluster?: string) {
     return () => { helmReleasesCache.listeners.delete(updateHandler) }
   }, [])
 
-  const notifyListeners = useCallback((isRefreshing: boolean) => {
+  const notifyListeners = useCallback((isRefreshing: boolean, isLoading = false) => {
     const state: HelmReleasesCacheState = {
       releases: helmReleasesCache.data,
+      isLoading,
       isRefreshing,
       consecutiveFailures: helmReleasesCache.consecutiveFailures,
       lastError: helmReleasesCache.lastError,
@@ -580,10 +583,11 @@ if (typeof window !== 'undefined') {
     helmReleasesCache.consecutiveFailures = 0
     helmReleasesCache.lastError = null
 
-    // Notify all listeners
+    // Notify all listeners with isLoading: true to trigger skeleton display
     helmReleasesCache.listeners.forEach(listener => {
       listener({
         releases: [],
+        isLoading: true,  // Trigger skeleton display
         isRefreshing: false,
         consecutiveFailures: 0,
         lastError: null,


### PR DESCRIPTION
## Summary

- Adds cache reset notification patterns to all remaining cache systems
- When demo mode toggles, all caches now properly notify subscribers
- Hooks re-render with `isLoading: true` to display skeletons immediately
- Complements PR #702 (Mode Transition Coordinator)

## Changes

### workloads.ts
- Add `WorkloadsSharedState` with `isResetting` flag
- Add subscriber Set and notify function
- Update cache reset to notify subscribers
- Add subscription to `usePods`, `useAllPods`, `usePodIssues`, `useDeploymentIssues`, `useDeployments`

### events.ts
- Add `EventsSharedState` with `isResetting` flag
- Add subscriber Set and notify function  
- Update cache reset to notify subscribers
- Add subscription to `useEvents`, `useWarningEvents`

### storage.ts
- Add `StorageSharedState` with `isResetting` flag
- Add subscriber Set and notify function
- Update cache reset to notify subscribers
- Add subscription to `usePVCs`

### networking.ts
- Add `NetworkingSharedState` with `isResetting` flag
- Add subscriber Set and notify function
- Update cache reset to notify subscribers
- Add subscription to `useServices`

### helm.ts
- Add `isLoading` to `HelmReleasesCacheState` interface
- Update listener handler to set `isLoading`
- Update `notifyListeners` to accept `isLoading` parameter
- Update cache reset to notify with `isLoading: true`

## Test plan

- [ ] Toggle demo mode ON: Cards using workloads/events/storage/networking/helm data show skeleton immediately
- [ ] Toggle demo mode OFF: Same cards show skeleton, then load live data
- [ ] No stale data visible after mode switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)