### PR TITLE
🐛 Show offline clusters in all cluster dropdowns with status indicators

### DIFF
--- a/web/src/components/cards/ResourceMarshall.tsx
+++ b/web/src/components/cards/ResourceMarshall.tsx
@@ -15,6 +15,7 @@ import { useResolveDependencies, type ResolvedDependency } from '../../hooks/use
 import { cn } from '../../lib/cn'
 import { DEP_CATEGORIES, KIND_ICONS, KNOWN_DEPENDENCY_KINDS } from '../../lib/resourceCategories'
 import { useCardLoadingState } from './CardDataContext'
+import { ClusterSelect } from '../ui/ClusterSelect'
 
 function groupDependencies(deps: ResolvedDependency[]) {
   const groups: { label: string; icon: typeof FileText; deps: ResolvedDependency[] }[] = []
@@ -64,12 +65,6 @@ export function ResourceMarshall() {
   // Dependency resolution
   const { data: depData, isLoading: depLoading, error: depError, resolve, reset } = useResolveDependencies()
 
-  // Cluster names
-  const clusterNames = useMemo(
-    () => clusters.map(c => c.name).sort(),
-    [clusters],
-  )
-
   // Handle cluster change
   const handleClusterChange = useCallback((cluster: string) => {
     setSelectedCluster(cluster)
@@ -118,16 +113,13 @@ export function ResourceMarshall() {
         {/* Cluster selector */}
         <div className="flex items-center gap-2">
           <label className="text-xs text-muted-foreground w-20 shrink-0">Cluster</label>
-          <select
+          <ClusterSelect
+            clusters={clusters}
             value={selectedCluster}
-            onChange={(e) => handleClusterChange(e.target.value)}
-            className="flex-1 text-sm rounded-md bg-secondary/50 border border-border px-2 py-1.5 text-foreground focus:outline-none focus:ring-1 focus:ring-blue-500/50"
-          >
-            <option value="">Select cluster...</option>
-            {clusterNames.map(c => (
-              <option key={c} value={c}>{c}</option>
-            ))}
-          </select>
+            onChange={handleClusterChange}
+            placeholder="Select cluster..."
+            className="flex-1"
+          />
         </div>
 
         {/* Namespace selector */}

--- a/web/src/components/ui/ClusterSelect.tsx
+++ b/web/src/components/ui/ClusterSelect.tsx
@@ -1,0 +1,165 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+import { ChevronDown } from 'lucide-react'
+import { ClusterStatusDot, getClusterState, type ClusterState } from './ClusterStatusBadge'
+import type { ClusterErrorType } from '../../lib/errorClassifier'
+import { cn } from '../../lib/cn'
+
+interface ClusterInfo {
+  name: string
+  healthy?: boolean
+  reachable?: boolean
+  nodeCount?: number
+  errorType?: ClusterErrorType
+}
+
+interface ClusterSelectProps {
+  clusters: ClusterInfo[]
+  value: string
+  onChange: (cluster: string) => void
+  disabled?: boolean
+  placeholder?: string
+  className?: string
+}
+
+/**
+ * Custom single-select cluster dropdown with health status indicators.
+ * Shows ClusterStatusDot next to each cluster name and disables offline clusters.
+ */
+export function ClusterSelect({
+  clusters,
+  value,
+  onChange,
+  disabled = false,
+  placeholder = 'Select cluster...',
+  className,
+}: ClusterSelectProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number; width: number } | null>(null)
+
+  const calculatePosition = useCallback(() => {
+    if (!buttonRef.current) return null
+    const rect = buttonRef.current.getBoundingClientRect()
+    return {
+      top: rect.bottom + 4,
+      left: rect.left,
+      width: rect.width,
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isOpen) {
+      setDropdownPos(calculatePosition())
+    } else {
+      setDropdownPos(null)
+    }
+  }, [isOpen, calculatePosition])
+
+  // Close on click outside
+  useEffect(() => {
+    if (!isOpen) return
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as Node
+      if (
+        buttonRef.current && !buttonRef.current.contains(target) &&
+        (!dropdownRef.current || !dropdownRef.current.contains(target))
+      ) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen])
+
+  const selectedCluster = clusters.find(c => c.name === value)
+  const selectedState: ClusterState | null = selectedCluster
+    ? (selectedCluster.healthy !== undefined || selectedCluster.reachable !== undefined
+        ? getClusterState(selectedCluster.healthy ?? true, selectedCluster.reachable, selectedCluster.nodeCount, undefined, selectedCluster.errorType)
+        : 'healthy')
+    : null
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => !disabled && setIsOpen(!isOpen)}
+        disabled={disabled}
+        className={cn(
+          'flex items-center gap-2 text-sm rounded-md bg-secondary/50 border border-border px-2 py-1.5 text-foreground focus:outline-none focus:ring-1 focus:ring-blue-500/50 text-left',
+          disabled && 'opacity-50 cursor-not-allowed',
+          className,
+        )}
+      >
+        {selectedState && <ClusterStatusDot state={selectedState} size="sm" />}
+        <span className="flex-1 truncate">{value || placeholder}</span>
+        <ChevronDown className="w-3 h-3 text-muted-foreground shrink-0" />
+      </button>
+
+      {isOpen && dropdownPos && createPortal(
+        <div
+          ref={dropdownRef}
+          className="fixed max-h-48 overflow-y-auto rounded-lg bg-card border border-border shadow-lg z-50"
+          style={{ top: dropdownPos.top, left: dropdownPos.left, width: dropdownPos.width }}
+          onMouseDown={e => e.stopPropagation()}
+        >
+          <div className="p-1">
+            {/* Empty option */}
+            <button
+              onClick={() => { onChange(''); setIsOpen(false) }}
+              className={cn(
+                'w-full px-2 py-1.5 text-xs text-left rounded transition-colors',
+                !value ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-muted-foreground',
+              )}
+            >
+              {placeholder}
+            </button>
+            {clusters.map(cluster => {
+              const clusterState: ClusterState = cluster.healthy !== undefined || cluster.reachable !== undefined
+                ? getClusterState(cluster.healthy ?? true, cluster.reachable, cluster.nodeCount, undefined, cluster.errorType)
+                : 'healthy'
+
+              const isUnreachable = cluster.reachable === false
+              const stateLabel = clusterState === 'healthy' ? '' :
+                clusterState === 'degraded' ? 'degraded' :
+                clusterState === 'unreachable-auth' ? 'needs auth' :
+                clusterState === 'unreachable-timeout' ? 'offline' :
+                clusterState.startsWith('unreachable') ? 'offline' : ''
+
+              return (
+                <button
+                  key={cluster.name}
+                  onClick={() => {
+                    if (!isUnreachable) {
+                      onChange(cluster.name)
+                      setIsOpen(false)
+                    }
+                  }}
+                  disabled={isUnreachable}
+                  className={cn(
+                    'w-full px-2 py-1.5 text-xs text-left rounded transition-colors flex items-center gap-2',
+                    isUnreachable
+                      ? 'opacity-40 cursor-not-allowed'
+                      : value === cluster.name
+                        ? 'bg-purple-500/20 text-purple-400'
+                        : 'hover:bg-secondary text-foreground',
+                  )}
+                  title={stateLabel ? `${cluster.name} (${stateLabel})` : cluster.name}
+                >
+                  <ClusterStatusDot state={clusterState} size="sm" />
+                  <span className="flex-1 truncate">{cluster.name}</span>
+                  {stateLabel && (
+                    <span className="text-[10px] text-muted-foreground shrink-0">{stateLabel}</span>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        </div>,
+        document.body,
+      )}
+    </>
+  )
+}

--- a/web/src/lib/cards/CardComponents.tsx
+++ b/web/src/lib/cards/CardComponents.tsx
@@ -342,6 +342,8 @@ export function CardClusterFilter({
                   )
                 : 'healthy'
 
+              const isUnreachable = cluster.reachable === false
+
               // Get status label for tooltip
               const stateLabel = clusterState === 'healthy' ? '' :
                 clusterState === 'degraded' ? 'degraded' :
@@ -352,11 +354,14 @@ export function CardClusterFilter({
               return (
                 <button
                   key={cluster.name}
-                  onClick={() => onToggle(cluster.name)}
+                  onClick={() => !isUnreachable && onToggle(cluster.name)}
+                  disabled={isUnreachable}
                   className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors flex items-center gap-2 ${
-                    selectedClusters.includes(cluster.name)
-                      ? 'bg-purple-500/20 text-purple-400'
-                      : 'hover:bg-secondary text-foreground'
+                    isUnreachable
+                      ? 'opacity-40 cursor-not-allowed'
+                      : selectedClusters.includes(cluster.name)
+                        ? 'bg-purple-500/20 text-purple-400'
+                        : 'hover:bg-secondary text-foreground'
                   }`}
                   title={stateLabel ? `${cluster.name} (${stateLabel})` : cluster.name}
                 >

--- a/web/src/lib/cards/cardHooks.ts
+++ b/web/src/lib/cards/cardHooks.ts
@@ -159,11 +159,10 @@ export function useCardFilters<T>(
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  // Available clusters for local filter (respects global filter, uses deduplicated clusters)
+  // Available clusters for local filter dropdown (includes unreachable for display)
   const availableClusters = useMemo(() => {
-    const reachable = deduplicatedClusters.filter(c => c.reachable !== false)
-    if (isAllClustersSelected) return reachable
-    return reachable.filter(c => selectedClusters.includes(c.name))
+    if (isAllClustersSelected) return deduplicatedClusters
+    return deduplicatedClusters.filter(c => selectedClusters.includes(c.name))
   }, [deduplicatedClusters, selectedClusters, isAllClustersSelected])
 
   const toggleClusterFilter = useCallback((clusterName: string) => {
@@ -945,20 +944,15 @@ export function useChartFilters(
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  // Get reachable clusters (using deduplicated clusters)
-  const reachableClusters = useMemo(() => {
-    return deduplicatedClusters.filter(c => c.reachable !== false)
-  }, [deduplicatedClusters])
-
-  // Available clusters for filtering (respects global filter)
+  // Available clusters for filter dropdown (includes unreachable for display)
   const availableClusters = useMemo(() => {
-    if (isAllClustersSelected) return reachableClusters
-    return reachableClusters.filter(c => selectedClusters.includes(c.name))
-  }, [reachableClusters, selectedClusters, isAllClustersSelected])
+    if (isAllClustersSelected) return deduplicatedClusters
+    return deduplicatedClusters.filter(c => selectedClusters.includes(c.name))
+  }, [deduplicatedClusters, selectedClusters, isAllClustersSelected])
 
-  // Filtered clusters based on global + local filters
+  // Filtered clusters based on global + local filters (reachable only for data)
   const filteredClusters = useMemo(() => {
-    let result = reachableClusters
+    let result = deduplicatedClusters.filter(c => c.reachable !== false)
     if (!isAllClustersSelected) {
       result = result.filter(c => selectedClusters.includes(c.name))
     }
@@ -966,7 +960,7 @@ export function useChartFilters(
       result = result.filter(c => localClusterFilter.includes(c.name))
     }
     return result
-  }, [reachableClusters, selectedClusters, isAllClustersSelected, localClusterFilter])
+  }, [deduplicatedClusters, selectedClusters, isAllClustersSelected, localClusterFilter])
 
   const toggleClusterFilter = useCallback((clusterName: string) => {
     if (localClusterFilter.includes(clusterName)) {


### PR DESCRIPTION
## Summary
- Offline/unreachable clusters were hidden from all cluster filter dropdowns — users couldn't see which clusters were offline
- Now ALL clusters are shown in every cluster dropdown with health status indicators (green dot = healthy, yellow dot = offline/unreachable)
- Offline clusters are visible but **not selectable** (dimmed, disabled, with status label like "offline" or "needs auth")
- Fix applied at the unified component/hook level — zero individual card changes needed for the ~25 cards using `CardClusterFilter`

## Changes
| File | Change |
|------|--------|
| `cardHooks.ts` | Include unreachable clusters in `availableClusters` for dropdown display; keep data filtering reachable-only |
| `useLocalClusterFilter.ts` | Same separation of display vs data filtering |
| `CardComponents.tsx` | Disable unreachable clusters in `CardClusterFilter` dropdown |
| `ClusterFilterDropdown.tsx` | Add `ClusterStatusDot` health indicators and disabled state |
| `ClusterSelect.tsx` | **NEW** — shared single-select dropdown with health dots (replaces native `<select>`) |
| `ResourceMarshall.tsx` | Replace native `<select>` with `ClusterSelect` |

## Test plan
- [x] Build passes (`npm run build`)
- [x] Multi-select filter dropdowns show all clusters including offline (verified via CDP)
- [x] Offline clusters shown with yellow dot and "offline"/"needs auth" label
- [x] Offline clusters are disabled (not clickable)
- [x] ResourceMarshall cluster dropdown shows health indicators
- [x] Data integrity: only reachable cluster data appears in cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)