### PR TITLE
✨ Screen reader support and ARIA live regions (a11y Phase 3)

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1261,6 +1261,8 @@ export function CardWrapper({
             {showDemoIndicator && (
               <span
                 data-testid="demo-badge"
+                role="status"
+                aria-live="polite"
                 className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400"
                 title={effectiveIsDemoData ? t('cardWrapper.demoBadgeTitle') : t('cardWrapper.demoModeTitle')}
               >
@@ -1270,6 +1272,8 @@ export function CardWrapper({
             {/* Live data indicator - for time-series/trend cards with real data */}
             {isLive && !showDemoIndicator && (
               <span
+                role="status"
+                aria-live="polite"
                 className="text-[10px] px-1.5 py-0.5 rounded bg-green-500/20 text-green-400"
                 title={t('cardWrapper.liveBadgeTitle')}
               >
@@ -1279,6 +1283,8 @@ export function CardWrapper({
             {/* Failure indicator */}
             {effectiveIsFailed && (
               <span
+                role="alert"
+                aria-live="assertive"
                 className="text-[10px] px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 flex items-center gap-1"
                 title={t('cardWrapper.refreshFailedCount', { count: effectiveConsecutiveFailures })}
               >

--- a/web/src/components/cards/ClusterCosts.tsx
+++ b/web/src/components/cards/ClusterCosts.tsx
@@ -809,7 +809,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
             )}
           </div>
           <span className="flex items-center gap-1">
-            <TrendingUp className="w-3 h-3" />
+            <TrendingUp className="w-3 h-3" aria-hidden="true" />
             {t('cards:clusterCosts.clusterCount', { count: totalItems })}
           </span>
         </div>

--- a/web/src/components/cards/EventsTimeline.tsx
+++ b/web/src/components/cards/EventsTimeline.tsx
@@ -261,21 +261,21 @@ function EventsTimelineInternal() {
       <div className="grid grid-cols-3 gap-2 mb-4">
         <div className="p-2 rounded-lg bg-orange-500/10 border border-orange-500/20">
           <div className="flex items-center gap-1.5 mb-1">
-            <AlertTriangle className="w-3 h-3 text-orange-400" />
+            <AlertTriangle className="w-3 h-3 text-orange-400" aria-hidden="true" />
             <span className="text-xs text-orange-400">{t('common:common.warnings')}</span>
           </div>
           <span className="text-lg font-bold text-foreground">{totalWarnings}</span>
         </div>
         <div className="p-2 rounded-lg bg-green-500/10 border border-green-500/20">
           <div className="flex items-center gap-1.5 mb-1">
-            <CheckCircle className="w-3 h-3 text-green-400" />
+            <CheckCircle className="w-3 h-3 text-green-400" aria-hidden="true" />
             <span className="text-xs text-green-400">{t('common:common.normal')}</span>
           </div>
           <span className="text-lg font-bold text-foreground">{totalNormal}</span>
         </div>
         <div className="p-2 rounded-lg bg-secondary/50">
           <div className="flex items-center gap-1.5 mb-1">
-            <Activity className="w-3 h-3 text-muted-foreground" />
+            <Activity className="w-3 h-3 text-muted-foreground" aria-hidden="true" />
             <span className="text-xs text-muted-foreground">{t('eventsTimeline.peak')}</span>
           </div>
           <span className="text-lg font-bold text-foreground">{peakEvents}</span>
@@ -289,7 +289,7 @@ function EventsTimelineInternal() {
             {t('eventsTimeline.noEventsInRange')}
           </div>
         ) : (
-          <div style={{ width: '100%', minHeight: CHART_HEIGHT_STANDARD, height: CHART_HEIGHT_STANDARD }}>
+          <div style={{ width: '100%', minHeight: CHART_HEIGHT_STANDARD, height: CHART_HEIGHT_STANDARD }} role="img" aria-label={`Events timeline chart showing ${totalWarnings} warnings and ${totalNormal} normal events, peak ${peakEvents} events`}>
           <ResponsiveContainer width="100%" height={CHART_HEIGHT_STANDARD}>
             <AreaChart data={timeSeriesData} margin={{ top: 5, right: 5, left: 0, bottom: 5 }}>
               <defs>

--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -338,7 +338,7 @@ export function GPUUsageTrend() {
         </div>
         <div className={`p-2 rounded-lg bg-secondary/50 border border-border`} title={`${usagePercent}% GPU utilization`}>
           <div className="flex items-center gap-1 mb-1">
-            <TrendingUp className={`w-3 h-3 ${getUsageColor()}`} />
+            <TrendingUp className={`w-3 h-3 ${getUsageColor()}`} aria-hidden="true" />
             <span className={`text-xs ${getUsageColor()}`}>Usage</span>
           </div>
           <span className={`text-sm font-bold ${getUsageColor()}`}>{usagePercent}%</span>
@@ -352,7 +352,7 @@ export function GPUUsageTrend() {
             No GPU data available
           </div>
         ) : (
-          <div style={{ width: '100%', minHeight: CHART_HEIGHT_STANDARD, height: CHART_HEIGHT_STANDARD }}>
+          <div style={{ width: '100%', minHeight: CHART_HEIGHT_STANDARD, height: CHART_HEIGHT_STANDARD }} role="img" aria-label={`GPU usage trend chart: ${currentTotals.allocated} of ${currentTotals.available} GPUs in use (${usagePercent}% utilization)`}>
             <ResponsiveContainer width="100%" height={CHART_HEIGHT_STANDARD}>
               <AreaChart data={history} margin={{ top: 5, right: 5, left: 0, bottom: 5 }}>
                 <defs>

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -1262,7 +1262,7 @@ function ContributorItem({ contributor }: { contributor: GitHubContributor }) {
             {contributor.contributions} {t('cards:github.contributions')}
           </div>
         </div>
-        <TrendingUp className="w-4 h-4 text-green-400" />
+        <TrendingUp className="w-4 h-4 text-green-400" aria-hidden="true" />
       </div>
     </a>
   )

--- a/web/src/components/cards/KubecostOverview.tsx
+++ b/web/src/components/cards/KubecostOverview.tsx
@@ -112,7 +112,7 @@ export function KubecostOverview({ config: _config }: KubecostOverviewProps) {
         <div className="flex items-center justify-between mb-2">
           <p className="text-xs text-muted-foreground font-medium">Savings Recommendations</p>
           <span className="flex items-center gap-1 text-xs text-green-400">
-            <TrendingDown className="w-3 h-3" />
+            <TrendingDown className="w-3 h-3" aria-hidden="true" />
             ${DEMO_COST_SUMMARY.savings}/mo potential
           </span>
         </div>

--- a/web/src/components/cards/ResourceTrend.tsx
+++ b/web/src/components/cards/ResourceTrend.tsx
@@ -323,14 +323,14 @@ export function ResourceTrend() {
       <div className="flex-1 min-h-[160px]">
         {history.length < 2 ? (
           <div className="h-full flex flex-col items-center justify-center text-muted-foreground text-sm">
-            <TrendingUp className="w-6 h-6 mb-2 opacity-50" />
+            <TrendingUp className="w-6 h-6 mb-2 opacity-50" aria-hidden="true" />
             <span>{history.length === 0 ? 'No resource data available' : 'Collecting data...'}</span>
             {history.length === 1 && (
               <span className="text-xs mt-1">Chart will appear after next interval</span>
             )}
           </div>
         ) : (
-          <div style={{ width: '100%', minHeight: CHART_HEIGHT_STANDARD, height: CHART_HEIGHT_STANDARD }}>
+          <div style={{ width: '100%', minHeight: CHART_HEIGHT_STANDARD, height: CHART_HEIGHT_STANDARD }} role="img" aria-label={`Resource trend chart showing ${lines.map(l => l.name).join(', ')} over time`}>
           <ResponsiveContainer width="100%" height={CHART_HEIGHT_STANDARD}>
             <LineChart data={history} margin={{ top: 5, right: 5, left: 0, bottom: 5 }}>
               <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} />

--- a/web/src/components/cards/StockMarketTicker.tsx
+++ b/web/src/components/cards/StockMarketTicker.tsx
@@ -391,6 +391,8 @@ function Sparkline({ data, isPositive }: { data: number[]; isPositive: boolean }
       className="w-20 h-8"
       viewBox="0 0 100 100"
       preserveAspectRatio="none"
+      role="img"
+      aria-label={`Price trend: ${isPositive ? 'rising' : 'falling'}`}
     >
       <polyline
         points={points}
@@ -477,7 +479,7 @@ function StockRow({
         <div className="text-right flex-shrink-0">
           <div className="font-semibold text-sm">${stock.price.toFixed(2)}</div>
           <div className={`text-xs flex items-center justify-end gap-1 ${isPositive ? 'text-green-500' : 'text-red-500'}`}>
-            {isPositive ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
+            {isPositive ? <TrendingUp className="w-3 h-3" aria-hidden="true" /> : <TrendingDown className="w-3 h-3" aria-hidden="true" />}
             <span>{isPositive ? '+' : ''}{stock.changePercent.toFixed(2)}%</span>
           </div>
         </div>

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -205,11 +205,12 @@ Please provide:
         target="_blank"
         rel="noopener noreferrer"
         title={!isFailed ? title : undefined}
+        aria-label={`Run #${run.runNumber}: ${title}`}
         onClick={e => e.stopPropagation()}
       >
         <div className={`w-3 h-3 rounded-full ${color} ${isRunning ? 'animate-pulse' : ''} ${
           isHighlighted ? 'ring-2 ring-white/50 scale-125' : 'group-hover:ring-2 group-hover:ring-white/30'
-        } transition-all`} />
+        } transition-all`} aria-hidden="true" />
       </a>
       {isFailed && showPopup && popupPos && createPortal(
         <div

--- a/web/src/components/ui/ClusterStatusBadge.tsx
+++ b/web/src/components/ui/ClusterStatusBadge.tsx
@@ -190,8 +190,10 @@ export function ClusterStatusBadge({
         className
       )}
       title={tooltip}
+      role="status"
+      aria-label={`Cluster status: ${tooltip.replace(/\n/g, ', ')}`}
     >
-      <Icon className={iconSize} />
+      <Icon className={iconSize} aria-hidden="true" />
       {showLabel && <span>{displayLabel}</span>}
     </span>
   )
@@ -228,6 +230,8 @@ export function ClusterStatusDot({
     <span
       className={cn('rounded-full', dotColors[state], dotSize, className)}
       title={config.label}
+      role="status"
+      aria-label={`Cluster status: ${config.label}`}
     />
   )
 }

--- a/web/src/components/ui/RefreshIndicator.tsx
+++ b/web/src/components/ui/RefreshIndicator.tsx
@@ -77,8 +77,11 @@ export function RefreshIndicator({
           className
         )}
         title="Updating..."
+        role="status"
+        aria-live="polite"
+        aria-label="Updating data"
       >
-        <RefreshCw className={cn(iconSize, 'animate-spin-min')} />
+        <RefreshCw className={cn(iconSize, 'animate-spin-min')} aria-hidden="true" />
         {showLabel && <span>Updating</span>}
       </span>
     )
@@ -93,8 +96,10 @@ export function RefreshIndicator({
         className
       )}
       title={tooltip}
+      role="status"
+      aria-label={lastUpdated ? `Last updated: ${formatLastSeen(lastUpdated)}` : 'Not yet updated'}
     >
-      <Clock className={iconSize} />
+      <Clock className={iconSize} aria-hidden="true" />
       {showLabel && (
         <span>
           {lastUpdated ? formatLastSeen(lastUpdated) : 'pending'}
@@ -186,10 +191,12 @@ export function RefreshButton({
     <div className={`flex items-center gap-1 ${className}`}>
       {isFailed && (
         <div
+          role="alert"
+          aria-live="assertive"
           className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 text-xs"
           title={`${consecutiveFailures} consecutive refresh failures`}
         >
-          <AlertTriangle className="w-3 h-3" />
+          <AlertTriangle className="w-3 h-3" aria-hidden="true" />
           <span>{t('refresh.failed')}</span>
         </div>
       )}
@@ -198,6 +205,7 @@ export function RefreshButton({
         disabled={disabled || isRefreshing || isVisuallySpinning}
         className={`${buttonPadding} hover:bg-secondary rounded transition-colors disabled:opacity-50`}
         title={tooltipText}
+        aria-label={tooltipText}
       >
         <RefreshCw
           className={`${sizeClasses} ${


### PR DESCRIPTION
## Summary
- Adds `role="status"` and `aria-live="polite"` to demo/live badges, `role="alert"` with `aria-live="assertive"` to failure indicators in CardWrapper
- Adds `aria-label` to ClusterStatusBadge, ClusterStatusDot, and NightlyE2EStatus RunDot components
- Adds `aria-live` regions to RefreshIndicator for update/idle state announcements
- Adds `role="img"` with descriptive `aria-label` to chart containers (EventsTimeline, ResourceTrend, GPUUsageTrend, StockMarketTicker sparkline)
- Marks decorative TrendingUp/TrendingDown icons as `aria-hidden="true"` across 6 components

## Test plan
- [ ] Screen reader (VoiceOver) announces demo/live/failed badge state changes
- [ ] ClusterStatusBadge and ClusterStatusDot read cluster status to screen reader
- [ ] NightlyE2EStatus run dots announce run number and status
- [ ] RefreshIndicator announces "Updating data" and "Last updated" states
- [ ] Chart containers provide text descriptions of chart data
- [ ] Decorative icons are hidden from screen readers
- [ ] Build passes, no new lint errors

Closes Phase 3 and remaining Phase 1 items of #1151.