### PR TITLE
🐛 Fix remaining cache compliance test failures

### DIFF
--- a/web/e2e/compliance/card-cache-compliance.spec.ts
+++ b/web/e2e/compliance/card-cache-compliance.spec.ts
@@ -799,6 +799,10 @@ test('card cache compliance — storage and retrieval', async ({ page }) => {
 
     const cardIds = selected.map((item) => item.cardId)
     await waitForCardsToLoad(page, cardIds, BATCH_LOAD_TIMEOUT_MS)
+    // Allow lazy (code-split) components to mount and report state.
+    // StackContext cards dynamically report isDemoData via useReportCardDataState —
+    // without this wait the cold snapshot may capture before the child reports.
+    await page.waitForTimeout(500)
 
     // Capture cold load state
     const snapshots = await captureColdSnapshots(page, cardIds)

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -508,7 +508,8 @@ export const DEMO_DATA_CARDS = new Set([
   // removed - they now use StackContext for live data and report isDemoData via useReportCardDataState
   // LLM-d Configurator - demo showcase of tuning options, not a complete YAML generator
   'llmd_configurator',
-  // LLM-d benchmark dashboard cards — all now use live data via useCachedBenchmarkReports()
+  // LLM-d benchmark dashboard cards — nightly E2E falls back to demo when no GH token
+  'nightly_e2e_status',
   // Provider health card uses real data from /settings/keys + useClusters()
   // Only shows demo data when getDemoMode() is true (handled inside the hook)
   // Cluster admin cards - demo until backend endpoints exist


### PR DESCRIPTION
## Summary
- Add `nightly_e2e_status` to `DEMO_DATA_CARDS` set — card falls back to demo when no GitHub token, so it needs the `isDemoData` prop for immediate badge display
- Add 500ms stabilization wait after `waitForCardsToLoad` in the cold load phase — gives lazy (code-split) StackContext components time to mount and report `isDemoData` via `useReportCardDataState` before snapshot capture

## Test Results
| Metric | Before | After |
|--------|--------|-------|
| Pass | 147 | 152 |
| Fail | 1 (`epp_routing`) | 0 |
| Warn | 26 | 22 |

Remaining 22 warnings:
- 11 "slow" (>500ms): game cards + kubectl/kubedle (heavyweight lazy components)
- 11 "skeleton visible on warm return": CacheStore async initialization

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` clean (no new errors)
- [x] Cache compliance test: 152 pass, 0 fail, 22 warn