### PR TITLE
🐛 fix(ui): replace hardcoded gray/slate/white Tailwind classes with semantic theme tokens

### DIFF
--- a/web/src/components/animations/SimpleGlobe.tsx
+++ b/web/src/components/animations/SimpleGlobe.tsx
@@ -84,8 +84,8 @@ export function SimpleGlobe({ className = '' }: SimpleGlobeProps) {
 
       {/* Title */}
       <div className="absolute bottom-8 text-center">
-        <h2 className="text-2xl font-bold text-white mb-2">Multi-Cluster Management</h2>
-        <p className="text-gray-400">Visualize and control your Kubernetes infrastructure</p>
+        <h2 className="text-2xl font-bold text-foreground mb-2">Multi-Cluster Management</h2>
+        <p className="text-muted-foreground">Visualize and control your Kubernetes infrastructure</p>
       </div>
     </div>
   )

--- a/web/src/components/animations/globe/GlobeLoader.tsx
+++ b/web/src/components/animations/globe/GlobeLoader.tsx
@@ -14,7 +14,7 @@ const GlobeLoader = () => {
       </div>
       <div className="text-center">
         <div className="text-blue-400 font-semibold text-lg">KubeStellar</div>
-        <div className="text-gray-400 text-sm">Initializing clusters...</div>
+        <div className="text-muted-foreground text-sm">Initializing clusters...</div>
         <div className="flex space-x-1 mt-2 justify-center">
           <div className="w-2 h-2 bg-blue-400 rounded-full animate-bounce"></div>
           <div className="w-2 h-2 bg-purple-400 rounded-full animate-bounce" style={{ animationDelay: "0.1s" }}></div>

--- a/web/src/components/layout/navbar/TokenUsageWidget.tsx
+++ b/web/src/components/layout/navbar/TokenUsageWidget.tsx
@@ -11,7 +11,7 @@ const CATEGORY_CONFIG: Record<TokenCategory, { label: string; icon: React.Elemen
   diagnose: { label: 'Diagnose', icon: Stethoscope, color: 'bg-blue-500' },
   insights: { label: 'Insights', icon: Lightbulb, color: 'bg-yellow-500' },
   predictions: { label: 'Predictions', icon: TrendingUp, color: 'bg-green-500' },
-  other: { label: 'Other', icon: MoreHorizontal, color: 'bg-gray-500' },
+  other: { label: 'Other', icon: MoreHorizontal, color: 'bg-muted-foreground' },
 }
 
 export function TokenUsageWidget() {


### PR DESCRIPTION
## I. Does this pull request fix one issue?

Fixes #1336

---

## ⅠI. Describe what this PR does

This PR resolves Issue #1336 by removing hardcoded Tailwind gray/slate/white color classes in the following files:

- web/src/components/animations/globe/SimpleGlobe.tsx
- web/src/components/animations/globe/GlobeLoader.tsx
- web/src/components/widget/TokenUsageWidget.tsx

### Changes made

- Replaced `text-white` → `text-foreground`
- Replaced `text-gray-*` → `text-muted-foreground`
- Replaced `bg-gray-500` → `bg-muted-foreground`
- Audited all three files to ensure no remaining `gray-*`, `slate-*`, or `white` classes remain

### TokenUsageWidget refinement

`bg-gray-500` was replaced with `bg-muted-foreground` instead of `bg-muted`.

Reason:
- `bg-muted` and `bg-secondary` resolve to the same HSL values as card/background surfaces in both light and dark themes.
- This caused the “Other” category dot to become visually indistinguishable.
- `bg-muted-foreground` provides a mid-tone neutral indicator that preserves the original visual intent while remaining theme-aware.

### Result

- All styling now uses semantic theme tokens.
- Components render correctly in both light and dark themes.
- No layout or logic changes were introduced.
- No visual regressions observed.

---


## Ⅲ. Special notes for reviewers

- Scope strictly limited to the three files listed in the issue.
- No unrelated refactoring or formatting changes.
- TypeScript compiles successfully (`npx tsc --noEmit`).
- DCO sign-off included.
- CI expected to pass.
