### PR TITLE
🐛 Gate auto-update on coding agent + fix double v prefix

### DIFF
--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -232,7 +232,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
                       {__DEV_MODE__ ? 'dev' : 'prod'}
                     </span>
                     <span className="text-muted-foreground font-mono">
-                      v{__APP_VERSION__} · {__COMMIT_HASH__.substring(0, 7)}
+                      {__APP_VERSION__.startsWith('v') ? __APP_VERSION__ : `v${__APP_VERSION__}`} · {__COMMIT_HASH__.substring(0, 7)}
                     </span>
                   </div>
 

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -39,6 +39,7 @@ export function UpdateSettings() {
     autoUpdateStatus,
     updateProgress,
     agentConnected,
+    hasCodingAgent,
     latestMainSHA,
     setAutoUpdateEnabled,
     triggerUpdate,
@@ -195,8 +196,8 @@ export function UpdateSettings() {
         </div>
       </div>
 
-      {/* Auto-Update Toggle */}
-      {!isHelmInstall && agentConnected && (
+      {/* Auto-Update Toggle — requires kc-agent + coding agent (Claude Code, etc.) */}
+      {!isHelmInstall && agentConnected && hasCodingAgent && (
         <div className="mb-4 p-4 rounded-lg bg-secondary/30 border border-border">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">

--- a/web/src/hooks/useVersionCheck.ts
+++ b/web/src/hooks/useVersionCheck.ts
@@ -280,6 +280,7 @@ export function useVersionCheck() {
   const [updateProgress, setUpdateProgress] = useState<UpdateProgress | null>(null)
   const [agentConnected, setAgentConnected] = useState(false)
   const [agentSupportsAutoUpdate, setAgentSupportsAutoUpdate] = useState(false)
+  const [hasCodingAgent, setHasCodingAgent] = useState(false)
   // Client-side SHA tracking for developer channel (fallback when kc-agent doesn't support auto-update)
   const [latestMainSHA, setLatestMainSHA] = useState<string | null>(null)
 
@@ -313,6 +314,9 @@ export function useVersionCheck() {
         if (data.install_method) {
           setInstallMethod(data.install_method as InstallMethod)
           setAgentSupportsAutoUpdate(true)
+        }
+        if (data.hasClaude) {
+          setHasCodingAgent(true)
         }
       }
     } catch {
@@ -673,6 +677,7 @@ export function useVersionCheck() {
     autoUpdateStatus,
     updateProgress,
     agentConnected,
+    hasCodingAgent,
     latestMainSHA,
 
     // Actions


### PR DESCRIPTION
## Summary
- Auto-update toggle now requires **both** kc-agent connected AND a coding agent detected (`hasClaude` from kc-agent `/health`). Without a coding agent, auto-update can't execute pull/build/restart, so the toggle shouldn't appear.
- Fix double "v" prefix in UserProfileDropdown developer panel (`vv0.3.11` → `v0.3.11`)

## Test plan
- [ ] With kc-agent + Claude Code detected: auto-update toggle visible
- [ ] With kc-agent but no coding agent: auto-update toggle hidden
- [ ] Developer panel version shows `v0.3.11-nightly.20260218` (no double v)