### PR TITLE
🐛 Fix benchmark workflow references in nightly E2E card

### DIFF
--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -90,7 +90,7 @@ var nightlyWorkflows = []NightlyWorkflow{
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "CKS"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-cks.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "CKS"},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-cks.yaml", Guide: "WVA", Acronym: "WVA", Platform: "CKS"},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-benchmarking-cks.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "CKS"},
+	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nightly-benchmark-cks.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "CKS"},
 }
 
 // NewNightlyE2EHandler creates a handler using the given GitHub token for API access.

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -47,7 +47,7 @@ const WORKFLOW_META: Record<string, { model: string; gpuType: string; gpuCount: 
   'nightly-e2e-pd-disaggregation-cks.yaml':   { model: 'Qwen3-0.6B',    gpuType: 'H100', gpuCount: 1 },
   'nightly-e2e-wide-ep-lws-cks.yaml':         { model: 'Qwen3-0.6B',    gpuType: 'H100', gpuCount: 1 },
   'nightly-e2e-wva-cks.yaml':                 { model: 'Llama-3.1-8B',  gpuType: 'H100', gpuCount: 2 },
-  'nightly-e2e-benchmarking-cks.yaml':         { model: 'TBD',           gpuType: 'TBD',  gpuCount: 0 },
+  'ci-nightly-benchmark-cks.yaml':             { model: 'TBD',           gpuType: 'TBD',  gpuCount: 0 },
 }
 
 function getWorkflowMeta(workflowFile: string) {

--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -49,13 +49,13 @@ export const NIGHTLY_WORKFLOWS: NightlyWorkflowConfig[] = [
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-gke.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'GKE' },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-gke.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'GKE' },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-gke.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'GKE' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-benchmarking-gke.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'GKE' },
+  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nighly-benchmark-gke.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'GKE' },
   // CKS
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-cks.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'CKS' },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-cks.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'CKS' },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-cks.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'CKS' },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wva-cks.yaml', guide: 'WVA', acronym: 'WVA', platform: 'CKS' },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-benchmarking-cks.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'CKS' },
+  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nightly-benchmark-cks.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'CKS' },
 ]
 
 // Seeded patterns per guide for deterministic demo data


### PR DESCRIPTION
## Summary
- CKS benchmark was pointing to nonexistent `nightly-e2e-benchmarking-cks.yaml` in `llm-d/llm-d`
- Fixed to `ci-nightly-benchmark-cks.yaml` in `llm-d/llm-d-benchmark` (where the actual benchmark runs)
- Fixed GKE demo data to match backend (`ci-nighly-benchmark-gke.yaml` in `llm-d/llm-d-benchmark`)
- Updated `NightlyE2EStatus.tsx` WORKFLOW_META key to match

## Test plan
- [ ] Verify nightly E2E card shows benchmark data for CKS platform