### PR TITLE
🐛 Include console binary rebuild in developer update command

### DIFF
--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -554,9 +554,9 @@ export function UpdateSettings() {
               {t('settings.updates.devSourceDesc')}
             </p>
             <div className="flex items-center gap-2">
-              <code className="flex-1 px-3 py-2 rounded-lg bg-secondary font-mono text-xs select-all overflow-x-auto">git pull origin main && cd web && npm run build && cd .. && go build -o $(which kc-agent) ./cmd/kc-agent</code>
+              <code className="flex-1 px-3 py-2 rounded-lg bg-secondary font-mono text-xs select-all overflow-x-auto">git pull origin main && cd web && npm run build && cd .. && go build -o $(which kc-agent) ./cmd/kc-agent && go build -o $(which console) ./cmd/console</code>
               <button
-                onClick={() => copyCommand('git pull origin main && cd web && npm run build && cd .. && go build -o $(which kc-agent) ./cmd/kc-agent', 'gitpull')}
+                onClick={() => copyCommand('git pull origin main && cd web && npm run build && cd .. && go build -o $(which kc-agent) ./cmd/kc-agent && go build -o $(which console) ./cmd/console', 'gitpull')}
                 className="shrink-0 flex items-center gap-1 px-3 py-2 rounded-lg bg-orange-500 text-white text-sm hover:bg-orange-600"
               >
                 <Copy className="w-4 h-4" />


### PR DESCRIPTION
Adds `go build -o $(which console) ./cmd/console` to the Source Update command so both agent and console binaries are rebuilt.