### PR TITLE
🐛 Fix community issues: AI modal contrast, dropdown opacity, visual regression

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -313,15 +313,12 @@ jobs:
           PLAYWRIGHT_BASE_URL: http://localhost:4173
         continue-on-error: true
 
-  # Visual regression tests - DISABLED until tests are stable
-  # TODO: Re-enable after test stabilization
   visual-regression:
     name: Visual Regression
-    if: false  # Disabled until tests are stable
+    if: github.event_name == 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Original condition: if: github.event_name == 'pull_request'
     defaults:
       run:
         working-directory: web

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -129,7 +129,7 @@ export function MissionSidebar() {
       <div
         data-tour="ai-missions"
         className={cn(
-          "fixed bg-card/95 backdrop-blur-sm border-border z-40 flex flex-col overflow-hidden",
+          "fixed bg-card border-border z-40 flex flex-col overflow-hidden shadow-2xl",
           "transition-[width,top,border,transform] duration-300 ease-in-out",
           // Mobile: bottom sheet
           isMobile && "inset-x-0 bottom-0 rounded-t-2xl border-t max-h-[80vh]",

--- a/web/src/lib/unified/card/hooks/useCardFiltering.ts
+++ b/web/src/lib/unified/card/hooks/useCardFiltering.ts
@@ -170,7 +170,7 @@ function FilterControl({
           onChange: (e: React.ChangeEvent<HTMLSelectElement>) =>
             onChange(e.target.value || undefined),
           className:
-            'px-3 py-1.5 text-sm bg-gray-800 border border-gray-700 rounded focus:outline-none focus:border-blue-500 text-gray-200',
+            'px-3 py-1.5 text-sm bg-gray-900 border border-gray-600 rounded focus:outline-none focus:border-blue-500 text-gray-200',
         },
         createElement('option', { value: '' }, config.placeholder ?? 'All'),
         config.options?.map((opt) =>


### PR DESCRIPTION
## Summary
Fixes three community-reported issues:

- **Fixes #1009** — AI diagnosis sidebar had poor contrast (95% opacity background). Now uses solid `bg-card` with `shadow-2xl` for clear separation from dashboard content.
- **Fixes #931** — Security issues dropdown was semi-transparent (`bg-gray-800`). Updated to `bg-gray-900` with brighter border for an opaque, professional look.
- **Fixes #927** — Re-enabled Playwright visual regression tests that were disabled with `if: false`. Now runs on PRs.

## Test plan
- [x] Build passes
- [x] AI Missions sidebar visually verified — solid background, no bleed-through
- [ ] Security dropdown opacity verified on Issues tab
- [ ] Playwright visual regression job runs on this PR