### PR TITLE
🐛 Rename Clusters page header to My Clusters

### DIFF
--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -1679,7 +1679,7 @@ export function Clusters() {
     <div data-testid="clusters-page" className="pt-16">
       {/* Header */}
       <DashboardHeader
-        title="Clusters"
+        title="My Clusters"
         subtitle="Manage your Kubernetes clusters"
         icon={<Server className="w-6 h-6 text-purple-400" />}
         isFetching={isFetching}


### PR DESCRIPTION
## Summary
- Rename the Clusters page header from "Clusters" to "My Clusters" to match the sidebar navigation label

## Test plan
- [ ] Open Clusters page — header says "My Clusters"

🤖 Generated with [Claude Code](https://claude.com/claude-code)