### PR TITLE
🐛 Remove BM nightly entry for CKS (no workflow exists)

### DIFF
--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -108,7 +108,6 @@ var nightlyWorkflows = []NightlyWorkflow{
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "CKS", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-cks.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "CKS", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2},
 	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-cks.yaml", Guide: "WVA", Acronym: "WVA", Platform: "CKS", Model: "Llama-3.1-8B", GPUType: "H100", GPUCount: 2},
-	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nightly-benchmark-cks.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "CKS", Model: "opt-125m", GPUType: "H100", GPUCount: 1},
 }
 
 // NewNightlyE2EHandler creates a handler using the given GitHub token for API access.

--- a/web/netlify/functions/nightly-e2e.mts
+++ b/web/netlify/functions/nightly-e2e.mts
@@ -92,7 +92,6 @@ const NIGHTLY_WORKFLOWS: NightlyWorkflow[] = [
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", guide: "PD Disaggregation", acronym: "PD", platform: "CKS", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2 },
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wide-ep-lws-cks.yaml", guide: "Wide EP + LWS", acronym: "WEP", platform: "CKS", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2 },
   { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wva-cks.yaml", guide: "WVA", acronym: "WVA", platform: "CKS", model: "Llama-3.1-8B", gpuType: "H100", gpuCount: 2 },
-  { repo: "llm-d/llm-d-benchmark", workflowFile: "ci-nightly-benchmark-cks.yaml", guide: "Benchmarking", acronym: "BM", platform: "CKS", model: "opt-125m", gpuType: "H100", gpuCount: 1 },
 ];
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -66,7 +66,6 @@ export const NIGHTLY_WORKFLOWS: NightlyWorkflowConfig[] = [
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-cks.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'CKS', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2 },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-cks.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'CKS', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2 },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wva-cks.yaml', guide: 'WVA', acronym: 'WVA', platform: 'CKS', model: 'Llama-3.1-8B', gpuType: 'H100', gpuCount: 2 },
-  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nightly-benchmark-cks.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'CKS', model: 'opt-125m', gpuType: 'H100', gpuCount: 1 },
 ]
 
 // Seeded patterns per guide for deterministic demo data


### PR DESCRIPTION
## Summary
- Remove Benchmarking (BM) guide from CKS platform in nightly E2E config
- No `ci-nightly-benchmark-cks` workflow exists in `llm-d/llm-d-benchmark`, so the card/widget was showing stale/empty data for this combination
- Fixed in all 3 locations: backend handler, frontend demo data, Netlify function

## Test plan
- [ ] Verify CKS section in Nightly E2E Status card shows 4 guides (IS, PD, WEP, WVA) — no BM
- [ ] Verify OCP and GKE BM entries are unaffected