### PR TITLE
🐛 chore: Replace any type assertions in AlertDetail, ClusterCosts, and …

### DIFF
--- a/web/src/components/alerts/AlertDetail.tsx
+++ b/web/src/components/alerts/AlertDetail.tsx
@@ -18,6 +18,7 @@ import { getSeverityIcon, getSeverityColor } from '../../types/alerts'
 import type { Alert } from '../../types/alerts'
 import { useToast } from '../ui/Toast'
 import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
 
 // Time thresholds for relative time formatting
 const MINUTES_PER_HOUR = 60 // Minutes in an hour
@@ -29,8 +30,7 @@ interface AlertDetailProps {
 }
 
 // Format relative time using i18n keys from the time section
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function formatRelativeTime(dateString: string, t: (key: any, opts?: any) => string): string {
+function formatRelativeTime(dateString: string, t: TFunction): string {
   const date = new Date(dateString)
   const now = new Date()
   const diffMs = now.getTime() - date.getTime()
@@ -38,10 +38,10 @@ function formatRelativeTime(dateString: string, t: (key: any, opts?: any) => str
   const diffHours = Math.floor(diffMins / 60)
   const diffDays = Math.floor(diffHours / 24)
 
-  if (diffMins < 1) return t('time.justNow')
-  if (diffMins < MINUTES_PER_HOUR) return t('time.minutesAgo', { count: diffMins })
-  if (diffHours < HOURS_PER_DAY) return t('time.hoursAgo', { count: diffHours })
-  return t('time.daysAgo', { count: diffDays })
+  if (diffMins < 1) return t('time.justNow') as string
+  if (diffMins < MINUTES_PER_HOUR) return t('time.minutesAgo', { count: diffMins }) as string
+  if (diffHours < HOURS_PER_DAY) return t('time.hoursAgo', { count: diffHours }) as string
+  return t('time.daysAgo', { count: diffDays }) as string
 }
 
 export function AlertDetail({ alert, onClose }: AlertDetailProps) {

--- a/web/src/components/cards/CRDHealth.tsx
+++ b/web/src/components/cards/CRDHealth.tsx
@@ -25,12 +25,13 @@ interface CRD {
 }
 
 type SortByOption = 'status' | 'name' | 'group' | 'instances'
+type SortTranslationKey = 'common:common.status' | 'common:common.name' | 'cards:crdHealth.group' | 'cards:crdHealth.instances'
 
-const SORT_OPTIONS_KEYS = [
-  { value: 'status' as const, labelKey: 'common.status' },
-  { value: 'name' as const, labelKey: 'common.name' },
-  { value: 'group' as const, labelKey: 'crdHealth.group' },
-  { value: 'instances' as const, labelKey: 'crdHealth.instances' },
+const SORT_OPTIONS_KEYS: ReadonlyArray<{ value: SortByOption; labelKey: SortTranslationKey }> = [
+  { value: 'status' as const, labelKey: 'common:common.status' },
+  { value: 'name' as const, labelKey: 'common:common.name' },
+  { value: 'group' as const, labelKey: 'cards:crdHealth.group' },
+  { value: 'instances' as const, labelKey: 'cards:crdHealth.instances' },
 ]
 
 const statusOrder: Record<string, number> = { NotEstablished: 0, Terminating: 1, Established: 2 }
@@ -38,8 +39,7 @@ const statusOrder: Record<string, number> = { NotEstablished: 0, Terminating: 1,
 export function CRDHealth({ config: _config }: CRDHealthProps) {
   const { t } = useTranslation(['cards', 'common'])
   const SORT_OPTIONS = useMemo(() =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey as any)) })),
+    SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) })),
     [t]
   )
   const { isLoading, deduplicatedClusters } = useClusters()

--- a/web/src/components/cards/ClusterCosts.tsx
+++ b/web/src/components/cards/ClusterCosts.tsx
@@ -42,12 +42,13 @@ const loadPersistedOverrides = (configOverrides?: Record<string, CloudProvider>)
 }
 type PricingMode = 'uniform' | 'per-cluster'
 type SortByOption = 'cost' | 'name' | 'cpus'
+type SortTranslationKey = 'cards:clusterCosts.sortCost' | 'cards:clusterCosts.sortName' | 'cards:clusterCosts.sortCPUs'
 
 // Labels are set at render time via t() — see getSortOptions()
-const SORT_OPTIONS_KEYS = [
-  { value: 'cost' as const, labelKey: 'clusterCosts.sortCost' },
-  { value: 'name' as const, labelKey: 'clusterCosts.sortName' },
-  { value: 'cpus' as const, labelKey: 'clusterCosts.sortCPUs' },
+const SORT_OPTIONS_KEYS: ReadonlyArray<{ value: SortByOption; labelKey: SortTranslationKey }> = [
+  { value: 'cost' as const, labelKey: 'cards:clusterCosts.sortCost' },
+  { value: 'name' as const, labelKey: 'cards:clusterCosts.sortName' },
+  { value: 'cpus' as const, labelKey: 'cards:clusterCosts.sortCPUs' },
 ]
 
 // Cloud provider icons (simple text badges for now, could be SVG logos)
@@ -187,8 +188,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
 
   // Build sort options with translated labels
   const SORT_OPTIONS = useMemo(() =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: t(opt.labelKey as any) as string })),
+    SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) })),
     [t]
   )
   const { deduplicatedClusters: allClusters, isLoading } = useClusters()


### PR DESCRIPTION
## Summary
Removes all `any` type assertions from three card components and replaces them with proper TypeScript types for improved type safety.

## Changes
- **AlertDetail.tsx**: Replace `(key: any, opts?: any)` with `TFunction` type from `i18next`
- **ClusterCosts.tsx**: Remove `(opt.labelKey as any)` assertion, define proper [SortTranslationKey](cci:2://file:///Users/matt/workspace/kubestellar-console/web/src/components/cards/ClusterCosts.tsx:44:0-44:119) union type
- **CRDHealth.tsx**: Remove `(opt.labelKey as any)` assertion, define proper [SortTranslationKey](cci:2://file:///Users/matt/workspace/kubestellar-console/web/src/components/cards/ClusterCosts.tsx:44:0-44:119) union type

## Technical Details
- Imported `TFunction` from `i18next` package for proper translation function typing
- Defined string literal union types for translation keys with namespace prefixes
- Added explicit type annotations to `SORT_OPTIONS_KEYS` constants
- Removed all `@typescript-eslint/no-explicit-any` eslint disable comments

## Testing
- `npm run build` passes with no new type errors
- All types properly defined with interfaces and union types
- Full type safety maintained throughout

Fixes #1326