### PR TITLE
🐛 Fix Contribute modal height jumping between tabs

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -232,7 +232,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
   }
 
   return (
-    <BaseModal isOpen={isOpen} onClose={handleClose} size="lg" closeOnBackdrop={true}>
+    <BaseModal isOpen={isOpen} onClose={handleClose} size="lg" closeOnBackdrop={true} className="!h-[80vh]">
       {/* Login Prompt Dialog */}
       {showLoginPrompt && (
         <>


### PR DESCRIPTION
## Summary
- Fix modal height inconsistency between Submit and Updates tabs
- Set fixed `h-[80vh]` instead of `min-h-[80vh]` so both tabs render at the same size
- Eliminates jumpiness when switching between tabs

## Test plan
- [ ] Open Contribute modal on Submit tab — note height
- [ ] Switch to Updates tab — verify same height (no jumping)
- [ ] Switch back to Submit — still same height