### PR TITLE
🐛 Fix nightly E2E card showing demo badge with live data

### DIFF
--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -508,8 +508,7 @@ export const DEMO_DATA_CARDS = new Set([
   // removed - they now use StackContext for live data and report isDemoData via useReportCardDataState
   // LLM-d Configurator - demo showcase of tuning options, not a complete YAML generator
   'llmd_configurator',
-  // LLM-d benchmark dashboard cards — nightly E2E falls back to demo when no GH token
-  'nightly_e2e_status',
+  // Note: nightly_e2e_status NOT here — dynamically reports isDemoData via useNightlyE2EData hook
   // Provider health card uses real data from /settings/keys + useClusters()
   // Only shows demo data when getDemoMode() is true (handled inside the hook)
   // Cluster admin cards - demo until backend endpoints exist


### PR DESCRIPTION
## Summary
- Remove `nightly_e2e_status` from `DEMO_DATA_CARDS` set (incorrectly added in PR #1143)
- The card dynamically reports `isDemoData` via `useNightlyE2EData` hook — it should NOT have a static `isDemoData={true}` prop

## What broke
PR #1143 added the card to `DEMO_DATA_CARDS` to fix a cache compliance test. This forced `isDemoData` prop=true on CardWrapper, which overrode the hook's dynamic reporting:
- Demo badge + yellow outline persisted even with live data
- Cached data appeared broken (badge always showed)
- Navigate-away-and-back restarted in "demo mode" visually despite shared CacheStore retaining live data

## Test plan
- [x] `npm run build` passes
- [x] Card shows live data without demo badge when backend is running
- [x] Card shows demo badge only during initial load (before fetch completes)
- [x] Navigate away and back: live data shows immediately (shared CacheStore)