### PR TITLE
🐛 Guard against undefined cluster label values in mission matcher

### DIFF
--- a/web/src/lib/missions/matcher.ts
+++ b/web/src/lib/missions/matcher.ts
@@ -136,7 +136,7 @@ export function matchMissionsToCluster(
           for (const [key, value] of Object.entries(cluster.labels)) {
             if (
               key.toLowerCase().includes(projectLower) ||
-              value.toLowerCase().includes(projectLower)
+              (value || '').toLowerCase().includes(projectLower)
             ) {
               score += 30
               matchReasons.push(`CNCF project "${mission.cncfProject}" found in cluster labels`)


### PR DESCRIPTION
## Summary

- Fix TypeError crash: `Cannot read properties of undefined (reading 'toLowerCase')` in `matchMissionsToCluster()` when cluster labels have undefined values
- Add null guard: `(value || '').toLowerCase()` at `matcher.ts:139`

## Test plan

- [ ] Open Mission Browser — should load without crash
- [ ] Recommendations tab should show match percentages and all results