### PR TITLE
✨ Show session expired banner on login page after 401

### DIFF
--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -1,6 +1,6 @@
-import { lazy, Suspense, useEffect } from 'react'
-import { Github } from 'lucide-react'
-import { Navigate } from 'react-router-dom'
+import { lazy, Suspense, useEffect, useMemo } from 'react'
+import { Github, AlertTriangle } from 'lucide-react'
+import { Navigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../../lib/auth'
 import { ROUTES } from '../../config/routes'
 
@@ -9,6 +9,8 @@ const GlobeAnimation = lazy(() => import('../animations/globe').then(m => ({ def
 
 export function Login() {
   const { login, isAuthenticated, isLoading } = useAuth()
+  const [searchParams] = useSearchParams()
+  const sessionExpired = useMemo(() => searchParams.get('reason') === 'session_expired', [searchParams])
 
   // Auto-login for Netlify deploy previews
   useEffect(() => {
@@ -77,10 +79,21 @@ export function Login() {
             </div>
           </div>
 
+          {/* Session expired banner */}
+          {sessionExpired && (
+            <div className="flex items-center gap-3 mb-6 px-4 py-3 rounded-lg border border-yellow-500/50 bg-yellow-500/10 text-yellow-300 text-sm">
+              <AlertTriangle className="w-5 h-5 shrink-0 text-yellow-400" />
+              <div>
+                <p className="font-medium">Session expired</p>
+                <p className="text-xs text-yellow-400/80 mt-0.5">Your session has timed out. Please sign in again.</p>
+              </div>
+            </div>
+          )}
+
           {/* Welcome text */}
           <div className="text-center mb-8">
             <h2 data-testid="login-welcome-heading" className="text-xl font-semibold text-foreground mb-2">
-              Welcome back
+              {sessionExpired ? 'Session expired' : 'Welcome back'}
             </h2>
             <p className="text-muted-foreground">
               Sign in to manage your multi-cluster deployments

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -28,8 +28,9 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([])
   const timeoutsRef = useRef<Map<string, number>>(new Map())
 
+  const toastCounter = useRef(0)
   const showToast = useCallback((message: string, type: ToastType = 'success') => {
-    const id = `toast-${Date.now()}`
+    const id = `toast-${Date.now()}-${++toastCounter.current}`
     setToasts((prev) => [...prev, { id, message, type }])
 
     // Auto-remove after 3 seconds

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -35,9 +35,9 @@ function handle401(): void {
   localStorage.removeItem('token')
   localStorage.removeItem('kc-user-cache')
 
-  // Redirect to login after a brief delay (allows console message to be seen)
+  // Redirect to login with session_expired reason so login page shows a banner
   setTimeout(() => {
-    window.location.href = '/login'
+    window.location.href = '/login?reason=session_expired'
   }, 100)
 }
 


### PR DESCRIPTION
## Summary
- When the backend returns 401 Unauthorized (expired OAuth session), the user is now redirected to `/login?reason=session_expired`
- The login page displays a prominent yellow "Session expired" banner explaining what happened
- Also fixes duplicate React toast key collisions (`Date.now()` can produce the same ID for toasts in the same millisecond)

## Changes
- `web/src/lib/api.ts` — Append `?reason=session_expired` to login redirect URL in `handle401()`
- `web/src/components/auth/Login.tsx` — Read `reason` query param, show session expired banner and update heading text
- `web/src/components/ui/Toast.tsx` — Add counter suffix to toast IDs to prevent duplicate key warnings

## Test plan
- [ ] Simulate 401 by clearing token from localStorage and refreshing — should redirect to login with banner
- [ ] Normal login flow still works without the banner
- [ ] Multiple rapid toasts no longer produce duplicate key warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)