### PR TITLE
✨ Token guidance banner for mission browser

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -99,7 +99,13 @@ func (h *MissionsHandler) BrowseConsoleKB(c *fiber.Ctx) error {
 	limitedBody := io.LimitReader(resp.Body, missionsMaxBodyBytes)
 	body, _ := io.ReadAll(limitedBody)
 	if resp.StatusCode != http.StatusOK {
-		return c.Status(resp.StatusCode).JSON(fiber.Map{"error": "GitHub API error", "status": resp.StatusCode})
+		code := "github_error"
+		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
+			code = "rate_limited"
+		} else if resp.StatusCode == http.StatusUnauthorized {
+			code = "token_invalid"
+		}
+		return c.Status(resp.StatusCode).JSON(fiber.Map{"error": "GitHub API error", "status": resp.StatusCode, "code": code})
 	}
 
 	// GitHub returns type:"dir", frontend expects type:"directory" — transform


### PR DESCRIPTION
When GitHub API returns 403 (rate limited) or 401 (invalid token), the mission browser now shows an amber guidance banner with:

- Clear explanation of what went wrong
- Direct link to create a GitHub PAT (pre-filled with public_repo scope)
- Copy-pasteable .env example: `GITHUB_TOKEN=ghp_your_token_here`
- Instructions to restart the console

**Backend:** Returns structured error codes (`rate_limited`, `token_invalid`) in browse API responses.
**Frontend:** Detects error codes and renders contextual guidance banner.