### PR TITLE
🐛 Fix nightly E2E workflow name mappings for OCP platform

### DIFF
--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -72,23 +72,24 @@ type NightlyE2EHandler struct {
 // nightlyWorkflows is the canonical list of nightly E2E workflows to monitor.
 var nightlyWorkflows = []NightlyWorkflow{
 	// OCP
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "OCP"},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "OCP"},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-precise-prefix-cache.yaml", Guide: "Precise Prefix Cache", Acronym: "PPC", Platform: "OCP"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-ocp.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "OCP"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-ocp.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "OCP"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-precise-prefix-cache-ocp.yaml", Guide: "Precise Prefix Cache", Acronym: "PPC", Platform: "OCP"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-simulated-accelerators.yaml", Guide: "Simulated Accelerators", Acronym: "SA", Platform: "OCP"},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-tiered-prefix-cache.yaml", Guide: "Tiered Prefix Cache", Acronym: "TPC", Platform: "OCP"},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "OCP"},
-	{Repo: "llm-d/llm-d-workload-variant-autoscaler", WorkflowFile: "nightly-e2e-openshift.yaml", Guide: "WVA", Acronym: "WVA", Platform: "OCP"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-tiered-prefix-cache-ocp.yaml", Guide: "Tiered Prefix Cache", Acronym: "TPC", Platform: "OCP"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-ocp.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "OCP"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-ocp.yaml", Guide: "WVA", Acronym: "WVA", Platform: "OCP"},
 	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-ocp.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "OCP"},
 	// GKE
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-gke.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "GKE"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-gke.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "GKE"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-gke.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "GKE"},
 	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-gke.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "GKE"},
-	// CKS (same tests as GKE — workflows not yet created)
+	// CKS
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-cks.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "CKS"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "CKS"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-cks.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "CKS"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-cks.yaml", Guide: "WVA", Acronym: "WVA", Platform: "CKS"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-benchmarking-cks.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "CKS"},
 }
 

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -29,23 +29,24 @@ const PLATFORM_COLORS: Record<string, string> = {
 /** Static metadata per workflow — model, GPU type, GPU count used in nightly runs */
 const WORKFLOW_META: Record<string, { model: string; gpuType: string; gpuCount: number }> = {
   // OCP
-  'nightly-e2e-inference-scheduling.yaml':   { model: 'Qwen3-32B',       gpuType: 'A100', gpuCount: 2 },
-  'nightly-e2e-pd-disaggregation.yaml':      { model: 'Qwen3-0.6B',      gpuType: 'A100', gpuCount: 1 },
-  'nightly-e2e-precise-prefix-cache.yaml':   { model: 'Qwen3-32B',       gpuType: 'A100', gpuCount: 2 },
-  'nightly-e2e-simulated-accelerators.yaml': { model: 'Simulated',       gpuType: 'CPU',  gpuCount: 0 },
-  'nightly-e2e-tiered-prefix-cache.yaml':    { model: 'Qwen3-0.6B',      gpuType: 'A100', gpuCount: 1 },
-  'nightly-e2e-wide-ep-lws.yaml':            { model: 'Qwen3-0.6B',      gpuType: 'A100', gpuCount: 1 },
-  'nightly-e2e-openshift.yaml':              { model: 'Llama-3.1-8B',    gpuType: 'A100', gpuCount: 2 },
-  'ci-nighly-benchmark-ocp.yaml':            { model: 'opt-125m',        gpuType: 'A100', gpuCount: 1 },
+  'nightly-e2e-inference-scheduling-ocp.yaml': { model: 'Qwen3-32B',       gpuType: 'A100', gpuCount: 2 },
+  'nightly-e2e-pd-disaggregation-ocp.yaml':    { model: 'Qwen3-0.6B',      gpuType: 'A100', gpuCount: 1 },
+  'nightly-e2e-precise-prefix-cache-ocp.yaml': { model: 'Qwen3-32B',       gpuType: 'A100', gpuCount: 2 },
+  'nightly-e2e-simulated-accelerators.yaml':   { model: 'Simulated',       gpuType: 'CPU',  gpuCount: 0 },
+  'nightly-e2e-tiered-prefix-cache-ocp.yaml':  { model: 'Qwen3-0.6B',      gpuType: 'A100', gpuCount: 1 },
+  'nightly-e2e-wide-ep-lws-ocp.yaml':          { model: 'Qwen3-0.6B',      gpuType: 'A100', gpuCount: 1 },
+  'nightly-e2e-wva-ocp.yaml':                  { model: 'Llama-3.1-8B',    gpuType: 'A100', gpuCount: 2 },
+  'ci-nighly-benchmark-ocp.yaml':              { model: 'opt-125m',        gpuType: 'A100', gpuCount: 1 },
   // GKE
   'nightly-e2e-inference-scheduling-gke.yaml': { model: 'Qwen3-32B',     gpuType: 'L4',   gpuCount: 2 },
   'nightly-e2e-pd-disaggregation-gke.yaml':   { model: 'Qwen3-0.6B',    gpuType: 'L4',   gpuCount: 1 },
   'nightly-e2e-wide-ep-lws-gke.yaml':         { model: 'DeepSeek-R1',    gpuType: 'L4',   gpuCount: 8 },
   'ci-nighly-benchmark-gke.yaml':             { model: 'Llama-3.2-1B',   gpuType: 'H100', gpuCount: 1 },
-  // CKS (workflows not yet created)
-  'nightly-e2e-inference-scheduling-cks.yaml': { model: 'Qwen3-32B',     gpuType: 'TBD',  gpuCount: 2 },
-  'nightly-e2e-pd-disaggregation-cks.yaml':   { model: 'Qwen3-0.6B',    gpuType: 'TBD',  gpuCount: 1 },
-  'nightly-e2e-wide-ep-lws-cks.yaml':         { model: 'Qwen3-0.6B',    gpuType: 'TBD',  gpuCount: 1 },
+  // CKS
+  'nightly-e2e-inference-scheduling-cks.yaml': { model: 'Qwen3-32B',     gpuType: 'H100', gpuCount: 2 },
+  'nightly-e2e-pd-disaggregation-cks.yaml':   { model: 'Qwen3-0.6B',    gpuType: 'H100', gpuCount: 1 },
+  'nightly-e2e-wide-ep-lws-cks.yaml':         { model: 'Qwen3-0.6B',    gpuType: 'H100', gpuCount: 1 },
+  'nightly-e2e-wva-cks.yaml':                 { model: 'Llama-3.1-8B',  gpuType: 'H100', gpuCount: 2 },
   'nightly-e2e-benchmarking-cks.yaml':         { model: 'TBD',           gpuType: 'TBD',  gpuCount: 0 },
 }
 

--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -37,23 +37,24 @@ export interface NightlyGuideStatus {
 
 export const NIGHTLY_WORKFLOWS: NightlyWorkflowConfig[] = [
   // OCP
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'OCP' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'OCP' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-precise-prefix-cache.yaml', guide: 'Precise Prefix Cache', acronym: 'PPC', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-ocp.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-ocp.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-precise-prefix-cache-ocp.yaml', guide: 'Precise Prefix Cache', acronym: 'PPC', platform: 'OCP' },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-simulated-accelerators.yaml', guide: 'Simulated Accelerators', acronym: 'SA', platform: 'OCP' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-tiered-prefix-cache.yaml', guide: 'Tiered Prefix Cache', acronym: 'TPC', platform: 'OCP' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'OCP' },
-  { repo: 'llm-d/llm-d-workload-variant-autoscaler', workflowFile: 'nightly-e2e-openshift.yaml', guide: 'WVA', acronym: 'WVA', platform: 'OCP' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-benchmarking.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-tiered-prefix-cache-ocp.yaml', guide: 'Tiered Prefix Cache', acronym: 'TPC', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-ocp.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'OCP' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wva-ocp.yaml', guide: 'WVA', acronym: 'WVA', platform: 'OCP' },
+  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nighly-benchmark-ocp.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'OCP' },
   // GKE
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-gke.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'GKE' },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-gke.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'GKE' },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-gke.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'GKE' },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-benchmarking-gke.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'GKE' },
-  // CKS (same tests as GKE — workflows not yet created)
+  // CKS
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-cks.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'CKS' },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-cks.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'CKS' },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-cks.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'CKS' },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wva-cks.yaml', guide: 'WVA', acronym: 'WVA', platform: 'CKS' },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-benchmarking-cks.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'CKS' },
 ]
 


### PR DESCRIPTION
## Summary
- OCP nightly workflows were renamed with `-ocp` suffix but the console still referenced old names, causing OCP runs to not show as in-progress or reflect latest results
- Adds WVA CKS workflow mapping (`nightly-e2e-wva-cks.yaml`)
- Updates CKS GPU types from TBD to H100

## Test plan
- [ ] Verify OCP IS/PD/etc show blinking blue when runs are in progress
- [ ] Verify CKS WVA row appears in the dashboard