### PR TITLE
✨ Add SSE streaming for operators, subscriptions, and helm releases

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -526,8 +526,14 @@ func (s *Server) setupRoutes() {
 	api.Get("/gitops/helm-values", gitopsHandlers.GetHelmValues)
 	api.Get("/gitops/kustomizations", gitopsHandlers.ListKustomizations)
 	api.Get("/gitops/operators", gitopsHandlers.ListOperators)
+	api.Get("/gitops/operators/stream", gitopsHandlers.StreamOperators)
+	api.Get("/gitops/operator-subscriptions", gitopsHandlers.ListOperatorSubscriptions)
+	api.Get("/gitops/operator-subscriptions/stream", gitopsHandlers.StreamOperatorSubscriptions)
+	api.Get("/gitops/helm-releases/stream", gitopsHandlers.StreamHelmReleases)
 	api.Post("/gitops/detect-drift", gitopsHandlers.DetectDrift)
 	api.Post("/gitops/sync", gitopsHandlers.Sync)
+	// Frontend compatibility alias
+	api.Get("/mcp/operator-subscriptions", gitopsHandlers.ListOperatorSubscriptions)
 
 	// MCS (Multi-Cluster Service) routes
 	mcsHandlers := handlers.NewMCSHandlers(s.k8sClient, s.hub)


### PR DESCRIPTION
## Summary
- Operators page showed "No operators" because `kubectl get csv -A -o json` returns 191MB for large OLM clusters, killed by timeouts
- Replace `-o json` with `jsonpath + --chunk-size=500` (few KB vs 191MB output)
- Add SSE streaming endpoints for progressive per-cluster rendering of operators, subscriptions, and helm releases
- Frontend hooks use SSE with REST fallback for progressive UI updates
- Add operator subscriptions REST + SSE endpoints (previously missing)

## New Endpoints
- `GET /api/gitops/operators/stream` (SSE)
- `GET /api/gitops/operator-subscriptions` (REST)
- `GET /api/gitops/operator-subscriptions/stream` (SSE)
- `GET /api/gitops/helm-releases/stream` (SSE)
- `GET /api/mcp/operator-subscriptions` (frontend alias)

## Test plan
- [ ] `go build ./...` compiles
- [ ] `npm run build && npm run lint` pass
- [ ] `curl /api/gitops/operators` returns operators (REST, 120s timeout)
- [ ] `curl /api/gitops/operators/stream` streams cluster_data events progressively
- [ ] Operators card on dashboard shows operators with progressive loading
- [ ] Demo mode shows demo operators