### PR TITLE
🐛 Fix dashboard cards showing no data in cluster mode

### DIFF
--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -42,6 +42,7 @@
 import { createContext, useContext, useLayoutEffect, useMemo } from 'react'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { isAgentUnavailable } from '../../hooks/useLocalAgent'
+import { isBackendConnected } from '../../hooks/useBackendHealth'
 import { useOptionalStack } from '../../contexts/StackContext'
 
 export interface CardDataState {
@@ -275,8 +276,9 @@ export function useCardDemoState(options: CardDemoStateOptions = {}): CardDemoSt
       return { shouldUseDemoData: true, reason: 'global-demo-mode' as DemoReason, showDemoBadge: true }
     }
 
-    // 4. Agent-dependent card but agent is offline
-    if (requires === 'agent' && isAgentUnavailable()) {
+    // 4. Agent-dependent card but agent is offline AND backend is also unavailable
+    //    When backend is connected (cluster mode), allow live data via backend API
+    if (requires === 'agent' && isAgentUnavailable() && !isBackendConnected()) {
       return { shouldUseDemoData: true, reason: 'agent-offline' as DemoReason, showDemoBadge: true }
     }
 

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -12,6 +12,7 @@ import { useSnoozedCards } from '../../hooks/useSnoozedCards'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { isDemoMode as checkIsDemoMode } from '../../lib/demoMode'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { isBackendConnected } from '../../hooks/useBackendHealth'
 import { useIsModeSwitching } from '../../lib/unified/demo'
 import { DEMO_EXEMPT_CARDS } from './cardRegistry'
 import { CardDataReportContext, type CardDataState } from './CardDataContext'
@@ -1023,7 +1024,7 @@ export function CardWrapper({
   // Force skeleton immediately when offline + demo OFF, without waiting for childDataState
   // This fixes the race condition where demo data briefly shows before skeleton
   // Cards with effectiveIsDemoData=true (explicitly showing demo) or demo-exempt cards are excluded
-  const forceSkeletonForOffline = !globalDemoMode && isAgentOffline && !isDemoExempt && !effectiveIsDemoData && !isDemoMode
+  const forceSkeletonForOffline = !globalDemoMode && isAgentOffline && !isBackendConnected() && !isDemoExempt && !effectiveIsDemoData && !isDemoMode
   const forceSkeletonForModeSwitching = isModeSwitching && !isDemoExempt
 
   // Default to 'list' skeleton type if not specified, enabling automatic skeleton display

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -97,7 +97,7 @@ export function Layout({ children }: LayoutProps) {
   const showNetworkBanner = !isOnline || wasOffline
   // Show offline banner only when agent is confirmed disconnected (not during 'connecting' state)
   // This prevents flickering during initial connection attempts
-  const showOfflineBanner = !isDemoMode && agentStatus === 'disconnected' && !offlineBannerDismissed
+  const showOfflineBanner = !isDemoMode && agentStatus === 'disconnected' && backendStatus !== 'connected' && !offlineBannerDismissed
 
   // Banner stacking: each banner's top offset depends on how many banners above it are visible.
   // Navbar is 64px (top-16). Each banner is ~36px tall.

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -615,8 +615,8 @@ export function useCachedDeployments(
     initialData: [] as Deployment[],
     demoData: getDemoDeployments(),
     fetcher: async () => {
-      // Try agent first (fast, no backend needed)
-      if (clusterCacheRef.clusters.length > 0) {
+      // Try agent first (fast, no backend needed) — skip if agent is unavailable
+      if (clusterCacheRef.clusters.length > 0 && !isAgentUnavailable()) {
         if (cluster) {
           const params = new URLSearchParams()
           const clusterInfo = clusterCacheRef.clusters.find(c => c.name === cluster)
@@ -657,7 +657,7 @@ export function useCachedDeployments(
       return []
     },
     progressiveFetcher: cluster ? undefined : async (onProgress) => {
-      if (clusterCacheRef.clusters.length > 0) {
+      if (clusterCacheRef.clusters.length > 0 && !isAgentUnavailable()) {
         return fetchDeploymentsViaAgent(namespace, onProgress)
       }
 
@@ -1515,8 +1515,8 @@ export function useCachedSecurityIssues(
     initialData: [] as SecurityIssue[],
     demoData: getDemoSecurityIssues(),
     fetcher: async () => {
-      // Try kubectl proxy first (uses agent to run kubectl commands)
-      if (clusterCacheRef.clusters.length > 0) {
+      // Try kubectl proxy first (uses agent to run kubectl commands) — skip if agent is unavailable
+      if (clusterCacheRef.clusters.length > 0 && !isAgentUnavailable()) {
         try {
           const issues = await fetchSecurityIssuesViaKubectl(cluster, namespace)
           if (issues.length > 0) return issues
@@ -1553,8 +1553,8 @@ export function useCachedSecurityIssues(
     },
     // Progressive loading: show results as each cluster completes
     progressiveFetcher: !cluster ? async (onProgress) => {
-      // Try kubectl proxy first (progressive)
-      if (clusterCacheRef.clusters.length > 0) {
+      // Try kubectl proxy first (progressive) — skip if agent is unavailable
+      if (clusterCacheRef.clusters.length > 0 && !isAgentUnavailable()) {
         try {
           const issues = await fetchSecurityIssuesViaKubectl(cluster, namespace, onProgress)
           if (issues.length > 0) return issues


### PR DESCRIPTION
## Summary

- **CardDataContext**: Allow live data when backend is connected, even if agent is offline (`isBackendConnected()` check)
- **CardWrapper**: Don't force skeleton display when backend provides data
- **Layout**: Hide "Offline" banner when backend is connected in cluster mode
- **useCachedData**: Skip agent-only fetch paths when agent is unavailable, allowing fallthrough to REST API fallback

When deployed in-cluster without kc-agent (e.g., on `kc.apps.fmaas-vllm-d.fmaas.res.ibm.com`), the backend API returns valid data via the ServiceAccount. However, three layers of frontend gating conflated "agent offline" with "no data source available", causing all cards to show loading skeletons and "--" stats.

## Test plan
- [ ] Verify cards show real data on `https://kc.apps.fmaas-vllm-d.fmaas.res.ibm.com/` (cluster mode, no agent)
- [ ] Verify no "Offline" orange banner when backend is connected
- [ ] Verify Stats Overview shows real numbers instead of "--"
- [ ] Verify demo mode ON/OFF toggle still works correctly
- [ ] Verify agent (live) mode works when kc-agent is running locally
- [ ] Verify agent-only cards (Hardware Health) gracefully show demo data