### PR TITLE
🐛 Fix Übersicht widget export: render function signature and preview

### DIFF
--- a/web/src/components/widgets/WidgetExportModal.tsx
+++ b/web/src/components/widgets/WidgetExportModal.tsx
@@ -447,6 +447,12 @@ function WidgetPreview({ config }: { config: WidgetConfig | null }) {
 
   if (config.type === 'card' && config.cardType) {
     const card = WIDGET_CARDS[config.cardType]
+
+    // Custom preview for nightly E2E status
+    if (config.cardType === 'nightly_e2e_status') {
+      return <NightlyE2EPreview style={previewStyle} />
+    }
+
     return (
       <div style={{ ...previewStyle, width: card?.defaultSize.width, height: card?.defaultSize.height }}>
         <div className="text-sm font-medium mb-2">{card?.displayName}</div>
@@ -504,6 +510,75 @@ function WidgetPreview({ config }: { config: WidgetConfig | null }) {
   }
 
   return null
+}
+
+// Nightly E2E preview with sample status dots
+function NightlyE2EPreview({ style }: { style: React.CSSProperties }) {
+  const platforms = [
+    {
+      name: 'OCP',
+      color: '#f97316',
+      guides: [
+        { acronym: 'IS', dots: ['g','g','r','g','g','g','g'] },
+        { acronym: 'PD', dots: ['g','g','g','g','g','g','g'] },
+        { acronym: 'PPC', dots: ['g','r','g','g','g','r','g'] },
+        { acronym: 'SA', dots: ['g','g','g','g','g','g','g'] },
+        { acronym: 'TPC', dots: ['g','g','g','r','g','g','g'] },
+        { acronym: 'WEP', dots: ['g','g','g','g','g','g','y'] },
+        { acronym: 'WVA', dots: ['g','r','g','g','r','g','g'] },
+        { acronym: 'BM', dots: ['r','r','g','r','g','r','g'] },
+      ],
+    },
+    {
+      name: 'GKE',
+      color: '#3b82f6',
+      guides: [
+        { acronym: 'IS', dots: ['g','g','g','g','g','g','g'] },
+        { acronym: 'PD', dots: ['r','g','g','g','g','g','g'] },
+        { acronym: 'WEP', dots: ['g','g','g','g','g','g','g'] },
+        { acronym: 'BM', dots: ['y','g','g','r','g','g','g'] },
+      ],
+    },
+    {
+      name: 'CKS',
+      color: '#a855f7',
+      guides: [
+        { acronym: 'IS', dots: [] as string[] },
+        { acronym: 'PD', dots: [] as string[] },
+        { acronym: 'WEP', dots: [] as string[] },
+        { acronym: 'BM', dots: [] as string[] },
+      ],
+    },
+  ]
+  const dotColor: Record<string, string> = { g: '#22c55e', r: '#ef4444', y: '#eab308' }
+
+  return (
+    <div style={{ ...style, width: 380, fontSize: '10px', padding: '10px 12px' }}>
+      <div style={{ fontWeight: 600, fontSize: '12px', marginBottom: '6px' }}>Nightly E2E Status</div>
+      <div style={{ display: 'flex', gap: '16px', marginBottom: '8px' }}>
+        <div><span style={{ fontSize: '16px', fontWeight: 700, color: '#a855f7' }}>87%</span><div style={{ color: '#9ca3af' }}>Pass Rate</div></div>
+        <div><span style={{ fontSize: '16px', fontWeight: 700 }}>16</span><div style={{ color: '#9ca3af' }}>Guides</div></div>
+        <div><span style={{ fontSize: '16px', fontWeight: 700, color: '#ef4444' }}>3</span><div style={{ color: '#9ca3af' }}>Failing</div></div>
+      </div>
+      {platforms.map((p) => (
+        <div key={p.name} style={{ marginBottom: '4px' }}>
+          <div style={{ color: p.color, fontWeight: 600, fontSize: '9px', marginBottom: '2px' }}>{p.name}</div>
+          {p.guides.map((g) => (
+            <div key={`${p.name}-${g.acronym}`} style={{ display: 'flex', alignItems: 'center', gap: '4px', marginBottom: '1px' }}>
+              <span style={{ width: '24px', fontWeight: 600, color: '#94a3b8' }}>{g.acronym}</span>
+              <div style={{ display: 'flex', gap: '2px' }}>
+                {g.dots.length > 0 ? g.dots.map((d, i) => (
+                  <span key={i} style={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: dotColor[d], display: 'inline-block' }} />
+                )) : (
+                  <span style={{ color: '#4b5563', fontSize: '8px' }}>no runs</span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  )
 }
 
 export default WidgetExportModal

--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -88,7 +88,7 @@ function generateCardRenderFunction(cardType: string): string {
   switch (cardType) {
     case 'cluster_health':
       return `
-export const render = ({ state }) => {
+export const render = (state) => {
   if (state.loading) {
     return <div style={styles.card}><span style={{color: styles.colors.info}}>Loading...</span></div>;
   }
@@ -122,7 +122,7 @@ export const render = ({ state }) => {
 
     case 'pod_issues':
       return `
-export const render = ({ state }) => {
+export const render = (state) => {
   if (state.loading) {
     return <div style={styles.card}><span style={{color: styles.colors.info}}>Loading...</span></div>;
   }
@@ -171,9 +171,77 @@ export const render = ({ state }) => {
   );
 };`
 
+    case 'nightly_e2e_status':
+      return `
+export const render = (state) => {
+  if (state.loading) {
+    return <div style={styles.card}><span style={{color: styles.colors.info}}>Loading...</span></div>;
+  }
+  if (state.error) {
+    return <div style={styles.card}><span style={{color: styles.colors.error}}>Error: {state.error}</span></div>;
+  }
+
+  const guides = state.data?.guides || [];
+  const platforms = ['OCP', 'GKE', 'CKS'];
+  const platformColors = { OCP: '#f97316', GKE: '#3b82f6', CKS: '#a855f7' };
+  const conclusionColors = { success: '#22c55e', failure: '#ef4444', cancelled: '#6b7280', skipped: '#6b7280' };
+  const totalGuides = guides.length;
+  const passing = guides.filter(g => g.latestConclusion === 'success').length;
+  const failing = guides.filter(g => g.latestConclusion === 'failure').length;
+  const passRate = totalGuides > 0 ? Math.round((passing / totalGuides) * 100) : 0;
+
+  return (
+    <div style={{...styles.card, padding: '12px'}}>
+      <div style={styles.cardTitle}>
+        <span style={{...styles.statusDot, backgroundColor: failing > 0 ? '#ef4444' : '#22c55e'}} />
+        Nightly E2E Status
+      </div>
+      <div style={{display: 'flex', gap: '16px', marginBottom: '10px'}}>
+        <div>
+          <div style={{fontSize: '20px', fontWeight: 700, color: '#a855f7'}}>{passRate}%</div>
+          <div style={{fontSize: '10px', color: '#9ca3af'}}>Pass Rate</div>
+        </div>
+        <div>
+          <div style={{fontSize: '20px', fontWeight: 700}}>{totalGuides}</div>
+          <div style={{fontSize: '10px', color: '#9ca3af'}}>Guides</div>
+        </div>
+        <div>
+          <div style={{fontSize: '20px', fontWeight: 700, color: failing > 0 ? '#ef4444' : '#22c55e'}}>{failing}</div>
+          <div style={{fontSize: '10px', color: '#9ca3af'}}>Failing</div>
+        </div>
+      </div>
+      {platforms.map(platform => {
+        const platGuides = guides.filter(g => g.platform === platform);
+        if (platGuides.length === 0) return null;
+        return (
+          <div key={platform} style={{marginBottom: '6px'}}>
+            <div style={{color: platformColors[platform], fontWeight: 600, fontSize: '10px', marginBottom: '2px'}}>{platform}</div>
+            {platGuides.map(g => (
+              <div key={g.guide + g.platform} style={{display: 'flex', alignItems: 'center', gap: '6px', marginBottom: '2px'}}>
+                <span style={{width: '28px', fontSize: '10px', fontWeight: 600, color: '#94a3b8'}}>{g.acronym}</span>
+                <span style={{fontSize: '10px', color: '#cbd5e1', width: '90px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'}}>{g.guide}</span>
+                <div style={{display: 'flex', gap: '2px'}}>
+                  {(g.runs || []).slice(0, 7).map((run, i) => (
+                    <span key={i} style={{
+                      width: 7, height: 7, borderRadius: '50%', display: 'inline-block',
+                      backgroundColor: run.status === 'in_progress' ? '#eab308' : (conclusionColors[run.conclusion] || '#6b7280'),
+                    }} />
+                  ))}
+                  {(!g.runs || g.runs.length === 0) && <span style={{color: '#4b5563', fontSize: '9px'}}>no runs</span>}
+                </div>
+                <span style={{fontSize: '9px', color: '#9ca3af', marginLeft: 'auto'}}>{g.passRate}%</span>
+              </div>
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+};`
+
     case 'gpu_overview':
       return `
-export const render = ({ state }) => {
+export const render = (state) => {
   if (state.loading) {
     return <div style={styles.card}><span style={{color: styles.colors.info}}>Loading...</span></div>;
   }
@@ -212,7 +280,7 @@ export const render = ({ state }) => {
 
     default:
       return `
-export const render = ({ state }) => {
+export const render = (state) => {
   if (state.loading) {
     return <div style={styles.card}><span style={{color: styles.colors.info}}>Loading...</span></div>;
   }
@@ -297,7 +365,7 @@ const StatBlock = ({ value, label, color }) => (
   </div>
 );
 
-export const render = ({ state }) => {
+export const render = (state) => {
   if (state.loading) {
     return <div style={styles.row}><span style={{color: styles.colors.info}}>Loading...</span></div>;
   }
@@ -419,7 +487,7 @@ ${template.cards.map((cardType) => generateMiniCardComponent(cardType)).join('\n
 
 ${template.stats?.map((statId) => generateMiniStatComponent(statId)).join('\n\n') || ''}
 
-export const render = ({ state }) => {
+export const render = (state) => {
   if (state.loading) {
     return <div style={styles.card}><span style={{color: styles.colors.info}}>Loading...</span></div>;
   }


### PR DESCRIPTION
## Summary
- Fix Übersicht render function signature from `({ state })` to `(state)` — Übersicht passes state as a direct positional argument, not wrapped in an object. This caused `"undefined is not an object (evaluating 'state.loading')"` runtime errors for all exported desktop widgets.
- Add custom Nightly E2E Status preview in the Export Widget modal showing platform groups (OCP/GKE/CKS) with colored status dots
- Add custom Übersicht render function for `nightly_e2e_status` card type with pass rates, guide rows grouped by platform, and colored run dots

## Test plan
- [ ] Export any widget (e.g., Cluster Health) → download `.widget.jsx` → place in Übersicht widgets folder → verify no runtime errors
- [ ] Export Nightly E2E Status widget → verify preview shows platform groups with colored dots
- [ ] Verify the downloaded Nightly E2E widget renders correctly in Übersicht with live data from the console API