### PR TITLE
🌱 Add PR notice: use Claude Opus 4.5/4.6 for all contributions

### DIFF
--- a/.github/workflows/pr-claude-notice.yml
+++ b/.github/workflows/pr-claude-notice.yml
@@ -1,0 +1,48 @@
+name: PR Claude Notice
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post Claude coding notice
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+
+            const body = [
+              `👋 Hey @${author} — thanks for opening this PR!`,
+              '',
+              '> **🤖 This project is developed exclusively using Claude Code (Opus 4.5 / 4.6).**',
+              '>',
+              '> Please do not submit hand-written code changes. All contributions to this repo',
+              '> should be authored using [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview)',
+              '> with **Claude Opus 4.5 or 4.6** as the model.',
+              '>',
+              '> This ensures consistency in code style, architecture patterns, test coverage,',
+              '> and commit quality across the entire codebase.',
+              '',
+              'If you need help getting set up with Claude Code, check out the',
+              '[installation guide](https://docs.anthropic.com/en/docs/claude-code/overview).',
+              '',
+              '---',
+              '*This is an automated message.*',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body,
+            });


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`pr-claude-notice.yml`) that posts a comment on every newly opened PR
- Reminds authors that this project is developed exclusively using Claude Code with Opus 4.5/4.6
- Asks contributors not to submit hand-written code changes

## Test plan
- [ ] Open a test PR and verify the bot comment appears
- [ ] Verify comment only fires on `opened` (not on every push/sync)