### PR TITLE
🐛 Route settings persistence through local kc-agent

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -182,7 +182,7 @@ func NewServer(cfg Config) (*Server, error) {
 
 	// Initialize persistent settings manager
 	settingsManager := settings.GetSettingsManager()
-	if err := settingsManager.MigrateFromConfigYaml(); err != nil {
+	if err := settingsManager.MigrateFromConfigYaml(agent.GetConfigManager()); err != nil {
 		log.Printf("Warning: Failed to migrate settings from config.yaml: %v", err)
 	}
 	log.Printf("Settings manager initialized (%s)", settingsManager.GetSettingsPath())


### PR DESCRIPTION
## Summary
- Settings (theme, AI mode, API keys, etc.) were being saved via `PUT /api/settings` to the **cluster backend**, which fails in-cluster with `permission denied` since the container filesystem is read-only
- Settings should persist to `~/.kc/settings.json` on the user's **local machine** via the kc-agent at `127.0.0.1:8585`
- Added `/settings` (GET/PUT), `/settings/export` (POST), `/settings/import` (PUT/POST) endpoints to the kc-agent
- Frontend `usePersistedSettings` now routes all settings calls to `LOCAL_AGENT_URL` instead of the relative `/api/settings` path
- Broke circular dependency between `settings` and `agent` packages using a `ConfigProvider` interface

## Test plan
- [ ] Start kc-agent locally, change a setting (e.g. theme), verify `~/.kc/settings.json` is updated
- [ ] Clear browser cache, reload — settings should restore from the local file
- [ ] Access console from cluster URL (pok-prod), verify settings sync works via agent
- [ ] Verify export/import settings backup works through the agent
- [ ] Verify `go build ./...` compiles cleanly (no circular imports)