### PR TITLE
🐛 Pass deploy token directly to Helm for vllm-d CI

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -136,8 +136,13 @@ jobs:
         continue-on-error: true
 
       - name: Deploy with Helm
+        env:
+          DEPLOY_TOKEN: ${{ secrets.VLLM_D_DEPLOY_TOKEN }}
         run: |
           helm upgrade --install kc ./deploy/helm/kubestellar-console \
+            --kube-apiserver https://kubernetes.default.svc \
+            --kube-ca-file /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+            --kube-token "$DEPLOY_TOKEN" \
             --namespace kc \
             --set image.repository=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} \
             --set image.tag=${{ github.sha }} \


### PR DESCRIPTION
## Summary
- Kubectl works with kubeconfig but Helm gets 401 reading it
- Pass `--kube-apiserver`, `--kube-ca-file`, and `--kube-token` directly to Helm
- Bypasses kubeconfig parsing differences between kubectl and Helm client-go

## Test plan
- [ ] deploy-vllm-d Helm step passes (previously failing with 401)
- [ ] deploy-pok-prod continues working