### PR TITLE
🐛 Fix stale user cache showing 'No email set' after OAuth login

### DIFF
--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -163,10 +163,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const setToken = useCallback((newToken: string, onboarded: boolean) => {
     localStorage.setItem(STORAGE_KEY_TOKEN, newToken)
     setTokenState(newToken)
-    // Set temporary user until we fetch full user data
-    const tempUser: User = { id: '', github_id: '', github_login: '', onboarded }
-    setUser(tempUser)
-    cacheUser(tempUser)
+    // Clear stale cached user — refreshUser() will fetch and cache real data.
+    // Do NOT cache the temp user: if refreshUser fails, the empty-field temp
+    // user persists in localStorage and the profile shows "No email set".
+    cacheUser(null)
+    setUser({ id: '', github_id: '', github_login: '', onboarded } as User)
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- The `setToken` callback in `auth.tsx` was caching a temporary user with all-empty fields (`id: ''`, `github_login: ''`, `email: undefined`)
- If `refreshUser()` failed or the page navigated before completion, this empty-field user persisted in `kc-user-cache` localStorage
- Profile showed "No email set" and a generic avatar even after successful OAuth login
- **Fix**: Clear the cache in `setToken` instead of writing the temp user. Only `refreshUser()` (which fetches real data from `/api/me`) should populate the cache

## Test plan
- [ ] Clear localStorage, login via GitHub OAuth
- [ ] Verify profile shows correct GitHub username and avatar on first load
- [ ] Kill backend mid-login, verify profile doesn't show empty fields on reload (uses last good cache or shows loading)