### PR TITLE
🐛 Remove artifacts link from failed dot hover

### DIFF
--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -116,18 +116,11 @@ function RunDot({ run, isHighlighted, onMouseEnter, onMouseLeave }: {
             <div className="text-slate-300 mb-1">
               Run #{run.runNumber} &middot; {isGPUFailure ? <span className="text-amber-400">GPU unavailable</span> : <span className="text-red-400">failed</span>} &middot; {formatTimeAgo(run.createdAt)}
             </div>
-            <div className="flex items-center gap-2">
-              <a href={logsUrl} target="_blank" rel="noopener noreferrer"
-                className="text-blue-400 hover:text-blue-300 transition-colors flex items-center gap-0.5"
-                onClick={e => e.stopPropagation()}>
-                View Logs <ExternalLink size={8} />
-              </a>
-              <a href={`${run.htmlUrl}/artifacts`} target="_blank" rel="noopener noreferrer"
-                className="text-blue-400 hover:text-blue-300 transition-colors flex items-center gap-0.5"
-                onClick={e => e.stopPropagation()}>
-                Artifacts <ExternalLink size={8} />
-              </a>
-            </div>
+            <a href={logsUrl} target="_blank" rel="noopener noreferrer"
+              className="text-blue-400 hover:text-blue-300 transition-colors flex items-center gap-0.5"
+              onClick={e => e.stopPropagation()}>
+              View Logs <ExternalLink size={8} />
+            </a>
             <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-slate-600" />
           </div>
         </div>

--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -306,7 +306,7 @@ ${wrapOpen}
                       <span key={i} className={'dot-tip-wrap' + (isFailed ? ' has-links' : '')} onClick={() => r.htmlUrl && run(\`open "\${r.htmlUrl}"\`)}>
                         <span className="tip">
                           {dotLabel}
-                          {isFailed && r.htmlUrl && <span><br/><a href={r.htmlUrl + '#logs'} onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}#logs"\`); }}>Logs</a><a href={r.htmlUrl + '/artifacts'} onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}/artifacts"\`); }}>Artifacts</a></span>}
+                          {isFailed && r.htmlUrl && <span><br/><a href={r.htmlUrl + '#logs'} onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}#logs"\`); }}>View Logs</a></span>}
                         </span>
                         <span style={{
                           width: 7, height: 7, borderRadius: '50%', display: 'inline-block', cursor: 'pointer',


### PR DESCRIPTION
The /artifacts URL 404s. The logs page already has both logs and artifacts, so only 'View Logs' is needed.