### PR TITLE
✨ Add GitHub activity rewards — earn coins from issues & PRs

### DIFF
--- a/pkg/api/handlers/rewards.go
+++ b/pkg/api/handlers/rewards.go
@@ -1,0 +1,328 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/api/middleware"
+)
+
+// Point values for GitHub contributions
+const (
+	pointsBugIssue     = 300
+	pointsFeatureIssue = 100
+	pointsOtherIssue   = 50
+	pointsPROpened     = 200
+	pointsPRMerged     = 500
+	rewardsCacheTTL    = 10 * time.Minute
+	rewardsAPITimeout  = 30 * time.Second
+	rewardsPerPage     = 100 // GitHub max per page
+	rewardsMaxPages    = 10  // GitHub search max 1000 results
+)
+
+// RewardsConfig holds configuration for the rewards handler.
+type RewardsConfig struct {
+	GitHubToken string // PAT with public_repo scope
+	Orgs        string // GitHub search org filter, e.g. "org:kubestellar org:llm-d"
+}
+
+// GitHubContribution represents a single scored contribution.
+type GitHubContribution struct {
+	Type      string `json:"type"`       // issue_bug, issue_feature, issue_other, pr_opened, pr_merged
+	Title     string `json:"title"`      // Issue/PR title
+	URL       string `json:"url"`        // GitHub URL
+	Repo      string `json:"repo"`       // owner/repo
+	Number    int    `json:"number"`     // Issue/PR number
+	Points    int    `json:"points"`     // Points awarded
+	CreatedAt string `json:"created_at"` // ISO 8601
+}
+
+// RewardsBreakdown summarizes counts by category.
+type RewardsBreakdown struct {
+	BugIssues     int `json:"bug_issues"`
+	FeatureIssues int `json:"feature_issues"`
+	OtherIssues   int `json:"other_issues"`
+	PRsOpened     int `json:"prs_opened"`
+	PRsMerged     int `json:"prs_merged"`
+}
+
+// GitHubRewardsResponse is the API response.
+type GitHubRewardsResponse struct {
+	TotalPoints   int                  `json:"total_points"`
+	Contributions []GitHubContribution `json:"contributions"`
+	Breakdown     RewardsBreakdown     `json:"breakdown"`
+	CachedAt      string               `json:"cached_at"`
+	FromCache     bool                 `json:"from_cache"`
+}
+
+type rewardsCacheEntry struct {
+	response  *GitHubRewardsResponse
+	fetchedAt time.Time
+}
+
+// RewardsHandler serves GitHub-sourced reward data.
+type RewardsHandler struct {
+	githubToken string
+	orgs        string
+	httpClient  *http.Client
+
+	mu    sync.RWMutex
+	cache map[string]*rewardsCacheEntry // keyed by github_login
+}
+
+// NewRewardsHandler creates a handler for GitHub activity rewards.
+func NewRewardsHandler(cfg RewardsConfig) *RewardsHandler {
+	return &RewardsHandler{
+		githubToken: cfg.GitHubToken,
+		orgs:        cfg.Orgs,
+		httpClient:  &http.Client{Timeout: rewardsAPITimeout},
+		cache:       make(map[string]*rewardsCacheEntry),
+	}
+}
+
+// GetGitHubRewards returns the logged-in user's GitHub contribution rewards.
+// GET /api/rewards/github
+func (h *RewardsHandler) GetGitHubRewards(c *fiber.Ctx) error {
+	githubLogin := middleware.GetGitHubLogin(c)
+	if githubLogin == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "GitHub login not available"})
+	}
+
+	// Check cache
+	h.mu.RLock()
+	if entry, ok := h.cache[githubLogin]; ok && time.Since(entry.fetchedAt) < rewardsCacheTTL {
+		h.mu.RUnlock()
+		resp := *entry.response
+		resp.FromCache = true
+		return c.JSON(resp)
+	}
+	h.mu.RUnlock()
+
+	// Cache miss — fetch from GitHub
+	resp, err := h.fetchUserRewards(githubLogin)
+	if err != nil {
+		log.Printf("[rewards] Failed to fetch GitHub rewards for %s: %v", githubLogin, err)
+
+		// Return stale cache if available
+		h.mu.RLock()
+		if entry, ok := h.cache[githubLogin]; ok {
+			h.mu.RUnlock()
+			stale := *entry.response
+			stale.FromCache = true
+			return c.JSON(stale)
+		}
+		h.mu.RUnlock()
+
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "GitHub API unavailable"})
+	}
+
+	// Update cache
+	h.mu.Lock()
+	h.cache[githubLogin] = &rewardsCacheEntry{
+		response:  resp,
+		fetchedAt: time.Now(),
+	}
+	h.mu.Unlock()
+
+	return c.JSON(resp)
+}
+
+func (h *RewardsHandler) fetchUserRewards(login string) (*GitHubRewardsResponse, error) {
+	var contributions []GitHubContribution
+
+	// 1. Fetch issues authored by user
+	issues, err := h.searchItems(login, "issue")
+	if err != nil {
+		log.Printf("[rewards] Warning: failed to search issues for %s: %v", login, err)
+	} else {
+		for _, item := range issues {
+			c := classifyIssue(item)
+			contributions = append(contributions, c)
+		}
+	}
+
+	// 2. Fetch PRs authored by user
+	prs, err := h.searchItems(login, "pr")
+	if err != nil {
+		log.Printf("[rewards] Warning: failed to search PRs for %s: %v", login, err)
+	} else {
+		for _, item := range prs {
+			cs := classifyPR(item)
+			contributions = append(contributions, cs...)
+		}
+	}
+
+	// Compute totals
+	total := 0
+	breakdown := RewardsBreakdown{}
+	for _, c := range contributions {
+		total += c.Points
+		switch c.Type {
+		case "issue_bug":
+			breakdown.BugIssues++
+		case "issue_feature":
+			breakdown.FeatureIssues++
+		case "issue_other":
+			breakdown.OtherIssues++
+		case "pr_opened":
+			breakdown.PRsOpened++
+		case "pr_merged":
+			breakdown.PRsMerged++
+		}
+	}
+
+	return &GitHubRewardsResponse{
+		TotalPoints:   total,
+		Contributions: contributions,
+		Breakdown:     breakdown,
+		CachedAt:      time.Now().UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// searchItem is the subset of GitHub Search issue/PR item we care about.
+type searchItem struct {
+	Title       string            `json:"title"`
+	HTMLURL     string            `json:"html_url"`
+	Number      int               `json:"number"`
+	CreatedAt   string            `json:"created_at"`
+	Labels      []searchLabel     `json:"labels"`
+	PullRequest *searchPRRef      `json:"pull_request,omitempty"`
+	RepoURL     string            `json:"repository_url"` // e.g. https://api.github.com/repos/kubestellar/console
+}
+
+type searchLabel struct {
+	Name string `json:"name"`
+}
+
+type searchPRRef struct {
+	MergedAt *string `json:"merged_at,omitempty"`
+}
+
+type searchResponse struct {
+	TotalCount int          `json:"total_count"`
+	Items      []searchItem `json:"items"`
+}
+
+// searchItems queries GitHub Search API with pagination.
+// itemType is "issue" or "pr".
+func (h *RewardsHandler) searchItems(login, itemType string) ([]searchItem, error) {
+	query := fmt.Sprintf("author:%s %s type:%s", login, h.orgs, itemType)
+	var allItems []searchItem
+
+	for page := 1; page <= rewardsMaxPages; page++ {
+		apiURL := fmt.Sprintf("https://api.github.com/search/issues?q=%s&per_page=%d&page=%d&sort=created&order=desc",
+			url.QueryEscape(query), rewardsPerPage, page)
+
+		req, err := http.NewRequest("GET", apiURL, nil)
+		if err != nil {
+			return allItems, fmt.Errorf("create request: %w", err)
+		}
+		req.Header.Set("Accept", "application/vnd.github.v3+json")
+		if h.githubToken != "" {
+			req.Header.Set("Authorization", "Bearer "+h.githubToken)
+		}
+
+		resp, err := h.httpClient.Do(req)
+		if err != nil {
+			return allItems, fmt.Errorf("execute request: %w", err)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return allItems, fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(body[:min(len(body), 200)]))
+		}
+
+		if err != nil {
+			return allItems, fmt.Errorf("read body: %w", err)
+		}
+
+		var sr searchResponse
+		if err := json.Unmarshal(body, &sr); err != nil {
+			return allItems, fmt.Errorf("unmarshal: %w", err)
+		}
+
+		allItems = append(allItems, sr.Items...)
+
+		// Stop if we've fetched all results or hit the page limit
+		if len(allItems) >= sr.TotalCount || len(sr.Items) < rewardsPerPage {
+			break
+		}
+	}
+
+	return allItems, nil
+}
+
+// classifyIssue determines the issue type based on labels.
+func classifyIssue(item searchItem) GitHubContribution {
+	typ := "issue_other"
+	points := pointsOtherIssue
+
+	for _, label := range item.Labels {
+		switch label.Name {
+		case "bug", "kind/bug", "type/bug":
+			typ = "issue_bug"
+			points = pointsBugIssue
+		case "enhancement", "feature", "kind/feature", "type/feature":
+			typ = "issue_feature"
+			points = pointsFeatureIssue
+		}
+	}
+
+	return GitHubContribution{
+		Type:      typ,
+		Title:     item.Title,
+		URL:       item.HTMLURL,
+		Repo:      extractRepo(item.RepoURL),
+		Number:    item.Number,
+		Points:    points,
+		CreatedAt: item.CreatedAt,
+	}
+}
+
+// classifyPR returns one or two contributions: pr_opened (always) + pr_merged (if merged).
+func classifyPR(item searchItem) []GitHubContribution {
+	repo := extractRepo(item.RepoURL)
+	result := []GitHubContribution{
+		{
+			Type:      "pr_opened",
+			Title:     item.Title,
+			URL:       item.HTMLURL,
+			Repo:      repo,
+			Number:    item.Number,
+			Points:    pointsPROpened,
+			CreatedAt: item.CreatedAt,
+		},
+	}
+
+	if item.PullRequest != nil && item.PullRequest.MergedAt != nil {
+		result = append(result, GitHubContribution{
+			Type:      "pr_merged",
+			Title:     item.Title,
+			URL:       item.HTMLURL,
+			Repo:      repo,
+			Number:    item.Number,
+			Points:    pointsPRMerged,
+			CreatedAt: *item.PullRequest.MergedAt,
+		})
+	}
+
+	return result
+}
+
+// extractRepo parses "kubestellar/console" from "https://api.github.com/repos/kubestellar/console".
+func extractRepo(repoURL string) string {
+	const prefix = "https://api.github.com/repos/"
+	if len(repoURL) > len(prefix) {
+		return repoURL[len(prefix):]
+	}
+	return repoURL
+}

--- a/web/src/hooks/useGitHubRewards.ts
+++ b/web/src/hooks/useGitHubRewards.ts
@@ -1,0 +1,82 @@
+/**
+ * Hook for fetching GitHub-sourced reward data.
+ * Queries the backend which proxies GitHub Search API for the logged-in user's
+ * issues and PRs across configured orgs, computes points on the fly.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { useAuth } from '../lib/auth'
+import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { BACKEND_DEFAULT_URL } from '../lib/constants'
+import type { GitHubRewardsResponse } from '../types/rewards'
+
+const CACHE_KEY = 'github-rewards-cache'
+const REFRESH_INTERVAL_MS = 10 * 60 * 1000 // 10 minutes
+
+function loadCache(): GitHubRewardsResponse | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+function saveCache(data: GitHubRewardsResponse): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify(data))
+  } catch {
+    // quota exceeded — ignore
+  }
+}
+
+export function useGitHubRewards() {
+  const { user, isAuthenticated } = useAuth()
+  const [data, setData] = useState<GitHubRewardsResponse | null>(loadCache)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const isDemoUser = !user || user.github_login === 'demo-user'
+
+  const fetchRewards = useCallback(async () => {
+    if (!isAuthenticated || isDemoUser) return
+
+    const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+    if (!token) return
+
+    setIsLoading(true)
+    try {
+      const apiBase = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
+      const res = await fetch(`${apiBase}/api/rewards/github`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error(`API error: ${res.status}`)
+      const result: GitHubRewardsResponse = await res.json()
+      setData(result)
+      saveCache(result)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+      // Keep stale data if we have it
+    } finally {
+      setIsLoading(false)
+    }
+  }, [isAuthenticated, isDemoUser])
+
+  // Fetch on mount and refresh periodically
+  useEffect(() => {
+    if (!isAuthenticated || isDemoUser) return
+
+    fetchRewards()
+    const interval = setInterval(fetchRewards, REFRESH_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [fetchRewards, isAuthenticated, isDemoUser])
+
+  return {
+    githubRewards: data,
+    githubPoints: data?.total_points ?? 0,
+    isLoading,
+    error,
+    refresh: fetchRewards,
+  }
+}

--- a/web/src/types/rewards.ts
+++ b/web/src/types/rewards.ts
@@ -165,3 +165,53 @@ export const ACHIEVEMENTS: Achievement[] = [
     requiredAction: 'linkedin_share',
   },
 ]
+
+// GitHub-sourced reward types
+export type GitHubRewardType =
+  | 'issue_bug'
+  | 'issue_feature'
+  | 'issue_other'
+  | 'pr_opened'
+  | 'pr_merged'
+
+export interface GitHubContribution {
+  type: GitHubRewardType
+  title: string
+  url: string
+  repo: string
+  number: number
+  points: number
+  created_at: string
+}
+
+export interface GitHubRewardsBreakdown {
+  bug_issues: number
+  feature_issues: number
+  other_issues: number
+  prs_opened: number
+  prs_merged: number
+}
+
+export interface GitHubRewardsResponse {
+  total_points: number
+  contributions: GitHubContribution[]
+  breakdown: GitHubRewardsBreakdown
+  cached_at: string
+  from_cache: boolean
+}
+
+export const GITHUB_REWARD_POINTS: Record<GitHubRewardType, number> = {
+  issue_bug: 300,
+  issue_feature: 100,
+  issue_other: 50,
+  pr_opened: 200,
+  pr_merged: 500,
+}
+
+export const GITHUB_REWARD_LABELS: Record<GitHubRewardType, string> = {
+  issue_bug: 'Bug Report',
+  issue_feature: 'Feature Request',
+  issue_other: 'Issue',
+  pr_opened: 'PR Opened',
+  pr_merged: 'PR Merged',
+}


### PR DESCRIPTION
## Summary
- New backend endpoint `GET /api/rewards/github` queries GitHub Search API for all issues and PRs authored by the logged-in user across `kubestellar` and `llm-d` orgs
- Points computed on-the-fly: bug issue=300, feature issue=100, other issue=50, PR opened=200, PR merged=500
- Per-user in-memory cache with 10-minute TTL; reuses existing `FEEDBACK_GITHUB_TOKEN` PAT
- Frontend `useGitHubRewards` hook fetches from backend, caches in localStorage for instant display
- `useRewards` merges GitHub points with localStorage console-only rewards, deduplicating bug/feature submissions made through console UI
- RewardsPanel shows "GitHub Contributions" section with breakdown badges (PRs Merged, PRs Opened, Bug Reports, Feature Requests, Issues) and scrollable contribution list linking to GitHub

## Files Changed
| File | Action | Description |
|------|--------|-------------|
| `pkg/api/handlers/rewards.go` | NEW | Backend handler: GitHub Search API, pagination, classification, caching |
| `pkg/api/server.go` | MODIFIED | Config field + route registration |
| `web/src/types/rewards.ts` | MODIFIED | GitHub reward types, point constants, response interface |
| `web/src/hooks/useGitHubRewards.ts` | NEW | Frontend hook: fetch, cache, auto-refresh |
| `web/src/hooks/useRewards.tsx` | MODIFIED | Merge GitHub points, dedup, expose in context |
| `web/src/components/rewards/RewardsPanel.tsx` | MODIFIED | GitHub Contributions UI section |

## Test plan
- [ ] `go build ./...` passes
- [ ] `npm run build` passes
- [ ] Log in as GitHub user → profile shows merged coin total
- [ ] Open Rewards panel → "GitHub Contributions" section with breakdown badges
- [ ] Click contribution → opens GitHub issue/PR in new tab
- [ ] Refresh button fetches fresh data from GitHub
- [ ] Demo users don't trigger GitHub API calls