### PR TITLE
🐛 Fix chunk load errors caught by wrong error boundary

### DIFF
--- a/web/src/components/ChunkErrorBoundary.tsx
+++ b/web/src/components/ChunkErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Component, type ReactNode, type ErrorInfo } from 'react'
 import { RefreshCw } from 'lucide-react'
 import i18next from 'i18next'
 import { emitError } from '../lib/analytics'
+import { isChunkLoadError } from '../lib/chunkErrors'
 
 // Reload throttle interval in milliseconds to prevent infinite reload loops
 const RELOAD_THROTTLE_MS = 30_000 // 30 seconds
@@ -85,15 +86,3 @@ export class ChunkErrorBoundary extends Component<Props, State> {
   }
 }
 
-function isChunkLoadError(error: Error): boolean {
-  const msg = error.message || ''
-  return (
-    msg.includes('Failed to fetch dynamically imported module') ||
-    msg.includes('Loading chunk') ||
-    msg.includes('Loading CSS chunk') ||
-    msg.includes('dynamically imported module') ||
-    msg.includes('error loading dynamically imported module') ||
-    // Vite-specific preload error
-    msg.includes('Unable to preload CSS')
-  )
-}

--- a/web/src/components/cards/DynamicCardErrorBoundary.tsx
+++ b/web/src/components/cards/DynamicCardErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ReactNode, type ErrorInfo } from 'react'
 import { AlertTriangle, RotateCcw } from 'lucide-react'
 import { emitError } from '../../lib/analytics'
+import { isChunkLoadError } from '../../lib/chunkErrors'
 
 // Maximum number of retry attempts before disabling the retry button
 const MAX_RETRY_ATTEMPTS = 3
@@ -33,11 +34,21 @@ export class DynamicCardErrorBoundary extends Component<Props, State> {
     this.state = { hasError: false, error: null, retryCount: 0, pendingRetry: false }
   }
 
-  static getDerivedStateFromError(error: Error): Partial<State> {
+  static getDerivedStateFromError(error: Error): Partial<State> | null {
+    // Let chunk load errors propagate to the global ChunkErrorBoundary,
+    // which auto-reloads the page to pick up fresh chunk references.
+    if (isChunkLoadError(error)) {
+      return null
+    }
     return { hasError: true, error }
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // Re-throw chunk load errors so ChunkErrorBoundary handles them
+    if (isChunkLoadError(error)) {
+      throw error
+    }
+
     console.error(`[DynamicCard:${this.props.cardId}] Render error:`, error, errorInfo)
     emitError('card_render', `[${this.props.cardId}] ${error.message}`)
     this.props.onError?.(error, errorInfo)

--- a/web/src/lib/chunkErrors.ts
+++ b/web/src/lib/chunkErrors.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared chunk-load error detection used by both ChunkErrorBoundary
+ * (global, auto-reloads) and DynamicCardErrorBoundary (per-card).
+ *
+ * When a new build is deployed, Vite chunk filenames change due to
+ * content hashing. Browsers with cached HTML still reference old
+ * chunk URLs, producing these characteristic error messages.
+ */
+export function isChunkLoadError(error: Error): boolean {
+  const msg = error.message || ''
+  return (
+    msg.includes('Failed to fetch dynamically imported module') ||
+    msg.includes('Loading chunk') ||
+    msg.includes('Loading CSS chunk') ||
+    msg.includes('dynamically imported module') ||
+    msg.includes('error loading dynamically imported module') ||
+    // Vite-specific preload error
+    msg.includes('Unable to preload CSS')
+  )
+}


### PR DESCRIPTION
## Summary

- **Problem**: After a rebuild (new deploy or dev server restart), chunk filenames change due to content hashing. Browsers with cached HTML reference old chunk URLs that 404. The global `ChunkErrorBoundary` (auto-reloads the page) never fires because the per-card `DynamicCardErrorBoundary` catches the error first, showing a useless "Card Render Error / Retry" UI where retry always fails.
- **Fix**: `DynamicCardErrorBoundary` now detects chunk load errors and re-throws them so `ChunkErrorBoundary` handles them with automatic page reload.
- **Shared utility**: Extract `isChunkLoadError()` into `lib/chunkErrors.ts` so both boundaries use the same detection logic.

## Files changed
- `web/src/lib/chunkErrors.ts` — new shared utility
- `web/src/components/ChunkErrorBoundary.tsx` — import from shared module
- `web/src/components/cards/DynamicCardErrorBoundary.tsx` — skip chunk errors, re-throw to global boundary

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes (no new errors)
- [ ] After a rebuild, navigating to a card with stale chunks triggers auto-reload instead of "Card Render Error"
- [ ] Regular card render errors still show the per-card error UI with retry button