### PR TITLE
✨ Marketplace enhancements: thumbnails, installed state, card presets, themes

### DIFF
--- a/web/src/components/dashboard/DashboardCards.tsx
+++ b/web/src/components/dashboard/DashboardCards.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Plus, LayoutGrid, ChevronDown, ChevronRight, Layout } from 'lucide-react'
 import { CardWrapper } from '../cards/CardWrapper'
 import { CARD_COMPONENTS, DEMO_DATA_CARDS, LIVE_DATA_CARDS } from '../cards/cardRegistry'
@@ -49,6 +49,16 @@ export function DashboardCards({
   const [isTemplatesOpen, setIsTemplatesOpen] = useState(false)
   const [isConfigureOpen, setIsConfigureOpen] = useState(false)
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null)
+
+  // Listen for marketplace card-preset installs
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { card_type, config, title } = (e as CustomEvent).detail || {}
+      if (card_type) onAddCard(card_type, config || {}, title)
+    }
+    window.addEventListener('kc-add-card-from-marketplace', handler)
+    return () => window.removeEventListener('kc-add-card-from-marketplace', handler)
+  }, [onAddCard])
 
   const handleAddCards = (suggestions: CardSuggestion[]) => {
     suggestions.forEach(card => {

--- a/web/src/components/marketplace/Marketplace.tsx
+++ b/web/src/components/marketplace/Marketplace.tsx
@@ -1,11 +1,27 @@
 import { useState } from 'react'
-import { Store, Search, Download, Tag, RefreshCw, Loader2, AlertCircle, Package } from 'lucide-react'
-import { useMarketplace, MarketplaceItem } from '../../hooks/useMarketplace'
+import { useNavigate } from 'react-router-dom'
+import { Store, Search, Download, Tag, RefreshCw, Loader2, AlertCircle, Package, Check, Trash2, LayoutGrid, Puzzle, Palette, ExternalLink, Heart } from 'lucide-react'
+import { useMarketplace, MarketplaceItem, MarketplaceItemType } from '../../hooks/useMarketplace'
 import { useToast } from '../ui/Toast'
 import { DashboardHeader } from '../shared/DashboardHeader'
+import { MarketplaceThumbnail } from './MarketplaceThumbnail'
 
-function MarketplaceCard({ item, onInstall }: { item: MarketplaceItem; onInstall: (item: MarketplaceItem) => void }) {
+const CONTRIBUTE_URL = 'https://github.com/kubestellar/console-marketplace'
+
+const TYPE_LABELS: Record<MarketplaceItemType, { label: string; icon: typeof LayoutGrid }> = {
+  dashboard: { label: 'Dashboards', icon: LayoutGrid },
+  'card-preset': { label: 'Card Presets', icon: Puzzle },
+  theme: { label: 'Themes', icon: Palette },
+}
+
+function MarketplaceCard({ item, onInstall, onRemove, isInstalled }: {
+  item: MarketplaceItem
+  onInstall: (item: MarketplaceItem) => void
+  onRemove: (item: MarketplaceItem) => void
+  isInstalled: boolean
+}) {
   const [installing, setInstalling] = useState(false)
+  const [removing, setRemoving] = useState(false)
 
   const handleInstall = async () => {
     setInstalling(true)
@@ -15,6 +31,17 @@ function MarketplaceCard({ item, onInstall }: { item: MarketplaceItem; onInstall
       setInstalling(false)
     }
   }
+
+  const handleRemove = async () => {
+    setRemoving(true)
+    try {
+      await onRemove(item)
+    } finally {
+      setRemoving(false)
+    }
+  }
+
+  const typeInfo = TYPE_LABELS[item.type]
 
   return (
     <div className="group bg-card border border-border rounded-lg overflow-hidden hover:border-primary/30 transition-all hover:shadow-lg">
@@ -27,9 +54,7 @@ function MarketplaceCard({ item, onInstall }: { item: MarketplaceItem; onInstall
           />
         </div>
       ) : (
-        <div className="h-36 bg-gradient-to-br from-primary/10 to-primary/5 flex items-center justify-center">
-          <Package className="w-12 h-12 text-primary/30" />
-        </div>
+        <MarketplaceThumbnail itemId={item.id} itemType={item.type} className="group-hover:scale-105 transition-transform duration-300 origin-center" />
       )}
       <div className="p-4">
         <div className="flex items-start justify-between gap-2 mb-2">
@@ -50,25 +75,62 @@ function MarketplaceCard({ item, onInstall }: { item: MarketplaceItem; onInstall
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <span>{item.author}</span>
             <span>&middot;</span>
-            <span>{item.cardCount} cards</span>
-          </div>
-          <button
-            onClick={handleInstall}
-            disabled={installing}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors disabled:opacity-50"
-          >
-            {installing ? (
-              <Loader2 className="w-3 h-3 animate-spin" />
+            {item.type === 'theme' && item.themeColors ? (
+              <div className="flex gap-0.5">
+                {item.themeColors.slice(0, 5).map((color, i) => (
+                  <div key={i} className="w-3 h-3 rounded-full border border-border/50" style={{ backgroundColor: color }} />
+                ))}
+              </div>
+            ) : item.type === 'card-preset' ? (
+              <span className="flex items-center gap-1">
+                <typeInfo.icon className="w-3 h-3" />
+                1 card
+              </span>
             ) : (
-              <Download className="w-3 h-3" />
+              <span>{item.cardCount} cards</span>
             )}
-            Install
-          </button>
+          </div>
+          {isInstalled ? (
+            <div className="flex items-center gap-1.5">
+              <span className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-green-400 bg-green-500/10 rounded">
+                <Check className="w-3 h-3" />
+                Installed
+              </span>
+              <button
+                onClick={handleRemove}
+                disabled={removing}
+                className="flex items-center gap-1 px-2 py-1 text-[10px] text-red-400 hover:bg-red-500/10 rounded transition-colors disabled:opacity-50"
+                title="Remove"
+              >
+                {removing ? <Loader2 className="w-3 h-3 animate-spin" /> : <Trash2 className="w-3 h-3" />}
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={handleInstall}
+              disabled={installing}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors disabled:opacity-50"
+            >
+              {installing ? (
+                <Loader2 className="w-3 h-3 animate-spin" />
+              ) : (
+                <Download className="w-3 h-3" />
+              )}
+              Install
+            </button>
+          )}
         </div>
       </div>
     </div>
   )
 }
+
+const filterBtnClass = (active: boolean) =>
+  `flex items-center gap-1 px-2.5 py-1.5 text-xs rounded-md transition-colors ${
+    active
+      ? 'bg-primary/15 text-primary font-medium'
+      : 'bg-card border border-border text-muted-foreground hover:text-foreground'
+  }`
 
 export function Marketplace() {
   const {
@@ -80,17 +142,42 @@ export function Marketplace() {
     setSearchQuery,
     selectedTag,
     setSelectedTag,
+    selectedType,
+    setSelectedType,
     installItem,
+    removeItem,
+    isInstalled,
     refresh,
   } = useMarketplace()
   const { showToast } = useToast()
 
+  const navigate = useNavigate()
+
   const handleInstall = async (item: MarketplaceItem) => {
     try {
-      await installItem(item)
-      showToast(`Installed "${item.name}"`, 'success')
+      const result = await installItem(item)
+      if (result.type === 'card-preset') {
+        showToast(`Added "${item.name}" card to your dashboard`, 'success')
+      } else if (result.type === 'theme') {
+        showToast(`Installed theme "${item.name}" — activate in Settings`, 'success')
+      } else if (result.type === 'dashboard' && result.data?.id) {
+        const dashId = result.data.id
+        showToast(`Installed "${item.name}" — redirecting to dashboard...`, 'success')
+        setTimeout(() => navigate(`/custom-dashboard/${dashId}`), 1500)
+      } else {
+        showToast(`Installed "${item.name}"`, 'success')
+      }
     } catch {
       showToast(`Failed to install "${item.name}"`, 'error')
+    }
+  }
+
+  const handleRemove = async (item: MarketplaceItem) => {
+    try {
+      await removeItem(item)
+      showToast(`Removed "${item.name}"`, 'info')
+    } catch {
+      showToast(`Failed to remove "${item.name}"`, 'error')
     }
   }
 
@@ -98,7 +185,7 @@ export function Marketplace() {
     <div className="space-y-6">
       <DashboardHeader
         title="Marketplace"
-        subtitle="Community dashboards and card presets"
+        subtitle="Community dashboards, card presets, and themes"
         icon={<Store className="w-5 h-5" />}
         isFetching={isLoading}
         onRefresh={refresh}
@@ -112,31 +199,35 @@ export function Marketplace() {
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search dashboards..."
+            placeholder="Search marketplace..."
             className="w-full pl-9 pr-3 py-2 text-sm bg-card border border-border rounded-md focus:outline-none focus:ring-1 focus:ring-primary/50 text-foreground placeholder:text-muted-foreground"
           />
         </div>
 
-        <div className="flex flex-wrap items-center gap-1.5">
-          <button
-            onClick={() => setSelectedTag(null)}
-            className={`flex items-center gap-1 px-2.5 py-1.5 text-xs rounded-md transition-colors ${
-              !selectedTag
-                ? 'bg-primary/15 text-primary font-medium'
-                : 'bg-card border border-border text-muted-foreground hover:text-foreground'
-            }`}
-          >
+        {/* Type filter */}
+        <div className="flex items-center gap-1.5">
+          <button onClick={() => setSelectedType(null)} className={filterBtnClass(!selectedType)}>
             All
           </button>
+          {(Object.entries(TYPE_LABELS) as [MarketplaceItemType, typeof TYPE_LABELS[MarketplaceItemType]][]).map(([type, { label, icon: Icon }]) => (
+            <button
+              key={type}
+              onClick={() => setSelectedType(selectedType === type ? null : type)}
+              className={filterBtnClass(selectedType === type)}
+            >
+              <Icon className="w-3 h-3" />
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {/* Tag filter */}
+        <div className="flex flex-wrap items-center gap-1.5">
           {allTags.map(tag => (
             <button
               key={tag}
               onClick={() => setSelectedTag(selectedTag === tag ? null : tag)}
-              className={`flex items-center gap-1 px-2.5 py-1.5 text-xs rounded-md transition-colors ${
-                selectedTag === tag
-                  ? 'bg-primary/15 text-primary font-medium'
-                  : 'bg-card border border-border text-muted-foreground hover:text-foreground'
-              }`}
+              className={filterBtnClass(selectedTag === tag)}
             >
               <Tag className="w-3 h-3" />
               {tag}
@@ -175,10 +266,10 @@ export function Marketplace() {
         <div className="flex flex-col items-center justify-center py-20 text-center">
           <Package className="w-10 h-10 text-muted-foreground/50 mb-3" />
           <p className="text-sm text-muted-foreground mb-1">
-            {searchQuery || selectedTag ? 'No matching items' : 'No community content yet'}
+            {searchQuery || selectedTag || selectedType ? 'No matching items' : 'No community content yet'}
           </p>
           <p className="text-xs text-muted-foreground/70">
-            {searchQuery || selectedTag
+            {searchQuery || selectedTag || selectedType
               ? 'Try adjusting your search or filters'
               : 'Community dashboards and presets will appear here'}
           </p>
@@ -190,10 +281,32 @@ export function Marketplace() {
               key={item.id}
               item={item}
               onInstall={handleInstall}
+              onRemove={handleRemove}
+              isInstalled={isInstalled(item.id)}
             />
           ))}
         </div>
       )}
+
+      {/* Contribute */}
+      <div className="flex items-center justify-between bg-card border border-border rounded-lg px-5 py-4">
+        <div className="flex items-center gap-3">
+          <Heart className="w-5 h-5 text-pink-400 shrink-0" />
+          <div>
+            <p className="text-sm font-medium text-foreground">Share with the community</p>
+            <p className="text-xs text-muted-foreground">Contribute dashboards, card presets, or themes — just open a PR with your JSON file.</p>
+          </div>
+        </div>
+        <a
+          href={CONTRIBUTE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-primary/10 hover:bg-primary/20 text-primary rounded-md transition-colors shrink-0"
+        >
+          <ExternalLink className="w-3 h-3" />
+          Contribute
+        </a>
+      </div>
     </div>
   )
 }

--- a/web/src/components/marketplace/MarketplaceThumbnail.tsx
+++ b/web/src/components/marketplace/MarketplaceThumbnail.tsx
@@ -1,0 +1,95 @@
+interface ThumbnailConfig {
+  gradient: [string, string]
+  icon: string // SVG path data
+  label: string
+}
+
+const ITEM_THUMBNAILS: Record<string, ThumbnailConfig> = {
+  'sre-overview': {
+    gradient: ['#7c3aed', '#3b82f6'],
+    icon: 'M22 12h-4l-3 9L9 3l-3 9H2', // Activity
+    label: 'SRE',
+  },
+  'security-audit': {
+    gradient: ['#ef4444', '#f97316'],
+    icon: 'M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z', // Shield
+    label: 'SEC',
+  },
+  'gitops-pipeline': {
+    gradient: ['#10b981', '#06b6d4'],
+    icon: 'M6 3v12M18 9a3 3 0 100 6 3 3 0 000-6zM6 21a3 3 0 100-6 3 3 0 000 6zM18 15l-6 6', // GitBranch
+    label: 'OPS',
+  },
+}
+
+const TYPE_FALLBACKS: Record<string, ThumbnailConfig> = {
+  dashboard: {
+    gradient: ['#6366f1', '#8b5cf6'],
+    icon: 'M3 3h7v7H3zM14 3h7v7h-7zM3 14h7v7H3zM14 14h7v7h-7z', // LayoutGrid
+    label: '',
+  },
+  'card-preset': {
+    gradient: ['#06b6d4', '#3b82f6'],
+    icon: 'M21 8V5a2 2 0 00-2-2H5a2 2 0 00-2 2v3m18 0v11a2 2 0 01-2 2H5a2 2 0 01-2-2V8m18 0H3', // Card
+    label: '',
+  },
+  theme: {
+    gradient: ['#ec4899', '#a855f7'],
+    icon: 'M12 2a10 10 0 000 20c.6 0 1-.4 1-1v-1.5c0-.8-.7-1.5-1.5-1.5H9a2 2 0 01-2-2v-1a2 2 0 012-2h1a2 2 0 002-2V8a2 2 0 012-2h.5', // Palette
+    label: '',
+  },
+}
+
+export function MarketplaceThumbnail({ itemId, itemType, className }: {
+  itemId: string
+  itemType: 'dashboard' | 'card-preset' | 'theme'
+  className?: string
+}) {
+  const config = ITEM_THUMBNAILS[itemId] || TYPE_FALLBACKS[itemType] || TYPE_FALLBACKS.dashboard
+
+  return (
+    <div className={`h-36 overflow-hidden relative ${className || ''}`}>
+      <svg viewBox="0 0 400 144" className="w-full h-full" preserveAspectRatio="xMidYMid slice">
+        <defs>
+          <linearGradient id={`grad-${itemId}`} x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor={config.gradient[0]} stopOpacity="0.25" />
+            <stop offset="100%" stopColor={config.gradient[1]} stopOpacity="0.15" />
+          </linearGradient>
+          <linearGradient id={`icon-grad-${itemId}`} x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor={config.gradient[0]} stopOpacity="0.6" />
+            <stop offset="100%" stopColor={config.gradient[1]} stopOpacity="0.4" />
+          </linearGradient>
+        </defs>
+        {/* Background */}
+        <rect width="400" height="144" fill={`url(#grad-${itemId})`} />
+        {/* Grid dots pattern */}
+        {Array.from({ length: 8 }).map((_, row) =>
+          Array.from({ length: 16 }).map((_, col) => (
+            <circle
+              key={`${row}-${col}`}
+              cx={25 + col * 25}
+              cy={12 + row * 18}
+              r="1"
+              fill={config.gradient[0]}
+              opacity={0.15}
+            />
+          ))
+        )}
+        {/* Center icon */}
+        <g transform="translate(176, 48)" opacity="0.5">
+          <path
+            d={config.icon}
+            fill="none"
+            stroke={`url(#icon-grad-${itemId})`}
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            transform="scale(2)"
+          />
+        </g>
+        {/* Decorative lines */}
+        <line x1="0" y1="143" x2="400" y2="143" stroke={config.gradient[0]} strokeOpacity="0.2" strokeWidth="1" />
+      </svg>
+    </div>
+  )
+}

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -1,9 +1,13 @@
 import { useState, useEffect, useCallback } from 'react'
 import { api } from '../lib/api'
+import { addCustomTheme, removeCustomTheme } from '../lib/themes'
 
 const REGISTRY_URL = 'https://raw.githubusercontent.com/kubestellar/console-marketplace/main/registry.json'
 const CACHE_KEY = 'kc-marketplace-registry'
 const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
+const INSTALLED_KEY = 'kc-marketplace-installed'
+
+export type MarketplaceItemType = 'dashboard' | 'card-preset' | 'theme'
 
 export interface MarketplaceItem {
   id: string
@@ -15,7 +19,8 @@ export interface MarketplaceItem {
   downloadUrl: string
   tags: string[]
   cardCount: number
-  type: 'dashboard' | 'card-preset' | 'theme'
+  type: MarketplaceItemType
+  themeColors?: string[] // Preview colors for theme items
 }
 
 interface MarketplaceRegistry {
@@ -29,12 +34,44 @@ interface CachedRegistry {
   fetchedAt: number
 }
 
+interface InstalledEntry {
+  dashboardId?: string
+  installedAt: string
+  type: MarketplaceItemType
+}
+
+type InstalledMap = Record<string, InstalledEntry>
+
+function loadInstalled(): InstalledMap {
+  try {
+    return JSON.parse(localStorage.getItem(INSTALLED_KEY) || '{}')
+  } catch {
+    return {}
+  }
+}
+
+function saveInstalled(map: InstalledMap): void {
+  try {
+    localStorage.setItem(INSTALLED_KEY, JSON.stringify(map))
+  } catch {
+    // Non-critical
+  }
+}
+
+export interface InstallResult {
+  type: MarketplaceItemType
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: any
+}
+
 export function useMarketplace() {
   const [items, setItems] = useState<MarketplaceItem[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedTag, setSelectedTag] = useState<string | null>(null)
+  const [selectedType, setSelectedType] = useState<MarketplaceItemType | null>(null)
+  const [installedItems, setInstalledItems] = useState<InstalledMap>(loadInstalled)
 
   const fetchRegistry = useCallback(async () => {
     setIsLoading(true)
@@ -82,13 +119,71 @@ export function useMarketplace() {
     fetchRegistry()
   }, [fetchRegistry])
 
-  const installItem = useCallback(async (item: MarketplaceItem) => {
+  const markInstalled = useCallback((itemId: string, entry: InstalledEntry) => {
+    setInstalledItems(prev => {
+      const next = { ...prev, [itemId]: entry }
+      saveInstalled(next)
+      return next
+    })
+  }, [])
+
+  const markUninstalled = useCallback((itemId: string) => {
+    setInstalledItems(prev => {
+      const next = { ...prev }
+      delete next[itemId]
+      saveInstalled(next)
+      return next
+    })
+  }, [])
+
+  const isInstalled = useCallback((itemId: string): boolean => {
+    return itemId in installedItems
+  }, [installedItems])
+
+  const installItem = useCallback(async (item: MarketplaceItem): Promise<InstallResult> => {
     const response = await fetch(item.downloadUrl)
     if (!response.ok) throw new Error(`Download failed: ${response.status}`)
-    const dashboardJson = await response.json()
-    const { data } = await api.post('/api/dashboards/import', dashboardJson)
-    return data
-  }, [])
+    const json = await response.json()
+
+    if (item.type === 'card-preset') {
+      // Dispatch event for the active dashboard to pick up
+      window.dispatchEvent(new CustomEvent('kc-add-card-from-marketplace', { detail: json }))
+      markInstalled(item.id, { installedAt: new Date().toISOString(), type: 'card-preset' })
+      return { type: 'card-preset', data: json }
+    }
+
+    if (item.type === 'theme') {
+      addCustomTheme(json)
+      window.dispatchEvent(new Event('kc-custom-themes-changed'))
+      markInstalled(item.id, { installedAt: new Date().toISOString(), type: 'theme' })
+      return { type: 'theme', data: json }
+    }
+
+    // Dashboard — import via API
+    const { data } = await api.post('/api/dashboards/import', json)
+    markInstalled(item.id, {
+      dashboardId: data?.id,
+      installedAt: new Date().toISOString(),
+      type: 'dashboard',
+    })
+    return { type: 'dashboard', data }
+  }, [markInstalled])
+
+  const removeItem = useCallback(async (item: MarketplaceItem) => {
+    const entry = installedItems[item.id]
+    if (!entry) return
+
+    if (entry.type === 'dashboard' && entry.dashboardId) {
+      await api.delete(`/api/dashboards/${entry.dashboardId}`)
+    }
+
+    if (entry.type === 'theme') {
+      removeCustomTheme(item.id)
+      window.dispatchEvent(new Event('kc-custom-themes-changed'))
+    }
+
+    markUninstalled(item.id)
+  }, [installedItems, markUninstalled])
 
   // Collect all unique tags
   const allTags = Array.from(new Set(items.flatMap(i => i.tags))).sort()
@@ -99,7 +194,8 @@ export function useMarketplace() {
       item.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
       item.description.toLowerCase().includes(searchQuery.toLowerCase())
     const matchesTag = !selectedTag || item.tags.includes(selectedTag)
-    return matchesSearch && matchesTag
+    const matchesType = !selectedType || item.type === selectedType
+    return matchesSearch && matchesTag && matchesType
   })
 
   return {
@@ -112,7 +208,11 @@ export function useMarketplace() {
     setSearchQuery,
     selectedTag,
     setSelectedTag,
+    selectedType,
+    setSelectedType,
     installItem,
+    removeItem,
+    isInstalled,
     refresh: fetchRegistry,
   }
 }

--- a/web/src/lib/themes.ts
+++ b/web/src/lib/themes.ts
@@ -1477,8 +1477,34 @@ export const themeGroups = [
   { name: 'Aesthetic', themes: ['kanagawa', 'moonlight', 'horizon'] },
 ]
 
+// Custom themes from marketplace (localStorage)
+const CUSTOM_THEMES_KEY = 'kc-custom-themes'
+
+export function getCustomThemes(): Theme[] {
+  try {
+    return JSON.parse(localStorage.getItem(CUSTOM_THEMES_KEY) || '[]')
+  } catch {
+    return []
+  }
+}
+
+export function addCustomTheme(theme: Theme): void {
+  const customs = getCustomThemes().filter(t => t.id !== theme.id)
+  customs.push(theme)
+  localStorage.setItem(CUSTOM_THEMES_KEY, JSON.stringify(customs))
+}
+
+export function removeCustomTheme(themeId: string): void {
+  const customs = getCustomThemes().filter(t => t.id !== themeId)
+  localStorage.setItem(CUSTOM_THEMES_KEY, JSON.stringify(customs))
+}
+
+export function getAllThemes(): Theme[] {
+  return [...themes, ...getCustomThemes()]
+}
+
 export function getThemeById(id: string): Theme | undefined {
-  return themes.find(t => t.id === id)
+  return getAllThemes().find(t => t.id === id)
 }
 
 export function getDefaultTheme(): Theme {


### PR DESCRIPTION
## Summary
- **SVG gradient thumbnails** — each marketplace item gets a unique, visually distinct thumbnail based on its ID/type instead of a generic Package icon
- **Installed state tracking** — "Installed" badge with Remove button, persisted in localStorage across sessions
- **Post-install navigation** — dashboard installs show a toast then redirect to the new dashboard after 1.5s
- **Card preset support** — individual cards can be shared via marketplace and added to the current dashboard via CustomEvent bridge
- **Theme marketplace** — custom themes can be installed from marketplace and appear in Settings; reactive theme provider updates on install/remove
- **Type filters** — filter by All / Dashboards / Card Presets / Themes
- **Contribute section** — links to [console-marketplace](https://github.com/kubestellar/console-marketplace) repo with instructions

Also updated the marketplace repo with 3 seed card presets and 2 community themes.

## Test plan
- [ ] Navigate to `/marketplace` — each card shows distinct gradient SVG thumbnail
- [ ] Install "SRE Overview" — toast says "redirecting", navigates to custom dashboard after 1.5s
- [ ] Return to marketplace — SRE Overview shows green "Installed" badge + Remove button
- [ ] Click Remove — dashboard deleted, button reverts to "Install"
- [ ] Filter by "Card Presets" — see 3 card preset items
- [ ] Install a card preset — card appears on current dashboard
- [ ] Filter by "Themes" — see 2 theme items with color dots
- [ ] Install a theme — appears in Settings theme picker
- [ ] "Contribute" section visible at bottom with external link to marketplace repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)