### PR TITLE
🐛 Persist tour dismissed state to settings.json

### DIFF
--- a/web/src/lib/settingsSync.ts
+++ b/web/src/lib/settingsSync.ts
@@ -20,6 +20,7 @@ const LS_KEYS = {
   'accessibility-settings': 'accessibility',
   'github_token': 'githubToken',
   'kc_notification_config': 'notifications',
+  'kubestellar-console-tour-completed': 'tourCompleted',
 } as const
 
 /**
@@ -67,6 +68,10 @@ export function collectFromLocalStorage(): Partial<AllSettings> {
     try { result.notifications = JSON.parse(notifications) } catch { /* skip */ }
   }
 
+  // Tour completed (plain string 'true'/'false')
+  const tourCompleted = localStorage.getItem('kubestellar-console-tour-completed')
+  if (tourCompleted !== null) result.tourCompleted = tourCompleted === 'true'
+
   return result
 }
 
@@ -101,6 +106,10 @@ export function restoreToLocalStorage(settings: AllSettings): void {
 
   if (settings.notifications) {
     localStorage.setItem('kc_notification_config', JSON.stringify(settings.notifications))
+  }
+
+  if (settings.tourCompleted !== undefined) {
+    localStorage.setItem('kubestellar-console-tour-completed', String(settings.tourCompleted))
   }
 
   // Notify hooks to re-read from localStorage

--- a/web/src/lib/settingsTypes.ts
+++ b/web/src/lib/settingsTypes.ts
@@ -68,6 +68,7 @@ export interface AllSettings {
   accessibility: AccessibilitySettingsData
   profile: ProfileSettingsData
   widget: WidgetSettingsData
+  tourCompleted: boolean
 
   // Sensitive (decrypted in transit over localhost)
   apiKeys: Record<string, APIKeyEntry>


### PR DESCRIPTION
## Summary
- Tour completion/skip was only in localStorage — clearing browser cache re-showed the tour
- Now syncs tour state through the settings persistence system to `~/.kc/settings.json`
- On restore (cache cleared), tour state is recovered from the settings file

## Test plan
- [ ] Complete or skip the tour → verify `tourCompleted: true` appears in `~/.kc/settings.json`
- [ ] Clear localStorage → reload → verify tour does NOT re-prompt (restored from file)
- [ ] Reset tour from settings → verify it prompts again on next load