### PR TITLE
🐛 Hide demo data banner when agent is connected

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -872,8 +872,8 @@ export function Dashboard() {
       {/* Mission CTA - encourage users who haven't tried missions yet */}
       <MissionCTA />
 
-      {/* Demo Data Banner */}
-      {hasDemoDataCards && !demoBannerDismissed && (
+      {/* Demo Data Banner — only show when demo mode is active */}
+      {hasDemoDataCards && !demoBannerDismissed && getDemoMode() && (
         <div className="mb-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/30 flex items-center gap-3">
           <AlertTriangle className="w-5 h-5 text-yellow-400 flex-shrink-0" />
           <div className="flex-1">


### PR DESCRIPTION
## Problem

The yellow "Demo Data in Use" warning banner was showing even when connected to real clusters via the kc-agent. This is unnecessary and confusing when the user is running in live mode.

## Fix

Added `getDemoMode()` check to the banner's visibility condition. The banner now only shows when:
- Demo data cards are present on the dashboard
- User hasn't dismissed it
- **Demo mode is actually active** (new condition)

## Change

One line in `Dashboard.tsx` — added `&& getDemoMode()` to the banner render condition. `getDemoMode()` was already imported and used elsewhere in the same file (line 858).