### PR TITLE
🐛 Add enhanced scrollbar to panels and card content areas

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1403,7 +1403,7 @@ export function CardWrapper({
 
         {/* Content - hidden when collapsed, lazy loaded when visible or expanded */}
         {!isCollapsed && (
-          <div className="flex-1 p-4 overflow-auto min-h-0 flex flex-col">
+          <div className="flex-1 p-4 overflow-auto scroll-enhanced min-h-0 flex flex-col">
             {(isVisible || isExpanded) ? (
               <>
                 {/* Show skeleton overlay when loading with no cached data */}
@@ -1483,7 +1483,7 @@ export function CardWrapper({
           showBack={false}
         />
         <BaseModal.Content className={cn(
-          'overflow-auto flex flex-col',
+          'overflow-auto scroll-enhanced flex flex-col',
           FULLSCREEN_EXPANDED_CARDS.has(cardType)
             ? 'h-[calc(98vh-80px)]'
             : LARGE_EXPANDED_CARDS.has(cardType)

--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -332,7 +332,7 @@ export function Missions(_props: MissionsProps) {
             : 'Deploy a workload to start a mission'}
         />
       ) : (
-        <div className="flex-1 min-h-0 overflow-auto space-y-2">
+        <div className="flex-1 min-h-0 overflow-auto scroll-enhanced space-y-2">
           {visibleMissions.map(mission => {
             const isActive = mission.status === 'launching' || mission.status === 'deploying'
             return (

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -232,7 +232,7 @@ Start by running diagnostic commands to understand what's happening.`,
         </div>
 
         {/* Tab Content */}
-        <div className="flex-1 overflow-auto">
+        <div className="flex-1 overflow-auto scroll-enhanced">
           {activeTab === 'describe' && (
             <div className="bg-secondary/50 rounded p-4 font-mono text-xs overflow-auto max-h-[400px]">
               <div className="text-muted-foreground mb-2"># kubectl describe {resource.kind.toLowerCase()} {resource.name} {resource.namespace ? `-n ${resource.namespace}` : ''}</div>

--- a/web/src/components/dashboard/LivePreviewPanel.tsx
+++ b/web/src/components/dashboard/LivePreviewPanel.tsx
@@ -77,7 +77,7 @@ export function LivePreviewPanel({ tier, t1Config, t2Source, title, width = 6 }:
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto p-3">
+      <div className="flex-1 overflow-y-auto scroll-enhanced p-3">
         <div
           className={cn(
             'rounded-lg border border-border/50 bg-card/30 p-3 mx-auto transition-all',

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -206,7 +206,7 @@ export function Layout({ children }: LayoutProps) {
       <div className="flex flex-1 overflow-hidden transition-[padding-top] duration-300" style={{ paddingTop: NAVBAR_HEIGHT + totalBannerHeight }}>
         <Sidebar />
         <main className={cn(
-          'flex-1 p-4 md:p-6 transition-[margin] duration-300 overflow-y-auto',
+          'flex-1 p-4 md:p-6 transition-[margin] duration-300 overflow-y-auto scroll-enhanced',
           // Mobile: no left margin (sidebar overlays)
           // Desktop: respect collapsed state
           isMobile ? 'ml-0' : (config.collapsed ? 'ml-20' : 'ml-64'),

--- a/web/src/components/widget/MiniDashboard.tsx
+++ b/web/src/components/widget/MiniDashboard.tsx
@@ -284,7 +284,7 @@ export function MiniDashboard() {
     <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-900 to-gray-800 text-white flex items-center justify-center p-2">
       {/* Fixed-size widget container */}
       <div className="w-[520px] h-[320px] flex flex-col bg-gray-900/50 rounded-xl border border-gray-700/50 overflow-hidden">
-        <div className="flex-1 p-4 overflow-auto">
+        <div className="flex-1 p-4 overflow-auto scroll-enhanced">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">

--- a/web/src/lib/cards/CardRuntime.tsx
+++ b/web/src/lib/cards/CardRuntime.tsx
@@ -335,7 +335,7 @@ export function CardRuntime({ definition, config: _config, title }: CardRuntimeP
     switch (visualization) {
       case 'table':
         return (
-          <div className="flex-1 overflow-auto">
+          <div className="flex-1 overflow-auto scroll-enhanced">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-border">
@@ -375,7 +375,7 @@ export function CardRuntime({ definition, config: _config, title }: CardRuntimeP
       case 'status':
       default:
         return (
-          <div className="flex-1 space-y-2 overflow-y-auto min-h-card-content">
+          <div className="flex-1 space-y-2 overflow-y-auto scroll-enhanced min-h-card-content">
             {items.map((item, idx) => (
               <CardListItem
                 key={idx}

--- a/web/src/lib/unified/card/visualizations/ListVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/ListVisualization.tsx
@@ -175,7 +175,7 @@ export function ListVisualization({
       )}
 
       {/* List content */}
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto scroll-enhanced">
         {paginatedData.length === 0 ? (
           <div className="flex items-center justify-center h-full text-gray-500 text-sm">
             No items to display


### PR DESCRIPTION
## Summary
- Apply `scroll-enhanced` class (12px wide, visible track) to 10 scrollable areas:
  - Main content area (`Layout.tsx`)
  - Clusters page content
  - Mini dashboard content
  - Missions list
  - Live preview panel
  - Card wrapper content (normal + expanded mode — affects all cards)
  - Card runtime table and status views
  - List visualization

## Test plan
- [ ] Scrollbars are wider and more visible across all affected areas
- [ ] Card content scrollbars match sidebar/chat style
- [ ] No layout shifts or visual regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)