### PR TITLE
✨ Add unified Dashboard tab to GPU Reservations page

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -265,6 +265,7 @@ export const CARD_TITLES: Record<string, string> = {
   gpu_workloads: 'GPU Workloads',
   gpu_utilization: 'GPU Utilization',
   gpu_usage_trend: 'GPU Usage Trend',
+  gpu_namespace_allocations: 'GPU Namespace Allocations',
   hardware_health: 'Hardware Health',
 
   // Security, RBAC, and compliance


### PR DESCRIPTION
## Summary
- Adds a new **Dashboard** tab to the GPU Reservations page with full unified card features
- GPU Namespace Allocations card placed first (top left) with proper title
- All 8 GPU cards rendered in a 12-column responsive grid with resize support via ellipsis menu
- Cards support add, remove, resize, and localStorage persistence
- Added `gpu_namespace_allocations` to `CARD_TITLES` registry

## Test plan
- [ ] Navigate to GPU Reservations → Dashboard tab
- [ ] Verify GPU Namespace Allocations card is first (top left)
- [ ] Open ellipsis menu → verify Resize option is present
- [ ] Resize a card → verify it persists on page reload
- [ ] Remove a card via ellipsis menu → verify it persists
- [ ] Click Add Card → add a new card → verify it appears
- [ ] Verify other tabs (Overview, Calendar, Reservations, Inventory) still work