### PR TITLE
⚡ Warmup health cache on startup & increase SSE timeouts

### DIFF
--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -35,7 +35,7 @@ func writeSSEEvent(w *bufio.Writer, eventName string, data interface{}) {
 // sseOverallDeadline is the maximum wall-clock time an SSE stream stays open.
 // After this, any still-running goroutines are abandoned and a "done" event
 // is sent with partial results. This prevents the browser from hanging.
-const sseOverallDeadline = 45 * time.Second
+const sseOverallDeadline = 120 * time.Second
 
 // streamClusters is a generic helper that streams per-cluster results as SSE events.
 //
@@ -165,7 +165,7 @@ func (h *MCPHandlers) GetPodsStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "pods",
-		clusterTimeout: 15 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		pods, err := h.k8sClient.GetPods(ctx, cluster, namespace)
 		if err != nil {
@@ -187,7 +187,7 @@ func (h *MCPHandlers) FindPodIssuesStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "issues",
-		clusterTimeout: 5 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		issues, err := h.k8sClient.FindPodIssues(ctx, cluster, namespace)
 		if err != nil {
@@ -209,7 +209,7 @@ func (h *MCPHandlers) GetDeploymentsStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "deployments",
-		clusterTimeout: 5 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		deps, err := h.k8sClient.GetDeployments(ctx, cluster, namespace)
 		if err != nil {
@@ -233,7 +233,7 @@ func (h *MCPHandlers) GetEventsStream(c *fiber.Ctx) error {
 
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "events",
-		clusterTimeout: 5 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		events, err := h.k8sClient.GetEvents(ctx, cluster, namespace, limit)
 		if err != nil {
@@ -255,7 +255,7 @@ func (h *MCPHandlers) GetServicesStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "services",
-		clusterTimeout: 5 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		svcs, err := h.k8sClient.GetServices(ctx, cluster, namespace)
 		if err != nil {
@@ -277,7 +277,7 @@ func (h *MCPHandlers) CheckSecurityIssuesStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "issues",
-		clusterTimeout: 5 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		issues, err := h.k8sClient.CheckSecurityIssues(ctx, cluster, namespace)
 		if err != nil {
@@ -299,7 +299,7 @@ func (h *MCPHandlers) FindDeploymentIssuesStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "issues",
-		clusterTimeout: 5 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		issues, err := h.k8sClient.FindDeploymentIssues(ctx, cluster, namespace)
 		if err != nil {
@@ -320,7 +320,7 @@ func (h *MCPHandlers) GetNodesStream(c *fiber.Ctx) error {
 
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "nodes",
-		clusterTimeout: 15 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		return h.k8sClient.GetNodes(ctx, cluster)
 	})
@@ -337,7 +337,7 @@ func (h *MCPHandlers) GetGPUNodesStream(c *fiber.Ctx) error {
 
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "nodes",
-		clusterTimeout: 30 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		return h.k8sClient.GetGPUNodes(ctx, cluster)
 	})
@@ -355,7 +355,7 @@ func (h *MCPHandlers) GetWarningEventsStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "events",
-		clusterTimeout: 15 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		return h.k8sClient.GetWarningEvents(ctx, cluster, namespace, 50)
 	})
@@ -373,7 +373,7 @@ func (h *MCPHandlers) GetJobsStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "jobs",
-		clusterTimeout: 15 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		return h.k8sClient.GetJobs(ctx, cluster, namespace)
 	})
@@ -391,7 +391,7 @@ func (h *MCPHandlers) GetConfigMapsStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "configmaps",
-		clusterTimeout: 15 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		return h.k8sClient.GetConfigMaps(ctx, cluster, namespace)
 	})
@@ -409,7 +409,7 @@ func (h *MCPHandlers) GetSecretsStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "secrets",
-		clusterTimeout: 15 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		return h.k8sClient.GetSecrets(ctx, cluster, namespace)
 	})
@@ -426,7 +426,7 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatusStream(c *fiber.Ctx) error {
 
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "operators",
-		clusterTimeout: 15 * time.Second,
+		clusterTimeout: 60 * time.Second,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		status, err := h.k8sClient.GetNVIDIAOperatorStatus(ctx, cluster)
 		if err != nil {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -135,6 +135,9 @@ func NewServer(cfg Config) (*Server, error) {
 			log.Println("No kubeconfig found — connect clusters via Settings or place a kubeconfig at ~/.kube/config")
 		} else {
 			log.Println("Kubernetes client initialized successfully")
+			// Warmup: probe all clusters to populate health cache before serving.
+			// Without this, first load hits ALL clusters (including offline) = 30s+ load.
+			k8sClient.WarmupHealthCache()
 		}
 		k8sClient.SetOnReload(func() {
 			hub.BroadcastAll(handlers.Message{

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -20,7 +20,7 @@ export interface SSEFetchOptions<T> {
   signal?: AbortSignal
 }
 
-const SSE_TIMEOUT = 60_000 // 60s — backend now skips offline clusters and has 30s deadline
+const SSE_TIMEOUT = 180_000 // 180s — backend has 120s overall deadline, slow clusters need time
 
 /**
  * Open an SSE connection and progressively collect data.


### PR DESCRIPTION
## Summary
- **Add `WarmupHealthCache()`** — probes all clusters on startup using a lightweight namespace list (5s per-cluster timeout, all parallel). Completes in ~1s. Populates health cache before serving requests so `HealthyClusters()` can immediately skip offline clusters.
- **Increase per-cluster SSE timeout** from 5-15s to 60s — slow-but-healthy clusters (pok-prod-sa, vllm-d, platform-eval) can now return data at their own pace
- **Increase overall SSE deadline** from 45s to 120s — stream stays open for slow clusters
- **Increase frontend SSE timeout** from 60s to 180s — matches backend deadline

Without the warmup, the first page load hits ALL clusters (including offline) because the health cache starts empty. This caused 30s+ load times even after PR #1015.

## Test plan
- [x] `go build ./...` passes
- [x] `npx tsc --noEmit` passes
- [x] Backend logs show `[Warmup] probing N clusters...` and completes in ~1s
- [x] Warmup correctly identifies reachable vs unreachable clusters
- [ ] Dashboard shows data from fast clusters within 3-5s
- [ ] Slow clusters deliver data progressively without blocking