### PR TITLE
🐛 Fix settings scroll, .join crash, and auto-update 404 spam

### DIFF
--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -261,7 +261,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
   // Note: Token stored in localStorage base64 encoded - decode before use
   const encodedToken = config?.token || localStorage.getItem(STORAGE_KEY_GITHUB_TOKEN) || ''
   const token = encodedToken ? decodeToken(encodedToken) : ''
-  const reposKey = useMemo(() => repos.join(','), [repos.join(',')])
+  const reposKey = useMemo(() => repos.join(','), [repos])
 
   const fetchGitHubData = async (isManualRefresh = false) => {
     if (isDemoMode) {

--- a/web/src/components/drilldown/views/CRDDrillDown.tsx
+++ b/web/src/components/drilldown/views/CRDDrillDown.tsx
@@ -288,7 +288,7 @@ CRD Details:
 - Established: ${isEstablished ? 'Yes' : 'No'}
 
 Versions:
-${versions?.map(v => `- ${v.name}: served=${v.served}, storage=${v.storage}${v.deprecated ? ' (DEPRECATED)' : ''}`).join('\n') || 'Unknown'}
+${(versions ?? []).map(v => `- ${v.name}: served=${v.served}, storage=${v.storage}${v.deprecated ? ' (DEPRECATED)' : ''}`).join('\n') || 'Unknown'}
 
 ${deprecatedVersions.length > 0 ? `
 ⚠️ Deprecated Versions Found:

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { User, Mail, MessageSquare, Shield, Settings, LogOut, ChevronDown, Coins, Lightbulb, Linkedin, Globe, Check, Download, Code2, ExternalLink, Rocket, KeyRound, CheckCircle2, XCircle } from 'lucide-react'
+import { User, Mail, MessageSquare, Shield, Settings, LogOut, ChevronDown, Coins, Lightbulb, Linkedin, Globe, Check, Download, Code2, ExternalLink, Rocket, KeyRound, CheckCircle2, XCircle, GitBranch } from 'lucide-react'
 import { useRewards, REWARD_ACTIONS } from '../../hooks/useRewards'
+import { useVersionCheck } from '../../hooks/useVersionCheck'
 import { languages } from '../../lib/i18n'
 import { isDemoModeForced } from '../../lib/demoMode'
 import { checkOAuthConfigured } from '../../lib/api'
@@ -35,6 +36,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
   })
   const dropdownRef = useRef<HTMLDivElement>(null)
   const { totalCoins, awardCoins } = useRewards()
+  const { channel, setChannel, installMethod } = useVersionCheck()
   const { t, i18n } = useTranslation()
 
   const currentLanguage = languages.find(l => l.code === i18n.language) || languages[0]
@@ -248,6 +250,32 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
                       <span className="text-muted-foreground">{t('developer.checkingOauth')}</span>
                     )}
                   </div>
+
+                  {/* Developer update channel toggle */}
+                  {installMethod === 'dev' && (
+                    <button
+                      onClick={() => {
+                        setChannel(channel === 'developer' ? 'stable' : 'developer')
+                      }}
+                      className="flex items-center gap-2 text-xs"
+                    >
+                      <GitBranch className={`w-3.5 h-3.5 ${channel === 'developer' ? 'text-orange-400' : 'text-muted-foreground'}`} />
+                      <span className={channel === 'developer' ? 'text-orange-400' : 'text-muted-foreground'}>
+                        {t('settings.updates.developer')}
+                      </span>
+                      <div
+                        className={`ml-auto relative w-8 h-4 rounded-full transition-colors ${
+                          channel === 'developer' ? 'bg-orange-500' : 'bg-secondary'
+                        }`}
+                      >
+                        <div
+                          className={`absolute top-0.5 w-3 h-3 rounded-full bg-white shadow-sm transition-transform ${
+                            channel === 'developer' ? 'translate-x-4' : 'translate-x-0.5'
+                          }`}
+                        />
+                      </div>
+                    </button>
+                  )}
 
                   {/* Action buttons */}
                   <div className="flex flex-col gap-1 pt-1">


### PR DESCRIPTION
## Summary
- Fix `GitHubActivity` useMemo dependency array calling `.join()` inside deps (caused TypeError crash)
- Fix `CRDDrillDown` calling `.join()` on potentially undefined `versions` array
- Fix `useVersionCheck`: only fetch `/auto-update/status` when kc-agent supports it (prevents 404 spam)
- Fix `useVersionCheck`: fallback to backend `/health` for `install_method` (developer channel visibility)
- Settings page: use `IntersectionObserver` for active section tracking in sidebar
- Settings page: scroll with proper offset for sticky navbar
- Add Developer channel toggle to user profile dropdown

## Test plan
- [ ] Open Settings page, click nav items — sections should scroll into view below navbar
- [ ] Scroll through settings — left sidebar should highlight the currently visible section
- [ ] Open browser console — no more `/auto-update/status` 404 errors
- [ ] Verify Developer channel appears in update settings dropdown
- [ ] Verify Developer toggle appears in user profile dropdown > Developer panel