### PR TITLE
✨ Phase 2 accessibility: keyboard navigation for dashboard cards

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -165,6 +165,8 @@ interface CardWrapperProps {
   skeletonType?: CardSkeletonProps['type']
   /** Number of skeleton rows to show */
   skeletonRows?: number
+  /** Register a callback to expand the card programmatically (keyboard nav) */
+  registerExpandTrigger?: (expand: () => void) => void
   children: ReactNode
 }
 
@@ -856,10 +858,29 @@ export function CardWrapper({
   onChatMessagesChange,
   skeletonType,
   skeletonRows,
+  registerExpandTrigger,
   children,
 }: CardWrapperProps) {
   const { t } = useTranslation(['cards', 'common'])
   const [isExpanded, setIsExpanded] = useState(false)
+
+  // Register expand trigger for keyboard navigation
+  useEffect(() => {
+    registerExpandTrigger?.(() => setIsExpanded(true))
+  }, [registerExpandTrigger])
+
+  // Restore focus to card when expanded modal closes
+  const prevExpandedRef = useRef(false)
+  useEffect(() => {
+    if (prevExpandedRef.current && !isExpanded && cardId) {
+      const cardEl = document.querySelector(
+        `[data-card-id="${cardId}"]`
+      )?.closest('[tabindex="0"]') as HTMLElement | null
+      cardEl?.focus()
+    }
+    prevExpandedRef.current = isExpanded
+  }, [isExpanded, cardId])
+
   // Lazy mounting - only render children when card is visible in viewport
   const { ref: lazyRef, isVisible } = useLazyMount('200px')
   // Track animation key to re-trigger flash animation

--- a/web/src/components/dashboard/SharedSortableCard.tsx
+++ b/web/src/components/dashboard/SharedSortableCard.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, type KeyboardEvent } from 'react'
 import { GripVertical } from 'lucide-react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -17,9 +17,12 @@ interface SortableCardProps {
   isRefreshing?: boolean
   onRefresh?: () => void
   lastUpdated?: Date | null
+  onKeyDown?: (e: KeyboardEvent) => void
+  registerRef?: (el: HTMLElement | null) => void
+  registerExpandTrigger?: (expand: () => void) => void
 }
 
-export const SortableCard = memo(function SortableCard({ card, onConfigure, onReplace, onRemove, onWidthChange, isDragging, isRefreshing, onRefresh, lastUpdated }: SortableCardProps) {
+export const SortableCard = memo(function SortableCard({ card, onConfigure, onReplace, onRemove, onWidthChange, isDragging, isRefreshing, onRefresh, lastUpdated, onKeyDown, registerRef, registerExpandTrigger }: SortableCardProps) {
   const {
     attributes,
     listeners,
@@ -39,7 +42,15 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
   const CardComponent = CARD_COMPONENTS[card.card_type]
 
   return (
-    <div ref={setNodeRef} style={style} className="h-full">
+    <div
+      ref={(el) => { setNodeRef(el); registerRef?.(el) }}
+      style={style}
+      className="h-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:rounded-xl"
+      tabIndex={0}
+      role="gridcell"
+      aria-label={formatCardTitle(card.card_type)}
+      onKeyDown={onKeyDown}
+    >
       <CardWrapper
         cardId={card.id}
         cardType={card.card_type}
@@ -55,6 +66,7 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
         onReplace={onReplace}
         onRemove={onRemove}
         onWidthChange={onWidthChange}
+        registerExpandTrigger={registerExpandTrigger}
         dragHandle={
           <button
             {...attributes}
@@ -87,7 +99,8 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
     JSON.stringify(prevProps.card.config) === JSON.stringify(nextProps.card.config) &&
     prevProps.isDragging === nextProps.isDragging &&
     prevProps.isRefreshing === nextProps.isRefreshing &&
-    prevProps.lastUpdated === nextProps.lastUpdated
+    prevProps.lastUpdated === nextProps.lastUpdated &&
+    prevProps.onKeyDown === nextProps.onKeyDown
   )
 })
 

--- a/web/src/hooks/useCardGridNavigation.ts
+++ b/web/src/hooks/useCardGridNavigation.ts
@@ -1,0 +1,134 @@
+import { useCallback, useMemo, useRef } from 'react'
+
+interface CardLike {
+  id: string
+  position: { w: number; h: number }
+}
+
+interface GridPosition {
+  cardId: string
+  index: number
+  row: number
+  colStart: number
+}
+
+interface UseCardGridNavigationOptions {
+  cards: CardLike[]
+  onExpandCard: (cardId: string) => void
+  gridColumns?: number
+}
+
+function computeGridLayout(cards: CardLike[], gridColumns: number): GridPosition[] {
+  const layout: GridPosition[] = []
+  let row = 0
+  let col = 0
+
+  for (let i = 0; i < cards.length; i++) {
+    const w = Math.min(cards[i].position.w, gridColumns)
+    if (col + w > gridColumns) {
+      row++
+      col = 0
+    }
+    layout.push({ cardId: cards[i].id, index: i, row, colStart: col })
+    col += w
+  }
+  return layout
+}
+
+export function useCardGridNavigation({
+  cards,
+  onExpandCard,
+  gridColumns = 12,
+}: UseCardGridNavigationOptions) {
+  const cardRefMap = useRef<Map<string, HTMLElement>>(new Map())
+
+  const layout = useMemo(
+    () => computeGridLayout(cards, gridColumns),
+    [cards, gridColumns]
+  )
+
+  const registerCardRef = useCallback((cardId: string, el: HTMLElement | null) => {
+    if (el) {
+      cardRefMap.current.set(cardId, el)
+    } else {
+      cardRefMap.current.delete(cardId)
+    }
+  }, [])
+
+  const focusCard = useCallback((cardId: string) => {
+    const el = cardRefMap.current.get(cardId)
+    el?.focus()
+  }, [])
+
+  const handleGridKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // Don't handle if inside a modal or input
+    if (
+      e.target instanceof HTMLInputElement ||
+      e.target instanceof HTMLTextAreaElement ||
+      (e.target instanceof HTMLElement && e.target.closest('[role="dialog"]'))
+    ) {
+      return
+    }
+
+    // Find which card is focused
+    const target = e.currentTarget as HTMLElement
+    let currentIdx = -1
+    for (let i = 0; i < layout.length; i++) {
+      if (cardRefMap.current.get(layout[i].cardId) === target) {
+        currentIdx = i
+        break
+      }
+    }
+    if (currentIdx === -1) return
+
+    const current = layout[currentIdx]
+
+    switch (e.key) {
+      case 'ArrowRight': {
+        e.preventDefault()
+        const next = layout[currentIdx + 1]
+        if (next) focusCard(next.cardId)
+        break
+      }
+      case 'ArrowLeft': {
+        e.preventDefault()
+        const prev = layout[currentIdx - 1]
+        if (prev) focusCard(prev.cardId)
+        break
+      }
+      case 'ArrowDown': {
+        e.preventDefault()
+        const belowCards = layout.filter(p => p.row === current.row + 1)
+        if (belowCards.length > 0) {
+          const nearest = belowCards.reduce((best, p) =>
+            Math.abs(p.colStart - current.colStart) < Math.abs(best.colStart - current.colStart) ? p : best
+          )
+          focusCard(nearest.cardId)
+        }
+        break
+      }
+      case 'ArrowUp': {
+        e.preventDefault()
+        const aboveCards = layout.filter(p => p.row === current.row - 1)
+        if (aboveCards.length > 0) {
+          const nearest = aboveCards.reduce((best, p) =>
+            Math.abs(p.colStart - current.colStart) < Math.abs(best.colStart - current.colStart) ? p : best
+          )
+          focusCard(nearest.cardId)
+        }
+        break
+      }
+      case 'Enter':
+      case ' ': {
+        // Only expand when the card container itself is focused, not a button inside it
+        if (e.target === e.currentTarget) {
+          e.preventDefault()
+          onExpandCard(current.cardId)
+        }
+        break
+      }
+    }
+  }, [layout, onExpandCard, focusCard])
+
+  return { registerCardRef, handleGridKeyDown }
+}


### PR DESCRIPTION
## Summary
- Add `useCardGridNavigation` hook for arrow key grid navigation across dashboard cards
- Make cards focusable via Tab with visible focus ring (`focus-visible:ring-2`)
- Enter/Space on a focused card opens the expanded/fullscreen view
- Focus automatically restores to the card when the expanded modal closes
- Arrow keys navigate cards respecting the 12-column CSS grid layout (Up/Down finds nearest card by column position in adjacent row)

Partially addresses #1151 (Phase 2 — Keyboard Navigation)

## Test plan
- [ ] Tab through dashboard cards — focus ring visible, follows grid order
- [ ] Enter or Space on focused card — opens expanded view
- [ ] Escape from expanded view — modal closes, focus returns to originating card
- [ ] Arrow Left/Right — moves to adjacent card in reading order
- [ ] Arrow Up/Down — navigates to nearest card in the row above/below
- [ ] Drag-and-drop still works via grab handle
- [ ] Buttons inside cards (menu, refresh, collapse, expand) still work normally
- [ ] No interference with modal keyboard handling (Escape, Space in modals)