### PR TITLE
✨ Add nightly E2E status to widget export registry

### DIFF
--- a/web/src/lib/widgets/widgetRegistry.ts
+++ b/web/src/lib/widgets/widgetRegistry.ts
@@ -261,6 +261,17 @@ export const WIDGET_CARDS: Record<string, WidgetCardDefinition> = {
     defaultSize: { width: 250, height: 180 },
     category: 'workload',
   },
+  // llm-d Nightly E2E
+  nightly_e2e_status: {
+    cardType: 'nightly_e2e_status',
+    displayName: 'Nightly E2E Status',
+    description: 'Pass/fail status of llm-d nightly E2E workflows across OCP, GKE, and CKS',
+    apiEndpoints: ['/api/nightly-e2e/runs'],
+    supportsTheme: true,
+    minRefreshInterval: 300000,
+    defaultSize: { width: 400, height: 300 },
+    category: 'monitoring',
+  },
   // Provider health
   provider_health: {
     cardType: 'provider_health',


### PR DESCRIPTION
## Summary
- Registers `nightly_e2e_status` in `WIDGET_CARDS` so the "Export Widget" option appears in the card's kebab menu on the llm-d Benchmarks dashboard

## Test plan
- [ ] Open llm-d Benchmarks dashboard
- [ ] Click kebab menu on Nightly E2E Status card
- [ ] Verify "Export Widget" option is now visible