### PR TITLE
⚙️ Publish Helm chart from CI and fix docs

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,12 +1,10 @@
 name: Helm Chart Release
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       version:
-        description: 'Chart version to release'
+        description: 'Chart version to release (without v prefix, e.g. 0.3.9)'
         required: true
         default: '0.1.0'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,8 +261,76 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  notify:
+  helm-release:
     needs: [determine-version, release]
+    runs-on: ubuntu-latest
+    if: needs.release.result == 'success'
+    permissions:
+      contents: write
+      pages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - name: Update Chart.yaml version
+        run: |
+          VERSION="${{ needs.determine-version.outputs.version }}"
+          VERSION="${VERSION#v}"
+          sed -i "s/^version:.*/version: $VERSION/" deploy/helm/kubestellar-console/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" deploy/helm/kubestellar-console/Chart.yaml
+          cat deploy/helm/kubestellar-console/Chart.yaml
+
+      - name: Package Helm chart
+        run: |
+          mkdir -p .helm-releases
+          helm package deploy/helm/kubestellar-console -d .helm-releases
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: gh-pages
+          path: gh-pages
+        continue-on-error: true
+
+      - name: Create gh-pages branch if not exists
+        run: |
+          if [ ! -d "gh-pages" ]; then
+            mkdir -p gh-pages
+            cd gh-pages
+            git init
+            git checkout -b gh-pages
+            echo "# KubeStellar Console Helm Charts" > README.md
+            git add README.md
+            git commit -m "Initialize gh-pages"
+          fi
+
+      - name: Update Helm repository
+        run: |
+          cp .helm-releases/*.tgz gh-pages/
+          cd gh-pages
+          helm repo index . --url https://kubestellar.github.io/console
+          git add .
+          git commit -m "Release Helm chart ${{ needs.determine-version.outputs.version }}" || echo "No changes"
+
+      - name: Push to gh-pages
+        run: |
+          cd gh-pages
+          git push origin gh-pages --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify:
+    needs: [determine-version, release, helm-release]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -285,6 +353,7 @@ jobs:
             echo "- Docker Image: \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
             echo "- Binaries: kc-agent + console for linux/darwin (amd64/arm64)" >> $GITHUB_STEP_SUMMARY
             echo "- Homebrew: \`brew upgrade kc-agent\`" >> $GITHUB_STEP_SUMMARY
+            echo "- Helm Chart: \`helm repo add kubestellar-console https://kubestellar.github.io/console && helm install kc kubestellar-console/kubestellar-console\`" >> $GITHUB_STEP_SUMMARY
           else
             echo "### Status: ${{ needs.release.result }}" >> $GITHUB_STEP_SUMMARY
           fi

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ docker run -d \
 1. **Add the Helm repository**
 
 ```bash
-helm repo add kubestellar https://kubestellar.github.io/helm-charts
+helm repo add kubestellar-console https://kubestellar.github.io/console
 helm repo update
 ```
 
@@ -257,7 +257,7 @@ kubectl create secret generic console-secrets \
 3. **Install the chart**
 
 ```bash
-helm install kubestellar-console kubestellar/console \
+helm install kc kubestellar-console/kubestellar-console \
   --namespace kubestellar-console \
   --set ingress.enabled=true \
   --set ingress.host=console.your-domain.com
@@ -266,7 +266,7 @@ helm install kubestellar-console kubestellar/console \
 ### OpenShift Deployment
 
 ```bash
-helm install kubestellar-console kubestellar/console \
+helm install kc kubestellar-console/kubestellar-console \
   --namespace kubestellar-console \
   --create-namespace \
   -f deploy/helm/kubestellar-console/values-openshift.yaml \
@@ -373,7 +373,7 @@ When deploying with Helm, provide GitHub credentials via values or secrets:
 
 ```bash
 # Option 1: Via --set flags
-helm install kubestellar-console kubestellar/console \
+helm install kc kubestellar-console/kubestellar-console \
   --namespace kubestellar-console \
   --set github.clientId=$GITHUB_CLIENT_ID \
   --set github.clientSecret=$GITHUB_CLIENT_SECRET
@@ -385,7 +385,7 @@ github:
   clientSecret: "your-client-secret"
 EOF
 
-helm install kubestellar-console kubestellar/console \
+helm install kc kubestellar-console/kubestellar-console \
   --namespace kubestellar-console \
   -f my-values.yaml
 
@@ -395,7 +395,7 @@ kubectl create secret generic github-oauth \
   --from-literal=client-id=$GITHUB_CLIENT_ID \
   --from-literal=client-secret=$GITHUB_CLIENT_SECRET
 
-helm install kubestellar-console kubestellar/console \
+helm install kc kubestellar-console/kubestellar-console \
   --namespace kubestellar-console \
   --set github.existingSecret=github-oauth
 ```

--- a/deploy/helm/kubestellar-console/Chart.yaml
+++ b/deploy/helm/kubestellar-console/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubestellar-console
 description: KubeStellar Console - AI-powered multi-cluster Kubernetes dashboard
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.0.0
+appVersion: "0.0.0"
 keywords:
   - kubernetes
   - multi-cluster


### PR DESCRIPTION
## Summary
- Adds `helm-release` job to `release.yml` so the Helm chart is automatically published to GitHub Pages on every release
- Removes broken `release: [published]` trigger from `helm-release.yml` (GITHUB_TOKEN events don't trigger other workflows) — keeps `workflow_dispatch` for manual use
- Fixes README Helm repo URL (`kubestellar.github.io/helm-charts` → `kubestellar.github.io/console`) and chart name references
- Sets `Chart.yaml` version to `0.0.0` placeholder (CI overwrites with release version)

## Test plan
- [ ] Merge this PR
- [ ] Manually run `helm-release.yml` with `version=0.3.9` to bootstrap `gh-pages` branch
- [ ] Enable GitHub Pages on the repo (source: `gh-pages` branch)
- [ ] Verify: `helm repo add kubestellar-console https://kubestellar.github.io/console && helm search repo kubestellar-console`
- [ ] Future releases will automatically publish updated charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)