### PR TITLE
🐛 Fix nightly E2E widget: flashing blue for active jobs

### DIFF
--- a/web/src/components/widgets/WidgetExportModal.tsx
+++ b/web/src/components/widgets/WidgetExportModal.tsx
@@ -951,7 +951,7 @@ function NightlyE2EPreview() {
         { acronym: 'PPC', dots: ['g','r','g','g','g','r','g'] },
         { acronym: 'SA', dots: ['g','g','g','g','g','g','g'] },
         { acronym: 'TPC', dots: ['g','g','g','r','g','g','g'] },
-        { acronym: 'WEP', dots: ['g','g','g','g','g','g','y'] },
+        { acronym: 'WEP', dots: ['g','g','g','g','g','g','b'] },
         { acronym: 'WVA', dots: ['g','r','g','g','r','g','g'] },
         { acronym: 'BM', dots: ['r','r','g','r','g','r','g'] },
       ],
@@ -962,7 +962,7 @@ function NightlyE2EPreview() {
         { acronym: 'IS', dots: ['g','g','g','g','g','g','g'] },
         { acronym: 'PD', dots: ['r','g','g','g','g','g','g'] },
         { acronym: 'WEP', dots: ['g','g','g','g','g','g','g'] },
-        { acronym: 'BM', dots: ['y','g','g','r','g','g','g'] },
+        { acronym: 'BM', dots: ['b','g','g','r','g','g','g'] },
       ],
     },
     {
@@ -975,7 +975,7 @@ function NightlyE2EPreview() {
       ],
     },
   ]
-  const dotColor: Record<string, string> = { g: '#22c55e', r: '#ef4444', y: '#eab308' }
+  const dotColor: Record<string, string> = { g: '#22c55e', r: '#ef4444', b: '#60a5fa' }
 
   return (
     <div style={{ ...ps.card, width: 320, fontSize: '10px', padding: '10px 12px' }}>
@@ -993,7 +993,7 @@ function NightlyE2EPreview() {
               <span style={{ width: '24px', fontWeight: 600, color: '#94a3b8' }}>{g.acronym}</span>
               <div style={{ display: 'flex', gap: '2px' }}>
                 {g.dots.length > 0 ? g.dots.map((d, i) => (
-                  <span key={i} style={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: dotColor[d], display: 'inline-block' }} />
+                  <span key={i} style={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: dotColor[d], display: 'inline-block', ...(d === 'b' ? { animation: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite' } : {}) }} />
                 )) : (
                   <span style={{ color: '#4b5563', fontSize: '8px' }}>no runs</span>
                 )}

--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -244,7 +244,8 @@ ${wrapOpen}
                     {(g.runs || []).slice(0, 7).map((run, i) => (
                       <span key={i} style={{
                         width: 7, height: 7, borderRadius: '50%', display: 'inline-block',
-                        backgroundColor: run.status === 'in_progress' ? '#eab308' : (conclusionColors[run.conclusion] || '#6b7280'),
+                        backgroundColor: run.status === 'in_progress' ? '#60a5fa' : (conclusionColors[run.conclusion] || '#6b7280'),
+                        animation: run.status === 'in_progress' ? 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite' : 'none',
                       }} />
                     ))}
                     {(!g.runs || g.runs.length === 0) && <span style={{color: '#4b5563', fontSize: '9px'}}>no runs</span>}

--- a/web/src/lib/widgets/styleConverter.ts
+++ b/web/src/lib/widgets/styleConverter.ts
@@ -383,5 +383,9 @@ export const className = css\`
   }
   .drag-handle { cursor: grab; }
   .drag-handle:active { cursor: grabbing; }
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+  }
 \`;`
 }


### PR DESCRIPTION
## Summary
- Widget export code used **yellow** (`#eab308`) for `in_progress` runs while the dashboard card correctly used **blue** (`bg-blue-400`) with `animate-pulse`
- Changed widget dot color from yellow to blue (`#60a5fa`) with a CSS pulse animation
- Updated widget preview mock data to use blue dots for in-progress runs
- Added `@keyframes pulse` to the widget CSS so the animation works in Übersicht

## Test plan
- [ ] Export a Nightly E2E widget and verify active/running jobs show as flashing blue dots
- [ ] Open the widget export preview modal and verify blue pulsing dots appear for in-progress items
- [ ] Verify the dashboard card still shows blue pulsing dots for running jobs (unchanged)
- [ ] Build passes: `npm run build`