### PR TITLE
🐛 Fix mission steps not loading + add saved mission detail modal

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -18,6 +18,7 @@ import {
   Play,
   Trash2,
   CheckCircle2,
+  Eye,
 } from 'lucide-react'
 import { useSearchParams } from 'react-router-dom'
 import { useMissions } from '../../../hooks/useMissions'
@@ -26,7 +27,9 @@ import { cn } from '../../../lib/cn'
 import { AgentSelector } from '../../agent/AgentSelector'
 import { AgentIcon } from '../../agent/AgentIcon'
 import { MissionBrowser } from '../../missions/MissionBrowser'
+import { MissionDetailView } from '../../missions/MissionDetailView'
 import type { MissionExport } from '../../../lib/missions/types'
+import type { Mission } from '../../../hooks/useMissions'
 import type { FontSize } from './types'
 import { MissionListItem } from './MissionListItem'
 import { MissionChat } from './MissionChat'
@@ -43,6 +46,8 @@ export function MissionSidebar() {
   const [showBrowser, setShowBrowser] = useState(false)
   const [newMissionPrompt, setNewMissionPrompt] = useState('')
   const [showSavedToast, setShowSavedToast] = useState<string | null>(null)
+  const [viewingMission, setViewingMission] = useState<MissionExport | null>(null)
+  const [viewingMissionRaw, setViewingMissionRaw] = useState(false)
   const newMissionInputRef = useRef<HTMLTextAreaElement>(null)
 
   // Deep-link: open MissionBrowser to specific mission via ?mission= URL param
@@ -83,6 +88,26 @@ export function MissionSidebar() {
     setShowSavedToast(mission.title)
     setTimeout(() => setShowSavedToast(null), SAVED_TOAST_MS)
   }, [saveMission])
+
+  /** Convert a saved Mission to MissionExport for the detail view */
+  const savedMissionToExport = useCallback((m: Mission): MissionExport => ({
+    version: '1.0',
+    title: m.importedFrom?.title || m.title,
+    description: m.importedFrom?.description || m.description,
+    type: m.type,
+    tags: m.importedFrom?.tags || [],
+    missionClass: m.importedFrom?.missionClass as MissionExport['missionClass'],
+    cncfProject: m.importedFrom?.cncfProject,
+    steps: (m.importedFrom?.steps || []).map(s => ({
+      title: s.title,
+      description: s.description,
+    })),
+  }), [])
+
+  const handleViewSavedMission = useCallback((m: Mission) => {
+    setViewingMission(savedMissionToExport(m))
+    setViewingMissionRaw(false)
+  }, [savedMissionToExport])
 
   // Escape key: exit fullscreen first, then close sidebar
   useEffect(() => {
@@ -413,7 +438,11 @@ export function MissionSidebar() {
               </div>
               <div className="flex-1 overflow-y-auto scroll-enhanced p-1.5 space-y-1">
                 {savedMissions.map(m => (
-                  <div key={m.id} className="group p-2 rounded-lg hover:bg-secondary/60 transition-colors cursor-pointer border border-transparent hover:border-border">
+                  <div
+                    key={m.id}
+                    className="group p-2 rounded-lg hover:bg-secondary/60 transition-colors cursor-pointer border border-transparent hover:border-border"
+                    onClick={() => handleViewSavedMission(m)}
+                  >
                     <div className="flex items-start gap-2">
                       <Bookmark className="w-3.5 h-3.5 text-amber-500 mt-0.5 flex-shrink-0" />
                       <div className="flex-1 min-w-0">
@@ -431,6 +460,12 @@ export function MissionSidebar() {
                       </div>
                     </div>
                     <div className="flex items-center gap-1 mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <button
+                        onClick={(e) => { e.stopPropagation(); handleViewSavedMission(m) }}
+                        className="flex items-center gap-1 px-2 py-0.5 text-[10px] text-muted-foreground hover:text-foreground rounded hover:bg-secondary transition-colors"
+                      >
+                        <Eye className="w-2.5 h-2.5" /> View
+                      </button>
                       <button
                         onClick={(e) => { e.stopPropagation(); runSavedMission(m.id) }}
                         className="flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium bg-primary text-primary-foreground rounded hover:bg-primary/90 transition-colors"
@@ -478,7 +513,11 @@ export function MissionSidebar() {
               </div>
               <div className="space-y-1.5">
                 {savedMissions.map(m => (
-                  <div key={m.id} className="group flex items-center gap-3 p-3 rounded-lg border border-amber-500/20 bg-amber-500/5 hover:bg-amber-500/10 transition-colors">
+                  <div
+                    key={m.id}
+                    className="group flex items-center gap-3 p-3 rounded-lg border border-amber-500/20 bg-amber-500/5 hover:bg-amber-500/10 transition-colors cursor-pointer"
+                    onClick={() => handleViewSavedMission(m)}
+                  >
                     <Bookmark className="w-4 h-4 text-amber-500 flex-shrink-0" />
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium text-foreground truncate">{m.title}</p>
@@ -493,14 +532,21 @@ export function MissionSidebar() {
                     </div>
                     <div className="flex items-center gap-1.5 flex-shrink-0">
                       <button
-                        onClick={() => runSavedMission(m.id)}
+                        onClick={(e) => { e.stopPropagation(); handleViewSavedMission(m) }}
+                        className="p-1.5 text-muted-foreground hover:text-foreground rounded hover:bg-secondary transition-colors"
+                        title="View mission details"
+                      >
+                        <Eye className="w-3.5 h-3.5" />
+                      </button>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); runSavedMission(m.id) }}
                         className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
                         title="Run this mission"
                       >
                         <Play className="w-3 h-3" /> Run
                       </button>
                       <button
-                        onClick={() => dismissMission(m.id)}
+                        onClick={(e) => { e.stopPropagation(); dismissMission(m.id) }}
                         className="p-1.5 text-muted-foreground hover:text-red-400 rounded hover:bg-red-500/10 transition-colors"
                         title="Remove from library"
                       >
@@ -546,6 +592,41 @@ export function MissionSidebar() {
         </div>
       )}
     </div>
+
+      {/* Saved Mission Detail Modal */}
+      {viewingMission && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+          <div className={cn(
+            "relative bg-card border border-border rounded-xl shadow-2xl overflow-hidden flex flex-col",
+            isMobile ? "inset-2 fixed" : "w-[700px] max-h-[85vh]"
+          )}>
+            {/* Close button */}
+            <button
+              onClick={() => setViewingMission(null)}
+              className="absolute top-3 right-3 z-10 p-1.5 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <X className="w-4 h-4" />
+            </button>
+            {/* Scrollable content */}
+            <div className="flex-1 overflow-y-auto scroll-enhanced p-6">
+              <MissionDetailView
+                mission={viewingMission}
+                rawContent={JSON.stringify(viewingMission, null, 2)}
+                showRaw={viewingMissionRaw}
+                onToggleRaw={() => setViewingMissionRaw(prev => !prev)}
+                onImport={() => {
+                  // Find the matching saved mission and run it
+                  const match = savedMissions.find(m => m.title === viewingMission.title)
+                  if (match) runSavedMission(match.id)
+                  setViewingMission(null)
+                }}
+                onBack={() => setViewingMission(null)}
+                importLabel="Run"
+              />
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Mission Browser Dialog */}
       <MissionBrowser

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -256,6 +256,48 @@ function indexEntryToMission(entry: IndexEntry): MissionExport {
   }
 }
 
+/** Timeout for fetching individual mission files (ms) */
+const MISSION_FILE_FETCH_TIMEOUT_MS = 15_000
+
+/**
+ * Fetch the full mission file and extract steps.
+ *
+ * Mission files in console-kb store steps under a nested `mission` object:
+ *   { mission: { steps, uninstall, upgrade, troubleshooting, ... }, metadata, ... }
+ *
+ * This function fetches the file, extracts the nested data, and merges it
+ * into the index-based MissionExport so all sections (install, uninstall,
+ * upgrade, troubleshooting) are available in the detail view.
+ */
+async function fetchMissionContent(
+  indexMission: MissionExport,
+): Promise<{ mission: MissionExport; raw: string }> {
+  const sourcePath = indexMission.metadata?.source
+  if (!sourcePath) return { mission: indexMission, raw: JSON.stringify(indexMission, null, 2) }
+
+  const url = `/api/missions/file?path=${encodeURIComponent(sourcePath)}`
+  const response = await fetch(url, { signal: AbortSignal.timeout(MISSION_FILE_FETCH_TIMEOUT_MS) })
+  if (!response.ok) return { mission: indexMission, raw: JSON.stringify(indexMission, null, 2) }
+
+  const text = await response.text()
+  const parsed = JSON.parse(text)
+
+  // Extract steps from the nested `mission` object (console-kb file format)
+  // Falls back to top-level fields if the nested structure isn't present
+  const nested = parsed.mission || {}
+  const merged: MissionExport = {
+    ...indexMission,
+    steps: nested.steps || parsed.steps || indexMission.steps,
+    uninstall: nested.uninstall || parsed.uninstall,
+    upgrade: nested.upgrade || parsed.upgrade,
+    troubleshooting: nested.troubleshooting || parsed.troubleshooting,
+    resolution: nested.resolution || parsed.resolution,
+    prerequisites: parsed.prerequisites || indexMission.prerequisites,
+  }
+
+  return { mission: merged, raw: text }
+}
+
 /**
  * Load all missions from the pre-built index in a single API call.
  * Splits results into installers and solutions, populating both caches at once.
@@ -549,6 +591,27 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   }, [isOpen])
 
   // ============================================================================
+  // Select a card mission — fetch full content on demand
+  // ============================================================================
+
+  const selectCardMission = useCallback(async (mission: MissionExport) => {
+    // Show index metadata immediately for instant feedback
+    setSelectedMission(mission)
+    setRawContent(JSON.stringify(mission, null, 2))
+    setShowRaw(false)
+
+    // Fetch full file content (steps, uninstall, upgrade, troubleshooting)
+    try {
+      const { mission: fullMission, raw } = await fetchMissionContent(mission)
+      // Only update if this mission is still selected (user might have navigated away)
+      setSelectedMission((current) => current?.title === mission.title ? fullMission : current)
+      setRawContent((current) => current === JSON.stringify(mission, null, 2) ? raw : current)
+    } catch {
+      // Silently keep the index metadata — steps will show as empty
+    }
+  }, [])
+
+  // ============================================================================
   // Deep-link: auto-select mission by name when initialMission is set
   // ============================================================================
 
@@ -559,15 +622,12 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
              (m.cncfProject && m.cncfProject.toLowerCase() === initialMission.replace('install-', '').toLowerCase())
     )
     if (match) {
-      setSelectedMission(match)
       setActiveTab('installers')
-      api.get<string>(`/api/missions/browse?path=solutions/cncf-install/install-${(match.cncfProject || '').toLowerCase().replace(/[^a-z0-9]+/g, '-')}.json&raw=true`)
-        .then(({ data }) => setRawContent(typeof data === 'string' ? data : JSON.stringify(data, null, 2)))
-        .catch(() => {})
+      selectCardMission(match)
     } else if (installerMissions.length === 0 && activeTab !== 'installers') {
       setActiveTab('installers')
     }
-  }, [initialMission, isOpen, installerMissions, selectedMission, activeTab])
+  }, [initialMission, isOpen, installerMissions, selectedMission, activeTab, selectCardMission])
 
   // ============================================================================
   // Filtered installer & solution lists
@@ -1661,11 +1721,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                           <RecommendationCard
                             key={i}
                             match={match}
-                            onSelect={() => {
-                              setSelectedMission(match.mission)
-                              setRawContent(JSON.stringify(match.mission, null, 2))
-                              setShowRaw(false)
-                            }}
+                            onSelect={() => selectCardMission(match.mission)}
                             onImport={() => handleImport(match.mission)}
                           />
                         ))}
@@ -1678,11 +1734,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                       <RecommendationCard
                         key={i}
                         match={match}
-                        onSelect={() => {
-                          setSelectedMission(match.mission)
-                          setRawContent(JSON.stringify(match.mission, null, 2))
-                          setShowRaw(false)
-                        }}
+                        onSelect={() => selectCardMission(match.mission)}
                         onImport={() => handleImport(match.mission)}
                       />
                     ))}
@@ -1817,11 +1869,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                           key={i}
                           mission={mission}
                           compact={viewMode === 'list'}
-                          onSelect={() => {
-                            setSelectedMission(mission)
-                            setRawContent(JSON.stringify(mission, null, 2))
-                            setShowRaw(false)
-                          }}
+                          onSelect={() => selectCardMission(mission)}
                           onImport={() => handleImport(mission)}
                         />
                       ))}
@@ -1891,11 +1939,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                           key={i}
                           mission={mission}
                           compact={viewMode === 'list'}
-                          onSelect={() => {
-                            setSelectedMission(mission)
-                            setRawContent(JSON.stringify(mission, null, 2))
-                            setShowRaw(false)
-                          }}
+                          onSelect={() => selectCardMission(mission)}
                           onImport={() => handleImport(mission)}
                         />
                       ))}

--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -49,6 +49,8 @@ interface MissionDetailViewProps {
   onBack: () => void
   onImprove?: () => void
   matchScore?: number
+  /** Override the import button label (e.g. "Run" for saved missions) */
+  importLabel?: string
 }
 
 // Extract code blocks from markdown-style description
@@ -168,6 +170,7 @@ export function MissionDetailView({
   onBack,
   onImprove,
   matchScore,
+  importLabel = 'Import',
 }: MissionDetailViewProps) {
   const tabs: TabDef[] = [
     {
@@ -272,7 +275,7 @@ export function MissionDetailView({
             className="flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium rounded-lg bg-purple-600 hover:bg-purple-500 text-white transition-colors"
           >
             <Download className="w-4 h-4" />
-            Import
+            {importLabel}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **Fix on-demand step loading**: Mission cards in the browser now fetch full JSON content from `/api/missions/file` when clicked, populating Install, Uninstall, Upgrade, and Troubleshooting tabs. Previously all missions showed "No install steps available."
- **Add saved mission detail modal**: Clicking a saved mission card in the AI Missions sidebar (both normal and fullscreen modes) opens a modal with the full `MissionDetailView` showing tabbed sections and step details.
- **Add `importLabel` prop**: `MissionDetailView` now accepts an optional `importLabel` to show "Run" for saved missions instead of "Import."

## Test plan

- [ ] Open Mission Browser, click an installer card (e.g. Aeraki Mesh) — Install tab should show steps with copy-pasteable commands
- [ ] Click a solution card — similar step content should appear
- [ ] Save a mission to the library, then click on it in the sidebar — detail modal should open
- [ ] Verify the modal works in fullscreen mode (left sidebar panel)
- [ ] Verify Escape / X button closes the modal
- [ ] Verify "Run" button in the modal starts the mission
- [ ] Run `npm run build` and `npm run lint` — both pass