### PR TITLE
🐛 Add useCardLoadingState to RBACExplorer demo card

### DIFF
--- a/web/src/components/cards/RBACExplorer.tsx
+++ b/web/src/components/cards/RBACExplorer.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useCardLoadingState } from './CardDataContext'
 
 interface RBACFinding {
   id: string
@@ -20,6 +21,7 @@ const DEMO_FINDINGS: RBACFinding[] = [
 ]
 
 export function RBACExplorer() {
+  useCardLoadingState({ isLoading: false, hasAnyData: true, isDemoData: true })
   const [riskFilter, setRiskFilter] = useState<string | null>(null)
 
   const findings = DEMO_FINDINGS


### PR DESCRIPTION
## Summary
- Add missing `useCardLoadingState` call to RBACExplorer — was reverted by pre-commit hooks in PR #1140
- Ensures RBAC Explorer reports demo data state to CardWrapper synchronously via useLayoutEffect

## Test plan
- [ ] `npm run build` passes
- [ ] Cache compliance test shows RBACExplorer passing