### PR TITLE
🐛 Fix cards showing empty state on mode switch instead of cached data

### DIFF
--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -431,20 +431,26 @@ class CacheStore<T> {
   }
 
   /**
-   * Reset store to initial data state. Called when demo mode toggles ON
-   * to ensure cards show demo data instead of cached live data.
+   * Reset store for mode transition. Sets loading state and reloads any
+   * cached data from IndexedDB (stale-while-revalidate on mode switch).
+   * In demo mode, useCache returns demoData regardless of state.data,
+   * so the IndexedDB reload only matters for live mode transitions.
    */
   resetToInitialData(): void {
     this.fetchingRef = false
     this.initialDataLoaded = false
     this.setState({
       data: this.initialData,
-      isLoading: false,
+      isLoading: true,
       isRefreshing: false,
       error: null,
       isFailed: false,
       consecutiveFailures: 0,
     })
+    // Re-trigger IndexedDB load to recover cached live data
+    if (this.persist) {
+      this.storageLoadPromise = this.loadFromStorage()
+    }
   }
 
   // Fetching


### PR DESCRIPTION
## Summary
- Fix `resetToInitialData()` in cache layer to set `isLoading: true` (was `false`) and re-trigger IndexedDB load to recover previously cached live data during mode transitions
- Fix WorkloadDeployment card to properly report workloads loading state and show skeleton during initial load
- Affects all cards using `useCache` — when switching demo→live, cards now show cached data (stale-while-revalidate) instead of empty state

## Test plan
- [ ] Switch to demo mode, then back to live mode — cards should show cached data or skeleton (not "No deployments found")
- [ ] Workloads card shows skeleton while loading, then real data
- [ ] Deployment Status card shows cached deployments on mode switch
- [ ] Demo mode still shows demo data correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)