### PR TITLE
🐛 Fix alerts stat block showing 'Not available' on Cluster Admin dashboard

### DIFF
--- a/web/src/components/cluster-admin/ClusterAdmin.tsx
+++ b/web/src/components/cluster-admin/ClusterAdmin.tsx
@@ -32,7 +32,6 @@ export function ClusterAdmin() {
       case 'nodes': return { value: nodes.length, sublabel: 'total nodes', isDemo: isDemoData }
       case 'warnings': return { value: warningEvents.length, sublabel: 'warnings', isDemo: isDemoData }
       case 'pod_issues': return { value: podIssues.length, sublabel: 'pod issues', isDemo: isDemoData }
-      case 'alerts_firing': return { value: '-', sublabel: 'firing', isDemo: isDemoData }
       default: return { value: '-' }
     }
   }, [reachable, healthy, degraded, offline, nodes, warningEvents, podIssues, isDemoData])

--- a/web/src/hooks/useUniversalStats.ts
+++ b/web/src/hooks/useUniversalStats.ts
@@ -304,6 +304,7 @@ export function useUniversalStats() {
       // Alert stats
       // ══════════════════════════════════════════
       case 'firing':
+      case 'alerts_firing':
         return { value: firingAlerts, sublabel: 'firing', onClick: () => drillToAllAlerts('firing'), isClickable: firingAlerts > 0 }
       case 'resolved':
         return { value: resolvedAlerts, sublabel: 'resolved', isClickable: false }


### PR DESCRIPTION
## Problem
The Alerts stat block on the Cluster Admin dashboard shows 'Not available on this dashboard' instead of actual alert counts.

## Root Cause
Two issues combined:
1. `ClusterAdmin.tsx` had a hardcoded `alerts_firing` case returning `{ value: '-' }`
2. `useUniversalStats.ts` only handled `'firing'` (from Alerts dashboard), not `'alerts_firing'` (from Cluster Admin)

The merged stat getter correctly skips dashboard values of `'-'`, but the universal getter didn't recognize `'alerts_firing'` either, causing the 'Not available' fallback.

## Fix
- Removed the hardcoded `alerts_firing: '-'` case from `ClusterAdmin.tsx` (let it fall through)
- Added `'alerts_firing'` as an alias for the `'firing'` case in `useUniversalStats.ts`

Now the Cluster Admin dashboard correctly shows firing alert counts from the universal stats provider.