### PR TITLE
✨ Wire AI/ML cards to real Prometheus metrics via K8s API proxy

### DIFF
--- a/pkg/agent/prometheus.go
+++ b/pkg/agent/prometheus.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"k8s.io/client-go/rest"
+)
+
+const (
+	prometheusQueryTimeout = 10 * time.Second
+	prometheusServicePort  = "9090"
+	prometheusServiceName  = "prometheus"
+)
+
+// handlePrometheusQuery proxies a Prometheus query through the K8s API server.
+// It uses the cluster's REST config to authenticate and routes through the
+// API server's service proxy: /api/v1/namespaces/{ns}/services/{svc}:{port}/proxy/api/v1/query
+func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	if s.k8sClient == nil {
+		http.Error(w, `{"error":"k8s client not initialized"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	cluster := r.URL.Query().Get("cluster")
+	namespace := r.URL.Query().Get("namespace")
+	query := r.URL.Query().Get("query")
+
+	if cluster == "" || namespace == "" || query == "" {
+		http.Error(w, `{"error":"cluster, namespace, and query parameters are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Optional: specific evaluation time
+	queryTime := r.URL.Query().Get("time")
+
+	// Optional: custom Prometheus service name (default: "prometheus")
+	serviceName := r.URL.Query().Get("service")
+	if serviceName == "" {
+		serviceName = prometheusServiceName
+	}
+
+	config, err := s.k8sClient.GetRestConfig(cluster)
+	if err != nil {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status": "error",
+			"error":  fmt.Sprintf("failed to get cluster config: %v", err),
+		})
+		return
+	}
+
+	// Build the K8s API server proxy URL to reach Prometheus
+	proxyPath := fmt.Sprintf("/api/v1/namespaces/%s/services/%s:%s/proxy/api/v1/query",
+		url.PathEscape(namespace),
+		url.PathEscape(serviceName),
+		prometheusServicePort,
+	)
+
+	params := url.Values{}
+	params.Set("query", query)
+	if queryTime != "" {
+		params.Set("time", queryTime)
+	}
+
+	fullURL := fmt.Sprintf("%s%s?%s", config.Host, proxyPath, params.Encode())
+
+	// Create an HTTP client with the cluster's TLS/auth config
+	transport, err := rest.TransportFor(config)
+	if err != nil {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status": "error",
+			"error":  fmt.Sprintf("failed to create transport: %v", err),
+		})
+		return
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   prometheusQueryTimeout,
+	}
+
+	resp, err := client.Get(fullURL)
+	if err != nil {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status": "error",
+			"error":  fmt.Sprintf("prometheus query failed: %v", err),
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	// Stream the raw Prometheus response back to the caller
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -291,7 +291,10 @@ func (s *Server) Start() error {
 	// Backend process management
 	mux.HandleFunc("/restart-backend", s.handleRestartBackend)
 
-	// Prometheus metrics endpoint
+	// Prometheus query proxy - queries Prometheus in user clusters via K8s API server proxy
+	mux.HandleFunc("/prometheus/query", s.handlePrometheusQuery)
+
+	// Prometheus metrics endpoint (agent's own metrics)
 	mux.Handle("/metrics", GetMetricsHandler())
 
 	// WebSocket endpoint

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -953,6 +953,21 @@ func (m *MultiClusterClient) GetClient(contextName string) (*kubernetes.Clientse
 	return client, nil
 }
 
+// GetRestConfig returns the REST config for the specified cluster context.
+// Ensures the client (and config) is initialized first by calling GetClient.
+func (m *MultiClusterClient) GetRestConfig(contextName string) (*rest.Config, error) {
+	if _, err := m.GetClient(contextName); err != nil {
+		return nil, err
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	config, ok := m.configs[contextName]
+	if !ok {
+		return nil, fmt.Errorf("no config for context %s", contextName)
+	}
+	return rest.CopyConfig(config), nil
+}
+
 // GetDynamicClient returns a dynamic kubernetes client for the specified context
 func (m *MultiClusterClient) GetDynamicClient(contextName string) (dynamic.Interface, error) {
 	m.mu.RLock()

--- a/web/src/hooks/usePrometheusMetrics.ts
+++ b/web/src/hooks/usePrometheusMetrics.ts
@@ -1,0 +1,179 @@
+/**
+ * usePrometheusMetrics — polls vLLM Prometheus metrics via the agent's
+ * /prometheus/query proxy endpoint. Returns per-pod metric values that
+ * LLM-d cards use instead of simulated data.
+ */
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000
+
+/** Per-pod vLLM metrics */
+export interface PodMetrics {
+  kvCacheUsage: number       // 0-1 (vllm:gpu_cache_usage_perc)
+  requestsRunning: number    // integer (vllm:num_requests_running)
+  requestsWaiting: number    // integer (vllm:num_requests_waiting)
+  throughputTps: number      // tokens/sec (vllm:avg_generation_throughput_toks_per_s)
+  ttftP50: number            // seconds (histogram p50)
+  tpotP50: number            // seconds (histogram p50)
+}
+
+export interface PrometheusMetricsResult {
+  /** Per-pod metrics keyed by pod name */
+  metrics: Record<string, PodMetrics> | null
+  loading: boolean
+  error: string | null
+}
+
+// The 6 vLLM metric queries we need
+const METRIC_QUERIES = {
+  kvCacheUsage: 'vllm:gpu_cache_usage_perc',
+  requestsRunning: 'vllm:num_requests_running',
+  requestsWaiting: 'vllm:num_requests_waiting',
+  throughputTps: 'vllm:avg_generation_throughput_toks_per_s',
+  ttftP50: 'histogram_quantile(0.5, rate(vllm:time_to_first_token_seconds_bucket[5m]))',
+  tpotP50: 'histogram_quantile(0.5, rate(vllm:time_per_output_token_seconds_bucket[5m]))',
+} as const
+
+type MetricKey = keyof typeof METRIC_QUERIES
+
+/** Prometheus instant query response shape */
+interface PromResponse {
+  status: 'success' | 'error'
+  data?: {
+    resultType: 'vector' | 'matrix' | 'scalar' | 'string'
+    result: Array<{
+      metric: Record<string, string>
+      value: [number, string] // [timestamp, value]
+    }>
+  }
+  error?: string
+}
+
+/** Extract pod name from Prometheus metric labels */
+function extractPodName(metric: Record<string, string>): string {
+  return metric.pod || metric.kubernetes_pod_name || metric.instance || 'unknown'
+}
+
+async function queryPrometheus(
+  cluster: string,
+  namespace: string,
+  query: string,
+  signal: AbortSignal,
+): Promise<PromResponse> {
+  const params = new URLSearchParams({ cluster, namespace, query })
+  const resp = await fetch(`${LOCAL_AGENT_HTTP_URL}/prometheus/query?${params}`, {
+    signal,
+    headers: { Accept: 'application/json' },
+  })
+  if (!resp.ok) {
+    throw new Error(`Agent returned ${resp.status}`)
+  }
+  return resp.json()
+}
+
+export function usePrometheusMetrics(
+  cluster: string | undefined,
+  namespace: string | undefined,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+): PrometheusMetricsResult {
+  const [metrics, setMetrics] = useState<Record<string, PodMetrics> | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const fetchMetrics = useCallback(async () => {
+    if (!cluster || !namespace) return
+
+    // Cancel any in-flight request
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    setLoading(prev => !prev ? true : prev) // only set true on first load
+
+    try {
+      // Fire all 6 queries in parallel
+      const entries = Object.entries(METRIC_QUERIES) as [MetricKey, string][]
+      const results = await Promise.allSettled(
+        entries.map(([, query]) =>
+          queryPrometheus(cluster, namespace, query, controller.signal)
+        ),
+      )
+
+      if (controller.signal.aborted) return
+
+      // Build per-pod map
+      const podMap: Record<string, PodMetrics> = {}
+
+      const ensurePod = (name: string): PodMetrics => {
+        if (!podMap[name]) {
+          podMap[name] = {
+            kvCacheUsage: 0,
+            requestsRunning: 0,
+            requestsWaiting: 0,
+            throughputTps: 0,
+            ttftP50: 0,
+            tpotP50: 0,
+          }
+        }
+        return podMap[name]
+      }
+
+      let hasAnyData = false
+
+      results.forEach((result, i) => {
+        if (result.status !== 'fulfilled') return
+        const resp = result.value
+        if (resp.status !== 'success' || !resp.data?.result) return
+
+        const key = entries[i][0]
+        for (const item of resp.data.result) {
+          const pod = extractPodName(item.metric)
+          const val = parseFloat(item.value[1])
+          if (isNaN(val)) continue
+
+          hasAnyData = true
+          const pm = ensurePod(pod)
+          pm[key] = val
+        }
+      })
+
+      if (!hasAnyData) {
+        setMetrics(null)
+        setError('No Prometheus data available')
+      } else {
+        setMetrics(podMap)
+        setError(null)
+      }
+    } catch (e) {
+      if (controller.signal.aborted) return
+      setMetrics(null)
+      setError(e instanceof Error ? e.message : 'Unknown error')
+    } finally {
+      if (!controller.signal.aborted) {
+        setLoading(false)
+      }
+    }
+  }, [cluster, namespace])
+
+  useEffect(() => {
+    if (!cluster || !namespace) {
+      setMetrics(null)
+      setError(null)
+      setLoading(false)
+      return
+    }
+
+    // Fetch immediately, then poll
+    fetchMetrics()
+    const interval = setInterval(fetchMetrics, pollIntervalMs)
+
+    return () => {
+      clearInterval(interval)
+      abortRef.current?.abort()
+    }
+  }, [fetchMetrics, pollIntervalMs])
+
+  return { metrics, loading, error }
+}


### PR DESCRIPTION
## Summary

- Adds a Prometheus query proxy endpoint to the agent backend that routes queries through the K8s API server's service proxy, using existing kubeconfig auth — no port-forwarding or extra config needed
- Frontend hook (`usePrometheusMetrics`) polls 6 vLLM metrics every 5 seconds
- 4 LLM-d visualization cards (LLMdFlow, KVCacheMonitor, EPPRouting, PDDisaggregation) now display **real** per-pod Prometheus metrics when available, with graceful fallback to simulated data

### Architecture
```
Frontend cards → usePrometheusMetrics() hook
  → GET http://127.0.0.1:8585/prometheus/query?cluster=X&namespace=Y&query=Z
  → Agent handlePrometheusQuery()
  → K8s API server proxy: /api/v1/namespaces/{ns}/services/prometheus:9090/proxy/api/v1/query
  → Prometheus in user cluster
```

### vLLM Metrics Used
| Metric | Used For |
|--------|----------|
| `vllm:gpu_cache_usage_perc` | KV cache utilization, GPU memory |
| `vllm:num_requests_running` | Active connections, load |
| `vllm:num_requests_waiting` | Queue depth |
| `vllm:avg_generation_throughput_toks_per_s` | Throughput (tokens/sec, RPS) |
| `histogram_quantile(0.5, vllm:time_to_first_token_seconds_bucket)` | Prefill latency (TTFT) |
| `histogram_quantile(0.5, vllm:time_per_output_token_seconds_bucket)` | Decode latency (TPOT) |

### Files Changed
- **`pkg/k8s/client.go`** — `GetRestConfig()` method for public access to cluster REST configs
- **`pkg/agent/prometheus.go`** — New handler proxying Prometheus queries through K8s API server
- **`pkg/agent/server.go`** — Register `/prometheus/query` route
- **`web/src/hooks/usePrometheusMetrics.ts`** — New hook polling vLLM metrics
- **`web/src/components/cards/llmd/LLMdFlow.tsx`** — Real metrics for load, queue, throughput
- **`web/src/components/cards/llmd/KVCacheMonitor.tsx`** — Real KV cache utilization per pod
- **`web/src/components/cards/llmd/EPPRouting.tsx`** — Real load/RPS per node
- **`web/src/components/cards/llmd/PDDisaggregation.tsx`** — Real latency, throughput, GPU memory

## Test plan
- [ ] `go build ./...` passes
- [ ] `npm run build` passes
- [ ] `npm run lint` passes (no new errors)
- [ ] With stack selected on cluster with Prometheus: cards show real values (not sine waves)
- [ ] Without stack selected: cards show demo data (unchanged behavior)
- [ ] With Prometheus unavailable: cards gracefully fall back to simulated values
- [ ] Agent `/prometheus/query?cluster=X&namespace=Y&query=vllm:gpu_cache_usage_perc` returns real data