### PR TITLE
🐛 Fix mode switching requiring manual browser refresh

### DIFF
--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -19,6 +19,7 @@ import { useCache, type RefreshCategory } from '../lib/cache'
 import { isBackendUnavailable } from '../lib/api'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { isDemoMode } from '../lib/demoMode'
+import { useDemoMode } from './useDemoMode'
 import { clusterCacheRef } from './mcp/shared'
 import type {
   PodInfo,
@@ -298,6 +299,7 @@ export function useCachedPods(
   namespace?: string,
   options?: { limit?: number; category?: RefreshCategory }
 ): CachedHookResult<PodInfo[]> & { pods: PodInfo[] } {
+  const { isDemoMode: demoMode } = useDemoMode()
   const { limit = 100, category = 'pods' } = options || {}
   const key = `pods:${cluster || 'all'}:${namespace || 'all'}:${limit}`
 
@@ -305,7 +307,7 @@ export function useCachedPods(
     key,
     category,
     initialData: getDemoPods(),
-    enabled: !isDemoMode(),
+    enabled: !demoMode,
     fetcher: async () => {
       let pods: PodInfo[]
       if (cluster) {
@@ -344,6 +346,7 @@ export function useCachedEvents(
   namespace?: string,
   options?: { limit?: number; category?: RefreshCategory }
 ): CachedHookResult<ClusterEvent[]> & { events: ClusterEvent[] } {
+  const { isDemoMode: demoMode } = useDemoMode()
   const { limit = 20, category = 'realtime' } = options || {}
   const key = `events:${cluster || 'all'}:${namespace || 'all'}:${limit}`
 
@@ -351,7 +354,7 @@ export function useCachedEvents(
     key,
     category,
     initialData: getDemoEvents(),
-    enabled: !isDemoMode(),
+    enabled: !demoMode,
     fetcher: async () => {
       const data = await fetchAPI<{ events: ClusterEvent[] }>('events', { cluster, namespace, limit })
       return data.events || []
@@ -380,6 +383,7 @@ export function useCachedPodIssues(
   namespace?: string,
   options?: { category?: RefreshCategory }
 ): CachedHookResult<PodIssue[]> & { issues: PodIssue[] } {
+  const { isDemoMode: demoMode } = useDemoMode()
   const { category = 'pods' } = options || {}
   const key = `podIssues:${cluster || 'all'}:${namespace || 'all'}`
 
@@ -387,7 +391,7 @@ export function useCachedPodIssues(
     key,
     category,
     initialData: getDemoPodIssues(),
-    enabled: !isDemoMode(),
+    enabled: !demoMode,
     fetcher: async () => {
       let issues: PodIssue[]
 
@@ -443,6 +447,7 @@ export function useCachedDeploymentIssues(
   namespace?: string,
   options?: { category?: RefreshCategory }
 ): CachedHookResult<DeploymentIssue[]> & { issues: DeploymentIssue[] } {
+  const { isDemoMode: demoMode } = useDemoMode()
   const { category = 'deployments' } = options || {}
   const key = `deploymentIssues:${cluster || 'all'}:${namespace || 'all'}`
 
@@ -450,7 +455,7 @@ export function useCachedDeploymentIssues(
     key,
     category,
     initialData: getDemoDeploymentIssues(),
-    enabled: !isDemoMode(),
+    enabled: !demoMode,
     fetcher: async () => {
       // Try agent first — derive deployment issues from deployment data
       if (clusterCacheRef.clusters.length > 0) {
@@ -518,6 +523,7 @@ export function useCachedDeployments(
   namespace?: string,
   options?: { category?: RefreshCategory }
 ): CachedHookResult<Deployment[]> & { deployments: Deployment[] } {
+  const { isDemoMode: demoMode } = useDemoMode()
   const { category = 'deployments' } = options || {}
   const key = `deployments:${cluster || 'all'}:${namespace || 'all'}`
 
@@ -525,7 +531,7 @@ export function useCachedDeployments(
     key,
     category,
     initialData: getDemoDeployments(),
-    enabled: !isDemoMode(),
+    enabled: !demoMode,
     fetcher: async () => {
       // Try agent first (fast, no backend needed)
       if (clusterCacheRef.clusters.length > 0) {
@@ -591,6 +597,7 @@ export function useCachedServices(
   namespace?: string,
   options?: { category?: RefreshCategory }
 ): CachedHookResult<Service[]> & { services: Service[] } {
+  const { isDemoMode: demoMode } = useDemoMode()
   const { category = 'services' } = options || {}
   const key = `services:${cluster || 'all'}:${namespace || 'all'}`
 
@@ -598,7 +605,7 @@ export function useCachedServices(
     key,
     category,
     initialData: getDemoServices(),
-    enabled: !isDemoMode(),
+    enabled: !demoMode,
     fetcher: async () => {
       const data = await fetchAPI<{ services: Service[] }>('services', { cluster, namespace })
       return data.services || []
@@ -751,13 +758,14 @@ export function useCachedProwJobs(
   prowCluster = 'prow',
   namespace = 'prow'
 ): CachedHookResult<ProwJob[]> & { jobs: ProwJob[]; status: ProwStatus; formatTimeAgo: typeof formatTimeAgo } {
+  const { isDemoMode: demoMode } = useDemoMode()
   const key = `prowjobs:${prowCluster}:${namespace}`
 
   const result = useCache({
     key,
     category: 'gitops',
     initialData: getDemoProwJobs(),
-    enabled: !isDemoMode(),
+    enabled: !demoMode,
     fetcher: () => fetchProwJobs(prowCluster, namespace),
   })
 
@@ -1060,13 +1068,14 @@ function computeLLMdStatus(servers: LLMdServer[], consecutiveFailures: number): 
 export function useCachedLLMdServers(
   clusters: string[] = ['vllm-d', 'platform-eval']
 ): CachedHookResult<LLMdServer[]> & { servers: LLMdServer[]; status: LLMdStatus } {
+  const { isDemoMode: demoMode } = useDemoMode()
   const key = `llmd-servers:${clusters.join(',')}`
 
   const result = useCache({
     key,
     category: 'gitops',
     initialData: getDemoLLMdServers(),
-    enabled: !isDemoMode(),
+    enabled: !demoMode,
     fetcher: () => fetchLLMdServers(clusters),
   })
 
@@ -1124,13 +1133,14 @@ async function fetchLLMdModels(clusters: string[]): Promise<LLMdModel[]> {
 export function useCachedLLMdModels(
   clusters: string[] = ['vllm-d', 'platform-eval']
 ): CachedHookResult<LLMdModel[]> & { models: LLMdModel[] } {
+  const { isDemoMode: demoMode } = useDemoMode()
   const key = `llmd-models:${clusters.join(',')}`
 
   const result = useCache({
     key,
     category: 'gitops',
     initialData: getDemoLLMdModels(),
-    enabled: !isDemoMode(),
+    enabled: !demoMode,
     fetcher: () => fetchLLMdModels(clusters),
   })
 
@@ -1249,6 +1259,7 @@ export function useCachedSecurityIssues(
   namespace?: string,
   options?: { category?: RefreshCategory }
 ): CachedHookResult<SecurityIssue[]> & { issues: SecurityIssue[] } {
+  const { isDemoMode: demoMode } = useDemoMode()
   const { category = 'pods' } = options || {}
   const key = `securityIssues:${cluster || 'all'}:${namespace || 'all'}`
 
@@ -1256,7 +1267,7 @@ export function useCachedSecurityIssues(
     key,
     category,
     initialData: getDemoSecurityIssues(),
-    enabled: !isDemoMode(),
+    enabled: !demoMode,
     fetcher: async () => {
       // Try kubectl proxy first (uses agent to run kubectl commands)
       if (clusterCacheRef.clusters.length > 0) {


### PR DESCRIPTION
## Summary
Fix mode switching (demo ↔ live) requiring manual browser refresh to see updated content.

## Problem
When switching between demo mode and live mode, cards showed "Demo" badges but content remained skeletons. Data only appeared after manually refreshing the browser.

## Root Cause
The `useCachedData` wrapper hooks used `isDemoMode()` function which evaluates **once** at mount time:

```typescript
// OLD - evaluates once, never updates
enabled: !isDemoMode()
```

When demo mode changed, this value never updated because the parent component had no dependency on demo mode.

## Fix
Replace static `isDemoMode()` function with reactive `useDemoMode()` hook:

```typescript
// NEW - subscribes to changes, triggers re-render
const { isDemoMode: demoMode } = useDemoMode()
// ...
enabled: !demoMode
```

The hook subscribes to demo mode changes and triggers component re-renders, which causes `useCache` to receive the updated `enabled` value.

## Hooks Updated
- `useCachedPods`
- `useCachedEvents`
- `useCachedPodIssues`
- `useCachedDeploymentIssues`
- `useCachedDeployments`
- `useCachedServices`
- `useCachedProwJobs`
- `useCachedLLMdServers`
- `useCachedLLMdModels`
- `useCachedSecurityIssues`

## Test Plan
- [ ] Start in live mode with data showing
- [ ] Toggle to demo mode - verify demo data appears immediately (no manual refresh)
- [ ] Toggle back to live mode - verify live data appears immediately
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)