### PR TITLE
✨ Add pok-prod-sa as automated deployment target

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -141,7 +141,7 @@ jobs:
   deploy-pok-prod:
     needs: build
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-    runs-on: [self-hosted, pok-prod]
+    runs-on: [self-hosted, kc-pok]
     environment: pok-prod
 
     steps:


### PR DESCRIPTION
## Summary
- Adds `deploy-pok-prod` job to the build-deploy workflow
- Both vllm-d and pok-prod-sa clusters now receive automatic deploys on every push to main
- Uses `kc-pok` labeled self-hosted runners on the pok-prod-sa cluster (ARC runner deployment created)
- Deploys to namespace `kubestellar-console` with route `kc-kubestellar-console-kubestellar-console.apps.pokprod001.ete14.res.ibm.com`
- Adds `all` and `pok-prod` options to manual workflow dispatch (replaces `staging`)

## Infrastructure Setup (already done)
- Created `kubestellar-console-runners` RunnerDeployment on pok-prod-sa (2 replicas, label: kc-pok)
- Copied `arc-github-secret-kubestellar` from vllm-d to pok-prod-sa for GitHub App auth
- Created `pok-prod` GitHub environment
- Set `KUBECONFIG_POK_PROD` GitHub secret (backup, not used by workflow)

## Test plan
- [ ] Merge to main and verify both deploy jobs run successfully
- [ ] Check vllm-d deployment still works as before
- [ ] Check pok-prod deployment reaches the cluster and pod is Running
- [ ] Verify route is accessible: https://kc-kubestellar-console-kubestellar-console.apps.pokprod001.ete14.res.ibm.com