### PR TITLE
🐛 Fix Copilot Session link and preview timing

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -249,11 +249,9 @@ func (h *FeedbackHandler) ListAllFeatureRequests(c *fiber.Ctx) error {
 		// Check for linked PR - if we have one, at minimum it's fix_ready
 		var prNumber int
 		var prURL string
-		var copilotSessionURL string
 		if pr, ok := linkedPRs[issue.Number]; ok {
 			prNumber = pr.Number
 			prURL = pr.HTMLURL
-			copilotSessionURL = pr.HTMLURL
 			// If PR is merged (check MergedAt since Merged field isn't in list response), status is fix_complete
 			if pr.MergedAt != nil {
 				status = "fix_complete"
@@ -297,10 +295,9 @@ func (h *FeedbackHandler) ListAllFeatureRequests(c *fiber.Ctx) error {
 			GitHubIssueNumber: issue.Number,
 			GitHubIssueURL:    issue.HTMLURL,
 			Status:            status,
-			PRNumber:          prNumber,
-			PRURL:             prURL,
-			CopilotSessionURL: copilotSessionURL,
-			ClosedByUser:      closedByUser,
+			PRNumber:     prNumber,
+			PRURL:        prURL,
+			ClosedByUser: closedByUser,
 			CreatedAt:         issue.CreatedAt,
 			UpdatedAt:         issue.UpdatedAt,
 		})

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -686,34 +686,18 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialSubTab
                                   </div>
                                 </>
                               )}
-                              {/* Show PR and Copilot session links during AI processing (feasibility_study) */}
-                              {request.status === 'feasibility_study' && (
-                                <div className="flex flex-wrap gap-2 mt-1.5">
-                                  {request.pr_url && (
-                                    <a
-                                      href={request.pr_url}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="text-xs flex items-center gap-1 text-purple-400 hover:text-purple-300"
-                                      onClick={e => e.stopPropagation()}
-                                    >
-                                      <GitPullRequest className="w-3 h-3" />
-                                      PR #{request.pr_number}
-                                    </a>
-                                  )}
-                                  {request.copilot_session_url && (
-                                    <a
-                                      href={request.copilot_session_url}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="text-xs flex items-center gap-1 text-purple-400 hover:text-purple-300"
-                                      onClick={e => e.stopPropagation()}
-                                    >
-                                      <ExternalLink className="w-3 h-3" />
-                                      Copilot Session
-                                    </a>
-                                  )}
-                                </div>
+                              {/* Show PR link during AI processing (feasibility_study) */}
+                              {request.status === 'feasibility_study' && request.pr_url && (
+                                <a
+                                  href={request.pr_url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-xs flex items-center gap-1 mt-1.5 text-purple-400 hover:text-purple-300"
+                                  onClick={e => e.stopPropagation()}
+                                >
+                                  <GitPullRequest className="w-3 h-3" />
+                                  PR #{request.pr_number}
+                                </a>
                               )}
                               {/* Show PR link if fix is ready */}
                               {request.status === 'fix_ready' && request.pr_url && (
@@ -788,11 +772,10 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialSubTab
                                   <p className="line-clamp-3">{request.latest_comment}</p>
                                 </div>
                               )}
-                              {/* Preview section: show preview URL from server or on-demand check result */}
-                              {(() => {
-                                const serverPreview = request.netlify_preview_url
+                              {/* Preview section: only for fix_ready/fix_complete — not during AI working */}
+                              {(request.status === 'fix_ready' || request.status === 'fix_complete') && (() => {
                                 const checkedPreview = request.pr_number ? previewResults[request.pr_number] : null
-                                const previewUrl = serverPreview || (checkedPreview?.status === 'ready' ? checkedPreview.preview_url : null)
+                                const previewUrl = request.netlify_preview_url || (checkedPreview?.status === 'ready' ? checkedPreview.preview_url : null)
                                 const isCheckingThis = previewChecking === request.pr_number
 
                                 if (previewUrl && request.status === 'fix_ready') {
@@ -818,8 +801,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialSubTab
                                     </div>
                                   )
                                 }
-                                if (previewUrl && !request.closed_by_user) {
-                                  // Simple preview link for other statuses
+                                if (previewUrl) {
                                   return (
                                     <a
                                       href={previewUrl}
@@ -829,12 +811,12 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialSubTab
                                       onClick={e => e.stopPropagation()}
                                     >
                                       <Eye className="w-3 h-3" />
-                                      Preview Fix
+                                      Preview
                                     </a>
                                   )
                                 }
-                                // No preview yet — show Check Preview button if there's a PR
-                                if (request.pr_number && !request.closed_by_user && request.status !== 'closed') {
+                                // No preview yet — show Check Preview button
+                                if (request.pr_number && request.status === 'fix_ready') {
                                   return (
                                     <div className="mt-1.5 flex items-center gap-2">
                                       <button


### PR DESCRIPTION
## Summary
- Remove fake "Copilot Session" link — it was just the PR URL duplicated, misleading users
- Only show preview controls (Check Preview button, Preview Available) for `fix_ready` and `fix_complete` statuses
- No preview controls during `feasibility_study` (AI Working) — draft PRs don't have deploy previews

## Test plan
- [ ] Queue item in "AI Working" status shows PR link but NOT "Copilot Session" or "Preview Fix"
- [ ] Queue item in "Fix Ready" status shows "Check Preview" button
- [ ] Clicking "Check Preview" queries GitHub Deployments API and shows result