### PR TITLE
✨ kc-agent self-update + developer update instructions

### DIFF
--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -554,11 +554,9 @@ export function UpdateSettings() {
               {t('settings.updates.devSourceDesc')}
             </p>
             <div className="flex items-center gap-2">
-              <code className="flex-1 px-3 py-2 rounded-lg bg-secondary font-mono text-xs select-all overflow-x-auto">
-                git pull origin main && cd web && npm run build
-              </code>
+              <code className="flex-1 px-3 py-2 rounded-lg bg-secondary font-mono text-xs select-all overflow-x-auto">git pull origin main && cd web && npm run build && cd .. && go build -o $(which kc-agent) ./cmd/kc-agent</code>
               <button
-                onClick={() => copyCommand('git pull origin main && cd web && npm run build', 'gitpull')}
+                onClick={() => copyCommand('git pull origin main && cd web && npm run build && cd .. && go build -o $(which kc-agent) ./cmd/kc-agent', 'gitpull')}
                 className="shrink-0 flex items-center gap-1 px-3 py-2 rounded-lg bg-orange-500 text-white text-sm hover:bg-orange-600"
               >
                 <Copy className="w-4 h-4" />

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -495,7 +495,7 @@
       "clusterDeployment": "Cluster Deployment",
       "clusterDeploymentDesc": "Update your Helm release to the latest chart version.",
       "devSourceUpdate": "Source Update",
-      "devSourceDesc": "Pull the latest changes and rebuild.",
+      "devSourceDesc": "Pull the latest changes, rebuild the frontend, and update the local agent.",
       "devCodingAgent": "Use a Coding Agent",
       "devCodingAgentDesc": "AI coding agents like Claude Code, Cursor, or Windsurf can pull, build, and restart the console for you automatically.",
       "copied": "Copied!",


### PR DESCRIPTION
## Summary
- After developer channel auto-updates (git pull + frontend build + backend restart), **kc-agent now rebuilds itself** from the updated source and `exec()`s into the new binary — keeping it in sync with the codebase
- Updated the **Source Update** command in Developer channel settings to include `go build -o $(which kc-agent) ./cmd/kc-agent`
- Updated description to mention agent update

## How self-update works
1. After backend restart + health check pass, `selfUpdate()` is called
2. Runs `go build -o <binary>.new ./cmd/kc-agent` in the repo
3. Atomically renames `.new` over the current binary
4. Calls `syscall.Exec()` to replace the running process with the new binary
5. If any step fails, the old process keeps running (no downtime)

## Test plan
- [ ] Enable developer channel auto-update, push a commit to main
- [ ] Verify kc-agent rebuilds and exec()s into new binary (check logs for "kc-agent rebuilt, exec-ing")
- [ ] Verify the Source Update command in settings includes the agent rebuild step
- [ ] Verify manual copy button copies the full command including agent rebuild