### PR TITLE
🐛 Fix installer fetch cancellation bug + add author info to cards

### DIFF
--- a/web/src/components/missions/InstallerCard.tsx
+++ b/web/src/components/missions/InstallerCard.tsx
@@ -82,9 +82,26 @@ export function InstallerCard({ mission, onImport, onSelect }: InstallerCardProp
           ))}
         </div>
 
-        {/* Actions */}
+        {/* Author + Actions */}
         <div className="flex items-center justify-between pt-2 border-t border-border">
-          <div className="flex items-center gap-1 text-muted-foreground">
+          <div className="flex items-center gap-2 text-muted-foreground min-w-0">
+            {mission.authorGithub && (
+              <a
+                href={`https://github.com/${mission.authorGithub}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={e => e.stopPropagation()}
+                className="inline-flex items-center gap-1 text-[10px] hover:text-purple-400 transition-colors group/author"
+                title={mission.author ?? mission.authorGithub}
+              >
+                <img
+                  src={`https://github.com/${mission.authorGithub}.png?size=32`}
+                  alt={mission.authorGithub}
+                  className="w-4 h-4 rounded-full"
+                />
+                <span className="truncate max-w-[80px]">{mission.authorGithub}</span>
+              </a>
+            )}
             {mission.cncfProject && (
               <a
                 href={`https://www.cncf.io/projects/${mission.cncfProject}`}
@@ -104,7 +121,7 @@ export function InstallerCard({ mission, onImport, onSelect }: InstallerCardProp
               e.stopPropagation()
               onImport()
             }}
-            className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+            className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors flex-shrink-0"
           >
             <Download className="w-3 h-3" />
             Install

--- a/web/src/components/missions/SolutionCard.tsx
+++ b/web/src/components/missions/SolutionCard.tsx
@@ -56,15 +56,33 @@ export function SolutionCard({ mission, onImport, onSelect }: SolutionCardProps)
 
       {/* Footer */}
       <div className="flex items-center justify-between pt-2 border-t border-border">
-        <span className="text-[10px] text-muted-foreground">
-          {mission.steps?.length ?? 0} steps
-        </span>
+        <div className="flex items-center gap-2 text-muted-foreground min-w-0">
+          {mission.authorGithub ? (
+            <a
+              href={`https://github.com/${mission.authorGithub}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={e => e.stopPropagation()}
+              className="inline-flex items-center gap-1 text-[10px] hover:text-purple-400 transition-colors"
+              title={mission.author ?? mission.authorGithub}
+            >
+              <img
+                src={`https://github.com/${mission.authorGithub}.png?size=32`}
+                alt={mission.authorGithub}
+                className="w-4 h-4 rounded-full"
+              />
+              <span className="truncate max-w-[80px]">{mission.authorGithub}</span>
+            </a>
+          ) : (
+            <span className="text-[10px]">{mission.steps?.length ?? 0} steps</span>
+          )}
+        </div>
         <button
           onClick={(e) => {
             e.stopPropagation()
             onImport()
           }}
-          className="px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+          className="px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors flex-shrink-0"
         >
           Import
         </button>

--- a/web/src/lib/missions/types.ts
+++ b/web/src/lib/missions/types.ts
@@ -31,6 +31,8 @@ export interface MissionExport {
   missionClass?: MissionClass
   difficulty?: string
   installMethods?: string[]
+  author?: string
+  authorGithub?: string
   prerequisites?: string[]
   steps: MissionStep[]
   resolution?: {


### PR DESCRIPTION
## Fixes

### Fetch cancellation bug (only 1 installer loaded)
The `useEffect` for fetching installers had `installerMissions.length` in its dependency array. When the first mission loaded and `setInstallerMissions` was called, the length changed from 0→1, triggering the effect cleanup which set `cancelled = true`, killing the in-flight loop. The new effect saw `length > 0` and bailed immediately.

**Fix:** Use a `useRef` to track whether fetch has been initiated, and remove state length from the dep array. Same fix applied to the Solutions fetch.

### Author info on cards
Both InstallerCard and SolutionCard now show:
- GitHub avatar (32px, from github.com/user.png)  
- Username as a link to their GitHub profile
- Appears in the card footer next to the action button