### PR TITLE
🐛 Fix ~1 minute delay when switching dashboards after backend restart

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,6 @@
 const API_BASE = ''
-const DEFAULT_TIMEOUT = 5000 // 5 seconds default timeout
-const BACKEND_CHECK_INTERVAL = 60000 // 60 seconds between backend checks when unavailable
+const DEFAULT_TIMEOUT = 15000 // 15 seconds default timeout
+const BACKEND_CHECK_INTERVAL = 10000 // 10 seconds between backend checks when unavailable
 
 // Error class for unauthenticated requests
 export class UnauthenticatedError extends Error {
@@ -272,10 +272,9 @@ class ApiClient {
     } catch (err) {
       clearTimeout(timeoutId)
       if (err instanceof Error && err.name === 'AbortError') {
-        markBackendFailure()
         throw new Error(`Request timeout after ${(options?.timeout ?? DEFAULT_TIMEOUT) / 1000}s: ${path}`)
       }
-      // Network errors also indicate backend issues
+      // Only mark backend failure on actual network errors (fetch TypeError)
       if (err instanceof TypeError && err.message.includes('fetch')) {
         markBackendFailure()
       }


### PR DESCRIPTION
## Summary
- Remove `markBackendFailure()` from timeout (AbortError) handler — a slow response is not the same as a dead backend
- Increase default API timeout from 5s to 15s to accommodate cold-start K8s cluster connections
- Reduce backend check interval from 60s to 10s for faster recovery when backend is genuinely unavailable

## Root Cause
On first load after a backend restart, the K8s client needs to establish TLS handshakes, run API discovery, and aggregate health across all clusters. This takes >5 seconds. The frontend's 5-second timeout fired, calling `markBackendFailure()` which locked out ALL API calls for 60 seconds (`BACKEND_CHECK_INTERVAL`). Total delay: ~5s timeout + ~60s lockout = ~65 seconds of blank dashboard.

## Test plan
- [ ] Restart backend, load UI — first dashboard should appear within 15s (not 60+s)
- [ ] Switch dashboards immediately after first load — no minute-long delay
- [ ] Kill backend entirely — frontend should detect unavailability within 10s and show error state
- [ ] Restart backend after kill — frontend should recover within 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)