### PR TITLE
🐛 Fix unsafe .join() calls, settings scroll, and auto-update 404s

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -6,7 +6,7 @@
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#7c3aed" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="KubeStellar" />
     <link rel="apple-touch-icon" href="/pwa-icon-192.png" />

--- a/web/src/components/cards/rss/RSSFeed.tsx
+++ b/web/src/components/cards/rss/RSSFeed.tsx
@@ -64,7 +64,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
     const firstFeed = savedFeeds[0]
     if (firstFeed) {
       const cacheKey = firstFeed.isAggregate
-        ? `aggregate:${firstFeed.sourceUrls?.join(',')}:${firstFeed.name}`
+        ? `aggregate:${(firstFeed.sourceUrls ?? []).join(',')}:${firstFeed.name}`
         : firstFeed.url
       const cached = getCachedFeed(cacheKey, true)
       if (cached && cached.items.length > 0) {
@@ -80,7 +80,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
     const firstFeed = savedFeeds[0]
     if (firstFeed) {
       return firstFeed.isAggregate
-        ? `aggregate:${firstFeed.sourceUrls?.join(',')}:${firstFeed.name}`
+        ? `aggregate:${(firstFeed.sourceUrls ?? []).join(',')}:${firstFeed.name}`
         : firstFeed.url
     }
     return null
@@ -93,7 +93,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
     const firstFeed = savedFeeds[0]
     if (firstFeed) {
       const cacheKey = firstFeed.isAggregate
-        ? `aggregate:${firstFeed.sourceUrls?.join(',')}:${firstFeed.name}`
+        ? `aggregate:${(firstFeed.sourceUrls ?? []).join(',')}:${firstFeed.name}`
         : firstFeed.url
       const cached = getCachedFeed(cacheKey, true)
       return !cached || cached.items.length === 0
@@ -129,7 +129,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
 
   // Get cache key for current feed
   const currentCacheKey = activeFeed?.isAggregate
-    ? `aggregate:${activeFeed.sourceUrls?.join(',')}:${activeFeed.name}`
+    ? `aggregate:${(activeFeed.sourceUrls ?? []).join(',')}:${activeFeed.name}`
     : activeFeed?.url
 
   // Check if displayed items match the active feed
@@ -325,7 +325,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
       setError(null)
       // Cache demo data so warm return finds it immediately
       const cacheKey = activeFeed?.isAggregate
-        ? `aggregate:${activeFeed.sourceUrls?.join(',')}:${activeFeed.name}`
+        ? `aggregate:${(activeFeed.sourceUrls ?? []).join(',')}:${activeFeed.name}`
         : activeFeed?.url
       if (cacheKey) cacheFeed(cacheKey, demoItems)
       return
@@ -334,7 +334,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
     if (!activeFeed?.url && !activeFeed?.isAggregate) return
 
     const cacheKey = activeFeed.isAggregate
-      ? `aggregate:${activeFeed.sourceUrls?.join(',')}:${activeFeed.name}`
+      ? `aggregate:${(activeFeed.sourceUrls ?? []).join(',')}:${activeFeed.name}`
       : activeFeed.url
 
     // Always show cached content first (even if stale) for better UX
@@ -503,8 +503,8 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
     setEditingAggregateIndex(index)
     setAggregateName(feed.name)
     setSelectedSourceUrls(feed.sourceUrls || [])
-    setAggregateIncludeTerms(feed.filter?.includeTerms.join(', ') || '')
-    setAggregateExcludeTerms(feed.filter?.excludeTerms.join(', ') || '')
+    setAggregateIncludeTerms((feed.filter?.includeTerms ?? []).join(', '))
+    setAggregateExcludeTerms((feed.filter?.excludeTerms ?? []).join(', '))
     setShowAggregateCreator(true)
   }, [feeds])
 
@@ -571,8 +571,8 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
   // Initialize filter editor with current feed's filter
   const openFilterEditor = useCallback(() => {
     const filter = activeFeed?.filter
-    setTempIncludeTerms(filter?.includeTerms.join(', ') || '')
-    setTempExcludeTerms(filter?.excludeTerms.join(', ') || '')
+    setTempIncludeTerms((filter?.includeTerms ?? []).join(', '))
+    setTempExcludeTerms((filter?.excludeTerms ?? []).join(', '))
     setShowFilterEditor(true)
   }, [activeFeed?.filter])
 

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -443,7 +443,7 @@ function NamespaceResources({ clusterName, namespace }: NamespaceResourcesProps)
       namespace: svc.namespace,
       status: svc.type,
       statusColor: 'cyan',
-      detail: svc.ports?.slice(0, 2).join(', '),
+      detail: (svc.ports ?? []).slice(0, 2).join(', '),
       labels: svc.labels,
       annotations: svc.annotations,
       data: { type: svc.type, clusterIP: svc.clusterIP, externalIP: svc.externalIP, ports: svc.ports, age: svc.age }

--- a/web/src/components/clusters/NodeDetailPanel.tsx
+++ b/web/src/components/clusters/NodeDetailPanel.tsx
@@ -40,7 +40,7 @@ export function NodeDetailPanel({ node, clusterName, onClose }: NodeDetailPanelP
       initialPrompt: `I need help diagnosing and repairing issues with node "${node.name}" in cluster "${clusterName}".
 
 Current node conditions:
-${node.conditions?.map(c => `- ${c.type}: ${c.status}${c.message ? ` (${c.message})` : ''}${c.reason ? ` [${c.reason}]` : ''}`).join('\n') || 'No conditions available'}
+${(node.conditions ?? []).map(c => `- ${c.type}: ${c.status}${c.message ? ` (${c.message})` : ''}${c.reason ? ` [${c.reason}]` : ''}`).join('\n') || 'No conditions available'}
 
 Node details:
 - Internal IP: ${node.internalIP || 'N/A'}

--- a/web/src/components/clusters/components/NamespaceResources.tsx
+++ b/web/src/components/clusters/components/NamespaceResources.tsx
@@ -127,7 +127,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
       namespace: svc.namespace,
       status: svc.type,
       statusColor: 'cyan',
-      detail: svc.ports?.slice(0, 2).join(', '),
+      detail: (svc.ports ?? []).slice(0, 2).join(', '),
       data: { type: svc.type, clusterIP: svc.clusterIP, externalIP: svc.externalIP, ports: svc.ports, age: svc.age }
     }))
 

--- a/web/src/components/settings/Settings.tsx
+++ b/web/src/components/settings/Settings.tsx
@@ -119,14 +119,19 @@ export function Settings() {
   }, [restoredFromFile])
   const contentRef = useRef<HTMLDivElement>(null)
 
-  // Offset for sticky navbar (px from top of viewport)
-  const SCROLL_OFFSET = 80
+  // Offset for section headers inside the scroll container (px)
+  const SCROLL_OFFSET = 16
+
+  const getScrollContainer = () => document.getElementById('main-content')
 
   const scrollToSection = (sectionId: string, smooth = true) => {
     const element = document.getElementById(sectionId)
-    if (!element) return
-    const y = element.getBoundingClientRect().top + window.scrollY - SCROLL_OFFSET - 16
-    window.scrollTo({ top: y, behavior: smooth ? 'smooth' : 'auto' })
+    const container = getScrollContainer()
+    if (!element || !container) return
+    const containerRect = container.getBoundingClientRect()
+    const elementRect = element.getBoundingClientRect()
+    const y = elementRect.top - containerRect.top + container.scrollTop - SCROLL_OFFSET
+    container.scrollTo({ top: y, behavior: smooth ? 'smooth' : 'auto' })
   }
 
   // Handle deep linking - scroll to section based on URL hash
@@ -148,6 +153,9 @@ export function Settings() {
 
   // Track active section on scroll using IntersectionObserver
   useEffect(() => {
+    const container = getScrollContainer()
+    if (!container) return
+
     const allSectionIds = SETTINGS_NAV.flatMap(g => g.items.map(i => i.id))
     const visibleSections = new Map<string, number>()
 
@@ -169,7 +177,8 @@ export function Settings() {
         }
       },
       {
-        rootMargin: `-${SCROLL_OFFSET}px 0px -40% 0px`,
+        root: container,
+        rootMargin: '0px 0px -40% 0px',
         threshold: [0, 0.1, 0.5],
       }
     )

--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -514,7 +514,7 @@ ${generateWidgetStyles()}
 // Sub-components for each card/stat
 ${template.cards.map((cardType) => generateMiniCardComponent(cardType)).join('\n\n')}
 
-${template.stats?.map((statId) => generateMiniStatComponent(statId)).join('\n\n') || ''}
+${(template.stats ?? []).map((statId) => generateMiniStatComponent(statId)).join('\n\n')}
 
 export const render = ({ output }) => {
   let data = null;
@@ -644,7 +644,7 @@ export function getWidgetFilename(config: WidgetConfig): string {
     case 'card':
       return `${config.cardType?.replace(/_/g, '-')}.widget.jsx`
     case 'stat':
-      return `stats-${config.statIds?.join('-')}.widget.jsx`
+      return `stats-${(config.statIds ?? []).join('-')}.widget.jsx`
     case 'template':
       return `${config.templateId?.replace(/_/g, '-')}.widget.jsx`
     default:


### PR DESCRIPTION
## Summary
- Fix settings sidebar nav scroll — was using `window.scrollTo()` but the scroll container is `<main id="main-content">` which has `overflow-y: auto`
- Fix IntersectionObserver for active section tracking — set `root` to the `main-content` element
- Fix `/auto-update/status` 404 spam — guard `fetchAutoUpdateStatus` with `agentSupportsAutoUpdate` check inside the function
- Initialize `installMethod` to `'dev'` on localhost instead of waiting for async `/health` fetch
- Fix 12 unsafe `.join()` patterns: `x?.map().join()` and `x?.slice().join()` → `(x ?? []).map().join()` 
- Replace deprecated `apple-mobile-web-app-capable` meta tag with `mobile-web-app-capable`

## Test plan
- [ ] Navigate to Settings, click sidebar items → page scrolls to correct section
- [ ] Scroll settings page → left nav highlights current section
- [ ] No `/auto-update/status` 404 errors in console
- [ ] Developer channel shows in Update Settings dropdown on localhost
- [ ] No `.join()` TypeError crashes in console