### PR TITLE
✨ Add llm-d benchmark dashboard with 7 InferenceMAX-style cards

### DIFF
--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -170,6 +170,14 @@ const PDDisaggregation = lazy(() => _llmdBundle.then(m => ({ default: m.PDDisagg
 const LLMdBenchmarks = lazy(() => _llmdBundle.then(m => ({ default: m.LLMdBenchmarks })))
 const LLMdAIInsights = lazy(() => _llmdBundle.then(m => ({ default: m.LLMdAIInsights })))
 const LLMdConfigurator = lazy(() => _llmdBundle.then(m => ({ default: m.LLMdConfigurator })))
+// LLM-d benchmark dashboard cards (share the same barrel bundle)
+const BenchmarkHero = lazy(() => _llmdBundle.then(m => ({ default: m.BenchmarkHero })))
+const ParetoFrontier = lazy(() => _llmdBundle.then(m => ({ default: m.ParetoFrontier })))
+const HardwareLeaderboard = lazy(() => _llmdBundle.then(m => ({ default: m.HardwareLeaderboard })))
+const LatencyBreakdown = lazy(() => _llmdBundle.then(m => ({ default: m.LatencyBreakdown })))
+const ThroughputComparison = lazy(() => _llmdBundle.then(m => ({ default: m.ThroughputComparison })))
+const PerformanceTimeline = lazy(() => _llmdBundle.then(m => ({ default: m.PerformanceTimeline })))
+const ResourceUtilization = lazy(() => _llmdBundle.then(m => ({ default: m.ResourceUtilization })))
 const GitHubCIMonitor = lazy(() => _workloadMonitorBundle.then(m => ({ default: m.GitHubCIMonitor })))
 const ClusterHealthMonitor = lazy(() => _workloadMonitorBundle.then(m => ({ default: m.ClusterHealthMonitor })))
 const ProviderHealth = lazy(() => import('./ProviderHealth').then(m => ({ default: m.ProviderHealth })))
@@ -406,6 +414,15 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   llmd_ai_insights: LLMdAIInsights,
   llmd_configurator: LLMdConfigurator,
 
+  // LLM-d benchmark dashboard cards
+  benchmark_hero: BenchmarkHero,
+  pareto_frontier: ParetoFrontier,
+  hardware_leaderboard: HardwareLeaderboard,
+  latency_breakdown: LatencyBreakdown,
+  throughput_comparison: ThroughputComparison,
+  performance_timeline: PerformanceTimeline,
+  resource_utilization: ResourceUtilization,
+
   // Dynamic Card (Card Factory meta-component)
   dynamic_card: DynamicCard,
 
@@ -488,6 +505,14 @@ export const DEMO_DATA_CARDS = new Set([
   // removed - they now use StackContext for live data and report isDemoData via useReportCardDataState
   // LLM-d Configurator - demo showcase of tuning options, not a complete YAML generator
   'llmd_configurator',
+  // LLM-d benchmark dashboard cards - demo until live backend exists
+  'benchmark_hero',
+  'pareto_frontier',
+  'hardware_leaderboard',
+  'latency_breakdown',
+  'throughput_comparison',
+  'performance_timeline',
+  'resource_utilization',
   // Provider health card uses real data from /settings/keys + useClusters()
   // Only shows demo data when getDemoMode() is true (handled inside the hook)
   // Kagenti cards - demo until kagenti-operator is installed on clusters
@@ -649,6 +674,14 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   llmd_benchmarks: () => import('./llmd'),
   llmd_ai_insights: () => import('./llmd'),
   llmd_configurator: () => import('./llmd'),
+  // LLM-d benchmark dashboard cards — all share the llmd barrel bundle
+  benchmark_hero: () => import('./llmd'),
+  pareto_frontier: () => import('./llmd'),
+  hardware_leaderboard: () => import('./llmd'),
+  latency_breakdown: () => import('./llmd'),
+  throughput_comparison: () => import('./llmd'),
+  performance_timeline: () => import('./llmd'),
+  resource_utilization: () => import('./llmd'),
   // Kagenti AI Agents — all share one chunk via barrel
   kagenti_status: () => import('./KagentiStatusCard'),
   kagenti_agent_fleet: () => import('./kagenti'),
@@ -823,6 +856,15 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   llmd_benchmarks: 6,     // Benchmark charts
   llmd_ai_insights: 6,    // AI insights panel
   llmd_configurator: 4,   // Configurator showcase
+
+  // LLM-d benchmark dashboard cards (all full-width)
+  benchmark_hero: 12,
+  pareto_frontier: 12,
+  hardware_leaderboard: 12,
+  latency_breakdown: 12,
+  throughput_comparison: 12,
+  performance_timeline: 12,
+  resource_utilization: 12,
 
   // Event dashboard cards
   event_summary: 6,

--- a/web/src/components/cards/llmd/BenchmarkHero.tsx
+++ b/web/src/components/cards/llmd/BenchmarkHero.tsx
@@ -1,0 +1,238 @@
+/**
+ * BenchmarkHero — Headline summary of latest benchmark results
+ *
+ * Shows model, hardware, framework, date, hero metrics (throughput, TTFT,
+ * TPOT, request latency), delta indicators vs previous run, and a bottom
+ * strip with total requests, failure rate, GPU util, and power draw.
+ */
+import { useMemo } from 'react'
+import { motion } from 'framer-motion'
+import { Zap, Clock, Activity, Cpu, TrendingUp, TrendingDown, ArrowRight } from 'lucide-react'
+import { useReportCardDataState } from '../CardDataContext'
+import {
+  generateBenchmarkReports,
+  getHardwareShort,
+  getModelShort,
+  CONFIG_COLORS,
+} from '../../../lib/llmd/benchmarkMockData'
+
+function fmtNum(n: number, decimals = 0): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`
+  return n.toFixed(decimals)
+}
+
+function Delta({ value, invert = false }: { value: number; invert?: boolean }) {
+  const positive = invert ? value < 0 : value > 0
+  const color = positive ? 'text-emerald-400' : 'text-red-400'
+  const Icon = positive ? TrendingUp : TrendingDown
+  return (
+    <span className={`inline-flex items-center gap-0.5 text-[11px] font-medium ${color}`}>
+      <Icon size={11} />
+      {Math.abs(value).toFixed(1)}%
+    </span>
+  )
+}
+
+function HeroMetric({
+  label,
+  value,
+  unit,
+  delta,
+  color,
+  icon: Icon,
+  invertDelta = false,
+  delay = 0,
+}: {
+  label: string
+  value: string
+  unit: string
+  delta: number
+  color: string
+  icon: typeof Zap
+  invertDelta?: boolean
+  delay?: number
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay }}
+      className="flex-1 bg-slate-800/60 border border-slate-700/50 rounded-xl p-4 relative overflow-hidden group"
+    >
+      <div
+        className="absolute inset-0 opacity-[0.04] group-hover:opacity-[0.08] transition-opacity"
+        style={{ background: `radial-gradient(ellipse at 50% 0%, ${color}, transparent 70%)` }}
+      />
+      <div className="relative">
+        <div className="flex items-center gap-1.5 mb-2">
+          <Icon size={13} style={{ color }} />
+          <span className="text-[11px] text-slate-400 uppercase tracking-wider font-medium">{label}</span>
+        </div>
+        <div className="flex items-baseline gap-1.5">
+          <span className="text-2xl font-bold text-white tracking-tight">{value}</span>
+          <span className="text-xs text-slate-400">{unit}</span>
+        </div>
+        <div className="mt-1.5">
+          <Delta value={delta} invert={invertDelta} />
+        </div>
+      </div>
+    </motion.div>
+  )
+}
+
+export function BenchmarkHero() {
+  useReportCardDataState({ isDemoData: true, isFailed: false, consecutiveFailures: 0, hasData: true })
+
+  const { latest, prev, engine, gpuMetrics } = useMemo(() => {
+    const reports = generateBenchmarkReports()
+    // Pick the best llm-d disaggregated result as "latest"
+    const llmdReports = reports.filter(r =>
+      r.scenario.stack.some(c => c.standardized.role === 'prefill')
+    )
+    const best = llmdReports.sort((a, b) => {
+      const ta = a.results.request_performance.aggregate.throughput.output_token_rate?.mean ?? 0
+      const tb = b.results.request_performance.aggregate.throughput.output_token_rate?.mean ?? 0
+      return tb - ta
+    })[0] ?? reports[0]
+
+    // Find a standalone baseline as "previous"
+    const eng = best.scenario.stack.find(c => c.standardized.kind === 'inference_engine')
+    const baseline = reports.find(r => {
+      const e = r.scenario.stack.find(c => c.standardized.kind === 'inference_engine')
+      return e?.standardized.model?.name === eng?.standardized.model?.name
+        && e?.standardized.accelerator?.model === eng?.standardized.accelerator?.model
+        && e?.standardized.tool === 'vllm'
+    })
+
+    const gpuM = best.results.observability?.metrics ?? []
+    return { latest: best, prev: baseline, engine: eng, gpuMetrics: gpuM }
+  }, [])
+
+  const agg = latest.results.request_performance.aggregate
+  const prevAgg = prev?.results.request_performance.aggregate
+
+  const throughput = agg.throughput.output_token_rate?.mean ?? 0
+  const prevThroughput = prevAgg?.throughput.output_token_rate?.mean ?? 1
+  const ttft = (agg.latency.time_to_first_token?.p50 ?? 0) * 1000
+  const prevTtft = (prevAgg?.latency.time_to_first_token?.p50 ?? 1) * 1000
+  const tpot = (agg.latency.time_per_output_token?.p50 ?? 0) * 1000
+  const prevTpot = (prevAgg?.latency.time_per_output_token?.p50 ?? 1) * 1000
+  const reqLat = (agg.latency.request_latency?.p50 ?? 0) * 1000
+  const prevReqLat = (prevAgg?.latency.request_latency?.p50 ?? 1) * 1000
+
+  const hw = getHardwareShort(engine?.standardized.accelerator?.model ?? '')
+  const model = getModelShort(engine?.standardized.model?.name ?? '')
+  const config = latest.scenario.stack.some(c => c.standardized.role === 'prefill')
+    ? 'disaggregated'
+    : engine?.standardized.tool === 'llm-d' ? 'llm-d' : 'standalone'
+
+  const gpuUtil = gpuMetrics.find(m => m.name.includes('gpu_util'))?.samples?.[0]?.value ?? 0
+  const gpuPower = gpuMetrics.find(m => m.name.includes('gpu_power'))?.samples?.[0]?.value ?? 0
+
+  return (
+    <div className="p-5 h-full flex flex-col gap-4">
+      {/* Top row: Run info */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <motion.div
+            initial={{ scale: 0 }}
+            animate={{ scale: 1 }}
+            className="p-2 rounded-xl"
+            style={{ background: `${CONFIG_COLORS[config]}20` }}
+          >
+            <Zap size={20} style={{ color: CONFIG_COLORS[config] }} />
+          </motion.div>
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="text-white font-semibold text-lg">{model}</span>
+              <ArrowRight size={14} className="text-slate-500" />
+              <span className="text-slate-300 font-medium">{hw}</span>
+              <span className="text-xs px-2 py-0.5 rounded-full font-medium"
+                style={{ background: `${CONFIG_COLORS[config]}20`, color: CONFIG_COLORS[config] }}>
+                {config}
+              </span>
+            </div>
+            <div className="text-xs text-slate-400 mt-0.5">
+              {engine?.standardized.tool} {engine?.standardized.tool_version?.split(':').pop()} &middot;{' '}
+              {new Date(latest.run.time.start).toLocaleDateString()} &middot;{' '}
+              {latest.run.time.duration.replace('PT', '').replace('S', 's')}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Hero metrics row */}
+      <div className="grid grid-cols-4 gap-3 flex-1">
+        <HeroMetric
+          label="Output Throughput"
+          value={fmtNum(throughput)}
+          unit="tok/s"
+          delta={((throughput / prevThroughput) - 1) * 100}
+          color="#3b82f6"
+          icon={Zap}
+          delay={0.1}
+        />
+        <HeroMetric
+          label="TTFT (p50)"
+          value={fmtNum(ttft, 1)}
+          unit="ms"
+          delta={((ttft / prevTtft) - 1) * 100}
+          color="#f59e0b"
+          icon={Clock}
+          invertDelta
+          delay={0.2}
+        />
+        <HeroMetric
+          label="TPOT (p50)"
+          value={fmtNum(tpot, 2)}
+          unit="ms/tok"
+          delta={((tpot / prevTpot) - 1) * 100}
+          color="#8b5cf6"
+          icon={Activity}
+          invertDelta
+          delay={0.3}
+        />
+        <HeroMetric
+          label="Req Latency (p50)"
+          value={fmtNum(reqLat, 0)}
+          unit="ms"
+          delta={((reqLat / prevReqLat) - 1) * 100}
+          color="#10b981"
+          icon={Clock}
+          invertDelta
+          delay={0.4}
+        />
+      </div>
+
+      {/* Bottom strip */}
+      <div className="flex items-center gap-6 px-1 text-xs text-slate-400">
+        <div className="flex items-center gap-1.5">
+          <span className="text-slate-500">Requests:</span>
+          <span className="text-white font-mono">{agg.requests.total.toLocaleString()}</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-slate-500">Failures:</span>
+          <span className={`font-mono ${agg.requests.failures > 0 ? 'text-red-400' : 'text-emerald-400'}`}>
+            {agg.requests.failures === 0 ? '0' : agg.requests.failures}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Cpu size={11} className="text-slate-500" />
+          <span className="text-slate-500">GPU Util:</span>
+          <span className="text-white font-mono">{gpuUtil.toFixed(0)}%</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <Zap size={11} className="text-slate-500" />
+          <span className="text-slate-500">Power:</span>
+          <span className="text-white font-mono">{gpuPower.toFixed(0)}W</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-slate-500">GPUs:</span>
+          <span className="text-white font-mono">{engine?.standardized.accelerator?.count ?? 1}x {hw}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default BenchmarkHero

--- a/web/src/components/cards/llmd/HardwareLeaderboard.tsx
+++ b/web/src/components/cards/llmd/HardwareLeaderboard.tsx
@@ -1,0 +1,165 @@
+/**
+ * HardwareLeaderboard — Sortable ranked table comparing configurations
+ *
+ * Columns: Rank, Hardware, Model, Config, Framework, Throughput/GPU,
+ * TTFT p50, TPOT p50, p99 Latency, Score, llm-d Advantage %.
+ * Top 3 get medal styling. Rows are sortable by any column.
+ */
+import { useState, useMemo } from 'react'
+import { Trophy, ChevronUp, ChevronDown, ArrowUpDown } from 'lucide-react'
+import { useReportCardDataState } from '../CardDataContext'
+import {
+  generateBenchmarkReports,
+  generateLeaderboardRows,
+  CONFIG_COLORS,
+  type LeaderboardRow,
+} from '../../../lib/llmd/benchmarkMockData'
+
+type SortKey = keyof Pick<LeaderboardRow, 'score' | 'throughputPerGpu' | 'ttftP50Ms' | 'tpotP50Ms' | 'p99LatencyMs' | 'llmdAdvantage'>
+type SortDir = 'asc' | 'desc'
+
+const MEDAL = ['', '\uD83E\uDD47', '\uD83E\uDD48', '\uD83E\uDD49'] // gold, silver, bronze
+
+const COLUMNS: { key: SortKey; label: string; unit: string; higherBetter: boolean; width: string }[] = [
+  { key: 'throughputPerGpu', label: 'Throughput/GPU', unit: 'tok/s', higherBetter: true, width: 'w-[100px]' },
+  { key: 'ttftP50Ms', label: 'TTFT p50', unit: 'ms', higherBetter: false, width: 'w-[80px]' },
+  { key: 'tpotP50Ms', label: 'TPOT p50', unit: 'ms', higherBetter: false, width: 'w-[80px]' },
+  { key: 'p99LatencyMs', label: 'p99 Latency', unit: 'ms', higherBetter: false, width: 'w-[80px]' },
+  { key: 'score', label: 'Score', unit: '', higherBetter: true, width: 'w-[70px]' },
+  { key: 'llmdAdvantage', label: 'Advantage', unit: '%', higherBetter: true, width: 'w-[80px]' },
+]
+
+function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
+  if (!active) return <ArrowUpDown size={11} className="text-slate-600" />
+  return dir === 'desc'
+    ? <ChevronDown size={12} className="text-blue-400" />
+    : <ChevronUp size={12} className="text-blue-400" />
+}
+
+export function HardwareLeaderboard() {
+  useReportCardDataState({ isDemoData: true, isFailed: false, consecutiveFailures: 0, hasData: true })
+
+  const [sortKey, setSortKey] = useState<SortKey>('score')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+  const [modelFilter, setModelFilter] = useState<string>('all')
+
+  const allRows = useMemo(() => {
+    const reports = generateBenchmarkReports()
+    return generateLeaderboardRows(reports)
+  }, [])
+
+  const models = useMemo(() => [...new Set(allRows.map(r => r.model))], [allRows])
+
+  const rows = useMemo(() => {
+    let filtered = modelFilter === 'all' ? allRows : allRows.filter(r => r.model === modelFilter)
+    filtered = [...filtered].sort((a, b) => {
+      const av = a[sortKey] ?? -Infinity
+      const bv = b[sortKey] ?? -Infinity
+      return sortDir === 'desc' ? (bv as number) - (av as number) : (av as number) - (bv as number)
+    })
+    filtered.forEach((r, i) => { r.rank = i + 1 })
+    return filtered
+  }, [allRows, sortKey, sortDir, modelFilter])
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) setSortDir(d => d === 'desc' ? 'asc' : 'desc')
+    else { setSortKey(key); setSortDir('desc') }
+  }
+
+  return (
+    <div className="p-4 h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Trophy size={16} className="text-amber-400" />
+          <span className="text-sm font-medium text-white">Hardware Leaderboard</span>
+          <span className="text-xs text-slate-500">{rows.length} configs</span>
+        </div>
+        <select
+          value={modelFilter}
+          onChange={e => setModelFilter(e.target.value)}
+          className="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-xs text-white"
+        >
+          <option value="all">All Models</option>
+          {models.map(m => <option key={m} value={m}>{m}</option>)}
+        </select>
+      </div>
+
+      {/* Table */}
+      <div className="flex-1 min-h-0 overflow-auto">
+        <table className="w-full text-xs">
+          <thead className="sticky top-0 bg-slate-900/95 backdrop-blur-sm z-10">
+            <tr className="border-b border-slate-700/50">
+              <th className="text-left py-2 px-2 text-slate-500 font-medium w-[36px]">#</th>
+              <th className="text-left py-2 px-2 text-slate-500 font-medium w-[70px]">Hardware</th>
+              <th className="text-left py-2 px-2 text-slate-500 font-medium w-[100px]">Model</th>
+              <th className="text-left py-2 px-2 text-slate-500 font-medium w-[90px]">Config</th>
+              {COLUMNS.map(col => (
+                <th
+                  key={col.key}
+                  onClick={() => toggleSort(col.key)}
+                  className={`text-right py-2 px-2 text-slate-500 font-medium cursor-pointer hover:text-white transition-colors ${col.width}`}
+                >
+                  <div className="flex items-center justify-end gap-1">
+                    <span>{col.label}</span>
+                    <SortIcon active={sortKey === col.key} dir={sortDir} />
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(row => (
+              <tr
+                key={`${row.hardware}-${row.model}-${row.config}`}
+                className={`border-b border-slate-800/50 transition-colors hover:bg-slate-800/30 ${
+                  row.config !== 'standalone' ? 'bg-blue-500/[0.03]' : ''
+                }`}
+              >
+                <td className="py-2 px-2 font-mono text-slate-400">
+                  {row.rank <= 3 ? (
+                    <span className="text-sm">{MEDAL[row.rank]}</span>
+                  ) : (
+                    row.rank
+                  )}
+                </td>
+                <td className="py-2 px-2 text-white font-medium">{row.hardware}</td>
+                <td className="py-2 px-2 text-slate-300 truncate max-w-[100px]">{row.model}</td>
+                <td className="py-2 px-2">
+                  <span
+                    className="px-1.5 py-0.5 rounded text-[10px] font-medium"
+                    style={{ background: `${CONFIG_COLORS[row.config]}20`, color: CONFIG_COLORS[row.config] }}
+                  >
+                    {row.config}
+                  </span>
+                </td>
+                <td className="py-2 px-2 text-right font-mono text-white">{row.throughputPerGpu.toLocaleString()}</td>
+                <td className="py-2 px-2 text-right font-mono text-slate-300">{row.ttftP50Ms.toFixed(1)}</td>
+                <td className="py-2 px-2 text-right font-mono text-slate-300">{row.tpotP50Ms.toFixed(2)}</td>
+                <td className="py-2 px-2 text-right font-mono text-slate-300">{row.p99LatencyMs.toLocaleString()}</td>
+                <td className="py-2 px-2 text-right">
+                  <span className={`font-mono font-bold ${
+                    row.score >= 70 ? 'text-emerald-400' : row.score >= 50 ? 'text-amber-400' : 'text-slate-400'
+                  }`}>
+                    {row.score.toFixed(1)}
+                  </span>
+                </td>
+                <td className="py-2 px-2 text-right">
+                  {row.llmdAdvantage != null ? (
+                    <span className={`font-mono font-medium ${row.llmdAdvantage > 0 ? 'text-emerald-400' : 'text-red-400'}`}>
+                      {row.llmdAdvantage > 0 ? '+' : ''}{row.llmdAdvantage}%
+                    </span>
+                  ) : (
+                    <span className="text-slate-600">—</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+export default HardwareLeaderboard

--- a/web/src/components/cards/llmd/LatencyBreakdown.tsx
+++ b/web/src/components/cards/llmd/LatencyBreakdown.tsx
@@ -1,0 +1,213 @@
+/**
+ * LatencyBreakdown — Percentile comparison of latency metrics
+ *
+ * Grouped horizontal bar chart showing p50/p90/p95/p99 for each config.
+ * Tabs to switch between TTFT, TPOT, ITL, NTPOT, and request latency.
+ */
+import { useState, useMemo } from 'react'
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, Legend } from 'recharts'
+import { useReportCardDataState } from '../CardDataContext'
+import {
+  generateBenchmarkReports,
+  getHardwareShort,
+  getModelShort,
+  CONFIG_COLORS,
+  type BenchmarkReport,
+  type Statistics,
+} from '../../../lib/llmd/benchmarkMockData'
+
+type MetricTab = 'ttft' | 'tpot' | 'itl' | 'ntpot' | 'request'
+
+const TABS: { key: MetricTab; label: string }[] = [
+  { key: 'ttft', label: 'TTFT' },
+  { key: 'tpot', label: 'TPOT' },
+  { key: 'itl', label: 'ITL' },
+  { key: 'ntpot', label: 'NTPOT' },
+  { key: 'request', label: 'Request' },
+]
+
+const PERCENTILE_COLORS: Record<string, string> = {
+  p50: '#22c55e',
+  p90: '#eab308',
+  p95: '#f97316',
+  p99: '#ef4444',
+}
+
+function getLatencyField(report: BenchmarkReport, tab: MetricTab): Statistics | undefined {
+  const lat = report.results.request_performance.aggregate.latency
+  switch (tab) {
+    case 'ttft': return lat.time_to_first_token
+    case 'tpot': return lat.time_per_output_token
+    case 'itl': return lat.inter_token_latency
+    case 'ntpot': return lat.normalized_time_per_output_token
+    case 'request': return lat.request_latency
+  }
+}
+
+interface BarEntry {
+  name: string
+  config: string
+  p50: number
+  p90: number
+  p95: number
+  p99: number
+}
+
+function CustomTooltip({ active, payload }: { active?: boolean; payload?: Array<{ name: string; value: number; color: string }> }) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="bg-slate-900/95 backdrop-blur-sm border border-slate-700 rounded-lg p-3 shadow-xl text-xs">
+      {payload.map(p => (
+        <div key={p.name} className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-1.5">
+            <div className="w-2 h-2 rounded-full" style={{ backgroundColor: p.color }} />
+            <span className="text-slate-300">{p.name}</span>
+          </div>
+          <span className="font-mono text-white">{p.value.toFixed(2)} ms</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function LatencyBreakdown() {
+  useReportCardDataState({ isDemoData: true, isFailed: false, consecutiveFailures: 0, hasData: true })
+
+  const [tab, setTab] = useState<MetricTab>('ttft')
+  const [modelFilter, setModelFilter] = useState<string>('all')
+
+  const { reports, models } = useMemo(() => {
+    const all = generateBenchmarkReports()
+    const mdls = [...new Set(all.map(r => {
+      const e = r.scenario.stack.find(c => c.standardized.kind === 'inference_engine')
+      return getModelShort(e?.standardized.model?.name ?? '')
+    }))]
+    return { reports: all, models: mdls }
+  }, [])
+
+  const data: BarEntry[] = useMemo(() => {
+    let filtered = reports
+    if (modelFilter !== 'all') {
+      filtered = reports.filter(r => {
+        const e = r.scenario.stack.find(c => c.standardized.kind === 'inference_engine')
+        return getModelShort(e?.standardized.model?.name ?? '') === modelFilter
+      })
+    }
+    // Pick one report per config + hardware combo
+    const seen = new Set<string>()
+    const entries: BarEntry[] = []
+
+    for (const r of filtered) {
+      const engine = r.scenario.stack.find(c => c.standardized.kind === 'inference_engine')
+      const hw = getHardwareShort(engine?.standardized.accelerator?.model ?? '')
+      const config = r.scenario.stack.some(c => c.standardized.role === 'prefill')
+        ? 'disaggregated'
+        : engine?.standardized.tool === 'llm-d' ? 'llm-d' : 'standalone'
+      const key = `${hw}-${config}`
+      if (seen.has(key)) continue
+      seen.add(key)
+
+      const stats = getLatencyField(r, tab)
+      if (!stats) continue
+
+      const toMs = stats.units === 's' ? 1000 : stats.units === 's/token' ? 1000 : 1
+
+      entries.push({
+        name: `${hw} ${config}`,
+        config,
+        p50: (stats.p50 ?? stats.mean) * toMs,
+        p90: (stats.p90 ?? stats.mean * 1.3) * toMs,
+        p95: (stats.p95 ?? stats.mean * 1.6) * toMs,
+        p99: (stats.p99 ?? stats.mean * 2.3) * toMs,
+      })
+    }
+
+    return entries.sort((a, b) => a.p50 - b.p50)
+  }, [reports, modelFilter, tab])
+
+  // Find best llm-d improvement
+  const improvement = useMemo(() => {
+    const standalone = data.find(d => d.config === 'standalone')
+    const llmd = data.find(d => d.config === 'disaggregated') ?? data.find(d => d.config === 'llm-d')
+    if (!standalone || !llmd) return null
+    return Math.round((1 - llmd.p99 / standalone.p99) * 100)
+  }, [data])
+
+  return (
+    <div className="p-4 h-full flex flex-col">
+      {/* Header + tabs */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-medium text-white">Latency Breakdown</span>
+          {improvement && improvement > 0 && (
+            <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-emerald-500/20 text-emerald-400">
+              llm-d reduces p99 by {improvement}%
+            </span>
+          )}
+        </div>
+        <select
+          value={modelFilter}
+          onChange={e => setModelFilter(e.target.value)}
+          className="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-xs text-white"
+        >
+          <option value="all">All Models</option>
+          {models.map(m => <option key={m} value={m}>{m}</option>)}
+        </select>
+      </div>
+
+      {/* Metric tabs */}
+      <div className="flex gap-1 mb-3 bg-slate-800/80 rounded-lg p-0.5 w-fit">
+        {TABS.map(t => (
+          <button
+            key={t.key}
+            onClick={() => setTab(t.key)}
+            className={`px-3 py-1 text-xs rounded-md font-medium transition-colors ${
+              tab === t.key ? 'bg-blue-500/20 text-blue-400' : 'text-slate-400 hover:text-white'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Chart */}
+      <div className="flex-1 min-h-0">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} layout="vertical" margin={{ top: 5, right: 20, bottom: 5, left: 10 }}>
+            <XAxis type="number" stroke="#71717a" fontSize={10} />
+            <YAxis
+              type="category"
+              dataKey="name"
+              stroke="#71717a"
+              fontSize={10}
+              width={120}
+              tick={({ x, y, payload }: { x: string | number; y: string | number; payload: { value: string } }) => {
+                const entry = data.find(d => d.name === payload.value)
+                const color = entry ? CONFIG_COLORS[entry.config] : '#a1a1aa'
+                return (
+                  <text x={Number(x)} y={Number(y)} dy={4} textAnchor="end" fill={color} fontSize={10}>
+                    {payload.value}
+                  </text>
+                )
+              }}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend
+              wrapperStyle={{ fontSize: 10 }}
+              formatter={(value: string) => <span className="text-slate-400 text-[10px]">{value}</span>}
+            />
+            {Object.entries(PERCENTILE_COLORS).map(([pct, color]) => (
+              <Bar key={pct} dataKey={pct} name={pct.toUpperCase()} fill={color} radius={[0, 3, 3, 0]} barSize={8}>
+                {data.map((entry, i) => (
+                  <Cell key={i} fill={color} fillOpacity={entry.config === 'standalone' ? 0.5 : 0.9} />
+                ))}
+              </Bar>
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}
+
+export default LatencyBreakdown

--- a/web/src/components/cards/llmd/ParetoFrontier.tsx
+++ b/web/src/components/cards/llmd/ParetoFrontier.tsx
@@ -1,0 +1,287 @@
+/**
+ * ParetoFrontier — Interactive scatter plot showing latency-throughput tradeoff
+ *
+ * X-axis: output throughput per GPU, Y-axis: TTFT p50 (inverted).
+ * Points colored by hardware, shaped by config. Pareto-optimal curve overlaid.
+ * Filters for hardware, model, framework.
+ */
+import { useState, useMemo, useCallback } from 'react'
+import {
+  ScatterChart, Scatter, XAxis, YAxis, Tooltip, ResponsiveContainer,
+  ReferenceLine, ZAxis,
+} from 'recharts'
+import { Filter } from 'lucide-react'
+import { useReportCardDataState } from '../CardDataContext'
+import {
+  generateBenchmarkReports,
+  extractParetoPoints,
+  computeParetoFrontier,
+  HARDWARE_COLORS,
+  CONFIG_COLORS,
+  getHardwareShort,
+  getModelShort,
+  type ParetoPoint,
+} from '../../../lib/llmd/benchmarkMockData'
+
+interface ScatterDot {
+  cx?: number
+  cy?: number
+  payload?: ParetoPoint
+}
+
+const CONFIG_SHAPES: Record<string, string> = {
+  standalone: 'circle',
+  'llm-d': 'diamond',
+  disaggregated: 'star',
+}
+
+function CustomDot({ cx: rawCx, cy: rawCy, payload }: ScatterDot) {
+  if (!payload) return null
+  const cx = rawCx ?? 0
+  const cy = rawCy ?? 0
+  const hw = getHardwareShort(payload.hardware)
+  const color = HARDWARE_COLORS[hw] ?? '#6b7280'
+  const shape = CONFIG_SHAPES[payload.config] ?? 'circle'
+  const r = 6
+
+  if (shape === 'diamond') {
+    return (
+      <g>
+        <polygon
+          points={`${cx},${cy - r} ${cx + r},${cy} ${cx},${cy + r} ${cx - r},${cy}`}
+          fill={color}
+          fillOpacity={0.8}
+          stroke={color}
+          strokeWidth={1.5}
+          style={{ filter: `drop-shadow(0 0 3px ${color})` }}
+        />
+      </g>
+    )
+  }
+  if (shape === 'star') {
+    const pts: string[] = []
+    for (let i = 0; i < 5; i++) {
+      const angle = (i * 72 - 90) * Math.PI / 180
+      pts.push(`${cx + r * Math.cos(angle)},${cy + r * Math.sin(angle)}`)
+      const innerAngle = ((i * 72 + 36) - 90) * Math.PI / 180
+      pts.push(`${cx + r * 0.5 * Math.cos(innerAngle)},${cy + r * 0.5 * Math.sin(innerAngle)}`)
+    }
+    return (
+      <polygon
+        points={pts.join(' ')}
+        fill={color}
+        fillOpacity={0.8}
+        stroke={color}
+        strokeWidth={1}
+        style={{ filter: `drop-shadow(0 0 3px ${color})` }}
+      />
+    )
+  }
+  return (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={r}
+      fill={color}
+      fillOpacity={0.7}
+      stroke={color}
+      strokeWidth={1.5}
+      style={{ filter: `drop-shadow(0 0 3px ${color})` }}
+    />
+  )
+}
+
+function CustomTooltip({ active, payload }: { active?: boolean; payload?: Array<{ payload: ParetoPoint }> }) {
+  if (!active || !payload?.[0]) return null
+  const p = payload[0].payload
+  const hw = getHardwareShort(p.hardware)
+  const model = getModelShort(p.model)
+  return (
+    <div className="bg-slate-900/95 backdrop-blur-sm border border-slate-700 rounded-lg p-3 shadow-xl text-xs">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="font-semibold text-white">{model}</span>
+        <span className="text-slate-400">{hw}</span>
+        <span className="px-1.5 py-0.5 rounded text-[10px] font-medium"
+          style={{ background: `${CONFIG_COLORS[p.config]}20`, color: CONFIG_COLORS[p.config] }}>
+          {p.config}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-slate-300">
+        <span>Throughput/GPU:</span><span className="font-mono text-white">{p.throughputPerGpu.toFixed(0)} tok/s</span>
+        <span>TTFT p50:</span><span className="font-mono text-white">{p.ttftP50Ms.toFixed(1)} ms</span>
+        <span>TPOT p50:</span><span className="font-mono text-white">{p.tpotP50Ms.toFixed(2)} ms</span>
+        <span>p99 Latency:</span><span className="font-mono text-white">{p.p99LatencyMs.toFixed(0)} ms</span>
+      </div>
+    </div>
+  )
+}
+
+export function ParetoFrontier() {
+  useReportCardDataState({ isDemoData: true, isFailed: false, consecutiveFailures: 0, hasData: true })
+
+  const [hwFilter, setHwFilter] = useState<Set<string>>(new Set())
+  const [modelFilter, setModelFilter] = useState<string>('all')
+  const [showFilters, setShowFilters] = useState(false)
+
+  const { allPoints, models, hardwareList } = useMemo(() => {
+    const reports = generateBenchmarkReports()
+    const pts = extractParetoPoints(reports)
+    const mdls = [...new Set(pts.map(p => getModelShort(p.model)))]
+    const hws = [...new Set(pts.map(p => getHardwareShort(p.hardware)))]
+    return { allPoints: pts, models: mdls, hardwareList: hws }
+  }, [])
+
+  const filtered = useMemo(() => {
+    let pts = allPoints
+    if (hwFilter.size > 0) {
+      pts = pts.filter(p => hwFilter.has(getHardwareShort(p.hardware)))
+    }
+    if (modelFilter !== 'all') {
+      pts = pts.filter(p => getModelShort(p.model) === modelFilter)
+    }
+    return pts
+  }, [allPoints, hwFilter, modelFilter])
+
+  const frontier = useMemo(() => computeParetoFrontier(filtered), [filtered])
+
+  const toggleHw = useCallback((hw: string) => {
+    setHwFilter(prev => {
+      const next = new Set(prev)
+      if (next.has(hw)) next.delete(hw)
+      else next.add(hw)
+      return next
+    })
+  }, [])
+
+  return (
+    <div className="p-4 h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-sm font-medium text-white">Pareto Frontier: Throughput vs Latency</div>
+        <button
+          onClick={() => setShowFilters(!showFilters)}
+          className={`p-1.5 rounded-lg transition-colors ${showFilters ? 'bg-blue-500/20 text-blue-400' : 'bg-slate-800 text-slate-400 hover:text-white'}`}
+        >
+          <Filter size={14} />
+        </button>
+      </div>
+
+      {/* Filters */}
+      {showFilters && (
+        <div className="flex flex-wrap items-center gap-3 mb-3 pb-3 border-b border-slate-700/50">
+          <div className="flex items-center gap-1.5">
+            <span className="text-[10px] text-slate-500 uppercase tracking-wider">Hardware:</span>
+            {hardwareList.map(hw => (
+              <button
+                key={hw}
+                onClick={() => toggleHw(hw)}
+                className={`px-2 py-0.5 rounded text-xs font-medium transition-all ${
+                  hwFilter.size === 0 || hwFilter.has(hw)
+                    ? 'text-white'
+                    : 'text-slate-500 opacity-50'
+                }`}
+                style={{
+                  background: hwFilter.size === 0 || hwFilter.has(hw)
+                    ? `${HARDWARE_COLORS[hw] ?? '#6b7280'}30`
+                    : undefined,
+                  color: hwFilter.size === 0 || hwFilter.has(hw)
+                    ? HARDWARE_COLORS[hw] ?? '#6b7280'
+                    : undefined,
+                }}
+              >
+                {hw}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="text-[10px] text-slate-500 uppercase tracking-wider">Model:</span>
+            <select
+              value={modelFilter}
+              onChange={e => setModelFilter(e.target.value)}
+              className="bg-slate-800 border border-slate-700 rounded px-2 py-0.5 text-xs text-white"
+            >
+              <option value="all">All Models</option>
+              {models.map(m => <option key={m} value={m}>{m}</option>)}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {/* Chart */}
+      <div className="flex-1 min-h-0">
+        <ResponsiveContainer width="100%" height="100%">
+          <ScatterChart margin={{ top: 10, right: 20, bottom: 30, left: 20 }}>
+            <XAxis
+              type="number"
+              dataKey="throughputPerGpu"
+              name="Throughput/GPU"
+              stroke="#71717a"
+              fontSize={10}
+              label={{ value: 'Output Throughput (tok/s/GPU)', position: 'insideBottom', offset: -15, fill: '#71717a', fontSize: 10 }}
+            />
+            <YAxis
+              type="number"
+              dataKey="ttftP50Ms"
+              name="TTFT p50"
+              stroke="#71717a"
+              fontSize={10}
+              reversed
+              label={{ value: 'TTFT p50 (ms) — lower is better', angle: -90, position: 'insideLeft', offset: 5, fill: '#71717a', fontSize: 10 }}
+            />
+            <ZAxis range={[60, 60]} />
+            <Tooltip content={<CustomTooltip />} />
+
+            {/* Pareto frontier line */}
+            {frontier.length > 1 && frontier.map((pt, i) => {
+              if (i === 0) return null
+              const prev = frontier[i - 1]
+              return (
+                <ReferenceLine
+                  key={`pf-${i}`}
+                  segment={[
+                    { x: prev.throughputPerGpu, y: prev.ttftP50Ms },
+                    { x: pt.throughputPerGpu, y: pt.ttftP50Ms },
+                  ]}
+                  stroke="#f59e0b"
+                  strokeWidth={2}
+                  strokeDasharray="6 3"
+                  strokeOpacity={0.6}
+                />
+              )
+            })}
+
+            <Scatter
+              data={filtered}
+              shape={(props: ScatterDot) => <CustomDot {...props} />}
+            />
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center justify-center gap-6 mt-2 text-[10px]">
+        <div className="flex items-center gap-3">
+          {Object.entries(HARDWARE_COLORS).map(([hw, color]) => (
+            <div key={hw} className="flex items-center gap-1">
+              <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: color }} />
+              <span className="text-slate-400">{hw}</span>
+            </div>
+          ))}
+        </div>
+        <div className="w-px h-3 bg-slate-700" />
+        <div className="flex items-center gap-3">
+          {Object.entries(CONFIG_SHAPES).map(([cfg, shape]) => (
+            <div key={cfg} className="flex items-center gap-1">
+              <span className="text-slate-400">
+                {shape === 'circle' ? '\u25CF' : shape === 'diamond' ? '\u25C6' : '\u2605'}
+              </span>
+              <span className="text-slate-400">{cfg}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ParetoFrontier

--- a/web/src/components/cards/llmd/PerformanceTimeline.tsx
+++ b/web/src/components/cards/llmd/PerformanceTimeline.tsx
@@ -1,0 +1,204 @@
+/**
+ * PerformanceTimeline — Time-series trend of nightly benchmark results
+ *
+ * Shows throughput/latency trends over 90 days of nightly CI runs.
+ * Lines per config with confidence band. Time range selector.
+ */
+import { useState, useMemo } from 'react'
+import {
+  LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer,
+} from 'recharts'
+import { TrendingUp, TrendingDown } from 'lucide-react'
+import { useReportCardDataState } from '../CardDataContext'
+import {
+  generateTimelineReports,
+  CONFIG_COLORS,
+} from '../../../lib/llmd/benchmarkMockData'
+
+type MetricKey = 'outputThroughput' | 'ttftP50Ms' | 'tpotP50Ms' | 'p99LatencyMs'
+type TimeRange = 7 | 30 | 90
+
+const METRICS: { key: MetricKey; label: string; unit: string; higherBetter: boolean }[] = [
+  { key: 'outputThroughput', label: 'Output Throughput', unit: 'tok/s', higherBetter: true },
+  { key: 'ttftP50Ms', label: 'TTFT p50', unit: 'ms', higherBetter: false },
+  { key: 'tpotP50Ms', label: 'TPOT p50', unit: 'ms', higherBetter: false },
+  { key: 'p99LatencyMs', label: 'p99 Latency', unit: 'ms', higherBetter: false },
+]
+
+interface ChartPoint {
+  date: string
+  [lineKey: string]: string | number | undefined
+}
+
+function CustomTooltip({ active, payload, label }: { active?: boolean; payload?: Array<{ name: string; value: number; color: string }>; label?: string }) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="bg-slate-900/95 backdrop-blur-sm border border-slate-700 rounded-lg p-3 shadow-xl text-xs">
+      <div className="text-slate-400 mb-2">{label}</div>
+      {payload.filter(p => p.value !== undefined).map(p => (
+        <div key={p.name} className="flex items-center justify-between gap-4 py-0.5">
+          <div className="flex items-center gap-1.5">
+            <div className="w-2 h-2 rounded-full" style={{ backgroundColor: p.color }} />
+            <span className="text-slate-300">{p.name}</span>
+          </div>
+          <span className="font-mono text-white">{typeof p.value === 'number' ? p.value.toFixed(1) : p.value}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function PerformanceTimeline() {
+  useReportCardDataState({ isDemoData: true, isFailed: false, consecutiveFailures: 0, hasData: true })
+
+  const [metric, setMetric] = useState<MetricKey>('outputThroughput')
+  const [range, setRange] = useState<TimeRange>(30)
+
+  const allPoints = useMemo(() => generateTimelineReports(90), [])
+
+  // Get unique line keys (hardware + config combos)
+  const lineKeys = useMemo(() => {
+    const keys = new Set<string>()
+    allPoints.forEach(p => keys.add(`${p.hardware} ${p.config}`))
+    return [...keys]
+  }, [allPoints])
+
+  // Build chart data: one row per date, columns per line key
+  const { chartData, trendInfo } = useMemo(() => {
+    const cutoff = new Date()
+    cutoff.setDate(cutoff.getDate() - range)
+    const cutoffStr = cutoff.toISOString().slice(0, 10)
+
+    const filtered = allPoints.filter(p => p.date >= cutoffStr)
+
+    // Group by date
+    const dateMap = new Map<string, ChartPoint>()
+    for (const p of filtered) {
+      if (!dateMap.has(p.date)) dateMap.set(p.date, { date: p.date })
+      const row = dateMap.get(p.date)!
+      const key = `${p.hardware} ${p.config}`
+      row[key] = p[metric]
+    }
+
+    const data = [...dateMap.values()].sort((a, b) => a.date.localeCompare(b.date))
+
+    // Compute trend for each line
+    const trends: Record<string, number> = {}
+    for (const key of lineKeys) {
+      const vals = data.map(d => d[key]).filter((v): v is number => typeof v === 'number')
+      if (vals.length >= 2) {
+        const first = vals.slice(0, 5).reduce((a, b) => a + b, 0) / Math.min(5, vals.length)
+        const last = vals.slice(-5).reduce((a, b) => a + b, 0) / Math.min(5, vals.length)
+        trends[key] = ((last / first) - 1) * 100
+      }
+    }
+
+    return { chartData: data, trendInfo: trends }
+  }, [allPoints, metric, range, lineKeys])
+
+  const metricInfo = METRICS.find(m => m.key === metric)!
+
+  // Assign colors: use config color + slight variation per hardware
+  const lineColors = useMemo(() => {
+    const colors: Record<string, string> = {}
+    lineKeys.forEach(key => {
+      const config = key.split(' ').pop() ?? ''
+      colors[key] = CONFIG_COLORS[config] ?? '#6b7280'
+    })
+    return colors
+  }, [lineKeys])
+
+  return (
+    <div className="p-4 h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm font-medium text-white">Performance Timeline</span>
+        <div className="flex items-center gap-2">
+          {([7, 30, 90] as TimeRange[]).map(r => (
+            <button
+              key={r}
+              onClick={() => setRange(r)}
+              className={`px-2 py-0.5 text-xs rounded font-medium transition-colors ${
+                range === r ? 'bg-blue-500/20 text-blue-400' : 'text-slate-400 hover:text-white'
+              }`}
+            >
+              {r}d
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Metric tabs */}
+      <div className="flex gap-1 mb-3 bg-slate-800/80 rounded-lg p-0.5 w-fit">
+        {METRICS.map(m => (
+          <button
+            key={m.key}
+            onClick={() => setMetric(m.key)}
+            className={`px-3 py-1 text-xs rounded-md font-medium transition-colors ${
+              metric === m.key ? 'bg-blue-500/20 text-blue-400' : 'text-slate-400 hover:text-white'
+            }`}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Trend indicators */}
+      <div className="flex items-center gap-4 mb-2 text-[10px]">
+        {lineKeys.map(key => {
+          const trend = trendInfo[key]
+          if (trend === undefined) return null
+          const positive = metricInfo.higherBetter ? trend > 0 : trend < 0
+          return (
+            <div key={key} className="flex items-center gap-1">
+              <div className="w-2 h-2 rounded-full" style={{ backgroundColor: lineColors[key] }} />
+              <span className="text-slate-400">{key}:</span>
+              <span className={positive ? 'text-emerald-400' : 'text-red-400'}>
+                {positive ? <TrendingUp size={10} className="inline" /> : <TrendingDown size={10} className="inline" />}
+                {' '}{Math.abs(trend).toFixed(1)}%
+              </span>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Chart */}
+      <div className="flex-1 min-h-0">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 10 }}>
+            <XAxis
+              dataKey="date"
+              stroke="#71717a"
+              fontSize={9}
+              tickFormatter={(d: string) => {
+                const parts = d.split('-')
+                return `${parts[1]}/${parts[2]}`
+              }}
+            />
+            <YAxis stroke="#71717a" fontSize={10} />
+            <Tooltip content={<CustomTooltip />} />
+            {lineKeys.map(key => (
+              <Line
+                key={key}
+                type="monotone"
+                dataKey={key}
+                stroke={lineColors[key]}
+                strokeWidth={2}
+                dot={false}
+                connectNulls
+                strokeOpacity={0.9}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Y-axis label */}
+      <div className="text-center text-[10px] text-slate-500 mt-1">
+        {metricInfo.label} ({metricInfo.unit})
+      </div>
+    </div>
+  )
+}
+
+export default PerformanceTimeline

--- a/web/src/components/cards/llmd/ResourceUtilization.tsx
+++ b/web/src/components/cards/llmd/ResourceUtilization.tsx
@@ -1,0 +1,221 @@
+/**
+ * ResourceUtilization — GPU resource utilization during benchmark runs
+ *
+ * Three sub-charts (memory, compute, power) comparing standalone vs llm-d.
+ * Includes efficiency metric (throughput/watt).
+ */
+import { useState, useMemo } from 'react'
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
+import { Cpu, Zap, HardDrive } from 'lucide-react'
+import { useReportCardDataState } from '../CardDataContext'
+import {
+  generateBenchmarkReports,
+  getHardwareShort,
+  getModelShort,
+  CONFIG_COLORS,
+  type BenchmarkReport,
+} from '../../../lib/llmd/benchmarkMockData'
+
+type ViewMode = 'overview' | 'efficiency'
+
+interface GpuEntry {
+  hardware: string
+  config: string
+  label: string
+  gpuUtil: number
+  gpuMem: number
+  gpuPower: number
+  throughput: number
+  throughputPerWatt: number
+}
+
+function extractGpuData(report: BenchmarkReport): { util: number; mem: number; power: number } {
+  const metrics = report.results.observability?.metrics ?? []
+  const util = metrics.find(m => m.name.includes('gpu_util'))?.samples?.[0]?.value ?? 0
+  const mem = metrics.find(m => m.name.includes('gpu_mem'))?.samples?.[0]?.value ?? 0
+  const power = metrics.find(m => m.name.includes('gpu_power'))?.samples?.[0]?.value ?? 0
+  return { util, mem, power }
+}
+
+function MiniBar({ label, items, dataKey, unit, icon: Icon, color }: {
+  label: string
+  items: GpuEntry[]
+  dataKey: keyof GpuEntry
+  unit: string
+  icon: typeof Cpu
+  color: string
+}) {
+  return (
+    <div className="flex-1 flex flex-col">
+      <div className="flex items-center gap-1.5 mb-2">
+        <Icon size={12} style={{ color }} />
+        <span className="text-[10px] text-slate-400 uppercase tracking-wider font-medium">{label}</span>
+      </div>
+      <div className="flex-1 min-h-0">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={items} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
+            <XAxis dataKey="label" stroke="#71717a" fontSize={8} angle={-30} textAnchor="end" height={40} />
+            <YAxis stroke="#71717a" fontSize={9} width={35} />
+            <Tooltip
+              contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', borderRadius: '8px', fontSize: '11px' }}
+              formatter={(value: number | undefined) => [`${(value ?? 0).toFixed(1)} ${unit}`, label]}
+              labelStyle={{ color: '#e5e5e5' }}
+            />
+            <Bar dataKey={dataKey as string} radius={[3, 3, 0, 0]} barSize={16}>
+              {items.map((entry, i) => (
+                <Cell key={i} fill={CONFIG_COLORS[entry.config] ?? '#6b7280'} fillOpacity={0.85} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}
+
+export function ResourceUtilization() {
+  useReportCardDataState({ isDemoData: true, isFailed: false, consecutiveFailures: 0, hasData: true })
+
+  const [view, setView] = useState<ViewMode>('overview')
+  const entries = useMemo(() => {
+    const reports = generateBenchmarkReports()
+
+    const items: GpuEntry[] = []
+    const seen = new Set<string>()
+
+    for (const r of reports) {
+      const engine = r.scenario.stack.find(c => c.standardized.kind === 'inference_engine')
+      const hw = getHardwareShort(engine?.standardized.accelerator?.model ?? '')
+      const model = getModelShort(engine?.standardized.model?.name ?? '')
+      const config = r.scenario.stack.some(c => c.standardized.role === 'prefill')
+        ? 'disaggregated'
+        : engine?.standardized.tool === 'llm-d' ? 'llm-d' : 'standalone'
+
+      const key = `${hw}-${model}-${config}`
+      if (seen.has(key)) continue
+      seen.add(key)
+
+      const gpu = extractGpuData(r)
+      const throughput = r.results.request_performance.aggregate.throughput.output_token_rate?.mean ?? 0
+
+      items.push({
+        hardware: hw,
+        config,
+        label: `${hw}\n${config}`,
+        gpuUtil: gpu.util,
+        gpuMem: gpu.mem,
+        gpuPower: gpu.power,
+        throughput,
+        throughputPerWatt: gpu.power > 0 ? throughput / gpu.power : 0,
+      })
+    }
+
+    return items
+  }, [])
+
+  return (
+    <div className="p-4 h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm font-medium text-white">GPU Resource Utilization</span>
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1 bg-slate-800/80 rounded-lg p-0.5">
+            <button
+              onClick={() => setView('overview')}
+              className={`px-2 py-0.5 text-xs rounded font-medium transition-colors ${
+                view === 'overview' ? 'bg-blue-500/20 text-blue-400' : 'text-slate-400 hover:text-white'
+              }`}
+            >
+              Resources
+            </button>
+            <button
+              onClick={() => setView('efficiency')}
+              className={`px-2 py-0.5 text-xs rounded font-medium transition-colors ${
+                view === 'efficiency' ? 'bg-blue-500/20 text-blue-400' : 'text-slate-400 hover:text-white'
+              }`}
+            >
+              Efficiency
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {view === 'overview' ? (
+        /* Three sub-charts side by side */
+        <div className="flex-1 min-h-0 grid grid-cols-3 gap-4">
+          <MiniBar
+            label="Compute Util"
+            items={entries}
+            dataKey="gpuUtil"
+            unit="%"
+            icon={Cpu}
+            color="#3b82f6"
+          />
+          <MiniBar
+            label="Memory Util"
+            items={entries}
+            dataKey="gpuMem"
+            unit="%"
+            icon={HardDrive}
+            color="#8b5cf6"
+          />
+          <MiniBar
+            label="Power Draw"
+            items={entries}
+            dataKey="gpuPower"
+            unit="W"
+            icon={Zap}
+            color="#f59e0b"
+          />
+        </div>
+      ) : (
+        /* Efficiency view: throughput/watt comparison */
+        <div className="flex-1 min-h-0">
+          <div className="flex items-center gap-1.5 mb-2">
+            <Zap size={12} className="text-emerald-400" />
+            <span className="text-[10px] text-slate-400 uppercase tracking-wider font-medium">
+              Throughput per Watt (tok/s/W)
+            </span>
+          </div>
+          <div className="flex-1 min-h-0" style={{ height: 'calc(100% - 24px)' }}>
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={entries} layout="vertical" margin={{ top: 5, right: 20, bottom: 5, left: 10 }}>
+                <XAxis type="number" stroke="#71717a" fontSize={10} />
+                <YAxis
+                  type="category"
+                  dataKey="label"
+                  stroke="#71717a"
+                  fontSize={9}
+                  width={90}
+                  tick={{ fill: '#a1a1aa' }}
+                />
+                <Tooltip
+                  contentStyle={{ backgroundColor: '#1e293b', border: '1px solid #334155', borderRadius: '8px', fontSize: '11px' }}
+                  formatter={(value: number | undefined) => [`${(value ?? 0).toFixed(2)} tok/s/W`, 'Efficiency']}
+                  labelStyle={{ color: '#e5e5e5' }}
+                />
+                <Bar dataKey="throughputPerWatt" radius={[0, 3, 3, 0]} barSize={14}>
+                  {entries.map((entry, i) => (
+                    <Cell key={i} fill={CONFIG_COLORS[entry.config] ?? '#6b7280'} fillOpacity={0.85} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      )}
+
+      {/* Legend */}
+      <div className="flex items-center justify-center gap-4 mt-2 text-[10px]">
+        {Object.entries(CONFIG_COLORS).map(([cfg, color]) => (
+          <div key={cfg} className="flex items-center gap-1">
+            <div className="w-2.5 h-2.5 rounded" style={{ backgroundColor: color }} />
+            <span className="text-slate-400">{cfg}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default ResourceUtilization

--- a/web/src/components/cards/llmd/ThroughputComparison.tsx
+++ b/web/src/components/cards/llmd/ThroughputComparison.tsx
@@ -1,0 +1,239 @@
+/**
+ * ThroughputComparison — Multi-bar chart comparing throughput
+ *
+ * Vertical grouped bar chart with X-axis hardware types, bars per config
+ * (standalone, llm-d, disaggregated). Secondary axis toggle for input/output/total
+ * tokens and request rate. Improvement labels on bars.
+ */
+import { useState, useMemo } from 'react'
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, Legend } from 'recharts'
+import { useReportCardDataState } from '../CardDataContext'
+import {
+  generateBenchmarkReports,
+  getHardwareShort,
+  getModelShort,
+  CONFIG_COLORS,
+  type BenchmarkReport,
+} from '../../../lib/llmd/benchmarkMockData'
+
+type MetricMode = 'output' | 'input' | 'total' | 'request'
+
+const MODES: { key: MetricMode; label: string; unit: string }[] = [
+  { key: 'output', label: 'Output tok/s', unit: 'tok/s' },
+  { key: 'input', label: 'Input tok/s', unit: 'tok/s' },
+  { key: 'total', label: 'Total tok/s', unit: 'tok/s' },
+  { key: 'request', label: 'Requests/s', unit: 'req/s' },
+]
+
+function getThroughput(report: BenchmarkReport, mode: MetricMode): number {
+  const t = report.results.request_performance.aggregate.throughput
+  switch (mode) {
+    case 'output': return t.output_token_rate?.mean ?? 0
+    case 'input': return t.input_token_rate?.mean ?? 0
+    case 'total': return t.total_token_rate?.mean ?? 0
+    case 'request': return t.request_rate?.mean ?? 0
+  }
+}
+
+interface BarEntry {
+  hardware: string
+  standalone: number
+  'llm-d': number
+  disaggregated: number
+  llmdImprove: number | null
+  disaggImprove: number | null
+}
+
+function CustomTooltip({ active, payload, label }: { active?: boolean; payload?: Array<{ name: string; value: number; color: string }>; label?: string }) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="bg-slate-900/95 backdrop-blur-sm border border-slate-700 rounded-lg p-3 shadow-xl text-xs">
+      <div className="text-white font-medium mb-2">{label}</div>
+      {payload.map(p => (
+        <div key={p.name} className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-1.5">
+            <div className="w-2 h-2 rounded-full" style={{ backgroundColor: p.color }} />
+            <span className="text-slate-300">{p.name}</span>
+          </div>
+          <span className="font-mono text-white">{p.value.toLocaleString(undefined, { maximumFractionDigits: 1 })}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ImprovementLabel({ x, y, width, value }: { x?: string | number; y?: string | number; width?: number; value: number | null }) {
+  if (value == null || value <= 0) return null
+  const nx = typeof x === 'number' ? x : 0
+  const ny = typeof y === 'number' ? y : 0
+  return (
+    <text
+      x={nx + (width ?? 0) / 2}
+      y={ny - 4}
+      textAnchor="middle"
+      fill="#22c55e"
+      fontSize={9}
+      fontWeight={600}
+    >
+      +{value}%
+    </text>
+  )
+}
+
+export function ThroughputComparison() {
+  useReportCardDataState({ isDemoData: true, isFailed: false, consecutiveFailures: 0, hasData: true })
+
+  const [mode, setMode] = useState<MetricMode>('output')
+  const [modelFilter, setModelFilter] = useState<string>('all')
+
+  const { reports, models } = useMemo(() => {
+    const all = generateBenchmarkReports()
+    const mdls = [...new Set(all.map(r => {
+      const e = r.scenario.stack.find(c => c.standardized.kind === 'inference_engine')
+      return getModelShort(e?.standardized.model?.name ?? '')
+    }))]
+    return { reports: all, models: mdls }
+  }, [])
+
+  const data: BarEntry[] = useMemo(() => {
+    let filtered = reports
+    if (modelFilter !== 'all') {
+      filtered = reports.filter(r => {
+        const e = r.scenario.stack.find(c => c.standardized.kind === 'inference_engine')
+        return getModelShort(e?.standardized.model?.name ?? '') === modelFilter
+      })
+    }
+
+    // Group by hardware
+    const hwMap = new Map<string, { standalone: number; 'llm-d': number; disaggregated: number }>()
+
+    for (const r of filtered) {
+      const engine = r.scenario.stack.find(c => c.standardized.kind === 'inference_engine')
+      const hw = getHardwareShort(engine?.standardized.accelerator?.model ?? '')
+      const config = r.scenario.stack.some(c => c.standardized.role === 'prefill')
+        ? 'disaggregated'
+        : engine?.standardized.tool === 'llm-d' ? 'llm-d' : 'standalone'
+      const val = getThroughput(r, mode)
+
+      if (!hwMap.has(hw)) hwMap.set(hw, { standalone: 0, 'llm-d': 0, disaggregated: 0 })
+      const entry = hwMap.get(hw)!
+      // Take max value per config per hardware
+      if (val > entry[config]) entry[config] = val
+    }
+
+    return Array.from(hwMap.entries()).map(([hw, vals]) => {
+      const base = vals.standalone || 1
+      return {
+        hardware: hw,
+        ...vals,
+        llmdImprove: vals['llm-d'] > 0 && vals.standalone > 0
+          ? Math.round(((vals['llm-d'] / base) - 1) * 100)
+          : null,
+        disaggImprove: vals.disaggregated > 0 && vals.standalone > 0
+          ? Math.round(((vals.disaggregated / base) - 1) * 100)
+          : null,
+      }
+    })
+  }, [reports, modelFilter, mode])
+
+  const modeInfo = MODES.find(m => m.key === mode)!
+
+  return (
+    <div className="p-4 h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-sm font-medium text-white">Throughput Comparison</span>
+        <select
+          value={modelFilter}
+          onChange={e => setModelFilter(e.target.value)}
+          className="bg-slate-800 border border-slate-700 rounded px-2 py-1 text-xs text-white"
+        >
+          <option value="all">All Models</option>
+          {models.map(m => <option key={m} value={m}>{m}</option>)}
+        </select>
+      </div>
+
+      {/* Mode tabs */}
+      <div className="flex gap-1 mb-3 bg-slate-800/80 rounded-lg p-0.5 w-fit">
+        {MODES.map(m => (
+          <button
+            key={m.key}
+            onClick={() => setMode(m.key)}
+            className={`px-3 py-1 text-xs rounded-md font-medium transition-colors ${
+              mode === m.key ? 'bg-blue-500/20 text-blue-400' : 'text-slate-400 hover:text-white'
+            }`}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Chart */}
+      <div className="flex-1 min-h-0">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} margin={{ top: 20, right: 20, bottom: 5, left: 10 }}>
+            <XAxis dataKey="hardware" stroke="#71717a" fontSize={11} tick={{ fill: '#e5e5e5' }} />
+            <YAxis stroke="#71717a" fontSize={10} />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend
+              wrapperStyle={{ fontSize: 10 }}
+              formatter={(value: string) => <span className="text-slate-400 text-[10px]">{value}</span>}
+            />
+            <Bar dataKey="standalone" name="Standalone" fill={CONFIG_COLORS.standalone} radius={[3, 3, 0, 0]} barSize={20}>
+              {data.map((_, i) => (
+                <Cell key={i} fill={CONFIG_COLORS.standalone} />
+              ))}
+            </Bar>
+            <Bar
+              dataKey="llm-d"
+              name="llm-d"
+              fill={CONFIG_COLORS['llm-d']}
+              radius={[3, 3, 0, 0]}
+              barSize={20}
+              label={/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+                (props: any) => (
+                <ImprovementLabel
+                  x={props.x}
+                  y={props.y}
+                  width={props.width}
+                  value={data[props.index as number]?.llmdImprove ?? null}
+                />
+              )}
+            >
+              {data.map((_, i) => (
+                <Cell key={i} fill={CONFIG_COLORS['llm-d']} />
+              ))}
+            </Bar>
+            <Bar
+              dataKey="disaggregated"
+              name="Disaggregated"
+              fill={CONFIG_COLORS.disaggregated}
+              radius={[3, 3, 0, 0]}
+              barSize={20}
+              label={/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+                (props: any) => (
+                <ImprovementLabel
+                  x={props.x}
+                  y={props.y}
+                  width={props.width}
+                  value={data[props.index as number]?.disaggImprove ?? null}
+                />
+              )}
+            >
+              {data.map((_, i) => (
+                <Cell key={i} fill={CONFIG_COLORS.disaggregated} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Unit label */}
+      <div className="text-center text-[10px] text-slate-500 mt-1">
+        {modeInfo.unit} per GPU
+      </div>
+    </div>
+  )
+}
+
+export default ThroughputComparison

--- a/web/src/components/cards/llmd/index.ts
+++ b/web/src/components/cards/llmd/index.ts
@@ -11,3 +11,12 @@ export { PDDisaggregation } from './PDDisaggregation'
 export { LLMdBenchmarks } from './LLMdBenchmarks'
 export { LLMdAIInsights } from './LLMdAIInsights'
 export { LLMdConfigurator } from './LLMdConfigurator'
+
+// Benchmark dashboard cards
+export { BenchmarkHero } from './BenchmarkHero'
+export { ParetoFrontier } from './ParetoFrontier'
+export { HardwareLeaderboard } from './HardwareLeaderboard'
+export { LatencyBreakdown } from './LatencyBreakdown'
+export { ThroughputComparison } from './ThroughputComparison'
+export { PerformanceTimeline } from './PerformanceTimeline'
+export { ResourceUtilization } from './ResourceUtilization'

--- a/web/src/config/dashboards/index.ts
+++ b/web/src/config/dashboards/index.ts
@@ -31,6 +31,7 @@ import { dataComplianceDashboardConfig } from './data-compliance'
 import { arcadeDashboardConfig } from './arcade'
 import { deployDashboardConfig } from './deploy'
 import { aiAgentsDashboardConfig } from './ai-agents'
+import { llmdBenchmarksDashboardConfig } from './llmd-benchmarks'
 
 /**
  * Registry of all unified dashboard configurations
@@ -62,6 +63,7 @@ export const DASHBOARD_CONFIGS: DashboardConfigRegistry = {
   arcade: arcadeDashboardConfig,
   deploy: deployDashboardConfig,
   'ai-agents': aiAgentsDashboardConfig,
+  'llm-d-benchmarks': llmdBenchmarksDashboardConfig,
 }
 
 /**
@@ -149,4 +151,5 @@ export {
   arcadeDashboardConfig,
   deployDashboardConfig,
   aiAgentsDashboardConfig,
+  llmdBenchmarksDashboardConfig,
 }

--- a/web/src/config/dashboards/llmd-benchmarks.ts
+++ b/web/src/config/dashboards/llmd-benchmarks.ts
@@ -1,0 +1,33 @@
+/**
+ * LLM-d Benchmarks Dashboard Configuration
+ *
+ * Performance tracking across clouds and accelerators.
+ * All cards are full-width (12 columns) for maximum visual impact.
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const llmdBenchmarksDashboardConfig: UnifiedDashboardConfig = {
+  id: 'llm-d-benchmarks',
+  name: 'llm-d Benchmarks',
+  subtitle: 'Performance tracking across clouds and accelerators',
+  route: '/llm-d-benchmarks',
+  statsType: 'ai-ml',
+  cards: [
+    { id: 'bench-hero-1', cardType: 'benchmark_hero', title: 'Latest Benchmark', position: { w: 12, h: 3 } },
+    { id: 'bench-pareto-1', cardType: 'pareto_frontier', title: 'Pareto Frontier', position: { w: 12, h: 5 } },
+    { id: 'bench-leaderboard-1', cardType: 'hardware_leaderboard', title: 'Hardware Leaderboard', position: { w: 12, h: 5 } },
+    { id: 'bench-latency-1', cardType: 'latency_breakdown', title: 'Latency Breakdown', position: { w: 12, h: 4 } },
+    { id: 'bench-throughput-1', cardType: 'throughput_comparison', title: 'Throughput Comparison', position: { w: 12, h: 4 } },
+    { id: 'bench-timeline-1', cardType: 'performance_timeline', title: 'Performance Timeline', position: { w: 12, h: 5 } },
+    { id: 'bench-resource-1', cardType: 'resource_utilization', title: 'Resource Utilization', position: { w: 12, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 60000,
+  },
+  storageKey: 'llmd-benchmarks-dashboard-cards',
+}
+
+export default llmdBenchmarksDashboardConfig

--- a/web/src/lib/llmd/benchmarkMockData.ts
+++ b/web/src/lib/llmd/benchmarkMockData.ts
@@ -1,0 +1,648 @@
+/**
+ * LLM-d Benchmark Mock Data
+ *
+ * TypeScript interfaces and generators mirroring the llm-d-benchmark v0.2
+ * Benchmark Report schema. Used for dashboard visualization when no live
+ * backend is connected.
+ *
+ * Schema reference: llm-d/llm-d-benchmark/benchmark_report/schema_v0_2.py
+ */
+
+// ---------------------------------------------------------------------------
+// Core interfaces (simplified from Pydantic v0.2 schema)
+// ---------------------------------------------------------------------------
+
+export interface Statistics {
+  units: string
+  mean: number
+  min?: number
+  p0p1?: number
+  p1?: number
+  p5?: number
+  p10?: number
+  p25?: number
+  p50?: number
+  p75?: number
+  p90?: number
+  p95?: number
+  p99?: number
+  p99p9?: number
+  max?: number
+  stddev?: number
+}
+
+export interface Accelerator {
+  model: string
+  count: number
+  memory?: number
+  parallelism?: { dp: number; tp: number; pp: number; ep: number }
+}
+
+export interface StackComponent {
+  metadata: { label: string; cfg_id: string; description?: string }
+  standardized: {
+    kind: string
+    tool: string
+    tool_version: string
+    role?: 'prefill' | 'decode' | 'aggregate'
+    replicas?: number
+    model?: { name: string; quantization?: string }
+    accelerator?: Accelerator
+  }
+}
+
+export interface LoadConfig {
+  metadata: { cfg_id: string; description?: string }
+  standardized: {
+    tool: string
+    tool_version: string
+    source: 'random' | 'sampled' | 'unknown'
+    input_seq_len: { distribution: string; value: number }
+    output_seq_len?: { distribution: string; value: number }
+    rate_qps?: number
+    concurrency?: number
+  }
+}
+
+export interface LatencyStats {
+  time_to_first_token?: Statistics
+  time_per_output_token?: Statistics
+  inter_token_latency?: Statistics
+  normalized_time_per_output_token?: Statistics
+  request_latency?: Statistics
+}
+
+export interface ThroughputStats {
+  input_token_rate?: Statistics
+  output_token_rate?: Statistics
+  total_token_rate?: Statistics
+  request_rate?: Statistics
+}
+
+export interface RequestStats {
+  total: number
+  failures: number
+  incomplete?: number
+  input_length?: Statistics
+  output_length?: Statistics
+}
+
+export interface TimeSeriesPoint {
+  ts: string
+  value?: number
+  mean?: number
+  p50?: number
+  p90?: number
+  p95?: number
+  p99?: number
+}
+
+export interface ObservabilityMetric {
+  name: string
+  metric_ref?: { id: string; version: number }
+  component_id: string
+  type: 'counter' | 'gauge' | 'histogram' | 'summary'
+  unit: string
+  description?: string
+  labels?: Record<string, string>
+  samples?: TimeSeriesPoint[]
+}
+
+export interface ComponentHealth {
+  component_label: string
+  total_restarts: number
+  failed_replicas: number
+  replica_health?: { replica_id: string; restarts: number; healthy: boolean }[]
+}
+
+export interface BenchmarkReport {
+  version: string
+  run: {
+    uid: string
+    eid: string
+    cid?: string
+    time: { start: string; end: string; duration: string }
+    user: string
+  }
+  scenario: {
+    stack: StackComponent[]
+    load: LoadConfig
+  }
+  results: {
+    request_performance: {
+      aggregate: {
+        requests: RequestStats
+        latency: LatencyStats
+        throughput: ThroughputStats
+      }
+      time_series?: {
+        latency?: { time_to_first_token?: { units: string; series: TimeSeriesPoint[] } }
+        throughput?: { output_token_rate?: { units: string; series: TimeSeriesPoint[] } }
+      }
+    }
+    observability?: { metrics?: ObservabilityMetric[] }
+    component_health?: ComponentHealth[]
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Derived types for card consumption
+// ---------------------------------------------------------------------------
+
+export interface ParetoPoint {
+  uid: string
+  model: string
+  hardware: string
+  hardwareMemory: number
+  gpuCount: number
+  config: 'standalone' | 'llm-d' | 'disaggregated'
+  framework: string
+  seqLen: string
+  throughputPerGpu: number
+  ttftP50Ms: number
+  tpotP50Ms: number
+  p99LatencyMs: number
+  requestRate: number
+}
+
+export interface LeaderboardRow {
+  rank: number
+  hardware: string
+  model: string
+  config: 'standalone' | 'llm-d' | 'disaggregated'
+  framework: string
+  throughputPerGpu: number
+  ttftP50Ms: number
+  tpotP50Ms: number
+  p99LatencyMs: number
+  score: number
+  llmdAdvantage: number | null
+  report: BenchmarkReport
+}
+
+export interface TimelinePoint {
+  date: string
+  hardware: string
+  model: string
+  config: 'standalone' | 'llm-d' | 'disaggregated'
+  ttftP50Ms: number
+  tpotP50Ms: number
+  outputThroughput: number
+  p99LatencyMs: number
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const HARDWARE_CONFIGS: { model: string; memory: number; costPerHr: number }[] = [
+  { model: 'NVIDIA-H100-80GB-HBM3', memory: 80, costPerHr: 2.50 },
+  { model: 'NVIDIA-A100-SXM4-80GB', memory: 80, costPerHr: 1.50 },
+  { model: 'NVIDIA-L40S', memory: 48, costPerHr: 1.00 },
+  { model: 'NVIDIA-H200-141GB', memory: 141, costPerHr: 3.80 },
+]
+
+const MODELS = [
+  { name: 'meta-llama/Llama-3-70B-Instruct', short: 'Llama-3-70B' },
+  { name: 'meta-llama/Llama-3.2-1B-Instruct', short: 'Llama-3.2-1B' },
+  { name: 'Qwen/Qwen3-32B', short: 'Qwen3-32B' },
+  { name: 'deepseek-ai/DeepSeek-R1-0528', short: 'DeepSeek-R1' },
+]
+
+const CONFIGS: ('standalone' | 'llm-d' | 'disaggregated')[] = ['standalone', 'llm-d', 'disaggregated']
+
+const SEQ_LENS = [
+  { label: '1k1k', isl: 1024, osl: 1024 },
+  { label: '1k8k', isl: 1024, osl: 8192 },
+  { label: '8k1k', isl: 8192, osl: 1024 },
+]
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let uidCounter = 0
+function uid(): string {
+  uidCounter++
+  return `bench-${uidCounter.toString(16).padStart(8, '0')}`
+}
+
+function hash(s: string): string {
+  let h = 0
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) - h + s.charCodeAt(i)) | 0
+  }
+  return Math.abs(h).toString(16).padStart(8, '0')
+}
+
+/** Seeded pseudo-random for reproducible mock data */
+function seededRandom(seed: number): () => number {
+  let s = seed
+  return () => {
+    s = (s * 16807 + 0) % 2147483647
+    return (s - 1) / 2147483646
+  }
+}
+
+function makeStats(mean: number, units: string, spread = 0.25): Statistics {
+  const s = spread * mean
+  return {
+    units,
+    mean,
+    min: Math.max(0, mean - s * 2),
+    p10: Math.max(0, mean - s * 1.3),
+    p25: Math.max(0, mean - s * 0.7),
+    p50: mean,
+    p75: mean + s * 0.7,
+    p90: mean + s * 1.3,
+    p95: mean + s * 1.6,
+    p99: mean + s * 2.3,
+    p99p9: mean + s * 3,
+    max: mean + s * 3.5,
+    stddev: s,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Performance model: given hardware + model + config, produce realistic metrics
+// ---------------------------------------------------------------------------
+
+interface PerfProfile {
+  baseTtftMs: number
+  baseTpotMs: number
+  baseThroughputPerGpu: number
+  baseRequestLatencyMs: number
+}
+
+function getPerfProfile(hwModel: string, modelName: string, config: string): PerfProfile {
+  // Base performance varies by model size
+  const modelSize = modelName.includes('70B') ? 70
+    : modelName.includes('32B') ? 32
+    : modelName.includes('R1') ? 671
+    : 1
+
+  // Hardware speed factor
+  const hwFactor = hwModel.includes('H200') ? 1.4
+    : hwModel.includes('H100') ? 1.0
+    : hwModel.includes('A100') ? 0.65
+    : hwModel.includes('L40S') ? 0.45
+    : 1.0
+
+  // Config improvement factors (llm-d advantage)
+  const configTtftFactor = config === 'disaggregated' ? 0.45 : config === 'llm-d' ? 0.65 : 1.0
+  const configThroughputFactor = config === 'disaggregated' ? 1.85 : config === 'llm-d' ? 1.55 : 1.0
+  const configLatencyFactor = config === 'disaggregated' ? 0.5 : config === 'llm-d' ? 0.7 : 1.0
+
+  // Scale by model size
+  const sizeFactor = modelSize < 5 ? 0.1 : modelSize < 40 ? 0.5 : modelSize < 100 ? 1.0 : 2.5
+
+  return {
+    baseTtftMs: (250 * sizeFactor / hwFactor) * configTtftFactor,
+    baseTpotMs: (15 * sizeFactor / hwFactor) * configTtftFactor,
+    baseThroughputPerGpu: (800 / sizeFactor * hwFactor) * configThroughputFactor,
+    baseRequestLatencyMs: (500 * sizeFactor / hwFactor) * configLatencyFactor,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report generator
+// ---------------------------------------------------------------------------
+
+export function generateBenchmarkReport(
+  hw: typeof HARDWARE_CONFIGS[number],
+  model: typeof MODELS[number],
+  config: typeof CONFIGS[number],
+  seqLen: typeof SEQ_LENS[number],
+  dateStr: string,
+  rand: () => number,
+): BenchmarkReport {
+  const perf = getPerfProfile(hw.model, model.name, config)
+
+  // Add some randomness
+  const jitter = () => 0.9 + rand() * 0.2
+
+  const ttft = perf.baseTtftMs * jitter()
+  const tpot = perf.baseTpotMs * jitter()
+  const throughput = perf.baseThroughputPerGpu * jitter()
+  const latency = perf.baseRequestLatencyMs * jitter()
+  const gpuCount = model.name.includes('70B') || model.name.includes('R1') ? 8 : model.name.includes('32B') ? 4 : 1
+
+  const runUid = uid()
+
+  const stack: StackComponent[] = [{
+    metadata: { label: 'vllm-svc-0', cfg_id: hash(`${hw.model}-${model.name}-${config}`) },
+    standardized: {
+      kind: 'inference_engine',
+      tool: config === 'standalone' ? 'vllm' : 'llm-d',
+      tool_version: config === 'standalone' ? 'vllm/vllm-openai:v0.8.5' : 'ghcr.io/llm-d/llm-d-cuda:0.3.1',
+      role: config === 'disaggregated' ? 'decode' : undefined,
+      replicas: config === 'disaggregated' ? 2 : 1,
+      model: { name: model.name, quantization: 'fp16' },
+      accelerator: {
+        model: hw.model,
+        count: gpuCount,
+        memory: hw.memory,
+        parallelism: { dp: 1, tp: gpuCount, pp: 1, ep: 1 },
+      },
+    },
+  }]
+
+  if (config === 'disaggregated') {
+    stack.push({
+      metadata: { label: 'vllm-prefill-0', cfg_id: hash(`prefill-${hw.model}-${model.name}`) },
+      standardized: {
+        kind: 'inference_engine',
+        tool: 'llm-d',
+        tool_version: 'ghcr.io/llm-d/llm-d-cuda:0.3.1',
+        role: 'prefill',
+        replicas: 3,
+        model: { name: model.name, quantization: 'fp16' },
+        accelerator: { model: hw.model, count: gpuCount, memory: hw.memory, parallelism: { dp: 1, tp: gpuCount, pp: 1, ep: 1 } },
+      },
+    })
+    stack.push({
+      metadata: { label: 'epp-0', cfg_id: hash(`epp-${config}`) },
+      standardized: {
+        kind: 'generic',
+        tool: 'llm-d-inference-scheduler',
+        tool_version: 'ghcr.io/llm-d/llm-d-inference-scheduler:0.3.2',
+      },
+    })
+  } else if (config === 'llm-d') {
+    stack.push({
+      metadata: { label: 'epp-0', cfg_id: hash(`epp-${config}`) },
+      standardized: {
+        kind: 'generic',
+        tool: 'llm-d-inference-scheduler',
+        tool_version: 'ghcr.io/llm-d/llm-d-inference-scheduler:0.3.2',
+      },
+    })
+  }
+
+  const totalRequests = 500 + Math.floor(rand() * 500)
+  const failures = rand() < 0.9 ? 0 : Math.floor(rand() * 3)
+
+  const gpuUtil = 40 + rand() * 45
+  const gpuMemUtil = 60 + rand() * 30
+  const gpuPower = 300 + rand() * 200
+
+  return {
+    version: '0.2',
+    run: {
+      uid: runUid,
+      eid: hash(`exp-${dateStr}-${hw.model}`),
+      time: {
+        start: `${dateStr}T02:00:00Z`,
+        end: `${dateStr}T02:17:00Z`,
+        duration: 'PT1020S',
+      },
+      user: 'ci-nightly',
+    },
+    scenario: {
+      stack,
+      load: {
+        metadata: { cfg_id: hash(`load-${seqLen.label}`) },
+        standardized: {
+          tool: 'inference-perf',
+          tool_version: '0.3.0',
+          source: 'sampled',
+          input_seq_len: { distribution: 'fixed', value: seqLen.isl },
+          output_seq_len: { distribution: 'gaussian', value: seqLen.osl },
+          rate_qps: 10 + rand() * 20,
+          concurrency: 32 + Math.floor(rand() * 96),
+        },
+      },
+    },
+    results: {
+      request_performance: {
+        aggregate: {
+          requests: {
+            total: totalRequests,
+            failures,
+            input_length: makeStats(seqLen.isl, 'count', 0.1),
+            output_length: makeStats(seqLen.osl, 'count', 0.15),
+          },
+          latency: {
+            time_to_first_token: makeStats(ttft / 1000, 's'),
+            time_per_output_token: makeStats(tpot / 1000, 's/token'),
+            inter_token_latency: makeStats(tpot * 1.05 / 1000, 's/token'),
+            normalized_time_per_output_token: makeStats((ttft / seqLen.osl + tpot) / 1000, 's/token'),
+            request_latency: makeStats(latency / 1000, 's'),
+          },
+          throughput: {
+            output_token_rate: makeStats(throughput, 'tokens/s'),
+            input_token_rate: makeStats(throughput * 0.8, 'tokens/s'),
+            total_token_rate: makeStats(throughput * 1.8, 'tokens/s'),
+            request_rate: makeStats(throughput / seqLen.osl, 'queries/s'),
+          },
+        },
+      },
+      observability: {
+        metrics: [
+          { name: `gpu_util.vllm-svc-0`, component_id: 'vllm-svc-0', type: 'gauge', unit: 'percent', labels: { gpu: '0' }, samples: [{ ts: `${dateStr}T02:05:00Z`, value: gpuUtil }] },
+          { name: `gpu_mem.vllm-svc-0`, component_id: 'vllm-svc-0', type: 'gauge', unit: 'percent', labels: { gpu: '0' }, samples: [{ ts: `${dateStr}T02:05:00Z`, value: gpuMemUtil }] },
+          { name: `gpu_power.vllm-svc-0`, component_id: 'vllm-svc-0', type: 'gauge', unit: 'Watts', labels: { gpu: '0' }, samples: [{ ts: `${dateStr}T02:05:00Z`, value: gpuPower }] },
+        ],
+      },
+      component_health: stack.map(c => ({
+        component_label: c.metadata.label,
+        total_restarts: rand() < 0.85 ? 0 : Math.floor(rand() * 2),
+        failed_replicas: 0,
+      })),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public generators
+// ---------------------------------------------------------------------------
+
+/** Generate a set of benchmark reports across hardware × model × config. */
+export function generateBenchmarkReports(): BenchmarkReport[] {
+  const rand = seededRandom(42)
+  const reports: BenchmarkReport[] = []
+  const today = new Date()
+  const dateStr = today.toISOString().slice(0, 10)
+
+  for (const hw of HARDWARE_CONFIGS) {
+    for (const model of MODELS) {
+      for (const config of CONFIGS) {
+        // Skip unrealistic combos: large models on small GPUs
+        if (model.name.includes('70B') && hw.model.includes('L40S')) continue
+        if (model.name.includes('R1') && !hw.model.includes('H100') && !hw.model.includes('H200')) continue
+
+        reports.push(generateBenchmarkReport(hw, model, config, SEQ_LENS[0], dateStr, rand))
+      }
+    }
+  }
+  return reports
+}
+
+/** Generate 90 days of nightly reports for timeline visualization. */
+export function generateTimelineReports(days = 90): TimelinePoint[] {
+  const rand = seededRandom(123)
+  const points: TimelinePoint[] = []
+  const now = Date.now()
+
+  // Pick a subset of configs to track over time
+  const tracked = [
+    { hw: HARDWARE_CONFIGS[0], model: MODELS[0], config: 'standalone' as const },
+    { hw: HARDWARE_CONFIGS[0], model: MODELS[0], config: 'llm-d' as const },
+    { hw: HARDWARE_CONFIGS[0], model: MODELS[0], config: 'disaggregated' as const },
+    { hw: HARDWARE_CONFIGS[1], model: MODELS[0], config: 'llm-d' as const },
+  ]
+
+  for (let d = days; d >= 0; d--) {
+    const date = new Date(now - d * 86400000)
+    const dateStr = date.toISOString().slice(0, 10)
+
+    // Simulate gradual improvement over time (llm-d gets better)
+    const improvementFactor = 1 - (d / days) * 0.15 // 15% improvement over period
+
+    for (const t of tracked) {
+      const perf = getPerfProfile(t.hw.model, t.model.name, t.config)
+      const cfgFactor = t.config === 'standalone' ? 1.0 : improvementFactor
+      const jitter = () => 0.95 + rand() * 0.1
+
+      points.push({
+        date: dateStr,
+        hardware: t.hw.model.replace('NVIDIA-', '').replace('-SXM4-80GB', '').replace('-80GB-HBM3', ''),
+        model: t.model.short,
+        config: t.config,
+        ttftP50Ms: perf.baseTtftMs * cfgFactor * jitter(),
+        tpotP50Ms: perf.baseTpotMs * cfgFactor * jitter(),
+        outputThroughput: perf.baseThroughputPerGpu / cfgFactor * jitter(),
+        p99LatencyMs: perf.baseRequestLatencyMs * 2.3 * cfgFactor * jitter(),
+      })
+    }
+  }
+  return points
+}
+
+/** Extract Pareto-plottable points from a set of reports. */
+export function extractParetoPoints(reports: BenchmarkReport[]): ParetoPoint[] {
+  return reports.map(r => {
+    const engine = r.scenario.stack.find(c => c.standardized.kind === 'inference_engine')
+    if (!engine) return null
+
+    const acc = engine.standardized.accelerator
+    const gpuCount = acc?.count ?? 1
+    const outputRate = r.results.request_performance.aggregate.throughput.output_token_rate?.mean ?? 0
+    const ttft = (r.results.request_performance.aggregate.latency.time_to_first_token?.p50 ?? 0) * 1000
+    const tpot = (r.results.request_performance.aggregate.latency.time_per_output_token?.p50 ?? 0) * 1000
+    const p99 = (r.results.request_performance.aggregate.latency.request_latency?.p99 ?? 0) * 1000
+
+    const config: ParetoPoint['config'] = r.scenario.stack.some(c => c.standardized.role === 'prefill')
+      ? 'disaggregated'
+      : engine.standardized.tool === 'llm-d' ? 'llm-d' : 'standalone'
+
+    return {
+      uid: r.run.uid,
+      model: engine.standardized.model?.name ?? 'unknown',
+      hardware: acc?.model ?? 'unknown',
+      hardwareMemory: acc?.memory ?? 0,
+      gpuCount,
+      config,
+      framework: engine.standardized.tool,
+      seqLen: `${r.scenario.load.standardized.input_seq_len.value}/${r.scenario.load.standardized.output_seq_len?.value ?? '?'}`,
+      throughputPerGpu: outputRate / gpuCount,
+      ttftP50Ms: ttft,
+      tpotP50Ms: tpot,
+      p99LatencyMs: p99,
+      requestRate: r.results.request_performance.aggregate.throughput.request_rate?.mean ?? 0,
+    }
+  }).filter((p): p is ParetoPoint => p !== null)
+}
+
+/** Compute Pareto-optimal frontier from a set of points (maximizing throughput, minimizing TTFT). */
+export function computeParetoFrontier(points: ParetoPoint[]): ParetoPoint[] {
+  // Sort by throughput ascending
+  const sorted = [...points].sort((a, b) => a.throughputPerGpu - b.throughputPerGpu)
+  const frontier: ParetoPoint[] = []
+  let minTtft = Infinity
+
+  // Sweep from highest throughput to lowest, keeping points with lower TTFT
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    if (sorted[i].ttftP50Ms < minTtft) {
+      minTtft = sorted[i].ttftP50Ms
+      frontier.push(sorted[i])
+    }
+  }
+  return frontier.reverse()
+}
+
+/** Generate leaderboard rows from reports. */
+export function generateLeaderboardRows(reports: BenchmarkReport[]): LeaderboardRow[] {
+  const points = extractParetoPoints(reports)
+
+  // Compute composite score: normalize each metric to 0-100, weighted average
+  const maxThroughput = Math.max(...points.map(p => p.throughputPerGpu), 1)
+  const minTtft = Math.min(...points.map(p => p.ttftP50Ms), 1)
+  const minP99 = Math.min(...points.map(p => p.p99LatencyMs), 1)
+
+  const rows: LeaderboardRow[] = points.map((p, i) => {
+    const throughputScore = (p.throughputPerGpu / maxThroughput) * 100
+    const ttftScore = (minTtft / p.ttftP50Ms) * 100
+    const p99Score = (minP99 / p.p99LatencyMs) * 100
+    const score = throughputScore * 0.4 + ttftScore * 0.35 + p99Score * 0.25
+
+    // Compute llm-d advantage vs standalone for same hardware + model
+    let advantage: number | null = null
+    if (p.config !== 'standalone') {
+      const baseline = points.find(
+        pp => pp.hardware === p.hardware && pp.model === p.model && pp.config === 'standalone'
+      )
+      if (baseline) {
+        advantage = Math.round(((p.throughputPerGpu / baseline.throughputPerGpu) - 1) * 100)
+      }
+    }
+
+    const hw = p.hardware.replace('NVIDIA-', '').replace('-SXM4-80GB', '').replace('-80GB-HBM3', '').replace('-141GB', '')
+
+    return {
+      rank: 0,
+      hardware: hw,
+      model: p.model.split('/').pop() ?? p.model,
+      config: p.config,
+      framework: p.framework,
+      throughputPerGpu: Math.round(p.throughputPerGpu),
+      ttftP50Ms: Math.round(p.ttftP50Ms * 100) / 100,
+      tpotP50Ms: Math.round(p.tpotP50Ms * 100) / 100,
+      p99LatencyMs: Math.round(p.p99LatencyMs),
+      score: Math.round(score * 10) / 10,
+      llmdAdvantage: advantage,
+      report: reports[i],
+    }
+  })
+
+  // Sort by score descending and assign ranks
+  rows.sort((a, b) => b.score - a.score)
+  rows.forEach((r, i) => { r.rank = i + 1 })
+
+  return rows
+}
+
+/** Get hardware short name for display. */
+export function getHardwareShort(model: string): string {
+  return model.replace('NVIDIA-', '').replace('-SXM4-80GB', '').replace('-80GB-HBM3', '').replace('-141GB', '')
+}
+
+/** Get model short name for display. */
+export function getModelShort(name: string): string {
+  return name.split('/').pop() ?? name
+}
+
+/** Color palette for hardware types. */
+export const HARDWARE_COLORS: Record<string, string> = {
+  'H100': '#3b82f6',
+  'H200': '#8b5cf6',
+  'A100': '#f59e0b',
+  'L40S': '#10b981',
+}
+
+/** Color palette for config types. */
+export const CONFIG_COLORS: Record<string, string> = {
+  'standalone': '#6b7280',
+  'llm-d': '#3b82f6',
+  'disaggregated': '#10b981',
+}


### PR DESCRIPTION
## Summary
- Adds a new **llm-d Benchmarks** dashboard at `/llm-d-benchmarks` with 7 full-width (12-col) cards visualizing benchmark results across cloud providers and accelerators
- **BenchmarkHero**: Headline metrics (throughput, TTFT, TPOT, latency) with animated delta indicators vs baseline
- **ParetoFrontier**: Interactive scatter plot showing latency-throughput tradeoff with Pareto-optimal curve overlay, filterable by hardware/model
- **HardwareLeaderboard**: Sortable ranked table comparing configurations with composite scores and medal rankings
- **LatencyBreakdown**: Percentile bar chart (p50/p90/p95/p99) across TTFT, TPOT, ITL, NTPOT metrics with improvement callouts
- **ThroughputComparison**: Grouped bar chart across hardware types with improvement % labels
- **PerformanceTimeline**: 90-day time-series trends with configurable metrics and time ranges (7d/30d/90d)
- **ResourceUtilization**: GPU compute/memory/power comparison with efficiency (throughput/watt) view
- Includes mock data layer (`benchmarkMockData.ts`) matching the Benchmark Report v0.2 schema with generators for reports, timelines, Pareto points, and leaderboard rows

## Test plan
- [x] `npm run build` passes clean
- [x] `npm run lint` — no errors in new files
- [ ] Navigate to `/llm-d-benchmarks` and verify all 7 cards render with mock data
- [ ] Test filters (model, hardware), sort columns, metric toggles, view mode switches
- [ ] Verify existing AI/ML dashboard cards still work
- [ ] Test expanded card views