### PR TITLE
🐛 Fix OPA card not detecting Gatekeeper on late-reachable clusters

### DIFF
--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -1877,6 +1877,19 @@ function OPAPoliciesInternal({ config: _config }: OPAPoliciesProps) {
     }
   }, [hasTriggeredInitialCheck, reachableClusters, statuses, checkClusters])
 
+  // Check newly reachable clusters that weren't available during the initial check.
+  // Clusters like platform-eval and vllm-d may be slow to respond to warmup but become
+  // reachable after a few minutes — this ensures they get checked when they come online.
+  useEffect(() => {
+    if (!hasTriggeredInitialCheck) return // Wait for initial check to complete first
+    if (shouldUseDemoData) return
+
+    const newlyReachable = reachableClusters.filter(c => !statusesRef.current[c.name])
+    if (newlyReachable.length === 0) return
+
+    checkClusters(newlyReachable)
+  }, [hasTriggeredInitialCheck, reachableClusters, shouldUseDemoData, checkClusters])
+
   const handleInstallOPA = (clusterName: string) => {
     startMission({
       title: `Install OPA Gatekeeper on ${clusterName}`,


### PR DESCRIPTION
## Summary
- Clusters like `vllm-d` and `platform-eval` may timeout during warmup but become reachable minutes later
- The OPA card only checked clusters that were reachable at initial load time and never re-checked
- Adds a `useEffect` that watches for newly reachable clusters and triggers OPA checks for any that don't yet have a status entry

## Test plan
- [ ] Start console with real clusters where some are slow to respond
- [ ] Verify clusters that become reachable after initial load get their OPA status checked
- [ ] Verify no duplicate checks occur for already-checked clusters