### PR TITLE
🐛 Fix demo mode not populating demo data in hooks

### DIFF
--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -63,15 +63,17 @@ export function useEvents(cluster?: string, namespace?: string, limit = 20) {
   const [lastRefresh, setLastRefresh] = useState<Date | null>(cached?.timestamp || null)
 
   const refetch = useCallback(async (silent = false) => {
-    // Skip fetching entirely in demo mode — use demo data
+    // In demo mode, use demo data
     if (isDemoMode()) {
-      if (!eventsCache) {
-        setEvents(getDemoEvents())
-      }
+      const demoEvents = getDemoEvents().filter(e =>
+        (!cluster || e.cluster === cluster) && (!namespace || e.namespace === namespace)
+      ).slice(0, limit)
+      setEvents(demoEvents)
       const now = new Date()
       setLastUpdated(now)
       setLastRefresh(now)
       setIsLoading(false)
+      setError(null)
       if (!silent) {
         setIsRefreshing(true)
         setTimeout(() => setIsRefreshing(false), MIN_REFRESH_INDICATOR_MS)
@@ -295,13 +297,17 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
       params.append('limit', limit.toString())
       const url = `/api/mcp/events/warnings?${params}`
 
-      // Skip API calls in demo mode
+      // In demo mode, use demo data
       if (isDemoMode()) {
-        if (!warningEventsCache) {
-          setEvents(getDemoEvents().filter(e => e.type === 'Warning'))
-        }
+        const demoWarnings = getDemoEvents().filter(e =>
+          e.type === 'Warning' &&
+          (!cluster || e.cluster === cluster) &&
+          (!namespace || e.namespace === namespace)
+        ).slice(0, limit)
+        setEvents(demoWarnings)
         const now = new Date()
         setLastUpdated(now)
+        setError(null)
         setIsLoading(false)
         if (!silent) {
           setIsRefreshing(true)


### PR DESCRIPTION
## Summary
- When switching to demo mode, hooks were returning early without setting demo data
- Cards would show empty/stale data instead of demo data
- This is part of the unified demo mode switching plan

## Changes
- **usePods**: Now properly populates demo pods when `isDemoMode()` is true
- **usePodIssues**: Added `getDemoPodIssues()` and properly sets demo data
- **useDeploymentIssues**: Now always sets demo data in demo mode (not just when cache empty)
- **useDeployments**: Added demo mode check at start, uses `getDemoDeployments()`
- **useEvents**: Now always sets demo events in demo mode with filtering
- **useWarningEvents**: Now always sets demo warning events in demo mode
- **useServices**: Moved demo mode check to start of refetch function

## Test plan
- [ ] Toggle demo mode ON - cards should show demo data
- [ ] Toggle demo mode OFF - cards should show live data
- [ ] No stale data should remain after mode switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)