### PR TITLE
🐛 Fix BenchmarkHero crash on empty reports + default API key

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -742,7 +742,7 @@ func LoadConfigFromEnv() Config {
 		// Skip onboarding questionnaire for new users
 		SkipOnboarding: os.Getenv("SKIP_ONBOARDING") == "true",
 		// Benchmark data from Google Drive
-		BenchmarkGoogleDriveAPIKey: os.Getenv("GOOGLE_DRIVE_API_KEY"),
+		BenchmarkGoogleDriveAPIKey: getEnvOrDefault("GOOGLE_DRIVE_API_KEY", "AIzaSyADkXfBwkPkDOfYVtsKC_KNtM3B0P59BSQ"),
 		BenchmarkFolderID:          getEnvOrDefault("BENCHMARK_FOLDER_ID", "1r2Z2Xp1L0KonUlvQHvEzed8AO9Xj8IPm"),
 	}
 }

--- a/web/src/components/cards/llmd/BenchmarkHero.tsx
+++ b/web/src/components/cards/llmd/BenchmarkHero.tsx
@@ -89,6 +89,8 @@ export function BenchmarkHero() {
 
   const { latest, prev, engine, gpuMetrics } = useMemo(() => {
     const reports = effectiveReports
+    if (reports.length === 0) return { latest: null, prev: null, engine: null, gpuMetrics: [] }
+
     // Pick the best llm-d disaggregated result as "latest"
     const llmdReports = reports.filter(r =>
       r.scenario.stack.some(c => c.standardized.role === 'prefill')
@@ -98,6 +100,8 @@ export function BenchmarkHero() {
       const tb = b.results.request_performance.aggregate.throughput.output_token_rate?.mean ?? 0
       return tb - ta
     })[0] ?? reports[0]
+
+    if (!best) return { latest: null, prev: null, engine: null, gpuMetrics: [] }
 
     // Find a standalone baseline as "previous"
     const eng = best.scenario.stack.find(c => c.standardized.kind === 'inference_engine')
@@ -111,6 +115,8 @@ export function BenchmarkHero() {
     const gpuM = best.results.observability?.metrics ?? []
     return { latest: best, prev: baseline, engine: eng, gpuMetrics: gpuM }
   }, [effectiveReports])
+
+  if (!latest) return <div className="p-5 h-full flex items-center justify-center text-slate-400 text-sm">No benchmark data available</div>
 
   const agg = latest.results.request_performance.aggregate
   const prevAgg = prev?.results.request_performance.aggregate


### PR DESCRIPTION
## Summary
- Fix crash in BenchmarkHero when `effectiveReports` is empty (e.g. backend returns no data or auth fails) — guards against `best.scenario` being undefined
- Set default `GOOGLE_DRIVE_API_KEY` so benchmark data works out of the box without `.env` configuration

## Test plan
- [ ] Navigate to llm-d Benchmarks dashboard — no crash even when backend returns empty reports
- [ ] Benchmark cards show live data when backend is running with Google Drive access
- [ ] Build passes