### PR TITLE
🐛 Fix Nightly E2E card showing error during cold loading

### DIFF
--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -598,7 +598,7 @@ export function NightlyE2EStatus() {
 
   const { showSkeleton } = useCardLoadingState({
     isLoading,
-    hasAnyData: guides.length > 0 && !isDemoFallback,
+    hasAnyData: guides.length > 0,
     isFailed,
     consecutiveFailures,
     isDemoData: isDemoFallback,


### PR DESCRIPTION
## Summary
- Fix the Nightly E2E Tests card showing "Error: Load Failed" / "Refresh Failed" during cold loading (initial page load before API responds)
- The `hasAnyData` check incorrectly excluded demo fallback data, causing CardWrapper to treat initial load as a failure
- Now matches the pattern used by all other cards (GPUStatus, ArgoCDHealth, ClusterMetrics, etc.)

## Test plan
- [ ] Hard refresh console — Nightly E2E card shows skeleton then content, never "Error: Load Failed"
- [ ] Card still shows demo badge (yellow outline) when using demo data
- [ ] Card shows real data when API is available