### PR TITLE
✨ Update indicator: shared state, auto-scroll, commit list

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -24,6 +24,7 @@ import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
 import { KeepAliveOutlet } from './KeepAliveOutlet'
 import { UpdateProgressBanner } from '../updates/UpdateProgressBanner'
 import { useUpdateProgress } from '../../hooks/useUpdateProgress'
+import { VersionCheckProvider } from '../../hooks/useVersionCheck'
 
 
 // Module-level constant — computed once, never changes on re-render.
@@ -254,6 +255,7 @@ export function Layout({ children }: LayoutProps) {
   useDeepLink()
 
   return (
+    <VersionCheckProvider>
     <TourProvider>
     <div className="h-screen bg-background overflow-hidden flex flex-col">
       {/* Skip to content link for keyboard users and screen readers */}
@@ -507,5 +509,6 @@ export function Layout({ children }: LayoutProps) {
       )}
     </div>
     </TourProvider>
+    </VersionCheckProvider>
   )
 }

--- a/web/src/components/layout/navbar/UpdateIndicator.tsx
+++ b/web/src/components/layout/navbar/UpdateIndicator.tsx
@@ -3,19 +3,14 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Download } from 'lucide-react'
 import { useVersionCheck } from '../../../hooks/useVersionCheck'
-import { ROUTES } from '../../../config/routes'
+import { getSettingsWithHash } from '../../../config/routes'
 
 export function UpdateIndicator() {
   const navigate = useNavigate()
   const { t } = useTranslation()
-  const { hasUpdate, latestRelease, channel, autoUpdateStatus, latestMainSHA, skipVersion, checkForUpdates } = useVersionCheck()
+  const { hasUpdate, latestRelease, channel, autoUpdateStatus, latestMainSHA, skipVersion } = useVersionCheck()
   const [showUpdateDropdown, setShowUpdateDropdown] = useState(false)
   const updateRef = useRef<HTMLDivElement>(null)
-
-  // Check for updates on mount (respects rate limiting)
-  useEffect(() => {
-    checkForUpdates()
-  }, [checkForUpdates])
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -68,7 +63,7 @@ export function UpdateIndicator() {
             <div className="flex gap-2">
               <button
                 onClick={() => {
-                  navigate(ROUTES.SETTINGS)
+                  navigate(getSettingsWithHash('system-updates-settings'))
                   setShowUpdateDropdown(false)
                 }}
                 className="flex-1 px-3 py-1.5 text-xs font-medium bg-green-500 text-white rounded hover:bg-green-600 transition-colors"

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -497,6 +497,7 @@
       "devSourceUpdate": "Source Update",
       "devSourceDesc": "Pull the latest changes, rebuild the frontend, and update the local agent.",
       "devMakeUpdateDesc": "Pulls latest code, builds frontend and Go binaries, then restarts all processes.",
+      "recentCommits": "{{count}} new commit(s) on main",
       "devCodingAgent": "Use a Coding Agent",
       "devCodingAgentDesc": "AI coding agents like Claude Code, Cursor, or Windsurf can pull, build, and restart the console for you automatically.",
       "copied": "Copied!",


### PR DESCRIPTION
## Summary
- **Shared state via Context**: `useVersionCheck` now uses a `VersionCheckProvider` mounted in Layout, so the navbar `UpdateIndicator` and `UpdateSettings` share one instance — fixes the indicator not appearing without hard refresh
- **Auto-scroll**: Clicking "View Details" in the update dropdown navigates to `settings#system-updates-settings`, which auto-scrolls to the System Updates section
- **Commit list**: Developer channel shows a collapsible list of recent commits between current build SHA and latest main HEAD (via GitHub Compare API)

## Test plan
- [ ] Verify update indicator shows in navbar without hard refresh when an update is available
- [ ] Click "View Details" in the indicator dropdown → should scroll to System Updates in Settings
- [ ] On Developer channel with update available, expand commit list → should show recent commits