### PR TITLE
🐛 Fix SSE streaming timeouts for operators/helm/subscriptions

### DIFF
--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -20,7 +20,7 @@ export interface SSEFetchOptions<T> {
   signal?: AbortSignal
 }
 
-const SSE_TIMEOUT = 60_000
+const SSE_TIMEOUT = 240_000 // 4 minutes — operators can take 100s+ for large clusters
 
 /**
  * Open an SSE connection and progressively collect data.


### PR DESCRIPTION
## Summary
- Increase `operatorPerClusterTimeout` from 60s to 180s — vllm-d takes ~100s for 1360 CSVs, pok-prod-sa ~100s for 1957 CSVs
- Increase `operatorRestOverallTimeout` from 120s to 200s
- Increase frontend `SSE_TIMEOUT` from 60s to 240s in `sseClient.ts`
- Send `cluster_data` events for ALL clusters (including empty ones) so the frontend sees progress immediately

## Test plan
- [x] SSE streaming verified: 7 clusters stream progressively
- [x] Small clusters (kind-testing123, prow, ks-docs-oci, konflux-ci) return in 1-2s
- [x] Large OLM clusters complete within timeout: vllm-d (1360 ops, ~97s), pok-prod-sa (1957 ops, ~99s), platform-eval (1908 ops, ~117s)
- [x] Total: 5,225 operators streamed successfully
- [x] Go build passes
- [x] TypeScript build passes