### PR TITLE
✨ Add GPU failure detection to nightly E2E status card

### DIFF
--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -80,6 +80,7 @@ export function useNightlyE2EData() {
                       updatedAt: r.updatedAt,
                       htmlUrl: r.htmlUrl,
                       runNumber: r.runNumber,
+                      failureReason: r.failureReason || '',
                     })
                   ),
                   passRate: g.passRate,

--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -24,6 +24,7 @@ export interface NightlyRun {
   updatedAt: string
   htmlUrl: string
   runNumber: number
+  failureReason?: 'gpu_unavailable' | 'test_failure' | ''
 }
 
 export interface NightlyGuideStatus {


### PR DESCRIPTION
## Summary
- **Backend**: Calls GitHub Actions Jobs API to inspect step-level failures for each failed nightly run. Classifies failures as `gpu_unavailable` (GPU availability check step failed) vs `test_failure` (actual test code failed). Uses concurrent goroutines for parallel classification across runs.
- **Frontend**: GPU unavailability failures rendered in **amber** instead of red across RunDots, sparkline points, and the Übersicht widget. Separated GPU/test failure counts in the detail panel stats grid. Updated legend with amber "GPU" entry. AI summary now mentions GPU failure count when present.
- **Hook/Types**: Added `failureReason` field to `NightlyRun` interface and passthrough in `useNightlyE2EData` hook.

## How it works
When the backend fetches workflow runs, it spawns goroutines for each failed run to call `GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs`. If any failed step name matches the pattern "gpu" + "availab" (case-insensitive), the run is classified as `gpu_unavailable`. Otherwise it's `test_failure`.

## Visual changes
- **Amber dots** (`bg-amber-400` / `#f59e0b`) for GPU failures instead of red
- **Separate stat boxes**: "Failed" (red) and "GPU" (amber) in the detail panel
- **Legend**: Added amber "GPU" entry between "Fail" and "Running"
- **AI Summary**: "N GPU unavailability failures" mentioned when applicable

## Test plan
- [ ] Backend builds clean (`go build ./...`)
- [ ] Frontend builds and lints (`npm run build`, `npm run lint`)
- [ ] Verify amber dots appear for GPU failures in the nightly card
- [ ] Verify tooltip shows "(GPU unavailable)" for amber dots
- [ ] Verify detail panel shows separate GPU/test failure counts
- [ ] Verify widget export includes amber GPU handling