### PR TITLE
🐛 Fix dashboard card height not applying from config

### DIFF
--- a/web/src/config/dashboards/llmd-benchmarks.ts
+++ b/web/src/config/dashboards/llmd-benchmarks.ts
@@ -15,7 +15,7 @@ export const llmdBenchmarksDashboardConfig: UnifiedDashboardConfig = {
   cards: [
     { id: 'bench-nightly-1', cardType: 'nightly_e2e_status', title: 'Nightly E2E Status', position: { w: 12, h: 5 } },
     { id: 'bench-hero-1', cardType: 'benchmark_hero', title: 'Latest Benchmark', position: { w: 12, h: 3 } },
-    { id: 'bench-pareto-1', cardType: 'pareto_frontier', title: 'Pareto Frontier', position: { w: 12, h: 16 } },
+    { id: 'bench-pareto-1', cardType: 'pareto_frontier', title: 'Pareto Frontier', position: { w: 12, h: 8 } },
     { id: 'bench-leaderboard-1', cardType: 'hardware_leaderboard', title: 'Hardware Leaderboard', position: { w: 12, h: 5 } },
     { id: 'bench-latency-1', cardType: 'latency_breakdown', title: 'Latency Breakdown', position: { w: 12, h: 4 } },
     { id: 'bench-throughput-1', cardType: 'throughput_comparison', title: 'Throughput Comparison', position: { w: 12, h: 4 } },

--- a/web/src/lib/dashboards/DashboardComponents.tsx
+++ b/web/src/lib/dashboards/DashboardComponents.tsx
@@ -63,7 +63,9 @@ export const SortableDashboardCard = memo(function SortableDashboardCard({
     transition,
     // Only apply multi-column span on desktop; mobile uses single column
     gridColumn: isMobile ? 'span 1' : `span ${cardWidth}`,
-    gridRow: isMobile ? undefined : `span ${cardHeight}`,
+    // Use minHeight instead of gridRow span — CSS Grid auto rows have no
+    // fixed height so `span N` doesn't actually size the element.
+    minHeight: isMobile ? undefined : `${cardHeight * 100}px`,
     opacity: isDragging ? 0.5 : 1,
   }
 


### PR DESCRIPTION
## Summary
- `SortableDashboardCard` used `gridRow: span N` for card height, but CSS Grid auto rows have no fixed height so the spans were a no-op
- Switched to `minHeight` inline style (`cardHeight * 100px`) so height configs actually take effect
- Reduced Pareto Frontier default height from h:16 to h:8 (800px)

## Test plan
- [ ] Navigate to llm-d Benchmarks dashboard
- [ ] Verify Pareto card renders at ~800px height
- [ ] Verify other cards respect their height configs
- [ ] `npm run build` passes clean