### PR TITLE
🐛 fix cluster health false-positive on page load

### DIFF
--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -249,7 +249,7 @@ interface DroppableGroupProps {
   group: ClusterGroup
   isExpanded: boolean
   isRefreshing: boolean
-  clusterHealthMap: Map<string, boolean>
+  clusterHealthMap: Map<string, boolean | undefined>
   onToggle: () => void
   onEdit: () => void
   onDelete: () => void
@@ -420,7 +420,7 @@ function DroppableGroup({ group, isExpanded, isRefreshing, clusterHealthMap, onT
 
 interface CreateGroupFormProps {
   availableClusters: string[]
-  clusterHealthMap: Map<string, boolean>
+  clusterHealthMap: Map<string, boolean | undefined>
   onSave: (group: ClusterGroup) => void
   onCancel: () => void
 }
@@ -711,7 +711,7 @@ function StaticClusterPicker({
   accentColor,
 }: {
   availableClusters: string[]
-  clusterHealthMap: Map<string, boolean>
+  clusterHealthMap: Map<string, boolean | undefined>
   selectedClusters: Set<string>
   onToggle: (cluster: string) => void
   accentColor: 'blue' | 'yellow'
@@ -971,7 +971,7 @@ function AIAssistant({
 interface EditGroupFormProps {
   group: ClusterGroup
   availableClusters: string[]
-  clusterHealthMap: Map<string, boolean>
+  clusterHealthMap: Map<string, boolean | undefined>
   onSave: (updates: Partial<ClusterGroup>) => void
   onCancel: () => void
 }

--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -670,7 +670,7 @@ function ConsoleUsersTab({
 }
 
 interface ClusterUsersTabProps {
-  clusters: Array<{ name: string; healthy: boolean }>
+  clusters: Array<{ name: string; healthy?: boolean }>
   selectedCluster: string
   setSelectedCluster: (cluster: string) => void
   users: OpenShiftUser[]
@@ -768,7 +768,7 @@ function ClusterUsersTab({
 }
 
 interface ServiceAccountsTabProps {
-  clusters: Array<{ name: string; healthy: boolean }>
+  clusters: Array<{ name: string; healthy?: boolean }>
   selectedCluster: string
   setSelectedCluster: (cluster: string) => void
   selectedNamespace: string

--- a/web/src/components/ui/ClusterStatusBadge.tsx
+++ b/web/src/components/ui/ClusterStatusBadge.tsx
@@ -103,7 +103,7 @@ const STATE_CONFIGS: Record<ClusterState, StateConfig> = {
  * Determine cluster state based on health data
  */
 export function getClusterState(
-  healthy: boolean,
+  healthy: boolean | undefined,
   reachable?: boolean,
   nodeCount?: number,
   readyNodes?: number,

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -192,6 +192,8 @@ function mergeWithStoredClusters(newClusters: ClusterInfo[]): ClusterInfo[] {
         podCount: pickMetric(cluster.podCount, cached.podCount),
         pvcCount: cluster.pvcCount ?? cached.pvcCount, // pvcCount can be 0
         pvcBoundCount: cluster.pvcBoundCount ?? cached.pvcBoundCount,
+        healthy: cluster.healthy ?? cached.healthy, // Preserve last-known health until fresh check completes
+        reachable: cluster.reachable ?? cached.reachable,
         distribution: cluster.distribution || cached.distribution,
         namespaces: cluster.namespaces?.length ? cluster.namespaces : cached.namespaces,
       }
@@ -778,7 +780,7 @@ async function fetchClusterListFromAgent(): Promise<ClusterInfo[] | null> {
         context: c.context || c.name,
         server: c.server,
         user: c.user,
-        healthy: true, // Will be updated by health check
+        // healthy left undefined until health check completes (prevents false-positive green status)
         reachable: undefined, // Unknown until health check completes
         source: 'kubeconfig',
         nodeCount: undefined, // undefined = still checking, 0 = unreachable

--- a/web/src/hooks/mcp/types.ts
+++ b/web/src/hooks/mcp/types.ts
@@ -3,7 +3,7 @@ export interface ClusterInfo {
   context: string
   server?: string
   user?: string
-  healthy: boolean
+  healthy?: boolean
   source?: string
   nodeCount?: number
   podCount?: number


### PR DESCRIPTION
## Summary
- Clusters briefly showed as healthy (green checkmark) on page load before transitioning to offline/degraded once real health data arrived
- Root cause: `fetchClusterListFromAgent()` set `healthy: true` as placeholder before health checks completed
- Fix: make `healthy` optional (undefined = not yet checked), remove forced `healthy: true`, preserve last-known cached state, show loading spinner until health check completes

## Test plan
- [ ] On page load, clusters show spinner (not green check) until health check completes
- [ ] After health checks: healthy=green, offline=yellow, degraded=orange
- [ ] Cached cluster state from previous session is preserved (last-known good state)
- [ ] New/unknown clusters show loading spinner
- [ ] Demo mode still works correctly
- [ ] `npm run build` passes
- [ ] `npm run lint` passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)