### PR TITLE
✨ Preview warmup delay and hide closed request notifications

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -378,6 +378,7 @@ func (h *FeedbackHandler) CheckPreviewStatus(c *fiber.Ctx) error {
 	var statuses []struct {
 		State     string `json:"state"`
 		TargetURL string `json:"target_url"`
+		CreatedAt string `json:"created_at"`
 	}
 	if err := json.NewDecoder(resp2.Body).Decode(&statuses); err != nil {
 		return c.JSON(fiber.Map{"status": "error", "message": "Failed to parse deployment statuses"})
@@ -392,6 +393,7 @@ func (h *FeedbackHandler) CheckPreviewStatus(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{
 			"status":      "ready",
 			"preview_url": latestStatus.TargetURL,
+			"ready_at":    latestStatus.CreatedAt,
 		})
 	}
 


### PR DESCRIPTION
## Summary
- Add 30-second warmup delay before showing "Preview Available" link to allow Netlify routes to come online after deployment succeeds
- Backend returns `ready_at` timestamp from GitHub deployment status `created_at`
- Frontend shows "Preview warming up... (Xs)" countdown during warmup period
- Filter out notifications for closed requests from Activity tab — closing from Queue now removes them from Activity too
- Compute unread count excluding closed request notifications so badge count is accurate

## Test plan
- [ ] Close a request from Queue → verify its notification disappears from Activity tab
- [ ] Check preview on a recently deployed PR → verify warmup countdown shows
- [ ] After 30s, verify "Try It" button appears
- [ ] Verify unread badge count excludes closed requests