### PR TITLE
🐛 fix: replace deprecated Netlify URL with canonical production URL in CORS allowed origins

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -36,8 +36,8 @@ var defaultAllowedOrigins = []string{
 	"http://127.0.0.1",
 	"https://127.0.0.1",
 	// Known deployment URLs
-	"https://kubestellarconsole.netlify.app",
-	"http://kubestellarconsole.netlify.app",
+	"https://console.kubestellar.io",
+	"http://console.kubestellar.io",
 	// Wildcard: any *.ibm.com subdomain (OpenShift routes, etc.)
 	"https://*.ibm.com",
 	"http://*.ibm.com",


### PR DESCRIPTION
### 📌 Fixes

Fixes #932

---

### 📝 Summary of Changes

- Replaced the outdated `kubestellarconsole.netlify.app` URL with the canonical production URL `console.kubestellar.io` in the WebSocket CORS allowed origins list.

---

### Changes Made

- [x] Fixed `pkg/agent/server.go` — updated `defaultAllowedOrigins` to use `https://console.kubestellar.io` and `http://console.kubestellar.io` instead of the deprecated Netlify preview URLs.

---

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

```diff
- "https://kubestellarconsole.netlify.app",
- "http://kubestellarconsole.netlify.app",
+ "https://console.kubestellar.io",
+ "http://console.kubestellar.io",
```

---

### 👀 Reviewer Notes

This is a one-file, two-line change. The Netlify URL was a deployment preview domain used during early development. The correct canonical URL `console.kubestellar.io` is what's listed on the `kubestellar/console` GitHub page and should be the authoritative origin allowed for WebSocket CORS.