### PR TITLE
🐛 Eagerly import demo-only compliance cards to prevent blank cards

### DIFF
--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -215,6 +215,7 @@ export function ComplianceScore({ config: _config }: CardConfig) {
   useCardLoadingState({
     isLoading: false,
     hasAnyData: true,
+    isDemoData: true,
   })
 
   return (

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -73,11 +73,10 @@ const OpenCostOverview = lazy(() => import('./OpenCostOverview').then(m => ({ de
 const KubecostOverview = lazy(() => import('./KubecostOverview').then(m => ({ default: m.KubecostOverview })))
 const OPAPolicies = lazy(() => import('./OPAPolicies').then(m => ({ default: m.OPAPolicies })))
 const KyvernoPolicies = lazy(() => import('./KyvernoPolicies').then(m => ({ default: m.KyvernoPolicies })))
-const FalcoAlerts = lazy(() => import('./ComplianceCards').then(m => ({ default: m.FalcoAlerts })))
-const TrivyScan = lazy(() => import('./ComplianceCards').then(m => ({ default: m.TrivyScan })))
-const KubescapeScan = lazy(() => import('./ComplianceCards').then(m => ({ default: m.KubescapeScan })))
-const PolicyViolations = lazy(() => import('./ComplianceCards').then(m => ({ default: m.PolicyViolations })))
-const ComplianceScore = lazy(() => import('./ComplianceCards').then(m => ({ default: m.ComplianceScore })))
+// Eagerly import demo-only compliance cards — they're tiny (~255 lines total),
+// contain only hardcoded demo data, and lazy loading them causes blank cards
+// while heavier modules (OPA) saturate the dev server's transform pipeline.
+import { FalcoAlerts, TrivyScan, KubescapeScan, PolicyViolations, ComplianceScore } from './ComplianceCards'
 const VaultSecrets = lazy(() => import('./DataComplianceCards').then(m => ({ default: m.VaultSecrets })))
 const ExternalSecrets = lazy(() => import('./DataComplianceCards').then(m => ({ default: m.ExternalSecrets })))
 const CertManager = lazy(() => import('./DataComplianceCards').then(m => ({ default: m.CertManager })))


### PR DESCRIPTION
## Summary
- Switch ComplianceCards from `lazy()` to eager import in cardRegistry — they're tiny (~255 lines) with only hardcoded demo data
- Prevents blank grey boxes while heavier modules (OPA Policies) saturate the dev server's module transform pipeline
- Add missing `isDemoData: true` to ComplianceScore's `useCardLoadingState` for consistency

## Test plan
- [ ] Navigate to Compliance dashboard — demo cards (Compliance Score, Policy Violations, Falco, Trivy, Kubescape) render immediately
- [ ] OPA Policies card loading doesn't delay demo card rendering
- [ ] `npm run build` and `npm run lint` pass