### PR TITLE
🐛 Fix Helm chart image tag: keep v prefix in appVersion

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -47,7 +47,8 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           sed -i "s/^version:.*/version: $VERSION/" deploy/helm/kubestellar-console/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" deploy/helm/kubestellar-console/Chart.yaml
+          # appVersion keeps "v" prefix to match Docker image tags (v0.3.9, etc.)
+          sed -i "s/^appVersion:.*/appVersion: \"v$VERSION\"/" deploy/helm/kubestellar-console/Chart.yaml
           cat deploy/helm/kubestellar-console/Chart.yaml
 
       - name: Package Helm chart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,10 +284,11 @@ jobs:
 
       - name: Update Chart.yaml version
         run: |
-          VERSION="${{ needs.determine-version.outputs.version }}"
-          VERSION="${VERSION#v}"
-          sed -i "s/^version:.*/version: $VERSION/" deploy/helm/kubestellar-console/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" deploy/helm/kubestellar-console/Chart.yaml
+          FULL_VERSION="${{ needs.determine-version.outputs.version }}"
+          CHART_VERSION="${FULL_VERSION#v}"
+          sed -i "s/^version:.*/version: $CHART_VERSION/" deploy/helm/kubestellar-console/Chart.yaml
+          # appVersion keeps "v" prefix to match Docker image tags (v0.3.9, etc.)
+          sed -i "s/^appVersion:.*/appVersion: \"$FULL_VERSION\"/" deploy/helm/kubestellar-console/Chart.yaml
           cat deploy/helm/kubestellar-console/Chart.yaml
 
       - name: Package Helm chart


### PR DESCRIPTION
## Summary
- Docker images are tagged as `v0.3.9` but chart `appVersion` was `0.3.9` (no `v`), causing `ImagePullBackOff: manifest unknown`
- Keep `v` prefix in `appVersion` so the deployment template resolves the correct image tag

## Test plan
- [ ] Merge, republish chart, test on vllm-d

🤖 Generated with [Claude Code](https://claude.com/claude-code)