### PR TITLE
🐛 Remove redundant refresh button from marketplace

### DIFF
--- a/web/src/components/marketplace/Marketplace.tsx
+++ b/web/src/components/marketplace/Marketplace.tsx
@@ -235,13 +235,6 @@ export function Marketplace() {
           ))}
         </div>
 
-        <button
-          onClick={refresh}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground bg-card border border-border rounded-md transition-colors ml-auto"
-          title="Refresh registry"
-        >
-          <RefreshCw className="w-3.5 h-3.5" />
-        </button>
       </div>
 
       {/* Content */}

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -73,23 +73,25 @@ export function useMarketplace() {
   const [selectedType, setSelectedType] = useState<MarketplaceItemType | null>(null)
   const [installedItems, setInstalledItems] = useState<InstalledMap>(loadInstalled)
 
-  const fetchRegistry = useCallback(async () => {
+  const fetchRegistry = useCallback(async (skipCache = false) => {
     setIsLoading(true)
     setError(null)
 
-    // Check localStorage cache
-    try {
-      const cached = localStorage.getItem(CACHE_KEY)
-      if (cached) {
-        const parsed: CachedRegistry = JSON.parse(cached)
-        if (Date.now() - parsed.fetchedAt < CACHE_TTL_MS) {
-          setItems(parsed.data.items)
-          setIsLoading(false)
-          return
+    // Check localStorage cache (skip on manual refresh)
+    if (!skipCache) {
+      try {
+        const cached = localStorage.getItem(CACHE_KEY)
+        if (cached) {
+          const parsed: CachedRegistry = JSON.parse(cached)
+          if (Date.now() - parsed.fetchedAt < CACHE_TTL_MS) {
+            setItems(parsed.data.items)
+            setIsLoading(false)
+            return
+          }
         }
+      } catch {
+        // Cache read failed — continue to fetch
       }
-    } catch {
-      // Cache read failed — continue to fetch
     }
 
     try {
@@ -213,6 +215,6 @@ export function useMarketplace() {
     installItem,
     removeItem,
     isInstalled,
-    refresh: fetchRegistry,
+    refresh: () => fetchRegistry(true),
   }
 }


### PR DESCRIPTION
## Summary
- Remove duplicate refresh button from the marketplace filter bar (DashboardHeader already has one)
- Make manual refresh bypass the localStorage cache so users always get fresh registry data

## Test plan
- [ ] Only one refresh icon visible on marketplace page (in the header)
- [ ] Clicking refresh fetches fresh data from GitHub (bypasses 1hr cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)