### PR TITLE
✨ GPU over-allocation prevention, calendar spanning bars, mandatory quota

### DIFF
--- a/pkg/models/gpu.go
+++ b/pkg/models/gpu.go
@@ -39,31 +39,33 @@ type GPUReservation struct {
 
 // CreateGPUReservationInput is the input for creating a GPU reservation
 type CreateGPUReservationInput struct {
-	Title         string `json:"title" validate:"required,min=3,max=200"`
-	Description   string `json:"description" validate:"max=2000"`
-	Cluster       string `json:"cluster" validate:"required"`
-	Namespace     string `json:"namespace" validate:"required"`
-	GPUCount      int    `json:"gpu_count" validate:"required,min=1"`
-	GPUType       string `json:"gpu_type"`
-	StartDate     string `json:"start_date" validate:"required"`
-	DurationHours int    `json:"duration_hours" validate:"min=1"`
-	Notes         string `json:"notes" validate:"max=2000"`
-	QuotaName     string `json:"quota_name"`
-	QuotaEnforced bool   `json:"quota_enforced"`
+	Title          string `json:"title" validate:"required,min=3,max=200"`
+	Description    string `json:"description" validate:"max=2000"`
+	Cluster        string `json:"cluster" validate:"required"`
+	Namespace      string `json:"namespace" validate:"required"`
+	GPUCount       int    `json:"gpu_count" validate:"required,min=1"`
+	GPUType        string `json:"gpu_type"`
+	StartDate      string `json:"start_date" validate:"required"`
+	DurationHours  int    `json:"duration_hours" validate:"min=1"`
+	Notes          string `json:"notes" validate:"max=2000"`
+	QuotaName      string `json:"quota_name"`
+	QuotaEnforced  bool   `json:"quota_enforced"`
+	MaxClusterGPUs int    `json:"max_cluster_gpus"`
 }
 
 // UpdateGPUReservationInput is the input for updating a GPU reservation
 type UpdateGPUReservationInput struct {
-	Title         *string            `json:"title,omitempty"`
-	Description   *string            `json:"description,omitempty"`
-	Cluster       *string            `json:"cluster,omitempty"`
-	Namespace     *string            `json:"namespace,omitempty"`
-	GPUCount      *int               `json:"gpu_count,omitempty"`
-	GPUType       *string            `json:"gpu_type,omitempty"`
-	StartDate     *string            `json:"start_date,omitempty"`
-	DurationHours *int               `json:"duration_hours,omitempty"`
-	Notes         *string            `json:"notes,omitempty"`
-	Status        *ReservationStatus `json:"status,omitempty"`
-	QuotaName     *string            `json:"quota_name,omitempty"`
-	QuotaEnforced *bool              `json:"quota_enforced,omitempty"`
+	Title          *string            `json:"title,omitempty"`
+	Description    *string            `json:"description,omitempty"`
+	Cluster        *string            `json:"cluster,omitempty"`
+	Namespace      *string            `json:"namespace,omitempty"`
+	GPUCount       *int               `json:"gpu_count,omitempty"`
+	GPUType        *string            `json:"gpu_type,omitempty"`
+	StartDate      *string            `json:"start_date,omitempty"`
+	DurationHours  *int               `json:"duration_hours,omitempty"`
+	Notes          *string            `json:"notes,omitempty"`
+	Status         *ReservationStatus `json:"status,omitempty"`
+	QuotaName      *string            `json:"quota_name,omitempty"`
+	QuotaEnforced  *bool              `json:"quota_enforced,omitempty"`
+	MaxClusterGPUs *int               `json:"max_cluster_gpus,omitempty"`
 }

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -89,6 +89,7 @@ type Store interface {
 	ListUserGPUReservations(userID uuid.UUID) ([]models.GPUReservation, error)
 	UpdateGPUReservation(reservation *models.GPUReservation) error
 	DeleteGPUReservation(id uuid.UUID) error
+	GetClusterReservedGPUCount(cluster string, excludeID *uuid.UUID) (int, error)
 
 	// Lifecycle
 	Close() error

--- a/web/src/hooks/useGPUReservations.ts
+++ b/web/src/hooks/useGPUReservations.ts
@@ -38,6 +38,7 @@ export interface CreateGPUReservationInput {
   notes?: string
   quota_name?: string
   quota_enforced?: boolean
+  max_cluster_gpus?: number
 }
 
 export interface UpdateGPUReservationInput {
@@ -53,6 +54,7 @@ export interface UpdateGPUReservationInput {
   status?: ReservationStatus
   quota_name?: string
   quota_enforced?: boolean
+  max_cluster_gpus?: number
 }
 
 // Demo mock data


### PR DESCRIPTION
## Summary
- **Over-allocation prevention**: Backend rejects GPU reservations that would exceed cluster capacity (returns 409 Conflict with detailed message). Adds `GetClusterReservedGPUCount` store method to sum active/pending reservations per cluster.
- **Calendar spanning bars**: Multi-day reservations now render as continuous spanning bars (like Google Calendar) instead of separate pills per day. Green dot = active, yellow dot = pending, grayed out = completed/cancelled.
- **Mandatory quota enforcement**: K8s ResourceQuota creation is now always enforced — removed the optional toggle from the reservation form.
- **UX improvements**: "+" button at bottom-right of each calendar day to quickly create reservation for that date. Demo mode adds yellow border to all GPU reservation components.

## Test plan
- [x] Go backend builds (`go build ./...`)
- [x] Frontend builds (`npm run build`)
- [x] 9/9 over-allocation API tests passed (create at capacity, reject over-capacity, update rejection, cancel-then-reclaim, cross-cluster independence, backward compatibility)
- [x] 12/12 CRUD API tests passed (create, list, get, update, delete, validation, persistence)
- [ ] Verify calendar renders multi-day bars correctly in browser
- [ ] Verify "+" button opens reservation form with correct date

🤖 Generated with [Claude Code](https://claude.com/claude-code)