### PR TITLE
🐛 Show install dialog instead of sign-out on demo site

### DIFF
--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -1,8 +1,10 @@
 import { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { User, Mail, MessageSquare, Shield, Settings, LogOut, ChevronDown, Coins, Lightbulb, Linkedin, Globe, Check } from 'lucide-react'
+import { User, Mail, MessageSquare, Shield, Settings, LogOut, ChevronDown, Coins, Lightbulb, Linkedin, Globe, Check, Download } from 'lucide-react'
 import { useRewards, REWARD_ACTIONS } from '../../hooks/useRewards'
 import { languages } from '../../lib/i18n'
+import { isDemoModeForced } from '../../lib/demoMode'
+import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
 
 interface UserProfileDropdownProps {
   user: {
@@ -20,6 +22,7 @@ interface UserProfileDropdownProps {
 export function UserProfileDropdown({ user, onLogout, onPreferences, onFeedback }: UserProfileDropdownProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [showLanguageSubmenu, setShowLanguageSubmenu] = useState(false)
+  const [showSetupDialog, setShowSetupDialog] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
   const { totalCoins, awardCoins } = useRewards()
   const { t, i18n } = useTranslation()
@@ -212,16 +215,39 @@ export function UserProfileDropdown({ user, onLogout, onPreferences, onFeedback 
             <button
               onClick={() => {
                 setIsOpen(false)
-                onLogout()
+                if (isDemoModeForced) {
+                  setShowSetupDialog(true)
+                } else {
+                  onLogout()
+                }
               }}
-              className="w-full flex items-center gap-3 px-3 py-2 text-sm text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
+              className={`w-full flex items-center gap-3 px-3 py-2 text-sm rounded-lg transition-colors ${
+                isDemoModeForced
+                  ? 'text-purple-400 hover:bg-purple-500/10'
+                  : 'text-red-400 hover:bg-red-500/10'
+              }`}
             >
-              <LogOut className="w-4 h-4" />
-              {t('actions.signOut')}
+              {isDemoModeForced ? (
+                <>
+                  <Download className="w-4 h-4" />
+                  {t('actions.getYourOwn')}
+                </>
+              ) : (
+                <>
+                  <LogOut className="w-4 h-4" />
+                  {t('actions.signOut')}
+                </>
+              )}
             </button>
           </div>
         </div>
       )}
+
+      {/* Setup instructions dialog — shown when demo users click sign out */}
+      <SetupInstructionsDialog
+        isOpen={showSetupDialog}
+        onClose={() => setShowSetupDialog(false)}
+      />
     </div>
   )
 }

--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -30,6 +30,7 @@
     "restore": "Restore",
     "skip": "Skip",
     "signOut": "Sign Out",
+    "getYourOwn": "Get Your Own Console",
     "viewDetails": "View Details",
     "copied": "Copied!"
   },

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -30,6 +30,7 @@
     "restore": "Restore",
     "skip": "Skip",
     "signOut": "Sign Out",
+    "getYourOwn": "Get Your Own Console",
     "viewDetails": "View Details",
     "copied": "Copied!"
   },

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -30,6 +30,7 @@
     "restore": "Restore",
     "skip": "Skip",
     "signOut": "Sign Out",
+    "getYourOwn": "Get Your Own Console",
     "viewDetails": "View Details",
     "copied": "Copied!"
   },

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -30,6 +30,7 @@
     "restore": "Restore",
     "skip": "Skip",
     "signOut": "Sign Out",
+    "getYourOwn": "Get Your Own Console",
     "viewDetails": "View Details",
     "copied": "Copied!"
   },

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -30,6 +30,7 @@
     "restore": "Restore",
     "skip": "Skip",
     "signOut": "Sign Out",
+    "getYourOwn": "Get Your Own Console",
     "viewDetails": "View Details",
     "copied": "Copied!"
   },

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -30,6 +30,7 @@
     "restore": "Restore",
     "skip": "Skip",
     "signOut": "Sign Out",
+    "getYourOwn": "Get Your Own Console",
     "viewDetails": "View Details",
     "copied": "Copied!"
   },

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -30,6 +30,7 @@
     "restore": "Restore",
     "skip": "Skip",
     "signOut": "Sign Out",
+    "getYourOwn": "Get Your Own Console",
     "viewDetails": "View Details",
     "copied": "Copied!"
   },

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -30,6 +30,7 @@
     "restore": "Restore",
     "skip": "Skip",
     "signOut": "Sign Out",
+    "getYourOwn": "Get Your Own Console",
     "viewDetails": "View Details",
     "copied": "Copied!"
   },

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -30,6 +30,7 @@
     "restore": "Restore",
     "skip": "Skip",
     "signOut": "Sign Out",
+    "getYourOwn": "Get Your Own Console",
     "viewDetails": "View Details",
     "copied": "Copied!"
   },


### PR DESCRIPTION
## Summary
- On console.kubestellar.io (forced demo mode), the "Sign Out" button now opens the **SetupInstructionsDialog** instead of logging out
- Button changes to "Get Your Own Console" with download icon and purple styling
- Prevents the confusing loop where demo users sign out → auto-logged back in

## Changes
- **UserProfileDropdown.tsx**: Check `isDemoModeForced` on sign-out click; show setup dialog instead of calling `onLogout()`
- **i18n**: Added `actions.getYourOwn` key to all 9 locales

Fixes #1190

## Test plan
- [ ] Build passes
- [ ] On demo site: dropdown shows "Get Your Own Console" (purple) instead of "Sign Out" (red)
- [ ] Clicking it opens SetupInstructionsDialog
- [ ] On non-demo installs: "Sign Out" button works normally