### PR TITLE
🐛 Fix stack selector scrollbar jumping from top to bottom

### DIFF
--- a/web/src/components/cards/llmd/StackSelector.tsx
+++ b/web/src/components/cards/llmd/StackSelector.tsx
@@ -238,13 +238,6 @@ export function StackSelector() {
 
   const { stacks, isLoading, selectedStack, selectedStackId, setSelectedStackId, refetch, isDemoMode } = stackContext
 
-  // Debug: Log stacks when dropdown is open
-  useEffect(() => {
-    if (isOpen && stacks.length > 0) {
-      console.log('[StackSelector] stacks:', stacks.length, 'clusters:', [...new Set(stacks.map(s => s.cluster))])
-    }
-  }, [isOpen, stacks])
-
   // Filter and sort stacks
   const filteredAndSortedStacks = useMemo(() => {
     let result = stacks
@@ -487,8 +480,11 @@ export function StackSelector() {
               </div>
             </div>
 
-            {/* Stack list */}
-            <div className="max-h-80 min-h-[100px] overflow-y-auto overscroll-contain">
+            {/* Stack list - custom scrollbar for better grip */}
+            <div
+              className="max-h-[28rem] min-h-[100px] overflow-y-auto overscroll-contain [&::-webkit-scrollbar]:w-3 [&::-webkit-scrollbar-track]:bg-slate-900/50 [&::-webkit-scrollbar-thumb]:bg-slate-500/60 [&::-webkit-scrollbar-thumb:hover]:bg-slate-400/80 [&::-webkit-scrollbar-thumb]:rounded-full"
+              style={{ scrollbarColor: 'rgba(100,116,139,0.6) rgba(15,23,42,0.5)' }}
+            >
               {filteredAndSortedStacks.length > 0 ? (
                 Object.entries(stacksByCluster).sort(([a], [b]) => a.localeCompare(b)).map(([cluster, clusterStacks]) => (
                   <div key={cluster}>


### PR DESCRIPTION
## Summary
- Increase stack selector scroll area from 320px to 448px so more items are visible and the scrollbar thumb is larger/easier to grab
- Add wider (12px), more visible scrollbar with visible track background and higher-opacity thumb
- Remove debug console.log that fired on every stacks update while dropdown was open

## Root Cause
The scrollbar was nearly invisible — 8px wide with a 30% opacity thumb on a completely transparent track. Users couldn't see or grab the thumb, so they clicked the scrollbar track instead, which jumps by a full page. With only ~320px viewport for ~1100px of content, two track clicks jumped from top to bottom.

## Test plan
- [ ] Open AI/ML dashboard → click stack selector dropdown
- [ ] Verify scrollbar is visible with a semi-transparent track
- [ ] Drag the scrollbar thumb — should move smoothly to intermediate positions
- [ ] Scroll with mouse wheel/trackpad — content should scroll gradually
- [ ] Verify all 16 stacks across 2 clusters are visible when scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)