### PR TITLE
🐛 Fix vitest worker RPC timeout errors in dashboard tests

### DIFF
--- a/web/src/components/dashboard/AddCardModal.test.tsx
+++ b/web/src/components/dashboard/AddCardModal.test.tsx
@@ -1,4 +1,15 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock the heavy cardRegistry (pulled in transitively via CardFactoryModal)
+vi.mock('../cards/cardRegistry', () => ({
+  CARD_COMPONENTS: {},
+  DEMO_DATA_CARDS: [],
+  LIVE_DATA_CARDS: [],
+  MODULE_MAP: {},
+  CARD_SIZES: {},
+  registerDynamicCardType: vi.fn(),
+}))
+
 import * as AddCardModalModule from './AddCardModal'
 
 describe('AddCardModal Component', () => {

--- a/web/src/components/dashboard/CardFactoryModal.test.tsx
+++ b/web/src/components/dashboard/CardFactoryModal.test.tsx
@@ -1,4 +1,15 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock the heavy cardRegistry to avoid loading all card bundles
+vi.mock('../cards/cardRegistry', () => ({
+  CARD_COMPONENTS: {},
+  DEMO_DATA_CARDS: [],
+  LIVE_DATA_CARDS: [],
+  MODULE_MAP: {},
+  CARD_SIZES: {},
+  registerDynamicCardType: vi.fn(),
+}))
+
 import * as CardFactoryModalModule from './CardFactoryModal'
 
 describe('CardFactoryModal Component', () => {

--- a/web/src/components/dashboard/SharedSortableCard.test.tsx
+++ b/web/src/components/dashboard/SharedSortableCard.test.tsx
@@ -1,4 +1,15 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+
+// Mock the heavy cardRegistry to avoid loading all card bundles
+vi.mock('../cards/cardRegistry', () => ({
+  CARD_COMPONENTS: {},
+  DEMO_DATA_CARDS: [],
+  LIVE_DATA_CARDS: [],
+  MODULE_MAP: {},
+  CARD_SIZES: {},
+  registerDynamicCardType: vi.fn(),
+}))
+
 import * as SharedSortableCardModule from './SharedSortableCard'
 
 describe('SharedSortableCard (SortableCard) Component', () => {


### PR DESCRIPTION
## Summary
- Mock `cardRegistry` in `SharedSortableCard.test.tsx`, `AddCardModal.test.tsx`, and `CardFactoryModal.test.tsx`
- These export-existence tests were loading the entire card registry (200+ card bundles), causing vitest worker RPC timeouts (`Closing rpc while "fetch" was pending`) during full suite runs
- With mocks, the heavy dynamic imports are avoided entirely

## Test plan
- [x] `npx vitest run` — **80 test files, 116 tests, 0 failures, 0 errors**
- [x] `npm run build` passes