### PR TITLE
✨ Add deploy.sh for one-command Kubernetes deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,47 @@ This downloads the console and kc-agent binaries, starts both, and opens your br
    ```
 3. Restart: `curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash`
 
+### Deploy to Kubernetes
+
+One command. Requires `helm` and `kubectl`.
+
+```bash
+curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/deploy.sh | bash
+```
+
+Options:
+
+| Flag | Description |
+|------|-------------|
+| `--context, -c <name>` | Kubernetes context (default: current) |
+| `--namespace, -n <name>` | Namespace (default: kubestellar-console) |
+| `--openshift` | Enable OpenShift Route |
+| `--ingress <host>` | Enable Ingress with hostname |
+| `--github-oauth` | Prompt for GitHub OAuth credentials |
+| `--uninstall` | Remove the console |
+
+Examples:
+
+```bash
+# Deploy to a specific cluster
+curl -sSL .../deploy.sh | bash -s -- --context my-cluster
+
+# Deploy with OpenShift Route
+curl -sSL .../deploy.sh | bash -s -- --openshift
+
+# Deploy with Ingress
+curl -sSL .../deploy.sh | bash -s -- --ingress console.example.com
+
+# Deploy with GitHub OAuth
+GITHUB_CLIENT_ID=xxx GITHUB_CLIENT_SECRET=yyy \
+  curl -sSL .../deploy.sh | bash
+
+# Uninstall
+curl -sSL .../deploy.sh | bash -s -- --uninstall
+```
+
+Or manually with Helm — see [Kubernetes Deployment (Helm)](#kubernetes-deployment-helm) below.
+
 ### Claude Code Plugins
 
 For AI-powered operations, install [Claude Code](https://claude.ai/claude-code) and the KubeStellar plugins:

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# KubeStellar Console - Deploy to Kubernetes
+#
+# Deploys KubeStellar Console to any Kubernetes cluster via Helm.
+# Works with OpenShift, EKS, GKE, AKS, kind, k3s, or any distribution.
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/deploy.sh | bash
+#
+# Options:
+#   --context, -c <name>        Kubernetes context (default: current context)
+#   --namespace, -n <name>      Namespace (default: kubestellar-console)
+#   --release, -r <name>        Helm release name (default: kc)
+#   --version, -v <version>     Chart version (default: latest)
+#   --set <key=value>           Pass additional Helm --set values
+#   --openshift                 Enable OpenShift Route instead of port-forward
+#   --ingress <host>            Enable Ingress with the given hostname
+#   --github-oauth              Prompt for GitHub OAuth credentials
+#   --uninstall                 Remove the console from the cluster
+#
+# Environment variables (alternative to flags):
+#   GITHUB_CLIENT_ID            GitHub OAuth client ID
+#   GITHUB_CLIENT_SECRET        GitHub OAuth client secret
+#   CLAUDE_API_KEY              Claude API key for AI features
+
+set -e
+
+# --- Defaults ---
+NAMESPACE="kubestellar-console"
+RELEASE="kc"
+CHART_VERSION=""
+CONTEXT=""
+HELM_REPO="kubestellar-console"
+HELM_REPO_URL="https://kubestellar.github.io/console"
+CHART="kubestellar-console/kubestellar-console"
+OPENSHIFT=false
+INGRESS_HOST=""
+GITHUB_OAUTH=false
+UNINSTALL=false
+EXTRA_SETS=()
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --context|-c) CONTEXT="$2"; shift 2 ;;
+        --namespace|-n) NAMESPACE="$2"; shift 2 ;;
+        --release|-r) RELEASE="$2"; shift 2 ;;
+        --version|-v) CHART_VERSION="$2"; shift 2 ;;
+        --set) EXTRA_SETS+=("--set" "$2"); shift 2 ;;
+        --openshift) OPENSHIFT=true; shift ;;
+        --ingress) INGRESS_HOST="$2"; shift 2 ;;
+        --github-oauth) GITHUB_OAUTH=true; shift ;;
+        --uninstall) UNINSTALL=true; shift ;;
+        *) shift ;;
+    esac
+done
+
+# --- Context flag ---
+KUBE_ARGS=()
+if [ -n "$CONTEXT" ]; then
+    KUBE_ARGS=("--kube-context" "$CONTEXT")
+fi
+
+# --- Uninstall ---
+if [ "$UNINSTALL" = true ]; then
+    echo "=== Uninstalling KubeStellar Console ==="
+    echo ""
+    helm uninstall "$RELEASE" --namespace "$NAMESPACE" "${KUBE_ARGS[@]}" 2>/dev/null || echo "  Release not found"
+    kubectl delete namespace "$NAMESPACE" "${KUBE_ARGS[@]/#--kube-context/--context}" 2>/dev/null || echo "  Namespace not found"
+    echo ""
+    echo "Done."
+    exit 0
+fi
+
+# --- Prerequisites ---
+echo "=== KubeStellar Console — Deploy to Kubernetes ==="
+echo ""
+
+for cmd in helm kubectl; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "Error: $cmd is required but not found."
+        echo "  Install Helm: https://helm.sh/docs/intro/install/"
+        echo "  Install kubectl: https://kubernetes.io/docs/tasks/tools/"
+        exit 1
+    fi
+done
+
+# Verify cluster connectivity
+CURRENT_CTX=$(kubectl config current-context 2>/dev/null || true)
+if [ -n "$CONTEXT" ]; then
+    echo "  Context:   $CONTEXT"
+    if ! kubectl cluster-info "${KUBE_ARGS[@]/#--kube-context/--context}" &>/dev/null 2>&1; then
+        echo "Error: Cannot connect to cluster with context '$CONTEXT'"
+        exit 1
+    fi
+elif [ -n "$CURRENT_CTX" ]; then
+    echo "  Context:   $CURRENT_CTX (current)"
+else
+    echo "Error: No Kubernetes context found. Set one with --context or kubectl config use-context."
+    exit 1
+fi
+echo "  Namespace: $NAMESPACE"
+echo "  Release:   $RELEASE"
+echo ""
+
+# --- Add Helm repo ---
+echo "Adding Helm repository..."
+helm repo add "$HELM_REPO" "$HELM_REPO_URL" 2>/dev/null || true
+helm repo update "$HELM_REPO" >/dev/null 2>&1
+echo ""
+
+# --- Build Helm values ---
+HELM_ARGS=("--namespace" "$NAMESPACE" "--create-namespace")
+HELM_ARGS+=("${KUBE_ARGS[@]}")
+
+if [ -n "$CHART_VERSION" ]; then
+    HELM_ARGS+=("--version" "$CHART_VERSION")
+fi
+
+# GitHub OAuth
+if [ "$GITHUB_OAUTH" = true ] && [ -z "$GITHUB_CLIENT_ID" ]; then
+    echo "--- GitHub OAuth Setup ---"
+    echo "Create an OAuth App at: https://github.com/settings/developers"
+    echo ""
+    read -rp "  GitHub Client ID: " GITHUB_CLIENT_ID
+    read -rp "  GitHub Client Secret: " GITHUB_CLIENT_SECRET
+    echo ""
+fi
+
+if [ -n "$GITHUB_CLIENT_ID" ] && [ -n "$GITHUB_CLIENT_SECRET" ]; then
+    HELM_ARGS+=("--set" "github.clientId=$GITHUB_CLIENT_ID")
+    HELM_ARGS+=("--set" "github.clientSecret=$GITHUB_CLIENT_SECRET")
+    echo "  GitHub OAuth: enabled"
+else
+    echo "  GitHub OAuth: disabled (auto-login as dev-user)"
+fi
+
+# Claude AI
+if [ -n "$CLAUDE_API_KEY" ]; then
+    HELM_ARGS+=("--set" "claude.apiKey=$CLAUDE_API_KEY")
+    echo "  Claude AI:    enabled"
+fi
+
+# OpenShift Route
+if [ "$OPENSHIFT" = true ]; then
+    HELM_ARGS+=("--set" "route.enabled=true")
+    echo "  Exposure:     OpenShift Route"
+fi
+
+# Ingress
+if [ -n "$INGRESS_HOST" ]; then
+    HELM_ARGS+=("--set" "ingress.enabled=true")
+    HELM_ARGS+=("--set" "ingress.hosts[0].host=$INGRESS_HOST")
+    HELM_ARGS+=("--set" "ingress.hosts[0].paths[0].path=/")
+    HELM_ARGS+=("--set" "ingress.hosts[0].paths[0].pathType=Prefix")
+    echo "  Exposure:     Ingress ($INGRESS_HOST)"
+fi
+
+# Extra --set values
+HELM_ARGS+=("${EXTRA_SETS[@]}")
+
+echo ""
+
+# --- Install or Upgrade ---
+echo "Deploying..."
+if helm status "$RELEASE" --namespace "$NAMESPACE" "${KUBE_ARGS[@]}" >/dev/null 2>&1; then
+    helm upgrade "$RELEASE" "$CHART" "${HELM_ARGS[@]}" --wait --timeout 120s
+else
+    helm install "$RELEASE" "$CHART" "${HELM_ARGS[@]}" --wait --timeout 120s
+fi
+
+echo ""
+echo "=== KubeStellar Console is deployed ==="
+echo ""
+
+# --- Access instructions ---
+if [ "$OPENSHIFT" = true ]; then
+    ROUTE_HOST=$(kubectl get route "$RELEASE-kubestellar-console" \
+        --namespace "$NAMESPACE" \
+        "${KUBE_ARGS[@]/#--kube-context/--context}" \
+        -o jsonpath='{.spec.host}' 2>/dev/null || true)
+    if [ -n "$ROUTE_HOST" ]; then
+        echo "  URL: https://$ROUTE_HOST"
+    else
+        echo "  Route created — check: kubectl get route -n $NAMESPACE"
+    fi
+elif [ -n "$INGRESS_HOST" ]; then
+    echo "  URL: https://$INGRESS_HOST"
+    echo "  (Ensure DNS and Ingress controller are configured)"
+else
+    echo "  To access the console, run:"
+    echo ""
+    CTX_FLAG=""
+    if [ -n "$CONTEXT" ]; then
+        CTX_FLAG=" --context $CONTEXT"
+    fi
+    echo "    kubectl port-forward${CTX_FLAG} -n $NAMESPACE svc/$RELEASE-kubestellar-console 8080:8080"
+    echo ""
+    echo "  Then open: http://localhost:8080"
+fi
+
+echo ""
+echo "To uninstall: $0 --uninstall${CONTEXT:+ --context $CONTEXT}"
+echo ""

--- a/web/src/components/onboarding/DemoInstallGuide.tsx
+++ b/web/src/components/onboarding/DemoInstallGuide.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import { Link } from 'react-router-dom'
-import { X, Copy, Check, ExternalLink, Settings, Rocket, Key, Download, ChevronRight, Github } from 'lucide-react'
+import { X, Copy, Check, ExternalLink, Settings, Rocket, Key, Download, ChevronRight, Github, Server } from 'lucide-react'
 import { useDemoMode, isDemoModeForced } from '../../hooks/useDemoMode'
 import { cn } from '../../lib/cn'
 
@@ -135,10 +135,27 @@ export function InstallModal({ onClose }: { onClose: () => void }) {
               </div>
             </div>
 
-            {/* Step 3: Optional - AI keys */}
+            {/* Step 3: Optional - Deploy to Kubernetes */}
             <div className="flex gap-3">
               <div className="flex items-center justify-center w-8 h-8 rounded-full border-2 border-dashed border-gray-600 text-gray-500 text-sm font-bold shrink-0">
                 3
+              </div>
+              <div className="flex-1 min-w-0 pt-0.5">
+                <div className="flex items-center gap-2 mb-1.5">
+                  <Server className="w-4 h-4 text-green-400" />
+                  <h3 className="text-sm font-semibold text-muted-foreground">Optional: Deploy to Kubernetes</h3>
+                </div>
+                <CopyCommand command="curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/deploy.sh | bash" />
+                <p className="text-[11px] text-muted-foreground/70 mt-1.5">
+                  Requires <code className="font-mono text-gray-400">helm</code> and <code className="font-mono text-gray-400">kubectl</code>. Supports <code className="font-mono text-gray-400">--context</code>, <code className="font-mono text-gray-400">--openshift</code>, and <code className="font-mono text-gray-400">--ingress</code> flags.
+                </p>
+              </div>
+            </div>
+
+            {/* Step 4: Optional - AI keys */}
+            <div className="flex gap-3">
+              <div className="flex items-center justify-center w-8 h-8 rounded-full border-2 border-dashed border-gray-600 text-gray-500 text-sm font-bold shrink-0">
+                4
               </div>
               <div className="flex-1 min-w-0 pt-0.5">
                 <div className="flex items-center gap-2 mb-1.5">

--- a/web/src/components/setup/SetupInstructionsDialog.tsx
+++ b/web/src/components/setup/SetupInstructionsDialog.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Rocket, Copy, Check, Terminal, ExternalLink, ChevronDown, ChevronRight, KeyRound } from 'lucide-react'
+import { Rocket, Copy, Check, Terminal, ExternalLink, ChevronDown, ChevronRight, KeyRound, Server } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 
 interface SetupInstructionsDialogProps {
@@ -14,6 +14,7 @@ const DOCS_URL = 'https://console-docs.kubestellar.io'
 const CURL_BASE = 'https://raw.githubusercontent.com/kubestellar/console/main'
 
 const QUICKSTART_CMD = `curl -sSL ${CURL_BASE}/start.sh | bash`
+const K8S_DEPLOY_CMD = `curl -sSL ${CURL_BASE}/deploy.sh | bash`
 
 const OAUTH_STEPS = [
   { label: 'Go to', link: 'https://github.com/settings/developers', linkText: 'GitHub Developer Settings' },
@@ -30,6 +31,7 @@ export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDi
   const [copiedStep, setCopiedStep] = useState<number | null>(null)
   const [showOAuthGuide, setShowOAuthGuide] = useState(false)
   const [showDevGuide, setShowDevGuide] = useState(false)
+  const [showK8sGuide, setShowK8sGuide] = useState(false)
 
   const copyToClipboard = async (text: string, stepKey: number) => {
     await navigator.clipboard.writeText(text)
@@ -113,6 +115,48 @@ export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDi
                       </div>
                       <p className="text-xs text-muted-foreground">
                         Requires Go 1.24+ and Node.js 20+. Compiles from source and starts a Vite dev server on port 5174.
+                      </p>
+                    </div>
+                  )}
+                </div>
+
+                {/* Kubernetes deploy guide */}
+                <div className="mt-2">
+                  <button
+                    onClick={() => setShowK8sGuide(!showK8sGuide)}
+                    className="flex items-center gap-1.5 text-xs text-purple-400 hover:text-purple-300 transition-colors"
+                  >
+                    {showK8sGuide ? (
+                      <ChevronDown className="w-3.5 h-3.5" />
+                    ) : (
+                      <ChevronRight className="w-3.5 h-3.5" />
+                    )}
+                    <Server className="w-3.5 h-3.5" />
+                    Or deploy to a Kubernetes cluster
+                  </button>
+                  {showK8sGuide && (
+                    <div className="mt-2 rounded-lg border border-purple-500/20 bg-purple-500/5 p-3 space-y-2">
+                      <p className="text-xs text-muted-foreground">
+                        One command — requires <code className="font-mono text-foreground/70">helm</code> and <code className="font-mono text-foreground/70">kubectl</code>
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <code className="flex-1 rounded bg-muted px-3 py-1.5 text-xs font-mono text-foreground select-all overflow-x-auto">
+                          {K8S_DEPLOY_CMD}
+                        </code>
+                        <button
+                          onClick={() => copyToClipboard(K8S_DEPLOY_CMD, 400)}
+                          className="shrink-0 p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                          title="Copy command"
+                        >
+                          {copiedStep === 400 ? (
+                            <Check className="w-3.5 h-3.5 text-green-400" />
+                          ) : (
+                            <Copy className="w-3.5 h-3.5" />
+                          )}
+                        </button>
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        Supports <code className="font-mono text-foreground/70">--context</code>, <code className="font-mono text-foreground/70">--openshift</code>, <code className="font-mono text-foreground/70">--ingress &lt;host&gt;</code>, and <code className="font-mono text-foreground/70">--github-oauth</code> flags.
                       </p>
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- New `deploy.sh` script for deploying to any Kubernetes cluster via Helm (similar to `start.sh` for localhost)
- Supports `--context`, `--openshift`, `--ingress <host>`, `--github-oauth`, `--uninstall` flags
- Auto-adds Helm repo, creates namespace, installs/upgrades chart, shows access instructions
- Added "Deploy to Kubernetes" section to:
  - SetupInstructionsDialog (setup modal)
  - DemoInstallGuide (demo mode install modal)
  - README.md with examples

## Test plan
- [ ] `curl -sSL .../deploy.sh | bash -s -- --context vllm-d` deploys successfully
- [ ] `--uninstall` cleans up
- [ ] UI shows the new Kubernetes deploy option in expandable sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)