### PR TITLE
🐛 Globally disable GPU compositing triggers in presentation mode

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -589,20 +589,27 @@
   animation: none !important;
 }
 
-/* Disable GPU compositing layers that cause screen-sharing flickering */
-.presentation-mode .glass {
+/* Disable GPU compositing layers that cause screen-sharing flickering.
+   backdrop-filter, filter, will-change, and animated box-shadow each create
+   GPU compositing layers that screen capture software (Teams/Zoom) must
+   re-render every frame — causing visible flicker even when the UI is static. */
+.presentation-mode * {
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
-}
-
-.presentation-mode .status-healthy,
-.presentation-mode .status-warning,
-.presentation-mode .status-error {
-  box-shadow: none !important;
+  will-change: auto !important;
 }
 
 .presentation-mode [class*="weather-"] {
   filter: none !important;
+}
+
+.presentation-mode [class*="status-"] {
+  box-shadow: none !important;
+}
+
+/* Hide the Three.js globe canvas — continuous requestAnimationFrame loop */
+.presentation-mode canvas {
+  display: none !important;
 }
 
 /* High contrast mode */


### PR DESCRIPTION
## Summary

PR #797 only covered `.glass` in index.css, but **30+ components** use `backdrop-blur-sm` Tailwind classes directly in JSX (modals, tooltips, sidebars, overlays, etc.), and the Three.js globe runs a continuous `requestAnimationFrame` loop. All of these create GPU compositing layers that screen capture software re-renders every frame.

This broadens the fix to disable ALL GPU compositing triggers in presentation mode:
- **`backdrop-filter: none`** on all elements (covers `.glass` + 30+ `backdrop-blur-sm` instances)
- **`will-change: auto`** on all elements (was forcing GPU layer promotion)
- **`filter: none`** on weather card elements
- **`box-shadow: none`** on status indicators
- **`canvas { display: none }`** hides the Three.js globe animation loop

## Test plan

- [ ] Toggle presentation mode ON while sharing screen over Teams/Zoom
- [ ] Confirm flickering is eliminated
- [ ] Verify modals/tooltips/sidebars no longer show blur but remain functional
- [ ] Verify globe disappears in presentation mode
- [ ] Toggle presentation mode OFF → all effects return

🤖 Generated with [Claude Code](https://claude.com/claude-code)