### PR TITLE
🐛 Switch to clean GA4 property to eliminate spam

### DIFF
--- a/pkg/api/handlers/analytics_proxy.go
+++ b/pkg/api/handlers/analytics_proxy.go
@@ -54,7 +54,7 @@ func GA4CollectProxy(c *fiber.Ctx) error {
 	// This is a public identifier (not a secret), same as any website's GA ID.
 	realMeasurementID := os.Getenv("GA4_REAL_MEASUREMENT_ID")
 	if realMeasurementID == "" {
-		realMeasurementID = "G-QPGNKGNNY2"
+		realMeasurementID = "G-PXWNVQ8D1T"
 	}
 
 	// Decode base64-encoded payload from `d` parameter.


### PR DESCRIPTION
## Summary
- Switches the backend analytics proxy from the old measurement ID (`G-QPGNKGNNY2`) to a fresh one (`G-PXWNVQ8D1T`)
- The old ID was scraped by Measurement Protocol spammers (9,400+ fake users/day hitting Google directly)
- The new ID has never been exposed in client-side code — it only exists server-side in the proxy
- One-line change in `analytics_proxy.go`

## Test plan
- [ ] `go build ./...` passes
- [ ] Restart console, verify analytics events flow to new property
- [ ] Confirm old property stops receiving real traffic (only spam)
- [ ] Confirm new property shows only real users