### PR TITLE
🐛 Fix card dropdown menu transparency

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1303,7 +1303,7 @@ export function CardWrapper({
               </button>
               {showMenu && menuPosition && createPortal(
                 <div
-                  className="fixed w-48 glass rounded-lg py-1 z-50 shadow-xl"
+                  className="fixed w-48 bg-popover border border-border rounded-lg py-1 z-50 shadow-xl"
                   style={{ top: menuPosition.top, right: menuPosition.right }}
                 >
                   <button
@@ -1345,7 +1345,7 @@ export function CardWrapper({
                       </button>
                       {showResizeMenu && (
                         <div className={cn(
-                          'absolute top-0 w-36 glass rounded-lg py-1 z-20',
+                          'absolute top-0 w-36 bg-popover border border-border rounded-lg py-1 z-20 shadow-xl',
                           resizeMenuOnLeft ? 'right-full mr-1' : 'left-full ml-1'
                         )}>
                           {WIDTH_OPTIONS.map((option) => (


### PR DESCRIPTION
## Summary
- Replace `glass` class (92% opacity) with `bg-popover border-border` (solid opaque) on card kebab menu and resize submenu
- Content was bleeding through the dropdown, making menu items hard to read

## Test plan
- [x] `npm run build` passes
- [x] Menu is fully opaque over card content