### PR TITLE
🐛 Obfuscate analytics proxy paths to bypass ad blocker filter lists

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -35,14 +35,14 @@
   to = "/.netlify/functions/presence"
   status = 200
 
-# GA4 analytics proxy — bypass ad blockers via first-party domain
+# GA4 analytics proxy — opaque paths bypass ad blocker filter lists
 [[redirects]]
-  from = "/t/g/js"
+  from = "/api/a"
   to = "https://www.googletagmanager.com/gtag/js"
   status = 200
   force = true
 
-# GA4 analytics proxy — event collection handled by analytics-collect function
+# GA4 event collection handled by analytics-collect function at /api/m
 # (uses Config.path in the function, no redirect needed)
 
 # SPA routing - redirect all routes to index.html (only if file doesn't exist)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -692,9 +692,9 @@ func (s *Server) setupRoutes() {
 		s.hub.HandleConnection(c)
 	}))
 
-	// GA4 analytics proxy — bypass ad blockers via first-party domain
-	s.app.Get("/t/g/js", handlers.GA4ScriptProxy)
-	s.app.All("/t/g/collect", handlers.GA4CollectProxy)
+	// GA4 analytics proxy — opaque paths bypass ad blocker filter lists
+	s.app.Get("/api/a", handlers.GA4ScriptProxy)
+	s.app.All("/api/m", handlers.GA4CollectProxy)
 
 	// Serve static files in production
 	if !s.config.DevMode {

--- a/web/netlify/functions/analytics-collect.mts
+++ b/web/netlify/functions/analytics-collect.mts
@@ -92,5 +92,5 @@ export default async (req: Request) => {
 };
 
 export const config: Config = {
-  path: "/t/g/collect",
+  path: "/api/m",
 };

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -159,7 +159,11 @@ manualChunks: (id) => {
         target: 'http://localhost:8080',
         changeOrigin: true,
       },
-      '/t/g': {
+      '/api/a': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+      '/api/m': {
         target: 'http://localhost:8080',
         changeOrigin: true,
       },


### PR DESCRIPTION
## Summary
- EasyPrivacy/uBlock filter lists match `/g/collect` on **any domain**, blocking our first-party proxy even though it's same-origin
- This is why international users (higher ad blocker usage) don't appear in GA4 while US users do
- **Fix**: Rename proxy paths to opaque names (`/api/a` for script, `/api/m` for metrics collection)
- Monkey-patch `sendBeacon`/`fetch` to rewrite gtag.js's hardcoded `/g/collect` path before the request reaches the network stack (and ad blocker WebRequest interceptors)

## Files changed
- `analytics.ts` — Patch sendBeacon/fetch, use opaque proxy paths
- `analytics-collect.mts` — Config.path `/t/g/collect` → `/api/m`
- `netlify.toml` — Script redirect `/t/g/js` → `/api/a`
- `server.go` — Backend routes updated to match
- `vite.config.ts` — Dev proxy routes updated

## Test plan
- [ ] Verify `console.kubestellar.io/api/m?v=2&tid=G-TEST` returns 204
- [ ] Verify `console.kubestellar.io/api/a?id=G-0000000000` returns gtag.js
- [ ] Ask Indian user to refresh — should now appear in GA4 Realtime