### PR TITLE
✨ Nightly E2E Status card for llm-d Benchmarks dashboard

### DIFF
--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -148,6 +148,7 @@ const LLMdBenchmarks = lazy(() => _llmdBundle.then(m => ({ default: m.LLMdBenchm
 const LLMdAIInsights = lazy(() => _llmdBundle.then(m => ({ default: m.LLMdAIInsights })))
 const LLMdConfigurator = lazy(() => _llmdBundle.then(m => ({ default: m.LLMdConfigurator })))
 // LLM-d benchmark dashboard cards (share the same barrel bundle)
+const NightlyE2EStatus = lazy(() => _llmdBundle.then(m => ({ default: m.NightlyE2EStatus })))
 const BenchmarkHero = lazy(() => _llmdBundle.then(m => ({ default: m.BenchmarkHero })))
 const ParetoFrontier = lazy(() => _llmdBundle.then(m => ({ default: m.ParetoFrontier })))
 const HardwareLeaderboard = lazy(() => _llmdBundle.then(m => ({ default: m.HardwareLeaderboard })))
@@ -383,6 +384,7 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   llmd_configurator: LLMdConfigurator,
 
   // LLM-d benchmark dashboard cards
+  nightly_e2e_status: NightlyE2EStatus,
   benchmark_hero: BenchmarkHero,
   pareto_frontier: ParetoFrontier,
   hardware_leaderboard: HardwareLeaderboard,
@@ -635,6 +637,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   llmd_ai_insights: () => import('./llmd'),
   llmd_configurator: () => import('./llmd'),
   // LLM-d benchmark dashboard cards — all share the llmd barrel bundle
+  nightly_e2e_status: () => import('./llmd'),
   benchmark_hero: () => import('./llmd'),
   pareto_frontier: () => import('./llmd'),
   hardware_leaderboard: () => import('./llmd'),
@@ -751,6 +754,8 @@ export const LIVE_DATA_CARDS = new Set([
   'kagenti_agent_discovery',
   'kagenti_security',
   'kagenti_topology',
+  // Nightly E2E status card — fetches GitHub Actions workflow runs
+  'nightly_e2e_status',
 ])
 
 /**
@@ -818,6 +823,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   llmd_configurator: 4,   // Configurator showcase
 
   // LLM-d benchmark dashboard cards (all full-width)
+  nightly_e2e_status: 12,
   benchmark_hero: 12,
   pareto_frontier: 12,
   hardware_leaderboard: 12,

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -1,0 +1,274 @@
+/**
+ * NightlyE2EStatus — Report card for llm-d nightly E2E workflow status
+ *
+ * Shows per-guide pass/fail history with colored run dots, trend indicators,
+ * and aggregate statistics. Grouped by platform (OCP, GKE).
+ * Fetches from GitHub Actions API; falls back to demo data without a token.
+ */
+import { useMemo } from 'react'
+import { motion } from 'framer-motion'
+import {
+  TestTube2, ExternalLink, TrendingUp, TrendingDown, Minus,
+  CheckCircle, XCircle, Loader2, AlertTriangle,
+} from 'lucide-react'
+import { useReportCardDataState } from '../CardDataContext'
+import { useNightlyE2EData } from '../../../hooks/useNightlyE2EData'
+import type { NightlyGuideStatus, NightlyRun } from '../../../lib/llmd/nightlyE2EDemoData'
+
+const PLATFORM_ORDER = ['OCP', 'GKE'] as const
+
+const PLATFORM_COLORS: Record<string, string> = {
+  OCP: '#ef4444',  // red
+  GKE: '#3b82f6',  // blue
+}
+
+function formatTimeAgo(iso: string): string {
+  const seconds = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (seconds < 60) return 'just now'
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+function RunDot({ run }: { run: NightlyRun }) {
+  const isRunning = run.status === 'in_progress'
+  const color = isRunning
+    ? 'bg-blue-400'
+    : run.conclusion === 'success'
+      ? 'bg-emerald-400'
+      : run.conclusion === 'failure'
+        ? 'bg-red-400'
+        : run.conclusion === 'cancelled'
+          ? 'bg-slate-500'
+          : 'bg-yellow-400'
+
+  const title = isRunning
+    ? `Running (started ${formatTimeAgo(run.createdAt)})`
+    : `${run.conclusion} — ${formatTimeAgo(run.createdAt)}`
+
+  return (
+    <a
+      href={run.htmlUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={title}
+      className="group relative"
+      onClick={e => e.stopPropagation()}
+    >
+      <div className={`w-3 h-3 rounded-full ${color} ${isRunning ? 'animate-pulse' : ''} group-hover:ring-2 group-hover:ring-white/30 transition-all`} />
+    </a>
+  )
+}
+
+function TrendIndicator({ trend, passRate }: { trend: 'up' | 'down' | 'steady'; passRate: number }) {
+  const Icon = trend === 'up' ? TrendingUp : trend === 'down' ? TrendingDown : Minus
+  const color = passRate === 100
+    ? 'text-emerald-400'
+    : passRate >= 70
+      ? 'text-yellow-400'
+      : 'text-red-400'
+
+  return (
+    <div className={`flex items-center gap-1 ${color}`}>
+      <Icon size={12} />
+      <span className="text-xs font-mono">{passRate}%</span>
+    </div>
+  )
+}
+
+function GuideRow({ guide, delay }: { guide: NightlyGuideStatus; delay: number }) {
+  const workflowUrl = `https://github.com/${guide.repo}/actions/workflows/${guide.workflowFile}`
+  const StatusIcon = guide.latestConclusion === 'success'
+    ? CheckCircle
+    : guide.latestConclusion === 'failure'
+      ? XCircle
+      : guide.latestConclusion === 'in_progress'
+        ? Loader2
+        : AlertTriangle
+
+  const iconColor = guide.latestConclusion === 'success'
+    ? 'text-emerald-400'
+    : guide.latestConclusion === 'failure'
+      ? 'text-red-400'
+      : guide.latestConclusion === 'in_progress'
+        ? 'text-blue-400 animate-spin'
+        : 'text-slate-400'
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -8 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.3, delay }}
+      className="flex items-center gap-3 py-1.5 px-2 rounded-lg hover:bg-slate-800/40 transition-colors group"
+    >
+      <StatusIcon size={14} className={`shrink-0 ${iconColor}`} />
+      <span className="text-xs text-slate-200 w-40 truncate shrink-0" title={guide.guide}>
+        {guide.guide}
+      </span>
+      <div className="flex items-center gap-1.5 shrink-0">
+        {guide.runs.map((run) => (
+          <RunDot key={run.id} run={run} />
+        ))}
+        {/* Pad with empty dots if fewer than 7 runs */}
+        {Array.from({ length: Math.max(0, 7 - guide.runs.length) }).map((_, i) => (
+          <div key={`empty-${i}`} className="w-3 h-3 rounded-full bg-slate-700/50" />
+        ))}
+      </div>
+      <TrendIndicator trend={guide.trend} passRate={guide.passRate} />
+      <a
+        href={workflowUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded hover:bg-slate-700"
+        onClick={e => e.stopPropagation()}
+      >
+        <ExternalLink size={12} className="text-slate-400" />
+      </a>
+    </motion.div>
+  )
+}
+
+export function NightlyE2EStatus() {
+  const { guides, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useNightlyE2EData()
+
+  useReportCardDataState({
+    isDemoData: isDemoFallback,
+    isFailed,
+    consecutiveFailures,
+    isLoading,
+    hasData: guides.length > 0,
+  })
+
+  const { stats, grouped, lastRunTime } = useMemo(() => {
+    const total = guides.length
+    const allRuns = guides.flatMap(g => g.runs)
+    const completedRuns = allRuns.filter(r => r.status === 'completed')
+    const passedRuns = completedRuns.filter(r => r.conclusion === 'success')
+    const overallPassRate = completedRuns.length > 0
+      ? Math.round((passedRuns.length / completedRuns.length) * 100)
+      : 0
+
+    const failing = guides.filter(g => g.latestConclusion === 'failure').length
+
+    // Find most recent run across all guides
+    const mostRecent = allRuns
+      .map(r => new Date(r.updatedAt).getTime())
+      .sort((a, b) => b - a)[0]
+
+    // Group by platform
+    const byPlatform = new Map<string, NightlyGuideStatus[]>()
+    for (const p of PLATFORM_ORDER) {
+      const pg = guides.filter(g => g.platform === p)
+      if (pg.length > 0) byPlatform.set(p, pg)
+    }
+
+    return {
+      stats: { total, overallPassRate, failing },
+      grouped: byPlatform,
+      lastRunTime: mostRecent ? new Date(mostRecent).toISOString() : null,
+    }
+  }, [guides])
+
+  return (
+    <div className="p-4 h-full flex flex-col gap-3 overflow-hidden">
+      {/* Stats row */}
+      <div className="grid grid-cols-4 gap-3">
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.05 }}
+          className="bg-slate-800/60 border border-slate-700/50 rounded-xl p-3 text-center"
+        >
+          <div className={`text-xl font-bold ${stats.overallPassRate >= 90 ? 'text-emerald-400' : stats.overallPassRate >= 70 ? 'text-yellow-400' : 'text-red-400'}`}>
+            {stats.overallPassRate}%
+          </div>
+          <div className="text-[10px] text-slate-400 uppercase tracking-wider mt-0.5">Pass Rate</div>
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.1 }}
+          className="bg-slate-800/60 border border-slate-700/50 rounded-xl p-3 text-center"
+        >
+          <div className="text-xl font-bold text-white">{stats.total}</div>
+          <div className="text-[10px] text-slate-400 uppercase tracking-wider mt-0.5">Guides</div>
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.15 }}
+          className="bg-slate-800/60 border border-slate-700/50 rounded-xl p-3 text-center"
+        >
+          <div className={`text-xl font-bold ${stats.failing > 0 ? 'text-red-400' : 'text-emerald-400'}`}>
+            {stats.failing}
+          </div>
+          <div className="text-[10px] text-slate-400 uppercase tracking-wider mt-0.5">Failing</div>
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, delay: 0.2 }}
+          className="bg-slate-800/60 border border-slate-700/50 rounded-xl p-3 text-center"
+        >
+          <div className="text-xl font-bold text-slate-200">
+            {lastRunTime ? formatTimeAgo(lastRunTime) : '—'}
+          </div>
+          <div className="text-[10px] text-slate-400 uppercase tracking-wider mt-0.5">Last Run</div>
+        </motion.div>
+      </div>
+
+      {/* Guide rows grouped by platform */}
+      <div className="flex-1 overflow-y-auto min-h-0 space-y-2">
+        {[...grouped.entries()].map(([platform, platformGuides]) => (
+          <div key={platform}>
+            <div className="flex items-center gap-2 px-2 mb-1">
+              <TestTube2 size={12} style={{ color: PLATFORM_COLORS[platform] }} />
+              <span className="text-[10px] font-semibold uppercase tracking-wider"
+                style={{ color: PLATFORM_COLORS[platform] }}>
+                {platform}
+              </span>
+              <div className="flex-1 h-px bg-slate-700/50" />
+              <span className="text-[10px] text-slate-500">
+                {platformGuides.filter(g => g.latestConclusion === 'success').length}/{platformGuides.length} passing
+              </span>
+            </div>
+            {platformGuides.map((guide, gi) => (
+              <GuideRow
+                key={`${guide.guide}-${guide.platform}`}
+                guide={guide}
+                delay={0.25 + gi * 0.04}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Legend */}
+      <div className="flex items-center justify-center gap-4 text-[10px] text-slate-500 pt-1 border-t border-slate-700/30">
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 rounded-full bg-emerald-400" />
+          <span>pass</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 rounded-full bg-red-400" />
+          <span>fail</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 rounded-full bg-blue-400" />
+          <span>running</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-2 h-2 rounded-full bg-slate-500" />
+          <span>cancelled</span>
+        </div>
+        <span className="text-slate-600">|</span>
+        <span>newest run on left</span>
+      </div>
+    </div>
+  )
+}
+
+export default NightlyE2EStatus

--- a/web/src/components/cards/llmd/index.ts
+++ b/web/src/components/cards/llmd/index.ts
@@ -13,6 +13,7 @@ export { LLMdAIInsights } from './LLMdAIInsights'
 export { LLMdConfigurator } from './LLMdConfigurator'
 
 // Benchmark dashboard cards
+export { NightlyE2EStatus } from './NightlyE2EStatus'
 export { BenchmarkHero } from './BenchmarkHero'
 export { ParetoFrontier } from './ParetoFrontier'
 export { HardwareLeaderboard } from './HardwareLeaderboard'

--- a/web/src/config/dashboards/llmd-benchmarks.ts
+++ b/web/src/config/dashboards/llmd-benchmarks.ts
@@ -13,6 +13,7 @@ export const llmdBenchmarksDashboardConfig: UnifiedDashboardConfig = {
   route: '/llm-d-benchmarks',
   statsType: 'ai-ml',
   cards: [
+    { id: 'bench-nightly-1', cardType: 'nightly_e2e_status', title: 'Nightly E2E Status', position: { w: 12, h: 5 } },
     { id: 'bench-hero-1', cardType: 'benchmark_hero', title: 'Latest Benchmark', position: { w: 12, h: 3 } },
     { id: 'bench-pareto-1', cardType: 'pareto_frontier', title: 'Pareto Frontier', position: { w: 12, h: 10 } },
     { id: 'bench-leaderboard-1', cardType: 'hardware_leaderboard', title: 'Hardware Leaderboard', position: { w: 12, h: 5 } },

--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -1,0 +1,139 @@
+/**
+ * Hook for fetching nightly E2E workflow run status from GitHub Actions API.
+ *
+ * Fetches the last 7 runs for each of the 10 nightly E2E workflows across
+ * llm-d/llm-d and llm-d/llm-d-workload-variant-autoscaler. Uses the GitHub
+ * token from localStorage (base64-encoded, same as GitHubCIMonitor).
+ *
+ * Falls back to demo data when no token is available or the API is unreachable.
+ */
+import { useCache } from '../lib/cache'
+import {
+  NIGHTLY_WORKFLOWS,
+  generateDemoNightlyData,
+  type NightlyGuideStatus,
+  type NightlyRun,
+} from '../lib/llmd/nightlyE2EDemoData'
+
+const RUNS_PER_WORKFLOW = 7
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
+
+const DEMO_DATA = generateDemoNightlyData()
+
+function decodeToken(encoded: string): string {
+  try {
+    return atob(encoded)
+  } catch {
+    return encoded
+  }
+}
+
+function computeTrend(runs: NightlyRun[]): 'up' | 'down' | 'steady' {
+  if (runs.length < 4) return 'steady'
+  const recent = runs.slice(0, 3)
+  const older = runs.slice(3)
+  const recentPass = recent.filter(r => r.conclusion === 'success').length / recent.length
+  const olderPass = older.filter(r => r.conclusion === 'success').length / older.length
+  if (recentPass > olderPass + 0.1) return 'up'
+  if (recentPass < olderPass - 0.1) return 'down'
+  return 'steady'
+}
+
+function computePassRate(runs: NightlyRun[]): number {
+  const completed = runs.filter(r => r.status === 'completed')
+  if (completed.length === 0) return 0
+  return Math.round((completed.filter(r => r.conclusion === 'success').length / completed.length) * 100)
+}
+
+export interface NightlyE2EData {
+  guides: NightlyGuideStatus[]
+  isDemo: boolean
+}
+
+export function useNightlyE2EData() {
+  const cacheResult = useCache<NightlyE2EData>({
+    key: 'nightly-e2e-status',
+    category: 'default',
+    initialData: { guides: DEMO_DATA, isDemo: true },
+    demoData: { guides: DEMO_DATA, isDemo: true },
+    persist: true,
+    refreshInterval: REFRESH_INTERVAL_MS,
+    fetcher: async () => {
+      const storedToken = localStorage.getItem('github_token')
+      const token = storedToken ? decodeToken(storedToken) : null
+      if (!token) {
+        return { guides: DEMO_DATA, isDemo: true }
+      }
+
+      const headers = {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github.v3+json',
+      }
+
+      const results = await Promise.allSettled(
+        NIGHTLY_WORKFLOWS.map(async (wf) => {
+          const url = `https://api.github.com/repos/${wf.repo}/actions/workflows/${wf.workflowFile}/runs?per_page=${RUNS_PER_WORKFLOW}`
+          const res = await fetch(url, { headers })
+          if (res.status === 401 || res.status === 403) {
+            throw new Error('AUTH_FAILED')
+          }
+          if (!res.ok) {
+            throw new Error(`HTTP ${res.status}`)
+          }
+          const data = await res.json()
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const runs: NightlyRun[] = (data.workflow_runs ?? []).map((r: any) => ({
+            id: r.id,
+            status: r.status,
+            conclusion: r.conclusion,
+            createdAt: r.created_at,
+            updatedAt: r.updated_at,
+            htmlUrl: r.html_url,
+            runNumber: r.run_number,
+          }))
+          return { wf, runs }
+        })
+      )
+
+      // If any request got auth failure, fall back to demo
+      const authFailed = results.some(
+        r => r.status === 'rejected' && r.reason?.message === 'AUTH_FAILED'
+      )
+      if (authFailed) {
+        return { guides: DEMO_DATA, isDemo: true }
+      }
+
+      const guides: NightlyGuideStatus[] = NIGHTLY_WORKFLOWS.map((wf, i) => {
+        const result = results[i]
+        const runs = result.status === 'fulfilled' ? result.value.runs : []
+        return {
+          guide: wf.guide,
+          platform: wf.platform,
+          repo: wf.repo,
+          workflowFile: wf.workflowFile,
+          runs,
+          passRate: computePassRate(runs),
+          trend: computeTrend(runs),
+          latestConclusion: runs[0]?.conclusion ?? runs[0]?.status ?? null,
+        }
+      })
+
+      const hasAnyData = guides.some(g => g.runs.length > 0)
+      if (!hasAnyData) {
+        return { guides: DEMO_DATA, isDemo: true }
+      }
+
+      return { guides, isDemo: false }
+    },
+  })
+
+  const { guides, isDemo } = cacheResult.data
+  return {
+    guides,
+    isDemoFallback: isDemo,
+    isLoading: cacheResult.isLoading,
+    isFailed: cacheResult.isFailed,
+    consecutiveFailures: cacheResult.consecutiveFailures,
+    refetch: cacheResult.refetch,
+  }
+}

--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -1,0 +1,115 @@
+/**
+ * Demo data for the Nightly E2E Status card.
+ *
+ * Generates realistic workflow run history for all 10 nightly E2E guides
+ * so the card renders correctly without a GitHub token.
+ */
+
+export interface NightlyWorkflowConfig {
+  repo: string
+  workflowFile: string
+  guide: string
+  platform: 'OCP' | 'GKE'
+}
+
+export interface NightlyRun {
+  id: number
+  status: 'completed' | 'in_progress' | 'queued'
+  conclusion: 'success' | 'failure' | 'cancelled' | 'skipped' | null
+  createdAt: string
+  updatedAt: string
+  htmlUrl: string
+  runNumber: number
+}
+
+export interface NightlyGuideStatus {
+  guide: string
+  platform: 'OCP' | 'GKE'
+  repo: string
+  workflowFile: string
+  runs: NightlyRun[]
+  passRate: number
+  trend: 'up' | 'down' | 'steady'
+  latestConclusion: string | null
+}
+
+export const NIGHTLY_WORKFLOWS: NightlyWorkflowConfig[] = [
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling.yaml', guide: 'Inference Scheduling', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation.yaml', guide: 'PD Disaggregation', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-precise-prefix-cache.yaml', guide: 'Precise Prefix Cache', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-simulated-accelerators.yaml', guide: 'Simulated Accelerators', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-tiered-prefix-cache.yaml', guide: 'Tiered Prefix Cache', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws.yaml', guide: 'Wide EP + LWS', platform: 'OCP' },
+  { repo: 'llm-d/llm-d-workload-variant-autoscaler', workflowFile: 'nightly-e2e-openshift.yaml', guide: 'WVA', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-gke.yaml', guide: 'Inference Scheduling', platform: 'GKE' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-gke.yaml', guide: 'PD Disaggregation', platform: 'GKE' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-gke.yaml', guide: 'Wide EP + LWS', platform: 'GKE' },
+]
+
+// Seeded patterns per guide for deterministic demo data
+const DEMO_PATTERNS: Record<string, ('success' | 'failure' | 'in_progress')[]> = {
+  'Inference Scheduling-OCP': ['success', 'success', 'failure', 'success', 'success', 'success', 'success'],
+  'PD Disaggregation-OCP': ['success', 'success', 'success', 'success', 'success', 'success', 'success'],
+  'Precise Prefix Cache-OCP': ['success', 'failure', 'success', 'success', 'success', 'failure', 'success'],
+  'Simulated Accelerators-OCP': ['success', 'success', 'success', 'success', 'success', 'success', 'success'],
+  'Tiered Prefix Cache-OCP': ['success', 'success', 'success', 'failure', 'success', 'success', 'success'],
+  'Wide EP + LWS-OCP': ['success', 'success', 'success', 'success', 'success', 'success', 'in_progress'],
+  'WVA-OCP': ['success', 'failure', 'success', 'success', 'failure', 'success', 'success'],
+  'Inference Scheduling-GKE': ['success', 'success', 'success', 'success', 'success', 'success', 'success'],
+  'PD Disaggregation-GKE': ['failure', 'success', 'success', 'success', 'success', 'success', 'success'],
+  'Wide EP + LWS-GKE': ['success', 'success', 'success', 'success', 'success', 'success', 'success'],
+}
+
+function computeTrend(runs: NightlyRun[]): 'up' | 'down' | 'steady' {
+  if (runs.length < 4) return 'steady'
+  const recent = runs.slice(0, 3)
+  const older = runs.slice(3)
+  const recentPass = recent.filter(r => r.conclusion === 'success').length / recent.length
+  const olderPass = older.filter(r => r.conclusion === 'success').length / older.length
+  if (recentPass > olderPass + 0.1) return 'up'
+  if (recentPass < olderPass - 0.1) return 'down'
+  return 'steady'
+}
+
+function computePassRate(runs: NightlyRun[]): number {
+  const completed = runs.filter(r => r.status === 'completed')
+  if (completed.length === 0) return 0
+  return Math.round((completed.filter(r => r.conclusion === 'success').length / completed.length) * 100)
+}
+
+export function generateDemoNightlyData(): NightlyGuideStatus[] {
+  const now = Date.now()
+  const DAY_MS = 24 * 60 * 60 * 1000
+
+  return NIGHTLY_WORKFLOWS.map((wf, wfIdx) => {
+    const key = `${wf.guide}-${wf.platform}`
+    const pattern = DEMO_PATTERNS[key] ?? ['success', 'success', 'success', 'success', 'success', 'success', 'success']
+
+    const runs: NightlyRun[] = pattern.map((result, i) => {
+      const createdAt = new Date(now - (i * DAY_MS) - (2 * 60 * 60 * 1000)) // 2am each night
+      const duration = result === 'in_progress' ? 0 : (30 + Math.random() * 30) * 60 * 1000 // 30-60 min
+      const updatedAt = result === 'in_progress' ? new Date() : new Date(createdAt.getTime() + duration)
+
+      return {
+        id: 10000 + wfIdx * 100 + i,
+        status: result === 'in_progress' ? 'in_progress' : 'completed',
+        conclusion: result === 'in_progress' ? null : result,
+        createdAt: createdAt.toISOString(),
+        updatedAt: updatedAt.toISOString(),
+        htmlUrl: `https://github.com/${wf.repo}/actions/workflows/${wf.workflowFile}`,
+        runNumber: 100 - i,
+      }
+    })
+
+    return {
+      guide: wf.guide,
+      platform: wf.platform,
+      repo: wf.repo,
+      workflowFile: wf.workflowFile,
+      runs,
+      passRate: computePassRate(runs),
+      trend: computeTrend(runs),
+      latestConclusion: runs[0]?.conclusion ?? runs[0]?.status ?? null,
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- Adds a new **Nightly E2E Status** card at the top of the llm-d Benchmarks dashboard
- Monitors all 10 nightly E2E workflows across `llm-d/llm-d` (9 workflows) and `llm-d/llm-d-workload-variant-autoscaler` (1 workflow)
- Shows aggregate stats (pass rate, total guides, failing count, last run time), per-guide rows with 7 colored run dots, trend indicators, and external links
- Grouped by platform (OCP first, then GKE)
- Fetches from GitHub Actions API using the stored GitHub token; falls back to demo data when no token is available

## Workflows Monitored
| Guide | Platforms |
|-------|-----------|
| Inference Scheduling | OCP, GKE |
| PD Disaggregation | OCP, GKE |
| Precise Prefix Cache | OCP |
| Simulated Accelerators | OCP |
| Tiered Prefix Cache | OCP |
| Wide EP + LWS | OCP, GKE |
| WVA | OCP |

## New Files
- `web/src/hooks/useNightlyE2EData.ts` — Data hook (GitHub Actions API + demo fallback)
- `web/src/lib/llmd/nightlyE2EDemoData.ts` — Demo data generator
- `web/src/components/cards/llmd/NightlyE2EStatus.tsx` — Card component

## Test plan
- [ ] `go build ./...` passes
- [ ] `npm run build` passes
- [ ] `npm run lint` — no new errors (77 pre-existing)
- [ ] Navigate to llm-d Benchmarks dashboard — card appears at top
- [ ] Without GitHub token: demo data renders with yellow Demo badge
- [ ] With GitHub token: real workflow runs display with colored dots
- [ ] External links open correct GitHub Actions pages