### PR TITLE
✨ Wire up mission sharing: browser, export dialog, API routes

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -508,6 +508,10 @@ func (s *Server) setupRoutes() {
 	api.Post("/namespaces/:name/access", namespaces.GrantNamespaceAccess)
 	api.Delete("/namespaces/:name/access/:binding", namespaces.RevokeNamespaceAccess)
 
+	// Mission knowledge base routes (browse, validate, share)
+	missions := handlers.NewMissionsHandler()
+	missions.RegisterRoutes(api.Group("/missions"))
+
 	// MCP routes (cluster operations via kubestellar tools and direct k8s)
 	// SECURITY: All MCP routes require authentication in both dev and production modes
 	api.Get("/mcp/status", mcpHandlers.GetStatus)

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import {
   X,
   ChevronRight,
@@ -13,12 +13,15 @@ import {
   Type,
   MessageSquarePlus,
   Send,
+  Globe,
 } from 'lucide-react'
 import { useMissions } from '../../../hooks/useMissions'
 import { useMobile } from '../../../hooks/useMobile'
 import { cn } from '../../../lib/cn'
 import { AgentSelector } from '../../agent/AgentSelector'
 import { AgentIcon } from '../../agent/AgentIcon'
+import { MissionBrowser } from '../../missions/MissionBrowser'
+import type { MissionExport } from '../../../lib/missions/types'
 import type { FontSize } from './types'
 import { MissionListItem } from './MissionListItem'
 import { MissionChat } from './MissionChat'
@@ -31,8 +34,19 @@ export function MissionSidebar() {
   const [collapsedMissions, setCollapsedMissions] = useState<Set<string>>(new Set())
   const [fontSize, setFontSize] = useState<FontSize>('base')
   const [showNewMission, setShowNewMission] = useState(false)
+  const [showBrowser, setShowBrowser] = useState(false)
   const [newMissionPrompt, setNewMissionPrompt] = useState('')
   const newMissionInputRef = useRef<HTMLTextAreaElement>(null)
+
+  const handleImportMission = useCallback((mission: MissionExport) => {
+    startMission({
+      type: 'custom',
+      title: mission.title,
+      description: mission.description || mission.title,
+      initialPrompt: mission.resolution?.summary || mission.description,
+    })
+    setShowBrowser(false)
+  }, [startMission])
 
   // Escape key: exit fullscreen first, then close sidebar
   useEffect(() => {
@@ -178,6 +192,14 @@ export function MissionSidebar() {
             title={t('missionSidebar.startNewMission')}
           >
             <MessageSquarePlus className="w-4 h-4" />
+          </button>
+          {/* Browse Community Missions */}
+          <button
+            onClick={() => setShowBrowser(true)}
+            className="p-1.5 rounded transition-colors hover:bg-secondary text-muted-foreground hover:text-foreground"
+            title="Browse community missions"
+          >
+            <Globe className="w-4 h-4" />
           </button>
           <AgentSelector compact={!isFullScreen} />
           {/* Font size controls */}
@@ -356,6 +378,13 @@ export function MissionSidebar() {
         </div>
       )}
     </div>
+
+      {/* Mission Browser Dialog */}
+      <MissionBrowser
+        isOpen={showBrowser}
+        onClose={() => setShowBrowser(false)}
+        onImport={handleImportMission}
+      />
     </>
   )
 }

--- a/web/src/components/missions/ResolutionHistoryPanel.tsx
+++ b/web/src/components/missions/ResolutionHistoryPanel.tsx
@@ -14,6 +14,7 @@ import {
   ChevronRight,
   Trash2,
   Share2,
+  Download,
   CheckCircle,
   Clock,
   Tag,
@@ -21,6 +22,7 @@ import {
 } from 'lucide-react'
 import { useResolutions, type Resolution } from '../../hooks/useResolutions'
 import { cn } from '../../lib/cn'
+import { ShareMissionDialog } from './ShareMissionDialog'
 import { useTranslation } from 'react-i18next'
 
 interface ResolutionHistoryPanelProps {
@@ -34,6 +36,7 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
   const [showPersonal, setShowPersonal] = useState(true)
   const [showShared, setShowShared] = useState(true)
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
+  const [exportResolution, setExportResolution] = useState<Resolution | null>(null)
   const deleteConfirmTimerRef = useRef<ReturnType<typeof setTimeout>>()
 
   useEffect(() => {
@@ -118,6 +121,7 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
                     onApply={onApplyResolution ? () => onApplyResolution(resolution) : undefined}
                     onDelete={() => handleDelete(resolution.id)}
                     onShare={() => handleShare(resolution.id)}
+                    onExport={() => setExportResolution(resolution)}
                     isDeleteConfirm={deleteConfirmId === resolution.id}
                     canShare
                   />
@@ -148,6 +152,7 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
                     onToggle={() => toggleExpand(resolution.id)}
                     onApply={onApplyResolution ? () => onApplyResolution(resolution) : undefined}
                     onDelete={() => handleDelete(resolution.id)}
+                    onExport={() => setExportResolution(resolution)}
                     isDeleteConfirm={deleteConfirmId === resolution.id}
                     showSharedBy
                   />
@@ -157,6 +162,15 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
           </div>
         )}
       </div>
+
+      {/* Export dialog */}
+      {exportResolution && (
+        <ShareMissionDialog
+          resolution={exportResolution}
+          isOpen={true}
+          onClose={() => setExportResolution(null)}
+        />
+      )}
     </div>
   )
 }
@@ -168,6 +182,7 @@ interface ResolutionCardProps {
   onApply?: () => void
   onDelete: () => void
   onShare?: () => void
+  onExport?: () => void
   isDeleteConfirm: boolean
   showSharedBy?: boolean
   canShare?: boolean
@@ -180,6 +195,7 @@ function ResolutionCard({
   onApply,
   onDelete,
   onShare,
+  onExport,
   isDeleteConfirm,
   showSharedBy,
   canShare,
@@ -290,6 +306,18 @@ function ResolutionCard({
                   title="Share to team"
                 >
                   <Share2 className="w-3 h-3" />
+                </button>
+              )}
+              {onExport && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onExport()
+                  }}
+                  className="flex items-center justify-center gap-1 px-2 py-1.5 text-[10px] bg-emerald-500/20 hover:bg-emerald-500/30 text-emerald-400 border border-emerald-500/30 rounded transition-colors"
+                  title="Export mission"
+                >
+                  <Download className="w-3 h-3" />
                 </button>
               )}
               <button

--- a/web/src/components/missions/ShareMissionDialog.tsx
+++ b/web/src/components/missions/ShareMissionDialog.tsx
@@ -1,0 +1,246 @@
+/**
+ * Share Mission Dialog
+ *
+ * Export a saved resolution as JSON file, clipboard, or markdown.
+ * Runs security scanning before export to detect sensitive data.
+ */
+
+import { useState, useCallback } from 'react'
+import {
+  X,
+  Download,
+  Copy,
+  FileText,
+  CheckCircle,
+  AlertTriangle,
+  Shield,
+  Loader2,
+} from 'lucide-react'
+import type { Resolution } from '../../hooks/useResolutions'
+import type { MissionExport, FileScanResult } from '../../lib/missions/types'
+import { fullScan } from '../../lib/missions/scanner/index'
+import { cn } from '../../lib/cn'
+
+interface ShareMissionDialogProps {
+  resolution: Resolution
+  isOpen: boolean
+  onClose: () => void
+}
+
+type ExportChannel = 'json' | 'clipboard' | 'markdown'
+
+function resolutionToMissionExport(resolution: Resolution): MissionExport {
+  return {
+    version: '1.0',
+    title: resolution.title,
+    description: resolution.resolution.summary || resolution.title,
+    type: 'troubleshoot',
+    tags: [
+      resolution.issueSignature.type,
+      ...(resolution.issueSignature.resourceKind ? [resolution.issueSignature.resourceKind] : []),
+    ].filter(Boolean),
+    category: 'troubleshooting',
+    steps: resolution.resolution.steps.map((step, i) => ({
+      title: `Step ${i + 1}`,
+      description: step,
+    })),
+    resolution: {
+      summary: resolution.resolution.summary || '',
+      steps: resolution.resolution.steps,
+      yaml: resolution.resolution.yaml,
+    },
+    metadata: {
+      author: resolution.sharedBy || resolution.userId,
+      source: 'kubestellar-console',
+      createdAt: resolution.createdAt,
+      updatedAt: resolution.updatedAt,
+    },
+  }
+}
+
+function missionToMarkdown(mission: MissionExport): string {
+  const lines = [
+    `# ${mission.title}`,
+    '',
+    `**Type:** ${mission.type}`,
+    `**Tags:** ${mission.tags.join(', ')}`,
+    '',
+    '## Problem',
+    mission.description,
+    '',
+  ]
+
+  if (mission.resolution?.summary) {
+    lines.push('## Solution', mission.resolution.summary, '')
+  }
+
+  if (mission.steps.length > 0) {
+    lines.push('## Steps')
+    mission.steps.forEach((step, i) => {
+      lines.push(`${i + 1}. ${step.description}`)
+    })
+    lines.push('')
+  }
+
+  if (mission.resolution?.yaml) {
+    lines.push('## YAML', '```yaml', mission.resolution.yaml, '```', '')
+  }
+
+  return lines.join('\n')
+}
+
+export function ShareMissionDialog({ resolution, isOpen, onClose }: ShareMissionDialogProps) {
+  const [scanResult, setScanResult] = useState<FileScanResult | null>(null)
+  const [scanning, setScanning] = useState(false)
+  const [exported, setExported] = useState<ExportChannel | null>(null)
+
+  const mission = resolutionToMissionExport(resolution)
+
+  const runScan = useCallback(() => {
+    setScanning(true)
+    try {
+      const result = fullScan(mission)
+      setScanResult(result)
+    } catch {
+      setScanResult(null)
+    } finally {
+      setScanning(false)
+    }
+  }, [mission])
+
+  const handleExport = useCallback(async (channel: ExportChannel) => {
+    // Run scan first if not done yet
+    if (!scanResult && !scanning) {
+      runScan()
+    }
+
+    const json = JSON.stringify(mission, null, 2)
+
+    switch (channel) {
+      case 'json': {
+        const blob = new Blob([json], { type: 'application/json' })
+        const url = URL.createObjectURL(blob)
+        const a = document.createElement('a')
+        a.href = url
+        a.download = `${mission.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 60)}.json`
+        a.click()
+        URL.revokeObjectURL(url)
+        break
+      }
+      case 'clipboard':
+        await navigator.clipboard.writeText(json)
+        break
+      case 'markdown':
+        await navigator.clipboard.writeText(missionToMarkdown(mission))
+        break
+    }
+
+    setExported(channel)
+    setTimeout(() => setExported(null), 2000)
+  }, [mission, scanResult, scanning, runScan])
+
+  if (!isOpen) return null
+
+  const hasWarnings = scanResult && scanResult.findings.some(f => f.severity === 'warning' || f.severity === 'error')
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-md mx-4">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <div className="flex items-center gap-2">
+            <Shield className="w-4 h-4 text-primary" />
+            <h3 className="text-sm font-semibold text-foreground">Export Mission</h3>
+          </div>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground transition-colors">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Mission preview */}
+        <div className="p-4 border-b border-border">
+          <p className="text-xs font-medium text-foreground truncate">{resolution.title}</p>
+          <p className="text-[10px] text-muted-foreground mt-1">
+            {resolution.issueSignature.type} · {resolution.resolution.steps.length} steps
+          </p>
+        </div>
+
+        {/* Security scan status */}
+        <div className="px-4 py-3 border-b border-border">
+          {scanning ? (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="w-3 h-3 animate-spin" />
+              Scanning for sensitive data...
+            </div>
+          ) : scanResult ? (
+            <div className={cn('flex items-center gap-2 text-xs', hasWarnings ? 'text-yellow-400' : 'text-green-400')}>
+              {hasWarnings ? <AlertTriangle className="w-3 h-3" /> : <CheckCircle className="w-3 h-3" />}
+              {hasWarnings
+                ? `${scanResult.findings.filter(f => f.severity !== 'info').length} finding(s) — review before sharing externally`
+                : 'No sensitive data detected'}
+            </div>
+          ) : (
+            <button
+              onClick={runScan}
+              className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Shield className="w-3 h-3" />
+              Run security scan before export
+            </button>
+          )}
+        </div>
+
+        {/* Export channels */}
+        <div className="p-4 space-y-2">
+          <ExportButton
+            icon={<Download className="w-4 h-4" />}
+            label="Download JSON"
+            description="Save as .json file"
+            active={exported === 'json'}
+            onClick={() => handleExport('json')}
+          />
+          <ExportButton
+            icon={<Copy className="w-4 h-4" />}
+            label="Copy JSON"
+            description="Copy to clipboard"
+            active={exported === 'clipboard'}
+            onClick={() => handleExport('clipboard')}
+          />
+          <ExportButton
+            icon={<FileText className="w-4 h-4" />}
+            label="Copy Markdown"
+            description="Human-readable format"
+            active={exported === 'markdown'}
+            onClick={() => handleExport('markdown')}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ExportButton({ icon, label, description, active, onClick }: {
+  icon: React.ReactNode
+  label: string
+  description: string
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'w-full flex items-center gap-3 p-3 rounded-lg border transition-colors text-left',
+        active
+          ? 'border-green-500/50 bg-green-500/10 text-green-400'
+          : 'border-border hover:border-primary/30 hover:bg-accent/50 text-foreground'
+      )}
+    >
+      <div className="flex-shrink-0">{active ? <CheckCircle className="w-4 h-4 text-green-400" /> : icon}</div>
+      <div>
+        <p className="text-xs font-medium">{active ? 'Done!' : label}</p>
+        <p className="text-[10px] text-muted-foreground">{description}</p>
+      </div>
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary

Wires up orphaned mission sharing components that were merged but never integrated:

### Changes
- **Backend**: Register missions API routes in `server.go` (`NewMissionsHandler` + `RegisterRoutes`)
- **ShareMissionDialog**: New component with JSON download, clipboard copy, and markdown export channels, plus security scanning integration
- **MissionBrowser**: Wired into MissionSidebar via Globe button in header — opens file-explorer-style community mission browser
- **Export button**: Added to ResolutionCard for both personal AND shared resolutions (green Download icon)

### Testing
- `go build ./...` ✅
- `npm run build` ✅
- `npm run lint` ✅ (no new issues)