### PR TITLE
✨ Add log/artifact links on hover for failed nightly run dots

### DIFF
--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -299,11 +299,15 @@ ${wrapOpen}
                   <div style={{display: 'flex', gap: '2px', alignItems: 'center'}}>
                     {runs.map((r, i) => {
                       const isGpu = r.conclusion === 'failure' && r.failureReason === 'gpu_unavailable';
+                      const isFailed = r.conclusion === 'failure';
                       const dotLabel = (r.conclusion || r.status) + (isGpu ? ' (GPU)' : '') + ' — ' + timeAgo(r.updatedAt || r.createdAt);
                       const dotColor = r.status !== 'completed' ? '#60a5fa' : isGpu ? '#f59e0b' : (conclusionColors[r.conclusion] || '#6b7280');
                       return (
-                      <span key={i} className="dot-tip-wrap" onClick={() => r.htmlUrl && run(\`open "\${r.htmlUrl}"\`)}>
-                        <span className="tip">{dotLabel}</span>
+                      <span key={i} className={'dot-tip-wrap' + (isFailed ? ' has-links' : '')} onClick={() => r.htmlUrl && run(\`open "\${r.htmlUrl}"\`)}>
+                        <span className="tip">
+                          {dotLabel}
+                          {isFailed && r.htmlUrl && <><br/><a href={r.htmlUrl + '#logs'} onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}#logs"\`); }}>Logs</a><a href={r.htmlUrl + '/artifacts'} onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}/artifacts"\`); }}>Artifacts</a></>}
+                        </span>
                         <span style={{
                           width: 7, height: 7, borderRadius: '50%', display: 'inline-block', cursor: 'pointer',
                           backgroundColor: dotColor,

--- a/web/src/lib/widgets/styleConverter.ts
+++ b/web/src/lib/widgets/styleConverter.ts
@@ -427,6 +427,16 @@ export const className = css\`
     box-shadow: 0 2px 8px rgba(0,0,0,0.3);
   }
   .dot-tip-wrap:hover .tip { display: block; }
+  .dot-tip-wrap.has-links .tip {
+    pointer-events: auto;
+    padding: 4px 8px;
+  }
+  .dot-tip-wrap.has-links .tip a {
+    color: #60a5fa;
+    text-decoration: none;
+    margin-left: 6px;
+  }
+  .dot-tip-wrap.has-links .tip a:hover { color: #93bbfc; text-decoration: underline; }
   .spark-tip-wrap { position: relative; }
   .spark-tip-wrap .spark-tip {
     display: none;


### PR DESCRIPTION
## Summary
- Hovering over a **failed run dot** (red or amber) now shows a popup with:
  - Run number, failure type (GPU unavailable / failed), and time ago
  - **View Logs** link → opens GitHub Actions run page at `#logs` anchor
  - **Artifacts** link → opens the run's artifacts page (pod logs retained for 7 days)
- Non-failed dots retain the simple title tooltip (no popup)
- Updated in the **console card** (React), **widget code generator**, and **live Übersicht widget**

## How it works
- **Card**: `RunDot` component now uses a `useState` for popup visibility. Failed dots render a positioned popup div with clickable links.
- **Widget**: Failed dots get `has-links` CSS class which enables `pointer-events: auto` on the tooltip, allowing link clicks. Links use Übersicht's `run()` to open URLs in the browser.

## Test plan
- [ ] Hover over a green (success) dot → simple title tooltip, no popup
- [ ] Hover over a red (failed) dot → popup with run info + Logs/Artifacts links
- [ ] Hover over an amber (GPU) dot → popup with "GPU unavailable" + Logs/Artifacts links  
- [ ] Click "View Logs" → opens GitHub Actions run page scrolled to logs
- [ ] Click "Artifacts" → opens the artifacts download page
- [ ] Widget: same behavior with CSS tooltips