### PR TITLE
🐛 Fix Security Issues and GPU Status showing empty state while loading

### DIFF
--- a/web/src/components/cards/GPUStatus.tsx
+++ b/web/src/components/cards/GPUStatus.tsx
@@ -142,7 +142,7 @@ export function GPUStatus({ config }: GPUStatusProps) {
     )
   }
 
-  if (showEmptyState || preFilteredNodes.length === 0) {
+  if (showEmptyState || (!hookLoading && preFilteredNodes.length === 0)) {
     return (
       <div className="h-full flex flex-col content-loaded">
         <div className="flex items-center justify-end mb-3">

--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -213,7 +213,7 @@ export function SecurityIssues({ config }: SecurityIssuesProps) {
     )
   }
 
-  if (showEmptyState || issues.length === 0) {
+  if (showEmptyState || (!isLoading && issues.length === 0)) {
     return (
       <div className="h-full flex flex-col">
         <div className="flex items-center justify-end mb-3">


### PR DESCRIPTION
## Summary
- Security Issues card showed "No security issues" while data was still loading
- GPU Status card showed "No GPU Data" while data was still loading
- Both now gate the empty state on `!isLoading`, so the skeleton displays until data arrives

## Test plan
- [ ] Security Issues card shows skeleton while loading, then either issues or "No security issues"
- [ ] GPU Status card shows skeleton while loading, then either GPU data or "No GPU Data"

🤖 Generated with [Claude Code](https://claude.com/claude-code)