### PR TITLE
🐛 Fix quickstart: include web/dist root files, remove dev mode

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,6 +56,8 @@ archives:
       - tar.gz
     name_template: "console_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
+      - src: "web/dist/*"
+        dst: "web/dist"
       - src: "web/dist/**/*"
         dst: "web/dist"
 

--- a/start.sh
+++ b/start.sh
@@ -214,7 +214,7 @@ fi
 # Start console (serves frontend from web/dist at the specified port)
 echo "Starting console on port $PORT..."
 cd "$INSTALL_DIR"
-PORT="$PORT" DEV_MODE="${DEV_MODE:-true}" ./console --port "$PORT" &
+./console --port "$PORT" &
 CONSOLE_PID=$!
 
 # Wait for console to be ready


### PR DESCRIPTION
## Summary

- **GoReleaser**: Add `web/dist/*` glob to include `index.html`, `favicon.ico`, and other root-level files in the console archive. The existing `web/dist/**/*` pattern only matched files in subdirectories.
- **start.sh**: Remove `DEV_MODE=true` default. Binary quickstart should run in production mode to serve `web/dist/` static files at `:8080`.

## Test plan
- [ ] Trigger release, verify `console_*_linux_arm64.tar.gz` contains `web/dist/index.html`
- [ ] Run `start.sh` on Lima VM, verify `GET /` returns 200 (not 404)
- [ ] Verify console serves frontend at `http://localhost:8080`

🤖 Generated with [Claude Code](https://claude.com/claude-code)