### PR TITLE
✨ Make commit list items link to their PRs

### DIFF
--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -858,15 +858,27 @@ function CommitList({ commits }: { commits: Array<{ sha: string; message: string
       </button>
       {expanded && (
         <div className="border-t border-border max-h-64 overflow-y-auto">
-          {commits.map((commit) => (
-            <div key={commit.sha} className="flex items-start gap-3 px-4 py-2 border-b border-border/50 last:border-b-0 hover:bg-secondary/30">
-              <code className="text-xs font-mono text-orange-400 shrink-0 pt-0.5">{commit.sha.slice(0, 7)}</code>
-              <div className="min-w-0 flex-1">
-                <p className="text-sm text-foreground truncate">{commit.message}</p>
-                <p className="text-xs text-muted-foreground">{commit.author} &middot; {formatCommitDate(commit.date)}</p>
-              </div>
-            </div>
-          ))}
+          {commits.map((commit) => {
+            const prMatch = commit.message.match(/\(#(\d+)\)/)
+            const url = prMatch
+              ? `https://github.com/kubestellar/console/pull/${prMatch[1]}`
+              : `https://github.com/kubestellar/console/commit/${commit.sha}`
+            return (
+              <a
+                key={commit.sha}
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-start gap-3 px-4 py-2 border-b border-border/50 last:border-b-0 hover:bg-secondary/30 cursor-pointer no-underline"
+              >
+                <code className="text-xs font-mono text-orange-400 shrink-0 pt-0.5">{commit.sha.slice(0, 7)}</code>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm text-foreground truncate">{commit.message}</p>
+                  <p className="text-xs text-muted-foreground">{commit.author} &middot; {formatCommitDate(commit.date)}</p>
+                </div>
+              </a>
+            )
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Extract PR numbers from commit messages (e.g. `(#1343)`) and make each commit row in the Update Settings commit list a clickable link to the corresponding GitHub PR
- Falls back to linking to the commit SHA if no PR number is found in the message
- Opens links in a new tab

## Test plan
- [ ] Open Settings > Updates, expand the recent commits list
- [ ] Verify each commit row is clickable and opens the correct PR on GitHub
- [ ] Verify commits without PR numbers link to the commit page instead