### PR TITLE
🐛 Revert BM/CKS removal and filter queued runs

### DIFF
--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -66,6 +66,7 @@ export const NIGHTLY_WORKFLOWS: NightlyWorkflowConfig[] = [
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-cks.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'CKS', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2 },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-cks.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'CKS', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2 },
   { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wva-cks.yaml', guide: 'WVA', acronym: 'WVA', platform: 'CKS', model: 'Llama-3.1-8B', gpuType: 'H100', gpuCount: 2 },
+  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nightly-benchmark-cks.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'CKS', model: 'opt-125m', gpuType: 'H100', gpuCount: 1 },
 ]
 
 // Seeded patterns per guide for deterministic demo data


### PR DESCRIPTION
## Summary
- Re-adds BM/CKS (Benchmarking on CKS) workflow entry that was incorrectly removed in PR #1145
- Filters out GitHub Actions runs with status `queued` in both backend and Netlify function so they don't show as run dots on the Nightly E2E Status card
- BM/CKS is now listed in the card but shows no run history (since its 3 runs are all stuck in "queued" and never executed)

## Test plan
- [ ] Verify BM/CKS appears in the Nightly E2E Status card under the CKS platform section
- [ ] Verify no run dots appear for BM/CKS (all 3 runs are "queued" and filtered out)
- [ ] Verify other workflows still show their runs correctly (only "queued" status filtered, not "in_progress" or "completed")