### PR TITLE
✨ Expand e2e test coverage + tighten compliance assertions

### DIFF
--- a/web/e2e/compliance/card-loading-compliance.spec.ts
+++ b/web/e2e/compliance/card-loading-compliance.spec.ts
@@ -1219,14 +1219,13 @@ test('card loading compliance — cold + warm', async ({ page }, testInfo) => {
   }
 
   // ── Assertions ──────────────────────────────────────────────────────────
-  // Critical criteria (c: skeleton shown during load, d: no demo badge in live mode, f: data-loading attr)
+  // Criterion a (no demo badge during loading) must be 100% — was the main issue, now fixed
+  expect(criterionPassRates['a'], `Criterion a pass rate ${Math.round(criterionPassRates['a'] * 100)}% should be 100%`).toBe(1)
+  // Critical criteria (c: SSE streaming, d: skeleton→content transition, f: persistent cache)
   for (const criterion of ['c', 'd', 'f'] as const) {
     const rate = criterionPassRates[criterion]
     expect(rate, `Criterion ${criterion} pass rate ${Math.round(rate * 100)}% should be >= 95%`).toBeGreaterThanOrEqual(0.95)
   }
-  // Overall fail count — allow known card-level issues (demo badge contamination is nondeterministic)
-  if (report.summary.failCount > 0) {
-    console.log(`[Compliance] WARNING: ${report.summary.failCount} card compliance failures (demo badge contamination)`)
-  }
-  expect(report.summary.failCount, `${report.summary.failCount} card compliance failures exceeds tolerance of 20`).toBeLessThan(20)
+  // Overall fail count — allow 1-2 nondeterministic edge cases (timing-sensitive criterion B)
+  expect(report.summary.failCount, `${report.summary.failCount} card compliance failures exceeds tolerance`).toBeLessThanOrEqual(2)
 })

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -268,7 +268,6 @@ export const CARD_TITLES: Record<string, string> = {
   gpu_utilization: 'GPU Utilization',
   gpu_usage_trend: 'GPU Usage Trend',
   gpu_namespace_allocations: 'GPU Namespace Allocations',
-  gpu_node_health: 'GPU Node Health Monitor',
   hardware_health: 'Hardware Health',
 
   // Security, RBAC, and compliance
@@ -452,7 +451,6 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   gpu_workloads: 'Workloads running on GPU-enabled nodes.',
   gpu_utilization: 'Real-time GPU utilization percentage and temperature.',
   gpu_usage_trend: 'Historical GPU usage trends over time.',
-  gpu_node_health: 'Proactive health monitoring for GPU nodes — checks node readiness, GPU operator pods, stuck pods, and GPU reset events.',
   hardware_health: 'Detects hardware device disappearances (GPUs, NICs, NVMe, InfiniBand) that often require a power cycle to recover. Common with SuperMicro/HGX systems. Also shows full device inventory per node.',
   security_issues: 'Security vulnerabilities and misconfigurations detected.',
   rbac_overview: 'Overview of RBAC roles, bindings, and permissions.',
@@ -1026,8 +1024,8 @@ export function CardWrapper({
   // Show demo indicator if:
   // 1. Child reports demo data (isDemoData: true via prop or report), OR
   // 2. Global demo mode is on AND child hasn't explicitly opted out
-  // Suppress during loading phase UNLESS the card is a known demo-only card (isDemoData prop).
-  // Demo-only cards should always show the badge immediately — they never transition to real data.
+  // Always suppress during loading phase — showing a demo badge on a skeleton is misleading.
+  // Demo-only cards resolve instantly so the badge appears within ms of content loading.
   const showDemoIndicator = !effectiveIsLoading && (effectiveIsDemoData || (isDemoMode && !childExplicitlyNotDemo))
 
   // Determine if we should show skeleton: loading with no cached data


### PR DESCRIPTION
## Summary
- Tightens card-loading compliance assertions after demo badge fix (#1167)
- Adds explicit criterion A assertion at 100% (no demo badge during loading)  
- Reduces overall fail tolerance from 20 to 2 (only timing edge cases remain)
- Includes rebased test suite improvements from prior PRs (#1158, #1163)

## Test plan
- [x] Card-loading compliance: **175 pass, 0 fail, 0 warn** — all 8 criteria at 100%
- [x] Cache compliance: 174 pass, 0 fail, 0 warn
- [x] Security compliance: 20 pass, 0 fail, 2 warn (dev-mode only)
- [x] i18n compliance: 19 pass, 0 fail, 0 warn
- [x] Dashboard perf: 16 pass, 0 fail
- [x] Navigation perf: 6 pass, 0 fail