### PR TITLE
✨ Fix mission cancel/stop and add cluster selection for installs

### DIFF
--- a/pkg/agent/protocol/messages.go
+++ b/pkg/agent/protocol/messages.go
@@ -11,7 +11,8 @@ const (
 	TypeClaude        MessageType = "claude"        // Legacy - routes to selected agent
 	TypeChat          MessageType = "chat"          // Generic chat with selected agent
 	TypeListAgents    MessageType = "list_agents"   // List available AI agents
-	TypeSelectAgent   MessageType = "select_agent"  // Select an AI agent
+	TypeSelectAgent   MessageType = "select_agent"   // Select an AI agent
+	TypeCancelChat    MessageType = "cancel_chat"    // Cancel in-progress chat
 	TypeRenameContext MessageType = "rename_context"
 
 	// Response types

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -95,6 +95,10 @@ type Server struct {
 	backendCmd *exec.Cmd
 	backendMux sync.Mutex
 
+	// Active chat cancel functions — maps sessionID → cancel for in-progress chats
+	activeChatCtxs   map[string]context.CancelFunc
+	activeChatCtxsMu sync.Mutex
+
 	// Auto-update system
 	updateChecker *UpdateChecker
 
@@ -164,6 +168,7 @@ func NewServer(cfg Config) (*Server, error) {
 		agentToken:     agentToken,
 		sessionStart:   now,
 		todayDate:      now.Format("2006-01-02"),
+		activeChatCtxs: make(map[string]context.CancelFunc),
 	}
 
 	server.upgrader = websocket.Upgrader{
@@ -1786,13 +1791,18 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 
-		// For chat messages, use streaming handler that can send multiple responses
+		// For chat messages, run in a goroutine so cancel messages can be received
 		if msg.Type == protocol.TypeChat || msg.Type == protocol.TypeClaude {
 			forceAgent := ""
 			if msg.Type == protocol.TypeClaude {
 				forceAgent = "claude"
 			}
-			s.handleChatMessageStreaming(conn, msg, forceAgent)
+			go func(m protocol.Message, fa string) {
+				s.handleChatMessageStreaming(conn, m, fa, &writeMu, &closed)
+			}(msg, forceAgent)
+		} else if msg.Type == protocol.TypeCancelChat {
+			// Cancel an in-progress chat by session ID
+			s.handleCancelChat(conn, msg, &writeMu)
 		} else if msg.Type == protocol.TypeKubectl {
 			// Handle kubectl messages concurrently so one slow cluster
 			// doesn't block the entire WebSocket message loop.
@@ -1897,13 +1907,24 @@ func (s *Server) handleKubectlMessage(msg protocol.Message) protocol.Message {
 	}
 }
 
-// handleChatMessageStreaming handles chat messages with streaming support
-// This allows sending multiple WebSocket messages for progress events and text chunks
-func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.Message, forceAgent string) {
+// handleChatMessageStreaming handles chat messages with streaming support.
+// Runs in a goroutine so the WebSocket read loop stays free to receive cancel messages.
+// writeMu/closed are shared with the read loop for safe concurrent WebSocket writes.
+func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.Message, forceAgent string, writeMu *sync.Mutex, closed *atomic.Bool) {
+	// safeWrite sends a WebSocket message only if the connection is still open and not cancelled
+	safeWrite := func(ctx context.Context, outMsg protocol.Message) {
+		if closed.Load() || ctx.Err() != nil {
+			return
+		}
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		conn.WriteJSON(outMsg)
+	}
+
 	// Parse payload
 	payloadBytes, err := json.Marshal(msg.Payload)
 	if err != nil {
-		conn.WriteJSON(s.errorResponse(msg.ID, "invalid_payload", "Failed to parse chat request"))
+		safeWrite(context.Background(), s.errorResponse(msg.ID, "invalid_payload", "Failed to parse chat request"))
 		return
 	}
 
@@ -1912,7 +1933,7 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 		// Try legacy ClaudeRequest format for backward compatibility
 		var legacyReq protocol.ClaudeRequest
 		if err := json.Unmarshal(payloadBytes, &legacyReq); err != nil {
-			conn.WriteJSON(s.errorResponse(msg.ID, "invalid_payload", "Invalid chat request format"))
+			safeWrite(context.Background(), s.errorResponse(msg.ID, "invalid_payload", "Invalid chat request format"))
 			return
 		}
 		req.Prompt = legacyReq.Prompt
@@ -1920,9 +1941,23 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 	}
 
 	if req.Prompt == "" {
-		conn.WriteJSON(s.errorResponse(msg.ID, "empty_prompt", "Prompt cannot be empty"))
+		safeWrite(context.Background(), s.errorResponse(msg.ID, "empty_prompt", "Prompt cannot be empty"))
 		return
 	}
+
+	// Create cancellable context — cancel_chat messages will call the cancel function
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Register cancel function so handleCancelChat can stop this session
+	s.activeChatCtxsMu.Lock()
+	s.activeChatCtxs[req.SessionID] = cancel
+	s.activeChatCtxsMu.Unlock()
+	defer func() {
+		s.activeChatCtxsMu.Lock()
+		delete(s.activeChatCtxs, req.SessionID)
+		s.activeChatCtxsMu.Unlock()
+	}()
 
 	// Determine which agent to use
 	agentName := req.Agent
@@ -1954,7 +1989,7 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 		// Try mixed-mode: use thinking agent + CLI execution agent
 		if toolAgent := s.findToolCapableAgent(); toolAgent != "" {
 			log.Printf("[Chat] Mixed-mode: thinking=%s, execution=%s", agentName, toolAgent)
-			s.handleMixedModeChat(conn, msg, req, agentName, toolAgent, req.SessionID)
+			s.handleMixedModeChat(ctx, conn, msg, req, agentName, toolAgent, req.SessionID, writeMu, closed)
 			return
 		}
 		log.Printf("[Chat] No tool-capable agent available, keeping %s (best-effort)", agentName)
@@ -1970,7 +2005,7 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 		log.Printf("[Chat] Agent %q not found, trying default", agentName)
 		provider, err = s.registry.GetDefault()
 		if err != nil {
-			conn.WriteJSON(s.errorResponse(msg.ID, "no_agent", "No AI agent available. Please configure an API key"))
+			safeWrite(ctx, s.errorResponse(msg.ID, "no_agent", "No AI agent available. Please configure an API key"))
 			return
 		}
 		agentName = provider.Name()
@@ -1978,7 +2013,7 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 	}
 
 	if !provider.IsAvailable() {
-		conn.WriteJSON(s.errorResponse(msg.ID, "agent_unavailable", fmt.Sprintf("Agent %s is not available", agentName)))
+		safeWrite(ctx, s.errorResponse(msg.ID, "agent_unavailable", fmt.Sprintf("Agent %s is not available", agentName)))
 		return
 	}
 
@@ -1998,7 +2033,7 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 	}
 
 	// Send initial progress message so user sees feedback immediately
-	conn.WriteJSON(protocol.Message{
+	safeWrite(ctx, protocol.Message{
 		ID:   msg.ID,
 		Type: protocol.TypeProgress,
 		Payload: protocol.ProgressPayload{
@@ -2014,8 +2049,7 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 
 		onChunk := func(chunk string) {
 			streamedContent.WriteString(chunk)
-			// Send stream message for text chunk
-			conn.WriteJSON(protocol.Message{
+			safeWrite(ctx, protocol.Message{
 				ID:   msg.ID,
 				Type: protocol.TypeStream,
 				Payload: protocol.ChatStreamPayload{
@@ -2027,15 +2061,15 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 			})
 		}
 
+		const maxCmdDisplayLen = 60
 		onProgress := func(event StreamEvent) {
 			// Build human-readable step description
 			step := event.Tool
 			if event.Type == "tool_use" {
 				// For tool_use, show what tool is being called
 				if cmd, ok := event.Input["command"].(string); ok {
-					// Truncate long commands
-					if len(cmd) > 60 {
-						cmd = cmd[:60] + "..."
+					if len(cmd) > maxCmdDisplayLen {
+						cmd = cmd[:maxCmdDisplayLen] + "..."
 					}
 					step = fmt.Sprintf("%s: %s", event.Tool, cmd)
 				}
@@ -2043,8 +2077,7 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 				step = fmt.Sprintf("%s completed", event.Tool)
 			}
 
-			// Send progress message
-			conn.WriteJSON(protocol.Message{
+			safeWrite(ctx, protocol.Message{
 				ID:   msg.ID,
 				Type: protocol.TypeProgress,
 				Payload: protocol.ProgressPayload{
@@ -2056,9 +2089,14 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 			})
 		}
 
-		resp, err = streamingProvider.StreamChatWithProgress(context.Background(), chatReq, onChunk, onProgress)
+		resp, err = streamingProvider.StreamChatWithProgress(ctx, chatReq, onChunk, onProgress)
 		if err != nil {
-			conn.WriteJSON(s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s: %s", agentName, err.Error())))
+			// Don't send error if we were cancelled — the frontend already knows
+			if ctx.Err() != nil {
+				log.Printf("[Chat] Session %s cancelled", req.SessionID)
+				return
+			}
+			safeWrite(ctx, s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s: %s", agentName, err.Error())))
 			return
 		}
 
@@ -2068,11 +2106,21 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 		}
 	} else {
 		// Fall back to non-streaming for providers that don't support progress
-		resp, err = provider.Chat(context.Background(), chatReq)
+		resp, err = provider.Chat(ctx, chatReq)
 		if err != nil {
-			conn.WriteJSON(s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s: %s", agentName, err.Error())))
+			if ctx.Err() != nil {
+				log.Printf("[Chat] Session %s cancelled", req.SessionID)
+				return
+			}
+			safeWrite(ctx, s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s: %s", agentName, err.Error())))
 			return
 		}
+	}
+
+	// Don't send result if cancelled
+	if ctx.Err() != nil {
+		log.Printf("[Chat] Session %s cancelled after completion", req.SessionID)
+		return
 	}
 
 	// Ensure we have a valid response object to avoid nil panics
@@ -2097,7 +2145,7 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 	}
 
 	// Send final result
-	conn.WriteJSON(protocol.Message{
+	safeWrite(ctx, protocol.Message{
 		ID:   msg.ID,
 		Type: protocol.TypeResult,
 		Payload: protocol.ChatStreamPayload{
@@ -2112,6 +2160,37 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 			},
 		},
 	})
+}
+
+// handleCancelChat cancels an in-progress chat session by calling its context cancel function
+func (s *Server) handleCancelChat(conn *websocket.Conn, msg protocol.Message, writeMu *sync.Mutex) {
+	payloadBytes, _ := json.Marshal(msg.Payload)
+	var req struct {
+		SessionID string `json:"sessionId"`
+	}
+	json.Unmarshal(payloadBytes, &req)
+
+	s.activeChatCtxsMu.Lock()
+	cancelFn, ok := s.activeChatCtxs[req.SessionID]
+	s.activeChatCtxsMu.Unlock()
+
+	if ok {
+		cancelFn()
+		log.Printf("[Chat] Cancelled chat for session %s", req.SessionID)
+	} else {
+		log.Printf("[Chat] No active chat to cancel for session %s", req.SessionID)
+	}
+
+	writeMu.Lock()
+	conn.WriteJSON(protocol.Message{
+		ID:   msg.ID,
+		Type: protocol.TypeResult,
+		Payload: map[string]interface{}{
+			"cancelled": ok,
+			"sessionId": req.SessionID,
+		},
+	})
+	writeMu.Unlock()
 }
 
 // handleChatMessage handles chat messages (both legacy claude and new chat types)
@@ -2298,15 +2377,25 @@ func (s *Server) errorResponse(id, code, message string) protocol.Message {
 // 1. Thinking agent (API) analyzes the prompt and generates a plan
 // 2. Execution agent (CLI) runs any commands
 // 3. Thinking agent analyzes the results
-func (s *Server) handleMixedModeChat(conn *websocket.Conn, msg protocol.Message, req protocol.ChatRequest, thinkingAgent, executionAgent string, sessionID string) {
+func (s *Server) handleMixedModeChat(ctx context.Context, conn *websocket.Conn, msg protocol.Message, req protocol.ChatRequest, thinkingAgent, executionAgent string, sessionID string, writeMu *sync.Mutex, closed *atomic.Bool) {
+	// safeWrite sends a WebSocket message only if the connection is still open and not cancelled
+	safeWrite := func(outMsg protocol.Message) {
+		if closed.Load() || ctx.Err() != nil {
+			return
+		}
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		conn.WriteJSON(outMsg)
+	}
+
 	thinkingProvider, err := s.registry.Get(thinkingAgent)
 	if err != nil {
-		conn.WriteJSON(s.errorResponse(msg.ID, "agent_error", fmt.Sprintf("Thinking agent %s not found", thinkingAgent)))
+		safeWrite(s.errorResponse(msg.ID, "agent_error", fmt.Sprintf("Thinking agent %s not found", thinkingAgent)))
 		return
 	}
 	execProvider, err := s.registry.Get(executionAgent)
 	if err != nil {
-		conn.WriteJSON(s.errorResponse(msg.ID, "agent_error", fmt.Sprintf("Execution agent %s not found", executionAgent)))
+		safeWrite(s.errorResponse(msg.ID, "agent_error", fmt.Sprintf("Execution agent %s not found", executionAgent)))
 		return
 	}
 
@@ -2316,10 +2405,8 @@ func (s *Server) handleMixedModeChat(conn *websocket.Conn, msg protocol.Message,
 		history = append(history, ChatMessage{Role: m.Role, Content: m.Content})
 	}
 
-	ctx := context.Background()
-
 	// Phase 1: Send thinking phase indicator
-	conn.WriteJSON(protocol.Message{
+	safeWrite(protocol.Message{
 		ID:   msg.ID,
 		Type: "mixed_mode_thinking",
 		Payload: map[string]interface{}{
@@ -2345,18 +2432,22 @@ User request: %s`, req.Prompt)
 
 	thinkingResp, err := thinkingProvider.Chat(ctx, &thinkingReq)
 	if err != nil {
+		if ctx.Err() != nil {
+			log.Printf("[MixedMode] Session %s cancelled", sessionID)
+			return
+		}
 		log.Printf("[MixedMode] Thinking agent error: %v", err)
-		conn.WriteJSON(s.errorResponse(msg.ID, "mixed_mode_error", fmt.Sprintf("Thinking agent error: %v", err)))
+		safeWrite(s.errorResponse(msg.ID, "mixed_mode_error", fmt.Sprintf("Thinking agent error: %v", err)))
 		return
 	}
 	if thinkingResp == nil {
 		log.Printf("[MixedMode] Thinking agent returned nil response")
-		conn.WriteJSON(s.errorResponse(msg.ID, "mixed_mode_error", "Thinking agent returned empty response"))
+		safeWrite(s.errorResponse(msg.ID, "mixed_mode_error", "Thinking agent returned empty response"))
 		return
 	}
 
 	// Stream the thinking response
-	conn.WriteJSON(protocol.Message{
+	safeWrite(protocol.Message{
 		ID:   msg.ID,
 		Type: "stream_chunk",
 		Payload: map[string]interface{}{
@@ -2379,7 +2470,7 @@ User request: %s`, req.Prompt)
 
 	if len(commands) == 0 {
 		// No commands to execute - just return thinking response
-		conn.WriteJSON(protocol.Message{
+		safeWrite(protocol.Message{
 			ID:   msg.ID,
 			Type: "stream_end",
 			Payload: map[string]interface{}{
@@ -2391,7 +2482,7 @@ User request: %s`, req.Prompt)
 	}
 
 	// Phase 2: Execute commands via CLI agent
-	conn.WriteJSON(protocol.Message{
+	safeWrite(protocol.Message{
 		ID:   msg.ID,
 		Type: "mixed_mode_executing",
 		Payload: map[string]interface{}{
@@ -2415,9 +2506,13 @@ User request: %s`, req.Prompt)
 
 	execResp, err := execProvider.Chat(ctx, &execReq)
 	if err != nil {
+		if ctx.Err() != nil {
+			log.Printf("[MixedMode] Session %s cancelled during execution", sessionID)
+			return
+		}
 		log.Printf("[MixedMode] Execution agent error: %v", err)
 		execContent = fmt.Sprintf("Execution Error: %v", err)
-		conn.WriteJSON(protocol.Message{
+		safeWrite(protocol.Message{
 			ID:   msg.ID,
 			Type: "stream_chunk",
 			Payload: map[string]interface{}{
@@ -2430,7 +2525,7 @@ User request: %s`, req.Prompt)
 		if execResp != nil {
 			execContent = execResp.Content
 		}
-		conn.WriteJSON(protocol.Message{
+		safeWrite(protocol.Message{
 			ID:   msg.ID,
 			Type: "stream_chunk",
 			Payload: map[string]interface{}{
@@ -2442,7 +2537,7 @@ User request: %s`, req.Prompt)
 	}
 
 	// Phase 3: Feed results back to thinking agent for analysis
-	conn.WriteJSON(protocol.Message{
+	safeWrite(protocol.Message{
 		ID:   msg.ID,
 		Type: "mixed_mode_thinking",
 		Payload: map[string]interface{}{
@@ -2467,9 +2562,13 @@ Command output:
 
 	analysisResp, err := thinkingProvider.Chat(ctx, &analysisReq)
 	if err != nil {
+		if ctx.Err() != nil {
+			log.Printf("[MixedMode] Session %s cancelled during analysis", sessionID)
+			return
+		}
 		log.Printf("[MixedMode] Analysis error: %v", err)
 	} else if analysisResp != nil {
-		conn.WriteJSON(protocol.Message{
+		safeWrite(protocol.Message{
 			ID:   msg.ID,
 			Type: "stream_chunk",
 			Payload: map[string]interface{}{
@@ -2481,7 +2580,7 @@ Command output:
 	}
 
 	// End stream
-	conn.WriteJSON(protocol.Message{
+	safeWrite(protocol.Message{
 		ID:   msg.ID,
 		Type: "stream_end",
 		Payload: map[string]interface{}{

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -33,6 +33,7 @@ import type { Mission } from '../../../hooks/useMissions'
 import type { FontSize } from './types'
 import { MissionListItem } from './MissionListItem'
 import { MissionChat } from './MissionChat'
+import { ClusterSelectionDialog } from '../../missions/ClusterSelectionDialog'
 import { useTranslation } from 'react-i18next'
 import { SAVED_TOAST_MS, FOCUS_DELAY_MS } from '../../../lib/constants/network'
 
@@ -49,6 +50,8 @@ export function MissionSidebar() {
   const [viewingMission, setViewingMission] = useState<MissionExport | null>(null)
   const [viewingMissionRaw, setViewingMissionRaw] = useState(false)
   const newMissionInputRef = useRef<HTMLTextAreaElement>(null)
+  // Cluster selection for install missions
+  const [pendingRunMissionId, setPendingRunMissionId] = useState<string | null>(null)
 
   // Deep-link: open MissionBrowser to specific mission via ?mission= URL param
   const [searchParams, setSearchParams] = useSearchParams()
@@ -108,6 +111,19 @@ export function MissionSidebar() {
     setViewingMission(savedMissionToExport(m))
     setViewingMissionRaw(false)
   }, [savedMissionToExport])
+
+  // Run mission — for install/deploy types, show cluster picker first
+  const handleRunMission = useCallback((missionId: string) => {
+    const mission = missions.find(m => m.id === missionId)
+    const isInstall = mission?.importedFrom?.missionClass === 'install' || mission?.type === 'deploy'
+    if (isInstall) {
+      setPendingRunMissionId(missionId)
+    } else {
+      runSavedMission(missionId)
+    }
+  }, [missions, runSavedMission])
+
+  const pendingMission = pendingRunMissionId ? missions.find(m => m.id === pendingRunMissionId) : null
 
   // Escape key: exit fullscreen first, then close sidebar
   useEffect(() => {
@@ -467,7 +483,7 @@ export function MissionSidebar() {
                         <Eye className="w-2.5 h-2.5" /> View
                       </button>
                       <button
-                        onClick={(e) => { e.stopPropagation(); runSavedMission(m.id) }}
+                        onClick={(e) => { e.stopPropagation(); handleRunMission(m.id) }}
                         className="flex items-center gap-1 px-2 py-0.5 text-[10px] font-medium bg-primary text-primary-foreground rounded hover:bg-primary/90 transition-colors"
                       >
                         <Play className="w-2.5 h-2.5" /> Run
@@ -539,7 +555,7 @@ export function MissionSidebar() {
                         <Eye className="w-3.5 h-3.5" />
                       </button>
                       <button
-                        onClick={(e) => { e.stopPropagation(); runSavedMission(m.id) }}
+                        onClick={(e) => { e.stopPropagation(); handleRunMission(m.id) }}
                         className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
                         title="Run this mission"
                       >
@@ -623,7 +639,7 @@ export function MissionSidebar() {
                 onImport={() => {
                   // Find the matching saved mission and run it
                   const match = savedMissions.find(m => m.title === viewingMission.title)
-                  if (match) runSavedMission(match.id)
+                  if (match) handleRunMission(match.id)
                   setViewingMission(null)
                 }}
                 onBack={() => setViewingMission(null)}
@@ -642,6 +658,19 @@ export function MissionSidebar() {
         onImport={handleImportMission}
         initialMission={deepLinkMission || undefined}
       />
+
+      {/* Cluster Selection Dialog for install missions */}
+      {pendingRunMissionId && (
+        <ClusterSelectionDialog
+          open
+          missionTitle={pendingMission?.title ?? 'Mission'}
+          onSelect={(cluster) => {
+            runSavedMission(pendingRunMissionId, cluster || undefined)
+            setPendingRunMissionId(null)
+          }}
+          onCancel={() => setPendingRunMissionId(null)}
+        />
+      )}
     </>
   )
 }

--- a/web/src/components/missions/ClusterSelectionDialog.tsx
+++ b/web/src/components/missions/ClusterSelectionDialog.tsx
@@ -1,0 +1,134 @@
+/**
+ * ClusterSelectionDialog — Prompts the user to select a target cluster
+ * before running an install-type mission.
+ */
+
+import { useState, useEffect } from 'react'
+import { X, Server, Check } from 'lucide-react'
+import { cn } from '../../lib/cn'
+import { useClusters } from '../../hooks/mcp/clusters'
+
+/** Delay before auto-selecting a single online cluster (ms) */
+const AUTO_SELECT_DELAY_MS = 600
+
+interface ClusterSelectionDialogProps {
+  open: boolean
+  missionTitle: string
+  onSelect: (cluster: string) => void
+  onCancel: () => void
+}
+
+export function ClusterSelectionDialog({ open, missionTitle, onSelect, onCancel }: ClusterSelectionDialogProps) {
+  const { clusters, isLoading } = useClusters()
+  const [selected, setSelected] = useState<string | null>(null)
+
+  // Filter to reachable/healthy clusters
+  const onlineClusters = (clusters || []).filter(c => c.reachable !== false && c.healthy !== false)
+  const offlineClusters = (clusters || []).filter(c => c.reachable === false || c.healthy === false)
+
+  // Auto-select if only one online cluster
+  useEffect(() => {
+    if (onlineClusters.length === 1 && !selected) {
+      const timer = setTimeout(() => {
+        onSelect(onlineClusters[0].context || onlineClusters[0].name)
+      }, AUTO_SELECT_DELAY_MS)
+      return () => clearTimeout(timer)
+    }
+  }, [onlineClusters, selected, onSelect])
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="w-full max-w-md rounded-lg border border-border bg-card shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">Select Target Cluster</h3>
+            <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-[320px]">{missionTitle}</p>
+          </div>
+          <button onClick={onCancel} className="p-1 rounded hover:bg-secondary transition-colors">
+            <X className="w-4 h-4 text-muted-foreground" />
+          </button>
+        </div>
+
+        {/* Cluster list */}
+        <div className="p-3 max-h-64 overflow-y-auto space-y-1.5">
+          {isLoading && (
+            <p className="text-xs text-muted-foreground text-center py-4">Loading clusters...</p>
+          )}
+
+          {!isLoading && onlineClusters.length === 0 && (
+            <p className="text-xs text-muted-foreground text-center py-4">No online clusters found</p>
+          )}
+
+          {onlineClusters.map(cluster => {
+            const id = cluster.context || cluster.name
+            const isSelected = selected === id
+            return (
+              <button
+                key={id}
+                onClick={() => setSelected(id)}
+                className={cn(
+                  'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg border text-left transition-all',
+                  isSelected
+                    ? 'border-purple-500 bg-purple-500/10'
+                    : 'border-border hover:border-purple-500/30 bg-secondary/30 hover:bg-secondary/50'
+                )}
+              >
+                <div className="relative flex-shrink-0">
+                  <Server className="w-4 h-4 text-muted-foreground" />
+                  <span className="absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full bg-green-500 ring-1 ring-card" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-foreground truncate">{cluster.name}</p>
+                  {cluster.context !== cluster.name && cluster.context && (
+                    <p className="text-[10px] text-muted-foreground truncate">{cluster.context}</p>
+                  )}
+                </div>
+                {isSelected && <Check className="w-4 h-4 text-purple-400 flex-shrink-0" />}
+              </button>
+            )
+          })}
+
+          {/* Show offline clusters as disabled */}
+          {offlineClusters.map(cluster => {
+            const id = cluster.context || cluster.name
+            return (
+              <div
+                key={id}
+                className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-border/50 opacity-40 cursor-not-allowed"
+              >
+                <div className="relative flex-shrink-0">
+                  <Server className="w-4 h-4 text-muted-foreground" />
+                  <span className="absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500 ring-1 ring-card" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm text-muted-foreground truncate">{cluster.name}</p>
+                  <p className="text-[10px] text-red-400">Offline</p>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center justify-between px-4 py-3 border-t border-border">
+          <button
+            onClick={() => onSelect('')}
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Skip (use current context)
+          </button>
+          <button
+            onClick={() => selected && onSelect(selected)}
+            disabled={!selected}
+            className="px-4 py-1.5 text-xs font-medium rounded bg-purple-600 hover:bg-purple-500 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            Run Mission
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -84,7 +84,7 @@ interface MissionContextValue {
   // Actions
   startMission: (params: StartMissionParams) => string
   saveMission: (params: SaveMissionParams) => string
-  runSavedMission: (missionId: string) => void
+  runSavedMission: (missionId: string, cluster?: string) => void
   sendMessage: (missionId: string, content: string) => void
   cancelMission: (missionId: string) => void
   dismissMission: (missionId: string) => void
@@ -798,23 +798,29 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     return missionId
   }, [])
 
-  // Run a previously saved mission
-  const runSavedMission = useCallback((missionId: string) => {
+  // Run a previously saved mission, optionally targeting a specific cluster
+  const runSavedMission = useCallback((missionId: string, cluster?: string) => {
     const mission = missions.find(m => m.id === missionId)
     if (!mission || mission.status !== 'saved') return
 
-    const initialPrompt = mission.importedFrom?.steps
+    const basePrompt = mission.importedFrom?.steps
       ? `${mission.description}\n\nSteps:\n${mission.importedFrom.steps.map((s, i) => `${i + 1}. ${s.title}: ${s.description}`).join('\n')}`
       : mission.description
+
+    // Inject cluster targeting context if a cluster was selected
+    const initialPrompt = cluster
+      ? `Target cluster: ${cluster}\n\nIMPORTANT: All kubectl commands MUST use --context=${cluster}\n\n${basePrompt}`
+      : basePrompt
 
     setMissions(prev => prev.map(m =>
       m.id === missionId ? {
         ...m,
         status: 'pending',
+        cluster: cluster || undefined,
         messages: [{
           id: `msg-${Date.now()}`,
           role: 'user' as const,
-          content: initialPrompt,
+          content: basePrompt, // Show original prompt in UI (not cluster prefix)
           timestamp: new Date(),
         }],
         updatedAt: new Date(),
@@ -860,8 +866,46 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     })
   }, [missions, ensureConnection, selectedAgent])
 
+  // Cancel a running mission — sends cancel signal to backend to kill agent process
+  const cancelMission = useCallback((missionId: string) => {
+    // Send cancel signal to backend to abort the in-progress agent turn
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({
+        id: `cancel-${Date.now()}`,
+        type: 'cancel_chat',
+        payload: { sessionId: missionId },
+      }))
+    }
+
+    setMissions(prev => prev.map(m =>
+      m.id === missionId ? {
+        ...m,
+        status: 'failed',
+        currentStep: undefined,
+        updatedAt: new Date(),
+        messages: [
+          ...m.messages,
+          {
+            id: `msg-${Date.now()}`,
+            role: 'system',
+            content: 'Mission cancelled by user.',
+            timestamp: new Date(),
+          }
+        ]
+      } : m
+    ))
+  }, [])
+
   // Send a follow-up message
   const sendMessage = useCallback((missionId: string, content: string) => {
+    // Detect stop/cancel keywords — treat as a cancel action
+    const STOP_KEYWORDS = ['stop', 'cancel', 'abort', 'halt', 'quit']
+    const isStopCommand = STOP_KEYWORDS.some(kw => content.trim().toLowerCase() === kw)
+    if (isStopCommand) {
+      cancelMission(missionId)
+      return
+    }
+
     // Track token usage for this mission
     setActiveTokenCategory('missions')
 
@@ -925,27 +969,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
         } : m
       ))
     })
-  }, [ensureConnection, missions, selectedAgent])
-
-  // Cancel a running mission
-  const cancelMission = useCallback((missionId: string) => {
-    setMissions(prev => prev.map(m =>
-      m.id === missionId ? {
-        ...m,
-        status: 'failed',
-        updatedAt: new Date(),
-        messages: [
-          ...m.messages,
-          {
-            id: `msg-${Date.now()}`,
-            role: 'system',
-            content: 'Mission cancelled by user.',
-            timestamp: new Date(),
-          }
-        ]
-      } : m
-    ))
-  }, [])
+  }, [cancelMission, ensureConnection, missions, selectedAgent])
 
   // Dismiss/remove a mission from the list
   const dismissMission = useCallback((missionId: string) => {


### PR DESCRIPTION
## Summary
- **Cancel/Stop**: AI mission cancel now actually kills the backend agent turn. Chat handler runs in a goroutine with a cancellable context, so the WebSocket read loop can receive `cancel_chat` messages while chat is in progress. Frontend sends the cancel signal over WS and also detects stop keywords (stop, cancel, abort, halt, quit).
- **Cluster Selection**: Install-type missions (CNCF installers) now show a cluster picker dialog before running. The selected cluster is injected as `--context=<cluster>` in the prompt. Auto-selects if only one online cluster.

## Test plan
- [ ] Start an AI mission, wait for agent execution, click Cancel → agent process killed, mission shows "cancelled"
- [ ] While mission running, type "stop" → mission cancels same as Cancel button
- [ ] Import a CNCF install mission, click Run → cluster picker appears. Select cluster → prompt includes `--context=<cluster>`
- [ ] Start troubleshoot/custom mission → no cluster picker, runs directly
- [ ] Only 1 online cluster → auto-select, skip dialog
- [ ] Build/lint pass