### PR TITLE
🐛 Restore demo fallback for GPU reservations on localhost

### DIFF
--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -11,7 +11,7 @@ import {
   CheckCircle2,
   Settings2,
   TrendingUp,
-
+  FlaskConical,
   Trash2,
   Pencil,
   Loader2,
@@ -33,7 +33,7 @@ import {
 } from '../../hooks/useMCP'
 import type { GPUNode } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
-
+import { useDemoMode } from '../../hooks/useDemoMode'
 import { useAuth } from '../../lib/auth'
 import { useToast } from '../ui/Toast'
 import { DonutChart } from '../charts/PieChart'
@@ -181,6 +181,7 @@ export function GPUReservations() {
   }, [refetchGPUNodes, refetchClusters])
   const { showIndicator: isRefreshingDashboard, triggerRefresh } = useRefreshIndicator(refetchAll)
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
+  const { isDemoMode: demoMode } = useDemoMode()
   const { user } = useAuth()
   const { showToast } = useToast()
   const [activeTab, setActiveTab] = useState<ViewTab>('overview')
@@ -564,7 +565,15 @@ export function GPUReservations() {
   return (
     <div className="pt-16">
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-foreground">{t('gpuReservations.title')}</h1>
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-bold text-foreground">{t('gpuReservations.title')}</h1>
+          {demoMode && (
+            <span className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-full bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
+              <FlaskConical className="w-3 h-3" />
+              {t('gpuReservations.demo')}
+            </span>
+          )}
+        </div>
         <div className="text-muted-foreground">{t('gpuReservations.subtitle')}</div>
       </div>
 
@@ -648,7 +657,7 @@ export function GPUReservations() {
         <div className="space-y-6">
           {/* Quick Stats */}
           <div className="grid grid-cols-4 gap-4">
-            <div className={'glass p-4 rounded-lg'}>
+            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
               <div className="flex items-center gap-3">
                 <div className="p-2 rounded-lg bg-purple-500/20">
                   <Zap className="w-5 h-5 text-purple-400" />
@@ -659,7 +668,7 @@ export function GPUReservations() {
                 </div>
               </div>
             </div>
-            <div className={'glass p-4 rounded-lg'}>
+            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
               <div className="flex items-center gap-3">
                 <div className="p-2 rounded-lg bg-green-500/20">
                   <CheckCircle2 className="w-5 h-5 text-green-400" />
@@ -670,7 +679,7 @@ export function GPUReservations() {
                 </div>
               </div>
             </div>
-            <div className={'glass p-4 rounded-lg'}>
+            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
               <div className="flex items-center gap-3">
                 <div className="p-2 rounded-lg bg-blue-500/20">
                   <Settings2 className="w-5 h-5 text-blue-400" />
@@ -681,7 +690,7 @@ export function GPUReservations() {
                 </div>
               </div>
             </div>
-            <div className={'glass p-4 rounded-lg'}>
+            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
               <div className="flex items-center gap-3">
                 <div className="p-2 rounded-lg bg-yellow-500/20">
                   <AlertTriangle className="w-5 h-5 text-yellow-400" />
@@ -697,7 +706,7 @@ export function GPUReservations() {
           {/* Charts Row */}
           <div className="grid grid-cols-3 gap-4">
             {/* Utilization */}
-            <div className={'glass p-4 rounded-lg'}>
+            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
               <h3 className="text-sm font-medium text-muted-foreground mb-4">{t('gpuReservations.charts.gpuUtilization')}</h3>
               <div className="flex items-center justify-center">
                 <div className="relative w-32 h-32">
@@ -723,7 +732,7 @@ export function GPUReservations() {
             </div>
 
             {/* GPU Types */}
-            <div className={'glass p-4 rounded-lg'}>
+            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
               <h3 className="text-sm font-medium text-muted-foreground mb-4">{t('common:common.gpuTypes')}</h3>
               {stats.typeChartData.length > 0 ? (
                 <DonutChart data={stats.typeChartData} size={150} thickness={20} showLegend={true} />
@@ -733,7 +742,7 @@ export function GPUReservations() {
             </div>
 
             {/* Usage by Namespace */}
-            <div className={'glass p-4 rounded-lg'}>
+            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
               <h3 className="text-sm font-medium text-muted-foreground mb-4">{t('gpuReservations.charts.gpuUsageByNamespace')}</h3>
               {stats.usageByNamespace.length > 0 ? (
                 <DonutChart data={stats.usageByNamespace} size={150} thickness={20} showLegend={true} />
@@ -745,14 +754,14 @@ export function GPUReservations() {
 
           {/* Cluster Allocation */}
           {stats.clusterUsage.length > 0 && (
-            <div className={'glass p-4 rounded-lg'}>
+            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
               <h3 className="text-sm font-medium text-muted-foreground mb-4">{t('gpuReservations.charts.gpuAllocationByCluster')}</h3>
               <BarChart data={stats.clusterUsage} height={200} color={getChartColorByName('primary')} showGrid={true} />
             </div>
           )}
 
           {/* Active Reservations */}
-          <div className={'glass p-4 rounded-lg'}>
+          <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
             <h3 className="text-sm font-medium text-muted-foreground mb-4">
               {showOnlyMine ? t('gpuReservations.overview.myGpuReservations') : t('gpuReservations.overview.activeGpuReservations')}
             </h3>
@@ -797,7 +806,7 @@ export function GPUReservations() {
       {/* Calendar Tab */}
       {activeTab === 'calendar' && (
         <div className="space-y-6">
-          <div className={'glass p-4 rounded-lg'}>
+          <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
             <div className="flex items-center justify-center gap-4 mb-4">
               {(['prev', 'heading', 'next'] as const).map(item => {
                 if (item === 'heading') return (
@@ -955,7 +964,7 @@ export function GPUReservations() {
           )}
           <div className="grid gap-4">
             {filteredReservations.map(r => (
-              <div key={r.id} className={'glass p-4 rounded-lg'}>
+              <div key={r.id} className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
                 <div className="flex items-center justify-between mb-3">
                   <div className="flex items-center gap-3">
                     <div className="p-2 rounded-lg bg-purple-500/20">
@@ -1035,7 +1044,7 @@ export function GPUReservations() {
 
       {/* Selected Reservation Details — renders for both calendar and quotas tabs */}
       {selectedReservation && (
-        <div className={'glass p-4 rounded-lg'}>
+        <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-medium text-foreground">{t('gpuReservations.reservationDetails.title')}</h3>
             <button onClick={() => setSelectedReservation(null)} className="p-1 rounded hover:bg-secondary transition-colors" aria-label={t('gpuReservations.reservationDetails.close')}>
@@ -1130,7 +1139,7 @@ export function GPUReservations() {
           {gpuClusters.map(cluster => {
             const clusterNodes = nodes.filter(n => n.cluster === cluster.name)
             return (
-              <div key={cluster.name} className={'glass p-4 rounded-lg'}>
+              <div key={cluster.name} className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center gap-3">
                     <ClusterBadge cluster={cluster.name} size="sm" />


### PR DESCRIPTION
## Summary
- GPU reservations now try real API first, fall back to demo data when API is unreachable and demo mode is on
- Restores demo badge and yellow demo borders when in demo mode
- On cluster deployments the API succeeds so data stays live regardless of demo toggle

## Test plan
- [ ] Localhost + demo mode on: demo reservations and demo badge visible
- [ ] Localhost + demo mode off: empty state (no backend)
- [ ] Cluster deployment + demo mode: real live data from API