### PR TITLE
🌱 Increase Pareto Frontier card height to h:16

### DIFF
--- a/web/src/config/dashboards/llmd-benchmarks.ts
+++ b/web/src/config/dashboards/llmd-benchmarks.ts
@@ -14,7 +14,7 @@ export const llmdBenchmarksDashboardConfig: UnifiedDashboardConfig = {
   statsType: 'ai-ml',
   cards: [
     { id: 'bench-hero-1', cardType: 'benchmark_hero', title: 'Latest Benchmark', position: { w: 12, h: 3 } },
-    { id: 'bench-pareto-1', cardType: 'pareto_frontier', title: 'Pareto Frontier', position: { w: 12, h: 10 } },
+    { id: 'bench-pareto-1', cardType: 'pareto_frontier', title: 'Pareto Frontier', position: { w: 12, h: 16 } },
     { id: 'bench-leaderboard-1', cardType: 'hardware_leaderboard', title: 'Hardware Leaderboard', position: { w: 12, h: 5 } },
     { id: 'bench-latency-1', cardType: 'latency_breakdown', title: 'Latency Breakdown', position: { w: 12, h: 4 } },
     { id: 'bench-throughput-1', cardType: 'throughput_comparison', title: 'Throughput Comparison', position: { w: 12, h: 4 } },


### PR DESCRIPTION
## Summary
- Pareto Frontier card height increased from h:10 to h:16 for better scatter plot visibility

## Test plan
- [x] Chart renders with more vertical space for data point separation