### PR TITLE
🐛 Disable GPU compositing layers in presentation mode to fix screen-sharing flickering

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -589,6 +589,22 @@
   animation: none !important;
 }
 
+/* Disable GPU compositing layers that cause screen-sharing flickering */
+.presentation-mode .glass {
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+.presentation-mode .status-healthy,
+.presentation-mode .status-warning,
+.presentation-mode .status-error {
+  box-shadow: none !important;
+}
+
+.presentation-mode [class*="weather-"] {
+  filter: none !important;
+}
+
 /* High contrast mode */
 .high-contrast {
   --border: 0 0% 100%;


### PR DESCRIPTION
## Summary

- Disables `backdrop-filter: blur(12px)` on `.glass` panels in presentation mode — the #1 cause of screen-sharing flickering
- Removes `box-shadow` glow effects from status indicators (`.status-healthy`, `.status-warning`, `.status-error`)
- Disables `filter: blur/drop-shadow` on weather card elements

These CSS properties create GPU compositing layers that screen capture software (Teams, Zoom) must re-render every frame, causing visible flickering even when the UI is static.

Complements #791 which eliminated DOM thrashing from skeleton/content swaps during loading states.

## Test plan

- [ ] Toggle presentation mode ON → verify glass panels lose blur (solid semi-transparent background remains)
- [ ] Verify status indicators lose glow but keep color
- [ ] Verify weather cards lose blur/shadow effects
- [ ] Share screen over Teams/Zoom → confirm flickering is eliminated
- [ ] Toggle presentation mode OFF → all effects return

🤖 Generated with [Claude Code](https://claude.com/claude-code)