### PR TITLE
✨ Enable GA4 analytics for localhost and containerized deployments

### DIFF
--- a/pkg/api/handlers/analytics_proxy.go
+++ b/pkg/api/handlers/analytics_proxy.go
@@ -50,7 +50,12 @@ func GA4CollectProxy(c *fiber.Ctx) error {
 		return c.SendStatus(fiber.StatusForbidden)
 	}
 
+	// GA4 Measurement ID — env var overrides the built-in default.
+	// This is a public tracking identifier (not a secret), same as any website's GA ID.
 	realMeasurementID := os.Getenv("GA4_REAL_MEASUREMENT_ID")
+	if realMeasurementID == "" {
+		realMeasurementID = "G-QPGNKGNNY2"
+	}
 
 	// Decode base64-encoded payload from `d` parameter.
 	// Browser sends: /api/m?d=<base64(v=2&tid=G-0000000000&cid=...)>


### PR DESCRIPTION
## Summary
- Adds built-in default GA4 measurement ID (`G-QPGNKGNNY2`) to the Go backend proxy
- Analytics now works out of the box for localhost and containerized deployments — no `.env` configuration needed
- The measurement ID is a public tracking identifier (same as any website's GA ID), not a secret
- Env var `GA4_REAL_MEASUREMENT_ID` can still override the default

## Test plan
- [ ] Start console locally with `startup-oauth.sh` — analytics events flow to GA4
- [ ] GA4 Realtime shows localhost users with correct deployment_type