### PR TITLE
🐛 Fix nightly E2E: queued/waiting runs show as flashing blue

### DIFF
--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -81,7 +81,7 @@ function formatTimeAgo(iso: string): string {
 }
 
 function RunDot({ run }: { run: NightlyRun }) {
-  const isRunning = run.status === 'in_progress'
+  const isRunning = run.status !== 'completed'
   const color = isRunning
     ? 'bg-blue-400'
     : run.conclusion === 'success'

--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -244,8 +244,8 @@ ${wrapOpen}
                     {(g.runs || []).slice(0, 7).map((run, i) => (
                       <span key={i} style={{
                         width: 7, height: 7, borderRadius: '50%', display: 'inline-block',
-                        backgroundColor: run.status === 'in_progress' ? '#60a5fa' : (conclusionColors[run.conclusion] || '#6b7280'),
-                        animation: run.status === 'in_progress' ? 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite' : 'none',
+                        backgroundColor: run.status !== 'completed' ? '#60a5fa' : (conclusionColors[run.conclusion] || '#6b7280'),
+                        animation: run.status !== 'completed' ? 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite' : 'none',
                       }} />
                     ))}
                     {(!g.runs || g.runs.length === 0) && <span style={{color: '#4b5563', fontSize: '9px'}}>no runs</span>}


### PR DESCRIPTION
## Summary
- Runs with status `queued`, `waiting`, or `pending` were showing as grey dots because only `in_progress` was treated as active
- Changed check from `status === 'in_progress'` to `status !== 'completed'` so all non-completed runs show as flashing blue
- Fixes both the dashboard card and the Übersicht widget export

## Test plan
- [ ] Verify queued runs next to in-progress runs both show as flashing blue (no grey dots)
- [ ] Verify completed runs still show correct colors (green/red/grey)
- [ ] Build passes: `npm run build`