### PR TITLE
✨ Add CoreWeave as recognized cluster vendor

### DIFF
--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -13,7 +13,7 @@ import { CloudProviderIcon, detectCloudProvider as detectCloudProviderShared, ge
 import { useTranslation } from 'react-i18next'
 
 // Cloud provider types
-type CloudProvider = 'eks' | 'gke' | 'aks' | 'openshift' | 'oci' | 'alibaba' | 'digitalocean' | 'rancher' | 'kind' | 'minikube' | 'k3s' | 'unknown'
+type CloudProvider = 'eks' | 'gke' | 'aks' | 'openshift' | 'oci' | 'alibaba' | 'digitalocean' | 'rancher' | 'coreweave' | 'kind' | 'minikube' | 'k3s' | 'unknown'
 
 // Get console URL for a specific provider
 function getConsoleUrlForProvider(provider: string, clusterName: string, apiServerUrl?: string): string | null {
@@ -55,6 +55,8 @@ function getConsoleUrlForProvider(provider: string, clusterName: string, apiServ
       return 'https://cs.console.aliyun.com/#/k8s/cluster/list'
     case 'digitalocean':
       return 'https://cloud.digitalocean.com/kubernetes/clusters'
+    case 'coreweave':
+      return 'https://cloud.coreweave.com/kubernetes'
     default:
       return null
   }
@@ -70,6 +72,7 @@ function getProviderInfo(provider: CloudProvider): { color: string; bgColor: str
     case 'alibaba': return { color: 'text-orange-300', bgColor: 'bg-orange-500/20' }
     case 'digitalocean': return { color: 'text-blue-400', bgColor: 'bg-blue-500/20' }
     case 'rancher': return { color: 'text-green-400', bgColor: 'bg-green-500/20' }
+    case 'coreweave': return { color: 'text-indigo-400', bgColor: 'bg-indigo-500/20' }
     case 'kind': return { color: 'text-blue-300', bgColor: 'bg-blue-500/20' }
     case 'minikube': return { color: 'text-purple-400', bgColor: 'bg-purple-500/20' }
     case 'k3s': return { color: 'text-green-300', bgColor: 'bg-green-500/20' }

--- a/web/src/components/ui/CloudProviderIcon.tsx
+++ b/web/src/components/ui/CloudProviderIcon.tsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
-export type CloudProvider = 'eks' | 'gke' | 'aks' | 'openshift' | 'oci' | 'alibaba' | 'digitalocean' | 'rancher' | 'kind' | 'minikube' | 'k3s' | 'kubernetes'
+export type CloudProvider = 'eks' | 'gke' | 'aks' | 'openshift' | 'oci' | 'alibaba' | 'digitalocean' | 'rancher' | 'coreweave' | 'kind' | 'minikube' | 'k3s' | 'kubernetes'
 
 interface CloudProviderIconProps {
   provider: CloudProvider
@@ -178,6 +178,33 @@ const RancherIcon: React.FC<{ size: number; className?: string }> = ({ size, cla
   </svg>
 )
 
+// CoreWeave icon - blue rounded rect with stylized CW wave mark
+const CoreWeaveIcon: React.FC<{ size: number; className?: string }> = ({ size, className }) => (
+  <svg viewBox="0 0 24 24" width={size} height={size} className={className}>
+    <defs>
+      <linearGradient id="cwGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" stopColor="#3B5BFF" />
+        <stop offset="100%" stopColor="#2741E7" />
+      </linearGradient>
+    </defs>
+    {/* Background */}
+    <rect width="24" height="24" rx="4" fill="url(#cwGradient)" />
+    {/* Stylized double-wave / CW mark */}
+    <path
+      d="M4 14 C6 10, 8 10, 10 14 C12 18, 14 18, 16 14"
+      stroke="white" strokeWidth="2.2" strokeLinecap="round" fill="none"
+    />
+    <path
+      d="M8 14 C10 10, 12 10, 14 14 C16 18, 18 18, 20 14"
+      stroke="white" strokeWidth="2.2" strokeLinecap="round" fill="none" opacity="0.6"
+    />
+    {/* Small cloud dots above */}
+    <circle cx="7" cy="8" r="1" fill="white" opacity="0.5" />
+    <circle cx="12" cy="7" r="1.3" fill="white" opacity="0.7" />
+    <circle cx="17" cy="8" r="1" fill="white" opacity="0.5" />
+  </svg>
+)
+
 // Kind icon - official logo (ship in bottle)
 const KindIcon: React.FC<{ size: number; className?: string }> = ({ size, className }) => (
   <img
@@ -293,6 +320,8 @@ export function CloudProviderIcon({ provider, size = 16, className }: CloudProvi
       return <DigitalOceanIcon {...iconProps} />
     case 'rancher':
       return <RancherIcon {...iconProps} />
+    case 'coreweave':
+      return <CoreWeaveIcon {...iconProps} />
     case 'kind':
       return <KindIcon {...iconProps} />
     case 'minikube':
@@ -315,6 +344,7 @@ export function getProviderLabel(provider: CloudProvider): string {
     case 'alibaba': return 'Alibaba ACK'
     case 'digitalocean': return 'DigitalOcean'
     case 'rancher': return 'Rancher'
+    case 'coreweave': return 'CoreWeave'
     case 'kind': return 'Kind'
     case 'minikube': return 'Minikube'
     case 'k3s': return 'K3s'
@@ -335,6 +365,7 @@ export function useProviderLabel(provider: CloudProvider): string {
     case 'alibaba': return t('cloudProviders.alibabaAck')
     case 'digitalocean': return t('cloudProviders.digitalocean')
     case 'rancher': return t('cloudProviders.rancher')
+    case 'coreweave': return t('cloudProviders.coreweave')
     case 'kind': return t('cloudProviders.kind')
     case 'minikube': return t('cloudProviders.minikube')
     case 'k3s': return t('cloudProviders.k3s')
@@ -353,6 +384,7 @@ export function getProviderColor(provider: CloudProvider): string {
     case 'alibaba': return '#FF6A00'     // Alibaba Orange
     case 'digitalocean': return '#0080FF' // DO Blue
     case 'rancher': return '#2453FF'     // Rancher Blue
+    case 'coreweave': return '#2741E7'   // CoreWeave Blue
     case 'kind': return '#2496ED'        // Kind Blue
     case 'minikube': return '#326CE5'    // K8s Blue
     case 'k3s': return '#FFC61C'         // K3s Yellow
@@ -371,6 +403,7 @@ export function getProviderBorderClass(provider: CloudProvider): string {
     case 'alibaba': return 'border-orange-500/40'
     case 'digitalocean': return 'border-blue-400/40'
     case 'rancher': return 'border-blue-600/40'
+    case 'coreweave': return 'border-indigo-600/40'
     case 'kind': return 'border-blue-400/40'
     case 'minikube': return 'border-blue-500/40'
     case 'k3s': return 'border-yellow-500/40'
@@ -417,6 +450,8 @@ export function getConsoleUrl(provider: CloudProvider, clusterName: string, apiS
       return 'https://cs.console.aliyun.com/#/k8s/cluster/list'
     case 'digitalocean':
       return 'https://cloud.digitalocean.com/kubernetes/clusters'
+    case 'coreweave':
+      return 'https://cloud.coreweave.com/kubernetes'
     default:
       return null
   }
@@ -497,6 +532,8 @@ export function detectCloudProvider(
   if (name.includes('digitalocean') || name.includes('do-') || name.includes('doks')) {
     return 'digitalocean'
   }
+  // CoreWeave by name
+  if (name.includes('coreweave')) return 'coreweave'
   // Rancher by name
   if (name.includes('rancher')) return 'rancher'
   // Local development clusters by name
@@ -528,6 +565,10 @@ export function detectCloudProvider(
   // DigitalOcean by URL
   if (serverUrl.includes('.digitalocean.com') || serverUrl.includes('k8s.ondigitalocean')) {
     return 'digitalocean'
+  }
+  // CoreWeave by URL
+  if (serverUrl.includes('.coreweave.com')) {
+    return 'coreweave'
   }
   // OpenShift by URL - check for specific OpenShift domains (NOT just :6443 port)
   if (serverUrl.includes('openshift.com') || serverUrl.includes('openshiftapps.com') || serverUrl.includes('.openshift.')) {

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1725,6 +1725,7 @@
     "alibabaAck": "Alibaba ACK",
     "digitalocean": "DigitalOcean",
     "rancher": "Rancher",
+    "coreweave": "CoreWeave",
     "kind": "Kind",
     "minikube": "Minikube",
     "k3s": "K3s",


### PR DESCRIPTION
## Summary
- Adds CoreWeave as a recognized cloud provider with automatic detection via `.coreweave.com` URL pattern and `coreweave` name pattern
- Branded icon (blue gradient with double-wave mark), color scheme (#2741E7 Royal Blue), border class, and console URL
- Updated ClusterDetailModal with CoreWeave provider info and console link
- Added i18n translation for CoreWeave label

## Test plan
- [ ] Clusters with `.coreweave.com` API server URL should show CoreWeave icon and branding
- [ ] Clusters with "coreweave" in the name should be detected as CoreWeave
- [ ] Cluster detail modal should show CoreWeave color scheme and console link
- [ ] Other providers remain unaffected