### PR TITLE
🐛 Fix quickstart: auto-generate JWT_SECRET for production mode

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -211,6 +211,15 @@ if [ -x "$INSTALL_DIR/kc-agent" ]; then
     sleep 1
 fi
 
+# Generate JWT_SECRET if not set (required in production mode)
+if [ -z "$JWT_SECRET" ]; then
+    if command -v openssl &>/dev/null; then
+        export JWT_SECRET=$(openssl rand -hex 32)
+    else
+        export JWT_SECRET=$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')
+    fi
+fi
+
 # Start console (serves frontend from web/dist at the specified port)
 echo "Starting console on port $PORT..."
 cd "$INSTALL_DIR"


### PR DESCRIPTION
## Summary
- start.sh didn't set `JWT_SECRET`, causing the console binary to crash with `FATAL: JWT_SECRET environment variable is required in production mode`
- Auto-generates a random JWT_SECRET using `openssl rand -hex 32` (with `/dev/urandom` fallback)
- Same approach used in `startup-oauth.sh`

## Test plan
- [x] Verified on Lima VM: console previously crashed without JWT_SECRET
- [ ] Re-test on Lima VM after release with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)