### PR TITLE
🐛 Eliminate visual flickering during data refreshes

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1186,8 +1186,8 @@ export function CardWrapper({
             'flex flex-col transition-all duration-200',
             isCollapsed ? 'h-auto' : 'h-full',
             showDemoIndicator && '!border-2 !border-yellow-500/50',
-            // Only animate for actual loading, not offline state (prevents flicker when agent status changes)
-            (isVisuallySpinning || effectiveIsLoading) && !forceSkeletonForOffline && 'animate-card-refresh-pulse',
+            // Only pulse during initial skeleton display, not background refreshes (prevents flicker)
+            shouldShowSkeleton && !forceSkeletonForOffline && 'animate-card-refresh-pulse',
             getFlashClass()
           )}
           onMouseEnter={() => setShowSummary(true)}


### PR DESCRIPTION
## Summary
- **StatsOverview**: Replace conditional rendering between `SkeletonStatBlock` and `StatBlock` with always rendering `StatBlock`, passing `isLoading` prop for pulse animation overlay
- **UnifiedStatBlock**: Replace `if (showSkeleton) return <skeleton>` pattern with always rendering the same layout, using `animate-pulse` and placeholder values when loading
- **CardWrapper**: Restrict `animate-card-refresh-pulse` to initial skeleton display only — background refreshes are already indicated by the spinning RefreshCw icon in the header

## Problem
All stat blocks and cards visually flicker during routine data refreshes because loading triggers a full DOM swap (skeleton nodes replace content nodes), causing the browser to tear down and rebuild the entire subtree. This is visible as a flash on every auto-refresh cycle.

## Solution
Keep the same DOM tree mounted at all times. When loading, apply CSS `animate-pulse` and dim the values instead of replacing the entire component tree. This eliminates the visual flash while still showing a clear loading state.

## Test plan
- [ ] Stat blocks show `-` with pulse on initial load, then numbers appear without DOM flash
- [ ] Auto-refresh cycles update numbers in-place with no visible flicker
- [ ] Cards don't pulse their borders during background refreshes
- [ ] Cards still show skeleton on initial load (no cached data)
- [ ] Demo → Live mode switching works smoothly
- [ ] Build passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)