### PR TITLE
✨ Add repo/path watching to MissionBrowser, remove duplicate ActiveUsersWidget

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -16,7 +16,6 @@ import { TokenUsageWidget } from './TokenUsageWidget'
 import { ClusterFilterPanel } from './ClusterFilterPanel'
 import { AgentStatusIndicator } from './AgentStatusIndicator'
 import { UpdateIndicator } from './UpdateIndicator'
-import { ActiveUsersWidget } from './ActiveUsersWidget'
 import { ROUTES } from '../../../config/routes'
 
 export function Navbar() {
@@ -79,9 +78,6 @@ export function Navbar() {
 
         {/* Extended desktop items: lg+ (1024px) */}
         <div className="hidden lg:flex items-center gap-2">
-          {/* Active Users */}
-          <ActiveUsersWidget />
-
           {/* Update Indicator */}
           <UpdateIndicator />
 
@@ -162,9 +158,6 @@ export function Navbar() {
                   </div>
 
                   {/* Items hidden at <lg (1024px): update, token usage, feature request, tour */}
-                  <div className="px-3 py-2">
-                    <ActiveUsersWidget />
-                  </div>
                   <div className="px-3 py-2">
                     <UpdateIndicator />
                   </div>


### PR DESCRIPTION
## Changes

### MissionBrowser: Add watched repos and file paths
- **"+" buttons** next to "My Repositories" and "Local Files" headers in the sidebar
- **Inline forms** for adding `owner/repo` or file paths (Escape to cancel)
- **Watched sources** appear as tree children with trash icon to remove
- **Persisted** in localStorage across sessions (`kc_mission_watched_repos`, `kc_mission_watched_paths`)

### Remove duplicate ActiveUsersWidget
- Removed from top navbar (desktop lg+ and mobile overflow menu)
- Already shown in the lower-left sidebar

### Build
- `npm run build` ✅