### PR TITLE
🐛 Fix Helm chart: auto-generate JWT_SECRET

### DIFF
--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -98,13 +98,11 @@ spec:
                   name: {{ .Values.claude.existingSecret | default (include "kubestellar-console.fullname" .) }}
                   key: {{ .Values.claude.existingSecretKey | default "claude-api-key" }}
             {{- end }}
-            {{- if or .Values.jwt.existingSecret .Values.jwt.secret }}
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.jwt.existingSecret | default (include "kubestellar-console.fullname" .) }}
                   key: {{ .Values.jwt.existingSecretKey | default "jwt-secret" }}
-            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/kubestellar-console/templates/secret.yaml
+++ b/deploy/helm/kubestellar-console/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or (and .Values.github.clientId .Values.github.clientSecret) .Values.claude.apiKey }}
+{{- if not .Values.jwt.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +7,7 @@ metadata:
     {{- include "kubestellar-console.labels" . | nindent 4 }}
 type: Opaque
 data:
+  jwt-secret: {{ (.Values.jwt.secret | default (randAlphaNum 64)) | b64enc | quote }}
   {{- if and .Values.github.clientId .Values.github.clientSecret }}
   github-client-id: {{ .Values.github.clientId | b64enc | quote }}
   github-client-secret: {{ .Values.github.clientSecret | b64enc | quote }}

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -85,8 +85,10 @@ ai:
     criticalThreshold: 95 # Percentage at which to restrict AI features
 
 # JWT configuration
+# A random JWT secret is auto-generated if left empty.
+# To provide your own, set jwt.secret or use an existing Kubernetes secret.
 jwt:
-  secret: ""  # Auto-generated if empty
+  secret: ""
   existingSecret: ""
   existingSecretKey: jwt-secret
 


### PR DESCRIPTION
## Summary
- Fix crash: `FATAL: JWT_SECRET environment variable is required in production mode`
- Secret template now always creates the Secret with an auto-generated `jwt-secret` key (64 random chars via `randAlphaNum`)
- Deployment template now always injects `JWT_SECRET` env var (was previously conditional on `jwt.secret` being set)
- Zero-config install now works: `helm install kc kubestellar-console/kubestellar-console`

## Test plan
- [ ] Merge, republish chart via `helm-release.yml`
- [ ] `helm upgrade` on vllm-d and verify pod starts without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)