### PR TITLE
✨ Add per-card Bug report button to every dashboard card

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useState, useEffect, useCallback, useRef, useMemo, createContext, useContext, ComponentType, Suspense } from 'react'
 import { createPortal } from 'react-dom'
 import {
-  Maximize2, MoreVertical, Clock, Settings, Replace, Trash2, RefreshCw, MoveHorizontal, ChevronRight, ChevronDown, Info, Download, Link2,
+  Maximize2, MoreVertical, Clock, Settings, Replace, Trash2, RefreshCw, MoveHorizontal, ChevronRight, ChevronDown, Info, Download, Link2, Bug,
   // Card icons
   AlertTriangle, Box, Activity, Database, Server, Cpu, Network, Shield, Package, GitBranch, FileCode, Gauge, AlertCircle, Layers, HardDrive, Globe, Users, Terminal, TrendingUp, Gamepad2, Puzzle, Target, Zap, Crown, Ghost, Bird, Rocket, Wand2, Stethoscope, MonitorCheck, Workflow, Split, Router, BookOpen, Cloudy, Rss, Frame, Wrench, Phone,
 } from 'lucide-react'
@@ -21,6 +21,7 @@ import { ChatMessage } from './CardChat'
 import { CardSkeleton, type CardSkeletonProps } from '../../lib/cards/CardComponents'
 import { isCardExportable } from '../../lib/widgets/widgetRegistry'
 import { WidgetExportModal } from '../widgets/WidgetExportModal'
+import { FeatureRequestModal } from '../feedback/FeatureRequestModal'
 
 // Minimum duration to show spin animation (ensures at least one full rotation)
 const MIN_SPIN_DURATION = 500
@@ -863,6 +864,7 @@ export function CardWrapper({
 }: CardWrapperProps) {
   const { t } = useTranslation(['cards', 'common'])
   const [isExpanded, setIsExpanded] = useState(false)
+  const [showBugReport, setShowBugReport] = useState(false)
 
   // Register expand trigger for keyboard navigation
   useEffect(() => {
@@ -1342,6 +1344,14 @@ export function CardWrapper({
             >
               <Maximize2 className="w-4 h-4" aria-hidden="true" />
             </button>
+            <button
+              onClick={() => setShowBugReport(true)}
+              className="p-1.5 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors"
+              aria-label={t('cardWrapper.reportIssue')}
+              title={t('cardWrapper.reportIssue')}
+            >
+              <Bug className="w-4 h-4" aria-hidden="true" />
+            </button>
             <div className="relative" data-tour="card-menu">
               <button
                 ref={menuButtonRef}
@@ -1595,6 +1605,17 @@ export function CardWrapper({
         isOpen={showWidgetExport}
         onClose={() => setShowWidgetExport(false)}
         cardType={cardType}
+      />
+
+      {/* Per-card bug/feature report modal */}
+      <FeatureRequestModal
+        isOpen={showBugReport}
+        onClose={() => setShowBugReport(false)}
+        initialTab="submit"
+        initialContext={{
+          cardType,
+          cardTitle: title || CARD_TITLES[cardType] || cardType,
+        }}
       />
       </>
     </CardDataReportContext.Provider>

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { X, Bug, Sparkles, Loader2, ExternalLink, Bell, Check, Clock, GitPullRequest, GitMerge, Eye, RefreshCw, MessageSquare, Settings, Github, Coins, Lightbulb, AlertCircle } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 import {
@@ -30,6 +30,10 @@ interface FeatureRequestModalProps {
   isOpen: boolean
   onClose: () => void
   initialTab?: TabType
+  initialContext?: {
+    cardType: string
+    cardTitle: string
+  }
 }
 
 type TabType = 'submit' | 'updates'
@@ -72,7 +76,7 @@ function getStatusInfo(status: RequestStatus, closedByUser?: boolean): { label: 
   return { label, ...colors[status] }
 }
 
-export function FeatureRequestModal({ isOpen, onClose, initialTab }: FeatureRequestModalProps) {
+export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContext }: FeatureRequestModalProps) {
   const { t } = useTranslation()
   const { user, isAuthenticated, token } = useAuth()
   const { showToast } = useToast()
@@ -101,6 +105,15 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab }: FeatureRequ
   const [showSetupDialog, setShowSetupDialog] = useState(false)
   const [previewChecking, setPreviewChecking] = useState<number | null>(null) // PR number being checked
   const [previewResults, setPreviewResults] = useState<Record<number, { status: string; preview_url?: string; ready_at?: string; message?: string }>>({})
+
+  // Pre-fill description when opened from a card's bug button
+  useEffect(() => {
+    if (isOpen && initialContext) {
+      const bugExample = `Card: ${initialContext.cardTitle} (${initialContext.cardType})\n\nExample bug report: (replace this with a detailed bug report)\n`
+      setDescription(bugExample)
+      setRequestType('bug')
+    }
+  }, [isOpen, initialContext])
 
   const handleCheckPreview = async (prNumber: number) => {
     setPreviewChecking(prNumber)

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -514,6 +514,7 @@
     "refreshFailedRetry_other": "Refresh failed {{count}} times - click to retry",
     "refreshData": "Refresh data",
     "expandFullScreen": "Expand card to full screen",
+    "reportIssue": "Report issue for this card",
     "cardMenuTooltip": "Card menu - configure, replace, or remove",
     "configureTooltip": "Configure card settings like cluster and namespace filters",
     "copyLink": "Copy Link",


### PR DESCRIPTION
## Summary
- Adds a Bug icon button to every card's toolbar (between expand and 3-dot menu) in CardWrapper
- Clicking it opens the Contribute modal pre-filled with the card's name and type
- Uses the same `<Bug>` icon from lucide-react as the navbar for consistency
- Zero changes needed per-card — CardWrapper handles everything

## Test plan
- [ ] Open any dashboard card — verify Bug icon appears in toolbar
- [ ] Click Bug icon — Contribute modal opens on Submit tab with card context pre-filled
- [ ] Verify pre-filled text shows card title and type
- [ ] Switch between Bug/Feature type — verify toggle works
- [ ] Submit a bug report — verify GitHub issue is created with card context
- [ ] Click navbar Bug button — verify it still works without card context (no regression)