### PR TITLE
🐛 Improve missions browse resilience and diagnostics

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -73,13 +74,21 @@ func (h *MissionsHandler) githubGet(url string, clientToken string) (*http.Respo
 	// If auth failed (401/403) or got 404 with a token (raw.githubusercontent returns 404 for bad tokens),
 	// retry without auth — the target repo is public
 	if hasToken && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound) {
+		log.Printf("[missions] GitHub token returned %d for %s — retrying without auth (token may be expired)", resp.StatusCode, url)
 		resp.Body.Close()
 		retryReq, err := http.NewRequest("GET", url, nil)
 		if err != nil {
 			return nil, err
 		}
 		retryReq.Header.Set("Accept", "application/vnd.github.v3+json")
-		return h.httpClient.Do(retryReq)
+		retryResp, err := h.httpClient.Do(retryReq)
+		if err != nil {
+			return nil, err
+		}
+		if retryResp.StatusCode == http.StatusForbidden || retryResp.StatusCode == http.StatusTooManyRequests {
+			log.Printf("[missions] Unauthenticated retry also failed (%d) for %s — likely rate-limited (check GITHUB_TOKEN in .env)", retryResp.StatusCode, url)
+		}
+		return retryResp, nil
 	}
 
 	return resp, nil

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -527,7 +527,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   }
 
   const matchesMission = (m: MissionExport, query: string) => {
-    const haystack = [m.title, m.description, ...(m.tags || [])].join(' ')
+    const haystack = [m.title || '', m.description || '', ...(m.tags || [])].join(' ')
     return andMatch(haystack, query)
   }
 


### PR DESCRIPTION
## Problem

When GITHUB_TOKEN is expired, the missions browse API:
1. Sends request with expired token → GitHub returns 401
2. Retries without auth → quickly exhausts unauthenticated rate limit (60 req/hr)
3. All browse calls return 403 to the frontend
4. Frontend crashes with `Cannot read properties of undefined (reading 'toLowerCase')`

The root cause is an expired `ghp_` token in the running console process while `.env` has a valid `gho_` token — meaning the console was started with the old token.

## Changes

### Frontend (MissionBrowser.tsx)
- Add null safety to `matchesMission` helper — `m.title || ''` and `m.description || ''` fallbacks prevent crash when mission objects have undefined fields

### Backend (missions.go)
- Add diagnostic logging when GitHub token fails and unauthenticated fallback also fails
- Logs now clearly indicate: "token may be expired" and "check GITHUB_TOKEN in .env"
- Makes it immediately obvious in server logs why missions return 403

## Root Cause Resolution
The running console needs to be restarted with the current valid token from `.env`.