### PR TITLE
✨ Add developer panel to user profile dropdown

### DIFF
--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -513,6 +513,16 @@
     "notConnected": "Not connected",
     "defaultRole": "User"
   },
+  "developer": {
+    "title": "Developer",
+    "oauthConfigured": "OAuth configured",
+    "oauthNotConfigured": "OAuth not configured",
+    "checkingOauth": "Checking OAuth...",
+    "setupInstructions": "Setup Instructions",
+    "configureOauth": "Configure GitHub OAuth",
+    "githubRepo": "GitHub Repository",
+    "docs": "Documentation"
+  },
   "language": {
     "select": "Select Language"
   },

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -513,6 +513,16 @@
     "notConnected": "Not connected",
     "defaultRole": "User"
   },
+  "developer": {
+    "title": "Developer",
+    "oauthConfigured": "OAuth configured",
+    "oauthNotConfigured": "OAuth not configured",
+    "checkingOauth": "Checking OAuth...",
+    "setupInstructions": "Setup Instructions",
+    "configureOauth": "Configure GitHub OAuth",
+    "githubRepo": "GitHub Repository",
+    "docs": "Documentation"
+  },
   "language": {
     "select": "Select Language"
   },

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -513,6 +513,16 @@
     "notConnected": "Not connected",
     "defaultRole": "User"
   },
+  "developer": {
+    "title": "Developer",
+    "oauthConfigured": "OAuth configured",
+    "oauthNotConfigured": "OAuth not configured",
+    "checkingOauth": "Checking OAuth...",
+    "setupInstructions": "Setup Instructions",
+    "configureOauth": "Configure GitHub OAuth",
+    "githubRepo": "GitHub Repository",
+    "docs": "Documentation"
+  },
   "language": {
     "select": "Select Language"
   },

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -513,6 +513,16 @@
     "notConnected": "Not connected",
     "defaultRole": "User"
   },
+  "developer": {
+    "title": "Developer",
+    "oauthConfigured": "OAuth configured",
+    "oauthNotConfigured": "OAuth not configured",
+    "checkingOauth": "Checking OAuth...",
+    "setupInstructions": "Setup Instructions",
+    "configureOauth": "Configure GitHub OAuth",
+    "githubRepo": "GitHub Repository",
+    "docs": "Documentation"
+  },
   "language": {
     "select": "Select Language"
   },

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -513,6 +513,16 @@
     "notConnected": "Not connected",
     "defaultRole": "User"
   },
+  "developer": {
+    "title": "Developer",
+    "oauthConfigured": "OAuth configured",
+    "oauthNotConfigured": "OAuth not configured",
+    "checkingOauth": "Checking OAuth...",
+    "setupInstructions": "Setup Instructions",
+    "configureOauth": "Configure GitHub OAuth",
+    "githubRepo": "GitHub Repository",
+    "docs": "Documentation"
+  },
   "language": {
     "select": "Select Language"
   },

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -513,6 +513,16 @@
     "notConnected": "Not connected",
     "defaultRole": "User"
   },
+  "developer": {
+    "title": "Developer",
+    "oauthConfigured": "OAuth configured",
+    "oauthNotConfigured": "OAuth not configured",
+    "checkingOauth": "Checking OAuth...",
+    "setupInstructions": "Setup Instructions",
+    "configureOauth": "Configure GitHub OAuth",
+    "githubRepo": "GitHub Repository",
+    "docs": "Documentation"
+  },
   "language": {
     "select": "Select Language"
   },

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -513,6 +513,16 @@
     "notConnected": "Not connected",
     "defaultRole": "User"
   },
+  "developer": {
+    "title": "Developer",
+    "oauthConfigured": "OAuth configured",
+    "oauthNotConfigured": "OAuth not configured",
+    "checkingOauth": "Checking OAuth...",
+    "setupInstructions": "Setup Instructions",
+    "configureOauth": "Configure GitHub OAuth",
+    "githubRepo": "GitHub Repository",
+    "docs": "Documentation"
+  },
   "language": {
     "select": "Select Language"
   },

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -513,6 +513,16 @@
     "notConnected": "Not connected",
     "defaultRole": "User"
   },
+  "developer": {
+    "title": "Developer",
+    "oauthConfigured": "OAuth configured",
+    "oauthNotConfigured": "OAuth not configured",
+    "checkingOauth": "Checking OAuth...",
+    "setupInstructions": "Setup Instructions",
+    "configureOauth": "Configure GitHub OAuth",
+    "githubRepo": "GitHub Repository",
+    "docs": "Documentation"
+  },
   "language": {
     "select": "Select Language"
   },

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -513,6 +513,16 @@
     "notConnected": "Not connected",
     "defaultRole": "User"
   },
+  "developer": {
+    "title": "Developer",
+    "oauthConfigured": "OAuth configured",
+    "oauthNotConfigured": "OAuth not configured",
+    "checkingOauth": "Checking OAuth...",
+    "setupInstructions": "Setup Instructions",
+    "configureOauth": "Configure GitHub OAuth",
+    "githubRepo": "GitHub Repository",
+    "docs": "Documentation"
+  },
   "language": {
     "select": "Select Language"
   },


### PR DESCRIPTION
## Summary
- Adds a collapsible **Developer** section in the user profile dropdown for local/cluster installs
- Hidden on demo site (console.kubestellar.io) since it's not relevant there
- Shows: version info (dev/prod badge + version + commit SHA), OAuth status (configured/not configured), and quick links

## What's in the panel
- **Version**: dev/prod mode badge, version number, commit hash
- **OAuth Status**: Lazy-checked when panel is expanded — green check if configured, yellow warning if not
- **Setup Instructions**: Opens the existing SetupInstructionsDialog (curl command, run from source, OAuth setup)
- **Configure GitHub OAuth**: Direct link to GitHub Developer Settings (only shown when OAuth is not configured)
- **GitHub Repository**: Link to kubestellar/console
- **Documentation**: Link to console-docs.kubestellar.io

## Why
Previously, developers running the console locally had no easy way to find setup instructions, check OAuth status, or access docs from within the UI. The SetupInstructionsDialog existed but was only reachable through the demo site sign-out flow or feedback dialog error state.

## Test plan
- [ ] Open profile dropdown on localhost — see "Developer" section with expand chevron
- [ ] Expand — verify version, OAuth status, and all links render
- [ ] Click "Setup Instructions" — verify dialog opens
- [ ] On console.kubestellar.io — verify Developer section is NOT shown