### PR TITLE
🐛 Fix demo/live data leaking across mode boundaries

### DIFF
--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -31,10 +31,17 @@ import {
 } from '../../hooks/useClusterGroups'
 import { useClusters } from '../../hooks/useMCP'
 import { useCardLoadingState } from './CardDataContext'
+import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface ClusterGroupsProps {
   config?: Record<string, unknown>
 }
+
+const DEMO_GROUPS: ClusterGroup[] = [
+  { name: 'production', kind: 'static', clusters: ['eks-prod-us-east-1', 'openshift-prod', 'do-nyc1-prod'], color: 'green' },
+  { name: 'staging', kind: 'static', clusters: ['gke-staging', 'aks-dev-westeu'], color: 'blue' },
+  { name: 'edge', kind: 'dynamic', clusters: ['k3s-edge', 'kind-local', 'minikube'], color: 'purple', query: { filters: [{ field: 'nodeCount', operator: 'lte', value: '3' }] } },
+]
 
 // ============================================================================
 // Constants
@@ -104,8 +111,10 @@ function relativeTime(iso: string): string {
 // ============================================================================
 
 export function ClusterGroups(_props: ClusterGroupsProps) {
-  const { groups, createGroup, updateGroup, deleteGroup, evaluateGroup, isPersisted } = useClusterGroups()
+  const { groups: liveGroups, createGroup, updateGroup, deleteGroup, evaluateGroup, isPersisted } = useClusterGroups()
   const { deduplicatedClusters: clusters, isLoading } = useClusters()
+  const { isDemoMode: demoMode } = useDemoMode()
+  const groups = demoMode ? DEMO_GROUPS : liveGroups
   const [isCreating, setIsCreating] = useState(false)
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
@@ -157,13 +166,15 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
             </span>
           )}
         </div>
-        <button
-          onClick={() => setIsCreating(true)}
-          className="flex items-center gap-1 px-2 py-1 text-xs rounded-md bg-blue-500/20 text-blue-400 hover:bg-blue-500/30 transition-colors"
-        >
-          <Plus className="w-3 h-3" />
-          New Group
-        </button>
+        {!demoMode && (
+          <button
+            onClick={() => setIsCreating(true)}
+            className="flex items-center gap-1 px-2 py-1 text-xs rounded-md bg-blue-500/20 text-blue-400 hover:bg-blue-500/30 transition-colors"
+          >
+            <Plus className="w-3 h-3" />
+            New Group
+          </button>
+        )}
       </div>
 
       {/* Create form */}

--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -27,10 +27,44 @@ import {
   CardEmptyState,
 } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
+import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface MissionsProps {
   config?: Record<string, unknown>
 }
+
+const DEMO_MISSIONS: DeployMission[] = [
+  {
+    id: 'demo-1',
+    workload: 'nginx-frontend',
+    namespace: 'production',
+    sourceCluster: 'eks-prod-us-east-1',
+    targetClusters: ['openshift-prod', 'do-nyc1-prod'],
+    groupName: 'production',
+    status: 'orbit',
+    clusterStatuses: [
+      { cluster: 'openshift-prod', status: 'running', replicas: 3, readyReplicas: 3 },
+      { cluster: 'do-nyc1-prod', status: 'running', replicas: 3, readyReplicas: 3 },
+    ],
+    startedAt: Date.now() - 300000,
+    completedAt: Date.now() - 240000,
+  },
+  {
+    id: 'demo-2',
+    workload: 'api-gateway',
+    namespace: 'staging',
+    sourceCluster: 'gke-staging',
+    targetClusters: ['aks-dev-westeu', 'rancher-mgmt'],
+    groupName: 'staging',
+    status: 'orbit',
+    clusterStatuses: [
+      { cluster: 'aks-dev-westeu', status: 'running', replicas: 2, readyReplicas: 2 },
+      { cluster: 'rancher-mgmt', status: 'running', replicas: 2, readyReplicas: 2 },
+    ],
+    startedAt: Date.now() - 180000,
+    completedAt: Date.now() - 120000,
+  },
+]
 
 const STATUS_CONFIG: Record<DeployMissionStatus, {
   icon: typeof Rocket
@@ -106,8 +140,12 @@ const SORT_OPTIONS: { value: SortByOption; label: string }[] = [
 const CLUSTER_FILTER_KEY = 'kubestellar-card-filter:deployment-missions-clusters'
 
 export function Missions(_props: MissionsProps) {
-  const { missions, activeMissions, completedMissions } = useDeployMissions()
+  const { missions: liveMissions, activeMissions: liveActive, completedMissions: liveCompleted } = useDeployMissions()
   const { deduplicatedClusters, isLoading } = useClusters()
+  const { isDemoMode: demoMode } = useDemoMode()
+  const missions = demoMode ? DEMO_MISSIONS : liveMissions
+  const activeMissions = demoMode ? [] : liveActive
+  const completedMissions = demoMode ? DEMO_MISSIONS : liveCompleted
   const [expandedMissions, setExpandedMissions] = useState<Set<string>>(new Set())
   const [hideCompleted, setHideCompleted] = useState(false)
 

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -303,7 +303,8 @@ export function useCachedPods(
   const result = useCache({
     key,
     category,
-    initialData: getDemoPods(),
+    initialData: [] as PodInfo[],
+    demoData: getDemoPods(),
     fetcher: async () => {
       let pods: PodInfo[]
       if (cluster) {
@@ -348,7 +349,8 @@ export function useCachedEvents(
   const result = useCache({
     key,
     category,
-    initialData: getDemoEvents(),
+    initialData: [] as ClusterEvent[],
+    demoData: getDemoEvents(),
     fetcher: async () => {
       const data = await fetchAPI<{ events: ClusterEvent[] }>('events', { cluster, namespace, limit })
       return data.events || []
@@ -383,7 +385,8 @@ export function useCachedPodIssues(
   const result = useCache({
     key,
     category,
-    initialData: getDemoPodIssues(),
+    initialData: [] as PodIssue[],
+    demoData: getDemoPodIssues(),
     fetcher: async () => {
       let issues: PodIssue[]
 
@@ -414,7 +417,7 @@ export function useCachedPodIssues(
         return issues.sort((a, b) => (b.restarts || 0) - (a.restarts || 0))
       }
 
-      return getDemoPodIssues()
+      return []
     },
   })
 
@@ -445,7 +448,8 @@ export function useCachedDeploymentIssues(
   const result = useCache({
     key,
     category,
-    initialData: getDemoDeploymentIssues(),
+    initialData: [] as DeploymentIssue[],
+    demoData: getDemoDeploymentIssues(),
     fetcher: async () => {
       // Try agent first — derive deployment issues from deployment data
       if (clusterCacheRef.clusters.length > 0) {
@@ -488,7 +492,7 @@ export function useCachedDeploymentIssues(
         return data.issues || []
       }
 
-      return getDemoDeploymentIssues()
+      return []
     },
   })
 
@@ -519,7 +523,8 @@ export function useCachedDeployments(
   const result = useCache({
     key,
     category,
-    initialData: getDemoDeployments(),
+    initialData: [] as Deployment[],
+    demoData: getDemoDeployments(),
     fetcher: async () => {
       // Try agent first (fast, no backend needed)
       if (clusterCacheRef.clusters.length > 0) {
@@ -560,7 +565,7 @@ export function useCachedDeployments(
         return await fetchFromAllClusters<Deployment>('deployments', 'deployments', { namespace })
       }
 
-      return getDemoDeployments()
+      return []
     },
   })
 
@@ -591,7 +596,8 @@ export function useCachedServices(
   const result = useCache({
     key,
     category,
-    initialData: getDemoServices(),
+    initialData: [] as Service[],
+    demoData: getDemoServices(),
     fetcher: async () => {
       const data = await fetchAPI<{ services: Service[] }>('services', { cluster, namespace })
       return data.services || []
@@ -747,7 +753,8 @@ export function useCachedProwJobs(
   const result = useCache({
     key,
     category: 'gitops',
-    initialData: getDemoProwJobs(),
+    initialData: [] as ProwJob[],
+    demoData: getDemoProwJobs(),
     fetcher: () => fetchProwJobs(prowCluster, namespace),
   })
 
@@ -1053,7 +1060,8 @@ export function useCachedLLMdServers(
   const result = useCache({
     key,
     category: 'gitops',
-    initialData: getDemoLLMdServers(),
+    initialData: [] as LLMdServer[],
+    demoData: getDemoLLMdServers(),
     fetcher: () => fetchLLMdServers(clusters),
   })
 
@@ -1114,7 +1122,8 @@ export function useCachedLLMdModels(
   const result = useCache({
     key,
     category: 'gitops',
-    initialData: getDemoLLMdModels(),
+    initialData: [] as LLMdModel[],
+    demoData: getDemoLLMdModels(),
     fetcher: () => fetchLLMdModels(clusters),
   })
 
@@ -1209,7 +1218,8 @@ export function useCachedWorkloads(
   const result = useCache({
     key,
     category,
-    initialData: getDemoWorkloads(),
+    initialData: [] as Workload[],
+    demoData: getDemoWorkloads(),
     fetcher: async () => {
       // Try agent first (fast, no backend needed)
       const agentData = await fetchWorkloadsFromAgent()
@@ -1244,7 +1254,7 @@ export function useCachedWorkloads(
         }
       }
 
-      return getDemoWorkloads()
+      return []
     },
   })
 
@@ -1369,7 +1379,8 @@ export function useCachedSecurityIssues(
   const result = useCache({
     key,
     category,
-    initialData: getDemoSecurityIssues(),
+    initialData: [] as SecurityIssue[],
+    demoData: getDemoSecurityIssues(),
     fetcher: async () => {
       // Try kubectl proxy first (uses agent to run kubectl commands)
       if (clusterCacheRef.clusters.length > 0) {
@@ -1405,7 +1416,7 @@ export function useCachedSecurityIssues(
         }
       }
 
-      return getDemoSecurityIssues()
+      return []
     },
   })
 

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -558,8 +558,10 @@ export interface UseCacheOptions<T> {
   category?: RefreshCategory
   /** Custom refresh interval in ms (overrides category) */
   refreshInterval?: number
-  /** Initial data when cache is empty */
+  /** Initial data when cache is empty (used as loading state in live mode) */
   initialData: T
+  /** Data to display in demo mode (defaults to initialData if not provided) */
+  demoData?: T
   /** Whether to persist to IndexedDB (default: true) */
   persist?: boolean
   /** Whether to auto-refresh at interval (default: true) */
@@ -599,6 +601,7 @@ export function useCache<T>({
   category = 'default',
   refreshInterval,
   initialData,
+  demoData,
   persist = true,
   autoRefresh = true,
   enabled = true,
@@ -680,10 +683,11 @@ export function useCache<T>({
     }
   }, [shared])
 
-  // When disabled (demo mode), return initialData instead of cached live data
+  // When disabled (demo mode), return demoData (or initialData) instead of cached live data
   // This ensures demo mode shows demo content while preserving cache for live mode
+  const demoDisplayData = demoData !== undefined ? demoData : initialData
   return {
-    data: effectiveEnabled ? state.data : initialData,
+    data: effectiveEnabled ? state.data : demoDisplayData,
     isLoading: effectiveEnabled ? state.isLoading : false,
     isRefreshing: state.isRefreshing,
     error: state.error,


### PR DESCRIPTION
## Summary
- Add `demoData` parameter to `useCache` to separate demo display data from initial loading state — previously `initialData` served both roles, causing demo data ("web-frontend") to appear in live mode when fetchers failed
- Update all 11 cached hooks to use `initialData: []` + `demoData: getDemoXxx()` and remove 5 fetcher fallbacks that returned demo data on failure
- Add demo mode awareness to ClusterGroups card (shows demo groups instead of localStorage groups)
- Add demo mode awareness to Deployment Missions card (shows demo missions instead of localStorage missions)

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Live mode: Deployment Status shows real deployments, not "web-frontend"
- [ ] Demo mode: ClusterGroups shows "production"/"staging"/"edge" groups
- [ ] Demo mode: Deployment Missions shows "nginx-frontend"/"api-gateway" missions
- [ ] Toggle demo↔live: all cards recover correct data without page reload
- [ ] With backend down in live mode: cards show empty state, not demo data

🤖 Generated with [Claude Code](https://claude.com/claude-code)