### PR TITLE
📖 Clarify Run Locally modal describes all three services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,6 @@ After completing implementation tasks, create test tasks that use:
 ## TODO
 
 - [ ] Test token counter works with predictions in the offline detector
-- [ ] Does the "Run Locally" modal (start-dev.sh / startup-oauth.sh) include agent installation?
+- [x] Does the "Run Locally" modal (start-dev.sh / startup-oauth.sh) include agent installation? YES — startup-oauth.sh auto-installs kc-agent via Homebrew, and the modal notes "The script automatically installs the local agent"
 - [x] Replace left sidebar scroller with custom scroller (apply learnings from llm-d stack dropdown and AI mission chat scroller)
 - [x] Security Issues card shows "No security issues" while still loading — should show "Loading" instead

--- a/web/src/components/setup/SetupInstructionsDialog.tsx
+++ b/web/src/components/setup/SetupInstructionsDialog.tsx
@@ -18,7 +18,7 @@ const STEPS = [
   {
     number: 1,
     title: 'Start the console',
-    description: 'Clones the repo, installs dependencies, and starts all services',
+    description: 'Clones the repo, installs dependencies, and starts the backend, frontend, and local agent',
     command: `curl -sSL ${CURL_BASE}/start-dev.sh | bash`,
     altCommand: `curl -sSL ${CURL_BASE}/startup-oauth.sh | bash`,
     altLabel: 'With GitHub OAuth login',
@@ -157,7 +157,7 @@ export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDi
                               </button>
                             </div>
                             <p className="text-xs text-muted-foreground">
-                              The script automatically installs the local agent via Homebrew.
+                              The script installs dependencies and starts the backend, frontend, and local agent.
                             </p>
                           </div>
                         )}


### PR DESCRIPTION
## Summary
- Update the "Run Locally" modal (SetupInstructionsDialog) to explicitly state the script starts the backend, frontend, and local agent
- Previously said "starts all services" which was vague

## Test plan
- [ ] Open the "Run Locally" modal and verify updated description text

🤖 Generated with [Claude Code](https://claude.com/claude-code)