### PR TITLE
🐛 Fix analytics-collect Netlify Function 502 error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -42,11 +42,8 @@
   status = 200
   force = true
 
-# GA4 analytics proxy — event collection via Netlify Function (rewrites decoy tid → real)
-[[redirects]]
-  from = "/t/g/collect"
-  to = "/.netlify/functions/analytics-collect"
-  status = 200
+# GA4 analytics proxy — event collection handled by analytics-collect function
+# (uses Config.path in the function, no redirect needed)
 
 # SPA routing - redirect all routes to index.html (only if file doesn't exist)
 [[redirects]]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -38,6 +38,7 @@
       "devDependencies": {
         "@axe-core/playwright": "^4.10.0",
         "@eslint/js": "^9.17.0",
+        "@netlify/functions": "^5.1.2",
         "@playwright/test": "^1.57.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1868,6 +1869,19 @@
         "node": "^18.14.0 || >=20"
       }
     },
+    "node_modules/@netlify/functions": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-5.1.2.tgz",
+      "integrity": "sha512-tpPiLSkQatuexH8AdAZ8RlALvT7ixOE9VhvpkzQGNvihcms8hzmvUDuSxQa7UneTj/sHsdirnXmnJ+nmf+Nx/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/types": "2.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@netlify/otel": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@netlify/otel/-/otel-5.1.1.tgz",
@@ -1888,6 +1902,16 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@netlify/runtime-utils/-/runtime-utils-2.3.0.tgz",
       "integrity": "sha512-cW8weDvsKV7zfia2m5EcBy6KILGoPD+eYZ3qWNGnIo05DGF28goPES0xKSDkNYgAF/2rRSIhie2qcBhbGVgSRg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || >=20"
+      }
+    },
+    "node_modules/@netlify/types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@netlify/types/-/types-2.3.0.tgz",
+      "integrity": "sha512-5gxMWh/S7wr0uHKSTbMv4bjWmWSpwpeLYvErWeVNAPll5/QNFo9aWimMAUuh8ReLY3/fg92XAroVVu7+z27Snw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.14.0 || >=20"

--- a/web/package.json
+++ b/web/package.json
@@ -68,6 +68,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.10.0",
     "@eslint/js": "^9.17.0",
+    "@netlify/functions": "^5.1.2",
     "@playwright/test": "^1.57.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
## Summary
The analytics-collect Netlify Function was returning 502 on production. Fixes:
- Add `@netlify/functions` for proper V2 function types
- Use `Netlify.env.get()` (V2 API) with `process.env` fallback for env var access
- Use `Config.path` for direct function routing instead of redirect in `netlify.toml`
- Return actual error message in 502 response for debugging

## Test plan
- [ ] Deploy preview: `curl -X POST https://deploy-preview-XXXX.../t/g/collect?v=2&tid=G-TEST` should return 204