### PR TITLE
🐛 Fix perf test: ESM compat and timing calculation

### DIFF
--- a/web/e2e/perf/dashboard-perf.spec.ts
+++ b/web/e2e/perf/dashboard-perf.spec.ts
@@ -1,6 +1,9 @@
 import { test, type Page } from '@playwright/test'
 import * as fs from 'fs'
 import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 import {
   setupNetworkInterceptor,
   waitForCardContent,
@@ -181,8 +184,8 @@ async function measureDashboard(
     route: dashboard.route,
     mode,
     navigationStartMs: navStart,
-    firstCardVisibleMs: firstCardTime === Infinity ? -1 : firstCardTime - navStart,
-    lastCardVisibleMs: lastCardTime === 0 ? -1 : lastCardTime - navStart,
+    firstCardVisibleMs: firstCardTime === Infinity ? -1 : firstCardTime,
+    lastCardVisibleMs: lastCardTime === 0 ? -1 : lastCardTime,
     totalApiRequests: networkTimings.size,
     cards: cardMetrics,
   }


### PR DESCRIPTION
## Summary
- Fix `__dirname` not defined error in ESM context by using `fileURLToPath(import.meta.url)`
- Fix `firstCardVisibleMs` / `lastCardVisibleMs` double-subtraction bug — `timeToFirstContent` is already relative to `navStart`, so don't subtract `navStart` again

## Test plan
- [x] `./scripts/perf-test.sh --demo-only` passes all 25 tests with correct timing values

🤖 Generated with [Claude Code](https://claude.com/claude-code)