### PR TITLE
🐛 Fix Activity tab showing count but empty list

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -228,6 +228,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialSubTab
         setActiveTab('updates')
         setUpdatesSubTab('requests')
         refreshRequests()
+        refreshNotifications()
       }, 3000)
     } catch (err) {
       setError(t('feedback.submitFailed'))

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -455,6 +455,7 @@ export function useNotifications() {
 
     pollingRef.current = window.setInterval(() => {
       loadUnreadCount()
+      loadNotifications()
     }, 30000)
 
     return () => {
@@ -462,7 +463,7 @@ export function useNotifications() {
         clearInterval(pollingRef.current)
       }
     }
-  }, [loadUnreadCount])
+  }, [loadUnreadCount, loadNotifications])
 
   const markAsRead = useCallback(async (id: string) => {
     // In demo mode, just update local state


### PR DESCRIPTION
## Summary
- Notification polling only refreshed `unreadCount`, not the `notifications` list — after submitting feedback, the Activity badge showed "1" but the list was empty
- Now polls both count and list every 30s
- Also refreshes notifications when auto-switching to Queue after submit

## Test plan
- [ ] Submit feedback → auto-switch to Queue → click Activity → notification appears
- [ ] Badge count matches actual notification list