### PR TITLE
🐛 Fix cluster health flicker and add refresh spin animation

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -466,7 +466,7 @@ func NewMultiClusterClient(kubeconfig string) (*MultiClusterClient, error) {
 		dynamicClients: make(map[string]dynamic.Interface),
 		configs:        make(map[string]*rest.Config),
 		healthCache:    make(map[string]*ClusterHealth),
-		cacheTTL:       30 * time.Second,
+		cacheTTL:       60 * time.Second,
 		cacheTime:      make(map[string]time.Time),
 	}
 

--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useState, useCallback } from 'react'
 import { Pencil, Globe, User, ShieldAlert, ChevronRight, Star, WifiOff, RefreshCw, ExternalLink, AlertCircle, Cpu, Box, Server, KeyRound } from 'lucide-react'
 import { FlashingValue } from '../../ui/FlashingValue'
 import { ClusterInfo } from '../../../hooks/useMCP'
@@ -76,6 +76,7 @@ const FullClusterCard = memo(function FullClusterCard({
   const hasCachedData = cluster.nodeCount !== undefined && cluster.nodeCount > 0
   const initialLoading = loading && !hasCachedData
   const refreshing = cluster.refreshing === true
+  const [spinKey, setSpinKey] = useState(0)
 
   const provider = (cluster.distribution as ReturnType<typeof detectCloudProvider>) ||
     detectCloudProvider(cluster.name, cluster.server, cluster.namespaces, cluster.user)
@@ -83,6 +84,12 @@ const FullClusterCard = memo(function FullClusterCard({
   const providerColor = getProviderColor(provider)
   const themeColor = '#9333ea'
   const consoleUrl = getConsoleUrl(provider, cluster.name, cluster.server)
+
+  const handleRefresh = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    setSpinKey(k => k + 1)
+    onRefreshCluster?.()
+  }, [onRefreshCluster])
 
   return (
     <div
@@ -127,7 +134,7 @@ const FullClusterCard = memo(function FullClusterCard({
               )}
               {onRefreshCluster && (
                 <button
-                  onClick={(e) => { e.stopPropagation(); onRefreshCluster() }}
+                  onClick={handleRefresh}
                   disabled={refreshing}
                   className={`flex items-center p-1 rounded transition-colors ${
                     refreshing ? 'bg-blue-500/20 text-blue-400' :
@@ -136,7 +143,7 @@ const FullClusterCard = memo(function FullClusterCard({
                   }`}
                   title={refreshing ? 'Refreshing...' : unreachable ? 'Retry connection' : 'Refresh cluster data'}
                 >
-                  <RefreshCw className={`w-3.5 h-3.5 ${refreshing ? 'animate-spin' : ''}`} />
+                  <RefreshCw key={spinKey} className={`w-3.5 h-3.5 ${spinKey > 0 ? 'animate-spin-once' : ''}`} />
                 </button>
               )}
             </div>
@@ -275,6 +282,13 @@ const ListClusterCard = memo(function ListClusterCard({
   const hasCachedData = cluster.nodeCount !== undefined && cluster.nodeCount > 0
   const initialLoading = loading && !hasCachedData
   const refreshing = cluster.refreshing === true
+  const [spinKey, setSpinKey] = useState(0)
+
+  const handleRefresh = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    setSpinKey(k => k + 1)
+    onRefreshCluster?.()
+  }, [onRefreshCluster])
 
   const provider = (cluster.distribution as ReturnType<typeof detectCloudProvider>) ||
     detectCloudProvider(cluster.name, cluster.server, cluster.namespaces, cluster.user)
@@ -392,7 +406,7 @@ const ListClusterCard = memo(function ListClusterCard({
           <div className="flex items-center gap-1 flex-shrink-0">
             {onRefreshCluster && (
               <button
-                onClick={(e) => { e.stopPropagation(); onRefreshCluster() }}
+                onClick={handleRefresh}
                 disabled={refreshing}
                 className={`p-1.5 rounded transition-colors ${
                   refreshing ? 'text-blue-400' :
@@ -401,7 +415,7 @@ const ListClusterCard = memo(function ListClusterCard({
                 }`}
                 title={refreshing ? 'Refreshing...' : 'Refresh'}
               >
-                <RefreshCw className={`w-3.5 h-3.5 ${refreshing ? 'animate-spin' : ''}`} />
+                <RefreshCw key={spinKey} className={`w-3.5 h-3.5 ${spinKey > 0 ? 'animate-spin-once' : ''}`} />
               </button>
             )}
             {!permissionsLoading && !isClusterAdmin && !unreachable && (

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -829,7 +829,7 @@ export async function fetchSingleClusterHealth(clusterName: string, kubectlConte
     try {
       const context = kubectlContext || clusterName
       const controller = new AbortController()
-      const timeoutId = setTimeout(() => controller.abort(), 15000) // 15s timeout
+      const timeoutId = setTimeout(() => controller.abort(), 35000) // 35s timeout — large clusters can take 10s+ uncached
       const response = await fetch(`${LOCAL_AGENT_URL}/cluster-health?cluster=${encodeURIComponent(context)}`, {
         signal: controller.signal,
         headers: { 'Accept': 'application/json' },
@@ -857,7 +857,7 @@ export async function fetchSingleClusterHealth(clusterName: string, kubectlConte
     const response = await fetch(
       `/api/mcp/clusters/${encodeURIComponent(clusterName)}/health`,
       {
-        signal: AbortSignal.timeout(10000),
+        signal: AbortSignal.timeout(35000),
         headers: token ? { 'Authorization': `Bearer ${token}` } : {},
       }
     )

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -576,6 +576,10 @@
   animation: spin-min 1s linear infinite;
 }
 
+.animate-spin-once {
+  animation: spin-min 0.6s ease-in-out 1;
+}
+
 /* Rocket launch / blast-off animation */
 @keyframes rocket-launch {
   0%, 100% {


### PR DESCRIPTION
## Summary
- **Cluster health flicker**: Large clusters (e.g. `pok-prod-sa`, 18 nodes, 860KB+ node payload) intermittently show as Offline because the frontend's 15s fetch timeout and backend's 10s fallback timeout are too tight. Increased both to 35s. Also increased agent health cache TTL from 30s to 60s so the frontend doesn't constantly trigger expensive uncached fetches.
- **Refresh animation**: Cluster refresh button now does a clean single 360° rotation on click via `animate-spin-once` CSS class, instead of continuous `animate-spin` that could barely start on fast responses.

## Changes
- `pkg/k8s/client.go`: Health cache TTL 30s → 60s
- `web/src/hooks/mcp/shared.ts`: Agent fetch timeout 15s → 35s, backend fallback 10s → 35s
- `web/src/components/clusters/components/ClusterGrid.tsx`: Refresh button uses `spinKey` state + `animate-spin-once` for one-shot rotation
- `web/src/index.css`: Add `animate-spin-once` keyframe (0.6s, single iteration)

## Test plan
- [x] `pok-prod-sa` stays healthy across multiple refresh cycles (no flicker)
- [x] Refresh button does one full rotation when clicked
- [x] `go build ./...` and `tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)