### PR TITLE
🐛 Fix WebSocket CORS preflight for Private Network Access

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -1312,6 +1312,19 @@ func (s *Server) handleRenameContextHTTP(w http.ResponseWriter, r *http.Request)
 
 // handleWebSocket handles WebSocket connections
 func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	// Handle CORS preflight for Private Network Access (required by Chrome 104+)
+	if r.Method == http.MethodOptions {
+		origin := r.Header.Get("Origin")
+		if s.isAllowedOrigin(origin) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+		}
+		w.Header().Set("Access-Control-Allow-Private-Network", "true")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Upgrade, Connection, Sec-WebSocket-Key, Sec-WebSocket-Version, Sec-WebSocket-Protocol")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	// SECURITY: Validate token if configured
 	if !s.validateToken(r) {
 		log.Printf("SECURITY: Rejected WebSocket connection - invalid or missing token")


### PR DESCRIPTION
## Summary
- The `/ws` WebSocket endpoint returned 400 on OPTIONS preflight because gorilla/websocket rejects non-upgrade requests
- Chrome 104+ requires Private Network Access (PNA) preflight to succeed before connecting from HTTPS pages to `127.0.0.1`
- This caused the local kc-agent to show as "Offline" when the console is accessed via HTTPS OpenShift routes
- Added explicit OPTIONS handling in the WS handler to return proper CORS + PNA headers

## Test plan
- [ ] Access `https://kc.apps.fmaas-vllm-d.fmaas.res.ibm.com` with local kc-agent running
- [ ] Verify WebSocket connects successfully (no "Offline" banner)
- [ ] Verify agent health check passes
- [ ] `curl -X OPTIONS -H "Origin: https://..." -H "Access-Control-Request-Private-Network: true" http://127.0.0.1:8585/ws` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)