### PR TITLE
🐛 Fix isDemoData mismatch on 21 cards using real data hooks

### DIFF
--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -482,7 +482,6 @@ export const DEMO_DATA_CARDS = new Set([
   'argocd_sync_status',
   // GitOps cards - use mock data
   'kustomization_status',
-  'overlay_comparison',
   // Helm cards - all now use real data via helm CLI backend
   // Namespace cards - namespace_quotas, namespace_rbac, resource_capacity, and helm_release_status now have real data support
   // Cost management integrations - demo until connected

--- a/web/src/config/cards/chart-versions.ts
+++ b/web/src/config/cards/chart-versions.ts
@@ -25,7 +25,7 @@ export const chartVersionsConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'Package', title: 'No Charts', message: 'No chart versions found', variant: 'info' },
   loadingState: { type: 'list', rows: 5 },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default chartVersionsConfig

--- a/web/src/config/cards/cluster-costs.ts
+++ b/web/src/config/cards/cluster-costs.ts
@@ -23,7 +23,7 @@ export const clusterCostsConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'DollarSign', title: 'No Cost Data', message: 'Cost data not available', variant: 'info' },
   loadingState: { type: 'chart' },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default clusterCostsConfig

--- a/web/src/config/cards/cluster-locations.ts
+++ b/web/src/config/cards/cluster-locations.ts
@@ -19,7 +19,7 @@ export const clusterLocationsConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'MapPin', title: 'No Location Data', message: 'Cluster location data not available', variant: 'info' },
   loadingState: { type: 'custom' },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default clusterLocationsConfig

--- a/web/src/config/cards/cluster-network.ts
+++ b/web/src/config/cards/cluster-network.ts
@@ -19,7 +19,7 @@ export const clusterNetworkConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'Network', title: 'No Network Data', message: 'Network data not available', variant: 'info' },
   loadingState: { type: 'custom' },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default clusterNetworkConfig

--- a/web/src/config/cards/crd-health.ts
+++ b/web/src/config/cards/crd-health.ts
@@ -28,7 +28,7 @@ export const crdHealthConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'FileCode', title: 'No CRDs', message: 'No Custom Resource Definitions found', variant: 'info' },
   loadingState: { type: 'list', rows: 5 },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default crdHealthConfig

--- a/web/src/config/cards/gitops-drift.ts
+++ b/web/src/config/cards/gitops-drift.ts
@@ -73,5 +73,6 @@ export const gitopsDriftConfig: UnifiedCardConfig = {
     params: ['resource', 'kind', 'namespace'],
   },
 
-  isDemoData: true,
+  isDemoData: false,
+  isLive: true,
 }

--- a/web/src/config/cards/gpu-inventory.ts
+++ b/web/src/config/cards/gpu-inventory.ts
@@ -29,7 +29,7 @@ export const gpuInventoryConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'Cpu', title: 'No GPUs', message: 'No GPU resources found', variant: 'info' },
   loadingState: { type: 'list', rows: 5 },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default gpuInventoryConfig

--- a/web/src/config/cards/gpu-status.ts
+++ b/web/src/config/cards/gpu-status.ts
@@ -25,7 +25,7 @@ export const gpuStatusConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'Activity', title: 'No GPUs', message: 'No GPU status available', variant: 'info' },
   loadingState: { type: 'list', rows: 5 },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default gpuStatusConfig

--- a/web/src/config/cards/gpu-usage-trend.ts
+++ b/web/src/config/cards/gpu-usage-trend.ts
@@ -23,7 +23,7 @@ export const gpuUsageTrendConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'BarChart2', title: 'No Data', message: 'No GPU trend data', variant: 'info' },
   loadingState: { type: 'chart' },
-  isDemoData: true,
+  isDemoData: false,
   isLive: true,
 }
 export default gpuUsageTrendConfig

--- a/web/src/config/cards/gpu-utilization.ts
+++ b/web/src/config/cards/gpu-utilization.ts
@@ -23,7 +23,7 @@ export const gpuUtilizationConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'TrendingUp', title: 'No Data', message: 'No GPU utilization data', variant: 'info' },
   loadingState: { type: 'chart' },
-  isDemoData: true,
+  isDemoData: false,
   isLive: true,
 }
 export default gpuUtilizationConfig

--- a/web/src/config/cards/gpu-workloads.ts
+++ b/web/src/config/cards/gpu-workloads.ts
@@ -25,7 +25,7 @@ export const gpuWorkloadsConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'Zap', title: 'No Workloads', message: 'No GPU workloads found', variant: 'info' },
   loadingState: { type: 'list', rows: 5 },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default gpuWorkloadsConfig

--- a/web/src/config/cards/network-overview.ts
+++ b/web/src/config/cards/network-overview.ts
@@ -16,7 +16,7 @@ export const networkOverviewConfig: UnifiedCardConfig = {
   defaultWidth: 4,
   defaultHeight: 3,
 
-  isDemoData: true, // Uses demo data hook in registerHooks.ts
+  isDemoData: false,
 
   dataSource: {
     type: 'hook',

--- a/web/src/config/cards/opa-policies.ts
+++ b/web/src/config/cards/opa-policies.ts
@@ -28,7 +28,7 @@ export const opaPoliciesConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'Shield', title: 'No Policies', message: 'No OPA policies found', variant: 'info' },
   loadingState: { type: 'list', rows: 5 },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default opaPoliciesConfig

--- a/web/src/config/cards/overlay-comparison.ts
+++ b/web/src/config/cards/overlay-comparison.ts
@@ -19,7 +19,7 @@ export const overlayComparisonConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'GitCompare', title: 'No Overlays', message: 'Select overlays to compare', variant: 'info' },
   loadingState: { type: 'custom' },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default overlayComparisonConfig

--- a/web/src/config/cards/pvc-status.ts
+++ b/web/src/config/cards/pvc-status.ts
@@ -114,7 +114,7 @@ export const pvcStatusConfig: UnifiedCardConfig = {
   },
 
   // Metadata
-  isDemoData: true,
+  isDemoData: false,
   isLive: true,
 }
 

--- a/web/src/config/cards/resource-capacity.ts
+++ b/web/src/config/cards/resource-capacity.ts
@@ -23,7 +23,7 @@ export const resourceCapacityConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'BarChart3', title: 'No Data', message: 'No capacity data available', variant: 'info' },
   loadingState: { type: 'chart' },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default resourceCapacityConfig

--- a/web/src/config/cards/security-issues.ts
+++ b/web/src/config/cards/security-issues.ts
@@ -16,7 +16,8 @@ export const securityIssuesConfig: UnifiedCardConfig = {
   defaultWidth: 6,
   defaultHeight: 3,
 
-  isDemoData: true, // Uses demo data hook in registerHooks.ts
+  isDemoData: false,
+  isLive: true,
 
   dataSource: {
     type: 'hook',

--- a/web/src/config/cards/service-status.ts
+++ b/web/src/config/cards/service-status.ts
@@ -101,7 +101,7 @@ export const serviceStatusConfig: UnifiedCardConfig = {
   },
 
   // Metadata
-  isDemoData: true,
+  isDemoData: false,
   isLive: true,
 }
 

--- a/web/src/config/cards/storage-overview.ts
+++ b/web/src/config/cards/storage-overview.ts
@@ -16,7 +16,7 @@ export const storageOverviewConfig: UnifiedCardConfig = {
   defaultWidth: 4,
   defaultHeight: 3,
 
-  isDemoData: true, // Uses demo data hook in registerHooks.ts
+  isDemoData: false,
 
   dataSource: {
     type: 'hook',

--- a/web/src/config/cards/top-pods.ts
+++ b/web/src/config/cards/top-pods.ts
@@ -16,7 +16,8 @@ export const topPodsConfig: UnifiedCardConfig = {
   defaultWidth: 6,
   defaultHeight: 3,
 
-  isDemoData: true, // Uses demo data hook in registerHooks.ts
+  isDemoData: false,
+  isLive: true,
 
   dataSource: {
     type: 'hook',

--- a/web/src/config/cards/upgrade-status.ts
+++ b/web/src/config/cards/upgrade-status.ts
@@ -25,7 +25,7 @@ export const upgradeStatusConfig: UnifiedCardConfig = {
   },
   emptyState: { icon: 'ArrowUpCircle', title: 'All Current', message: 'All clusters are up to date', variant: 'success' },
   loadingState: { type: 'list', rows: 4 },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default upgradeStatusConfig


### PR DESCRIPTION
## Summary
- Fix 21 card configs that had `isDemoData: true` but their components use real Kubernetes API / MCP data hooks
- Set `isDemoData: false` and `isLive: true` on all 21 configs
- Remove `overlay_comparison` from `DEMO_DATA_CARDS` array in cardRegistry.ts
- Remove misleading `// Uses demo data hook in registerHooks.ts` comments from 4 config files

## Cards Fixed
| Card | Real Data Hook |
|------|---------------|
| gpu_inventory | useGPUNodes |
| gpu_status | useGPUNodes |
| gpu_workloads | useGPUNodes |
| gpu_utilization | useGPUNodes |
| gpu_usage_trend | useGPUNodes |
| cluster_costs | useClusters |
| cluster_locations | useClusters |
| cluster_network | useClusters |
| resource_capacity | useClusters |
| upgrade_status | useClusters |
| crd_health | useCRDs |
| top_pods | useCachedPods |
| security_issues | useCachedSecurityIssues |
| service_status | useCachedServices |
| pvc_status | usePVCs |
| storage_overview | usePVCs + useNodes |
| network_overview | useCachedServices + useIngresses |
| chart_versions | useHelmReleases |
| gitops_drift | useGitOpsDrifts |
| opa_policies | useOPAPolicies |
| overlay_comparison | useMissions |

## Test plan
- [x] Build passes (`npm run build`)
- [ ] Verify cards render correctly without demo badge/yellow outline
- [ ] Verify cards show real data when connected to clusters