### PR TITLE
🐛 Reject feedback submissions when FEEDBACK_GITHUB_TOKEN is missing

### DIFF
--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -109,6 +109,13 @@ spec:
                   name: {{ .Values.githubToken.existingSecret | default (include "kubestellar-console.fullname" .) }}
                   key: {{ .Values.githubToken.existingSecretKey | default "github-token" }}
             {{- end }}
+            {{- if or .Values.feedbackGithubToken.existingSecret .Values.feedbackGithubToken.token }}
+            - name: FEEDBACK_GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.feedbackGithubToken.existingSecret | default (include "kubestellar-console.fullname" .) }}
+                  key: {{ .Values.feedbackGithubToken.existingSecretKey | default "feedback-github-token" }}
+            {{- end }}
             {{- if or .Values.googleDrive.existingSecret .Values.googleDrive.apiKey }}
             - name: GOOGLE_DRIVE_API_KEY
               valueFrom:

--- a/deploy/helm/kubestellar-console/templates/secret.yaml
+++ b/deploy/helm/kubestellar-console/templates/secret.yaml
@@ -18,6 +18,9 @@ data:
   {{- if .Values.githubToken.token }}
   github-token: {{ .Values.githubToken.token | b64enc | quote }}
   {{- end }}
+  {{- if .Values.feedbackGithubToken.token }}
+  feedback-github-token: {{ .Values.feedbackGithubToken.token | b64enc | quote }}
+  {{- end }}
   {{- if .Values.googleDrive.apiKey }}
   google-drive-api-key: {{ .Values.googleDrive.apiKey | b64enc | quote }}
   {{- end }}

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -76,6 +76,12 @@ githubToken:
   existingSecret: ""
   existingSecretKey: github-token
 
+# GitHub token for issue creation from the Contribute dialog (requires repo scope)
+feedbackGithubToken:
+  token: ""
+  existingSecret: ""
+  existingSecretKey: feedback-github-token
+
 # Google Drive API key for benchmark data
 googleDrive:
   apiKey: ""

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -24,6 +24,7 @@
 #   2. Create a .env file:
 #      GITHUB_CLIENT_ID=<your-client-id>
 #      GITHUB_CLIENT_SECRET=<your-client-secret>
+#      FEEDBACK_GITHUB_TOKEN=<your-pat>  (optional, enables Contribute dialog issue creation)
 #   3. Run: ./startup-oauth.sh           (production build, fast load)
 #      Or:  ./startup-oauth.sh --dev     (Vite dev server, HMR)
 


### PR DESCRIPTION
## Summary
- Return 503 with clear error message when `FEEDBACK_GITHUB_TOKEN` is not configured, instead of silently creating orphaned database records
- Error message tells the user to add `FEEDBACK_GITHUB_TOKEN=<your-pat>` to `.env`
- Log a startup warning when the token is missing so operators know the feature is disabled
- If GitHub API call fails after DB record is created, clean up the orphan and return error
- Add `feedbackGithubToken` to Helm chart (values.yaml, secret.yaml, deployment.yaml)
- Document `FEEDBACK_GITHUB_TOKEN` in startup-oauth.sh setup instructions

## Test plan
- [ ] Start console without `FEEDBACK_GITHUB_TOKEN` — verify startup log shows warning
- [ ] Submit from Contribute dialog without token — verify 503 error with `.env` instructions
- [ ] Start console with `FEEDBACK_GITHUB_TOKEN` — verify issue creation works end-to-end
- [ ] Helm template renders `FEEDBACK_GITHUB_TOKEN` env var when `feedbackGithubToken` is configured