### PR TITLE
🐛 Fix leaderboard pagination rendering duplicate rows + taller Pareto card

### DIFF
--- a/web/src/components/cards/llmd/HardwareLeaderboard.tsx
+++ b/web/src/components/cards/llmd/HardwareLeaderboard.tsx
@@ -162,7 +162,7 @@ export function HardwareLeaderboard() {
           <tbody>
             {rows.map(row => (
               <tr
-                key={row.report.run.uid}
+                key={row.rank}
                 className={`border-b border-slate-800/50 transition-colors hover:bg-slate-800/30 ${
                   row.config !== 'standalone' ? 'bg-blue-500/[0.03]' : ''
                 }`}

--- a/web/src/config/dashboards/llmd-benchmarks.ts
+++ b/web/src/config/dashboards/llmd-benchmarks.ts
@@ -14,7 +14,7 @@ export const llmdBenchmarksDashboardConfig: UnifiedDashboardConfig = {
   statsType: 'ai-ml',
   cards: [
     { id: 'bench-hero-1', cardType: 'benchmark_hero', title: 'Latest Benchmark', position: { w: 12, h: 3 } },
-    { id: 'bench-pareto-1', cardType: 'pareto_frontier', title: 'Pareto Frontier', position: { w: 12, h: 5 } },
+    { id: 'bench-pareto-1', cardType: 'pareto_frontier', title: 'Pareto Frontier', position: { w: 12, h: 10 } },
     { id: 'bench-leaderboard-1', cardType: 'hardware_leaderboard', title: 'Hardware Leaderboard', position: { w: 12, h: 5 } },
     { id: 'bench-latency-1', cardType: 'latency_breakdown', title: 'Latency Breakdown', position: { w: 12, h: 4 } },
     { id: 'bench-throughput-1', cardType: 'throughput_comparison', title: 'Throughput Comparison', position: { w: 12, h: 4 } },

--- a/web/src/lib/llmd/benchmarkMockData.ts
+++ b/web/src/lib/llmd/benchmarkMockData.ts
@@ -595,12 +595,15 @@ export function computeParetoFrontier(points: ParetoPoint[]): ParetoPoint[] {
 export function generateLeaderboardRows(reports: BenchmarkReport[]): LeaderboardRow[] {
   const points = extractParetoPoints(reports)
 
+  // Build uid→report lookup (extractParetoPoints filters nulls, so indices don't match)
+  const reportByUid = new Map(reports.map(r => [r.run.uid, r]))
+
   // Compute composite score: normalize each metric to 0-100, weighted average
   const maxThroughput = Math.max(...points.map(p => p.throughputPerGpu), 1)
   const minTtft = Math.min(...points.map(p => p.ttftP50Ms), 1)
   const minP99 = Math.min(...points.map(p => p.p99LatencyMs), 1)
 
-  const rows: LeaderboardRow[] = points.map((p, i) => {
+  const rows: LeaderboardRow[] = points.map((p) => {
     const throughputScore = (p.throughputPerGpu / maxThroughput) * 100
     const ttftScore = (minTtft / p.ttftP50Ms) * 100
     const p99Score = (minP99 / p.p99LatencyMs) * 100
@@ -631,7 +634,7 @@ export function generateLeaderboardRows(reports: BenchmarkReport[]): Leaderboard
       p99LatencyMs: Math.round(p.p99LatencyMs),
       score: Math.round(score * 10) / 10,
       llmdAdvantage: advantage,
-      report: reports[i],
+      report: reportByUid.get(p.uid) ?? reports[0],
     }
   })
 


### PR DESCRIPTION
## Summary
- **Fix duplicate rows in Hardware Leaderboard**: `generateLeaderboardRows` used `reports[i]` but `i` was the index into the filtered `points` array, not the original `reports`. Multiple rows got the same report reference → duplicate React keys → phantom DOM nodes (30+ rows rendered when page size was 10).
- **Fix React key**: Changed from `row.report.run.uid` (not unique) to `row.rank` (unique sequential rank).
- **Taller Pareto Frontier**: Default height increased from h:5 to h:10 for better chart visibility.

## Test plan
- [x] Build passes (`npm run build`)
- [x] Pagination shows exactly 10 rows per page (verified via CDP)
- [x] Pagination controls show correct total (174 configs across 18 pages)
- [x] Page navigation works (next/prev buttons)
- [x] Live data streams correctly with no Demo badges