### PR TITLE
✨ Fix Mission Explorer search, view mode, cache persistence, and refresh

### DIFF
--- a/web/src/components/missions/InstallerCard.tsx
+++ b/web/src/components/missions/InstallerCard.tsx
@@ -17,9 +17,10 @@ interface InstallerCardProps {
   mission: MissionExport
   onImport: () => void
   onSelect: () => void
+  compact?: boolean
 }
 
-export function InstallerCard({ mission, onImport, onSelect }: InstallerCardProps) {
+export function InstallerCard({ mission, onImport, onSelect, compact }: InstallerCardProps) {
   const category = mission.category ?? 'Orchestration'
   const gradient = CNCF_CATEGORY_GRADIENTS[category] ?? ['#6366f1', '#8b5cf6']
   const iconPath = CNCF_CATEGORY_ICONS[category] ?? CNCF_CATEGORY_ICONS['Orchestration']
@@ -30,6 +31,46 @@ export function InstallerCard({ mission, onImport, onSelect }: InstallerCardProp
   const shortTitle = (mission.title ?? '')
     .replace(/^Install and Configure\s+/i, '')
     .replace(/\s+on Kubernetes$/i, '')
+
+  if (compact) {
+    return (
+      <div
+        className="flex items-center gap-3 px-3 py-2 rounded-lg border border-border bg-card hover:border-purple-500/30 transition-all cursor-pointer group"
+        onClick={onSelect}
+      >
+        <div
+          className="w-8 h-8 rounded flex items-center justify-center flex-shrink-0"
+          style={{ background: `linear-gradient(135deg, ${gradient[0]}, ${gradient[1]})` }}
+        >
+          <svg viewBox="0 0 24 24" className="w-4 h-4 text-white/80" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round">
+            <path d={iconPath} />
+          </svg>
+        </div>
+        <div className="flex-1 min-w-0">
+          <h4 className="text-sm font-medium text-foreground truncate group-hover:text-purple-400 transition-colors">
+            {shortTitle || mission.title}
+          </h4>
+        </div>
+        <div className="flex items-center gap-1">
+          <span className={cn('text-[10px]', mission.steps?.length ? 'text-green-400' : 'text-muted-foreground/30')} title="Install"><Download className="w-3 h-3" /></span>
+          <span className={cn('text-[10px]', mission.uninstall?.length ? 'text-red-400' : 'text-muted-foreground/30')} title="Uninstall"><Trash2 className="w-3 h-3" /></span>
+          <span className={cn('text-[10px]', mission.upgrade?.length ? 'text-blue-400' : 'text-muted-foreground/30')} title="Upgrade"><ArrowUpCircle className="w-3 h-3" /></span>
+          <span className={cn('text-[10px]', mission.troubleshooting?.length ? 'text-yellow-400' : 'text-muted-foreground/30')} title="Troubleshoot"><AlertTriangle className="w-3 h-3" /></span>
+        </div>
+        {maturity && (
+          <span className={cn('px-1.5 py-0.5 text-[10px] font-medium rounded-full border flex-shrink-0', maturity.bg, maturity.color, maturity.border)}>
+            {maturity.label}
+          </span>
+        )}
+        <button
+          onClick={(e) => { e.stopPropagation(); onImport() }}
+          className="px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors flex-shrink-0"
+        >
+          <Download className="w-3 h-3" />
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -28,6 +28,7 @@ import {
   Plus,
   Trash2,
   ExternalLink,
+  RefreshCw,
 } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { api } from '../../lib/api'
@@ -253,6 +254,21 @@ function startMissionCacheFetch() {
   fetchSolutionsToCache()
 }
 
+function resetMissionCache() {
+  missionCache.installers = []
+  missionCache.solutions = []
+  missionCache.installersDone = false
+  missionCache.solutionsDone = false
+  missionCache.installersFetching = false
+  missionCache.solutionsFetching = false
+  if (missionCache.abortController) {
+    missionCache.abortController.abort()
+    missionCache.abortController = null
+  }
+  notifyCacheListeners()
+  startMissionCacheFetch()
+}
+
 // ============================================================================
 // Component
 // ============================================================================
@@ -386,15 +402,12 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
     setSelectedPath(null)
     setSelectedMission(null)
     setDirectoryEntries([])
-    setSearchQuery('')
-    setCategoryFilter('All')
-    setCncfFilter('')
     setShowRaw(false)
     setRawContent(null)
     setScanResult(null)
     setPendingImport(null)
     setIsScanning(false)
-    setActiveTab('recommended')
+    // Preserve activeTab, searchQuery, and filter state across re-opens
   }, [isOpen, isAuthenticated, user, watchedRepos, watchedPaths])
 
   // ============================================================================
@@ -565,6 +578,22 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   // Filtered installer & solution lists
   // ============================================================================
 
+  // Effective search: local tab search overrides global search
+  const effectiveInstallerSearch = installerSearch || searchQuery
+  const effectiveSolutionSearch = solutionSearch || searchQuery
+
+  // AND search: each space-separated term must match somewhere in the mission
+  const andMatch = (text: string, query: string) => {
+    const terms = query.toLowerCase().split(/\s+/).filter(Boolean)
+    const lower = text.toLowerCase()
+    return terms.every(term => lower.includes(term))
+  }
+
+  const matchesMission = (m: MissionExport, query: string) => {
+    const haystack = [m.title, m.description, ...(m.tags || [])].join(' ')
+    return andMatch(haystack, query)
+  }
+
   const filteredInstallers = useMemo(() => {
     let list = installerMissions
     if (installerCategoryFilter !== 'All') {
@@ -573,32 +602,22 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
     if (installerMaturityFilter !== 'All') {
       list = list.filter(m => m.tags?.includes(installerMaturityFilter))
     }
-    if (installerSearch) {
-      const q = installerSearch.toLowerCase()
-      list = list.filter(m =>
-        m.title.toLowerCase().includes(q) ||
-        m.description.toLowerCase().includes(q) ||
-        m.tags?.some(t => t.toLowerCase().includes(q))
-      )
+    if (effectiveInstallerSearch) {
+      list = list.filter(m => matchesMission(m, effectiveInstallerSearch))
     }
     return list
-  }, [installerMissions, installerCategoryFilter, installerMaturityFilter, installerSearch])
+  }, [installerMissions, installerCategoryFilter, installerMaturityFilter, effectiveInstallerSearch])
 
   const filteredSolutions = useMemo(() => {
     let list = solutionMissions
     if (solutionTypeFilter !== 'All') {
       list = list.filter(m => m.type === solutionTypeFilter.toLowerCase())
     }
-    if (solutionSearch) {
-      const q = solutionSearch.toLowerCase()
-      list = list.filter(m =>
-        m.title.toLowerCase().includes(q) ||
-        m.description.toLowerCase().includes(q) ||
-        m.tags?.some(t => t.toLowerCase().includes(q))
-      )
+    if (effectiveSolutionSearch) {
+      list = list.filter(m => matchesMission(m, effectiveSolutionSearch))
     }
     return list
-  }, [solutionMissions, solutionTypeFilter, solutionSearch])
+  }, [solutionMissions, solutionTypeFilter, effectiveSolutionSearch])
 
   // ============================================================================
   // Tree expansion & lazy loading
@@ -958,7 +977,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search missions by name, tag, or description…"
+            placeholder={activeTab === 'installers' ? 'Search installers… (AND logic: "argo events" = argo AND events)' : activeTab === 'solutions' ? 'Search solutions…' : 'Search missions by name, tag, or description…'}
             className="w-full pl-10 pr-4 py-2 bg-secondary border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/40"
             autoFocus
           />
@@ -1062,6 +1081,13 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
             )}
           </button>
         ))}
+        <button
+          onClick={() => resetMissionCache()}
+          className="ml-auto inline-flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary rounded transition-colors"
+          title="Refresh all mission data"
+        >
+          <RefreshCw className={cn('w-3.5 h-3.5', (!missionCache.installersDone || !missionCache.solutionsDone) && 'animate-spin')} />
+        </button>
       </div>
 
       {/* ================================================================== */}
@@ -1532,11 +1558,15 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                         Loading… {installerMissions.length} found so far
                       </div>
                     )}
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+                    <div className={viewMode === 'grid'
+                      ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3"
+                      : "flex flex-col gap-2"
+                    }>
                       {filteredInstallers.map((mission, i) => (
                         <InstallerCard
                           key={i}
                           mission={mission}
+                          compact={viewMode === 'list'}
                           onSelect={() => {
                             setSelectedMission(mission)
                             setRawContent(JSON.stringify(mission, null, 2))
@@ -1602,11 +1632,15 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                         Loading… {solutionMissions.length} found so far
                       </div>
                     )}
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                    <div className={viewMode === 'grid'
+                      ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3"
+                      : "flex flex-col gap-2"
+                    }>
                       {filteredSolutions.map((mission, i) => (
                         <SolutionCard
                           key={i}
                           mission={mission}
+                          compact={viewMode === 'list'}
                           onSelect={() => {
                             setSelectedMission(mission)
                             setRawContent(JSON.stringify(mission, null, 2))

--- a/web/src/components/missions/SolutionCard.tsx
+++ b/web/src/components/missions/SolutionCard.tsx
@@ -19,10 +19,39 @@ interface SolutionCardProps {
   mission: MissionExport
   onImport: () => void
   onSelect: () => void
+  compact?: boolean
 }
 
-export function SolutionCard({ mission, onImport, onSelect }: SolutionCardProps) {
+export function SolutionCard({ mission, onImport, onSelect, compact }: SolutionCardProps) {
   const typeStyle = TYPE_COLORS[mission.type] ?? TYPE_COLORS.custom
+
+  if (compact) {
+    return (
+      <div
+        className="flex items-center gap-3 px-3 py-2 rounded-lg border border-border bg-card hover:border-purple-500/30 transition-all cursor-pointer group"
+        onClick={onSelect}
+      >
+        <span className={cn('flex-shrink-0 px-1.5 py-0.5 text-[10px] font-medium rounded-full', typeStyle.bg, typeStyle.color)}>
+          {mission.type}
+        </span>
+        <h4 className="flex-1 text-sm font-medium text-foreground truncate group-hover:text-purple-400 transition-colors">
+          {mission.title}
+        </h4>
+        {mission.category && (
+          <span className="px-1.5 py-0.5 text-[10px] rounded bg-purple-500/10 text-purple-400 border border-purple-500/20 flex-shrink-0">
+            {mission.category}
+          </span>
+        )}
+        <span className="text-[10px] text-muted-foreground flex-shrink-0">{mission.steps?.length ?? 0} steps</span>
+        <button
+          onClick={(e) => { e.stopPropagation(); onImport() }}
+          className="px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors flex-shrink-0"
+        >
+          Import
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div


### PR DESCRIPTION
Fixes multiple Mission Explorer issues:

**Search:**
- Global search bar now filters Installers/Solutions tabs (was only Recommended)
- AND logic: `argo events` matches items containing both terms
- Local tab search overrides global when populated
- Dynamic placeholder per tab

**View mode (card ↔ list):**
- Toggle now works on Installers and Solutions grids (was only directory listing)
- List view shows compact single-row layout with coverage icons
- Added `compact` prop to InstallerCard and SolutionCard

**Cache persistence:**
- Preserved activeTab, searchQuery, and filter state across dialog re-opens
- Removed init effect resets that cleared tab/search/filter state
- Module-level cache persists across sidebar close/open cycles

**Refresh button:**
- Added ↻ button in tab bar to re-fetch all mission data
- Spins while loading