### PR TITLE
🐛 Fix AI Missions failing when console started from Claude Code session

### DIFF
--- a/startup-demo.sh
+++ b/startup-demo.sh
@@ -20,6 +20,7 @@ echo -e "${GREEN}=== KubeStellar Console - Demo Mode ===${NC}"
 echo ""
 
 # Environment
+unset CLAUDECODE  # Allow AI Missions to spawn claude-code even when started from a Claude Code session
 export DEV_MODE=true
 export SKIP_ONBOARDING=true
 export FRONTEND_URL=http://localhost:5174

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -144,6 +144,7 @@ if [ -z "$JWT_SECRET" ]; then
 fi
 
 # Environment
+unset CLAUDECODE  # Allow AI Missions to spawn claude-code even when started from a Claude Code session
 export SKIP_ONBOARDING=true
 if [ "$USE_DEV_SERVER" = true ]; then
     export DEV_MODE=true


### PR DESCRIPTION
## Summary
- When the console is started from a Claude Code session, the `CLAUDECODE` env var is inherited by the Go backend
- AI Missions that invoke `claude-code` CLI fail with: "Claude Code cannot be launched inside another Claude Code session"
- Fix: `unset CLAUDECODE` in both `startup-oauth.sh` and `startup-demo.sh` before launching the backend

## Test plan
- [ ] Start console from a Claude Code session via `bash startup-oauth.sh`
- [ ] Trigger an AI Mission (e.g., diagnose a hardware health issue)
- [ ] Verify the mission executes successfully without the nested session error