### PR TITLE
🐛 Add marketplace dashboards to sidebar with vanity URLs

### DIFF
--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -142,6 +142,10 @@ export function useMarketplace() {
     return itemId in installedItems
   }, [installedItems])
 
+  const getInstalledDashboardId = useCallback((itemId: string): string | undefined => {
+    return installedItems[itemId]?.dashboardId
+  }, [installedItems])
+
   const installItem = useCallback(async (item: MarketplaceItem): Promise<InstallResult> => {
     const response = await fetch(item.downloadUrl)
     if (!response.ok) throw new Error(`Download failed: ${response.status}`)
@@ -215,6 +219,7 @@ export function useMarketplace() {
     installItem,
     removeItem,
     isInstalled,
+    getInstalledDashboardId,
     refresh: () => fetchRegistry(true),
   }
 }


### PR DESCRIPTION
## Summary
- Installed marketplace dashboards now appear in the left sidebar immediately
- Uses marketplace item slug as URL (e.g., `/custom-dashboard/sre-overview`) instead of backend UUID
- Seeds localStorage with card data for instant loading without waiting for API
- Removing a marketplace dashboard also removes its sidebar entry

## Test plan
- [ ] Install "SRE Overview" from marketplace — appears in left sidebar
- [ ] URL shows `/custom-dashboard/sre-overview` (not a UUID)
- [ ] Dashboard loads cards correctly
- [ ] Remove from marketplace — sidebar entry disappears
- [ ] Refresh page — installed dashboard persists in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)