### PR TITLE
✨ Allow typing custom namespace in GPU reservation form

### DIFF
--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -1275,14 +1275,22 @@ function ReservationFormModal({
           {/* Namespace */}
           <div>
             <label className="block text-sm font-medium text-muted-foreground mb-1">Namespace *</label>
-            <select value={namespace} onChange={e => setNamespace(e.target.value)}
+            <input
+              list="ns-options"
+              value={namespace}
+              onChange={e => setNamespace(e.target.value)}
+              placeholder={clusterNamespaces.length > 0 ? 'Select or type a namespace...' : 'Type a namespace name...'}
               disabled={!!editingReservation || !cluster}
-              className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground disabled:opacity-50">
-              <option value="">Select namespace...</option>
+              className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground disabled:opacity-50"
+            />
+            <datalist id="ns-options">
               {clusterNamespaces.map(ns => (
-                <option key={ns} value={ns}>{ns}</option>
+                <option key={ns} value={ns} />
               ))}
-            </select>
+            </datalist>
+            {namespace && !clusterNamespaces.includes(namespace) && (
+              <p className="text-xs text-yellow-400 mt-1">New namespace — a ResourceQuota will be created in &quot;{namespace}&quot;</p>
+            )}
           </div>
 
           {/* GPU Count */}


### PR DESCRIPTION
## Summary
- Replace `<select>` dropdown with `<input>` + `<datalist>` combo box for the namespace field
- Users can now select existing namespaces OR type a custom namespace name
- Shows a yellow hint when a new namespace will be created
- Fixes empty dropdown on slow clusters (like pok-prod-sa) where namespace loading times out

## Test plan
- [ ] Open GPU Reservations → Create Reservation
- [ ] Select a cluster with loaded namespaces — verify dropdown suggestions appear
- [ ] Type a custom namespace name — verify yellow "New namespace" hint appears
- [ ] Select a slow cluster — verify you can still type a namespace name manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)