### PR TITLE
✨ Unify Contribute modal: merge Queue + Activity, simplify Submit form

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.5.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/oauth2 v0.30.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.0
@@ -54,6 +55,7 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/onsi/gomega v1.33.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
@@ -61,6 +63,7 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.3 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.55.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
+github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=

--- a/pkg/api/handlers/auth_test.go
+++ b/pkg/api/handlers/auth_test.go
@@ -1,0 +1,220 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/api/middleware"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// setupAuthTest creates a fresh Fiber app and an AuthHandler with a mock store
+func setupAuthTest() (*fiber.App, *test.MockStore, *AuthHandler) {
+	app := fiber.New()
+	mockStore := new(test.MockStore)
+	cfg := AuthConfig{
+		GitHubClientID: "", // Trigger DevMode
+		JWTSecret:      "test-secret",
+		FrontendURL:    "http://frontend",
+		DevMode:        true,
+	}
+	handler := NewAuthHandler(mockStore, cfg)
+
+	return app, mockStore, handler
+}
+
+func TestDevModeLogin(t *testing.T) {
+	app, mockStore, handler := setupAuthTest()
+	app.Get("/auth/dev", handler.devModeLogin)
+
+	t.Run("Create new dev user success", func(t *testing.T) {
+		mockStore.On("GetUserByGitHubID", "dev-dev-user").Return(nil, nil).Once()
+		mockStore.On("CreateUser", mock.Anything).Return(nil).Once()
+		mockStore.On("UpdateLastLogin", mock.Anything).Return(nil).Once()
+
+		req, _ := http.NewRequest("GET", "/auth/dev", nil)
+		resp, err := app.Test(req, 5000)
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+
+		loc, _ := resp.Location()
+		assert.Contains(t, loc.String(), "token=")
+		assert.Contains(t, loc.String(), "onboarded=true") // Dev user is auto-onboarded
+	})
+
+	t.Run("Existing dev user success", func(t *testing.T) {
+		existingUser := &models.User{
+			ID:          uuid.New(),
+			GitHubID:    "dev-dev-user",
+			GitHubLogin: "dev-user",
+			Onboarded:   false,
+		}
+
+		mockStore.On("GetUserByGitHubID", "dev-dev-user").Return(existingUser, nil).Once()
+		mockStore.On("UpdateUser", mock.Anything).Return(nil).Once()
+		mockStore.On("UpdateLastLogin", existingUser.ID).Return(nil).Once()
+
+		req, _ := http.NewRequest("GET", "/auth/dev", nil)
+		resp, err := app.Test(req, 5000)
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+
+		loc, _ := resp.Location()
+		assert.Contains(t, loc.String(), "token=")
+		assert.Contains(t, loc.String(), "onboarded=false")
+	})
+}
+
+func TestRefreshToken(t *testing.T) {
+	app, mockStore, handler := setupAuthTest()
+	app.Post("/auth/refresh", handler.RefreshToken)
+
+	t.Run("Valid token refresh", func(t *testing.T) {
+		// 1. Generate a valid token manually
+		uid := uuid.New()
+		user := &models.User{ID: uid, GitHubLogin: "test", Onboarded: true}
+		token, _ := handler.generateJWT(user)
+
+		// 2. Setup mock
+		mockStore.On("GetUser", uid).Return(user, nil).Once()
+
+		// 3. Request
+		req, _ := http.NewRequest("POST", "/auth/refresh", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := app.Test(req, 5000)
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&body)
+		assert.NotEmpty(t, body["token"])
+		assert.Equal(t, true, body["onboarded"])
+	})
+
+	t.Run("Missing Authorization Header", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "/auth/refresh", nil)
+		resp, _ := app.Test(req, 5000)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("Invalid Token", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", "/auth/refresh", nil)
+		req.Header.Set("Authorization", "Bearer invalid-token-string")
+		resp, _ := app.Test(req, 5000)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("User Not Found", func(t *testing.T) {
+		uid := uuid.New()
+		user := &models.User{ID: uid}
+		token, _ := handler.generateJWT(user)
+
+		mockStore.On("GetUser", uid).Return(nil, nil).Once()
+
+		req, _ := http.NewRequest("POST", "/auth/refresh", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, _ := app.Test(req, 5000)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+
+	t.Run("Expired Token", func(t *testing.T) {
+		// Generate expired token
+		claims := middleware.UserClaims{
+			UserID: uuid.New(),
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(-1 * time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+		signed, _ := token.SignedString([]byte("test-secret"))
+
+		req, _ := http.NewRequest("POST", "/auth/refresh", nil)
+		req.Header.Set("Authorization", "Bearer "+signed)
+		resp, _ := app.Test(req, 5000)
+
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	})
+}
+
+func TestGitHubLogin_Redirects(t *testing.T) {
+	app, _, _ := setupAuthTest()
+	// Override config to simulate existing OAuth credentials
+	cfg := AuthConfig{
+		GitHubClientID: "client-id",
+		GitHubSecret:   "secret",
+		BackendURL:     "http://backend",
+	}
+	handler := NewAuthHandler(nil, cfg)
+	app.Get("/auth/github", handler.GitHubLogin)
+
+	req, _ := http.NewRequest("GET", "/auth/github", nil)
+	resp, err := app.Test(req, 5000)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+
+	loc, _ := resp.Location()
+	assert.Contains(t, loc.String(), "github.com/login/oauth/authorize")
+	assert.Contains(t, loc.String(), "client_id=client-id")
+}
+
+func TestGenerateJWT(t *testing.T) {
+	_, _, handler := setupAuthTest()
+	user := &models.User{
+		ID:          uuid.New(),
+		GitHubLogin: "test-user",
+	}
+
+	token, err := handler.generateJWT(user)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, token)
+
+	// Verify manually
+	parsed, err := jwt.ParseWithClaims(token, &middleware.UserClaims{}, func(t *jwt.Token) (interface{}, error) {
+		return []byte("test-secret"), nil
+	})
+	assert.NoError(t, err)
+	claims, ok := parsed.Claims.(*middleware.UserClaims)
+	assert.True(t, ok)
+	assert.Equal(t, user.ID, claims.UserID)
+	assert.Equal(t, "test-user", claims.GitHubLogin)
+}
+
+func TestGitHubCallback_MissingCode(t *testing.T) {
+	app, _, handler := setupAuthTest()
+	app.Get("/auth/callback", handler.GitHubCallback)
+
+	req, _ := http.NewRequest("GET", "/auth/callback", nil)
+	resp, _ := app.Test(req, 5000)
+
+	assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+	loc, _ := resp.Location()
+	assert.Contains(t, loc.String(), "error=missing_code")
+}
+
+func TestGitHubCallback_InvalidState(t *testing.T) {
+	app, _, handler := setupAuthTest()
+	app.Get("/auth/callback", handler.GitHubCallback)
+
+	// Provide code but no state
+	req, _ := http.NewRequest("GET", "/auth/callback?code=123", nil)
+	resp, _ := app.Test(req, 5000)
+
+	assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+	loc, _ := resp.Location()
+	assert.Contains(t, loc.String(), "error=csrf_validation_failed")
+}
+
+// We cannot easily test successful GitHubCallback flow without mocking oauth lib
+// or doing extensive interface extraction, but we covered the error headers above.

--- a/pkg/api/handlers/gateway_test.go
+++ b/pkg/api/handlers/gateway_test.go
@@ -1,0 +1,243 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/kubestellar/console/pkg/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// gatewayGVRs returns the standard GVR-to-list-kind map for Gateway resources.
+func gatewayGVRs() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}:      "GatewayList",
+		{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "gateways"}: "GatewayList",
+	}
+}
+
+// httpRouteGVRs returns the standard GVR-to-list-kind map for HTTPRoute resources.
+func httpRouteGVRs() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "httproutes"}:      "HTTPRouteList",
+		{Group: "gateway.networking.k8s.io", Version: "v1beta1", Resource: "httproutes"}: "HTTPRouteList",
+	}
+}
+
+func TestListGateways(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewGatewayHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/gateway/gateways", handler.ListGateways)
+
+	gw := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "Gateway",
+			"metadata": map[string]interface{}{
+				"name":      "my-gateway",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"gatewayClassName": "test-class",
+			},
+		},
+	}
+
+	dynClient := injectDynamicCluster(env, "test-cluster", gatewayGVRs())
+
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{
+			Object: map[string]interface{}{"kind": "GatewayList", "apiVersion": "gateway.networking.k8s.io/v1"},
+			Items:  []unstructured.Unstructured{*gw},
+		}, nil
+	})
+
+	// Case 1: List all (success)
+	req, _ := http.NewRequest("GET", "/api/gateway/gateways", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var list v1alpha1.GatewayList
+	body, _ := io.ReadAll(resp.Body)
+	err = json.Unmarshal(body, &list)
+	require.NoError(t, err)
+	require.NotEmpty(t, list.Items)
+	assert.Equal(t, "my-gateway", list.Items[0].Name)
+
+	// Case 2: List specific cluster (success)
+	req2, _ := http.NewRequest("GET", "/api/gateway/gateways?cluster=test-cluster", nil)
+	resp2, err := env.App.Test(req2, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp2.StatusCode)
+
+	// Case 3: List specific cluster (failure — error swallowed, returns 200 with empty list)
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("simulated error")
+	})
+
+	req3, _ := http.NewRequest("GET", "/api/gateway/gateways?cluster=test-cluster", nil)
+	resp3, err := env.App.Test(req3, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp3.StatusCode)
+}
+
+func TestGetGateway(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewGatewayHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/gateway/gateways/:cluster/:namespace/:name", handler.GetGateway)
+
+	gw := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "Gateway",
+			"metadata": map[string]interface{}{
+				"name":      "target-gw",
+				"namespace": "default",
+			},
+		},
+	}
+
+	dynClient := injectDynamicCluster(env, "c1", gatewayGVRs())
+
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{
+			Object: map[string]interface{}{"kind": "GatewayList", "apiVersion": "gateway.networking.k8s.io/v1"},
+			Items:  []unstructured.Unstructured{*gw},
+		}, nil
+	})
+
+	// Case 1: Found
+	req, _ := http.NewRequest("GET", "/api/gateway/gateways/c1/default/target-gw", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Case 2: Not Found (name filter excludes it)
+	req2, _ := http.NewRequest("GET", "/api/gateway/gateways/c1/default/missing", nil)
+	resp2, err := env.App.Test(req2, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 404, resp2.StatusCode)
+
+	// Case 3: Client Error → treated as not found
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("list failure")
+	})
+	req3, _ := http.NewRequest("GET", "/api/gateway/gateways/c1/default/target-gw", nil)
+	resp3, err := env.App.Test(req3, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 404, resp3.StatusCode)
+}
+
+func TestListHTTPRoutes(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewGatewayHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/gateway/httproutes", handler.ListHTTPRoutes)
+
+	route := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "HTTPRoute",
+			"metadata": map[string]interface{}{
+				"name":      "my-route",
+				"namespace": "default",
+			},
+		},
+	}
+
+	dynClient := injectDynamicCluster(env, "test-cluster", httpRouteGVRs())
+
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{
+			Object: map[string]interface{}{"kind": "HTTPRouteList", "apiVersion": "gateway.networking.k8s.io/v1"},
+			Items:  []unstructured.Unstructured{*route},
+		}, nil
+	})
+
+	// Case 1: List all
+	req, _ := http.NewRequest("GET", "/api/gateway/httproutes", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var list v1alpha1.HTTPRouteList
+	body, _ := io.ReadAll(resp.Body)
+	err = json.Unmarshal(body, &list)
+	require.NoError(t, err)
+	assert.NotEmpty(t, list.Items)
+	assert.Equal(t, "my-route", list.Items[0].Name)
+
+	// Case 2: Specific cluster failure — error swallowed, returns 200
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("route error")
+	})
+	req2, _ := http.NewRequest("GET", "/api/gateway/httproutes?cluster=test-cluster", nil)
+	resp2, err := env.App.Test(req2, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp2.StatusCode)
+}
+
+func TestGetHTTPRoute(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewGatewayHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/gateway/httproutes/:cluster/:namespace/:name", handler.GetHTTPRoute)
+
+	route := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "HTTPRoute",
+			"metadata": map[string]interface{}{
+				"name":      "target-route",
+				"namespace": "default",
+			},
+		},
+	}
+
+	dynClient := injectDynamicCluster(env, "c1", httpRouteGVRs())
+
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{
+			Object: map[string]interface{}{"kind": "HTTPRouteList", "apiVersion": "gateway.networking.k8s.io/v1"},
+			Items:  []unstructured.Unstructured{*route},
+		}, nil
+	})
+
+	// Case 1: Found
+	req, _ := http.NewRequest("GET", "/api/gateway/httproutes/c1/default/target-route", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Case 2: 404
+	req2, _ := http.NewRequest("GET", "/api/gateway/httproutes/c1/default/missing", nil)
+	resp2, err := env.App.Test(req2, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 404, resp2.StatusCode)
+}
+
+func TestGetGatewayAPIStatus(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewGatewayHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/gateway/status", handler.GetGatewayAPIStatus)
+
+	_ = injectDynamicCluster(env, "test-cluster", gatewayGVRs())
+
+	req, _ := http.NewRequest("GET", "/api/gateway/status", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var res map[string]interface{}
+	body, _ := io.ReadAll(resp.Body)
+	json.Unmarshal(body, &res)
+	clusters := res["clusters"].([]interface{})
+	assert.NotEmpty(t, clusters)
+}

--- a/pkg/api/handlers/mcs_test.go
+++ b/pkg/api/handlers/mcs_test.go
@@ -1,0 +1,248 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/kubestellar/console/pkg/api/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// serviceExportGVRs returns the GVR-to-list-kind map for ServiceExport resources.
+func serviceExportGVRs() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		{Group: "multicluster.x-k8s.io", Version: "v1alpha1", Resource: "serviceexports"}: "ServiceExportList",
+	}
+}
+
+// serviceImportGVRs returns the GVR-to-list-kind map for ServiceImport resources.
+func serviceImportGVRs() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		{Group: "multicluster.x-k8s.io", Version: "v1alpha1", Resource: "serviceimports"}: "ServiceImportList",
+	}
+}
+
+func TestListServiceExports(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCSHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/mcs/exports", handler.ListServiceExports)
+
+	export := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "multicluster.x-k8s.io/v1alpha1",
+			"kind":       "ServiceExport",
+			"metadata": map[string]interface{}{
+				"name":      "my-svc",
+				"namespace": "default",
+			},
+		},
+	}
+
+	dynClient := injectDynamicCluster(env, "test-cluster", serviceExportGVRs())
+
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{
+			Object: map[string]interface{}{"kind": "ServiceExportList", "apiVersion": "multicluster.x-k8s.io/v1alpha1"},
+			Items:  []unstructured.Unstructured{*export},
+		}, nil
+	})
+
+	// Case 1: List all
+	req, _ := http.NewRequest("GET", "/api/mcs/exports", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var list v1alpha1.ServiceExportList
+	body, _ := io.ReadAll(resp.Body)
+	err = json.Unmarshal(body, &list)
+	require.NoError(t, err)
+	require.NotEmpty(t, list.Items)
+	assert.Equal(t, "my-svc", list.Items[0].Name)
+
+	// Case 2: Specific cluster failure — error swallowed, returns 200
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("export list error")
+	})
+	req2, _ := http.NewRequest("GET", "/api/mcs/exports?cluster=test-cluster", nil)
+	resp2, err := env.App.Test(req2, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp2.StatusCode)
+}
+
+func TestGetServiceExport(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCSHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/mcs/exports/:cluster/:namespace/:name", handler.GetServiceExport)
+
+	export := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "multicluster.x-k8s.io/v1alpha1",
+			"kind":       "ServiceExport",
+			"metadata": map[string]interface{}{
+				"name":      "target-svc",
+				"namespace": "default",
+			},
+		},
+	}
+
+	dynClient := injectDynamicCluster(env, "c1", serviceExportGVRs())
+
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{
+			Object: map[string]interface{}{"kind": "ServiceExportList", "apiVersion": "multicluster.x-k8s.io/v1alpha1"},
+			Items:  []unstructured.Unstructured{*export},
+		}, nil
+	})
+
+	// Found
+	req, _ := http.NewRequest("GET", "/api/mcs/exports/c1/default/target-svc", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Client Error → 404
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("fail")
+	})
+	req2, _ := http.NewRequest("GET", "/api/mcs/exports/c1/default/target-svc", nil)
+	resp2, err := env.App.Test(req2, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 404, resp2.StatusCode)
+}
+
+func TestListServiceImports(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCSHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/mcs/imports", handler.ListServiceImports)
+
+	imp := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "multicluster.x-k8s.io/v1alpha1",
+			"kind":       "ServiceImport",
+			"metadata": map[string]interface{}{
+				"name":      "remote-svc",
+				"namespace": "default",
+			},
+		},
+	}
+
+	dynClient := injectDynamicCluster(env, "test-cluster", serviceImportGVRs())
+
+	dynClient.PrependReactor("list", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.UnstructuredList{
+			Object: map[string]interface{}{"kind": "ServiceImportList", "apiVersion": "multicluster.x-k8s.io/v1alpha1"},
+			Items:  []unstructured.Unstructured{*imp},
+		}, nil
+	})
+
+	// List all
+	req, _ := http.NewRequest("GET", "/api/mcs/imports", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var list v1alpha1.ServiceImportList
+	body, _ := io.ReadAll(resp.Body)
+	err = json.Unmarshal(body, &list)
+	require.NoError(t, err)
+	assert.NotEmpty(t, list.Items)
+}
+
+func TestCreateServiceExport(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCSHandlers(env.K8sClient, env.Hub)
+	env.App.Post("/api/mcs/exports", handler.CreateServiceExport)
+
+	dynClient := injectDynamicCluster(env, "c1", serviceExportGVRs())
+
+	// Success reactor
+	dynClient.PrependReactor("create", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, &unstructured.Unstructured{}, nil
+	})
+
+	// Case 1: Success
+	payload := map[string]string{
+		"cluster":     "c1",
+		"namespace":   "default",
+		"serviceName": "my-svc",
+	}
+	body, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("POST", "/api/mcs/exports", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 201, resp.StatusCode)
+
+	// Verify creation via actions
+	found := false
+	for _, action := range dynClient.Actions() {
+		if action.GetVerb() == "create" && action.GetResource().Resource == "serviceexports" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Create action not found")
+
+	// Case 2: Validation Error (missing serviceName)
+	payloadInvalid := map[string]string{
+		"cluster":   "c1",
+		"namespace": "default",
+	}
+	bodyInvalid, _ := json.Marshal(payloadInvalid)
+	reqInvalid, _ := http.NewRequest("POST", "/api/mcs/exports", bytes.NewReader(bodyInvalid))
+	reqInvalid.Header.Set("Content-Type", "application/json")
+
+	respInvalid, err := env.App.Test(reqInvalid, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 400, respInvalid.StatusCode)
+
+	// Case 3: Client Error → 500
+	dynClient.PrependReactor("create", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("create failed")
+	})
+	reqFail, _ := http.NewRequest("POST", "/api/mcs/exports", bytes.NewReader(body))
+	reqFail.Header.Set("Content-Type", "application/json")
+
+	respFail, err := env.App.Test(reqFail)
+	require.NoError(t, err)
+	assert.Equal(t, 500, respFail.StatusCode)
+}
+
+func TestDeleteServiceExport(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCSHandlers(env.K8sClient, env.Hub)
+	env.App.Delete("/api/mcs/exports/:cluster/:namespace/:name", handler.DeleteServiceExport)
+
+	dynClient := injectDynamicCluster(env, "c1", serviceExportGVRs())
+
+	// Success reactor
+	dynClient.PrependReactor("delete", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, nil
+	})
+
+	// Case 1: Success
+	req, _ := http.NewRequest("DELETE", "/api/mcs/exports/c1/default/svc1", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Case 2: Client Error → 500
+	dynClient.PrependReactor("delete", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("delete failed")
+	})
+	reqFail, _ := http.NewRequest("DELETE", "/api/mcs/exports/c1/default/svc1", nil)
+	respFail, err := env.App.Test(reqFail, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 500, respFail.StatusCode)
+}

--- a/pkg/api/handlers/settings_test.go
+++ b/pkg/api/handlers/settings_test.go
@@ -1,0 +1,195 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/kubestellar/console/pkg/settings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSettings(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewSettingsHandler(env.Settings)
+	env.App.Get("/api/settings", handler.GetSettings)
+
+	// Case 1: File missing (default settings)
+	req := httptest.NewRequest("GET", "/api/settings", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result settings.AllSettings
+	body, _ := io.ReadAll(resp.Body)
+	err = json.Unmarshal(body, &result)
+	require.NoError(t, err)
+	// Check default
+	assert.Equal(t, "kubestellar", result.Theme)
+	assert.Equal(t, "medium", result.AIMode)
+
+	// Case 2: File exists with custom data
+	// Modify something and save
+	result.Theme = "light"
+	err = env.Settings.SaveAll(&result)
+	require.NoError(t, err)
+
+	// Request again
+	req2 := httptest.NewRequest("GET", "/api/settings", nil)
+	resp2, err := env.App.Test(req2, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp2.StatusCode)
+
+	var result2 settings.AllSettings
+	body2, _ := io.ReadAll(resp2.Body)
+	err = json.Unmarshal(body2, &result2)
+	require.NoError(t, err)
+	assert.Equal(t, "light", result2.Theme)
+}
+
+func TestSaveSettings(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewSettingsHandler(env.Settings)
+	env.App.Put("/api/settings", handler.SaveSettings)
+
+	// Case 1: Valid save
+	payload := settings.AllSettings{
+		Theme:  "light",
+		AIMode: "cloud",
+		APIKeys: map[string]settings.APIKeyEntry{
+			"openai": {APIKey: "sk-test", Model: "gpt-4"},
+		},
+	}
+	data, _ := json.Marshal(payload)
+	req := httptest.NewRequest("PUT", "/api/settings", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Verify persistence in memory
+	stored, err := env.Settings.GetAll()
+	require.NoError(t, err)
+	assert.Equal(t, "light", stored.Theme)
+	assert.Equal(t, "cloud", stored.AIMode)
+	assert.Equal(t, "sk-test", stored.APIKeys["openai"].APIKey)
+
+	// Case 2: Malformed JSON
+	reqInvalid := httptest.NewRequest("PUT", "/api/settings", bytes.NewReader([]byte("{invalid-json")))
+	reqInvalid.Header.Set("Content-Type", "application/json")
+	respInvalid, err := env.App.Test(reqInvalid, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 400, respInvalid.StatusCode)
+}
+
+func TestExportImportSettings(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewSettingsHandler(env.Settings)
+	env.App.Post("/api/settings/export", handler.ExportSettings)
+	env.App.Post("/api/settings/import", handler.ImportSettings)
+
+	// Setup initial state
+	initial := &settings.AllSettings{
+		Theme: "light",
+		APIKeys: map[string]settings.APIKeyEntry{
+			"openai": {APIKey: "sk-secret", Model: "gpt-4"},
+		},
+	}
+	err := env.Settings.SaveAll(initial)
+	require.NoError(t, err)
+
+	// Case 1: Export
+	reqExport := httptest.NewRequest("POST", "/api/settings/export", nil)
+	respExport, err := env.App.Test(reqExport, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, respExport.StatusCode)
+
+	exportedData, err := io.ReadAll(respExport.Body)
+	require.NoError(t, err)
+	assert.NotEmpty(t, exportedData)
+	assert.Contains(t, string(exportedData), "encrypted") // Should contain encrypted fields
+
+	// Case 2: Import valid blob
+	// Create new clean environment to simulate another machine
+	env2 := setupTestEnv(t)
+	// IMPORTANT: ImportEncrypted requires the SAME key to decrypt encrypted fields.
+	// Since setupTestEnv relies on the singleton which holds the key in memory,
+	// env2 actually shares the same key as env1 (because we didn't restart the process).
+	// This is perfect for simulating a restore on the same machine/key setup.
+
+	handler2 := NewSettingsHandler(env2.Settings)
+	env2.App.Post("/api/settings/import", handler2.ImportSettings)
+
+	reqImport := httptest.NewRequest("POST", "/api/settings/import", bytes.NewReader(exportedData))
+	reqImport.Header.Set("Content-Type", "application/json")
+
+	respImport, err := env2.App.Test(reqImport, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, respImport.StatusCode)
+
+	// Verify imported data
+	imported, err := env2.Settings.GetAll()
+	require.NoError(t, err)
+	assert.Equal(t, "light", imported.Theme)
+	assert.Equal(t, "sk-secret", imported.APIKeys["openai"].APIKey) // Should be decrypted successfully
+
+	// Case 3: Import invalid blob
+	reqInvalid := httptest.NewRequest("POST", "/api/settings/import", bytes.NewReader([]byte("not-json")))
+	respInvalid, err := env2.App.Test(reqInvalid, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 400, respInvalid.StatusCode)
+
+	// Case 4: Import empty body
+	reqEmpty := httptest.NewRequest("POST", "/api/settings/import", nil)
+	respEmpty, err := env2.App.Test(reqEmpty, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 400, respEmpty.StatusCode)
+}
+
+func TestSettingsFileError(t *testing.T) {
+	// Simulate permission error
+	if os.Getuid() == 0 {
+		t.Skip("Skipping permission test as root")
+	}
+
+	env := setupTestEnv(t)
+	handler := NewSettingsHandler(env.Settings)
+	env.App.Put("/api/settings", handler.SaveSettings)
+
+	// Make directory read-only to force save error
+	err := os.Chmod(env.TempDir, 0500)
+	require.NoError(t, err)
+	defer os.Chmod(env.TempDir, 0700)
+
+	// The SettingsManager writes to a temp file then renames, or writes directly.
+	// We need to invalidate the settings path specifically.
+	// However, SettingsManager also does MkdirAll.
+	// If parent dir is not writable, Save should fail.
+
+	// Create payload
+	payload := settings.AllSettings{Theme: "fail"}
+	data, _ := json.Marshal(payload)
+	req := httptest.NewRequest("PUT", "/api/settings", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+
+	// This relies on file system permissions which can be flaky in some CI envs.
+	// If it fails to fail (because temp dir behavior), we might just accept it.
+	// But let's try.
+
+	// Actually, `handler.SaveSettings` logs error and returns 500.
+	// Let's see if we can trigger it.
+
+	// Note: setupTestEnv sets the settings path inside `TempDir`.
+	// Changing permission of TempDir should block writing `settings.json` inside it.
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	// If it successfully writes (somehow), status will be 200. If failed, 500.
+	// We assert 500.
+	assert.Equal(t, 500, resp.StatusCode)
+}

--- a/pkg/api/handlers/setup_test.go
+++ b/pkg/api/handlers/setup_test.go
@@ -1,0 +1,98 @@
+package handlers
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/k8s"
+	"github.com/kubestellar/console/pkg/settings"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+type testEnv struct {
+	App       *fiber.App
+	TempDir   string
+	Settings  *settings.SettingsManager
+	K8sClient *k8s.MultiClusterClient
+	Hub       *Hub
+}
+
+// setupTestEnv creates a new test environment with a fresh Fiber app and an initialized
+// SettingsManager pointing to a temporary directory.
+func setupTestEnv(t *testing.T) *testEnv {
+	// Create a temporary directory for settings
+	tempDir := t.TempDir()
+	settingsPath := filepath.Join(tempDir, "settings.json")
+	keyPath := filepath.Join(tempDir, ".keyfile")
+
+	// Initialize SettingsManager
+	manager := settings.GetSettingsManager()
+	// Override paths for testing isolation
+	manager.SetSettingsPath(settingsPath)
+	manager.SetKeyPath(keyPath)
+
+	// Ensure we start with a clean state for this test run relative to the file.
+	_ = manager.Load()
+
+	// Initialize K8s Client with a fake cluster
+	k8sClient, _ := k8s.NewMultiClusterClient("")
+	// Inject a fake client for a "test-cluster" context
+	fakeClient := k8sfake.NewSimpleClientset()
+	k8sClient.InjectClient("test-cluster", fakeClient)
+
+	// Initialize Hub
+	hub := NewHub()
+	go hub.Run() // Start hub loop (in background)
+	t.Cleanup(func() {
+		hub.Close()
+	})
+
+	app := fiber.New()
+
+	// Return the environment
+	return &testEnv{
+		App:       app,
+		TempDir:   tempDir,
+		Settings:  manager,
+		K8sClient: k8sClient,
+		Hub:       hub,
+	}
+}
+
+// injectDynamicCluster creates a fake dynamic client with custom list kinds (for CRD resources
+// like Gateway, HTTPRoute, ServiceExport, etc.) and injects both dynamic and typed clients
+// into the test environment for the given cluster name.
+//
+// gvrKinds maps each GVR to its list kind string (e.g. "GatewayList").
+// Returns the dynamic client for reactor registration.
+func injectDynamicCluster(env *testEnv, cluster string, gvrKinds map[schema.GroupVersionResource]string) *fake.FakeDynamicClient {
+	scheme := runtime.NewScheme()
+	dynClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrKinds)
+	env.K8sClient.InjectDynamicClient(cluster, dynClient)
+	env.K8sClient.InjectClient(cluster, k8sfake.NewSimpleClientset())
+	return dynClient
+}
+
+// injectDynamicClusterWithObjects creates a fake dynamic client seeded with typed K8s objects
+// (Deployments, Pods, Services, etc.) and injects both dynamic and typed clients into the test
+// environment for the given cluster name.
+//
+// The scheme must have the relevant types registered (e.g. via k8sscheme.AddToScheme).
+// typedObjects are optional typed K8s objects to seed into the typed client.
+// Returns the dynamic client for further reactor registration if needed.
+func injectDynamicClusterWithObjects(
+	env *testEnv,
+	cluster string,
+	scheme *runtime.Scheme,
+	dynamicObjects []runtime.Object,
+	typedObjects ...runtime.Object,
+) *fake.FakeDynamicClient {
+	dynClient := fake.NewSimpleDynamicClient(scheme, dynamicObjects...)
+	env.K8sClient.InjectDynamicClient(cluster, dynClient)
+	env.K8sClient.InjectClient(cluster, k8sfake.NewSimpleClientset(typedObjects...))
+	return dynClient
+}

--- a/pkg/api/handlers/workloads_test.go
+++ b/pkg/api/handlers/workloads_test.go
@@ -1,0 +1,581 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/kubestellar/console/pkg/agent"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newK8sScheme returns a scheme with standard K8s types registered.
+func newK8sScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = k8sscheme.AddToScheme(scheme)
+	return scheme
+}
+
+func TestListWorkloads(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewWorkloadHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/workloads", handler.ListWorkloads)
+
+	scheme := newK8sScheme()
+
+	deployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deploy",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: func(i int32) *int32 { return &i }(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "c1", Image: "nginx"}},
+				},
+			},
+		},
+	}
+
+	injectDynamicClusterWithObjects(env, "test-cluster", scheme, []runtime.Object{deployment})
+
+	req, _ := http.NewRequest("GET", "/api/workloads?cluster=test-cluster", nil)
+	resp, err := env.App.Test(req, 5000)
+
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var response map[string]interface{}
+	body, _ := io.ReadAll(resp.Body)
+	err = json.Unmarshal(body, &response)
+	require.NoError(t, err)
+
+	items := response["items"].([]interface{})
+	assert.NotEmpty(t, items)
+	workload := items[0].(map[string]interface{})
+	assert.Equal(t, "test-deploy", workload["name"])
+}
+
+func TestGetWorkload(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewWorkloadHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/workloads/:cluster/:namespace/:name", handler.GetWorkload)
+
+	scheme := newK8sScheme()
+
+	deployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-app",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: func(i int32) *int32 { return &i }(2),
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas:      2,
+			ReadyReplicas: 2,
+		},
+	}
+
+	injectDynamicClusterWithObjects(env, "test-cluster", scheme, []runtime.Object{deployment})
+
+	// 1. Success Case
+	req, _ := http.NewRequest("GET", "/api/workloads/test-cluster/default/my-app", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var workload map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&workload)
+	assert.Equal(t, "my-app", workload["name"])
+	assert.Equal(t, "test-cluster", workload["deployments"].([]interface{})[0].(map[string]interface{})["cluster"])
+
+	// 2. Not Found
+	reqNotFound, _ := http.NewRequest("GET", "/api/workloads/test-cluster/default/missing", nil)
+	respNotFound, _ := env.App.Test(reqNotFound, 5000)
+	assert.Equal(t, 404, respNotFound.StatusCode)
+}
+
+func TestDeployWorkload(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewWorkloadHandlers(env.K8sClient, env.Hub)
+	env.App.Post("/api/workloads/deploy", handler.DeployWorkload)
+
+	scheme := newK8sScheme()
+
+	// Source Deployment
+	srcDep := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "src-app",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: func(i int32) *int32 { return &i }(1),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx"}}},
+			},
+		},
+	}
+
+	injectDynamicClusterWithObjects(env, "source-cluster", scheme, []runtime.Object{srcDep})
+	targetDyn := injectDynamicClusterWithObjects(env, "target-cluster", scheme, nil)
+
+	// Payload
+	payload := map[string]interface{}{
+		"workloadName":   "src-app",
+		"namespace":      "default",
+		"sourceCluster":  "source-cluster",
+		"targetClusters": []string{"target-cluster"},
+		"replicas":       3,
+	}
+
+	data, _ := json.Marshal(payload)
+
+	req, _ := http.NewRequest("POST", "/api/workloads/deploy", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("Deploy returned %d: %s", resp.StatusCode, string(body))
+	}
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Verify result body
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Equal(t, true, result["success"])
+
+	// Verify deployment created in target
+	gvr := appsv1.SchemeGroupVersion.WithResource("deployments")
+	dep, err := targetDyn.Resource(gvr).Namespace("default").Get(context.Background(), "src-app", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "src-app", dep.GetName())
+
+	// Check Replicas (int64 for unstructured)
+	spec := dep.Object["spec"].(map[string]interface{})
+	assert.Equal(t, int64(3), spec["replicas"])
+}
+
+func TestGetDeployStatus(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewWorkloadHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/workloads/deploy-status/:cluster/:namespace/:name", handler.GetDeployStatus)
+
+	scheme := newK8sScheme()
+
+	deploy := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "status-app", Namespace: "default"},
+		Spec:       appsv1.DeploymentSpec{Replicas: func(i int32) *int32 { return &i }(5)},
+		Status:     appsv1.DeploymentStatus{ReadyReplicas: 3, Replicas: 5},
+	}
+
+	injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{deploy})
+
+	req, _ := http.NewRequest("GET", "/api/workloads/deploy-status/c1/default/status-app", nil)
+	resp, err := env.App.Test(req, 5000)
+
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var status map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&status)
+	assert.Equal(t, float64(5), status["replicas"])
+	assert.Equal(t, float64(3), status["readyReplicas"])
+}
+
+func TestScaleWorkload(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewWorkloadHandlers(env.K8sClient, env.Hub)
+	env.App.Post("/api/workloads/scale", handler.ScaleWorkload)
+
+	// Payload
+	payload := map[string]interface{}{
+		"workloadName":   "scale-app",
+		"namespace":      "default",
+		"targetClusters": []string{"scale-cluster"},
+		"replicas":       10,
+	}
+
+	data, _ := json.Marshal(payload)
+	req, _ := http.NewRequest("POST", "/api/workloads/scale", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	assert.Equal(t, true, result["success"])
+}
+
+func TestDeleteWorkload(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewWorkloadHandlers(env.K8sClient, env.Hub)
+	env.App.Delete("/api/workloads/:cluster/:namespace/:name", handler.DeleteWorkload)
+
+	req, _ := http.NewRequest("DELETE", "/api/workloads/c1/default/del-app", nil)
+	resp, err := env.App.Test(req, 5000)
+
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestClusterGroupsCRUD(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewWorkloadHandlers(env.K8sClient, env.Hub)
+
+	env.App.Get("/api/cluster-groups", handler.ListClusterGroups)
+	env.App.Post("/api/cluster-groups", handler.CreateClusterGroup)
+	env.App.Put("/api/cluster-groups/:name", handler.UpdateClusterGroup)
+	env.App.Delete("/api/cluster-groups/:name", handler.DeleteClusterGroup)
+
+	createPayload := map[string]interface{}{
+		"name":     "group1",
+		"kind":     "static",
+		"clusters": []string{"c1", "c2"},
+		"color":    "blue",
+	}
+	data, _ := json.Marshal(createPayload)
+	req, _ := http.NewRequest("POST", "/api/cluster-groups", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 201, resp.StatusCode)
+
+	req, _ = http.NewRequest("GET", "/api/cluster-groups", nil)
+	resp, err = env.App.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var listResp map[string][]map[string]interface{}
+	body, _ := io.ReadAll(resp.Body)
+	json.Unmarshal(body, &listResp)
+	assert.Equal(t, 1, len(listResp["groups"]))
+	assert.Equal(t, "group1", listResp["groups"][0]["name"])
+
+	updatePayload := map[string]interface{}{
+		"name":     "group1",
+		"kind":     "static",
+		"clusters": []string{"c1"},
+		"color":    "red",
+	}
+	data, _ = json.Marshal(updatePayload)
+	req, _ = http.NewRequest("PUT", "/api/cluster-groups/group1", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err = env.App.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	req, _ = http.NewRequest("DELETE", "/api/cluster-groups/group1", nil)
+	resp, err = env.App.Test(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	req, _ = http.NewRequest("GET", "/api/cluster-groups", nil)
+	resp, _ = env.App.Test(req)
+	var listRespEmpty map[string][]interface{}
+	bodyEmpty, _ := io.ReadAll(resp.Body)
+	json.Unmarshal(bodyEmpty, &listRespEmpty)
+	assert.Empty(t, listRespEmpty["groups"])
+}
+
+func TestEvaluateClusterQuery(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewWorkloadHandlers(env.K8sClient, env.Hub)
+	env.App.Post("/api/cluster-groups/evaluate", handler.EvaluateClusterQuery)
+
+	config := &api.Config{
+		Contexts: map[string]*api.Context{
+			"c1-ctx": {Cluster: "cluster1"},
+		},
+		Clusters: map[string]*api.Cluster{
+			"cluster1": {Server: "https://c1.com"},
+		},
+	}
+	env.K8sClient.SetRawConfig(config)
+
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node1",
+			Labels: map[string]string{"region": "us-east"},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+		},
+	}
+
+	c1Client := k8sfake.NewSimpleClientset(node)
+	env.K8sClient.InjectClient("c1-ctx", c1Client)
+
+	// Complex Query with various operators
+	query := map[string]interface{}{
+		"labelSelector": "region=us-east",
+		"filters": []map[string]interface{}{
+			{"field": "cpuCores", "operator": "gte", "value": "2"},
+			{"field": "memoryGB", "operator": "gt", "value": "8"},
+			{"field": "healthy", "operator": "eq", "value": "true"},
+		},
+	}
+
+	data, _ := json.Marshal(query)
+	req, _ := http.NewRequest("POST", "/api/cluster-groups/evaluate", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	body, _ := io.ReadAll(resp.Body)
+	json.Unmarshal(body, &result)
+
+	clusters := result["clusters"].([]interface{})
+	assert.Equal(t, 1, len(clusters))
+	assert.Equal(t, "c1-ctx", clusters[0])
+}
+
+// MockAIProvider implements agent.AIProvider for testing.
+type MockAIProvider struct {
+	Response string
+}
+
+func (m *MockAIProvider) Name() string        { return "mock-ai" }
+func (m *MockAIProvider) DisplayName() string { return "Mock AI" }
+func (m *MockAIProvider) Description() string { return "Mock AI Provider" }
+func (m *MockAIProvider) Provider() string    { return "mock" }
+func (m *MockAIProvider) IsAvailable() bool   { return true }
+func (m *MockAIProvider) Chat(ctx context.Context, req *agent.ChatRequest) (*agent.ChatResponse, error) {
+	return &agent.ChatResponse{
+		Content: m.Response,
+		Agent:   "mock-ai",
+		Done:    true,
+	}, nil
+}
+func (m *MockAIProvider) StreamChat(ctx context.Context, req *agent.ChatRequest, onChunk func(chunk string)) (*agent.ChatResponse, error) {
+	onChunk(m.Response)
+	return &agent.ChatResponse{Content: m.Response, Done: true}, nil
+}
+
+func TestGenerateClusterQuery(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewWorkloadHandlers(env.K8sClient, env.Hub)
+	env.App.Post("/api/cluster-groups/generate", handler.GenerateClusterQuery)
+
+	// Register Mock AI
+	registry := agent.GetRegistry()
+	mockAI := &MockAIProvider{
+		Response: `{"suggestedName": "west-cpu-group", "query": {"labelSelector": "region=us-west", "filters": [{"field": "cpuCores", "operator": "gte", "value": "4"}]}}`,
+	}
+	registry.Register(mockAI)
+	registry.SetDefault("mock-ai")
+
+	payload := map[string]string{"prompt": "Find powerful clusters in west"}
+	data, _ := json.Marshal(payload)
+
+	req, _ := http.NewRequest("POST", "/api/cluster-groups/generate", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	body, _ := io.ReadAll(resp.Body)
+	json.Unmarshal(body, &result)
+
+	query := result["query"].(map[string]interface{})
+	assert.Equal(t, "region=us-west", query["labelSelector"])
+}
+
+func TestResolveDependencies(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewWorkloadHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/workloads/resolve-deps/:cluster/:namespace/:name", handler.ResolveDependencies)
+
+	scheme := newK8sScheme()
+	_ = apiextensionsv1.AddToScheme(scheme)
+
+	deploy := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: func(i int32) *int32 { return &i }(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "app"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "app"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx"}}},
+			},
+		},
+	}
+
+	svc := &corev1.Service{
+		TypeMeta:   metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "app-svc", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "app"},
+		},
+	}
+
+	injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{deploy, svc})
+
+	req, _ := http.NewRequest("GET", "/api/workloads/resolve-deps/c1/default/app", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	body, _ := io.ReadAll(resp.Body)
+	json.Unmarshal(body, &result)
+
+	// Should find Service dependency
+	deps := result["dependencies"].([]interface{})
+	foundSvc := false
+	for _, d := range deps {
+		dep := d.(map[string]interface{})
+		if dep["kind"] == "Service" && dep["name"] == "app-svc" {
+			foundSvc = true
+		}
+	}
+	assert.True(t, foundSvc, "Should find matching service")
+}
+
+func TestMonitorWorkload(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewWorkloadHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/workloads/monitor/:cluster/:namespace/:name", handler.MonitorWorkload)
+
+	scheme := newK8sScheme()
+	_ = apiextensionsv1.AddToScheme(scheme)
+
+	deploy := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "monitored-app", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: func(i int32) *int32 { return &i }(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "monitored"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "monitored"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx"}}},
+			},
+		},
+	}
+
+	injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{deploy})
+
+	req, _ := http.NewRequest("GET", "/api/workloads/monitor/c1/default/monitored-app", nil)
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	var result map[string]interface{}
+	body, _ := io.ReadAll(resp.Body)
+	json.Unmarshal(body, &result)
+
+	assert.Equal(t, "monitored-app", result["workload"])
+	assert.NotNil(t, result["status"])
+}
+
+func TestGetDeployLogs(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewWorkloadHandlers(env.K8sClient, env.Hub)
+	env.App.Get("/api/workloads/logs/:cluster/:namespace/:name", handler.GetDeployLogs)
+
+	scheme := newK8sScheme()
+
+	pod := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "log-pod-1",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "log-app"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main"}},
+		},
+	}
+
+	deploy := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "log-app", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "log-app"}},
+		},
+	}
+
+	t.Run("Smoke_WithDeploymentAndPod", func(t *testing.T) {
+		// Smoke test: ensure no panic and handler returns a valid HTTP response.
+		// The fake client does not implement the pod log subresource, so we cannot
+		// assert exact log content. We verify the handler resolves the deployment,
+		// finds matching pods, and returns without crashing.
+		injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{pod, deploy}, pod)
+
+		req, _ := http.NewRequest("GET", "/api/workloads/logs/c1/default/log-app", nil)
+		resp, err := env.App.Test(req, 5000)
+		require.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+	})
+
+	t.Run("Smoke_WithoutDeployment", func(t *testing.T) {
+		// Smoke test: GetDeployLogs always returns 200 with an events payload.
+		// Even when no deployment exists, the handler falls through to listing pods
+		// by label/name prefix and returns an empty events list — it never returns 404.
+		// We verify the handler does not crash and returns a well-formed response.
+		injectDynamicClusterWithObjects(env, "c1", scheme, []runtime.Object{pod}, pod)
+
+		req, _ := http.NewRequest("GET", "/api/workloads/logs/c1/default/missing-app", nil)
+		resp, err := env.App.Test(req, 5000)
+		require.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		var result map[string]interface{}
+		body, _ := io.ReadAll(resp.Body)
+		json.Unmarshal(body, &result)
+		assert.Equal(t, "events", result["type"])
+	})
+
+	t.Run("MissingCluster_Returns500", func(t *testing.T) {
+		// When the cluster context does not exist, GetClient fails and handler returns 500.
+		req, _ := http.NewRequest("GET", "/api/workloads/logs/nonexistent-cluster/default/app", nil)
+		resp, err := env.App.Test(req, 5000)
+		require.NoError(t, err)
+		assert.Equal(t, 500, resp.StatusCode)
+	})
+}

--- a/pkg/api/middleware/auth_test.go
+++ b/pkg/api/middleware/auth_test.go
@@ -1,0 +1,139 @@
+package middleware
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJWTAuth(t *testing.T) {
+	app := fiber.New()
+	handler := JWTAuth("test-secret")
+
+	// Protected route
+	app.Get("/protected", handler, func(c *fiber.Ctx) error {
+		return c.SendString("success")
+	})
+
+	t.Run("Valid Token", func(t *testing.T) {
+		token, _ := generateTestToken("test-secret", time.Now().Add(time.Hour))
+		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := app.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+	})
+
+	t.Run("Missing Header", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/protected", nil)
+		resp, _ := app.Test(req, 5000)
+		assert.Equal(t, 401, resp.StatusCode)
+	})
+
+	t.Run("Invalid Format", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Header.Set("Authorization", "InvalidFormat")
+		resp, _ := app.Test(req, 5000)
+		assert.Equal(t, 401, resp.StatusCode)
+	})
+
+	t.Run("Invalid Signature", func(t *testing.T) {
+		token, _ := generateTestToken("WRONG-SECRET", time.Now().Add(time.Hour))
+		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, _ := app.Test(req, 5000)
+		assert.Equal(t, 401, resp.StatusCode)
+	})
+
+	t.Run("Expired Token", func(t *testing.T) {
+		token, _ := generateTestToken("test-secret", time.Now().Add(-1*time.Hour))
+		req := httptest.NewRequest("GET", "/protected", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, _ := app.Test(req, 5000)
+		assert.Equal(t, 401, resp.StatusCode)
+	})
+
+	t.Run("Query Param Fallback (Stream)", func(t *testing.T) {
+		// Middleware supports query param ?_token=... for /stream paths
+		token, _ := generateTestToken("test-secret", time.Now().Add(time.Hour))
+		req := httptest.NewRequest("GET", "/protected/stream?_token="+token, nil)
+
+		// Setup stream route specifically
+		app.Get("/protected/stream", handler, func(c *fiber.Ctx) error {
+			return c.SendString("stream-ok")
+		})
+
+		resp, err := app.Test(req, 5000)
+		assert.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+	})
+}
+
+func TestGetContextHelpers(t *testing.T) {
+	app := fiber.New()
+
+	// Middleware that injects user data manually to test helpers
+	app.Use(func(c *fiber.Ctx) error {
+		uid := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+		c.Locals("userID", uid)
+		c.Locals("githubLogin", "test-user")
+		return c.Next()
+	})
+
+	app.Get("/me", func(c *fiber.Ctx) error {
+		uid := GetUserID(c)
+		login := GetGitHubLogin(c)
+		return c.JSON(fiber.Map{
+			"uid":   uid.String(),
+			"login": login,
+		})
+	})
+
+	req := httptest.NewRequest("GET", "/me", nil)
+	resp, _ := app.Test(req, 5000)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// Validate body content
+	// (Implementation detail: we trust Fiber locals works, we are testing the Get* helpers)
+}
+
+func generateTestToken(secret string, expiry time.Time) (string, error) {
+	claims := UserClaims{
+		UserID:      uuid.New(),
+		GitHubLogin: "test",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expiry),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(secret))
+}
+
+func TestValidateJWT(t *testing.T) {
+	secret := "test-secret"
+
+	t.Run("Valid", func(t *testing.T) {
+		token, _ := generateTestToken(secret, time.Now().Add(time.Hour))
+		claims, err := ValidateJWT(token, secret)
+		assert.NoError(t, err)
+		assert.NotNil(t, claims)
+	})
+
+	t.Run("Expired", func(t *testing.T) {
+		token, _ := generateTestToken(secret, time.Now().Add(-1*time.Hour))
+		_, err := ValidateJWT(token, secret)
+		assert.Error(t, err)
+	})
+
+	t.Run("Invalid Signature", func(t *testing.T) {
+		token, _ := generateTestToken("wrong", time.Now().Add(time.Hour))
+		_, err := ValidateJWT(token, secret)
+		assert.Error(t, err)
+	})
+}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -53,9 +53,9 @@ type MultiClusterClient struct {
 	cacheTime       map[string]time.Time
 	watcher         *fsnotify.Watcher
 	stopWatch       chan struct{}
-	onReload        func()                // Callback when config is reloaded
-	inClusterConfig *rest.Config          // In-cluster config when running inside k8s
-	slowClusters    map[string]time.Time  // clusters that recently timed out (reduced timeout)
+	onReload        func()               // Callback when config is reloaded
+	inClusterConfig *rest.Config         // In-cluster config when running inside k8s
+	slowClusters    map[string]time.Time // clusters that recently timed out (reduced timeout)
 }
 
 // IsInCluster returns true if the server is running inside a Kubernetes cluster

--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -1,0 +1,141 @@
+package test
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockStore is a mock implementation of store.Store
+type MockStore struct {
+	mock.Mock
+}
+
+func (m *MockStore) GetUser(id uuid.UUID) (*models.User, error) {
+	args := m.Called(id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.User), args.Error(1)
+}
+
+func (m *MockStore) GetUserByGitHubID(githubID string) (*models.User, error) {
+	args := m.Called(githubID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.User), args.Error(1)
+}
+
+func (m *MockStore) CreateUser(user *models.User) error {
+	args := m.Called(user)
+	return args.Error(0)
+}
+
+func (m *MockStore) UpdateUser(user *models.User) error {
+	args := m.Called(user)
+	return args.Error(0)
+}
+
+func (m *MockStore) UpdateLastLogin(userID uuid.UUID) error {
+	args := m.Called(userID)
+	return args.Error(0)
+}
+
+// Implement other methods as needed or with empty mocks
+
+func (m *MockStore) ListUsers() ([]models.User, error)                  { return nil, nil }
+func (m *MockStore) DeleteUser(id uuid.UUID) error                      { return nil }
+func (m *MockStore) UpdateUserRole(userID uuid.UUID, role string) error { return nil }
+func (m *MockStore) CountUsersByRole() (int, int, int, error)           { return 0, 0, 0, nil }
+
+func (m *MockStore) SaveOnboardingResponse(response *models.OnboardingResponse) error { return nil }
+func (m *MockStore) GetOnboardingResponses(userID uuid.UUID) ([]models.OnboardingResponse, error) {
+	return nil, nil
+}
+func (m *MockStore) SetUserOnboarded(userID uuid.UUID) error { return nil }
+
+func (m *MockStore) GetDashboard(id uuid.UUID) (*models.Dashboard, error)            { return nil, nil }
+func (m *MockStore) GetUserDashboards(userID uuid.UUID) ([]models.Dashboard, error)  { return nil, nil }
+func (m *MockStore) GetDefaultDashboard(userID uuid.UUID) (*models.Dashboard, error) { return nil, nil }
+func (m *MockStore) CreateDashboard(dashboard *models.Dashboard) error               { return nil }
+func (m *MockStore) UpdateDashboard(dashboard *models.Dashboard) error               { return nil }
+func (m *MockStore) DeleteDashboard(id uuid.UUID) error                              { return nil }
+
+func (m *MockStore) GetCard(id uuid.UUID) (*models.Card, error)                     { return nil, nil }
+func (m *MockStore) GetDashboardCards(dashboardID uuid.UUID) ([]models.Card, error) { return nil, nil }
+func (m *MockStore) CreateCard(card *models.Card) error                             { return nil }
+func (m *MockStore) UpdateCard(card *models.Card) error                             { return nil }
+func (m *MockStore) DeleteCard(id uuid.UUID) error                                  { return nil }
+func (m *MockStore) UpdateCardFocus(cardID uuid.UUID, summary string) error         { return nil }
+
+func (m *MockStore) AddCardHistory(history *models.CardHistory) error { return nil }
+func (m *MockStore) GetUserCardHistory(userID uuid.UUID, limit int) ([]models.CardHistory, error) {
+	return nil, nil
+}
+
+func (m *MockStore) GetPendingSwap(id uuid.UUID) (*models.PendingSwap, error) { return nil, nil }
+func (m *MockStore) GetUserPendingSwaps(userID uuid.UUID) ([]models.PendingSwap, error) {
+	return nil, nil
+}
+func (m *MockStore) GetDueSwaps() ([]models.PendingSwap, error)                    { return nil, nil }
+func (m *MockStore) CreatePendingSwap(swap *models.PendingSwap) error              { return nil }
+func (m *MockStore) UpdateSwapStatus(id uuid.UUID, status models.SwapStatus) error { return nil }
+func (m *MockStore) SnoozeSwap(id uuid.UUID, newSwapAt time.Time) error            { return nil }
+
+func (m *MockStore) RecordEvent(event *models.UserEvent) error { return nil }
+func (m *MockStore) GetRecentEvents(userID uuid.UUID, since time.Duration) ([]models.UserEvent, error) {
+	return nil, nil
+}
+
+func (m *MockStore) CreateFeatureRequest(request *models.FeatureRequest) error      { return nil }
+func (m *MockStore) GetFeatureRequest(id uuid.UUID) (*models.FeatureRequest, error) { return nil, nil }
+func (m *MockStore) GetFeatureRequestByIssueNumber(issueNumber int) (*models.FeatureRequest, error) {
+	return nil, nil
+}
+func (m *MockStore) GetFeatureRequestByPRNumber(prNumber int) (*models.FeatureRequest, error) {
+	return nil, nil
+}
+func (m *MockStore) GetUserFeatureRequests(userID uuid.UUID) ([]models.FeatureRequest, error) {
+	return nil, nil
+}
+func (m *MockStore) GetAllFeatureRequests() ([]models.FeatureRequest, error)   { return nil, nil }
+func (m *MockStore) UpdateFeatureRequest(request *models.FeatureRequest) error { return nil }
+func (m *MockStore) UpdateFeatureRequestStatus(id uuid.UUID, status models.RequestStatus) error {
+	return nil
+}
+func (m *MockStore) CloseFeatureRequest(id uuid.UUID, closedByUser bool) error { return nil }
+func (m *MockStore) UpdateFeatureRequestPR(id uuid.UUID, prNumber int, prURL string) error {
+	return nil
+}
+func (m *MockStore) UpdateFeatureRequestPreview(id uuid.UUID, previewURL string) error    { return nil }
+func (m *MockStore) UpdateFeatureRequestLatestComment(id uuid.UUID, comment string) error { return nil }
+
+func (m *MockStore) CreatePRFeedback(feedback *models.PRFeedback) error { return nil }
+func (m *MockStore) GetPRFeedback(featureRequestID uuid.UUID) ([]models.PRFeedback, error) {
+	return nil, nil
+}
+
+func (m *MockStore) CreateNotification(notification *models.Notification) error { return nil }
+func (m *MockStore) GetUserNotifications(userID uuid.UUID, limit int) ([]models.Notification, error) {
+	return nil, nil
+}
+func (m *MockStore) GetUnreadNotificationCount(userID uuid.UUID) (int, error) { return 0, nil }
+func (m *MockStore) MarkNotificationRead(id uuid.UUID) error                  { return nil }
+func (m *MockStore) MarkAllNotificationsRead(userID uuid.UUID) error          { return nil }
+
+func (m *MockStore) CreateGPUReservation(reservation *models.GPUReservation) error  { return nil }
+func (m *MockStore) GetGPUReservation(id uuid.UUID) (*models.GPUReservation, error) { return nil, nil }
+func (m *MockStore) ListGPUReservations() ([]models.GPUReservation, error)          { return nil, nil }
+func (m *MockStore) ListUserGPUReservations(userID uuid.UUID) ([]models.GPUReservation, error) {
+	return nil, nil
+}
+func (m *MockStore) UpdateGPUReservation(reservation *models.GPUReservation) error { return nil }
+func (m *MockStore) DeleteGPUReservation(id uuid.UUID) error                       { return nil }
+func (m *MockStore) GetClusterReservedGPUCount(cluster string, excludeID *uuid.UUID) (int, error) {
+	return 0, nil
+}
+
+func (m *MockStore) Close() error { return nil }

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -365,7 +365,6 @@ export function UserProfileDropdown({ user, onLogout, onPreferences, onFeedback 
         isOpen={showRewards}
         onClose={() => setShowRewards(false)}
         initialTab="updates"
-        initialSubTab="activity"
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- Renamed modal header from "Feedback" to "Contribute"
- Merged Queue and Activity sub-tabs into a single scrollable Updates view with section headers (Your Requests, Notifications, GitHub Contributions)
- Removed separate Title input — first line of description auto-extracts as title
- Enlarged textarea (10 rows) with rich example prompts and monospace font
- Enabled `closeOnBackdrop` so clicking outside the dialog closes it
- Removed `initialSubTab` prop from `FeatureRequestModal` and its usage in `UserProfileDropdown`

## Test plan
- [ ] Open Contribute modal from navbar — verify header says "Contribute"
- [ ] Switch to Updates tab — verify single scrollable view (no sub-tabs)
- [ ] Submit a bug report with multi-line description — verify first line becomes title
- [ ] Click outside the modal — verify it closes
- [ ] Open via profile dropdown coins link — verify opens to Updates tab