### PR TITLE
🐛 Fix Kagenti card font sizes for consistency

### DIFF
--- a/web/src/components/cards/KagentiStatusCard.tsx
+++ b/web/src/components/cards/KagentiStatusCard.tsx
@@ -34,8 +34,8 @@ function MetricTile({ icon: Icon, label, value, sub, accent }: {
       </div>
       <div className="min-w-0">
         <div className="text-lg font-semibold leading-tight">{value}</div>
-        <div className="text-[10px] text-muted-foreground truncate">{label}</div>
-        {sub && <div className="text-[10px] text-muted-foreground/60">{sub}</div>}
+        <div className="text-xs text-muted-foreground truncate">{label}</div>
+        {sub && <div className="text-xs text-muted-foreground/60">{sub}</div>}
       </div>
     </div>
   )
@@ -160,7 +160,7 @@ export function KagentiStatusCard({ config }: KagentiStatusCardProps) {
       {/* Framework distribution */}
       {maxFramework.length > 0 && (
         <div className="px-1">
-          <div className="text-[10px] uppercase tracking-wider text-muted-foreground/60 mb-1.5">Frameworks</div>
+          <div className="text-xs uppercase tracking-wider text-muted-foreground/60 mb-1.5">Frameworks</div>
           <div className="space-y-1">
             {maxFramework.slice(0, 4).map(([fw, count]) => (
               <div key={fw} className="flex items-center gap-2">
@@ -181,7 +181,7 @@ export function KagentiStatusCard({ config }: KagentiStatusCardProps) {
       {/* Cluster breakdown */}
       {Object.keys(stats.clusterAgents).length > 0 && (
         <div className="px-1">
-          <div className="text-[10px] uppercase tracking-wider text-muted-foreground/60 mb-1.5">Clusters</div>
+          <div className="text-xs uppercase tracking-wider text-muted-foreground/60 mb-1.5">Clusters</div>
           <div className="space-y-1">
             {Object.entries(stats.clusterAgents).map(([cluster, counts]) => (
               <div key={cluster} className="flex items-center gap-2 text-xs">
@@ -198,7 +198,7 @@ export function KagentiStatusCard({ config }: KagentiStatusCardProps) {
       {/* Recent builds */}
       {recentBuilds.length > 0 && (
         <div className="px-1">
-          <div className="text-[10px] uppercase tracking-wider text-muted-foreground/60 mb-1.5">Recent Builds</div>
+          <div className="text-xs uppercase tracking-wider text-muted-foreground/60 mb-1.5">Recent Builds</div>
           <div className="space-y-1">
             {recentBuilds.map(b => (
               <div key={`${b.cluster}-${b.namespace}-${b.name}`} className="flex items-center gap-2 text-xs">

--- a/web/src/components/cards/kagenti/KagentiAgentDiscovery.tsx
+++ b/web/src/components/cards/kagenti/KagentiAgentDiscovery.tsx
@@ -85,7 +85,7 @@ export function KagentiAgentDiscovery({ config }: KagentiAgentDiscoveryProps) {
       {/* Skill tags summary */}
       {skillSummary.length > 0 && (
         <div className="px-1">
-          <div className="text-[10px] uppercase tracking-wider text-muted-foreground/60 mb-1">Top Skills</div>
+          <div className="text-xs uppercase tracking-wider text-muted-foreground/60 mb-1">Top Skills</div>
           <div className="flex flex-wrap gap-1">
             {skillSummary.map(([skill, count]) => (
               <span
@@ -115,8 +115,8 @@ export function KagentiAgentDiscovery({ config }: KagentiAgentDiscoveryProps) {
           >
             <Radar className="w-3.5 h-3.5 text-violet-400 shrink-0" />
             <div className="min-w-0 flex-1">
-              <div className="text-xs font-medium truncate">{card.name}</div>
-              <div className="text-[10px] text-muted-foreground/60 flex items-center gap-1">
+              <div className="text-sm font-medium truncate">{card.name}</div>
+              <div className="text-xs text-muted-foreground/60 flex items-center gap-1">
                 <Server className="w-2.5 h-2.5" />
                 {card.cluster}
                 {card.agentName && <span>/ {card.agentName}</span>}
@@ -125,10 +125,10 @@ export function KagentiAgentDiscovery({ config }: KagentiAgentDiscoveryProps) {
             {card.identityBinding ? (
               <Shield className="w-3 h-3 text-emerald-400" />
             ) : (
-              <span className="text-[10px] text-zinc-500">No ID</span>
+              <span className="text-xs text-zinc-500">No ID</span>
             )}
             {(card.skills || []).length > 0 && (
-              <span className="text-[10px] text-muted-foreground/40">
+              <span className="text-xs text-muted-foreground/40">
                 {card.skills.length} skill{card.skills.length !== 1 ? 's' : ''}
               </span>
             )}

--- a/web/src/components/cards/kagenti/KagentiAgentFleet.tsx
+++ b/web/src/components/cards/kagenti/KagentiAgentFleet.tsx
@@ -104,14 +104,14 @@ export function KagentiAgentFleet({ config }: KagentiAgentFleetProps) {
           >
             <Bot className="w-3.5 h-3.5 text-violet-400 shrink-0" />
             <div className="min-w-0 flex-1">
-              <div className="text-xs font-medium truncate">{agent.name}</div>
-              <div className="text-[10px] text-muted-foreground/60 flex items-center gap-1">
+              <div className="text-sm font-medium truncate">{agent.name}</div>
+              <div className="text-xs text-muted-foreground/60 flex items-center gap-1">
                 <Server className="w-2.5 h-2.5" />
                 {agent.cluster}
                 {agent.framework && <span className="text-violet-400/60">/ {agent.framework}</span>}
               </div>
             </div>
-            <div className="text-[10px] text-muted-foreground/50">
+            <div className="text-xs text-muted-foreground/50">
               {agent.readyReplicas}/{agent.replicas}
             </div>
             <StatusBadge status={agent.status} />

--- a/web/src/components/cards/kagenti/KagentiBuildPipeline.tsx
+++ b/web/src/components/cards/kagenti/KagentiBuildPipeline.tsx
@@ -140,15 +140,15 @@ export function KagentiBuildPipeline({ config }: KagentiBuildPipelineProps) {
           >
             <BuildStatusIcon status={build.status} />
             <div className="min-w-0 flex-1">
-              <div className="text-xs font-medium truncate">{build.name}</div>
-              <div className="text-[10px] text-muted-foreground/60 flex items-center gap-1">
+              <div className="text-sm font-medium truncate">{build.name}</div>
+              <div className="text-xs text-muted-foreground/60 flex items-center gap-1">
                 <Server className="w-2.5 h-2.5" />
                 {build.cluster}
                 {build.pipeline && <span>/ {build.pipeline}</span>}
                 {build.mode && <span className="text-blue-400/60">({build.mode})</span>}
               </div>
             </div>
-            <div className="text-[10px] text-muted-foreground/40">
+            <div className="text-xs text-muted-foreground/40">
               {timeAgo(build.startTime || build.completionTime)}
             </div>
           </div>

--- a/web/src/components/cards/kagenti/KagentiSecurity.tsx
+++ b/web/src/components/cards/kagenti/KagentiSecurity.tsx
@@ -55,15 +55,15 @@ export function KagentiSecurity({ config }: { config?: Record<string, unknown> }
         <div className="grid grid-cols-3 gap-2 text-center">
           <div className="rounded bg-emerald-400/10 py-1.5">
             <div className="text-sm font-bold text-emerald-400">{stats.strict}</div>
-            <div className="text-[10px] text-gray-500">Strict</div>
+            <div className="text-xs text-gray-500">Strict</div>
           </div>
           <div className="rounded bg-amber-400/10 py-1.5">
             <div className="text-sm font-bold text-amber-400">{stats.permissive}</div>
-            <div className="text-[10px] text-gray-500">Permissive</div>
+            <div className="text-xs text-gray-500">Permissive</div>
           </div>
           <div className="rounded bg-red-400/10 py-1.5">
             <div className="text-sm font-bold text-red-400">{stats.unbound}</div>
-            <div className="text-[10px] text-gray-500">Unbound</div>
+            <div className="text-xs text-gray-500">Unbound</div>
           </div>
         </div>
       </div>

--- a/web/src/components/cards/kagenti/KagentiSecurityPosture.tsx
+++ b/web/src/components/cards/kagenti/KagentiSecurityPosture.tsx
@@ -106,13 +106,13 @@ export function KagentiSecurityPosture({ config }: KagentiSecurityPostureProps) 
         <ShieldCheck className={`w-8 h-8 ${scoreColor}`} />
         <div>
           <div className={`text-2xl font-bold ${scoreColor}`}>{security.score}%</div>
-          <div className="text-[10px] text-muted-foreground">Security Score</div>
+          <div className="text-xs text-muted-foreground">Security Score</div>
         </div>
       </div>
 
       {/* Identity binding */}
       <div className="px-1">
-        <div className="text-[10px] uppercase tracking-wider text-muted-foreground/60 mb-1.5">SPIFFE Identity Binding</div>
+        <div className="text-xs uppercase tracking-wider text-muted-foreground/60 mb-1.5">SPIFFE Identity Binding</div>
         <div className="space-y-1.5">
           <div className="flex items-center gap-2 text-xs">
             <ShieldCheck className="w-3.5 h-3.5 text-emerald-400" />
@@ -136,7 +136,7 @@ export function KagentiSecurityPosture({ config }: KagentiSecurityPostureProps) 
 
       {/* Tool credentials */}
       <div className="px-1">
-        <div className="text-[10px] uppercase tracking-wider text-muted-foreground/60 mb-1.5">Tool Credentials</div>
+        <div className="text-xs uppercase tracking-wider text-muted-foreground/60 mb-1.5">Tool Credentials</div>
         <div className="space-y-1.5">
           <div className="flex items-center gap-2 text-xs">
             <Lock className="w-3.5 h-3.5 text-emerald-400" />

--- a/web/src/components/cards/kagenti/KagentiToolRegistry.tsx
+++ b/web/src/components/cards/kagenti/KagentiToolRegistry.tsx
@@ -83,15 +83,15 @@ export function KagentiToolRegistry({ config }: KagentiToolRegistryProps) {
           >
             <Wrench className="w-3.5 h-3.5 text-cyan-400 shrink-0" />
             <div className="min-w-0 flex-1">
-              <div className="text-xs font-medium truncate">{tool.name}</div>
-              <div className="text-[10px] text-muted-foreground/60 flex items-center gap-1">
+              <div className="text-sm font-medium truncate">{tool.name}</div>
+              <div className="text-xs text-muted-foreground/60 flex items-center gap-1">
                 <Server className="w-2.5 h-2.5" />
                 {tool.cluster}
                 {tool.toolPrefix && <span className="text-cyan-400/60">prefix: {tool.toolPrefix}</span>}
               </div>
             </div>
             {tool.targetRef && (
-              <span className="text-[10px] text-muted-foreground/50 truncate max-w-[80px]">
+              <span className="text-xs text-muted-foreground/50 truncate max-w-[80px]">
                 {tool.targetRef}
               </span>
             )}

--- a/web/src/components/cards/kagenti/KagentiTopology.tsx
+++ b/web/src/components/cards/kagenti/KagentiTopology.tsx
@@ -110,7 +110,7 @@ export function KagentiTopology({ config }: { config?: Record<string, unknown> }
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Legend */}
-      <div className="flex items-center gap-4 px-3 pt-2 pb-1 text-[10px] text-gray-500">
+      <div className="flex items-center gap-4 px-3 pt-2 pb-1 text-xs text-gray-500">
         <div className="flex items-center gap-1">
           <div className="w-3 h-3 rounded-full border-2 border-blue-400" />
           <span>Agent</span>


### PR DESCRIPTION
## Summary
- Standardize font sizes across all 8 Kagenti (AI Agents) dashboard cards to match other dashboard cards (Deploy, Clusters, etc.)
- List item names: `text-xs` → `text-sm font-medium`
- Sublabels/info text: `text-[10px]` → `text-xs`
- Section headers: `text-[10px] uppercase` → `text-xs uppercase`
- Status badges kept at `text-[10px]` (standard badge pattern)

## Test plan
- [ ] Navigate to AI Agents dashboard and verify text is readable and consistent
- [ ] Compare font sizes with Deploy and Clusters dashboards for visual consistency
- [ ] Verify no layout breakage in any of the 8 Kagenti cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)