### PR TITLE
🌱 Add spinner to loading page app shell

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -16,18 +16,21 @@
     <style>
       /* Inline app shell — visible before JS loads */
       #app-shell{display:flex;align-items:center;justify-content:center;min-height:100vh;flex-direction:column;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#a1a1aa}
-      #app-shell svg{width:48px;height:48px;animation:pulse 2s ease-in-out infinite}
+      #app-shell svg.logo{width:48px;height:48px;animation:pulse 2s ease-in-out infinite}
       #app-shell p{margin-top:16px;font-size:14px;letter-spacing:0.05em;opacity:0.7}
+      .spinner{width:24px;height:24px;margin-top:20px;border:2.5px solid rgba(124,58,237,0.2);border-top-color:#7c3aed;border-radius:50%;animation:spin .8s linear infinite}
       @keyframes pulse{0%,100%{opacity:.4}50%{opacity:1}}
+      @keyframes spin{to{transform:rotate(360deg)}}
     </style>
   </head>
   <body>
     <div id="root">
       <div id="app-shell">
-        <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5">
+        <svg class="logo" viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5">
           <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
         </svg>
         <p>Loading KubeStellar Console</p>
+        <div class="spinner"></div>
       </div>
     </div>
     <script type="module" src="/src/main.tsx"></script>


### PR DESCRIPTION
Adds a CSS spinner to the inline app shell in index.html. The pulsing logo alone didn't clearly indicate loading — now there's a spinning circle below the text.