### PR TITLE
🐛 Expand mission sidebar when startMission is called

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -684,6 +684,7 @@ The AI missions feature requires the local agent to be running.
     setMissions(prev => [mission, ...prev])
     setActiveMissionId(missionId)
     setIsSidebarOpen(true)
+    setIsSidebarMinimized(false)
 
     // Send to agent
     ensureConnection().then(() => {


### PR DESCRIPTION
## Summary
- `startMission()` called `setIsSidebarOpen(true)` but didn't clear `isSidebarMinimized`
- If the sidebar was previously minimized, clicking "AI Diagnose" on a failed RunDot would start the mission but the sidebar stayed in its thin minimized strip — the chat wasn't visible
- Now also calls `setIsSidebarMinimized(false)` to match `openSidebar()` behavior

## Test plan
- [ ] Click "AI Diagnose" on a failed nightly E2E dot — sidebar opens fully with the mission chat visible
- [ ] Minimize sidebar, then click "AI Diagnose" — sidebar expands to full width showing the chat