### PR TITLE
🐛 Fix Kagenti card fonts to match standard cards

### DIFF
--- a/web/src/components/cards/KagentiStatusCard.tsx
+++ b/web/src/components/cards/KagentiStatusCard.tsx
@@ -35,7 +35,7 @@ function MetricTile({ icon: Icon, label, value, sub, accent }: {
       <div className="min-w-0">
         <div className="text-lg font-semibold leading-tight">{value}</div>
         <div className="text-xs text-muted-foreground truncate">{label}</div>
-        {sub && <div className="text-xs text-muted-foreground/60">{sub}</div>}
+        {sub && <div className="text-xs text-muted-foreground">{sub}</div>}
       </div>
     </div>
   )
@@ -122,7 +122,7 @@ export function KagentiStatusCard({ config }: KagentiStatusCardProps) {
       <div className="flex flex-col items-center justify-center py-8 text-center">
         <Bot className="w-10 h-10 text-muted-foreground/30 mb-3" />
         <div className="text-sm font-medium text-muted-foreground">No Kagenti Agents Found</div>
-        <div className="text-xs text-muted-foreground/60 mt-1 max-w-[200px]">
+        <div className="text-xs text-muted-foreground mt-1 max-w-[200px]">
           Install the kagenti-operator to deploy AI agents on your clusters
         </div>
       </div>
@@ -160,7 +160,7 @@ export function KagentiStatusCard({ config }: KagentiStatusCardProps) {
       {/* Framework distribution */}
       {maxFramework.length > 0 && (
         <div className="px-1">
-          <div className="text-xs uppercase tracking-wider text-muted-foreground/60 mb-1.5">Frameworks</div>
+          <div className="text-xs uppercase tracking-wider text-muted-foreground mb-1.5">Frameworks</div>
           <div className="space-y-1">
             {maxFramework.slice(0, 4).map(([fw, count]) => (
               <div key={fw} className="flex items-center gap-2">
@@ -171,7 +171,7 @@ export function KagentiStatusCard({ config }: KagentiStatusCardProps) {
                     style={{ width: `${(count / agents.length) * 100}%` }}
                   />
                 </div>
-                <div className="text-xs text-muted-foreground/60 w-6 text-right">{count}</div>
+                <div className="text-xs text-muted-foreground w-6 text-right">{count}</div>
               </div>
             ))}
           </div>
@@ -181,7 +181,7 @@ export function KagentiStatusCard({ config }: KagentiStatusCardProps) {
       {/* Cluster breakdown */}
       {Object.keys(stats.clusterAgents).length > 0 && (
         <div className="px-1">
-          <div className="text-xs uppercase tracking-wider text-muted-foreground/60 mb-1.5">Clusters</div>
+          <div className="text-xs uppercase tracking-wider text-muted-foreground mb-1.5">Clusters</div>
           <div className="space-y-1">
             {Object.entries(stats.clusterAgents).map(([cluster, counts]) => (
               <div key={cluster} className="flex items-center gap-2 text-xs">
@@ -198,7 +198,7 @@ export function KagentiStatusCard({ config }: KagentiStatusCardProps) {
       {/* Recent builds */}
       {recentBuilds.length > 0 && (
         <div className="px-1">
-          <div className="text-xs uppercase tracking-wider text-muted-foreground/60 mb-1.5">Recent Builds</div>
+          <div className="text-xs uppercase tracking-wider text-muted-foreground mb-1.5">Recent Builds</div>
           <div className="space-y-1">
             {recentBuilds.map(b => (
               <div key={`${b.cluster}-${b.namespace}-${b.name}`} className="flex items-center gap-2 text-xs">

--- a/web/src/components/cards/kagenti/KagentiAgentFleet.tsx
+++ b/web/src/components/cards/kagenti/KagentiAgentFleet.tsx
@@ -83,7 +83,7 @@ export function KagentiAgentFleet({ config }: KagentiAgentFleetProps) {
       <div className="flex flex-col items-center justify-center py-8 text-center">
         <Bot className="w-10 h-10 text-muted-foreground/30 mb-3" />
         <div className="text-sm font-medium text-muted-foreground">No Agents Deployed</div>
-        <div className="text-xs text-muted-foreground/60 mt-1">Deploy kagenti agents to see them here</div>
+        <div className="text-xs text-muted-foreground mt-1">Deploy kagenti agents to see them here</div>
       </div>
     )
   }
@@ -105,17 +105,17 @@ export function KagentiAgentFleet({ config }: KagentiAgentFleetProps) {
             <Bot className="w-3.5 h-3.5 text-violet-400 shrink-0" />
             <div className="min-w-0 flex-1">
               <div className="text-sm font-medium truncate">{agent.name}</div>
-              <div className="text-xs text-muted-foreground/60 flex items-center gap-1">
+              <div className="text-xs text-muted-foreground flex items-center gap-1">
                 <Server className="w-2.5 h-2.5" />
                 {agent.cluster}
                 {agent.framework && <span className="text-violet-400/60">/ {agent.framework}</span>}
               </div>
             </div>
-            <div className="text-xs text-muted-foreground/50">
+            <div className="text-xs text-muted-foreground">
               {agent.readyReplicas}/{agent.replicas}
             </div>
             <StatusBadge status={agent.status} />
-            <ChevronRight className="w-3 h-3 text-muted-foreground/20 group-hover:text-muted-foreground/50" />
+            <ChevronRight className="w-3 h-3 text-muted-foreground/20 group-hover:text-muted-foreground" />
           </div>
         ))}
       </div>

--- a/web/src/components/cards/kagenti/KagentiSecurity.tsx
+++ b/web/src/components/cards/kagenti/KagentiSecurity.tsx
@@ -41,7 +41,7 @@ export function KagentiSecurity({ config }: { config?: Record<string, unknown> }
       <div className="rounded-lg border border-white/5 bg-white/[0.02] p-3">
         <div className="flex items-center gap-2 mb-2">
           <Shield className="w-4 h-4 text-violet-400" />
-          <span className="text-sm text-gray-200 font-medium">SPIFFE Identity Coverage</span>
+          <span className="text-sm text-foreground font-medium">SPIFFE Identity Coverage</span>
         </div>
         <div className="flex items-center gap-3 mb-2">
           <div className="flex-1 h-3 bg-white/5 rounded-full overflow-hidden">
@@ -55,15 +55,15 @@ export function KagentiSecurity({ config }: { config?: Record<string, unknown> }
         <div className="grid grid-cols-3 gap-2 text-center">
           <div className="rounded bg-emerald-400/10 py-1.5">
             <div className="text-sm font-bold text-emerald-400">{stats.strict}</div>
-            <div className="text-xs text-gray-500">Strict</div>
+            <div className="text-xs text-muted-foreground">Strict</div>
           </div>
           <div className="rounded bg-amber-400/10 py-1.5">
             <div className="text-sm font-bold text-amber-400">{stats.permissive}</div>
-            <div className="text-xs text-gray-500">Permissive</div>
+            <div className="text-xs text-muted-foreground">Permissive</div>
           </div>
           <div className="rounded bg-red-400/10 py-1.5">
             <div className="text-sm font-bold text-red-400">{stats.unbound}</div>
-            <div className="text-xs text-gray-500">Unbound</div>
+            <div className="text-xs text-muted-foreground">Unbound</div>
           </div>
         </div>
       </div>
@@ -80,9 +80,9 @@ export function KagentiSecurity({ config }: { config?: Record<string, unknown> }
               <div key={`${agent.cluster}-${agent.name}`} className="flex items-center justify-between text-xs py-1 px-2 rounded bg-red-400/5 border border-red-400/10">
                 <div className="flex items-center gap-1.5">
                   <ShieldAlert className="w-3 h-3 text-red-400" />
-                  <span className="text-gray-300">{agent.agentName}</span>
+                  <span className="text-foreground">{agent.agentName}</span>
                 </div>
-                <span className="text-gray-500 truncate max-w-[80px]">{agent.cluster}</span>
+                <span className="text-muted-foreground truncate max-w-[80px]">{agent.cluster}</span>
               </div>
             ))}
           </div>
@@ -98,7 +98,7 @@ export function KagentiSecurity({ config }: { config?: Record<string, unknown> }
       )}
 
       {stats.total === 0 && (
-        <div className="text-center py-6 text-gray-500 text-xs">No AgentCards found</div>
+        <div className="text-center py-6 text-muted-foreground text-xs">No AgentCards found</div>
       )}
     </div>
   )

--- a/web/src/components/cards/kagenti/KagentiTopology.tsx
+++ b/web/src/components/cards/kagenti/KagentiTopology.tsx
@@ -99,7 +99,7 @@ export function KagentiTopology({ config }: { config?: Record<string, unknown> }
 
   if (nodes.length === 0) {
     return (
-      <div className="h-full flex flex-col min-h-card items-center justify-center text-gray-500 text-xs">
+      <div className="h-full flex flex-col min-h-card items-center justify-center text-muted-foreground text-xs">
         No agents or tools to visualize
       </div>
     )
@@ -110,24 +110,24 @@ export function KagentiTopology({ config }: { config?: Record<string, unknown> }
   return (
     <div className="h-full flex flex-col min-h-card">
       {/* Legend */}
-      <div className="flex items-center gap-4 px-3 pt-2 pb-1 text-xs text-gray-500">
+      <div className="flex items-center gap-4 px-3 pt-2 pb-1 text-xs text-muted-foreground">
         <div className="flex items-center gap-1">
-          <div className="w-3 h-3 rounded-full border-2 border-blue-400" />
+          <div className="w-2.5 h-2.5 rounded-full border-2 border-blue-400" />
           <span>Agent</span>
         </div>
         <div className="flex items-center gap-1">
-          <div className="w-3 h-3 rounded bg-gray-500" />
+          <div className="w-2.5 h-2.5 rounded bg-muted-foreground/50" />
           <span>MCP Tool</span>
         </div>
         <div className="flex items-center gap-1">
-          <div className="w-6 h-0 border-t border-dashed border-gray-500" />
+          <div className="w-6 h-0 border-t border-dashed border-muted-foreground/50" />
           <span>Connection</span>
         </div>
       </div>
 
       {/* SVG graph */}
       <div className="flex-1 overflow-auto px-2 pb-2">
-        <svg width="100%" height={svgHeight} viewBox={`0 0 420 ${svgHeight}`} className="w-full">
+        <svg width="100%" height={svgHeight} viewBox={`0 0 420 ${svgHeight}`} className="w-full" style={{ fontFamily: 'var(--font-family)' }}>
           {/* Edges */}
           {edges.map((edge, i) => {
             const from = nodes.find(n => n.id === edge.from)
@@ -167,10 +167,10 @@ export function KagentiTopology({ config }: { config?: Record<string, unknown> }
               <text
                 x={node.type === 'agent' ? node.x - 60 : node.x + 20}
                 y={node.y + 4}
-                fill="#d1d5db"
-                fontSize={10}
+                fill="currentColor"
+                fontSize={11}
                 textAnchor={node.type === 'agent' ? 'end' : 'start'}
-                className="select-none"
+                className="select-none text-muted-foreground"
               >
                 {node.label.length > 16 ? node.label.slice(0, 14) + '...' : node.label}
               </text>


### PR DESCRIPTION
## Summary
- Add `fontFamily: var(--font-family)` to SVG in Agent Topology card — text was rendering in browser default font instead of Inter
- Replace hardcoded `text-gray-*` colors with theme tokens (`text-foreground`, `text-muted-foreground`) in Kagenti Overview, Agent Fleet, Agent Topology, and Security cards
- Remove excessive `/60` opacity modifiers on text content that made text appear lighter than standard cards

## Test plan
- [x] Build passes
- [ ] Verify Agent Topology SVG labels now render in Inter font
- [ ] Verify Kagenti Overview and Agent Fleet text weight/color matches standard cards like Deployment Status

🤖 Generated with [Claude Code](https://claude.com/claude-code)