### PR TITLE
✨ Auto-QA tuner v2: weighted rotation, dynamic limits, PR guidance

### DIFF
--- a/.github/workflows/auto-qa-tuner.yml
+++ b/.github/workflows/auto-qa-tuner.yml
@@ -180,8 +180,61 @@ jobs:
             }])
           ' "$CONFIG" > "$TMP" && mv "$TMP" "$CONFIG"
 
+          # ── Compute rotation weights from acceptance rates ──
+          # High-acceptance categories get more focus days, blocked get 0
+          # Formula: weight = acceptance_rate * 1.5 (capped at 2.0, min 0.3)
+          #   blocked → 0, boosted → 2.0, normal scales linearly
+          TMP=$(mktemp)
+          jq '
+            .rotation_weights = (
+              .categories | to_entries | map(
+                if .value.status == "blocked" then {key: .key, value: 0}
+                elif .value.status == "boosted" then {key: .key, value: 2.0}
+                elif (.value.merged + .value.closed) < 3 then {key: .key, value: 1.0}
+                else {key: .key, value: ((.value.acceptance_rate * 1.5 * 100 | round) / 100 | if . > 2.0 then 2.0 elif . < 0.3 then 0.3 else . end)}
+                end
+              ) | from_entries
+            )
+          ' "$CONFIG" > "$TMP" && mv "$TMP" "$CONFIG"
+
+          # ── Compute dynamic max issues per run ──
+          # High overall acceptance → more issues (5), low → fewer (2)
+          TOTAL_M=$(jq '[.categories[].merged] | add // 0' "$CONFIG")
+          TOTAL_C=$(jq '[.categories[].closed] | add // 0' "$CONFIG")
+          TOTAL_ALL=$((TOTAL_M + TOTAL_C))
+          if [ "$TOTAL_ALL" -gt 0 ]; then
+            RATE=$(echo "scale=2; $TOTAL_M * 100 / $TOTAL_ALL" | bc)
+            RATE_INT=${RATE%.*}
+            if [ "$RATE_INT" -ge 70 ]; then
+              MAX_ISSUES=5
+            elif [ "$RATE_INT" -ge 50 ]; then
+              MAX_ISSUES=3
+            else
+              MAX_ISSUES=2
+            fi
+          else
+            MAX_ISSUES=3
+          fi
+          TMP=$(mktemp)
+          jq --argjson mi "$MAX_ISSUES" '.max_issues_override = $mi' "$CONFIG" > "$TMP" && mv "$TMP" "$CONFIG"
+
+          # ── Compute PR guidance from size data ──
+          BEST_SIZE=$(jq -r '.weekly_insights.best_pr_size // "S"' "$CONFIG")
+          case "$BEST_SIZE" in
+            XS) GUIDANCE="Keep changes under 10 lines for best acceptance rate." ;;
+            S)  GUIDANCE="Keep changes under 50 lines (size S) for best acceptance rate. Split larger fixes into multiple PRs." ;;
+            M)  GUIDANCE="Changes up to 200 lines (size M) are acceptable. Avoid PRs over 200 lines." ;;
+            *)  GUIDANCE="Keep PRs small and focused. Smaller PRs have higher acceptance rates." ;;
+          esac
+          TMP=$(mktemp)
+          jq --arg g "$GUIDANCE" '.pr_guidance = $g' "$CONFIG" > "$TMP" && mv "$TMP" "$CONFIG"
+
           echo "Updated tuning config:"
           jq '.categories | to_entries[] | "\(.key): merged=\(.value.merged) closed=\(.value.closed) rate=\(.value.acceptance_rate) status=\(.value.status)"' -r "$CONFIG"
+          echo "Rotation weights:"
+          jq -r '.rotation_weights | to_entries[] | "  \(.key): \(.value)"' "$CONFIG"
+          echo "Max issues: $(jq '.max_issues_override' "$CONFIG")"
+          echo "PR guidance: $(jq -r '.pr_guidance' "$CONFIG")"
 
       - name: Commit tuning config
         run: |

--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -82,12 +82,21 @@ jobs:
           if [ -f "$CONFIG" ]; then
             BLOCKED=$(jq -r '[.categories | to_entries[] | select(.value.status == "blocked") | .key] | join(",")' "$CONFIG")
             BOOSTED=$(jq -r '[.categories | to_entries[] | select(.value.status == "boosted") | .key] | join(",")' "$CONFIG")
+            MAX_ISSUES=$(jq -r '.max_issues_override // 0' "$CONFIG")
+            PR_GUIDANCE=$(jq -r '.pr_guidance // ""' "$CONFIG")
+            # Export rotation weights as JSON for the focus step
+            jq -r '.rotation_weights // {}' "$CONFIG" > /tmp/rotation-weights.json
             echo "blocked=$BLOCKED" >> "$GITHUB_OUTPUT"
             echo "boosted=$BOOSTED" >> "$GITHUB_OUTPUT"
-            echo "Tuning config loaded — blocked: ${BLOCKED:-none}, boosted: ${BOOSTED:-none}"
+            echo "max_issues=$MAX_ISSUES" >> "$GITHUB_OUTPUT"
+            echo "pr_guidance=$PR_GUIDANCE" >> "$GITHUB_OUTPUT"
+            echo "Tuning config loaded — blocked: ${BLOCKED:-none}, boosted: ${BOOSTED:-none}, max_issues: ${MAX_ISSUES:-default}"
           else
             echo "blocked=" >> "$GITHUB_OUTPUT"
             echo "boosted=" >> "$GITHUB_OUTPUT"
+            echo "max_issues=0" >> "$GITHUB_OUTPUT"
+            echo "pr_guidance=" >> "$GITHUB_OUTPUT"
+            echo '{}' > /tmp/rotation-weights.json
             echo "No tuning config found, running all checks"
           fi
 
@@ -99,20 +108,69 @@ jobs:
             echo "area=$OVERRIDE" >> "$GITHUB_OUTPUT"
             echo "Focus override: $OVERRIDE"
           else
-            DOY=$(date -u +%j)  # Day of year (1-366)
-            SLOT=$(( 10#$DOY % 8 ))  # 10# forces base-10 (date +%j zero-pads, which bash reads as octal)
-            case $SLOT in
-              0) FOCUS="performance" ;;
-              1) FOCUS="security" ;;
-              2) FOCUS="a11y" ;;
-              3) FOCUS="operator" ;;
-              4) FOCUS="sre" ;;
-              5) FOCUS="features" ;;
-              6) FOCUS="resilience" ;;
-              7) FOCUS="consistency" ;;
-            esac
-            echo "area=$FOCUS" >> "$GITHUB_OUTPUT"
-            echo "Day-of-year $DOY slot $SLOT focus: $FOCUS"
+            # All 8 focus areas
+            AREAS=("performance" "security" "a11y" "operator" "sre" "features" "resilience" "consistency")
+
+            # Try weighted selection from tuning config
+            WEIGHTS_FILE="/tmp/rotation-weights.json"
+            HAS_WEIGHTS=false
+            if [ -f "$WEIGHTS_FILE" ] && [ "$(jq 'length' "$WEIGHTS_FILE" 2>/dev/null)" -gt 0 ]; then
+              HAS_WEIGHTS=true
+            fi
+
+            if [ "$HAS_WEIGHTS" = true ]; then
+              # Weighted random: build a pool where each area appears N times based on weight
+              # Weight 0 = skip, weight 1.0 = 10 entries, weight 2.0 = 20 entries, weight 0.5 = 5 entries
+              POOL=()
+              for AREA in "${AREAS[@]}"; do
+                W=$(jq -r --arg a "$AREA" '.[$a] // 1.0' "$WEIGHTS_FILE")
+                # Convert weight to integer pool entries (weight * 10)
+                ENTRIES=$(echo "$W * 10" | bc 2>/dev/null | cut -d. -f1)
+                ENTRIES=${ENTRIES:-10}
+                [ "$ENTRIES" -le 0 ] && continue
+                [ "$ENTRIES" -gt 20 ] && ENTRIES=20
+                for ((i=0; i<ENTRIES; i++)); do
+                  POOL+=("$AREA")
+                done
+              done
+
+              if [ ${#POOL[@]} -gt 0 ]; then
+                # Use time-based seed for reproducible-per-hour selection
+                HOUR_SEED=$(date -u +%Y%m%d%H)
+                IDX=$(( ( $(echo "$HOUR_SEED" | cksum | cut -d' ' -f1) ) % ${#POOL[@]} ))
+                FOCUS="${POOL[$IDX]}"
+                echo "area=$FOCUS" >> "$GITHUB_OUTPUT"
+                echo "Weighted selection: $FOCUS (pool size: ${#POOL[@]}, seed: $HOUR_SEED)"
+                # Log weights for debugging
+                for AREA in "${AREAS[@]}"; do
+                  W=$(jq -r --arg a "$AREA" '.[$a] // 1.0' "$WEIGHTS_FILE")
+                  echo "  $AREA: weight=$W"
+                done
+              else
+                # All weights are 0 — fall back to fixed rotation
+                DOY=$(date -u +%j)
+                SLOT=$(( 10#$DOY % 8 ))
+                FOCUS="${AREAS[$SLOT]}"
+                echo "area=$FOCUS" >> "$GITHUB_OUTPUT"
+                echo "All weights zero, fallback to slot $SLOT: $FOCUS"
+              fi
+            else
+              # No tuning config — use original fixed rotation
+              DOY=$(date -u +%j)  # Day of year (1-366)
+              SLOT=$(( 10#$DOY % 8 ))  # 10# forces base-10 (date +%j zero-pads, which bash reads as octal)
+              case $SLOT in
+                0) FOCUS="performance" ;;
+                1) FOCUS="security" ;;
+                2) FOCUS="a11y" ;;
+                3) FOCUS="operator" ;;
+                4) FOCUS="sre" ;;
+                5) FOCUS="features" ;;
+                6) FOCUS="resilience" ;;
+                7) FOCUS="consistency" ;;
+              esac
+              echo "area=$FOCUS" >> "$GITHUB_OUTPUT"
+              echo "Day-of-year $(date -u +%j) slot $SLOT focus: $FOCUS (no tuning weights)"
+            fi
           fi
 
       # ── Layer 1: Baseline Quality Checks ──────────────────────────
@@ -3152,6 +3210,8 @@ jobs:
           # Tuning (from auto-qa-tuner feedback loop)
           BLOCKED_CATEGORIES: ${{ steps.tuning.outputs.blocked }}
           BOOSTED_CATEGORIES: ${{ steps.tuning.outputs.boosted }}
+          TUNED_MAX_ISSUES: ${{ steps.tuning.outputs.max_issues }}
+          PR_GUIDANCE: ${{ steps.tuning.outputs.pr_guidance }}
           # Control
           COMMIT_SHA: ${{ github.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -3160,7 +3220,10 @@ jobs:
           script: |
             const fs = require('fs');
             const prefix = process.env.ISSUE_PREFIX;
-            const maxIssues = parseInt(process.env.MAX_ISSUES_PER_RUN);
+            const tunedMax = parseInt(process.env.TUNED_MAX_ISSUES || '0');
+            const maxIssues = tunedMax > 0 ? tunedMax : parseInt(process.env.MAX_ISSUES_PER_RUN);
+            const prGuidance = process.env.PR_GUIDANCE || '';
+            if (tunedMax > 0) core.info(`Using tuned max issues: ${tunedMax} (default was ${process.env.MAX_ISSUES_PER_RUN})`);
             const sha = process.env.COMMIT_SHA.substring(0, 7);
             const fullSha = process.env.COMMIT_SHA;
             const runUrl = process.env.RUN_URL;
@@ -3195,6 +3258,7 @@ jobs:
                 '',
                 '### How to Fix',
                 ...fixes.map(f => `- ${f}`),
+                ...(prGuidance ? ['', `> **PR Guidance:** ${prGuidance}`] : []),
                 '',
                 '---',
                 `*This issue was automatically created by the [Auto-QA workflow](${runUrl}).*`,
@@ -3215,6 +3279,7 @@ jobs:
                 '',
                 `### ${isEnhancement ? 'Suggested Improvements' : 'How to Fix'}`,
                 ...fixes.map(f => `- ${f}`),
+                ...(prGuidance ? ['', `> **PR Guidance:** ${prGuidance}`] : []),
                 '',
                 '---',
                 `*This issue was automatically created by the [Auto-QA workflow](${runUrl}) during **${areaName}** focus day.*`,


### PR DESCRIPTION
## Summary
- Tuner now **actually drives auto-qa behavior** through 3 runtime channels
- **Weighted rotation**: Focus areas selected by acceptance-rate weights, not fixed 8-day cycle. Blocked categories (0% acceptance) get weight 0 — never selected. Boosted categories get weight 2.0 — selected 2x more often.
- **Dynamic max issues**: Overall acceptance rate controls issue creation rate. High acceptance (>70%) → 5 issues/run. Low (<50%) → only 2.
- **PR guidance**: Every Copilot issue body includes optimal PR size guidance from weekly analysis. e.g. "Keep changes under 50 lines for best acceptance rate."

## How the feedback loop works
```
auto-qa.yml (hourly) → creates issues → Copilot PRs → maintainer merges/closes
                ↑                                              ↓
          reads config ← auto-qa-tuner.yml (daily) ← tracks outcomes
```

## Test plan
- [ ] Trigger daily tuner — verify rotation_weights, max_issues_override, pr_guidance appear in config
- [ ] Trigger auto-qa — verify weighted focus selection in logs, PR guidance in issue bodies, dynamic max issues