### PR TITLE
🐛 Fix mission explorer not populating installers/solutions without auth

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -12,6 +12,9 @@ const DEFAULT_TIMEOUT = MCP_HOOK_TIMEOUT_MS
 const BACKEND_CHECK_INTERVAL = 10000 // 10 seconds between backend checks when unavailable
 const TOKEN_REFRESH_HEADER = 'X-Token-Refresh' // server signals when token should be refreshed
 
+// Public API paths that don't require authentication (served without JWT on the backend)
+const PUBLIC_API_PREFIXES = ['/api/missions/browse', '/api/missions/file']
+
 // Error class for unauthenticated requests
 export class UnauthenticatedError extends Error {
   constructor() {
@@ -316,7 +319,8 @@ class ApiClient {
 
   async get<T = any>(path: string, options?: { headers?: Record<string, string>; timeout?: number; requiresAuth?: boolean }): Promise<{ data: T }> {
     // Skip API calls to protected endpoints when not authenticated
-    if (options?.requiresAuth !== false && !this.hasToken()) {
+    const isPublicPath = PUBLIC_API_PREFIXES.some(prefix => path.startsWith(prefix))
+    if (options?.requiresAuth !== false && !isPublicPath && !this.hasToken()) {
       throw new UnauthenticatedError()
     }
 


### PR DESCRIPTION
## Problem
The Mission Explorer's Installers and Solutions tabs were empty when the user hadn't logged in yet (or was in demo mode).

## Root Cause
The frontend API client (`api.get()`) throws `UnauthenticatedError` before making any request when no valid JWT token is present. The mission browse/file endpoints are **public** on the backend (registered outside the JWT middleware group), but the client-side `hasToken()` check was rejecting them before they could reach the server.

## Fix
Added a `PUBLIC_API_PREFIXES` list in `api.ts` that auto-detects public paths (`/api/missions/browse`, `/api/missions/file`) and skips the auth requirement for them. This is a 2-line change in the auth guard logic.