### PR TITLE
⚡ Performance overhaul: skip offline clusters, SSE-only data fetching

### DIFF
--- a/pkg/api/handlers/gateway.go
+++ b/pkg/api/handlers/gateway.go
@@ -92,7 +92,7 @@ func (h *GatewayHandlers) GetGatewayAPIStatus(c *fiber.Ctx) error {
 		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
 	}
 
-	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 	}

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -164,7 +164,7 @@ func (h *GitOpsHandlers) ListHelmReleases(c *fiber.Ctx) error {
 
 	// Query all clusters in parallel with timeout
 	if h.k8sClient != nil {
-		clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
 			return c.Status(500).JSON(fiber.Map{"error": err.Error(), "releases": []HelmRelease{}})
 		}
@@ -246,7 +246,7 @@ func (h *GitOpsHandlers) ListKustomizations(c *fiber.Ctx) error {
 
 	// Query all clusters in parallel with timeout
 	if h.k8sClient != nil {
-		clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
 			return c.Status(500).JSON(fiber.Map{"error": err.Error(), "kustomizations": []Kustomization{}})
 		}
@@ -407,7 +407,7 @@ func (h *GitOpsHandlers) ListOperators(c *fiber.Ctx) error {
 	// Query all clusters in parallel — operators are slow, so we wait for all
 	// (no maxResponseDeadline; SSE streaming is preferred for UI)
 	if h.k8sClient != nil {
-		clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
 			return c.Status(500).JSON(fiber.Map{"error": err.Error(), "operators": []Operator{}})
 		}
@@ -479,7 +479,7 @@ func (h *GitOpsHandlers) StreamOperators(c *fiber.Ctx) error {
 		return nil
 	}
 
-	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 	}
@@ -667,7 +667,7 @@ func (h *GitOpsHandlers) ListOperatorSubscriptions(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient != nil {
-		clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
 			return c.Status(500).JSON(fiber.Map{"error": err.Error(), "subscriptions": []OperatorSubscription{}})
 		}
@@ -734,7 +734,7 @@ func (h *GitOpsHandlers) StreamOperatorSubscriptions(c *fiber.Ctx) error {
 		return nil
 	}
 
-	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 	}
@@ -867,7 +867,7 @@ func (h *GitOpsHandlers) StreamHelmReleases(c *fiber.Ctx) error {
 		return nil
 	}
 
-	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 	}

--- a/pkg/api/handlers/mcs.go
+++ b/pkg/api/handlers/mcs.go
@@ -92,7 +92,7 @@ func (h *MCSHandlers) GetMCSStatus(c *fiber.Ctx) error {
 		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
 	}
 
-	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 	}

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -171,7 +171,7 @@ func (h *RBACHandler) ListK8sServiceAccounts(c *fiber.Ctx) error {
 	}
 
 	// Get SAs from all clusters
-	clusters, err := h.k8sClient.DeduplicatedClusters(ctx)
+	clusters, _, err := h.k8sClient.HealthyClusters(ctx)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list clusters")
 	}

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -414,7 +414,7 @@ func (h *WorkloadHandlers) EvaluateClusterQuery(c *fiber.Ctx) error {
 	// Deduplicate clusters — multiple kubeconfig contexts can point to the
 	// same physical cluster (e.g. "vllm-d" and "default/api-fmaas-vllm-d-…").
 	// We only want one result per unique server URL.
-	dedupClusters, err := h.k8sClient.DeduplicatedClusters(ctx)
+	dedupClusters, _, err := h.k8sClient.HealthyClusters(ctx)
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": "Failed to list clusters: " + err.Error()})
 	}

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -829,7 +829,7 @@ export async function fetchSingleClusterHealth(clusterName: string, kubectlConte
     try {
       const context = kubectlContext || clusterName
       const controller = new AbortController()
-      const timeoutId = setTimeout(() => controller.abort(), 65000) // 65s timeout — large clusters can take 30s+ uncached
+      const timeoutId = setTimeout(() => controller.abort(), 15000) // 15s timeout — offline clusters fail fast
       const response = await fetch(`${LOCAL_AGENT_URL}/cluster-health?cluster=${encodeURIComponent(context)}`, {
         signal: controller.signal,
         headers: { 'Accept': 'application/json' },
@@ -857,7 +857,7 @@ export async function fetchSingleClusterHealth(clusterName: string, kubectlConte
     const response = await fetch(
       `/api/mcp/clusters/${encodeURIComponent(clusterName)}/health`,
       {
-        signal: AbortSignal.timeout(65000),
+        signal: AbortSignal.timeout(15000), // 15s — offline clusters fail fast
         headers: token ? { 'Authorization': `Bearer ${token}` } : {},
       }
     )
@@ -1162,7 +1162,7 @@ async function processClusterHealth(cluster: ClusterInfo): Promise<void> {
 
 // Concurrency limit for health checks - rolling concurrency for 100+ clusters
 // Keep at 2 to avoid overwhelming the local agent WebSocket connection
-const HEALTH_CHECK_CONCURRENCY = 2
+const HEALTH_CHECK_CONCURRENCY = 6
 
 // Progressive health check with rolling concurrency
 // Uses continuous processing: as soon as one finishes, the next starts

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -20,7 +20,7 @@ export interface SSEFetchOptions<T> {
   signal?: AbortSignal
 }
 
-const SSE_TIMEOUT = 240_000 // 4 minutes — operators can take 100s+ for large clusters
+const SSE_TIMEOUT = 60_000 // 60s — backend now skips offline clusters and has 30s deadline
 
 /**
  * Open an SSE connection and progressively collect data.


### PR DESCRIPTION
## Summary

Comprehensive performance overhaul to make the console responsive. Previously the dashboard took 30+ seconds to become interactive because every API call spawned goroutines for all 13 clusters (6-8 offline), each waiting 15-30s to timeout.

**Key changes:**

- **Backend: Skip offline clusters** — New `HealthyClusters()` method filters clusters by cached health status. All 31 handlers now only query healthy/unknown clusters, instantly skipping offline ones
- **Backend: SSE improvements** — `streamClusters()` emits `cluster_skipped` events for offline clusters, has 45s overall deadline, bumped pod timeout to 15s for large clusters (pok-prod-sa)
- **Frontend: SSE-only data fetching** — Converted 8 REST-only hooks to SSE streaming (usePods, useAllPods, usePodIssues, useDeploymentIssues, useEvents, useWarningEvents, useSecurityIssues, useNodes). Removed REST fallback from useJobs
- **Frontend: Faster health checks** — Increased concurrency from 2→6, reduced per-cluster timeout from 65s→15s, reduced SSE client timeout from 240s→60s
- **Backend: REST fallback** — Raised `maxResponseDeadline` from 5s→30s so REST endpoints return useful data when they are used

**Expected impact:**

| Metric | Before | After |
|--------|--------|-------|
| Time to first card data | 30-40s | 3-5s |
| SSE stream completion | 30-60s | 5-10s |
| Health check duration | 300+s worst case | 15-45s max |
| Goroutines wasted on offline clusters | 6-8 per request | 0 |

## Test plan

- [ ] `go build ./...` passes
- [ ] `npm run build` passes
- [ ] Dashboard cards show data progressively within 3-5s
- [ ] Offline clusters show as skipped (not blocking)
- [ ] SSE streams complete within 10-15s
- [ ] Health checks complete within 20-45s
- [ ] Demo mode still works instantly
- [ ] Large clusters (pok-prod-sa) return data within 15s per-cluster timeout