### PR TITLE
🐛 fix: auto-open setup dialog on mission agent connection error

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -21,6 +21,7 @@ import { AgentBadge, AgentIcon } from '../../agent/AgentIcon'
 import { ResolutionKnowledgePanel } from '../../missions/ResolutionKnowledgePanel'
 import { ResolutionHistoryPanel } from '../../missions/ResolutionHistoryPanel'
 import { SaveResolutionDialog } from '../../missions/SaveResolutionDialog'
+import { SetupInstructionsDialog } from '../../setup/SetupInstructionsDialog'
 import { STATUS_CONFIG, TYPE_ICONS } from './types'
 import type { FontSize } from './types'
 import { TypingIndicator } from './TypingIndicator'
@@ -44,6 +45,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
   const [showSaveDialog, setShowSaveDialog] = useState(false)
   const [appliedResolutionId, setAppliedResolutionId] = useState<string | null>(null)
   const [resolutionPanelView, setResolutionPanelView] = useState<'related' | 'history'>('related')
+  const [showSetupDialog, setShowSetupDialog] = useState(false)
 
   // Find related resolutions based on mission content
   const relatedResolutions = useMemo(() => {
@@ -149,6 +151,14 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
       inputRef.current?.focus()
     }
   }, [mission.status])
+
+  // Auto-open setup dialog when agent connection error occurs
+  useEffect(() => {
+    const lastMsg = mission.messages[mission.messages.length - 1]
+    if (lastMsg?.role === 'system' && lastMsg.content.includes('Local Agent Not Connected')) {
+      setShowSetupDialog(true)
+    }
+  }, [mission.messages])
 
   // Scroll to bottom when entering full screen mode
   useEffect(() => {
@@ -719,6 +729,12 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
       onSaved={() => {
         // Could show a toast notification here
       }}
+    />
+
+    {/* Setup Instructions Dialog - auto-opened on agent connection error */}
+    <SetupInstructionsDialog
+      isOpen={showSetupDialog}
+      onClose={() => setShowSetupDialog(false)}
     />
     </>
   )

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -340,15 +340,7 @@ export function MissionProvider({ children }: { children: ReactNode }) {
           if (pendingRequests.current.size > 0) {
             const errorContent = `**Local Agent Not Connected**
 
-The AI missions feature requires the local agent to be running.
-
-**To get started:**
-1. Install and run the console locally:
-   \`\`\`
-   curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start-dev.sh | bash
-   \`\`\`
-2. Open the console: http://localhost:5174
-3. [⚙️ Configure API Keys →](/settings) for Claude, OpenAI, or Gemini`
+Install the console locally with the KubeStellar Console agent to use AI missions.`
 
             const pendingMissionIds = new Set(pendingRequests.current.values())
             setMissions(prev => prev.map(m => {
@@ -734,15 +726,7 @@ The AI missions feature requires the local agent to be running.
     }).catch(() => {
       const errorContent = `**Local Agent Not Connected**
 
-The AI missions feature requires the local agent to be running.
-
-**To get started:**
-1. Install and run the console locally:
-   \`\`\`
-   curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start-dev.sh | bash
-   \`\`\`
-2. Open the console: http://localhost:5174
-3. [⚙️ Configure API Keys →](/settings) for Claude, OpenAI, or Gemini`
+Install the console locally with the KubeStellar Console agent to use AI missions.`
 
       setMissions(prev => prev.map(m =>
         m.id === missionId ? {


### PR DESCRIPTION
When a user tries to run an AI mission without the kc-agent connected, the error message now:

1. **Shows a concise message**: "Install the console locally with the KubeStellar Console agent to use AI missions"
2. **Auto-opens the Setup Instructions dialog** with full install instructions (curl command, kc-agent details, etc.)

Previously the error showed a truncated curl command and outdated API keys directions inline in the chat. Now it leverages the existing `SetupInstructionsDialog` which has complete, well-formatted instructions.

### Changes
- `useMissions.tsx`: Simplified both error message templates (disconnect + send failure)
- `MissionChat.tsx`: Added `SetupInstructionsDialog` import + auto-open effect when connection error system message appears

Fixes the issue where the curl command was cut off in the missions panel and directions referenced API keys instead of kc-agent.