### PR TITLE
🐛 Add GPU Node Health Monitor to card catalog

### DIFF
--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -99,6 +99,7 @@ const CARD_CATALOG = {
     { type: 'gpu_inventory', title: 'GPU Inventory', description: 'Detailed GPU list', visualization: 'table' },
     { type: 'gpu_workloads', title: 'GPU Workloads', description: 'Pods running on GPU nodes or in NVIDIA namespaces', visualization: 'table' },
     { type: 'gpu_usage_trend', title: 'GPU Usage Trend', description: 'GPU used vs available over time with stacked area chart', visualization: 'timeseries' },
+    { type: 'gpu_node_health', title: 'GPU Node Health Monitor', description: 'Proactive health monitoring for GPU nodes — checks node readiness, GPU operator pods, stuck pods, and GPU reset events', visualization: 'status' },
   ],
   'Storage': [
     { type: 'storage_overview', title: 'Storage Overview', description: 'Total storage capacity and PVC summary', visualization: 'status' },


### PR DESCRIPTION
## Summary
- Adds the GPU Node Health Monitor card to the `CARD_CATALOG` in `AddCardModal.tsx` under the Compute category
- The card was registered in the config registry and card registry but wasn't discoverable in the Add Cards modal

## Test plan
- [ ] Search "gpu node" in Add Cards modal → GPU Node Health Monitor appears