### PR TITLE
🐛 Revert GA4 to direct Google URLs

### DIFF
--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -62,7 +62,7 @@ export function initAnalytics() {
 
   // Inject gtag.js script
   const script = document.createElement('script')
-  script.src = `/t/g/js?id=${measurementId}`
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`
   script.async = true
   document.head.appendChild(script)
 
@@ -75,7 +75,7 @@ export function initAnalytics() {
   gtag('config', measurementId, {
     send_page_view: false,
     cookie_flags: 'SameSite=None;Secure',
-    transport_url: `${window.location.origin}/t`,
+    // transport_url: `${window.location.origin}/t`, // first-party proxy (disabled — needs validation)
   })
 
   // Set persistent user properties


### PR DESCRIPTION
## Summary
- Reverts gtag.js script loading to `googletagmanager.com` (direct)
- Disables `transport_url` proxy for event collection
- Proxy infrastructure (Netlify redirects, Go handlers) remains for future use
- Fixes analytics drop caused by proxy deployment

## Context
The first-party proxy was technically working (verified 200/204 responses) but user counts dropped from ~2K to 1 after deployment. Reverting to direct URLs to restore analytics while we investigate further.