### PR TITLE
✨ Add AI Diagnose on failed nightly E2E dots + alert policy + macOS notification

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -394,6 +394,7 @@ func (s *Server) setupRoutes() {
 	// Nightly E2E status is public GitHub Actions data, safe for desktop widgets
 	nightlyE2EPublic := handlers.NewNightlyE2EHandler(s.config.GitHubToken)
 	s.app.Get("/api/public/nightly-e2e/runs", nightlyE2EPublic.GetRuns)
+	s.app.Get("/api/public/nightly-e2e/run-logs", nightlyE2EPublic.GetRunLogs)
 
 	// MCP handlers (used in protected routes below)
 	mcpHandlers := handlers.NewMCPHandlers(s.bridge, s.k8sClient)
@@ -628,6 +629,7 @@ func (s *Server) setupRoutes() {
 	// Nightly E2E status (GitHub Actions proxy with server-side token + cache)
 	nightlyE2E := handlers.NewNightlyE2EHandler(s.config.GitHubToken)
 	api.Get("/nightly-e2e/runs", nightlyE2E.GetRuns)
+	api.Get("/nightly-e2e/run-logs", nightlyE2E.GetRunLogs)
 
 	// GPU reservation routes
 	gpuHandler := handlers.NewGPUHandler(s.store)

--- a/web/src/types/alerts.ts
+++ b/web/src/types/alerts.ts
@@ -8,6 +8,7 @@ export type AlertConditionType =
   | 'cpu_pressure'
   | 'disk_pressure'
   | 'weather_alerts'
+  | 'nightly_e2e_failure'
   | 'custom'
 
 // Alert severity levels
@@ -200,6 +201,18 @@ export const PRESET_ALERT_RULES: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt
     channels: [{ type: 'browser', enabled: true, config: {} }],
     aiDiagnose: false,
   },
+  {
+    name: 'Nightly E2E Failure',
+    description: 'Alert when any nightly E2E workflow run fails',
+    enabled: true,
+    condition: {
+      type: 'nightly_e2e_failure',
+      duration: 0,
+    },
+    severity: 'warning',
+    channels: [{ type: 'browser', enabled: true, config: {} }],
+    aiDiagnose: true,
+  },
 ]
 
 // Helper to get severity color
@@ -255,6 +268,8 @@ export function formatCondition(condition: AlertCondition): string {
         return `Wind speed > ${condition.windSpeedThreshold || 40} mph`
       }
       return condition.weatherCondition?.replace(/_/g, ' ') || 'Weather alert'
+    case 'nightly_e2e_failure':
+      return 'Nightly E2E workflow run failed'
     case 'custom':
       return condition.customQuery || 'Custom condition'
     default:


### PR DESCRIPTION
## Summary

- **Backend**: New `GET /api/nightly-e2e/run-logs` endpoint that fetches GitHub Actions job logs for failed workflow runs with 200KB tail truncation and 10-minute caching
- **UI**: "AI Diagnose" button on failed `RunDot` hover popups — fetches logs and launches an AI troubleshooting mission with full run context (guide, platform, model, GPU, failure reason)
- **Alerts**: New `nightly_e2e_failure` condition type with auto-enabled preset rule. Fires on any new failed nightly E2E run, sends browser notification (surfaces as macOS native notification) with deep link to the Nightly E2E Status card
- **Preset migration**: Existing users automatically get the new alert rule without clearing stored rules
- **Browser notification**: Requests permission on mount; notifications include deep link to the card via `?card=nightly_e2e_status`

## Test plan
- [ ] Open Nightly E2E card → hover a red/amber dot → verify "AI Diagnose" button appears alongside "View Logs"
- [ ] Click "AI Diagnose" → verify mission sidebar opens with log analysis
- [ ] Open Alerts panel → verify "Nightly E2E Failure" rule exists and is enabled
- [ ] If failed runs exist, verify alert fires and macOS notification appears
- [ ] Verify clicking notification navigates to the Nightly E2E card
- [ ] `go build ./...` passes
- [ ] `npm run build` passes
- [ ] `npx tsc --noEmit` passes