### PR TITLE
🐛 Add skeleton loading state to remaining cards missing useCardLoadingState

### DIFF
--- a/tasks.json
+++ b/tasks.json
@@ -154,10 +154,75 @@
       "id": "ai-ml-cards-skeleton-loading",
       "subject": "Add skeleton loading and refresh animation to all AI/ML and AI Agent dashboard cards",
       "description": "All cards on the AI/ML Workloads, AI Agents, and GPU Reservations dashboards show empty/collapsed states until data loads. They should display skeleton placeholders and animate the refresh icon while fetching data.\n\nAffected cards:\n\n**AI/ML Dashboard (14 cards):**\n- LLMdFlow (llmd_flow) - LLM-d request flow visualization\n- KVCacheMonitor (kvcache_monitor) - KV cache metrics\n- EPPRouting (epp_routing) - EPP routing visualization\n- PDDisaggregation (pd_disaggregation) - Prefill/Decode visualization\n- LLMdBenchmarks (llmd_benchmarks) - Performance benchmarks\n- LLMdAIInsights (llmd_ai_insights) - AI insights and anomaly detection\n- LLMdConfigurator (llmd_configurator) - LLM-d stack configuration\n- LLMModels (llm_models) - LLM model serving instances\n- LLMInference (llm_inference) - LLM inference servers\n- LLMdStackMonitor (llmd_stack_monitor) - Overall stack health\n- MLJobs (ml_jobs) - ML training jobs\n- MLNotebooks (ml_notebooks) - Jupyter/ML notebooks\n- GPUOverview (gpu_overview) - GPU count and allocation\n- HardwareHealth\n\n**AI Agents Dashboard (7 cards):**\n- KagentiStatusCard (kagenti_status) - Agent fleet overview\n- KagentiAgentFleet (kagenti_agent_fleet) - Agent list\n- KagentiBuildPipeline (kagenti_build_pipeline) - Build pipeline\n- KagentiToolRegistry (kagenti_tool_registry) - MCP tools\n- KagentiAgentDiscovery (kagenti_agent_discovery) - Agent discovery\n- KagentiSecurityPosture (kagenti_security_posture) - Security posture\n- KagentiTopology (kagenti_topology) - Network topology\n\n**GPU Reservations Dashboard (7 cards):**\n- GPUOverview (gpu_overview) - GPU overview\n- GPUStatus (gpu_status) - Per-cluster GPU status\n- GPUInventory (gpu_inventory) - Per-node GPU inventory\n- GPUUtilization (gpu_utilization) - GPU utilization donut chart\n- GPUUsageTrend (gpu_usage_trend) - Historical GPU trends\n- GPUWorkloads (gpu_workloads) - GPU-requesting workloads\n- HardwareHealth\n\nFor each card:\n1. Show skeleton placeholders (shimmer bars/circles) while data is loading\n2. Animate the refresh icon (spin) during data fetch\n3. Card should maintain its expanded size during loading (not collapse)\n4. Follow the same pattern used by OPA Policies card (opa-policies-loading-state task)",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "created": "2026-02-09",
-      "tags": ["ux", "skeleton", "loading-state", "ai-ml", "ai-agents", "gpu", "dashboard-cards"]
+      "completedAt": "2026-02-09",
+      "tags": ["ux", "skeleton", "loading-state", "ai-ml", "ai-agents", "gpu", "dashboard-cards"],
+      "resolution": "Fixed in PR #775. Added useCardLoadingState to MLJobs, MLNotebooks, LLMdStackMonitor, KagentiTopology, KagentiSecurity. Added useReportCardDataState with hasData:true to LLMdConfigurator. Added hasData:true to 6 LLM-d visualization cards (LLMdFlow, EPPRouting, LLMdAIInsights, PDDisaggregation, KVCacheMonitor, LLMdBenchmarks)."
+    },
+    {
+      "id": "arcade-cards-skeleton-loading",
+      "subject": "Add skeleton loading and refresh animation to all Arcade dashboard cards",
+      "description": "All game cards on the Arcade dashboard show empty/collapsed states until the game loads. They should display skeleton placeholders and animate the refresh icon while loading.\n\nAffected cards (22 games):\n- Checkers, KubeChess, SudokuGame, ContainerTetris, NodeInvaders\n- KubeMan, KubeKong, PodCrosser, PodPitfall, PodBrothers\n- KubeGalaga, KubePong, KubeSnake, KubeKart, Game2048\n- PodSweeper, Kubedle, MatchGame, Solitaire, FlappyPod\n- KubeCraft, KubeDoom\n\nFor each card: add useReportCardDataState({ hasData: true }) since games are self-contained (no external data fetch). This tells CardWrapper the card is ready immediately.",
+      "status": "pending",
+      "priority": "medium",
+      "created": "2026-02-10",
+      "tags": ["ux", "skeleton", "loading-state", "arcade", "games", "dashboard-cards"]
+    },
+    {
+      "id": "alerts-cards-skeleton-loading",
+      "subject": "Add skeleton loading and refresh animation to all Alerts dashboard cards",
+      "description": "Cards on the Alerts dashboard show empty/collapsed states until data loads. They should display skeleton placeholders and animate the refresh icon while fetching data.\n\nAffected cards:\n- ActiveAlerts (active_alerts)\n- AlertRules (alert_rules)\n- FalcoAlerts (falco_alerts) - if missing hook\n- WarningEvents (warning_events)\n- EventSummary (event_summary)\n\nFor each card: verify if useCardLoadingState or useReportCardDataState is already present. If missing, add the appropriate hook based on whether the card fetches data (useCardLoadingState) or shows static/demo data (useReportCardDataState with hasData:true).",
+      "status": "pending",
+      "priority": "medium",
+      "created": "2026-02-10",
+      "tags": ["ux", "skeleton", "loading-state", "alerts", "dashboard-cards"]
+    },
+    {
+      "id": "cost-cards-skeleton-loading",
+      "subject": "Add skeleton loading and refresh animation to all Cost dashboard cards",
+      "description": "Cards on the Cost dashboard show empty/collapsed states until data loads.\n\nAffected cards:\n- ClusterCosts (cluster_costs)\n- KubecostOverview (kubecost_overview) - static demo data\n- OpenCostOverview (opencost_overview) - static demo data\n- ResourceCapacity (resource_capacity)\n- ResourceTrend (resource_trend)\n\nFor each card: verify if useCardLoadingState or useReportCardDataState is already present. If missing, add the appropriate hook.",
+      "status": "pending",
+      "priority": "medium",
+      "created": "2026-02-10",
+      "tags": ["ux", "skeleton", "loading-state", "cost", "dashboard-cards"]
+    },
+    {
+      "id": "data-compliance-cards-skeleton-loading",
+      "subject": "Add skeleton loading and refresh animation to all Data Compliance dashboard cards",
+      "description": "Cards on the Data Compliance dashboard show empty/collapsed states until data loads.\n\nAffected cards:\n- VaultSecrets (vault_secrets)\n- ExternalSecrets (external_secrets)\n- CertManager (cert_manager)\n- NamespaceRBAC (namespace_rbac)\n\nFor each card: verify if useCardLoadingState or useReportCardDataState is already present. If missing, add the appropriate hook.",
+      "status": "pending",
+      "priority": "medium",
+      "created": "2026-02-10",
+      "tags": ["ux", "skeleton", "loading-state", "data-compliance", "dashboard-cards"]
+    },
+    {
+      "id": "helm-cards-skeleton-loading",
+      "subject": "Add skeleton loading and refresh animation to all Helm dashboard cards",
+      "description": "Cards on the Helm dashboard show empty/collapsed states until data loads.\n\nAffected cards:\n- HelmReleaseStatus (helm_release_status)\n- ChartVersions (chart_versions)\n- HelmHistory (helm_history)\n- HelmValuesDiff (helm_values_diff)\n\nFor each card: verify if useCardLoadingState or useReportCardDataState is already present. If missing, add the appropriate hook.",
+      "status": "pending",
+      "priority": "medium",
+      "created": "2026-02-10",
+      "tags": ["ux", "skeleton", "loading-state", "helm", "dashboard-cards"]
+    },
+    {
+      "id": "network-cards-skeleton-loading",
+      "subject": "Add skeleton loading and refresh animation to all Network dashboard cards",
+      "description": "Cards on the Network dashboard show empty/collapsed states until data loads.\n\nAffected cards:\n- NetworkOverview (network_overview)\n- ServiceStatus (service_status)\n- IngressStatus (ingress_status) - if present\n- NetworkPolicyStatus (network_policy_status) - if present\n\nFor each card: verify if useCardLoadingState or useReportCardDataState is already present. If missing, add the appropriate hook.",
+      "status": "pending",
+      "priority": "medium",
+      "created": "2026-02-10",
+      "tags": ["ux", "skeleton", "loading-state", "network", "dashboard-cards"]
+    },
+    {
+      "id": "services-cards-skeleton-loading",
+      "subject": "Add skeleton loading and refresh animation to all Services dashboard cards",
+      "description": "Cards on the Services dashboard show empty/collapsed states until data loads.\n\nAffected cards:\n- ServiceStatus (service_status)\n- IngressStatus (ingress_status) - if present\n- GatewayStatus (gateway_status)\n- ServiceExports (service_exports)\n- ServiceImports (service_imports)\n- ServiceTopology (service_topology) - static demo data\n\nFor each card: verify if useCardLoadingState or useReportCardDataState is already present. If missing, add the appropriate hook.",
+      "status": "pending",
+      "priority": "medium",
+      "created": "2026-02-10",
+      "tags": ["ux", "skeleton", "loading-state", "services", "dashboard-cards"]
     }
   ]
 }

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -8,6 +8,7 @@ import {
   CardControlsRow,
   CardPaginationFooter,
 } from '../../lib/cards'
+import { useCardLoadingState } from './CardDataContext'
 import type { SortDirection } from '../../lib/cards'
 
 // Types for GitHub activity data
@@ -478,6 +479,8 @@ export const GitHubActivity = forwardRef<GitHubActivityRef, { config?: GitHubAct
     openIssueCount,
     refetch,
   } = useGitHubActivity(effectiveConfig)
+
+  useCardLoadingState({ isLoading, hasAnyData: !!repoInfo })
 
   // Expose refresh method via ref for CardWrapper refresh button
   useImperativeHandle(ref, () => ({

--- a/web/src/components/cards/KubecostOverview.tsx
+++ b/web/src/components/cards/KubecostOverview.tsx
@@ -1,5 +1,6 @@
 import { TrendingDown, AlertTriangle, ExternalLink, AlertCircle, PieChart, ChevronRight } from 'lucide-react'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
+import { useReportCardDataState } from './CardDataContext'
 
 interface KubecostOverviewProps {
   config?: {
@@ -35,6 +36,7 @@ const DEMO_RECOMMENDATIONS = [
 
 export function KubecostOverview({ config: _config }: KubecostOverviewProps) {
   const { drillToCost } = useDrillDownActions()
+  useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0 })
 
   return (
     <div className="h-full flex flex-col min-h-card content-loaded">

--- a/web/src/components/cards/KyvernoPolicies.tsx
+++ b/web/src/components/cards/KyvernoPolicies.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { AlertTriangle, CheckCircle, ExternalLink, AlertCircle, FileCheck } from 'lucide-react'
 import { CardSearchInput } from '../../lib/cards'
+import { useReportCardDataState } from './CardDataContext'
 
 interface KyvernoPoliciesProps {
   config?: Record<string, unknown>
@@ -60,6 +61,7 @@ const DEMO_STATS = {
 }
 
 export function KyvernoPolicies({ config: _config }: KyvernoPoliciesProps) {
+  useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0 })
   const [localSearch, setLocalSearch] = useState('')
 
   // Filter policies by local search

--- a/web/src/components/cards/NetworkUtils.tsx
+++ b/web/src/components/cards/NetworkUtils.tsx
@@ -4,6 +4,7 @@ import {
   Play, Square, Trash2, Plus, CheckCircle, XCircle,
   AlertTriangle, Loader2
 } from 'lucide-react'
+import { useCardLoadingState } from './CardDataContext'
 
 // Types
 interface PingResult {
@@ -63,6 +64,7 @@ const DEFAULT_HOSTS = [
 export function NetworkUtils() {
   const [activeTab, setActiveTab] = useState<'ping' | 'ports' | 'info'>('ping')
   const [isInitialized, setIsInitialized] = useState(false)
+  useCardLoadingState({ isLoading: !isInitialized, hasAnyData: isInitialized })
   const [savedHosts, setSavedHosts] = useState<SavedHost[]>(() => {
     try {
       const saved = localStorage.getItem(STORAGE_KEY)

--- a/web/src/components/cards/OpenCostOverview.tsx
+++ b/web/src/components/cards/OpenCostOverview.tsx
@@ -2,6 +2,7 @@ import { Server, Box, HardDrive, ExternalLink, AlertCircle, ChevronRight } from 
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
+import { useReportCardDataState } from './CardDataContext'
 
 interface OpenCostOverviewProps {
   config?: {
@@ -40,6 +41,7 @@ const DEMO_NAMESPACE_COSTS: NamespaceCost[] = [
 
 export function OpenCostOverview({ config: _config }: OpenCostOverviewProps) {
   const { drillToCost } = useDrillDownActions()
+  useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0 })
 
   const {
     items: filteredCosts,

--- a/web/src/components/cards/ServiceTopology.tsx
+++ b/web/src/components/cards/ServiceTopology.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo, useCallback } from 'react'
 import { ZoomIn, ZoomOut, Maximize2, ArrowRight } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import type { TopologyNode, TopologyEdge, TopologyHealthStatus } from '../../types/topology'
+import { useReportCardDataState } from './CardDataContext'
 
 // Demo topology data
 const DEMO_NODES: TopologyNode[] = [
@@ -79,6 +80,7 @@ interface ServiceTopologyProps {
 }
 
 export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
+  useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0 })
   const [zoom, setZoom] = useState(1)
   const [selectedNode, setSelectedNode] = useState<string | null>(null)
   const [hoveredNode, setHoveredNode] = useState<string | null>(null)

--- a/web/src/components/cards/StockMarketTicker.tsx
+++ b/web/src/components/cards/StockMarketTicker.tsx
@@ -10,6 +10,7 @@ import {
   CardControlsRow,
   CardPaginationFooter,
 } from '../../lib/cards'
+import { useCardLoadingState } from './CardDataContext'
 
 // Stock search result interface
 interface StockSearchResult {
@@ -545,6 +546,7 @@ export function StockMarketTicker({ config }: StockMarketTickerProps) {
   // Generate stock data
   const [stockData, setStockData] = useState<StockData[]>([])
   const [isLoadingData, setIsLoadingData] = useState(true)
+  useCardLoadingState({ isLoading: isLoadingData, hasAnyData: stockData.length > 0 })
 
   // --- useCardData hook replaces manual sort/pagination state ---
   const {

--- a/web/src/components/cards/rss/RSSFeed.tsx
+++ b/web/src/components/cards/rss/RSSFeed.tsx
@@ -6,6 +6,7 @@ import {
 import { cn } from '../../../lib/cn'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../../lib/cards/CardComponents'
+import { useCardLoadingState } from '../CardDataContext'
 import type { FeedItem, FeedConfig, FeedFilter, RSSFeedProps, RSSItemRaw } from './types'
 import { PRESET_FEEDS, CORS_PROXIES } from './constants'
 import { loadSavedFeeds, saveFeeds, getCachedFeed, cacheFeed } from './storage'
@@ -101,6 +102,8 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
   const [sourceFilter, setSourceFilter] = useState<string[]>([]) // Empty = all sources
   const [showSourceFilter, setShowSourceFilter] = useState(false)
   const sourceFilterRef = useRef<HTMLDivElement>(null)
+
+  useCardLoadingState({ isLoading, hasAnyData: items.length > 0 })
 
   const activeFeed = feeds[activeFeedIndex] || feeds[0]
 

--- a/web/src/components/cards/weather/Weather.tsx
+++ b/web/src/components/cards/weather/Weather.tsx
@@ -6,6 +6,7 @@ import {
 } from 'lucide-react'
 import { WeatherAnimation, getWeatherCondition, getConditionColor } from './WeatherAnimation'
 import { WEATHER_API } from '../../../config/externalApis'
+import { useCardLoadingState } from '../CardDataContext'
 import type {
   GeocodingResult,
   ForecastDay,
@@ -60,6 +61,7 @@ export function Weather({ config }: { config?: WeatherConfig }) {
   const [currentWeather, setCurrentWeather] = useState<CurrentWeather | null>(null)
   const [forecast, setForecast] = useState<ForecastDay[]>([])
   const [hourlyForecast, setHourlyForecast] = useState<HourlyForecast[]>([])
+  useCardLoadingState({ isLoading, hasAnyData: !!currentWeather })
 
   // Save locations to localStorage whenever they change
   useEffect(() => {

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -8,6 +8,7 @@ import { Pagination } from '../../ui/Pagination'
 import { CardControls } from '../../ui/CardControls'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import { CardSearchInput, CardAIActions } from '../../../lib/cards'
+import { useCardLoadingState } from '../CardDataContext'
 import type { SortDirection } from '../../../lib/cards/cardHooks'
 import { cn } from '../../../lib/cn'
 import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
@@ -140,6 +141,8 @@ export const GitHubCIMonitor = forwardRef<GitHubCIMonitorRef, GitHubCIMonitorPro
   const [repos, setRepos] = useState<string[]>(() => ghConfig?.repos || loadRepos())
   const [isEditingRepos, setIsEditingRepos] = useState(false)
   const [newRepoInput, setNewRepoInput] = useState('')
+
+  useCardLoadingState({ isLoading, hasAnyData: workflows.length > 0 })
 
   const fetchWorkflows = useCallback(async (isRefresh = false) => {
     const storedToken = localStorage.getItem('github_token')


### PR DESCRIPTION
## Summary
- Adds `useCardLoadingState` to 6 data-fetching cards (NetworkUtils, StockMarketTicker, Weather, RSSFeed, GitHubActivity, GitHubCIMonitor) so CardWrapper shows skeleton placeholders and spinning refresh icon during loading
- Adds `useReportCardDataState({ hasData: true })` to 4 static demo cards (KubecostOverview, OpenCostOverview, KyvernoPolicies, ServiceTopology) so CardWrapper knows they're ready immediately
- Adds tasks.json entries for remaining dashboards needing the same fix: arcade, alerts, cost, data compliance, helm, network, services

## Test plan
- [ ] Navigate to dashboards containing these cards
- [ ] Cards should show skeleton loading animation before data appears
- [ ] Refresh icon should spin while loading
- [ ] Cards should not collapse/show empty state during load

🤖 Generated with [Claude Code](https://claude.com/claude-code)