### PR TITLE
🌱 Add i18n to 15 shared UI and dashboard components

### DIFF
--- a/web/src/components/ChunkErrorBoundary.tsx
+++ b/web/src/components/ChunkErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import { Component, type ReactNode, type ErrorInfo } from 'react'
 import { RefreshCw } from 'lucide-react'
+import i18next from 'i18next'
 
 // Reload throttle interval in milliseconds to prevent infinite reload loops
 const RELOAD_THROTTLE_MS = 30_000 // 30 seconds
@@ -62,16 +63,16 @@ export class ChunkErrorBoundary extends Component<Props, State> {
           <div className="text-center p-8 max-w-md">
             <RefreshCw className="w-12 h-12 text-purple-400 mx-auto mb-4" />
             <h2 className="text-lg font-semibold text-foreground mb-2">
-              App Updated
+              {i18next.t('common:chunkError.appUpdated')}
             </h2>
             <p className="text-sm text-muted-foreground mb-6">
-              A new version was deployed. Please reload to continue.
+              {i18next.t('common:chunkError.newVersionDeployed')}
             </p>
             <button
               onClick={this.handleReload}
               className="px-4 py-2 bg-purple-500 hover:bg-purple-600 text-white rounded-lg text-sm font-medium transition-colors"
             >
-              Reload Page
+              {i18next.t('common:chunkError.reloadPage')}
             </button>
           </div>
         </div>

--- a/web/src/components/agent/AgentSetupDialog.tsx
+++ b/web/src/components/agent/AgentSetupDialog.tsx
@@ -12,7 +12,7 @@ const SNOOZED_KEY = 'kc-agent-setup-snoozed'
 const SNOOZE_DURATION = 24 * 60 * 60 * 1000 // 24 hours
 
 export function AgentSetupDialog() {
-  const { t: _t } = useTranslation()
+  const { t } = useTranslation('common')
   const { status, isConnected } = useLocalAgent()
   const [show, setShow] = useState(false)
   const [copied, setCopied] = useState(false)
@@ -59,8 +59,8 @@ export function AgentSetupDialog() {
   return (
     <BaseModal isOpen={show} onClose={() => handleDismiss(false)} size="md">
       <BaseModal.Header
-        title="Welcome to KubeStellar Console"
-        description="To access your local clusters and Claude Code, install our lightweight agent."
+        title={t('agentSetup.welcomeTitle')}
+        description={t('agentSetup.welcomeDescription')}
         icon={Download}
         onClose={() => handleDismiss(false)}
         showBack={false}
@@ -69,9 +69,9 @@ export function AgentSetupDialog() {
       <BaseModal.Content>
         {/* Install Option */}
         <div className="rounded-lg border border-primary/20 bg-primary/5 p-4">
-          <div className="font-medium">Quick Install (recommended)</div>
+          <div className="font-medium">{t('agentSetup.quickInstall')}</div>
           <p className="mt-1 text-sm text-muted-foreground">
-            Copy this command and run it in your terminal:
+            {t('agentSetup.copyAndRun')}
           </p>
           <div className="mt-3 flex items-center gap-2">
             <code className="flex-1 rounded bg-muted px-3 py-2 text-sm font-mono select-all overflow-x-auto">
@@ -81,18 +81,18 @@ export function AgentSetupDialog() {
               onClick={copyToClipboard}
               className="shrink-0 rounded bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
             >
-              {copied ? 'Copied!' : 'Copy'}
+              {copied ? t('agentSetup.copied') : t('agentSetup.copy')}
             </button>
           </div>
           <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
-            <span>✓ Your kubeconfig clusters</span>
-            <span>✓ Real-time token usage</span>
-            <span>✓ Local & secure</span>
+            <span>✓ {t('agentSetup.kubeconfigClusters')}</span>
+            <span>✓ {t('agentSetup.realtimeTokenUsage')}</span>
+            <span>✓ {t('agentSetup.localAndSecure')}</span>
           </div>
         </div>
 
         <p className="mt-4 text-xs text-muted-foreground">
-          You can install the agent anytime from Settings.
+          {t('agentSetup.installFromSettings')}
         </p>
       </BaseModal.Content>
 
@@ -101,7 +101,7 @@ export function AgentSetupDialog() {
           onClick={() => handleDismiss(true)}
           className="text-sm text-muted-foreground hover:text-foreground"
         >
-          Don't show again
+          {t('agentSetup.dontShowAgain')}
         </button>
         <div className="flex-1" />
         <div className="flex gap-3">
@@ -109,13 +109,13 @@ export function AgentSetupDialog() {
             onClick={() => handleDismiss(false)}
             className="rounded border px-4 py-2 text-sm font-medium hover:bg-muted"
           >
-            Continue with Demo Data
+            {t('agentSetup.continueWithDemoData')}
           </button>
           <button
             onClick={handleSnooze}
             className="rounded border px-4 py-2 text-sm font-medium hover:bg-muted"
           >
-            Remind Me Later
+            {t('agentSetup.remindMeLater')}
           </button>
         </div>
       </BaseModal.Footer>

--- a/web/src/components/agent/AgentStatus.tsx
+++ b/web/src/components/agent/AgentStatus.tsx
@@ -4,14 +4,14 @@ import { useLocalAgent } from '@/hooks/useLocalAgent'
 import { useTranslation } from 'react-i18next'
 
 export function AgentStatus() {
-  const { t: _t } = useTranslation()
+  const { t } = useTranslation('common')
   const { status, health, error, isDemoMode } = useLocalAgent()
 
   if (status === 'connecting') {
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground">
         <div className="h-2 w-2 animate-pulse rounded-full bg-yellow-500" />
-        Connecting to local agent...
+        {t('agentStatus.connectingToAgent')}
       </div>
     )
   }
@@ -21,10 +21,10 @@ export function AgentStatus() {
       <div className="rounded-lg border border-yellow-500/20 bg-yellow-500/10 p-4">
         <div className="flex items-center gap-2 text-sm font-medium text-yellow-600 dark:text-yellow-400">
           <div className="h-2 w-2 rounded-full bg-yellow-500" />
-          Demo Mode - Local Agent Not Connected
+          {t('agentStatus.demoModeTitle')}
         </div>
         <p className="mt-2 text-sm text-muted-foreground">
-          {error || 'Install the local agent to access your clusters and Claude Code.'}
+          {error || t('agentStatus.demoModeDefaultMessage')}
         </p>
       </div>
     )
@@ -33,14 +33,15 @@ export function AgentStatus() {
   return (
     <div className="flex items-center gap-2 text-sm text-green-600 dark:text-green-400">
       <div className="h-2 w-2 rounded-full bg-green-500" />
-      Connected to local agent v{health?.version}
-      {health?.clusters && ` - ${health.clusters} clusters`}
-      {health?.hasClaude && ' - Claude available'}
+      {t('agentStatus.connectedToAgent', { version: health?.version })}
+      {health?.clusters && t('agentStatus.clustersCount', { count: health.clusters })}
+      {health?.hasClaude && t('agentStatus.claudeAvailable')}
     </div>
   )
 }
 
 export function AgentInstallBanner() {
+  const { t } = useTranslation('common')
   const { isDemoMode } = useLocalAgent()
 
   if (!isDemoMode) return null
@@ -53,13 +54,13 @@ export function AgentInstallBanner() {
 
   return (
     <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-6">
-      <h3 className="text-lg font-semibold">Connect to Your Local Environment</h3>
+      <h3 className="text-lg font-semibold">{t('agentStatus.connectToLocalEnv')}</h3>
       <p className="mt-1 text-sm text-muted-foreground">
-        Install the local agent to access your kubeconfig clusters and Claude Code.
+        {t('agentStatus.installAgentDescription')}
       </p>
 
       <div className="mt-4">
-        <div className="text-sm font-medium mb-2">Copy and paste this command:</div>
+        <div className="text-sm font-medium mb-2">{t('agentStatus.copyAndPaste')}</div>
         <div className="flex items-center gap-2">
           <code className="flex-1 rounded bg-muted px-4 py-3 text-sm font-mono select-all">
             {installCommand}
@@ -68,15 +69,15 @@ export function AgentInstallBanner() {
             onClick={() => copyToClipboard(installCommand)}
             className="rounded bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
-            Copy
+            {t('agentSetup.copy')}
           </button>
         </div>
       </div>
 
       <div className="mt-4 flex gap-4 text-xs text-muted-foreground">
-        <span>✓ Access all your clusters</span>
-        <span>✓ Real-time token tracking</span>
-        <span>✓ Runs locally (secure)</span>
+        <span>✓ {t('agentStatus.accessAllClusters')}</span>
+        <span>✓ {t('agentStatus.realtimeTokenTracking')}</span>
+        <span>✓ {t('agentStatus.runsLocally')}</span>
       </div>
     </div>
   )

--- a/web/src/components/aiagents/AIAgents.tsx
+++ b/web/src/components/aiagents/AIAgents.tsx
@@ -11,7 +11,7 @@ const AI_AGENTS_CARDS_KEY = 'kubestellar-aiagents-cards'
 const DEFAULT_AIAGENTS_CARDS = getDefaultCards('ai-agents')
 
 export function AIAgents() {
-  const { t: _t } = useTranslation()
+  const { t } = useTranslation('common')
   const { summary, isLoading, refetch, error } = useKagentiSummary()
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
 
@@ -44,8 +44,8 @@ export function AIAgents() {
 
   return (
     <DashboardPage
-      title="AI Agents"
-      subtitle="Kagenti agent platform — deploy, secure, and manage AI agents"
+      title={t('aiAgents.title')}
+      subtitle={t('aiAgents.subtitle')}
       icon="Bot"
       storageKey={AI_AGENTS_CARDS_KEY}
       defaultCards={DEFAULT_AIAGENTS_CARDS}
@@ -58,13 +58,13 @@ export function AIAgents() {
       hasData={hasData}
       isDemoData={isDemoData}
       emptyState={{
-        title: 'AI Agents Dashboard',
-        description: 'Add cards to monitor kagenti agents, MCP tools, build pipelines, and security posture across your clusters.',
+        title: t('aiAgents.emptyStateTitle'),
+        description: t('aiAgents.emptyStateDescription'),
       }}
     >
       {error && (
         <div className="mb-4 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400">
-          <div className="font-medium">Error loading kagenti data</div>
+          <div className="font-medium">{t('aiAgents.errorLoading')}</div>
           <div className="text-sm text-muted-foreground">{error}</div>
         </div>
       )}

--- a/web/src/components/aiml/AIML.tsx
+++ b/web/src/components/aiml/AIML.tsx
@@ -16,7 +16,7 @@ const AIML_CARDS_KEY = 'kubestellar-aiml-cards'
 const DEFAULT_AIML_CARDS = getDefaultCards('ai-ml')
 
 export function AIML() {
-  const { t: _t } = useTranslation()
+  const { t } = useTranslation('common')
   const { clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error } = useClusters()
   const { nodes: gpuNodes, isLoading: gpuLoading } = useGPUNodes()
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
@@ -83,8 +83,8 @@ export function AIML() {
   return (
     <StackProvider>
       <DashboardPage
-        title="AI/ML"
-        subtitle="Monitor AI and Machine Learning workloads"
+        title={t('aiml.title')}
+        subtitle={t('aiml.subtitle')}
         icon="Brain"
         storageKey={AIML_CARDS_KEY}
         defaultCards={DEFAULT_AIML_CARDS}
@@ -97,14 +97,14 @@ export function AIML() {
         hasData={reachableClusters.length > 0 || hasRealData}
         isDemoData={isDemoData}
         emptyState={{
-          title: 'AI/ML Dashboard',
-          description: 'Add cards to monitor GPU utilization, ML workloads, and model training across your clusters.',
+          title: t('aiml.emptyStateTitle'),
+          description: t('aiml.emptyStateDescription'),
         }}
         headerExtra={<StackSelector />}
       >
         {error && (
           <div className="mb-4 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400">
-            <div className="font-medium">Error loading cluster data</div>
+            <div className="font-medium">{t('aiml.errorLoading')}</div>
             <div className="text-sm text-muted-foreground">{error}</div>
           </div>
         )}

--- a/web/src/components/alerts/AlertDetail.tsx
+++ b/web/src/components/alerts/AlertDetail.tsx
@@ -28,8 +28,9 @@ interface AlertDetailProps {
   onClose?: () => void
 }
 
-// Format relative time
-function formatRelativeTime(dateString: string): string {
+// Format relative time using i18n keys from the time section
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function formatRelativeTime(dateString: string, t: (key: any, opts?: any) => string): string {
   const date = new Date(dateString)
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
@@ -37,10 +38,10 @@ function formatRelativeTime(dateString: string): string {
   const diffHours = Math.floor(diffMins / 60)
   const diffDays = Math.floor(diffHours / 24)
 
-  if (diffMins < 1) return 'Just now'
-  if (diffMins < MINUTES_PER_HOUR) return `${diffMins} minutes ago`
-  if (diffHours < HOURS_PER_DAY) return `${diffHours} hours ago`
-  return `${diffDays} days ago`
+  if (diffMins < 1) return t('time.justNow')
+  if (diffMins < MINUTES_PER_HOUR) return t('time.minutesAgo', { count: diffMins })
+  if (diffHours < HOURS_PER_DAY) return t('time.hoursAgo', { count: diffHours })
+  return t('time.daysAgo', { count: diffDays })
 }
 
 export function AlertDetail({ alert, onClose }: AlertDetailProps) {
@@ -163,20 +164,20 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
           {alert.resource && (
             <div className="flex items-center gap-2 text-sm">
               <AlertTriangle className="w-4 h-4 text-muted-foreground" />
-              <span className="text-muted-foreground">Resource:</span>
+              <span className="text-muted-foreground">{t('alerts.resource')}</span>
               <span className="text-foreground">{alert.resource}</span>
             </div>
           )}
           <div className="flex items-center gap-2 text-sm">
             <Clock className="w-4 h-4 text-muted-foreground" />
-            <span className="text-muted-foreground">Fired:</span>
-            <span className="text-foreground">{formatRelativeTime(alert.firedAt)}</span>
+            <span className="text-muted-foreground">{t('alerts.fired')}</span>
+            <span className="text-foreground">{formatRelativeTime(alert.firedAt, t)}</span>
           </div>
           {alert.acknowledgedAt && (
             <div className="flex items-center gap-2 text-sm">
               <CheckCircle className="w-4 h-4 text-green-400" />
-              <span className="text-muted-foreground">Acknowledged:</span>
-              <span className="text-green-400">{formatRelativeTime(alert.acknowledgedAt)}</span>
+              <span className="text-muted-foreground">{t('alerts.acknowledged')}</span>
+              <span className="text-green-400">{formatRelativeTime(alert.acknowledgedAt, t)}</span>
             </div>
           )}
         </div>
@@ -187,7 +188,7 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
           className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
         >
           {showDetails ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
-          {showDetails ? 'Hide Details' : 'Show Details'}
+          {showDetails ? t('alerts.hideDetails') : t('alerts.showDetails')}
         </button>
 
         {showDetails && alert.details && (
@@ -203,7 +204,7 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
               <Bot className="w-4 h-4 text-purple-400" />
-              <span className="text-sm font-medium text-foreground">AI Diagnosis</span>
+              <span className="text-sm font-medium text-foreground">{t('alerts.aiDiagnosis')}</span>
             </div>
             {!alert.aiDiagnosis?.missionId && (
               <button
@@ -214,12 +215,12 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
                 {isRunningDiagnosis ? (
                   <>
                     <RefreshCw className="w-3 h-3 animate-spin" />
-                    Analyzing...
+                    {t('alerts.analyzing')}
                   </>
                 ) : (
                   <>
                     <Bot className="w-3 h-3" />
-                    Run Diagnosis
+                    {t('alerts.runDiagnosis')}
                   </>
                 )}
               </button>
@@ -230,21 +231,21 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
             <div className="space-y-3">
               {alert.aiDiagnosis.summary && (
                 <div>
-                  <span className="text-xs text-muted-foreground">Summary</span>
+                  <span className="text-xs text-muted-foreground">{t('alerts.summary')}</span>
                   <p className="text-sm text-foreground mt-1">{alert.aiDiagnosis.summary}</p>
                 </div>
               )}
 
               {alert.aiDiagnosis.rootCause && (
                 <div>
-                  <span className="text-xs text-muted-foreground">Root Cause</span>
+                  <span className="text-xs text-muted-foreground">{t('alerts.rootCause')}</span>
                   <p className="text-sm text-foreground mt-1">{alert.aiDiagnosis.rootCause}</p>
                 </div>
               )}
 
               {alert.aiDiagnosis.suggestions && alert.aiDiagnosis.suggestions.length > 0 && (
                 <div>
-                  <span className="text-xs text-muted-foreground">Suggested Actions</span>
+                  <span className="text-xs text-muted-foreground">{t('alerts.suggestedActions')}</span>
                   <ul className="mt-1 space-y-1">
                     {alert.aiDiagnosis.suggestions.map((suggestion, idx) => (
                       <li key={idx} className="text-sm text-foreground flex items-start gap-2">
@@ -262,13 +263,13 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
                   className="flex items-center gap-1 text-xs text-purple-400 hover:text-purple-300 transition-colors"
                 >
                   <ExternalLink className="w-3 h-3" />
-                  View AI Mission
+                  {t('alerts.viewAIMission')}
                 </button>
               )}
             </div>
           ) : (
             <p className="text-sm text-muted-foreground">
-              No AI diagnosis yet. Click "Run Diagnosis" to analyze this alert with AI.
+              {t('alerts.noDiagnosisYet')}
             </p>
           )}
         </div>
@@ -278,7 +279,7 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
           <div className="border-t border-border/50 pt-4">
             <div className="flex items-center gap-2 mb-2">
               <Slack className="w-4 h-4 text-muted-foreground" />
-              <span className="text-sm font-medium text-foreground">Send to Slack</span>
+              <span className="text-sm font-medium text-foreground">{t('alerts.sendToSlack')}</span>
             </div>
             <div className="flex flex-wrap gap-2">
               {webhooks.map(webhook => (
@@ -295,7 +296,7 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
             </div>
             {slackSent && (
               <p className="text-xs text-green-400 mt-2">
-                Notification sent to Slack!
+                {t('alerts.slackSent')}
               </p>
             )}
           </div>
@@ -310,7 +311,7 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
               onClick={handleAcknowledge}
               className="px-3 py-1.5 text-sm rounded-lg bg-secondary hover:bg-secondary/80 text-foreground transition-colors"
             >
-              Acknowledge
+              {t('alerts.acknowledge')}
             </button>
           )}
           {alert.status === 'firing' && (
@@ -318,7 +319,7 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
               onClick={handleResolve}
               className="px-3 py-1.5 text-sm rounded-lg bg-green-500/20 hover:bg-green-500/30 text-green-400 transition-colors"
             >
-              Resolve
+              {t('alerts.resolve')}
             </button>
           )}
         </div>
@@ -327,7 +328,7 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
             onClick={onClose}
             className="px-3 py-1.5 text-sm rounded-lg bg-secondary hover:bg-secondary/80 text-foreground transition-colors"
           >
-            Close
+            {t('actions.close')}
           </button>
         )}
       </div>

--- a/web/src/components/alerts/AlertRuleEditor.tsx
+++ b/web/src/components/alerts/AlertRuleEditor.tsx
@@ -84,7 +84,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
     const newErrors: Record<string, string> = {}
 
     if (!name.trim()) {
-      newErrors.name = 'Name is required'
+      newErrors.name = t('alerts.nameRequired')
     }
 
     if (conditionType === 'gpu_usage' || conditionType === 'memory_pressure') {
@@ -343,7 +343,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
                 {weatherCondition === 'extreme_heat' && (
                   <div>
                     <label className="block text-xs text-muted-foreground mb-1">
-                      Temperature Threshold (°F)
+                      {t('alerts.temperatureThreshold')}
                     </label>
                     <div className="flex items-center gap-2">
                       <input
@@ -367,7 +367,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
                 {weatherCondition === 'high_wind' && (
                   <div>
                     <label className="block text-xs text-muted-foreground mb-1">
-                      Wind Speed Threshold (mph)
+                      {t('alerts.windSpeedThreshold')}
                     </label>
                     <div className="flex items-center gap-2">
                       <input
@@ -393,7 +393,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
             {/* Duration */}
             <div>
               <label className="block text-xs text-muted-foreground mb-1">
-                Duration (seconds before alerting)
+                {t('alerts.durationSeconds')}
               </label>
               <div className="flex items-center gap-2">
                 <input
@@ -404,7 +404,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
                   onChange={e => setDuration(Number(e.target.value))}
                   className="w-24 px-3 py-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
                 />
-                <span className="text-sm text-muted-foreground">seconds (0 = immediate)</span>
+                <span className="text-sm text-muted-foreground">{t('alerts.durationHint')}</span>
               </div>
             </div>
 
@@ -437,28 +437,28 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
           {/* Notification Channels */}
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <h4 className="text-sm font-medium text-foreground">Notification Channels</h4>
+              <h4 className="text-sm font-medium text-foreground">{t('alerts.notificationChannels')}</h4>
               <div className="flex gap-2">
                 <button
                   onClick={() => addChannel('browser')}
                   className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
                 >
                   <Bell className="w-3 h-3" />
-                  Browser
+                  {t('alerts.browser')}
                 </button>
                 <button
                   onClick={() => addChannel('slack')}
                   className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
                 >
                   <Slack className="w-3 h-3" />
-                  Slack
+                  {t('alerts.slack')}
                 </button>
                 <button
                   onClick={() => addChannel('webhook')}
                   className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
                 >
                   <Webhook className="w-3 h-3" />
-                  Webhook
+                  {t('alerts.webhook')}
                 </button>
               </div>
             </div>
@@ -549,7 +549,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
 
           {/* AI Diagnosis */}
           <div className="space-y-2">
-            <h4 className="text-sm font-medium text-foreground">AI Integration</h4>
+            <h4 className="text-sm font-medium text-foreground">{t('alerts.aiIntegration')}</h4>
             <button
               onClick={() => setAiDiagnose(!aiDiagnose)}
               className={`w-full p-3 rounded-lg text-left transition-colors ${
@@ -562,10 +562,10 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
                 <Bot className={`w-5 h-5 ${aiDiagnose ? 'text-purple-400' : 'text-muted-foreground'}`} />
                 <div>
                   <span className="text-sm font-medium text-foreground">
-                    AI Diagnosis
+                    {t('alerts.aiDiagnosis')}
                   </span>
                   <p className="text-xs text-muted-foreground">
-                    Automatically analyze alerts and suggest remediation actions
+                    {t('alerts.aiDiagnosisDesc')}
                   </p>
                 </div>
               </div>
@@ -581,13 +581,13 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
             onClick={onCancel}
             className="px-4 py-2 text-sm rounded-lg bg-secondary text-foreground hover:bg-secondary/80 transition-colors"
           >
-            Cancel
+            {t('actions.cancel')}
           </button>
           <button
             onClick={handleSave}
             className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors"
           >
-            {rule ? 'Save Changes' : 'Create Rule'}
+            {rule ? t('alerts.saveChanges') : t('alerts.createRule')}
           </button>
         </div>
       </BaseModal.Footer>

--- a/web/src/components/alerts/Alerts.tsx
+++ b/web/src/components/alerts/Alerts.tsx
@@ -15,7 +15,7 @@ const ALERTS_STORAGE_KEY = 'kubestellar-alerts-dashboard-cards'
 const DEFAULT_ALERT_CARDS = getDefaultCards('alerts')
 
 export function Alerts() {
-  const { t: _t } = useTranslation()
+  const { t } = useTranslation()
   const { stats, evaluateConditions } = useAlerts()
   const { rules } = useAlertRules()
   const { isRefreshing: dataRefreshing, refetch, error } = useClusters()
@@ -71,8 +71,8 @@ export function Alerts() {
 
   return (
     <DashboardPage
-      title="Alerts"
-      subtitle="Monitor alerts and rules across clusters"
+      title={t('alerts.title')}
+      subtitle={t('alerts.subtitle')}
       icon="Bell"
       storageKey={ALERTS_STORAGE_KEY}
       defaultCards={DEFAULT_ALERT_CARDS}
@@ -84,7 +84,7 @@ export function Alerts() {
       lastUpdated={lastUpdated}
       hasData={stats.firing > 0 || enabledRulesCount > 0}
       emptyState={{
-        title: 'Alerts Dashboard',
+        title: t('alerts.dashboardTitle'),
         description: 'Add cards to monitor alerts, rules, and issues across your clusters.',
       }}
     >
@@ -93,7 +93,7 @@ export function Alerts() {
         <div className="mb-4 p-4 rounded-lg bg-red-500/10 border border-red-500/20 flex items-start gap-3">
           <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
           <div className="flex-1">
-            <p className="text-sm font-medium text-red-400">Error loading alert data</p>
+            <p className="text-sm font-medium text-red-400">{t('alerts.errorLoading')}</p>
             <p className="text-xs text-muted-foreground mt-1">{error}</p>
           </div>
         </div>

--- a/web/src/components/arcade/Arcade.tsx
+++ b/web/src/components/arcade/Arcade.tsx
@@ -84,6 +84,7 @@ const SortableArcadeCard = memo(function SortableArcadeCard({
     transition,
   } = useSortable({ id: card.id })
 
+  const { t } = useTranslation('common')
   const { isMobile } = useMobile()
   const cardWidth = card.position?.w || 4
   const style = {
@@ -115,7 +116,7 @@ const SortableArcadeCard = memo(function SortableArcadeCard({
             {...attributes}
             {...listeners}
             className="p-1 rounded hover:bg-secondary cursor-grab active:cursor-grabbing"
-            title="Drag to reorder"
+            title={t('arcade.dragToReorder')}
           >
             <GripVertical className="w-4 h-4 text-muted-foreground" />
           </button>
@@ -146,7 +147,7 @@ function ArcadeDragPreviewCard({ card }: { card: DashboardCard }) {
 }
 
 export function Arcade() {
-  const { t: _t } = useTranslation()
+  const { t } = useTranslation('common')
   const [searchParams, setSearchParams] = useSearchParams()
   const location = useLocation()
 
@@ -252,9 +253,9 @@ export function Arcade() {
             <div>
               <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
                 <Gamepad2 className="w-6 h-6 text-pink-400" />
-                Arcade
+                {t('arcade.title')}
               </h1>
-              <p className="text-muted-foreground">Take a break with Kubernetes-themed games</p>
+              <p className="text-muted-foreground">{t('arcade.subtitle')}</p>
             </div>
           </div>
           <label
@@ -282,7 +283,7 @@ export function Arcade() {
         <div className="flex items-center justify-center gap-8 flex-wrap">
           <div className="flex items-center gap-2 text-sm">
             <Gamepad2 className="w-5 h-5 text-pink-400" />
-            <span className="text-muted-foreground">Games Available:</span>
+            <span className="text-muted-foreground">{t('arcade.gamesAvailable')}</span>
             <span className="font-bold text-pink-400">{cards.length}</span>
           </div>
           <div className="flex items-center gap-2 text-sm">
@@ -307,7 +308,7 @@ export function Arcade() {
             className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
           >
             <LayoutGrid className="w-4 h-4" />
-            <span>Arcade Games ({cards.length})</span>
+            <span>{t('arcade.arcadeGames', { count: cards.length })}</span>
             {showCards ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
           </button>
         </div>
@@ -320,16 +321,16 @@ export function Arcade() {
                 <div className="flex justify-center mb-4">
                   <Gamepad2 className="w-12 h-12 text-pink-400" />
                 </div>
-                <h3 className="text-lg font-medium text-foreground mb-2">Arcade Dashboard</h3>
+                <h3 className="text-lg font-medium text-foreground mb-2">{t('arcade.emptyStateTitle')}</h3>
                 <p className="text-muted-foreground text-sm max-w-md mx-auto mb-4">
-                  Add games to your arcade! Choose from Kubernetes-themed classics like Flappy Pod, Container Tetris, and more.
+                  {t('arcade.emptyStateDescription')}
                 </p>
                 <button
                   onClick={() => setShowAddCard(true)}
                   className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium bg-pink-500/20 text-pink-400 hover:bg-pink-500/30 rounded-lg transition-colors"
                 >
                   <Plus className="w-4 h-4" />
-                  Add Games
+                  {t('arcade.addGames')}
                 </button>
               </div>
             ) : (

--- a/web/src/components/auth/AuthCallback.tsx
+++ b/web/src/components/auth/AuthCallback.tsx
@@ -7,12 +7,12 @@ import { useTranslation } from 'react-i18next'
 import { useToast } from '../ui/Toast'
 
 export function AuthCallback() {
-  const { t: _t } = useTranslation()
+  const { t } = useTranslation('common')
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const { setToken, refreshUser } = useAuth()
   const { showToast } = useToast()
-  const [status, setStatus] = useState('Signing you in...')
+  const [status, setStatus] = useState(t('authCallback.signingIn'))
   const hasProcessed = useRef(false)
 
   useEffect(() => {
@@ -33,7 +33,7 @@ export function AuthCallback() {
 
     if (token) {
       setToken(token, true)
-      setStatus('Fetching user info...')
+      setStatus(t('authCallback.fetchingUserInfo'))
 
       // Navigate directly to the last visited dashboard route instead of '/'
       // to avoid a flash of the default dashboard before useLastRoute redirects.
@@ -51,9 +51,9 @@ export function AuthCallback() {
       }).catch((err) => {
         clearTimeout(timeoutId)
         console.error('Failed to refresh user:', err)
-        showToast('Failed to fetch user info, proceeding anyway', 'warning')
+        showToast(t('authCallback.failedToFetchUser'), 'warning')
         // Still try to proceed if we have a token
-        setStatus('Completing sign in...')
+        setStatus(t('authCallback.completingSignIn'))
         setTimeout(() => {
           navigate(destination)
         }, 500)

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next'
 const GlobeAnimation = lazy(() => import('../animations/globe').then(m => ({ default: m.GlobeAnimation })))
 
 export function Login() {
-  const { t: _t } = useTranslation()
+  const { t } = useTranslation('common')
   const { login, isAuthenticated, isLoading } = useAuth()
   const [searchParams] = useSearchParams()
   const sessionExpired = useMemo(() => searchParams.get('reason') === 'session_expired', [searchParams])
@@ -98,8 +98,8 @@ export function Login() {
             <div className="flex items-center gap-3 mb-6 px-4 py-3 rounded-lg border border-yellow-500/50 bg-yellow-500/10 text-yellow-300 text-sm">
               <AlertTriangle className="w-5 h-5 shrink-0 text-yellow-400" />
               <div>
-                <div className="font-medium">Session expired</div>
-                <div className="text-xs text-yellow-400/80 mt-0.5">Your session has timed out. Please sign in again.</div>
+                <div className="font-medium">{t('login.sessionExpired')}</div>
+                <div className="text-xs text-yellow-400/80 mt-0.5">{t('login.sessionTimedOut')}</div>
               </div>
             </div>
           )}
@@ -107,10 +107,10 @@ export function Login() {
           {/* Welcome text */}
           <div className="text-center mb-8">
             <h2 data-testid="login-welcome-heading" className="text-xl font-semibold text-foreground mb-2">
-              {sessionExpired ? 'Session expired' : 'Welcome back'}
+              {sessionExpired ? t('login.sessionExpired') : t('login.welcomeBack')}
             </h2>
             <p className="text-muted-foreground">
-              Sign in to manage your multi-cluster deployments
+              {t('login.signInDescription')}
             </p>
           </div>
 
@@ -121,12 +121,12 @@ export function Login() {
             className="w-full flex items-center justify-center gap-3 bg-white text-gray-900 font-medium py-3 px-4 rounded-lg hover:bg-gray-100 transition-all duration-200 hover:shadow-lg"
           >
             <Github className="w-5 h-5" />
-            Continue with GitHub
+            {t('login.continueWithGitHub')}
           </button>
 
           {/* Footer */}
           <div className="text-center text-sm text-muted-foreground mt-8">
-            By signing in, you agree to our Terms of Service
+            {t('login.termsOfService')}
           </div>
         </div>
       </div>

--- a/web/src/components/ui/CardSearch.tsx
+++ b/web/src/components/ui/CardSearch.tsx
@@ -28,13 +28,14 @@ interface CardSearchProps {
 export function CardSearch({
   value,
   onChange,
-  placeholder = 'Search...',
+  placeholder,
   className,
   debounceMs = 300,
   defaultExpanded = false,
   size = 'sm',
 }: CardSearchProps) {
   const { t } = useTranslation()
+  const resolvedPlaceholder = placeholder ?? t('common.search')
   const [isExpanded, setIsExpanded] = useState(defaultExpanded || !!value)
   const [localValue, setLocalValue] = useState(value)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -109,7 +110,7 @@ export function CardSearch({
         value={localValue}
         onChange={(e) => handleChange(e.target.value)}
         onBlur={handleBlur}
-        placeholder={placeholder}
+        placeholder={resolvedPlaceholder}
         className={cn(
           'w-28 rounded-lg bg-secondary/50 border border-border/50 text-foreground placeholder:text-muted-foreground',
           'focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20',
@@ -122,7 +123,7 @@ export function CardSearch({
         <button
           onClick={handleClear}
           className="absolute right-2 p-0.5 rounded hover:bg-secondary/80 text-muted-foreground hover:text-foreground"
-          title="Clear search"
+          title={t('common.clearSearch')}
         >
           <X className={cn(iconSize, 'w-3 h-3')} />
         </button>

--- a/web/src/components/ui/ClusterFilterDropdown.tsx
+++ b/web/src/components/ui/ClusterFilterDropdown.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
 import { Filter, ChevronDown, Server } from 'lucide-react'
 import { ClusterStatusDot, getClusterState, type ClusterState } from './ClusterStatusBadge'
 import type { ClusterErrorType } from '../../lib/errorClassifier'
@@ -30,6 +31,7 @@ export function ClusterFilterDropdown({
   clusterFilterRef,
   minClusters = 1,
 }: ClusterFilterDropdownProps) {
+  const { t } = useTranslation()
   const buttonRef = useRef<HTMLButtonElement>(null)
   const [dropdownStyle, setDropdownStyle] = useState<{ top: number; left?: number; right?: number } | null>(null)
 
@@ -92,7 +94,7 @@ export function ClusterFilterDropdown({
               ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
               : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
           }`}
-          title="Filter by cluster"
+          title={t('clusterFilter.filterByCluster')}
         >
           <Filter className="w-3 h-3" />
           <ChevronDown className="w-3 h-3" />
@@ -115,7 +117,7 @@ export function ClusterFilterDropdown({
                   localClusterFilter.length === 0 ? 'bg-purple-500/20 text-purple-400' : 'hover:bg-secondary text-foreground'
                 }`}
               >
-                All clusters
+                {t('clusterFilter.allClusters')}
               </button>
               {availableClusters.map(cluster => {
                 const clusterState: ClusterState = cluster.healthy !== undefined || cluster.reachable !== undefined
@@ -130,10 +132,10 @@ export function ClusterFilterDropdown({
 
                 const isUnreachable = cluster.reachable === false
                 const stateLabel = clusterState === 'healthy' ? '' :
-                  clusterState === 'degraded' ? 'degraded' :
-                  clusterState === 'unreachable-auth' ? 'needs auth' :
-                  clusterState === 'unreachable-timeout' ? 'offline' :
-                  clusterState.startsWith('unreachable') ? 'offline' : ''
+                  clusterState === 'degraded' ? t('clusterFilter.degraded') :
+                  clusterState === 'unreachable-auth' ? t('clusterFilter.needsAuth') :
+                  clusterState === 'unreachable-timeout' ? t('clusterFilter.offline') :
+                  clusterState.startsWith('unreachable') ? t('clusterFilter.offline') : ''
 
                 return (
                   <button

--- a/web/src/components/ui/Pagination.tsx
+++ b/web/src/components/ui/Pagination.tsx
@@ -120,7 +120,7 @@ export function Pagination({
         {/* Items per page selector */}
         {showItemsPerPage && onItemsPerPageChange && (
           <div className="flex items-center gap-2">
-            <span className="text-muted-foreground">Per page:</span>
+            <span className="text-muted-foreground">{t('pagination.perPage')}</span>
             <select
               value={itemsPerPage}
               onChange={(e) => onItemsPerPageChange(Number(e.target.value))}
@@ -141,7 +141,7 @@ export function Pagination({
             onClick={() => onPageChange(1)}
             disabled={!canGoPrevious}
             className="p-1.5 rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed text-muted-foreground hover:text-foreground transition-colors"
-            title="First page"
+            title={t('pagination.firstPage')}
           >
             <ChevronsLeft className="w-4 h-4" />
           </button>
@@ -149,7 +149,7 @@ export function Pagination({
             onClick={() => onPageChange(currentPage - 1)}
             disabled={!canGoPrevious}
             className="p-1.5 rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed text-muted-foreground hover:text-foreground transition-colors"
-            title="Previous page"
+            title={t('pagination.previousPage')}
           >
             <ChevronLeft className="w-4 h-4" />
           </button>
@@ -162,7 +162,7 @@ export function Pagination({
             onClick={() => onPageChange(currentPage + 1)}
             disabled={!canGoNext}
             className="p-1.5 rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed text-muted-foreground hover:text-foreground transition-colors"
-            title="Next page"
+            title={t('pagination.nextPage')}
           >
             <ChevronRight className="w-4 h-4" />
           </button>
@@ -170,7 +170,7 @@ export function Pagination({
             onClick={() => onPageChange(totalPages)}
             disabled={!canGoNext}
             className="p-1.5 rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed text-muted-foreground hover:text-foreground transition-colors"
-            title="Last page"
+            title={t('pagination.lastPage')}
           >
             <ChevronsRight className="w-4 h-4" />
           </button>

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   Server, CheckCircle2, XCircle, WifiOff, Box, Cpu, MemoryStick, HardDrive, Zap, Layers,
   FolderOpen, AlertCircle, AlertTriangle, AlertOctagon, Package, Ship, Settings, Clock,
@@ -148,10 +149,12 @@ export function StatsOverview({
   collapsedStorageKey,
   lastUpdated,
   className = '',
-  title = 'Stats Overview',
+  title,
   showConfigButton = true,
   isDemoData = false,
 }: StatsOverviewProps) {
+  const { t } = useTranslation()
+  const resolvedTitle = title ?? t('statsOverview.title')
   const { blocks, saveBlocks, visibleBlocks, defaultBlocks } = useStatsConfig(dashboardType)
   const { status: agentStatus } = useLocalAgent()
   const { isDemoMode } = useDemoMode()
@@ -206,24 +209,24 @@ export function StatsOverview({
               className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
             >
               <Activity className="w-4 h-4" />
-              <span>{title}</span>
+              <span>{resolvedTitle}</span>
               {isExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
             </button>
           ) : (
             <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
               <Activity className="w-4 h-4" />
-              <span>{title}</span>
+              <span>{resolvedTitle}</span>
             </div>
           )}
           {isDemoData && (
             <span className="flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
               <FlaskConical className="w-2.5 h-2.5" />
-              Demo
+              {t('statsOverview.demo')}
             </span>
           )}
           {lastUpdated && (
             <span className="text-xs text-muted-foreground/60">
-              Updated {lastUpdated.toLocaleTimeString()}
+              {t('statsOverview.updated', { time: lastUpdated.toLocaleTimeString() })}
             </span>
           )}
         </div>
@@ -231,7 +234,7 @@ export function StatsOverview({
           <button
             onClick={() => setIsConfigOpen(true)}
             className="p-1 text-muted-foreground hover:text-foreground hover:bg-secondary rounded transition-colors"
-            title="Configure stats"
+            title={t('statsOverview.configureStats')}
           >
             <Settings className="w-4 h-4" />
           </button>
@@ -244,7 +247,7 @@ export function StatsOverview({
           {visibleBlocks.map(block => {
             const data = effectiveIsLoading
               ? { value: '-' as string | number, sublabel: undefined }
-              : (getStatValue(block.id) ?? { value: '-' as string | number, sublabel: 'Not available' })
+              : (getStatValue(block.id) ?? { value: '-' as string | number, sublabel: t('statsOverview.notAvailable') })
             return (
               <StatBlock
                 key={block.id}
@@ -265,7 +268,7 @@ export function StatsOverview({
         blocks={blocks}
         onSave={saveBlocks}
         defaultBlocks={defaultBlocks}
-        title={`Configure ${title}`}
+        title={`${t('actions.configure')} ${resolvedTitle}`}
       />
     </div>
   )

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1082,6 +1082,26 @@
     "allReasons": "All Reasons"
   },
   "alerts": {
+    "title": "Alerts",
+    "subtitle": "Monitor alerts and rules across clusters",
+    "dashboardTitle": "Alerts Dashboard",
+    "errorLoading": "Error loading alert data",
+    "resource": "Resource:",
+    "fired": "Fired:",
+    "acknowledged": "Acknowledged:",
+    "showDetails": "Show Details",
+    "hideDetails": "Hide Details",
+    "runDiagnosis": "Run Diagnosis",
+    "analyzing": "Analyzing...",
+    "summary": "Summary",
+    "rootCause": "Root Cause",
+    "suggestedActions": "Suggested Actions",
+    "viewAIMission": "View AI Mission",
+    "noDiagnosisYet": "No AI diagnosis yet. Click \"Run Diagnosis\" to analyze this alert with AI.",
+    "sendToSlack": "Send to Slack",
+    "slackSent": "Notification sent to Slack!",
+    "acknowledge": "Acknowledge",
+    "resolve": "Resolve",
     "weather": {
       "severeStorm": "Severe Storm",
       "extremeHeat": "Extreme Heat",
@@ -1658,7 +1678,26 @@
   },
   "pagination": {
     "showing": "Showing {{start}}-{{end}} of {{total}}",
-    "noItems": "No items"
+    "noItems": "No items",
+    "perPage": "Per page:",
+    "firstPage": "First page",
+    "previousPage": "Previous page",
+    "nextPage": "Next page",
+    "lastPage": "Last page"
+  },
+  "clusterFilter": {
+    "filterByCluster": "Filter by cluster",
+    "allClusters": "All clusters",
+    "degraded": "degraded",
+    "needsAuth": "needs auth",
+    "offline": "offline"
+  },
+  "statsOverview": {
+    "title": "Stats Overview",
+    "configureStats": "Configure stats",
+    "demo": "Demo",
+    "notAvailable": "Not available",
+    "updated": "Updated {{time}}"
   },
   "refresh": {
     "failed": "Failed"
@@ -1759,6 +1798,7 @@
     "searchGPUClusters": "Search GPU clusters...",
     "searchStacks": "Search stacks...",
     "searchHardware": "Search hardware, model...",
+    "clearSearch": "Clear search",
     "filter": "Filter",
     "filterBy": "Filter by...",
     "noResults": "No results found",
@@ -2382,5 +2422,77 @@
     "pod": "Pod",
     "deploy": "Deploy",
     "ns": "NS"
+  },
+  "chunkError": {
+    "appUpdated": "App Updated",
+    "newVersionDeployed": "A new version was deployed. Please reload to continue.",
+    "reloadPage": "Reload Page"
+  },
+  "agentSetup": {
+    "welcomeTitle": "Welcome to KubeStellar Console",
+    "welcomeDescription": "To access your local clusters and Claude Code, install our lightweight agent.",
+    "quickInstall": "Quick Install (recommended)",
+    "copyAndRun": "Copy this command and run it in your terminal:",
+    "copy": "Copy",
+    "copied": "Copied!",
+    "kubeconfigClusters": "Your kubeconfig clusters",
+    "realtimeTokenUsage": "Real-time token usage",
+    "localAndSecure": "Local & secure",
+    "installFromSettings": "You can install the agent anytime from Settings.",
+    "dontShowAgain": "Don't show again",
+    "continueWithDemoData": "Continue with Demo Data",
+    "remindMeLater": "Remind Me Later"
+  },
+  "agentStatus": {
+    "connectingToAgent": "Connecting to local agent...",
+    "demoModeTitle": "Demo Mode - Local Agent Not Connected",
+    "demoModeDefaultMessage": "Install the local agent to access your clusters and Claude Code.",
+    "connectedToAgent": "Connected to local agent v{{version}}",
+    "clustersCount": " - {{count}} clusters",
+    "claudeAvailable": " - Claude available",
+    "connectToLocalEnv": "Connect to Your Local Environment",
+    "installAgentDescription": "Install the local agent to access your kubeconfig clusters and Claude Code.",
+    "copyAndPaste": "Copy and paste this command:",
+    "accessAllClusters": "Access all your clusters",
+    "realtimeTokenTracking": "Real-time token tracking",
+    "runsLocally": "Runs locally (secure)"
+  },
+  "login": {
+    "sessionExpired": "Session expired",
+    "sessionTimedOut": "Your session has timed out. Please sign in again.",
+    "welcomeBack": "Welcome back",
+    "signInDescription": "Sign in to manage your multi-cluster deployments",
+    "continueWithGitHub": "Continue with GitHub",
+    "termsOfService": "By signing in, you agree to our Terms of Service"
+  },
+  "authCallback": {
+    "signingIn": "Signing you in...",
+    "fetchingUserInfo": "Fetching user info...",
+    "failedToFetchUser": "Failed to fetch user info, proceeding anyway",
+    "completingSignIn": "Completing sign in..."
+  },
+  "aiAgents": {
+    "title": "AI Agents",
+    "subtitle": "Kagenti agent platform — deploy, secure, and manage AI agents",
+    "emptyStateTitle": "AI Agents Dashboard",
+    "emptyStateDescription": "Add cards to monitor kagenti agents, MCP tools, build pipelines, and security posture across your clusters.",
+    "errorLoading": "Error loading kagenti data"
+  },
+  "aiml": {
+    "title": "AI/ML",
+    "subtitle": "Monitor AI and Machine Learning workloads",
+    "emptyStateTitle": "AI/ML Dashboard",
+    "emptyStateDescription": "Add cards to monitor GPU utilization, ML workloads, and model training across your clusters.",
+    "errorLoading": "Error loading cluster data"
+  },
+  "arcade": {
+    "title": "Arcade",
+    "subtitle": "Take a break with Kubernetes-themed games",
+    "gamesAvailable": "Games Available:",
+    "arcadeGames": "Arcade Games ({{count}})",
+    "emptyStateTitle": "Arcade Dashboard",
+    "emptyStateDescription": "Add games to your arcade! Choose from Kubernetes-themed classics like Flappy Pod, Container Tetris, and more.",
+    "addGames": "Add Games",
+    "dragToReorder": "Drag to reorder"
   }
 }


### PR DESCRIPTION
## Summary
- Extract hardcoded English strings from 15 non-card components
- Add ~100 new translation keys to `common.json`
- Components covered:
  - **Auth**: Login, AuthCallback
  - **Agent**: AgentSetupDialog, AgentStatus  
  - **Alerts**: AlertDetail, AlertRuleEditor, Alerts page
  - **Dashboard pages**: AIAgents, AIML, Arcade
  - **Shared UI**: Pagination, CardSearch, ClusterFilterDropdown, StatsOverview
  - **Error boundary**: ChunkErrorBoundary (class component, uses `i18next.t()` directly)

## Test plan
- [ ] Verify build passes
- [ ] Check Login page renders correctly
- [ ] Check Agent setup dialog strings
- [ ] Check Alert detail/editor forms
- [ ] Verify pagination labels