### PR TITLE
🐛 Fix CORS origin mismatch for HTTP OpenShift routes

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -36,7 +36,9 @@ var defaultAllowedOrigins = []string{
 	"https://127.0.0.1",
 	// Known deployment URLs
 	"https://kubestellarconsole.netlify.app",
+	"http://kubestellarconsole.netlify.app",
 	"https://kc.apps.fmaas-vllm-d.fmaas.res.ibm.com",
+	"http://kc.apps.fmaas-vllm-d.fmaas.res.ibm.com",
 }
 
 // Server is the local agent WebSocket server


### PR DESCRIPTION
## Summary
- The kc-agent's allowed origins only included `https://` variants of deployment URLs
- OpenShift routes on vllm-d serve over `http://`, causing CORS preflight failures
- This prevented the local agent from being detected (showed "Offline" in the console)
- Added `http://` variants of known deployment URLs to the allowed origins list

## Test plan
- [ ] Access `http://kc.apps.fmaas-vllm-d.fmaas.res.ibm.com` with local kc-agent running
- [ ] Verify agent status shows "Connected" instead of "Offline"
- [ ] Verify cluster data loads from local agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)