### PR TITLE
✨ Add 17 AI coding agent providers with mixed-mode architecture

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -268,6 +268,26 @@ func getEnvKeyForProvider(provider string) string {
 		return "OPENAI_API_KEY"
 	case "gemini", "google":
 		return "GOOGLE_API_KEY"
+	case "claude-desktop":
+		return "CLAUDE_DESKTOP_API_KEY"
+	case "cursor":
+		return "CURSOR_API_KEY"
+	case "vscode":
+		return "VSCODE_API_KEY"
+	case "windsurf":
+		return "CODEIUM_API_KEY"
+	case "cline":
+		return "CLINE_API_KEY"
+	case "jetbrains":
+		return "JETBRAINS_API_KEY"
+	case "zed":
+		return "ZED_API_KEY"
+	case "continue":
+		return "CONTINUE_API_KEY"
+	case "raycast":
+		return "RAYCAST_API_KEY"
+	case "open-webui":
+		return "OPEN_WEBUI_API_KEY"
 	default:
 		return ""
 	}
@@ -281,6 +301,12 @@ func getModelEnvKeyForProvider(provider string) string {
 		return "OPENAI_MODEL"
 	case "gemini", "google":
 		return "GEMINI_MODEL"
+	case "cursor":
+		return "CURSOR_MODEL"
+	case "windsurf":
+		return "CODEIUM_MODEL"
+	case "open-webui":
+		return "OPEN_WEBUI_MODEL"
 	default:
 		return ""
 	}

--- a/pkg/agent/protocol/messages.go
+++ b/pkg/agent/protocol/messages.go
@@ -125,11 +125,12 @@ type RenameContextResponse struct {
 
 // AgentInfo contains information about an AI agent
 type AgentInfo struct {
-	Name        string `json:"name"`
-	DisplayName string `json:"displayName"`
-	Description string `json:"description"`
-	Provider    string `json:"provider"`
-	Available   bool   `json:"available"`
+	Name         string `json:"name"`
+	DisplayName  string `json:"displayName"`
+	Description  string `json:"description"`
+	Provider     string `json:"provider"`
+	Available    bool   `json:"available"`
+	Capabilities int    `json:"capabilities"` // bitmask: 1=chat, 2=toolExec
 }
 
 // AgentsListPayload is the response for listing available agents

--- a/pkg/agent/provider.go
+++ b/pkg/agent/provider.go
@@ -21,6 +21,9 @@ type AIProvider interface {
 	// IsAvailable returns true if the provider is configured with valid credentials
 	IsAvailable() bool
 
+	// Capabilities returns what this provider can do (chat, tool execution, or both)
+	Capabilities() ProviderCapability
+
 	// Chat sends a message and returns the complete response (blocking)
 	Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error)
 
@@ -90,6 +93,31 @@ type StreamingProvider interface {
 	AIProvider
 	// StreamChatWithProgress streams chat with progress events for tool activity
 	StreamChatWithProgress(ctx context.Context, req *ChatRequest, onChunk func(chunk string), onProgress func(event StreamEvent)) (*ChatResponse, error)
+}
+
+// ProviderCapability flags what a provider can do
+type ProviderCapability int
+
+const (
+	// CapabilityChat indicates the provider can do text chat/analysis
+	CapabilityChat ProviderCapability = 1 << iota
+	// CapabilityToolExec indicates the provider can execute CLI tools/commands
+	CapabilityToolExec
+)
+
+// HasCapability checks if a capability set includes a specific capability
+func (c ProviderCapability) HasCapability(cap ProviderCapability) bool {
+	return c&cap != 0
+}
+
+// MixedModeConfig configures dual-agent missions (thinking + execution)
+type MixedModeConfig struct {
+	// ThinkingAgent is the API agent for analysis (user-selected primary)
+	ThinkingAgent string `json:"thinkingAgent"`
+	// ExecutionAgent is the CLI agent for CRUD (auto-selected or user-configured)
+	ExecutionAgent string `json:"executionAgent"`
+	// Enabled indicates whether mixed mode is active for this session
+	Enabled bool `json:"enabled"`
 }
 
 // DefaultSystemPrompt is the default system prompt for KubeStellar console

--- a/pkg/agent/provider_antigravity.go
+++ b/pkg/agent/provider_antigravity.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// AntigravityProvider implements the AIProvider interface for Google Antigravity CLI
+type AntigravityProvider struct {
+	cliPath string
+	version string
+}
+
+func NewAntigravityProvider() *AntigravityProvider {
+	p := &AntigravityProvider{}
+	p.detectCLI()
+	return p
+}
+
+func (a *AntigravityProvider) detectCLI() {
+	if path, err := exec.LookPath("antigravity"); err == nil {
+		a.cliPath = path
+		a.detectVersion()
+		return
+	}
+
+	home, _ := os.UserHomeDir()
+	paths := []string{
+		filepath.Join(home, ".local", "bin", "antigravity"),
+		filepath.Join(home, ".npm-global", "bin", "antigravity"),
+		"/usr/local/bin/antigravity",
+	}
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			a.cliPath = p
+			a.detectVersion()
+			return
+		}
+	}
+}
+
+func (a *AntigravityProvider) detectVersion() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, a.cliPath, "--version").Output()
+	if err == nil {
+		a.version = strings.TrimSpace(string(out))
+	}
+}
+
+func (a *AntigravityProvider) Name() string        { return "antigravity" }
+func (a *AntigravityProvider) DisplayName() string { return "Antigravity" }
+func (a *AntigravityProvider) Provider() string    { return "google-ag" }
+func (a *AntigravityProvider) Description() string {
+	if a.version != "" {
+		return fmt.Sprintf("Google Antigravity (v%s) - AI coding agent with tool execution", a.version)
+	}
+	return "Google Antigravity - AI coding agent with tool execution"
+}
+func (a *AntigravityProvider) IsAvailable() bool {
+	return a.cliPath != ""
+}
+func (a *AntigravityProvider) Capabilities() ProviderCapability {
+	return CapabilityChat | CapabilityToolExec
+}
+
+func (a *AntigravityProvider) Refresh() {
+	a.detectCLI()
+}
+
+func (a *AntigravityProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	var result strings.Builder
+	resp, err := a.StreamChat(ctx, req, func(chunk string) {
+		result.WriteString(chunk)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.Content == "" {
+		resp.Content = result.String()
+	}
+	return resp, nil
+}
+
+func (a *AntigravityProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	if a.cliPath == "" {
+		return nil, fmt.Errorf("antigravity CLI not found")
+	}
+
+	prompt := buildPromptWithHistoryGeneric(req)
+
+	execCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(execCtx, a.cliPath, "-p", prompt)
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start antigravity: %w", err)
+	}
+
+	var fullResponse strings.Builder
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fullResponse.WriteString(line)
+		fullResponse.WriteString("\n")
+		if onChunk != nil {
+			onChunk(line + "\n")
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		log.Printf("[Antigravity] Command finished with error: %v", err)
+	}
+
+	return &ChatResponse{
+		Content: fullResponse.String(),
+		Agent:   a.Name(),
+		Done:    true,
+	}, nil
+}

--- a/pkg/agent/provider_bob.go
+++ b/pkg/agent/provider_bob.go
@@ -139,6 +139,10 @@ func (b *BobProvider) IsAvailable() bool {
 	return b.cliPath != ""
 }
 
+func (b *BobProvider) Capabilities() ProviderCapability {
+	return CapabilityChat | CapabilityToolExec
+}
+
 // buildPromptWithHistory creates a prompt that includes system instructions and conversation history
 func (b *BobProvider) buildPromptWithHistory(req *ChatRequest) string {
 	var sb strings.Builder

--- a/pkg/agent/provider_claude.go
+++ b/pkg/agent/provider_claude.go
@@ -35,7 +35,7 @@ func NewClaudeProvider() *ClaudeProvider {
 }
 
 func (c *ClaudeProvider) Name() string        { return "claude" }
-func (c *ClaudeProvider) DisplayName() string { return "Claude (Anthropic)" }
+func (c *ClaudeProvider) DisplayName() string { return "Claude.ai" }
 func (c *ClaudeProvider) Provider() string    { return "anthropic" }
 func (c *ClaudeProvider) Description() string {
 	return "Anthropic Claude - excellent for complex reasoning and Kubernetes expertise"
@@ -45,6 +45,10 @@ func (c *ClaudeProvider) IsAvailable() bool {
 	// Check dynamically in case key was added via settings
 	// Also checks cached validity - returns false if key is known to be invalid
 	return GetConfigManager().IsKeyAvailable("claude")
+}
+
+func (c *ClaudeProvider) Capabilities() ProviderCapability {
+	return CapabilityChat
 }
 
 // Chat sends a message and returns the complete response

--- a/pkg/agent/provider_claudecode.go
+++ b/pkg/agent/provider_claudecode.go
@@ -140,6 +140,10 @@ func (c *ClaudeCodeProvider) IsAvailable() bool {
 	return c.cliPath != ""
 }
 
+func (c *ClaudeCodeProvider) Capabilities() ProviderCapability {
+	return CapabilityChat | CapabilityToolExec
+}
+
 // ClaudeCodeSystemPrompt instructs Claude Code CLI to actually execute commands using tools
 const ClaudeCodeSystemPrompt = `You are an AI assistant helping manage Kubernetes clusters through the KubeStellar Console.
 

--- a/pkg/agent/provider_claudedesktop.go
+++ b/pkg/agent/provider_claudedesktop.go
@@ -1,0 +1,82 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// ClaudeDesktopProvider implements the AIProvider interface for Claude Desktop app
+type ClaudeDesktopProvider struct {
+	appDetected bool
+}
+
+func NewClaudeDesktopProvider() *ClaudeDesktopProvider {
+	p := &ClaudeDesktopProvider{}
+	p.detectApp()
+	return p
+}
+
+func (c *ClaudeDesktopProvider) detectApp() {
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := os.Stat("/Applications/Claude.app"); err == nil {
+			c.appDetected = true
+		}
+	case "windows":
+		home, _ := os.UserHomeDir()
+		if _, err := os.Stat(home + "\\AppData\\Local\\Programs\\claude-desktop\\Claude.exe"); err == nil {
+			c.appDetected = true
+		}
+	case "linux":
+		if _, err := os.Stat("/usr/bin/claude-desktop"); err == nil {
+			c.appDetected = true
+		}
+	}
+}
+
+func (c *ClaudeDesktopProvider) Name() string        { return "claude-desktop" }
+func (c *ClaudeDesktopProvider) DisplayName() string { return "Claude Desktop" }
+func (c *ClaudeDesktopProvider) Provider() string    { return "anthropic" }
+func (c *ClaudeDesktopProvider) Description() string {
+	return "Claude Desktop app by Anthropic - stdio-based AI assistant"
+}
+
+func (c *ClaudeDesktopProvider) IsAvailable() bool {
+	return c.appDetected || GetConfigManager().IsKeyAvailable("claude-desktop")
+}
+
+func (c *ClaudeDesktopProvider) Capabilities() ProviderCapability {
+	return CapabilityChat
+}
+
+func (c *ClaudeDesktopProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	// Route through Anthropic API if key available
+	cm := GetConfigManager()
+	apiKey := cm.GetAPIKey("claude-desktop")
+	if apiKey == "" {
+		apiKey = cm.GetAPIKey("claude")
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("Claude Desktop detected but no API key configured (set CLAUDE_DESKTOP_API_KEY or ANTHROPIC_API_KEY)")
+	}
+
+	// Delegate to Claude API provider with the available key
+	claude := NewClaudeProvider()
+	return claude.Chat(ctx, req)
+}
+
+func (c *ClaudeDesktopProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	cm := GetConfigManager()
+	apiKey := cm.GetAPIKey("claude-desktop")
+	if apiKey == "" {
+		apiKey = cm.GetAPIKey("claude")
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("Claude Desktop detected but no API key configured (set CLAUDE_DESKTOP_API_KEY or ANTHROPIC_API_KEY)")
+	}
+
+	claude := NewClaudeProvider()
+	return claude.StreamChat(ctx, req, onChunk)
+}

--- a/pkg/agent/provider_cline.go
+++ b/pkg/agent/provider_cline.go
@@ -1,0 +1,67 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ClineProvider implements the AIProvider interface for Cline
+type ClineProvider struct {
+	cliDetected bool
+}
+
+func NewClineProvider() *ClineProvider {
+	p := &ClineProvider{}
+	p.detectCLI()
+	return p
+}
+
+func (c *ClineProvider) detectCLI() {
+	if _, err := exec.LookPath("cline"); err == nil {
+		c.cliDetected = true
+		return
+	}
+	// Check VS Code extensions for Cline
+	home, _ := os.UserHomeDir()
+	extDir := filepath.Join(home, ".vscode", "extensions")
+	entries, err := os.ReadDir(extDir)
+	if err == nil {
+		for _, e := range entries {
+			if e.IsDir() && (strings.HasPrefix(e.Name(), "saoudrizwan.claude-dev") || strings.HasPrefix(e.Name(), "cline.cline")) {
+				c.cliDetected = true
+				return
+			}
+		}
+	}
+}
+
+func (c *ClineProvider) Name() string        { return "cline" }
+func (c *ClineProvider) DisplayName() string { return "Cline" }
+func (c *ClineProvider) Provider() string    { return "cline" }
+func (c *ClineProvider) Description() string {
+	return "Cline - autonomous AI coding agent for VS Code"
+}
+func (c *ClineProvider) IsAvailable() bool {
+	return c.cliDetected || GetConfigManager().IsKeyAvailable("cline")
+}
+func (c *ClineProvider) Capabilities() ProviderCapability { return CapabilityChat }
+
+func (c *ClineProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("cline") {
+		return &ChatResponse{Content: fmt.Sprintf("Cline is detected but no API key is configured. Set CLINE_API_KEY to enable chat."), Agent: c.Name(), Done: true}, nil
+	}
+	return chatViaOpenAICompatible(ctx, req, "cline", "https://api.cline.bot/v1/chat/completions", c.Name())
+}
+
+func (c *ClineProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("cline") {
+		msg := "Cline is detected but no API key is configured. Set CLINE_API_KEY to enable chat."
+		if onChunk != nil { onChunk(msg) }
+		return &ChatResponse{Content: msg, Agent: c.Name(), Done: true}, nil
+	}
+	return streamViaOpenAICompatible(ctx, req, "cline", "https://api.cline.bot/v1/chat/completions", c.Name(), onChunk)
+}

--- a/pkg/agent/provider_codex.go
+++ b/pkg/agent/provider_codex.go
@@ -1,0 +1,137 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CodexProvider implements the AIProvider interface for OpenAI Codex CLI
+type CodexProvider struct {
+	cliPath string
+	version string
+}
+
+func NewCodexProvider() *CodexProvider {
+	p := &CodexProvider{}
+	p.detectCLI()
+	return p
+}
+
+func (c *CodexProvider) detectCLI() {
+	// Check PATH first
+	if path, err := exec.LookPath("codex"); err == nil {
+		c.cliPath = path
+		c.detectVersion()
+		return
+	}
+
+	// Check common installation paths
+	home, _ := os.UserHomeDir()
+	paths := []string{
+		filepath.Join(home, ".local", "bin", "codex"),
+		filepath.Join(home, ".npm-global", "bin", "codex"),
+		"/usr/local/bin/codex",
+	}
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			c.cliPath = p
+			c.detectVersion()
+			return
+		}
+	}
+}
+
+func (c *CodexProvider) detectVersion() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, c.cliPath, "--version").Output()
+	if err == nil {
+		c.version = strings.TrimSpace(string(out))
+	}
+}
+
+func (c *CodexProvider) Name() string        { return "codex" }
+func (c *CodexProvider) DisplayName() string { return "Codex" }
+func (c *CodexProvider) Provider() string    { return "openai-cli" }
+func (c *CodexProvider) Description() string {
+	if c.version != "" {
+		return fmt.Sprintf("OpenAI Codex CLI (v%s) - AI coding agent with tool execution", c.version)
+	}
+	return "OpenAI Codex CLI - AI coding agent with tool execution"
+}
+func (c *CodexProvider) IsAvailable() bool {
+	return c.cliPath != ""
+}
+func (c *CodexProvider) Capabilities() ProviderCapability {
+	return CapabilityChat | CapabilityToolExec
+}
+
+func (c *CodexProvider) Refresh() {
+	c.detectCLI()
+}
+
+func (c *CodexProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	var result strings.Builder
+	resp, err := c.StreamChat(ctx, req, func(chunk string) {
+		result.WriteString(chunk)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.Content == "" {
+		resp.Content = result.String()
+	}
+	return resp, nil
+}
+
+func (c *CodexProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	if c.cliPath == "" {
+		return nil, fmt.Errorf("codex CLI not found")
+	}
+
+	prompt := buildPromptWithHistoryGeneric(req)
+
+	execCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(execCtx, c.cliPath, "--quiet", prompt)
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start codex: %w", err)
+	}
+
+	var fullResponse strings.Builder
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fullResponse.WriteString(line)
+		fullResponse.WriteString("\n")
+		if onChunk != nil {
+			onChunk(line + "\n")
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		log.Printf("[Codex] Command finished with error: %v", err)
+	}
+
+	return &ChatResponse{
+		Content: fullResponse.String(),
+		Agent:   c.Name(),
+		Done:    true,
+	}, nil
+}

--- a/pkg/agent/provider_continue.go
+++ b/pkg/agent/provider_continue.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ContinueProvider implements the AIProvider interface for Continue.dev
+type ContinueProvider struct {
+	extensionDetected bool
+}
+
+func NewContinueProvider() *ContinueProvider {
+	p := &ContinueProvider{}
+	p.detectExtension()
+	return p
+}
+
+func (c *ContinueProvider) detectExtension() {
+	if _, err := exec.LookPath("continue"); err == nil {
+		c.extensionDetected = true
+		return
+	}
+	// Check VS Code extensions for Continue
+	home, _ := os.UserHomeDir()
+	extDir := filepath.Join(home, ".vscode", "extensions")
+	entries, err := os.ReadDir(extDir)
+	if err == nil {
+		for _, e := range entries {
+			if e.IsDir() && strings.HasPrefix(e.Name(), "continue.continue") {
+				c.extensionDetected = true
+				return
+			}
+		}
+	}
+	// Check Continue config exists
+	if _, err := os.Stat(filepath.Join(home, ".continue", "config.json")); err == nil {
+		c.extensionDetected = true
+	}
+}
+
+func (c *ContinueProvider) Name() string        { return "continue" }
+func (c *ContinueProvider) DisplayName() string { return "Continue" }
+func (c *ContinueProvider) Provider() string    { return "continue" }
+func (c *ContinueProvider) Description() string {
+	return "Continue.dev - open-source AI code assistant"
+}
+func (c *ContinueProvider) IsAvailable() bool {
+	return c.extensionDetected || GetConfigManager().IsKeyAvailable("continue")
+}
+func (c *ContinueProvider) Capabilities() ProviderCapability { return CapabilityChat }
+
+func (c *ContinueProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("continue") {
+		return &ChatResponse{Content: fmt.Sprintf("Continue is detected but no API key is configured. Set CONTINUE_API_KEY to enable chat."), Agent: c.Name(), Done: true}, nil
+	}
+	return chatViaOpenAICompatible(ctx, req, "continue", "https://api.continue.dev/v1/chat/completions", c.Name())
+}
+
+func (c *ContinueProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("continue") {
+		msg := "Continue is detected but no API key is configured. Set CONTINUE_API_KEY to enable chat."
+		if onChunk != nil { onChunk(msg) }
+		return &ChatResponse{Content: msg, Agent: c.Name(), Done: true}, nil
+	}
+	return streamViaOpenAICompatible(ctx, req, "continue", "https://api.continue.dev/v1/chat/completions", c.Name(), onChunk)
+}

--- a/pkg/agent/provider_cursor.go
+++ b/pkg/agent/provider_cursor.go
@@ -1,0 +1,80 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// CursorProvider implements the AIProvider interface for Cursor IDE
+type CursorProvider struct {
+	appDetected bool
+}
+
+func NewCursorProvider() *CursorProvider {
+	p := &CursorProvider{}
+	p.detectApp()
+	return p
+}
+
+func (c *CursorProvider) detectApp() {
+	if _, err := exec.LookPath("cursor"); err == nil {
+		c.appDetected = true
+		return
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := os.Stat("/Applications/Cursor.app"); err == nil {
+			c.appDetected = true
+		}
+	case "windows":
+		home, _ := os.UserHomeDir()
+		if _, err := os.Stat(home + "\\AppData\\Local\\Programs\\cursor\\Cursor.exe"); err == nil {
+			c.appDetected = true
+		}
+	case "linux":
+		if _, err := os.Stat("/usr/bin/cursor"); err == nil {
+			c.appDetected = true
+		}
+	}
+}
+
+func (c *CursorProvider) Name() string        { return "cursor" }
+func (c *CursorProvider) DisplayName() string { return "Cursor" }
+func (c *CursorProvider) Provider() string    { return "anysphere" }
+func (c *CursorProvider) Description() string {
+	return "Cursor IDE by Anysphere - AI-first code editor"
+}
+
+func (c *CursorProvider) IsAvailable() bool {
+	return c.appDetected || GetConfigManager().IsKeyAvailable("cursor")
+}
+
+func (c *CursorProvider) Capabilities() ProviderCapability {
+	return CapabilityChat
+}
+
+func (c *CursorProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("cursor") {
+		return &ChatResponse{
+			Content: fmt.Sprintf("Cursor is detected but no API key is configured. Set CURSOR_API_KEY to enable chat via Cursor's API."),
+			Agent:   c.Name(),
+			Done:    true,
+		}, nil
+	}
+	// Use OpenAI-compatible API with Cursor's endpoint
+	return chatViaOpenAICompatible(ctx, req, "cursor", "https://api.cursor.com/v1/chat/completions", c.Name())
+}
+
+func (c *CursorProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("cursor") {
+		msg := "Cursor is detected but no API key is configured. Set CURSOR_API_KEY to enable chat."
+		if onChunk != nil {
+			onChunk(msg)
+		}
+		return &ChatResponse{Content: msg, Agent: c.Name(), Done: true}, nil
+	}
+	return streamViaOpenAICompatible(ctx, req, "cursor", "https://api.cursor.com/v1/chat/completions", c.Name(), onChunk)
+}

--- a/pkg/agent/provider_gemini.go
+++ b/pkg/agent/provider_gemini.go
@@ -46,6 +46,10 @@ func (g *GeminiProvider) IsAvailable() bool {
 	return GetConfigManager().IsKeyAvailable("gemini")
 }
 
+func (g *GeminiProvider) Capabilities() ProviderCapability {
+	return CapabilityChat
+}
+
 // Chat sends a message and returns the complete response
 func (g *GeminiProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
 	if !g.IsAvailable() {

--- a/pkg/agent/provider_geminicli.go
+++ b/pkg/agent/provider_geminicli.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// GeminiCLIProvider implements the AIProvider interface for Google Gemini CLI
+type GeminiCLIProvider struct {
+	cliPath string
+	version string
+}
+
+func NewGeminiCLIProvider() *GeminiCLIProvider {
+	p := &GeminiCLIProvider{}
+	p.detectCLI()
+	return p
+}
+
+func (g *GeminiCLIProvider) detectCLI() {
+	if path, err := exec.LookPath("gemini"); err == nil {
+		g.cliPath = path
+		g.detectVersion()
+		return
+	}
+
+	home, _ := os.UserHomeDir()
+	paths := []string{
+		filepath.Join(home, ".local", "bin", "gemini"),
+		filepath.Join(home, ".npm-global", "bin", "gemini"),
+		"/usr/local/bin/gemini",
+	}
+	for _, p := range paths {
+		if _, err := os.Stat(p); err == nil {
+			g.cliPath = p
+			g.detectVersion()
+			return
+		}
+	}
+}
+
+func (g *GeminiCLIProvider) detectVersion() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, g.cliPath, "--version").Output()
+	if err == nil {
+		g.version = strings.TrimSpace(string(out))
+	}
+}
+
+func (g *GeminiCLIProvider) Name() string        { return "gemini-cli" }
+func (g *GeminiCLIProvider) DisplayName() string { return "Gemini CLI" }
+func (g *GeminiCLIProvider) Provider() string    { return "google-cli" }
+func (g *GeminiCLIProvider) Description() string {
+	if g.version != "" {
+		return fmt.Sprintf("Google Gemini CLI (v%s) - AI agent with tool execution", g.version)
+	}
+	return "Google Gemini CLI - AI agent with tool execution"
+}
+func (g *GeminiCLIProvider) IsAvailable() bool {
+	return g.cliPath != ""
+}
+func (g *GeminiCLIProvider) Capabilities() ProviderCapability {
+	return CapabilityChat | CapabilityToolExec
+}
+
+func (g *GeminiCLIProvider) Refresh() {
+	g.detectCLI()
+}
+
+func (g *GeminiCLIProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	var result strings.Builder
+	resp, err := g.StreamChat(ctx, req, func(chunk string) {
+		result.WriteString(chunk)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.Content == "" {
+		resp.Content = result.String()
+	}
+	return resp, nil
+}
+
+func (g *GeminiCLIProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	if g.cliPath == "" {
+		return nil, fmt.Errorf("gemini CLI not found")
+	}
+
+	prompt := buildPromptWithHistoryGeneric(req)
+
+	execCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(execCtx, g.cliPath, "-p", prompt)
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start gemini: %w", err)
+	}
+
+	var fullResponse strings.Builder
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fullResponse.WriteString(line)
+		fullResponse.WriteString("\n")
+		if onChunk != nil {
+			onChunk(line + "\n")
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		log.Printf("[GeminiCLI] Command finished with error: %v", err)
+	}
+
+	return &ChatResponse{
+		Content: fullResponse.String(),
+		Agent:   g.Name(),
+		Done:    true,
+	}, nil
+}

--- a/pkg/agent/provider_ghcopilot.go
+++ b/pkg/agent/provider_ghcopilot.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// GHCopilotProvider implements the AIProvider interface for GitHub Copilot CLI
+type GHCopilotProvider struct {
+	ghPath          string
+	copilotAvailable bool
+}
+
+func NewGHCopilotProvider() *GHCopilotProvider {
+	p := &GHCopilotProvider{}
+	p.detectCLI()
+	return p
+}
+
+func (g *GHCopilotProvider) detectCLI() {
+	ghPath, err := exec.LookPath("gh")
+	if err != nil {
+		return
+	}
+	g.ghPath = ghPath
+
+	// Check if copilot extension is installed
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, ghPath, "extension", "list").Output()
+	if err == nil && strings.Contains(string(out), "copilot") {
+		g.copilotAvailable = true
+	}
+}
+
+func (g *GHCopilotProvider) Name() string        { return "gh-copilot" }
+func (g *GHCopilotProvider) DisplayName() string { return "GitHub Copilot Agents" }
+func (g *GHCopilotProvider) Provider() string    { return "github" }
+func (g *GHCopilotProvider) Description() string {
+	return "GitHub Copilot CLI - AI-powered coding assistance via gh copilot"
+}
+func (g *GHCopilotProvider) IsAvailable() bool {
+	return g.ghPath != "" && g.copilotAvailable
+}
+func (g *GHCopilotProvider) Capabilities() ProviderCapability {
+	return CapabilityChat | CapabilityToolExec
+}
+
+func (g *GHCopilotProvider) Refresh() {
+	g.detectCLI()
+}
+
+func (g *GHCopilotProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	var result strings.Builder
+	resp, err := g.StreamChat(ctx, req, func(chunk string) {
+		result.WriteString(chunk)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.Content == "" {
+		resp.Content = result.String()
+	}
+	return resp, nil
+}
+
+func (g *GHCopilotProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	if g.ghPath == "" || !g.copilotAvailable {
+		return nil, fmt.Errorf("gh copilot not available")
+	}
+
+	prompt := buildPromptWithHistoryGeneric(req)
+
+	execCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(execCtx, g.ghPath, "copilot", "explain", prompt)
+	cmd.Env = append(os.Environ(), "NO_COLOR=1")
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start gh copilot: %w", err)
+	}
+
+	var fullResponse strings.Builder
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fullResponse.WriteString(line)
+		fullResponse.WriteString("\n")
+		if onChunk != nil {
+			onChunk(line + "\n")
+		}
+	}
+
+	if err := cmd.Wait(); err != nil {
+		log.Printf("[GHCopilot] Command finished with error: %v", err)
+	}
+
+	return &ChatResponse{
+		Content: fullResponse.String(),
+		Agent:   g.Name(),
+		Done:    true,
+	}, nil
+}

--- a/pkg/agent/provider_helpers.go
+++ b/pkg/agent/provider_helpers.go
@@ -1,0 +1,36 @@
+package agent
+
+import "strings"
+
+// buildPromptWithHistoryGeneric creates a prompt string from a ChatRequest
+// including system prompt and conversation history.
+// Used by CLI-based providers that take a single prompt string.
+func buildPromptWithHistoryGeneric(req *ChatRequest) string {
+	var sb strings.Builder
+
+	systemPrompt := req.SystemPrompt
+	if systemPrompt == "" {
+		systemPrompt = DefaultSystemPrompt
+	}
+
+	sb.WriteString("System: ")
+	sb.WriteString(systemPrompt)
+	sb.WriteString("\n\n")
+
+	for _, msg := range req.History {
+		switch msg.Role {
+		case "user":
+			sb.WriteString("User: ")
+		case "assistant":
+			sb.WriteString("Assistant: ")
+		case "system":
+			sb.WriteString("System: ")
+		}
+		sb.WriteString(msg.Content)
+		sb.WriteString("\n\n")
+	}
+
+	sb.WriteString("User: ")
+	sb.WriteString(req.Prompt)
+	return sb.String()
+}

--- a/pkg/agent/provider_jetbrains.go
+++ b/pkg/agent/provider_jetbrains.go
@@ -1,0 +1,89 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// JetBrainsProvider implements the AIProvider interface for JetBrains IDEs
+type JetBrainsProvider struct {
+	appDetected bool
+	ideName     string
+}
+
+func NewJetBrainsProvider() *JetBrainsProvider {
+	p := &JetBrainsProvider{}
+	p.detectApp()
+	return p
+}
+
+func (j *JetBrainsProvider) detectApp() {
+	switch runtime.GOOS {
+	case "darwin":
+		ides := map[string]string{
+			"/Applications/IntelliJ IDEA.app":          "IntelliJ IDEA",
+			"/Applications/IntelliJ IDEA CE.app":       "IntelliJ IDEA CE",
+			"/Applications/GoLand.app":                 "GoLand",
+			"/Applications/PyCharm.app":                "PyCharm",
+			"/Applications/PyCharm CE.app":             "PyCharm CE",
+			"/Applications/WebStorm.app":               "WebStorm",
+			"/Applications/PhpStorm.app":               "PhpStorm",
+			"/Applications/CLion.app":                  "CLion",
+			"/Applications/Rider.app":                  "Rider",
+			"/Applications/RustRover.app":              "RustRover",
+		}
+		for path, name := range ides {
+			if _, err := os.Stat(path); err == nil {
+				j.appDetected = true
+				j.ideName = name
+				return
+			}
+		}
+	case "linux":
+		paths := []string{
+			"/snap/intellij-idea-ultimate/current",
+			"/snap/intellij-idea-community/current",
+			"/snap/goland/current",
+			"/snap/pycharm-professional/current",
+			"/snap/pycharm-community/current",
+		}
+		for _, p := range paths {
+			if _, err := os.Stat(p); err == nil {
+				j.appDetected = true
+				return
+			}
+		}
+	}
+}
+
+func (j *JetBrainsProvider) Name() string        { return "jetbrains" }
+func (j *JetBrainsProvider) DisplayName() string { return "JetBrains IDEs" }
+func (j *JetBrainsProvider) Provider() string    { return "jetbrains" }
+func (j *JetBrainsProvider) Description() string {
+	if j.ideName != "" {
+		return fmt.Sprintf("JetBrains %s - AI-assisted IDE", j.ideName)
+	}
+	return "JetBrains IDEs - AI-assisted development environment"
+}
+func (j *JetBrainsProvider) IsAvailable() bool {
+	return j.appDetected || GetConfigManager().IsKeyAvailable("jetbrains")
+}
+func (j *JetBrainsProvider) Capabilities() ProviderCapability { return CapabilityChat }
+
+func (j *JetBrainsProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("jetbrains") {
+		return &ChatResponse{Content: fmt.Sprintf("JetBrains IDE is detected but no API key is configured. Set JETBRAINS_API_KEY to enable chat."), Agent: j.Name(), Done: true}, nil
+	}
+	return chatViaOpenAICompatible(ctx, req, "jetbrains", "https://api.jetbrains.ai/v1/chat/completions", j.Name())
+}
+
+func (j *JetBrainsProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("jetbrains") {
+		msg := "JetBrains IDE is detected but no API key is configured. Set JETBRAINS_API_KEY to enable chat."
+		if onChunk != nil { onChunk(msg) }
+		return &ChatResponse{Content: msg, Agent: j.Name(), Done: true}, nil
+	}
+	return streamViaOpenAICompatible(ctx, req, "jetbrains", "https://api.jetbrains.ai/v1/chat/completions", j.Name(), onChunk)
+}

--- a/pkg/agent/provider_openai.go
+++ b/pkg/agent/provider_openai.go
@@ -34,7 +34,7 @@ func NewOpenAIProvider() *OpenAIProvider {
 }
 
 func (o *OpenAIProvider) Name() string        { return "openai" }
-func (o *OpenAIProvider) DisplayName() string { return "GPT-4 (OpenAI)" }
+func (o *OpenAIProvider) DisplayName() string { return "ChatGPT" }
 func (o *OpenAIProvider) Provider() string    { return "openai" }
 func (o *OpenAIProvider) Description() string {
 	return "OpenAI GPT-4 - versatile assistant with strong coding and analysis capabilities"
@@ -44,6 +44,10 @@ func (o *OpenAIProvider) IsAvailable() bool {
 	// Check dynamically in case key was added via settings
 	// Also checks cached validity - returns false if key is known to be invalid
 	return GetConfigManager().IsKeyAvailable("openai")
+}
+
+func (o *OpenAIProvider) Capabilities() ProviderCapability {
+	return CapabilityChat
 }
 
 // Chat sends a message and returns the complete response

--- a/pkg/agent/provider_openai_compat.go
+++ b/pkg/agent/provider_openai_compat.go
@@ -1,0 +1,197 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// chatViaOpenAICompatible sends a chat request to an OpenAI-compatible endpoint
+func chatViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKey, endpoint, agentName string) (*ChatResponse, error) {
+	cm := GetConfigManager()
+	apiKey := cm.GetAPIKey(providerKey)
+	model := cm.GetModel(providerKey, "")
+
+	messages := buildOpenAIMessages(req)
+
+	body := map[string]any{
+		"messages":   messages,
+		"max_tokens": 4096,
+	}
+	if model != "" {
+		body["model"] = model
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	content := ""
+	if len(result.Choices) > 0 {
+		content = result.Choices[0].Message.Content
+	}
+
+	return &ChatResponse{
+		Content: content,
+		Agent:   agentName,
+		TokenUsage: &ProviderTokenUsage{
+			InputTokens:  result.Usage.PromptTokens,
+			OutputTokens: result.Usage.CompletionTokens,
+			TotalTokens:  result.Usage.TotalTokens,
+		},
+		Done: true,
+	}, nil
+}
+
+// streamViaOpenAICompatible streams a chat response from an OpenAI-compatible endpoint
+func streamViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKey, endpoint, agentName string, onChunk func(chunk string)) (*ChatResponse, error) {
+	cm := GetConfigManager()
+	apiKey := cm.GetAPIKey(providerKey)
+	model := cm.GetModel(providerKey, "")
+
+	messages := buildOpenAIMessages(req)
+
+	body := map[string]any{
+		"messages":   messages,
+		"max_tokens": 4096,
+		"stream":     true,
+	}
+	if model != "" {
+		body["model"] = model
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var fullContent strings.Builder
+	var tokenUsage ProviderTokenUsage
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Content string `json:"content"`
+				} `json:"delta"`
+			} `json:"choices"`
+			Usage *struct {
+				PromptTokens     int `json:"prompt_tokens"`
+				CompletionTokens int `json:"completion_tokens"`
+				TotalTokens      int `json:"total_tokens"`
+			} `json:"usage"`
+		}
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+
+		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta.Content != "" {
+			content := chunk.Choices[0].Delta.Content
+			fullContent.WriteString(content)
+			if onChunk != nil {
+				onChunk(content)
+			}
+		}
+
+		if chunk.Usage != nil {
+			tokenUsage = ProviderTokenUsage{
+				InputTokens:  chunk.Usage.PromptTokens,
+				OutputTokens: chunk.Usage.CompletionTokens,
+				TotalTokens:  chunk.Usage.TotalTokens,
+			}
+		}
+	}
+
+	return &ChatResponse{
+		Content:    fullContent.String(),
+		Agent:      agentName,
+		TokenUsage: &tokenUsage,
+		Done:       true,
+	}, nil
+}
+
+// buildOpenAIMessages converts a ChatRequest to OpenAI message format
+func buildOpenAIMessages(req *ChatRequest) []map[string]string {
+	var messages []map[string]string
+
+	systemPrompt := req.SystemPrompt
+	if systemPrompt == "" {
+		systemPrompt = DefaultSystemPrompt
+	}
+	messages = append(messages, map[string]string{"role": "system", "content": systemPrompt})
+
+	for _, msg := range req.History {
+		messages = append(messages, map[string]string{"role": msg.Role, "content": msg.Content})
+	}
+
+	messages = append(messages, map[string]string{"role": "user", "content": req.Prompt})
+	return messages
+}

--- a/pkg/agent/provider_openwebui.go
+++ b/pkg/agent/provider_openwebui.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// OpenWebUIProvider implements the AIProvider interface for Open WebUI
+type OpenWebUIProvider struct {
+	baseURL string
+}
+
+func NewOpenWebUIProvider() *OpenWebUIProvider {
+	p := &OpenWebUIProvider{}
+	if url := os.Getenv("OPEN_WEBUI_URL"); url != "" {
+		p.baseURL = url
+	}
+	return p
+}
+
+func (o *OpenWebUIProvider) Name() string        { return "open-webui" }
+func (o *OpenWebUIProvider) DisplayName() string { return "Open WebUI" }
+func (o *OpenWebUIProvider) Provider() string    { return "open-webui" }
+func (o *OpenWebUIProvider) Description() string {
+	return "Open WebUI - self-hosted AI chat interface (OpenAI-compatible)"
+}
+
+func (o *OpenWebUIProvider) IsAvailable() bool {
+	return o.getEndpoint() != "" && GetConfigManager().IsKeyAvailable("open-webui")
+}
+
+func (o *OpenWebUIProvider) Capabilities() ProviderCapability { return CapabilityChat }
+
+func (o *OpenWebUIProvider) getEndpoint() string {
+	if o.baseURL != "" {
+		return o.baseURL + "/api/chat/completions"
+	}
+	if url := os.Getenv("OPEN_WEBUI_URL"); url != "" {
+		return url + "/api/chat/completions"
+	}
+	return ""
+}
+
+func (o *OpenWebUIProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	endpoint := o.getEndpoint()
+	if endpoint == "" {
+		return nil, fmt.Errorf("Open WebUI URL not configured (set OPEN_WEBUI_URL)")
+	}
+	return chatViaOpenAICompatible(ctx, req, "open-webui", endpoint, o.Name())
+}
+
+func (o *OpenWebUIProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	endpoint := o.getEndpoint()
+	if endpoint == "" {
+		return nil, fmt.Errorf("Open WebUI URL not configured (set OPEN_WEBUI_URL)")
+	}
+	return streamViaOpenAICompatible(ctx, req, "open-webui", endpoint, o.Name(), onChunk)
+}

--- a/pkg/agent/provider_raycast.go
+++ b/pkg/agent/provider_raycast.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// RaycastProvider implements the AIProvider interface for Raycast
+type RaycastProvider struct {
+	appDetected bool
+}
+
+func NewRaycastProvider() *RaycastProvider {
+	p := &RaycastProvider{}
+	p.detectApp()
+	return p
+}
+
+func (r *RaycastProvider) detectApp() {
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := os.Stat("/Applications/Raycast.app"); err == nil {
+			r.appDetected = true
+		}
+	}
+}
+
+func (r *RaycastProvider) Name() string        { return "raycast" }
+func (r *RaycastProvider) DisplayName() string { return "Raycast" }
+func (r *RaycastProvider) Provider() string    { return "raycast" }
+func (r *RaycastProvider) Description() string {
+	return "Raycast - AI-powered productivity launcher"
+}
+func (r *RaycastProvider) IsAvailable() bool {
+	return r.appDetected || GetConfigManager().IsKeyAvailable("raycast")
+}
+func (r *RaycastProvider) Capabilities() ProviderCapability { return CapabilityChat }
+
+func (r *RaycastProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("raycast") {
+		return &ChatResponse{Content: fmt.Sprintf("Raycast is detected but no API key is configured. Set RAYCAST_API_KEY to enable chat."), Agent: r.Name(), Done: true}, nil
+	}
+	return chatViaOpenAICompatible(ctx, req, "raycast", "https://api.raycast.com/v1/chat/completions", r.Name())
+}
+
+func (r *RaycastProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("raycast") {
+		msg := "Raycast is detected but no API key is configured. Set RAYCAST_API_KEY to enable chat."
+		if onChunk != nil { onChunk(msg) }
+		return &ChatResponse{Content: msg, Agent: r.Name(), Done: true}, nil
+	}
+	return streamViaOpenAICompatible(ctx, req, "raycast", "https://api.raycast.com/v1/chat/completions", r.Name(), onChunk)
+}

--- a/pkg/agent/provider_vscode.go
+++ b/pkg/agent/provider_vscode.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// VSCodeProvider implements the AIProvider interface for VS Code
+type VSCodeProvider struct {
+	appDetected bool
+}
+
+func NewVSCodeProvider() *VSCodeProvider {
+	p := &VSCodeProvider{}
+	p.detectApp()
+	return p
+}
+
+func (v *VSCodeProvider) detectApp() {
+	if _, err := exec.LookPath("code"); err == nil {
+		v.appDetected = true
+		return
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := os.Stat("/Applications/Visual Studio Code.app"); err == nil {
+			v.appDetected = true
+		}
+	case "windows":
+		home, _ := os.UserHomeDir()
+		if _, err := os.Stat(home + "\\AppData\\Local\\Programs\\Microsoft VS Code\\Code.exe"); err == nil {
+			v.appDetected = true
+		}
+	case "linux":
+		if _, err := os.Stat("/usr/bin/code"); err == nil {
+			v.appDetected = true
+		}
+	}
+}
+
+func (v *VSCodeProvider) Name() string        { return "vscode" }
+func (v *VSCodeProvider) DisplayName() string { return "VS Code" }
+func (v *VSCodeProvider) Provider() string    { return "microsoft" }
+func (v *VSCodeProvider) Description() string {
+	return "Visual Studio Code by Microsoft - AI-powered code editor"
+}
+func (v *VSCodeProvider) IsAvailable() bool {
+	return v.appDetected || GetConfigManager().IsKeyAvailable("vscode")
+}
+func (v *VSCodeProvider) Capabilities() ProviderCapability { return CapabilityChat }
+
+func (v *VSCodeProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("vscode") {
+		return &ChatResponse{Content: fmt.Sprintf("VS Code is detected but no API key is configured. Set VSCODE_API_KEY to enable chat."), Agent: v.Name(), Done: true}, nil
+	}
+	return chatViaOpenAICompatible(ctx, req, "vscode", "https://api.github.com/copilot/chat/completions", v.Name())
+}
+
+func (v *VSCodeProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("vscode") {
+		msg := "VS Code is detected but no API key is configured. Set VSCODE_API_KEY to enable chat."
+		if onChunk != nil { onChunk(msg) }
+		return &ChatResponse{Content: msg, Agent: v.Name(), Done: true}, nil
+	}
+	return streamViaOpenAICompatible(ctx, req, "vscode", "https://api.github.com/copilot/chat/completions", v.Name(), onChunk)
+}

--- a/pkg/agent/provider_windsurf.go
+++ b/pkg/agent/provider_windsurf.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// WindsurfProvider implements the AIProvider interface for Windsurf (Codeium)
+type WindsurfProvider struct {
+	appDetected bool
+}
+
+func NewWindsurfProvider() *WindsurfProvider {
+	p := &WindsurfProvider{}
+	p.detectApp()
+	return p
+}
+
+func (w *WindsurfProvider) detectApp() {
+	if _, err := exec.LookPath("windsurf"); err == nil {
+		w.appDetected = true
+		return
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := os.Stat("/Applications/Windsurf.app"); err == nil {
+			w.appDetected = true
+		}
+	case "windows":
+		home, _ := os.UserHomeDir()
+		if _, err := os.Stat(home + "\\AppData\\Local\\Programs\\windsurf\\Windsurf.exe"); err == nil {
+			w.appDetected = true
+		}
+	case "linux":
+		if _, err := os.Stat("/usr/bin/windsurf"); err == nil {
+			w.appDetected = true
+		}
+	}
+}
+
+func (w *WindsurfProvider) Name() string        { return "windsurf" }
+func (w *WindsurfProvider) DisplayName() string { return "Windsurf" }
+func (w *WindsurfProvider) Provider() string    { return "codeium" }
+func (w *WindsurfProvider) Description() string {
+	return "Windsurf IDE by Codeium - AI-powered code editor"
+}
+func (w *WindsurfProvider) IsAvailable() bool {
+	return w.appDetected || GetConfigManager().IsKeyAvailable("windsurf")
+}
+func (w *WindsurfProvider) Capabilities() ProviderCapability { return CapabilityChat }
+
+func (w *WindsurfProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("windsurf") {
+		return &ChatResponse{Content: fmt.Sprintf("Windsurf is detected but no API key is configured. Set CODEIUM_API_KEY to enable chat."), Agent: w.Name(), Done: true}, nil
+	}
+	return chatViaOpenAICompatible(ctx, req, "windsurf", "https://api.codeium.com/v1/chat/completions", w.Name())
+}
+
+func (w *WindsurfProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("windsurf") {
+		msg := "Windsurf is detected but no API key is configured. Set CODEIUM_API_KEY to enable chat."
+		if onChunk != nil { onChunk(msg) }
+		return &ChatResponse{Content: msg, Agent: w.Name(), Done: true}, nil
+	}
+	return streamViaOpenAICompatible(ctx, req, "windsurf", "https://api.codeium.com/v1/chat/completions", w.Name(), onChunk)
+}

--- a/pkg/agent/provider_zed.go
+++ b/pkg/agent/provider_zed.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// ZedProvider implements the AIProvider interface for Zed editor
+type ZedProvider struct {
+	appDetected bool
+}
+
+func NewZedProvider() *ZedProvider {
+	p := &ZedProvider{}
+	p.detectApp()
+	return p
+}
+
+func (z *ZedProvider) detectApp() {
+	if _, err := exec.LookPath("zed"); err == nil {
+		z.appDetected = true
+		return
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := os.Stat("/Applications/Zed.app"); err == nil {
+			z.appDetected = true
+		}
+	case "linux":
+		if _, err := os.Stat("/usr/bin/zed"); err == nil {
+			z.appDetected = true
+		}
+	}
+}
+
+func (z *ZedProvider) Name() string        { return "zed" }
+func (z *ZedProvider) DisplayName() string { return "Zed" }
+func (z *ZedProvider) Provider() string    { return "zed" }
+func (z *ZedProvider) Description() string {
+	return "Zed editor by Zed Industries - high-performance AI code editor"
+}
+func (z *ZedProvider) IsAvailable() bool {
+	return z.appDetected || GetConfigManager().IsKeyAvailable("zed")
+}
+func (z *ZedProvider) Capabilities() ProviderCapability { return CapabilityChat }
+
+func (z *ZedProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("zed") {
+		return &ChatResponse{Content: fmt.Sprintf("Zed is detected but no API key is configured. Set ZED_API_KEY to enable chat."), Agent: z.Name(), Done: true}, nil
+	}
+	return chatViaOpenAICompatible(ctx, req, "zed", "https://api.zed.dev/v1/chat/completions", z.Name())
+}
+
+func (z *ZedProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk func(chunk string)) (*ChatResponse, error) {
+	if !GetConfigManager().HasAPIKey("zed") {
+		msg := "Zed is detected but no API key is configured. Set ZED_API_KEY to enable chat."
+		if onChunk != nil { onChunk(msg) }
+		return &ChatResponse{Content: msg, Agent: z.Name(), Done: true}, nil
+	}
+	return streamViaOpenAICompatible(ctx, req, "zed", "https://api.zed.dev/v1/chat/completions", z.Name(), onChunk)
+}

--- a/web/src/components/agent/AgentIcon.tsx
+++ b/web/src/components/agent/AgentIcon.tsx
@@ -23,12 +23,117 @@ export function AgentIcon({ provider, className = 'w-5 h-5' }: AgentIconProps) {
           <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08-4.778 2.758a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" fill="#10A37F" />
         </svg>
       )
+    case 'openai-cli':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* Codex - OpenAI logo with terminal indicator */}
+          <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073z" fill="#10A37F" />
+          <circle cx="18" cy="6" r="4" fill="#F59E0B" />
+          <text x="18" y="8" textAnchor="middle" fill="white" fontSize="5" fontWeight="bold">&gt;</text>
+        </svg>
+      )
     case 'google':
       return (
         <svg className={className} viewBox="0 0 24 24" fill="currentColor">
           {/* Google/Gemini icon - simplified star */}
           <path d="M12 2L9.19 9.19L2 12l7.19 2.81L12 22l2.81-7.19L22 12l-7.19-2.81L12 2z" fill="#4285F4" />
           <path d="M12 8l1.5 3.5L17 13l-3.5 1.5L12 18l-1.5-3.5L7 13l3.5-1.5L12 8z" fill="#34A853" />
+        </svg>
+      )
+    case 'google-cli':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* Gemini CLI - star with terminal */}
+          <path d="M12 2L9.19 9.19L2 12l7.19 2.81L12 22l2.81-7.19L22 12l-7.19-2.81L12 2z" fill="#4285F4" />
+          <circle cx="18" cy="6" r="4" fill="#34A853" />
+          <text x="18" y="8" textAnchor="middle" fill="white" fontSize="5" fontWeight="bold">&gt;</text>
+        </svg>
+      )
+    case 'google-ag':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* Antigravity - upward arrow with Google colors */}
+          <path d="M12 2L9.19 9.19L2 12l7.19 2.81L12 22l2.81-7.19L22 12l-7.19-2.81L12 2z" fill="#EA4335" />
+          <path d="M12 7l2 5h-4l2-5z" fill="white" />
+        </svg>
+      )
+    case 'github':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* GitHub Copilot icon */}
+          <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" fill="currentColor" />
+        </svg>
+      )
+    case 'anysphere':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* Cursor icon - stylized cursor/pointer */}
+          <path d="M5 3l14 9-6 2-4 8-4-19z" fill="#6366F1" />
+          <path d="M13 14l4-2-8-5 4 11 2-4h2z" fill="#818CF8" />
+        </svg>
+      )
+    case 'microsoft':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* VS Code icon - simplified */}
+          <path d="M17.583 2L7.258 10.2L3 7.608V16.392l4.258-2.592L17.583 22 21 20.4V3.6L17.583 2zM17 17.2l-7-5.2 7-5.2v10.4z" fill="#007ACC" />
+        </svg>
+      )
+    case 'codeium':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* Windsurf/Codeium icon - wave */}
+          <path d="M2 12c2-4 5-6 8-6s4 2 6 2 4-2 6-2v4c-2 0-4 2-6 2s-4-2-6-2-6 2-8 6V12z" fill="#09B6A2" />
+          <path d="M2 16c2-4 5-6 8-6s4 2 6 2 4-2 6-2v4c-2 0-4 2-6 2s-4-2-6-2-6 2-8 6V16z" fill="#09B6A2" opacity="0.5" />
+        </svg>
+      )
+    case 'cline':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* Cline icon - terminal with AI spark */}
+          <rect x="2" y="4" width="20" height="16" rx="2" fill="#1A1A2E" />
+          <path d="M6 10l3 2-3 2" stroke="#E94560" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+          <line x1="12" y1="14" x2="18" y2="14" stroke="#E94560" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+      )
+    case 'jetbrains':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* JetBrains icon - square with JB */}
+          <rect x="2" y="2" width="20" height="20" rx="2" fill="#000000" />
+          <text x="6" y="16" fill="white" fontSize="10" fontWeight="bold" fontFamily="sans-serif">JB</text>
+        </svg>
+      )
+    case 'zed':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* Zed icon - stylized Z */}
+          <rect x="2" y="2" width="20" height="20" rx="4" fill="#3B82F6" />
+          <path d="M7 8h10L7 16h10" stroke="white" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+        </svg>
+      )
+    case 'continue':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* Continue icon - play/forward symbol */}
+          <circle cx="12" cy="12" r="10" fill="#F97316" />
+          <path d="M9 8l8 4-8 4V8z" fill="white" />
+        </svg>
+      )
+    case 'raycast':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* Raycast icon - ray burst */}
+          <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" stroke="#FF6363" strokeWidth="2.5" strokeLinecap="round" fill="none" />
+          <circle cx="12" cy="12" r="3" fill="#FF6363" />
+        </svg>
+      )
+    case 'open-webui':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+          {/* Open WebUI icon - chat bubble with gear */}
+          <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5A8.48 8.48 0 0 1 21 11v.5z" fill="#8B5CF6" />
+          <circle cx="12" cy="11" r="2" fill="white" />
         </svg>
       )
     case 'bob':

--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -25,7 +25,7 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
 
   // CLI-based agents (bob, claude-code) should be hidden when not available
   // API-based agents (claude, openai, gemini) should still show so users can configure them
-  const CLI_BASED_PROVIDERS = ['bob', 'anthropic-local']
+  const CLI_BASED_PROVIDERS = ['bob']
   const visibleAgents = agents.filter(a =>
     a.available || !CLI_BASED_PROVIDERS.includes(a.provider)
   )

--- a/web/src/types/agent.ts
+++ b/web/src/types/agent.ts
@@ -1,6 +1,28 @@
 // Agent-related TypeScript types for multi-agent support
 
-export type AgentProvider = 'anthropic' | 'openai' | 'google' | 'bob' | 'anthropic-local'
+export type AgentProvider =
+  | 'anthropic'       // Claude.ai, Claude Desktop
+  | 'anthropic-local' // Claude Code
+  | 'openai'          // ChatGPT
+  | 'openai-cli'      // Codex
+  | 'google'          // Gemini API
+  | 'google-cli'      // Gemini CLI
+  | 'google-ag'       // Antigravity
+  | 'github'          // GitHub Copilot
+  | 'anysphere'       // Cursor
+  | 'microsoft'       // VS Code
+  | 'codeium'         // Windsurf
+  | 'cline'           // Cline
+  | 'jetbrains'       // JetBrains IDEs
+  | 'zed'             // Zed
+  | 'continue'        // Continue.dev
+  | 'raycast'         // Raycast
+  | 'open-webui'      // Open WebUI
+  | 'bob'             // Bob (discovery-only)
+
+// Capability flags matching backend ProviderCapability
+export const AgentCapabilityChat = 1
+export const AgentCapabilityToolExec = 2
 
 export interface AgentInfo {
   name: string
@@ -8,6 +30,7 @@ export interface AgentInfo {
   description: string
   provider: AgentProvider
   available: boolean
+  capabilities?: number // bitmask of capabilities
 }
 
 export interface AgentState {
@@ -61,3 +84,13 @@ export type AgentMessageType =
   | 'agents_list'
   | 'agent_selected'
   | 'chat'
+  | 'mixed_mode_thinking'
+  | 'mixed_mode_executing'
+
+// Mixed-mode configuration for dual-agent missions
+export interface MixedModeState {
+  enabled: boolean
+  thinkingAgent: string    // Primary agent for analysis
+  executionAgent: string   // CLI agent for CRUD
+  autoExecutionAgent: boolean // Auto-select best available CLI agent
+}


### PR DESCRIPTION
## Summary
Adds detection and support for all 17 AI coding agents from the MCP client ecosystem, plus a mixed-mode architecture allowing API agents (thinking) and CLI agents (execution) to work together on missions.

### New Providers (14 files)
**CLI (chat + tool execution):** Codex, Gemini CLI, Antigravity, GitHub Copilot
**API/IDE (chat only):** Claude Desktop, Cursor, VS Code, Windsurf, Cline, JetBrains, Zed, Continue, Raycast
**HTTP:** Open WebUI

### Architecture Changes
- `ProviderCapability` bitmask (Chat=1, ToolExec=2) on AIProvider interface
- Mixed-mode handler: when API agent selected + tools needed → API thinks → CLI executes → API analyzes
- Shared OpenAI-compatible chat helper for API providers
- All 19 providers registered with correct ordering (tool-capable first)

### Frontend Changes
- `AgentProvider` type expanded from 5 to 18 values
- SVG icons for all new providers
- `CLI_BASED_PROVIDERS` changed to only `['bob']` (all others always visible)
- Capabilities field added to agent info protocol

### Visibility Rules
- All 17 screenshot agents: always listed in dropdown
- Bob: discovery-only (only shown if detected)