### PR TITLE
🐛 Fix benchmark card titles not showing from CARD_TITLES map

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -334,6 +334,16 @@ export const CARD_TITLES: Record<string, string> = {
   ml_jobs: 'ML Jobs',
   ml_notebooks: 'ML Notebooks',
 
+  // Benchmark cards
+  nightly_e2e_status: 'Nightly E2E Status',
+  benchmark_hero: 'Latest Benchmark',
+  pareto_frontier: 'Performance Explorer',
+  hardware_leaderboard: 'Hardware Leaderboard',
+  latency_breakdown: 'Latency Breakdown',
+  throughput_comparison: 'Throughput Comparison',
+  performance_timeline: 'Performance Timeline',
+  resource_utilization: 'Resource Utilization',
+
   // Games
   sudoku_game: 'Sudoku Game',
   match_game: 'Kube Match',


### PR DESCRIPTION
## Summary
- Added all 8 benchmark card types to the `CARD_TITLES` map in `CardWrapper.tsx`
- Without this, benchmark cards fell through to cached localStorage titles instead of using the authoritative title from the map
- Fixes the "Performance Explorer" title not showing for the Pareto Frontier card

## Test plan
- [ ] `npm run build` passes
- [ ] Navigate to llm-d Benchmarks dashboard — all card titles match their configured names
- [ ] "Performance Explorer" shows instead of "Throughput vs Latency"