### PR TITLE
🐛 Fix deployment automation: settings crash, runner label, Claude secret

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -125,7 +125,6 @@ jobs:
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} \
             --set image.tag=${{ github.sha }} \
             --set github.existingSecret=kc-secrets \
-            --set claude.existingSecret=kc-secrets \
             --set jwt.existingSecret=kc-secrets \
             --set route.enabled=true \
             --set route.host=kc.apps.fmaas-vllm-d.fmaas.res.ibm.com \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,12 +49,13 @@ COPY --from=backend-builder /app/console .
 # Copy frontend build
 COPY --from=frontend-builder /app/dist ./web/dist
 
-# Create data directory
-RUN mkdir -p /app/data
+# Create data and settings directories
+RUN mkdir -p /app/data /app/.kc
 
 # Environment variables
 ENV PORT=8080
 ENV DATABASE_PATH=/app/data/console.db
+ENV HOME=/app
 
 EXPOSE 8080
 

--- a/pkg/settings/manager.go
+++ b/pkg/settings/manager.go
@@ -48,6 +48,8 @@ func GetSettingsManager() *SettingsManager {
 		}
 		if err := globalSettingsManager.init(); err != nil {
 			log.Printf("[settings] initialization error: %v", err)
+			// Ensure settings is never nil even when init fails
+			globalSettingsManager.settings = DefaultSettings()
 		}
 	})
 	return globalSettingsManager


### PR DESCRIPTION
## Summary
- Remove `claude.existingSecret=kc-secrets` from Helm deploy command (key `claude-api-key` doesn't exist in `kc-secrets`, causing `CreateContainerConfigError`)
- Fix nil pointer crash in `SettingsManager.MigrateFromConfigYaml()` when `init()` fails in container (home dir `/` is not writable)
- Set `HOME=/app` in Dockerfile and create `/app/.kc` directory so settings are writable

## Root Causes Found
1. **Runner label typo**: ARC RunnerDeployment on vllm-d had label `kkc` instead of `kc` — patched live
2. **Empty GitHub Environment secrets**: `KSC_OAUTH_CLIENT_ID`, `KSC_OAUTH_CLIENT_SECRET`, `KSC_JWT_SECRET` were not set in the `vllm-d` environment — now configured
3. **Missing Claude API key**: Helm deploy referenced `claude.existingSecret=kc-secrets` but the secret doesn't contain `claude-api-key`
4. **Settings nil pointer**: Container can't create `/.kc` directory, `init()` fails, `settings` stays nil, crash on `MigrateFromConfigYaml()`

## Test plan
- [ ] CI build passes
- [ ] Deploy job picks up self-hosted runner (label fixed to `kc`)
- [ ] Pod starts without `CreateContainerConfigError`
- [ ] Pod doesn't crash with nil pointer in SettingsManager
- [ ] `https://kc.apps.fmaas-vllm-d.fmaas.res.ibm.com` loads with GitHub OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)