### PR TITLE
🐛 Fix feedback modal: placeholder overwrite, misleading errors, weak validation

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -335,8 +335,9 @@ class ApiClient {
           handle401()
           throw new UnauthorizedError()
         }
+        const errorText = await response.text().catch(() => '')
         // Note: Don't mark backend as failed on 500s - health check is source of truth
-        throw new Error(`API error: ${response.status}`)
+        throw new Error(errorText || `API error: ${response.status}`)
       }
       markBackendSuccess()
       const data = await response.json()
@@ -378,8 +379,9 @@ class ApiClient {
           handle401()
           throw new UnauthorizedError()
         }
+        const errorText = await response.text().catch(() => '')
         // Note: Don't mark backend as failed on 500s - health check is source of truth
-        throw new Error(`API error: ${response.status}`)
+        throw new Error(errorText || `API error: ${response.status}`)
       }
       markBackendSuccess()
       const data = await response.json()
@@ -420,8 +422,9 @@ class ApiClient {
           handle401()
           throw new UnauthorizedError()
         }
+        const errorText = await response.text().catch(() => '')
         // Note: Don't mark backend as failed on 500s - health check is source of truth
-        throw new Error(`API error: ${response.status}`)
+        throw new Error(errorText || `API error: ${response.status}`)
       }
       markBackendSuccess()
     } catch (err) {


### PR DESCRIPTION
## Summary
- **Placeholder text overwrites user input** — `initialContext` is an inline object creating a new ref each render, causing the pre-fill `useEffect` to re-fire continuously. Fixed with `useRef` to only pre-fill once when the modal opens.
- **Misleading error message** — "Unable to submit — GitHub login may be required" was shown for ALL submission errors, including backend validation failures (400). Now parses and displays the actual backend error (e.g., "Description must be at least 20 characters").
- **Frontend validation too loose** — Only checked 10 chars total, but backend requires title >= 10, description >= 20, and >= 3 words. Frontend now validates the same rules before sending.
- **api.ts POST/PUT/DELETE missing error text** — GET already parsed response body on error, but write methods discarded it. All methods now include response text in thrown errors.

## Test plan
- [ ] Open Contribute modal from a card's bug button — placeholder should appear once and not overwrite typed text
- [ ] Submit with short description — should show specific validation error, not "GitHub login may be required"
- [ ] Submit with valid content — should create GitHub issue successfully