### PR TITLE
🐛 Fix developer channel update notifications never appearing

### DIFF
--- a/web/src/hooks/useVersionCheck.ts
+++ b/web/src/hooks/useVersionCheck.ts
@@ -190,13 +190,18 @@ function isCacheValid(cache: ReleasesCache): boolean {
 
 /**
  * Load channel preference from localStorage.
+ * Defaults to 'developer' for localhost (dev installs), 'stable' otherwise.
  */
 function loadChannel(): UpdateChannel {
   const stored = localStorage.getItem(UPDATE_STORAGE_KEYS.CHANNEL)
   if (stored === 'stable' || stored === 'unstable' || stored === 'developer') {
     return stored
   }
-  return 'stable' // Default to stable
+  // Dev installs (localhost) default to developer channel so they get notified of new main commits
+  if (typeof window !== 'undefined' && (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1')) {
+    return 'developer'
+  }
+  return 'stable'
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Default channel now "developer" for localhost** — dev installs were defaulting to "stable" channel, which explicitly suppresses notifications for dev versions via `isDevVersion()` guard in `isNewerVersion()`
- **Fix UpdateIndicator for developer channel** — the green badge checked `!latestRelease` which is always null for developer channel (uses SHA comparison, not GitHub releases). Now uses `autoUpdateStatus.hasUpdate` and shows the latest commit SHA

## Root cause
Two independent bugs:
1. `loadChannel()` always returned `'stable'` for first-time users. On stable channel, `isNewerVersion()` returns `false` for dev versions (line 118: `if (isDevVersion(currentTag)) return false`)
2. `UpdateIndicator` line 31: `if (!hasUpdate || !latestRelease)` — developer channel sets `latestRelease = null` by design (it tracks commits, not releases), so the badge never rendered

## Test plan
- [ ] Fresh localStorage (clear `kc-update-channel` key) on localhost → channel should default to "developer"
- [ ] With kc-agent running and new commit on main → green badge appears in navbar
- [ ] Clicking badge shows commit SHA and "View Details" button
- [ ] Non-localhost installs still default to "stable" channel