### PR TITLE
🐛 Fix cache compliance test failures and warnings

### DIFF
--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -141,11 +141,10 @@ export function useCardLoadingState(options: CardLoadingStateOptions) {
     isDemoData,
   } = options
 
-  // During initial load, demo data from initialData doesn't count as "real" data.
-  // Show skeleton instead of flashing demo content (yellow border + Demo badge).
-  // Once loading finishes, demo fallback data is shown normally with the badge.
-  // When refreshing with cached REAL data, show cached content + refresh animation.
-  const hasRealData = isLoading ? (hasAnyData && !isDemoData) : hasAnyData
+  // Data is considered "real" (displayable) if there is any data at all.
+  // Demo data should be shown immediately with the Demo badge — not hidden behind a skeleton.
+  // When refreshing with cached data, show cached content + refresh animation.
+  const hasRealData = hasAnyData
   const hasData = !isLoading || hasRealData
 
   // Report state to CardWrapper for refresh animation and status badges

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1024,9 +1024,9 @@ export function CardWrapper({
   // Show demo indicator if:
   // 1. Child reports demo data (isDemoData: true via prop or report), OR
   // 2. Global demo mode is on AND child hasn't explicitly opted out
-  // BUT suppress during loading phase — users don't need to see "DEMO" badge
-  // flash momentarily while data is loading
-  const showDemoIndicator = !effectiveIsLoading && (effectiveIsDemoData || (isDemoMode && !childExplicitlyNotDemo))
+  // Suppress during loading phase UNLESS the card is a known demo-only card (isDemoData prop).
+  // Demo-only cards should always show the badge immediately — they never transition to real data.
+  const showDemoIndicator = (!effectiveIsLoading || isDemoData) && (effectiveIsDemoData || (isDemoMode && !childExplicitlyNotDemo))
 
   // Determine if we should show skeleton: loading with no cached data
   // OR when demo mode is OFF and agent is offline (prevents showing stale demo data)

--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -69,8 +69,7 @@ export function FalcoAlerts({ config: _config }: CardConfig) {
 // Trivy Vulnerability Scanner Card
 export function TrivyScan({ config: _config }: CardConfig) {
   const { t } = useTranslation()
-  // Integration approach: Query VulnerabilityReport CRDs from Trivy Operator
-  // UI already displays integration notice with install guide when Trivy is not detected
+  useCardLoadingState({ isLoading: false, hasAnyData: true, isDemoData: true })
   const demoVulns = {
     critical: 3,
     high: 12,
@@ -123,8 +122,7 @@ export function TrivyScan({ config: _config }: CardConfig) {
 
 // Kubescape Security Posture Card
 export function KubescapeScan({ config: _config }: CardConfig) {
-  // Integration approach: Query Kubescape scan results from ConfigurationScanSummary CRDs
-  // UI already displays integration notice with install guide when Kubescape is not detected
+  useCardLoadingState({ isLoading: false, hasAnyData: true, isDemoData: true })
   const score = 78
   const frameworks = [
     { name: 'NSA-CISA', score: 82 },
@@ -182,6 +180,7 @@ export function KubescapeScan({ config: _config }: CardConfig) {
 
 // Policy Violations Aggregated Card
 export function PolicyViolations({ config: _config }: CardConfig) {
+  useCardLoadingState({ isLoading: false, hasAnyData: true, isDemoData: true })
   const violations = [
     { policy: 'require-labels', count: 12, tool: 'Gatekeeper' },
     { policy: 'disallow-privileged', count: 5, tool: 'Kyverno' },

--- a/web/src/components/cards/DataComplianceCards.tsx
+++ b/web/src/components/cards/DataComplianceCards.tsx
@@ -17,6 +17,7 @@ interface CardConfig {
 // HashiCorp Vault - Secrets Management Card
 export function VaultSecrets({ config: _config }: CardConfig) {
   const { t } = useTranslation()
+  useCardLoadingState({ isLoading: false, hasAnyData: true, isDemoData: true })
   const demoData = {
     status: 'unsealed',
     secrets: 156,


### PR DESCRIPTION
## Summary
- Fix 7 test failures where demo badge appeared on warm return but not cold load
- Fix 11 test warnings where skeletons appeared on warm return for demo data cards
- Three root causes addressed in CardWrapper, CardDataContext, and 5 pure demo cards

## Root Cause Analysis

**Failures (7)**: `showDemoIndicator` in CardWrapper suppressed demo badge when `effectiveIsLoading` was true. On cold load, loading state starts true (150ms timeout or hook init), hiding the badge. On warm return, cached data resolves instantly so badge shows. Fix: don't suppress badge for cards with `isDemoData` prop (DEMO_DATA_CARDS).

**Warnings (11)**: `hasRealData` in CardDataContext treated demo data as non-displayable during loading (`hasAnyData && !isDemoData`), causing `showSkeleton: true`. Fix: simplified to `hasAnyData` since demo data should display immediately with the Demo badge.

**Missing hooks (5 cards)**: TrivyScan, KubescapeScan, PolicyViolations, VaultSecrets, RBACExplorer lacked `useCardLoadingState` calls, so CardWrapper fell back to the 150ms timeout for loading state detection.

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes (no new errors)
- [ ] Run cache compliance test to verify 0 failures, 0 warnings