### PR TITLE
✨ Add contributor ladder with 8 levels and progress tracking

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -17,6 +17,7 @@ import { isDemoModeForced } from '../../lib/demoMode'
 import { useToast } from '../ui/Toast'
 import { useTranslation } from 'react-i18next'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
+import { ContributorBanner } from '../rewards/ContributorLadder'
 import { GITHUB_REWARD_LABELS, REWARD_ACTIONS } from '../../types/rewards'
 import type { GitHubContribution } from '../../types/rewards'
 
@@ -465,6 +466,9 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
         {activeTab === 'updates' ? (
           /* Updates Tab — unified scrollable view */
           <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
+              {/* Contributor banner — coins + level + progress */}
+              <ContributorBanner />
+
               {/* Actions header */}
               <div className="p-2 border-b border-border/50 flex items-center justify-between flex-shrink-0">
                 {actionError ? (

--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { User, Mail, MessageSquare, Shield, Settings, LogOut, ChevronDown, Coins, Lightbulb, Linkedin, Globe, Check, Download, Code2, ExternalLink, Rocket, KeyRound, CheckCircle2, XCircle, GitBranch } from 'lucide-react'
 import { useRewards, REWARD_ACTIONS } from '../../hooks/useRewards'
+import { getContributorLevel } from '../../types/rewards'
 import { useVersionCheck } from '../../hooks/useVersionCheck'
 import { languages } from '../../lib/i18n'
 import { isDemoModeForced } from '../../lib/demoMode'
@@ -169,6 +170,9 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
               <Coins className="w-4 h-4 text-yellow-500" />
               <span className="text-muted-foreground">{t('profile.coins')}</span>
               <span className="text-yellow-400 font-medium">{totalCoins.toLocaleString()}</span>
+              <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${getContributorLevel(totalCoins).current.bgClass} ${getContributorLevel(totalCoins).current.textClass}`}>
+                {getContributorLevel(totalCoins).current.name}
+              </span>
               <ChevronDown className="w-3 h-3 ml-auto text-muted-foreground -rotate-90" />
             </button>
             {/* Language selector */}

--- a/web/src/components/rewards/ContributorLadder.tsx
+++ b/web/src/components/rewards/ContributorLadder.tsx
@@ -1,0 +1,166 @@
+/**
+ * ContributorLadder — shows current level, progress to next, and the full ladder
+ */
+
+import { useState } from 'react'
+import {
+  Telescope, Compass, Map, Rocket, Shield, Star, Crown, Sparkles,
+  Coins, ChevronDown, ChevronUp, Linkedin,
+} from 'lucide-react'
+import { useRewards } from '../../hooks/useRewards'
+import { getContributorLevel, CONTRIBUTOR_LEVELS } from '../../types/rewards'
+import type { ContributorLevel } from '../../types/rewards'
+
+const LEVEL_ICONS: Record<string, React.FC<{ className?: string }>> = {
+  Telescope,
+  Compass,
+  Map,
+  Rocket,
+  Shield,
+  Star,
+  Crown,
+  Sparkles,
+}
+
+function LevelIcon({ level, className }: { level: ContributorLevel; className?: string }) {
+  const Icon = LEVEL_ICONS[level.icon] || Star
+  return <Icon className={className} />
+}
+
+/** Compact banner showing coins + level for the top of the Updates tab */
+export function ContributorBanner() {
+  const { totalCoins, githubPoints } = useRewards()
+  const { current, next, progress, coinsToNext } = getContributorLevel(totalCoins)
+  const [showLadder, setShowLadder] = useState(false)
+
+  const handleLinkedInShare = () => {
+    const text = `I'm a Level ${current.rank} "${current.name}" contributor on the KubeStellar Console with ${totalCoins.toLocaleString()} coins! Join the open-source KubeStellar project and start your contributor journey.`
+    const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent('https://kubestellar.io')}&summary=${encodeURIComponent(text)}`
+    window.open(linkedInUrl, '_blank', 'width=600,height=600')
+  }
+
+  return (
+    <div className="border-b border-border/50">
+      {/* Main banner */}
+      <div className="px-3 py-2.5">
+        {/* Top row: coins + level badge + share */}
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-2.5">
+            <div className="flex items-center gap-1.5">
+              <Coins className="w-4 h-4 text-yellow-500" />
+              <span className="text-lg font-bold text-yellow-400">{totalCoins.toLocaleString()}</span>
+              <span className="text-xs text-muted-foreground">coins</span>
+            </div>
+            <div className={`flex items-center gap-1 px-2 py-0.5 rounded-full border ${current.bgClass} ${current.borderClass}`}>
+              <LevelIcon level={current} className={`w-3 h-3 ${current.textClass}`} />
+              <span className={`text-[10px] font-semibold uppercase tracking-wider ${current.textClass}`}>
+                {current.name}
+              </span>
+            </div>
+          </div>
+          <div className="flex items-center gap-1">
+            {totalCoins > 0 && (
+              <button
+                onClick={handleLinkedInShare}
+                className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-[#0A66C2] transition-colors"
+                title={`Share your ${current.name} status on LinkedIn`}
+              >
+                <Linkedin className="w-3.5 h-3.5" />
+              </button>
+            )}
+            <button
+              onClick={() => setShowLadder(!showLadder)}
+              className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {showLadder ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+              Levels
+            </button>
+          </div>
+        </div>
+
+        {/* Progress bar to next level */}
+        {next ? (
+          <div>
+            <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1">
+              <span className={current.textClass}>{current.name}</span>
+              <span>{coinsToNext.toLocaleString()} coins to {next.name}</span>
+            </div>
+            <div className="h-1.5 rounded-full bg-secondary overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${
+                  current.color === 'gray' ? 'bg-gray-400' :
+                  current.color === 'blue' ? 'bg-blue-400' :
+                  current.color === 'cyan' ? 'bg-cyan-400' :
+                  current.color === 'green' ? 'bg-green-400' :
+                  current.color === 'purple' ? 'bg-purple-400' :
+                  current.color === 'amber' ? 'bg-amber-400' :
+                  current.color === 'orange' ? 'bg-orange-400' :
+                  'bg-yellow-400'
+                }`}
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="text-[10px] text-yellow-400 text-center">
+            Max level reached!
+          </div>
+        )}
+
+        {githubPoints > 0 && (
+          <p className="text-[10px] text-muted-foreground mt-1">
+            Includes {githubPoints.toLocaleString()} from GitHub contributions
+          </p>
+        )}
+      </div>
+
+      {/* Expandable ladder */}
+      {showLadder && (
+        <div className="px-3 pb-3 pt-1">
+          <div className="space-y-1">
+            {CONTRIBUTOR_LEVELS.map((level) => {
+              const isCurrentLevel = level.rank === current.rank
+              const isUnlocked = totalCoins >= level.minCoins
+              return (
+                <div
+                  key={level.rank}
+                  className={`flex items-center gap-2 px-2 py-1.5 rounded-lg transition-colors ${
+                    isCurrentLevel
+                      ? `${level.bgClass} border ${level.borderClass}`
+                      : isUnlocked
+                        ? 'bg-secondary/20'
+                        : 'opacity-40'
+                  }`}
+                >
+                  <div className={`w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0 ${
+                    isUnlocked ? level.bgClass : 'bg-secondary'
+                  }`}>
+                    <LevelIcon
+                      level={level}
+                      className={`w-3.5 h-3.5 ${isUnlocked ? level.textClass : 'text-muted-foreground'}`}
+                    />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-1.5">
+                      <span className={`text-xs font-medium ${isUnlocked ? 'text-foreground' : 'text-muted-foreground'}`}>
+                        {level.name}
+                      </span>
+                      {isCurrentLevel && (
+                        <span className={`text-[9px] px-1 py-0.5 rounded ${level.bgClass} ${level.textClass} font-bold uppercase`}>
+                          You
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <span className={`text-[10px] font-mono ${isUnlocked ? level.textClass : 'text-muted-foreground'}`}>
+                    {level.minCoins.toLocaleString()}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/rewards/index.ts
+++ b/web/src/components/rewards/index.ts
@@ -1,4 +1,5 @@
 export { CoinDisplay, CoinBadge } from './CoinDisplay'
+export { ContributorBanner } from './ContributorLadder'
 export { GitHubInviteModal, GitHubInviteButton } from './GitHubInvite'
 export { LinkedInShareButton, LinkedInShareCard } from './LinkedInShare'
 export { RewardsPanel } from './RewardsPanel'

--- a/web/src/types/rewards.ts
+++ b/web/src/types/rewards.ts
@@ -215,3 +215,131 @@ export const GITHUB_REWARD_LABELS: Record<GitHubRewardType, string> = {
   pr_opened: 'PR Opened',
   pr_merged: 'PR Merged',
 }
+
+// ── Contributor Ladder ──────────────────────────────────────────────
+
+export interface ContributorLevel {
+  rank: number
+  name: string
+  icon: string         // Lucide icon name
+  minCoins: number
+  color: string        // Tailwind color prefix (e.g., 'gray', 'blue')
+  bgClass: string      // Background classes for the badge
+  textClass: string    // Text color class
+  borderClass: string  // Border color class
+}
+
+export const CONTRIBUTOR_LEVELS: ContributorLevel[] = [
+  {
+    rank: 1,
+    name: 'Observer',
+    icon: 'Telescope',
+    minCoins: 0,
+    color: 'gray',
+    bgClass: 'bg-gray-500/20',
+    textClass: 'text-gray-400',
+    borderClass: 'border-gray-500/30',
+  },
+  {
+    rank: 2,
+    name: 'Explorer',
+    icon: 'Compass',
+    minCoins: 100,
+    color: 'blue',
+    bgClass: 'bg-blue-500/20',
+    textClass: 'text-blue-400',
+    borderClass: 'border-blue-500/30',
+  },
+  {
+    rank: 3,
+    name: 'Navigator',
+    icon: 'Map',
+    minCoins: 500,
+    color: 'cyan',
+    bgClass: 'bg-cyan-500/20',
+    textClass: 'text-cyan-400',
+    borderClass: 'border-cyan-500/30',
+  },
+  {
+    rank: 4,
+    name: 'Pilot',
+    icon: 'Rocket',
+    minCoins: 1500,
+    color: 'green',
+    bgClass: 'bg-green-500/20',
+    textClass: 'text-green-400',
+    borderClass: 'border-green-500/30',
+  },
+  {
+    rank: 5,
+    name: 'Commander',
+    icon: 'Shield',
+    minCoins: 3000,
+    color: 'purple',
+    bgClass: 'bg-purple-500/20',
+    textClass: 'text-purple-400',
+    borderClass: 'border-purple-500/30',
+  },
+  {
+    rank: 6,
+    name: 'Captain',
+    icon: 'Star',
+    minCoins: 5000,
+    color: 'amber',
+    bgClass: 'bg-amber-500/20',
+    textClass: 'text-amber-400',
+    borderClass: 'border-amber-500/30',
+  },
+  {
+    rank: 7,
+    name: 'Admiral',
+    icon: 'Crown',
+    minCoins: 10000,
+    color: 'orange',
+    bgClass: 'bg-orange-500/20',
+    textClass: 'text-orange-400',
+    borderClass: 'border-orange-500/30',
+  },
+  {
+    rank: 8,
+    name: 'Legend',
+    icon: 'Sparkles',
+    minCoins: 25000,
+    color: 'yellow',
+    bgClass: 'bg-gradient-to-r from-yellow-500/20 via-amber-500/20 to-orange-500/20',
+    textClass: 'text-yellow-400',
+    borderClass: 'border-yellow-500/40',
+  },
+]
+
+/** Returns the current level and the next level (null if max) */
+export function getContributorLevel(totalCoins: number): {
+  current: ContributorLevel
+  next: ContributorLevel | null
+  progress: number // 0-100 percent to next level
+  coinsToNext: number
+} {
+  let current = CONTRIBUTOR_LEVELS[0]
+  let next: ContributorLevel | null = null
+
+  for (let i = CONTRIBUTOR_LEVELS.length - 1; i >= 0; i--) {
+    if (totalCoins >= CONTRIBUTOR_LEVELS[i].minCoins) {
+      current = CONTRIBUTOR_LEVELS[i]
+      next = i < CONTRIBUTOR_LEVELS.length - 1 ? CONTRIBUTOR_LEVELS[i + 1] : null
+      break
+    }
+  }
+
+  if (!next) {
+    return { current, next: null, progress: 100, coinsToNext: 0 }
+  }
+
+  const rangeStart = current.minCoins
+  const rangeEnd = next.minCoins
+  const coinsInRange = totalCoins - rangeStart
+  const rangeSize = rangeEnd - rangeStart
+  const progress = Math.min(100, Math.round((coinsInRange / rangeSize) * 100))
+  const coinsToNext = rangeEnd - totalCoins
+
+  return { current, next, progress, coinsToNext }
+}


### PR DESCRIPTION
## Summary
- Adds an 8-tier contributor ladder system (Observer → Explorer → Navigator → Pilot → Commander → Captain → Admiral → Legend) based on coin thresholds
- Shows coin total, current level badge, and progress bar to next level at the top of the Updates tab in the Contribute modal
- Adds level badge next to coins in the user profile dropdown
- Includes expandable full ladder view showing all levels with unlock status
- LinkedIn share button appears when user has coins

## Test plan
- [ ] Open Contribute modal → Updates tab and verify the ContributorBanner appears with coin total, level badge, and progress bar
- [ ] Click "Levels" to expand the full ladder and verify all 8 levels display correctly
- [ ] Verify the current level shows "You" badge and unlocked levels have color while locked levels are dimmed
- [ ] Open user profile dropdown and verify level badge appears next to coins
- [ ] Earn coins (e.g., submit a feature request) and verify level progress updates