### PR TITLE
🐛 Add HTTP fallback for mission cancel when WebSocket is disconnected

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -327,6 +327,9 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/local-cluster-tools", s.handleLocalClusterTools)
 	mux.HandleFunc("/local-clusters", s.handleLocalClusters)
 
+	// Chat cancel endpoint — HTTP fallback when WebSocket is disconnected
+	mux.HandleFunc("/cancel-chat", s.handleCancelChatHTTP)
+
 	// Backend process management
 	mux.HandleFunc("/restart-backend", s.handleRestartBackend)
 
@@ -2191,6 +2194,49 @@ func (s *Server) handleCancelChat(conn *websocket.Conn, msg protocol.Message, wr
 		},
 	})
 	writeMu.Unlock()
+}
+
+// handleCancelChatHTTP is the HTTP fallback for cancelling in-progress chat sessions.
+// Used when the WebSocket connection is unavailable (e.g., disconnected during long agent runs).
+func (s *Server) handleCancelChatHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set("Access-Control-Allow-Private-Network", "true")
+
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.SessionID == "" {
+		http.Error(w, `{"error":"sessionId is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	s.activeChatCtxsMu.Lock()
+	cancelFn, ok := s.activeChatCtxs[req.SessionID]
+	s.activeChatCtxsMu.Unlock()
+
+	if ok {
+		cancelFn()
+		log.Printf("[Chat] Cancelled chat via HTTP for session %s", req.SessionID)
+	} else {
+		log.Printf("[Chat] No active chat to cancel via HTTP for session %s", req.SessionID)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"cancelled": ok,
+		"sessionId": req.SessionID,
+	})
 }
 
 // handleChatMessage handles chat messages (both legacy claude and new chat types)

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -3,7 +3,7 @@ import type { AgentInfo, AgentsListPayload, AgentSelectedPayload, ChatStreamPayl
 import { getDemoMode } from './useDemoMode'
 import { addCategoryTokens, setActiveTokenCategory } from './useTokenUsage'
 import { detectIssueSignature, findSimilarResolutionsStandalone, generateResolutionPromptContext } from './useResolutions'
-import { LOCAL_AGENT_WS_URL } from '../lib/constants'
+import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
 
 export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'saved'
@@ -868,15 +868,26 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     })
   }, [missions, ensureConnection, selectedAgent])
 
-  // Cancel a running mission — sends cancel signal to backend to kill agent process
+  // Cancel a running mission — sends cancel signal to backend to kill agent process.
+  // Uses WebSocket if connected, otherwise falls back to HTTP POST endpoint.
   const cancelMission = useCallback((missionId: string) => {
-    // Send cancel signal to backend to abort the in-progress agent turn
+    // Try WebSocket first (fastest path when connected)
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       wsRef.current.send(JSON.stringify({
         id: `cancel-${Date.now()}`,
         type: 'cancel_chat',
         payload: { sessionId: missionId },
       }))
+    } else {
+      // HTTP fallback — WS may be disconnected during long agent runs
+      fetch(`${LOCAL_AGENT_HTTP_URL}/cancel-chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId: missionId }),
+      }).catch(() => {
+        // Best-effort: if both WS and HTTP fail, the local state update
+        // still marks the mission as cancelled in the UI
+      })
     }
 
     setMissions(prev => prev.map(m =>


### PR DESCRIPTION
## Summary
- Adds `POST /cancel-chat` HTTP endpoint to kc-agent as a fallback for cancelling in-progress AI missions
- Frontend `cancelMission()` now tries WebSocket first, then falls back to HTTP POST when WS is disconnected
- Fixes bug where Cancel button silently failed during long-running agent turns because the WebSocket connection dropped while the agent was executing

## Problem
During multi-turn agent execution, the WebSocket connection between the frontend and kc-agent could drop (shown as "Connection lost" banner). When the user clicked Cancel:
1. `cancelMission()` checked `wsRef.current?.readyState === WebSocket.OPEN` — which was `false`
2. The `cancel_chat` WS message was silently skipped
3. Local state still updated to `'failed'`, hiding the Cancel button
4. The backend agent process kept running indefinitely

## Fix
- **Backend**: New `handleCancelChatHTTP` handler at `POST /cancel-chat` that looks up the session's cancel function and calls it (same logic as the WS handler)
- **Frontend**: `cancelMission()` tries WS send first; if WS is not `OPEN`, fires `fetch()` to the HTTP endpoint instead

## Test plan
- [ ] Start an AI mission, wait for agent execution, click Cancel with WS connected → agent killed via WS
- [ ] Start an AI mission, simulate WS disconnect (e.g., long-running agent), click Cancel → agent killed via HTTP fallback
- [ ] Verify "stop" keyword in chat still works
- [ ] Build: `go build ./...` and `npm run build` pass