### PR TITLE
🐛 Increase OPA Phase 1 timeout to 25s and cache TTL to 60 minutes

### DIFF
--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -270,7 +270,7 @@ async function checkGatekeeperInstalled(clusterName: string): Promise<Gatekeeper
   try {
     const nsResult = await kubectlProxy.exec(
       ['get', 'namespace', 'gatekeeper-system', '--ignore-not-found', '-o', 'name'],
-      { context: clusterName, timeout: 15000, priority: true }
+      { context: clusterName, timeout: 25000, priority: true }
     )
     const installed = !!(nsResult.output && nsResult.output.includes('gatekeeper-system'))
     return { cluster: clusterName, installed, loading: installed } // loading=true means details pending
@@ -1581,7 +1581,7 @@ function OPAPoliciesInternal({ config: _config }: OPAPoliciesProps) {
         const parsed = JSON.parse(cached)
         const cacheTime = localStorage.getItem(STORAGE_KEY_OPA_CACHE_TIME)
         const cacheAge = cacheTime ? Date.now() - parseInt(cacheTime, 10) : Infinity
-        if (cacheAge < 10 * 60 * 1000) { // 10 minutes
+        if (cacheAge < 60 * 60 * 1000) { // 60 minutes — installation status rarely changes
           return parsed
         }
       }


### PR DESCRIPTION
## Summary
- Increase Phase 1 namespace check timeout from 15s to 25s for slow remote clusters (vllm-d, platform-eval)
- Extend localStorage cache TTL from 10 minutes to 60 minutes — Gatekeeper installation status rarely changes, and the longer TTL ensures the no-downgrade protection persists across console restarts

## Root cause
After a console restart, if the 10-minute cache has expired, there's no cached `installed: true` to protect against timeout downgrades. The Phase 1 namespace check times out for slow clusters, and without cached state, they incorrectly show "Not installed".

## Test plan
- [ ] Navigate to Compliance dashboard with slow clusters (vllm-d, platform-eval)
- [ ] Both clusters should detect Gatekeeper and show policies/violations
- [ ] Restart console, navigate back within 60 minutes — cached statuses persist
- [ ] `npm run build` and `npm run lint` pass