### PR TITLE
⚡ Add gzip compression for 70% faster page loads

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gofiber/contrib/websocket"
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/compress"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/logger"
 	"github.com/gofiber/fiber/v2/middleware/recover"
@@ -254,6 +255,11 @@ func startLoadingServer(addr string) *http.Server {
 func (s *Server) setupMiddleware() {
 	// Recovery middleware
 	s.app.Use(recover.New())
+
+	// Gzip/Brotli compression — reduces JS/CSS/WASM transfer size ~70%
+	s.app.Use(compress.New(compress.Config{
+		Level: compress.LevelDefault,
+	}))
 
 	// Logger
 	s.app.Use(logger.New(logger.Config{


### PR DESCRIPTION
## Problem
The Fiber server serves **5.2MB of uncompressed JavaScript** (1.1MB index + 4.1MB vendor). On pokprod's constrained egress, this causes **28+ second blank screen** before the app renders.

## Fix
Add Fiber's built-in `compress` middleware (gzip). This is a single middleware addition that compresses all HTTP responses.

**Expected improvement:**
| Asset | Before | After (gzip) |
|-------|--------|-------------|
| index.js | 1.1 MB | ~300 KB |
| vendor.js | 4.1 MB | ~1.1 MB |
| **Total** | **5.2 MB** | **~1.4 MB** |

Page load should drop from **28s → ~5-8s** on pokprod.

## Changes
- Added `compress.New()` middleware to `setupMiddleware()` in `pkg/api/server.go`
- Uses `compress.LevelDefault` (gzip level 6) — good balance of speed vs compression
- `klauspost/compress` is already an indirect dependency, no new deps needed