### PR TITLE
🐛 Reset cache failures when manually refreshing a cluster

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -4,6 +4,7 @@ import { isDemoMode, isNetlifyDeployment, isDemoToken, subscribeDemoMode } from 
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { getPresentationMode } from '../usePresentationMode'
 import { registerCacheReset } from '../../lib/modeTransition'
+import { resetFailuresForCluster } from '../../lib/cache'
 import type { ClusterInfo, ClusterHealth } from './types'
 
 // Refresh interval for automatic polling (2 minutes) - manual refresh bypasses this
@@ -1405,6 +1406,9 @@ export async function fullFetchClusters() {
 export async function refreshSingleCluster(clusterName: string): Promise<void> {
   // Clear failure tracking on manual refresh - user is explicitly requesting fresh data
   clearClusterFailure(clusterName)
+
+  // Reset cache layer failure counters so backoff is removed immediately
+  resetFailuresForCluster(clusterName)
 
   // Look up the cluster's context for kubectl commands
   const clusterInfo = clusterCache.clusters.find(c => c.name === clusterName)


### PR DESCRIPTION
## Summary

- Add `resetFailuresForCluster(clusterName)` to the cache layer
- Call it from `refreshSingleCluster` to immediately remove backoff

## Problem

After PR #780, the cache layer uses exponential backoff on failures (up to 10 min). When a cluster comes back online and the user clicks the refresh button, the cluster health refreshes immediately but other cached data (pods, deployments, etc.) would still wait for their backed-off interval.

## Solution

When `refreshSingleCluster` is called (user clicks refresh on cluster card):
1. Clear cluster health failure tracking (existing behavior)
2. **NEW:** Reset cache layer failures for caches related to that cluster

The `resetFailuresForCluster` function:
- Iterates over all registered caches
- Finds keys containing the cluster name or `:all:` (cross-cluster caches)
- Resets their `consecutiveFailures` counter to 0
- This removes backoff so next refresh happens at normal interval

## Test plan

- [x] Lint passes for modified files
- [ ] Click refresh on a cluster card with backed-off caches
- [ ] Verify console log: `[Cache] Reset failures for N caches related to cluster "X"`
- [ ] Verify subsequent refreshes happen at normal interval (not 10 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)