### PR TITLE
🐛 Fix refresh spinner to match console speed and spin until data returns

### DIFF
--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useCallback } from 'react'
+import { memo } from 'react'
 import { Pencil, Globe, User, ShieldAlert, ChevronRight, Star, WifiOff, RefreshCw, ExternalLink, AlertCircle, Cpu, Box, Server, KeyRound } from 'lucide-react'
 import { FlashingValue } from '../../ui/FlashingValue'
 import { ClusterInfo } from '../../../hooks/useMCP'
@@ -76,7 +76,6 @@ const FullClusterCard = memo(function FullClusterCard({
   const hasCachedData = cluster.nodeCount !== undefined && cluster.nodeCount > 0
   const initialLoading = loading && !hasCachedData
   const refreshing = cluster.refreshing === true
-  const [spinKey, setSpinKey] = useState(0)
 
   const provider = (cluster.distribution as ReturnType<typeof detectCloudProvider>) ||
     detectCloudProvider(cluster.name, cluster.server, cluster.namespaces, cluster.user)
@@ -84,12 +83,6 @@ const FullClusterCard = memo(function FullClusterCard({
   const providerColor = getProviderColor(provider)
   const themeColor = '#9333ea'
   const consoleUrl = getConsoleUrl(provider, cluster.name, cluster.server)
-
-  const handleRefresh = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
-    setSpinKey(k => k + 1)
-    onRefreshCluster?.()
-  }, [onRefreshCluster])
 
   return (
     <div
@@ -134,7 +127,7 @@ const FullClusterCard = memo(function FullClusterCard({
               )}
               {onRefreshCluster && (
                 <button
-                  onClick={handleRefresh}
+                  onClick={(e) => { e.stopPropagation(); onRefreshCluster() }}
                   disabled={refreshing}
                   className={`flex items-center p-1 rounded transition-colors ${
                     refreshing ? 'bg-blue-500/20 text-blue-400' :
@@ -143,7 +136,7 @@ const FullClusterCard = memo(function FullClusterCard({
                   }`}
                   title={refreshing ? 'Refreshing...' : unreachable ? 'Retry connection' : 'Refresh cluster data'}
                 >
-                  <RefreshCw key={spinKey} className={`w-3.5 h-3.5 ${spinKey > 0 ? 'animate-spin-once' : ''}`} />
+                  <RefreshCw className={`w-3.5 h-3.5 ${refreshing ? 'animate-spin' : ''}`} />
                 </button>
               )}
             </div>
@@ -282,13 +275,6 @@ const ListClusterCard = memo(function ListClusterCard({
   const hasCachedData = cluster.nodeCount !== undefined && cluster.nodeCount > 0
   const initialLoading = loading && !hasCachedData
   const refreshing = cluster.refreshing === true
-  const [spinKey, setSpinKey] = useState(0)
-
-  const handleRefresh = useCallback((e: React.MouseEvent) => {
-    e.stopPropagation()
-    setSpinKey(k => k + 1)
-    onRefreshCluster?.()
-  }, [onRefreshCluster])
 
   const provider = (cluster.distribution as ReturnType<typeof detectCloudProvider>) ||
     detectCloudProvider(cluster.name, cluster.server, cluster.namespaces, cluster.user)
@@ -406,7 +392,7 @@ const ListClusterCard = memo(function ListClusterCard({
           <div className="flex items-center gap-1 flex-shrink-0">
             {onRefreshCluster && (
               <button
-                onClick={handleRefresh}
+                onClick={(e) => { e.stopPropagation(); onRefreshCluster() }}
                 disabled={refreshing}
                 className={`p-1.5 rounded transition-colors ${
                   refreshing ? 'text-blue-400' :
@@ -415,7 +401,7 @@ const ListClusterCard = memo(function ListClusterCard({
                 }`}
                 title={refreshing ? 'Refreshing...' : 'Refresh'}
               >
-                <RefreshCw key={spinKey} className={`w-3.5 h-3.5 ${spinKey > 0 ? 'animate-spin-once' : ''}`} />
+                <RefreshCw className={`w-3.5 h-3.5 ${refreshing ? 'animate-spin' : ''}`} />
               </button>
             )}
             {!permissionsLoading && !isClusterAdmin && !unreachable && (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -576,10 +576,6 @@
   animation: spin-min 1s linear infinite;
 }
 
-.animate-spin-once {
-  animation: spin-min 0.6s ease-in-out 1;
-}
-
 /* Rocket launch / blast-off animation */
 @keyframes rocket-launch {
   0%, 100% {


### PR DESCRIPTION
## Summary
- Revert one-shot `animate-spin-once` (0.6s) back to standard `animate-spin` (1s linear infinite)
- Spinner now runs continuously while `refreshing` is true, stopping when data comes back
- Matches spinner speed used by Loader2/RefreshCw everywhere else in the console

## Changes
- `ClusterGrid.tsx`: Remove `spinKey`/`useState`/`useCallback`, use `animate-spin` while `refreshing`
- `index.css`: Remove unused `animate-spin-once` class

🤖 Generated with [Claude Code](https://claude.com/claude-code)