### PR TITLE
🐛 Fix tab badge shifting as installer count increases

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -1054,11 +1054,11 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
           >
             <span>{tab.icon}</span>
             {tab.label}
-            {tab.id === 'installers' && installerMissions.length > 0 && (
-              <span className="text-[10px] bg-secondary px-1.5 py-0.5 rounded-full">{installerMissions.length}</span>
+            {tab.id === 'installers' && (
+              <span className="text-[10px] bg-secondary px-1.5 py-0.5 rounded-full min-w-[28px] text-center tabular-nums">{installerMissions.length || '–'}</span>
             )}
-            {tab.id === 'solutions' && solutionMissions.length > 0 && (
-              <span className="text-[10px] bg-secondary px-1.5 py-0.5 rounded-full">{solutionMissions.length}</span>
+            {tab.id === 'solutions' && (
+              <span className="text-[10px] bg-secondary px-1.5 py-0.5 rounded-full min-w-[28px] text-center tabular-nums">{solutionMissions.length || '–'}</span>
             )}
           </button>
         ))}


### PR DESCRIPTION
Fixes the layout shift in the Mission Explorer tab bar as installer/solution counts increment during loading.

**Changes:**
- Added `min-w-[28px]`, `text-center`, and `tabular-nums` to count badges for stable width
- Show badge with '–' placeholder when count is 0 to reserve space during loading
- Prevents tabs from jumping left/right as counts go from 0→50→100→164