### PR TITLE
🐛 Fix Demo Mode pill truncation in navbar

### DIFF
--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -140,7 +140,7 @@ export function AgentStatusIndicator() {
     <div className="relative" ref={agentRef}>
       <button
         onClick={() => setShowAgentStatus(!showAgentStatus)}
-        className={cn('flex items-center justify-center gap-2 w-[5.5rem] py-1.5 rounded-lg', pillStyle.bg)}
+        className={cn('flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg whitespace-nowrap', pillStyle.bg)}
         title={pillStyle.title}
       >
         <pillStyle.Icon className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- Replace fixed `w-[5.5rem]` with `px-3 whitespace-nowrap` so the agent status pill auto-sizes to fit its content
- "Demo Mode" label was being truncated/cut off

## Test plan
- [x] Verified locally — pill now fits "Demo Mode" text with icon and dot