### PR TITLE
✨ Per-run metadata in nightly E2E detail panel

### DIFF
--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -36,6 +36,8 @@ type NightlyWorkflow struct {
 }
 
 // NightlyRun represents a single workflow run from the GitHub Actions API.
+// Per-run metadata (Model, GPUType, GPUCount) is populated from the workflow
+// defaults so the UI can display infrastructure details per dot on hover.
 type NightlyRun struct {
 	ID            int64   `json:"id"`
 	Status        string  `json:"status"`
@@ -45,6 +47,10 @@ type NightlyRun struct {
 	HTMLURL       string  `json:"htmlUrl"`
 	RunNumber     int     `json:"runNumber"`
 	FailureReason string  `json:"failureReason,omitempty"`
+	Model         string  `json:"model"`
+	GPUType       string  `json:"gpuType"`
+	GPUCount      int     `json:"gpuCount"`
+	Event         string  `json:"event"`
 }
 
 // NightlyGuideStatus holds runs and computed stats for a single guide.
@@ -267,6 +273,7 @@ func (h *NightlyE2EHandler) fetchWorkflowRuns(wf NightlyWorkflow) ([]NightlyRun,
 			UpdatedAt  string  `json:"updated_at"`
 			HTMLURL    string  `json:"html_url"`
 			RunNumber  int     `json:"run_number"`
+			Event      string  `json:"event"`
 		} `json:"workflow_runs"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
@@ -283,6 +290,10 @@ func (h *NightlyE2EHandler) fetchWorkflowRuns(wf NightlyWorkflow) ([]NightlyRun,
 			UpdatedAt:  r.UpdatedAt,
 			HTMLURL:    r.HTMLURL,
 			RunNumber:  r.RunNumber,
+			Model:      wf.Model,
+			GPUType:    wf.GPUType,
+			GPUCount:   wf.GPUCount,
+			Event:      r.Event,
 		}
 	}
 

--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -81,6 +81,10 @@ export function useNightlyE2EData() {
                       htmlUrl: r.htmlUrl,
                       runNumber: r.runNumber,
                       failureReason: r.failureReason || '',
+                      model: r.model ?? g.model ?? 'Unknown',
+                      gpuType: r.gpuType ?? g.gpuType ?? 'Unknown',
+                      gpuCount: r.gpuCount ?? g.gpuCount ?? 0,
+                      event: r.event ?? 'schedule',
                     })
                   ),
                   passRate: g.passRate,

--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -25,6 +25,10 @@ export interface NightlyRun {
   htmlUrl: string
   runNumber: number
   failureReason?: 'gpu_unavailable' | 'test_failure' | ''
+  model: string
+  gpuType: string
+  gpuCount: number
+  event: string
 }
 
 export interface NightlyGuideStatus {
@@ -122,6 +126,10 @@ export function generateDemoNightlyData(): NightlyGuideStatus[] {
         updatedAt: updatedAt.toISOString(),
         htmlUrl: `https://github.com/${wf.repo}/actions/workflows/${wf.workflowFile}`,
         runNumber: 100 - i,
+        model: wf.model,
+        gpuType: wf.gpuType,
+        gpuCount: wf.gpuCount,
+        event: 'schedule',
       }
     })
 

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -890,6 +890,8 @@
     "model": "Model",
     "gpu": "GPU",
     "avgDuration": "Avg duration",
+    "duration": "Duration",
+    "hoverDotForDetails": "hover dot for details",
     "lastPass": "Last pass",
     "lastFail": "Last fail",
     "totalRuns": "Total runs",


### PR DESCRIPTION
## Summary
- Adds `model`, `gpuType`, `gpuCount`, and `event` fields to each `NightlyRun` in the backend API response
- Detail panel infrastructure section (Model, GPU, Duration) now updates per-run when hovering individual run dots
- Run dots in the detail panel get a highlight ring when hovered, with a "Run #N · Xm ago" label
- Avg duration still shows when no dot is hovered; switches to that run's specific duration on hover

## Test plan
- [ ] Verify build passes (`go build ./...` + `npm run build`)
- [ ] Open nightly E2E card, hover a guide row to see detail panel
- [ ] In the detail panel, hover individual run dots at the bottom — model/GPU/duration should update
- [ ] Verify hint text "hover dot for details" shows when no dot is hovered
- [ ] Verify demo data mode works correctly with per-run fields