### PR TITLE
✨ Prefetch dashboard card data on initial load

### DIFF
--- a/web/src/lib/prefetchCardData.ts
+++ b/web/src/lib/prefetchCardData.ts
@@ -1,0 +1,63 @@
+/**
+ * Prefetch core Kubernetes data at startup so dashboard cards render instantly.
+ *
+ * Two tiers:
+ *  1. Core data (pods, events, deployments, etc.) — most dashboards need these
+ *  2. Specialty data (Prow, LLM-d) — niche dashboards, fetched after core completes
+ *
+ * Safety:
+ * - Runs via requestIdleCallback — only when browser is idle
+ * - 500ms stagger between fetches — no burst
+ * - Each fetch has built-in timeouts
+ * - Failures are silently ignored (cards fall back to on-demand fetch or demo data)
+ */
+
+import { prefetchCache } from './cache'
+import { coreFetchers, specialtyFetchers } from '../hooks/useCachedData'
+
+const STAGGER_MS = 500
+
+interface PrefetchEntry {
+  key: string
+  fetcher: () => Promise<unknown>
+  initial: never[]
+}
+
+const CORE_ENTRIES: PrefetchEntry[] = [
+  { key: 'pods:all:all:100',         fetcher: coreFetchers.pods,             initial: [] },
+  { key: 'podIssues:all:all',        fetcher: coreFetchers.podIssues,        initial: [] },
+  { key: 'events:all:all:20',        fetcher: coreFetchers.events,           initial: [] },
+  { key: 'deploymentIssues:all:all', fetcher: coreFetchers.deploymentIssues, initial: [] },
+  { key: 'deployments:all:all',      fetcher: coreFetchers.deployments,      initial: [] },
+  { key: 'services:all:all',         fetcher: coreFetchers.services,         initial: [] },
+  { key: 'securityIssues:all:all',   fetcher: coreFetchers.securityIssues,   initial: [] },
+  { key: 'workloads:all:all',        fetcher: coreFetchers.workloads,        initial: [] },
+]
+
+const SPECIALTY_ENTRIES: PrefetchEntry[] = [
+  { key: 'prowjobs:prow:prow',                    fetcher: specialtyFetchers.prowJobs,    initial: [] },
+  { key: 'llmd-servers:vllm-d,platform-eval',     fetcher: specialtyFetchers.llmdServers, initial: [] },
+  { key: 'llmd-models:vllm-d,platform-eval',      fetcher: specialtyFetchers.llmdModels,  initial: [] },
+]
+
+let prefetched = false
+
+export function prefetchCardData(): void {
+  if (prefetched) return
+  prefetched = true
+
+  // Tier 1: Core data — staggered 500ms apart
+  CORE_ENTRIES.forEach((entry, i) => {
+    setTimeout(() => {
+      prefetchCache(entry.key, entry.fetcher, entry.initial).catch(() => {})
+    }, i * STAGGER_MS)
+  })
+
+  // Tier 2: Specialty data — starts after core completes
+  const specialtyDelay = CORE_ENTRIES.length * STAGGER_MS + 1000
+  SPECIALTY_ENTRIES.forEach((entry, i) => {
+    setTimeout(() => {
+      prefetchCache(entry.key, entry.fetcher, entry.initial).catch(() => {})
+    }, specialtyDelay + i * STAGGER_MS)
+  })
+}


### PR DESCRIPTION
## Summary
- Prefetch core Kubernetes data (pods, events, deployments, services, security issues, workloads) during browser idle time after login
- Tier 2 prefetch for specialty data (Prow jobs, LLM-d servers/models) after core data completes
- Dashboard cards render instantly instead of showing skeleton loaders when navigating

## Implementation
- Added `coreFetchers` and `specialtyFetchers` exports to `useCachedData.ts` — standalone async functions (no React hooks) mirroring each hook's default fetcher
- New `lib/prefetchCardData.ts` orchestrator — two-tier staggered prefetch (500ms intervals, 1s gap between tiers)
- `DataPrefetchInit` component in `App.tsx` — runs via `requestIdleCallback` after authentication

## Performance safety
- `requestIdleCallback` with 10s timeout — only runs when browser is idle
- 500ms stagger between fetches — no network burst
- Reuses existing `prefetchCache()` from cache layer (near-no-op if data already cached)
- Each fetch has built-in 5-15s timeouts
- Failures silently ignored — cards fall back to on-demand fetch or demo data

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Login, open DevTools Network tab — observe staggered API calls during idle
- [ ] Navigate to any dashboard — cards render with data immediately
- [ ] Check IndexedDB (Application > IndexedDB > kc-cache) — keys populated
- [ ] Demo mode still works (prefetch fails silently, cards show demo data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)