### PR TITLE
🐛 Replace gtag.js with custom tracker for complete ad blocker immunity

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -35,15 +35,8 @@
   to = "/.netlify/functions/presence"
   status = 200
 
-# GA4 analytics proxy — opaque paths bypass ad blocker filter lists
-[[redirects]]
-  from = "/api/a"
-  to = "https://www.googletagmanager.com/gtag/js"
-  status = 200
-  force = true
-
-# GA4 event collection handled by analytics-collect function at /api/m
-# (uses Config.path in the function, no redirect needed)
+# GA4 event collection — custom lightweight tracker sends directly to /api/m
+# (Netlify Function via Config.path, no gtag.js loaded)
 
 # SPA routing - redirect all routes to index.html (only if file doesn't exist)
 [[redirects]]

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -692,8 +692,7 @@ func (s *Server) setupRoutes() {
 		s.hub.HandleConnection(c)
 	}))
 
-	// GA4 analytics proxy — opaque paths bypass ad blocker filter lists
-	s.app.Get("/api/a", handlers.GA4ScriptProxy)
+	// GA4 analytics — custom tracker sends events to /api/m, proxy rewrites tid and forwards
 	s.app.All("/api/m", handlers.GA4CollectProxy)
 
 	// Serve static files in production

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -159,10 +159,6 @@ manualChunks: (id) => {
         target: 'http://localhost:8080',
         changeOrigin: true,
       },
-      '/api/a': {
-        target: 'http://localhost:8080',
-        changeOrigin: true,
-      },
       '/api/m': {
         target: 'http://localhost:8080',
         changeOrigin: true,


### PR DESCRIPTION
## Summary
- gtag.js is detectable by content-based ad blockers (Brave, uBlock Origin) even when served from a first-party proxy — this is why the Indian user in Rajkot doesn't show up in GA4
- **Replace gtag.js entirely** with a custom ~120-line tracker embedded in the app bundle
- No external scripts loaded = nothing to fingerprint or block
- Events sent directly to `/api/m` via `sendBeacon` using GA4 Measurement Protocol format
- Same public API — all 25+ exported tracking functions work identically

## What changed
- `analytics.ts` — Complete rewrite: custom `send()` function with client ID, session management, engagement tracking. No `window.gtag`, no `window.dataLayer`, no external script loading
- `netlify.toml` — Remove `/api/a` script redirect (no longer needed)
- `server.go` — Remove `/api/a` route (no script proxy needed)
- `vite.config.ts` — Remove `/api/a` dev proxy

## Test plan
- [ ] Refresh console.kubestellar.io → events should appear in GA4 Realtime
- [ ] Ask Indian user (Rajkot) to refresh → should now appear in GA4
- [ ] Verify events flow: Network tab shows `/api/m?v=2&tid=G-0000000000&...` requests