### PR TITLE
🌱 Remove 'Replace Card' option from card context menu

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useState, useEffect, useCallback, useRef, useMemo, createContext, useContext, ComponentType, Suspense } from 'react'
 import { createPortal } from 'react-dom'
 import {
-  Maximize2, MoreVertical, Clock, Settings, Replace, Trash2, RefreshCw, MoveHorizontal, ChevronRight, ChevronDown, Info, Download, Link2, Bug,
+  Maximize2, MoreVertical, Clock, Settings, Trash2, RefreshCw, MoveHorizontal, ChevronRight, ChevronDown, Info, Download, Link2, Bug,
   // Card icons
   AlertTriangle, Box, Activity, Database, Server, Cpu, Network, Shield, Package, GitBranch, FileCode, Gauge, AlertCircle, Layers, HardDrive, Globe, Users, Terminal, TrendingUp, Gamepad2, Puzzle, Target, Zap, Crown, Ghost, Bird, Rocket, Wand2, Stethoscope, MonitorCheck, Workflow, Split, Router, BookOpen, Cloudy, Rss, Frame, Wrench, Phone,
 } from 'lucide-react'
@@ -158,7 +158,6 @@ interface CardWrapperProps {
   onSwap?: (newType: string) => void
   onSwapCancel?: () => void
   onConfigure?: () => void
-  onReplace?: () => void
   onRemove?: () => void
   onRefresh?: () => void
   /** Callback when card width is changed */
@@ -863,7 +862,6 @@ export function CardWrapper({
   onSwap,
   onSwapCancel,
   onConfigure,
-  onReplace,
   onRemove,
   onRefresh,
   onWidthChange,
@@ -1485,18 +1483,6 @@ export function CardWrapper({
                           {t('cardWrapper.exportWidget')}
                         </button>
                       )}
-                      <button
-                        onClick={() => {
-                          setShowMenu(false)
-                          onReplace?.()
-                        }}
-                        className="w-full px-4 py-2 text-left text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 flex items-center gap-2"
-                        role="menuitem"
-                        title={t('cardWrapper.replaceTooltip')}
-                      >
-                        <Replace className="w-4 h-4" aria-hidden="true" />
-                        {t('common:buttons.replaceCard')}
-                      </button>
                       <button
                         onClick={() => {
                           setShowMenu(false)

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -21,7 +21,7 @@ import {
 } from '@dnd-kit/sortable'
 import { useTranslation } from 'react-i18next'
 import { api, BackendUnavailableError, UnauthenticatedError } from '../../lib/api'
-import { emitCardAdded, emitCardRemoved, emitCardDragged, emitCardReplaced, emitCardConfigured } from '../../lib/analytics'
+import { emitCardAdded, emitCardRemoved, emitCardDragged, emitCardConfigured } from '../../lib/analytics'
 import { useDashboards } from '../../hooks/useDashboards'
 import { useClusters } from '../../hooks/useMCP'
 import { useCardHistory } from '../../hooks/useCardHistory'
@@ -33,7 +33,6 @@ import { CARD_COMPONENTS, DEMO_DATA_CARDS, prefetchCardChunks } from '../cards/c
 import { ROUTES } from '../../config/routes'
 import { getDefaultCardsForDashboard } from '../../config/dashboards'
 import { AddCardModal } from './AddCardModal'
-import { ReplaceCardModal } from './ReplaceCardModal'
 import { ConfigureCardModal } from './ConfigureCardModal'
 import { CardRecommendations } from './CardRecommendations'
 import { safeGetItem, safeSetItem, safeGetJSON, safeSetJSON } from '../../lib/utils/localStorage'
@@ -80,7 +79,6 @@ export function Dashboard() {
   const [isLoading, setIsLoading] = useState(false) // Cards are pre-populated from localStorage/defaults — never block
   const location = useLocation()
   const navigate = useNavigate()
-  const [isReplaceCardOpen, setIsReplaceCardOpen] = useState(false)
   const [isConfigureCardOpen, setIsConfigureCardOpen] = useState(false)
   const [selectedCard, setSelectedCard] = useState<Card | null>(null)
   const [localCards, setLocalCards] = useState<Card[]>(() => {
@@ -116,7 +114,7 @@ export function Dashboard() {
   const { dashboards, moveCardToDashboard, createDashboard, exportDashboard, importDashboard } = useDashboards()
   const { showToast } = useToast()
   const { t } = useTranslation()
-  const { recordCardRemoved, recordCardAdded, recordCardReplaced, recordCardConfigured } = useCardHistory()
+  const { recordCardRemoved, recordCardAdded, recordCardConfigured } = useCardHistory()
 
   // Cluster data for refresh functionality and stats - most cards depend on this
   // Use deduplicated clusters to avoid double-counting same server with different contexts
@@ -624,11 +622,6 @@ export function Dashboard() {
     setIsConfigureCardOpen(true)
   }, [])
 
-  const handleReplaceCard = useCallback((card: Card) => {
-    setSelectedCard(card)
-    setIsReplaceCardOpen(true)
-  }, [])
-
   const handleWidthChange = useCallback(async (cardId: string, newWidth: number) => {
     setLocalCards((prev) =>
       prev.map((c) =>
@@ -653,32 +646,6 @@ export function Dashboard() {
       }
     }
   }, [dashboard, localCards])
-
-  const handleCardReplaced = useCallback((oldCardId: string, newCardType: string, newTitle?: string, newConfig?: Record<string, unknown>) => {
-    // Find the old card to get its previous type
-    const oldCard = localCards.find((c) => c.id === oldCardId)
-    if (oldCard) {
-      emitCardReplaced(oldCard.card_type, newCardType)
-      recordCardReplaced(
-        oldCardId,
-        newCardType,
-        oldCard.card_type,
-        newTitle,
-        newConfig,
-        dashboard?.id,
-        dashboard?.name
-      )
-    }
-    setLocalCards((prev) =>
-      prev.map((c) =>
-        c.id === oldCardId
-          ? { ...c, card_type: newCardType, title: newTitle, config: newConfig || {} }
-          : c
-      )
-    )
-    setIsReplaceCardOpen(false)
-    setSelectedCard(null)
-  }, [localCards, dashboard, recordCardReplaced])
 
   const handleCardConfigured = useCallback(async (cardId: string, newConfig: Record<string, unknown>, newTitle?: string) => {
     const card = localCards.find((c) => c.id === cardId)
@@ -916,7 +883,6 @@ export function Dashboard() {
                 key={card.id}
                 card={card}
                 onConfigure={() => handleConfigureCard(card)}
-                onReplace={() => handleReplaceCard(card)}
                 onRemove={() => handleRemoveCard(card.id)}
                 onWidthChange={(newWidth) => handleWidthChange(card.id, newWidth)}
                 isDragging={activeId === card.id}
@@ -978,17 +944,6 @@ export function Dashboard() {
         onClose={closeAddCardModal}
         onAddCards={handleAddCards}
         existingCardTypes={currentCardTypes}
-      />
-
-      {/* Replace Card Modal */}
-      <ReplaceCardModal
-        isOpen={isReplaceCardOpen}
-        card={selectedCard}
-        onClose={() => {
-          setIsReplaceCardOpen(false)
-          setSelectedCard(null)
-        }}
-        onReplace={handleCardReplaced}
       />
 
       {/* Configure Card Modal */}

--- a/web/src/components/dashboard/SharedSortableCard.tsx
+++ b/web/src/components/dashboard/SharedSortableCard.tsx
@@ -10,7 +10,6 @@ import type { Card } from './dashboardUtils'
 interface SortableCardProps {
   card: Card
   onConfigure: () => void
-  onReplace: () => void
   onRemove: () => void
   onWidthChange: (newWidth: number) => void
   isDragging: boolean
@@ -28,7 +27,7 @@ const NARROW_BREAKPOINT = 1024
 /** Minimum card column span at narrow viewports */
 const MIN_NARROW_COLS = 6
 
-export const SortableCard = memo(function SortableCard({ card, onConfigure, onReplace, onRemove, onWidthChange, isDragging, isRefreshing, onRefresh, lastUpdated, onKeyDown, registerRef, registerExpandTrigger }: SortableCardProps) {
+export const SortableCard = memo(function SortableCard({ card, onConfigure, onRemove, onWidthChange, isDragging, isRefreshing, onRefresh, lastUpdated, onKeyDown, registerRef, registerExpandTrigger }: SortableCardProps) {
   const {
     attributes,
     listeners,
@@ -84,7 +83,6 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
         onRefresh={onRefresh}
         lastUpdated={lastUpdated}
         onConfigure={onConfigure}
-        onReplace={onReplace}
         onRemove={onRemove}
         onWidthChange={onWidthChange}
         registerExpandTrigger={registerExpandTrigger}


### PR DESCRIPTION
Removes the Replace Card button from the card dropdown menu, the ReplaceCardModal usage from Dashboard, and all related state/handlers/props.