### PR TITLE
✨ Fix benchmark workflow registry and add rich widget previews

### DIFF
--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -78,12 +78,12 @@ var nightlyWorkflows = []NightlyWorkflow{
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-tiered-prefix-cache.yaml", Guide: "Tiered Prefix Cache", Acronym: "TPC", Platform: "OCP"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "OCP"},
 	{Repo: "llm-d/llm-d-workload-variant-autoscaler", WorkflowFile: "nightly-e2e-openshift.yaml", Guide: "WVA", Acronym: "WVA", Platform: "OCP"},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-benchmarking.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "OCP"},
+	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-ocp.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "OCP"},
 	// GKE
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-gke.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "GKE"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-gke.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "GKE"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-gke.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "GKE"},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-benchmarking-gke.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "GKE"},
+	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-gke.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "GKE"},
 	// CKS (same tests as GKE — workflows not yet created)
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-cks.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "CKS"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "CKS"},

--- a/web/src/components/widgets/WidgetExportModal.tsx
+++ b/web/src/components/widgets/WidgetExportModal.tsx
@@ -424,7 +424,77 @@ function StatItem({
   )
 }
 
-// Simple widget preview
+// --- Shared preview styles matching Übersicht widget appearance ---
+const ps = {
+  card: {
+    backgroundColor: 'rgba(17, 24, 39, 0.9)',
+    borderRadius: '12px',
+    padding: '12px 14px',
+    border: '1px solid rgba(255, 255, 255, 0.1)',
+    color: '#f9fafb',
+    fontFamily: 'Inter, -apple-system, sans-serif',
+    fontSize: '11px',
+    lineHeight: 1.4,
+    boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)',
+  } as React.CSSProperties,
+  title: {
+    fontSize: '12px',
+    fontWeight: 600,
+    color: '#f9fafb',
+    marginBottom: '8px',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+  } as React.CSSProperties,
+  dot: (color: string) => ({
+    width: 7,
+    height: 7,
+    borderRadius: '50%',
+    backgroundColor: color,
+    display: 'inline-block',
+    flexShrink: 0,
+  }) as React.CSSProperties,
+  statBlock: {
+    backgroundColor: 'rgba(17, 24, 39, 0.9)',
+    borderRadius: '6px',
+    border: '1px solid rgba(255, 255, 255, 0.1)',
+    padding: '6px 10px',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: '54px',
+  } as React.CSSProperties,
+  statVal: {
+    fontSize: '18px',
+    fontWeight: 700,
+    lineHeight: 1.2,
+  } as React.CSSProperties,
+  statLbl: {
+    fontSize: '9px',
+    color: '#9ca3af',
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+    marginTop: '1px',
+  } as React.CSSProperties,
+  row: { display: 'flex', gap: '6px', alignItems: 'center' } as React.CSSProperties,
+  col: { display: 'flex', flexDirection: 'column' as const, gap: '4px' } as React.CSSProperties,
+  muted: { color: '#9ca3af', fontSize: '10px' } as React.CSSProperties,
+  colors: { healthy: '#22c55e', warning: '#eab308', error: '#ef4444', info: '#3b82f6', purple: '#9333ea' },
+}
+
+// Sample stat data for realistic previews
+const SAMPLE_STATS: Record<string, number | string> = {
+  total_clusters: 4,
+  total_pods: 128,
+  total_gpus: 32,
+  cpu_usage: '67%',
+  memory_usage: '54%',
+  unhealthy_pods: 3,
+  active_alerts: 2,
+}
+
+// Widget preview with realistic mock data
 function WidgetPreview({ config }: { config: WidgetConfig | null }) {
   if (!config) {
     return (
@@ -435,89 +505,443 @@ function WidgetPreview({ config }: { config: WidgetConfig | null }) {
     )
   }
 
-  // Render a simple preview based on config type
-  const previewStyle = {
-    backgroundColor: 'rgba(17, 24, 39, 0.9)',
-    borderRadius: '12px',
-    padding: '16px',
-    border: '1px solid rgba(255, 255, 255, 0.1)',
-    color: '#f9fafb',
-    fontFamily: 'Inter, sans-serif',
-  }
-
   if (config.type === 'card' && config.cardType) {
-    const card = WIDGET_CARDS[config.cardType]
-
-    // Custom preview for nightly E2E status
-    if (config.cardType === 'nightly_e2e_status') {
-      return <NightlyE2EPreview style={previewStyle} />
-    }
-
-    return (
-      <div style={{ ...previewStyle, width: card?.defaultSize.width, height: card?.defaultSize.height }}>
-        <div className="text-sm font-medium mb-2">{card?.displayName}</div>
-        <div className="text-2xl font-bold text-purple-400">—</div>
-        <div className="text-xs text-gray-400 mt-1">Preview</div>
-      </div>
-    )
+    return <CardPreview cardType={config.cardType} />
   }
 
   if (config.type === 'stat' && config.statIds) {
-    return (
-      <div style={{ ...previewStyle, display: 'flex', gap: '8px' }}>
-        {config.statIds.map((id) => {
-          const stat = WIDGET_STATS[id]
-          return (
-            <div
-              key={id}
-              style={{
-                padding: '8px 12px',
-                backgroundColor: 'rgba(31, 41, 55, 0.5)',
-                borderRadius: '8px',
-                borderTop: `3px solid ${stat?.color || '#9333ea'}`,
-                textAlign: 'center',
-              }}
-            >
-              <div style={{ fontSize: '18px', fontWeight: 700, color: stat?.color || '#fff' }}>—</div>
-              <div style={{ fontSize: '10px', color: '#9ca3af' }}>{stat?.displayName}</div>
-            </div>
-          )
-        })}
-      </div>
-    )
+    return <StatPreview statIds={config.statIds} />
   }
 
   if (config.type === 'template' && config.templateId) {
-    const template = WIDGET_TEMPLATES[config.templateId]
-    return (
-      <div
-        style={{
-          ...previewStyle,
-          width: Math.min(template?.size.width || 300, 300),
-          height: Math.min(template?.size.height || 200, 200),
-        }}
-      >
-        <div className="text-sm font-medium mb-2">{template?.displayName}</div>
-        <div className="grid grid-cols-2 gap-2">
-          {template?.cards.slice(0, 4).map((c) => (
-            <div key={c} className="h-8 bg-purple-500/20 rounded flex items-center justify-center text-[10px] text-purple-300">
-              {c.replace(/_/g, ' ')}
-            </div>
-          ))}
-        </div>
-      </div>
-    )
+    return <TemplatePreview templateId={config.templateId} />
   }
 
   return null
 }
 
+// --- Card previews ---
+function CardPreview({ cardType }: { cardType: string }) {
+  const card = WIDGET_CARDS[cardType]
+  if (!card) return null
+
+  switch (cardType) {
+    case 'cluster_health':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.warning)} /> Cluster Health</div>
+          <div style={ps.row}>
+            <div style={{ ...ps.statBlock, borderLeft: `3px solid ${ps.colors.healthy}` }}>
+              <span style={{ ...ps.statVal, color: ps.colors.healthy }}>3</span>
+              <span style={ps.statLbl}>Healthy</span>
+            </div>
+            <div style={{ ...ps.statBlock, borderLeft: `3px solid ${ps.colors.error}` }}>
+              <span style={{ ...ps.statVal, color: ps.colors.error }}>1</span>
+              <span style={ps.statLbl}>Unhealthy</span>
+            </div>
+          </div>
+        </div>
+      )
+
+    case 'pod_issues':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.warning)} /> Pod Issues</div>
+          <div style={ps.muted}>4 total issues</div>
+          <div style={{ ...ps.col, marginTop: '6px' }}>
+            <div style={{ ...ps.row, padding: '3px 6px', backgroundColor: 'rgba(239,68,68,0.1)', borderRadius: '4px' }}>
+              <span style={{ color: ps.colors.error, fontWeight: 600, fontSize: '12px' }}>2</span>
+              <span style={ps.muted}>CrashLoopBackOff</span>
+            </div>
+            <div style={{ ...ps.row, padding: '3px 6px', backgroundColor: 'rgba(234,179,8,0.1)', borderRadius: '4px' }}>
+              <span style={{ color: ps.colors.warning, fontWeight: 600, fontSize: '12px' }}>1</span>
+              <span style={ps.muted}>OOMKilled</span>
+            </div>
+            <div style={{ ...ps.row, padding: '3px 6px', backgroundColor: 'rgba(59,130,246,0.1)', borderRadius: '4px' }}>
+              <span style={{ color: ps.colors.info, fontWeight: 600, fontSize: '12px' }}>1</span>
+              <span style={ps.muted}>ImagePullBackOff</span>
+            </div>
+          </div>
+        </div>
+      )
+
+    case 'gpu_overview':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.purple)} /> GPU Overview</div>
+          <div style={{ textAlign: 'center', marginBottom: '8px' }}>
+            <div style={{ fontSize: '28px', fontWeight: 700, color: ps.colors.purple }}>72%</div>
+            <div style={ps.muted}>Utilization</div>
+          </div>
+          <div style={ps.row}>
+            <div style={ps.statBlock}>
+              <span style={ps.statVal}>32</span>
+              <span style={ps.statLbl}>Total</span>
+            </div>
+            <div style={ps.statBlock}>
+              <span style={{ ...ps.statVal, color: ps.colors.purple }}>23</span>
+              <span style={ps.statLbl}>Allocated</span>
+            </div>
+          </div>
+        </div>
+      )
+
+    case 'hardware_health':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.warning)} /> Hardware Health</div>
+          <div style={{ ...ps.row, marginBottom: '6px' }}>
+            <div style={{ ...ps.statBlock, borderLeft: `3px solid ${ps.colors.healthy}` }}>
+              <span style={ps.statVal}>4</span>
+              <span style={ps.statLbl}>Nodes</span>
+            </div>
+            <div style={{ ...ps.statBlock, borderLeft: `3px solid ${ps.colors.purple}` }}>
+              <span style={{ ...ps.statVal, color: ps.colors.purple }}>16</span>
+              <span style={ps.statLbl}>GPUs</span>
+            </div>
+            <div style={{ ...ps.statBlock, borderLeft: `3px solid ${ps.colors.info}` }}>
+              <span style={{ ...ps.statVal, color: ps.colors.info }}>8</span>
+              <span style={ps.statLbl}>NICs</span>
+            </div>
+          </div>
+          <div style={ps.col}>
+            <div style={{ fontSize: '9px', fontWeight: 600, color: '#9ca3af', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Alerts (2)</div>
+            <div style={{ ...ps.row, padding: '3px 6px', backgroundColor: 'rgba(239,68,68,0.1)', borderRadius: '4px', borderLeft: `3px solid ${ps.colors.error}` }}>
+              <span style={{ fontSize: '10px', color: ps.colors.error, fontWeight: 600 }}>GPU</span>
+              <span style={{ fontSize: '9px', color: '#9ca3af', marginLeft: '2px' }}>worker-3 (-2)</span>
+            </div>
+            <div style={{ ...ps.row, padding: '3px 6px', backgroundColor: 'rgba(234,179,8,0.1)', borderRadius: '4px', borderLeft: `3px solid ${ps.colors.warning}` }}>
+              <span style={{ fontSize: '10px', color: ps.colors.warning, fontWeight: 600 }}>NIC</span>
+              <span style={{ fontSize: '9px', color: '#9ca3af', marginLeft: '2px' }}>worker-1 (-1)</span>
+            </div>
+          </div>
+        </div>
+      )
+
+    case 'nightly_e2e_status':
+      return <NightlyE2EPreview />
+
+    case 'security_issues':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.warning)} /> Security Issues</div>
+          <div style={ps.col}>
+            {[
+              { label: 'Privileged containers', count: 3, color: ps.colors.error },
+              { label: 'No resource limits', count: 12, color: ps.colors.warning },
+              { label: 'Running as root', count: 5, color: ps.colors.error },
+            ].map((item) => (
+              <div key={item.label} style={{ ...ps.row, padding: '3px 6px', backgroundColor: item.color === ps.colors.error ? 'rgba(239,68,68,0.1)' : 'rgba(234,179,8,0.1)', borderRadius: '4px' }}>
+                <span style={{ color: item.color, fontWeight: 600, fontSize: '12px', minWidth: '16px' }}>{item.count}</span>
+                <span style={ps.muted}>{item.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    case 'active_alerts':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.error)} /> Active Alerts</div>
+          <div style={ps.col}>
+            {[
+              { name: 'HighMemoryUsage', severity: 'critical', ns: 'monitoring' },
+              { name: 'PodCrashLooping', severity: 'warning', ns: 'default' },
+              { name: 'NodeDiskPressure', severity: 'warning', ns: 'kube-system' },
+            ].map((a) => (
+              <div key={a.name} style={{ ...ps.row, padding: '3px 6px', backgroundColor: a.severity === 'critical' ? 'rgba(239,68,68,0.1)' : 'rgba(234,179,8,0.1)', borderRadius: '4px', borderLeft: `3px solid ${a.severity === 'critical' ? ps.colors.error : ps.colors.warning}` }}>
+                <span style={{ fontSize: '10px', color: a.severity === 'critical' ? ps.colors.error : ps.colors.warning, fontWeight: 600 }}>{a.name}</span>
+                <span style={{ fontSize: '9px', color: '#6b7280', marginLeft: 'auto' }}>{a.ns}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    case 'helm_releases':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.healthy)} /> Helm Releases</div>
+          <div style={ps.col}>
+            {[
+              { name: 'ingress-nginx', status: 'deployed', ver: '4.8.3' },
+              { name: 'cert-manager', status: 'deployed', ver: '1.13.2' },
+              { name: 'prometheus', status: 'deployed', ver: '25.8.0' },
+              { name: 'redis', status: 'failed', ver: '18.4.0' },
+            ].map((r) => (
+              <div key={r.name} style={{ ...ps.row, justifyContent: 'space-between' }}>
+                <span style={{ fontSize: '10px', fontWeight: 500 }}>{r.name}</span>
+                <span style={{ fontSize: '9px', color: r.status === 'deployed' ? ps.colors.healthy : ps.colors.error }}>{r.status}</span>
+                <span style={{ fontSize: '9px', color: '#6b7280' }}>{r.ver}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    case 'top_pods':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.info)} /> Top Pods</div>
+          <div style={ps.col}>
+            {[
+              { name: 'ml-training-job-7x', cpu: '3.2 cores', mem: '12.4 Gi' },
+              { name: 'prometheus-server-0', cpu: '1.8 cores', mem: '8.2 Gi' },
+              { name: 'elasticsearch-data-1', cpu: '1.4 cores', mem: '6.1 Gi' },
+            ].map((p) => (
+              <div key={p.name} style={{ ...ps.row, justifyContent: 'space-between', fontSize: '10px' }}>
+                <span style={{ fontWeight: 500, maxWidth: '110px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.name}</span>
+                <span style={{ color: '#60a5fa' }}>{p.cpu}</span>
+                <span style={{ color: '#c084fc' }}>{p.mem}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    case 'event_summary':
+    case 'warning_events':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(cardType === 'warning_events' ? ps.colors.warning : ps.colors.info)} /> {card.displayName}</div>
+          <div style={ps.col}>
+            {[
+              { type: 'Warning', count: 12, msg: 'BackOff restarting failed container' },
+              { type: 'Warning', count: 5, msg: 'Readiness probe failed' },
+              { type: 'Normal', count: 34, msg: 'Scheduled successfully' },
+            ].map((e, i) => (
+              <div key={i} style={{ ...ps.row, fontSize: '10px' }}>
+                <span style={{ color: e.type === 'Warning' ? ps.colors.warning : ps.colors.healthy, fontWeight: 600, minWidth: '18px' }}>{e.count}</span>
+                <span style={{ color: '#cbd5e1', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.msg}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    case 'operator_status':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.healthy)} /> Operator Status</div>
+          <div style={ps.col}>
+            {[
+              { name: 'cert-manager', ready: true },
+              { name: 'gpu-operator', ready: true },
+              { name: 'prometheus-operator', ready: true },
+              { name: 'node-feature-discovery', ready: false },
+            ].map((o) => (
+              <div key={o.name} style={{ ...ps.row, fontSize: '10px' }}>
+                <span style={ps.dot(o.ready ? ps.colors.healthy : ps.colors.warning)} />
+                <span>{o.name}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    case 'storage_overview':
+    case 'pvc_status':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.info)} /> {card.displayName}</div>
+          <div style={ps.row}>
+            <div style={ps.statBlock}>
+              <span style={{ ...ps.statVal, fontSize: '16px', color: ps.colors.info }}>24</span>
+              <span style={ps.statLbl}>PVCs</span>
+            </div>
+            <div style={ps.statBlock}>
+              <span style={{ ...ps.statVal, fontSize: '16px', color: ps.colors.healthy }}>22</span>
+              <span style={ps.statLbl}>Bound</span>
+            </div>
+            <div style={ps.statBlock}>
+              <span style={{ ...ps.statVal, fontSize: '16px', color: ps.colors.warning }}>2</span>
+              <span style={ps.statLbl}>Pending</span>
+            </div>
+          </div>
+        </div>
+      )
+
+    case 'network_overview':
+    case 'service_status':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.info)} /> {card.displayName}</div>
+          <div style={{ ...ps.row, marginBottom: '6px' }}>
+            <div style={ps.statBlock}>
+              <span style={{ ...ps.statVal, fontSize: '16px' }}>18</span>
+              <span style={ps.statLbl}>Services</span>
+            </div>
+            <div style={ps.statBlock}>
+              <span style={{ ...ps.statVal, fontSize: '16px', color: ps.colors.info }}>6</span>
+              <span style={ps.statLbl}>Policies</span>
+            </div>
+          </div>
+          <div style={ps.col}>
+            {['ClusterIP (12)', 'LoadBalancer (4)', 'NodePort (2)'].map((s) => (
+              <div key={s} style={{ fontSize: '10px', color: '#9ca3af' }}>{s}</div>
+            ))}
+          </div>
+        </div>
+      )
+
+    case 'opencost_overview':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.healthy)} /> OpenCost Overview</div>
+          <div style={{ textAlign: 'center', marginBottom: '8px' }}>
+            <div style={{ fontSize: '24px', fontWeight: 700, color: ps.colors.healthy }}>$1,247</div>
+            <div style={ps.muted}>Monthly estimate</div>
+          </div>
+          <div style={ps.row}>
+            <div style={ps.statBlock}>
+              <span style={{ ...ps.statVal, fontSize: '14px', color: '#60a5fa' }}>$482</span>
+              <span style={ps.statLbl}>Compute</span>
+            </div>
+            <div style={ps.statBlock}>
+              <span style={{ ...ps.statVal, fontSize: '14px', color: '#c084fc' }}>$635</span>
+              <span style={ps.statLbl}>GPU</span>
+            </div>
+            <div style={ps.statBlock}>
+              <span style={{ ...ps.statVal, fontSize: '14px', color: '#22d3ee' }}>$130</span>
+              <span style={ps.statLbl}>Storage</span>
+            </div>
+          </div>
+        </div>
+      )
+
+    case 'provider_health':
+      return (
+        <div style={ps.card}>
+          <div style={ps.title}><span style={ps.dot(ps.colors.healthy)} /> Provider Health</div>
+          <div style={ps.col}>
+            {[
+              { name: 'OpenAI', status: 'operational', color: ps.colors.healthy },
+              { name: 'Anthropic', status: 'operational', color: ps.colors.healthy },
+              { name: 'AWS', status: 'degraded', color: ps.colors.warning },
+              { name: 'GCP', status: 'operational', color: ps.colors.healthy },
+            ].map((p) => (
+              <div key={p.name} style={{ ...ps.row, justifyContent: 'space-between', fontSize: '10px' }}>
+                <span style={{ fontWeight: 500 }}>{p.name}</span>
+                <span style={{ color: p.color }}>{p.status}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )
+
+    default:
+      return <GenericCardPreview card={card} />
+  }
+}
+
+// Generic card preview based on category
+function GenericCardPreview({ card }: { card: WidgetCardDefinition }) {
+  const categoryData: Record<string, { dot: string; items: { label: string; value: string; color?: string }[] }> = {
+    cluster: { dot: ps.colors.healthy, items: [{ label: 'Ready', value: '3/4', color: ps.colors.healthy }, { label: 'Nodes', value: '12' }, { label: 'Version', value: 'v1.28' }] },
+    workload: { dot: ps.colors.info, items: [{ label: 'Running', value: '45', color: ps.colors.healthy }, { label: 'Pending', value: '2', color: ps.colors.warning }, { label: 'Failed', value: '1', color: ps.colors.error }] },
+    gpu: { dot: ps.colors.purple, items: [{ label: 'Total', value: '32' }, { label: 'Allocated', value: '24', color: ps.colors.purple }, { label: 'Available', value: '8', color: ps.colors.healthy }] },
+    security: { dot: ps.colors.warning, items: [{ label: 'Critical', value: '2', color: ps.colors.error }, { label: 'Warning', value: '5', color: ps.colors.warning }, { label: 'Info', value: '8', color: ps.colors.info }] },
+    monitoring: { dot: ps.colors.info, items: [{ label: 'Active', value: '3', color: ps.colors.info }, { label: 'Resolved', value: '12', color: ps.colors.healthy }, { label: 'Silenced', value: '1' }] },
+  }
+  const data = categoryData[card.category] || categoryData.monitoring
+  return (
+    <div style={ps.card}>
+      <div style={ps.title}><span style={ps.dot(data.dot)} /> {card.displayName}</div>
+      <div style={ps.row}>
+        {data.items.map((item) => (
+          <div key={item.label} style={ps.statBlock}>
+            <span style={{ ...ps.statVal, fontSize: '16px', color: item.color || '#f9fafb' }}>{item.value}</span>
+            <span style={ps.statLbl}>{item.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// --- Stat previews ---
+function StatPreview({ statIds }: { statIds: string[] }) {
+  return (
+    <div style={{ ...ps.card, display: 'flex', gap: '6px', padding: '8px 10px' }}>
+      {statIds.map((id) => {
+        const stat = WIDGET_STATS[id]
+        const value = SAMPLE_STATS[id] ?? '—'
+        return (
+          <div key={id} style={{ ...ps.statBlock, borderTop: `3px solid ${stat?.color || '#9333ea'}`, textAlign: 'center' }}>
+            <span style={{ ...ps.statVal, fontSize: '16px', color: stat?.color || '#fff' }}>{value}</span>
+            <span style={ps.statLbl}>{stat?.displayName}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// --- Template previews ---
+function TemplatePreview({ templateId }: { templateId: string }) {
+  const template = WIDGET_TEMPLATES[templateId]
+  if (!template) return null
+
+  const statsRow = template.stats && template.stats.length > 0 ? (
+    <div style={{ display: 'flex', gap: '4px', marginBottom: '6px' }}>
+      {template.stats.map((id) => {
+        const stat = WIDGET_STATS[id]
+        const value = SAMPLE_STATS[id] ?? '—'
+        return (
+          <div key={id} style={{ ...ps.statBlock, flex: 1, borderTop: `2px solid ${stat?.color || '#9333ea'}`, textAlign: 'center', padding: '4px 6px' }}>
+            <span style={{ fontSize: '14px', fontWeight: 700, color: stat?.color || '#fff' }}>{value}</span>
+            <span style={{ ...ps.statLbl, fontSize: '8px' }}>{stat?.displayName}</span>
+          </div>
+        )
+      })}
+    </div>
+  ) : null
+
+  const cardMiniStyle: React.CSSProperties = {
+    flex: 1,
+    backgroundColor: 'rgba(31, 41, 55, 0.5)',
+    borderRadius: '6px',
+    padding: '4px 6px',
+    border: '1px solid rgba(255, 255, 255, 0.05)',
+  }
+
+  const isGrid = template.layout === 'grid'
+  const isRow = template.layout === 'row'
+  const cardsContainer: React.CSSProperties = isGrid
+    ? { display: 'grid', gridTemplateColumns: `repeat(${template.gridCols || 2}, 1fr)`, gap: '4px' }
+    : isRow
+    ? { display: 'flex', gap: '4px' }
+    : { display: 'flex', flexDirection: 'column', gap: '4px' }
+
+  return (
+    <div style={{ ...ps.card, maxWidth: 320 }}>
+      <div style={{ ...ps.title, fontSize: '11px', marginBottom: '6px' }}>{template.displayName}</div>
+      {statsRow}
+      {template.cards.length > 0 && (
+        <div style={cardsContainer}>
+          {template.cards.map((cardType) => {
+            const c = WIDGET_CARDS[cardType]
+            return (
+              <div key={cardType} style={cardMiniStyle}>
+                <div style={{ fontSize: '9px', fontWeight: 600, color: '#d1d5db', marginBottom: '2px' }}>{c?.displayName || cardType}</div>
+                <div style={{ fontSize: '14px', fontWeight: 700, color: ps.colors.purple }}>
+                  {cardType === 'cluster_health' ? '3/4' : cardType === 'pod_issues' ? '4' : cardType === 'gpu_overview' ? '72%' : cardType === 'security_issues' ? '20' : '—'}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // Nightly E2E preview with sample status dots
-function NightlyE2EPreview({ style }: { style: React.CSSProperties }) {
+function NightlyE2EPreview() {
   const platforms = [
     {
-      name: 'OCP',
-      color: '#f97316',
+      name: 'OCP', color: '#f97316',
       guides: [
         { acronym: 'IS', dots: ['g','g','r','g','g','g','g'] },
         { acronym: 'PD', dots: ['g','g','g','g','g','g','g'] },
@@ -530,8 +954,7 @@ function NightlyE2EPreview({ style }: { style: React.CSSProperties }) {
       ],
     },
     {
-      name: 'GKE',
-      color: '#3b82f6',
+      name: 'GKE', color: '#3b82f6',
       guides: [
         { acronym: 'IS', dots: ['g','g','g','g','g','g','g'] },
         { acronym: 'PD', dots: ['r','g','g','g','g','g','g'] },
@@ -540,8 +963,7 @@ function NightlyE2EPreview({ style }: { style: React.CSSProperties }) {
       ],
     },
     {
-      name: 'CKS',
-      color: '#a855f7',
+      name: 'CKS', color: '#a855f7',
       guides: [
         { acronym: 'IS', dots: [] as string[] },
         { acronym: 'PD', dots: [] as string[] },
@@ -553,12 +975,12 @@ function NightlyE2EPreview({ style }: { style: React.CSSProperties }) {
   const dotColor: Record<string, string> = { g: '#22c55e', r: '#ef4444', y: '#eab308' }
 
   return (
-    <div style={{ ...style, width: 380, fontSize: '10px', padding: '10px 12px' }}>
-      <div style={{ fontWeight: 600, fontSize: '12px', marginBottom: '6px' }}>Nightly E2E Status</div>
-      <div style={{ display: 'flex', gap: '16px', marginBottom: '8px' }}>
-        <div><span style={{ fontSize: '16px', fontWeight: 700, color: '#a855f7' }}>87%</span><div style={{ color: '#9ca3af' }}>Pass Rate</div></div>
-        <div><span style={{ fontSize: '16px', fontWeight: 700 }}>16</span><div style={{ color: '#9ca3af' }}>Guides</div></div>
-        <div><span style={{ fontSize: '16px', fontWeight: 700, color: '#ef4444' }}>3</span><div style={{ color: '#9ca3af' }}>Failing</div></div>
+    <div style={{ ...ps.card, width: 320, fontSize: '10px', padding: '10px 12px' }}>
+      <div style={ps.title}><span style={ps.dot('#22c55e')} /> Nightly E2E Status</div>
+      <div style={{ display: 'flex', gap: '14px', marginBottom: '8px' }}>
+        <div><span style={{ fontSize: '16px', fontWeight: 700, color: '#a855f7' }}>87%</span><div style={ps.muted}>Pass Rate</div></div>
+        <div><span style={{ fontSize: '16px', fontWeight: 700 }}>16</span><div style={ps.muted}>Guides</div></div>
+        <div><span style={{ fontSize: '16px', fontWeight: 700, color: '#ef4444' }}>3</span><div style={ps.muted}>Failing</div></div>
       </div>
       {platforms.map((p) => (
         <div key={p.name} style={{ marginBottom: '4px' }}>


### PR DESCRIPTION
## Summary
- **Fix Benchmarking "no runs"**: The nightly E2E widget showed "no runs" for Benchmarking because the workflow registry pointed to `llm-d/llm-d` with wrong filenames. Fixed to point to `llm-d/llm-d-benchmark` with correct workflow files (`ci-nighly-benchmark-ocp.yaml`, `ci-nighly-benchmark-gke.yaml`).
- **Rich widget export previews**: Replaced generic "—" placeholder previews in the widget export modal with card-type-specific mock data previews for all 20+ card types (cluster health, GPU overview, pod issues, security, alerts, Helm, operators, storage, network, cost, events, nightly E2E, provider health, etc.). Stat blocks and templates also show realistic sample data.

## Test plan
- [ ] Verify Benchmarking rows in the Nightly E2E card now show runs (OCP and GKE)
- [ ] Open widget export modal → verify each card type shows a realistic preview instead of generic dashes
- [ ] Verify stat block previews show sample numbers
- [ ] Verify template previews show card + stat layout