### PR TITLE
🐛 Remove hardcoded isDemoData from llm-d Benchmarks dashboard

### DIFF
--- a/web/src/components/llmd-benchmarks/LLMdBenchmarks.tsx
+++ b/web/src/components/llmd-benchmarks/LLMdBenchmarks.tsx
@@ -15,7 +15,6 @@ export function LLMdBenchmarks() {
       statsType="clusters"
       isLoading={false}
       isRefreshing={false}
-      isDemoData
     />
   )
 }


### PR DESCRIPTION
## Summary
- Remove hardcoded `isDemoData` (always true) from llm-d Benchmarks `DashboardPage`
- Stats Overview now correctly shows no Demo badge when displaying real cluster data
- Individual benchmark cards handle their own demo state via `useCardDemoState`

## Test plan
- [ ] Stats Overview on llm-d Benchmarks page shows no Demo badge with real cluster data
- [ ] Benchmark cards still show Demo badge when backend returns error