### PR TITLE
✨ Benchmark UI polish: dark chart, generic title, hover stats

### DIFF
--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -5,7 +5,7 @@
  * and aggregate statistics. Grouped by platform (OCP, GKE).
  * Fetches from GitHub Actions API; falls back to demo data without a token.
  */
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { motion } from 'framer-motion'
 import {
   TestTube2, ExternalLink, TrendingUp, TrendingDown, Minus,
@@ -80,7 +80,12 @@ function TrendIndicator({ trend, passRate }: { trend: 'up' | 'down' | 'steady'; 
   )
 }
 
-function GuideRow({ guide, delay }: { guide: NightlyGuideStatus; delay: number }) {
+function GuideRow({ guide, delay, isSelected, onMouseEnter }: {
+  guide: NightlyGuideStatus
+  delay: number
+  isSelected: boolean
+  onMouseEnter: () => void
+}) {
   const workflowUrl = `https://github.com/${guide.repo}/actions/workflows/${guide.workflowFile}`
   const StatusIcon = guide.latestConclusion === 'success'
     ? CheckCircle
@@ -103,7 +108,10 @@ function GuideRow({ guide, delay }: { guide: NightlyGuideStatus; delay: number }
       initial={{ opacity: 0, x: -8 }}
       animate={{ opacity: 1, x: 0 }}
       transition={{ duration: 0.3, delay }}
-      className="flex items-center gap-3 py-1.5 px-2 rounded-lg hover:bg-slate-800/40 transition-colors group"
+      className={`flex items-center gap-3 py-1.5 px-2 rounded-lg transition-colors group cursor-pointer ${
+        isSelected ? 'bg-slate-700/50 ring-1 ring-slate-600/50' : 'hover:bg-slate-800/40'
+      }`}
+      onMouseEnter={onMouseEnter}
     >
       <StatusIcon size={14} className={`shrink-0 ${iconColor}`} />
       <span className="text-xs text-slate-200 w-48 truncate shrink-0" title={guide.guide}>
@@ -133,8 +141,142 @@ function GuideRow({ guide, delay }: { guide: NightlyGuideStatus; delay: number }
   )
 }
 
+function GuideDetailPanel({ guide }: { guide: NightlyGuideStatus }) {
+  const completedRuns = guide.runs.filter(r => r.status === 'completed')
+  const passed = completedRuns.filter(r => r.conclusion === 'success').length
+  const failed = completedRuns.filter(r => r.conclusion === 'failure').length
+  const cancelled = completedRuns.filter(r => r.conclusion === 'cancelled').length
+  const running = guide.runs.filter(r => r.status === 'in_progress').length
+
+  // Consecutive streak
+  let streak = 0
+  let streakType: 'success' | 'failure' | null = null
+  for (const run of guide.runs) {
+    if (run.status !== 'completed') continue
+    if (!streakType) streakType = run.conclusion === 'success' ? 'success' : 'failure'
+    if ((streakType === 'success' && run.conclusion === 'success') ||
+        (streakType === 'failure' && run.conclusion !== 'success')) {
+      streak++
+    } else break
+  }
+
+  // Last success & failure timestamps
+  const lastSuccess = guide.runs.find(r => r.conclusion === 'success')
+  const lastFailure = guide.runs.find(r => r.conclusion === 'failure')
+
+  const workflowUrl = `https://github.com/${guide.repo}/actions/workflows/${guide.workflowFile}`
+
+  return (
+    <motion.div
+      key={`${guide.guide}-${guide.platform}`}
+      initial={{ opacity: 0, x: 8 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.2 }}
+      className="h-full flex flex-col"
+    >
+      {/* Header */}
+      <div className="mb-3">
+        <div className="flex items-center gap-2 mb-1">
+          <span className="font-mono font-bold text-sm" style={{ color: PLATFORM_COLORS[guide.platform] }}>
+            {guide.acronym}
+          </span>
+          <span className="text-sm font-semibold text-slate-200 truncate">{guide.guide}</span>
+        </div>
+        <div className="flex items-center gap-2 text-[10px] text-slate-500">
+          <span style={{ color: PLATFORM_COLORS[guide.platform] }}>{guide.platform}</span>
+          <span>&middot;</span>
+          <a href={workflowUrl} target="_blank" rel="noopener noreferrer"
+            className="hover:text-slate-300 transition-colors flex items-center gap-0.5">
+            {guide.repo.split('/')[1]} <ExternalLink size={9} />
+          </a>
+        </div>
+      </div>
+
+      {/* Pass rate big number */}
+      <div className="bg-slate-800/60 border border-slate-700/50 rounded-lg p-3 mb-3 text-center">
+        <div className={`text-2xl font-bold ${
+          guide.passRate >= 90 ? 'text-emerald-400' : guide.passRate >= 70 ? 'text-yellow-400' : guide.passRate > 0 ? 'text-red-400' : 'text-slate-500'
+        }`}>
+          {guide.passRate}%
+        </div>
+        <div className="text-[10px] text-slate-400 uppercase tracking-wider">Pass Rate</div>
+      </div>
+
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 gap-2 mb-3">
+        <StatBox label="Passed" value={String(passed)} color="text-emerald-400" />
+        <StatBox label="Failed" value={String(failed)} color="text-red-400" />
+        <StatBox label="Cancelled" value={String(cancelled)} color="text-slate-400" />
+        <StatBox label="Running" value={String(running)} color="text-blue-400" />
+      </div>
+
+      {/* Streak */}
+      {streakType && streak > 0 && (
+        <div className={`flex items-center gap-2 px-2.5 py-1.5 rounded-lg border mb-3 ${
+          streakType === 'success'
+            ? 'bg-emerald-950/30 border-emerald-800/40'
+            : 'bg-red-950/30 border-red-800/40'
+        }`}>
+          {streakType === 'success' ? (
+            <TrendingUp size={13} className="text-emerald-400" />
+          ) : (
+            <TrendingDown size={13} className="text-red-400" />
+          )}
+          <span className="text-xs text-slate-300">
+            {streak} consecutive {streakType === 'success' ? 'passes' : 'failures'}
+          </span>
+        </div>
+      )}
+
+      {/* Timestamps */}
+      <div className="space-y-1.5 flex-1">
+        {lastSuccess && (
+          <div className="flex items-center justify-between text-[11px]">
+            <span className="text-slate-500">Last pass</span>
+            <span className="text-emerald-400 font-mono">{formatTimeAgo(lastSuccess.updatedAt)}</span>
+          </div>
+        )}
+        {lastFailure && (
+          <div className="flex items-center justify-between text-[11px]">
+            <span className="text-slate-500">Last fail</span>
+            <span className="text-red-400 font-mono">{formatTimeAgo(lastFailure.updatedAt)}</span>
+          </div>
+        )}
+        <div className="flex items-center justify-between text-[11px]">
+          <span className="text-slate-500">Total runs</span>
+          <span className="text-slate-300 font-mono">{guide.runs.length}</span>
+        </div>
+        <div className="flex items-center justify-between text-[11px]">
+          <span className="text-slate-500">Trend</span>
+          <TrendIndicator trend={guide.trend} passRate={guide.passRate} />
+        </div>
+      </div>
+
+      {/* Run history visual */}
+      <div className="mt-auto pt-2 border-t border-slate-700/30">
+        <div className="text-[10px] text-slate-500 mb-1.5">Run history (newest first)</div>
+        <div className="flex items-center gap-1 flex-wrap">
+          {guide.runs.map((run) => (
+            <RunDot key={run.id} run={run} />
+          ))}
+        </div>
+      </div>
+    </motion.div>
+  )
+}
+
+function StatBox({ label, value, color }: { label: string; value: string; color: string }) {
+  return (
+    <div className="bg-slate-800/40 border border-slate-700/30 rounded-lg p-2 text-center">
+      <div className={`text-base font-bold ${color}`}>{value}</div>
+      <div className="text-[9px] text-slate-500 uppercase tracking-wider">{label}</div>
+    </div>
+  )
+}
+
 export function NightlyE2EStatus() {
   const { guides, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useNightlyE2EData()
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
 
   useReportCardDataState({
     isDemoData: isDemoFallback,
@@ -144,6 +286,11 @@ export function NightlyE2EStatus() {
     isRefreshing,
     hasData: guides.length > 0,
   })
+
+  const selectedGuide = useMemo(() => {
+    if (!selectedKey) return null
+    return guides.find(g => `${g.guide}-${g.platform}` === selectedKey) ?? null
+  }, [guides, selectedKey])
 
   const { stats, grouped, lastRunTime } = useMemo(() => {
     const total = guides.length
@@ -223,30 +370,50 @@ export function NightlyE2EStatus() {
         </motion.div>
       </div>
 
-      {/* Guide rows grouped by platform */}
-      <div className="flex-1 overflow-y-auto min-h-0 space-y-2">
-        {[...grouped.entries()].map(([platform, platformGuides]) => (
-          <div key={platform}>
-            <div className="flex items-center gap-2 px-2 mb-1">
-              <TestTube2 size={12} style={{ color: PLATFORM_COLORS[platform] }} />
-              <span className="text-[10px] font-semibold uppercase tracking-wider"
-                style={{ color: PLATFORM_COLORS[platform] }}>
-                {platform}
-              </span>
-              <div className="flex-1 h-px bg-slate-700/50" />
-              <span className="text-[10px] text-slate-500">
-                {platformGuides.filter(g => g.latestConclusion === 'success').length}/{platformGuides.length} passing
-              </span>
+      {/* Two-column layout: guide rows (left) + detail panel (right) */}
+      <div className="flex flex-1 min-h-0 gap-3">
+        {/* Guide rows grouped by platform */}
+        <div className="flex-1 overflow-y-auto min-h-0 space-y-2">
+          {[...grouped.entries()].map(([platform, platformGuides]) => (
+            <div key={platform}>
+              <div className="flex items-center gap-2 px-2 mb-1">
+                <TestTube2 size={12} style={{ color: PLATFORM_COLORS[platform] }} />
+                <span className="text-[10px] font-semibold uppercase tracking-wider"
+                  style={{ color: PLATFORM_COLORS[platform] }}>
+                  {platform}
+                </span>
+                <div className="flex-1 h-px bg-slate-700/50" />
+                <span className="text-[10px] text-slate-500">
+                  {platformGuides.filter(g => g.latestConclusion === 'success').length}/{platformGuides.length} passing
+                </span>
+              </div>
+              {platformGuides.map((guide, gi) => {
+                const key = `${guide.guide}-${guide.platform}`
+                return (
+                  <GuideRow
+                    key={key}
+                    guide={guide}
+                    delay={0.25 + gi * 0.04}
+                    isSelected={selectedKey === key}
+                    onMouseEnter={() => setSelectedKey(key)}
+                  />
+                )
+              })}
             </div>
-            {platformGuides.map((guide, gi) => (
-              <GuideRow
-                key={`${guide.guide}-${guide.platform}`}
-                guide={guide}
-                delay={0.25 + gi * 0.04}
-              />
-            ))}
-          </div>
-        ))}
+          ))}
+        </div>
+
+        {/* Detail panel (right side) */}
+        <div className="w-52 shrink-0 bg-slate-800/30 border border-slate-700/40 rounded-xl p-3 overflow-y-auto">
+          {selectedGuide ? (
+            <GuideDetailPanel guide={selectedGuide} />
+          ) : (
+            <div className="h-full flex flex-col items-center justify-center text-center gap-2">
+              <TestTube2 size={20} className="text-slate-600" />
+              <p className="text-[11px] text-slate-500">Hover over a test to see detailed statistics</p>
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Legend */}

--- a/web/src/components/cards/llmd/ParetoFrontier.tsx
+++ b/web/src/components/cards/llmd/ParetoFrontier.tsx
@@ -382,7 +382,7 @@ export function ParetoFrontier({ config }: ParetoFrontierProps) {
               return pt && pt.gpuCount > 1 ? `${pt.gpuCount}` : ''
             },
             fontSize: 9,
-            color: '#555',
+            color: '#94a3b8',
             position: 'top',
             distance: 4,
           },
@@ -411,16 +411,16 @@ export function ParetoFrontier({ config }: ParetoFrontierProps) {
     }
 
     return {
-      backgroundColor: '#e8e8e4',
+      backgroundColor: '#1a1d2e',
       grid: { top: 16, right: 16, bottom: 42, left: 70 },
       tooltip: {
         trigger: 'item',
-        backgroundColor: 'rgba(255,255,255,0.97)',
-        borderColor: '#d1d5db',
+        backgroundColor: 'rgba(15,23,42,0.97)',
+        borderColor: '#334155',
         borderWidth: 1,
         padding: [10, 14],
-        textStyle: { color: '#1f2937', fontSize: 11 },
-        extraCssText: 'box-shadow:0 4px 12px rgba(0,0,0,0.1);',
+        textStyle: { color: '#e2e8f0', fontSize: 11 },
+        extraCssText: 'box-shadow:0 4px 12px rgba(0,0,0,0.3);',
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         formatter: (params: any) => {
           const pt = params.data?.point as ParetoPoint | undefined
@@ -429,18 +429,18 @@ export function ParetoFrontier({ config }: ParetoFrontierProps) {
           const model = getModelShort(pt.model)
           const c = HARDWARE_COLORS[hw] ?? '#6b7280'
           return (
-            `<div style="font-weight:600;margin-bottom:6px;color:#111">${model} ` +
-            `<span style="color:#666">${hw}</span> ` +
-            `<span style="background:${c}18;color:${c};padding:1px 6px;border-radius:4px;font-size:10px">${pt.config}</span></div>` +
+            `<div style="font-weight:600;margin-bottom:6px;color:#f1f5f9">${model} ` +
+            `<span style="color:#94a3b8">${hw}</span> ` +
+            `<span style="background:${c}30;color:${c};padding:1px 6px;border-radius:4px;font-size:10px">${pt.config}</span></div>` +
             `<div style="display:grid;grid-template-columns:auto auto;gap:2px 14px;font-size:11px">` +
-            `<span style="color:#888">Throughput/GPU:</span><span style="font-family:monospace;color:#111">${pt.throughputPerGpu.toFixed(0)} tok/s</span>` +
-            `<span style="color:#888">TTFT p50:</span><span style="font-family:monospace;color:#111">${pt.ttftP50Ms.toFixed(1)} ms</span>` +
-            `<span style="color:#888">TPOT p50:</span><span style="font-family:monospace;color:#111">${pt.tpotP50Ms.toFixed(2)} ms/tok</span>` +
-            `<span style="color:#888">p99 Latency:</span><span style="font-family:monospace;color:#111">${pt.p99LatencyMs.toFixed(0)} ms</span>` +
-            `<span style="color:#888">GPUs:</span><span style="font-family:monospace;color:#111">${pt.gpuCount}\u00d7</span>` +
-            `<span style="color:#888">ISL/OSL:</span><span style="font-family:monospace;color:#111">${pt.seqLen}</span>` +
-            `<span style="color:#888">Power/GPU:</span><span style="font-family:monospace;color:#111">${pt.powerPerGpuKw.toFixed(2)} kW</span>` +
-            `<span style="color:#888">TCO/GPU/hr:</span><span style="font-family:monospace;color:#111">$${pt.tcoPerGpuHr.toFixed(2)}</span>` +
+            `<span style="color:#94a3b8">Throughput/GPU:</span><span style="font-family:monospace;color:#e2e8f0">${pt.throughputPerGpu.toFixed(0)} tok/s</span>` +
+            `<span style="color:#94a3b8">TTFT p50:</span><span style="font-family:monospace;color:#e2e8f0">${pt.ttftP50Ms.toFixed(1)} ms</span>` +
+            `<span style="color:#94a3b8">TPOT p50:</span><span style="font-family:monospace;color:#e2e8f0">${pt.tpotP50Ms.toFixed(2)} ms/tok</span>` +
+            `<span style="color:#94a3b8">p99 Latency:</span><span style="font-family:monospace;color:#e2e8f0">${pt.p99LatencyMs.toFixed(0)} ms</span>` +
+            `<span style="color:#94a3b8">GPUs:</span><span style="font-family:monospace;color:#e2e8f0">${pt.gpuCount}\u00d7</span>` +
+            `<span style="color:#94a3b8">ISL/OSL:</span><span style="font-family:monospace;color:#e2e8f0">${pt.seqLen}</span>` +
+            `<span style="color:#94a3b8">Power/GPU:</span><span style="font-family:monospace;color:#e2e8f0">${pt.powerPerGpuKw.toFixed(2)} kW</span>` +
+            `<span style="color:#94a3b8">TCO/GPU/hr:</span><span style="font-family:monospace;color:#e2e8f0">$${pt.tcoPerGpuHr.toFixed(2)}</span>` +
             `</div>`
           )
         },
@@ -451,21 +451,21 @@ export function ParetoFrontier({ config }: ParetoFrontierProps) {
         name: `${preset.xAxis.label} (${preset.xAxis.unit})`,
         nameLocation: 'middle',
         nameGap: 26,
-        nameTextStyle: { color: '#555', fontSize: 11, fontWeight: 500 },
-        axisLine: { lineStyle: { color: '#d1d5db' } },
-        splitLine: { lineStyle: { color: '#e5e7eb', type: 'dashed' } },
-        axisLabel: { color: '#666', fontSize: 10 },
+        nameTextStyle: { color: '#94a3b8', fontSize: 11, fontWeight: 500 },
+        axisLine: { lineStyle: { color: '#334155' } },
+        splitLine: { lineStyle: { color: '#1e293b', type: 'dashed' } },
+        axisLabel: { color: '#64748b', fontSize: 10 },
       },
       yAxis: {
         type: 'value',
         name: `${preset.yAxis.label} (${preset.yAxis.unit})`,
         nameLocation: 'middle',
         nameGap: 58,
-        nameTextStyle: { color: '#555', fontSize: 11, fontWeight: 500 },
-        axisLine: { lineStyle: { color: '#d1d5db' } },
-        splitLine: { lineStyle: { color: '#e5e7eb', type: 'dashed' } },
+        nameTextStyle: { color: '#94a3b8', fontSize: 11, fontWeight: 500 },
+        axisLine: { lineStyle: { color: '#334155' } },
+        splitLine: { lineStyle: { color: '#1e293b', type: 'dashed' } },
         axisLabel: {
-          color: '#666',
+          color: '#64748b',
           fontSize: 10,
           formatter: preset.yAxis.formatter ?? ((v: number) => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v)),
         },

--- a/web/src/config/dashboards/llmd-benchmarks.ts
+++ b/web/src/config/dashboards/llmd-benchmarks.ts
@@ -15,7 +15,7 @@ export const llmdBenchmarksDashboardConfig: UnifiedDashboardConfig = {
   cards: [
     { id: 'bench-nightly-1', cardType: 'nightly_e2e_status', title: 'Nightly E2E Status', position: { w: 12, h: 5 } },
     { id: 'bench-hero-1', cardType: 'benchmark_hero', title: 'Latest Benchmark', position: { w: 12, h: 3 } },
-    { id: 'bench-pareto-1', cardType: 'pareto_frontier', title: 'Pareto Frontier', position: { w: 12, h: 8 } },
+    { id: 'bench-pareto-1', cardType: 'pareto_frontier', title: 'Performance Explorer', position: { w: 12, h: 8 } },
     { id: 'bench-leaderboard-1', cardType: 'hardware_leaderboard', title: 'Hardware Leaderboard', position: { w: 12, h: 5 } },
     { id: 'bench-latency-1', cardType: 'latency_breakdown', title: 'Latency Breakdown', position: { w: 12, h: 4 } },
     { id: 'bench-throughput-1', cardType: 'throughput_comparison', title: 'Throughput Comparison', position: { w: 12, h: 4 } },


### PR DESCRIPTION
## Summary
- Darken Performance Explorer (Pareto) chart background to `#1a1d2e` with matching dark axis/tooltip styling
- Rename card title from "Pareto Frontier" to "Performance Explorer" since it now has 10 chart presets
- Add hover detail panel to Nightly E2E Status card: hovering a test row shows pass rate, pass/fail/cancelled/running counts, consecutive streak, last pass/fail timestamps, and run history dots

## Test plan
- [ ] Performance Explorer card has dark chart background with readable axis labels and tooltips
- [ ] Card title shows "Performance Explorer" instead of "Pareto Frontier"
- [ ] Nightly E2E Status: hover over any test row to see detail panel on right
- [ ] Detail panel shows: pass rate, stats grid, streak indicator, timestamps, run dots
- [ ] Empty state shows "Hover over a test to see detailed statistics"
- [ ] `npm run build` passes clean