### PR TITLE
✨ Stream benchmark data via SSE and fix Shared Drive traversal

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -572,6 +572,7 @@ func (s *Server) setupRoutes() {
 	// Benchmark data routes (llm-d benchmark results from Google Drive)
 	benchmarkHandlers := handlers.NewBenchmarkHandlers(s.config.BenchmarkGoogleDriveAPIKey, s.config.BenchmarkFolderID)
 	api.Get("/benchmarks/reports", benchmarkHandlers.GetReports)
+	api.Get("/benchmarks/reports/stream", benchmarkHandlers.StreamReports)
 
 	// GPU reservation routes
 	gpuHandler := handlers.NewGPUHandler(s.store)

--- a/web/src/components/cards/llmd/BenchmarkHero.tsx
+++ b/web/src/components/cards/llmd/BenchmarkHero.tsx
@@ -8,7 +8,7 @@
 import { useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { Zap, Clock, Activity, Cpu, TrendingUp, TrendingDown, ArrowRight } from 'lucide-react'
-import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
+import { useReportCardDataState } from '../CardDataContext'
 import { useCachedBenchmarkReports } from '../../../hooks/useBenchmarkData'
 import {
   generateBenchmarkReports,
@@ -82,10 +82,9 @@ function HeroMetric({
 }
 
 export function BenchmarkHero() {
-  const { data: liveReports, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
-  const { shouldUseDemoData } = useCardDemoState({ requires: 'backend', isLiveDataAvailable: !isFailed })
-  const effectiveReports = useMemo(() => shouldUseDemoData ? generateBenchmarkReports() : (liveReports ?? []), [shouldUseDemoData, liveReports])
-  useReportCardDataState({ isDemoData: shouldUseDemoData, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
+  const effectiveReports = useMemo(() => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []), [isDemoFallback, liveReports])
+  useReportCardDataState({ isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
 
   const { latest, prev, engine, gpuMetrics } = useMemo(() => {
     const reports = effectiveReports

--- a/web/src/components/cards/llmd/HardwareLeaderboard.tsx
+++ b/web/src/components/cards/llmd/HardwareLeaderboard.tsx
@@ -7,7 +7,7 @@
  */
 import { useState, useMemo } from 'react'
 import { Trophy, ChevronUp, ChevronDown, ArrowUpDown } from 'lucide-react'
-import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
+import { useReportCardDataState } from '../CardDataContext'
 import { useCachedBenchmarkReports } from '../../../hooks/useBenchmarkData'
 import {
   generateBenchmarkReports,
@@ -38,10 +38,9 @@ function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
 }
 
 export function HardwareLeaderboard() {
-  const { data: liveReports, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
-  const { shouldUseDemoData } = useCardDemoState({ requires: 'backend', isLiveDataAvailable: !isFailed })
-  const effectiveReports = useMemo(() => shouldUseDemoData ? generateBenchmarkReports() : (liveReports ?? []), [shouldUseDemoData, liveReports])
-  useReportCardDataState({ isDemoData: shouldUseDemoData, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
+  const effectiveReports = useMemo(() => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []), [isDemoFallback, liveReports])
+  useReportCardDataState({ isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
 
   const [sortKey, setSortKey] = useState<SortKey>('score')
   const [sortDir, setSortDir] = useState<SortDir>('desc')

--- a/web/src/components/cards/llmd/LatencyBreakdown.tsx
+++ b/web/src/components/cards/llmd/LatencyBreakdown.tsx
@@ -6,7 +6,7 @@
  */
 import { useState, useMemo } from 'react'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, Legend } from 'recharts'
-import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
+import { useReportCardDataState } from '../CardDataContext'
 import { useCachedBenchmarkReports } from '../../../hooks/useBenchmarkData'
 import {
   generateBenchmarkReports,
@@ -72,10 +72,9 @@ function CustomTooltip({ active, payload }: { active?: boolean; payload?: Array<
 }
 
 export function LatencyBreakdown() {
-  const { data: liveReports, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
-  const { shouldUseDemoData } = useCardDemoState({ requires: 'backend', isLiveDataAvailable: !isFailed })
-  const effectiveReports = useMemo(() => shouldUseDemoData ? generateBenchmarkReports() : (liveReports ?? []), [shouldUseDemoData, liveReports])
-  useReportCardDataState({ isDemoData: shouldUseDemoData, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
+  const effectiveReports = useMemo(() => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []), [isDemoFallback, liveReports])
+  useReportCardDataState({ isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
 
   const [tab, setTab] = useState<MetricTab>('ttft')
   const [modelFilter, setModelFilter] = useState<string>('all')

--- a/web/src/components/cards/llmd/ParetoFrontier.tsx
+++ b/web/src/components/cards/llmd/ParetoFrontier.tsx
@@ -11,7 +11,7 @@ import {
   ReferenceLine, ZAxis,
 } from 'recharts'
 import { Filter } from 'lucide-react'
-import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
+import { useReportCardDataState } from '../CardDataContext'
 import { useCachedBenchmarkReports } from '../../../hooks/useBenchmarkData'
 import {
   generateBenchmarkReports,
@@ -118,10 +118,9 @@ function CustomTooltip({ active, payload }: { active?: boolean; payload?: Array<
 }
 
 export function ParetoFrontier() {
-  const { data: liveReports, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
-  const { shouldUseDemoData } = useCardDemoState({ requires: 'backend', isLiveDataAvailable: !isFailed })
-  const effectiveReports = useMemo(() => shouldUseDemoData ? generateBenchmarkReports() : (liveReports ?? []), [shouldUseDemoData, liveReports])
-  useReportCardDataState({ isDemoData: shouldUseDemoData, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
+  const effectiveReports = useMemo(() => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []), [isDemoFallback, liveReports])
+  useReportCardDataState({ isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
 
   const [hwFilter, setHwFilter] = useState<Set<string>>(new Set())
   const [modelFilter, setModelFilter] = useState<string>('all')

--- a/web/src/components/cards/llmd/ResourceUtilization.tsx
+++ b/web/src/components/cards/llmd/ResourceUtilization.tsx
@@ -7,7 +7,7 @@
 import { useState, useMemo } from 'react'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
 import { Cpu, Zap, HardDrive } from 'lucide-react'
-import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
+import { useReportCardDataState } from '../CardDataContext'
 import { useCachedBenchmarkReports } from '../../../hooks/useBenchmarkData'
 import {
   generateBenchmarkReports,
@@ -75,10 +75,9 @@ function MiniBar({ label, items, dataKey, unit, icon: Icon, color }: {
 }
 
 export function ResourceUtilization() {
-  const { data: liveReports, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
-  const { shouldUseDemoData } = useCardDemoState({ requires: 'backend', isLiveDataAvailable: !isFailed })
-  const effectiveReports = useMemo(() => shouldUseDemoData ? generateBenchmarkReports() : (liveReports ?? []), [shouldUseDemoData, liveReports])
-  useReportCardDataState({ isDemoData: shouldUseDemoData, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
+  const effectiveReports = useMemo(() => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []), [isDemoFallback, liveReports])
+  useReportCardDataState({ isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
 
   const [view, setView] = useState<ViewMode>('overview')
   const entries = useMemo(() => {

--- a/web/src/components/cards/llmd/ThroughputComparison.tsx
+++ b/web/src/components/cards/llmd/ThroughputComparison.tsx
@@ -7,7 +7,7 @@
  */
 import { useState, useMemo } from 'react'
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, Legend } from 'recharts'
-import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
+import { useReportCardDataState } from '../CardDataContext'
 import { useCachedBenchmarkReports } from '../../../hooks/useBenchmarkData'
 import {
   generateBenchmarkReports,
@@ -82,10 +82,9 @@ function ImprovementLabel({ x, y, width, value }: { x?: string | number; y?: str
 }
 
 export function ThroughputComparison() {
-  const { data: liveReports, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
-  const { shouldUseDemoData } = useCardDemoState({ requires: 'backend', isLiveDataAvailable: !isFailed })
-  const effectiveReports = useMemo(() => shouldUseDemoData ? generateBenchmarkReports() : (liveReports ?? []), [shouldUseDemoData, liveReports])
-  useReportCardDataState({ isDemoData: shouldUseDemoData, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
+  const effectiveReports = useMemo(() => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []), [isDemoFallback, liveReports])
+  useReportCardDataState({ isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
 
   const [mode, setMode] = useState<MetricMode>('output')
   const [modelFilter, setModelFilter] = useState<string>('all')

--- a/web/src/hooks/useBenchmarkData.ts
+++ b/web/src/hooks/useBenchmarkData.ts
@@ -1,11 +1,11 @@
 /**
- * Hook for fetching live benchmark data from the backend.
+ * Hook for fetching live benchmark data from the backend via SSE streaming.
  *
- * When a Google Drive API key is configured on the backend, this returns
- * real benchmark reports (v0.1 data adapted to the v0.2 BenchmarkReport
- * interface). When not configured or in demo mode, returns mock data from
- * generateBenchmarkReports().
+ * Uses Server-Sent Events to stream benchmark reports incrementally from
+ * Google Drive. Cards update progressively as batches arrive. Falls back to
+ * demo data when backend is unavailable or returns empty.
  */
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { useCache } from '../lib/cache'
 import {
   generateBenchmarkReports,
@@ -20,31 +20,135 @@ function authHeaders(): Record<string, string> {
 const DEMO_REPORTS = generateBenchmarkReports()
 
 export function useCachedBenchmarkReports() {
-  const result = useCache<BenchmarkReport[]>({
+  const [streamedReports, setStreamedReports] = useState<BenchmarkReport[]>([])
+  const [isStreaming, setIsStreaming] = useState(false)
+  const [streamDone, setStreamDone] = useState(false)
+  const [, setStreamError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+  const hasStartedRef = useRef(false)
+
+  // Cache hook provides demo fallback + persistence
+  const cacheResult = useCache<BenchmarkReport[]>({
     key: 'benchmark-reports',
     category: 'costs',
-    refreshInterval: 3_600_000, // 1 hour — data updates daily
+    refreshInterval: 3_600_000,
     initialData: [],
     demoData: DEMO_REPORTS,
     fetcher: async () => {
+      // If streaming already completed, return its data
+      if (streamedReports.length > 0 && streamDone) {
+        return streamedReports
+      }
+      // Fallback: try non-streaming endpoint (returns cache quickly)
       const res = await fetch('/api/benchmarks/reports', {
         headers: authHeaders(),
       })
-
-      if (res.status === 503) {
-        // Backend not configured — caller should fall back to demo data
-        throw new Error('BENCHMARK_UNAVAILABLE')
-      }
-
-      if (!res.ok) {
-        throw new Error(`Benchmark API error: ${res.status}`)
-      }
-
+      if (res.status === 503) throw new Error('BENCHMARK_UNAVAILABLE')
+      if (!res.ok) throw new Error(`Benchmark API error: ${res.status}`)
       const data = await res.json()
       return (data.reports ?? []) as BenchmarkReport[]
     },
-    demoWhenEmpty: true, // Fall back to demo if live returns empty
+    demoWhenEmpty: true,
   })
 
-  return result
+  const startStream = useCallback(() => {
+    if (hasStartedRef.current) return
+    hasStartedRef.current = true
+
+    const abort = new AbortController()
+    abortRef.current = abort
+    setIsStreaming(true)
+    setStreamDone(false)
+    setStreamError(null)
+
+    const token = localStorage.getItem('token')
+
+    fetch('/api/benchmarks/reports/stream', {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      signal: abort.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok || !res.body) {
+          setIsStreaming(false)
+          setStreamError(`Stream error: ${res.status}`)
+          return
+        }
+
+        const reader = res.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+
+          buffer += decoder.decode(value, { stream: true })
+
+          // Parse SSE events
+          const lines = buffer.split('\n')
+          buffer = lines.pop() ?? ''
+
+          let eventType = ''
+          let dataLines: string[] = []
+
+          for (const line of lines) {
+            if (line.startsWith('event: ')) {
+              eventType = line.slice(7).trim()
+            } else if (line.startsWith('data: ')) {
+              dataLines.push(line.slice(6))
+            } else if (line === '') {
+              if (eventType && dataLines.length > 0) {
+                const rawData = dataLines.join('\n')
+                if (eventType === 'batch') {
+                  try {
+                    const batch = JSON.parse(rawData) as BenchmarkReport[]
+                    setStreamedReports(prev => [...prev, ...batch])
+                  } catch {
+                    // ignore parse errors
+                  }
+                } else if (eventType === 'done') {
+                  setStreamDone(true)
+                  setIsStreaming(false)
+                } else if (eventType === 'error') {
+                  setStreamError(rawData)
+                  setIsStreaming(false)
+                }
+              }
+              eventType = ''
+              dataLines = []
+            }
+          }
+        }
+
+        setIsStreaming(false)
+        setStreamDone(true)
+      })
+      .catch((err) => {
+        if (err.name !== 'AbortError') {
+          setStreamError(err.message)
+          setIsStreaming(false)
+        }
+      })
+  }, [])
+
+  useEffect(() => {
+    startStream()
+    return () => {
+      abortRef.current?.abort()
+    }
+  }, [startStream])
+
+  // Use streamed data if we have any, otherwise fall back to cache/demo
+  const hasStreamedData = streamedReports.length > 0
+  const effectiveData = hasStreamedData ? streamedReports : cacheResult.data
+  const effectiveIsDemoFallback = hasStreamedData ? false : cacheResult.isDemoFallback
+
+  return {
+    ...cacheResult,
+    data: effectiveData,
+    isDemoFallback: effectiveIsDemoFallback,
+    isLoading: cacheResult.isLoading || (isStreaming && !hasStreamedData),
+    isStreaming,
+    streamProgress: streamedReports.length,
+  }
 }

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -739,6 +739,8 @@ export interface UseCacheResult<T> {
   refetch: () => Promise<void>
   /** Clear cache and refetch */
   clearAndRefetch: () => Promise<void>
+  /** Whether demoWhenEmpty fallback is active (live data returned empty, showing demo data) */
+  isDemoFallback: boolean
 }
 
 export function useCache<T>({
@@ -878,6 +880,7 @@ export function useCache<T>({
     isFailed: state.isFailed,
     consecutiveFailures: state.consecutiveFailures,
     lastRefresh: state.lastRefresh,
+    isDemoFallback: shouldFallbackToDemo || !effectiveEnabled,
     refetch,
     clearAndRefetch,
   }


### PR DESCRIPTION
## Summary
- **SSE Streaming**: New `/api/benchmarks/reports/stream` endpoint streams benchmark report batches as they're fetched from Google Drive, so cards render progressively instead of waiting for all data
- **Shared Drive fix**: Added `supportsAllDrives=true` to all Google Drive API calls — the benchmark folder lives on a Shared Drive
- **Deep folder traversal**: Fixed traversal to handle the actual 5-level hierarchy (experiment → run → results → individual-result → YAML files)
- **File prefix fix**: Changed from `benchmark_report_stage_` to `benchmark_report` to match actual file names (`benchmark_report,_stage_...`)
- **Demo badge**: Added `isDemoFallback` to `useCache` return type and wired it through all 6 benchmark cards, replacing `useCardDemoState` with the hook's built-in fallback signal

## Test plan
- [ ] Backend streams batches via SSE when hitting `/api/benchmarks/reports/stream`
- [ ] Cards populate progressively as batches arrive
- [ ] Demo badge + yellow border appear when backend is unavailable
- [ ] `npm run build` and `go build ./...` pass
- [ ] Non-streaming endpoint `/api/benchmarks/reports` still works as cache fallback