### PR TITLE
🐛 Fix kagenti demo-only cards showing empty state in cluster mode

### DIFF
--- a/web/src/hooks/mcp/kagenti.ts
+++ b/web/src/hooks/mcp/kagenti.ts
@@ -178,6 +178,7 @@ export function useKagentiAgents(options?: { cluster?: string; namespace?: strin
     category: 'clusters',
     initialData: [] as KagentiAgent[],
     demoData: getDemoAgents(),
+    enabled: !isAgentUnavailable(),
     fetcher: async () => {
       const agents = await agentFetchAllClusters<KagentiAgent>(
         '/kagenti/agents', 'agents', options?.namespace, options?.cluster,
@@ -195,6 +196,7 @@ export function useKagentiBuilds(options?: { cluster?: string; namespace?: strin
     category: 'clusters',
     initialData: [] as KagentiBuild[],
     demoData: getDemoBuilds(),
+    enabled: !isAgentUnavailable(),
     fetcher: async () => {
       const builds = await agentFetchAllClusters<KagentiBuild>(
         '/kagenti/builds', 'builds', options?.namespace, options?.cluster,
@@ -212,6 +214,7 @@ export function useKagentiCards(options?: { cluster?: string; namespace?: string
     category: 'clusters',
     initialData: [] as KagentiCard[],
     demoData: getDemoCards(),
+    enabled: !isAgentUnavailable(),
     fetcher: async () => {
       const cards = await agentFetchAllClusters<KagentiCard>(
         '/kagenti/cards', 'cards', options?.namespace, options?.cluster,
@@ -229,6 +232,7 @@ export function useKagentiTools(options?: { cluster?: string; namespace?: string
     category: 'clusters',
     initialData: [] as KagentiTool[],
     demoData: getDemoTools(),
+    enabled: !isAgentUnavailable(),
     fetcher: async () => {
       const tools = await agentFetchAllClusters<KagentiTool>(
         '/kagenti/tools', 'tools', options?.namespace, options?.cluster,


### PR DESCRIPTION
## Summary
- Kagenti hooks were fetching via agent even when agent was unavailable, returning empty `[]`
- `useCache` served those empty arrays instead of the defined `demoData`
- Fix: add `enabled: !isAgentUnavailable()` to all 4 kagenti `useCache` calls
- When agent is unavailable, `useCache` returns `demoData` (demo agents, builds, cards, tools)
- Only kagenti hooks had this problem — other demo-only cards either use static mock data (ArgoCD) or backend API (MCS)

## Test plan
- [ ] vllm-d: Kagenti Overview, Agent Fleet, Build Pipeline, MCP Tool Registry show demo data
- [ ] Localhost demo mode: same cards show demo data
- [ ] Localhost with agent: cards try to fetch real data from agent