### PR TITLE
🐛 Fix prediction tokens not attributed in token counter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ After completing implementation tasks, create test tasks that use:
 
 ## TODO
 
-- [ ] Test token counter works with predictions in the offline detector
+- [x] Test token counter works with predictions in the offline detector — Fixed: `useAIPredictions.ts` was missing `setActiveTokenCategory('predictions')` calls, so prediction tokens were never attributed to the 'predictions' category
 - [x] Does the "Run Locally" modal (start-dev.sh / startup-oauth.sh) include agent installation? YES — startup-oauth.sh auto-installs kc-agent via Homebrew, and the modal notes "The script automatically installs the local agent"
 - [x] Replace left sidebar scroller with custom scroller (apply learnings from llm-d stack dropdown and AI mission chat scroller)
 - [x] Security Issues card shows "No security issues" while still loading — should show "Loading" instead

--- a/web/src/hooks/useAIPredictions.ts
+++ b/web/src/hooks/useAIPredictions.ts
@@ -7,6 +7,7 @@ import type {
 import { getPredictionSettings, getSettingsForBackend } from './usePredictionSettings'
 import { getDemoMode } from './useDemoMode'
 import { isAgentUnavailable, reportAgentDataSuccess, reportAgentDataError } from './useLocalAgent'
+import { setActiveTokenCategory } from './useTokenUsage'
 import { fullFetchClusters, clusterCache } from './mcp/shared'
 
 const AGENT_HTTP_URL = 'http://127.0.0.1:8585'
@@ -289,6 +290,7 @@ export function useAIPredictions() {
   // Trigger analysis
   const analyze = useCallback(async (specificProviders?: string[]) => {
     setIsAnalyzing(true)
+    setActiveTokenCategory('predictions')
     try {
       await triggerAnalysis(specificProviders)
       // Wait a bit then fetch results
@@ -296,6 +298,7 @@ export function useAIPredictions() {
       await fetchAIPredictions()
     } finally {
       setIsAnalyzing(false)
+      setActiveTokenCategory(null)
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- `useAIPredictions.ts` was missing `setActiveTokenCategory('predictions')` calls when triggering AI analysis
- Prediction tokens were never attributed to the 'predictions' category in the navbar token counter widget
- Added token category tracking around the `analyze` callback, matching the pattern used by `useMissions.tsx`

## Test plan
- [ ] Trigger AI prediction analysis in the offline detector card
- [ ] Verify the token counter widget shows non-zero 'Predictions' category tokens after analysis runs
- [ ] Verify other categories (missions, diagnose, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)