### PR TITLE
✨ Add tiered GPU health checks with ConfigMap results and alert integration

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -499,6 +499,7 @@ func (s *Server) setupRoutes() {
 	api.Get("/mcp/gpu-nodes/health/cronjob", mcpHandlers.GetGPUHealthCronJobStatus)
 	api.Post("/mcp/gpu-nodes/health/cronjob", mcpHandlers.InstallGPUHealthCronJob)
 	api.Delete("/mcp/gpu-nodes/health/cronjob", mcpHandlers.UninstallGPUHealthCronJob)
+	api.Get("/mcp/gpu-nodes/health/cronjob/results", mcpHandlers.GetGPUHealthCronJobResults)
 	api.Get("/mcp/nvidia-operators", mcpHandlers.GetNVIDIAOperatorStatus)
 	api.Get("/mcp/nodes", mcpHandlers.GetNodes)
 	api.Get("/mcp/events", mcpHandlers.GetEvents)

--- a/web/src/components/alerts/AlertRuleEditor.tsx
+++ b/web/src/components/alerts/AlertRuleEditor.tsx
@@ -32,6 +32,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
 
   const CONDITION_TYPES: { value: AlertConditionType; label: string; description: string }[] = [
     { value: 'gpu_usage', label: t('alerts.conditions.gpuUsage'), description: t('alerts.conditions.gpuUsageDesc') },
+    { value: 'gpu_health_cronjob', label: 'GPU Health CronJob', description: 'Alert when CronJob health checks detect issues on GPU nodes' },
     { value: 'node_not_ready', label: t('alerts.conditions.nodeNotReady'), description: t('alerts.conditions.nodeNotReadyDesc') },
     { value: 'pod_crash', label: t('alerts.conditions.podCrash'), description: t('alerts.conditions.podCrashDesc') },
     { value: 'memory_pressure', label: t('alerts.conditions.memoryPressure'), description: t('alerts.conditions.memoryPressureDesc') },

--- a/web/src/hooks/mcp/types.ts
+++ b/web/src/hooks/mcp/types.ts
@@ -199,11 +199,22 @@ export interface GPUNodeHealthStatus {
   checkedAt: string
 }
 
+export interface GPUHealthCheckResult {
+  nodeName: string
+  status: 'healthy' | 'degraded' | 'unhealthy'
+  gpuCount?: number
+  checks: GPUNodeHealthCheck[]
+  issues: string[]
+}
+
 export interface GPUHealthCronJobStatus {
   installed: boolean
   cluster: string
   namespace?: string
   schedule?: string
+  tier: number
+  version: number
+  updateAvailable: boolean
   lastRun?: string
   lastResult?: string
   nextRun?: string
@@ -211,6 +222,7 @@ export interface GPUHealthCronJobStatus {
   activeJobs: number
   failedJobs: number
   successJobs: number
+  lastResults?: GPUHealthCheckResult[]
 }
 
 // NVIDIA Operator Status types

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -1812,7 +1812,7 @@ export function useGPUHealthCronJob(cluster?: string) {
     fetchStatus()
   }, [fetchStatus])
 
-  const install = useCallback(async (opts?: { namespace?: string; schedule?: string }) => {
+  const install = useCallback(async (opts?: { namespace?: string; schedule?: string; tier?: number }) => {
     if (!cluster) return
     setActionInProgress('install')
     setError(null)
@@ -1829,6 +1829,7 @@ export function useGPUHealthCronJob(cluster?: string) {
           cluster,
           namespace: opts?.namespace,
           schedule: opts?.schedule,
+          tier: opts?.tier ?? 2,
         }),
       })
       if (!response.ok) {

--- a/web/src/types/alerts.ts
+++ b/web/src/types/alerts.ts
@@ -1,6 +1,7 @@
 // Alert condition types
 export type AlertConditionType =
   | 'gpu_usage'
+  | 'gpu_health_cronjob'
   | 'node_not_ready'
   | 'pod_crash'
   | 'memory_pressure'
@@ -175,6 +176,18 @@ export const PRESET_ALERT_RULES: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt
     aiDiagnose: false,
   },
   {
+    name: 'GPU Health CronJob',
+    description: 'Alert when GPU health CronJob detects issues (requires CronJob installed)',
+    enabled: false,
+    condition: {
+      type: 'gpu_health_cronjob',
+      duration: 0, // Immediate — CronJob already ran checks
+    },
+    severity: 'warning',
+    channels: [{ type: 'browser', enabled: true, config: {} }],
+    aiDiagnose: true,
+  },
+  {
     name: 'Severe Weather Alert',
     description: 'Alert on extreme weather conditions',
     enabled: false,
@@ -222,6 +235,8 @@ export function formatCondition(condition: AlertCondition): string {
   switch (condition.type) {
     case 'gpu_usage':
       return `GPU usage > ${condition.threshold}%`
+    case 'gpu_health_cronjob':
+      return 'GPU health CronJob detects issues'
     case 'node_not_ready':
       return 'Node not in Ready state'
     case 'pod_crash':


### PR DESCRIPTION
## Summary

- **4-tier GPU health check system**: Tier 1 (Critical) → Tier 4 (Deep), each adding progressively more checks. Per-cluster tier configuration via dropdown in the GPU Node Health Monitor card.
- **ConfigMap-based results**: CronJob writes structured JSON to a `gpu-health-results` ConfigMap. Console reads and displays per-node check results with pass/fail badges.
- **Alert integration**: New `gpu_health_cronjob` alert condition type. AlertsContext polls results every 60s and fires browser notifications (with deep-link to affected GPU node), Slack webhooks, and generic webhooks when issues are detected.
- **Dynamic RBAC**: ClusterRole rules expand based on tier level — no unnecessary privileges for lower tiers.
- **Version-stamped CronJob**: Labels track script version and tier. Auto-reconciliation updates the CronJob when the console ships a new version.

### Tier Details

| Tier | Name | Checks Added |
|------|------|-------------|
| 1 | Critical | Node Ready, cordoned, stuck pods, NVIDIA operator pods (GFD, device-plugin, DCGM), GPU reset/XID events |
| 2 | Standard | + capacity vs allocatable mismatch, pending GPU pods, driver pods, DiskPressure/MemoryPressure/PIDPressure, quota exhaustion |
| 3 | Full | + zero utilization, MIG config drift, RDMA/InfiniBand pods, failed jobs on GPU nodes, evicted pods |
| 4 | Deep | + nvidia-smi (ECC errors, temperature), dmesg GPU kernel errors, NVLink status (via debug pod) |

### Files Changed (9)

**Backend:**
- `pkg/k8s/client.go` — Tiered script builder, ConfigMap write/read, version labels, expanded RBAC, auto-reconcile
- `pkg/api/handlers/mcp.go` — Tier in install body, new results endpoint
- `pkg/api/server.go` — New route `/api/mcp/gpu-nodes/health/cronjob/results`

**Frontend:**
- `web/src/hooks/mcp/types.ts` — `GPUHealthCheckResult` interface, updated `GPUHealthCronJobStatus`
- `web/src/hooks/useCachedData.ts` — Tier parameter in install callback
- `web/src/types/alerts.ts` — `gpu_health_cronjob` condition type + preset rule
- `web/src/contexts/AlertsContext.tsx` — CronJob evaluator + results polling + browser notifications
- `web/src/components/alerts/AlertRuleEditor.tsx` — New condition type in UI
- `web/src/components/cards/ProactiveGPUNodeHealthMonitor.tsx` — Tier selector, update button, results display

## Test plan

- [ ] `go build ./...` passes clean
- [ ] `npm run build` passes clean
- [ ] Install CronJob on a cluster with tier 2, verify CronJob is created with correct labels
- [ ] Wait for CronJob run → verify `gpu-health-results` ConfigMap is created with JSON
- [ ] Card shows tier badge, version, and per-node check results
- [ ] Change tier → "Update" button appears → click updates CronJob in place
- [ ] Create alert rule for `gpu_health_cronjob` → fires browser notification on CronJob issues
- [ ] Click notification → deep-links to affected GPU node in console
- [ ] Slack webhook fires when configured on the alert rule