### PR TITLE
🐛 Fix dashboard cards showing permanent skeletons on initial load

### DIFF
--- a/web/src/hooks/mcp/config.ts
+++ b/web/src/hooks/mcp/config.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { api } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { isDemoMode } from '../../lib/demoMode'
+import { registerRefetch } from '../../lib/modeTransition'
 import { LOCAL_AGENT_URL } from './shared'
 import type { ConfigMap, Secret, ServiceAccount } from './types'
 
@@ -66,7 +67,11 @@ export function useConfigMaps(cluster?: string, namespace?: string) {
 
   useEffect(() => {
     refetch()
-  }, [refetch])
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`configmaps:${cluster || 'all'}:${namespace || 'all'}`, refetch)
+    return () => unregisterRefetch()
+  }, [refetch, cluster, namespace])
 
   return { configmaps, isLoading, error, refetch }
 }
@@ -132,7 +137,11 @@ export function useSecrets(cluster?: string, namespace?: string) {
 
   useEffect(() => {
     refetch()
-  }, [refetch])
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`secrets:${cluster || 'all'}:${namespace || 'all'}`, refetch)
+    return () => unregisterRefetch()
+  }, [refetch, cluster, namespace])
 
   return { secrets, isLoading, error, refetch }
 }
@@ -198,7 +207,11 @@ export function useServiceAccounts(cluster?: string, namespace?: string) {
 
   useEffect(() => {
     refetch()
-  }, [refetch])
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`serviceaccounts:${cluster || 'all'}:${namespace || 'all'}`, refetch)
+    return () => unregisterRefetch()
+  }, [refetch, cluster, namespace])
 
   return { serviceAccounts, isLoading, error, refetch }
 }

--- a/web/src/hooks/mcp/kagenti.ts
+++ b/web/src/hooks/mcp/kagenti.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { isAgentUnavailable, reportAgentDataSuccess, reportAgentDataError } from '../useLocalAgent'
 import { clusterCacheRef, LOCAL_AGENT_URL, getEffectiveInterval } from './shared'
 import { isDemoMode, isNetlifyDeployment } from '../../lib/demoMode'
+import { registerRefetch } from '../../lib/modeTransition'
 
 // ─── Types ─────────────────────────────────────────────────────────
 
@@ -223,8 +224,16 @@ export function useKagentiAgents(options?: { cluster?: string; namespace?: strin
     mountedRef.current = true
     fetchData()
     const interval = setInterval(() => fetchData(true), getEffectiveInterval(POLL_INTERVAL))
-    return () => { mountedRef.current = false; clearInterval(interval) }
-  }, [fetchData])
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`kagenti-agents:${options?.cluster || 'all'}:${options?.namespace || 'all'}`, () => fetchData(false))
+
+    return () => {
+      mountedRef.current = false
+      clearInterval(interval)
+      unregisterRefetch()
+    }
+  }, [fetchData, options?.cluster, options?.namespace])
 
   return { data, isLoading, error, consecutiveFailures, isRefreshing, refetch: fetchData }
 }
@@ -275,8 +284,16 @@ export function useKagentiBuilds(options?: { cluster?: string; namespace?: strin
     mountedRef.current = true
     fetchData()
     const interval = setInterval(() => fetchData(true), getEffectiveInterval(POLL_INTERVAL))
-    return () => { mountedRef.current = false; clearInterval(interval) }
-  }, [fetchData])
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`kagenti-builds:${options?.cluster || 'all'}:${options?.namespace || 'all'}`, () => fetchData(false))
+
+    return () => {
+      mountedRef.current = false
+      clearInterval(interval)
+      unregisterRefetch()
+    }
+  }, [fetchData, options?.cluster, options?.namespace])
 
   return { data, isLoading, error, consecutiveFailures, isRefreshing, refetch: fetchData }
 }
@@ -327,8 +344,16 @@ export function useKagentiCards(options?: { cluster?: string; namespace?: string
     mountedRef.current = true
     fetchData()
     const interval = setInterval(() => fetchData(true), getEffectiveInterval(POLL_INTERVAL))
-    return () => { mountedRef.current = false; clearInterval(interval) }
-  }, [fetchData])
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`kagenti-cards:${options?.cluster || 'all'}:${options?.namespace || 'all'}`, () => fetchData(false))
+
+    return () => {
+      mountedRef.current = false
+      clearInterval(interval)
+      unregisterRefetch()
+    }
+  }, [fetchData, options?.cluster, options?.namespace])
 
   return { data, isLoading, error, consecutiveFailures, isRefreshing, refetch: fetchData }
 }
@@ -379,8 +404,16 @@ export function useKagentiTools(options?: { cluster?: string; namespace?: string
     mountedRef.current = true
     fetchData()
     const interval = setInterval(() => fetchData(true), getEffectiveInterval(POLL_INTERVAL))
-    return () => { mountedRef.current = false; clearInterval(interval) }
-  }, [fetchData])
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`kagenti-tools:${options?.cluster || 'all'}:${options?.namespace || 'all'}`, () => fetchData(false))
+
+    return () => {
+      mountedRef.current = false
+      clearInterval(interval)
+      unregisterRefetch()
+    }
+  }, [fetchData, options?.cluster, options?.namespace])
 
   return { data, isLoading, error, consecutiveFailures, isRefreshing, refetch: fetchData }
 }

--- a/web/src/hooks/mcp/operators.ts
+++ b/web/src/hooks/mcp/operators.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { api } from '../../lib/api'
 import { isDemoMode } from '../../lib/demoMode'
+import { registerRefetch } from '../../lib/modeTransition'
 import { clusterCacheRef, subscribeClusterCache } from './shared'
 import type { Operator, OperatorSubscription } from './types'
 
@@ -159,8 +160,14 @@ export function useOperators(cluster?: string) {
 
     doFetch()
 
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`operators:${cacheKey}`, () => {
+      setFetchVersion(v => v + 1)
+    })
+
     return () => {
       cancelled = true
+      unregisterRefetch()
     }
   }, [cluster, clusterCount, fetchVersion, cacheKey])
 
@@ -278,8 +285,14 @@ export function useOperatorSubscriptions(cluster?: string) {
 
     doFetch()
 
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`operator-subscriptions:${cacheKey}`, () => {
+      setFetchVersion(v => v + 1)
+    })
+
     return () => {
       cancelled = true
+      unregisterRefetch()
     }
   }, [cluster, clusterCount, fetchVersion, cacheKey])
 

--- a/web/src/hooks/mcp/rbac.ts
+++ b/web/src/hooks/mcp/rbac.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { api } from '../../lib/api'
 import { isDemoMode } from '../../lib/demoMode'
+import { registerRefetch } from '../../lib/modeTransition'
 import type { K8sRole, K8sRoleBinding, K8sServiceAccountInfo } from './types'
 
 // Demo RBAC data for when demo mode is enabled
@@ -134,7 +135,11 @@ export function useK8sRoles(cluster?: string, namespace?: string, includeSystem 
 
   useEffect(() => {
     refetch()
-  }, [refetch])
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`k8s-roles:${cluster || 'all'}:${namespace || 'all'}`, refetch)
+    return () => unregisterRefetch()
+  }, [refetch, cluster, namespace])
 
   return { roles, isLoading, error, refetch }
 }
@@ -182,7 +187,11 @@ export function useK8sRoleBindings(cluster?: string, namespace?: string, include
 
   useEffect(() => {
     refetch()
-  }, [refetch])
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`k8s-role-bindings:${cluster || 'all'}:${namespace || 'all'}`, refetch)
+    return () => unregisterRefetch()
+  }, [refetch, cluster, namespace])
 
   return { bindings, isLoading, error, refetch }
 }
@@ -223,7 +232,11 @@ export function useK8sServiceAccounts(cluster?: string, namespace?: string) {
 
   useEffect(() => {
     refetch()
-  }, [refetch])
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`k8s-service-accounts:${cluster || 'all'}:${namespace || 'all'}`, refetch)
+    return () => unregisterRefetch()
+  }, [refetch, cluster, namespace])
 
   return { serviceAccounts, isLoading, error, refetch }
 }


### PR DESCRIPTION
## Summary
- Add unified `registerRefetch` system for mode transitions in `modeTransition.ts`
- Update all MCP hooks to register for mode transition refetch
- Add initial load trigger in `UnifiedDemoProvider` that calls `triggerAllRefetches()` on mount

## Problem
Dashboard cards were stuck showing skeletons on initial page load in both Demo and Live modes. Data only appeared after manual browser refresh (F5).

## Root Cause
`triggerAllRefetches()` was only called when mode *changes*, not on initial page load:
```typescript
// In UnifiedDemoProvider - only ran when mode changed
if (previousModeRef.current !== isDemoMode) {
  // triggerAllRefetches() called here - but never on initial load
}
```

## Solution
Add initialization useEffect that triggers all registered refetches after a short delay on mount:
```typescript
useEffect(() => {
  if (!initialLoadTriggeredRef.current) {
    initialLoadTriggeredRef.current = true
    const timeoutId = setTimeout(() => {
      console.log('[UnifiedDemo] Triggering initial data load')
      triggerAllRefetches()
    }, 100)
    return () => clearTimeout(timeoutId)
  }
}, [])
```

## Hooks Updated
All MCP hooks now register for mode transition refetch:
- compute, config, events, helm, kagenti, networking, operators, rbac, security, storage, workloads

## Test Plan
- [x] Initial page load in demo mode shows demo data (no permanent skeletons)
- [x] Initial page load after hard refresh shows data
- [x] Build passes
- [x] Lint passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)