### PR TITLE
🐛 Fix CreatePolicyModal buttons disabled despite cluster selected

### DIFF
--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -1104,23 +1104,16 @@ function CreatePolicyModal({
     [statuses]
   )
 
-  // Auto-select first installed cluster
-  useEffect(() => {
-    if (isOpen && !selectedCluster && installedClusters.length > 0) {
-      setSelectedCluster(installedClusters[0])
-    }
-  }, [isOpen, selectedCluster, installedClusters])
-
-  // Reset state when modal opens
+  // Reset state and auto-select first installed cluster when modal opens
   useEffect(() => {
     if (isOpen) {
-      setSelectedCluster('')
       setFlow('choose')
       setUserDescription('')
       setYamlContent('')
       setIsAnalyzing(false)
+      setSelectedCluster(installedClusters.length > 0 ? installedClusters[0] : '')
     }
-  }, [isOpen])
+  }, [isOpen, installedClusters])
 
   // Gather cluster security data and start AI mission
   const handleAnalyzeAndSuggest = async () => {


### PR DESCRIPTION
## Summary
- Fixed a React state race condition in `CreatePolicyModal` where two competing `useEffect` hooks (auto-select and reset) caused the `selectedCluster` state to always end up as `''`, leaving all 4 flow buttons permanently disabled
- Merged the two effects into a single atomic effect that resets form state and auto-selects the first installed cluster in one pass

## Root Cause
When the modal opened (`isOpen` → `true`), both effects fired in declaration order:
1. **Auto-select** set `selectedCluster` to the first installed cluster
2. **Reset** set `selectedCluster` back to `''`

React batched both setState calls, the last one (`''`) won, and since `''` equals the current state, no re-render triggered to fix it. The buttons' `disabled={!selectedCluster}` condition remained `true` forever.

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint clean (no new warnings)
- [x] Browser tested: modal opens with cluster auto-selected and all buttons enabled
- [x] Verified all 4 flows work: Analyze, Describe, Template, Custom YAML
- [x] Back navigation between flows works correctly