### PR TITLE
✨ Add architecture note to demo mode setup dialog

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -316,7 +316,7 @@ export function Layout({ children }: LayoutProps) {
               Demo Mode
             </span>
             <span className="hidden md:inline text-xs text-yellow-400/70">
-              Showing sample data from all cloud providers
+              Showing sample data only — install locally to monitor your real clusters
             </span>
             <button
               onClick={() => setShowSetupDialog(true)}

--- a/web/src/components/setup/SetupInstructionsDialog.tsx
+++ b/web/src/components/setup/SetupInstructionsDialog.tsx
@@ -53,6 +53,35 @@ export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDi
 
       <BaseModal.Content>
         <div className="space-y-3">
+          {/* Architecture note */}
+          <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-3">
+            <div className="flex items-start gap-2.5">
+              <div className="flex-shrink-0 w-5 h-5 rounded-full bg-blue-500/20 flex items-center justify-center mt-0.5">
+                <span className="text-blue-400 text-xs font-bold">i</span>
+              </div>
+              <div className="text-xs text-muted-foreground space-y-1.5">
+                <p>
+                  <span className="text-blue-400 font-medium">console.kubestellar.io is a demo</span> — it shows sample data only.
+                  To monitor your real clusters, install the console locally or in a cluster:
+                </p>
+                <div className="font-mono text-[11px] text-foreground/60 leading-relaxed">
+                  <span className="text-blue-400">Browser</span>
+                  {' \u2192 '}
+                  <span className="text-purple-400">Frontend</span>
+                  {' \u2192 '}
+                  <span className="text-purple-400">Backend</span>
+                  {' \u2192 '}
+                  <span className="text-purple-400">kc-agent</span>
+                  {' \u2192 '}
+                  <span className="text-green-400">Your clusters</span>
+                </div>
+                <p className="text-muted-foreground/70">
+                  The kc-agent reads your kubeconfig and streams live data from all your clusters to the console.
+                </p>
+              </div>
+            </div>
+          </div>
+
           {/* Single-step quickstart */}
           <div className="rounded-lg border border-border/50 bg-secondary/30 p-3">
             <div className="flex items-start gap-3">


### PR DESCRIPTION
## Summary

- Adds a "How it works" architecture section to the setup instructions dialog, explaining the data flow: `Browser → Frontend → Backend → kc-agent → Your clusters`
- Makes it clear that console.kubestellar.io is demo-only and real cluster monitoring requires local/in-cluster installation
- Updates the demo mode banner text from "Showing sample data from all cloud providers" to "Showing sample data only — install locally to monitor your real clusters"

## Motivation

Issue #1203 — users visiting console.kubestellar.io don't understand they need to install locally to see real cluster data. The existing "Demo Mode" banner and setup dialog didn't explicitly explain the architecture or that the kc-agent is the bridge to their clusters.

## Test plan

- [ ] Visit console.kubestellar.io and verify updated banner text
- [ ] Click "Want your own local KubeStellar Console?" and verify the architecture note appears above the quickstart command
- [ ] Verify the data flow diagram renders correctly

Closes #1203