### PR TITLE
✨ Add GPU namespace drill-down and pod-level GPU details

### DIFF
--- a/web/src/components/cards/GPUNamespaceAllocations.tsx
+++ b/web/src/components/cards/GPUNamespaceAllocations.tsx
@@ -1,0 +1,272 @@
+import { useMemo } from 'react'
+import { Box, ChevronRight, Server } from 'lucide-react'
+import { useGPUNodes, useAllPods } from '../../hooks/useMCP'
+import { useDrillDownActions } from '../../hooks/useDrillDown'
+import { ClusterBadge } from '../ui/ClusterBadge'
+import { CardClusterFilter, CardSearchInput } from '../../lib/cards'
+import { CardControls } from '../ui/CardControls'
+import { Pagination } from '../ui/Pagination'
+import { Skeleton } from '../ui/Skeleton'
+import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
+import { useCardLoadingState } from './CardDataContext'
+
+interface GPUNamespaceAllocationsProps {
+  config?: Record<string, unknown>
+}
+
+type SortByOption = 'gpuCount' | 'namespace' | 'podCount'
+
+const SORT_OPTIONS = [
+  { value: 'gpuCount' as const, label: 'GPUs' },
+  { value: 'namespace' as const, label: 'Namespace' },
+  { value: 'podCount' as const, label: 'Pods' },
+]
+
+interface NamespaceGPUAllocation {
+  namespace: string
+  gpuRequested: number
+  podCount: number
+  clusters: string[]
+}
+
+// Check if any container in the pod requests GPUs
+function hasGPUResourceRequest(containers?: { gpuRequested?: number }[]): boolean {
+  if (!containers) return false
+  return containers.some(c => (c.gpuRequested ?? 0) > 0)
+}
+
+// Normalize cluster name for matching
+function normalizeClusterName(cluster: string): string {
+  if (!cluster) return ''
+  const parts = cluster.split('/')
+  return parts[parts.length - 1] || cluster
+}
+
+const NAMESPACE_SORT_COMPARATORS: Record<SortByOption, (a: NamespaceGPUAllocation, b: NamespaceGPUAllocation) => number> = {
+  gpuCount: (a, b) => a.gpuRequested - b.gpuRequested,
+  namespace: commonComparators.string<NamespaceGPUAllocation>('namespace'),
+  podCount: (a, b) => a.podCount - b.podCount,
+}
+
+export function GPUNamespaceAllocations({ config: _config }: GPUNamespaceAllocationsProps) {
+  const { nodes: gpuNodes, isLoading: gpuLoading } = useGPUNodes()
+  const { pods: allPods, isLoading: podsLoading } = useAllPods()
+  const { drillToGPUNamespace } = useDrillDownActions()
+
+  const isLoading = (gpuLoading && gpuNodes.length === 0) || (podsLoading && allPods.length === 0)
+
+  useCardLoadingState({
+    isLoading: gpuLoading || podsLoading,
+    hasAnyData: gpuNodes.length > 0 || allPods.length > 0,
+  })
+
+  // Compute per-namespace GPU allocations
+  const namespaceAllocations = useMemo(() => {
+    const gpuNodeKeys = new Set(
+      gpuNodes.map(node => `${normalizeClusterName(node.cluster || '')}:${node.name}`)
+    )
+
+    // Filter to GPU pods
+    const gpuPods = allPods.filter(pod => {
+      if (!pod.cluster) return false
+      if (hasGPUResourceRequest(pod.containers)) return true
+      if (pod.node) {
+        const podKey = `${normalizeClusterName(pod.cluster)}:${pod.node}`
+        if (gpuNodeKeys.has(podKey)) return true
+      }
+      return false
+    })
+
+    // Group by namespace
+    const nsMap = new Map<string, { gpuRequested: number; podCount: number; clusters: Set<string> }>()
+    for (const pod of gpuPods) {
+      const ns = pod.namespace || 'default'
+      const existing = nsMap.get(ns) || { gpuRequested: 0, podCount: 0, clusters: new Set<string>() }
+
+      const podGPUs = pod.containers?.reduce((sum, c) => sum + (c.gpuRequested ?? 0), 0) ?? 0
+      existing.gpuRequested += podGPUs
+      existing.podCount += 1
+      if (pod.cluster) existing.clusters.add(pod.cluster)
+
+      nsMap.set(ns, existing)
+    }
+
+    return Array.from(nsMap.entries()).map(([namespace, data]) => ({
+      namespace,
+      gpuRequested: data.gpuRequested,
+      podCount: data.podCount,
+      clusters: Array.from(data.clusters),
+    }))
+  }, [allPods, gpuNodes])
+
+  const {
+    items: displayItems,
+    totalItems,
+    currentPage,
+    totalPages,
+    goToPage,
+    needsPagination,
+    itemsPerPage,
+    setItemsPerPage,
+    filters,
+    sorting,
+  } = useCardData<NamespaceGPUAllocation, SortByOption>(namespaceAllocations, {
+    filter: {
+      searchFields: ['namespace'] as (keyof NamespaceGPUAllocation)[],
+      storageKey: 'gpu-namespace-allocations',
+    },
+    sort: {
+      defaultField: 'gpuCount',
+      defaultDirection: 'desc',
+      comparators: NAMESPACE_SORT_COMPARATORS,
+    },
+    defaultLimit: 5,
+  })
+
+  const totalGPUs = useMemo(() =>
+    namespaceAllocations.reduce((sum, ns) => sum + ns.gpuRequested, 0),
+    [namespaceAllocations]
+  )
+
+  if (isLoading) {
+    return (
+      <div className="h-full flex flex-col min-h-card">
+        <div className="flex items-center justify-between mb-3">
+          <Skeleton variant="text" width={120} height={16} />
+          <Skeleton variant="rounded" width={80} height={28} />
+        </div>
+        <div className="space-y-2">
+          {[1, 2, 3, 4].map(i => (
+            <Skeleton key={i} variant="rounded" height={60} />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (namespaceAllocations.length === 0) {
+    return (
+      <div className="h-full flex flex-col content-loaded">
+        <div className="flex-1 flex flex-col items-center justify-center text-center">
+          <div className="w-12 h-12 rounded-full bg-secondary flex items-center justify-center mb-3">
+            <Box className="w-6 h-6 text-muted-foreground" />
+          </div>
+          <p className="text-foreground font-medium">No GPU Workloads</p>
+          <p className="text-sm text-muted-foreground">No namespaces with GPU allocations detected</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col content-loaded overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+            {totalGPUs} GPUs across {namespaceAllocations.length} ns
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {filters.localClusterFilter && filters.localClusterFilter.length > 0 && (
+            <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
+              <Server className="w-3 h-3" />
+              {filters.localClusterFilter.length}/{filters.availableClusters.length}
+            </span>
+          )}
+
+          {filters.availableClusters && filters.availableClusters.length > 0 && (
+            <CardClusterFilter
+              availableClusters={filters.availableClusters}
+              selectedClusters={filters.localClusterFilter}
+              onToggle={filters.toggleClusterFilter}
+              onClear={filters.clearClusterFilter}
+              isOpen={filters.showClusterFilter}
+              setIsOpen={filters.setShowClusterFilter}
+              containerRef={filters.clusterFilterRef}
+              minClusters={1}
+            />
+          )}
+
+          <CardControls
+            limit={itemsPerPage}
+            onLimitChange={setItemsPerPage}
+            sortBy={sorting.sortBy}
+            sortOptions={SORT_OPTIONS}
+            onSortChange={sorting.setSortBy}
+            sortDirection={sorting.sortDirection}
+            onSortDirectionChange={sorting.setSortDirection}
+          />
+        </div>
+      </div>
+
+      {/* Search */}
+      <CardSearchInput
+        value={filters.search}
+        onChange={filters.setSearch}
+        placeholder="Search namespaces..."
+        className="mb-4"
+      />
+
+      {/* Namespace list */}
+      <div className="flex-1 space-y-2 overflow-y-auto">
+        {displayItems.map((ns) => (
+          <div
+            key={ns.namespace}
+            onClick={() => drillToGPUNamespace(ns.namespace, {
+              gpuRequested: ns.gpuRequested,
+              podCount: ns.podCount,
+              clusters: ns.clusters,
+            })}
+            className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+          >
+            <div className="flex items-center gap-2 mb-2 min-w-0">
+              <Box className="w-4 h-4 text-purple-400 shrink-0" />
+              <span className="text-sm font-medium text-foreground truncate min-w-0 flex-1 group-hover:text-purple-400">
+                {ns.namespace}
+              </span>
+              <ChevronRight className="w-4 h-4 text-muted-foreground shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+            </div>
+            <div className="flex items-center justify-between text-xs gap-2">
+              <div className="flex items-center gap-2">
+                {ns.clusters.slice(0, 2).map(c => (
+                  <ClusterBadge key={c} cluster={c} size="sm" />
+                ))}
+                {ns.clusters.length > 2 && (
+                  <span className="text-muted-foreground">+{ns.clusters.length - 2}</span>
+                )}
+              </div>
+              <div className="flex items-center gap-3 shrink-0">
+                <span className="text-muted-foreground">{ns.podCount} pods</span>
+                <span className="font-mono text-purple-400 font-medium">{ns.gpuRequested} GPUs</span>
+              </div>
+            </div>
+            {/* Proportion bar */}
+            {totalGPUs > 0 && (
+              <div className="mt-2 h-1.5 bg-secondary rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-purple-500 transition-all"
+                  style={{ width: `${(ns.gpuRequested / totalGPUs) * 100}%` }}
+                />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Pagination */}
+      {needsPagination && itemsPerPage !== 'unlimited' && (
+        <div className="pt-2 border-t border-border/50 mt-2">
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            totalItems={totalItems}
+            itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : totalItems}
+            onPageChange={goToPage}
+            showItemsPerPage={false}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -45,6 +45,7 @@ const GPUInventory = lazy(() => import('./GPUInventory').then(m => ({ default: m
 const GPUStatus = lazy(() => import('./GPUStatus').then(m => ({ default: m.GPUStatus })))
 const GPUOverview = lazy(() => import('./GPUOverview').then(m => ({ default: m.GPUOverview })))
 const GPUWorkloads = lazy(() => import('./GPUWorkloads').then(m => ({ default: m.GPUWorkloads })))
+const GPUNamespaceAllocations = lazy(() => import('./GPUNamespaceAllocations').then(m => ({ default: m.GPUNamespaceAllocations })))
 const SecurityIssues = lazy(() => import('./SecurityIssues').then(m => ({ default: m.SecurityIssues })))
 const EventSummary = lazy(() => import('./EventSummary').then(m => ({ default: m.EventSummary })))
 const WarningEvents = lazy(() => import('./WarningEvents').then(m => ({ default: m.WarningEvents })))
@@ -231,6 +232,7 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   gpu_status: GPUStatus,
   gpu_overview: GPUOverview,
   gpu_workloads: GPUWorkloads,
+  gpu_namespace_allocations: GPUNamespaceAllocations,
   security_issues: SecurityIssues,
   // Live data trend cards
   events_timeline: EventsTimeline,
@@ -560,6 +562,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   gpu_status: () => import('./GPUStatus'),
   gpu_overview: () => import('./GPUOverview'),
   gpu_workloads: () => import('./GPUWorkloads'),
+  gpu_namespace_allocations: () => import('./GPUNamespaceAllocations'),
   security_issues: () => import('./SecurityIssues'),
   events_timeline: () => import('./EventsTimeline'),
   pod_health_trend: () => import('./PodHealthTrend'),
@@ -852,6 +855,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   gpu_status: 6,
   gpu_inventory: 6,
   gpu_workloads: 6,
+  gpu_namespace_allocations: 6,
   opa_policies: 6,
   kyverno_policies: 6,
   falco_alerts: 4,

--- a/web/src/components/drilldown/DrillDownModal.tsx
+++ b/web/src/components/drilldown/DrillDownModal.tsx
@@ -27,6 +27,7 @@ import { LogsDrillDown } from './views/LogsDrillDown'
 import { EventsDrillDown } from './views/EventsDrillDown'
 import { NodeDrillDown } from './views/NodeDrillDown'
 import { GPUNodeDrillDown } from './views/GPUNodeDrillDown'
+const GPUNamespaceDrillDown = lazy(() => import('./views/GPUNamespaceDrillDown').then(m => ({ default: m.GPUNamespaceDrillDown })))
 import { YAMLDrillDown } from './views/YAMLDrillDown'
 
 // Loading fallback for lazy-loaded drilldown views
@@ -61,6 +62,7 @@ const getViewIcon = (type: string) => {
     case 'serviceaccount': return <User className="w-4 h-4 text-purple-400" />
     case 'node': return <Cpu className="w-4 h-4 text-orange-400" />
     case 'gpu-node': return <Cpu className="w-4 h-4 text-purple-400" />
+    case 'gpu-namespace': return <Box className="w-4 h-4 text-purple-400" />
     case 'logs': return <FileText className="w-4 h-4 text-yellow-400" />
     case 'events': return <Zap className="w-4 h-4 text-amber-400" />
     // Phase 2 view types
@@ -165,6 +167,8 @@ export function DrillDownModal() {
         return <NodeDrillDown data={data} />
       case 'gpu-node':
         return <GPUNodeDrillDown data={data} />
+      case 'gpu-namespace':
+        return <GPUNamespaceDrillDown data={data} />
       case 'yaml':
         return <YAMLDrillDown data={data} />
       case 'resources':

--- a/web/src/components/drilldown/views/GPUNamespaceDrillDown.tsx
+++ b/web/src/components/drilldown/views/GPUNamespaceDrillDown.tsx
@@ -1,0 +1,249 @@
+import { useMemo } from 'react'
+import { Box, Cpu, ChevronRight } from 'lucide-react'
+import { useGPUNodes, useAllPods } from '../../../hooks/useMCP'
+import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { ClusterBadge } from '../../ui/ClusterBadge'
+import { StatusIndicator, type Status } from '../../charts/StatusIndicator'
+
+interface Props {
+  data: Record<string, unknown>
+}
+
+// Check if any container requests GPUs
+function hasGPUResourceRequest(containers?: { gpuRequested?: number }[]): boolean {
+  if (!containers) return false
+  return containers.some(c => (c.gpuRequested ?? 0) > 0)
+}
+
+function normalizeClusterName(cluster: string): string {
+  if (!cluster) return ''
+  const parts = cluster.split('/')
+  return parts[parts.length - 1] || cluster
+}
+
+function podStatusToIndicator(status: string): Status {
+  const lower = status.toLowerCase()
+  if (lower === 'running' || lower === 'succeeded' || lower === 'completed') return 'healthy'
+  if (lower === 'pending') return 'pending'
+  if (lower === 'failed' || lower === 'error' || lower === 'crashloopbackoff' || lower === 'evicted') return 'error'
+  return 'unknown'
+}
+
+export function GPUNamespaceDrillDown({ data }: Props) {
+  const namespace = data.namespace as string
+  const passedGpuRequested = data.gpuRequested as number | undefined
+  const passedPodCount = data.podCount as number | undefined
+  const passedClusters = data.clusters as string[] | undefined
+
+  const { nodes: gpuNodes } = useGPUNodes()
+  const { pods: allPods } = useAllPods()
+  const { drillToPod, drillToGPUNode } = useDrillDownActions()
+
+  // Find GPU pods in this namespace
+  const gpuPods = useMemo(() => {
+    const gpuNodeKeys = new Set(
+      gpuNodes.map(node => `${normalizeClusterName(node.cluster || '')}:${node.name}`)
+    )
+
+    return allPods.filter(pod => {
+      if (!pod.cluster) return false
+      if (pod.namespace !== namespace) return false
+      if (hasGPUResourceRequest(pod.containers)) return true
+      if (pod.node) {
+        const podKey = `${normalizeClusterName(pod.cluster)}:${pod.node}`
+        if (gpuNodeKeys.has(podKey)) return true
+      }
+      return false
+    })
+  }, [allPods, gpuNodes, namespace])
+
+  // Compute summary stats from live data (fallback to passed data)
+  const totalGPUs = useMemo(() =>
+    gpuPods.reduce((sum, pod) =>
+      sum + (pod.containers?.reduce((s, c) => s + (c.gpuRequested ?? 0), 0) ?? 0), 0),
+    [gpuPods]
+  )
+  const podCount = gpuPods.length || passedPodCount || 0
+  const gpuRequested = totalGPUs || passedGpuRequested || 0
+  const clusters = useMemo(() => {
+    const set = new Set(gpuPods.map(p => p.cluster).filter(Boolean) as string[])
+    return set.size > 0 ? Array.from(set) : (passedClusters || [])
+  }, [gpuPods, passedClusters])
+
+  // Group pods by node for the node breakdown
+  const podsByNode = useMemo(() => {
+    const map = new Map<string, typeof gpuPods>()
+    for (const pod of gpuPods) {
+      const nodeKey = pod.node || 'unscheduled'
+      const existing = map.get(nodeKey) || []
+      existing.push(pod)
+      map.set(nodeKey, existing)
+    }
+    return Array.from(map.entries()).sort((a, b) => b[1].length - a[1].length)
+  }, [gpuPods])
+
+  // Find GPU node data for drill-down
+  const gpuNodeMap = useMemo(() => {
+    const map = new Map<string, typeof gpuNodes[0]>()
+    for (const node of gpuNodes) {
+      map.set(node.name, node)
+    }
+    return map
+  }, [gpuNodes])
+
+  return (
+    <div className="space-y-6">
+      {/* Summary */}
+      <div className="p-6 rounded-lg bg-card/50 border border-border">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-10 h-10 rounded-lg bg-purple-500/20 flex items-center justify-center">
+            <Box className="w-5 h-5 text-purple-400" />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-foreground">{namespace}</h3>
+            <p className="text-sm text-muted-foreground">GPU Namespace Allocations</p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-4">
+          <div className="p-3 rounded-lg bg-secondary/30">
+            <div className="text-sm text-muted-foreground">GPUs Requested</div>
+            <div className="text-2xl font-bold font-mono text-purple-400">{gpuRequested}</div>
+          </div>
+          <div className="p-3 rounded-lg bg-secondary/30">
+            <div className="text-sm text-muted-foreground">GPU Pods</div>
+            <div className="text-2xl font-bold text-foreground">{podCount}</div>
+          </div>
+          <div className="p-3 rounded-lg bg-secondary/30">
+            <div className="text-sm text-muted-foreground">Clusters</div>
+            <div className="flex items-center gap-1 mt-1 flex-wrap">
+              {clusters.slice(0, 3).map(c => (
+                <ClusterBadge key={c} cluster={c} size="sm" />
+              ))}
+              {clusters.length > 3 && (
+                <span className="text-xs text-muted-foreground">+{clusters.length - 3}</span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Pod list */}
+      <div>
+        <h3 className="text-lg font-semibold text-foreground mb-4">
+          GPU Pods ({gpuPods.length})
+        </h3>
+
+        {gpuPods.length === 0 ? (
+          <div className="p-8 rounded-lg bg-card/50 border border-border text-center">
+            <p className="text-muted-foreground">No GPU pods found in this namespace</p>
+            <p className="text-xs text-muted-foreground mt-1">Data may still be loading</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {gpuPods.map(pod => {
+              const podGPUs = pod.containers?.reduce((s, c) => s + (c.gpuRequested ?? 0), 0) ?? 0
+              const status = (pod.status || 'Unknown') as string
+              return (
+                <div
+                  key={`${pod.cluster}:${pod.namespace}:${pod.name}`}
+                  onClick={() => drillToPod(pod.cluster!, pod.namespace!, pod.name, { status })}
+                  className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+                >
+                  <div className="flex items-center justify-between mb-1">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <StatusIndicator status={podStatusToIndicator(status)} size="sm" />
+                      <span className="text-sm font-medium text-foreground truncate group-hover:text-purple-400">
+                        {pod.name}
+                      </span>
+                      <ChevronRight className="w-3.5 h-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+                    </div>
+                    <span className="font-mono text-sm text-purple-400 font-medium shrink-0">
+                      {podGPUs} GPU{podGPUs !== 1 ? 's' : ''}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                    {pod.cluster && <ClusterBadge cluster={pod.cluster} size="sm" />}
+                    {pod.node && (
+                      <span className="flex items-center gap-1">
+                        <Cpu className="w-3 h-3" />
+                        {pod.node}
+                      </span>
+                    )}
+                    {pod.containers && pod.containers.length > 0 && (
+                      <span>{pod.containers.length} container{pod.containers.length !== 1 ? 's' : ''}</span>
+                    )}
+                  </div>
+                  {/* Container GPU breakdown */}
+                  {pod.containers && pod.containers.some(c => (c.gpuRequested ?? 0) > 0) && (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {pod.containers.filter(c => (c.gpuRequested ?? 0) > 0).map(c => (
+                        <span
+                          key={c.name}
+                          className="px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-400 text-xs"
+                        >
+                          {c.name}: {c.gpuRequested} GPU{(c.gpuRequested ?? 0) !== 1 ? 's' : ''}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Node breakdown */}
+      {podsByNode.length > 0 && (
+        <div>
+          <h3 className="text-lg font-semibold text-foreground mb-4">
+            Node Distribution ({podsByNode.length} nodes)
+          </h3>
+          <div className="space-y-2">
+            {podsByNode.map(([nodeName, pods]) => {
+              const gpuNodeData = gpuNodeMap.get(nodeName)
+              const nodeGPUs = pods.reduce((sum, pod) =>
+                sum + (pod.containers?.reduce((s, c) => s + (c.gpuRequested ?? 0), 0) ?? 0), 0)
+              const nodeCluster = pods[0]?.cluster || ''
+
+              return (
+                <div
+                  key={nodeName}
+                  onClick={() => {
+                    if (gpuNodeData && nodeCluster) {
+                      drillToGPUNode(nodeCluster, nodeName, {
+                        gpuType: gpuNodeData.gpuType,
+                        gpuCount: gpuNodeData.gpuCount,
+                        gpuAllocated: gpuNodeData.gpuAllocated,
+                      })
+                    }
+                  }}
+                  className={`p-3 rounded-lg bg-secondary/30 transition-colors ${
+                    gpuNodeData ? 'hover:bg-secondary/50 cursor-pointer group' : ''
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Cpu className="w-4 h-4 text-orange-400" />
+                      <span className="text-sm font-medium text-foreground group-hover:text-orange-400">
+                        {nodeName}
+                      </span>
+                      {gpuNodeData && (
+                        <ChevronRight className="w-3.5 h-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                      )}
+                    </div>
+                    <div className="flex items-center gap-3 text-xs">
+                      <span className="text-muted-foreground">{pods.length} pod{pods.length !== 1 ? 's' : ''}</span>
+                      <span className="font-mono text-purple-400 font-medium">{nodeGPUs} GPUs</span>
+                    </div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/config/dashboards/gpu.ts
+++ b/web/src/config/dashboards/gpu.ts
@@ -16,6 +16,7 @@ export const gpuDashboardConfig: UnifiedDashboardConfig = {
     { id: 'gpu-utilization-1', cardType: 'gpu_utilization', position: { w: 6, h: 3 } },
     { id: 'gpu-usage-trend-1', cardType: 'gpu_usage_trend', position: { w: 6, h: 3 } },
     { id: 'gpu-workloads-1', cardType: 'gpu_workloads', position: { w: 6, h: 3 } },
+    { id: 'gpu-namespace-alloc-1', cardType: 'gpu_namespace_allocations', position: { w: 6, h: 3 } },
     { id: 'hardware-health-1', cardType: 'hardware_health', title: 'Hardware Health', position: { w: 6, h: 3 } },
   ],
   features: {

--- a/web/src/hooks/useDrillDown.tsx
+++ b/web/src/hooks/useDrillDown.tsx
@@ -18,6 +18,7 @@ export type DrillDownViewType =
   | 'events'
   | 'logs'
   | 'gpu-node'
+  | 'gpu-namespace'
   | 'yaml'
   | 'resources'
   | 'custom'
@@ -196,6 +197,8 @@ function getViewKey(view: DrillDownView): string {
     case 'node':
     case 'gpu-node':
       return `node:${data.cluster}:${data.node}`
+    case 'gpu-namespace':
+      return `gpu-namespace:${data.namespace}`
     case 'logs':
       return `logs:${data.cluster}:${data.namespace}:${data.pod}:${data.container || ''}`
     case 'events':
@@ -352,6 +355,15 @@ export function useDrillDownActions() {
       title: node,
       subtitle: 'GPU Node',
       data: { cluster, node, ...gpuData },
+    })
+  }, [openOrPush])
+
+  const drillToGPUNamespace = useCallback((namespace: string, gpuData?: Record<string, unknown>) => {
+    openOrPush({
+      type: 'gpu-namespace',
+      title: namespace,
+      subtitle: 'GPU Namespace Allocations',
+      data: { namespace, ...gpuData },
     })
   }, [openOrPush])
 
@@ -702,6 +714,7 @@ export function useDrillDownActions() {
     drillToEvents,
     drillToNode,
     drillToGPUNode,
+    drillToGPUNamespace,
     drillToYAML,
     drillToResources,
     drillToConfigMap,


### PR DESCRIPTION
## Summary
Closes #898

- **New `GPUNamespaceAllocations` card**: Shows per-namespace GPU usage on the GPU dashboard with search, sort, pagination, and cluster filtering. Click a namespace row to drill into details.
- **New `GPUNamespaceDrillDown` view**: Lists all GPU pods in a namespace with container-level GPU breakdown, pod status, and node distribution. Click a pod to navigate to PodDrillDown, or click a node to navigate to GPUNodeDrillDown.
- **Enhanced `GPUNodeDrillDown`**: Now shows which pods are consuming GPUs on the node with per-container GPU request breakdown and clickthrough to pod details.
- Registered `gpu-namespace` view type in the drill-down navigation system
- Added card to GPU dashboard layout

## Test plan
- [ ] Navigate to GPU Reservations dashboard — verify new "GPU Namespace Allocations" card renders
- [ ] Click a namespace row — verify drill-down modal opens showing GPU pods in that namespace
- [ ] Click a pod in the namespace drill-down — verify navigation to PodDrillDown
- [ ] Click a node in the namespace drill-down — verify navigation to GPUNodeDrillDown
- [ ] Navigate to an existing GPU node drill-down — verify "GPU Pods on Node" section appears
- [ ] Test search/sort/pagination in the namespace allocations card
- [ ] Test empty state when no GPU pods exist