### PR TITLE
🐛 Client-side SHA check for developer channel update notifications

### DIFF
--- a/web/src/components/layout/navbar/UpdateIndicator.tsx
+++ b/web/src/components/layout/navbar/UpdateIndicator.tsx
@@ -8,7 +8,7 @@ import { ROUTES } from '../../../config/routes'
 export function UpdateIndicator() {
   const navigate = useNavigate()
   const { t } = useTranslation()
-  const { hasUpdate, latestRelease, channel, autoUpdateStatus, skipVersion, checkForUpdates } = useVersionCheck()
+  const { hasUpdate, latestRelease, channel, autoUpdateStatus, latestMainSHA, skipVersion, checkForUpdates } = useVersionCheck()
   const [showUpdateDropdown, setShowUpdateDropdown] = useState(false)
   const updateRef = useRef<HTMLDivElement>(null)
 
@@ -32,10 +32,11 @@ export function UpdateIndicator() {
     return null
   }
 
-  // Developer channel: latestRelease is null, use SHA from autoUpdateStatus
-  const isDeveloperUpdate = channel === 'developer' && autoUpdateStatus?.hasUpdate
+  // Developer channel: latestRelease is null, use SHA from autoUpdateStatus or client-side check
+  const isDeveloperUpdate = channel === 'developer' && hasUpdate
+  const devSHA = autoUpdateStatus?.latestSHA ?? latestMainSHA
   const updateLabel = isDeveloperUpdate
-    ? `New commit: ${autoUpdateStatus?.latestSHA?.slice(0, 7) ?? 'unknown'}`
+    ? `New commit: ${devSHA?.slice(0, 7) ?? 'unknown'}`
     : latestRelease?.tag ?? ''
 
   // Need either a release update or a developer channel update


### PR DESCRIPTION
## Summary
- Adds client-side fallback for developer channel update notifications when kc-agent doesn't support `/auto-update/status`
- Fetches latest `main` branch HEAD SHA directly from GitHub API (`git/ref/heads/main`)
- Compares build-time `__COMMIT_HASH__` with remote SHA to detect available updates
- Caches SHA in localStorage for offline/rate-limited scenarios

## Problem
PR #1272 fixed the developer channel defaulting but relied on kc-agent's `/auto-update/status` endpoint. The published Homebrew kc-agent binary (v0.3.11-nightly) doesn't include this endpoint yet, so `autoUpdateStatus` was always null and `hasUpdate` was always false for developer channel users.

## Solution
When `agentSupportsAutoUpdate` is false (kc-agent doesn't have the endpoint), the hook falls back to:
1. Fetching `https://api.github.com/repos/kubestellar/console/git/ref/heads/main` directly
2. Extracting the SHA from the response
3. Comparing with the build-time commit hash
4. Showing the green update badge in the navbar when they differ

Uses the GitHub OAuth token from localStorage if available (higher rate limit).

## Test plan
- [ ] Developer channel defaults on localhost
- [ ] Green update badge appears when local build SHA differs from main HEAD
- [ ] Badge does NOT appear when SHAs match (in-sync with main)
- [ ] Clicking badge shows dropdown with short SHA
- [ ] Works without kc-agent auto-update support