### PR TITLE
🐛 Fix GA4 geolocation for localhost installs

### DIFF
--- a/pkg/api/handlers/analytics_proxy.go
+++ b/pkg/api/handlers/analytics_proxy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -90,7 +91,11 @@ func GA4CollectProxy(c *fiber.Ctx) error {
 		if realMeasurementID != "" && params.Get("tid") != "" {
 			params.Set("tid", realMeasurementID)
 		}
-		if clientIP != "" {
+		// Only set _uip when we have a routable (public) IP.
+		// For localhost deployments the proxy's outbound IP IS the
+		// user's real public IP, so omitting _uip lets GA4 geolocate
+		// from the connection source — which is correct.
+		if clientIP != "" && !isPrivateIP(clientIP) {
 			params.Set("_uip", clientIP)
 		}
 		qs = params.Encode()
@@ -103,7 +108,7 @@ func GA4CollectProxy(c *fiber.Ctx) error {
 	}
 	req.Header.Set("Content-Type", c.Get("Content-Type", "text/plain"))
 	req.Header.Set("User-Agent", c.Get("User-Agent"))
-	if clientIP != "" {
+	if clientIP != "" && !isPrivateIP(clientIP) {
 		req.Header.Set("X-Forwarded-For", clientIP)
 	}
 
@@ -152,4 +157,17 @@ func stripPort(host string) string {
 		return host[:i]
 	}
 	return host
+}
+
+// isPrivateIP returns true for loopback, link-local, and RFC-1918 addresses.
+// When the proxy runs on the user's own machine (localhost install), c.IP()
+// returns 127.0.0.1 — sending that as _uip tells GA4 the user is at a
+// non-routable address, killing geolocation.  By detecting private IPs we
+// can skip the _uip override and let GA4 use the connection's source IP.
+func isPrivateIP(ip string) bool {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	return parsed.IsLoopback() || parsed.IsPrivate() || parsed.IsLinkLocalUnicast()
 }


### PR DESCRIPTION
## Problem
The analytics proxy was setting `_uip=127.0.0.1` for all localhost users, which overrides GA4's natural IP geolocation. Since GA4 cannot geolocate loopback/RFC-1918 addresses, the map widget showed no location dots for any localhost install.

## Root Cause
`c.IP()` returns `127.0.0.1` for localhost requests. The proxy unconditionally forwarded this as `_uip` and `X-Forwarded-For` to GA4, telling it "this user's IP is 127.0.0.1" — a non-routable address with no geolocation data.

## Fix
Added `isPrivateIP()` check using Go's `net.IP` methods (`IsLoopback`, `IsPrivate`, `IsLinkLocalUnicast`). When the client IP is private, the proxy skips the `_uip` and `X-Forwarded-For` overrides. For localhost deployments, the proxy's outbound TCP connection already comes from the user's real public IP, so GA4 geolocates correctly without any override.

Production deployments behind load balancers are unaffected — `X-Forwarded-For` contains the real public IP which passes the private IP check.

## Testing
- `go build ./...` passes
- Localhost: no `_uip` sent → GA4 uses connection source IP → correct geolocation
- Production: public IP from `X-Forwarded-For` → still forwarded as before