### PR TITLE
fix: sidebar collapse button visibility

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -304,7 +304,7 @@ export function Sidebar() {
           data-testid="sidebar-collapse-toggle"
           onClick={toggleCollapsed}
           aria-expanded={!config.collapsed}
-          className="absolute -right-3 top-6 p-1 rounded-full bg-secondary border border-border text-muted-foreground hover:text-foreground z-10 hidden md:block"
+          className="sticky top-2 float-right -mr-4 mb-4 p-1 rounded-full bg-secondary border border-border text-muted-foreground hover:text-foreground z-10 hidden md:block shadow-md"
         >
           {config.collapsed ? <ChevronRight className="w-4 h-4" aria-hidden="true" /> : <ChevronLeft className="w-4 h-4" aria-hidden="true" />}
         </button>


### PR DESCRIPTION
### 📌 Fixes

Fixes #1259 

---

### 📝 Summary of Changes

Fixes the sidebar collapse toggle button becoming hidden when scrolling through navigation items.

---

### Changes Made

- Changed button positioning from `absolute -right-3 top-6` to `sticky top-2`
- Added `float-right -mr-4 mb-4` for proper edge positioning
- Added `shadow-md` for better visibility over scrolling content
- Button now remains visible at the top during scroll

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

https://github.com/user-attachments/assets/d856c264-3573-454e-911c-70923c63e058


---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
