### PR TITLE
🐛 Fix marketplace remove not clearing sidebar entry

### DIFF
--- a/web/src/components/marketplace/Marketplace.tsx
+++ b/web/src/components/marketplace/Marketplace.tsx
@@ -149,7 +149,6 @@ export function Marketplace() {
     installItem,
     removeItem,
     isInstalled,
-    getInstalledDashboardId,
     refresh,
   } = useMarketplace()
   const { config: sidebarConfig, addItem, removeItem: removeSidebarItem } = useSidebarConfig()
@@ -192,14 +191,13 @@ export function Marketplace() {
 
   const handleRemove = async (item: MarketplaceItem) => {
     try {
-      // Find and remove sidebar entry for dashboards
-      const dashId = getInstalledDashboardId(item.id)
-      if (dashId) {
-        const href = `/custom-dashboard/${dashId}`
-        const sidebarItem = [...sidebarConfig.primaryNav, ...sidebarConfig.secondaryNav]
-          .find(si => si.href === href)
-        if (sidebarItem) removeSidebarItem(sidebarItem.id)
-      }
+      // Find and remove sidebar entry using the marketplace slug (not backend UUID)
+      const href = `/custom-dashboard/${item.id}`
+      const sidebarItem = [...sidebarConfig.primaryNav, ...sidebarConfig.secondaryNav]
+        .find(si => si.href === href)
+      if (sidebarItem) removeSidebarItem(sidebarItem.id)
+      // Clean up localStorage cards
+      try { localStorage.removeItem(`kubestellar-custom-dashboard-${item.id}-cards`) } catch { /* ok */ }
       await removeItem(item)
       showToast(`Removed "${item.name}"`, 'info')
     } catch {


### PR DESCRIPTION
## Summary
- Fixed marketplace remove handler using wrong ID for sidebar lookup (backend UUID vs marketplace slug)
- Added localStorage card cleanup on dashboard removal
- Removed unused `getInstalledDashboardId` import

## Test plan
- [ ] Install a marketplace dashboard (e.g., SRE Overview) — appears in sidebar
- [ ] Remove the dashboard from marketplace — sidebar entry is cleared
- [ ] Verify localStorage cards key is also cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)