### PR TITLE
✨ Harden UI compliance tests to catch initialData demo leak and cache persistence bugs

### DIFF
--- a/web/e2e/compliance/baseline/compliance-baseline.json
+++ b/web/e2e/compliance/baseline/compliance-baseline.json
@@ -7,7 +7,8 @@
     "e": 0.10,
     "f": 0.80,
     "g": 0.90,
-    "h": 0.80
+    "h": 0.80,
+    "i": 1.00
   },
   "max_fail_count": 20,
   "zero_tolerance_cards": [

--- a/web/e2e/mocks/liveMocks.ts
+++ b/web/e2e/mocks/liveMocks.ts
@@ -482,13 +482,17 @@ export async function setLiveColdMode(page: Page, user?: typeof mockUser): Promi
       localStorage.setItem('kc-backend-status', JSON.stringify({ available: true, timestamp: Date.now() }))
       localStorage.setItem('kc-sqlite-migrated', '2')
 
-      // Clear all caches for cold start
+      // Clear all caches for cold start — use allowlist so card-specific backup
+      // keys (e.g. nightly-e2e-cache) are also cleared
+      const COLD_KEEP_KEYS = new Set([
+        'token', 'kc-demo-mode', 'demo-user-onboarded',
+        'kubestellar-console-tour-completed', 'kc-user-cache',
+        'kc-backend-status', 'kc-sqlite-migrated',
+      ])
       for (let i = localStorage.length - 1; i >= 0; i--) {
         const key = localStorage.key(i)
-        if (!key) continue
-        if (key.includes('dashboard-cards') || key.startsWith('cache:') || key.includes('kubestellar-stack-cache')) {
-          localStorage.removeItem(key)
-        }
+        if (!key || COLD_KEEP_KEYS.has(key)) continue
+        localStorage.removeItem(key)
       }
     },
     { user: u },

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -147,7 +147,7 @@ export const GitHubCIMonitor = forwardRef<GitHubCIMonitorRef, GitHubCIMonitorPro
   const { data: ciData, isLoading, isFailed, refetch } = useCache<{ workflows: WorkflowRun[], isDemo: boolean }>({
     key: `github-ci:${reposKey}`,
     category: 'default',
-    initialData: { workflows: DEMO_WORKFLOWS, isDemo: true },
+    initialData: { workflows: [], isDemo: false },
     demoData: { workflows: DEMO_WORKFLOWS, isDemo: true },
     persist: true,
     fetcher: async () => {


### PR DESCRIPTION
## Summary
- **New criterion "i" (Initial Demo Flash)**: Detects when `initialData` contains demo data, which bypasses the skeleton phase and shows demo badges immediately on cold start. This would have caught the Nightly E2E card bug before it shipped.
- **Allowlist-based cache clearing**: `setLiveColdMode()` and batch cache clearing now use an allowlist instead of a blocklist, ensuring card-specific localStorage backup keys (like `nightly-e2e-cache`) are properly cleared during cold start testing.
- **Page reload persistence test**: New Phase 5.5 in cache compliance does `page.reload()` to test real browser refresh persistence — catches cards that only survive same-session navigation but lose data on actual reload.
- **Cold demo badge detection**: Cache compliance now flags demo badges during cold load as failures (previously passed silently).
- **GitHubCIMonitor fix**: Same `initialData: demo` bug as Nightly E2E — changed to empty initial data.

## Test plan
- [ ] `npm run build` passes
- [ ] Compliance tests pass against current (fixed) codebase
- [ ] Criterion "i" correctly catches cards with demo data as initialData