### PR TITLE
🐛 Fix Import/Install validation failing on card listings

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -823,27 +823,24 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
 
     // If steps are empty (index-only metadata), fetch full content first
     let resolvedMission = mission
-    let resolvedRaw = raw
     if ((!mission.steps || mission.steps.length === 0) && !raw) {
       try {
         const fetched = await fetchMissionContent(mission)
         resolvedMission = fetched.mission
-        resolvedRaw = fetched.raw
         setPendingImport(resolvedMission)
       } catch {
         // Fall through with index-only mission — validation will catch the empty steps
       }
     }
 
-    const content = resolvedRaw || JSON.stringify(resolvedMission, null, 2)
-    let parsed: unknown
-    try {
-      parsed = JSON.parse(content)
-    } catch {
-      parsed = resolvedMission
+    // When raw content is provided (e.g. file upload / detail view), parse and
+    // validate the raw JSON directly. Otherwise validate the merged MissionExport
+    // (raw file uses a nested format that doesn't match the flat validator schema).
+    let toValidate: unknown = resolvedMission
+    if (raw) {
+      try { toValidate = JSON.parse(raw) } catch { toValidate = resolvedMission }
     }
-
-    const validation = validateMissionExport(parsed)
+    const validation = validateMissionExport(toValidate)
     if (!validation.valid) {
       setScanResult({
         valid: false,


### PR DESCRIPTION
## Summary
- Fix Import/Install buttons showing "Issues found" errors (missing title, invalid type, tags not array, steps empty) when clicking from card listings
- Root cause: `handleImport` was re-parsing the raw file content (console-kb nested format) instead of validating the properly merged `MissionExport`
- Now validates `resolvedMission` directly, which has all fields correctly populated from index metadata + fetched file content

## Test plan
- [ ] Click Install on any installer card → should scan and import successfully
- [ ] Click Import on any solution card → should scan and import successfully  
- [ ] Click Import on any recommendation card → should scan and import successfully
- [ ] File upload import should still work (validates raw JSON)
- [ ] Detail view import should still work