### PR TITLE
🐛 Fix demo mode switching showing stale live data

### DIFF
--- a/web/src/lib/unified/demo/UnifiedDemoContext.ts
+++ b/web/src/lib/unified/demo/UnifiedDemoContext.ts
@@ -32,6 +32,7 @@ const defaultContextValue: UnifiedDemoContextValue = {
     console.warn('UnifiedDemoProvider not mounted')
   },
   isModeSwitching: false,
+  modeVersion: 0,
   getDemoData: <T = unknown>() => createDefaultDemoDataState<T>(),
   registerGenerator: () => {
     console.warn('UnifiedDemoProvider not mounted')
@@ -73,4 +74,14 @@ export function useIsDemoMode(): boolean {
 export function useIsModeSwitching(): boolean {
   const { isModeSwitching } = useContext(UnifiedDemoContext)
   return isModeSwitching
+}
+
+/**
+ * Hook to get the current mode version.
+ * Increments on each mode switch. Used to detect stale data.
+ * @returns Current mode version
+ */
+export function useModeVersion(): number {
+  const { modeVersion } = useContext(UnifiedDemoContext)
+  return modeVersion
 }

--- a/web/src/lib/unified/demo/types.ts
+++ b/web/src/lib/unified/demo/types.ts
@@ -96,6 +96,11 @@ export interface UnifiedDemoContextValue {
   setDemoMode: (value: boolean) => void
   /** Whether mode is currently switching (triggers skeleton) */
   isModeSwitching: boolean
+  /**
+   * Mode version counter - increments on each mode switch.
+   * Used to detect and discard stale data from before the switch.
+   */
+  modeVersion: number
   /** Get demo data for a component by ID */
   getDemoData: <T = unknown>(id: string) => DemoDataState<T>
   /** Register a demo data generator */


### PR DESCRIPTION
## Summary

- Fixed race condition where switching from live→demo mode showed stale live data instead of demo data
- Added `modeVersion` tracking to UnifiedDemo context to detect and discard stale data
- Live data captured before a mode switch is now properly discarded

## Problem

When switching from live→demo mode, cards were continuing to show live data instead of demo data. This was caused by:
1. `isDemoMode()` being checked at the START of async fetches
2. In-flight fetches completing after mode change and writing stale live data

## Solution

Centralized fix in the unified demo system using mode version tracking:
- `modeVersion` counter increments on each mode switch
- `useUnifiedData` hook tracks which version data was captured in
- Data captured before mode switch is automatically discarded
- Skeleton displayed during mode transition to prevent flickering

## Test Plan

- [x] Start in demo mode → verify demo data displays
- [x] Switch to live mode → verify live data displays
- [x] Switch back to demo mode → verify demo data (not stale live data)
- [x] Cards show proper "Demo" vs "Live" badges
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)