### PR TITLE
✨ Add Cluster dialog (Layer 1) with command-line instructions

### DIFF
--- a/web/src/components/clusters/AddClusterDialog.tsx
+++ b/web/src/components/clusters/AddClusterDialog.tsx
@@ -1,0 +1,149 @@
+import { useState, useCallback } from 'react'
+import { X, Terminal, Upload, FormInput, Copy, Check } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+interface AddClusterDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+type TabId = 'command-line' | 'import' | 'connect'
+
+const COMMANDS = [
+  {
+    comment: '# 1. Add cluster credentials',
+    command: 'kubectl config set-cluster <cluster-name> --server=https://<api-server>:6443',
+  },
+  {
+    comment: '# 2. Add authentication',
+    command: 'kubectl config set-credentials <user-name> --token=<your-token>',
+  },
+  {
+    comment: '# 3. Create a context',
+    command: 'kubectl config set-context <context-name> --cluster=<cluster-name> --user=<user-name>',
+  },
+  {
+    comment: '# 4. Switch to the new context (optional)',
+    command: 'kubectl config use-context <context-name>',
+  },
+]
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [text])
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-white/10 transition-colors"
+      title="Copy to clipboard"
+    >
+      {copied ? <Check className="w-4 h-4 text-green-400" /> : <Copy className="w-4 h-4" />}
+    </button>
+  )
+}
+
+export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
+  const { t } = useTranslation()
+  const [activeTab, setActiveTab] = useState<TabId>('command-line')
+
+  if (!open) return null
+
+  const tabs: { id: TabId; label: string; icon: React.ReactNode; disabled?: boolean }[] = [
+    { id: 'command-line', label: t('cluster.addClusterCommandLine'), icon: <Terminal className="w-4 h-4" /> },
+    { id: 'import', label: t('cluster.addClusterImport'), icon: <Upload className="w-4 h-4" />, disabled: true },
+    { id: 'connect', label: t('cluster.addClusterConnect'), icon: <FormInput className="w-4 h-4" />, disabled: true },
+  ]
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+
+      {/* Dialog */}
+      <div className="relative w-full max-w-2xl mx-4 bg-card border border-white/10 rounded-xl shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-white/10">
+          <h2 className="text-lg font-semibold text-foreground">{t('cluster.addClusterTitle')}</h2>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-white/10 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex border-b border-white/10 px-6">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => !tab.disabled && setActiveTab(tab.id)}
+              disabled={tab.disabled}
+              className={`flex items-center gap-2 px-4 py-3 text-sm font-medium transition-colors border-b-2 -mb-px ${
+                activeTab === tab.id
+                  ? 'border-purple-500 text-foreground'
+                  : tab.disabled
+                    ? 'border-transparent opacity-50 cursor-not-allowed text-muted-foreground'
+                    : 'border-transparent text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div className="px-6 py-5 max-h-[60vh] overflow-y-auto">
+          {activeTab === 'command-line' && (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                {t('cluster.addClusterCommandLineDesc')}
+              </p>
+
+              {COMMANDS.map((cmd, i) => (
+                <div key={i} className="bg-secondary rounded-lg p-4">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex-1 font-mono text-sm overflow-x-auto">
+                      <div className="text-muted-foreground">{cmd.comment}</div>
+                      <div className="text-foreground mt-1">{cmd.command}</div>
+                    </div>
+                    <CopyButton text={cmd.command} />
+                  </div>
+                </div>
+              ))}
+
+              <p className="text-xs text-muted-foreground bg-secondary/50 rounded-lg p-3 border border-white/5">
+                {t('cluster.addClusterAutoDetect')}
+              </p>
+            </div>
+          )}
+
+          {activeTab === 'import' && (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <Upload className="w-10 h-10 text-muted-foreground mb-3 opacity-50" />
+              <p className="text-sm text-muted-foreground">
+                {t('cluster.addClusterComingSoon')} — {t('cluster.addClusterImportDesc')}
+              </p>
+            </div>
+          )}
+
+          {activeTab === 'connect' && (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <FormInput className="w-10 h-10 text-muted-foreground mb-3 opacity-50" />
+              <p className="text-sm text-muted-foreground">
+                {t('cluster.addClusterComingSoon')} — {t('cluster.addClusterConnectDesc')}
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -17,6 +17,8 @@ import { FloatingDashboardActions } from '../dashboard/FloatingDashboardActions'
 import { DashboardTemplate } from '../dashboard/templates'
 import { useDashboard } from '../../lib/dashboards'
 import { ClusterDetailModal } from './ClusterDetailModal'
+import { AddClusterDialog } from './AddClusterDialog'
+import { EmptyClusterState } from './EmptyClusterState'
 import {
   RenameModal,
   StatsOverview,
@@ -1458,6 +1460,7 @@ export function Clusters() {
   const [showStats, setShowStats] = useState(true) // Stats overview visible by default
   const [showClusterGrid, setShowClusterGrid] = useState(true) // Cluster cards visible by default
   const [showGPUModal, setShowGPUModal] = useState(false)
+  const [showAddCluster, setShowAddCluster] = useState(false)
 
   // Use the shared dashboard hook for cards, DnD, modals, auto-refresh
   const {
@@ -1717,6 +1720,15 @@ export function Clusters() {
         onAutoRefreshChange={setAutoRefresh}
         autoRefreshId="clusters-auto-refresh"
         lastUpdated={lastUpdated}
+        rightExtra={
+          <button
+            onClick={() => setShowAddCluster(true)}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            {t('cluster.addCluster')}
+          </button>
+        }
       />
 
       {/* Stats Overview - collapsible */}
@@ -1795,17 +1807,21 @@ export function Clusters() {
                   localStorage.setItem(STORAGE_KEY_CLUSTER_LAYOUT, mode)
                 }}
               />
-              <ClusterGrid
-                clusters={filteredClusters}
-                layoutMode={layoutMode}
-                gpuByCluster={gpuByCluster}
-                isConnected={isConnected}
-                permissionsLoading={permissionsLoading}
-                isClusterAdmin={isClusterAdmin}
-                onSelectCluster={setSelectedCluster}
-                onRenameCluster={setRenamingCluster}
-                onRefreshCluster={refreshSingleCluster}
-              />
+              {filteredClusters.length === 0 && !isLoading && !showSkeletonContent ? (
+                <EmptyClusterState onAddCluster={() => setShowAddCluster(true)} />
+              ) : (
+                <ClusterGrid
+                  clusters={filteredClusters}
+                  layoutMode={layoutMode}
+                  gpuByCluster={gpuByCluster}
+                  isConnected={isConnected}
+                  permissionsLoading={permissionsLoading}
+                  isClusterAdmin={isClusterAdmin}
+                  onSelectCluster={setSelectedCluster}
+                  onRenameCluster={setRenamingCluster}
+                  onRefreshCluster={refreshSingleCluster}
+                />
+              )}
             </>
           )
         )}
@@ -2082,6 +2098,7 @@ export function Clusters() {
           operatorStatus={nvidiaOperators}
         />
       )}
+      <AddClusterDialog open={showAddCluster} onClose={() => setShowAddCluster(false)} />
     </div>
   )
 }

--- a/web/src/components/clusters/EmptyClusterState.tsx
+++ b/web/src/components/clusters/EmptyClusterState.tsx
@@ -1,0 +1,29 @@
+import { Server, Plus } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+interface EmptyClusterStateProps {
+  onAddCluster: () => void
+}
+
+export function EmptyClusterState({ onAddCluster }: EmptyClusterStateProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <Server className="w-12 h-12 text-muted-foreground mb-4 opacity-50" />
+      <h3 className="text-lg font-semibold text-foreground mb-2">
+        {t('cluster.noClusterTitle')}
+      </h3>
+      <p className="text-sm text-muted-foreground mb-6 max-w-md">
+        {t('cluster.noClusterDesc')}
+      </p>
+      <button
+        onClick={onAddCluster}
+        className="flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+      >
+        <Plus className="w-4 h-4" />
+        {t('cluster.addCluster')}
+      </button>
+    </div>
+  )
+}

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2459,7 +2459,19 @@
     "unhealthy": "Unhealthy",
     "clickToViewNodeDetails": "Click to view node details",
     "clickToViewWorkloads": "Click to view workloads by namespace",
-    "deleteGroup": "Delete group"
+    "deleteGroup": "Delete group",
+    "addCluster": "Add Cluster",
+    "addClusterTitle": "Add a Cluster",
+    "addClusterCommandLine": "Command Line",
+    "addClusterImport": "Import Kubeconfig",
+    "addClusterConnect": "Connect Manually",
+    "addClusterComingSoon": "Coming soon",
+    "addClusterCommandLineDesc": "Run these commands in your terminal to add a cluster to your kubeconfig:",
+    "addClusterAutoDetect": "The console automatically detects changes to your kubeconfig file. New clusters will appear within seconds.",
+    "addClusterImportDesc": "Paste or upload a kubeconfig file to import clusters.",
+    "addClusterConnectDesc": "Add a cluster by entering connection details manually.",
+    "noClusterTitle": "No clusters found",
+    "noClusterDesc": "Add a cluster to your kubeconfig to get started."
   },
   "remediation": {
     "title": "AI Remediation Console",


### PR DESCRIPTION
## Summary
Implements Layer 1 of the Add Cluster feature — frontend-only, no backend changes.

### New Components
- **AddClusterDialog** — modal with 3 tabs:
  - **Command Line** (active): shows kubectl commands with copy buttons
  - **Import Kubeconfig** (disabled): coming soon placeholder
  - **Connect Manually** (disabled): coming soon placeholder
- **EmptyClusterState** — shown when clusters array is empty with Add Cluster CTA

### Changes to Existing Code
- **Clusters.tsx**: Added "Add Cluster" button to DashboardHeader via `rightExtra` prop, empty state when no clusters, dialog rendering
- **common.json**: Added 12 i18n keys in the `cluster` section

### Verification
- `npm run build` passes successfully