### PR TITLE
✨ Convert REST-only hooks to SSE streaming + parallel fetching

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -492,6 +492,9 @@ func (s *Server) setupRoutes() {
 	api.Get("/mcp/events/stream", mcpHandlers.GetEventsStream)
 	api.Get("/mcp/services/stream", mcpHandlers.GetServicesStream)
 	api.Get("/mcp/security-issues/stream", mcpHandlers.CheckSecurityIssuesStream)
+	api.Get("/mcp/nodes/stream", mcpHandlers.GetNodesStream)
+	api.Get("/mcp/gpu-nodes/stream", mcpHandlers.GetGPUNodesStream)
+	api.Get("/mcp/events/warnings/stream", mcpHandlers.GetWarningEventsStream)
 
 	// GitOps routes (drift detection and sync)
 	// SECURITY: All GitOps routes require authentication in both dev and production modes

--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -53,7 +53,7 @@ class KubectlProxy {
   // Request queue to prevent overwhelming the WebSocket
   private requestQueue: QueuedRequest[] = []
   private activeRequests = 0
-  private readonly maxConcurrentRequests = 2 // Limit concurrent requests to local agent
+  private readonly maxConcurrentRequests = 4 // Limit concurrent requests to local agent
 
   /**
    * Ensure WebSocket is connected


### PR DESCRIPTION
## Summary
- **Phase 1**: Parallelize LLMd hooks — convert sequential cluster loops to `Promise.allSettled` with progressive callbacks, parallelize HPA/VA/VPA autoscaler queries within each cluster
- **Phase 2**: Add backend SSE endpoints for Nodes, GPUNodes, WarningEvents — 3 new Go handlers using `streamClusters()` generic helper
- **Phase 2**: Add frontend `useCachedNodes` and `useCachedWarningEvents` hooks with SSE progressive fetching via `fetchViaSSE<T>()`
- Bump `kubectlProxy.maxConcurrentRequests` from 2→4 to support increased parallel kubectl calls

## Test plan
- [ ] Verify frontend builds clean (`npm run build`)
- [ ] Verify Go backend builds clean (`go build .`)
- [ ] Verify AI/ML dashboard loads faster with parallel LLMd fetching
- [ ] Verify nodes/gpu/events dashboards show progressive card population via SSE
- [ ] Verify demo mode still works (SSE disabled, demo data returned)
- [ ] Verify existing SSE-enabled hooks still function correctly