### PR TITLE
🐛 Fix Nightly E2E card stuck in demo mode after sleep/wake

### DIFF
--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -131,7 +131,10 @@ export function useNightlyE2EData() {
         }
       }
 
-      return { guides: DEMO_DATA, isDemo: true }
+      // All endpoints failed or returned empty — throw so the cache treats
+      // this as a failure (increments consecutiveFailures, retries with backoff)
+      // instead of caching demo data as a "successful" result that sticks forever.
+      throw new Error('No nightly E2E data available')
     },
   })
 


### PR DESCRIPTION
## Summary
- When the backend API was unavailable (e.g., after laptop sleep/wake), the fetcher returned demo data as a **successful** cache result, which the cache layer persisted indefinitely
- Changed the fallback from `return { guides: DEMO_DATA, isDemo: true }` to `throw new Error(...)` so the cache treats API failures as errors, increments `consecutiveFailures`, applies exponential backoff, and retries automatically
- The cache's built-in `demoData` / `showOptimisticDemo` logic already handles showing demo data while loading — the fetcher should never return demo data directly

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Live data loads correctly on fresh page load (no Demo badge)
- [x] Card retains stale live data when API is blocked (simulated sleep/wake) — no Demo badge appears
- [x] Card recovers to live data when API becomes available again