### PR TITLE
✨ Contextual mission recommendations from live cluster data

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -34,6 +34,7 @@ import { cn } from '../../lib/cn'
 import { api } from '../../lib/api'
 import { useAuth } from '../../lib/auth'
 import { matchMissionsToCluster } from '../../lib/missions/matcher'
+import { useClusterContext } from '../../hooks/useClusterContext'
 import {
   emitSolutionSearchStarted,
   emitSolutionSearchCompleted,
@@ -284,6 +285,7 @@ function resetMissionCache(tab?: 'installers' | 'solutions') {
 export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: MissionBrowserProps) {
   useTranslation(['common', 'cards'])
   const { user, isAuthenticated } = useAuth()
+  const { clusterContext } = useClusterContext()
 
   // Navigation state
   const [searchQuery, setSearchQuery] = useState('')
@@ -434,19 +436,16 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       setSearchProgress({ step: 'Connecting', detail: 'Fetching cluster info…', found: 0, scanned: 0 })
 
       try {
-        // Step 1: Get cluster info + browse top-level in parallel
-        const [clusterWrap, topLevel] = await Promise.all([
-          api.get<{ name: string; provider?: string; version?: string; resources?: string[]; issues?: string[]; labels?: Record<string, string> }>('/api/cluster/current').catch(() => null),
-          api.get<BrowseEntry[]>('/api/missions/browse?path=solutions').catch((err) => {
-            const code = err?.response?.data?.code
-            if (code === 'rate_limited' || code === 'token_invalid') {
-              setTokenError(code)
-            }
-            return { data: [] as BrowseEntry[] }
-          }),
-        ])
+        // Step 1: Use live cluster context from hooks + browse top-level
+        const cluster = clusterContext
+        const topLevel = await api.get<BrowseEntry[]>('/api/missions/browse?path=solutions').catch((err) => {
+          const code = err?.response?.data?.code
+          if (code === 'rate_limited' || code === 'token_invalid') {
+            setTokenError(code)
+          }
+          return { data: [] as BrowseEntry[] }
+        })
         if (cancelled) return
-        const cluster = clusterWrap?.data ?? null
         setHasCluster(!!cluster)
         emitSolutionSearchStarted(!!cluster)
         const topDirs = (topLevel?.data ?? []).filter(e => e.type === 'directory')
@@ -534,7 +533,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
 
     fetchRecommendations()
     return () => { cancelled = true }
-  }, [isOpen])
+  }, [isOpen, clusterContext])
 
   // ============================================================================
   // Subscribe to module-level mission cache and trigger fetch on first open

--- a/web/src/hooks/useClusterContext.ts
+++ b/web/src/hooks/useClusterContext.ts
@@ -1,0 +1,119 @@
+/**
+ * useClusterContext – aggregates live cluster data into the shape
+ * that matchMissionsToCluster() expects for contextual recommendations.
+ *
+ * Combines: clusters, operators, helm releases, pod issues, security issues.
+ * Returns null when no clusters are connected (triggers generic mode).
+ */
+
+import { useMemo } from 'react'
+import { useClusters } from './mcp/clusters'
+import { useOperators } from './mcp/operators'
+import { useHelmReleases } from './mcp/helm'
+import { usePodIssues } from './mcp/workloads'
+import { useSecurityIssues } from './mcp/security'
+
+export interface ClusterContext {
+  name: string
+  provider?: string
+  version?: string
+  resources: string[]
+  issues: string[]
+  labels: Record<string, string>
+}
+
+export function useClusterContext(): {
+  clusterContext: ClusterContext | null
+  isLoading: boolean
+} {
+  const { deduplicatedClusters, isLoading: clustersLoading } = useClusters()
+  const { operators, isLoading: operatorsLoading } = useOperators()
+  const { releases, isLoading: helmLoading } = useHelmReleases()
+  const { issues: podIssues, isLoading: podLoading } = usePodIssues()
+  const { issues: securityIssues, isLoading: securityLoading } = useSecurityIssues()
+
+  const isLoading = clustersLoading || operatorsLoading || helmLoading || podLoading || securityLoading
+
+  const clusterContext = useMemo(() => {
+    const healthyClusters = deduplicatedClusters.filter(c => c.healthy)
+    if (healthyClusters.length === 0) return null
+
+    // Pick primary cluster (current context or first healthy)
+    const primary = healthyClusters.find(c => c.isCurrent) ?? healthyClusters[0]
+
+    // Build resources[] from operators + helm releases
+    const resources = new Set<string>()
+    for (const op of operators) {
+      resources.add(op.name.toLowerCase())
+      // Extract base name (e.g. "prometheus-operator" → "prometheus")
+      const base = op.name.replace(/-operator$/, '').replace(/-controller$/, '').toLowerCase()
+      if (base !== op.name.toLowerCase()) resources.add(base)
+    }
+    for (const rel of releases) {
+      resources.add(rel.name.toLowerCase())
+      // Extract chart base name (e.g. "prometheus-25.8.0" → "prometheus")
+      const chartBase = rel.chart.replace(/-[\d.]+$/, '').toLowerCase()
+      if (chartBase) resources.add(chartBase)
+    }
+
+    // Build issues[] from pod issues + security issues
+    const issues = new Set<string>()
+    for (const pi of podIssues) {
+      for (const issue of pi.issues) {
+        issues.add(issue)
+      }
+      if (pi.status && pi.status !== 'Running') {
+        issues.add(pi.status)
+      }
+    }
+    for (const si of securityIssues) {
+      issues.add(si.issue)
+    }
+
+    // Build labels from cluster metadata + namespaces
+    const labels: Record<string, string> = {}
+    if (primary.distribution) {
+      labels['distribution'] = primary.distribution
+    }
+    // Add namespace-derived labels (presence of monitoring/istio-system etc.)
+    for (const cluster of healthyClusters) {
+      if (cluster.namespaces) {
+        for (const ns of cluster.namespaces) {
+          if (ns.includes('istio')) labels['cncf.io/project'] = 'istio'
+          if (ns.includes('linkerd')) labels['cncf.io/project'] = 'linkerd'
+          if (ns.includes('monitoring') || ns.includes('prometheus')) labels['monitoring'] = 'true'
+          if (ns.includes('cert-manager')) labels['cert-manager'] = 'true'
+        }
+      }
+    }
+
+    // Derive provider from distribution or cluster name
+    const provider = deriveProvider(primary.distribution, primary.name)
+
+    return {
+      name: primary.name,
+      provider,
+      version: primary.namespaces ? undefined : undefined, // version not directly available
+      resources: Array.from(resources),
+      issues: Array.from(issues),
+      labels,
+    }
+  }, [deduplicatedClusters, operators, releases, podIssues, securityIssues])
+
+  return { clusterContext, isLoading }
+}
+
+/** Derive cloud provider from distribution string or cluster name */
+function deriveProvider(distribution?: string, name?: string): string | undefined {
+  const d = (distribution ?? '').toLowerCase()
+  const n = (name ?? '').toLowerCase()
+  if (d.includes('eks') || n.includes('eks')) return 'eks'
+  if (d.includes('gke') || n.includes('gke')) return 'gke'
+  if (d.includes('aks') || n.includes('aks')) return 'aks'
+  if (d.includes('openshift') || d.includes('ocp')) return 'openshift'
+  if (d.includes('k3s') || n.includes('k3s')) return 'k3s'
+  if (d.includes('kind') || n.includes('kind')) return 'kind'
+  if (d.includes('minikube') || n.includes('minikube')) return 'minikube'
+  if (d.includes('rke') || n.includes('rke')) return 'rke'
+  return undefined
+}

--- a/web/src/lib/missions/matcher.ts
+++ b/web/src/lib/missions/matcher.ts
@@ -16,6 +16,48 @@ interface ClusterInfo {
 }
 
 /**
+ * Map operator/helm names to related CNCF project keywords for cross-matching.
+ * E.g., having "prometheus-operator" installed should boost prometheus/alertmanager missions.
+ */
+const RESOURCE_TO_PROJECTS: Record<string, string[]> = {
+  prometheus: ['prometheus', 'alertmanager', 'monitoring', 'grafana', 'thanos'],
+  grafana: ['grafana', 'monitoring', 'observability', 'dashboards'],
+  'cert-manager': ['cert-manager', 'certificates', 'tls', 'lets-encrypt'],
+  istio: ['istio', 'service-mesh', 'envoy', 'traffic-management'],
+  linkerd: ['linkerd', 'service-mesh'],
+  'ingress-nginx': ['ingress', 'nginx', 'load-balancing'],
+  argocd: ['argocd', 'gitops', 'continuous-delivery'],
+  'argo-workflows': ['argo', 'workflows', 'ci-cd'],
+  flux: ['flux', 'gitops', 'continuous-delivery'],
+  vault: ['vault', 'secrets', 'security', 'hashicorp'],
+  'external-secrets': ['secrets', 'external-secrets', 'security'],
+  falco: ['falco', 'security', 'runtime-security'],
+  trivy: ['trivy', 'security', 'vulnerability-scanning'],
+  redis: ['redis', 'caching', 'data'],
+  elasticsearch: ['elasticsearch', 'logging', 'elk', 'observability'],
+  jaeger: ['jaeger', 'tracing', 'observability'],
+  'open-telemetry': ['opentelemetry', 'tracing', 'observability'],
+  keda: ['keda', 'autoscaling', 'scaling'],
+  knative: ['knative', 'serverless', 'eventing'],
+  harbor: ['harbor', 'registry', 'container-registry'],
+  velero: ['velero', 'backup', 'disaster-recovery'],
+  crossplane: ['crossplane', 'infrastructure', 'multi-cloud'],
+  kubestellar: ['kubestellar', 'multi-cluster', 'edge'],
+}
+
+/** Map issue patterns to solution categories */
+const ISSUE_TO_CATEGORIES: Record<string, string[]> = {
+  crashloopbackoff: ['troubleshoot', 'debugging', 'pod-restart'],
+  oomkilled: ['resources', 'memory', 'limits', 'troubleshoot'],
+  imagepullbackoff: ['registry', 'container-images', 'troubleshoot'],
+  'privileged container': ['security', 'pod-security', 'hardening'],
+  'host network': ['security', 'network-policy', 'hardening'],
+  'no resource limits': ['resources', 'best-practices', 'limits'],
+  pending: ['scheduling', 'resources', 'node-capacity'],
+  evicted: ['resources', 'node-pressure', 'troubleshoot'],
+}
+
+/**
  * Score and rank missions against cluster data.
  * Returns missions sorted by match score (highest first).
  * Always returns results — uses baseline scoring when no cluster matches exist.
@@ -24,6 +66,33 @@ export function matchMissionsToCluster(
   missions: MissionExport[],
   cluster: ClusterInfo | null
 ): MissionMatch[] {
+  // Pre-compute expanded resource keywords from installed resources
+  const expandedKeywords = new Set<string>()
+  if (cluster?.resources) {
+    for (const r of cluster.resources) {
+      expandedKeywords.add(r.toLowerCase())
+      // Expand via known mappings
+      for (const [key, projects] of Object.entries(RESOURCE_TO_PROJECTS)) {
+        if (r.toLowerCase().includes(key)) {
+          for (const p of projects) expandedKeywords.add(p)
+        }
+      }
+    }
+  }
+
+  // Pre-compute issue categories
+  const issueCategories = new Set<string>()
+  if (cluster?.issues) {
+    for (const issue of cluster.issues) {
+      const issueLower = issue.toLowerCase()
+      for (const [pattern, categories] of Object.entries(ISSUE_TO_CATEGORIES)) {
+        if (issueLower.includes(pattern)) {
+          for (const cat of categories) issueCategories.add(cat)
+        }
+      }
+    }
+  }
+
   const results: MissionMatch[] = []
 
   for (const mission of missions) {
@@ -31,33 +100,53 @@ export function matchMissionsToCluster(
     const matchReasons: string[] = []
 
     if (cluster) {
-      // Match by tags against cluster resources
-      if (mission.tags && cluster.resources) {
-        const lowerResources = cluster.resources.map((r) => r.toLowerCase())
+      // Match by tags against cluster resources (direct + expanded keywords)
+      if (mission.tags && expandedKeywords.size > 0) {
         for (const tag of mission.tags) {
-          if (lowerResources.some((r) => r.includes(tag.toLowerCase()))) {
+          if (expandedKeywords.has(tag.toLowerCase())) {
             score += 20
             matchReasons.push(`Tag "${tag}" matches cluster resource`)
           }
         }
       }
 
-      // Match by CNCF project against cluster labels
-      if (mission.cncfProject && cluster.labels) {
-        const projectLower = mission.cncfProject.toLowerCase()
-        for (const [key, value] of Object.entries(cluster.labels)) {
-          if (
-            key.toLowerCase().includes(projectLower) ||
-            value.toLowerCase().includes(projectLower)
-          ) {
-            score += 30
-            matchReasons.push(`CNCF project "${mission.cncfProject}" found in cluster labels`)
+      // Match mission category/tags against issue-derived categories
+      if (issueCategories.size > 0) {
+        const missionKeywords = [
+          ...(mission.tags ?? []),
+          mission.category ?? '',
+          mission.type ?? '',
+        ].map(s => s.toLowerCase())
+        for (const kw of missionKeywords) {
+          if (kw && issueCategories.has(kw)) {
+            score += 35
+            matchReasons.push(`Relevant to detected cluster issue`)
             break
           }
         }
       }
 
-      // Match troubleshoot missions against cluster issues
+      // Match by CNCF project against cluster labels + expanded keywords
+      if (mission.cncfProject) {
+        const projectLower = mission.cncfProject.toLowerCase()
+        if (expandedKeywords.has(projectLower)) {
+          score += 30
+          matchReasons.push(`CNCF project "${mission.cncfProject}" is installed`)
+        } else if (cluster.labels) {
+          for (const [key, value] of Object.entries(cluster.labels)) {
+            if (
+              key.toLowerCase().includes(projectLower) ||
+              value.toLowerCase().includes(projectLower)
+            ) {
+              score += 30
+              matchReasons.push(`CNCF project "${mission.cncfProject}" found in cluster labels`)
+              break
+            }
+          }
+        }
+      }
+
+      // Match troubleshoot missions against cluster issues (direct text match)
       if (mission.type === 'troubleshoot' && cluster.issues) {
         const descLower = mission.description.toLowerCase()
         for (const issue of cluster.issues) {


### PR DESCRIPTION
## Summary

Replaces the non-existent `/api/cluster/current` API endpoint with a client-side `useClusterContext()` hook that aggregates live data from existing hooks to power contextual mission recommendations.

## Problem

The Recommended tab in Browse Missions always showed generic "Explore CNCF Solutions" instead of "Recommended for Your Cluster." The matcher (`matchMissionsToCluster()`) was fully implemented but starved of data because the backend endpoint it depended on (`/api/cluster/current`) **did not exist**.

## Solution

### New: `useClusterContext()` hook
Aggregates data from 5 existing hooks into the shape the matcher expects:
- `useClusters()` → cluster name, provider, distribution, labels
- `useOperators()` → installed operator names as resources
- `useHelmReleases()` → installed helm releases as resources
- `usePodIssues()` → active pod issues
- `useSecurityIssues()` → security findings

### Enhanced matcher
- **30+ operator/helm → CNCF project keyword mappings** (e.g., prometheus-operator installed → boosts prometheus, alertmanager, monitoring, grafana, thanos missions)
- **Issue pattern → solution category matching** (e.g., CrashLoopBackOff → boosts troubleshoot/debugging missions)
- **Expanded keyword matching** for cross-referencing tags against installed resources

### Result
- "Recommended for Your Cluster" title when clusters connected
- Green ✓ Match badges with contextual reasons
- Falls back to "Explore CNCF Solutions" when no clusters connected

## Files Changed
- `web/src/hooks/useClusterContext.ts` — **NEW** cluster context aggregator hook
- `web/src/lib/missions/matcher.ts` — Enhanced scoring with keyword expansion
- `web/src/components/missions/MissionBrowser.tsx` — Wired hook, removed dead API call