### PR TITLE
🐛 Reduce flickering with presentation mode and failure backoff in cache layer

### DIFF
--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -25,6 +25,7 @@
 import { useEffect, useCallback, useRef, useSyncExternalStore } from 'react'
 import { isDemoMode, subscribeDemoMode } from '../demoMode'
 import { registerCacheReset, registerRefetch } from '../modeTransition'
+import { getPresentationMode } from '../../hooks/usePresentationMode'
 
 // ============================================================================
 // Configuration
@@ -43,6 +44,18 @@ const META_PREFIX = 'kc_meta:'
 
 /** Maximum consecutive failures before marking as failed */
 const MAX_FAILURES = 3
+
+/** Presentation mode refresh multiplier (5x slower to reduce flickering) */
+const PRESENTATION_MODE_MULTIPLIER = 5
+
+/** Minimum refresh interval in presentation mode (5 minutes) */
+const PRESENTATION_MODE_MIN_INTERVAL = 300_000
+
+/** Base backoff multiplier for consecutive failures */
+const FAILURE_BACKOFF_MULTIPLIER = 2
+
+/** Maximum backoff interval (10 minutes) */
+const MAX_BACKOFF_INTERVAL = 600_000
 
 /** Refresh rates by data category (in milliseconds) */
 export const REFRESH_RATES = {
@@ -76,6 +89,31 @@ export const REFRESH_RATES = {
 } as const
 
 export type RefreshCategory = keyof typeof REFRESH_RATES
+
+/**
+ * Calculate effective refresh interval considering:
+ * 1. Presentation mode (5x slower, min 5 minutes)
+ * 2. Consecutive failures (exponential backoff)
+ */
+function getEffectiveInterval(
+  baseInterval: number,
+  consecutiveFailures: number
+): number {
+  let interval = baseInterval
+
+  // Apply presentation mode multiplier
+  if (getPresentationMode()) {
+    interval = Math.max(interval * PRESENTATION_MODE_MULTIPLIER, PRESENTATION_MODE_MIN_INTERVAL)
+  }
+
+  // Apply exponential backoff for failures (2^failures, capped at MAX_BACKOFF)
+  if (consecutiveFailures > 0) {
+    const backoffMultiplier = Math.pow(FAILURE_BACKOFF_MULTIPLIER, Math.min(consecutiveFailures, 5))
+    interval = Math.min(interval * backoffMultiplier, MAX_BACKOFF_INTERVAL)
+  }
+
+  return interval
+}
 
 // ============================================================================
 // Types
@@ -694,7 +732,9 @@ export function useCache<T>({
   }, [store, refetch])
 
   // Initial fetch and auto-refresh
-  const effectiveInterval = refreshInterval ?? REFRESH_RATES[category]
+  // Calculate effective interval with presentation mode and failure backoff
+  const baseInterval = refreshInterval ?? REFRESH_RATES[category]
+  const effectiveInterval = getEffectiveInterval(baseInterval, state.consecutiveFailures)
 
   // Track mount state to distinguish initial mount from mode-switch re-fires.
   // On initial mount / page navigation: fetch immediately (needed for data).
@@ -727,12 +767,13 @@ export function useCache<T>({
     const unregisterRefetch = registerRefetch(`cache:${key}`, refetch)
 
     // Auto-refresh interval
+    // The interval restarts when consecutiveFailures changes (backoff kicks in)
     if (autoRefresh) {
       const intervalId = setInterval(refetch, effectiveInterval)
       return () => { clearInterval(intervalId); unregisterRefetch() }
     }
     return () => unregisterRefetch()
-  }, [effectiveEnabled, autoRefresh, effectiveInterval, refetch, store, key])
+  }, [effectiveEnabled, autoRefresh, effectiveInterval, refetch, store, key, state.consecutiveFailures])
 
   // Cleanup non-shared stores on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Cache layer now respects presentation mode (5x slower refresh, min 5 minutes)
- Adds exponential backoff on consecutive failures (2^n multiplier, capped at 10 min)
- Interval timer restarts when failure count changes to apply new backoff

## Problem

The console was flickering excessively because:
1. The unified cache layer ignored `getPresentationMode()`, polling at full speed (15-60s)
2. When clusters were unreachable (401 errors), failed requests retried at the same rate
3. Multiple hooks failing simultaneously created retry storms

## Solution

**Presentation mode:** When enabled, multiply base intervals by 5x with a 5-minute floor:
- `realtime`: 15s → 75s (capped to 5m)
- `pods`: 30s → 150s (capped to 5m)
- `deployments`: 60s → 5m

**Failure backoff:** Exponential backoff on consecutive failures:
- 1 failure: 2x interval
- 2 failures: 4x interval  
- 3 failures: 8x interval
- Capped at 10 minutes max

Example with unreachable cluster (pods category, 30s base):
- Normal: retry every 30s
- After 1 failure: 60s
- After 2 failures: 2m
- After 3+ failures: backs off to 4m, 8m, then caps at 10m

## Test plan

- [x] Lint passes for modified file
- [ ] Enable presentation mode, verify refresh intervals increase (check console logs)
- [ ] Disconnect cluster, verify backoff kicks in (intervals grow exponentially)
- [ ] Reconnect cluster, verify failures reset and normal intervals resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)