### PR TITLE
🐛 Fix gh-pages push for Helm chart release

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -64,12 +64,16 @@ jobs:
 
       - name: Create gh-pages branch if not exists
         run: |
-          if [ ! -d "gh-pages" ]; then
+          if [ ! -d "gh-pages/.git" ]; then
+            rm -rf gh-pages
             mkdir -p gh-pages
             cd gh-pages
             git init
+            git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
             git checkout -b gh-pages
-            echo "# Helm Charts" > README.md
+            echo "# KubeStellar Console Helm Charts" > README.md
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
             git add README.md
             git commit -m "Initialize gh-pages"
           fi
@@ -86,8 +90,6 @@ jobs:
         run: |
           cd gh-pages
           git push origin gh-pages --force
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,12 +304,16 @@ jobs:
 
       - name: Create gh-pages branch if not exists
         run: |
-          if [ ! -d "gh-pages" ]; then
+          if [ ! -d "gh-pages/.git" ]; then
+            rm -rf gh-pages
             mkdir -p gh-pages
             cd gh-pages
             git init
+            git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
             git checkout -b gh-pages
             echo "# KubeStellar Console Helm Charts" > README.md
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
             git add README.md
             git commit -m "Initialize gh-pages"
           fi
@@ -326,8 +330,6 @@ jobs:
         run: |
           cd gh-pages
           git push origin gh-pages --force
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   notify:
     needs: [determine-version, release, helm-release]


### PR DESCRIPTION
## Summary
- Fix `git push origin gh-pages` failing when bootstrapping the branch for the first time
- The `git init` for new gh-pages didn't configure remote origin or git user config
- Affects both `release.yml` (helm-release job) and `helm-release.yml` (manual workflow)

## Test plan
- [ ] Merge, then re-run `helm-release.yml` with `version=0.3.9`
- [ ] Verify gh-pages branch is created with chart package and index.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)