### PR TITLE
Add all-card TTFI performance matrix and CI hard gate (v2)

### DIFF
--- a/.github/workflows/perf-ttfi.yml
+++ b/.github/workflows/perf-ttfi.yml
@@ -1,0 +1,70 @@
+name: Performance TTFI Gate
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - 'web/**'
+      - 'scripts/perf-test.sh'
+      - '.github/workflows/perf-ttfi.yml'
+  workflow_dispatch:
+
+env:
+  CI: true
+
+jobs:
+  all-cards-ttfi:
+    name: All Cards TTFI (Hard Gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run all-card TTFI suite
+        run: npm run test:e2e:perf:ttfi
+
+      - name: Compare against baseline (hard fail)
+        run: node e2e/perf/compare-ttfi.mjs
+
+      - name: Upload TTFI artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ttfi-artifacts
+          path: |
+            web/e2e/test-results/ttfi-report.json
+            web/e2e/test-results/ttfi-summary.md
+            web/e2e/test-results/ttfi-regression.md
+            web/perf-report/
+          retention-days: 14
+
+      - name: Publish summary
+        if: always()
+        run: |
+          echo "## All-Card TTFI Gate" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f "e2e/test-results/ttfi-summary.md" ]; then
+            cat e2e/test-results/ttfi-summary.md >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f "e2e/test-results/ttfi-regression.md" ]; then
+            cat e2e/test-results/ttfi-regression.md >> $GITHUB_STEP_SUMMARY
+          fi

--- a/scripts/perf-test.sh
+++ b/scripts/perf-test.sh
@@ -5,6 +5,8 @@
 #   ./scripts/perf-test.sh              # All dashboards, both modes (production build)
 #   ./scripts/perf-test.sh --demo-only  # Demo mode only (production build)
 #   ./scripts/perf-test.sh --live-only  # Live mode only (production build)
+#   ./scripts/perf-test.sh --ttfi       # All-card TTFI matrix (cold/warm + demo/live)
+#   ./scripts/perf-test.sh --ttfi-gate  # All-card TTFI + hard budget gate
 #   ./scripts/perf-test.sh --dev        # Use Vite dev server instead of production build
 #
 # By default, tests run against a production build (vite preview) which
@@ -24,25 +26,41 @@ cd "$(dirname "$0")/../web"
 
 GREP_FILTER=""
 EXTRA_ENV=""
+TTFI_MODE=""
 
 for arg in "$@"; do
   case "$arg" in
     --demo-only) GREP_FILTER="--grep demo"; echo "Running demo mode tests only..." ;;
     --live-only) GREP_FILTER="--grep live"; echo "Running live mode tests only..." ;;
+    --ttfi)      TTFI_MODE="ttfi"; echo "Running all-card TTFI matrix..." ;;
+    --ttfi-gate) TTFI_MODE="ttfi-gate"; echo "Running all-card TTFI matrix with hard gate..." ;;
     --dev)       EXTRA_ENV="PERF_DEV=1"; echo "Using Vite dev server..." ;;
   esac
 done
 
-if [[ -z "$GREP_FILTER" && -z "$EXTRA_ENV" ]]; then
+if [[ -z "$GREP_FILTER" && -z "$EXTRA_ENV" && -z "$TTFI_MODE" ]]; then
   echo "Running all performance tests against production build..."
 fi
 
-env $EXTRA_ENV npx playwright test \
-  --config e2e/perf/perf.config.ts \
-  $GREP_FILTER
+if [[ "$TTFI_MODE" == "ttfi" ]]; then
+  env $EXTRA_ENV npx playwright test \
+    --config e2e/perf/perf.config.ts \
+    e2e/perf/all-cards-ttfi.spec.ts
+elif [[ "$TTFI_MODE" == "ttfi-gate" ]]; then
+  env $EXTRA_ENV npx playwright test \
+    --config e2e/perf/perf.config.ts \
+    e2e/perf/all-cards-ttfi.spec.ts
+  node e2e/perf/compare-ttfi.mjs
+else
+  env $EXTRA_ENV npx playwright test \
+    --config e2e/perf/perf.config.ts \
+    $GREP_FILTER
+fi
 
 echo ""
 echo "Reports:"
 echo "  JSON:    web/e2e/test-results/perf-report.json"
 echo "  Summary: web/e2e/test-results/perf-summary.txt"
+echo "  TTFI:    web/e2e/test-results/ttfi-report.json"
+echo "  Gate:    web/e2e/test-results/ttfi-regression.md"
 echo "  HTML:    web/e2e/perf-report/index.html"

--- a/web/e2e/perf/all-cards-ttfi.spec.ts
+++ b/web/e2e/perf/all-cards-ttfi.spec.ts
@@ -1,0 +1,401 @@
+import { expect, test, type Page } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+type PerfMode = 'live-cold' | 'live-warm' | 'demo-cold' | 'demo-warm'
+type DataSource = 'cache' | 'stream' | 'network' | 'demo'
+type Status = 'ok' | 'timeout' | 'error'
+
+interface ManifestItem {
+  cardType: string
+  cardId: string
+}
+
+interface ManifestData {
+  allCardTypes: string[]
+  totalCards: number
+  batch: number
+  batchSize: number
+  selected: ManifestItem[]
+}
+
+interface CardTTFIMetric {
+  cardType: string
+  cardId: string
+  mode: PerfMode
+  source: DataSource
+  status: Status
+  ttfi_ms: number
+  timedOut: boolean
+  batchIndex: number
+}
+
+interface TTFIReport {
+  timestamp: string
+  batchSize: number
+  cards: CardTTFIMetric[]
+}
+
+const mockUser = {
+  id: '1',
+  github_id: '12345',
+  github_login: 'perftest',
+  email: 'perf@test.com',
+  onboarded: true,
+}
+
+const BATCH_SIZE = 24
+const BATCH_TIMEOUT_MS = 18_000
+const report: TTFIReport = {
+  timestamp: new Date().toISOString(),
+  batchSize: BATCH_SIZE,
+  cards: [],
+}
+
+const MOCK_CLUSTER = 'perf-test-cluster'
+
+const MOCK_DATA: Record<string, Record<string, unknown[]>> = {
+  clusters: { clusters: [{ name: MOCK_CLUSTER, reachable: true, status: 'Ready' }] },
+  pods: {
+    pods: [
+      { name: 'nginx-1', namespace: 'default', cluster: MOCK_CLUSTER, status: 'Running' },
+      { name: 'api-1', namespace: 'kube-system', cluster: MOCK_CLUSTER, status: 'Running' },
+    ],
+  },
+  events: {
+    events: [
+      { type: 'Normal', reason: 'Scheduled', message: 'Pod scheduled', cluster: MOCK_CLUSTER },
+      { type: 'Warning', reason: 'BackOff', message: 'Restarting container', cluster: MOCK_CLUSTER },
+    ],
+  },
+  'pod-issues': { issues: [{ name: 'api-1', namespace: 'kube-system', cluster: MOCK_CLUSTER }] },
+  deployments: { deployments: [{ name: 'nginx', namespace: 'default', cluster: MOCK_CLUSTER }] },
+  'deployment-issues': { issues: [] },
+  services: { services: [{ name: 'nginx-svc', namespace: 'default', cluster: MOCK_CLUSTER }] },
+  'security-issues': { issues: [{ name: 'nginx-1', namespace: 'default', cluster: MOCK_CLUSTER }] },
+}
+
+function buildSSEResponse(endpoint: string): string {
+  const data = MOCK_DATA[endpoint] || { items: [] }
+  const key = Object.keys(data)[0] || 'items'
+  const items = data[key] || []
+  return [
+    'event: cluster_data',
+    `data: ${JSON.stringify({ cluster: MOCK_CLUSTER, [key]: items })}`,
+    '',
+    'event: done',
+    `data: ${JSON.stringify({ totalClusters: 1, source: 'mock' })}`,
+    '',
+  ].join('\n')
+}
+
+function getMockRESTData(url: string): Record<string, unknown> {
+  const match = url.match(/\/api\/mcp\/([^/?]+)/)
+  const endpoint = match?.[1] || ''
+  return MOCK_DATA[endpoint] ? { ...MOCK_DATA[endpoint], source: 'mock' } : { items: [], source: 'mock' }
+}
+
+async function setupAuth(page: Page) {
+  await page.route('**/api/me', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockUser) })
+  )
+}
+
+async function setupLiveMocks(page: Page) {
+  await page.route('**/api/mcp/*/stream**', (route) => {
+    const url = route.request().url()
+    const endpoint = url.match(/\/api\/mcp\/([^/]+)\/stream/)?.[1] || ''
+    route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      headers: { 'Cache-Control': 'no-cache', Connection: 'keep-alive' },
+      body: buildSSEResponse(endpoint),
+    })
+  })
+
+  await page.route('**/api/mcp/**', async (route) => {
+    if (route.request().url().includes('/stream')) {
+      await route.fallback()
+      return
+    }
+    const delay = 80 + Math.random() * 180
+    await new Promise((resolve) => setTimeout(resolve, delay))
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(getMockRESTData(route.request().url())),
+    })
+  })
+
+  await page.route('**/health', (route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) })
+  })
+
+  await page.route('**/api/workloads**', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ items: [] }) })
+  )
+
+  await page.route('**/api/**', async (route) => {
+    const url = route.request().url()
+    if (url.includes('/api/mcp/') || url.includes('/api/me') || url.includes('/api/workloads')) {
+      await route.fallback()
+      return
+    }
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ items: [] }) })
+  })
+
+  await page.route('http://127.0.0.1:8585/**', (route) => {
+    const url = route.request().url()
+    if (url.endsWith('/health') || url.includes('/health?')) {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', version: 'perf-test' }),
+      })
+      return
+    }
+    route.fulfill({ status: 503, contentType: 'application/json', body: '{"status":"unavailable"}' })
+  })
+
+  await page.routeWebSocket('ws://127.0.0.1:8585/**', (ws) => {
+    ws.onMessage((data) => {
+      try {
+        const msg = JSON.parse(String(data))
+        ws.send(JSON.stringify({ id: msg.id, type: 'result', payload: { output: '{"items":[]}', exitCode: 0 } }))
+      } catch {
+        // ignore
+      }
+    })
+  })
+}
+
+async function setMode(page: Page, mode: PerfMode) {
+  const isDemo = mode.startsWith('demo')
+  const isWarm = mode.endsWith('warm')
+
+  await page.addInitScript(
+    ({ demo, warm, user }: { demo: boolean; warm: boolean; user: unknown }) => {
+      localStorage.setItem('token', demo ? 'demo-token' : 'test-token')
+      localStorage.setItem('kc-demo-mode', String(demo))
+      localStorage.setItem('demo-user-onboarded', 'true')
+      localStorage.setItem('kubestellar-console-tour-completed', 'true')
+      localStorage.setItem('kc-user-cache', JSON.stringify(user))
+      localStorage.setItem('kc-backend-status', JSON.stringify({ available: true, timestamp: Date.now() }))
+      localStorage.setItem('kc-sqlite-migrated', '2')
+
+      if (!warm) {
+        for (let i = localStorage.length - 1; i >= 0; i--) {
+          const key = localStorage.key(i)
+          if (!key) continue
+          if (key.includes('dashboard-cards') || key.startsWith('cache:') || key.includes('kubestellar-stack-cache')) {
+            localStorage.removeItem(key)
+          }
+        }
+      }
+    },
+    { demo: isDemo, warm: isWarm, user: mockUser }
+  )
+
+  if (!isWarm) {
+    await page.addInitScript(() => {
+      const databases = ['kc_cache', 'kubestellar-cache']
+      for (const name of databases) {
+        try {
+          indexedDB.deleteDatabase(name)
+        } catch {
+          // ignore
+        }
+      }
+    })
+  }
+}
+
+async function getManifestForBatch(page: Page, batch: number, batchSize: number): Promise<ManifestData> {
+  await page.goto(`/__perf/all-cards?batch=${batch + 1}&size=${batchSize}`, { waitUntil: 'domcontentloaded' })
+  try {
+    await page.waitForFunction(() => !!window.__TTFI_MANIFEST__, { timeout: 60_000 })
+  } catch {
+    const debug = await page.evaluate(() => ({
+      path: window.location.pathname,
+      hasManifestEl: !!document.querySelector('[data-testid="ttfi-manifest"]'),
+      hasSidebar: !!document.querySelector('[data-testid="sidebar"]'),
+      bodyPreview: (document.body.textContent || '').slice(0, 300),
+      hasLoginForm: !!document.querySelector('input[type="password"]'),
+    }))
+    throw new Error(`TTFI manifest did not load: ${JSON.stringify(debug)}`)
+  }
+
+  const manifest = await page.evaluate(() => window.__TTFI_MANIFEST__)
+  if (!manifest) {
+    throw new Error('Missing __TTFI_MANIFEST__ from all-cards perf route')
+  }
+  return manifest as ManifestData
+}
+
+async function monitorBatch(page: Page, cardIds: string[], timeoutMs: number): Promise<{
+  loadTimes: Record<string, number>
+  timedOut: string[]
+}> {
+  const handle = await page.waitForFunction(
+    ({ ids, timeout }: { ids: string[]; timeout: number }) => {
+      const win = window as Window & {
+        __TTFI_MONITOR__?: { startedAt: number; loadTimes: Record<string, number> }
+      }
+      const now = performance.now()
+      if (!win.__TTFI_MONITOR__) {
+        win.__TTFI_MONITOR__ = { startedAt: now, loadTimes: {} }
+      }
+      const monitor = win.__TTFI_MONITOR__
+
+      for (const id of ids) {
+        if (monitor.loadTimes[id] !== undefined) continue
+        const card = document.querySelector(`[data-card-id="${id}"]`)
+        if (!card) continue
+
+        const isLoading = card.getAttribute('data-loading') === 'true'
+        if (isLoading) continue
+
+        let hasLargeSkeleton = false
+        for (const pulse of card.querySelectorAll('.animate-pulse')) {
+          const rect = (pulse as HTMLElement).getBoundingClientRect()
+          if (rect.height > 40) {
+            hasLargeSkeleton = true
+            break
+          }
+        }
+        if (hasLargeSkeleton) continue
+
+        const textLen = (card.textContent || '').trim().length
+        const hasVisualContent = !!card.querySelector('canvas,svg,iframe,table,img,video,pre,code,[role="img"]')
+        if (textLen <= 10 && !hasVisualContent) continue
+
+        monitor.loadTimes[id] = Math.round(now - monitor.startedAt)
+      }
+
+      const missing = ids.filter((id) => monitor.loadTimes[id] === undefined)
+      if (missing.length === 0) {
+        return { loadTimes: monitor.loadTimes, timedOut: [] }
+      }
+
+      if (now - monitor.startedAt > timeout) {
+        return { loadTimes: monitor.loadTimes, timedOut: missing }
+      }
+      return false
+    },
+    { ids: cardIds, timeout: timeoutMs },
+    { timeout: timeoutMs + 3_000, polling: 100 }
+  )
+  return (await handle.jsonValue()) as { loadTimes: Record<string, number>; timedOut: string[] }
+}
+
+async function prewarmIfNeeded(page: Page, mode: PerfMode, totalCards: number) {
+  if (!mode.endsWith('warm')) return
+  const batches = Math.ceil(totalCards / BATCH_SIZE)
+  for (let batch = 0; batch < batches; batch++) {
+    await getManifestForBatch(page, batch, BATCH_SIZE)
+    await page.waitForTimeout(350)
+  }
+}
+
+function modeToSource(mode: PerfMode): DataSource {
+  if (mode.startsWith('demo')) return 'demo'
+  if (mode.endsWith('warm')) return 'cache'
+  return 'network'
+}
+
+function summarizeMode(cards: CardTTFIMetric[]): string {
+  if (cards.length === 0) return 'no-cards'
+  const valid = cards.filter((c) => c.status === 'ok')
+  const timeouts = cards.filter((c) => c.status === 'timeout').length
+  const avg = valid.length
+    ? Math.round(valid.reduce((sum, c) => sum + c.ttfi_ms, 0) / valid.length)
+    : -1
+  const p95 = valid.length
+    ? [...valid].sort((a, b) => a.ttfi_ms - b.ttfi_ms)[Math.max(0, Math.ceil(valid.length * 0.95) - 1)].ttfi_ms
+    : -1
+  return `cards=${cards.length} ok=${valid.length} timeout=${timeouts} avg=${avg}ms p95=${p95}ms`
+}
+
+async function runMode(page: Page, mode: PerfMode): Promise<CardTTFIMetric[]> {
+  await setupAuth(page)
+  if (mode.startsWith('live')) {
+    await setupLiveMocks(page)
+  }
+  await setMode(page, mode)
+
+  const firstManifest = await getManifestForBatch(page, 0, BATCH_SIZE)
+  const totalCards = firstManifest.totalCards
+  await prewarmIfNeeded(page, mode, totalCards)
+
+  const expectedTypes = new Set(firstManifest.allCardTypes)
+  const seenTypes = new Set<string>()
+  const batches = Math.ceil(totalCards / BATCH_SIZE)
+  const results: CardTTFIMetric[] = []
+
+  for (let batch = 0; batch < batches; batch++) {
+    const manifest = await getManifestForBatch(page, batch, BATCH_SIZE)
+    const selected = manifest.selected || []
+    if (selected.length === 0) continue
+
+    for (const item of selected) seenTypes.add(item.cardType)
+
+    const cardIds = selected.map((item) => item.cardId)
+    const monitored = await monitorBatch(page, cardIds, BATCH_TIMEOUT_MS)
+
+    for (const item of selected) {
+      const ttfi = monitored.loadTimes[item.cardId]
+      const timedOut = monitored.timedOut.includes(item.cardId) || ttfi === undefined
+      results.push({
+        cardType: item.cardType,
+        cardId: item.cardId,
+        mode,
+        source: modeToSource(mode),
+        status: timedOut ? 'timeout' : 'ok',
+        ttfi_ms: timedOut ? BATCH_TIMEOUT_MS : ttfi,
+        timedOut,
+        batchIndex: batch,
+      })
+    }
+  }
+
+  expect(seenTypes.size, `${mode}: rendered card types`).toBe(expectedTypes.size)
+  return results
+}
+
+test.describe.configure({ mode: 'serial' })
+
+for (const mode of ['live-cold', 'live-warm', 'demo-cold', 'demo-warm'] as const) {
+  test(`all cards TTFI (${mode})`, async ({ page }) => {
+    const modeResults = await runMode(page, mode)
+    report.cards.push(...modeResults)
+    console.log(`[TTFI] ${mode}: ${summarizeMode(modeResults)}`)
+  })
+}
+
+test.afterAll(async () => {
+  const outDir = path.resolve(__dirname, '../test-results')
+  if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true })
+
+  const byMode = new Map<PerfMode, CardTTFIMetric[]>()
+  for (const mode of ['live-cold', 'live-warm', 'demo-cold', 'demo-warm'] as const) {
+    byMode.set(mode, report.cards.filter((card) => card.mode === mode))
+  }
+
+  const summaryLines = [
+    '# All-Card TTFI Summary',
+    '',
+    `Generated: ${new Date().toISOString()}`,
+    `Total records: ${report.cards.length}`,
+    '',
+  ]
+
+  for (const mode of ['live-cold', 'live-warm', 'demo-cold', 'demo-warm'] as const) {
+    summaryLines.push(`- ${mode}: ${summarizeMode(byMode.get(mode) || [])}`)
+  }
+
+  fs.writeFileSync(path.join(outDir, 'ttfi-report.json'), JSON.stringify(report, null, 2))
+  fs.writeFileSync(path.join(outDir, 'ttfi-summary.md'), `${summaryLines.join('\n')}\n`)
+})

--- a/web/e2e/perf/baseline/ttfi-baseline.json
+++ b/web/e2e/perf/baseline/ttfi-baseline.json
@@ -1,0 +1,24 @@
+{
+  "budgets": {
+    "live-cold": {
+      "max_ttfi_ms": 5000,
+      "max_p95_ms": 1500,
+      "max_timeout_count": 36
+    },
+    "live-warm": {
+      "max_ttfi_ms": 4000,
+      "max_p95_ms": 1200,
+      "max_timeout_count": 18
+    },
+    "demo-cold": {
+      "max_ttfi_ms": 2500,
+      "max_p95_ms": 800,
+      "max_timeout_count": 2
+    },
+    "demo-warm": {
+      "max_ttfi_ms": 2500,
+      "max_p95_ms": 900,
+      "max_timeout_count": 1
+    }
+  }
+}

--- a/web/e2e/perf/compare-ttfi.mjs
+++ b/web/e2e/perf/compare-ttfi.mjs
@@ -1,0 +1,89 @@
+import fs from 'fs'
+import path from 'path'
+
+const root = process.cwd()
+const reportPath = process.env.TTFI_REPORT_PATH || path.join(root, 'e2e', 'test-results', 'ttfi-report.json')
+const baselinePath = process.env.TTFI_BASELINE_PATH || path.join(root, 'e2e', 'perf', 'baseline', 'ttfi-baseline.json')
+const outputPath = process.env.TTFI_SUMMARY_PATH || path.join(root, 'e2e', 'test-results', 'ttfi-regression.md')
+
+function fail(msg) {
+  console.error(msg)
+  process.exit(1)
+}
+
+if (!fs.existsSync(reportPath)) fail(`TTFI report not found: ${reportPath}`)
+if (!fs.existsSync(baselinePath)) fail(`TTFI baseline not found: ${baselinePath}`)
+
+const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
+const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'))
+
+const cards = Array.isArray(report.cards) ? report.cards : []
+if (cards.length === 0) fail('TTFI report has no card metrics')
+
+const modes = ['live-cold', 'live-warm', 'demo-cold', 'demo-warm']
+const failures = []
+const lines = [
+  '# TTFI Regression Check',
+  '',
+  `Report: \`${path.relative(root, reportPath)}\``,
+  `Baseline: \`${path.relative(root, baselinePath)}\``,
+  '',
+]
+
+function percentile(values, pct) {
+  if (!values.length) return -1
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.max(0, Math.ceil(sorted.length * pct) - 1)]
+}
+
+for (const mode of modes) {
+  const modeCards = cards.filter((c) => c.mode === mode)
+  const budget = baseline.budgets?.[mode]
+  if (!budget) {
+    failures.push(`Missing budget for mode ${mode}`)
+    continue
+  }
+
+  const okCards = modeCards.filter((c) => c.status === 'ok')
+  const timeoutCards = modeCards.filter((c) => c.status === 'timeout')
+  const values = okCards.map((c) => c.ttfi_ms)
+  const avg = values.length ? Math.round(values.reduce((s, v) => s + v, 0) / values.length) : -1
+  const p95 = percentile(values, 0.95)
+
+  if (timeoutCards.length > budget.max_timeout_count) {
+    failures.push(`${mode}: timeout count ${timeoutCards.length} > budget ${budget.max_timeout_count}`)
+  }
+  if (p95 > budget.max_p95_ms) {
+    failures.push(`${mode}: p95 ${p95}ms > budget ${budget.max_p95_ms}ms`)
+  }
+
+  for (const card of okCards) {
+    if (card.ttfi_ms > budget.max_ttfi_ms) {
+      failures.push(`${mode}:${card.cardType} ttfi ${card.ttfi_ms}ms > max ${budget.max_ttfi_ms}ms`)
+    }
+  }
+
+  lines.push(`## ${mode}`)
+  lines.push(`- cards: ${modeCards.length}`)
+  lines.push(`- ok: ${okCards.length}`)
+  lines.push(`- timeout: ${timeoutCards.length}`)
+  lines.push(`- avg: ${avg}ms`)
+  lines.push(`- p95: ${p95}ms`)
+  lines.push('')
+}
+
+if (failures.length > 0) {
+  lines.push('## Failures')
+  for (const f of failures.slice(0, 200)) lines.push(`- ${f}`)
+  lines.push('')
+}
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+fs.writeFileSync(outputPath, `${lines.join('\n')}\n`)
+
+if (failures.length > 0) {
+  console.error(lines.join('\n'))
+  process.exit(1)
+}
+
+console.log(lines.join('\n'))

--- a/web/e2e/perf/perf.config.ts
+++ b/web/e2e/perf/perf.config.ts
@@ -23,7 +23,7 @@ function getWebServer() {
       command: `npm run dev -- --port ${DEV_PORT}`,
       url: `http://localhost:${DEV_PORT}`,
       reuseExistingServer: true,
-      timeout: 120_000,
+      timeout: 420_000,
     }
   }
 
@@ -32,7 +32,7 @@ function getWebServer() {
     command: `npm run build && npx vite preview --port ${PREVIEW_PORT}`,
     url: `http://localhost:${PREVIEW_PORT}`,
     reuseExistingServer: true,
-    timeout: 180_000,
+    timeout: 420_000,
   }
 }
 
@@ -40,7 +40,7 @@ const port = useDevServer ? DEV_PORT : PREVIEW_PORT
 
 export default defineConfig({
   testDir: '.',
-  timeout: 120_000,
+  timeout: 900_000,
   expect: { timeout: 30_000 },
   retries: 0,
   workers: 1,

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,9 @@
     "test:e2e:firefox": "playwright test --project=firefox",
     "test:e2e:webkit": "playwright test --project=webkit",
     "test:e2e:report": "playwright show-report",
+    "test:e2e:perf": "playwright test --config e2e/perf/perf.config.ts e2e/perf/dashboard-perf.spec.ts",
+    "test:e2e:perf:ttfi": "playwright test --config e2e/perf/perf.config.ts e2e/perf/all-cards-ttfi.spec.ts",
+    "test:e2e:perf:ttfi:gate": "npm run test:e2e:perf:ttfi && node e2e/perf/compare-ttfi.mjs",
     "test:e2e:coverage": "./scripts/run-e2e-coverage.sh",
     "coverage:report": "node scripts/coverage-report.mjs",
     "coverage:clean": "rimraf .nyc_output coverage"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -63,6 +63,7 @@ const MiniDashboard = lazy(() => import('./components/widget/MiniDashboard').the
 const UnifiedCardTest = lazy(() => import('./pages/UnifiedCardTest').then(m => ({ default: m.UnifiedCardTest })))
 const UnifiedStatsTest = lazy(() => import('./pages/UnifiedStatsTest').then(m => ({ default: m.UnifiedStatsTest })))
 const UnifiedDashboardTest = lazy(() => import('./pages/UnifiedDashboardTest').then(m => ({ default: m.UnifiedDashboardTest })))
+const AllCardsPerfTest = lazy(() => import('./pages/AllCardsPerfTest').then(m => ({ default: m.AllCardsPerfTest })))
 
 // Prefetch all lazy route chunks after initial page load.
 // Batched to avoid overwhelming the Vite dev server with simultaneous
@@ -276,6 +277,16 @@ function App() {
             <ProtectedRoute>
               <Layout>
                   <CustomDashboard />
+              </Layout>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/__perf/all-cards"
+          element={
+            <ProtectedRoute>
+              <Layout>
+                <AllCardsPerfTest />
               </Layout>
             </ProtectedRoute>
           }

--- a/web/src/pages/AllCardsPerfTest.tsx
+++ b/web/src/pages/AllCardsPerfTest.tsx
@@ -1,0 +1,141 @@
+import React, { useMemo } from 'react'
+import { CardWrapper } from '../components/cards/CardWrapper'
+import { DEMO_DATA_CARDS, getCardComponent, getRegisteredCardTypes } from '../components/cards/cardRegistry'
+import { formatCardTitle } from '../lib/formatCardTitle'
+
+const DEFAULT_BATCH_SIZE = 24
+
+interface PerfCardManifestItem {
+  cardType: string
+  cardId: string
+}
+
+declare global {
+  interface Window {
+    __TTFI_MANIFEST__?: {
+      allCardTypes: string[]
+      totalCards: number
+      batch: number
+      batchSize: number
+      selected: PerfCardManifestItem[]
+    }
+  }
+}
+
+function parsePositiveInt(value: string | null, fallback: number): number {
+  const parsed = Number.parseInt(value || '', 10)
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback
+  return parsed
+}
+
+type CardErrorBoundaryProps = {
+  cardType: string
+  children: React.ReactNode
+}
+
+type CardErrorBoundaryState = {
+  hasError: boolean
+  message: string
+}
+
+class CardErrorBoundary extends React.Component<CardErrorBoundaryProps, CardErrorBoundaryState> {
+  constructor(props: CardErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false, message: '' }
+  }
+
+  static getDerivedStateFromError(error: unknown): CardErrorBoundaryState {
+    return {
+      hasError: true,
+      message: error instanceof Error ? error.message : 'Unknown card render error',
+    }
+  }
+
+  override render() {
+    if (this.state.hasError) {
+      return (
+        <div data-testid={`ttfi-card-error-${this.props.cardType}`} className="text-xs text-red-400">
+          Card error: {this.state.message}
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
+export function AllCardsPerfTest() {
+  const params = new URLSearchParams(window.location.search)
+  const batch = Math.max(0, parsePositiveInt(params.get('batch'), 1) - 1)
+  const batchSize = parsePositiveInt(params.get('size'), DEFAULT_BATCH_SIZE)
+
+  const allCardTypes = useMemo(
+    () =>
+      getRegisteredCardTypes()
+        .filter((type) => type !== 'dynamic_card')
+        .sort(),
+    []
+  )
+
+  const selected = useMemo(() => {
+    const start = batch * batchSize
+    const items = allCardTypes.slice(start, start + batchSize)
+    return items.map((cardType, idx) => ({
+      cardType,
+      cardId: `ttfi-${batch}-${idx}-${cardType}`,
+    }))
+  }, [allCardTypes, batch, batchSize])
+
+  window.__TTFI_MANIFEST__ = {
+    allCardTypes,
+    totalCards: allCardTypes.length,
+    batch,
+    batchSize,
+    selected,
+  }
+
+  return (
+    <div className="p-4">
+      <div
+        data-testid="ttfi-manifest"
+        data-ttfi-total-cards={allCardTypes.length}
+        data-ttfi-batch={batch}
+        data-ttfi-batch-size={batchSize}
+        data-ttfi-selected={selected.length}
+        className="mb-4 text-xs text-muted-foreground"
+      >
+        all-cards batch {batch + 1} / {Math.max(1, Math.ceil(allCardTypes.length / batchSize))}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
+        {selected.map((item) => {
+          const CardComponent = getCardComponent(item.cardType)
+          const title = formatCardTitle(item.cardType)
+
+          return (
+            <div key={item.cardId} className="md:col-span-4">
+              <CardWrapper
+                cardId={item.cardId}
+                cardType={item.cardType}
+                title={title}
+                isDemoData={DEMO_DATA_CARDS.has(item.cardType)}
+                isRefreshing={false}
+                skeletonType="status"
+                skeletonRows={4}
+              >
+                <CardErrorBoundary cardType={item.cardType}>
+                  {CardComponent ? (
+                    <CardComponent config={{ perfMode: true }} />
+                  ) : (
+                    <div data-testid={`ttfi-missing-${item.cardType}`} className="text-xs text-amber-300">
+                      Missing card component: {item.cardType}
+                    </div>
+                  )}
+                </CardErrorBoundary>
+              </CardWrapper>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
This PR implements an **all-card time-to-first-item (TTFI) performance test framework** with a **hard CI gate** for regressions.

It adds a dedicated all-cards perf route, a Playwright matrix covering cold/warm + demo/live modes, baseline-budget comparison logic, and a CI workflow that fails PRs when TTFI budgets are exceeded.

## Why
Dashboard/card performance has been difficult to evaluate consistently across ~150+ card types and multiple runtime modes.

This PR provides:
- exhaustive card coverage (not just dashboard subsets),
- repeatable TTFI measurements,
- automated PR feedback via artifacts + summaries,
- hard regression protection in CI.

## What Changed

### 1) All-cards perf route
- Added `web/src/pages/AllCardsPerfTest.tsx`
- Added route `"/__perf/all-cards"` in `web/src/App.tsx`
- Route renders registered card types in deterministic batches and exposes manifest metadata (`window.__TTFI_MANIFEST__`) for test orchestration.

### 2) All-card TTFI Playwright suite
- Added `web/e2e/perf/all-cards-ttfi.spec.ts`
- Measures per-card TTFI across 4 modes:
  - `live-cold`
  - `live-warm`
  - `demo-cold`
  - `demo-warm`
- Uses robust card-readiness checks (loading state, skeleton absence, meaningful content).
- Produces:
  - `web/e2e/test-results/ttfi-report.json`
  - `web/e2e/test-results/ttfi-summary.md`

### 3) Hard gate comparator + baseline budgets
- Added `web/e2e/perf/compare-ttfi.mjs`
- Added baseline budgets in `web/e2e/perf/baseline/ttfi-baseline.json`
- Gate fails on:
  - mode timeout-count over budget,
  - mode p95 over budget,
  - per-card TTFI over budget.
- Writes regression summary:
  - `web/e2e/test-results/ttfi-regression.md`

### 4) CI workflow
- Added `.github/workflows/perf-ttfi.yml`
- Runs on PRs touching web/perf paths (and manually via `workflow_dispatch`).
- Executes full all-card matrix and hard gate comparison.
- Uploads artifacts and appends summary to `GITHUB_STEP_SUMMARY`.

### 5) Local developer workflows
- Updated `web/package.json` scripts:
  - `test:e2e:perf`
  - `test:e2e:perf:ttfi`
  - `test:e2e:perf:ttfi:gate`
- Updated `scripts/perf-test.sh`:
  - `--ttfi`
  - `--ttfi-gate`
- Updated `web/e2e/perf/perf.config.ts` timeouts for long-running all-card perf execution.

## Prior Work Reviewed
This implementation explicitly builds on earlier perf/caching/streaming efforts and avoids repeating partial-coverage patterns from prior related work (including `#807`, `#808`, `#822`, `#843`, `#854`, `#855`, `#856`, `#865`, `#873`, `#880`) by enforcing exhaustive registry-based coverage and CI gate enforcement.

## Validation
Executed in worktree branch:
- `npm run build` ✅
- `PERF_DEV=1 npm run test:e2e:perf:ttfi` ✅
- `node e2e/perf/compare-ttfi.mjs` ✅

Example run summary (local):
- `live-cold`: 152 cards (121 ok / 31 timeout)
- `live-warm`: 152 cards (138 ok / 14 timeout)
- `demo-cold`: 152 cards (152 ok / 0 timeout)
- `demo-warm`: 152 cards (152 ok / 0 timeout)

## Notes
- Baseline budgets in this PR are set to current measured behavior + guardrail headroom so the gate is immediately enforceable while still catching regressions.
- No merge is performed by automation/agent.

## Follow-ups (separate PRs)
1. Reduce live-mode timeout counts by migrating remaining outlier cards to unified cache/stream paths.
2. Add per-card source attribution (`cache|stream|network|demo`) at runtime instead of heuristic mode inference.
3. Add nightly trend workflow to auto-open issues on sustained degradation.
