### PR TITLE
🐛 Filter queue to only show feedback-submitted issues

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -398,8 +398,8 @@ func (h *FeedbackHandler) fetchGitHubIssues() ([]GitHubIssue, error) {
 		return nil, fmt.Errorf("GitHub not configured")
 	}
 
-	// Fetch both open and closed issues so merged items stay in the queue
-	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues?state=all&per_page=50&sort=updated&direction=desc",
+	// Fetch only issues submitted through the feedback system (labeled ai-fix-requested)
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues?state=all&labels=ai-fix-requested&per_page=50&sort=updated&direction=desc",
 		h.repoOwner, h.repoName)
 
 	req, err := http.NewRequest("GET", url, nil)


### PR DESCRIPTION
## Summary
- Queue was fetching ALL issues from kubestellar/console, showing unrelated issues and PRs
- Now filters by `ai-fix-requested` label, which is applied to every issue created through the feedback dialog
- Only feedback-submitted issues appear in Queue and Activity tabs

## Test plan
- [ ] Open feedback dialog → Queue tab → verify only feedback-created issues appear (not random repo issues)