### PR TITLE
✨ Add step-by-step detail entries to update progress banner

### DIFF
--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -83,7 +83,7 @@ export function UpdateSettings() {
   } = useVersionCheck()
 
   // WebSocket-driven update progress from kc-agent
-  const { progress: updateProgress, dismiss: dismissProgress } = useUpdateProgress()
+  const { progress: updateProgress, stepHistory, dismiss: dismissProgress } = useUpdateProgress()
 
   const CHANNEL_OPTIONS: { value: UpdateChannel; label: string; description: string; devOnly?: boolean }[] = [
     {
@@ -467,19 +467,39 @@ export function UpdateSettings() {
       {/* Update Progress Banner */}
       {isUpdating && (
         <div data-testid="update-progress-banner" className="mb-4 p-4 rounded-lg bg-blue-500/10 border border-blue-500/20">
-          <div className="flex items-center gap-3 mb-2">
+          {/* Header with current status */}
+          <div className="flex items-center gap-3 mb-3">
             <Loader2 className="w-4 h-4 text-blue-400 animate-spin" />
-            <div className="flex-1 min-w-0">
-              <p data-testid="update-progress-message" className="text-sm font-medium text-blue-400">
-                {updateProgress?.message ?? t('settings.updates.startingUpdate')}
-              </p>
-              {updateProgress?.step && updateProgress?.totalSteps && (
-                <p data-testid="update-step-indicator" className="text-xs text-blue-400/50 mt-0.5">
-                  Step {updateProgress.step} of {updateProgress.totalSteps}
-                </p>
-              )}
-            </div>
+            <p data-testid="update-progress-message" className="text-sm font-medium text-blue-400 flex-1 min-w-0">
+              {updateProgress?.message ?? t('settings.updates.startingUpdate')}
+            </p>
           </div>
+
+          {/* Step detail entries */}
+          {stepHistory.length > 0 && (
+            <div className="space-y-1.5 mb-3 pl-1">
+              {stepHistory.map((entry) => (
+                <div key={entry.step} className="flex items-center gap-2">
+                  {entry.status === 'completed' ? (
+                    <Check className="w-3.5 h-3.5 text-green-400 shrink-0" />
+                  ) : entry.status === 'active' ? (
+                    <Loader2 className="w-3.5 h-3.5 text-blue-400 animate-spin shrink-0" />
+                  ) : (
+                    <div className="w-3.5 h-3.5 rounded-full border border-muted-foreground/30 shrink-0" />
+                  )}
+                  <span className={`text-xs ${
+                    entry.status === 'completed' ? 'text-green-400/80' :
+                    entry.status === 'active' ? 'text-blue-400' :
+                    'text-muted-foreground/40'
+                  }`}>
+                    {entry.message}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Progress bar */}
           <div className="w-full bg-secondary rounded-full h-2">
             <div
               data-testid="update-progress-bar"

--- a/web/src/hooks/useUpdateProgress.ts
+++ b/web/src/hooks/useUpdateProgress.ts
@@ -1,22 +1,72 @@
-import { useEffect, useState, useRef } from 'react'
-import type { UpdateProgress } from '../types/updates'
+import { useEffect, useState, useRef, useCallback } from 'react'
+import type { UpdateProgress, UpdateStepEntry } from '../types/updates'
 import { LOCAL_AGENT_WS_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 const WS_RECONNECT_MS = 5000  // Reconnect interval after WebSocket disconnect
 const BACKEND_POLL_MS = 2000  // Poll interval when waiting for backend to come up
 const BACKEND_POLL_MAX = 90   // Max attempts (~3 min) before giving up
 
+/** Known update step labels for developer channel (7-step update) */
+const DEV_UPDATE_STEP_LABELS: Record<number, string> = {
+  1: 'Git pull',
+  2: 'npm install',
+  3: 'Frontend build',
+  4: 'Build console binary',
+  5: 'Build kc-agent binary',
+  6: 'Stopping services',
+  7: 'Restart',
+}
+
 /**
  * Hook that listens for update_progress WebSocket broadcasts from kc-agent.
  * Uses a separate WebSocket connection to avoid interfering with the shared one.
+ * Also tracks step history for detailed progress display.
  */
 export function useUpdateProgress() {
   const [progress, setProgress] = useState<UpdateProgress | null>(null)
+  const [stepHistory, setStepHistory] = useState<UpdateStepEntry[]>([])
   const wsRef = useRef<WebSocket | null>(null)
   const progressRef = useRef<UpdateProgress | null>(null)
 
   // Keep ref in sync so the connect closure always sees the latest value
   progressRef.current = progress
+
+  /** Build step entries from a progress event, preserving completed steps */
+  const updateStepHistory = useCallback((p: UpdateProgress) => {
+    if (!p.step || !p.totalSteps) return
+
+    setStepHistory(prev => {
+      const entries: UpdateStepEntry[] = []
+      for (let i = 1; i <= p.totalSteps!; i++) {
+        const label = DEV_UPDATE_STEP_LABELS[i] ?? `Step ${i}`
+        if (i < p.step!) {
+          // Completed: use previous timestamp if available, else now
+          const existing = prev.find(e => e.step === i)
+          entries.push({
+            step: i,
+            message: existing?.message ?? label,
+            status: 'completed',
+            timestamp: existing?.timestamp ?? Date.now(),
+          })
+        } else if (i === p.step!) {
+          entries.push({
+            step: i,
+            message: p.message || label,
+            status: 'active',
+            timestamp: Date.now(),
+          })
+        } else {
+          entries.push({
+            step: i,
+            message: label,
+            status: 'pending',
+            timestamp: 0,
+          })
+        }
+      }
+      return entries
+    })
+  }, [])
 
   useEffect(() => {
     let reconnectTimer: ReturnType<typeof setTimeout>
@@ -92,7 +142,9 @@ export function useUpdateProgress() {
           try {
             const msg = JSON.parse(event.data)
             if (msg.type === 'update_progress' && msg.payload) {
-              setProgress(msg.payload as UpdateProgress)
+              const p = msg.payload as UpdateProgress
+              setProgress(p)
+              updateStepHistory(p)
             }
           } catch {
             // Ignore parse errors
@@ -123,9 +175,12 @@ export function useUpdateProgress() {
         wsRef.current = null
       }
     }
-  }, [])
+  }, [updateStepHistory])
 
-  const dismiss = () => setProgress(null)
+  const dismiss = () => {
+    setProgress(null)
+    setStepHistory([])
+  }
 
-  return { progress, dismiss }
+  return { progress, stepHistory, dismiss }
 }

--- a/web/src/types/updates.ts
+++ b/web/src/types/updates.ts
@@ -80,6 +80,14 @@ export interface UpdateProgress {
   totalSteps?: number // total steps in the update (e.g. 7)
 }
 
+/** A single tracked step in the update progress history */
+export interface UpdateStepEntry {
+  step: number
+  message: string
+  status: 'completed' | 'active' | 'pending'
+  timestamp: number // Date.now() when the step was first seen
+}
+
 /**
  * Status returned by the kc-agent /auto-update/status endpoint.
  */


### PR DESCRIPTION
## Summary
- Replace single "Step X of Y" indicator with individual step entries in the update progress banner
- Each step shows: green checkmark (completed), spinner (active), or empty circle (pending)
- Step history tracked in `useUpdateProgress` hook via `UpdateStepEntry` type
- Countdown timer remains only at bottom-right (removed from individual items)
- Known step labels for developer channel: Git pull, npm install, Frontend build, Build console binary, Build kc-agent binary, Stopping services, Restart

## Test plan
- [ ] Trigger an update and verify all 7 steps appear as detail entries
- [ ] Completed steps show green checkmarks
- [ ] Active step shows spinner with live message from kc-agent
- [ ] Pending steps show empty circles with gray text
- [ ] Only one countdown timer at bottom-right
- [ ] Dismissing progress clears step history