### PR TITLE
🐛 Use caching for workloads card + fix double cache reset

### DIFF
--- a/web/src/components/cards/WorkloadDeployment.tsx
+++ b/web/src/components/cards/WorkloadDeployment.tsx
@@ -18,7 +18,8 @@ import {
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useCardData, commonComparators, CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards'
 import { cn } from '../../lib/cn'
-import { useWorkloads, Workload as ApiWorkload } from '../../hooks/useWorkloads'
+import { Workload as ApiWorkload } from '../../hooks/useWorkloads'
+import { useCachedWorkloads } from '../../hooks/useCachedData'
 import { useClusters } from '../../hooks/useMCP'
 import { useCardLoadingState } from './CardDataContext'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -416,8 +417,8 @@ export function WorkloadDeployment(_props: WorkloadDeploymentProps) {
   // Check demo mode to avoid fetching live data when in demo mode
   const { isDemoMode: demoMode } = useDemoMode()
 
-  // Fetch real workloads from API (skip when in demo mode)
-  const { data: realWorkloads } = useWorkloads(undefined, !demoMode)
+  // Fetch real workloads from cache (handles demo mode internally via useCache)
+  const { data: realWorkloads } = useCachedWorkloads()
 
   // Only use demo data when explicitly in demo mode
   const isDemo = demoMode

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -146,6 +146,7 @@ export function useWorkloads(options?: {
       const agentData = await fetchWorkloadsViaAgent(options)
       if (agentData) {
         setData(agentData)
+        setIsLoading(false)
         return
       }
     } catch {

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -294,14 +294,13 @@ class IndexedDBStorage {
 const idbStorage = new IndexedDBStorage()
 
 // ============================================================================
-// Demo Mode Integration - Clear caches when demo mode toggles ON
+// Demo Mode Integration - Clear caches on mode toggle
 // ============================================================================
 
-let lastDemoMode: boolean | null = null
-
 /**
- * Clear all in-memory cache stores. Called when demo mode toggles.
- * This ensures cards get fresh demo data instead of stale live data.
+ * Clear all in-memory cache stores. Called by mode transition coordinator
+ * when demo mode is toggled (in either direction).
+ * This ensures cards get fresh data for the new mode.
  */
 function clearAllInMemoryCaches(): void {
   const count = cacheRegistry.size
@@ -309,32 +308,12 @@ function clearAllInMemoryCaches(): void {
     (store as CacheStore<unknown>).resetToInitialData()
   }
   if (count > 0) {
-    console.log(`[Cache] Reset ${count} caches to initial data for demo mode`)
+    console.log(`[Cache] Reset ${count} caches to initial data for mode transition`)
   }
 }
 
-// Subscribe to demo mode changes at module level
+// Register with mode transition coordinator (called by toggleDemoMode)
 if (typeof window !== 'undefined') {
-  // Import is already at top of file, use it here
-  const checkDemoModeChange = () => {
-    const currentDemoMode = isDemoMode()
-    if (lastDemoMode !== null && lastDemoMode !== currentDemoMode) {
-      if (currentDemoMode) {
-        // Switching TO demo mode - clear all caches so cards show demo data
-        clearAllInMemoryCaches()
-      }
-      // Note: When switching FROM demo mode, we don't clear - let cards refetch live data
-    }
-    lastDemoMode = currentDemoMode
-  }
-
-  // Check on initial load
-  checkDemoModeChange()
-
-  // Subscribe to demo mode changes
-  subscribeDemoMode(checkDemoModeChange)
-
-  // Register with mode transition coordinator
   registerCacheReset('unified-cache', clearAllInMemoryCaches)
 }
 


### PR DESCRIPTION
## Summary

- Create `useCachedWorkloads()` in `useCachedData.ts` — gives the Workloads card on the Deploy page IndexedDB persistence, stale-while-revalidate, `registerRefetch()` mode transition support, and demo mode detection via `useCache`
- Update `WorkloadDeployment.tsx` to use `useCachedWorkloads()` instead of standalone `useWorkloads()` hook
- Remove redundant `subscribeDemoMode` handler in `cache/index.ts` that caused double `clearAllInMemoryCaches()` when switching to demo mode (visible in console as duplicate "[Cache] Reset N caches" lines)
- Fix `useWorkloads.ts` missing `setIsLoading(false)` when agent fetch succeeds (bug affected WorkloadMonitor and ResourceMarshall cards)

## Problem

The Workloads card on the Deploy page showed "0 total · 0 unique" after toggling demo↔live because `useWorkloads()` was a standalone hook that didn't participate in the caching layer or mode transition mechanism. Additionally, a double cache reset was clearing data unnecessarily.

## Test plan

- [ ] `npm run build` passes
- [ ] Deploy page Workloads card shows live data (32 total · 28 unique)
- [ ] Toggle to demo mode → demo data appears with skeletons
- [ ] Toggle back to live mode → live data recovers without page reload
- [ ] Console shows single "[Cache] Reset N caches" per toggle (no double)
- [ ] WorkloadMonitor and ResourceMarshall cards still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)