### PR TITLE
🐛 Fix benchmark cards: loading skeleton, refresh animation & cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,3 +69,64 @@ npm run dev -- --port 5174  # Frontend
 
 The backend (KC API server) runs on port 8080. The KC agent WebSocket runs on port 8585.
 
+---
+
+## Card Development Rules (ALWAYS FOLLOW)
+
+Every dashboard card component MUST follow these patterns for loading, caching, and demo data to work correctly.
+
+### 1. Always wire `isDemoData` and `isRefreshing`
+
+Every card using a `useCached*` hook MUST destructure `isDemoData` (or `isDemoFallback`) and `isRefreshing`, then pass both to `useCardLoadingState()` or `useReportCardDataState()`:
+
+```tsx
+const { data, isLoading, isRefreshing, isDemoData, isFailed, consecutiveFailures } = useCachedXxx()
+
+useCardLoadingState({
+  isLoading,
+  isRefreshing,          // ← Required for refresh icon animation
+  isDemoData,            // ← Required for Demo badge + yellow outline
+  hasAnyData: data.length > 0,
+  isFailed,
+  consecutiveFailures,
+})
+```
+
+Without `isDemoData`: cards show demo data without the Demo badge/yellow outline.
+Without `isRefreshing`: no refresh icon animation when data is being updated in background.
+
+### 2. Never use demo data during loading
+
+The hook's `isDemoFallback` must be `false` while `isLoading` is `true`. This ensures CardWrapper shows a loading skeleton instead of immediately rendering demo data.
+
+**Correct pattern in hooks:**
+```tsx
+const effectiveIsDemoFallback = cacheResult.isDemoFallback && !cacheResult.isLoading
+```
+
+**Wrong pattern:**
+```tsx
+const effectiveIsDemoFallback = cacheResult.isDemoFallback  // BUG: true during loading
+```
+
+### 3. Expected loading behavior
+
+| Scenario | Behavior |
+|----------|----------|
+| First visit, API keys present | Loading skeleton → live data |
+| Revisit, API keys present | Cached data instantly → refresh icon spins → updated data |
+| No API keys / demo mode | Demo data immediately (with Demo badge + yellow outline) |
+| API keys present, fetch fails | Loading skeleton → demo data fallback after timeout |
+
+### 4. Always use `useCache`/`useCached*` hooks
+
+All data fetching in cards MUST go through the cache layer (`useCache` or a `useCached*` hook from `hooks/useCachedData.ts`). This provides:
+- Persistent cache (IndexedDB/SQLite) for instant data on revisit
+- SWR (stale-while-revalidate) pattern
+- Automatic demo fallback
+- Loading/refreshing state management
+
+### 5. Hook ordering matters
+
+`useCardLoadingState` / `useReportCardDataState` must be called AFTER the hooks that provide `isDemoData`. React hooks run in order — if the loading state hook runs before data hooks, it won't have the correct values.
+

--- a/web/src/components/cards/llmd/BenchmarkHero.tsx
+++ b/web/src/components/cards/llmd/BenchmarkHero.tsx
@@ -90,9 +90,9 @@ function HeroMetric({
 }
 
 export function BenchmarkHero() {
-  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading, currentSince } = useCachedBenchmarkReports()
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing, currentSince } = useCachedBenchmarkReports()
   const effectiveReports = useMemo(() => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []), [isDemoFallback, liveReports])
-  useReportCardDataState({ isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
+  useReportCardDataState({ isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing, hasData: effectiveReports.length > 0 })
 
   const [customDays, setCustomDays] = useState('')
   const [showCustom, setShowCustom] = useState(false)

--- a/web/src/components/cards/llmd/HardwareLeaderboard.tsx
+++ b/web/src/components/cards/llmd/HardwareLeaderboard.tsx
@@ -53,9 +53,9 @@ function SortIcon({ active, dir }: { active: boolean; dir: SortDirection }) {
 }
 
 export function HardwareLeaderboard() {
-  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useCachedBenchmarkReports()
   const effectiveReports = useMemo(() => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []), [isDemoFallback, liveReports])
-  useReportCardDataState({ isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, hasData: effectiveReports.length > 0 })
+  useReportCardDataState({ isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing, hasData: effectiveReports.length > 0 })
 
   const [sortKey, setSortKey] = useState<SortKey>('score')
   const [sortDir, setSortDir] = useState<SortDirection>('desc')

--- a/web/src/components/cards/llmd/LatencyBreakdown.tsx
+++ b/web/src/components/cards/llmd/LatencyBreakdown.tsx
@@ -62,13 +62,13 @@ function CustomTooltip({ active, payload, label, unit }: {
 }
 
 export function LatencyBreakdown() {
-  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useCachedBenchmarkReports()
   const effectiveReports = useMemo(
     () => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []),
     [isDemoFallback, liveReports]
   )
   useReportCardDataState({
-    isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading,
+    isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing,
     hasData: effectiveReports.length > 0,
   })
 

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -134,13 +134,14 @@ function GuideRow({ guide, delay }: { guide: NightlyGuideStatus; delay: number }
 }
 
 export function NightlyE2EStatus() {
-  const { guides, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useNightlyE2EData()
+  const { guides, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useNightlyE2EData()
 
   useReportCardDataState({
     isDemoData: isDemoFallback,
     isFailed,
     consecutiveFailures,
     isLoading,
+    isRefreshing,
     hasData: guides.length > 0,
   })
 

--- a/web/src/components/cards/llmd/ParetoFrontier.tsx
+++ b/web/src/components/cards/llmd/ParetoFrontier.tsx
@@ -231,7 +231,7 @@ export function ParetoFrontier({ config }: ParetoFrontierProps) {
   const chartRef = useRef<ReactECharts>(null)
 
   // ---- Data ----
-  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useCachedBenchmarkReports()
   const effectiveReports = useMemo(
     () => (isDemoFallback ? generateBenchmarkReports() : (liveReports ?? [])),
     [isDemoFallback, liveReports],
@@ -241,6 +241,7 @@ export function ParetoFrontier({ config }: ParetoFrontierProps) {
     isFailed,
     consecutiveFailures,
     isLoading,
+    isRefreshing,
     hasData: effectiveReports.length > 0,
   })
 

--- a/web/src/components/cards/llmd/PerformanceTimeline.tsx
+++ b/web/src/components/cards/llmd/PerformanceTimeline.tsx
@@ -55,13 +55,13 @@ function getColor(value: number, min: number, max: number, higherBetter: boolean
 }
 
 export function PerformanceTimeline() {
-  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useCachedBenchmarkReports()
   const effectiveReports = useMemo(
     () => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []),
     [isDemoFallback, liveReports]
   )
   useReportCardDataState({
-    isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading,
+    isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing,
     hasData: effectiveReports.length > 0,
   })
 

--- a/web/src/components/cards/llmd/ResourceUtilization.tsx
+++ b/web/src/components/cards/llmd/ResourceUtilization.tsx
@@ -60,13 +60,13 @@ function CustomTooltip({ active, payload }: {
 }
 
 export function ResourceUtilization() {
-  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useCachedBenchmarkReports()
   const effectiveReports = useMemo(
     () => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []),
     [isDemoFallback, liveReports]
   )
   useReportCardDataState({
-    isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading,
+    isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing,
     hasData: effectiveReports.length > 0,
   })
 

--- a/web/src/components/cards/llmd/ThroughputComparison.tsx
+++ b/web/src/components/cards/llmd/ThroughputComparison.tsx
@@ -51,13 +51,13 @@ function CustomTooltip({ active, payload, label }: {
 }
 
 export function ThroughputComparison() {
-  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useCachedBenchmarkReports()
+  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useCachedBenchmarkReports()
   const effectiveReports = useMemo(
     () => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []),
     [isDemoFallback, liveReports]
   )
   useReportCardDataState({
-    isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading,
+    isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing,
     hasData: effectiveReports.length > 0,
   })
 

--- a/web/src/hooks/useBenchmarkData.ts
+++ b/web/src/hooks/useBenchmarkData.ts
@@ -218,7 +218,7 @@ export function useCachedBenchmarkReports() {
   // Use streamed data if we have any, otherwise fall back to cache/demo
   const hasStreamedData = stream.reports.length > 0
   const effectiveData = hasStreamedData ? stream.reports : cacheResult.data
-  const effectiveIsDemoFallback = hasStreamedData ? false : cacheResult.isDemoFallback
+  const effectiveIsDemoFallback = hasStreamedData ? false : (cacheResult.isDemoFallback && !cacheResult.isLoading)
 
   return {
     ...cacheResult,

--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -93,8 +93,9 @@ export function useNightlyE2EData() {
   const { guides, isDemo } = cacheResult.data
   return {
     guides,
-    isDemoFallback: isDemo,
+    isDemoFallback: isDemo && !cacheResult.isLoading,
     isLoading: cacheResult.isLoading,
+    isRefreshing: cacheResult.isRefreshing,
     isFailed: cacheResult.isFailed,
     consecutiveFailures: cacheResult.consecutiveFailures,
     refetch: cacheResult.refetch,


### PR DESCRIPTION
## Summary
- Fix benchmark cards showing demo data instead of loading skeleton on first load
- `isDemoFallback` was `true` during loading (due to `demoWhenEmpty: true`), causing cards to immediately render demo data and skip the skeleton
- Now `isDemoFallback` is only `true` after loading completes with no data (demo mode or missing API keys)
- Add `isRefreshing` to all 8 benchmark card components for refresh icon animation
- Add Card Development Rules section to CLAUDE.md documenting the required patterns

## Test plan
- [ ] Navigate to llm-d Benchmarks dashboard — cards show loading skeleton on first load (not demo data)
- [ ] Navigate away and back — cached data appears instantly, refresh icon spins while fetching
- [ ] Remove API keys — demo data shows with Demo badge + yellow outline
- [ ] `npm run build` passes clean