### PR TITLE
🐛 Fix widget tooltip: React fragment + hover gap issues

### DIFF
--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -306,7 +306,7 @@ ${wrapOpen}
                       <span key={i} className={'dot-tip-wrap' + (isFailed ? ' has-links' : '')} onClick={() => r.htmlUrl && run(\`open "\${r.htmlUrl}"\`)}>
                         <span className="tip">
                           {dotLabel}
-                          {isFailed && r.htmlUrl && <><br/><a href={r.htmlUrl + '#logs'} onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}#logs"\`); }}>Logs</a><a href={r.htmlUrl + '/artifacts'} onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}/artifacts"\`); }}>Artifacts</a></>}
+                          {isFailed && r.htmlUrl && <span><br/><a href={r.htmlUrl + '#logs'} onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}#logs"\`); }}>Logs</a><a href={r.htmlUrl + '/artifacts'} onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}/artifacts"\`); }}>Artifacts</a></span>}
                         </span>
                         <span style={{
                           width: 7, height: 7, borderRadius: '50%', display: 'inline-block', cursor: 'pointer',

--- a/web/src/lib/widgets/styleConverter.ts
+++ b/web/src/lib/widgets/styleConverter.ts
@@ -430,6 +430,15 @@ export const className = css\`
   .dot-tip-wrap.has-links .tip {
     pointer-events: auto;
     padding: 4px 8px;
+    bottom: calc(100% + 1px);
+  }
+  .dot-tip-wrap.has-links .tip::after {
+    content: '';
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    height: 8px;
   }
   .dot-tip-wrap.has-links .tip a {
     color: #60a5fa;


### PR DESCRIPTION
## Summary
Follow-up fix for #1121:
- **React fragment error**: Replace `<>...</>` with `<span>` — Übersicht widgets don't have React in scope
- **Hover gap**: Reduce tooltip gap from 4px to 1px and add invisible `::after` bridge element so the mouse can reach the tooltip links without the hover closing

## Test plan
- [ ] Widget renders without "Can't find variable: React" error
- [ ] Hovering a failed dot shows tooltip, mouse can reach Logs/Artifacts links