### PR TITLE
🐛 Restrict rewards to console repos only

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -807,7 +807,7 @@ func LoadConfigFromEnv() Config {
 		FeedbackRepoOwner:   getEnvOrDefault("FEEDBACK_REPO_OWNER", "kubestellar"),
 		FeedbackRepoName:    getEnvOrDefault("FEEDBACK_REPO_NAME", "console"),
 		// GitHub activity rewards
-		RewardsGitHubOrgs: getEnvOrDefault("REWARDS_GITHUB_ORGS", "org:kubestellar org:llm-d"),
+		RewardsGitHubOrgs: getEnvOrDefault("REWARDS_GITHUB_ORGS", "repo:kubestellar/console repo:kubestellar/console-marketplace"),
 		// Skip onboarding questionnaire for new users
 		SkipOnboarding: os.Getenv("SKIP_ONBOARDING") == "true",
 		// Benchmark data from Google Drive


### PR DESCRIPTION
## Summary
- Change default rewards scope from `org:kubestellar org:llm-d` (all repos) to `repo:kubestellar/console repo:kubestellar/console-marketplace`
- Coins should only be awarded for console-related contributions, not all org activity

## Test plan
- [ ] Restart backend → rewards only show console/console-marketplace contributions
- [ ] Override via `REWARDS_GITHUB_ORGS` env var still works