### PR TITLE
✨ Import saves to library, per-tab refresh, saved missions panel

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -14,6 +14,10 @@ import {
   MessageSquarePlus,
   Send,
   Globe,
+  Bookmark,
+  Play,
+  Trash2,
+  CheckCircle2,
 } from 'lucide-react'
 import { useSearchParams } from 'react-router-dom'
 import { useMissions } from '../../../hooks/useMissions'
@@ -30,13 +34,14 @@ import { useTranslation } from 'react-i18next'
 
 export function MissionSidebar() {
   const { t } = useTranslation(['common'])
-  const { missions, activeMission, isSidebarOpen, isSidebarMinimized, isFullScreen, setActiveMission, closeSidebar, dismissMission, minimizeSidebar, expandSidebar, setFullScreen, selectedAgent, startMission } = useMissions()
+  const { missions, activeMission, isSidebarOpen, isSidebarMinimized, isFullScreen, setActiveMission, closeSidebar, dismissMission, minimizeSidebar, expandSidebar, setFullScreen, selectedAgent, startMission, saveMission, runSavedMission } = useMissions()
   const { isMobile } = useMobile()
   const [collapsedMissions, setCollapsedMissions] = useState<Set<string>>(new Set())
   const [fontSize, setFontSize] = useState<FontSize>('base')
   const [showNewMission, setShowNewMission] = useState(false)
   const [showBrowser, setShowBrowser] = useState(false)
   const [newMissionPrompt, setNewMissionPrompt] = useState('')
+  const [showSavedToast, setShowSavedToast] = useState<string | null>(null)
   const newMissionInputRef = useRef<HTMLTextAreaElement>(null)
 
   // Deep-link: open MissionBrowser to specific mission via ?mission= URL param
@@ -53,15 +58,30 @@ export function MissionSidebar() {
     }
   }, [deepLinkMission, searchParams, setSearchParams])
 
+  // Split missions into saved (library) and active
+  const savedMissions = missions.filter(m => m.status === 'saved')
+  const activeMissions = missions.filter(m => m.status !== 'saved')
+
   const handleImportMission = useCallback((mission: MissionExport) => {
-    startMission({
-      type: 'custom',
+    const missionType = mission.missionClass === 'install' ? 'deploy' as const
+      : mission.type === 'troubleshoot' ? 'troubleshoot' as const
+      : mission.type === 'deploy' ? 'deploy' as const
+      : mission.type === 'upgrade' ? 'upgrade' as const
+      : 'custom' as const
+    saveMission({
+      type: missionType,
       title: mission.title,
       description: mission.description || mission.title,
+      missionClass: mission.missionClass,
+      cncfProject: mission.cncfProject,
+      steps: mission.steps?.map(s => ({ title: s.title, description: s.description })),
+      tags: mission.tags,
       initialPrompt: mission.resolution?.summary || mission.description,
     })
     setShowBrowser(false)
-  }, [startMission])
+    setShowSavedToast(mission.title)
+    setTimeout(() => setShowSavedToast(null), 4000)
+  }, [saveMission])
 
   // Escape key: exit fullscreen first, then close sidebar
   useEffect(() => {
@@ -336,6 +356,18 @@ export function MissionSidebar() {
         </div>
       )}
 
+      {/* Saved mission toast */}
+      {showSavedToast && (
+        <div className="mx-3 mt-2 p-2.5 bg-green-500/10 border border-green-500/30 rounded-lg flex items-center gap-2 animate-in fade-in slide-in-from-top-2 duration-300">
+          <CheckCircle2 className="w-4 h-4 text-green-500 flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-xs font-medium text-green-400 truncate">Saved to library</p>
+            <p className="text-[10px] text-muted-foreground truncate">{showSavedToast}</p>
+          </div>
+          <button onClick={() => { setActiveMission(null); setShowSavedToast(null) }} className="text-[10px] text-green-400 hover:underline flex-shrink-0">View</button>
+        </div>
+      )}
+
       {missions.length === 0 ? (
         <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
           <AgentIcon provider={getAgentProvider(selectedAgent)} className="w-12 h-12 opacity-50 mb-4" />
@@ -343,53 +375,173 @@ export function MissionSidebar() {
           <p className="text-xs text-muted-foreground/70 mt-1">
             {t('missionSidebar.startMissionPrompt')}
           </p>
-          {!showNewMission && (
+          <div className="flex items-center gap-2 mt-4">
+            {!showNewMission && (
+              <button
+                onClick={() => {
+                  setShowNewMission(true)
+                  setTimeout(() => newMissionInputRef.current?.focus(), 100)
+                }}
+                className="flex items-center gap-2 px-4 py-2 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+              >
+                <MessageSquarePlus className="w-4 h-4" />
+                {t('missionSidebar.startCustomMission')}
+              </button>
+            )}
             <button
-              onClick={() => {
-                setShowNewMission(true)
-                setTimeout(() => newMissionInputRef.current?.focus(), 100)
-              }}
-              className="mt-4 flex items-center gap-2 px-4 py-2 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+              onClick={() => setShowBrowser(true)}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium bg-secondary text-foreground rounded-lg hover:bg-secondary/80 transition-colors"
             >
-              <MessageSquarePlus className="w-4 h-4" />
-              {t('missionSidebar.startCustomMission')}
+              <Globe className="w-4 h-4" />
+              Browse Missions
             </button>
-          )}
+          </div>
         </div>
       ) : activeMission ? (
         <div className={cn(
-          "flex-1 flex flex-col min-h-0",
+          "flex-1 flex min-h-0",
           isFullScreen && "w-full"
         )}>
-          {/* Back to list if multiple missions */}
-          {missions.length > 1 && (
-            <button
-              onClick={() => setActiveMission(null)}
-              className="flex items-center gap-1 px-4 py-2 text-xs text-muted-foreground hover:text-foreground border-b border-border flex-shrink-0"
-            >
-              <ChevronLeft className="w-3 h-3" />
-              {t('missionSidebar.backToMissions', { count: missions.length })}
-            </button>
+          {/* Fullscreen: show saved missions panel on left */}
+          {isFullScreen && savedMissions.length > 0 && (
+            <div className="w-64 border-r border-border bg-secondary/20 flex flex-col overflow-hidden flex-shrink-0">
+              <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
+                <Bookmark className="w-4 h-4 text-amber-500" />
+                <span className="text-xs font-semibold text-foreground">Saved Missions</span>
+                <span className="text-[10px] bg-amber-500/20 text-amber-400 px-1.5 py-0.5 rounded-full ml-auto">{savedMissions.length}</span>
+              </div>
+              <div className="flex-1 overflow-y-auto scroll-enhanced p-1.5 space-y-1">
+                {savedMissions.map(m => (
+                  <div key={m.id} className="group p-2 rounded-lg hover:bg-secondary/60 transition-colors cursor-pointer border border-transparent hover:border-border">
+                    <div className="flex items-start gap-2">
+                      <Bookmark className="w-3.5 h-3.5 text-amber-500 mt-0.5 flex-shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <p className="text-xs font-medium text-foreground truncate">{m.title}</p>
+                        {m.importedFrom?.cncfProject && (
+                          <p className="text-[10px] text-muted-foreground truncate">{m.importedFrom.cncfProject}</p>
+                        )}
+                        {m.importedFrom?.tags && m.importedFrom.tags.length > 0 && (
+                          <div className="flex flex-wrap gap-0.5 mt-1">
+                            {m.importedFrom.tags.slice(0, 3).map(tag => (
+                              <span key={tag} className="text-[9px] px-1 py-0 bg-secondary rounded text-muted-foreground">{tag}</span>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1 mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <button
+                        onClick={(e) => { e.stopPropagation(); runSavedMission(m.id) }}
+                        className="flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium bg-primary text-primary-foreground rounded hover:bg-primary/90 transition-colors"
+                      >
+                        <Play className="w-2.5 h-2.5" /> Run
+                      </button>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); dismissMission(m.id) }}
+                        className="flex items-center gap-1 px-2 py-0.5 text-[10px] text-muted-foreground hover:text-red-400 rounded hover:bg-red-500/10 transition-colors"
+                      >
+                        <Trash2 className="w-2.5 h-2.5" /> Remove
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
           )}
-          <MissionChat mission={activeMission} isFullScreen={isFullScreen} fontSize={fontSize} onToggleFullScreen={() => setFullScreen(true)} />
+          <div className="flex-1 flex flex-col min-h-0">
+            {/* Back to list if multiple missions */}
+            {missions.length > 1 && (
+              <button
+                onClick={() => setActiveMission(null)}
+                className="flex items-center gap-1 px-4 py-2 text-xs text-muted-foreground hover:text-foreground border-b border-border flex-shrink-0"
+              >
+                <ChevronLeft className="w-3 h-3" />
+                {t('missionSidebar.backToMissions', { count: missions.length })}
+              </button>
+            )}
+            <MissionChat mission={activeMission} isFullScreen={isFullScreen} fontSize={fontSize} onToggleFullScreen={() => setFullScreen(true)} />
+          </div>
         </div>
       ) : (
         <div className={cn(
           "flex-1 overflow-y-auto scroll-enhanced p-2 space-y-2",
-          isFullScreen && "max-w-2xl mx-auto w-full"
+          isFullScreen && "max-w-3xl mx-auto w-full"
         )}>
-          {[...missions].reverse().map((mission) => (
-            <MissionListItem
-              key={mission.id}
-              mission={mission}
-              isActive={false}
-              onClick={() => setActiveMission(mission.id)}
-              onDismiss={() => dismissMission(mission.id)}
-              onExpand={() => { setActiveMission(mission.id); setFullScreen(true) }}
-              isCollapsed={collapsedMissions.has(mission.id)}
-              onToggleCollapse={() => toggleMissionCollapse(mission.id)}
-            />
-          ))}
+          {/* Saved missions section */}
+          {savedMissions.length > 0 && (
+            <div className="mb-3">
+              <div className="flex items-center gap-2 px-2 py-1.5 mb-1">
+                <Bookmark className="w-4 h-4 text-amber-500" />
+                <span className="text-xs font-semibold text-foreground">Saved Missions</span>
+                <span className="text-[10px] bg-amber-500/20 text-amber-400 px-1.5 py-0.5 rounded-full">{savedMissions.length}</span>
+              </div>
+              <div className="space-y-1.5">
+                {savedMissions.map(m => (
+                  <div key={m.id} className="group flex items-center gap-3 p-3 rounded-lg border border-amber-500/20 bg-amber-500/5 hover:bg-amber-500/10 transition-colors">
+                    <Bookmark className="w-4 h-4 text-amber-500 flex-shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-foreground truncate">{m.title}</p>
+                      <p className="text-xs text-muted-foreground truncate">{m.description}</p>
+                      {m.importedFrom?.tags && m.importedFrom.tags.length > 0 && (
+                        <div className="flex flex-wrap gap-1 mt-1">
+                          {m.importedFrom.tags.slice(0, 4).map(tag => (
+                            <span key={tag} className="text-[10px] px-1.5 py-0.5 bg-secondary rounded text-muted-foreground">{tag}</span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1.5 flex-shrink-0">
+                      <button
+                        onClick={() => runSavedMission(m.id)}
+                        className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+                        title="Run this mission"
+                      >
+                        <Play className="w-3 h-3" /> Run
+                      </button>
+                      <button
+                        onClick={() => dismissMission(m.id)}
+                        className="p-1.5 text-muted-foreground hover:text-red-400 rounded hover:bg-red-500/10 transition-colors"
+                        title="Remove from library"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Active missions section */}
+          {activeMissions.length > 0 && (
+            <>
+              {savedMissions.length > 0 && (
+                <div className="flex items-center gap-2 px-2 py-1.5">
+                  <span className="text-xs font-semibold text-foreground">Active Missions</span>
+                  <span className="text-[10px] bg-secondary px-1.5 py-0.5 rounded-full">{activeMissions.length}</span>
+                </div>
+              )}
+              {[...activeMissions].reverse().map((mission) => (
+                <MissionListItem
+                  key={mission.id}
+                  mission={mission}
+                  isActive={false}
+                  onClick={() => setActiveMission(mission.id)}
+                  onDismiss={() => dismissMission(mission.id)}
+                  onExpand={() => { setActiveMission(mission.id); setFullScreen(true) }}
+                  isCollapsed={collapsedMissions.has(mission.id)}
+                  onToggleCollapse={() => toggleMissionCollapse(mission.id)}
+                />
+              ))}
+            </>
+          )}
+
+          {/* Empty state when only saved missions, no active */}
+          {activeMissions.length === 0 && savedMissions.length > 0 && (
+            <div className="text-center py-4">
+              <p className="text-xs text-muted-foreground">No active missions. Click <strong>Run</strong> on a saved mission to start it.</p>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/web/src/components/layout/mission-sidebar/types.ts
+++ b/web/src/components/layout/mission-sidebar/types.ts
@@ -10,6 +10,7 @@ import {
   Rocket,
   Sparkles,
   Hammer,
+  Bookmark,
 } from 'lucide-react'
 import type { Mission, MissionStatus, MissionMessage } from '../../../hooks/useMissions'
 
@@ -31,6 +32,7 @@ export const STATUS_CONFIG: Record<MissionStatus, { icon: typeof Loader2; color:
   waiting_input: { icon: MessageSquare, color: 'text-purple-400', label: 'Waiting for input' },
   completed: { icon: CheckCircle, color: 'text-green-400', label: 'Completed' },
   failed: { icon: AlertCircle, color: 'text-red-400', label: 'Failed' },
+  saved: { icon: Bookmark, color: 'text-amber-400', label: 'Saved' },
 }
 
 export const TYPE_ICONS: Record<Mission['type'], typeof ArrowUpCircle> = {

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -254,19 +254,27 @@ function startMissionCacheFetch() {
   fetchSolutionsToCache()
 }
 
-function resetMissionCache() {
+function resetInstallerCache() {
   missionCache.installers = []
-  missionCache.solutions = []
   missionCache.installersDone = false
-  missionCache.solutionsDone = false
   missionCache.installersFetching = false
-  missionCache.solutionsFetching = false
-  if (missionCache.abortController) {
-    missionCache.abortController.abort()
-    missionCache.abortController = null
-  }
   notifyCacheListeners()
-  startMissionCacheFetch()
+  fetchInstallersToCache()
+}
+
+function resetSolutionCache() {
+  missionCache.solutions = []
+  missionCache.solutionsDone = false
+  missionCache.solutionsFetching = false
+  notifyCacheListeners()
+  fetchSolutionsToCache()
+}
+
+function resetMissionCache(tab?: 'installers' | 'solutions') {
+  if (tab === 'installers') return resetInstallerCache()
+  if (tab === 'solutions') return resetSolutionCache()
+  resetInstallerCache()
+  resetSolutionCache()
 }
 
 // ============================================================================
@@ -1082,11 +1090,11 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
           </button>
         ))}
         <button
-          onClick={() => resetMissionCache()}
+          onClick={() => resetMissionCache(activeTab === 'installers' || activeTab === 'solutions' ? activeTab : undefined)}
           className="ml-auto inline-flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary rounded transition-colors"
-          title="Refresh all mission data"
+          title={activeTab === 'installers' ? 'Refresh installers' : activeTab === 'solutions' ? 'Refresh solutions' : 'Refresh all mission data'}
         >
-          <RefreshCw className={cn('w-3.5 h-3.5', (!missionCache.installersDone || !missionCache.solutionsDone) && 'animate-spin')} />
+          <RefreshCw className={cn('w-3.5 h-3.5', (activeTab === 'installers' ? !missionCache.installersDone : activeTab === 'solutions' ? !missionCache.solutionsDone : (!missionCache.installersDone || !missionCache.solutionsDone)) && 'animate-spin')} />
         </button>
       </div>
 

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -6,7 +6,7 @@ import { detectIssueSignature, findSimilarResolutionsStandalone, generateResolut
 import { LOCAL_AGENT_WS_URL } from '../lib/constants'
 import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
 
-export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed'
+export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'saved'
 
 export interface MissionMessage {
   id: string
@@ -51,6 +51,15 @@ export interface Mission {
   agent?: string
   /** Resolutions that were auto-matched for this mission */
   matchedResolutions?: MatchedResolution[]
+  /** Original imported mission data (for saved/library missions) */
+  importedFrom?: {
+    title: string
+    description: string
+    missionClass?: string
+    cncfProject?: string
+    steps?: Array<{ title: string; description: string }>
+    tags?: string[]
+  }
 }
 
 interface MissionContextValue {
@@ -74,6 +83,8 @@ interface MissionContextValue {
 
   // Actions
   startMission: (params: StartMissionParams) => string
+  saveMission: (params: SaveMissionParams) => string
+  runSavedMission: (missionId: string) => void
   sendMessage: (missionId: string, content: string) => void
   cancelMission: (missionId: string) => void
   dismissMission: (missionId: string) => void
@@ -97,6 +108,17 @@ interface StartMissionParams {
   cluster?: string
   initialPrompt: string
   context?: Record<string, unknown>
+}
+
+interface SaveMissionParams {
+  title: string
+  description: string
+  type: Mission['type']
+  missionClass?: string
+  cncfProject?: string
+  steps?: Array<{ title: string; description: string }>
+  tags?: string[]
+  initialPrompt: string
 }
 
 const MissionContext = createContext<MissionContextValue | null>(null)
@@ -749,6 +771,95 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     return missionId
   }, [ensureConnection])
 
+  // Save a mission to library without running it
+  const saveMission = useCallback((params: SaveMissionParams): string => {
+    const missionId = `mission-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+
+    const mission: Mission = {
+      id: missionId,
+      title: params.title,
+      description: params.description,
+      type: params.type,
+      status: 'saved',
+      messages: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      importedFrom: {
+        title: params.title,
+        description: params.description,
+        missionClass: params.missionClass,
+        cncfProject: params.cncfProject,
+        steps: params.steps,
+        tags: params.tags,
+      },
+    }
+
+    setMissions(prev => [mission, ...prev])
+    return missionId
+  }, [])
+
+  // Run a previously saved mission
+  const runSavedMission = useCallback((missionId: string) => {
+    const mission = missions.find(m => m.id === missionId)
+    if (!mission || mission.status !== 'saved') return
+
+    const initialPrompt = mission.importedFrom?.steps
+      ? `${mission.description}\n\nSteps:\n${mission.importedFrom.steps.map((s, i) => `${i + 1}. ${s.title}: ${s.description}`).join('\n')}`
+      : mission.description
+
+    setMissions(prev => prev.map(m =>
+      m.id === missionId ? {
+        ...m,
+        status: 'pending',
+        messages: [{
+          id: `msg-${Date.now()}`,
+          role: 'user' as const,
+          content: initialPrompt,
+          timestamp: new Date(),
+        }],
+        updatedAt: new Date(),
+      } : m
+    ))
+    setActiveMissionId(missionId)
+    setIsSidebarOpen(true)
+    setIsSidebarMinimized(false)
+
+    ensureConnection().then(() => {
+      const requestId = `claude-${Date.now()}`
+      pendingRequests.current.set(requestId, missionId)
+
+      setMissions(prev => prev.map(m =>
+        m.id === missionId ? { ...m, status: 'running', currentStep: 'Connecting to agent...' } : m
+      ))
+
+      setActiveTokenCategory('missions')
+
+      wsRef.current?.send(JSON.stringify({
+        id: requestId,
+        type: 'chat',
+        payload: {
+          prompt: initialPrompt,
+          sessionId: missionId,
+          agent: selectedAgent || undefined,
+        }
+      }))
+    }).catch(() => {
+      setMissions(prev => prev.map(m =>
+        m.id === missionId ? {
+          ...m,
+          status: 'failed',
+          currentStep: undefined,
+          messages: [{
+            id: `msg-${Date.now()}`,
+            role: 'system' as const,
+            content: '**Local Agent Not Connected**\n\nInstall the console locally with the KubeStellar Console agent to use AI missions.',
+            timestamp: new Date(),
+          }]
+        } : m
+      ))
+    })
+  }, [missions, ensureConnection, selectedAgent])
+
   // Send a follow-up message
   const sendMessage = useCallback((missionId: string, content: string) => {
     // Track token usage for this mission
@@ -950,6 +1061,8 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       defaultAgent,
       agentsLoading,
       startMission,
+      saveMission,
+      runSavedMission,
       sendMessage,
       cancelMission,
       dismissMission,


### PR DESCRIPTION
## Changes

### Import saves to library (not auto-run)
- Clicking **Import** in Mission Browser now saves the mission to a library with `saved` status
- Mission is NOT sent to the AI agent — user must click **Run** when ready
- Toast notification confirms save with link to view saved missions

### Saved Missions panel
- **Sidebar**: Saved missions shown prominently at top with amber bookmark styling, Run/Remove buttons
- **Fullscreen**: Dedicated left panel showing saved missions for quick access while chatting
- Tags, CNCF project name, and description shown on each saved mission card

### Per-tab refresh
- Refresh button now only reloads the active tab (Installers or Solutions), not both
- Dynamic tooltip and spinner reflect which tab is refreshing

### Technical
- Added `saved` to `MissionStatus` type
- Added `importedFrom` field to `Mission` interface (stores original mission metadata)
- Added `saveMission()` and `runSavedMission()` to `useMissions` hook
- Updated `STATUS_CONFIG` with Bookmark icon for saved status