### PR TITLE
🐛 fix: Replaced hardcoded gray/slate colors in WidgetExportModal with theme tokens.

### DIFF
--- a/web/src/components/widgets/WidgetExportModal.tsx
+++ b/web/src/components/widgets/WidgetExportModal.tsx
@@ -264,13 +264,13 @@ export function WidgetExportModal({ isOpen, onClose, cardType, mode: _mode = 'pi
             </div>
 
             {showCode ? (
-              <div className="flex-1 bg-gray-900 rounded-lg p-3 overflow-auto">
-                <pre className="text-xs text-gray-300 whitespace-pre-wrap font-mono">
+              <div className="flex-1 bg-card rounded-lg p-3 overflow-auto">
+                <pre className="text-xs text-foreground/80 whitespace-pre-wrap font-mono">
                   {widgetCode || '// Select an item to generate widget code'}
                 </pre>
               </div>
             ) : (
-              <div className="flex-1 bg-gray-900/50 rounded-lg p-4 flex items-center justify-center">
+              <div className="flex-1 bg-secondary/50 rounded-lg p-4 flex items-center justify-center">
                 <WidgetPreview config={exportConfig} />
               </div>
             )}
@@ -434,7 +434,7 @@ function StatItem({
       </div>
       <div
         className={`ml-auto w-5 h-5 rounded border-2 flex items-center justify-center ${
-          selected ? 'bg-purple-500 border-purple-500' : 'border-gray-500'
+          selected ? 'bg-purple-500 border-purple-500' : 'border-muted-foreground'
         }`}
       >
         {selected && <Check className="w-3 h-3 text-white" />}


### PR DESCRIPTION


### 📌 Fixes

Fixes #1320  <issue-number> (Use "Fixes", "Closes", or "Resolves" for automatic closing)

---

### 📝 Summary of Changes
These changes are from the Issue description.
In web/src/components/widget/WidgetExportModal.tsx:

- text-gray-300 → text-foreground/80 (NOT text-muted-foreground — that's too dark)
- bg-gray-900 → bg-card
- bg-gray-900/50 → bg-secondary/50 (KEEP the /50 opacity — it's intentional for visual hierarchy)
- border-gray-500 → border-muted-foreground (NOT border-border — that's too dark)
- border-gray-700 → border-border
- text-gray-400 → text-muted-foreground


---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
