### PR TITLE
🐛 On-demand preview check via GitHub Deployments API

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -618,6 +618,7 @@ func (s *Server) setupRoutes() {
 	api.Post("/feedback/requests/:id/feedback", feedback.SubmitFeedback)
 	api.Post("/feedback/requests/:id/close", feedback.CloseRequest)
 	api.Post("/feedback/requests/:id/request-update", feedback.RequestUpdate)
+	api.Get("/feedback/preview/:pr_number", feedback.CheckPreviewStatus)
 	api.Get("/notifications", feedback.GetNotifications)
 	api.Get("/notifications/unread-count", feedback.GetUnreadCount)
 	api.Post("/notifications/:id/read", feedback.MarkNotificationRead)


### PR DESCRIPTION
## Summary
- Add `CheckPreviewStatus` endpoint (`GET /api/feedback/preview/:pr_number`) that queries GitHub Deployments API to verify Netlify deploy preview is actually ready before showing it
- Remove automatic DB preview URL lookup from queue loading — preview URLs are now fetched on-demand via "Check Preview" button
- Replace `ensureFeatureRequestExists` with `findFeatureRequest` (lookup only, no auto-creation) — webhook handlers no longer create DB records for external GitHub issues. GitHub is the source of truth; DB only tracks items submitted through the Console UI
- Frontend shows "Check Preview" button for queue items with a PR but no preview URL. Clicking it queries the Deployments API and shows the result

## Test plan
- [ ] Log in, submit a bug/feature request, verify it appears in the queue
- [ ] For a queue item with a PR, click "Check Preview" — should show "Building..." or the actual preview link when ready
- [ ] Verify webhook label events (triage/accepted, etc.) still update existing DB records
- [ ] Verify webhook events for issues NOT created through the Console are ignored (no DB records created)