### PR TITLE
🐛 Central fix: show skeleton instead of demo data flash during loading

### DIFF
--- a/web/e2e/compliance/card-loading-compliance.spec.ts
+++ b/web/e2e/compliance/card-loading-compliance.spec.ts
@@ -181,52 +181,63 @@ async function setupLiveMocks(page: Page) {
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) })
   })
 
-  await page.route('**/api/workloads**', (route) =>
+  await page.route('**/api/workloads**', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 150))
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ items: [] }) })
-  )
+  })
 
   // Endpoints that expect array responses (not { items: [] })
-  await page.route('**/api/dashboards**', (route) =>
+  await page.route('**/api/dashboards**', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 150))
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
-  )
+  })
 
-  await page.route('**/api/config/**', (route) =>
+  await page.route('**/api/config/**', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 150))
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) })
-  )
+  })
 
   // Richer mock data for old MCP hook endpoints — ensures caches have non-empty data
-  // so warm return (criterion g) finds real data in localStorage
-  await page.route('**/api/gitops/buildpack-images**', (route) =>
+  // so warm return (criterion g) finds real data in localStorage.
+  // All routes have 150ms delay so loading phase is observable by the 50ms monitor.
+  await page.route('**/api/gitops/buildpack-images**', async (route) => {
+    await new Promise((resolve) => setTimeout(resolve, 150))
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ images: [{ name: 'test-image', namespace: 'default', cluster: MOCK_CLUSTER, status: 'succeeded', builder: 'paketo' }] }) })
-  )
+  })
 
   await page.route('**/api/mcp/gpu-nodes**', async (route) => {
     if (route.request().url().includes('/stream')) { await route.fallback(); return }
+    await new Promise((resolve) => setTimeout(resolve, 150))
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ nodes: [{ name: 'gpu-node-1', cluster: MOCK_CLUSTER, gpus: [{ model: 'A100', memory: '80Gi', index: 0 }], labels: {}, allocatable: {}, capacity: {} }] }) })
   })
 
   await page.route('**/api/mcp/helm-releases**', async (route) => {
     if (route.request().url().includes('/stream')) { await route.fallback(); return }
+    await new Promise((resolve) => setTimeout(resolve, 150))
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ releases: [{ name: 'ingress-nginx', namespace: 'default', cluster: MOCK_CLUSTER, chart: 'nginx-1.0.0', status: 'deployed', revision: 1, updated: new Date().toISOString() }] }) })
   })
 
   await page.route('**/api/mcp/operators**', async (route) => {
     if (route.request().url().includes('/stream')) { await route.fallback(); return }
+    await new Promise((resolve) => setTimeout(resolve, 150))
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ operators: [{ name: 'test-operator', namespace: 'openshift-operators', cluster: MOCK_CLUSTER, status: 'Succeeded', version: '1.0.0' }] }) })
   })
 
   await page.route('**/api/mcp/operator-subscriptions**', async (route) => {
     if (route.request().url().includes('/stream')) { await route.fallback(); return }
+    await new Promise((resolve) => setTimeout(resolve, 150))
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ subscriptions: [{ name: 'test-sub', namespace: 'openshift-operators', cluster: MOCK_CLUSTER, package: 'test-operator', channel: 'stable', currentCSV: 'test-operator.v1.0.0', installedCSV: 'test-operator.v1.0.0' }] }) })
   })
 
   await page.route('**/api/mcp/resource-quotas**', async (route) => {
     if (route.request().url().includes('/stream')) { await route.fallback(); return }
+    await new Promise((resolve) => setTimeout(resolve, 150))
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ quotas: [{ name: 'default-quota', namespace: 'default', cluster: MOCK_CLUSTER, hard: { cpu: '4', memory: '8Gi' }, used: { cpu: '1', memory: '2Gi' } }] }) })
   })
 
   await page.route('**/api/mcp/nodes**', async (route) => {
     if (route.request().url().includes('/stream')) { await route.fallback(); return }
+    await new Promise((resolve) => setTimeout(resolve, 150))
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ nodes: [{ name: 'node-1', cluster: MOCK_CLUSTER, status: 'Ready', roles: ['control-plane'], kubeletVersion: 'v1.28.0', conditions: [{ type: 'Ready', status: 'True' }] }] }) })
   })
 
@@ -280,6 +291,8 @@ async function setupLiveMocks(page: Page) {
       await route.fallback()
       return
     }
+    // Delay ALL API responses so every card's loading phase is observable by the 50ms monitor
+    await new Promise((resolve) => setTimeout(resolve, 150))
     route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
   })
 

--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -141,9 +141,12 @@ export function useCardLoadingState(options: CardLoadingStateOptions) {
     isDemoData,
   } = options
 
-  // hasData is true once loading completes (even with empty data) OR if we have cached data
-  // This prevents flickering when data array is momentarily empty during refresh
-  const hasData = !isLoading || hasAnyData
+  // During initial load, demo data from initialData doesn't count as "real" data.
+  // Show skeleton instead of flashing demo content (yellow border + Demo badge).
+  // Once loading finishes, demo fallback data is shown normally with the badge.
+  // When refreshing with cached REAL data, show cached content + refresh animation.
+  const hasRealData = isLoading ? (hasAnyData && !isDemoData) : hasAnyData
+  const hasData = !isLoading || hasRealData
 
   // Report state to CardWrapper for refresh animation and status badges
   useReportCardDataState({
@@ -159,12 +162,12 @@ export function useCardLoadingState(options: CardLoadingStateOptions) {
   return {
     /** Whether the card has data to display (true once loading completes or has cached data) */
     hasData,
-    /** Whether to show skeleton loading state (only when loading with no cached data) */
-    showSkeleton: isLoading && !hasAnyData,
+    /** Whether to show skeleton loading state (only when loading with no cached/real data) */
+    showSkeleton: isLoading && !hasRealData,
     /** Whether to show empty state (loading finished but no data exists) */
     showEmptyState: !isLoading && !hasAnyData,
     /** Whether data is being refreshed (has cache, fetching update) */
-    isRefreshing: isLoading && hasData,
+    isRefreshing: isLoading && hasRealData,
   }
 }
 

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -686,12 +686,9 @@ export function NightlyE2EStatus() {
     }
   }, [])
 
-  // Show skeleton while fetching real data — don't flash demo data on initial load.
-  // hasAnyData is only true when we have REAL data (not demo fallback).
-  const hasRealData = guides.length > 0 && !isDemoFallback
   const { showSkeleton } = useCardLoadingState({
     isLoading,
-    hasAnyData: hasRealData,
+    hasAnyData: guides.length > 0,
     isFailed,
     consecutiveFailures,
     isDemoData: isDemoFallback,


### PR DESCRIPTION
## Summary
- **Central fix in `useCardLoadingState`**: during loading, demo data from `initialData` no longer counts as "real data" — skeleton shows instead of flashing demo content (yellow border + Demo badge)
- This fixes ALL cards that pass `isDemoData` to the hook — no per-card fixes needed
- Previously only NightlyE2EStatus had a manual workaround; now it's handled centrally and the per-card fix is reverted
- Compliance test: added 150ms delays to ALL mock API routes (workloads, dashboards, config, buildpacks, gpu-nodes, helm, operators, nodes, catch-all) so every card's loading phase is observable
- Criterion (a) "no demo badge during skeleton" coverage improved from 26% (45 cards) to 45% (78 cards)
- Remaining 96 skipped cards: 12 games + 83 cards using synchronous demo hooks (no async fetch = no loading phase to observe)

## Test plan
- [x] `npm run build` passes
- [x] Compliance test: 174/174 pass, all 8 criteria at 100%
- [x] Nightly E2E card: criterion a "2 loading snapshots, all clean"
- [x] Central fix verified: `hasRealData = isLoading ? (hasAnyData && !isDemoData) : hasAnyData`