### PR TITLE
🐛 Fix demo badge showing during card loading phase

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1028,7 +1028,7 @@ export function CardWrapper({
   // 2. Global demo mode is on AND child hasn't explicitly opted out
   // Suppress during loading phase UNLESS the card is a known demo-only card (isDemoData prop).
   // Demo-only cards should always show the badge immediately — they never transition to real data.
-  const showDemoIndicator = (!effectiveIsLoading || isDemoData) && (effectiveIsDemoData || (isDemoMode && !childExplicitlyNotDemo))
+  const showDemoIndicator = !effectiveIsLoading && (effectiveIsDemoData || (isDemoMode && !childExplicitlyNotDemo))
 
   // Determine if we should show skeleton: loading with no cached data
   // OR when demo mode is OFF and agent is offline (prevents showing stale demo data)


### PR DESCRIPTION
## Summary
- Removes the `isDemoData` prop bypass in `showDemoIndicator` logic that caused demo badges (yellow border + "Demo" badge) to appear during the loading phase
- Cards in the `DEMO_DATA_CARDS` set were getting `isDemoData={true}` as a prop, which bypassed the `!effectiveIsLoading` guard — changed `(!effectiveIsLoading || isDemoData)` to just `!effectiveIsLoading`
- Demo-only cards resolve instantly so the badge still appears within milliseconds after loading completes

## Test plan
- [x] `npm run build` passes
- [x] Card-loading compliance test: **175 pass, 0 fail, 0 warn** — all 8 criteria at 100%
- [x] Criterion A (no demo badge during loading) specifically verified at 100% pass rate