### PR TITLE
⚡ Fix production card loading — 17x warm start, 3.6x cold start

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1271,12 +1271,16 @@ export async function fullFetchClusters() {
     updateClusterCache({ isLoading: true, isRefreshing: true })
   }
 
-  // Helper to ensure minimum visible duration for refresh animation
+  // Helper to ensure minimum visible duration for refresh animation.
+  // On initial load (no cached data), skip the delay — show data ASAP.
+  // On refresh (cached data visible), enforce minimum so indicator is readable.
   const finishWithMinDuration = async (updates: Partial<typeof clusterCache>) => {
-    const elapsed = Date.now() - startTime
-    const minDuration = MIN_REFRESH_INDICATOR_MS
-    if (elapsed < minDuration) {
-      await new Promise(resolve => setTimeout(resolve, minDuration - elapsed))
+    if (hasCachedData) {
+      const elapsed = Date.now() - startTime
+      const minDuration = MIN_REFRESH_INDICATOR_MS
+      if (elapsed < minDuration) {
+        await new Promise(resolve => setTimeout(resolve, minDuration - elapsed))
+      }
     }
     fetchInProgress = false
     updateClusterCache(updates)

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -126,6 +126,7 @@ manualChunks: (id) => {
         './src/components/marketplace/Marketplace.tsx',
         './src/components/llmd-benchmarks/LLMdBenchmarks.tsx',
         './src/components/settings/Settings.tsx',
+        './src/components/namespaces/NamespaceManager.tsx',
         // Card registries and bundles
         './src/components/cards/cardRegistry.ts',
         './src/components/cards/deploy-bundle.ts',


### PR DESCRIPTION
## Summary

- **Remove inner Suspense with null fallback** from `cardRegistry.ts` — cards had two nested Suspense boundaries where the inner one (returning null) swallowed the suspension, hiding CardWrapper's visible CardSkeleton. Now the outer Suspense catches lazy chunk loading directly.
- **Skip 500ms artificial delay on initial load** in `shared.ts` — `MIN_REFRESH_INDICATOR_MS` was enforced even with no cached data, adding unnecessary delay to every cold start.
- **Prefetch default dashboard card chunks immediately** in `App.tsx` — card chunks weren't fetched until lazy-loaded `Dashboard.tsx` mounted. Now `DataPrefetchInit` kicks off chunk downloads for default cards as soon as auth completes.
- **Add NamespaceManager to Vite warmup** and missing `console_ai_offline_detection` preloader entry.

### Production timing results

| Scenario | Before | After | Improvement |
|----------|--------|-------|-------------|
| Warm start | 9.2s | 521ms | **17.7x faster** |
| Cold start | 9.6s | 2.7s | **3.6x faster** |

## Test plan

- [x] `npm run build` — builds clean
- [x] `npm run lint` — no new errors (pre-existing only)
- [x] Production warm start: content visible at 521ms (was 9.2s)
- [x] Production cold start: content visible at 2.7s (was 9.6s)
- [x] CDP screenshots confirm visible card content at 3s mark
- [ ] Verify skeleton is visible during cold start chunk loading
- [ ] Check all dashboard navigation works (no Suspense regressions)