### PR TITLE
🐛 Darken card kebab menu background

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1335,7 +1335,7 @@ export function CardWrapper({
               </button>
               {showMenu && menuPosition && createPortal(
                 <div
-                  className="fixed w-48 glass rounded-lg py-1 z-50 shadow-xl"
+                  className="fixed w-48 glass rounded-lg py-1 z-50 shadow-xl !bg-[rgba(10,15,25,0.98)]"
                   style={{ top: menuPosition.top, right: menuPosition.right }}
                 >
                   <button


### PR DESCRIPTION
## Summary

- Override the shared `glass` class background on the card kebab menu with a darker, near-opaque tone (`rgba(10,15,25,0.98)`) for better contrast and readability
- Uses Tailwind arbitrary value with `!important` to override the CSS variable without affecting the navbar/sidebar which share the `glass` class

## Test plan

- [ ] Click kebab menu on any card — background is dark and opaque
- [ ] Navbar and sidebar still use the standard glass background (unchanged)