### PR TITLE
🐛 Fix Check Now spinner not animating on Developer channel

### DIFF
--- a/web/src/hooks/useVersionCheck.ts
+++ b/web/src/hooks/useVersionCheck.ts
@@ -574,15 +574,20 @@ export function useVersionCheck() {
    * Force a fresh check, bypassing cache.
    */
   const forceCheck = useCallback(async (): Promise<void> => {
-    if (channel === 'developer') {
-      if (agentSupportsAutoUpdate) {
-        await fetchAutoUpdateStatus()
-      } else {
-        await fetchLatestMainSHA()
+    setIsChecking(true)
+    try {
+      if (channel === 'developer') {
+        if (agentSupportsAutoUpdate) {
+          await fetchAutoUpdateStatus()
+        } else {
+          await fetchLatestMainSHA()
+        }
+        return
       }
-      return
+      await fetchReleases(true)
+    } finally {
+      setIsChecking(false)
     }
-    await fetchReleases(true)
   }, [fetchReleases, channel, fetchAutoUpdateStatus, agentSupportsAutoUpdate, fetchLatestMainSHA])
 
   /**


### PR DESCRIPTION
## Summary
- `forceCheck()` for the Developer channel called `fetchAutoUpdateStatus()` or `fetchLatestMainSHA()` without wrapping in `setIsChecking(true/false)`, so the RefreshCw spin animation in UpdateSettings never triggered
- Now wraps the entire `forceCheck` body in `setIsChecking(true)` / `finally { setIsChecking(false) }` so the spinner fires on all channels

## Test plan
- [ ] Open Settings > System Updates on Developer channel
- [ ] Click Check Now — verify the refresh icon spins 1 full turn