### PR TITLE
✨ Add --allowed-origins CLI flag to kc-agent

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -39,8 +39,9 @@ var Version = "dev"
 
 // Config holds agent configuration
 type Config struct {
-	Port       int
-	Kubeconfig string
+	Port           int
+	Kubeconfig     string
+	AllowedOrigins []string // Additional allowed origins (from --allowed-origins flag)
 }
 
 // AllowedOrigins for WebSocket connections (can be extended via env var)
@@ -130,6 +131,19 @@ func NewServer(cfg Config) (*Server, error) {
 				allowedOrigins = append(allowedOrigins, origin)
 			}
 		}
+	}
+
+	// Add custom origins from CLI flag
+	for _, origin := range cfg.AllowedOrigins {
+		origin = strings.TrimSpace(origin)
+		if origin != "" {
+			allowedOrigins = append(allowedOrigins, origin)
+		}
+	}
+
+	// Log non-default origins so users can verify their configuration
+	if len(allowedOrigins) > len(defaultAllowedOrigins) {
+		log.Printf("Custom allowed origins: %v", allowedOrigins[len(defaultAllowedOrigins):])
 	}
 
 	// Optional shared secret for authentication


### PR DESCRIPTION
## Summary
- Adds `--allowed-origins` CLI flag to kc-agent for passing additional WebSocket origins
- Both CLI flag and `KC_ALLOWED_ORIGINS` env var are additive on top of built-in defaults
- Logs non-default origins at startup so users can verify their configuration

## Usage
```bash
kc-agent --allowed-origins "https://my-console.example.com,https://other.example.com"
```

## Test plan
- [x] `go build ./cmd/kc-agent/` compiles
- [x] `go build ./...` full project builds
- [x] `go test ./pkg/agent/` all tests pass
- [x] `go vet` clean
- [x] `--help` shows the new flag
- [x] No flag / no env var: existing behavior unchanged