### PR TITLE
✨ Wire GITHUB_TOKEN + GOOGLE_DRIVE_API_KEY into CI deployments

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -117,6 +117,8 @@ jobs:
             --from-literal=github-client-id=${{ secrets.KSC_OAUTH_CLIENT_ID }} \
             --from-literal=github-client-secret=${{ secrets.KSC_OAUTH_CLIENT_SECRET }} \
             --from-literal=jwt-secret=${{ secrets.KSC_JWT_SECRET }} \
+            --from-literal=github-token=${{ secrets.KSC_GITHUB_TOKEN }} \
+            --from-literal=google-drive-api-key=${{ secrets.KSC_GOOGLE_DRIVE_API_KEY }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy with Helm
@@ -127,6 +129,8 @@ jobs:
             --set image.tag=${{ github.sha }} \
             --set github.existingSecret=kc-secrets \
             --set jwt.existingSecret=kc-secrets \
+            --set githubToken.existingSecret=kc-secrets \
+            --set googleDrive.existingSecret=kc-secrets \
             --set route.enabled=true \
             --set route.host=kc.apps.fmaas-vllm-d.fmaas.res.ibm.com \
             --wait \
@@ -167,6 +171,8 @@ jobs:
             --from-literal=github-client-id=${{ secrets.KSC_OAUTH_CLIENT_ID }} \
             --from-literal=github-client-secret=${{ secrets.KSC_OAUTH_CLIENT_SECRET }} \
             --from-literal=jwt-secret=${{ secrets.KSC_JWT_SECRET }} \
+            --from-literal=github-token=${{ secrets.KSC_GITHUB_TOKEN }} \
+            --from-literal=google-drive-api-key=${{ secrets.KSC_GOOGLE_DRIVE_API_KEY }} \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy with Helm
@@ -177,6 +183,8 @@ jobs:
             --set image.tag=${{ github.sha }} \
             --set github.existingSecret=kc-kubestellar-console \
             --set jwt.existingSecret=kc-kubestellar-console \
+            --set githubToken.existingSecret=kc-kubestellar-console \
+            --set googleDrive.existingSecret=kc-kubestellar-console \
             --set route.enabled=true \
             --set route.host=kc-kubestellar-console-kubestellar-console.apps.pokprod001.ete14.res.ibm.com \
             --wait \

--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -98,6 +98,22 @@ spec:
                   name: {{ .Values.claude.existingSecret | default (include "kubestellar-console.fullname" .) }}
                   key: {{ .Values.claude.existingSecretKey | default "claude-api-key" }}
             {{- end }}
+            {{- if or .Values.githubToken.existingSecret .Values.githubToken.token }}
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.githubToken.existingSecret | default (include "kubestellar-console.fullname" .) }}
+                  key: {{ .Values.githubToken.existingSecretKey | default "github-token" }}
+            {{- end }}
+            {{- if or .Values.googleDrive.existingSecret .Values.googleDrive.apiKey }}
+            - name: GOOGLE_DRIVE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.googleDrive.existingSecret | default (include "kubestellar-console.fullname" .) }}
+                  key: {{ .Values.googleDrive.existingSecretKey | default "google-drive-api-key" }}
+            - name: BENCHMARK_FOLDER_ID
+              value: {{ .Values.googleDrive.folderId | quote }}
+            {{- end }}
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/kubestellar-console/templates/secret.yaml
+++ b/deploy/helm/kubestellar-console/templates/secret.yaml
@@ -15,4 +15,10 @@ data:
   {{- if .Values.claude.apiKey }}
   claude-api-key: {{ .Values.claude.apiKey | b64enc | quote }}
   {{- end }}
+  {{- if .Values.githubToken.token }}
+  github-token: {{ .Values.githubToken.token | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.googleDrive.apiKey }}
+  google-drive-api-key: {{ .Values.googleDrive.apiKey | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -69,6 +69,19 @@ github:
     clientId: github-client-id
     clientSecret: github-client-secret
 
+# GitHub token for server-side API access (nightly E2E status, etc.)
+githubToken:
+  token: ""
+  existingSecret: ""
+  existingSecretKey: github-token
+
+# Google Drive API key for benchmark data
+googleDrive:
+  apiKey: ""
+  existingSecret: ""
+  existingSecretKey: google-drive-api-key
+  folderId: "1r2Z2Xp1L0KonUlvQHvEzed8AO9Xj8IPm"
+
 # Claude AI configuration (optional)
 claude:
   apiKey: ""


### PR DESCRIPTION
## Summary
- Nightly E2E Status card and benchmark cards were stuck in demo mode on deployed instances (vllm-d, pok-prod-sa) because server-side API tokens were not configured
- Added `github-token` and `google-drive-api-key` to K8s secrets in both deploy jobs
- Added Helm values (`githubToken`, `googleDrive`) with `existingSecret` support
- Wired `GITHUB_TOKEN`, `GOOGLE_DRIVE_API_KEY`, and `BENCHMARK_FOLDER_ID` env vars in deployment template

## Action required
Add these GitHub repo secrets before the next deploy:
- **`KSC_GITHUB_TOKEN`** — GitHub PAT with `public_repo` scope (for nightly E2E workflow status)
- **`KSC_GOOGLE_DRIVE_API_KEY`** — Google Drive API key (for benchmark data streaming)

## Deployed URLs
- **vllm-d**: https://kc.apps.fmaas-vllm-d.fmaas.res.ibm.com/llm-d-benchmarks
- **pok-prod-sa**: https://kc-kubestellar-console-kubestellar-console.apps.pokprod001.ete14.res.ibm.com/llm-d-benchmarks

## Test plan
- [ ] Add `KSC_GITHUB_TOKEN` and `KSC_GOOGLE_DRIVE_API_KEY` as GitHub repo secrets
- [ ] Merge PR — CI triggers deploy to both clusters
- [ ] Verify vllm-d: nightly E2E card shows live data (no Demo badge)
- [ ] Verify vllm-d: benchmark cards show real data from Google Drive
- [ ] Verify pok-prod-sa: same checks