### PR TITLE
🐛 Fix cluster mode detection and skeleton gating for in-cluster deployments

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -295,10 +295,12 @@ func (s *Server) setupRoutes() {
 		if atomic.LoadInt32(&s.shuttingDown) == 1 {
 			return c.JSON(fiber.Map{"status": "shutting_down", "version": Version})
 		}
+		inCluster := s.k8sClient != nil && s.k8sClient.IsInCluster()
 		return c.JSON(fiber.Map{
 			"status":           "ok",
 			"version":          Version,
 			"oauth_configured": s.config.GitHubClientID != "",
+			"in_cluster":       inCluster,
 		})
 	})
 

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -40,6 +40,12 @@ type MultiClusterClient struct {
 	inClusterConfig *rest.Config // In-cluster config when running inside k8s
 }
 
+// IsInCluster returns true if the server is running inside a Kubernetes cluster
+// (i.e., has a valid in-cluster ServiceAccount config).
+func (m *MultiClusterClient) IsInCluster() bool {
+	return m.inClusterConfig != nil
+}
+
 // ClusterInfo represents basic cluster information
 type ClusterInfo struct {
 	Name      string `json:"name"`

--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -42,7 +42,7 @@
 import { createContext, useContext, useLayoutEffect, useMemo } from 'react'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { isAgentUnavailable } from '../../hooks/useLocalAgent'
-import { isBackendConnected } from '../../hooks/useBackendHealth'
+import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useOptionalStack } from '../../contexts/StackContext'
 
 export interface CardDataState {
@@ -278,7 +278,7 @@ export function useCardDemoState(options: CardDemoStateOptions = {}): CardDemoSt
 
     // 4. Agent-dependent card but agent is offline AND backend is also unavailable
     //    When backend is connected (cluster mode), allow live data via backend API
-    if (requires === 'agent' && isAgentUnavailable() && !isBackendConnected()) {
+    if (requires === 'agent' && isAgentUnavailable() && !isInClusterMode()) {
       return { shouldUseDemoData: true, reason: 'agent-offline' as DemoReason, showDemoBadge: true }
     }
 

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -12,7 +12,7 @@ import { useSnoozedCards } from '../../hooks/useSnoozedCards'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { isDemoMode as checkIsDemoMode } from '../../lib/demoMode'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
-import { isBackendConnected } from '../../hooks/useBackendHealth'
+import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useIsModeSwitching } from '../../lib/unified/demo'
 import { DEMO_EXEMPT_CARDS } from './cardRegistry'
 import { CardDataReportContext, type CardDataState } from './CardDataContext'
@@ -1024,7 +1024,7 @@ export function CardWrapper({
   // Force skeleton immediately when offline + demo OFF, without waiting for childDataState
   // This fixes the race condition where demo data briefly shows before skeleton
   // Cards with effectiveIsDemoData=true (explicitly showing demo) or demo-exempt cards are excluded
-  const forceSkeletonForOffline = !globalDemoMode && isAgentOffline && !isBackendConnected() && !isDemoExempt && !effectiveIsDemoData && !isDemoMode
+  const forceSkeletonForOffline = !globalDemoMode && isAgentOffline && !isInClusterMode() && !isDemoExempt && !effectiveIsDemoData && !isDemoMode
   const forceSkeletonForModeSwitching = isModeSwitching && !isDemoExempt
 
   // Default to 'list' skeleton type if not specified, enabling automatic skeleton display

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -41,6 +41,7 @@ const CLUSTERS_CARDS_KEY = 'kubestellar-clusters-cards'
 const DEFAULT_CLUSTERS_CARDS = getDefaultCards('clusters')
 
 import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { usePermissions } from '../../hooks/usePermissions'
@@ -1375,7 +1376,7 @@ export function Clusters() {
   // When demo mode is OFF and agent is not connected, force skeleton display
   // Also show skeleton during mode switching for smooth transitions
   const isAgentOffline = agentStatus === 'disconnected'
-  const forceSkeletonForOffline = !isDemoMode && isAgentOffline
+  const forceSkeletonForOffline = !isDemoMode && isAgentOffline && !isInClusterMode()
   const { isClusterAdmin, loading: permissionsLoading } = usePermissions()
   const {
     selectedClusters: globalSelectedClusters,

--- a/web/src/components/clusters/components/StatsOverview.tsx
+++ b/web/src/components/clusters/components/StatsOverview.tsx
@@ -3,6 +3,7 @@ import { WifiOff, HardDrive, Server, CheckCircle2, XCircle, Cpu, MemoryStick, La
 import { formatStat, formatMemoryStat } from '../../../lib/formatStats'
 import { StatsConfigModal, useStatsConfig } from '../../ui/StatsConfig'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
+import { isInClusterMode } from '../../../hooks/useBackendHealth'
 import { useDemoMode } from '../../../hooks/useDemoMode'
 import { Skeleton } from '../../ui/Skeleton'
 
@@ -218,7 +219,7 @@ export function StatsOverview({
 
   // When demo mode is OFF and agent is not connected, force skeleton display
   const isAgentOffline = agentStatus === 'disconnected'
-  const forceLoadingForOffline = !isDemoMode && isAgentOffline
+  const forceLoadingForOffline = !isDemoMode && isAgentOffline && !isInClusterMode()
 
   // Resource data is available if we have reachable clusters with node data
   const hasData = forceLoadingForOffline ? false : stats.hasResourceData !== false

--- a/web/src/components/dashboard/MissionSuggestions.tsx
+++ b/web/src/components/dashboard/MissionSuggestions.tsx
@@ -5,6 +5,7 @@ import { useMissionSuggestions, MissionSuggestion, MissionType } from '../../hoo
 import { useSnoozedMissions, formatTimeRemaining } from '../../hooks/useSnoozedMissions'
 import { useMissions } from '../../hooks/useMissions'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { Skeleton } from '../ui/Skeleton'
 
@@ -59,7 +60,7 @@ export function MissionSuggestions() {
   const { status: agentStatus } = useLocalAgent()
   const { isDemoMode } = useDemoMode()
   const isAgentOffline = agentStatus === 'disconnected'
-  const forceSkeletonForOffline = !isDemoMode && isAgentOffline
+  const forceSkeletonForOffline = !isDemoMode && isAgentOffline && !isInClusterMode()
 
   // Force dependency on snoozedMissions for reactivity
   void snoozedMissions

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -8,7 +8,7 @@ import { cn } from '../../../lib/cn'
 
 export function AgentStatusIndicator() {
   const { status: agentStatus, health: agentHealth, connectionEvents, isConnected, isDegraded, dataErrorCount, lastDataError } = useLocalAgent()
-  const { status: backendStatus, isConnected: isBackendConnected } = useBackendHealth()
+  const { status: backendStatus, isConnected: isBackendConnected, isInClusterMode } = useBackendHealth()
   const { isDemoMode: isDemoModeHook, toggleDemoMode } = useDemoMode()
   // Synchronous fallback prevents flash of WifiOff icon during React transitions
   const isDemoMode = isDemoModeHook || getDemoMode()
@@ -130,7 +130,7 @@ export function AgentStatusIndicator() {
     ? { bg: 'bg-green-500/10 text-green-400 hover:bg-green-500/20', dot: 'bg-green-400', label: 'AI', Icon: Wifi, title: 'Local Agent connected' }
     : stableStatus === 'connecting'
     ? { bg: 'bg-yellow-500/10 text-yellow-400 hover:bg-yellow-500/20', dot: 'bg-yellow-400 animate-pulse', label: 'AI', Icon: Wifi, title: 'Connecting to agent...' }
-    : isBackendConnected
+    : isInClusterMode
     ? { bg: 'bg-blue-500/10 text-blue-400 hover:bg-blue-500/20', dot: 'bg-blue-400', label: 'Cluster', Icon: Server, title: 'In-cluster mode - using ServiceAccount' }
     : { bg: 'bg-red-500/10 text-red-400 hover:bg-red-500/20', dot: 'bg-red-400', label: 'Offline', Icon: WifiOff, title: 'Local Agent disconnected' }
 
@@ -193,10 +193,10 @@ export function AgentStatusIndicator() {
             <div className="flex items-center gap-2">
               <div className={cn(
                 'w-3 h-3 rounded-full',
-                isDemoMode ? 'bg-gray-400' : isDegraded ? 'bg-yellow-400' : isConnected ? 'bg-green-400' : agentStatus === 'connecting' ? 'bg-yellow-400' : isBackendConnected ? 'bg-blue-400' : 'bg-red-400'
+                isDemoMode ? 'bg-gray-400' : isDegraded ? 'bg-yellow-400' : isConnected ? 'bg-green-400' : agentStatus === 'connecting' ? 'bg-yellow-400' : isInClusterMode ? 'bg-blue-400' : 'bg-red-400'
               )} />
               <span className={cn('text-sm font-medium', isDemoMode ? 'text-muted-foreground' : 'text-foreground')}>
-                {isDemoMode ? 'Local Agent: Bypassed' : isDegraded ? 'Local Agent: Degraded' : isConnected ? 'Local Agent: Connected' : agentStatus === 'connecting' ? 'Local Agent: Connecting...' : isBackendConnected ? 'Cluster Mode' : 'Local Agent: Disconnected'}
+                {isDemoMode ? 'Local Agent: Bypassed' : isDegraded ? 'Local Agent: Degraded' : isConnected ? 'Local Agent: Connected' : agentStatus === 'connecting' ? 'Local Agent: Connecting...' : isInClusterMode ? 'Cluster Mode' : 'Local Agent: Disconnected'}
               </span>
               {isConnected && agentHealth?.version && agentHealth.version !== 'demo' && (
                 <span className="text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
@@ -211,7 +211,7 @@ export function AgentStatusIndicator() {
                 ? `Connected but experiencing data errors (${dataErrorCount} in last minute)`
                 : isConnected
                 ? `Connected to local agent at 127.0.0.1:8585`
-                : isBackendConnected
+                : isInClusterMode
                 ? 'Using in-cluster ServiceAccount (read-only)'
                 : 'Unable to connect to local agent'
               }

--- a/web/src/components/security/Security.tsx
+++ b/web/src/components/security/Security.tsx
@@ -12,6 +12,7 @@ import { StatBlockValue } from '../ui/StatsOverview'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useIsModeSwitching } from '../../lib/unified/demo'
 import { useCachedSecurityIssues } from '../../hooks/useCachedData'
 import { Skeleton } from '../ui/Skeleton'
@@ -55,7 +56,7 @@ export function Security() {
   // When demo mode is OFF and agent is not connected, force skeleton display
   // Also show skeleton during mode switching for smooth transitions
   const isAgentOffline = agentStatus === 'disconnected'
-  const forceSkeletonForOffline = !isDemoMode && isAgentOffline || isModeSwitching
+  const forceSkeletonForOffline = (!isDemoMode && isAgentOffline && !isInClusterMode()) || isModeSwitching
 
   // Fetch cached security issues (stale-while-revalidate pattern)
   const { issues: cachedSecurityIssues, isLoading: securityLoading, isRefreshing: securityRefreshing } = useCachedSecurityIssues()

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -9,6 +9,7 @@ import {
 import { StatBlockConfig, DashboardStatsType } from './StatsBlockDefinitions'
 import { StatsConfigModal, useStatsConfig } from './StatsConfig'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useIsModeSwitching } from '../../lib/unified/demo'
 
@@ -159,7 +160,7 @@ export function StatsOverview({
   // When demo mode is OFF and agent is confirmed disconnected, force skeleton display
   // Don't force skeleton during 'connecting' - show cached data to prevent flicker
   const isAgentOffline = agentStatus === 'disconnected'
-  const forceLoadingForOffline = !isDemoMode && !isDemoData && isAgentOffline
+  const forceLoadingForOffline = !isDemoMode && !isDemoData && isAgentOffline && !isInClusterMode()
   // Show skeleton during mode switching for smooth transitions
   const effectiveIsLoading = isLoading || forceLoadingForOffline || isModeSwitching
   const effectiveHasData = forceLoadingForOffline ? false : hasData

--- a/web/src/components/workloads/Workloads.tsx
+++ b/web/src/components/workloads/Workloads.tsx
@@ -4,6 +4,7 @@ import { useDeploymentIssues, usePodIssues, useClusters, useDeployments } from '
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useIsModeSwitching } from '../../lib/unified/demo'
 import { StatusIndicator } from '../charts/StatusIndicator'
@@ -44,7 +45,7 @@ export function Workloads() {
   const isRefreshing = podIssuesRefreshing || deploymentIssuesRefreshing || deploymentsRefreshing
   // Show skeletons when loading with no data OR when agent is offline and demo mode is OFF OR mode switching
   const isAgentOffline = agentStatus === 'disconnected'
-  const forceSkeletonForOffline = !isDemoMode && isAgentOffline
+  const forceSkeletonForOffline = !isDemoMode && isAgentOffline && !isInClusterMode()
   const showSkeletons = ((allDeployments.length === 0 && podIssues.length === 0 && deploymentIssues.length === 0) && isLoading) || forceSkeletonForOffline || isModeSwitching
 
   // Combined refresh


### PR DESCRIPTION
## Summary
- Backend `/health` endpoint now returns `in_cluster: true/false` so the frontend can distinguish in-cluster deployment from localhost
- New `isInClusterMode()` replaces `isBackendConnected()` for all skeleton/offline gating — prevents localhost from incorrectly entering "Cluster mode" when only the Go backend is running
- Fixes 6 additional components (Workloads, Clusters, Security, MissionSuggestions, clusters/StatsOverview, ui/StatsOverview) that were still forcing skeletons when agent was offline, blocking real data in cluster mode
- Stat blocks now show real data in cluster mode instead of "--"
- AgentStatusIndicator pill only shows "Cluster" when backend confirms `in_cluster: true`

## Behavior
| Scenario | Agent | Backend | in_cluster | Pill | Data |
|---|---|---|---|---|---|
| Localhost, no agent | off | connected | false | Offline → Demo | Demo data |
| Localhost, agent on | on | connected | false | AI (green) | Live data |
| In-cluster (vllm-d) | off | connected | true | Cluster (blue) | Backend API data |
| Demo-only cards in cluster mode | off | connected | true | Cluster (blue) | Demo data (fallback) |

## Test plan
- [ ] Localhost: start Go backend only, verify pill shows "Offline" (not "Cluster"), demo mode works
- [ ] Localhost: start agent, verify pill shows "AI" green
- [ ] vllm-d: verify pill shows "Cluster" blue, stat blocks show real numbers, cards show real data
- [ ] vllm-d: demo-only cards (e.g. Kagenti) still show demo data in cluster mode
- [ ] Toggle demo mode ON/OFF in both environments — smooth transitions