### PR TITLE
🐛 Fix OAuth callback URL using localhost in deployed mode

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -302,7 +302,7 @@ func (s *Server) setupRoutes() {
 		GitHubSecret:     s.config.GitHubSecret,
 		JWTSecret:        s.config.JWTSecret,
 		FrontendURL:      s.config.FrontendURL,
-		BackendURL:       fmt.Sprintf("http://localhost:%d", s.config.Port),
+		BackendURL:       s.backendURL(),
 		DevUserLogin:     s.config.DevUserLogin,
 		DevUserEmail:     s.config.DevUserEmail,
 		DevUserAvatar:    s.config.DevUserAvatar,
@@ -607,6 +607,16 @@ func (s *Server) setupRoutes() {
 			return c.SendFile("./web/dist/index.html")
 		})
 	}
+}
+
+// backendURL returns the URL where the backend is reachable for OAuth callbacks.
+// In production (non-dev), frontend and backend are served from the same origin,
+// so we use FrontendURL. In dev mode, they run on separate ports.
+func (s *Server) backendURL() string {
+	if !s.config.DevMode && s.config.FrontendURL != "" {
+		return s.config.FrontendURL
+	}
+	return fmt.Sprintf("http://localhost:%d", s.config.Port)
 }
 
 // Start shuts down the temporary loading server and starts the real Fiber app.


### PR DESCRIPTION
## Summary
- In production mode, the OAuth callback redirect_uri was hardcoded to `http://localhost:8080/auth/github/callback`
- This meant GitHub would try to redirect to localhost after auth, which fails for the deployed instance at `https://kc.apps.fmaas-vllm-d.fmaas.res.ibm.com`
- Fix: In non-dev mode, use `FrontendURL` as the backend URL since both are served from the same origin behind the OpenShift route
- Dev mode continues using `http://localhost:{port}` since frontend/backend run on separate ports

## Test plan
- [ ] CI build passes
- [ ] Deploy to vllm-d succeeds
- [ ] Clicking "Continue with GitHub" redirects to GitHub with correct `redirect_uri=https://kc.apps.fmaas-vllm-d.fmaas.res.ibm.com/auth/github/callback`
- [ ] After GitHub auth, callback redirects back to the deployed app (not localhost)
- [ ] Local dev mode still works with localhost callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)