### PR TITLE
🐛 Fix GitHub tab: scrolling, partial data caching, username display

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -934,7 +934,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialSubTab
                   </div>
                 ) : (
                   /* GitHub Contributions Sub-tab */
-                  <div className="flex flex-col h-full">
+                  <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
                     {/* GitHub points summary */}
                     {githubRewards && (
                       <div className="p-3 border-b border-border/50 flex-shrink-0">
@@ -1016,7 +1016,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialSubTab
                                   {contrib.title}
                                 </p>
                                 <p className="text-xs text-muted-foreground">
-                                  {contrib.repo} #{contrib.number} · {GITHUB_REWARD_LABELS[contrib.type]}
+                                  @{currentGitHubLogin} · {contrib.repo} #{contrib.number} · {GITHUB_REWARD_LABELS[contrib.type]}
                                 </p>
                               </div>
                             </div>


### PR DESCRIPTION
## Summary
- Fix scrolling in GitHub contributions tab (content was not scrollable)
- Fix silent failure bug where partial results (issues only, 776/103K) would overwrite full cached data (2737/783K) when PR search fails
- Show GitHub username on each contribution line so users know contributions are theirs

## Test plan
- [ ] Open Feedback > Updates > GitHub tab — verify content scrolls
- [ ] Verify contribution lines show `@username` prefix
- [ ] Restart backend, check that partial API failures fall back to stale cache