### PR TITLE
🐛 Fix ENABLED_DASHBOARDS for vllm-d and pokprod deployments

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -133,6 +133,7 @@ jobs:
             --set googleDrive.existingSecret=kc-secrets \
             --set route.enabled=true \
             --set route.host=kc.apps.fmaas-vllm-d.fmaas.res.ibm.com \
+            --set-string enabledDashboards="dashboard,clusters,gpu-reservations,llm-d-benchmarks,ai-ml,arcade" \
             --wait \
             --timeout 5m
 
@@ -187,7 +188,7 @@ jobs:
             --set googleDrive.existingSecret=kc-kubestellar-console \
             --set route.enabled=true \
             --set route.host=kc-kubestellar-console-kubestellar-console.apps.pokprod001.ete14.res.ibm.com \
-            --set enabledDashboards="dashboard,gpu-reservations,llm-d-benchmarks,ai-ml,arcade" \
+            --set-string enabledDashboards="dashboard,clusters,gpu-reservations,llm-d-benchmarks,ai-ml,arcade" \
             --wait \
             --timeout 5m
 


### PR DESCRIPTION
## Summary

- **vllm-d**: Add `--set-string enabledDashboards` (was missing entirely — all dashboards shown)
- **pokprod**: Change `--set` to `--set-string` (Helm's `--set` splits on commas, mangling the value)
- Add `clusters` as 2nd item in the sidebar list for both deployments

Both deployments will now show 6 sidebar items: Dashboard, Clusters, GPU Reservations, llm-d Benchmarks, AI/ML, Arcade.

## Root Cause

Helm's `--set` flag treats commas as key=value pair delimiters. `--set enabledDashboards="a,b,c"` gets split into `enabledDashboards=a` + `b` + `c` (invalid). Using `--set-string` preserves the comma-separated string as-is.

## Test plan

- [ ] After merge and deploy, verify `/health` endpoint returns `enabled_dashboards` array on both clusters
- [ ] Verify sidebar shows 6 items on both https://kc.apps.fmaas-vllm-d.fmaas.res.ibm.com and https://kc-kubestellar-console-kubestellar-console.apps.pokprod001.ete14.res.ibm.com