### PR TITLE
✨ Mission deep-link URLs for CNCF outreach

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useState, useEffect } from 'react'
-import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom'
+import { Routes, Route, Navigate, useNavigate, useLocation, useParams } from 'react-router-dom'
 import { CardHistoryEntry } from './hooks/useCardHistory'
 import { Layout } from './components/layout/Layout'
 import { DrillDownModal } from './components/drilldown/DrillDownModal'
@@ -232,6 +232,12 @@ function SettingsSyncInit() {
   return null
 }
 
+/** Redirect /missions/:missionId → /?mission=:missionId to open MissionBrowser via deep-link */
+function MissionDeepLink() {
+  const { missionId } = useParams()
+  return <Navigate to={`/?mission=${encodeURIComponent(missionId || '')}`} replace />
+}
+
 // Route-to-title map for GA4 page view granularity and browser tab labeling
 const ROUTE_TITLES: Record<string, string> = {
   '/': 'Dashboard',
@@ -266,6 +272,7 @@ const ROUTE_TITLES: Record<string, string> = {
   '/llm-d-benchmarks': 'llm-d Benchmarks',
   '/arcade': 'Arcade',
   '/marketplace': 'Marketplace',
+  '/missions': 'Missions',
   '/history': 'Card History',
   '/settings': 'Settings',
   '/users': 'User Management',
@@ -388,6 +395,9 @@ function App() {
           <Route path="/test/unified-stats" element={<UnifiedStatsTest />} />
           <Route path="/test/unified-dashboard" element={<UnifiedDashboardTest />} />
         </Route>
+
+        {/* Mission deep-link: /missions/install-prometheus → opens MissionBrowser */}
+        <Route path="/missions/:missionId" element={<MissionDeepLink />} />
 
         <Route path="*" element={<Navigate to={ROUTES.HOME} replace />} />
       </Routes>

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -15,6 +15,7 @@ import {
   Send,
   Globe,
 } from 'lucide-react'
+import { useSearchParams } from 'react-router-dom'
 import { useMissions } from '../../../hooks/useMissions'
 import { useMobile } from '../../../hooks/useMobile'
 import { cn } from '../../../lib/cn'
@@ -37,6 +38,20 @@ export function MissionSidebar() {
   const [showBrowser, setShowBrowser] = useState(false)
   const [newMissionPrompt, setNewMissionPrompt] = useState('')
   const newMissionInputRef = useRef<HTMLTextAreaElement>(null)
+
+  // Deep-link: open MissionBrowser to specific mission via ?mission= URL param
+  const [searchParams, setSearchParams] = useSearchParams()
+  const deepLinkMission = searchParams.get('mission')
+
+  useEffect(() => {
+    if (deepLinkMission) {
+      setShowBrowser(true)
+      // Clear the param from URL after opening
+      const newParams = new URLSearchParams(searchParams)
+      newParams.delete('mission')
+      setSearchParams(newParams, { replace: true })
+    }
+  }, [deepLinkMission, searchParams, setSearchParams])
 
   const handleImportMission = useCallback((mission: MissionExport) => {
     startMission({
@@ -384,6 +399,7 @@ export function MissionSidebar() {
         isOpen={showBrowser}
         onClose={() => setShowBrowser(false)}
         onImport={handleImportMission}
+        initialMission={deepLinkMission || undefined}
       />
     </>
   )

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -65,6 +65,8 @@ interface MissionBrowserProps {
   isOpen: boolean
   onClose: () => void
   onImport: (mission: MissionExport) => void
+  /** Deep-link: auto-select a specific mission by name (e.g. 'install-prometheus') */
+  initialMission?: string
 }
 
 interface TreeNode {
@@ -138,7 +140,7 @@ function saveWatchedPaths(paths: string[]) {
 // Component
 // ============================================================================
 
-export function MissionBrowser({ isOpen, onClose, onImport }: MissionBrowserProps) {
+export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: MissionBrowserProps) {
   useTranslation(['common', 'cards'])
   const { user, isAuthenticated } = useAuth()
 
@@ -441,6 +443,27 @@ export function MissionBrowser({ isOpen, onClose, onImport }: MissionBrowserProp
     fetchInstallers()
     return () => { cancelled = true }
   }, [isOpen, activeTab])
+
+  // ============================================================================
+  // Deep-link: auto-select mission by name when initialMission is set
+  // ============================================================================
+
+  useEffect(() => {
+    if (!initialMission || !isOpen || selectedMission) return
+    const match = installerMissions.find(
+      (m) => m.title.toLowerCase().includes(initialMission.toLowerCase()) ||
+             (m.cncfProject && m.cncfProject.toLowerCase() === initialMission.replace('install-', '').toLowerCase())
+    )
+    if (match) {
+      setSelectedMission(match)
+      setActiveTab('installers')
+      api.get<string>(`/api/missions/browse?path=solutions/cncf-install/install-${(match.cncfProject || '').toLowerCase().replace(/[^a-z0-9]+/g, '-')}.json&raw=true`)
+        .then(({ data }) => setRawContent(typeof data === 'string' ? data : JSON.stringify(data, null, 2)))
+        .catch(() => {})
+    } else if (installerMissions.length === 0 && activeTab !== 'installers') {
+      setActiveTab('installers')
+    }
+  }, [initialMission, isOpen, installerMissions, selectedMission, activeTab])
 
   // ============================================================================
   // Fetch solution missions (non-installer solutions)

--- a/web/src/config/routes.ts
+++ b/web/src/config/routes.ts
@@ -63,6 +63,9 @@ export const ROUTES = {
   // Marketplace
   MARKETPLACE: '/marketplace',
 
+  // Mission deep-link (opens MissionBrowser to specific mission)
+  MISSION: '/missions/:missionId',
+
   // Widget
   WIDGET: '/widget',
 } as const
@@ -86,4 +89,11 @@ export function getLoginWithError(error: string): string {
  */
 export function getSettingsWithHash(hash: string): string {
   return `${ROUTES.SETTINGS}#${hash}`
+}
+
+/**
+ * Helper function to create a mission deep-link URL
+ */
+export function getMissionRoute(missionId: string): string {
+  return ROUTES.MISSION.replace(':missionId', encodeURIComponent(missionId))
 }


### PR DESCRIPTION
## Summary

Adds deep-link URL support so CNCF maintainers can be directed to specific missions.

### How It Works
- **URL format**: `/missions/install-prometheus` → opens MissionBrowser to the Prometheus install mission
- Internally redirects to `/?mission=install-prometheus`, which MissionSidebar reads and passes to MissionBrowser
- URL param is cleared after opening to keep the URL clean

### Files Changed
- **App.tsx** — Added `MissionDeepLink` redirect component + `/missions/:missionId` route
- **routes.ts** — Added `MISSION` route constant + `getMissionRoute()` helper
- **MissionSidebar.tsx** — Reads `?mission=` search param, auto-opens MissionBrowser with `initialMission`
- **MissionBrowser.tsx** — New `initialMission` prop auto-selects matching mission on load

### Usage for CNCF Outreach
Share links like: `https://console.kubestellar.io/missions/install-prometheus`
This opens the console directly to the Prometheus mission with the "Improve this AI Mission" button visible.

### Build
- ✅ `npm run build` passes
- ✅ `npm run lint` — 0 new errors