### PR TITLE
✨ GA4 anti-spam proxy, ad blocker bypass, and conversion funnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,11 @@ GEMINI_MODEL=
 # Default AI agent (optional - auto-detected based on available keys)
 # Options: claude, openai, gemini
 DEFAULT_AGENT=
+
+# ===========================================
+# GA4 Analytics — Anti-spam proxy
+# ===========================================
+# The frontend uses a DECOY Measurement ID (visible in source code).
+# The first-party proxy at /t/g/collect rewrites it to the real ID below.
+# Spammers who scrape the source code send hits to a non-existent property.
+GA4_REAL_MEASUREMENT_ID=

--- a/netlify.toml
+++ b/netlify.toml
@@ -42,11 +42,11 @@
   status = 200
   force = true
 
+# GA4 analytics proxy — event collection via Netlify Function (rewrites decoy tid → real)
 [[redirects]]
   from = "/t/g/collect"
-  to = "https://www.google-analytics.com/g/collect"
+  to = "/.netlify/functions/analytics-collect"
   status = 200
-  force = true
 
 # SPA routing - redirect all routes to index.html (only if file doesn't exist)
 [[redirects]]

--- a/web/netlify/functions/analytics-collect.mts
+++ b/web/netlify/functions/analytics-collect.mts
@@ -1,0 +1,83 @@
+/**
+ * Netlify Function: GA4 Analytics Collect Proxy
+ *
+ * Proxies GA4 event collection requests with two key features:
+ * 1. First-party domain bypass for ad blockers
+ * 2. Measurement ID rewriting (decoy→real) to defeat Measurement Protocol spam
+ *
+ * GA4_REAL_MEASUREMENT_ID must be set as a Netlify environment variable.
+ */
+
+const ALLOWED_HOSTS = new Set([
+  "console.kubestellar.io",
+  "localhost",
+  "127.0.0.1",
+]);
+
+function isAllowedOrigin(req: Request): boolean {
+  const origin = req.headers.get("origin") || "";
+  const referer = req.headers.get("referer") || "";
+
+  for (const header of [origin, referer]) {
+    if (!header) continue;
+    try {
+      const hostname = new URL(header).hostname;
+      if (ALLOWED_HOSTS.has(hostname) || hostname.endsWith(".netlify.app")) {
+        return true;
+      }
+    } catch {
+      /* ignore parse errors */
+    }
+  }
+  // Allow if neither header present (browsers always send one for fetch)
+  return !origin && !referer;
+}
+
+export default async (req: Request) => {
+  const headers = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers });
+  }
+
+  if (!isAllowedOrigin(req)) {
+    return new Response("Forbidden", { status: 403, headers });
+  }
+
+  const realMeasurementId = process.env.GA4_REAL_MEASUREMENT_ID;
+  const url = new URL(req.url);
+
+  // Rewrite tid from decoy → real Measurement ID
+  if (realMeasurementId && url.searchParams.has("tid")) {
+    url.searchParams.set("tid", realMeasurementId);
+  }
+
+  const targetUrl = `https://www.google-analytics.com/g/collect?${url.searchParams.toString()}`;
+
+  try {
+    const body = req.method === "POST" ? await req.text() : undefined;
+    const resp = await fetch(targetUrl, {
+      method: req.method,
+      headers: {
+        "Content-Type": req.headers.get("content-type") || "text/plain",
+        "User-Agent": req.headers.get("user-agent") || "",
+      },
+      body,
+    });
+
+    const responseBody = await resp.text();
+    return new Response(responseBody, {
+      status: resp.status,
+      headers: {
+        ...headers,
+        "Content-Type": resp.headers.get("content-type") || "text/plain",
+      },
+    });
+  } catch {
+    return new Response("Bad Gateway", { status: 502, headers });
+  }
+};

--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -5,6 +5,7 @@ import { AgentIcon } from './AgentIcon'
 import { BaseModal } from '../../lib/modals'
 import { KC_AGENT, AI_PROVIDER_DOCS } from '../../config/externalApis'
 import { useTranslation } from 'react-i18next'
+import { trackApiKeyConfigured, trackApiKeyRemoved, trackConversionStep } from '../../lib/analytics'
 
 const INSTALL_COMMAND = KC_AGENT.installCommand
 
@@ -117,6 +118,8 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
       setNewKeyValue('')
       setShowKey(false)
       await fetchKeysStatus()
+      trackApiKeyConfigured(provider)
+      trackConversionStep(5, 'api_key', { provider })
     } catch (err) {
       setError(err instanceof Error ? err.message : t('agent.failedToSaveKey'))
     } finally {
@@ -137,6 +140,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
       }
 
       await fetchKeysStatus()
+      trackApiKeyRemoved(provider)
     } catch (err) {
       setError(err instanceof Error ? err.message : t('agent.failedToDeleteKey'))
     } finally {

--- a/web/src/components/settings/sections/GitHubTokenSection.tsx
+++ b/web/src/components/settings/sections/GitHubTokenSection.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Save, RefreshCw, Check, X, Github, ExternalLink, Loader2 } from 'lucide-react'
 import { STORAGE_KEY_GITHUB_TOKEN } from '../../../lib/constants'
-import { trackGitHubTokenConfigured, trackGitHubTokenRemoved } from '../../../lib/analytics'
+import { trackGitHubTokenConfigured, trackGitHubTokenRemoved, trackConversionStep } from '../../../lib/analytics'
 
 interface GitHubTokenSectionProps {
   forceVersionCheck: () => void
@@ -135,6 +135,7 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
       setTimeout(() => setGithubTokenSaved(false), 2000)
 
       trackGitHubTokenConfigured()
+      trackConversionStep(6, 'github_token')
 
       // Trigger system updates check with the new token
       forceVersionCheck()

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { isDemoModeForced } from './useDemoMode'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { trackAgentConnected, trackAgentDisconnected, trackConversionStep } from '../lib/analytics'
 
 export interface AgentHealth {
   status: string
@@ -221,6 +222,7 @@ class AgentManager {
             status: 'connected',
             error: null,
           })
+          trackAgentConnected(data.version || 'unknown', data.clusters || 0)
         } else if (wasConnecting) {
           // Initial connection - connect immediately on first success
           this.addEvent('connected', `Connected to local agent v${data.version || 'unknown'}`)
@@ -230,6 +232,11 @@ class AgentManager {
             status: 'connected',
             error: null,
           })
+          trackAgentConnected(data.version || 'unknown', data.clusters || 0)
+          trackConversionStep(3, 'agent', { agent_version: data.version || 'unknown' })
+          if ((data.clusters || 0) > 0) {
+            trackConversionStep(4, 'clusters', { cluster_count: String(data.clusters) })
+          }
         } else if (wasConnected) {
           // Already connected - just update health data
           this.setState({
@@ -251,6 +258,7 @@ class AgentManager {
         const wasConnecting = this.state.status === 'connecting'
         if (wasConnected) {
           this.addEvent('disconnected', 'Lost connection to local agent')
+          trackAgentDisconnected()
         } else if (wasConnecting) {
           this.addEvent('error', 'Failed to connect - local agent not available')
         }

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useState, useEffect, useCallback, ReactNode 
 import { api, checkBackendAvailability, checkOAuthConfigured } from './api'
 import { dashboardSync } from './dashboards/dashboardSync'
 import { STORAGE_KEY_TOKEN, DEMO_TOKEN_VALUE, STORAGE_KEY_DEMO_MODE, STORAGE_KEY_ONBOARDED, STORAGE_KEY_USER_CACHE } from './constants'
-import { trackLogin, trackLogout, setAnalyticsUserId, setAnalyticsUserProperties } from './analytics'
+import { trackLogin, trackLogout, setAnalyticsUserId, setAnalyticsUserProperties, trackConversionStep } from './analytics'
 
 interface User {
   id: string
@@ -163,10 +163,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     if (isDemoMode) {
       trackLogin('demo')
+      trackConversionStep(2, 'login', { method: 'demo' })
       setDemoMode()
       return
     }
     trackLogin('github-oauth')
+    trackConversionStep(2, 'login', { method: 'github-oauth' })
     window.location.href = '/auth/github'
   }, [])
 


### PR DESCRIPTION
## Summary
- **Anti-spam**: Frontend uses a decoy Measurement ID (`G-0000000000`). The first-party proxy rewrites the `tid` query param to the real ID server-side. Spammers who scrape the source code send hits to a non-existent property — our real GA4 data stays clean.
- **Ad blocker bypass**: Re-enables the first-party proxy (`/t/g/js`, `/t/g/collect`) so analytics works for international users whose ad blockers block `googletagmanager.com` and `google-analytics.com`.
- **Conversion funnel**: Tracks a 6-step funnel (`ksc_conversion_step` event): discovery(1) → login(2) → agent(3) → clusters(4) → api_key(5) → github_token(6). This lets us identify where users drop off in the journey from demo → fully configured.

## Changes
| File | What |
|------|------|
| `analytics.ts` | Decoy ID, proxy URLs, 5 new tracking functions, conversion funnel |
| `analytics_proxy.go` | tid rewriting + origin/referer validation |
| `analytics-collect.mts` | NEW Netlify Function for tid rewriting (redirects can't rewrite query params) |
| `netlify.toml` | Route `/t/g/collect` to Netlify Function |
| `useLocalAgent.ts` | Agent connect/disconnect events + funnel steps 3-4 |
| `APIKeySettings.tsx` | API key config/remove events + funnel step 5 |
| `auth.tsx` | Login funnel step 2 |
| `GitHubTokenSection.tsx` | GitHub token funnel step 6 |
| `.env.example` | Document `GA4_REAL_MEASUREMENT_ID` |

## Architecture
```
Browser → /t/g/js (first-party, bypasses ad blockers)
Browser → /t/g/collect?tid=G-DECOY → proxy rewrites tid=G-REAL → google-analytics.com
Spammers → g-a.com/g/collect?tid=G-DECOY → hits non-existent property
```

## Deployment Note
After merge, set `GA4_REAL_MEASUREMENT_ID=G-QPGNKGNNY2` in the Netlify dashboard environment variables.

## Test plan
- [x] `go build ./cmd/console/` — backend compiles
- [x] `npm run build` — frontend builds
- [x] `eslint` — no new errors (0 errors on modified files)
- [ ] Verify proxy requests succeed in Chrome DevTools Network (`/t/g/`)
- [ ] Monitor GA4 Data API — confirm `localhost` spam disappears from real property
- [ ] Enable uBlock Origin → verify analytics still works through proxy