### PR TITLE
🐛 Fix null contributions crash on page load

### DIFF
--- a/pkg/api/handlers/rewards.go
+++ b/pkg/api/handlers/rewards.go
@@ -144,7 +144,7 @@ func (h *RewardsHandler) GetGitHubRewards(c *fiber.Ctx) error {
 }
 
 func (h *RewardsHandler) fetchUserRewards(login, token string) (*GitHubRewardsResponse, error) {
-	var contributions []GitHubContribution
+	contributions := make([]GitHubContribution, 0)
 	var fetchErr error
 
 	// 1. Fetch issues authored by user

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -917,7 +917,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab }: FeatureRequ
                           <Github className="w-6 h-6 mx-auto mb-2 opacity-50" />
                           <p className="text-xs">Log in with GitHub to see contributions</p>
                         </div>
-                      ) : githubRewards.contributions.length === 0 ? (
+                      ) : !githubRewards.contributions?.length ? (
                         <div className="p-6 text-center text-muted-foreground">
                           <Github className="w-6 h-6 mx-auto mb-2 opacity-50" />
                           <p className="text-xs">No contributions found — open issues or PRs to earn points</p>


### PR DESCRIPTION
## Summary
- Go backend: `var contributions []GitHubContribution` was nil, which JSON-marshals to `null` instead of `[]`
- Frontend: `githubRewards.contributions.length` crashes when `.contributions` is null
- **Fix**: Initialize with `make([]GitHubContribution, 0)` so JSON produces `[]`, plus add optional chaining (`?.length`) on the frontend for defense in depth

## Root Cause
When a user has no GitHub contributions, the Go slice is nil → JSON `null` → JS `.length` on null → `TypeError`

## Test plan
- [ ] Load console with no GitHub auth → no crash
- [ ] Load console with GitHub auth, user with no contributions → shows "No contributions found" message
- [ ] Load console with GitHub auth, user with contributions → shows contribution list