### PR TITLE
✨ Add section coverage icons to installer cards + fix resume loading

### DIFF
--- a/web/src/components/missions/InstallerCard.tsx
+++ b/web/src/components/missions/InstallerCard.tsx
@@ -3,7 +3,7 @@
  * Shows category icon+gradient, maturity badge, difficulty, install methods, and import button.
  */
 
-import { ExternalLink, Download, Wrench } from 'lucide-react'
+import { ExternalLink, Download, Wrench, Trash2, ArrowUpCircle, AlertTriangle } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import {
   CNCF_CATEGORY_GRADIENTS,
@@ -85,6 +85,22 @@ export function InstallerCard({ mission, onImport, onSelect }: InstallerCardProp
               {method}
             </span>
           ))}
+        </div>
+
+        {/* Section coverage icons */}
+        <div className="flex items-center gap-1.5">
+          <span className={cn('inline-flex items-center gap-0.5 text-[10px]', mission.steps?.length ? 'text-green-400' : 'text-muted-foreground/30')} title={mission.steps?.length ? `Install: ${mission.steps.length} steps` : 'No install steps'}>
+            <Download className="w-3 h-3" />
+          </span>
+          <span className={cn('inline-flex items-center gap-0.5 text-[10px]', mission.uninstall?.length ? 'text-red-400' : 'text-muted-foreground/30')} title={mission.uninstall?.length ? `Uninstall: ${mission.uninstall.length} steps` : 'No uninstall steps'}>
+            <Trash2 className="w-3 h-3" />
+          </span>
+          <span className={cn('inline-flex items-center gap-0.5 text-[10px]', mission.upgrade?.length ? 'text-blue-400' : 'text-muted-foreground/30')} title={mission.upgrade?.length ? `Upgrade: ${mission.upgrade.length} steps` : 'No upgrade steps'}>
+            <ArrowUpCircle className="w-3 h-3" />
+          </span>
+          <span className={cn('inline-flex items-center gap-0.5 text-[10px]', mission.troubleshooting?.length ? 'text-yellow-400' : 'text-muted-foreground/30')} title={mission.troubleshooting?.length ? `Troubleshooting: ${mission.troubleshooting.length} steps` : 'No troubleshooting steps'}>
+            <AlertTriangle className="w-3 h-3" />
+          </span>
         </div>
 
         {/* Author + Actions */}

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -409,7 +409,6 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
 
   useEffect(() => {
     if (!isOpen || activeTab !== 'installers' || installersFetched.current) return
-    installersFetched.current = true
     let cancelled = false
 
     async function fetchInstallers() {
@@ -435,7 +434,10 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
             }
           } catch { /* skip */ }
         }
-        if (!cancelled) setInstallerMissions(missions)
+        if (!cancelled) {
+          setInstallerMissions(missions)
+          installersFetched.current = true
+        }
       } catch { /* skip */ }
       finally { if (!cancelled) setLoadingInstallers(false) }
     }
@@ -471,7 +473,6 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
 
   useEffect(() => {
     if (!isOpen || activeTab !== 'solutions' || solutionsFetched.current) return
-    solutionsFetched.current = true
     let cancelled = false
 
     async function fetchSolutions() {
@@ -506,7 +507,10 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
             }
           } catch { /* skip */ }
         }
-        if (!cancelled) setSolutionMissions(missions)
+        if (!cancelled) {
+          setSolutionMissions(missions)
+          solutionsFetched.current = true
+        }
       } catch { /* skip */ }
       finally { if (!cancelled) setLoadingSolutions(false) }
     }


### PR DESCRIPTION
## Changes

### Section coverage icons on InstallerCard
Each card now shows 4 small icons indicating which sections have steps:
- ⬇️ Install (green when present)
- 🗑 Uninstall (red when present)  
- ⬆️ Upgrade (blue when present)
- ⚠️ Troubleshooting (yellow when present)

Dimmed icons = section not available. Hover for tooltip with step count. Makes it easy to see at a glance which missions are most complete.

### Fix: loading stops and won't resume
When clicking a tile mid-load, the fetch loop cancelled but `installersFetched.current` was already `true`, preventing re-fetch on return. Now only marks fetched after successful completion. Same fix applied to Solutions tab.