### PR TITLE
🐛 Remove hardcoded Google Drive API key from source

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -742,7 +742,7 @@ func LoadConfigFromEnv() Config {
 		// Skip onboarding questionnaire for new users
 		SkipOnboarding: os.Getenv("SKIP_ONBOARDING") == "true",
 		// Benchmark data from Google Drive
-		BenchmarkGoogleDriveAPIKey: getEnvOrDefault("GOOGLE_DRIVE_API_KEY", "AIzaSyADkXfBwkPkDOfYVtsKC_KNtM3B0P59BSQ"),
+		BenchmarkGoogleDriveAPIKey: os.Getenv("GOOGLE_DRIVE_API_KEY"),
 		BenchmarkFolderID:          getEnvOrDefault("BENCHMARK_FOLDER_ID", "1r2Z2Xp1L0KonUlvQHvEzed8AO9Xj8IPm"),
 	}
 }


### PR DESCRIPTION
## Summary
- Remove hardcoded `AIzaSy...` API key from `server.go` default value
- API key now only comes from `GOOGLE_DRIVE_API_KEY` env var (set in `.env`, which is gitignored)
- **Note:** Key was in git history from PR #920 — should be rotated

## Test plan
- [ ] Backend builds without errors
- [ ] Benchmarks work when `GOOGLE_DRIVE_API_KEY` is set in `.env`
- [ ] Benchmarks gracefully fall back to demo data when key is not set