### PR TITLE
🐛 Guard chart components against division by zero (NaN in SVG paths)

### DIFF
--- a/web/src/components/cards/llmd/KVCacheMonitor.tsx
+++ b/web/src/components/cards/llmd/KVCacheMonitor.tsx
@@ -29,7 +29,7 @@ interface PremiumGaugeProps {
 }
 
 function PremiumGauge({ value, maxValue, label, sublabel, size = 140 }: PremiumGaugeProps) {
-  const percentage = Math.min((value / maxValue) * 100, 100)
+  const percentage = maxValue > 0 ? Math.min((value / maxValue) * 100, 100) : 0
   const viewSize = 100
   const cx = viewSize / 2
   const cy = viewSize / 2

--- a/web/src/components/cards/llmd/shared/HorseshoeGauge.tsx
+++ b/web/src/components/cards/llmd/shared/HorseshoeGauge.tsx
@@ -36,7 +36,7 @@ export function HorseshoeGauge({
   size = 180,
 }: HorseshoeGaugeProps) {
   const { t: _t } = useTranslation()
-  const percentage = Math.min((value / maxValue) * 100, 100)
+  const percentage = maxValue > 0 ? Math.min((value / maxValue) * 100, 100) : 0
   const color = getColor(percentage)
   const uniqueId = useMemo(() => `horseshoe-${Math.random().toString(36).substr(2, 9)}`, [])
 

--- a/web/src/components/cards/llmd/shared/PremiumGauge.tsx
+++ b/web/src/components/cards/llmd/shared/PremiumGauge.tsx
@@ -87,13 +87,13 @@ export function PremiumGauge({
 
   // Calculate arc angles based on values
   const primaryAngle = useMemo(() => {
-    const percentage = Math.min(primary.value / primary.max, 1)
+    const percentage = primary.max > 0 ? Math.min(primary.value / primary.max, 1) : 0
     return startAngle + percentage * totalAngle
   }, [primary.value, primary.max, startAngle, totalAngle])
 
   const secondaryAngle = useMemo(() => {
     if (!secondary) return startAngle
-    const percentage = Math.min(secondary.value / secondary.max, 1)
+    const percentage = secondary.max > 0 ? Math.min(secondary.value / secondary.max, 1) : 0
     return startAngle + percentage * totalAngle
   }, [secondary, startAngle, totalAngle])
 

--- a/web/src/components/charts/Gauge.tsx
+++ b/web/src/components/charts/Gauge.tsx
@@ -21,7 +21,7 @@ export function Gauge({
   thresholds = { warning: 70, critical: 90 },
   invertColors = false,
 }: GaugeProps) {
-  const percentage = Math.min((value / max) * 100, 100)
+  const percentage = max > 0 ? Math.min((value / max) * 100, 100) : 0
   const rotation = (percentage / 100) * 180 - 90 // -90 to 90 degrees
 
   const getColor = () => {

--- a/web/src/components/charts/ProgressBar.tsx
+++ b/web/src/components/charts/ProgressBar.tsx
@@ -24,7 +24,7 @@ export function ProgressBar({
   variant = 'default',
   thresholds,
 }: ProgressBarProps) {
-  const percentage = Math.min((value / max) * 100, 100)
+  const percentage = max > 0 ? Math.min((value / max) * 100, 100) : 0
 
   const getColor = () => {
     if (color) return color
@@ -100,7 +100,7 @@ export function SegmentedProgressBar({
   showLegend = true,
   title,
 }: SegmentedProgressBarProps) {
-  const total = max || segments.reduce((sum, s) => sum + s.value, 0)
+  const total = max || segments.reduce((sum, s) => sum + s.value, 0) || 1
 
   const sizeClasses = {
     sm: 'h-1.5',
@@ -172,7 +172,7 @@ export function CircularProgress({
   label,
   thresholds,
 }: CircularProgressProps) {
-  const percentage = Math.min((value / max) * 100, 100)
+  const percentage = max > 0 ? Math.min((value / max) * 100, 100) : 0
   const radius = (size - strokeWidth) / 2
   const circumference = radius * 2 * Math.PI
   const offset = circumference - (percentage / 100) * circumference


### PR DESCRIPTION
## Summary
- Guards all chart percentage calculations against `max=0` producing `NaN` via division by zero
- Fixes `<path> attribute d: Expected number, "M NaN NaN A 56 56 …"` errors in SVG rendering
- Affected components: `Gauge`, `ProgressBar`, `CircularProgress`, `SegmentedProgressBar`, `HorseshoeGauge`, `PremiumGauge`, `KVCacheMonitor`

## Root Cause
When `max` (or `maxValue`) is `0`, expressions like `(value / max) * 100` produce `NaN`, which propagates through `polarToCartesian()` into SVG `<path d="M NaN NaN A ...">` attributes. This happens when drill-down views receive data with zero-max values (e.g., `gpuCount=0`, `replicas=0`).

## Fix
Simple guard: `max > 0 ? Math.min((value / max) * 100, 100) : 0` applied consistently across all chart components.

## Test plan
- [ ] Click healthy/unhealthy stat blocks on main dashboard — no NaN SVG errors in console
- [ ] View cluster drill-down with nodes that have `gpuCount=0` — gauge renders as empty (0%)
- [ ] View scaled-to-zero deployments — gauge renders correctly
- [ ] Build passes, no new lint errors