### PR TITLE
🐛 Fix Helm comma escaping for enabledDashboards deploy

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -133,7 +133,7 @@ jobs:
             --set googleDrive.existingSecret=kc-secrets \
             --set route.enabled=true \
             --set route.host=kc.apps.fmaas-vllm-d.fmaas.res.ibm.com \
-            --set-string enabledDashboards="dashboard,clusters,gpu-reservations,llm-d-benchmarks,ai-ml,arcade" \
+            --set-string enabledDashboards="dashboard\,clusters\,gpu-reservations\,llm-d-benchmarks\,ai-ml\,arcade" \
             --wait \
             --timeout 5m
 
@@ -188,7 +188,7 @@ jobs:
             --set googleDrive.existingSecret=kc-kubestellar-console \
             --set route.enabled=true \
             --set route.host=kc-kubestellar-console-kubestellar-console.apps.pokprod001.ete14.res.ibm.com \
-            --set-string enabledDashboards="dashboard,clusters,gpu-reservations,llm-d-benchmarks,ai-ml,arcade" \
+            --set-string enabledDashboards="dashboard\,clusters\,gpu-reservations\,llm-d-benchmarks\,ai-ml\,arcade" \
             --wait \
             --timeout 5m
 


### PR DESCRIPTION
## Summary

- Both vllm-d and pokprod deploys were failing with: `Error: failed parsing --set-string data: key "clusters" has no value (cannot end with ,)`
- Helm's `--set-string` still treats commas as key=value pair separators
- Fix: escape commas with `\,` so Helm passes the full string as a single value
- Changes `--set-string enabledDashboards="dashboard,clusters,..."` to `--set-string enabledDashboards="dashboard\,clusters\,..."`

## Test plan
- [x] Verified Helm docs confirm `\,` is the correct escape for literal commas in `--set` and `--set-string`
- [ ] After merge, verify both deploy jobs succeed in CI
- [ ] Verify `/health` endpoint returns correct `enabled_dashboards` array on both clusters