### PR TITLE
🌱 Add scroll-enhanced class for wider, visible scrollbars

### DIFF
--- a/web/src/components/cards/llmd/StackSelector.tsx
+++ b/web/src/components/cards/llmd/StackSelector.tsx
@@ -480,11 +480,8 @@ export function StackSelector() {
               </div>
             </div>
 
-            {/* Stack list - custom scrollbar for better grip */}
-            <div
-              className="max-h-[28rem] min-h-[100px] overflow-y-auto overscroll-contain [&::-webkit-scrollbar]:w-3 [&::-webkit-scrollbar-track]:bg-slate-900/50 [&::-webkit-scrollbar-thumb]:bg-slate-500/60 [&::-webkit-scrollbar-thumb:hover]:bg-slate-400/80 [&::-webkit-scrollbar-thumb]:rounded-full"
-              style={{ scrollbarColor: 'rgba(100,116,139,0.6) rgba(15,23,42,0.5)' }}
-            >
+            {/* Stack list */}
+            <div className="max-h-[28rem] min-h-[100px] overflow-y-auto overscroll-contain scroll-enhanced">
               {filteredAndSortedStacks.length > 0 ? (
                 Object.entries(stacksByCluster).sort(([a], [b]) => a.localeCompare(b)).map(([cluster, clusterStacks]) => (
                   <div key={cluster}>

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -389,7 +389,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
       <div
         ref={messagesContainerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto p-4 space-y-4 min-h-0"
+        className="flex-1 overflow-y-auto scroll-enhanced p-4 space-y-4 min-h-0"
       >
         {mission.messages.map((msg, index) => {
           // Find if this is the last assistant message
@@ -609,7 +609,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
 
       {/* Right sidebar for full screen mode */}
       {isFullScreen && (
-        <div className="w-80 flex-shrink-0 flex flex-col gap-4 overflow-y-auto">
+        <div className="w-80 flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
           {/* Original Ask */}
           <div className="bg-card border border-border rounded-lg p-4">
             <h4 className="text-sm font-semibold text-foreground mb-2 flex items-center gap-2">

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -336,7 +336,7 @@ export function MissionSidebar() {
         </div>
       ) : (
         <div className={cn(
-          "flex-1 overflow-y-auto p-2 space-y-2",
+          "flex-1 overflow-y-auto scroll-enhanced p-2 space-y-2",
           isFullScreen && "max-w-2xl mx-auto w-full"
         )}>
           {[...missions].reverse().map((mission) => (

--- a/web/src/components/missions/ResolutionHistoryPanel.tsx
+++ b/web/src/components/missions/ResolutionHistoryPanel.tsx
@@ -57,7 +57,7 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
 
   if (totalResolutions === 0) {
     return (
-      <div className="w-72 flex-shrink-0 flex flex-col gap-4 overflow-y-auto">
+      <div className="w-72 flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
         <div className="bg-card border border-border rounded-lg p-4">
           <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
             <BookMarked className="w-4 h-4 text-purple-400" />
@@ -78,7 +78,7 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
   }
 
   return (
-    <div className="w-72 flex-shrink-0 flex flex-col gap-4 overflow-y-auto">
+    <div className="w-72 flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
       <div className="bg-card border border-border rounded-lg p-4">
         <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
           <BookMarked className="w-4 h-4 text-purple-400" />

--- a/web/src/components/missions/ResolutionKnowledgePanel.tsx
+++ b/web/src/components/missions/ResolutionKnowledgePanel.tsx
@@ -42,7 +42,7 @@ export function ResolutionKnowledgePanel({
 
   if (relatedResolutions.length === 0) {
     return (
-      <div className="w-72 flex-shrink-0 flex flex-col gap-4 overflow-y-auto">
+      <div className="w-72 flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
         <div className="bg-card border border-border rounded-lg p-4">
           <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
             <BookOpen className="w-4 h-4 text-purple-400" />
@@ -64,7 +64,7 @@ export function ResolutionKnowledgePanel({
   }
 
   return (
-    <div className="w-72 flex-shrink-0 flex flex-col gap-4 overflow-y-auto">
+    <div className="w-72 flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
       <div className="bg-card border border-border rounded-lg p-4">
         <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
           <BookOpen className="w-4 h-4 text-purple-400" />

--- a/web/src/components/ui/AlertBadge.tsx
+++ b/web/src/components/ui/AlertBadge.tsx
@@ -379,7 +379,7 @@ export function AlertBadge() {
             )}
 
             {/* Alerts List */}
-            <div className="max-h-64 overflow-y-auto">
+            <div className="max-h-64 overflow-y-auto scroll-enhanced">
               {displayedAlerts.length === 0 ? (
                 <div className="p-6 text-center text-muted-foreground">
                   {stats.firing === 0 ? (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -345,6 +345,23 @@
   background: var(--scrollbar-thumb-hover);
 }
 
+/* Enhanced scrollbar for panels, sidebars, and dropdowns where
+   the default thin scrollbar is too hard to see/grab */
+.scroll-enhanced::-webkit-scrollbar {
+  width: 12px;
+}
+.scroll-enhanced::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.5);
+  border-radius: 6px;
+}
+.scroll-enhanced::-webkit-scrollbar-thumb {
+  background: rgba(100, 116, 139, 0.5);
+  border-radius: 6px;
+}
+.scroll-enhanced::-webkit-scrollbar-thumb:hover {
+  background: rgba(100, 116, 139, 0.75);
+}
+
 
 /* Star field background - only when theme supports it */
 .star-field {


### PR DESCRIPTION
## Summary
- Create reusable `.scroll-enhanced` CSS class in index.css (12px wide scrollbar, visible track, higher opacity thumb with hover state)
- Apply to 7 key scroll areas: AI Mission sidebar/chat/fullscreen, resolution panels, alert dropdown, stack selector
- Replace inline Tailwind scrollbar overrides from PR #788 with the shared class

## Affected Areas
- **AI Mission sidebar** — mission list scroll
- **AI Mission chat** — message history scroll
- **AI Mission full screen** — right sidebar panel scroll
- **Resolution History panel** — full screen mode
- **Resolution Knowledge panel** — full screen mode
- **Alert badge dropdown** — alert list scroll
- **Stack selector dropdown** — replaces inline webkit styles

## Test plan
- [ ] Open AI Mission sidebar → scrollbar should be wider and visible
- [ ] Open AI Mission in full screen → chat and right sidebar scrollbars visible
- [ ] Click alert badge (top nav) → alert list scrollbar visible
- [ ] Open AI/ML page → stack selector dropdown scrollbar still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)