### PR TITLE
🐛 Fix demo mode showing permanent skeletons on initial load

### DIFF
--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -700,7 +700,7 @@ export function useCache<T>({
   // This ensures demo mode shows demo content while preserving cache for live mode
   return {
     data: effectiveEnabled ? state.data : initialData,
-    isLoading: state.isLoading,
+    isLoading: effectiveEnabled ? state.isLoading : false,
     isRefreshing: state.isRefreshing,
     error: state.error,
     isFailed: state.isFailed,


### PR DESCRIPTION
## Summary
Fix the root cause of dashboard cards showing permanent skeletons on initial page load in demo mode.

## Problem
Cards showed "Demo" badges but their content was skeleton placeholders. Data only appeared after manual browser refresh.

## Root Cause
The `useCache` hook was returning `state.isLoading` (which starts as `true`) even when demo mode was active (`effectiveEnabled=false`). This caused cards to see `isLoading=true` and render skeletons, even though demo data was already available via `initialData`.

## Fix
One-line change in `web/src/lib/cache/index.ts`:

```typescript
// Before (BUG)
isLoading: state.isLoading,

// After (FIX) 
isLoading: effectiveEnabled ? state.isLoading : false,
```

When demo mode is active, immediately return `isLoading=false` so cards render demo data.

## Test Plan
- [x] Build passes
- [x] Dashboard shows data immediately on initial load (no permanent skeletons)
- [x] Live mode data loading still works
- [x] Demo mode shows demo data without skeletons

🤖 Generated with [Claude Code](https://claude.com/claude-code)