### PR TITLE
🐛 Fix large clusters showing as Offline due to 10s health check timeout

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -1094,7 +1094,7 @@ func (s *Server) handleClusterHealthHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
 	health, err := s.k8sClient.GetClusterHealth(ctx, cluster)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -769,8 +769,9 @@ func (m *MultiClusterClient) GetClient(contextName string) (*kubernetes.Clientse
 		}
 	}
 
-	// Set reasonable timeouts
-	config.Timeout = 10 * time.Second
+	// Set reasonable timeouts — large OpenShift clusters (18+ nodes) can return
+	// 800KB+ node payloads that take >10s over higher-latency links
+	config.Timeout = 30 * time.Second
 
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -814,7 +815,7 @@ func (m *MultiClusterClient) GetDynamicClient(contextName string) (dynamic.Inter
 				return nil, fmt.Errorf("failed to get config for context %s: %w", contextName, err)
 			}
 		}
-		config.Timeout = 10 * time.Second
+		config.Timeout = 30 * time.Second
 		m.configs[contextName] = config
 	}
 


### PR DESCRIPTION
## Summary
- **Root cause**: `pok-prod-sa` (18-node OpenShift cluster) returns ~860KB of node data that takes ~9s over the network. The K8s REST client timeout (`config.Timeout`) and agent `/cluster-health` handler timeout were both 10s — just barely not enough.
- **Fix**: Increase both timeouts from 10s to 30s, matching other agent handler timeouts.
- **Result**: `pok-prod-sa` now reports `healthy=true, reachable=true, nodes=18` instead of `Offline`.

## Changes
- `pkg/agent/server.go`: Health check handler context timeout 10s → 30s
- `pkg/k8s/client.go`: REST client `config.Timeout` 10s → 30s (both regular and dynamic clients)

## Test plan
- [x] `curl http://localhost:8585/cluster-health?cluster=pok-prod-sa` returns `healthy=true, nodes=18`
- [x] `curl http://localhost:8585/cluster-health?cluster=ks-docs-oci` still works (0.2s)
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)