### PR TITLE
🐛 Restore overscroll-contain on stack selector dropdown

### DIFF
--- a/web/src/components/cards/llmd/StackSelector.tsx
+++ b/web/src/components/cards/llmd/StackSelector.tsx
@@ -488,7 +488,7 @@ export function StackSelector() {
             </div>
 
             {/* Stack list */}
-            <div className="max-h-80 min-h-[100px] overflow-y-auto">
+            <div className="max-h-80 min-h-[100px] overflow-y-auto overscroll-contain">
               {filteredAndSortedStacks.length > 0 ? (
                 Object.entries(stacksByCluster).sort(([a], [b]) => a.localeCompare(b)).map(([cluster, clusterStacks]) => (
                   <div key={cluster}>


### PR DESCRIPTION
## Summary
- Scrolling to the bottom of the stack selector dropdown caused the dashboard behind it to scroll
- Re-adds `overscroll-contain` to prevent scroll chaining (was accidentally removed in #786)
- The `contain: layout` and `willChange` properties that caused the empty-list bug are still removed

## Test plan
- [ ] Open stack selector dropdown, scroll to bottom of list
- [ ] Dashboard should NOT scroll when reaching the end of the dropdown list

🤖 Generated with [Claude Code](https://claude.com/claude-code)