### PR TITLE
✨ Integrate UnifiedDemoProvider into App startup

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import { CardEventProvider } from './lib/cardEvents'
 import { ToastProvider } from './components/ui/Toast'
 import { AlertsProvider } from './contexts/AlertsContext'
 import { RewardsProvider } from './hooks/useRewards'
+import { UnifiedDemoProvider } from './lib/unified/demo'
 import { ChunkErrorBoundary } from './components/ChunkErrorBoundary'
 import { ROUTES } from './config/routes'
 
@@ -188,6 +189,7 @@ function App() {
   return (
     <ThemeProvider>
     <AuthProvider>
+    <UnifiedDemoProvider>
       <RewardsProvider>
       <ToastProvider>
       <GlobalFiltersProvider>
@@ -658,6 +660,7 @@ function App() {
       </GlobalFiltersProvider>
       </ToastProvider>
       </RewardsProvider>
+    </UnifiedDemoProvider>
     </AuthProvider>
     </ThemeProvider>
   )

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,9 @@ import './index.css'
 import './lib/i18n'
 // Register unified card data hooks (must be before App renders)
 import './lib/unified/registerHooks'
+// Register demo data generators for unified demo system
+import { registerAllDemoGenerators } from './lib/unified/demo'
+registerAllDemoGenerators()
 // Import cache utilities
 import { migrateFromLocalStorage, preloadCacheFromStorage } from './lib/cache'
 // Import dynamic card/stats persistence loaders


### PR DESCRIPTION
## Summary
- Register demo data generators at app startup (main.tsx)
- Wrap App with UnifiedDemoProvider for global demo mode state
- Enables mode switching with skeleton transitions across all components

This is part of the unified demo/skeleton system implementation (Phase 4).

## Test plan
- [ ] Verify build passes
- [ ] Verify lint passes  
- [ ] Verify demo mode toggle triggers skeleton transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)