### PR TITLE
🐛 Guard against undefined entries in cluster resources/issues arrays

### DIFF
--- a/web/src/lib/missions/matcher.ts
+++ b/web/src/lib/missions/matcher.ts
@@ -70,6 +70,7 @@ export function matchMissionsToCluster(
   const expandedKeywords = new Set<string>()
   if (cluster?.resources) {
     for (const r of cluster.resources) {
+      if (!r) continue
       expandedKeywords.add(r.toLowerCase())
       // Expand via known mappings
       for (const [key, projects] of Object.entries(RESOURCE_TO_PROJECTS)) {
@@ -84,6 +85,7 @@ export function matchMissionsToCluster(
   const issueCategories = new Set<string>()
   if (cluster?.issues && Array.isArray(cluster.issues)) {
     for (const issue of cluster.issues) {
+      if (!issue) continue
       const issueLower = issue.toLowerCase()
       for (const [pattern, categories] of Object.entries(ISSUE_TO_CATEGORIES)) {
         if (issueLower.includes(pattern)) {
@@ -150,6 +152,7 @@ export function matchMissionsToCluster(
       if (mission.type === 'troubleshoot' && Array.isArray(cluster.issues)) {
         const descLower = (mission.description || '').toLowerCase()
         for (const issue of cluster.issues) {
+          if (!issue) continue
           if (descLower.includes(issue.toLowerCase())) {
             score += 40
             matchReasons.push(`Addresses cluster issue: ${issue}`)


### PR DESCRIPTION
## Summary

Follow-up to #1585 — additional null guards in `matchMissionsToCluster()`:
- Guard `cluster.resources` entries before `.toLowerCase()`
- Guard `cluster.issues` entries in both the pre-compute loop and text match loop
- These arrays can contain `undefined` values from the backend, causing TypeError crashes

## Test plan

- [ ] Open Mission Browser — no black screen crash
- [ ] Recommendations load with match percentages