### PR TITLE
🐛 Use pod-mounted CA cert for vllm-d CI deploy

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -107,10 +107,9 @@ jobs:
       - name: Configure kubeconfig
         run: |
           export KUBECONFIG="$RUNNER_TEMP/kubeconfig"
-          echo "${{ secrets.VLLM_D_CA_CERT }}" > "$RUNNER_TEMP/ca.crt"
           kubectl config set-cluster vllm-d \
             --server=https://kubernetes.default.svc \
-            --certificate-authority="$RUNNER_TEMP/ca.crt" \
+            --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
             --embed-certs=true
           kubectl config set-credentials deployer --token="${{ secrets.VLLM_D_DEPLOY_TOKEN }}"
           kubectl config set-context deploy --cluster=vllm-d --user=deployer


### PR DESCRIPTION
## Summary
- Fix vllm-d CI deploy TLS error by using pod-mounted CA cert instead of GitHub secret
- Previous attempt stored the wrong CA (service-ca) in `VLLM_D_CA_CERT` secret
- Pod-mounted `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt` is the correct API server TLS CA
- Keep `VLLM_D_DEPLOY_TOKEN` for reliable auth (long-lived SA token)

## Test plan
- [ ] CI build succeeds
- [ ] deploy-vllm-d job passes (previously failing with TLS cert error)
- [ ] deploy-pok-prod job continues working