### PR TITLE
🐛 Preserve isDemo flag when falling back to universal stats

### DIFF
--- a/web/src/hooks/useUniversalStats.ts
+++ b/web/src/hooks/useUniversalStats.ts
@@ -471,9 +471,12 @@ export function createMergedStatValueGetter(
       return dashboardValue
     }
 
-    // Fall back to universal getter
+    // Fall back to universal getter, preserving dashboard demo metadata
     const universalValue = universalGetter(blockId)
     if (universalValue?.value !== undefined) {
+      if (dashboardValue?.isDemo !== undefined && universalValue.isDemo === undefined) {
+        return { ...universalValue, isDemo: dashboardValue.isDemo }
+      }
       return universalValue
     }
 


### PR DESCRIPTION
Addresses Copilot review feedback on PR #1570.

When `createMergedStatValueGetter` falls back from a dashboard-specific getter to the universal getter, carry over the `isDemo` flag from the dashboard value if the universal value doesn't set one.

Without this, stat blocks like `alerts_firing` on the Cluster Admin dashboard lose their demo styling when the value comes from the universal getter — other blocks on the same page still show demo indicators, creating an inconsistent UI.