### PR TITLE
🐛 Add /t/g proxy route to Vite dev server config

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -159,6 +159,10 @@ manualChunks: (id) => {
         target: 'http://localhost:8080',
         changeOrigin: true,
       },
+      '/t/g': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
       '/ws': {
         target: 'ws://localhost:8080',
         ws: true,


### PR DESCRIPTION
## Summary
- The GA4 analytics proxy endpoints (`/t/g/js`, `/t/g/collect`) are served by the Go backend (port 8080) but were missing from the Vite dev server proxy config, causing 404s during local development
- Adds `/t/g` proxy rule to `vite.config.ts` so analytics requests are forwarded to the backend

## Test plan
- [x] Backend responds 200 on `/t/g/js` and 204 on `/t/g/collect`
- [ ] After Vite restart, verify proxy requests succeed from browser