### PR TITLE
🐛 Fix demo cards showing blank body during lazy chunk loading

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1027,11 +1027,14 @@ export function CardWrapper({
 
   // Default to 'list' skeleton type if not specified, enabling automatic skeleton display
   const effectiveSkeletonType = skeletonType || 'list'
-  // Demo data cards should NEVER show skeleton - they always have hardcoded data ready to display
-  // This includes both explicitly marked isDemoData cards AND cards in global demo mode
+  // Demo/DEMO_DATA_CARDS suppress skeleton only when child has reported having data.
+  // During React.lazy() chunk loading, CardSuspenseFallback reports hasData: false —
+  // in that case, show skeleton even for demo cards so the body isn't blank.
+  // Once the actual card component mounts and reports hasData: true, skeleton is suppressed.
   // Also delay skeleton display by 100ms to prevent flicker when cache loads quickly
   // Mode switching forces skeleton to show for smooth transitions (no delay for mode switching)
-  const wantsToShowSkeleton = !(effectiveIsDemoData || isDemoMode) && ((effectiveIsLoading && !effectiveHasData && !effectiveIsRefreshing) || forceSkeletonForOffline) || forceSkeletonForModeSwitching
+  const demoSuppressesSkeleton = (effectiveIsDemoData || isDemoMode) && effectiveHasData
+  const wantsToShowSkeleton = !demoSuppressesSkeleton && ((effectiveIsLoading && !effectiveHasData && !effectiveIsRefreshing) || forceSkeletonForOffline) || forceSkeletonForModeSwitching
   const shouldShowSkeleton = (wantsToShowSkeleton && skeletonDelayPassed) || forceSkeletonForModeSwitching
 
   // Mark initial load as complete when data is ready or various timeouts pass


### PR DESCRIPTION
## Summary
- Cards in `DEMO_DATA_CARDS` (kagenti, kubecost, opencost, gateway, argocd, etc.) showed blank body with no skeleton on initial load
- Root cause: CardWrapper blanket-suppressed skeleton for all demo cards via `!(effectiveIsDemoData || isDemoMode)`, even during React.lazy() chunk loading when no content had rendered yet
- Fix: Only suppress skeleton when child has actually reported having data (`effectiveHasData`), so skeleton shows normally during chunk loading

## Test plan
- [ ] Load a dashboard with demo-only cards (Kagenti, Kubecost, OpenCost, Gateway Status)
- [ ] Verify skeleton shows briefly during initial chunk loading instead of blank body
- [ ] Verify demo data renders correctly after chunk loads
- [ ] Verify mode switching (demo/live) still shows smooth skeleton transitions
- [ ] Verify non-demo cards still show skeleton normally during initial load

🤖 Generated with [Claude Code](https://claude.com/claude-code)