### PR TITLE
🐛 Fix Operator Status card calling wrong API endpoint

### DIFF
--- a/web/src/hooks/mcp/operators.ts
+++ b/web/src/hooks/mcp/operators.ts
@@ -115,7 +115,7 @@ export function useOperators(cluster?: string) {
         const allOperators: Operator[] = []
         for (const c of allClusters) {
           try {
-            const { data } = await api.get<{ operators: Operator[] }>(`/api/mcp/operators?cluster=${encodeURIComponent(c.name)}`)
+            const { data } = await api.get<{ operators: Operator[] }>(`/api/gitops/operators?cluster=${encodeURIComponent(c.name)}`)
             allOperators.push(...(data.operators || []).map(op => ({ ...op, cluster: c.name })))
           } catch {
             // Skip clusters where operator API is unavailable
@@ -134,7 +134,7 @@ export function useOperators(cluster?: string) {
       }
 
       try {
-        const { data } = await api.get<{ operators: Operator[] }>(`/api/mcp/operators?cluster=${encodeURIComponent(cluster)}`)
+        const { data } = await api.get<{ operators: Operator[] }>(`/api/gitops/operators?cluster=${encodeURIComponent(cluster)}`)
         if (!cancelled) {
           const newOperators = (data.operators || []).map(op => ({ ...op, cluster }))
           setOperators(newOperators)


### PR DESCRIPTION
## Summary
- The operators hook was calling `/api/mcp/operators` which doesn't exist in the backend
- The correct endpoint is `/api/gitops/operators` (registered in `server.go` at line 501)
- Requests were silently failing (caught and swallowed), returning empty data
- This caused "No operators" to display even when OLM operators are installed

## Test plan
- [ ] Visit Operators dashboard — operators should now load from clusters
- [ ] Verify operator status, version, and upgrade info display correctly