### PR TITLE
🐛 Fix stale matcher tests to match always-return-results behavior

### DIFF
--- a/web/src/lib/missions/__tests__/matcher.test.ts
+++ b/web/src/lib/missions/__tests__/matcher.test.ts
@@ -49,11 +49,12 @@ describe('matchMissionsToCluster', () => {
     expect(results[0].score).toBe(40) // 20 + 20
   })
 
-  it('returns empty array when no cluster resources', () => {
+  it('returns baseline-scored results when no cluster resources', () => {
     const missions = [makeMission({ tags: ['istio'] })]
     const cluster = { name: 'empty' }
     const results = matchMissionsToCluster(missions, cluster)
-    expect(results).toHaveLength(0)
+    expect(results).toHaveLength(1)
+    expect(results[0].score).toBe(1) // baseline minimum
   })
 
   it('matches troubleshoot missions against cluster issues', () => {
@@ -66,11 +67,12 @@ describe('matchMissionsToCluster', () => {
     const cluster = { name: 'test', issues: ['CrashLoopBackOff'] }
     const results = matchMissionsToCluster(missions, cluster)
     expect(results).toHaveLength(1)
-    expect(results[0].score).toBe(40)
-    expect(results[0].matchReasons[0]).toContain('CrashLoopBackOff')
+    // 40 for direct issue text match + 35 for issue-category match on type 'troubleshoot'
+    expect(results[0].score).toBe(75)
+    expect(results[0].matchReasons.some((r) => r.includes('CrashLoopBackOff'))).toBe(true)
   })
 
-  it('does not match non-troubleshoot missions against issues', () => {
+  it('scores non-troubleshoot missions lower against issues', () => {
     const missions = [
       makeMission({
         type: 'deploy',
@@ -79,7 +81,9 @@ describe('matchMissionsToCluster', () => {
     ]
     const cluster = { name: 'test', issues: ['CrashLoopBackOff'] }
     const results = matchMissionsToCluster(missions, cluster)
-    expect(results).toHaveLength(0)
+    // deploy type does not get direct issue text match or issue-category boost
+    expect(results).toHaveLength(1)
+    expect(results[0].score).toBe(1) // baseline minimum only
   })
 
   it('matches upgrade missions against cluster version', () => {
@@ -131,14 +135,16 @@ describe('matchMissionsToCluster', () => {
     expect(results).toHaveLength(0)
   })
 
-  it('returns no matches when cluster has no data', () => {
+  it('returns baseline-scored results when cluster has no data', () => {
     const missions = [
       makeMission({ tags: ['istio'], cncfProject: 'istio' }),
       makeMission({ type: 'troubleshoot', description: 'Fix pods' }),
     ]
     const cluster = { name: 'bare-cluster' }
     const results = matchMissionsToCluster(missions, cluster)
-    expect(results).toHaveLength(0)
+    expect(results).toHaveLength(2)
+    expect(results[0].score).toBe(1) // baseline minimum
+    expect(results[1].score).toBe(1)
   })
 
   it('combines tag + CNCF project scores', () => {


### PR DESCRIPTION
## Summary
matcher.ts was updated in PRs #1547, #1552, #1556 to always return results with baseline scoring (minimum score of 1) for the 'Recommended for You' section. The 4 failing tests expected empty arrays for non-matching missions and outdated score values.

## Changes
- Rename 'returns empty array' tests to 'returns baseline-scored results' 
- Update troubleshoot issue score from 40→75 (now includes +35 issue-category match)
- Update non-troubleshoot issue test to check baseline score instead of empty array
- Update 'no cluster data' test to expect baseline-scored results

## Verification
All **293/293 tests pass**, **89/89 test files pass** (was 289/293, 88/89)