### PR TITLE
🐛 Fix Kagenti demo data fallback and llm-d flow graph overlap

### DIFF
--- a/web/src/components/cards/llmd/LLMdFlow.tsx
+++ b/web/src/components/cards/llmd/LLMdFlow.tsx
@@ -1031,7 +1031,7 @@ export function LLMdFlow() {
       {/* SVG Flow Diagram - overflow visible allows labels to extend beyond viewBox */}
       <svg
         viewBox="-5 -5 120 130"
-        className="w-full h-full overflow-visible"
+        className="w-full h-[calc(100%-2rem)] mt-8 overflow-visible"
         preserveAspectRatio="xMidYMid meet"
         style={{ overflow: 'visible' }}
       >

--- a/web/src/hooks/mcp/kagenti.ts
+++ b/web/src/hooks/mcp/kagenti.ts
@@ -178,6 +178,7 @@ export function useKagentiAgents(options?: { cluster?: string; namespace?: strin
     category: 'clusters',
     initialData: [] as KagentiAgent[],
     demoData: getDemoAgents(),
+    demoWhenEmpty: true,
     enabled: !isAgentUnavailable(),
     fetcher: async () => {
       const agents = await agentFetchAllClusters<KagentiAgent>(
@@ -196,6 +197,7 @@ export function useKagentiBuilds(options?: { cluster?: string; namespace?: strin
     category: 'clusters',
     initialData: [] as KagentiBuild[],
     demoData: getDemoBuilds(),
+    demoWhenEmpty: true,
     enabled: !isAgentUnavailable(),
     fetcher: async () => {
       const builds = await agentFetchAllClusters<KagentiBuild>(
@@ -214,6 +216,7 @@ export function useKagentiCards(options?: { cluster?: string; namespace?: string
     category: 'clusters',
     initialData: [] as KagentiCard[],
     demoData: getDemoCards(),
+    demoWhenEmpty: true,
     enabled: !isAgentUnavailable(),
     fetcher: async () => {
       const cards = await agentFetchAllClusters<KagentiCard>(
@@ -232,6 +235,7 @@ export function useKagentiTools(options?: { cluster?: string; namespace?: string
     category: 'clusters',
     initialData: [] as KagentiTool[],
     demoData: getDemoTools(),
+    demoWhenEmpty: true,
     enabled: !isAgentUnavailable(),
     fetcher: async () => {
       const tools = await agentFetchAllClusters<KagentiTool>(


### PR DESCRIPTION
## Summary
- Adds `demoWhenEmpty` option to `useCache` so demo-only cards (listed in `DEMO_DATA_CARDS`) show demo data when live fetch returns empty results, rather than showing empty "No data" states with a Demo badge
- Applies `demoWhenEmpty: true` to all 4 Kagenti hooks (agents, builds, cards, tools) — fixes the AI Agents dashboard showing empty cards in live/AI mode when Kagenti is not installed
- Fixes llm-d Request Flow card where SVG flow diagram overlapped the header stats text by adding vertical offset

## Test plan
- [ ] Verify Kagenti cards on AI Agents dashboard show demo data with Demo badge in live mode
- [ ] Verify llm-d Request Flow card header text is not overlapped by the flow diagram
- [ ] Verify cards in global demo mode still work correctly
- [ ] Verify cards with real data (non-empty) are unaffected by `demoWhenEmpty`