### PR TITLE
🐛 Fix duplicate NightlyE2EStatus exports from PR #934 squash merge

### DIFF
--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -147,8 +147,6 @@ const PDDisaggregation = lazy(() => _llmdBundle.then(m => ({ default: m.PDDisagg
 const LLMdBenchmarks = lazy(() => _llmdBundle.then(m => ({ default: m.LLMdBenchmarks })))
 const LLMdAIInsights = lazy(() => _llmdBundle.then(m => ({ default: m.LLMdAIInsights })))
 const LLMdConfigurator = lazy(() => _llmdBundle.then(m => ({ default: m.LLMdConfigurator })))
-// Nightly E2E status card (shares the llmd barrel bundle)
-const NightlyE2EStatus = lazy(() => _llmdBundle.then(m => ({ default: m.NightlyE2EStatus })))
 // LLM-d benchmark dashboard cards (share the same barrel bundle)
 const NightlyE2EStatus = lazy(() => _llmdBundle.then(m => ({ default: m.NightlyE2EStatus })))
 const BenchmarkHero = lazy(() => _llmdBundle.then(m => ({ default: m.BenchmarkHero })))
@@ -384,9 +382,6 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   llmd_benchmarks: LLMdBenchmarks,
   llmd_ai_insights: LLMdAIInsights,
   llmd_configurator: LLMdConfigurator,
-
-  // Nightly E2E status card
-  nightly_e2e_status: NightlyE2EStatus,
 
   // LLM-d benchmark dashboard cards
   nightly_e2e_status: NightlyE2EStatus,
@@ -641,8 +636,6 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   llmd_benchmarks: () => import('./llmd'),
   llmd_ai_insights: () => import('./llmd'),
   llmd_configurator: () => import('./llmd'),
-  // Nightly E2E status card — shares the llmd barrel bundle
-  nightly_e2e_status: () => import('./llmd'),
   // LLM-d benchmark dashboard cards — all share the llmd barrel bundle
   nightly_e2e_status: () => import('./llmd'),
   benchmark_hero: () => import('./llmd'),
@@ -763,8 +756,6 @@ export const LIVE_DATA_CARDS = new Set([
   'kagenti_agent_discovery',
   'kagenti_security',
   'kagenti_topology',
-  // Nightly E2E status card — fetches GitHub Actions workflow runs
-  'nightly_e2e_status',
 ])
 
 /**
@@ -830,9 +821,6 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   llmd_benchmarks: 6,     // Benchmark charts
   llmd_ai_insights: 6,    // AI insights panel
   llmd_configurator: 4,   // Configurator showcase
-
-  // Nightly E2E status card (full-width)
-  nightly_e2e_status: 12,
 
   // LLM-d benchmark dashboard cards (all full-width)
   nightly_e2e_status: 12,

--- a/web/src/components/cards/llmd/index.ts
+++ b/web/src/components/cards/llmd/index.ts
@@ -12,9 +12,6 @@ export { LLMdBenchmarks } from './LLMdBenchmarks'
 export { LLMdAIInsights } from './LLMdAIInsights'
 export { LLMdConfigurator } from './LLMdConfigurator'
 
-// Nightly E2E status card
-export { NightlyE2EStatus } from './NightlyE2EStatus'
-
 // Benchmark dashboard cards
 export { NightlyE2EStatus } from './NightlyE2EStatus'
 export { BenchmarkHero } from './BenchmarkHero'


### PR DESCRIPTION
## Summary
- Remove duplicate `NightlyE2EStatus` declarations in `cardRegistry.ts` (4 duplicates) and `llmd/index.ts` (1 duplicate)
- Caused by squash merge of PR #934 on top of existing nightly card registrations on main
- Without this fix, the dev server and build fail with `ERROR: Multiple exports with the same name "NightlyE2EStatus"`

## Test plan
- [x] Dev server starts without errors
- [x] Operators page loads correctly
- [x] `npm run build` passes