### PR TITLE
🐛 Fix benchmark cards showing demo data in live mode

### DIFF
--- a/pkg/api/handlers/benchmarks.go
+++ b/pkg/api/handlers/benchmarks.go
@@ -443,7 +443,7 @@ func (h *BenchmarkHandlers) GetReports(c *fiber.Ctx) error {
 		})
 	}
 
-	since := c.Query("since", "30d")
+	since := c.Query("since", "0")
 
 	// Try cache first
 	if reports, ok := h.cache.get(since); ok {
@@ -489,7 +489,7 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 		})
 	}
 
-	since := c.Query("since", "30d")
+	since := c.Query("since", "0")
 
 	// If cache is fresh, send it all at once
 	if reports, ok := h.cache.get(since); ok {

--- a/web/src/hooks/useBenchmarkData.ts
+++ b/web/src/hooks/useBenchmarkData.ts
@@ -44,7 +44,7 @@ let streamState: StreamState = {
   isDone: false,
   status: '',
   error: null,
-  since: '30d',
+  since: '0',
 }
 
 const subscribers = new Set<() => void>()


### PR DESCRIPTION
## Summary
- Default `since=30d` filter was excluding all Google Drive benchmark data (created Oct 2025)
- Changed default to `0` (no filter) on both backend and frontend
- Benchmark cards now show live data from Google Drive instead of demo fallback

## Test plan
- [x] Navigate to llm-d Benchmarks page — cards show real data (Qwen3-0.6B, H100, etc.)
- [x] No "Demo" badge visible
- [x] Build passes