### PR TITLE
🐛 Fix TestGetGatewayAPIStatus panic blocking nightly releases

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -91,6 +91,13 @@ func (m *MultiClusterClient) SetRawConfig(config *api.Config) {
 	m.rawConfig = config
 }
 
+// GetRawConfig returns the raw kubeconfig (for testing)
+func (m *MultiClusterClient) GetRawConfig() *api.Config {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.rawConfig
+}
+
 // InjectClient injects a typed client for a cluster (for testing)
 func (m *MultiClusterClient) InjectClient(contextName string, client kubernetes.Interface) {
 	m.mu.Lock()


### PR DESCRIPTION
## Problem

`TestGetGatewayAPIStatus` panics with:
```
panic: interface conversion: interface {} is nil, not []interface {}
```

This has been blocking all nightly and weekly releases since Feb 20 (4 consecutive failures).

## Root Cause

The test calls `HealthyClusters()` → `ListClusters()` → `LoadConfig()`, but the test setup never sets `rawConfig`. Without a kubeconfig, `LoadConfig` fails, the handler returns a 500 error with `{"error": "..."}`, and the test's unsafe type assertion on `res["clusters"]` panics on nil.

## Fix

- Set a minimal `rawConfig` in `setupTestEnv()` so `ListClusters` discovers the injected `test-cluster`
- Add `addClusterToRawConfig()` helper called from `injectDynamicCluster` / `injectDynamicClusterWithObjects` so dynamically injected clusters are also discoverable
- Add `GetRawConfig()` accessor on `MultiClusterClient` for test helpers

All 28 handler tests pass. Full `./pkg/...` test suite green.