### PR TITLE
✨ Add Installers & Solutions tabs to Mission Browser

### DIFF
--- a/web/src/components/missions/InstallerCard.tsx
+++ b/web/src/components/missions/InstallerCard.tsx
@@ -1,0 +1,116 @@
+/**
+ * InstallerCard — Rich card for CNCF installer missions.
+ * Shows category icon+gradient, maturity badge, difficulty, install methods, and import button.
+ */
+
+import { ExternalLink, Download } from 'lucide-react'
+import { cn } from '../../lib/cn'
+import {
+  CNCF_CATEGORY_GRADIENTS,
+  CNCF_CATEGORY_ICONS,
+  MATURITY_CONFIG,
+  DIFFICULTY_CONFIG,
+} from '../../lib/cncf-constants'
+import type { MissionExport } from '../../lib/missions/types'
+
+interface InstallerCardProps {
+  mission: MissionExport
+  onImport: () => void
+  onSelect: () => void
+}
+
+export function InstallerCard({ mission, onImport, onSelect }: InstallerCardProps) {
+  const category = mission.category ?? 'Orchestration'
+  const gradient = CNCF_CATEGORY_GRADIENTS[category] ?? ['#6366f1', '#8b5cf6']
+  const iconPath = CNCF_CATEGORY_ICONS[category] ?? CNCF_CATEGORY_ICONS['Orchestration']
+  const maturityTag = mission.tags?.find(t => ['graduated', 'incubating', 'sandbox'].includes(t))
+  const maturity = maturityTag ? MATURITY_CONFIG[maturityTag] : null
+  const difficulty = mission.difficulty ? DIFFICULTY_CONFIG[mission.difficulty] : null
+
+  return (
+    <div
+      className="flex flex-col rounded-lg border border-border bg-card hover:border-purple-500/30 transition-all cursor-pointer group overflow-hidden"
+      onClick={onSelect}
+    >
+      {/* Category gradient header with icon */}
+      <div
+        className="relative h-20 flex items-center justify-center"
+        style={{
+          background: `linear-gradient(135deg, ${gradient[0]}, ${gradient[1]})`,
+        }}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          className="w-10 h-10 text-white/80"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d={iconPath} />
+        </svg>
+        {/* Category label */}
+        <span className="absolute bottom-1.5 right-2 text-[10px] font-medium text-white/70 bg-black/20 px-1.5 py-0.5 rounded">
+          {category}
+        </span>
+      </div>
+
+      {/* Content */}
+      <div className="flex flex-col flex-1 p-3 gap-2">
+        <h4 className="text-sm font-medium text-foreground line-clamp-1 group-hover:text-purple-400 transition-colors">
+          {mission.title}
+        </h4>
+        <p className="text-xs text-muted-foreground line-clamp-2">{mission.description}</p>
+
+        {/* Badges row */}
+        <div className="flex flex-wrap gap-1 mt-auto">
+          {maturity && (
+            <span className={cn('inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full border', maturity.bg, maturity.color, maturity.border)}>
+              {maturity.label}
+            </span>
+          )}
+          {difficulty && (
+            <span className={cn('inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded-full', difficulty.bg, difficulty.color)}>
+              {mission.difficulty}
+            </span>
+          )}
+          {mission.installMethods?.map(method => (
+            <span key={method} className="px-1.5 py-0.5 text-[10px] rounded bg-secondary text-muted-foreground">
+              {method}
+            </span>
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center justify-between pt-2 border-t border-border">
+          <div className="flex items-center gap-1 text-muted-foreground">
+            {mission.cncfProject && (
+              <a
+                href={`https://www.cncf.io/projects/${mission.cncfProject}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={e => e.stopPropagation()}
+                className="inline-flex items-center gap-0.5 text-[10px] hover:text-purple-400 transition-colors"
+                title="View on CNCF"
+              >
+                <ExternalLink className="w-3 h-3" />
+                CNCF
+              </a>
+            )}
+          </div>
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onImport()
+            }}
+            className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+          >
+            <Download className="w-3 h-3" />
+            Install
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/missions/SolutionCard.tsx
+++ b/web/src/components/missions/SolutionCard.tsx
@@ -1,0 +1,74 @@
+/**
+ * SolutionCard — Card for browsing solution missions (troubleshoot, repair, analyze, etc.).
+ * Shows type badge, category, tags, description, and import button.
+ */
+
+import { cn } from '../../lib/cn'
+import type { MissionExport } from '../../lib/missions/types'
+
+const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
+  troubleshoot: { bg: 'bg-orange-500/15', color: 'text-orange-400' },
+  repair: { bg: 'bg-red-500/15', color: 'text-red-400' },
+  analyze: { bg: 'bg-blue-500/15', color: 'text-blue-400' },
+  upgrade: { bg: 'bg-green-500/15', color: 'text-green-400' },
+  deploy: { bg: 'bg-purple-500/15', color: 'text-purple-400' },
+  custom: { bg: 'bg-gray-500/15', color: 'text-gray-400' },
+}
+
+interface SolutionCardProps {
+  mission: MissionExport
+  onImport: () => void
+  onSelect: () => void
+}
+
+export function SolutionCard({ mission, onImport, onSelect }: SolutionCardProps) {
+  const typeStyle = TYPE_COLORS[mission.type] ?? TYPE_COLORS.custom
+
+  return (
+    <div
+      className="flex flex-col p-3 rounded-lg border border-border bg-card hover:border-purple-500/30 transition-colors cursor-pointer group"
+      onClick={onSelect}
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <h4 className="text-sm font-medium text-foreground line-clamp-1 group-hover:text-purple-400 transition-colors">
+          {mission.title}
+        </h4>
+        <span className={cn('flex-shrink-0 px-1.5 py-0.5 text-[10px] font-medium rounded-full', typeStyle.bg, typeStyle.color)}>
+          {mission.type}
+        </span>
+      </div>
+
+      <p className="text-xs text-muted-foreground line-clamp-2 mb-2">{mission.description}</p>
+
+      {/* Tags */}
+      <div className="flex flex-wrap gap-1 mb-2 mt-auto">
+        {mission.category && (
+          <span className="px-1.5 py-0.5 text-[10px] rounded bg-purple-500/10 text-purple-400 border border-purple-500/20">
+            {mission.category}
+          </span>
+        )}
+        {mission.tags?.slice(0, 3).map(tag => (
+          <span key={tag} className="px-1.5 py-0.5 text-[10px] rounded bg-secondary text-muted-foreground">
+            {tag}
+          </span>
+        ))}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between pt-2 border-t border-border">
+        <span className="text-[10px] text-muted-foreground">
+          {mission.steps?.length ?? 0} steps
+        </span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            onImport()
+          }}
+          className="px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+        >
+          Import
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/lib/cncf-constants.ts
+++ b/web/src/lib/cncf-constants.ts
@@ -1,0 +1,41 @@
+/** Shared CNCF styling constants used across Marketplace and Mission Browser */
+
+export const CNCF_CATEGORY_GRADIENTS: Record<string, [string, string]> = {
+  'Observability': ['#3b82f6', '#06b6d4'],
+  'Orchestration': ['#10b981', '#14b8a6'],
+  'Runtime': ['#f59e0b', '#f97316'],
+  'Provisioning': ['#ec4899', '#f43f5e'],
+  'Security': ['#ef4444', '#dc2626'],
+  'Service Mesh': ['#06b6d4', '#0ea5e9'],
+  'App Definition': ['#8b5cf6', '#6366f1'],
+  'Serverless': ['#a855f7', '#7c3aed'],
+  'Storage': ['#84cc16', '#22c55e'],
+  'Streaming': ['#f97316', '#eab308'],
+  'Networking': ['#0ea5e9', '#3b82f6'],
+}
+
+export const CNCF_CATEGORY_ICONS: Record<string, string> = {
+  'Observability': 'M22 12h-4l-3 9L9 3l-3 9H2',
+  'Orchestration': 'M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5',
+  'Runtime': 'M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10zM12 6v6l4 2',
+  'Provisioning': 'M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z',
+  'Security': 'M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z',
+  'Service Mesh': 'M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5',
+  'App Definition': 'M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2zM2 8h20M8 2v4',
+  'Serverless': 'M13 2L3 14h9l-1 8 10-12h-9l1-8',
+  'Storage': 'M21 5c0 1.1-4 2-9 2S3 6.1 3 5m18 0c0-1.1-4-2-9-2S3 3.9 3 5m18 0v14c0 1.1-4 2-9 2s-9-.9-9-2V5m18 7c0 1.1-4 2-9 2s-9-.9-9-2',
+  'Streaming': 'M22 12h-4l-3 9L9 3l-3 9H2',
+  'Networking': 'M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zM2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z',
+}
+
+export const MATURITY_CONFIG: Record<string, { color: string; bg: string; border: string; label: string }> = {
+  graduated: { color: 'text-emerald-400', bg: 'bg-emerald-500/15', border: 'border-emerald-500/30', label: 'Graduated' },
+  incubating: { color: 'text-blue-400', bg: 'bg-blue-500/15', border: 'border-blue-500/30', label: 'Incubating' },
+  sandbox: { color: 'text-amber-400', bg: 'bg-amber-500/15', border: 'border-amber-500/30', label: 'Sandbox' },
+}
+
+export const DIFFICULTY_CONFIG: Record<string, { color: string; bg: string }> = {
+  beginner: { color: 'text-green-400', bg: 'bg-green-500/10' },
+  intermediate: { color: 'text-yellow-400', bg: 'bg-yellow-500/10' },
+  advanced: { color: 'text-red-400', bg: 'bg-red-500/10' },
+}

--- a/web/src/lib/missions/types.ts
+++ b/web/src/lib/missions/types.ts
@@ -18,6 +18,8 @@ export interface MissionStep {
   validation?: string
 }
 
+export type MissionClass = 'solution' | 'install'
+
 export interface MissionExport {
   version: string
   title: string
@@ -26,6 +28,9 @@ export interface MissionExport {
   tags: string[]
   category?: string
   cncfProject?: string
+  missionClass?: MissionClass
+  difficulty?: string
+  installMethods?: string[]
   prerequisites?: string[]
   steps: MissionStep[]
   resolution?: {


### PR DESCRIPTION
## Summary

Adds a tabbed navigation to the AI Mission Browser with three tabs:

### 🔍 Recommended (existing)
AI-matched solutions based on cluster state — no changes to existing behavior.

### 📦 Installers (new)
Browse CNCF installer missions as rich cards with:
- Category icon + gradient header (reuses existing CNCF styling)
- Maturity badges (Graduated/Incubating/Sandbox)
- Difficulty levels and install methods
- Filter by CNCF category, maturity level, and search
- Links to CNCF project pages
- One-click import

### 🛠️ Solutions (new)
Browse all non-installer solution missions with:
- Type badges (troubleshoot/repair/analyze/etc.)
- Category and tag display
- Filter by type and search
- One-click import

## Changes

- **MissionBrowser.tsx** — Add tab bar, tab state, installer/solution fetch effects, filtered lists, tab content panels
- **InstallerCard.tsx** — New component: rich card with CNCF category gradient header, maturity/difficulty badges
- **SolutionCard.tsx** — New component: card with type badge, category, tags
- **cncf-constants.ts** — Shared CNCF styling constants (category gradients, icons, maturity config)
- **types.ts** — Add `missionClass`, `difficulty`, `installMethods` to MissionExport

## Design Decisions
- Lazy-loads installer/solution data only when tab is first activated (no extra API calls on default view)
- Category icon + gradient instead of individual project logos (simpler, scales to 217 projects)
- Selecting a card switches to Recommended tab to show the full mission preview
- Shared CNCF constants extracted for reuse across Marketplace and Mission Browser

Closes #N/A — implements CNCF Installer & Solution Mission Browser feature