### PR TITLE
🐛 Fix dashboard refresh redirecting to Settings

### DIFF
--- a/web/src/hooks/useLastRoute.ts
+++ b/web/src/hooks/useLastRoute.ts
@@ -205,15 +205,16 @@ export function useLastRoute() {
 
   // Save last route and scroll position on path change
   useEffect(() => {
-    // Don't track auth-related pages or the root path
+    // Don't track auth-related pages
     if (location.pathname.startsWith('/auth') ||
         location.pathname === '/login' ||
-        location.pathname === '/onboarding' ||
-        location.pathname === '/') {
+        location.pathname === '/onboarding') {
       return
     }
 
     try {
+      // Save the current path (including '/' for Dashboard)
+      // so refresh returns to the current page, not a stale saved route
       localStorage.setItem(LAST_ROUTE_KEY, location.pathname)
     } catch {
       // Ignore localStorage errors
@@ -241,14 +242,17 @@ export function useLastRoute() {
       const lastRoute = localStorage.getItem(LAST_ROUTE_KEY)
       const firstSidebarRoute = getFirstDashboardRoute()
 
+      // If lastRoute is '/' or same as current, no redirect needed
       if (lastRoute && lastRoute !== '/' && lastRoute !== location.pathname) {
         navigate(lastRoute, { replace: true })
         setTimeout(() => {
           restoreScrollPosition(lastRoute)
         }, 150)
-      } else if (firstSidebarRoute && firstSidebarRoute !== '/') {
+      } else if (!lastRoute && firstSidebarRoute && firstSidebarRoute !== '/') {
+        // Only use firstSidebarRoute if no lastRoute was saved
         navigate(firstSidebarRoute, { replace: true })
       }
+      // If lastRoute is '/', stay on '/' (Dashboard) - no action needed
     } catch {
       // Ignore localStorage errors
     }


### PR DESCRIPTION
## Summary

- Fixed bug where refreshing on Dashboard would redirect to Settings (or last visited non-root route)
- Now properly saves '/' as lastRoute so Dashboard visits are tracked

## Problem

When on the Dashboard and hitting refresh, the app would redirect to Settings. This happened because:
1. The root path '/' was excluded from being saved as lastRoute
2. So visiting Dashboard didn't update lastRoute, leaving Settings there
3. On refresh, the restore logic saw pathname='/' and redirected to the stale lastRoute ('/settings')

## Solution

- Allow '/' to be saved as lastRoute so Dashboard visits are tracked
- Only use firstSidebarRoute fallback when no lastRoute exists at all
- If lastRoute is '/', stay on Dashboard (no redirect needed)

## Test Plan

- [x] Build passes
- [ ] Navigate to Settings, then Dashboard, then refresh → should stay on Dashboard
- [ ] Navigate to Clusters, then refresh → should stay on Clusters
- [ ] Direct navigation to Dashboard, then refresh → should stay on Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)