### PR TITLE
🐛 Add AbortSignal.timeout to all fetch() calls

### DIFF
--- a/scripts/consistency-test.sh
+++ b/scripts/consistency-test.sh
@@ -382,16 +382,20 @@ phase5() {
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
 
-    # Skip refetch/prefetch patterns
+    # Skip refetch/prefetch patterns and commented-out code
     echo "$line" | grep -qE '(refetch|prefetch|registerRefetch|fetchPRCount|fetchData|fetchNodes|fetchClusters|fetchGitHub|fetchStatus)' && continue
+    # The content portion (after file:line:) may have leading whitespace before //
+    local content_part
+    content_part=$(echo "$line" | cut -d: -f3- | sed 's/^[[:space:]]*//')
+    [[ "$content_part" == //* ]] && continue
 
     local filepath
     filepath=$(echo "$line" | cut -d: -f1)
     local linenum
     linenum=$(echo "$line" | cut -d: -f2)
 
-    # Check next 10 lines for 'signal' or AbortSignal
-    local end=$((linenum + 10))
+    # Check next 15 lines for 'signal' or AbortSignal (fetch options can span many lines)
+    local end=$((linenum + 15))
     local max_lines
     max_lines=$(wc -l < "$filepath" | tr -d ' ')
     [[ $end -gt $max_lines ]] && end=$max_lines

--- a/web/src/components/agent/APIKeySettings.tsx
+++ b/web/src/components/agent/APIKeySettings.tsx
@@ -6,6 +6,7 @@ import { BaseModal, ConfirmDialog } from '../../lib/modals'
 import { KC_AGENT, AI_PROVIDER_DOCS } from '../../config/externalApis'
 import { useTranslation } from 'react-i18next'
 import { emitApiKeyConfigured, emitApiKeyRemoved, emitConversionStep } from '../../lib/analytics'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 
 const INSTALL_COMMAND = KC_AGENT.installCommand
 
@@ -133,7 +134,9 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
     try {
       setLoading(true)
       setError(null)
-      const response = await fetch(`${KC_AGENT_URL}/settings/keys`)
+      const response = await fetch(`${KC_AGENT_URL}/settings/keys`, {
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
       if (!response.ok) {
         throw new Error(t('agent.failedToFetchKeyStatus'))
       }
@@ -162,6 +165,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ provider, apiKey: newKeyValue }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       if (!response.ok) {
@@ -188,6 +192,7 @@ export function APIKeySettings({ isOpen, onClose }: APIKeySettingsProps) {
       setSaving(true)
       const response = await fetch(`${KC_AGENT_URL}/settings/keys/${provider}`, {
         method: 'DELETE',
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       if (!response.ok) {

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react'
 import { GitPullRequest, GitBranch, Star, Users, Package, TrendingUp, AlertCircle, Clock, CheckCircle, XCircle, GitMerge, Settings, X, Plus, Check } from 'lucide-react'
-import { STORAGE_KEY_GITHUB_TOKEN } from '../../lib/constants'
+import { STORAGE_KEY_GITHUB_TOKEN, FETCH_EXTERNAL_TIMEOUT_MS } from '../../lib/constants'
 import { Skeleton } from '../ui/Skeleton'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { cn } from '../../lib/cn'
@@ -331,7 +331,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
       }
 
       // Fetch repository info
-      const repoResponse = await fetch(`https://api.github.com/repos/${targetRepo}`, { headers })
+      const repoResponse = await fetch(`https://api.github.com/repos/${targetRepo}`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
       if (!repoResponse.ok) throw new Error(`Failed to fetch repo: ${repoResponse.statusText}`)
       const repoData = await repoResponse.json()
       setRepoInfo(repoData)
@@ -339,8 +339,8 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
       // Fetch open PRs and closed/merged PRs separately to ensure we get merged PRs
       // For active repos, all "recently updated" PRs might be open ones
       const [openPRsResponse, closedPRsResponse] = await Promise.all([
-        fetch(`https://api.github.com/repos/${targetRepo}/pulls?state=open&per_page=50&sort=updated`, { headers }),
-        fetch(`https://api.github.com/repos/${targetRepo}/pulls?state=closed&per_page=50&sort=updated`, { headers })
+        fetch(`https://api.github.com/repos/${targetRepo}/pulls?state=open&per_page=50&sort=updated`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }),
+        fetch(`https://api.github.com/repos/${targetRepo}/pulls?state=closed&per_page=50&sort=updated`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
       ])
 
       if (!openPRsResponse.ok) throw new Error(`Failed to fetch open PRs: ${openPRsResponse.statusText}`)
@@ -359,8 +359,8 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
 
       // Fetch open Issues count and recent issues
       const [openIssuesResponse, recentIssuesResponse] = await Promise.all([
-        fetch(`https://api.github.com/repos/${targetRepo}/issues?state=open&per_page=1`, { headers }),
-        fetch(`https://api.github.com/repos/${targetRepo}/issues?state=all&per_page=50&sort=updated`, { headers })
+        fetch(`https://api.github.com/repos/${targetRepo}/issues?state=open&per_page=1`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }),
+        fetch(`https://api.github.com/repos/${targetRepo}/issues?state=all&per_page=50&sort=updated`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
       ])
 
       // Get open issue count from Link header or response body
@@ -384,13 +384,13 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
       setIssues(filteredIssues)
 
       // Fetch Releases
-      const releasesResponse = await fetch(`https://api.github.com/repos/${targetRepo}/releases?per_page=10`, { headers })
+      const releasesResponse = await fetch(`https://api.github.com/repos/${targetRepo}/releases?per_page=10`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
       if (!releasesResponse.ok) throw new Error(`Failed to fetch releases: ${releasesResponse.statusText}`)
       const releasesData = await releasesResponse.json()
       setReleases(releasesData)
 
       // Fetch Contributors
-      const contributorsResponse = await fetch(`https://api.github.com/repos/${targetRepo}/contributors?per_page=20`, { headers })
+      const contributorsResponse = await fetch(`https://api.github.com/repos/${targetRepo}/contributors?per_page=20`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
       if (!contributorsResponse.ok) throw new Error(`Failed to fetch contributors: ${contributorsResponse.statusText}`)
       const contributorsData = await contributorsResponse.json()
       setContributors(contributorsData)

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -9,7 +9,7 @@ import { useClusters } from '../../hooks/useMCP'
 import { useCachedHardwareHealth, type DeviceAlert, type NodeDeviceInventory, type DeviceCounts } from '../../hooks/useCachedData'
 import { useSnoozedAlerts, SNOOZE_DURATIONS, formatSnoozeRemaining, type SnoozeDuration } from '../../hooks/useSnoozedAlerts'
 import { useTranslation } from 'react-i18next'
-import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
+import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 
 // Sort field options
 type SortField = 'severity' | 'nodeName' | 'cluster' | 'deviceType'
@@ -299,6 +299,7 @@ export function HardwareHealthCard() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ alertId }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       // Refetch to update cached data (the cleared alert won't be in the response)
       refetch()

--- a/web/src/components/cards/StockMarketTicker.tsx
+++ b/web/src/components/cards/StockMarketTicker.tsx
@@ -13,6 +13,7 @@ import {
 import { useCardLoadingState } from './CardDataContext'
 import { useCache } from '../../lib/cache'
 import { useTranslation } from 'react-i18next'
+import { FETCH_EXTERNAL_TIMEOUT_MS } from '../../lib/constants'
 import type { TFunction } from 'i18next'
 
 // Stock search result interface
@@ -121,7 +122,8 @@ async function fetchRealStockData(symbols: string[]): Promise<StockData[]> {
     const symbolsString = symbols.join(',')
     const yahooUrl = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${symbolsString}&fields=symbol,longName,regularMarketPrice,regularMarketChange,regularMarketChangePercent,regularMarketOpen,regularMarketDayHigh,regularMarketDayLow,regularMarketVolume,marketCap,fiftyTwoWeekHigh,fiftyTwoWeekLow`
     const response = await fetch(
-      `${CORS_PROXY}${encodeURIComponent(yahooUrl)}`
+      `${CORS_PROXY}${encodeURIComponent(yahooUrl)}`,
+      { signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }
     )
 
     if (!response.ok) {
@@ -215,7 +217,8 @@ async function searchStocks(query: string): Promise<StockSearchResult[]> {
     // Using Yahoo Finance search API via CORS proxy
     const yahooSearchUrl = `https://query1.finance.yahoo.com/v1/finance/search?q=${encodeURIComponent(query)}&quotesCount=10&newsCount=0`
     const response = await fetch(
-      `${CORS_PROXY}${encodeURIComponent(yahooSearchUrl)}`
+      `${CORS_PROXY}${encodeURIComponent(yahooSearchUrl)}`,
+      { signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }
     )
 
     if (!response.ok) {

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -17,7 +17,7 @@ import type { PredictedRisk, TrendDirection } from '../../../types/predictions'
 import { CardControlsRow, CardSearchInput, CardPaginationFooter, CardAIActions } from '../../../lib/cards/CardComponents'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { useTranslation } from 'react-i18next'
-import { LOCAL_AGENT_HTTP_URL } from '../../../lib/constants'
+import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 
 // ============================================================================
 // Unified Item Type for all card items
@@ -169,7 +169,9 @@ async function fetchAllNodes(): Promise<NodeData[]> {
 
   nodesFetchInProgress = true
   try {
-    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/nodes`)
+    const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
     if (response.ok) {
       const data = await response.json()
       nodesCache = data.nodes || []

--- a/web/src/components/cards/contour-status/useContourStatus.ts
+++ b/web/src/components/cards/contour-status/useContourStatus.ts
@@ -1,6 +1,7 @@
 import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { CONTOUR_DEMO_DATA } from './demoData'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import type { ContourDemoData } from './demoData'
 
 export type ContourStatus = ContourDemoData
@@ -72,6 +73,7 @@ function isPodReady(pod: BackendPodInfo): boolean {
 async function fetchContourStatus(): Promise<ContourStatus> {
   const resp = await fetch('/api/mcp/pods', {
     headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
 
   if (!resp.ok) {

--- a/web/src/components/cards/flatcar_status/useFlatcarStatus.ts
+++ b/web/src/components/cards/flatcar_status/useFlatcarStatus.ts
@@ -1,6 +1,7 @@
 import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { FLATCAR_DEMO_DATA, type FlatcarDemoData } from './demoData'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { compareFlatcarVersions } from './versionUtils'
 
 export interface FlatcarStatus {
@@ -44,6 +45,7 @@ interface BackendNodeInfo {
 async function fetchFlatcarStatus(): Promise<FlatcarStatus> {
   const resp = await fetch('/api/mcp/nodes', {
     headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
 
   if (!resp.ok) {

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -18,7 +18,7 @@ import { useNightlyE2EData } from '../../../hooks/useNightlyE2EData'
 import { useAIMode } from '../../../hooks/useAIMode'
 import { useMissions } from '../../../hooks/useMissions'
 import { useApiKeyCheck, ApiKeyPromptModal } from '../console-missions/shared'
-import { BACKEND_DEFAULT_URL } from '../../../lib/constants'
+import { BACKEND_DEFAULT_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import type { NightlyGuideStatus, NightlyRun } from '../../../lib/llmd/nightlyE2EDemoData'
 import { useTranslation } from 'react-i18next'
 
@@ -143,7 +143,8 @@ function RunDot({ run, guide, isHighlighted, onMouseEnter, onMouseLeave }: {
       try {
         const API_BASE = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
         const resp = await fetch(
-          `${API_BASE}/api/public/nightly-e2e/run-logs?repo=${encodeURIComponent(guide.repo)}&runId=${run.id}`
+          `${API_BASE}/api/public/nightly-e2e/run-logs?repo=${encodeURIComponent(guide.repo)}&runId=${run.id}`,
+          { signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) }
         )
         let logsContent = 'Failed to fetch logs — analyze using the GitHub URL below.'
         if (resp.ok) {

--- a/web/src/components/cards/thanos_status/useThanosStatus.ts
+++ b/web/src/components/cards/thanos_status/useThanosStatus.ts
@@ -1,6 +1,7 @@
 import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { THANOS_DEMO_DATA, type ThanosDemoData } from './demoData'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 
 export interface ThanosTarget {
     name: string
@@ -58,6 +59,7 @@ interface PromQueryResult {
 async function fetchThanosStatus(): Promise<ThanosStatus> {
     const resp = await fetch('/api/v1/query?query=up', {
         headers: { Accept: 'application/json' },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
 
     if (!resp.ok) {

--- a/web/src/components/cards/weather/Weather.tsx
+++ b/web/src/components/cards/weather/Weather.tsx
@@ -9,6 +9,7 @@ import { WeatherAnimation, getWeatherCondition, getConditionColor } from './Weat
 import { WEATHER_API } from '../../../config/externalApis'
 import { useCardLoadingState } from '../CardDataContext'
 import { useCache } from '../../../lib/cache'
+import { FETCH_EXTERNAL_TIMEOUT_MS } from '../../../lib/constants'
 import type {
   GeocodingResult,
   ForecastDay,
@@ -133,7 +134,8 @@ export function Weather({ config }: { config?: WeatherConfig }) {
         `&current=temperature_2m,relative_humidity_2m,apparent_temperature,is_day,weather_code,wind_speed_10m` +
         `&hourly=temperature_2m,weather_code,precipitation_probability` +
         `&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max,sunrise,sunset` +
-        `&temperature_unit=${tempUnit}&wind_speed_unit=${windUnit}&forecast_days=${forecastLength}&timezone=auto`
+        `&temperature_unit=${tempUnit}&wind_speed_unit=${windUnit}&forecast_days=${forecastLength}&timezone=auto`,
+        { signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }
       )
 
       if (!response.ok) throw new Error('Failed to fetch weather data')
@@ -209,7 +211,8 @@ export function Weather({ config }: { config?: WeatherConfig }) {
     setIsSearching(true)
     try {
       const response = await fetch(
-        `${WEATHER_API.geocodingUrl}?name=${encodeURIComponent(query)}&count=5&language=en&format=json`
+        `${WEATHER_API.geocodingUrl}?name=${encodeURIComponent(query)}&count=5&language=en&format=json`,
+        { signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }
       )
 
       if (response.ok) {

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -3,7 +3,7 @@ import {
   GitBranch, AlertTriangle, CheckCircle, XCircle,
   Clock, Loader2, ExternalLink, Key, Settings, Plus, X, Check,
 } from 'lucide-react'
-import { STORAGE_KEY_GITHUB_TOKEN } from '../../../lib/constants'
+import { STORAGE_KEY_GITHUB_TOKEN, FETCH_EXTERNAL_TIMEOUT_MS } from '../../../lib/constants'
 import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
 import { CardControls } from '../../ui/CardControls'
@@ -162,6 +162,7 @@ export const GitHubCIMonitor = forwardRef<GitHubCIMonitorRef, GitHubCIMonitorPro
         try {
           const response = await fetch(`https://api.github.com/repos/${repo}/actions/runs?per_page=10`, {
             headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github.v3+json' },
+            signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS),
           })
           if (response.status === 401 || response.status === 403) {
             // Token lacks actions scope or is invalid — fall back to demo data

--- a/web/src/components/clusters/AddClusterDialog.tsx
+++ b/web/src/components/clusters/AddClusterDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { X, Terminal, Upload, FormInput, Copy, Check, Loader2, ChevronDown, ChevronUp, Shield, KeyRound } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
+import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 
 interface AddClusterDialogProps {
   open: boolean
@@ -142,6 +142,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ kubeconfig: kubeconfigYaml }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!res.ok) {
         const body = await res.json().catch(() => ({ error: res.statusText }))
@@ -164,6 +165,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ kubeconfig: kubeconfigYaml }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!res.ok) {
         const body = await res.json().catch(() => ({ error: res.statusText }))
@@ -201,6 +203,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
           caData: caData ? btoa(caData) : undefined,
           skipTlsVerify: skipTls,
         }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       const data = await res.json()
       setTestResult(data)
@@ -230,6 +233,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
           skipTlsVerify: skipTls,
           namespace: namespace || undefined,
         }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!res.ok) {
         const body = await res.json().catch(() => ({ error: res.statusText }))

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -52,7 +52,7 @@ import { Gauge } from '../charts/Gauge'
 import { ClusterCardSkeleton, StatsOverviewSkeleton } from '../ui/ClusterCardSkeleton'
 import { useIsModeSwitching } from '../../lib/unified/demo'
 import { useTranslation } from 'react-i18next'
-import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_CLUSTER_LAYOUT } from '../../lib/constants'
+import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_CLUSTER_LAYOUT, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 
 // Helper to format labels/annotations for tooltip
 function formatMetadata(labels?: Record<string, string>, annotations?: Record<string, string>): string {
@@ -1546,6 +1546,7 @@ export function Clusters() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ oldName, newName }),
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
     if (!response.ok) {
       const data = await response.json()

--- a/web/src/components/drilldown/RemediationConsole.tsx
+++ b/web/src/components/drilldown/RemediationConsole.tsx
@@ -3,6 +3,7 @@ import { Sparkles, X, Play, Pause, CheckCircle, Loader2, Copy, Download, Termina
 import { cn } from '../../lib/cn'
 import { useTokenUsage } from '../../hooks/useTokenUsage'
 import { safeGetItem } from '../../lib/utils/localStorage'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 import { useTranslation } from 'react-i18next'
 
 interface LogEntry {
@@ -211,6 +212,7 @@ export function RemediationConsole({
           cluster,
           namespace,
         }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       if (!response.ok) {

--- a/web/src/components/drilldown/views/EventsDrillDown.tsx
+++ b/web/src/components/drilldown/views/EventsDrillDown.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, RefreshCw, Terminal, Copy, CheckCircle } from 'lucide-reac
 import { StatusIndicator } from '../../charts/StatusIndicator'
 import { getDemoMode } from '../../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 
 interface ClusterEvent {
   type: string
@@ -87,7 +88,9 @@ export function EventsDrillDown({ data }: Props) {
       }
       params.append('limit', '100')
 
-      const response = await fetch(`http://127.0.0.1:8585/events?${params}`)
+      const response = await fetch(`http://127.0.0.1:8585/events?${params}`, {
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
       if (response.ok) {
         const data = await response.json()
         setEvents(data.events || [])

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../hooks/useFeatureRequests'
 import { useAuth } from '../../lib/auth'
 import { useRewards } from '../../hooks/useRewards'
-import { BACKEND_DEFAULT_URL, STORAGE_KEY_TOKEN, DEMO_TOKEN_VALUE } from '../../lib/constants'
+import { BACKEND_DEFAULT_URL, STORAGE_KEY_TOKEN, DEMO_TOKEN_VALUE, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 import { isDemoModeForced } from '../../lib/demoMode'
 import { useToast } from '../ui/Toast'
 import { useTranslation } from 'react-i18next'
@@ -123,6 +123,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
     try {
       const res = await fetch(`${BACKEND_DEFAULT_URL}/api/feedback/preview/${prNumber}`, {
         headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (res.ok) {
         const data = await res.json()

--- a/web/src/components/gitops/SyncDialog.tsx
+++ b/web/src/components/gitops/SyncDialog.tsx
@@ -4,6 +4,7 @@ import { Check, AlertTriangle, Play, Loader2, ChevronRight, GitBranch, Box, Serv
 import { BaseModal } from '../../lib/modals'
 import { TechnicalAcronym } from '../shared/TechnicalAcronym'
 import { safeGetItem } from '../../lib/utils/localStorage'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 
 // Sync phases
 type SyncPhase = 'detection' | 'plan' | 'execution' | 'complete'
@@ -147,6 +148,7 @@ export function SyncDialog({
           cluster,
           namespace,
         }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       updateLastLog('success')
@@ -249,6 +251,7 @@ export function SyncDialog({
           cluster,
           namespace,
         }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       updateLastLog('success')

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -17,7 +17,7 @@ import { useNetworkStatus } from '../../hooks/useNetworkStatus'
 import { useBackendHealth } from '../../hooks/useBackendHealth'
 import { useDeepLink } from '../../hooks/useDeepLink'
 import { cn } from '../../lib/cn'
-import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
+import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 import { TourOverlay, TourPrompt } from '../onboarding/Tour'
 import { TourProvider } from '../../hooks/useTour'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
@@ -137,6 +137,7 @@ export function Layout({ children }: LayoutProps) {
       const resp = await fetch(`${LOCAL_AGENT_HTTP_URL}/restart-backend`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (resp.ok) {
         const data = await resp.json()

--- a/web/src/components/settings/sections/GitHubTokenSection.tsx
+++ b/web/src/components/settings/sections/GitHubTokenSection.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Save, RefreshCw, Check, X, Github, ExternalLink, Loader2 } from 'lucide-react'
-import { STORAGE_KEY_GITHUB_TOKEN } from '../../../lib/constants'
+import { STORAGE_KEY_GITHUB_TOKEN, FETCH_EXTERNAL_TIMEOUT_MS } from '../../../lib/constants'
 import { emitGitHubTokenConfigured, emitGitHubTokenRemoved, emitConversionStep } from '../../../lib/analytics'
 
 interface GitHubTokenSectionProps {
@@ -94,6 +94,7 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
           'Authorization': `Bearer ${token}`,
           'Accept': 'application/vnd.github.v3+json',
         },
+        signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS),
       })
 
       if (!response.ok) {

--- a/web/src/components/settings/sections/ProfileSection.tsx
+++ b/web/src/components/settings/sections/ProfileSection.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Save, User, Loader2, AlertCircle, RefreshCw } from 'lucide-react'
-import { STORAGE_KEY_TOKEN } from '../../../lib/constants'
+import { STORAGE_KEY_TOKEN, FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 
 interface ProfileSectionProps {
   initialEmail: string
@@ -41,6 +41,7 @@ export function ProfileSection({ initialEmail, initialSlackId, refreshUser, isLo
           ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
         },
         body: JSON.stringify({ email, slackId }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!response.ok) {
         throw new Error('Failed to save profile')

--- a/web/src/components/widget/MiniDashboard.tsx
+++ b/web/src/components/widget/MiniDashboard.tsx
@@ -12,7 +12,7 @@ import { RefreshCw, Maximize2, Download } from 'lucide-react'
 import { useClusters, useGPUNodes, usePodIssues } from '../../hooks/useMCP'
 import { cn } from '../../lib/cn'
 import { useTranslation } from 'react-i18next'
-import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
+import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 
 // Node data type from agent
 interface NodeData {
@@ -97,7 +97,9 @@ export function MiniDashboard() {
 
   const fetchNodes = useCallback(async () => {
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/nodes`)
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/nodes`, {
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
       if (response.ok) {
         const data = await response.json()
         setAllNodes(data.nodes || [])

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -10,7 +10,7 @@ import type {
 } from '../types/alerts'
 import type { GPUHealthCheckResult } from '../hooks/mcp/types'
 import type { NightlyGuideStatus } from '../lib/llmd/nightlyE2EDemoData'
-import { BACKEND_DEFAULT_URL, STORAGE_KEY_AUTH_TOKEN } from '../lib/constants'
+import { BACKEND_DEFAULT_URL, STORAGE_KEY_AUTH_TOKEN, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants'
 import { PRESET_ALERT_RULES } from '../types/alerts'
 import { sendNotificationWithDeepLink } from '../hooks/useDeepLink'
 
@@ -133,7 +133,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
           try {
             const resp = await fetch(
               `${API_BASE}/api/mcp/gpu-nodes/health/cronjob/results?cluster=${encodeURIComponent(cluster.name)}`,
-              { headers: { Authorization: `Bearer ${token}` } }
+              { headers: { Authorization: `Bearer ${token}` }, signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) }
             )
             if (resp.ok) {
               const data = await resp.json()
@@ -165,7 +165,9 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
     const fetchNightlyE2E = async () => {
       try {
         const API_BASE = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
-        const resp = await fetch(`${API_BASE}/api/public/nightly-e2e/runs`)
+        const resp = await fetch(`${API_BASE}/api/public/nightly-e2e/runs`, {
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+        })
         if (resp.ok) {
           const data = await resp.json()
           if (Array.isArray(data)) {
@@ -408,6 +410,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({ alert, channels }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       // Silently ignore auth errors - user may not be logged in

--- a/web/src/hooks/mcp/buildpacks.ts
+++ b/web/src/hooks/mcp/buildpacks.ts
@@ -4,6 +4,7 @@ import { useDemoMode } from '../useDemoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { MIN_REFRESH_INDICATOR_MS, getEffectiveInterval } from './shared'
+import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
 
 export interface BuildpackImage {
   name: string
@@ -194,7 +195,7 @@ export function useBuildpackImages(cluster?: string) {
           headers['Authorization'] = `Bearer ${token}`
         }
 
-        const response = await fetch(url, { method: 'GET', headers })
+        const response = await fetch(url, { method: 'GET', headers, signal: AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS) })
         if (response.status === 404) {
           // Endpoint not yet available; treat as empty list
           const newImages: BuildpackImage[] = []

--- a/web/src/hooks/mcp/crossplane.ts
+++ b/web/src/hooks/mcp/crossplane.ts
@@ -3,6 +3,7 @@ import { isNetlifyDeployment, isDemoMode } from '../../lib/demoMode'
 import { useDemoMode } from '../useDemoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { MIN_REFRESH_INDICATOR_MS, getEffectiveInterval } from './shared'
+import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
 
 export interface CrossplaneManagedResource {
   apiVersion: string
@@ -219,7 +220,7 @@ export function useCrossplaneManagedResources(cluster?: string) {
           return
         }
 
-        const response = await fetch(url)
+        const response = await fetch(url, { signal: AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS) })
         if (!response.ok) {
           throw new Error(`API error: ${response.status}`)
         }

--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -5,6 +5,7 @@ import { useDemoMode } from '../useDemoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { MIN_REFRESH_INDICATOR_MS, getEffectiveInterval } from './shared'
+import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
 import type { HelmRelease, HelmHistoryEntry } from './types'
 
 // Demo Helm releases shown when in demo mode
@@ -235,7 +236,7 @@ export function useHelmReleases(cluster?: string) {
       if (!sseSucceeded) {
         const headers: Record<string, string> = { 'Content-Type': 'application/json' }
         headers['Authorization'] = `Bearer ${token}`
-        const response = await fetch(url, { method: 'GET', headers })
+        const response = await fetch(url, { method: 'GET', headers, signal: AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS) })
         if (!response.ok) {
           throw new Error(`API error: ${response.status}`)
         }
@@ -404,7 +405,7 @@ export function useHelmHistory(cluster?: string, release?: string, namespace?: s
       // Use direct fetch to bypass the global circuit breaker
       const headers: Record<string, string> = { 'Content-Type': 'application/json' }
       headers['Authorization'] = `Bearer ${token}`
-      const response = await fetch(url, { method: 'GET', headers })
+      const response = await fetch(url, { method: 'GET', headers, signal: AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS) })
       if (!response.ok) {
         throw new Error(`API error: ${response.status}`)
       }
@@ -558,6 +559,7 @@ export function useHelmValues(cluster?: string, release?: string, namespace?: st
       const response = await fetch(url, {
         method: 'GET',
         headers,
+        signal: AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS),
       })
       if (!response.ok) {
         throw new Error(`API error: ${response.status}`)
@@ -671,6 +673,7 @@ export function useHelmValues(cluster?: string, release?: string, namespace?: st
           const response = await fetch(url, {
             method: 'GET',
             headers,
+            signal: AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS),
           })
           if (!response.ok) {
             throw new Error(`API error: ${response.status}`)

--- a/web/src/hooks/mcp/security.ts
+++ b/web/src/hooks/mcp/security.ts
@@ -5,6 +5,7 @@ import { useDemoMode } from '../useDemoMode'
 import { registerRefetch } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { MIN_REFRESH_INDICATOR_MS, REFRESH_INTERVAL_MS, getEffectiveInterval } from './shared'
+import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
 import type { SecurityIssue, GitOpsDrift } from './types'
 
 // LocalStorage cache keys
@@ -205,7 +206,7 @@ export function useGitOpsDrifts(cluster?: string, namespace?: string) {
       // Use direct fetch to bypass the global circuit breaker
       const headers: Record<string, string> = { 'Content-Type': 'application/json' }
       headers['Authorization'] = `Bearer ${token}`
-      const response = await fetch(url, { method: 'GET', headers })
+      const response = await fetch(url, { method: 'GET', headers, signal: AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS) })
       if (!response.ok) {
         throw new Error(`API error: ${response.status}`)
       }

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -7,6 +7,7 @@ import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef } from './shared'
+import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
 import type { PodInfo, PodIssue, Deployment, DeploymentIssue, Job, HPA, ReplicaSet, StatefulSet, DaemonSet, CronJob } from './types'
 
 // ---------------------------------------------------------------------------
@@ -999,7 +1000,7 @@ export function useDeployments(cluster?: string, namespace?: string) {
       const token = localStorage.getItem(STORAGE_KEY_TOKEN)
       const headers: Record<string, string> = { 'Content-Type': 'application/json' }
       headers['Authorization'] = `Bearer ${token}`
-      const response = await fetch(url, { method: 'GET', headers })
+      const response = await fetch(url, { method: 'GET', headers, signal: AbortSignal.timeout(MCP_HOOK_TIMEOUT_MS) })
       if (!response.ok) {
         throw new Error(`API error: ${response.status}`)
       }

--- a/web/src/hooks/useAIPredictions.ts
+++ b/web/src/hooks/useAIPredictions.ts
@@ -11,6 +11,7 @@ import { setActiveTokenCategory } from './useTokenUsage'
 import { fullFetchClusters, clusterCache } from './mcp/shared'
 
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 const AGENT_HTTP_URL = LOCAL_AGENT_HTTP_URL
 const POLL_INTERVAL = 30000 // Poll every 30 seconds as fallback
@@ -217,6 +218,7 @@ async function triggerAnalysis(specificProviders?: string[]): Promise<boolean> {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ providers: specificProviders }),
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
 
     if (response.ok) {

--- a/web/src/hooks/useBackendHealth.ts
+++ b/web/src/hooks/useBackendHealth.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 export type BackendStatus = 'connected' | 'disconnected' | 'connecting'
 
@@ -78,6 +79,7 @@ class BackendHealthManager {
       const response = await fetch('/health', {
         method: 'GET',
         headers: { Accept: 'application/json' },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       if (response.ok) {

--- a/web/src/hooks/useBenchmarkData.ts
+++ b/web/src/hooks/useBenchmarkData.ts
@@ -18,6 +18,7 @@ import {
   type BenchmarkReport,
 } from '../lib/llmd/benchmarkMockData'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 function authHeaders(): Record<string, string> {
   const token = localStorage.getItem(STORAGE_KEY_TOKEN)
@@ -207,6 +208,7 @@ export function useCachedBenchmarkReports() {
       // Fallback: try non-streaming endpoint (returns cache quickly)
       const res = await fetch(`/api/benchmarks/reports?since=${encodeURIComponent(stream.since)}`, {
         headers: authHeaders(),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (res.status === 503) throw new Error('BENCHMARK_UNAVAILABLE')
       if (!res.ok) throw new Error(`Benchmark API error: ${res.status}`)

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -23,6 +23,7 @@ import { fetchSSE } from '../lib/sseClient'
 import { clusterCacheRef } from './mcp/shared'
 import { isAgentUnavailable } from './useLocalAgent'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type {
   PodInfo,
   PodIssue,
@@ -70,6 +71,7 @@ async function fetchAPI<T>(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
 
   if (!response.ok) {
@@ -1387,6 +1389,7 @@ export function useCachedWorkloads(
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,
           },
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
         })
         if (res.ok) {
           const data = await res.json()
@@ -1418,6 +1421,7 @@ export function useCachedWorkloads(
       if (hasRealToken && !isBackendUnavailable()) {
         const res = await fetch('/api/workloads', {
           headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
         })
         if (res.ok) {
           const data = await res.json()
@@ -1592,6 +1596,7 @@ export function useCachedSecurityIssues(
               'Content-Type': 'application/json',
               Authorization: `Bearer ${token}`,
             },
+            signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
           })
           if (response.ok) {
             const data = await response.json() as { issues: SecurityIssue[] }
@@ -1824,6 +1829,7 @@ export function useGPUHealthCronJob(cluster?: string) {
           schedule: opts?.schedule,
           tier: opts?.tier ?? 2,
         }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!response.ok) {
         const text = await response.text()
@@ -1854,6 +1860,7 @@ export function useGPUHealthCronJob(cluster?: string) {
           cluster,
           namespace: opts?.namespace,
         }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!response.ok) {
         const text = await response.text()
@@ -2011,6 +2018,7 @@ export const coreFetchers = {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (response.ok) {
         const data = await response.json() as { issues: SecurityIssue[] }
@@ -2035,6 +2043,7 @@ export const coreFetchers = {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (res.ok) {
         const data = await res.json()

--- a/web/src/hooks/useClusterGroups.ts
+++ b/web/src/hooks/useClusterGroups.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { usePersistence } from './usePersistence'
 import { useClusterGroups as useCRClusterGroups, ClusterGroup as CRClusterGroup } from './useConsoleCRs'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 // ============================================================================
 // Types
@@ -169,6 +170,7 @@ export function useClusterGroups() {
           method: 'POST',
           headers: authHeaders(),
           body: JSON.stringify(group),
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
         })
       } catch {
         // Backend sync is best-effort; localStorage is primary
@@ -198,6 +200,7 @@ export function useClusterGroups() {
             method: 'PUT',
             headers: authHeaders(),
             body: JSON.stringify({ ...group, ...updates }),
+            signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
           })
         } catch {
           // best-effort
@@ -216,6 +219,7 @@ export function useClusterGroups() {
         await fetch(`/api/cluster-groups/${encodeURIComponent(name)}`, {
           method: 'DELETE',
           headers: authHeaders(),
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
         })
       } catch {
         // best-effort
@@ -239,6 +243,7 @@ export function useClusterGroups() {
         method: 'POST',
         headers: authHeaders(),
         body: JSON.stringify(group.query),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!resp.ok) return group.clusters
 
@@ -262,6 +267,7 @@ export function useClusterGroups() {
         method: 'POST',
         headers: authHeaders(),
         body: JSON.stringify(query),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!resp.ok) return { clusters: [], count: 0 }
 
@@ -279,6 +285,7 @@ export function useClusterGroups() {
         method: 'POST',
         headers: authHeaders(),
         body: JSON.stringify({ prompt }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!resp.ok) {
         return { error: `Request failed: ${resp.status}` }

--- a/web/src/hooks/useConsoleCRs.ts
+++ b/web/src/hooks/useConsoleCRs.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { usePersistence } from './usePersistence'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 // =============================================================================
 // Types
@@ -196,7 +197,9 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
     }
 
     try {
-      const response = await fetch(`/api/persistence/${endpoint}`)
+      const response = await fetch(`/api/persistence/${endpoint}`, {
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
       if (response.ok) {
         const data = await response.json()
         if (isMounted.current) {
@@ -223,7 +226,9 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
     if (!shouldUseCRs) return null
 
     try {
-      const response = await fetch(`/api/persistence/${endpoint}/${name}`)
+      const response = await fetch(`/api/persistence/${endpoint}/${name}`, {
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
       if (response.ok) {
         return await response.json()
       }
@@ -242,6 +247,7 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(item),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (response.ok) {
         const created = await response.json()
@@ -264,6 +270,7 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(item),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (response.ok) {
         const updated = await response.json()
@@ -284,6 +291,7 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
     try {
       const response = await fetch(`/api/persistence/${endpoint}/${name}`, {
         method: 'DELETE',
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (response.ok || response.status === 204) {
         // Optimistic update
@@ -349,6 +357,7 @@ export function useWorkloadDeployments() {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(status),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (response.ok) {
         return await response.json()

--- a/web/src/hooks/useDependencies.ts
+++ b/web/src/hooks/useDependencies.ts
@@ -3,6 +3,7 @@ import { isAgentUnavailable } from './useLocalAgent'
 import { clusterCacheRef } from './mcp/shared'
 import { isDemoMode } from '../lib/demoMode'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 export interface ResolvedDependency {
   kind: string
@@ -160,7 +161,7 @@ export function useResolveDependencies() {
       try {
         const res = await fetch(
           `/api/workloads/resolve-deps/${encodeURIComponent(cluster)}/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
-          { headers: authHeaders() },
+          { headers: authHeaders(), signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) },
         )
         if (!res.ok) {
           throw new Error(`REST ${res.status}`)

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -4,6 +4,7 @@ import { clusterCacheRef } from './mcp/shared'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import type { DeployStartedPayload, DeployResultPayload, DeployedDep } from '../lib/cardEvents'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN, STORAGE_KEY_MISSIONS_ACTIVE, STORAGE_KEY_MISSIONS_HISTORY } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 function authHeaders(): Record<string, string> {
   const token = localStorage.getItem(STORAGE_KEY_TOKEN)
@@ -257,7 +258,7 @@ export function useDeployMissions() {
               try {
                 const res = await fetch(
                   `/api/workloads/deploy-status/${encodeURIComponent(cluster)}/${encodeURIComponent(mission.namespace)}/${encodeURIComponent(mission.workload)}`,
-                  { headers: authHeaders() }
+                  { headers: authHeaders(), signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) }
                 )
                 if (!res.ok) {
                   return { cluster, status: 'pending', replicas: 0, readyReplicas: 0 }
@@ -276,7 +277,7 @@ export function useDeployMissions() {
                 try {
                   const logRes = await fetch(
                     `/api/workloads/deploy-logs/${encodeURIComponent(cluster)}/${encodeURIComponent(mission.namespace)}/${encodeURIComponent(mission.workload)}?tail=8`,
-                    { headers: authHeaders() }
+                    { headers: authHeaders(), signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) }
                   )
                   if (logRes.ok) {
                     const logData = await logRes.json()

--- a/web/src/hooks/useGitHubRewards.ts
+++ b/web/src/hooks/useGitHubRewards.ts
@@ -8,6 +8,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useAuth } from '../lib/auth'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { BACKEND_DEFAULT_URL } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type { GitHubRewardsResponse } from '../types/rewards'
 
 const CACHE_KEY = 'github-rewards-cache'
@@ -49,6 +50,7 @@ export function useGitHubRewards() {
       const apiBase = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
       const res = await fetch(`${apiBase}/api/rewards/github`, {
         headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!res.ok) throw new Error(`API error: ${res.status}`)
       const result: GitHubRewardsResponse = await res.json()

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { isDemoModeForced } from './useDemoMode'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { emitAgentConnected, emitAgentDisconnected, emitConversionStep } from '../lib/analytics'
 
 export interface AgentHealth {
@@ -202,6 +203,7 @@ class AgentManager {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
         method: 'GET',
         headers: { Accept: 'application/json' },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       if (response.ok) {

--- a/web/src/hooks/useLocalClusterTools.ts
+++ b/web/src/hooks/useLocalClusterTools.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useLocalAgent } from './useLocalAgent'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { useDemoMode } from './useDemoMode'
 import { useClusterProgress } from './useClusterProgress'
 
@@ -64,7 +65,9 @@ export function useLocalClusterTools() {
     }
 
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-cluster-tools`)
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-cluster-tools`, {
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
       if (response.ok) {
         const data = await response.json()
         setTools(data.tools || [])
@@ -92,7 +95,9 @@ export function useLocalClusterTools() {
 
     setIsLoading(true)
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-clusters`)
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-clusters`, {
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
       if (response.ok) {
         const data = await response.json()
         setClusters(data.clusters || [])
@@ -135,6 +140,7 @@ export function useLocalClusterTools() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ tool, name }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       if (response.ok) {
@@ -179,6 +185,7 @@ export function useLocalClusterTools() {
     try {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-clusters?tool=${tool}&name=${name}`, {
         method: 'DELETE',
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       if (response.ok) {

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { api } from '../lib/api'
 import { addCustomTheme, removeCustomTheme } from '../lib/themes'
 import { emitMarketplaceInstall, emitMarketplaceRemove } from '../lib/analytics'
+import { FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
 
 const REGISTRY_URL = 'https://raw.githubusercontent.com/kubestellar/console-marketplace/main/registry.json'
 const CACHE_KEY = 'kc-marketplace-registry'
@@ -126,7 +127,9 @@ export function useMarketplace() {
     }
 
     try {
-      const response = await fetch(REGISTRY_URL)
+      const response = await fetch(REGISTRY_URL, {
+        signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS),
+      })
       if (!response.ok) throw new Error(`Registry fetch failed: ${response.status}`)
       const data: MarketplaceRegistry = await response.json()
       setItems(mergeRegistryItems(data))
@@ -178,7 +181,9 @@ export function useMarketplace() {
   }, [installedItems])
 
   const installItem = useCallback(async (item: MarketplaceItem): Promise<InstallResult> => {
-    const response = await fetch(item.downloadUrl)
+    const response = await fetch(item.downloadUrl, {
+      signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS),
+    })
     if (!response.ok) throw new Error(`Download failed: ${response.status}`)
     const json = await response.json()
 
@@ -348,7 +353,8 @@ export function useAuthorProfile(handle?: string, enabled = false): AuthorProfil
     const fetchPRCount = async (repo: string): Promise<number> => {
       try {
         const res = await fetch(
-          `https://api.github.com/search/issues?q=author:${encodeURIComponent(handle)}+repo:${repo}+type:pr+is:merged&per_page=1`
+          `https://api.github.com/search/issues?q=author:${encodeURIComponent(handle)}+repo:${repo}+type:pr+is:merged&per_page=1`,
+          { signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }
         )
         if (!res.ok) return 0
         const data = await res.json()

--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -17,6 +17,7 @@ import {
 } from '../lib/llmd/nightlyE2EDemoData'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 import { isNetlifyDeployment } from '../lib/demoMode'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 const REFRESH_IDLE_MS = 5 * 60 * 1000    // 5 minutes when idle
 const REFRESH_ACTIVE_MS = 2 * 60 * 1000  // 2 minutes when jobs are running
@@ -80,6 +81,7 @@ export function useNightlyE2EData() {
               ...(endpoint.includes('/public/') ? {} : getAuthHeaders()),
               Accept: 'application/json',
             },
+            signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
           })
           if (res.ok) {
             const data = await res.json()

--- a/web/src/hooks/useNotificationAPI.ts
+++ b/web/src/hooks/useNotificationAPI.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react'
 import { Alert, AlertChannel } from '../types/alerts'
 import { BACKEND_DEFAULT_URL, STORAGE_KEY_AUTH_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
 
@@ -36,6 +37,7 @@ export function useNotificationAPI() {
           method: 'POST',
           headers: getAuthHeaders(),
           body: JSON.stringify({ type, config } as TestNotificationRequest),
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
         })
 
         const data = await response.json()
@@ -66,6 +68,7 @@ export function useNotificationAPI() {
           method: 'POST',
           headers: getAuthHeaders(),
           body: JSON.stringify({ alert, channels } as SendAlertNotificationRequest),
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
         })
 
         const data = await response.json()

--- a/web/src/hooks/usePersistedSettings.ts
+++ b/web/src/hooks/usePersistedSettings.ts
@@ -8,6 +8,7 @@ import {
   SETTINGS_CHANGED_EVENT,
 } from '../lib/settingsSync'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 const DEBOUNCE_MS = 1000
 
@@ -84,6 +85,7 @@ export function usePersistedSettings() {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/settings/export`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!response.ok) throw new Error('Export failed')
       const blob = await response.blob()

--- a/web/src/hooks/usePersistence.ts
+++ b/web/src/hooks/usePersistence.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useLocalAgent } from './useLocalAgent'
 import { useAuth } from '../lib/auth'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 // =============================================================================
 // Types
@@ -78,7 +79,8 @@ export function usePersistence() {
 
     try {
       const response = await fetch('/api/persistence/config', {
-        headers: { Authorization: `Bearer ${token}` }
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (response.ok) {
         const data = await response.json()
@@ -99,7 +101,8 @@ export function usePersistence() {
 
     try {
       const response = await fetch('/api/persistence/status', {
-        headers: { Authorization: `Bearer ${token}` }
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (response.ok) {
         const data = await response.json()
@@ -124,6 +127,7 @@ export function usePersistence() {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(updatedConfig),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       if (response.ok) {
@@ -176,6 +180,7 @@ export function usePersistence() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ cluster }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       if (response.ok) {
@@ -194,7 +199,7 @@ export function usePersistence() {
 
     setSyncing(true)
     try {
-      const response = await fetch('/api/persistence/sync', { method: 'POST' })
+      const response = await fetch('/api/persistence/sync', { method: 'POST', signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (response.ok) {
         await fetchStatus()
         return true

--- a/web/src/hooks/usePredictionFeedback.ts
+++ b/web/src/hooks/usePredictionFeedback.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { PredictionFeedback, StoredFeedback, PredictionType, PredictionStats } from '../types/predictions'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 const STORAGE_KEY = 'kubestellar-prediction-feedback'
 const FEEDBACK_CHANGED_EVENT = 'kubestellar-prediction-feedback-changed'
@@ -187,6 +188,7 @@ async function sendFeedbackToBackend(predictionId: string, feedback: PredictionF
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ predictionId, feedback }),
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}`)

--- a/web/src/hooks/useProviderHealth.ts
+++ b/web/src/hooks/useProviderHealth.ts
@@ -4,6 +4,7 @@ import { useClusters } from './mcp/clusters'
 import { detectCloudProvider, getProviderLabel } from '../components/ui/CloudProviderIcon'
 import type { CloudProvider } from '../components/ui/CloudProviderIcon'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 const REFRESH_INTERVAL = 60_000 // 60 seconds
 const STATUS_CHECK_TIMEOUT = 5_000
 
@@ -174,7 +175,9 @@ export function useProviderHealth() {
     // --- AI Providers from /settings/keys ---
     const unconfiguredProviders: string[] = []
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/settings/keys`)
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/settings/keys`, {
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
       if (response.ok) {
         const data: KeysStatusResponse = await response.json()
         const seen = new Set<string>()

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -1,4 +1,5 @@
 import { useCallback, useSyncExternalStore } from 'react'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 export interface SidebarItem {
   id: string
@@ -135,7 +136,7 @@ export async function fetchEnabledDashboards(): Promise<void> {
   if (enabledDashboardsFetched) return
   enabledDashboardsFetched = true
   try {
-    const resp = await fetch('/health')
+    const resp = await fetch('/health', { signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
     const data = await resp.json()
     if (data.enabled_dashboards && Array.isArray(data.enabled_dashboards) && data.enabled_dashboards.length > 0) {
       enabledDashboardIds = data.enabled_dashboards as string[]

--- a/web/src/hooks/useUpdateProgress.ts
+++ b/web/src/hooks/useUpdateProgress.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from 'react'
 import type { UpdateProgress } from '../types/updates'
-import { LOCAL_AGENT_WS_URL } from '../lib/constants/network'
+import { LOCAL_AGENT_WS_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 const WS_RECONNECT_MS = 5000 // Reconnect interval after WebSocket disconnect
 const BACKEND_POLL_MS = 2000 // Poll interval when waiting for backend to come up
@@ -28,7 +28,7 @@ export function useUpdateProgress() {
       setProgress({ status: 'restarting', message: 'Waiting for backend to come up...', progress: 90 })
       for (let i = 0; i < BACKEND_POLL_MAX; i++) {
         try {
-          const resp = await fetch('/health', { cache: 'no-store' })
+          const resp = await fetch('/health', { cache: 'no-store', signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
           if (resp.ok) {
             setProgress({ status: 'done', message: 'Update complete — restart successful', progress: 100 })
             return

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -11,7 +11,7 @@ import type {
 } from '../types/updates'
 import { UPDATE_STORAGE_KEYS } from '../types/updates'
 import { STORAGE_KEY_GITHUB_TOKEN } from '../lib/constants'
-import { LOCAL_AGENT_HTTP_URL } from '../lib/constants/network'
+import { LOCAL_AGENT_HTTP_URL, FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
 
 declare const __APP_VERSION__: string
 declare const __COMMIT_HASH__: string
@@ -595,7 +595,7 @@ function useVersionCheckCore() {
         }
       }
 
-      const response = await fetch(GITHUB_API_URL, { headers })
+      const response = await fetch(GITHUB_API_URL, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
 
       // Handle rate limiting
       if (response.status === 403) {

--- a/web/src/hooks/useWorkloadMonitor.ts
+++ b/web/src/hooks/useWorkloadMonitor.ts
@@ -7,6 +7,7 @@ import type {
 } from '../types/workloadMonitor'
 import { DEFAULT_REFRESH_MS } from '../types/workloadMonitor'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 function authHeaders(): Record<string, string> {
   const token = localStorage.getItem(STORAGE_KEY_TOKEN)
@@ -87,7 +88,7 @@ export function useWorkloadMonitor(
     try {
       const res = await fetch(
         `/api/workloads/monitor/${encodeURIComponent(cluster)}/${encodeURIComponent(namespace)}/${encodeURIComponent(workload)}`,
-        { headers: authHeaders() },
+        { headers: authHeaders(), signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) },
       )
 
       if (!res.ok) {

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -3,6 +3,7 @@ import { isAgentUnavailable } from './useLocalAgent'
 import { clusterCacheRef } from './mcp/shared'
 import { isDemoMode } from '../lib/demoMode'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 // Types
 export interface Workload {
@@ -186,7 +187,7 @@ export function useWorkloads(options?: {
       const queryString = params.toString()
       const url = `/api/workloads${queryString ? `?${queryString}` : ''}`
 
-      const res = await fetch(url, { headers: authHeaders() })
+      const res = await fetch(url, { headers: authHeaders(), signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!res.ok) {
         throw new Error(`Failed to fetch workloads: ${res.statusText}`)
       }
@@ -225,7 +226,7 @@ export function useClusterCapabilities(enabled = true) {
     setError(null)
 
     try {
-      const res = await fetch('/api/workloads/capabilities', { headers: authHeaders() })
+      const res = await fetch('/api/workloads/capabilities', { headers: authHeaders(), signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!res.ok) {
         throw new Error(`Failed to fetch capabilities: ${res.statusText}`)
       }
@@ -272,6 +273,7 @@ export function useDeployWorkload() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify(request),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!res.ok) {
         const errorData = await res.json()
@@ -318,6 +320,7 @@ export function useScaleWorkload() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },
         body: JSON.stringify(request),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!res.ok) {
         const errorData = await res.json()
@@ -362,6 +365,7 @@ export function useDeleteWorkload() {
       const res = await fetch(`/api/workloads/${params.cluster}/${params.namespace}/${params.name}`, {
         method: 'DELETE',
         headers: authHeaders(),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
       if (!res.ok) {
         const errorData = await res.json()

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4,6 +4,7 @@ import {
   STORAGE_KEY_TOKEN,
   STORAGE_KEY_USER_CACHE,
   DEMO_TOKEN_VALUE,
+  FETCH_DEFAULT_TIMEOUT_MS,
 } from './constants'
 import { emitSessionExpired } from './analytics'
 
@@ -263,6 +264,7 @@ class ApiClient {
         const response = await fetch(`${API_BASE}/auth/refresh`, {
           method: 'POST',
           headers: this.getHeaders(),
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
         })
         if (response.ok) {
           const data = await response.json()

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
 import { api, checkBackendAvailability, checkOAuthConfigured } from './api'
 import { dashboardSync } from './dashboards/dashboardSync'
-import { STORAGE_KEY_TOKEN, DEMO_TOKEN_VALUE, STORAGE_KEY_DEMO_MODE, STORAGE_KEY_ONBOARDED, STORAGE_KEY_USER_CACHE } from './constants'
+import { STORAGE_KEY_TOKEN, DEMO_TOKEN_VALUE, STORAGE_KEY_DEMO_MODE, STORAGE_KEY_ONBOARDED, STORAGE_KEY_USER_CACHE, FETCH_DEFAULT_TIMEOUT_MS } from './constants'
 import { emitLogin, emitLogout, setAnalyticsUserId, setAnalyticsUserProperties, emitConversionStep } from './analytics'
 
 interface User {
@@ -284,6 +284,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
               'Content-Type': 'application/json',
               Authorization: `Bearer ${currentToken}`,
             },
+            signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
           })
           if (response.ok) {
             const data = await response.json()

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -60,6 +60,12 @@ export const MCP_EXTENDED_TIMEOUT_MS = 30_000
 /** Timeout for backend API health checks */
 export const BACKEND_HEALTH_CHECK_TIMEOUT_MS = 2_000
 
+/** Default timeout for fetch() calls to the local backend API */
+export const FETCH_DEFAULT_TIMEOUT_MS = 10_000
+
+/** Timeout for fetch() calls to external services (GitHub API, registries, etc.) */
+export const FETCH_EXTERNAL_TIMEOUT_MS = 15_000
+
 // ============================================================================
 // UI Feedback Timeouts
 // ============================================================================

--- a/web/src/lib/unified/card/hooks/useDataSource.ts
+++ b/web/src/lib/unified/card/hooks/useDataSource.ts
@@ -10,6 +10,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import type { CardDataSource } from '../../types'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../constants'
 
 // Hook registry - populated by registerDataHook
 const dataHookRegistry: Record<
@@ -224,6 +225,7 @@ function useApiDataSourceInternal(
         method,
         headers: method === 'POST' ? { 'Content-Type': 'application/json' } : undefined,
         body: method === 'POST' && params ? JSON.stringify(params) : undefined,
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
Adds `AbortSignal.timeout()` to every `fetch()` call in the codebase that was missing one, preventing indefinite hangs on network failures.

**101 violations → 0** (Phase 5 of the consistency test is now clean)

### Timeout tiers
| Constant | Value | Target |
|----------|-------|--------|
| `FETCH_DEFAULT_TIMEOUT_MS` | 10s | Local backend API (`/api/...`) |
| `FETCH_EXTERNAL_TIMEOUT_MS` | 15s | External services (GitHub, weather, stock APIs) |
| `MCP_HOOK_TIMEOUT_MS` | 15s | MCP/agent proxy calls (already existed) |

Both new constants added to `lib/constants/network.ts`.

### Files changed
- 53 source files with fetch timeout additions
- 2 new constants in `lib/constants/network.ts`
- `consistency-test.sh` Phase 5 improvements (15-line lookahead, skip comments)

### Consistency test after this PR
| Phase | Status |
|-------|--------|
| 4 (localStorage Safety) | ✅ clean |
| 5 (Fetch Timeout) | ✅ clean |

## Test plan
- [x] `npm run build` passes
- [x] `npm run test:consistency` shows Phase 5 clean
- [x] No logic changes — only added timeout signals to existing fetch calls
- [x] Existing AbortControllers and signal params preserved (not overridden)