### PR TITLE
🐛 Fix new agents not appearing in dropdown and API key settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ vendor/
 .bob/
 /bin/*
 *.bak
+web/.netlify/

--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -43,6 +43,61 @@ const PROVIDER_INFO: Record<string, { docsUrl: string; placeholder: string }> = 
     docsUrl: AI_PROVIDER_DOCS.gemini,
     placeholder: 'AIza...',
   },
+  cursor: {
+    docsUrl: AI_PROVIDER_DOCS.cursor,
+    placeholder: 'cursor-...',
+  },
+  vscode: {
+    docsUrl: AI_PROVIDER_DOCS.vscode,
+    placeholder: 'vscode-...',
+  },
+  windsurf: {
+    docsUrl: AI_PROVIDER_DOCS.windsurf,
+    placeholder: 'codeium-...',
+  },
+  cline: {
+    docsUrl: AI_PROVIDER_DOCS.cline,
+    placeholder: 'cline-...',
+  },
+  jetbrains: {
+    docsUrl: AI_PROVIDER_DOCS.jetbrains,
+    placeholder: 'jb-...',
+  },
+  zed: {
+    docsUrl: AI_PROVIDER_DOCS.zed,
+    placeholder: 'zed-...',
+  },
+  continue: {
+    docsUrl: AI_PROVIDER_DOCS.continue,
+    placeholder: 'continue-...',
+  },
+  raycast: {
+    docsUrl: AI_PROVIDER_DOCS.raycast,
+    placeholder: 'raycast-...',
+  },
+  'open-webui': {
+    docsUrl: AI_PROVIDER_DOCS['open-webui'],
+    placeholder: 'owui-...',
+  },
+}
+
+// Map backend provider key names to AgentIcon provider values
+function providerToIconMap(provider: string): string {
+  const map: Record<string, string> = {
+    claude: 'anthropic',
+    openai: 'openai',
+    gemini: 'google',
+    cursor: 'anysphere',
+    vscode: 'microsoft',
+    windsurf: 'codeium',
+    cline: 'cline',
+    jetbrains: 'jetbrains',
+    zed: 'zed',
+    continue: 'continue',
+    raycast: 'raycast',
+    'open-webui': 'open-webui',
+  }
+  return map[provider] || provider
 }
 
 export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
@@ -233,7 +288,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex items-center gap-3">
                       <AgentIcon
-                        provider={key.provider === 'claude' ? 'anthropic' : key.provider === 'openai' ? 'openai' : 'google'}
+                        provider={providerToIconMap(key.provider)}
                         className="w-8 h-8"
                       />
                       <div>

--- a/web/src/config/externalApis.ts
+++ b/web/src/config/externalApis.ts
@@ -37,6 +37,15 @@ export const AI_PROVIDER_DOCS = {
   claude: 'https://console.anthropic.com/settings/keys',
   openai: 'https://platform.openai.com/api-keys',
   gemini: 'https://makersuite.google.com/app/apikey',
+  cursor: 'https://cursor.sh',
+  vscode: 'https://code.visualstudio.com',
+  windsurf: 'https://codeium.com',
+  cline: 'https://github.com/cline/cline',
+  jetbrains: 'https://www.jetbrains.com',
+  zed: 'https://zed.dev',
+  continue: 'https://continue.dev',
+  raycast: 'https://raycast.com',
+  'open-webui': 'https://github.com/open-webui/open-webui',
 } as const
 
 /**


### PR DESCRIPTION
## Problem
After adding 17 AI agent providers in #1304, the new agents were not showing in:
- Agent dropdown (only showing original 5)
- API Key Settings modal (only showing Claude, OpenAI, Gemini)

## Root Causes
1. `handleGetKeysStatus()` in server.go had a hardcoded list of only 3 providers
2. `validateAPIKeyValue()` returned error for unknown providers, blocking key saves
3. `ValidateAllKeys()` only checked 3 providers on startup
4. Frontend `PROVIDER_INFO` and `AI_PROVIDER_DOCS` only had 3 entries
5. `AgentIcon` provider mapping was hardcoded to 3 providers

## Fix
- Expanded backend to list all 12 API-key providers in settings endpoint
- Accept new provider keys without validation (no API endpoints for most)
- Added all provider docs URLs and key placeholders to frontend
- Added `providerToIconMap()` for correct icon rendering
- Added web/.netlify/ to .gitignore