### PR TITLE
✨ Move sidebar Customize button to dashboard floating menu

### DIFF
--- a/web/src/components/dashboard/FloatingDashboardActions.tsx
+++ b/web/src/components/dashboard/FloatingDashboardActions.tsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useEffect } from 'react'
-import { Plus, Layout, RotateCcw, Download, Upload } from 'lucide-react'
+import { Plus, Layout, RotateCcw, Download, Upload, Pencil } from 'lucide-react'
 import { useMissions } from '../../hooks/useMissions'
 import { useMobile } from '../../hooks/useMobile'
 import { ResetMode } from '../../hooks/useDashboardReset'
 import { ResetDialog } from './ResetDialog'
+import { SidebarCustomizer } from '../layout/SidebarCustomizer'
 
 interface FloatingDashboardActionsProps {
   onAddCard: () => void
@@ -37,6 +38,7 @@ export function FloatingDashboardActions({
   const { isMobile } = useMobile()
   const [isOpen, setIsOpen] = useState(false)
   const [showResetDialog, setShowResetDialog] = useState(false)
+  const [showCustomizer, setShowCustomizer] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -141,6 +143,14 @@ export function FloatingDashboardActions({
               </button>
             )}
             <button
+              onClick={() => { setIsOpen(false); setShowCustomizer(true) }}
+              className={menuBtnClass}
+              title="Customize sidebar"
+            >
+              <Pencil className="w-3.5 h-3.5" />
+              Customize
+            </button>
+            <button
               onClick={() => { setIsOpen(false); onOpenTemplates() }}
               data-tour="templates"
               className={menuBtnClass}
@@ -181,6 +191,11 @@ export function FloatingDashboardActions({
         isOpen={showResetDialog}
         onClose={() => setShowResetDialog(false)}
         onReset={handleReset}
+      />
+
+      <SidebarCustomizer
+        isOpen={showCustomizer}
+        onClose={() => setShowCustomizer(false)}
       />
     </>
   )

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -4,10 +4,9 @@ import { NavLink, useNavigate, useLocation } from 'react-router-dom'
 // Sidebar items are configured with icon names as strings (from sidebar config)
 // The renderIcon() function resolves these names dynamically via Icons[iconName]
 import * as Icons from 'lucide-react'
-import { Plus, Pencil, ChevronLeft, ChevronRight, CheckCircle2, AlertTriangle, WifiOff, GripVertical, User } from 'lucide-react'
+import { Plus, ChevronLeft, ChevronRight, CheckCircle2, AlertTriangle, WifiOff, GripVertical, User } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { SnoozedCards } from './SnoozedCards'
-import { SidebarCustomizer } from './SidebarCustomizer'
 import { useSidebarConfig, SidebarItem } from '../../hooks/useSidebarConfig'
 import { useMobile } from '../../hooks/useMobile'
 import { useClusters } from '../../hooks/useMCP'
@@ -22,7 +21,6 @@ export function Sidebar() {
   const { config, toggleCollapsed, reorderItems, updateItem, closeMobileSidebar } = useSidebarConfig()
   const { isMobile } = useMobile()
   const { deduplicatedClusters } = useClusters()
-  const [isCustomizerOpen, setIsCustomizerOpen] = useState(false)
   const dashboardContext = useDashboardContextOptional()
   const { viewerCount, hasError: viewersError } = useActiveUsers()
   const navigate = useNavigate()
@@ -372,22 +370,9 @@ export function Sidebar() {
           </div>
         )}
 
-        {/* Customize button and viewer count */}
-        <div className="mt-4 flex items-center justify-between">
-          <button
-            data-testid="sidebar-customize"
-            onClick={() => setIsCustomizerOpen(true)}
-            className={cn(
-              'flex items-center gap-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors',
-              isCollapsed ? 'justify-center w-full p-3' : 'px-3 py-2 text-xs'
-            )}
-            title={isCollapsed ? 'Customize sidebar' : undefined}
-          >
-            <Pencil className={isCollapsed ? 'w-5 h-5' : 'w-3 h-3'} />
-            {!isCollapsed && 'Customize'}
-          </button>
-          {/* Viewer count - small and inconspicuous */}
-          {!isCollapsed && (
+        {/* Viewer count */}
+        {!isCollapsed && (
+          <div className="mt-4 flex items-center justify-end">
             <div
               className="flex items-center gap-1 px-2 text-muted-foreground/60"
               title={`${viewerCount} active viewer${viewerCount !== 1 ? 's' : ''}`}
@@ -397,15 +382,10 @@ export function Sidebar() {
                 {viewersError ? '!' : viewerCount}
               </span>
             </div>
-          )}
-        </div>
+          </div>
+        )}
       </aside>
 
-      {/* Sidebar Customizer Modal */}
-      <SidebarCustomizer
-        isOpen={isCustomizerOpen}
-        onClose={() => setIsCustomizerOpen(false)}
-      />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Moved the "Customize" button from the bottom of the left sidebar into the dashboard's floating "+" action menu
- `FloatingDashboardActions` now self-contains `SidebarCustomizer` state — no changes needed in any of the 7 consumer components
- Sidebar bottom section simplified to just show the viewer count

## Test plan
- [ ] Click the "+" floating button on any dashboard — "Customize" option appears in the expanded menu
- [ ] Click "Customize" — the sidebar customizer modal opens and works as before
- [ ] Sidebar no longer has a "Customize" button at the bottom
- [ ] Viewer count still shows at the bottom of the sidebar
- [ ] Build and lint pass