### PR TITLE
🐛 Add demo data for Weather, GitHub Activity, RSS Feed cards

### DIFF
--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -488,6 +488,7 @@ export const DEMO_DATA_CARDS = new Set([
   'kagenti_agent_discovery',
   'kagenti_security',
   'kagenti_topology',
+  'kagenti_security_posture',
 ])
 
 /**
@@ -517,6 +518,8 @@ export const DEMO_EXEMPT_CARDS = new Set([
   'kube_pong',
   'kube_galaga',
   'kube_craft',
+  'kube_doom',
+  'dynamic_card',
 ])
 
 /**


### PR DESCRIPTION
## Summary
- **Weather card**: Added `getDemoWeatherData()` with current conditions, 7-day forecast, and 24-hour hourly data — bypasses Open-Meteo API in demo mode
- **GitHub Activity card**: Added `getDemoGitHubData()` with PRs, issues, releases, contributors — bypasses GitHub API in demo mode
- **RSS Feed card**: Added `getDemoRSSItems()` with 8 cloud-native themed articles — bypasses CORS-proxied RSS fetches in demo mode
- **Card registry**: Added `dynamic_card` to `DEMO_EXEMPT_CARDS`, `kagenti_security_posture` to `DEMO_DATA_CARDS`

## Context
Full audit of 153 card keys found 8 cards lacking demo data. This PR fixes the 3 external-API cards (Weather, GitHub Activity, RSS Feed). The remaining 5 were verified to already have demo data via MCP hooks, AlertsContext, or built-in mock generators.

## Test plan
- [ ] Open `http://localhost:5174` in demo mode, navigate to Dashboard — Weather card shows demo weather data
- [ ] Navigate to Dashboard — GitHub Activity card shows demo PRs/issues
- [ ] Navigate to Dashboard — RSS Feed card shows demo articles
- [ ] Verify no external API calls are made in demo mode (Network tab)
- [ ] `npm run build` passes
- [ ] `npm run lint` shows no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)