### PR TITLE
🐛 Add GHE OAuth URL to CD deploy workflows

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -127,6 +127,7 @@ jobs:
             --namespace kc \
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} \
             --set image.tag=${{ github.sha }} \
+            --set github.url=https://github.ibm.com \
             --set github.existingSecret=kc-secrets \
             --set jwt.existingSecret=kc-secrets \
             --set githubToken.existingSecret=kc-secrets \
@@ -182,6 +183,7 @@ jobs:
             --namespace kubestellar-console \
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} \
             --set image.tag=${{ github.sha }} \
+            --set github.url=https://github.ibm.com \
             --set github.existingSecret=kc-kubestellar-console \
             --set jwt.existingSecret=kc-kubestellar-console \
             --set githubToken.existingSecret=kc-kubestellar-console \


### PR DESCRIPTION
## Problem
Both vllm-d and pok-prod deploy jobs in `build-deploy.yml` were missing `--set github.url=https://github.ibm.com` in their `helm upgrade` commands. Without this, the `GITHUB_URL` env var is never set on the deployment, causing the console to default to github.com OAuth — overwriting any manually applied GHE configuration on every deploy.

## Fix
Added `--set github.url=https://github.ibm.com` to both deploy jobs' helm upgrade commands.

## Also done (live)
- Updated K8s secrets on both clusters with GHE OAuth client ID/secret
- Set `GITHUB_URL=https://github.ibm.com` on both live deployments (already rolled out)
- Updated GitHub Actions environment secrets (`KSC_OAUTH_CLIENT_ID`, `KSC_OAUTH_CLIENT_SECRET`) for both `vllm-d` and `pok-prod` environments