### PR TITLE
✨ Always show recommendations + GA4 analytics for solution browser

### DIFF
--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -269,6 +269,32 @@ export function emitMissionRated(missionType: string, rating: string) {
   send('ksc_mission_rated', { mission_type: missionType, rating })
 }
 
+// ── Mission Browser / Knowledge Base ──────────────────────────────
+
+export function emitSolutionSearchStarted(clusterConnected: boolean) {
+  send('ksc_solution_search', { cluster_connected: clusterConnected })
+}
+
+export function emitSolutionSearchCompleted(found: number, scanned: number) {
+  send('ksc_solution_search_done', { found, scanned })
+}
+
+export function emitSolutionBrowsed(path: string) {
+  send('ksc_solution_browsed', { path })
+}
+
+export function emitSolutionViewed(title: string, cncfProject?: string) {
+  send('ksc_solution_viewed', { title, cncf_project: cncfProject ?? '' })
+}
+
+export function emitSolutionImported(title: string, cncfProject?: string) {
+  send('ksc_solution_imported', { title, cncf_project: cncfProject ?? '' })
+}
+
+export function emitSolutionGitHubLink() {
+  send('ksc_solution_github_link')
+}
+
 // ── Auth ───────────────────────────────────────────────────────────
 
 export function emitLogin(method: string) {

--- a/web/src/lib/missions/matcher.ts
+++ b/web/src/lib/missions/matcher.ts
@@ -18,10 +18,11 @@ interface ClusterInfo {
 /**
  * Score and rank missions against cluster data.
  * Returns missions sorted by match score (highest first).
+ * Always returns results — uses baseline scoring when no cluster matches exist.
  */
 export function matchMissionsToCluster(
   missions: MissionExport[],
-  cluster: ClusterInfo
+  cluster: ClusterInfo | null
 ): MissionMatch[] {
   const results: MissionMatch[] = []
 
@@ -29,63 +30,84 @@ export function matchMissionsToCluster(
     let score = 0
     const matchReasons: string[] = []
 
-    // Match by tags against cluster resources
-    if (mission.tags && cluster.resources) {
-      const lowerResources = cluster.resources.map((r) => r.toLowerCase())
-      for (const tag of mission.tags) {
-        if (lowerResources.some((r) => r.includes(tag.toLowerCase()))) {
-          score += 20
-          matchReasons.push(`Tag "${tag}" matches cluster resource`)
+    if (cluster) {
+      // Match by tags against cluster resources
+      if (mission.tags && cluster.resources) {
+        const lowerResources = cluster.resources.map((r) => r.toLowerCase())
+        for (const tag of mission.tags) {
+          if (lowerResources.some((r) => r.includes(tag.toLowerCase()))) {
+            score += 20
+            matchReasons.push(`Tag "${tag}" matches cluster resource`)
+          }
+        }
+      }
+
+      // Match by CNCF project against cluster labels
+      if (mission.cncfProject && cluster.labels) {
+        const projectLower = mission.cncfProject.toLowerCase()
+        for (const [key, value] of Object.entries(cluster.labels)) {
+          if (
+            key.toLowerCase().includes(projectLower) ||
+            value.toLowerCase().includes(projectLower)
+          ) {
+            score += 30
+            matchReasons.push(`CNCF project "${mission.cncfProject}" found in cluster labels`)
+            break
+          }
+        }
+      }
+
+      // Match troubleshoot missions against cluster issues
+      if (mission.type === 'troubleshoot' && cluster.issues) {
+        const descLower = mission.description.toLowerCase()
+        for (const issue of cluster.issues) {
+          if (descLower.includes(issue.toLowerCase())) {
+            score += 40
+            matchReasons.push(`Addresses cluster issue: ${issue}`)
+          }
+        }
+      }
+
+      // Match upgrade missions against version
+      if (mission.type === 'upgrade' && cluster.version) {
+        const descLower = mission.description.toLowerCase()
+        if (descLower.includes(cluster.version) || descLower.includes('upgrade')) {
+          score += 15
+          matchReasons.push('Relevant to cluster version')
+        }
+      }
+
+      // Boost deploy missions for matching provider
+      if (mission.type === 'deploy' && cluster.provider && mission.tags) {
+        if (mission.tags.some((t) => t.toLowerCase() === cluster.provider?.toLowerCase())) {
+          score += 25
+          matchReasons.push(`Matches cluster provider: ${cluster.provider}`)
         }
       }
     }
 
-    // Match by CNCF project against cluster labels
-    if (mission.cncfProject && cluster.labels) {
-      const projectLower = mission.cncfProject.toLowerCase()
-      for (const [key, value] of Object.entries(cluster.labels)) {
-        if (
-          key.toLowerCase().includes(projectLower) ||
-          value.toLowerCase().includes(projectLower)
-        ) {
-          score += 30
-          matchReasons.push(`CNCF project "${mission.cncfProject}" found in cluster labels`)
-          break
-        }
-      }
+    // Baseline: score by engagement metadata (reactions, comments) so popular missions surface
+    const meta = (mission as unknown as Record<string, unknown>).metadata as Record<string, unknown> | undefined
+    const reactions = Number(meta?.reactions) || 0
+    const comments = Number(meta?.comments) || 0
+    if (reactions >= 20) {
+      score += 10
+      matchReasons.push(`High engagement (${reactions} reactions)`)
+    } else if (reactions >= 5) {
+      score += 5
+      matchReasons.push(`${reactions} reactions`)
+    }
+    if (comments >= 10) {
+      score += 5
     }
 
-    // Match troubleshoot missions against cluster issues
-    if (mission.type === 'troubleshoot' && cluster.issues) {
-      const descLower = mission.description.toLowerCase()
-      for (const issue of cluster.issues) {
-        if (descLower.includes(issue.toLowerCase())) {
-          score += 40
-          matchReasons.push(`Addresses cluster issue: ${issue}`)
-        }
-      }
+    // Minimum score of 1 so all missions are included
+    if (score === 0) {
+      score = 1
+      matchReasons.push('Community mission')
     }
 
-    // Match upgrade missions against version
-    if (mission.type === 'upgrade' && cluster.version) {
-      const descLower = mission.description.toLowerCase()
-      if (descLower.includes(cluster.version) || descLower.includes('upgrade')) {
-        score += 15
-        matchReasons.push('Relevant to cluster version')
-      }
-    }
-
-    // Boost deploy missions for matching provider
-    if (mission.type === 'deploy' && cluster.provider && mission.tags) {
-      if (mission.tags.some((t) => t.toLowerCase() === cluster.provider?.toLowerCase())) {
-        score += 25
-        matchReasons.push(`Matches cluster provider: ${cluster.provider}`)
-      }
-    }
-
-    if (score > 0) {
-      results.push({ mission, score, matchReasons })
-    }
+    results.push({ mission, score, matchReasons })
   }
 
   return results.sort((a, b) => b.score - a.score)


### PR DESCRIPTION
## Changes

### Always show recommendations (matcher fix)
- `matcher.ts`: Accept `ClusterInfo | null` — works even without cluster connection
- Baseline engagement scoring (reactions/comments from mission metadata)
- Minimum score of 1 ensures all missions appear in results

### Mission normalizer
- `normalizeMission()` converts kc-mission-v1 nested format (`{format, mission, metadata}`) to flat `MissionExport` shape
- Both fetch locations in progressive search now use normalizer

### GA4 Analytics events
New events tracked via existing analytics proxy:
- `ksc_solution_search` — search started (with cluster connected flag)
- `ksc_solution_search_done` — search completed (found/scanned counts)
- `ksc_solution_browsed` — directory navigation
- `ksc_solution_viewed` — mission file preview
- `ksc_solution_imported` — mission imported to user's missions
- `ksc_solution_github_link` — clicked 'Browse on GitHub' link