### PR TITLE
✨ Add GitHub Enterprise OAuth support via GITHUB_URL

### DIFF
--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
             - name: FRONTEND_URL
               value: "https://{{ (index .Values.ingress.hosts 0).host }}"
             {{- end }}
+            {{- if .Values.github.url }}
+            - name: GITHUB_URL
+              value: {{ .Values.github.url | quote }}
+            {{- end }}
             {{- if .Values.github.existingSecret }}
             - name: GITHUB_CLIENT_ID
               valueFrom:

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -61,6 +61,7 @@ resources:
 
 # GitHub OAuth configuration
 github:
+  url: ""  # GitHub Enterprise URL (e.g., "https://github.ibm.com"). Leave empty for github.com
   clientId: ""
   clientSecret: ""
   # Alternatively, use existing secret

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -48,6 +48,7 @@ type Config struct {
 	DatabasePath     string
 	GitHubClientID   string
 	GitHubSecret     string
+	GitHubURL        string // GitHub base URL (e.g., "https://github.ibm.com"), defaults to "https://github.com"
 	JWTSecret        string
 	FrontendURL      string
 	ClaudeAPIKey     string
@@ -347,6 +348,7 @@ func (s *Server) setupRoutes() {
 	auth := handlers.NewAuthHandler(s.store, handlers.AuthConfig{
 		GitHubClientID:   s.config.GitHubClientID,
 		GitHubSecret:     s.config.GitHubSecret,
+		GitHubURL:        s.config.GitHubURL,
 		JWTSecret:        s.config.JWTSecret,
 		FrontendURL:      s.config.FrontendURL,
 		BackendURL:       s.backendURL(),
@@ -801,6 +803,7 @@ func LoadConfigFromEnv() Config {
 		DatabasePath:     dbPath,
 		GitHubClientID:   os.Getenv("GITHUB_CLIENT_ID"),
 		GitHubSecret:     os.Getenv("GITHUB_CLIENT_SECRET"),
+		GitHubURL:        getEnvOrDefault("GITHUB_URL", "https://github.com"),
 		JWTSecret:        jwtSecret,
 		FrontendURL:      frontendURL,
 		ClaudeAPIKey:     os.Getenv("CLAUDE_API_KEY"),


### PR DESCRIPTION
## Summary
- Adds `GITHUB_URL` env var to configure GitHub base URL for OAuth
- Defaults to `https://github.com` (no behavior change for existing deployments)
- For GitHub Enterprise (e.g., github.ibm.com), set `GITHUB_URL=https://github.ibm.com`
- OAuth endpoints and API base URL are derived automatically:
  - `github.com` → OAuth at github.com, API at api.github.com
  - GHE → OAuth at {url}, API at {url}/api/v3
- Adds `github.url` Helm value for vllm-d / pok-prod-sa deployments
- GPU reservations dashboard automatically uses the GHE username from OAuth

## Usage
```bash
# GitHub Enterprise
GITHUB_URL=https://github.ibm.com \
GITHUB_CLIENT_ID=<ghe-oauth-client-id> \
GITHUB_CLIENT_SECRET=<ghe-oauth-secret> \
go run cmd/console/main.go

# Helm
helm install ksc ./deploy/helm/kubestellar-console \
  --set github.url=https://github.ibm.com \
  --set github.existingSecret=ksc-secrets
```

## Files changed
- `pkg/api/server.go` — Config struct, LoadConfigFromEnv, AuthConfig wiring
- `pkg/api/handlers/auth.go` — Dynamic OAuth endpoint + API URL
- `deploy/helm/kubestellar-console/values.yaml` — github.url value
- `deploy/helm/kubestellar-console/templates/deployment.yaml` — GITHUB_URL env var

## Test plan
- [x] `go build ./...` compiles
- [x] `go vet` clean
- [x] `go test ./pkg/api/...` all tests pass
- [x] Default behavior unchanged (no GITHUB_URL → github.com)
- [x] Helm template renders GITHUB_URL only when github.url is set