### PR TITLE
🐛 Fix 3 failing vitest tests

### DIFF
--- a/web/src/components/ChunkErrorBoundary.test.tsx
+++ b/web/src/components/ChunkErrorBoundary.test.tsx
@@ -2,6 +2,20 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { ChunkErrorBoundary } from './ChunkErrorBoundary'
 
+// Mock i18next so translations resolve to English strings
+vi.mock('i18next', () => ({
+  default: {
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'common:chunkError.appUpdated': 'App Updated',
+        'common:chunkError.newVersionDeployed': 'A new version was deployed. Please reload to continue.',
+        'common:chunkError.reloadPage': 'Reload Page',
+      }
+      return translations[key] ?? key
+    },
+  },
+}))
+
 describe('ChunkErrorBoundary Component', () => {
   let reloadSpy: ReturnType<typeof vi.fn>
 

--- a/web/src/components/ui/PaginatedList.test.tsx
+++ b/web/src/components/ui/PaginatedList.test.tsx
@@ -1,9 +1,0 @@
-import { describe, it, expect } from 'vitest'
-import * as PaginatedListModule from './PaginatedList'
-
-describe('PaginatedList Component', () => {
-  it('exports PaginatedList component', () => {
-    expect(PaginatedListModule.PaginatedList).toBeDefined()
-    expect(typeof PaginatedListModule.PaginatedList).toBe('function')
-  })
-})

--- a/web/src/components/ui/UnreachableIndicator.test.tsx
+++ b/web/src/components/ui/UnreachableIndicator.test.tsx
@@ -1,9 +1,0 @@
-import { describe, it, expect } from 'vitest'
-import * as UnreachableIndicatorModule from './UnreachableIndicator'
-
-describe('UnreachableIndicator Component', () => {
-  it('exports UnreachableIndicator component', () => {
-    expect(UnreachableIndicatorModule.UnreachableIndicator).toBeDefined()
-    expect(typeof UnreachableIndicatorModule.UnreachableIndicator).toBe('function')
-  })
-})


### PR DESCRIPTION
## Summary
- Delete orphaned `PaginatedList.test.tsx` — imports `./PaginatedList` which was never created
- Delete orphaned `UnreachableIndicator.test.tsx` — imports `./UnreachableIndicator` which was never created
- Fix `ChunkErrorBoundary.test.tsx` — mock `i18next` so `i18next.t()` calls return English translations instead of empty strings in the test environment

## Test plan
- [x] `npx vitest run` — 80 test files pass, 116 tests pass, 0 failures
- [x] `npm run build` passes