### PR TITLE
✨ Add GitHub contributions tab to feedback dialog

### DIFF
--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -5,6 +5,7 @@ import { useRewards, REWARD_ACTIONS } from '../../hooks/useRewards'
 import { languages } from '../../lib/i18n'
 import { isDemoModeForced } from '../../lib/demoMode'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
+import { FeatureRequestModal } from '../feedback/FeatureRequestModal'
 
 interface UserProfileDropdownProps {
   user: {
@@ -23,6 +24,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences, onFeedback 
   const [isOpen, setIsOpen] = useState(false)
   const [showLanguageSubmenu, setShowLanguageSubmenu] = useState(false)
   const [showSetupDialog, setShowSetupDialog] = useState(false)
+  const [showRewards, setShowRewards] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
   const { totalCoins, awardCoins } = useRewards()
   const { t, i18n } = useTranslation()
@@ -138,11 +140,18 @@ export function UserProfileDropdown({ user, onLogout, onPreferences, onFeedback 
                 {user.role || t('profile.defaultRole')}
               </span>
             </div>
-            <div className="flex items-center gap-3 px-2 py-1.5 text-sm">
+            <button
+              onClick={() => {
+                setIsOpen(false)
+                setShowRewards(true)
+              }}
+              className="w-full flex items-center gap-3 px-2 py-1.5 text-sm hover:bg-secondary/50 rounded-lg transition-colors"
+            >
               <Coins className="w-4 h-4 text-yellow-500" />
               <span className="text-muted-foreground">{t('profile.coins')}</span>
               <span className="text-yellow-400 font-medium">{totalCoins.toLocaleString()}</span>
-            </div>
+              <ChevronDown className="w-3 h-3 ml-auto text-muted-foreground -rotate-90" />
+            </button>
             {/* Language selector */}
             <div className="relative">
               <button
@@ -247,6 +256,14 @@ export function UserProfileDropdown({ user, onLogout, onPreferences, onFeedback 
       <SetupInstructionsDialog
         isOpen={showSetupDialog}
         onClose={() => setShowSetupDialog(false)}
+      />
+
+      {/* Rewards panel — opens feedback dialog to GitHub contributions tab */}
+      <FeatureRequestModal
+        isOpen={showRewards}
+        onClose={() => setShowRewards(false)}
+        initialTab="updates"
+        initialSubTab="github"
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- Adds a **GitHub** sub-tab to the Feedback dialog's Updates tab, showing the user's PRs and issues across kubestellar and llm-d orgs with point values, contribution type icons, breakdown badges, and links to GitHub
- Makes the **Coins** row in the User Profile dropdown clickable — clicking it opens the Feedback dialog directly to the GitHub contributions tab
- Contribution count badge shown on the GitHub sub-tab header

## Test plan
- [ ] Open the Feedback dialog (bug icon in navbar) → Updates tab → GitHub sub-tab shows contributions
- [ ] Click the coins row in the profile dropdown → opens Feedback dialog on the GitHub tab
- [ ] Verify each contribution links to the correct GitHub issue/PR
- [ ] Verify breakdown badges show correct counts (Merged, PRs, Bugs, Features, Issues)
- [ ] Verify refresh button re-fetches GitHub data
- [ ] Verify cache timestamp shows when data is cached