### PR TITLE
🐛 Fix cluster creation bypassing demo mode when kc-agent is connected

### DIFF
--- a/web/src/components/settings/sections/LocalClustersSection.tsx
+++ b/web/src/components/settings/sections/LocalClustersSection.tsx
@@ -74,8 +74,8 @@ export function LocalClustersSection() {
 
   return (
     <div id="local-clusters-settings" className="glass rounded-xl p-6">
-      {/* Demo Mode Banner */}
-      {isDemoMode && (
+      {/* Demo Mode Banner - only show when agent is disconnected */}
+      {isDemoMode && !isConnected && (
         <div className="mb-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
           <div className="flex items-center gap-2 text-yellow-400 text-sm">
             <AlertCircle className="w-4 h-4" />

--- a/web/src/hooks/useLocalClusterTools.ts
+++ b/web/src/hooks/useLocalClusterTools.ts
@@ -47,8 +47,8 @@ export function useLocalClusterTools() {
 
   // Fetch detected tools
   const fetchTools = useCallback(async () => {
-    // In demo mode, always show demo tools
-    if (isDemoMode) {
+    // In demo mode (without agent connected), show demo tools
+    if (isDemoMode && !isConnected) {
       setTools(DEMO_TOOLS)
       setError(null)
       return
@@ -74,8 +74,8 @@ export function useLocalClusterTools() {
 
   // Fetch existing clusters
   const fetchClusters = useCallback(async () => {
-    // In demo mode, always show demo clusters
-    if (isDemoMode) {
+    // In demo mode (without agent connected), show demo clusters
+    if (isDemoMode && !isConnected) {
       setClusters(DEMO_CLUSTERS)
       setError(null)
       return
@@ -104,8 +104,8 @@ export function useLocalClusterTools() {
 
   // Create a new cluster
   const createCluster = useCallback(async (tool: string, name: string): Promise<CreateClusterResult> => {
-    // In demo mode, simulate cluster creation
-    if (isDemoMode) {
+    // In demo mode (without agent connected), simulate cluster creation
+    if (isDemoMode && !isConnected) {
       setIsCreating(true)
       setError(null)
       
@@ -151,8 +151,8 @@ export function useLocalClusterTools() {
 
   // Delete a cluster
   const deleteCluster = useCallback(async (tool: string, name: string): Promise<boolean> => {
-    // In demo mode, simulate cluster deletion
-    if (isDemoMode) {
+    // In demo mode (without agent connected), simulate cluster deletion
+    if (isDemoMode && !isConnected) {
       setIsDeleting(name)
       setError(null)
       


### PR DESCRIPTION
## Summary
- When kc-agent is connected, local cluster operations (create, delete, list, detect tools) now call the real backend instead of returning simulated demo data
- Demo simulation only activates when **both** demo mode is on AND the agent is disconnected
- The demo mode banner in Settings > Local Clusters now also hides when kc-agent is connected

## Changes
- `web/src/hooks/useLocalClusterTools.ts`: Changed 4 `if (isDemoMode)` checks to `if (isDemoMode && !isConnected)` in `fetchTools`, `fetchClusters`, `createCluster`, and `deleteCluster`
- `web/src/components/settings/sections/LocalClustersSection.tsx`: Updated demo mode banner condition to also check `!isConnected`

## Test plan
- [ ] Start console with kc-agent running (`startup-oauth.sh`)
- [ ] Go to Settings > Local Clusters
- [ ] Verify demo mode banner does NOT show
- [ ] Verify real tools are detected (kind should show if installed)
- [ ] Create a Kind cluster with a test name — should show "Cluster creation started" (not "Simulation")
- [ ] Wait ~30s, click Refresh, verify the cluster appears
- [ ] Run `kind get clusters` in terminal to confirm
- [ ] Delete the test cluster, verify removal
- [ ] On Netlify (no kc-agent): verify demo simulation still works