### PR TITLE
🐛 Add null guards for .issues iterations to prevent TypeError

### DIFF
--- a/web/src/components/cards/PodIssues.tsx
+++ b/web/src/components/cards/PodIssues.tsx
@@ -82,7 +82,7 @@ export function PodIssues() {
       searchFields: ['name', 'namespace', 'cluster', 'status'],
       clusterField: 'cluster',
       statusField: 'status',
-      customPredicate: (issue, query) => issue.issues.some(i => i.toLowerCase().includes(query)),
+      customPredicate: (issue, query) => (issue.issues || []).some(i => i.toLowerCase().includes(query)),
       storageKey: 'pod-issues',
     },
     sort: {

--- a/web/src/hooks/useWorkloadMonitor.ts
+++ b/web/src/hooks/useWorkloadMonitor.ts
@@ -98,7 +98,7 @@ export function useWorkloadMonitor(
 
       const data: WorkloadMonitorResponse = await res.json()
       setResources(data.resources)
-      setIssues(data.issues)
+      setIssues(data.issues || [])
       setOverallStatus(data.status)
       setWorkloadKind(data.kind)
       setWarnings(data.warnings)

--- a/web/src/lib/missions/matcher.ts
+++ b/web/src/lib/missions/matcher.ts
@@ -82,7 +82,7 @@ export function matchMissionsToCluster(
 
   // Pre-compute issue categories
   const issueCategories = new Set<string>()
-  if (cluster?.issues) {
+  if (cluster?.issues && Array.isArray(cluster.issues)) {
     for (const issue of cluster.issues) {
       const issueLower = issue.toLowerCase()
       for (const [pattern, categories] of Object.entries(ISSUE_TO_CATEGORIES)) {
@@ -147,7 +147,7 @@ export function matchMissionsToCluster(
       }
 
       // Match troubleshoot missions against cluster issues (direct text match)
-      if (mission.type === 'troubleshoot' && cluster.issues) {
+      if (mission.type === 'troubleshoot' && Array.isArray(cluster.issues)) {
         const descLower = (mission.description || '').toLowerCase()
         for (const issue of cluster.issues) {
           if (descLower.includes(issue.toLowerCase())) {

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -131,7 +131,7 @@ function useUnifiedDeploymentIssues(params?: Record<string, unknown>) {
   const namespace = params?.namespace as string | undefined
   const result = useCachedDeploymentIssues(cluster, namespace)
   return {
-    data: result.issues,
+    data: result.issues || [],
     isLoading: result.isLoading,
     error: result.error ? new Error(result.error) : null,
     refetch: result.refetch,


### PR DESCRIPTION
## Problem
The Arcade page was crashing with `TypeError: e.issues is not iterable` in a `useMemo` call. This happened when `.issues` on cluster/pod data was unexpectedly not an array (e.g., undefined, null, or a non-iterable truthy value).

## Root Cause
Several code paths iterate over `.issues` using `for...of` loops or array methods without ensuring the value is actually an array:
- `matcher.ts`: `for (const issue of cluster.issues)` with only a truthy guard (not Array.isArray)
- `PodIssues.tsx`: `issue.issues.some()` in search predicate without null guard
- `useWorkloadMonitor.ts`: `setIssues(data.issues)` without fallback
- `registerHooks.ts`: `data: result.issues` without fallback

## Why Tests Didn't Catch This
- Zero unit tests exist for the Arcade page or game card components
- No Playwright e2e tests navigate to `/arcade`
- The crash occurred in a globally-rendered context provider, which unit tests typically mock

## Fix
Added defensive null guards:
- `Array.isArray()` checks before `for...of` loops in matcher.ts
- `|| []` fallbacks for array method calls and state setters

## Testing
- TypeScript: `tsc --noEmit` passes
- ESLint: all modified files pass
- Verified Arcade page renders 21 game cards on localhost:8080/arcade