### PR TITLE
✨ Add RBAC for in-cluster ServiceAccount fallback

### DIFF
--- a/deploy/helm/kubestellar-console/templates/clusterrole.yaml
+++ b/deploy/helm/kubestellar-console/templates/clusterrole.yaml
@@ -1,0 +1,148 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kubestellar-console.fullname" . }}
+  labels:
+    {{- include "kubestellar-console.labels" . | nindent 4 }}
+rules:
+  # Core v1 - read-only (secrets explicitly excluded)
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - pods
+      - pods/log
+      - services
+      - events
+      - configmaps
+      - serviceaccounts
+      - persistentvolumeclaims
+      - persistentvolumes
+      - limitranges
+      - namespaces
+    verbs: ["get", "list", "watch"]
+
+  # ResourceQuotas - full CRUD for GPU reservation enforcement
+  - apiGroups: [""]
+    resources:
+      - resourcequotas
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Apps v1 - read-only
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+      - statefulsets
+      - daemonsets
+    verbs: ["get", "list", "watch"]
+
+  # Batch v1 - read-only
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+
+  # Networking v1 - read-only
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs: ["get", "list", "watch"]
+
+  # Autoscaling v2 - read-only
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["get", "list", "watch"]
+
+  # RBAC v1 - read-only (for RBAC analysis features)
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+      - roles
+      - clusterroles
+      - rolebindings
+      - clusterrolebindings
+    verbs: ["get", "list", "watch"]
+
+  # Authorization - permission checks
+  - apiGroups: ["authorization.k8s.io"]
+    resources:
+      - selfsubjectaccessreviews
+    verbs: ["create"]
+
+  # Policy v1 - read-only
+  - apiGroups: ["policy"]
+    resources:
+      - poddisruptionbudgets
+    verbs: ["get", "list", "watch"]
+
+  # API Extensions - read-only (CRD discovery)
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources:
+      - customresourcedefinitions
+    verbs: ["get", "list", "watch"]
+
+  # Admission registration - read-only
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs: ["get", "list", "watch"]
+
+  # NVIDIA GPU Operator - read-only
+  - apiGroups: ["nvidia.com"]
+    resources:
+      - clusterpolicies
+    verbs: ["get", "list", "watch"]
+
+  # Mellanox Network Operator - read-only
+  - apiGroups: ["mellanox.com"]
+    resources:
+      - nicclusterpolicies
+    verbs: ["get", "list", "watch"]
+
+  # Kagenti - read-only
+  - apiGroups: ["agent.kagenti.dev"]
+    resources:
+      - agents
+      - agentbuilds
+      - agentcards
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["mcp.kagenti.com"]
+    resources:
+      - mcpservers
+    verbs: ["get", "list", "watch"]
+
+  # Console CRDs - full CRUD
+  - apiGroups: ["console.kubestellar.io"]
+    resources:
+      - managedworkloads
+      - managedworkloads/status
+      - clustergroups
+      - clustergroups/status
+      - workloaddeployments
+      - workloaddeployments/status
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Gateway API - read-only
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources:
+      - gateways
+      - httproutes
+    verbs: ["get", "list", "watch"]
+
+  # Multi-cluster services - read-only
+  - apiGroups: ["multicluster.x-k8s.io"]
+    resources:
+      - serviceexports
+      - serviceimports
+    verbs: ["get", "list", "watch"]
+
+  # OpenShift user API - read-only
+  - apiGroups: ["user.openshift.io"]
+    resources:
+      - users
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/deploy/helm/kubestellar-console/templates/clusterrolebinding.yaml
+++ b/deploy/helm/kubestellar-console/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubestellar-console.fullname" . }}
+  labels:
+    {{- include "kubestellar-console.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kubestellar-console.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kubestellar-console.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -15,6 +15,12 @@ serviceAccount:
   annotations: {}
   name: ""
 
+# RBAC configuration
+# When deployed in-cluster without the kc-agent, the console uses
+# its ServiceAccount for read-only cluster access + ResourceQuota CRUD
+rbac:
+  create: true
+
 podAnnotations: {}
 podLabels: {}
 

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -130,6 +130,8 @@ export function AgentStatusIndicator() {
     ? { bg: 'bg-green-500/10 text-green-400 hover:bg-green-500/20', dot: 'bg-green-400', label: 'AI', Icon: Wifi, title: 'Local Agent connected' }
     : stableStatus === 'connecting'
     ? { bg: 'bg-yellow-500/10 text-yellow-400 hover:bg-yellow-500/20', dot: 'bg-yellow-400 animate-pulse', label: 'AI', Icon: Wifi, title: 'Connecting to agent...' }
+    : isBackendConnected
+    ? { bg: 'bg-blue-500/10 text-blue-400 hover:bg-blue-500/20', dot: 'bg-blue-400', label: 'Cluster', Icon: Server, title: 'In-cluster mode - using ServiceAccount' }
     : { bg: 'bg-red-500/10 text-red-400 hover:bg-red-500/20', dot: 'bg-red-400', label: 'Offline', Icon: WifiOff, title: 'Local Agent disconnected' }
 
   return (
@@ -191,10 +193,10 @@ export function AgentStatusIndicator() {
             <div className="flex items-center gap-2">
               <div className={cn(
                 'w-3 h-3 rounded-full',
-                isDemoMode ? 'bg-gray-400' : isDegraded ? 'bg-yellow-400' : isConnected ? 'bg-green-400' : agentStatus === 'connecting' ? 'bg-yellow-400' : 'bg-red-400'
+                isDemoMode ? 'bg-gray-400' : isDegraded ? 'bg-yellow-400' : isConnected ? 'bg-green-400' : agentStatus === 'connecting' ? 'bg-yellow-400' : isBackendConnected ? 'bg-blue-400' : 'bg-red-400'
               )} />
               <span className={cn('text-sm font-medium', isDemoMode ? 'text-muted-foreground' : 'text-foreground')}>
-                Local Agent: {isDemoMode ? 'Bypassed' : isDegraded ? 'Degraded' : isConnected ? 'Connected' : agentStatus === 'connecting' ? 'Connecting...' : 'Disconnected'}
+                {isDemoMode ? 'Local Agent: Bypassed' : isDegraded ? 'Local Agent: Degraded' : isConnected ? 'Local Agent: Connected' : agentStatus === 'connecting' ? 'Local Agent: Connecting...' : isBackendConnected ? 'Cluster Mode' : 'Local Agent: Disconnected'}
               </span>
               {isConnected && agentHealth?.version && agentHealth.version !== 'demo' && (
                 <span className="text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
@@ -209,6 +211,8 @@ export function AgentStatusIndicator() {
                 ? `Connected but experiencing data errors (${dataErrorCount} in last minute)`
                 : isConnected
                 ? `Connected to local agent at 127.0.0.1:8585`
+                : isBackendConnected
+                ? 'Using in-cluster ServiceAccount (read-only)'
                 : 'Unable to connect to local agent'
               }
             </p>


### PR DESCRIPTION
## Summary
- Adds ClusterRole and ClusterRoleBinding to the Helm chart so the console's ServiceAccount has permissions when deployed in-cluster without the kc-agent
- Read-only access to all cluster resources (**secrets explicitly excluded**)
- Full CRUD on ResourceQuotas (GPU reservation enforcement)
- Create on SelfSubjectAccessReviews (permission checks)
- Full CRUD on `console.kubestellar.io` CRDs
- Updates navbar indicator to show "Cluster" (blue) instead of "Offline" (red) when running in-cluster mode

## Test plan
- [x] `helm template` renders RBAC resources correctly
- [x] TypeScript builds with zero errors
- [x] ESLint clean
- [x] Applied RBAC to OpenShift cluster (`vllm-d`) and tested 19 permission checks:
  - [x] Read-only ops: 11/11 pass (pods, nodes, deployments, events, etc.)
  - [x] Secrets denied: 2/2 pass (list, get)
  - [x] ResourceQuota CRUD: 4/4 pass (create, update, patch, delete)
  - [x] Write ops denied: 4/4 pass (create pods, delete deployments, create namespaces, update nodes)
  - [x] SelfSubjectAccessReview create: 1/1 pass
- [x] Console pod starts with no RBAC errors in logs
- [ ] Verify "Cluster" pill appears when kc-agent is unavailable (needs new image)