### PR TITLE
🐛 Fix gh-pages bootstrap for Helm chart release

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -55,40 +55,31 @@ jobs:
           mkdir -p .helm-releases
           helm package deploy/helm/kubestellar-console -d .helm-releases
 
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: gh-pages
-          path: gh-pages
-        continue-on-error: true
-
-      - name: Create gh-pages branch if not exists
+      - name: Publish to gh-pages
         run: |
-          if [ ! -d "gh-pages/.git" ]; then
-            rm -rf gh-pages
+          REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+
+          # Clone or create gh-pages branch
+          if git ls-remote --exit-code --heads "$REPO_URL" gh-pages >/dev/null 2>&1; then
+            git clone --branch gh-pages --single-branch "$REPO_URL" gh-pages
+          else
             mkdir -p gh-pages
             cd gh-pages
             git init
-            git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
             git checkout -b gh-pages
-            echo "# KubeStellar Console Helm Charts" > README.md
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add README.md
-            git commit -m "Initialize gh-pages"
+            git remote add origin "$REPO_URL"
+            cd ..
           fi
 
-      - name: Update Helm repository
-        run: |
-          cp .helm-releases/*.tgz gh-pages/
           cd gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Copy chart package and build index
+          cp ../.helm-releases/*.tgz .
           helm repo index . --url https://kubestellar.github.io/console
           git add .
           git commit -m "Release Helm chart ${{ steps.version.outputs.version }}" || echo "No changes"
-
-      - name: Push to gh-pages
-        run: |
-          cd gh-pages
           git push origin gh-pages --force
 
       - name: Summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,40 +295,31 @@ jobs:
           mkdir -p .helm-releases
           helm package deploy/helm/kubestellar-console -d .helm-releases
 
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: gh-pages
-          path: gh-pages
-        continue-on-error: true
-
-      - name: Create gh-pages branch if not exists
+      - name: Publish to gh-pages
         run: |
-          if [ ! -d "gh-pages/.git" ]; then
-            rm -rf gh-pages
+          REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+
+          # Clone or create gh-pages branch
+          if git ls-remote --exit-code --heads "$REPO_URL" gh-pages >/dev/null 2>&1; then
+            git clone --branch gh-pages --single-branch "$REPO_URL" gh-pages
+          else
             mkdir -p gh-pages
             cd gh-pages
             git init
-            git remote add origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
             git checkout -b gh-pages
-            echo "# KubeStellar Console Helm Charts" > README.md
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add README.md
-            git commit -m "Initialize gh-pages"
+            git remote add origin "$REPO_URL"
+            cd ..
           fi
 
-      - name: Update Helm repository
-        run: |
-          cp .helm-releases/*.tgz gh-pages/
           cd gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Copy chart package and build index
+          cp ../.helm-releases/*.tgz .
           helm repo index . --url https://kubestellar.github.io/console
           git add .
           git commit -m "Release Helm chart ${{ needs.determine-version.outputs.version }}" || echo "No changes"
-
-      - name: Push to gh-pages
-        run: |
-          cd gh-pages
           git push origin gh-pages --force
 
   notify:


### PR DESCRIPTION
## Summary
- Replace `actions/checkout` + fallback with a single robust script using `git ls-remote` to detect gh-pages existence
- The previous approach failed because `actions/checkout` with `continue-on-error` still created the directory, causing the fallback to be skipped even though the branch wasn't properly checked out

## Test plan
- [ ] Merge, then re-run `helm-release.yml` with `version=0.3.9`
- [ ] Verify gh-pages branch is created with chart package and index.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)