### PR TITLE
🐛 Add Cluster Admin to sidebar customizer catalog

### DIFF
--- a/web/src/components/layout/SidebarCustomizer.tsx
+++ b/web/src/components/layout/SidebarCustomizer.tsx
@@ -136,6 +136,7 @@ const KNOWN_ROUTES: KnownRoute[] = [
   { href: '/ai-agents', name: 'AI Agents', description: 'Kagenti agent platform — deploy, secure, and manage AI agents across clusters', icon: 'Bot', category: 'Core Dashboards' },
   { href: '/llm-d-benchmarks', name: 'llm-d Benchmarks', description: 'LLM inference benchmarks — throughput, latency, and GPU utilization across clouds and accelerators', icon: 'TrendingUp', category: 'Core Dashboards' },
   { href: '/compliance', name: 'Compliance', description: 'Regulatory compliance, audit logs, and policy enforcement', icon: 'ClipboardCheck', category: 'Core Dashboards' },
+  { href: '/cluster-admin', name: 'Cluster Admin', description: 'Multi-cluster operations, control plane health, node debugging, and infrastructure management', icon: 'ShieldAlert', category: 'Core Dashboards' },
   // Resource Pages
   { href: '/namespaces', name: 'Namespaces', description: 'Namespace management and resource allocation', icon: 'FolderTree', category: 'Resources' },
   { href: '/nodes', name: 'Nodes', description: 'Cluster node health and resource usage', icon: 'HardDrive', category: 'Resources' },


### PR DESCRIPTION
## Summary
- Adds the Cluster Admin dashboard entry to `KNOWN_ROUTES` in `SidebarCustomizer.tsx`
- Without this, the Cluster Admin dashboard doesn't appear in the "Customize Sidebar" modal even though the route, page component, and sidebar config all exist

## Test plan
- [ ] Open Customize Sidebar modal, search "cluster" — Cluster Admin now appears
- [ ] Add it to sidebar, verify it navigates to `/cluster-admin`