### PR TITLE
✨ Add instant loading page on backend startup

### DIFF
--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -40,7 +40,8 @@ func main() {
 		ensureDir(cfg.DatabasePath)
 	}
 
-	// Create and start server
+	// Create and start server — starts HTTP listener immediately with a loading
+	// page, then initializes services (DB, k8s, MCP, etc.) in the background.
 	server, err := api.NewServer(cfg)
 	if err != nil {
 		log.Fatalf("Failed to create server: %v", err)
@@ -59,7 +60,7 @@ func main() {
 		os.Exit(0)
 	}()
 
-	// Start server
+	// Block until shutdown (HTTP listener runs in background from NewServer)
 	if err := server.Start(); err != nil {
 		log.Fatalf("Server error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Backend starts a temporary loading page server immediately on startup, before heavy initialization (DB, k8s, MCP, AI providers)
- Users see a styled "Starting up..." page instead of "connection refused" while services initialize
- Loading page auto-polls `/health` and reloads when the backend is ready
- Once initialization completes, the temporary server shuts down and the real Fiber app takes over on the same port

## Test plan
- [ ] Run `./startup-oauth.sh` and immediately open `http://localhost:8080` — should see loading page
- [ ] Wait for init to complete — page auto-reloads to the real app
- [ ] Verify `/health` returns `{"status":"starting"}` during init, `{"status":"ok"}` after
- [ ] Verify all API routes work normally after initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)