### PR TITLE
📖 Fix install docs: binary quickstart as primary, correct callback URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,24 +139,31 @@ The agent implements several security measures:
 
 ## Installation
 
-### Prerequisites
-
-- Go 1.23+
-- Node.js 20+
-- Docker (for containerized deployment)
-- GitHub OAuth App (for authentication)
-- [Claude Code](https://claude.ai/claude-code) CLI installed
-- KubeStellar plugins from the [Claude Code Marketplace](https://marketplace.claude.ai) (source: [claude-plugins](https://github.com/kubestellar/claude-plugins)):
-  - `kubestellar-ops` - Kubernetes operations tools
-  - `kubestellar-deploy` - Multi-cluster deployment tools
-
 ### Quick Start
 
-**1. Install Claude Code** (if not already installed)
+Download pre-built binaries and start in seconds (only requires `curl`):
 
-Follow the installation instructions at [claude.ai/claude-code](https://claude.ai/claude-code)
+```bash
+curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash
+```
 
-**2. Install KubeStellar Plugins from Marketplace**
+This downloads the console and kc-agent binaries, starts both, and opens your browser at http://localhost:8080.
+
+**Optional: Enable GitHub OAuth login**
+
+1. Create a [GitHub OAuth App](https://github.com/settings/developers) with:
+   - Homepage URL: `http://localhost:8080`
+   - Callback URL: `http://localhost:8080/auth/github/callback`
+2. Create a `.env` file next to the binaries:
+   ```
+   GITHUB_CLIENT_ID=your-client-id
+   GITHUB_CLIENT_SECRET=your-client-secret
+   ```
+3. Restart with `./startup-oauth.sh`
+
+### Claude Code Plugins
+
+For AI-powered operations, install [Claude Code](https://claude.ai/claude-code) and the KubeStellar plugins:
 
 ```bash
 # Install from Claude Code Marketplace
@@ -164,17 +171,16 @@ claude plugins install kubestellar-ops
 claude plugins install kubestellar-deploy
 ```
 
-**3. Or Install via Homebrew** (alternative method, source: [homebrew-tap](https://github.com/kubestellar/homebrew-tap))
+Or via Homebrew (source: [homebrew-tap](https://github.com/kubestellar/homebrew-tap)):
 
 ```bash
-# Add the KubeStellar tap
 brew tap kubestellar/tap
-
-# Install KubeStellar tools
 brew install kubestellar-ops kubestellar-deploy
 ```
 
 ### Local Development
+
+Prerequisites: Go 1.24+, Node.js 20+
 
 1. **Clone the repository**
 
@@ -183,77 +189,29 @@ git clone https://github.com/kubestellar/console.git
 cd console
 ```
 
-2. **Install KubeStellar tools** (if not already installed via brew)
+2. **Start in dev mode** (no OAuth required)
 
 ```bash
-brew tap kubestellar/tap
-brew install kubestellar-ops kubestellar-deploy
+./start-dev.sh
 ```
 
-3. **Create a GitHub OAuth App**
+Opens frontend at http://localhost:5174, backend at http://localhost:8080. Uses a mock `dev-user` account.
 
-Go to GitHub → Settings → Developer settings → OAuth Apps → New OAuth App
+3. **Or start with GitHub OAuth**
 
-- Application name: `KubeStellar Console (dev)`
+Create a [GitHub OAuth App](https://github.com/settings/developers):
 - Homepage URL: `http://localhost:5174`
-- Authorization callback URL: `http://localhost:8080/auth/github/callback`
-
-4. **Configure environment variables**
-
-Create a `.env` file in the project root:
+- Callback URL: `http://localhost:8080/auth/github/callback`
 
 ```bash
-# .env file (copy from .env.example)
-GITHUB_CLIENT_ID=your_github_client_id
-GITHUB_CLIENT_SECRET=your_github_client_secret
-DEV_MODE=false
-FRONTEND_URL=http://localhost:5174
-JWT_SECRET=your-secret-key-here
-DATABASE_PATH=./data/console.db
+# Create .env with your credentials
+cat > .env << EOF
+GITHUB_CLIENT_ID=your-client-id
+GITHUB_CLIENT_SECRET=your-client-secret
+EOF
+
+./startup-oauth.sh
 ```
-
-**Important**: The `.env` file is gitignored. Never commit credentials.
-
-5. **Start with production mode (recommended)**
-
-Use the `prod.sh` script for real GitHub OAuth:
-
-```bash
-./scripts/prod.sh
-```
-
-This script:
-- Loads credentials from `.env`
-- Builds the backend
-- Starts backend and frontend together
-- Exits with error if `GITHUB_CLIENT_ID` or `GITHUB_CLIENT_SECRET` are missing
-
-6. **Or start manually**
-
-```bash
-# Start backend
-go build -o console-server ./cmd/console
-GITHUB_CLIENT_ID=xxx GITHUB_CLIENT_SECRET=yyy FRONTEND_URL=http://localhost:5174 ./console-server
-
-# Start frontend (in another terminal)
-cd web
-npm install
-npm run dev
-```
-
-7. **Development mode (skip OAuth)**
-
-For quick testing without GitHub OAuth:
-
-```bash
-./scripts/dev.sh
-```
-
-This uses a mock `dev-user` account.
-
-8. **Access the console**
-
-Open http://localhost:5174 and sign in with GitHub.
 
 ### Docker Deployment
 

--- a/dev.sh
+++ b/dev.sh
@@ -11,7 +11,7 @@
 # 3. Set:
 #    - Application name: KubeStellar Console (Dev)
 #    - Homepage URL: http://localhost:5174
-#    - Authorization callback URL: http://localhost:5174/auth/github/callback
+#    - Authorization callback URL: http://localhost:8080/auth/github/callback
 # 4. Copy the Client ID and generate a Client Secret
 
 set -e

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -19,7 +19,7 @@
 # Setup:
 #   1. Create a GitHub OAuth App at https://github.com/settings/developers
 #      - Homepage URL: http://localhost:5174
-#      - Callback URL: http://localhost:5174/auth/github/callback
+#      - Callback URL: http://localhost:8080/auth/github/callback
 #   2. Create a .env file:
 #      GITHUB_CLIENT_ID=<your-client-id>
 #      GITHUB_CLIENT_SECRET=<your-client-secret>

--- a/web/src/components/onboarding/DemoInstallGuide.tsx
+++ b/web/src/components/onboarding/DemoInstallGuide.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
-import { X, Copy, Check, ExternalLink, Settings, Rocket, Terminal, Key, Download, ChevronRight, Github } from 'lucide-react'
+import { X, Copy, Check, ExternalLink, Settings, Rocket, Key, Download, ChevronRight, Github } from 'lucide-react'
 import { useDemoMode, isDemoModeForced } from '../../hooks/useDemoMode'
 import { cn } from '../../lib/cn'
 
@@ -82,31 +82,30 @@ export function InstallModal({ onClose }: { onClose: () => void }) {
           {/* Steps */}
           <div className="px-6 space-y-5 pb-2">
 
-            {/* Step 1: Clone & install */}
+            {/* Step 1: Quick Start (binary) */}
             <div className="flex gap-3">
               <StepNumber n={1} />
               <div className="flex-1 min-w-0 pt-0.5">
                 <div className="flex items-center gap-2 mb-1.5">
                   <Download className="w-4 h-4 text-purple-400" />
-                  <h3 className="text-sm font-semibold text-foreground">Clone & Install</h3>
+                  <h3 className="text-sm font-semibold text-foreground">Start the Console</h3>
                 </div>
-                <div className="space-y-1.5">
-                  <CopyCommand command="git clone https://github.com/kubestellar/console.git && cd console" />
-                  <CopyCommand command="cd web && npm install && cd .." />
-                </div>
+                <CopyCommand command="curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash" />
                 <p className="text-[11px] text-muted-foreground/70 mt-1.5">
-                  Requires Go 1.23+, Node.js 20+, and npm
+                  Downloads pre-built binaries and starts in seconds. Only requires curl.
                 </p>
               </div>
             </div>
 
-            {/* Step 2: GitHub OAuth App */}
+            {/* Step 2: Optional - GitHub OAuth */}
             <div className="flex gap-3">
-              <StepNumber n={2} />
+              <div className="flex items-center justify-center w-8 h-8 rounded-full border-2 border-dashed border-gray-600 text-gray-500 text-sm font-bold shrink-0">
+                2
+              </div>
               <div className="flex-1 min-w-0 pt-0.5">
                 <div className="flex items-center gap-2 mb-1.5">
                   <Github className="w-4 h-4 text-blue-400" />
-                  <h3 className="text-sm font-semibold text-foreground">Create a GitHub OAuth App</h3>
+                  <h3 className="text-sm font-semibold text-muted-foreground">Optional: Enable GitHub OAuth</h3>
                 </div>
                 <p className="text-xs text-muted-foreground mb-2">
                   Go to{' '}
@@ -123,7 +122,7 @@ export function InstallModal({ onClose }: { onClose: () => void }) {
                 <div className="text-xs space-y-1 bg-black/30 rounded-lg px-3 py-2 border border-gray-700/30">
                   <div className="flex gap-2">
                     <span className="text-muted-foreground/70 shrink-0 w-28">Homepage URL</span>
-                    <span className="text-gray-300 font-mono">http://localhost:5174</span>
+                    <span className="text-gray-300 font-mono">http://localhost:8080</span>
                   </div>
                   <div className="flex gap-2">
                     <span className="text-muted-foreground/70 shrink-0 w-28">Callback URL</span>
@@ -131,37 +130,15 @@ export function InstallModal({ onClose }: { onClose: () => void }) {
                   </div>
                 </div>
                 <p className="text-[11px] text-muted-foreground/70 mt-1.5">
-                  Then set your Client ID &amp; Secret as environment variables
+                  Add credentials to a .env file and restart with <code className="font-mono text-gray-400">./startup-oauth.sh</code>
                 </p>
               </div>
             </div>
 
-            {/* Step 3: Run */}
-            <div className="flex gap-3">
-              <StepNumber n={3} />
-              <div className="flex-1 min-w-0 pt-0.5">
-                <div className="flex items-center gap-2 mb-1.5">
-                  <Terminal className="w-4 h-4 text-emerald-400" />
-                  <h3 className="text-sm font-semibold text-foreground">Run the Console</h3>
-                </div>
-                <p className="text-xs text-muted-foreground mb-2">
-                  Export your GitHub OAuth credentials, then start:
-                </p>
-                <div className="space-y-1.5">
-                  <CopyCommand command="export GITHUB_CLIENT_ID=<your-client-id>" />
-                  <CopyCommand command="export GITHUB_CLIENT_SECRET=<your-client-secret>" />
-                  <CopyCommand command="./scripts/dev.sh" />
-                </div>
-                <p className="text-[11px] text-muted-foreground/70 mt-1.5">
-                  Starts the backend on :8080 and frontend on :5174
-                </p>
-              </div>
-            </div>
-
-            {/* Step 4: Optional - AI keys */}
+            {/* Step 3: Optional - AI keys */}
             <div className="flex gap-3">
               <div className="flex items-center justify-center w-8 h-8 rounded-full border-2 border-dashed border-gray-600 text-gray-500 text-sm font-bold shrink-0">
-                4
+                3
               </div>
               <div className="flex-1 min-w-0 pt-0.5">
                 <div className="flex items-center gap-2 mb-1.5">


### PR DESCRIPTION
## Summary
- **README.md**: Add binary quickstart (`curl ... | bash`) as the primary install method. Move Go/Node.js prerequisites to "Local Development" section. Fix Go version 1.23 -> 1.24.
- **DemoInstallGuide.tsx**: Replace old 3-step dev workflow with single-step binary quickstart. Update OAuth URLs for production mode (port 8080).
- **dev.sh**: Fix OAuth callback URL in comments from `:5174` to `:8080` (callback always goes to backend).
- **startup-oauth.sh**: Same callback URL fix.

## Test plan
- [x] `npm run build` passes
- [x] Verified callback URL is always `http://localhost:8080/auth/github/callback` regardless of mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)