### PR TITLE
🐛 Fix nil pointer panic in feedback submit without FEEDBACK_GITHUB_TOKEN

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -109,17 +109,17 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 	}
 
 	// Create notification for the user
+	notifTitle := "Request Submitted"
+	if request.GitHubIssueNumber != nil {
+		notifTitle = fmt.Sprintf("Issue #%d Created", *request.GitHubIssueNumber)
+	}
 	notification := &models.Notification{
 		UserID:           userID,
 		FeatureRequestID: &request.ID,
 		NotificationType: models.NotificationTypeIssueCreated,
-		Title:            fmt.Sprintf("Issue #%d Created", *request.GitHubIssueNumber),
+		Title:            notifTitle,
 		Message:          fmt.Sprintf("Your %s request '%s' has been submitted.", request.RequestType, request.Title),
 		ActionURL:        request.GitHubIssueURL,
-	}
-	// Use generic title if no issue number
-	if request.GitHubIssueNumber == nil {
-		notification.Title = "Request Submitted"
 	}
 	h.store.CreateNotification(notification)
 


### PR DESCRIPTION
## Summary
- **Root cause**: `CreateFeatureRequest` panicked with nil pointer dereference when `FEEDBACK_GITHUB_TOKEN` is not set
- The notification struct literal dereferenced `*request.GitHubIssueNumber` (nil) before the nil check on the next line could run
- This caused all feedback submissions to return 500 for users without the token configured

## Fix
Check `GitHubIssueNumber != nil` **before** using it in `fmt.Sprintf`, not after.

## Before (panics)
```go
notification := &models.Notification{
    Title: fmt.Sprintf("Issue #%d Created", *request.GitHubIssueNumber), // PANIC if nil
}
if request.GitHubIssueNumber == nil { // too late
    notification.Title = "Request Submitted"
}
```

## After (safe)
```go
notifTitle := "Request Submitted"
if request.GitHubIssueNumber != nil {
    notifTitle = fmt.Sprintf("Issue #%d Created", *request.GitHubIssueNumber)
}
notification := &models.Notification{
    Title: notifTitle,
}
```

## Test plan
- [ ] `go build ./cmd/...` passes
- [ ] Submit feedback without `FEEDBACK_GITHUB_TOKEN` set → succeeds (no panic)
- [ ] Submit feedback with `FEEDBACK_GITHUB_TOKEN` set → creates GitHub issue as before