### PR TITLE
🐛 Fix nav perf test kc-agent mocks and add npm script

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "test:e2e:perf": "playwright test --config e2e/perf/perf.config.ts e2e/perf/dashboard-perf.spec.ts",
     "test:e2e:perf:ttfi": "playwright test --config e2e/perf/perf.config.ts e2e/perf/all-cards-ttfi.spec.ts",
     "test:e2e:perf:ttfi:gate": "npm run test:e2e:perf:ttfi && node e2e/perf/compare-ttfi.mjs",
+    "test:e2e:perf:nav": "playwright test --config e2e/perf/perf.config.ts e2e/perf/dashboard-nav.spec.ts",
     "test:e2e:ui-compliance": "playwright test --config e2e/compliance/compliance.config.ts e2e/compliance/card-loading-compliance.spec.ts",
     "test:e2e:ui-compliance:gate": "npm run test:e2e:ui-compliance && node e2e/compliance/compare-compliance.mjs",
     "test:e2e:coverage": "./scripts/run-e2e-coverage.sh",


### PR DESCRIPTION
## Summary
- Fix kc-agent mock in `dashboard-nav.spec.ts` to return 200 with valid empty data instead of 503 for non-health endpoints. When kc-agent returns 503, AgentManager transitions to 'disconnected' which triggers `forceSkeletonForOffline` in CardWrapper, forcing all cards into skeleton state regardless of data availability.
- Add the missing `test:e2e:perf:nav` npm script to package.json

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (no new errors)
- [x] `npm run test:e2e:perf:nav` passes all 4 tests (warmup, cold-nav, warm-nav, rapid-nav) in 2.7 minutes
- [x] All 60 navigations complete with correct per-navigation timing