### PR TITLE
✨ Real-time cluster creation/deletion progress with Docker pre-check

### DIFF
--- a/web/src/hooks/useClusterProgress.ts
+++ b/web/src/hooks/useClusterProgress.ts
@@ -1,0 +1,81 @@
+import { useEffect, useState, useRef, useCallback } from 'react'
+import { LOCAL_AGENT_WS_URL } from '../lib/constants/network'
+
+/** WebSocket reconnect delay after connection drops */
+const WS_RECONNECT_DELAY_MS = 10_000
+
+/** Auto-dismiss delay after a successful operation */
+export const CLUSTER_PROGRESS_AUTO_DISMISS_MS = 8_000
+
+export type ClusterProgressStatus =
+  | 'validating'
+  | 'creating'
+  | 'deleting'
+  | 'done'
+  | 'failed'
+
+export interface ClusterProgress {
+  tool: string
+  name: string
+  status: ClusterProgressStatus
+  message: string
+  /** 0-100 percentage of completion */
+  progress: number
+}
+
+/**
+ * Hook that listens for local_cluster_progress WebSocket broadcasts from kc-agent.
+ * Uses a dedicated WebSocket connection (same pattern as useUpdateProgress).
+ */
+export function useClusterProgress() {
+  const [progress, setProgress] = useState<ClusterProgress | null>(null)
+  const wsRef = useRef<WebSocket | null>(null)
+
+  useEffect(() => {
+    let reconnectTimer: ReturnType<typeof setTimeout>
+
+    function connect() {
+      try {
+        const ws = new WebSocket(LOCAL_AGENT_WS_URL)
+        wsRef.current = ws
+
+        ws.onmessage = (event) => {
+          try {
+            const msg = JSON.parse(event.data)
+            if (msg.type === 'local_cluster_progress' && msg.payload) {
+              setProgress(msg.payload as ClusterProgress)
+            }
+          } catch {
+            // Ignore parse errors
+          }
+        }
+
+        ws.onclose = () => {
+          wsRef.current = null
+          reconnectTimer = setTimeout(connect, WS_RECONNECT_DELAY_MS)
+        }
+
+        ws.onerror = () => {
+          ws.close()
+        }
+      } catch {
+        // Agent not available, retry later
+        reconnectTimer = setTimeout(connect, WS_RECONNECT_DELAY_MS)
+      }
+    }
+
+    connect()
+
+    return () => {
+      clearTimeout(reconnectTimer)
+      if (wsRef.current) {
+        wsRef.current.close()
+        wsRef.current = null
+      }
+    }
+  }, [])
+
+  const dismiss = useCallback(() => setProgress(null), [])
+
+  return { progress, dismiss }
+}


### PR DESCRIPTION
## Summary
- Backend broadcasts phased progress (`validating` → `creating`/`deleting` → `done`/`failed`) via WebSocket `local_cluster_progress` messages
- Docker daemon pre-flight check for kind/k3d catches missing Docker before creation fails silently — shows clear error: "Docker is not running. Start Docker Desktop or Rancher Desktop first."
- Frontend `useClusterProgress` hook (modeled on `useUpdateProgress`) listens on dedicated WebSocket connection
- Inline `ClusterProgressBanner` replaces the static green/red message with spinner + progress bar (active), checkmark with auto-dismiss (success), or detailed error (failure)
- Auto-refreshes cluster list when creation/deletion completes

## Test plan
- [ ] Create cluster with Docker stopped → should show "Checking prerequisites..." then red error banner with Docker message
- [ ] Create cluster with Docker running → should show phased progress (validating → creating → done) with blue progress bar, then green success
- [ ] Delete cluster → should show progress then green success with auto-dismiss
- [ ] Verify cluster list auto-refreshes after successful create/delete
- [ ] Verify dismiss (X) button works on all banner states