### PR TITLE
✨: add Metal3 monitoring card to KubeStellar Console

### DIFF
--- a/pkg/api/handlers/metal3.go
+++ b/pkg/api/handlers/metal3.go
@@ -1,0 +1,186 @@
+// Package handlers provides HTTP handlers for the console API.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/k8s"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// bareMetalHostGVR is the GroupVersionResource for Metal3 BareMetalHost CRDs.
+var bareMetalHostGVR = schema.GroupVersionResource{
+	Group:    "metal3.io",
+	Version:  "v1alpha1",
+	Resource: "baremetalhosts",
+}
+
+// Metal3HostSummary is the JSON shape returned to the frontend.
+type Metal3HostSummary struct {
+	Hosts []metal3HostItem `json:"hosts"`
+}
+
+// metal3HostItem holds the fields the frontend hook consumes per host.
+type metal3HostItem struct {
+	Provisioning *metal3Provisioning `json:"provisioning,omitempty"`
+	Conditions   []metal3Condition   `json:"conditions,omitempty"`
+}
+
+type metal3Provisioning struct {
+	State string `json:"state,omitempty"`
+}
+
+type metal3Condition struct {
+	Type   string `json:"type,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+// Metal3Handlers provides the /api/proxy/metal3/hosts endpoint.
+type Metal3Handlers struct {
+	k8sClient *k8s.MultiClusterClient
+}
+
+// NewMetal3Handlers creates a handler that talks to the k8s client.
+func NewMetal3Handlers(k8sClient *k8s.MultiClusterClient) *Metal3Handlers {
+	return &Metal3Handlers{k8sClient: k8sClient}
+}
+
+// GetHosts lists BareMetalHost resources across all healthy clusters and
+// returns the aggregated list to the frontend.
+func (h *Metal3Handlers) GetHosts(c *fiber.Ctx) error {
+	if h.k8sClient == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "no cluster access available",
+		})
+	}
+
+	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": fmt.Sprintf("failed to list clusters: %v", err),
+		})
+	}
+
+	var (
+		mu    sync.Mutex
+		wg    sync.WaitGroup
+		hosts []metal3HostItem
+	)
+
+	for _, cl := range clusters {
+		wg.Add(1)
+		go func(clusterName string) {
+			defer wg.Done()
+
+			ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+			defer cancel()
+
+			dynClient, err := h.k8sClient.GetDynamicClient(clusterName)
+			if err != nil {
+				return
+			}
+
+			list, err := dynClient.Resource(bareMetalHostGVR).
+				Namespace("").
+				List(ctx, metav1.ListOptions{})
+			if err != nil {
+				// CRD not installed on this cluster — skip silently.
+				if errors.IsNotFound(err) || errors.IsMethodNotSupported(err) {
+					return
+				}
+				return
+			}
+
+			for _, item := range list.Items {
+				h := metal3HostItem{}
+
+				// Extract provisioning state
+				if statusObj, ok := item.Object["status"].(map[string]interface{}); ok {
+					if provObj, ok := statusObj["provisioning"].(map[string]interface{}); ok {
+						if state, ok := provObj["state"].(string); ok {
+							h.Provisioning = &metal3Provisioning{State: state}
+						}
+					}
+				}
+
+				// Extract conditions
+				if statusObj, ok := item.Object["status"].(map[string]interface{}); ok {
+					if condRaw, ok := statusObj["conditions"].([]interface{}); ok {
+						for _, cr := range condRaw {
+							condMap, ok := cr.(map[string]interface{})
+							if !ok {
+								continue
+							}
+							cond := metal3Condition{}
+							if t, ok := condMap["type"].(string); ok {
+								cond.Type = t
+							}
+							if s, ok := condMap["status"].(string); ok {
+								cond.Status = s
+							}
+							h.Conditions = append(h.Conditions, cond)
+						}
+					}
+				}
+
+				mu.Lock()
+				hosts = append(hosts, h)
+				mu.Unlock()
+			}
+		}(cl.Name)
+	}
+
+	waitWithDeadline(&wg, maxResponseDeadline)
+
+	return c.JSON(Metal3HostSummary{Hosts: hosts})
+}
+
+// getDemoMetal3Hosts returns representative BareMetalHost demo data that
+// mirrors the METAL3_DEMO_DATA constants in the frontend demoData.ts.
+func getDemoMetal3Hosts() Metal3HostSummary {
+	type stateEntry struct {
+		state     string
+		count     int
+		bmcErrCnt int // how many of these have BMCAccessError=True
+	}
+
+	entries := []stateEntry{
+		{state: "provisioned", count: 8, bmcErrCnt: 0},
+		{state: "provisioning", count: 2, bmcErrCnt: 1},
+		{state: "deprovisioned", count: 1, bmcErrCnt: 0},
+		{state: "error", count: 1, bmcErrCnt: 1},
+	}
+
+	var hosts []metal3HostItem
+	for _, e := range entries {
+		for i := range e.count {
+			conds := []metal3Condition{}
+			if i < e.bmcErrCnt {
+				conds = append(conds, metal3Condition{Type: "BMCAccessError", Status: "True"})
+			}
+			hosts = append(hosts, metal3HostItem{
+				Provisioning: &metal3Provisioning{State: e.state},
+				Conditions:   conds,
+			})
+		}
+	}
+
+	return Metal3HostSummary{Hosts: hosts}
+}
+
+// GetHostsDemo handles the demo-mode path for GetHosts. Exported for testing.
+func (h *Metal3Handlers) GetHostsWithDemoCheck(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		demo := getDemoMetal3Hosts()
+		b, _ := json.Marshal(demo)
+		c.Set("Content-Type", "application/json")
+		return c.Send(b)
+	}
+	return h.GetHosts(c)
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -641,6 +641,10 @@ func (s *Server) setupRoutes() {
 	})
 	api.Get("/rewards/github", rewardsHandler.GetGitHubRewards)
 
+	// Metal3 bare metal host status
+	metal3 := handlers.NewMetal3Handlers(s.k8sClient)
+	api.Get("/proxy/metal3/hosts", metal3.GetHostsWithDemoCheck)
+
 	// Nightly E2E status (GitHub Actions proxy with server-side token + cache)
 	nightlyE2E := handlers.NewNightlyE2EHandler(s.config.GitHubToken)
 	api.Get("/nightly-e2e/runs", nightlyE2E.GetRuns)

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -175,6 +175,8 @@ const CrossplaneManagedResources = lazy(() => import('./crossplane-status/Crossp
 const BuildpacksStatus = lazy(() => import('./buildpacks-status').then(m => ({ default: m.BuildpacksStatus })))
 // Flatcar Container Linux card
 const FlatcarStatus = lazy(() => import('./flatcar_status').then(m => ({ default: m.FlatcarStatus })))
+// Metal3 bare metal host status card
+const Metal3Status = lazy(() => import('./metal3_status').then(m => ({ default: m.Metal3Status })))
 
 // Cluster admin cards — share one chunk via barrel import
 const _clusterAdminBundle = import('./cluster-admin-bundle')
@@ -414,6 +416,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   buildpacks_status: BuildpacksStatus,
   // Flatcar Container Linux
   flatcar_status: FlatcarStatus,
+  // Metal3 bare metal host status
+  metal3_status: Metal3Status,
 
   // LLM-d stunning visualization cards
   llmd_flow: LLMdFlow,
@@ -480,6 +484,7 @@ export const DEMO_DATA_CARDS = new Set([
   'service_topology',
   'buildpacks_status',
   'flatcar_status',
+  'metal3_status',
 
   // Workload Deployment - uses real data when backend is running, falls back to demo internally
   // NOT in DEMO_DATA_CARDS because the static badge can't detect runtime data source
@@ -724,6 +729,8 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   buildpacks_status: () => import('./buildpacks-status'),
   // Flatcar Container Linux
   flatcar_status: () => import('./flatcar_status'),
+  // Metal3 bare metal host status
+  metal3_status: () => import('./metal3_status'),
 }
 
 /**
@@ -858,6 +865,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   crossplane_managed_resources: 4,
   buildpacks_status: 6,
   flatcar_status: 6,
+  metal3_status: 6,
 
   // MCS cards
   service_exports: 6,

--- a/web/src/components/cards/metal3_status/demoData.ts
+++ b/web/src/components/cards/metal3_status/demoData.ts
@@ -1,0 +1,41 @@
+/**
+ * Demo data for the Metal3 bare metal host status card.
+ *
+ * These numbers are representative of a mid-size bare-metal provisioning
+ * environment managed by Metal3. They are used when the dashboard is in
+ * demo mode or when no Kubernetes clusters are connected.
+ *
+ * Note: bmcUnreachable > 0 and provisioningStates.provisioning > 0 ensures
+ * the demo data is internally consistent with the "degraded" health status.
+ */
+
+export interface Metal3DemoData {
+  totalHosts: number
+  provisioningStates: {
+    provisioned: number
+    provisioning: number
+    deprovisioned: number
+    available: number
+    error: number
+  }
+  bmcReachable: number
+  bmcUnreachable: number
+  health: 'healthy' | 'degraded'
+  lastUpdated: string
+}
+
+export const METAL3_DEMO_DATA: Metal3DemoData = {
+  totalHosts: 12,
+  provisioningStates: {
+    provisioned: 8,
+    provisioning: 2,
+    deprovisioned: 1,
+    available: 0,
+    error: 1,
+  },
+  // 2 BMCs unreachable → health is "degraded"
+  bmcReachable: 10,
+  bmcUnreachable: 2,
+  health: 'degraded',
+  lastUpdated: new Date(Date.now() - 4 * 60 * 1000).toISOString(), // 4 minutes ago
+}

--- a/web/src/components/cards/metal3_status/index.tsx
+++ b/web/src/components/cards/metal3_status/index.tsx
@@ -1,0 +1,141 @@
+import { CheckCircle, AlertTriangle, RefreshCw, Server, Wifi, WifiOff } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Skeleton } from '../../ui/Skeleton'
+import { useMetal3Status } from './useMetal3Status'
+
+function useFormatRelativeTime() {
+  const { t } = useTranslation('cards')
+  return (isoString: string): string => {
+    const diff = Date.now() - new Date(isoString).getTime()
+    if (isNaN(diff) || diff < 0) return t('metal3.syncedJustNow')
+    const minute = 60_000
+    const hour = 60 * minute
+    const day = 24 * hour
+    if (diff < minute) return t('metal3.syncedJustNow')
+    if (diff < hour) return t('metal3.syncedMinutesAgo', { count: Math.floor(diff / minute) })
+    if (diff < day) return t('metal3.syncedHoursAgo', { count: Math.floor(diff / hour) })
+    return t('metal3.syncedDaysAgo', { count: Math.floor(diff / day) })
+  }
+}
+
+interface MetricTileProps {
+  label: string
+  value: number | string
+  colorClass: string
+  icon: React.ReactNode
+}
+
+function MetricTile({ label, value, colorClass, icon }: MetricTileProps) {
+  return (
+    <div className="flex-1 p-3 rounded-lg bg-secondary/30 text-center">
+      <div className="flex items-center justify-center gap-1.5 mb-1">
+        {icon}
+      </div>
+      <span className={`text-2xl font-bold ${colorClass}`}>{value}</span>
+      <p className="text-xs text-muted-foreground mt-0.5">{label}</p>
+    </div>
+  )
+}
+
+export function Metal3Status() {
+  const { t } = useTranslation('cards')
+  const formatRelativeTime = useFormatRelativeTime()
+  const { data, error, showSkeleton, showEmptyState } = useMetal3Status()
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-3">
+        <Skeleton variant="rounded" height={36} />
+        <div className="flex gap-2">
+          <Skeleton variant="rounded" height={80} className="flex-1" />
+          <Skeleton variant="rounded" height={80} className="flex-1" />
+        </div>
+        <Skeleton variant="rounded" height={60} />
+        <Skeleton variant="rounded" height={40} />
+      </div>
+    )
+  }
+
+  if (error || showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">
+          {error ? t('metal3.fetchError') : t('metal3.noHosts')}
+        </p>
+        <p className="text-xs">{t('metal3.noHostsHint')}</p>
+      </div>
+    )
+  }
+
+  const isHealthy = data.health === 'healthy'
+  const { provisioned, provisioning, deprovisioned, available, error: errHosts } = data.provisioningStates
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4">
+      {/* Health badge + last updated */}
+      <div className="flex items-center justify-between">
+        <div
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+            isHealthy
+              ? 'bg-green-500/15 text-green-400'
+              : 'bg-orange-500/15 text-orange-400'
+          }`}
+        >
+          {isHealthy ? (
+            <CheckCircle className="w-4 h-4" />
+          ) : (
+            <AlertTriangle className="w-4 h-4" />
+          )}
+          {isHealthy ? t('metal3.healthy') : t('metal3.degraded')}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className="w-3 h-3" />
+          <span>{formatRelativeTime(data.lastUpdated)}</span>
+        </div>
+      </div>
+
+      {/* BMC reachability tiles */}
+      <div className="flex gap-3">
+        <MetricTile
+          label={t('metal3.totalHosts')}
+          value={data.totalHosts}
+          colorClass="text-blue-400"
+          icon={<Server className="w-4 h-4 text-blue-400" />}
+        />
+        <MetricTile
+          label={t('metal3.bmcReachable')}
+          value={data.bmcReachable}
+          colorClass="text-green-400"
+          icon={<Wifi className="w-4 h-4 text-green-400" />}
+        />
+        <MetricTile
+          label={t('metal3.bmcUnreachable')}
+          value={data.bmcUnreachable}
+          colorClass={data.bmcUnreachable > 0 ? 'text-red-400' : 'text-green-400'}
+          icon={<WifiOff className={`w-4 h-4 ${data.bmcUnreachable > 0 ? 'text-red-400' : 'text-muted-foreground'}`} />}
+        />
+      </div>
+
+      {/* Provisioning state breakdown */}
+      <div className="flex flex-col gap-2">
+        <p className="text-xs font-medium text-muted-foreground">{t('metal3.provisioningStates')}</p>
+        <div className="grid grid-cols-2 gap-2">
+          {[
+            { label: t('metal3.stateProvisioned'), value: provisioned, color: 'text-green-400' },
+            { label: t('metal3.stateProvisioning'), value: provisioning, color: provisioning > 0 ? 'text-yellow-400' : 'text-muted-foreground' },
+            { label: t('metal3.stateAvailable'), value: available, color: 'text-blue-400' },
+            { label: t('metal3.stateDeprovisioned'), value: deprovisioned, color: 'text-muted-foreground' },
+            { label: t('metal3.stateError'), value: errHosts, color: errHosts > 0 ? 'text-red-400' : 'text-muted-foreground' },
+          ].map(({ label, value, color }) => (
+            <div key={label} className="flex items-center justify-between px-2 py-1 rounded bg-secondary/20">
+              <span className="text-xs text-muted-foreground truncate">{label}</span>
+              <span className={`text-xs font-semibold ml-2 shrink-0 ${color}`}>{value}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/cards/metal3_status/useMetal3Status.ts
+++ b/web/src/components/cards/metal3_status/useMetal3Status.ts
@@ -1,0 +1,190 @@
+import { useCache } from '../../../lib/cache'
+import { useCardLoadingState } from '../CardDataContext'
+import { METAL3_DEMO_DATA, type Metal3DemoData } from './demoData'
+
+export interface Metal3Status {
+  totalHosts: number
+  provisioningStates: {
+    provisioned: number
+    provisioning: number
+    deprovisioned: number
+    available: number
+    error: number
+  }
+  bmcReachable: number
+  bmcUnreachable: number
+  health: 'healthy' | 'degraded'
+  lastUpdated: string
+}
+
+const CACHE_KEY = 'metal3-status'
+
+const INITIAL_DATA: Metal3Status = {
+  totalHosts: 0,
+  provisioningStates: {
+    provisioned: 0,
+    provisioning: 0,
+    deprovisioned: 0,
+    available: 0,
+    error: 0,
+  },
+  bmcReachable: 0,
+  bmcUnreachable: 0,
+  health: 'healthy',
+  lastUpdated: new Date().toISOString(),
+}
+
+/**
+ * BareMetalHost shape returned by the console backend at
+ * GET /api/proxy/metal3/hosts.
+ *
+ * The backend queries the metal3.io/v1alpha1 BareMetalHost CRD across all
+ * connected clusters via the dynamic Kubernetes client and returns a flat
+ * list. Only the fields consumed here are typed; all other fields are ignored.
+ *
+ * provisioning.state reflects the BareMetalHost .status.provisioning.state
+ * field, which can be: provisioned, provisioning, deprovisioning,
+ * deprovisioned, available, ready, inspecting, matching, registering,
+ * cleaning, deleting, or externally provisioned.
+ *
+ * bmc.address is the BMC endpoint and bmc.credentialsName indicates
+ * whether credentials are configured. The reachable flag is derived from
+ * the "BMCAccessError" condition (type=BMCAccessError, status=True → unreachable).
+ */
+interface BackendBareMetalHost {
+  provisioning?: {
+    state?: string
+  }
+  conditions?: Array<{
+    type?: string
+    status?: string
+  }>
+}
+
+async function fetchMetal3Status(): Promise<Metal3Status> {
+  const resp = await fetch('/api/proxy/metal3/hosts', {
+    headers: { Accept: 'application/json' },
+  })
+
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status}`)
+  }
+
+  const body: { hosts?: BackendBareMetalHost[] } = await resp.json()
+  const items = Array.isArray(body?.hosts) ? body.hosts : []
+
+  const states = {
+    provisioned: 0,
+    provisioning: 0,
+    deprovisioned: 0,
+    available: 0,
+    error: 0,
+  }
+
+  let bmcReachable = 0
+  let bmcUnreachable = 0
+
+  for (const host of items) {
+    const state = host.provisioning?.state ?? ''
+
+    // Normalise the many Metal3 states into the 5 display buckets
+    if (state === 'provisioned' || state === 'externally provisioned') {
+      states.provisioned++
+    } else if (
+      state === 'provisioning' ||
+      state === 'deprovisioning' ||
+      state === 'inspecting' ||
+      state === 'matching' ||
+      state === 'registering' ||
+      state === 'cleaning'
+    ) {
+      states.provisioning++
+    } else if (state === 'deprovisioned' || state === 'deleting') {
+      states.deprovisioned++
+    } else if (state === 'available' || state === 'ready') {
+      states.available++
+    } else {
+      // Covers "error", empty/unknown, and any future states
+      states.error++
+    }
+
+    // BMC reachability: BMCAccessError condition type=True → unreachable
+    const hasBMCError = host.conditions?.some(
+      (c) => c.type === 'BMCAccessError' && c.status === 'True',
+    )
+    if (hasBMCError) {
+      bmcUnreachable++
+    } else {
+      bmcReachable++
+    }
+  }
+
+  const health: 'healthy' | 'degraded' =
+    bmcUnreachable === 0 && states.provisioning === 0 && states.error === 0
+      ? 'healthy'
+      : 'degraded'
+
+  return {
+    totalHosts: items.length,
+    provisioningStates: states,
+    bmcReachable,
+    bmcUnreachable,
+    health,
+    lastUpdated: new Date().toISOString(),
+  }
+}
+
+function toDemoStatus(demo: Metal3DemoData): Metal3Status {
+  return {
+    totalHosts: demo.totalHosts,
+    provisioningStates: { ...demo.provisioningStates },
+    bmcReachable: demo.bmcReachable,
+    bmcUnreachable: demo.bmcUnreachable,
+    health: demo.health,
+    lastUpdated: demo.lastUpdated,
+  }
+}
+
+export interface UseMetal3StatusResult {
+  data: Metal3Status
+  loading: boolean
+  /** True when 3+ consecutive fetch failures and no cached data. */
+  error: boolean
+  /** True when loading AND no cached data (show skeleton). */
+  showSkeleton: boolean
+  /** True when loading finished but totalHosts is still 0 (show empty state). */
+  showEmptyState: boolean
+  /** Number of consecutive fetch failures. */
+  consecutiveFailures: number
+}
+
+export function useMetal3Status(): UseMetal3StatusResult {
+  const { data, isLoading, isFailed, consecutiveFailures, isDemoFallback } =
+    useCache<Metal3Status>({
+      key: CACHE_KEY,
+      category: 'default',
+      initialData: INITIAL_DATA,
+      demoData: toDemoStatus(METAL3_DEMO_DATA),
+      persist: true,
+      fetcher: fetchMetal3Status,
+    })
+
+  const hasAnyData = data.totalHosts > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: isDemoFallback,
+  })
+
+  return {
+    data,
+    loading: isLoading,
+    error: isFailed && !hasAnyData,
+    showSkeleton,
+    showEmptyState,
+    consecutiveFailures,
+  }
+}

--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -207,6 +207,7 @@ const CARD_CATALOG = {
   'Misc': [
     { type: 'buildpacks_status', title: 'Buildpacks Status', description: 'Cloud Native Buildpacks detection, builders, and image build status', visualization: 'status' },
     { type: 'flatcar_status', title: 'Flatcar Container Linux', description: 'Flatcar node OS versions, update status, and version distribution', visualization: 'status' },
+    { type: 'metal3_status', title: 'Metal3', description: 'Metal3 bare metal host provisioning, BMC status, and provisioning state breakdown', visualization: 'status' },
     { type: 'weather', title: 'Weather', description: 'Weather conditions with multi-day forecasts and animated backgrounds', visualization: 'status' },
     { type: 'github_activity', title: 'GitHub Activity', description: 'Monitor GitHub repository activity - PRs, issues, releases, and contributors', visualization: 'table' },
     { type: 'kubectl', title: 'Kubectl', description: 'Interactive kubectl terminal with AI assistance, YAML editor, and command history', visualization: 'table' },

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -252,7 +252,8 @@
     "kube_craft": "Kube Craft",
     "kube_chess": "Kube Chess",
     "provider_health": "Provider Health",
-    "flatcar_status": "Flatcar Container Linux"
+    "flatcar_status": "Flatcar Container Linux",
+    "metal3_status": "Metal3"
   },
   "descriptions": {
     "cluster_health": "Overall health status of all connected Kubernetes clusters.",
@@ -413,7 +414,8 @@
     "kube_craft": "Build and manage your cluster world.",
     "kube_chess": "Chess game with Kubernetes-themed pieces.",
     "console_offline_detection": "Monitor offline nodes, GPU issues, and AI-predicted failures.",
-    "flatcar_status": "Flatcar node OS versions, update status, and version distribution."
+    "flatcar_status": "Flatcar node OS versions, update status, and version distribution.",
+    "metal3_status": "Metal3 bare metal host provisioning, BMC status, and provisioning state breakdown."
   },
   "categories": {
     "core": "Core",
@@ -2562,6 +2564,26 @@
     "noFlatcarNodes": "No Flatcar nodes found",
     "noFlatcarNodesHint": "No nodes running Flatcar Container Linux detected.",
     "fetchError": "Failed to fetch Flatcar node status",
+    "syncedJustNow": "just now",
+    "syncedMinutesAgo": "{{count}}m ago",
+    "syncedHoursAgo": "{{count}}h ago",
+    "syncedDaysAgo": "{{count}}d ago"
+  },
+  "metal3": {
+    "healthy": "Healthy",
+    "degraded": "Degraded",
+    "totalHosts": "Bare Metal Hosts",
+    "bmcReachable": "BMC Reachable",
+    "bmcUnreachable": "BMC Unreachable",
+    "provisioningStates": "Provisioning States",
+    "stateProvisioned": "Provisioned",
+    "stateProvisioning": "Provisioning",
+    "stateAvailable": "Available",
+    "stateDeprovisioned": "Deprovisioned",
+    "stateError": "Error",
+    "noHosts": "No Metal3 hosts found",
+    "noHostsHint": "No BareMetalHost resources detected in connected clusters.",
+    "fetchError": "Failed to fetch Metal3 host status",
     "syncedJustNow": "just now",
     "syncedMinutesAgo": "{{count}}m ago",
     "syncedHoursAgo": "{{count}}h ago",


### PR DESCRIPTION
### Summary
This PR introduces a new **Metal3 Status** dashboard card for the KubeStellar Console, providing visibility into bare metal host provisioning and BMC health.

### Key Features
- New `metal3_status` card following existing console card patterns
- Demo mode support with realistic mock Metal3 data
- Live mode support using Metal3 BareMetalHost resources
- Displays host provisioning states and BMC reachability
- Health indicator reflecting overall Metal3 status
- Graceful handling of loading, error, and empty states

### Verification
- [x] Console runs locally via `./startup-oauth.sh`
- [x] Card appears in Add Cards catalog
- [x] Demo mode displays mock data correctly
- [x] Card renders without console or TypeScript errors

### Related Issue
kubestellar/console-marketplace#46