### PR TITLE
🐛 Fix make build and prefer local kc-agent over Homebrew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ web/dist/
 web/tsconfig.tsbuildinfo
 /console
 /console-server
+bin/
 *.exe
 *.out
 *.test

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,11 @@ pull:
 ## build: Build frontend and Go binaries
 build:
 	cd web && npm install --prefer-offline && npm run build
-	go build -o $$(which kc-agent) ./cmd/kc-agent
-	go build -o $$(which console) ./cmd/console
+	mkdir -p bin
+	go build -o bin/kc-agent ./cmd/kc-agent
+	go build -o bin/console ./cmd/console
+	@# Update Homebrew kc-agent if installed
+	@if command -v kc-agent >/dev/null 2>&1; then cp bin/kc-agent $$(which kc-agent) 2>/dev/null || true; fi
 
 ## restart: Restart all processes (kc-agent, backend, frontend)
 restart:


### PR DESCRIPTION
## Summary
- Build Go binaries to `bin/` directory instead of `$(which kc-agent)` / `$(which console)` — `which` returns empty when binaries aren't globally installed, causing `make build` to fail with "no Go files"
- `startup-oauth.sh` now prefers `bin/kc-agent` (locally built from source) over Homebrew version, so dev mode gets the latest features (auto-update endpoints, etc.)
- Add `bin/` to `.gitignore`

## Test plan
- [ ] `make update` completes successfully (pull + build + restart)
- [ ] `curl http://127.0.0.1:8585/auto-update/trigger -X POST` returns 200 (not 404)
- [ ] Fresh clone without Homebrew kc-agent: `make build && bash startup-oauth.sh` works