### PR TITLE
🐛 Fix demo mode data for 11 cards with missing data or empty dropdowns

### DIFF
--- a/web/src/components/cards/KustomizationStatus.tsx
+++ b/web/src/components/cards/KustomizationStatus.tsx
@@ -102,6 +102,13 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
     hasAnyData: kustomizationData.length > 0,
   })
 
+  // Auto-select first cluster in demo mode so card shows data immediately
+  useEffect(() => {
+    if (demoMode && !selectedCluster && allClusters.length > 0) {
+      setSelectedCluster(allClusters[0].name)
+    }
+  }, [demoMode, selectedCluster, allClusters])
+
   // Apply global filters to cluster list for the dropdown
   const clusters = useMemo(() => {
     let result = allClusters

--- a/web/src/components/cards/OverlayComparison.tsx
+++ b/web/src/components/cards/OverlayComparison.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { Plus, Minus, Edit, Layers, ChevronRight } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
@@ -58,6 +58,22 @@ export function OverlayComparison({ config }: OverlayComparisonProps) {
 
     return result
   }, [allClusters, globalSelectedClusters, isAllClustersSelected, customFilter])
+
+  // Auto-select cluster and overlays in demo mode so card shows data immediately
+  useEffect(() => {
+    if (demoMode && clusters.length > 0) {
+      if (!selectedCluster) {
+        setSelectedCluster(clusters[0].name)
+      }
+    }
+  }, [demoMode, clusters, selectedCluster])
+
+  useEffect(() => {
+    if (demoMode && selectedCluster && !selectedBase) {
+      setSelectedBase('base')
+      setSelectedOverlay('production')
+    }
+  }, [demoMode, selectedCluster, selectedBase])
 
   // Only show mock overlays/diffs in demo mode; live mode shows empty until real data source exists
   const overlays = selectedCluster && demoMode ? ['base', 'dev', 'staging', 'production'] : []

--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -417,6 +417,9 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
 }
 
 function getDemoEvents(): ClusterEvent[] {
+  const now = new Date()
+  const minutesAgo = (m: number) => new Date(now.getTime() - m * 60000).toISOString()
+
   return [
     {
       type: 'Warning',
@@ -426,6 +429,8 @@ function getDemoEvents(): ClusterEvent[] {
       namespace: 'batch',
       cluster: 'vllm-d',
       count: 3,
+      firstSeen: minutesAgo(25),
+      lastSeen: minutesAgo(5),
     },
     {
       type: 'Normal',
@@ -435,6 +440,8 @@ function getDemoEvents(): ClusterEvent[] {
       namespace: 'production',
       cluster: 'prod-east',
       count: 1,
+      firstSeen: minutesAgo(12),
+      lastSeen: minutesAgo(12),
     },
     {
       type: 'Warning',
@@ -444,6 +451,8 @@ function getDemoEvents(): ClusterEvent[] {
       namespace: 'production',
       cluster: 'prod-east',
       count: 15,
+      firstSeen: minutesAgo(45),
+      lastSeen: minutesAgo(2),
     },
     {
       type: 'Normal',
@@ -453,6 +462,8 @@ function getDemoEvents(): ClusterEvent[] {
       namespace: 'web',
       cluster: 'staging',
       count: 1,
+      firstSeen: minutesAgo(8),
+      lastSeen: minutesAgo(8),
     },
     {
       type: 'Warning',
@@ -462,6 +473,41 @@ function getDemoEvents(): ClusterEvent[] {
       namespace: 'data',
       cluster: 'staging',
       count: 8,
+      firstSeen: minutesAgo(30),
+      lastSeen: minutesAgo(1),
+    },
+    {
+      type: 'Normal',
+      reason: 'ScalingReplicaSet',
+      message: 'Scaled up replica set api-gateway-7d8c to 3',
+      object: 'Deployment/api-gateway',
+      namespace: 'production',
+      cluster: 'prod-east',
+      count: 1,
+      firstSeen: minutesAgo(18),
+      lastSeen: minutesAgo(18),
+    },
+    {
+      type: 'Normal',
+      reason: 'SuccessfulCreate',
+      message: 'Created pod: worker-5c6d7e8f9-abc12',
+      object: 'ReplicaSet/worker-5c6d7e8f9',
+      namespace: 'batch',
+      cluster: 'vllm-d',
+      count: 1,
+      firstSeen: minutesAgo(22),
+      lastSeen: minutesAgo(22),
+    },
+    {
+      type: 'Warning',
+      reason: 'FailedMount',
+      message: 'MountVolume.SetUp failed for volume "config": configmap "app-config" not found',
+      object: 'Pod/ml-inference-7f8g9h-xyz99',
+      namespace: 'ml',
+      cluster: 'vllm-d',
+      count: 4,
+      firstSeen: minutesAgo(35),
+      lastSeen: minutesAgo(3),
     },
   ]
 }

--- a/web/src/hooks/mcp/namespaces.ts
+++ b/web/src/hooks/mcp/namespaces.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { api } from '../../lib/api'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
 import { kubectlProxy } from '../../lib/kubectlProxy'
+import { isDemoMode } from '../../lib/demoMode'
 import { LOCAL_AGENT_URL, clusterCacheRef } from './shared'
 import type { PodInfo, NamespaceStats } from './types'
 
@@ -27,6 +28,14 @@ export function useNamespaces(cluster?: string) {
     if (!cluster) {
       setNamespaces([])
       setIsLoading(false)
+      return
+    }
+
+    // Demo mode returns synthetic namespaces immediately
+    if (isDemoMode()) {
+      setNamespaces(['default', 'kube-system', 'kube-public', 'monitoring', 'production', 'staging', 'batch', 'data', 'ingress', 'security'])
+      setIsLoading(false)
+      setError(null)
       return
     }
 


### PR DESCRIPTION
## Summary
- Add demo data to 5 hooks that returned empty data in demo mode (helm releases/history/values, events timestamps, namespaces, workloads, dependencies)
- Add auto-select useEffects to 6 cards whose dropdowns weren't pre-populated in demo mode (HelmHistory, HelmValuesDiff, KustomizationStatus, OverlayComparison, NamespaceRBAC, ResourceMarshall)
- All 11 cards from the audit now display data immediately in demo mode

## Cards Fixed
| Card | Issue | Fix |
|------|-------|-----|
| Helm Release Status | useHelmReleases returned empty | Added getDemoHelmReleases() |
| Helm History | No demo data + no auto-select | Added getDemoHelmHistory() + auto-select cluster/release |
| Helm Chart Versions | useHelmReleases returned empty | Fixed by getDemoHelmReleases() |
| Helm Values Diff | No demo data + no auto-select | Added getDemoHelmValues() + auto-select cluster/release |
| Recent Events | Events missing timestamps | Added firstSeen/lastSeen to getDemoEvents() |
| Events Timeline | Events missing timestamps | Fixed by getDemoEvents() timestamps |
| KustomizationStatus | No cluster auto-selected | Added auto-select first cluster |
| Overlay Comparison | No selections auto-made | Added auto-select cluster + base/overlay |
| Namespace RBAC | No cluster/namespace auto-selected | Added auto-select + demo namespaces |
| Resource Marshall | No demo workloads/deps + no auto-select | Added demo data to useWorkloads/useDependencies + cascading auto-select |
| Deployment Progress | Already works (worker-service has readyReplicas < replicas) | No change needed |

## Test plan
- [ ] Toggle demo mode on, cycle through all dashboards — cards should show data immediately
- [ ] Cards with dropdowns (Helm History, Helm Values Diff, Namespace RBAC, Resource Marshall, Kustomization Status, Overlay Comparison) should auto-populate selections
- [ ] `npm run build` passes
- [ ] `npm run lint` shows no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)