### PR TITLE
🐛 Add null guards to STATUS_CONFIG and TYPE_ICONS lookups

### DIFF
--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -490,7 +490,7 @@ interface MissionRowProps {
 }
 
 function MissionRow({ mission, isExpanded, onToggle, isActive, onDiagnose, onRepair }: MissionRowProps) {
-  const config = STATUS_CONFIG[mission.status]
+  const config = STATUS_CONFIG[mission.status] || STATUS_CONFIG.launching
   const StatusIcon = config.icon
   const elapsed = getElapsed(mission.startedAt, mission.completedAt)
   const [showLogs, setShowLogs] = useState(false)

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -246,9 +246,9 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
     // All other keys (including space) pass through to the input normally
   }
 
-  const config = STATUS_CONFIG[mission.status]
+  const config = STATUS_CONFIG[mission.status] || STATUS_CONFIG.pending
   const StatusIcon = config.icon
-  const TypeIcon = TYPE_ICONS[mission.type]
+  const TypeIcon = TYPE_ICONS[mission.type] || TYPE_ICONS.custom
 
   return (
     <>
@@ -644,8 +644,8 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               {/* Status */}
               <div className="flex items-center justify-between text-sm">
                 <span className="text-muted-foreground">{t('common.status')}</span>
-                <span className={cn('font-medium', STATUS_CONFIG[mission.status].color)}>
-                  {STATUS_CONFIG[mission.status].label}
+                <span className={cn('font-medium', (STATUS_CONFIG[mission.status] || STATUS_CONFIG.pending).color)}>
+                  {(STATUS_CONFIG[mission.status] || STATUS_CONFIG.pending).label}
                 </span>
               </div>
 

--- a/web/src/components/layout/mission-sidebar/MissionListItem.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionListItem.tsx
@@ -17,9 +17,9 @@ export function MissionListItem({ mission, isActive, onClick, onDismiss, onExpan
   isCollapsed: boolean
   onToggleCollapse: () => void
 }) {
-  const config = STATUS_CONFIG[mission.status]
+  const config = STATUS_CONFIG[mission.status] || STATUS_CONFIG.pending
   const StatusIcon = config.icon
-  const TypeIcon = TYPE_ICONS[mission.type]
+  const TypeIcon = TYPE_ICONS[mission.type] || TYPE_ICONS.custom
 
   return (
     <div


### PR DESCRIPTION
Fixes crash on login: `Cannot read properties of undefined (reading 'icon')`

## Problem
When missions loaded from localStorage have unrecognized or undefined status/type values, accessing `STATUS_CONFIG[mission.status].icon` crashes the app.

## Fix
Added fallback handling with `|| STATUS_CONFIG.pending` (or `.launching` for deploy missions) and `|| TYPE_ICONS.custom` in:
- `MissionListItem.tsx` (line 20-22)
- `MissionChat.tsx` (lines 249-251, 647-648)  
- `Missions.tsx` (line 493)

## Testing
- Built successfully
- Verified no JS errors on page load via Chrome CDP