### PR TITLE
✨ Add SSE streaming for jobs, configmaps, secrets, NVIDIA operators + fix 5s deadline

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -516,6 +516,10 @@ func (s *Server) setupRoutes() {
 	api.Get("/mcp/nodes/stream", mcpHandlers.GetNodesStream)
 	api.Get("/mcp/gpu-nodes/stream", mcpHandlers.GetGPUNodesStream)
 	api.Get("/mcp/events/warnings/stream", mcpHandlers.GetWarningEventsStream)
+	api.Get("/mcp/jobs/stream", mcpHandlers.GetJobsStream)
+	api.Get("/mcp/configmaps/stream", mcpHandlers.GetConfigMapsStream)
+	api.Get("/mcp/secrets/stream", mcpHandlers.GetSecretsStream)
+	api.Get("/mcp/nvidia-operators/stream", mcpHandlers.GetNVIDIAOperatorStatusStream)
 
 	// GitOps routes (drift detection and sync)
 	// SECURITY: All GitOps routes require authentication in both dev and production modes


### PR DESCRIPTION
## Summary
- Add SSE progressive streaming endpoints for 4 previously REST-only resources: Jobs, ConfigMaps, Secrets, NVIDIA Operator Status
- Fix critical bug in `streamClusters()`: the `waitWithDeadline(5s)` was killing **ALL** SSE streams prematurely — replaced with `wg.Wait()` since per-cluster timeouts already handle cancellation
- Frontend hooks now try SSE first for progressive rendering (data appears per-cluster as it arrives), with REST fallback
- GPU nodes frontend hook updated to use its existing backend SSE endpoint

## Details

### Backend (Go)
- `sse.go`: Added 4 new stream handlers (`GetJobsStream`, `GetConfigMapsStream`, `GetSecretsStream`, `GetNVIDIAOperatorStatusStream`) following the established `streamClusters` pattern
- `sse.go`: Fixed `streamClusters` to use `wg.Wait()` instead of `waitWithDeadline(&wg, maxResponseDeadline)` — the 5-second deadline was terminating all SSE streams before slow clusters could respond
- `server.go`: Registered 4 new `/stream` routes

### Frontend (TypeScript)
- `compute.ts`: GPU nodes now uses SSE (`/api/mcp/gpu-nodes/stream`) with REST fallback; NVIDIA operators also use SSE
- `workloads.ts`: Jobs hook uses SSE (`/api/mcp/jobs/stream`) with REST fallback  
- `config.ts`: ConfigMaps and Secrets hooks use SSE with REST fallback

## Test plan
- [ ] `go build ./...` passes
- [ ] `npm run build && npm run lint` pass (77 pre-existing errors, 0 new)
- [ ] SSE endpoints return `event: cluster_data` events progressively
- [ ] Dashboard cards show progressive loading as cluster data arrives
- [ ] Demo mode still works for all affected endpoints