### PR TITLE
✨ Sidebar dashboard customization: ordering, remove icon, and grab handle UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,11 +25,17 @@ FEEDBACK_REPO_NAME=console
 GITHUB_WEBHOOK_SECRET=
 
 # Sidebar dashboard filter (comma-separated dashboard IDs, empty = show all)
-# Available: dashboard, clusters, deploy, ai-ml, ai-agents, ci-cd, alerts,
+# The order here controls the sidebar display order.
+# Protected items (dashboard, clusters, deploy) cannot be removed by users.
+#
+# All available dashboard IDs:
+#   dashboard, clusters, deploy, ai-ml, ai-agents, ci-cd, alerts,
 #   arcade, compliance, compute, cost, data-compliance, deployments, events,
 #   gitops, gpu-reservations, helm, llm-d-benchmarks, logs, network, nodes,
 #   operators, pods, security, security-posture, services, storage, workloads
-# Example: ENABLED_DASHBOARDS=gpu-reservations,llm-d-benchmarks
+#
+# Example (llm-d focused):
+#   ENABLED_DASHBOARDS=dashboard,gpu-reservations,llm-d-benchmarks,ai-ml,arcade
 ENABLED_DASHBOARDS=
 
 # ===========================================

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -187,6 +187,7 @@ jobs:
             --set googleDrive.existingSecret=kc-kubestellar-console \
             --set route.enabled=true \
             --set route.host=kc-kubestellar-console-kubestellar-console.apps.pokprod001.ete14.res.ibm.com \
+            --set enabledDashboards="dashboard,gpu-reservations,llm-d-benchmarks,ai-ml,arcade" \
             --wait \
             --timeout 5m
 

--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -186,7 +186,7 @@ export function UserManagement({ config: _config }: UserManagementProps) {
       defaultDirection: 'asc',
       comparators: OPENSHIFT_USER_COMPARATORS,
     },
-    defaultLimit: 5,
+    defaultLimit: 10,
   })
 
   // ---------- useCardData for Service Accounts tab ----------
@@ -212,7 +212,7 @@ export function UserManagement({ config: _config }: UserManagementProps) {
       defaultDirection: 'asc',
       comparators: SA_COMPARATORS,
     },
-    defaultLimit: 5,
+    defaultLimit: 10,
   })
 
   // ---------- useCardData for Console Users tab ----------
@@ -237,7 +237,7 @@ export function UserManagement({ config: _config }: UserManagementProps) {
       defaultDirection: 'asc',
       comparators: consoleUserComparators,
     },
-    defaultLimit: 5,
+    defaultLimit: 10,
   })
 
   // Active tab's filter/sorting references for the controls row

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -4,10 +4,10 @@ import { NavLink, useNavigate, useLocation } from 'react-router-dom'
 // Sidebar items are configured with icon names as strings (from sidebar config)
 // The renderIcon() function resolves these names dynamically via Icons[iconName]
 import * as Icons from 'lucide-react'
-import { Plus, ChevronLeft, ChevronRight, CheckCircle2, AlertTriangle, WifiOff, GripVertical, User } from 'lucide-react'
+import { Plus, ChevronLeft, ChevronRight, CheckCircle2, AlertTriangle, WifiOff, GripVertical, X, User } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { SnoozedCards } from './SnoozedCards'
-import { useSidebarConfig, SidebarItem } from '../../hooks/useSidebarConfig'
+import { useSidebarConfig, SidebarItem, PROTECTED_SIDEBAR_IDS } from '../../hooks/useSidebarConfig'
 import { useMobile } from '../../hooks/useMobile'
 import { useClusters } from '../../hooks/useMCP'
 import { useDashboardContextOptional } from '../../hooks/useDashboardContext'
@@ -18,7 +18,7 @@ import { useActiveUsers } from '../../hooks/useActiveUsers'
 import { ROUTES } from '../../config/routes'
 
 export function Sidebar() {
-  const { config, toggleCollapsed, reorderItems, updateItem, closeMobileSidebar } = useSidebarConfig()
+  const { config, toggleCollapsed, reorderItems, updateItem, removeItem, closeMobileSidebar } = useSidebarConfig()
   const { isMobile } = useMobile()
   const { deduplicatedClusters } = useClusters()
   const dashboardContext = useDashboardContextOptional()
@@ -215,9 +215,8 @@ export function Sidebar() {
           <div className={cn(
             'flex items-center gap-3 rounded-lg text-sm font-medium',
             'bg-purple-500/20 text-purple-400',
-            isCollapsed ? 'justify-center p-3' : 'px-3 py-2 pl-2'
+            isCollapsed ? 'justify-center p-3' : 'px-3 py-2'
           )}>
-            {!isCollapsed && <GripVertical className="w-3.5 h-3.5 text-muted-foreground/50 flex-shrink-0" />}
             {renderIcon(item.icon, isCollapsed ? 'w-6 h-6' : 'w-5 h-5')}
             {!isCollapsed && (
               <input
@@ -233,6 +232,7 @@ export function Sidebar() {
                 className="flex-1 bg-transparent border-b border-purple-500 outline-none text-foreground text-sm min-w-0"
               />
             )}
+            {!isCollapsed && <GripVertical className="w-3.5 h-3.5 text-muted-foreground/50 flex-shrink-0" />}
           </div>
         ) : (
           // Normal navigation mode
@@ -244,19 +244,30 @@ export function Sidebar() {
               isActive
                 ? 'bg-purple-500/20 text-purple-400'
                 : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50',
-              isCollapsed ? 'justify-center p-3' : 'px-3 py-2',
-              !isCollapsed && 'pl-2'
+              isCollapsed ? 'justify-center p-3' : 'px-3 py-2'
             )}
             title={isCollapsed ? item.name : (item.isCustom && item.href.startsWith('/custom-dashboard/') ? 'Double-click to rename' : undefined)}
           >
-            {!isCollapsed && (
-              <GripVertical
-                className="w-3.5 h-3.5 text-muted-foreground/50 opacity-0 group-hover:opacity-100 transition-opacity cursor-grab active:cursor-grabbing flex-shrink-0"
-                onMouseDown={(e) => e.stopPropagation()}
-              />
-            )}
             {renderIcon(item.icon, isCollapsed ? 'w-6 h-6' : 'w-5 h-5')}
-            {!isCollapsed && item.name}
+            {!isCollapsed && <span className="flex-1 truncate">{item.name}</span>}
+            {!isCollapsed && (
+              <span className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0 ml-1">
+                {!PROTECTED_SIDEBAR_IDS.includes(item.id) && (
+                  <span
+                    role="button"
+                    onClick={(e) => { e.preventDefault(); e.stopPropagation(); removeItem(item.id) }}
+                    className="p-0.5 rounded hover:bg-red-500/20 hover:text-red-400 text-muted-foreground/50 transition-colors"
+                    title="Remove from sidebar"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </span>
+                )}
+                <GripVertical
+                  className="w-4 h-4 text-muted-foreground/50 cursor-grab active:cursor-grabbing"
+                  onMouseDown={(e) => e.stopPropagation()}
+                />
+              </span>
+            )}
           </NavLink>
         )}
       </div>


### PR DESCRIPTION
## Summary
- **ENABLED_DASHBOARDS ordering**: Changed from `Set<string>` to `string[]` so sidebar items match the exact order specified in the env var
- **Grab handle moved to right**: `GripVertical` icon now appears on the right side of sidebar item names (was on left)
- **Remove (X) icon**: Non-protected sidebar items show a remove icon on hover. Protected items (Dashboard, Clusters, Deploy) cannot be removed
- **pok-prod deployment**: Added `--set enabledDashboards=dashboard,gpu-reservations,llm-d-benchmarks,ai-ml,arcade` to the Helm deploy step in CI
- **User Management**: Increased default page size from 5 to 10 items

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (no new errors)
- [x] Set `ENABLED_DASHBOARDS=dashboard,gpu-reservations,llm-d-benchmarks,ai-ml,arcade` locally, verified sidebar shows only those 5 in that exact order
- [x] Verified X icon and grab handle appear on right side on hover
- [x] Verified X is hidden for protected items (Dashboard)
- [x] Verified clicking X removes item from sidebar
- [ ] CI deploys to pok-prod with `enabledDashboards` set