### PR TITLE
🐛 Fix saved mission modal UX issues

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -595,10 +595,16 @@ export function MissionSidebar() {
 
       {/* Saved Mission Detail Modal */}
       {viewingMission && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          onClick={(e) => { if (e.target === e.currentTarget) setViewingMission(null) }}
+          onKeyDown={(e) => { if (e.key === 'Escape') setViewingMission(null) }}
+          tabIndex={-1}
+          ref={(el) => el?.focus()}
+        >
           <div className={cn(
             "relative bg-card border border-border rounded-xl shadow-2xl overflow-hidden flex flex-col",
-            isMobile ? "inset-2 fixed" : "w-[700px] max-h-[85vh]"
+            isMobile ? "inset-2 fixed" : "w-[900px] max-h-[85vh]"
           )}>
             {/* Close button */}
             <button
@@ -622,6 +628,7 @@ export function MissionSidebar() {
                 }}
                 onBack={() => setViewingMission(null)}
                 importLabel="Run"
+                hideBackButton
               />
             </div>
           </div>

--- a/web/src/components/missions/InstallerCard.tsx
+++ b/web/src/components/missions/InstallerCard.tsx
@@ -316,7 +316,7 @@ export function InstallerCard({ mission, onImport, onSelect, compact }: Installe
             className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors flex-shrink-0"
           >
             <Download className="w-3 h-3" />
-            Install
+            Import
           </button>
         </div>
       </div>

--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -51,6 +51,8 @@ interface MissionDetailViewProps {
   matchScore?: number
   /** Override the import button label (e.g. "Run" for saved missions) */
   importLabel?: string
+  /** Hide the "Back to listing" button (e.g. when opened from saved missions) */
+  hideBackButton?: boolean
 }
 
 // Extract code blocks from markdown-style description
@@ -171,6 +173,7 @@ export function MissionDetailView({
   onImprove,
   matchScore,
   importLabel = 'Import',
+  hideBackButton = false,
 }: MissionDetailViewProps) {
   const tabs: TabDef[] = [
     {
@@ -226,14 +229,16 @@ export function MissionDetailView({
 
   return (
     <div className="space-y-5">
-      {/* Back button */}
-      <button
-        onClick={onBack}
-        className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Back to listing
-      </button>
+      {/* Back button — hidden when opened from saved missions (no listing context) */}
+      {!hideBackButton && (
+        <button
+          onClick={onBack}
+          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to listing
+        </button>
+      )}
 
       {/* Header */}
       <div className="flex items-start justify-between gap-4">


### PR DESCRIPTION
## Summary
- Hide "Back to listing" when opening mission from saved missions sidebar (not in browser context)
- Add ESC key and backdrop click to close the saved mission detail modal
- Widen modal from 700px to 900px for better content readability
- Rename installer card button "Install" → "Import" for consistency

## Test plan
- [ ] Click a saved mission → modal opens without "Back to listing" button
- [ ] Press ESC → modal closes
- [ ] Click backdrop → modal closes
- [ ] Click X button → modal closes
- [ ] Installer cards show "Import" button instead of "Install"
- [ ] Modal width is wider (900px)