### PR TITLE
✨ Nightly E2E: acronyms, benchmarking, CKS platform, widget catalog

### DIFF
--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -15,11 +15,12 @@ import { useReportCardDataState } from '../CardDataContext'
 import { useNightlyE2EData } from '../../../hooks/useNightlyE2EData'
 import type { NightlyGuideStatus, NightlyRun } from '../../../lib/llmd/nightlyE2EDemoData'
 
-const PLATFORM_ORDER = ['OCP', 'GKE'] as const
+const PLATFORM_ORDER = ['OCP', 'GKE', 'CKS'] as const
 
 const PLATFORM_COLORS: Record<string, string> = {
   OCP: '#ef4444',  // red
   GKE: '#3b82f6',  // blue
+  CKS: '#a855f7',  // purple
 }
 
 function formatTimeAgo(iso: string): string {
@@ -105,7 +106,8 @@ function GuideRow({ guide, delay }: { guide: NightlyGuideStatus; delay: number }
       className="flex items-center gap-3 py-1.5 px-2 rounded-lg hover:bg-slate-800/40 transition-colors group"
     >
       <StatusIcon size={14} className={`shrink-0 ${iconColor}`} />
-      <span className="text-xs text-slate-200 w-40 truncate shrink-0" title={guide.guide}>
+      <span className="text-xs text-slate-200 w-48 truncate shrink-0" title={guide.guide}>
+        <span className="font-mono font-semibold text-slate-400 mr-1.5">{guide.acronym}</span>
         {guide.guide}
       </span>
       <div className="flex items-center gap-1.5 shrink-0">

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -93,6 +93,7 @@ import { namespaceOverviewConfig } from './namespace-overview'
 import { namespaceQuotasConfig } from './namespace-quotas'
 import { namespaceRbacConfig } from './namespace-rbac'
 import { namespaceStatusConfig } from './namespace-status'
+import { nightlyE2eStatusConfig } from './nightly-e2e-status'
 import { networkOverviewConfig } from './network-overview'
 import { networkPolicyStatusConfig } from './network-policy-status'
 import { networkUtilsConfig } from './network-utils'
@@ -239,6 +240,7 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   namespace_quotas: namespaceQuotasConfig,
   namespace_rbac: namespaceRbacConfig,
   namespace_status: namespaceStatusConfig,
+  nightly_e2e_status: nightlyE2eStatusConfig,
   network_overview: networkOverviewConfig,
   network_policy_status: networkPolicyStatusConfig,
   network_utils: networkUtilsConfig,

--- a/web/src/config/cards/nightly-e2e-status.ts
+++ b/web/src/config/cards/nightly-e2e-status.ts
@@ -1,0 +1,22 @@
+/**
+ * Nightly E2E Status Card Configuration
+ */
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const nightlyE2eStatusConfig: UnifiedCardConfig = {
+  type: 'nightly_e2e_status',
+  title: 'Nightly E2E Status',
+  category: 'ci-cd',
+  description: 'llm-d nightly E2E workflow status across OCP and GKE platforms',
+  icon: 'TestTube2',
+  iconColor: 'text-emerald-400',
+  defaultWidth: 12,
+  defaultHeight: 5,
+  dataSource: { type: 'hook', hook: 'useNightlyE2EData' },
+  content: { type: 'custom', component: 'NightlyE2EStatusView' },
+  emptyState: { icon: 'TestTube2', title: 'No E2E Data', message: 'Configure a GitHub token to see nightly E2E status', variant: 'info' },
+  loadingState: { type: 'custom' },
+  isDemoData: false,
+  isLive: true,
+}
+export default nightlyE2eStatusConfig

--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -108,6 +108,7 @@ export function useNightlyE2EData() {
         const runs = result.status === 'fulfilled' ? result.value.runs : []
         return {
           guide: wf.guide,
+          acronym: wf.acronym,
           platform: wf.platform,
           repo: wf.repo,
           workflowFile: wf.workflowFile,

--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -9,7 +9,8 @@ export interface NightlyWorkflowConfig {
   repo: string
   workflowFile: string
   guide: string
-  platform: 'OCP' | 'GKE'
+  acronym: string
+  platform: 'OCP' | 'GKE' | 'CKS'
 }
 
 export interface NightlyRun {
@@ -24,7 +25,8 @@ export interface NightlyRun {
 
 export interface NightlyGuideStatus {
   guide: string
-  platform: 'OCP' | 'GKE'
+  acronym: string
+  platform: 'OCP' | 'GKE' | 'CKS'
   repo: string
   workflowFile: string
   runs: NightlyRun[]
@@ -34,20 +36,30 @@ export interface NightlyGuideStatus {
 }
 
 export const NIGHTLY_WORKFLOWS: NightlyWorkflowConfig[] = [
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling.yaml', guide: 'Inference Scheduling', platform: 'OCP' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation.yaml', guide: 'PD Disaggregation', platform: 'OCP' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-precise-prefix-cache.yaml', guide: 'Precise Prefix Cache', platform: 'OCP' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-simulated-accelerators.yaml', guide: 'Simulated Accelerators', platform: 'OCP' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-tiered-prefix-cache.yaml', guide: 'Tiered Prefix Cache', platform: 'OCP' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws.yaml', guide: 'Wide EP + LWS', platform: 'OCP' },
-  { repo: 'llm-d/llm-d-workload-variant-autoscaler', workflowFile: 'nightly-e2e-openshift.yaml', guide: 'WVA', platform: 'OCP' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-gke.yaml', guide: 'Inference Scheduling', platform: 'GKE' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-gke.yaml', guide: 'PD Disaggregation', platform: 'GKE' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-gke.yaml', guide: 'Wide EP + LWS', platform: 'GKE' },
+  // OCP
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-precise-prefix-cache.yaml', guide: 'Precise Prefix Cache', acronym: 'PPC', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-simulated-accelerators.yaml', guide: 'Simulated Accelerators', acronym: 'SA', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-tiered-prefix-cache.yaml', guide: 'Tiered Prefix Cache', acronym: 'TPC', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'OCP' },
+  { repo: 'llm-d/llm-d-workload-variant-autoscaler', workflowFile: 'nightly-e2e-openshift.yaml', guide: 'WVA', acronym: 'WVA', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-benchmarking.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'OCP' },
+  // GKE
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-gke.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'GKE' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-gke.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'GKE' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-gke.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'GKE' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-benchmarking-gke.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'GKE' },
+  // CKS (same tests as GKE — workflows not yet created)
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-cks.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'CKS' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-cks.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'CKS' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-cks.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'CKS' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-benchmarking-cks.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'CKS' },
 ]
 
 // Seeded patterns per guide for deterministic demo data
 const DEMO_PATTERNS: Record<string, ('success' | 'failure' | 'in_progress')[]> = {
+  // OCP
   'Inference Scheduling-OCP': ['success', 'success', 'failure', 'success', 'success', 'success', 'success'],
   'PD Disaggregation-OCP': ['success', 'success', 'success', 'success', 'success', 'success', 'success'],
   'Precise Prefix Cache-OCP': ['success', 'failure', 'success', 'success', 'success', 'failure', 'success'],
@@ -55,9 +67,13 @@ const DEMO_PATTERNS: Record<string, ('success' | 'failure' | 'in_progress')[]> =
   'Tiered Prefix Cache-OCP': ['success', 'success', 'success', 'failure', 'success', 'success', 'success'],
   'Wide EP + LWS-OCP': ['success', 'success', 'success', 'success', 'success', 'success', 'in_progress'],
   'WVA-OCP': ['success', 'failure', 'success', 'success', 'failure', 'success', 'success'],
+  'Benchmarking-OCP': ['failure', 'failure', 'success', 'failure', 'success', 'failure', 'success'],
+  // GKE
   'Inference Scheduling-GKE': ['success', 'success', 'success', 'success', 'success', 'success', 'success'],
   'PD Disaggregation-GKE': ['failure', 'success', 'success', 'success', 'success', 'success', 'success'],
   'Wide EP + LWS-GKE': ['success', 'success', 'success', 'success', 'success', 'success', 'success'],
+  'Benchmarking-GKE': ['in_progress', 'success', 'success', 'failure', 'success', 'success', 'success'],
+  // CKS — no runs yet, empty arrays
 }
 
 function computeTrend(runs: NightlyRun[]): 'up' | 'down' | 'steady' {
@@ -103,6 +119,7 @@ export function generateDemoNightlyData(): NightlyGuideStatus[] {
 
     return {
       guide: wf.guide,
+      acronym: wf.acronym,
       platform: wf.platform,
       repo: wf.repo,
       workflowFile: wf.workflowFile,


### PR DESCRIPTION
## Summary
- Display acronym labels (IS, PD, PPC, SA, TPC, WEP, WVA, BM) next to guide names in the Nightly E2E Status card
- Add Benchmarking (BM) workflows for OCP and GKE platforms
- Add CKS platform section with same tests as GKE (no runs yet — workflows pending creation)
- Register `nightly_e2e_status` in the card catalog so it appears in the Add Card widget picker

## Test plan
- [ ] Navigate to llm-d Benchmarks dashboard — card shows acronyms next to each guide name
- [ ] Verify OCP section shows 8 guides (IS, PD, PPC, SA, TPC, WEP, WVA, BM)
- [ ] Verify GKE section shows 4 guides (IS, PD, WEP, BM)
- [ ] Verify CKS section shows 4 guides with empty dots (no workflow runs yet)
- [ ] Open Add Card modal — Nightly E2E Status appears in the CI/CD category