### PR TITLE
🐛 Fix analytics-collect 502: handle GA4 204 null-body status

### DIFF
--- a/web/netlify/functions/analytics-collect.mts
+++ b/web/netlify/functions/analytics-collect.mts
@@ -72,11 +72,14 @@ export default async (req: Request) => {
       body,
     });
 
-    return new Response(await resp.text(), {
+    // 204/304 are null-body statuses — Response constructor throws if body is non-null
+    const isNullBody = resp.status === 204 || resp.status === 304;
+    const responseBody = isNullBody ? null : await resp.text();
+    return new Response(responseBody, {
       status: resp.status,
       headers: {
         ...corsHeaders,
-        "Content-Type": resp.headers.get("content-type") || "text/plain",
+        ...(!isNullBody && { "Content-Type": resp.headers.get("content-type") || "text/plain" }),
       },
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Google Analytics returns **204 No Content** for `/g/collect` requests
- The Web API `Response` constructor rejects a non-null body with 204/304 status codes, causing the Netlify Function to throw and return 502
- Fix: use `null` body for null-body status codes (204, 304)

## Test plan
- [ ] Verify `https://console.kubestellar.io/t/g/collect?v=2&tid=G-TEST` returns 204 (not 502) after deploy
- [ ] Verify GA4 events flow through the proxy in Chrome DevTools Network tab