### PR TITLE
✨ Add first-party GA4 analytics proxy to bypass ad blockers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -35,6 +35,19 @@
   to = "/.netlify/functions/presence"
   status = 200
 
+# GA4 analytics proxy — bypass ad blockers via first-party domain
+[[redirects]]
+  from = "/t/g/js"
+  to = "https://www.googletagmanager.com/gtag/js"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/t/g/collect"
+  to = "https://www.google-analytics.com/g/collect"
+  status = 200
+  force = true
+
 # SPA routing - redirect all routes to index.html (only if file doesn't exist)
 [[redirects]]
   from = "/*"

--- a/pkg/api/handlers/analytics_proxy.go
+++ b/pkg/api/handlers/analytics_proxy.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+var ga4Client = &http.Client{Timeout: 10 * time.Second}
+
+// GA4ScriptProxy proxies the gtag.js script through the console's own domain
+// so that ad blockers do not block it.
+func GA4ScriptProxy(c *fiber.Ctx) error {
+	target := "https://www.googletagmanager.com/gtag/js?" + string(c.Context().QueryArgs().QueryString())
+	resp, err := ga4Client.Get(target)
+	if err != nil {
+		return c.SendStatus(fiber.StatusBadGateway)
+	}
+	defer resp.Body.Close()
+	c.Set("Content-Type", resp.Header.Get("Content-Type"))
+	c.Set("Cache-Control", "public, max-age=3600")
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return c.SendStatus(fiber.StatusBadGateway)
+	}
+	return c.Status(resp.StatusCode).Send(body)
+}
+
+// GA4CollectProxy proxies GA4 event collection requests through the console's
+// own domain so that ad blockers do not block them.
+func GA4CollectProxy(c *fiber.Ctx) error {
+	target := "https://www.google-analytics.com/g/collect?" + string(c.Context().QueryArgs().QueryString())
+	req, err := http.NewRequest(c.Method(), target, bytes.NewReader(c.Body()))
+	if err != nil {
+		return c.SendStatus(fiber.StatusBadGateway)
+	}
+	req.Header.Set("Content-Type", c.Get("Content-Type", "text/plain"))
+	req.Header.Set("User-Agent", c.Get("User-Agent"))
+	resp, err := ga4Client.Do(req)
+	if err != nil {
+		return c.SendStatus(fiber.StatusBadGateway)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return c.SendStatus(fiber.StatusBadGateway)
+	}
+	return c.Status(resp.StatusCode).Send(body)
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -692,6 +692,10 @@ func (s *Server) setupRoutes() {
 		s.hub.HandleConnection(c)
 	}))
 
+	// GA4 analytics proxy — bypass ad blockers via first-party domain
+	s.app.Get("/t/g/js", handlers.GA4ScriptProxy)
+	s.app.All("/t/g/collect", handlers.GA4CollectProxy)
+
 	// Serve static files in production
 	if !s.config.DevMode {
 		s.app.Static("/", "./web/dist")

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -62,7 +62,7 @@ export function initAnalytics() {
 
   // Inject gtag.js script
   const script = document.createElement('script')
-  script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`
+  script.src = `/t/g/js?id=${measurementId}`
   script.async = true
   document.head.appendChild(script)
 
@@ -75,6 +75,7 @@ export function initAnalytics() {
   gtag('config', measurementId, {
     send_page_view: false,
     cookie_flags: 'SameSite=None;Secure',
+    transport_url: '/t/g',
   })
 
   // Set persistent user properties


### PR DESCRIPTION
## Summary
- Routes GA4 requests (`gtag.js` script + event collection) through the console's own domain (`/t/g/js`, `/t/g/collect`) so ad blockers cannot block analytics
- Netlify proxy redirects (status 200) for `console.kubestellar.io`
- Go reverse proxy handlers for localhost and cluster deployments
- Estimated 30-50% of developer users (especially international) were hidden by ad blockers blocking `googletagmanager.com` and `google-analytics.com`

## Test plan
- [ ] `go build` passes
- [ ] `npm run build` passes
- [ ] Chrome DevTools Network tab shows `/t/g/js` loading (no direct `googletagmanager.com` requests)
- [ ] GA4 Realtime shows events arriving
- [ ] With uBlock Origin enabled, analytics still works through proxy