### PR TITLE
🐛 Marketplace: include presets from registry.json

### DIFF
--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -50,11 +50,18 @@ interface MarketplaceRegistry {
   version: string
   updatedAt: string
   items: MarketplaceItem[]
+  /** Card presets, themes, and CNCF project presets — separate key in the registry */
+  presets?: MarketplaceItem[]
 }
 
 interface CachedRegistry {
   data: MarketplaceRegistry
   fetchedAt: number
+}
+
+/** Merge items + presets from the registry into a single array */
+function mergeRegistryItems(registry: MarketplaceRegistry): MarketplaceItem[] {
+  return [...(registry.items || []), ...(registry.presets || [])]
 }
 
 interface InstalledEntry {
@@ -108,7 +115,7 @@ export function useMarketplace() {
         if (cached) {
           const parsed: CachedRegistry = JSON.parse(cached)
           if (Date.now() - parsed.fetchedAt < CACHE_TTL_MS) {
-            setItems(parsed.data.items)
+            setItems(mergeRegistryItems(parsed.data))
             setIsLoading(false)
             return
           }
@@ -122,7 +129,7 @@ export function useMarketplace() {
       const response = await fetch(REGISTRY_URL)
       if (!response.ok) throw new Error(`Registry fetch failed: ${response.status}`)
       const data: MarketplaceRegistry = await response.json()
-      setItems(data.items || [])
+      setItems(mergeRegistryItems(data))
 
       // Cache the result
       try {


### PR DESCRIPTION
## Summary
- The `registry.json` in `console-marketplace` has two arrays: `items` (3 dashboards) and `presets` (73 card-presets, themes, CNCF project presets)
- `useMarketplace.ts` only read `data.items`, so the Marketplace page showed 3 items instead of all 76
- Added `presets` field to `MarketplaceRegistry` interface and a `mergeRegistryItems()` helper that combines both arrays
- Applied to both the fresh-fetch path and the localStorage cache restore path

## Test plan
- [ ] Open Marketplace page — should show 76 items (3 dashboards + 71 card-presets + 2 themes) instead of only 3
- [ ] Clear localStorage and reload — verify items load from fresh fetch
- [ ] Reload without clearing — verify items load from cache
- [ ] Type filter badges should show correct counts for dashboard, card-preset, and theme
- [ ] CNCF stats should reflect all items with `cncfProject` metadata