### PR TITLE
✨ Add UTM tracking, new analytics emitters, and live demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A proactive, AI-powered multi-cluster Kubernetes dashboard that adapts to how yo
 
 **Your clusters, your way - AI that learns how you work**
 
+[🚀 **Try the Live Demo →**](https://console.kubestellar.io?utm_source=github&utm_medium=readme&utm_campaign=live_demo)
+
 ![KubeStellar Console overview](docs/images/Console-overview.svg)
 
 ## What is KubeStellar Console?


### PR DESCRIPTION
## What

- Add UTM parameter capture to analytics initialization — tracks utm_source, utm_medium, utm_campaign, utm_term, utm_content from landing URLs and persists them in sessionStorage
- Add new event emitters for Deploy (workload deploy, template apply), Compliance (drill-down), Benchmarks (view), and ClusterAdmin (actions, stats drill-down)
- Add live demo link with UTM tracking to README header

## GA4 Configuration (already applied)

- Registered 13 new custom event dimensions (workload_name, cluster_group, template_name, stat_type, etc.)
- Registered 3 custom metrics (duration_sec, step_count, cluster_count)
- Configured 8 key events/conversions (login, agent_connected, mission_started/completed, tour_completed, etc.)

## Why

GA4 analytics showed 41 users in first 7 days but:
- No acquisition attribution (100% Direct traffic) — UTM tracking fixes this
- No feature interaction depth — new emitters fix this
- No conversion funnel visibility — custom dimensions + key events fix this