### PR TITLE
🐛 Show skeleton instead of demo-data flash on Nightly E2E card

### DIFF
--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -686,9 +686,12 @@ export function NightlyE2EStatus() {
     }
   }, [])
 
+  // Show skeleton while fetching real data — don't flash demo data on initial load.
+  // hasAnyData is only true when we have REAL data (not demo fallback).
+  const hasRealData = guides.length > 0 && !isDemoFallback
   const { showSkeleton } = useCardLoadingState({
     isLoading,
-    hasAnyData: guides.length > 0,
+    hasAnyData: hasRealData,
     isFailed,
     consecutiveFailures,
     isDemoData: isDemoFallback,


### PR DESCRIPTION
## Summary
- When navigating to the llm-d Benchmarks dashboard, the Nightly E2E card briefly flashed demo data (yellow border + Demo badge) before real data loaded
- Root cause: `useCardLoadingState` saw `hasAnyData=true` from demo `initialData`, so it never showed the skeleton
- Fix: only set `hasAnyData=true` when we have real (non-demo) data, so the skeleton displays during the initial fetch

## Test plan
- [x] `npm run build` passes
- [ ] Navigate to llm-d Benchmarks dashboard — card shows skeleton, then loads real data (no demo flash)