### PR TITLE
🐛 Fix AI button yellow flash during navigation

### DIFF
--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -76,13 +76,15 @@ export function useClusters() {
     }
   }, [])
 
-  // Re-fetch when demo mode changes (not on initial mount)
-  const initialMountRef = useRef(true)
+  // Re-fetch when demo mode actually changes (not on initial mount).
+  // Uses prev-value ref instead of initialMountRef to survive React 18
+  // StrictMode double-mounting, which would otherwise trigger
+  // aggressiveDetect on every navigation and cause a yellow AI flash.
+  const prevDemoModeRef = useRef(isDemoMode)
   useEffect(() => {
-    if (initialMountRef.current) {
-      initialMountRef.current = false
-      return
-    }
+    if (prevDemoModeRef.current === isDemoMode) return
+    prevDemoModeRef.current = isDemoMode
+
     // Reset fetch flag and failure tracking to allow re-fetching
     setInitialFetchStarted(false)
     setHealthCheckFailures(0)


### PR DESCRIPTION
## Summary
- Fixed the AI status indicator briefly flashing yellow ("Connecting to agent...") on every page navigation
- Root cause: React 18 StrictMode double-mounting broke the `initialMountRef` guard in `useClusters()`, causing `triggerAggressiveDetection()` to fire on every component mount
- Fix: Replace `initialMountRef` with a prev-value ref pattern that only fires when `isDemoMode` truly changes

## Test plan
- [x] Navigate between 5+ dashboards — no yellow flash observed
- [x] `npm run build` passes
- [ ] CI build/lint pass (ignore Playwright)