### PR TITLE
✨ Add ENABLED_DASHBOARDS env var for per-deployment sidebar filtering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,14 @@ FEEDBACK_REPO_NAME=console
 # Generate with: openssl rand -hex 32
 GITHUB_WEBHOOK_SECRET=
 
+# Sidebar dashboard filter (comma-separated dashboard IDs, empty = show all)
+# Available: dashboard, clusters, deploy, ai-ml, ai-agents, ci-cd, alerts,
+#   arcade, compliance, compute, cost, data-compliance, deployments, events,
+#   gitops, gpu-reservations, helm, llm-d-benchmarks, logs, network, nodes,
+#   operators, pods, security, security-posture, services, storage, workloads
+# Example: ENABLED_DASHBOARDS=gpu-reservations,llm-d-benchmarks
+ENABLED_DASHBOARDS=
+
 # ===========================================
 # AI Agent Configuration (at least one required for AI features)
 # ===========================================

--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -119,6 +119,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.jwt.existingSecret | default (include "kubestellar-console.fullname" .) }}
                   key: {{ .Values.jwt.existingSecretKey | default "jwt-secret" }}
+            {{- if .Values.enabledDashboards }}
+            - name: ENABLED_DASHBOARDS
+              value: {{ .Values.enabledDashboards | quote }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -129,6 +129,14 @@ kubestellar:
   opsPath: /usr/local/bin/kubestellar-ops
   deployPath: /usr/local/bin/kubestellar-deploy
 
+# Sidebar dashboard filter (comma-separated dashboard IDs, empty = show all)
+# Available IDs: dashboard, clusters, deploy, ai-ml, ai-agents, ci-cd, alerts,
+#   arcade, compliance, compute, cost, data-compliance, deployments, events,
+#   gitops, gpu-reservations, helm, llm-d-benchmarks, logs, network, nodes,
+#   operators, pods, security, security-posture, services, storage, workloads
+# Example: "gpu-reservations,llm-d-benchmarks"
+enabledDashboards: ""
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
## Summary
- Add `ENABLED_DASHBOARDS` env var to configure which dashboards appear in the sidebar per deployment
- Backend exposes the list via `/health` endpoint (runtime config, no rebuild needed)
- Frontend fetches on startup and filters the sidebar's `primaryNav` accordingly
- Empty/unset = show all 28 dashboards (backward compatible default)
- User-created custom dashboards are never filtered out

## Example
```bash
# .env for pok-prod-sa
ENABLED_DASHBOARDS=gpu-reservations,llm-d-benchmarks
```

## Test plan
- [ ] Set `ENABLED_DASHBOARDS=gpu-reservations,llm-d-benchmarks` in `.env` → restart → only those 2 dashboards in sidebar
- [ ] Unset `ENABLED_DASHBOARDS` → restart → all 28 dashboards appear
- [ ] Verify `/health` returns `enabled_dashboards` array when set
- [ ] Verify custom user-created dashboards still appear when filter is active
- [ ] Helm: verify `enabledDashboards` in values.yaml maps correctly