### PR TITLE
🐛 Fix nightly E2E card showing demo data without Demo badge

### DIFF
--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -11,7 +11,8 @@ import {
   TestTube2, ExternalLink, TrendingUp, TrendingDown, Minus,
   CheckCircle, XCircle, Loader2, AlertTriangle, Sparkles,
 } from 'lucide-react'
-import { useReportCardDataState } from '../CardDataContext'
+import { useCardLoadingState } from '../CardDataContext'
+import { Skeleton } from '../../ui/Skeleton'
 import { useNightlyE2EData } from '../../../hooks/useNightlyE2EData'
 import { useAIMode } from '../../../hooks/useAIMode'
 import type { NightlyGuideStatus, NightlyRun } from '../../../lib/llmd/nightlyE2EDemoData'
@@ -482,17 +483,16 @@ function StatBox({ label, value, color }: { label: string; value: string; color:
 }
 
 export function NightlyE2EStatus() {
-  const { guides, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useNightlyE2EData()
+  const { guides, isDemoFallback, isFailed, consecutiveFailures, isLoading } = useNightlyE2EData()
   const { shouldSummarize } = useAIMode()
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
 
-  useReportCardDataState({
-    isDemoData: isDemoFallback,
+  const { showSkeleton } = useCardLoadingState({
+    isLoading,
+    hasAnyData: guides.length > 0 && !isDemoFallback,
     isFailed,
     consecutiveFailures,
-    isLoading,
-    isRefreshing,
-    hasData: guides.length > 0,
+    isDemoData: isDemoFallback,
   })
 
   const selectedGuide = useMemo(() => {
@@ -529,6 +529,28 @@ export function NightlyE2EStatus() {
       lastRunTime: mostRecent ? new Date(mostRecent).toISOString() : null,
     }
   }, [guides])
+
+  if (showSkeleton) {
+    return (
+      <div className="p-4 h-full flex flex-col gap-3 overflow-hidden">
+        <div className="grid grid-cols-4 gap-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" height={64} />
+          ))}
+        </div>
+        <div className="flex flex-1 min-h-0 gap-3">
+          <div className="flex-1 space-y-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} variant="rounded" height={36} />
+            ))}
+          </div>
+          <div className="w-72 shrink-0">
+            <Skeleton variant="rounded" height={280} />
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="p-4 h-full flex flex-col gap-3 overflow-hidden">

--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -95,7 +95,7 @@ export function useNightlyE2EData() {
   const { guides, isDemo } = cacheResult.data
   return {
     guides,
-    isDemoFallback: isDemo && !cacheResult.isLoading,
+    isDemoFallback: isDemo,
     isLoading: cacheResult.isLoading,
     isRefreshing: cacheResult.isRefreshing,
     isFailed: cacheResult.isFailed,


### PR DESCRIPTION
## Summary
- On cold start (no cache), the card rendered demo data as real data — no Demo badge, no yellow outline
- Root cause: `isDemoFallback = isDemo && !isLoading` masked the demo flag during loading
- Fix: `isDemoFallback = isDemo` always reports demo state correctly
- Added skeleton loading state using `useCardLoadingState` so the card shows a shimmer skeleton instead of demo data while fetching

## Test plan
- [ ] Clear browser cache, reload — card shows skeleton, then real data (no demo flash)
- [ ] With cached data, card shows cached data immediately (no skeleton)
- [ ] When backend is down, card shows Demo badge correctly