### PR TITLE
🐛 Fix GA4 transport_url to use absolute origin

### DIFF
--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -75,7 +75,7 @@ export function initAnalytics() {
   gtag('config', measurementId, {
     send_page_view: false,
     cookie_flags: 'SameSite=None;Secure',
-    transport_url: '/t/g',
+    transport_url: `${window.location.origin}/t`,
   })
 
   // Set persistent user properties


### PR DESCRIPTION
## Summary
- GA4's `transport_url` config expects an origin URL, not a relative path
- `/t/g` was being resolved as hostname `t` → `https://t/g/g/collect` (ERR_NAME_NOT_RESOLVED)
- Changed to `window.location.origin + '/t'` so GA4 correctly builds `http://localhost:8080/t/g/collect`

## Test plan
- [ ] Chrome DevTools Network tab shows `POST /t/g/collect` succeeding (200/204)
- [ ] No `ERR_NAME_NOT_RESOLVED` errors for collect endpoint
- [ ] GA4 Realtime shows events arriving