### PR TITLE
🐛Fix: prevent cmd/console source directory from being ignored by .giti…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,13 @@ web/node_modules/
 # Build outputs
 web/dist/
 web/tsconfig.tsbuildinfo
-console
-console-server
+/console
+/console-server
 *.exe
+*.out
+*.test
+coverage.out
+
 
 # Environment and secrets
 .env
@@ -59,5 +63,5 @@ vendor/
 
 # Claude Code local files
 .bob/
-bin/
+/bin/*
 *.bak


### PR DESCRIPTION

### Summary

This PR updates `.gitignore` patterns that were unintentionally ignoring source directories in the repository, specifically the `cmd/console` Go application.

The previous rule:

```
console
```

matches **any file or directory named `console` anywhere in the repository**, which caused Git to ignore the following source path locally:

```
cmd/console/
```

As a result, contributors cloning the repository could not see `cmd/console/main.go` in their working tree even though it exists in the repository and is visible on GitHub.

---

### Problem

Because `.gitignore` patterns are recursive by default, the rule `console` ignored:

* `cmd/console/`
* any future directories named `console`

This led to:

* Missing source files after cloning
* Confusing onboarding experience for new contributors
* IDEs (e.g., VS Code) hiding valid project files

---

### Changes

* Replace broad ignore rules with root-scoped patterns:

  ```
  console        →   /console
  console-server →   /console-server
  ```

  This ensures only root-level build binaries are ignored.

* Add common Go build/test artifacts:

  ```
  *.out
  *.test
  coverage.out
  ```

* Make `bin/` ignore safer by limiting it to generated binaries.

---

### Why this change

The repository contains Go applications located under:

```
cmd/console/
cmd/kc-agent/
```

These directories should always remain visible and tracked.
The updated patterns preserve the intended behavior (ignoring build outputs) without affecting source code.

---

### Impact

✅ Prevents accidental hiding of source directories
✅ Improves contributor onboarding experience
✅ Aligns `.gitignore` with common Go project conventions
✅ No runtime or CI behavior changes

---

### Testing

* Fresh clone verified to include `cmd/console/main.go`
* `git check-ignore` confirms source directories are no longer ignored
* Build artifacts remain ignored as intended

---

### Notes

This is a non-functional change affecting only repository hygiene and developer experience.
fixes #1010 