### PR TITLE
🐛 Fix demo badge flash during cache hydration

### DIFF
--- a/web/e2e/compliance/card-cache-compliance.spec.ts
+++ b/web/e2e/compliance/card-cache-compliance.spec.ts
@@ -598,8 +598,9 @@ test('card cache compliance — storage and retrieval', async ({ page }) => {
 
   // ── Assertions ──────────────────────────────────────────────────────────
   expect(cacheHitRate, `Cache hit rate ${Math.round(cacheHitRate * 100)}% should be >= 80%`).toBeGreaterThanOrEqual(0.80)
-  // Allow up to 2 card failures (some cards like nightly_e2e_status may fall back to demo data)
-  expect(failCount, `${failCount} cache failures found (max 2 allowed)`).toBeLessThanOrEqual(2)
+  // Strict: zero cache failures allowed. Any card showing demo data on warm return
+  // (when it had live data on cold load) is a real bug that must be fixed.
+  expect(failCount, `${failCount} cache failures found — cards fell back to demo data instead of using cache`).toBe(0)
   if (avgTtc !== null) {
     expect(avgTtc, `Avg warm time-to-content ${Math.round(avgTtc)}ms should be < 500ms`).toBeLessThan(500)
   }

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -197,10 +197,12 @@ export const GitHubCIMonitor = forwardRef<GitHubCIMonitorRef, GitHubCIMonitorPro
   })
 
   const workflows = ciData.workflows
-  const isUsingDemoData = ciData.isDemo
+  // Don't report demo during cache hydration — initialData has isDemo: true as a
+  // placeholder. Only report demo once loading completes and we know the real state.
+  const isUsingDemoData = isLoading ? false : ciData.isDemo
   const error = isFailed ? 'Failed to fetch workflows' : null
 
-  useCardLoadingState({ isLoading, hasAnyData: workflows.length > 0 })
+  useCardLoadingState({ isLoading, hasAnyData: workflows.length > 0, isDemoData: isUsingDemoData })
 
   // Expose refresh method via ref for CardWrapper
   useImperativeHandle(ref, () => ({

--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -117,7 +117,10 @@ export function useNightlyE2EData() {
 
   return {
     guides,
-    isDemoFallback: isDemo,
+    // Don't report demo fallback while still loading — the initial demo data is a
+    // loading placeholder, not confirmed demo mode. Showing the Demo badge during
+    // cache hydration is misleading and fails cache compliance tests.
+    isDemoFallback: cacheResult.isLoading ? false : isDemo,
     isLoading: cacheResult.isLoading,
     isRefreshing: cacheResult.isRefreshing,
     isFailed: cacheResult.isFailed,


### PR DESCRIPTION
## Summary
- **Root cause**: Cards using `useCache` with `initialData: { isDemo: true }` briefly showed the Demo badge during IndexedDB cache hydration. The `initialData` is set synchronously while cache loads asynchronously, creating a timing gap.
- **Fix**: Suppress `isDemoFallback`/`isDemoData` reporting while `isLoading` is true in both `useNightlyE2EData` and `GitHubCIMonitor`
- **Also fixed**: `GitHubCIMonitor` was not passing `isDemoData` to `useCardLoadingState` at all (missing wiring)
- **Test**: Reverted the weakened cache compliance assertion back to strict `expect(failCount).toBe(0)` — all 175 cards pass with 0 failures

## Test plan
- [x] `card-cache-compliance`: 175 cards, 0 failures, 100% cache hit rate
- [x] `card-loading-compliance`: 100% pass rate on all criteria
- [x] `security-compliance`: 20 pass, 0 fail
- [x] `npm run build` passes
- [x] Lint clean on changed files