### PR TITLE
🐛 Fix deploy cards showing demo data in live mode

### DIFF
--- a/web/src/components/cards/ClusterDropZone.tsx
+++ b/web/src/components/cards/ClusterDropZone.tsx
@@ -70,9 +70,9 @@ export function ClusterDropZone({
 
   if (!isDragging || !draggedWorkload) return null
 
-  // Use demo data when in demo mode or when no real data available
-  const clusters = demoMode || !realClusters || realClusters.length === 0 ? DEMO_CLUSTERS : realClusters
-  const isDemo = demoMode || !realClusters || realClusters.length === 0
+  // Only use demo data when explicitly in demo mode
+  const clusters = demoMode ? DEMO_CLUSTERS : (realClusters ?? [])
+  const isDemo = demoMode
 
   // Filter out clusters where workload is already deployed and unavailable clusters
   const availableClusters = clusters.filter(

--- a/web/src/components/cards/OverlayComparison.tsx
+++ b/web/src/components/cards/OverlayComparison.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react'
 import { Plus, Minus, Edit, Layers, ChevronRight } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
+import { useDemoMode } from '../../hooks/useDemoMode'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
@@ -21,6 +22,7 @@ interface OverlayDiff {
 }
 
 export function OverlayComparison({ config }: OverlayComparisonProps) {
+  const { isDemoMode: demoMode } = useDemoMode()
   const { deduplicatedClusters: allClusters, isLoading } = useClusters()
   const { drillToKustomization } = useDrillDownActions()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
@@ -57,11 +59,10 @@ export function OverlayComparison({ config }: OverlayComparisonProps) {
     return result
   }, [allClusters, globalSelectedClusters, isAllClustersSelected, customFilter])
 
-  // Mock overlays
-  const overlays = selectedCluster ? ['base', 'dev', 'staging', 'production'] : []
+  // Only show mock overlays/diffs in demo mode; live mode shows empty until real data source exists
+  const overlays = selectedCluster && demoMode ? ['base', 'dev', 'staging', 'production'] : []
 
-  // Mock diff data
-  const diffs: OverlayDiff[] = selectedBase && selectedOverlay ? [
+  const diffs: OverlayDiff[] = selectedBase && selectedOverlay && demoMode ? [
     { resource: 'Deployment/app', type: 'patch', overlay: selectedOverlay, details: 'replicas: 1 → 3' },
     { resource: 'Deployment/app', type: 'patch', overlay: selectedOverlay, details: 'resources.limits.memory: 256Mi → 512Mi' },
     { resource: 'ConfigMap/app-config', type: 'patch', overlay: selectedOverlay, details: 'LOG_LEVEL: debug → info' },

--- a/web/src/components/cards/WorkloadDeployment.tsx
+++ b/web/src/components/cards/WorkloadDeployment.tsx
@@ -419,8 +419,8 @@ export function WorkloadDeployment(_props: WorkloadDeploymentProps) {
   // Fetch real workloads from API (skip when in demo mode)
   const { data: realWorkloads } = useWorkloads(undefined, !demoMode)
 
-  // Use demo data when in demo mode or when no real data available
-  const isDemo = demoMode || !realWorkloads || realWorkloads.length === 0
+  // Only use demo data when explicitly in demo mode
+  const isDemo = demoMode
 
   // In demo mode, derive available clusters from demo workloads' targetClusters
   // In live mode, use real clusters from the API
@@ -434,6 +434,7 @@ export function WorkloadDeployment(_props: WorkloadDeploymentProps) {
   }, [deduplicatedClusters, isDemo])
   const workloads: Workload[] = useMemo(() => {
     if (isDemo) return DEMO_WORKLOADS
+    if (!realWorkloads || realWorkloads.length === 0) return []
     // Transform API workloads to card format
     const mapped = realWorkloads.map((w: ApiWorkload) => {
       const clusters = w.targetClusters || (w.cluster ? [w.cluster] : [])


### PR DESCRIPTION
## Summary
- **WorkloadDeployment** and **ClusterDropZone** used `demoMode || !data || data.length === 0` which fell back to demo data in live mode when the backend returned no results. Now they only use demo data when explicitly in demo mode.
- **KustomizationStatus** and **OverlayComparison** always showed hardcoded demo data regardless of mode. Now they check `useDemoMode()` and only show demo content in demo mode.

## Test plan
- [x] Verified demo mode shows "24 total, 24 unique" workloads (demo data)
- [x] Verified live mode shows "32 total, 28 unique" workloads (real data)
- [x] Build passes (`npm run build`)
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)