### PR TITLE
🐛 Show install instructions instead of broken GitHub login in demo mode

### DIFF
--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -1454,6 +1454,9 @@
     "demo": "Demo",
     "loginRequired": "Login Required",
     "loginWithGitHub": "Login with GitHub",
+    "loginExplanation": "Please login with GitHub to submit feedback, request updates, or close requests.",
+    "loginDemoExplanation": "This is a public demo — GitHub login requires your own KubeStellar Console instance. Install locally to submit feedback and unlock all features.",
+    "getYourOwn": "Get Your Own Console",
     "requestSubmitted": "Request Submitted!",
     "status": {
       "open": "Open",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1454,6 +1454,9 @@
     "demo": "Demo",
     "loginRequired": "Login Required",
     "loginWithGitHub": "Login with GitHub",
+    "loginExplanation": "Please login with GitHub to submit feedback, request updates, or close requests.",
+    "loginDemoExplanation": "This is a public demo — GitHub login requires your own KubeStellar Console instance. Install locally to submit feedback and unlock all features.",
+    "getYourOwn": "Get Your Own Console",
     "requestSubmitted": "Request Submitted!",
     "status": {
       "open": "Open",

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -1454,6 +1454,9 @@
     "demo": "Demo",
     "loginRequired": "Login Required",
     "loginWithGitHub": "Login with GitHub",
+    "loginExplanation": "Please login with GitHub to submit feedback, request updates, or close requests.",
+    "loginDemoExplanation": "This is a public demo — GitHub login requires your own KubeStellar Console instance. Install locally to submit feedback and unlock all features.",
+    "getYourOwn": "Get Your Own Console",
     "requestSubmitted": "Request Submitted!",
     "status": {
       "open": "Open",

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -1454,6 +1454,9 @@
     "demo": "Demo",
     "loginRequired": "Login Required",
     "loginWithGitHub": "Login with GitHub",
+    "loginExplanation": "Please login with GitHub to submit feedback, request updates, or close requests.",
+    "loginDemoExplanation": "This is a public demo — GitHub login requires your own KubeStellar Console instance. Install locally to submit feedback and unlock all features.",
+    "getYourOwn": "Get Your Own Console",
     "requestSubmitted": "Request Submitted!",
     "status": {
       "open": "Open",

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -1454,6 +1454,9 @@
     "demo": "Demo",
     "loginRequired": "Login Required",
     "loginWithGitHub": "Login with GitHub",
+    "loginExplanation": "Please login with GitHub to submit feedback, request updates, or close requests.",
+    "loginDemoExplanation": "This is a public demo — GitHub login requires your own KubeStellar Console instance. Install locally to submit feedback and unlock all features.",
+    "getYourOwn": "Get Your Own Console",
     "requestSubmitted": "Request Submitted!",
     "status": {
       "open": "Open",

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -1454,6 +1454,9 @@
     "demo": "Demo",
     "loginRequired": "Login Required",
     "loginWithGitHub": "Login with GitHub",
+    "loginExplanation": "Please login with GitHub to submit feedback, request updates, or close requests.",
+    "loginDemoExplanation": "This is a public demo — GitHub login requires your own KubeStellar Console instance. Install locally to submit feedback and unlock all features.",
+    "getYourOwn": "Get Your Own Console",
     "requestSubmitted": "Request Submitted!",
     "status": {
       "open": "Open",

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -1454,6 +1454,9 @@
     "demo": "Demo",
     "loginRequired": "Login Required",
     "loginWithGitHub": "Login with GitHub",
+    "loginExplanation": "Please login with GitHub to submit feedback, request updates, or close requests.",
+    "loginDemoExplanation": "This is a public demo — GitHub login requires your own KubeStellar Console instance. Install locally to submit feedback and unlock all features.",
+    "getYourOwn": "Get Your Own Console",
     "requestSubmitted": "Request Submitted!",
     "status": {
       "open": "Open",

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -1454,6 +1454,9 @@
     "demo": "Demo",
     "loginRequired": "Login Required",
     "loginWithGitHub": "Login with GitHub",
+    "loginExplanation": "Please login with GitHub to submit feedback, request updates, or close requests.",
+    "loginDemoExplanation": "This is a public demo — GitHub login requires your own KubeStellar Console instance. Install locally to submit feedback and unlock all features.",
+    "getYourOwn": "Get Your Own Console",
     "requestSubmitted": "Request Submitted!",
     "status": {
       "open": "Open",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -1454,6 +1454,9 @@
     "demo": "Demo",
     "loginRequired": "Login Required",
     "loginWithGitHub": "Login with GitHub",
+    "loginExplanation": "Please login with GitHub to submit feedback, request updates, or close requests.",
+    "loginDemoExplanation": "This is a public demo — GitHub login requires your own KubeStellar Console instance. Install locally to submit feedback and unlock all features.",
+    "getYourOwn": "Get Your Own Console",
     "requestSubmitted": "Request Submitted!",
     "status": {
       "open": "Open",


### PR DESCRIPTION
## Summary
- On the public demo (console.kubestellar.io), clicking "Login" in the Feedback dialog redirected to `localhost:8080/auth/github` — which doesn't exist and shows a browser error
- Now when `isDemoModeForced` is true (Netlify deployment), the login button opens the **Setup Instructions dialog** instead, guiding users to install their own KubeStellar Console instance
- Updated the login prompt message to explain why login isn't available on the public demo
- Added i18n keys: `loginExplanation`, `loginDemoExplanation`, `getYourOwn` across all 9 locales

## Before
User clicks Login → "Login with GitHub" → redirects to `localhost:8080` → browser error ("Unable to connect")

## After
User clicks Login → "Get Your Own Console" → opens Setup Instructions dialog with install steps

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (no new errors)
- [x] Verified `isDemoModeForced` correctly detects Netlify deployments
- [x] Non-demo mode (local dev with backend) still redirects to GitHub OAuth as before