### PR TITLE
🐛 Add route and page component for llm-d Benchmarks dashboard

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -55,6 +55,7 @@ const Arcade = lazy(() => import('./components/arcade/Arcade').then(m => ({ defa
 const Deploy = lazy(() => import('./components/deploy/Deploy').then(m => ({ default: m.Deploy })))
 const AIML = lazy(() => import('./components/aiml/AIML').then(m => ({ default: m.AIML })))
 const AIAgents = lazy(() => import('./components/aiagents/AIAgents').then(m => ({ default: m.AIAgents })))
+const LLMdBenchmarks = lazy(() => import('./components/llmd-benchmarks/LLMdBenchmarks').then(m => ({ default: m.LLMdBenchmarks })))
 const CICD = lazy(() => import('./components/cicd/CICD').then(m => ({ default: m.CICD })))
 const Marketplace = lazy(() => import('./components/marketplace/Marketplace').then(m => ({ default: m.Marketplace })))
 const MiniDashboard = lazy(() => import('./components/widget/MiniDashboard').then(m => ({ default: m.MiniDashboard })))
@@ -97,6 +98,7 @@ if (typeof window !== 'undefined') {
       () => import('./components/deploy/Deploy'),
       () => import('./components/aiml/AIML'),
       () => import('./components/aiagents/AIAgents'),
+      () => import('./components/llmd-benchmarks/LLMdBenchmarks'),
       () => import('./components/cicd/CICD'),
       () => import('./components/marketplace/Marketplace'),
     ]
@@ -563,6 +565,16 @@ function App() {
             <ProtectedRoute>
               <Layout>
                   <AIAgents />
+              </Layout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/llm-d-benchmarks"
+          element={
+            <ProtectedRoute>
+              <Layout>
+                  <LLMdBenchmarks />
               </Layout>
             </ProtectedRoute>
           }

--- a/web/src/components/llmd-benchmarks/LLMdBenchmarks.tsx
+++ b/web/src/components/llmd-benchmarks/LLMdBenchmarks.tsx
@@ -1,0 +1,23 @@
+import { DashboardPage } from '../../lib/dashboards/DashboardPage'
+import { getDefaultCards } from '../../config/dashboards'
+
+const BENCHMARKS_CARDS_KEY = 'kubestellar-llmd-benchmarks-cards'
+const DEFAULT_BENCHMARKS_CARDS = getDefaultCards('llm-d-benchmarks')
+
+export function LLMdBenchmarks() {
+  return (
+    <DashboardPage
+      title="llm-d Benchmarks"
+      subtitle="Performance tracking across clouds and accelerators"
+      icon="TrendingUp"
+      storageKey={BENCHMARKS_CARDS_KEY}
+      defaultCards={DEFAULT_BENCHMARKS_CARDS}
+      statsType="clusters"
+      isLoading={false}
+      isRefreshing={false}
+      isDemoData
+    />
+  )
+}
+
+export default LLMdBenchmarks


### PR DESCRIPTION
## Summary
- Adds `LLMdBenchmarks` page component using `DashboardPage`
- Adds React Router route at `/llm-d-benchmarks` in App.tsx
- Adds lazy import and preloader entry

Without this, clicking the sidebar link redirected to `/`.

## Test plan
- [ ] Navigate to `/llm-d-benchmarks` — dashboard renders with 7 cards
- [ ] Click "llm-d Benchmarks" in sidebar — navigates correctly