### PR TITLE
✨ Add contributor leaderboard to Updates tab

### DIFF
--- a/pkg/api/handlers/rewards.go
+++ b/pkg/api/handlers/rewards.go
@@ -5,8 +5,12 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"net/url"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,6 +30,14 @@ const (
 	rewardsAPITimeout  = 30 * time.Second
 	rewardsPerPage     = 100 // GitHub max per page
 	rewardsMaxPages    = 10  // GitHub search max 1000 results
+
+	leaderboardCacheTTL     = 24 * time.Hour  // leaderboard refreshes once per day
+	contributorCacheTTL     = 15 * time.Minute // per-user detail cache
+	leaderboardDefaultLimit = 5                // default number of leaderboard entries
+	leaderboardMaxLimit     = 25               // max entries per request
+	contributorsMaxFetch    = 50               // max contributors from GitHub API per repo
+	prDetailMaxFetch        = 20               // max PRs to inspect for avg stats
+	roundingFactor          = 10.0             // multiplier for rounding to 1 decimal place
 )
 
 // RewardsConfig holds configuration for the rewards handler.
@@ -68,6 +80,84 @@ type rewardsCacheEntry struct {
 	fetchedAt time.Time
 }
 
+// LeaderboardEntry represents one contributor's ranking.
+type LeaderboardEntry struct {
+	Login       string           `json:"login"`
+	AvatarURL   string           `json:"avatar_url"`
+	TotalPoints int              `json:"total_points"`
+	Rank        int              `json:"rank"`
+	Breakdown   RewardsBreakdown `json:"breakdown"`
+	Level       string           `json:"level"`
+	LevelRank   int              `json:"level_rank"`
+}
+
+// LeaderboardResponse wraps the leaderboard entries with cache metadata.
+type LeaderboardResponse struct {
+	Entries   []LeaderboardEntry `json:"entries"`
+	CachedAt  string             `json:"cached_at"`
+	FromCache bool               `json:"from_cache"`
+}
+
+// ContributorStats provides detailed per-contributor metrics.
+type ContributorStats struct {
+	Login             string               `json:"login"`
+	AvatarURL         string               `json:"avatar_url"`
+	TotalPoints       int                  `json:"total_points"`
+	Breakdown         RewardsBreakdown     `json:"breakdown"`
+	Level             string               `json:"level"`
+	LevelRank         int                  `json:"level_rank"`
+	AvgPRIterations   float64              `json:"avg_pr_iterations"`
+	AvgPRTimeHours    float64              `json:"avg_pr_time_hours"`
+	FirstContribution string               `json:"first_contribution"`
+	MostActiveRepo    string               `json:"most_active_repo"`
+	TotalPRs          int                  `json:"total_prs"`
+	TotalIssues       int                  `json:"total_issues"`
+	Contributions     []GitHubContribution `json:"contributions"`
+	CachedAt          string               `json:"cached_at"`
+	FromCache         bool                 `json:"from_cache"`
+}
+
+type leaderboardCacheEntry struct {
+	response  *LeaderboardResponse
+	fetchedAt time.Time
+}
+
+type contributorCacheEntry struct {
+	response  *ContributorStats
+	fetchedAt time.Time
+}
+
+// contributorLevel maps point thresholds to level names (mirrors frontend CONTRIBUTOR_LEVELS).
+type contributorLevel struct {
+	rank     int
+	name     string
+	minCoins int
+}
+
+// contributorLevels is sorted ascending by minCoins, mirroring the frontend ladder.
+var contributorLevels = []contributorLevel{
+	{rank: 1, name: "Observer", minCoins: 0},
+	{rank: 2, name: "Explorer", minCoins: 100},
+	{rank: 3, name: "Navigator", minCoins: 500},
+	{rank: 4, name: "Pilot", minCoins: 1500},
+	{rank: 5, name: "Commander", minCoins: 3000},
+	{rank: 6, name: "Captain", minCoins: 5000},
+	{rank: 7, name: "Admiral", minCoins: 10000},
+	{rank: 8, name: "Legend", minCoins: 25000},
+}
+
+// getContributorLevelForPoints returns (levelName, levelRank) for a given points total.
+func getContributorLevelForPoints(totalPoints int) (string, int) {
+	level := contributorLevels[0]
+	for i := len(contributorLevels) - 1; i >= 0; i-- {
+		if totalPoints >= contributorLevels[i].minCoins {
+			level = contributorLevels[i]
+			break
+		}
+	}
+	return level.name, level.rank
+}
+
 // RewardsHandler serves GitHub-sourced reward data.
 type RewardsHandler struct {
 	githubToken string
@@ -76,15 +166,22 @@ type RewardsHandler struct {
 
 	mu    sync.RWMutex
 	cache map[string]*rewardsCacheEntry // keyed by github_login
+
+	leaderboardMu    sync.RWMutex
+	leaderboardCache *leaderboardCacheEntry
+
+	contributorMu    sync.RWMutex
+	contributorCache map[string]*contributorCacheEntry // keyed by github_login
 }
 
 // NewRewardsHandler creates a handler for GitHub activity rewards.
 func NewRewardsHandler(cfg RewardsConfig) *RewardsHandler {
 	return &RewardsHandler{
-		githubToken: cfg.GitHubToken,
-		orgs:        cfg.Orgs,
-		httpClient:  &http.Client{Timeout: rewardsAPITimeout},
-		cache:       make(map[string]*rewardsCacheEntry),
+		githubToken:      cfg.GitHubToken,
+		orgs:             cfg.Orgs,
+		httpClient:       &http.Client{Timeout: rewardsAPITimeout},
+		cache:            make(map[string]*rewardsCacheEntry),
+		contributorCache: make(map[string]*contributorCacheEntry),
 	}
 }
 
@@ -107,12 +204,7 @@ func (h *RewardsHandler) GetGitHubRewards(c *fiber.Ctx) error {
 	h.mu.RUnlock()
 
 	// Resolve token: prefer user's personal token from settings, fall back to server PAT
-	token := h.githubToken
-	if sm := settings.GetSettingsManager(); sm != nil {
-		if all, err := sm.GetAll(); err == nil && all.GitHubToken != "" {
-			token = all.GitHubToken
-		}
-	}
+	token := h.resolveToken()
 
 	// Cache miss — fetch from GitHub
 	resp, err := h.fetchUserRewards(githubLogin, token)
@@ -141,6 +233,17 @@ func (h *RewardsHandler) GetGitHubRewards(c *fiber.Ctx) error {
 	h.mu.Unlock()
 
 	return c.JSON(resp)
+}
+
+// resolveToken returns the best available GitHub token.
+func (h *RewardsHandler) resolveToken() string {
+	token := h.githubToken
+	if sm := settings.GetSettingsManager(); sm != nil {
+		if all, err := sm.GetAll(); err == nil && all.GitHubToken != "" {
+			token = all.GitHubToken
+		}
+	}
+	return token
 }
 
 func (h *RewardsHandler) fetchUserRewards(login, token string) (*GitHubRewardsResponse, error) {
@@ -206,13 +309,13 @@ func (h *RewardsHandler) fetchUserRewards(login, token string) (*GitHubRewardsRe
 
 // searchItem is the subset of GitHub Search issue/PR item we care about.
 type searchItem struct {
-	Title       string            `json:"title"`
-	HTMLURL     string            `json:"html_url"`
-	Number      int               `json:"number"`
-	CreatedAt   string            `json:"created_at"`
-	Labels      []searchLabel     `json:"labels"`
-	PullRequest *searchPRRef      `json:"pull_request,omitempty"`
-	RepoURL     string            `json:"repository_url"` // e.g. https://api.github.com/repos/kubestellar/console
+	Title       string        `json:"title"`
+	HTMLURL     string        `json:"html_url"`
+	Number      int           `json:"number"`
+	CreatedAt   string        `json:"created_at"`
+	Labels      []searchLabel `json:"labels"`
+	PullRequest *searchPRRef  `json:"pull_request,omitempty"`
+	RepoURL     string        `json:"repository_url"` // e.g. https://api.github.com/repos/kubestellar/console
 }
 
 type searchLabel struct {
@@ -343,4 +446,414 @@ func extractRepo(repoURL string) string {
 		return repoURL[len(prefix):]
 	}
 	return repoURL
+}
+
+// ── Leaderboard Endpoints ─────────────────────────────────────────────
+
+// githubContributor is the response shape from GitHub's Contributors API.
+type githubContributor struct {
+	Login     string `json:"login"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+// githubUser is the minimal shape from GET /users/:login.
+type githubUser struct {
+	Login     string `json:"login"`
+	AvatarURL string `json:"avatar_url"`
+}
+
+// prDetail is the minimal shape from GET /repos/:owner/:repo/pulls/:number.
+type prDetail struct {
+	CreatedAt      string `json:"created_at"`
+	MergedAt       string `json:"merged_at"`
+	ReviewComments int    `json:"review_comments"`
+	Commits        int    `json:"commits"`
+}
+
+// parseRepoPaths extracts "owner/repo" pairs from the orgs filter string.
+// Supports "repo:owner/repo" format.
+func parseRepoPaths(orgs string) []string {
+	var repos []string
+	for _, part := range strings.Fields(orgs) {
+		if strings.HasPrefix(part, "repo:") {
+			repos = append(repos, strings.TrimPrefix(part, "repo:"))
+		}
+	}
+	return repos
+}
+
+// GetLeaderboard returns the top contributors ranked by reward points.
+// GET /api/rewards/leaderboard?limit=5
+func (h *RewardsHandler) GetLeaderboard(c *fiber.Ctx) error {
+	limit, err := strconv.Atoi(c.Query("limit", strconv.Itoa(leaderboardDefaultLimit)))
+	if err != nil || limit < 1 {
+		limit = leaderboardDefaultLimit
+	}
+	if limit > leaderboardMaxLimit {
+		limit = leaderboardMaxLimit
+	}
+
+	// Check cache
+	h.leaderboardMu.RLock()
+	if h.leaderboardCache != nil && time.Since(h.leaderboardCache.fetchedAt) < leaderboardCacheTTL {
+		cached := *h.leaderboardCache.response
+		h.leaderboardMu.RUnlock()
+		cached.FromCache = true
+		if len(cached.Entries) > limit {
+			cached.Entries = cached.Entries[:limit]
+		}
+		return c.JSON(cached)
+	}
+	h.leaderboardMu.RUnlock()
+
+	token := h.resolveToken()
+
+	// Fetch contributors from each configured repo
+	repos := parseRepoPaths(h.orgs)
+	contributorMap := make(map[string]string) // login -> avatar_url
+
+	for _, repo := range repos {
+		apiURL := fmt.Sprintf("https://api.github.com/repos/%s/contributors?per_page=%d",
+			repo, contributorsMaxFetch)
+
+		req, reqErr := http.NewRequest("GET", apiURL, nil)
+		if reqErr != nil {
+			log.Printf("[leaderboard] Failed to create request for %s: %v", repo, reqErr)
+			continue
+		}
+		req.Header.Set("Accept", "application/vnd.github.v3+json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+
+		resp, doErr := h.httpClient.Do(req)
+		if doErr != nil {
+			log.Printf("[leaderboard] Failed to fetch contributors for %s: %v", repo, doErr)
+			continue
+		}
+
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil || resp.StatusCode != http.StatusOK {
+			log.Printf("[leaderboard] GitHub API error for %s: status=%d", repo, resp.StatusCode)
+			continue
+		}
+
+		var contributors []githubContributor
+		if unmarshalErr := json.Unmarshal(body, &contributors); unmarshalErr != nil {
+			log.Printf("[leaderboard] Failed to parse contributors for %s: %v", repo, unmarshalErr)
+			continue
+		}
+
+		for _, contrib := range contributors {
+			if _, exists := contributorMap[contrib.Login]; !exists {
+				contributorMap[contrib.Login] = contrib.AvatarURL
+			}
+		}
+	}
+
+	if len(contributorMap) == 0 {
+		// Fall back to stale cache
+		h.leaderboardMu.RLock()
+		if h.leaderboardCache != nil {
+			stale := *h.leaderboardCache.response
+			h.leaderboardMu.RUnlock()
+			stale.FromCache = true
+			if len(stale.Entries) > limit {
+				stale.Entries = stale.Entries[:limit]
+			}
+			return c.JSON(stale)
+		}
+		h.leaderboardMu.RUnlock()
+		return c.JSON(LeaderboardResponse{
+			Entries:  []LeaderboardEntry{},
+			CachedAt: time.Now().UTC().Format(time.RFC3339),
+		})
+	}
+
+	// Compute rewards for each contributor
+	var entries []LeaderboardEntry
+	for login, avatar := range contributorMap {
+		rewards, fetchErr := h.fetchUserRewards(login, token)
+		if fetchErr != nil {
+			log.Printf("[leaderboard] Failed to fetch rewards for %s: %v", login, fetchErr)
+			continue
+		}
+		if rewards.TotalPoints == 0 {
+			continue // skip zero-point contributors
+		}
+
+		levelName, levelRank := getContributorLevelForPoints(rewards.TotalPoints)
+		entries = append(entries, LeaderboardEntry{
+			Login:       login,
+			AvatarURL:   avatar,
+			TotalPoints: rewards.TotalPoints,
+			Breakdown:   rewards.Breakdown,
+			Level:       levelName,
+			LevelRank:   levelRank,
+		})
+	}
+
+	// Sort by points descending, then alphabetically by login for ties
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].TotalPoints != entries[j].TotalPoints {
+			return entries[i].TotalPoints > entries[j].TotalPoints
+		}
+		return entries[i].Login < entries[j].Login
+	})
+
+	// Assign ranks
+	for i := range entries {
+		entries[i].Rank = i + 1
+	}
+
+	response := &LeaderboardResponse{
+		Entries:  entries,
+		CachedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Cache the full result
+	h.leaderboardMu.Lock()
+	h.leaderboardCache = &leaderboardCacheEntry{
+		response:  response,
+		fetchedAt: time.Now(),
+	}
+	h.leaderboardMu.Unlock()
+
+	// Return trimmed result
+	result := *response
+	if len(result.Entries) > limit {
+		result.Entries = result.Entries[:limit]
+	}
+	return c.JSON(result)
+}
+
+// GetContributorDetail returns detailed stats for a specific contributor.
+// GET /api/rewards/contributor/:login
+func (h *RewardsHandler) GetContributorDetail(c *fiber.Ctx) error {
+	login := c.Params("login")
+	if login == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "login parameter required"})
+	}
+
+	// Check cache
+	h.contributorMu.RLock()
+	if entry, ok := h.contributorCache[login]; ok && time.Since(entry.fetchedAt) < contributorCacheTTL {
+		h.contributorMu.RUnlock()
+		result := *entry.response
+		result.FromCache = true
+		return c.JSON(result)
+	}
+	h.contributorMu.RUnlock()
+
+	token := h.resolveToken()
+
+	// Fetch basic rewards
+	rewards, err := h.fetchUserRewards(login, token)
+	if err != nil {
+		log.Printf("[contributor] Failed to fetch rewards for %s: %v", login, err)
+
+		// Return stale cache if available
+		h.contributorMu.RLock()
+		if entry, ok := h.contributorCache[login]; ok {
+			h.contributorMu.RUnlock()
+			stale := *entry.response
+			stale.FromCache = true
+			return c.JSON(stale)
+		}
+		h.contributorMu.RUnlock()
+
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{"error": "GitHub API unavailable"})
+	}
+
+	// Fetch avatar URL
+	avatarURL := h.fetchUserAvatar(login, token)
+
+	// Count issues and PRs
+	totalIssues := rewards.Breakdown.BugIssues + rewards.Breakdown.FeatureIssues + rewards.Breakdown.OtherIssues
+	totalPRs := rewards.Breakdown.PRsOpened
+
+	// Compute PR detail stats
+	avgIterations, avgTimeHours := h.computePRStats(login, token)
+
+	// Find first contribution and most active repo
+	firstContribution, mostActiveRepo := analyzeContributions(rewards.Contributions)
+
+	levelName, levelRank := getContributorLevelForPoints(rewards.TotalPoints)
+
+	stats := &ContributorStats{
+		Login:             login,
+		AvatarURL:         avatarURL,
+		TotalPoints:       rewards.TotalPoints,
+		Breakdown:         rewards.Breakdown,
+		Level:             levelName,
+		LevelRank:         levelRank,
+		AvgPRIterations:   avgIterations,
+		AvgPRTimeHours:    avgTimeHours,
+		FirstContribution: firstContribution,
+		MostActiveRepo:    mostActiveRepo,
+		TotalPRs:          totalPRs,
+		TotalIssues:       totalIssues,
+		Contributions:     rewards.Contributions,
+		CachedAt:          time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Cache the result
+	h.contributorMu.Lock()
+	h.contributorCache[login] = &contributorCacheEntry{
+		response:  stats,
+		fetchedAt: time.Now(),
+	}
+	h.contributorMu.Unlock()
+
+	return c.JSON(stats)
+}
+
+// fetchUserAvatar fetches the avatar URL for a GitHub login.
+func (h *RewardsHandler) fetchUserAvatar(login, token string) string {
+	apiURL := fmt.Sprintf("https://api.github.com/users/%s", url.PathEscape(login))
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var user githubUser
+	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
+		return ""
+	}
+	return user.AvatarURL
+}
+
+// computePRStats fetches merged PR details and returns (avgIterations, avgTimeHours).
+func (h *RewardsHandler) computePRStats(login, token string) (float64, float64) {
+	query := fmt.Sprintf("author:%s %s type:pr is:merged", login, h.orgs)
+	apiURL := fmt.Sprintf("https://api.github.com/search/issues?q=%s&per_page=%d&sort=created&order=desc",
+		url.QueryEscape(query), prDetailMaxFetch)
+
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return 0, 0
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return 0, 0
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return 0, 0
+	}
+
+	var sr searchResponse
+	if err := json.Unmarshal(body, &sr); err != nil {
+		return 0, 0
+	}
+
+	if len(sr.Items) == 0 {
+		return 0, 0
+	}
+
+	var totalIterations float64
+	var totalHours float64
+	var detailedCount int
+
+	for _, item := range sr.Items {
+		repo := extractRepo(item.RepoURL)
+		prURL := fmt.Sprintf("https://api.github.com/repos/%s/pulls/%d", repo, item.Number)
+
+		prReq, prErr := http.NewRequest("GET", prURL, nil)
+		if prErr != nil {
+			continue
+		}
+		prReq.Header.Set("Accept", "application/vnd.github.v3+json")
+		if token != "" {
+			prReq.Header.Set("Authorization", "Bearer "+token)
+		}
+
+		prResp, prDoErr := h.httpClient.Do(prReq)
+		if prDoErr != nil {
+			continue
+		}
+		prBody, prReadErr := io.ReadAll(prResp.Body)
+		prResp.Body.Close()
+		if prReadErr != nil || prResp.StatusCode != http.StatusOK {
+			continue
+		}
+
+		var detail prDetail
+		if unmarshalErr := json.Unmarshal(prBody, &detail); unmarshalErr != nil {
+			continue
+		}
+
+		totalIterations += float64(detail.ReviewComments)
+
+		if detail.MergedAt != "" && detail.CreatedAt != "" {
+			created, errC := time.Parse(time.RFC3339, detail.CreatedAt)
+			merged, errM := time.Parse(time.RFC3339, detail.MergedAt)
+			if errC == nil && errM == nil {
+				totalHours += merged.Sub(created).Hours()
+			}
+		}
+
+		detailedCount++
+		if detailedCount >= prDetailMaxFetch {
+			break
+		}
+	}
+
+	if detailedCount == 0 {
+		return 0, 0
+	}
+
+	avgIterations := math.Round(totalIterations/float64(detailedCount)*roundingFactor) / roundingFactor
+	avgHours := math.Round(totalHours/float64(detailedCount)*roundingFactor) / roundingFactor
+
+	return avgIterations, avgHours
+}
+
+// analyzeContributions finds the earliest contribution date and most active repo.
+func analyzeContributions(contributions []GitHubContribution) (string, string) {
+	if len(contributions) == 0 {
+		return "", ""
+	}
+
+	earliest := contributions[0].CreatedAt
+	repoCounts := make(map[string]int)
+
+	for _, c := range contributions {
+		if c.CreatedAt < earliest {
+			earliest = c.CreatedAt
+		}
+		repoCounts[c.Repo]++
+	}
+
+	mostActive := ""
+	maxCount := 0
+	for repo, count := range repoCounts {
+		if count > maxCount {
+			maxCount = count
+			mostActive = repo
+		}
+	}
+
+	return earliest, mostActive
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -668,6 +668,8 @@ func (s *Server) setupRoutes() {
 		Orgs:        s.config.RewardsGitHubOrgs,
 	})
 	api.Get("/rewards/github", rewardsHandler.GetGitHubRewards)
+	api.Get("/rewards/leaderboard", rewardsHandler.GetLeaderboard)
+	api.Get("/rewards/contributor/:login", rewardsHandler.GetContributorDetail)
 
 	// Nightly E2E status (GitHub Actions proxy with server-side token + cache)
 	nightlyE2E := handlers.NewNightlyE2EHandler(s.config.GitHubToken)

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -18,6 +18,7 @@ import { useToast } from '../ui/Toast'
 import { useTranslation } from 'react-i18next'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
 import { ContributorBanner } from '../rewards/ContributorLadder'
+import { ContributorLeaderboard } from '../rewards/ContributorLeaderboard'
 import { GITHUB_REWARD_LABELS, REWARD_ACTIONS } from '../../types/rewards'
 import type { GitHubContribution } from '../../types/rewards'
 
@@ -472,6 +473,9 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
           <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
               {/* Contributor banner — coins + level + progress */}
               <ContributorBanner />
+
+              {/* Leaderboard — top contributors by coins */}
+              <ContributorLeaderboard />
 
               {/* Actions header */}
               <div className="p-2 border-b border-border/50 flex items-center justify-between flex-shrink-0">

--- a/web/src/components/rewards/ContributorLeaderboard.tsx
+++ b/web/src/components/rewards/ContributorLeaderboard.tsx
@@ -1,0 +1,413 @@
+/**
+ * ContributorLeaderboard — shows top contributors ranked by coins, with search and detail panel.
+ */
+
+import { useState, useCallback } from 'react'
+import {
+  Trophy, Search, RefreshCw, ChevronDown, ChevronUp,
+  GitPullRequest, CircleDot, Clock, MessageSquare, Calendar, FolderGit2,
+  Medal,
+} from 'lucide-react'
+import { useLeaderboard, useContributorDetail } from '../../hooks/useLeaderboard'
+import { CONTRIBUTOR_LEVELS } from '../../types/rewards'
+import type { LeaderboardEntry } from '../../types/rewards'
+import { STORAGE_KEY_TOKEN } from '../../lib/constants'
+import { BACKEND_DEFAULT_URL } from '../../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
+import type { ContributorStats } from '../../types/rewards'
+
+const SEARCH_DEBOUNCE_MS = 300
+const HOURS_PER_DAY = 24
+const RANK_GOLD = 1
+const RANK_SILVER = 2
+const RANK_BRONZE = 3
+
+/** Returns Tailwind color class for a rank medal */
+function getRankColor(rank: number): string {
+  switch (rank) {
+    case RANK_GOLD: return 'text-yellow-400'
+    case RANK_SILVER: return 'text-gray-300'
+    case RANK_BRONZE: return 'text-amber-600'
+    default: return 'text-muted-foreground'
+  }
+}
+
+/** Returns the level's Tailwind text class from CONTRIBUTOR_LEVELS */
+function getLevelStyle(levelRank: number) {
+  const level = CONTRIBUTOR_LEVELS.find(l => l.rank === levelRank)
+  return {
+    textClass: level?.textClass ?? 'text-gray-400',
+    bgClass: level?.bgClass ?? 'bg-gray-500/20',
+    borderClass: level?.borderClass ?? 'border-gray-500/30',
+  }
+}
+
+/** Format hours as "2.4 days" or "18h" */
+function formatPRTime(hours: number): string {
+  if (hours <= 0) return '—'
+  if (hours >= HOURS_PER_DAY) {
+    const days = Math.round(hours / HOURS_PER_DAY * 10) / 10
+    return `${days}d`
+  }
+  return `${Math.round(hours)}h`
+}
+
+/** Format a date string as "Mar 2024" */
+function formatDate(dateStr: string): string {
+  if (!dateStr) return '—'
+  try {
+    const d = new Date(dateStr)
+    return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+  } catch {
+    return '—'
+  }
+}
+
+function LeaderboardRow({
+  entry,
+  isSelected,
+  onClick,
+}: {
+  entry: LeaderboardEntry
+  isSelected: boolean
+  onClick: () => void
+}) {
+  const rankColor = getRankColor(entry.rank)
+  const levelStyle = getLevelStyle(entry.level_rank)
+
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full flex items-center gap-2 px-2 py-1.5 text-left hover:bg-secondary/40 transition-colors cursor-pointer ${
+        isSelected ? 'bg-secondary/30' : ''
+      }`}
+    >
+      {/* Rank */}
+      <span className={`w-5 text-center text-xs font-bold ${rankColor}`}>
+        {entry.rank <= RANK_BRONZE ? (
+          <Medal className={`w-3.5 h-3.5 inline ${rankColor}`} />
+        ) : (
+          `#${entry.rank}`
+        )}
+      </span>
+
+      {/* Avatar */}
+      {entry.avatar_url ? (
+        <img
+          src={entry.avatar_url}
+          alt={entry.login}
+          className="w-5 h-5 rounded-full flex-shrink-0"
+        />
+      ) : (
+        <div className="w-5 h-5 rounded-full bg-muted flex items-center justify-center text-[9px] font-bold text-muted-foreground flex-shrink-0">
+          {entry.login.charAt(0).toUpperCase()}
+        </div>
+      )}
+
+      {/* Login */}
+      <span className="text-xs text-foreground truncate flex-1">{entry.login}</span>
+
+      {/* Coins */}
+      <span className="text-xs text-yellow-400 font-medium tabular-nums">
+        {entry.total_points.toLocaleString()}
+      </span>
+
+      {/* Level badge */}
+      <span className={`text-[9px] px-1.5 py-0.5 rounded border ${levelStyle.bgClass} ${levelStyle.textClass} ${levelStyle.borderClass}`}>
+        {entry.level}
+      </span>
+    </button>
+  )
+}
+
+function DetailPanel({ stats, isLoading }: { stats: ContributorStats | null; isLoading: boolean }) {
+  if (isLoading) {
+    return (
+      <div className="px-3 py-4 text-center">
+        <RefreshCw className="w-4 h-4 mx-auto animate-spin text-muted-foreground" />
+        <p className="text-[10px] text-muted-foreground mt-1">Loading stats...</p>
+      </div>
+    )
+  }
+
+  if (!stats) return null
+
+  const levelStyle = getLevelStyle(stats.level_rank)
+
+  return (
+    <div className="px-3 py-2.5 bg-purple-500/5 border-t border-purple-500/10">
+      {/* Header: avatar + login + level + coins */}
+      <div className="flex items-center gap-2 mb-2">
+        {stats.avatar_url ? (
+          <img src={stats.avatar_url} alt={stats.login} className="w-7 h-7 rounded-full" />
+        ) : (
+          <div className="w-7 h-7 rounded-full bg-muted flex items-center justify-center text-xs font-bold text-muted-foreground">
+            {stats.login.charAt(0).toUpperCase()}
+          </div>
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs font-medium text-foreground truncate">{stats.login}</span>
+            <span className={`text-[9px] px-1.5 py-0.5 rounded border ${levelStyle.bgClass} ${levelStyle.textClass} ${levelStyle.borderClass}`}>
+              {stats.level}
+            </span>
+          </div>
+          <span className="text-[10px] text-yellow-400">{stats.total_points.toLocaleString()} coins</span>
+        </div>
+      </div>
+
+      {/* Stat grid */}
+      <div className="grid grid-cols-4 gap-2 mb-2">
+        <div className="text-center">
+          <Clock className="w-3 h-3 mx-auto text-muted-foreground mb-0.5" />
+          <div className="text-[10px] font-medium text-foreground">{formatPRTime(stats.avg_pr_time_hours)}</div>
+          <div className="text-[8px] text-muted-foreground">Avg PR Time</div>
+        </div>
+        <div className="text-center">
+          <MessageSquare className="w-3 h-3 mx-auto text-muted-foreground mb-0.5" />
+          <div className="text-[10px] font-medium text-foreground">{stats.avg_pr_iterations || '—'}</div>
+          <div className="text-[8px] text-muted-foreground">Avg Reviews</div>
+        </div>
+        <div className="text-center">
+          <GitPullRequest className="w-3 h-3 mx-auto text-muted-foreground mb-0.5" />
+          <div className="text-[10px] font-medium text-foreground">{stats.total_prs}</div>
+          <div className="text-[8px] text-muted-foreground">PRs</div>
+        </div>
+        <div className="text-center">
+          <CircleDot className="w-3 h-3 mx-auto text-muted-foreground mb-0.5" />
+          <div className="text-[10px] font-medium text-foreground">{stats.total_issues}</div>
+          <div className="text-[8px] text-muted-foreground">Issues</div>
+        </div>
+      </div>
+
+      {/* Extra info row */}
+      <div className="flex items-center gap-3 text-[9px] text-muted-foreground">
+        {stats.first_contribution && (
+          <span className="flex items-center gap-1">
+            <Calendar className="w-2.5 h-2.5" />
+            Since {formatDate(stats.first_contribution)}
+          </span>
+        )}
+        {stats.most_active_repo && (
+          <span className="flex items-center gap-1 truncate">
+            <FolderGit2 className="w-2.5 h-2.5 flex-shrink-0" />
+            <span className="truncate">{stats.most_active_repo}</span>
+          </span>
+        )}
+      </div>
+
+      {/* Breakdown pills */}
+      {stats.breakdown && (
+        <div className="flex flex-wrap gap-1 mt-2">
+          {stats.breakdown.prs_merged > 0 && (
+            <span className="text-[9px] px-1.5 py-0.5 rounded bg-green-500/10 text-green-400 border border-green-500/20">
+              {stats.breakdown.prs_merged} Merged
+            </span>
+          )}
+          {stats.breakdown.prs_opened > 0 && (
+            <span className="text-[9px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-400 border border-blue-500/20">
+              {stats.breakdown.prs_opened} PRs
+            </span>
+          )}
+          {stats.breakdown.bug_issues > 0 && (
+            <span className="text-[9px] px-1.5 py-0.5 rounded bg-red-500/10 text-red-400 border border-red-500/20">
+              {stats.breakdown.bug_issues} Bugs
+            </span>
+          )}
+          {stats.breakdown.feature_issues > 0 && (
+            <span className="text-[9px] px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-400 border border-purple-500/20">
+              {stats.breakdown.feature_issues} Features
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function ContributorLeaderboard() {
+  const [isCollapsed, setIsCollapsed] = useState(false)
+  const [showSearch, setShowSearch] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedLogin, setSelectedLogin] = useState<string | null>(null)
+  const [searchResult, setSearchResult] = useState<ContributorStats | null>(null)
+  const [searchLoading, setSearchLoading] = useState(false)
+  const [searchError, setSearchError] = useState<string | null>(null)
+  const [refreshAnimating, setRefreshAnimating] = useState(false)
+
+  const { entries, isLoading, refresh } = useLeaderboard()
+  const { stats: detailStats, isLoading: detailLoading } = useContributorDetail(selectedLogin)
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshAnimating(true)
+    await refresh()
+    // Let animation complete one full turn
+    setTimeout(() => setRefreshAnimating(false), SEARCH_DEBOUNCE_MS)
+  }, [refresh])
+
+  const handleSearch = useCallback(async () => {
+    const query = searchQuery.trim()
+    if (!query) return
+
+    // Check if the query matches a leaderboard entry
+    const match = (entries || []).find(e => e.login.toLowerCase() === query.toLowerCase())
+    if (match) {
+      setSelectedLogin(match.login)
+      setSearchResult(null)
+      setSearchError(null)
+      return
+    }
+
+    // Search for the user via the contributor detail API
+    setSearchLoading(true)
+    setSearchError(null)
+    setSelectedLogin(null)
+    try {
+      const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+      if (!token) throw new Error('Not authenticated')
+
+      const apiBase = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
+      const res = await fetch(`${apiBase}/api/rewards/contributor/${encodeURIComponent(query)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+      if (!res.ok) throw new Error(`Not found (${res.status})`)
+      const result: ContributorStats = await res.json()
+      if (result.total_points === 0) {
+        setSearchError('No contributions found')
+        setSearchResult(null)
+      } else {
+        setSearchResult(result)
+        setSearchError(null)
+      }
+    } catch (err) {
+      setSearchError(err instanceof Error ? err.message : 'Search failed')
+      setSearchResult(null)
+    } finally {
+      setSearchLoading(false)
+    }
+  }, [searchQuery, entries])
+
+  const handleRowClick = (login: string) => {
+    if (selectedLogin === login) {
+      setSelectedLogin(null)
+    } else {
+      setSelectedLogin(login)
+      setSearchResult(null)
+    }
+  }
+
+  return (
+    <div className="border-b border-border/50">
+      {/* Header */}
+      <div className="px-2 py-1.5 flex items-center justify-between flex-shrink-0">
+        <button
+          onClick={() => setIsCollapsed(!isCollapsed)}
+          className="flex items-center gap-1.5 cursor-pointer hover:text-foreground transition-colors"
+        >
+          <Trophy className="w-3 h-3 text-yellow-500" />
+          <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">
+            Leaderboard
+          </span>
+          {isCollapsed ? (
+            <ChevronDown className="w-3 h-3 text-muted-foreground" />
+          ) : (
+            <ChevronUp className="w-3 h-3 text-muted-foreground" />
+          )}
+        </button>
+
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => {
+              setShowSearch(!showSearch)
+              if (showSearch) {
+                setSearchQuery('')
+                setSearchResult(null)
+                setSearchError(null)
+              }
+            }}
+            className="p-1 hover:bg-secondary/50 rounded transition-colors cursor-pointer"
+            title="Search contributor"
+          >
+            <Search className="w-3 h-3 text-muted-foreground" />
+          </button>
+          <button
+            onClick={handleRefresh}
+            disabled={isLoading}
+            className="p-1 hover:bg-secondary/50 rounded transition-colors disabled:opacity-50 cursor-pointer"
+            title="Refresh leaderboard"
+          >
+            <RefreshCw className={`w-3 h-3 text-muted-foreground ${refreshAnimating ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+      </div>
+
+      {/* Content (collapsible) */}
+      {!isCollapsed && (
+        <>
+          {/* Search bar */}
+          {showSearch && (
+            <div className="px-2 pb-1.5">
+              <div className="flex items-center gap-1">
+                <input
+                  type="text"
+                  value={searchQuery}
+                  onChange={e => setSearchQuery(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') handleSearch()
+                  }}
+                  placeholder="GitHub username..."
+                  className="flex-1 text-xs bg-secondary/50 border border-border/50 rounded px-2 py-1 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
+                  autoFocus
+                />
+                <button
+                  onClick={handleSearch}
+                  disabled={searchLoading || !searchQuery.trim()}
+                  className="text-[10px] px-2 py-1 bg-purple-500/20 text-purple-400 rounded hover:bg-purple-500/30 transition-colors disabled:opacity-50 cursor-pointer"
+                >
+                  {searchLoading ? '...' : 'Go'}
+                </button>
+              </div>
+              {searchError && (
+                <p className="text-[10px] text-red-400 mt-1 px-1">{searchError}</p>
+              )}
+            </div>
+          )}
+
+          {/* Search result detail */}
+          {searchResult && (
+            <DetailPanel stats={searchResult} isLoading={false} />
+          )}
+
+          {/* Leaderboard list */}
+          {isLoading && (entries || []).length === 0 ? (
+            <div className="px-3 py-4 text-center">
+              <RefreshCw className="w-4 h-4 mx-auto animate-spin text-muted-foreground" />
+              <p className="text-[10px] text-muted-foreground mt-1">Loading leaderboard...</p>
+            </div>
+          ) : (entries || []).length === 0 ? (
+            <div className="px-3 py-3 text-center">
+              <Trophy className="w-5 h-5 mx-auto text-muted-foreground/50 mb-1" />
+              <p className="text-[10px] text-muted-foreground">No contributors yet</p>
+            </div>
+          ) : (
+            <div>
+              {(entries || []).map(entry => (
+                <div key={entry.login}>
+                  <LeaderboardRow
+                    entry={entry}
+                    isSelected={selectedLogin === entry.login}
+                    onClick={() => handleRowClick(entry.login)}
+                  />
+                  {selectedLogin === entry.login && !searchResult && (
+                    <DetailPanel stats={detailStats} isLoading={detailLoading} />
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/rewards/index.ts
+++ b/web/src/components/rewards/index.ts
@@ -1,5 +1,6 @@
 export { CoinDisplay, CoinBadge } from './CoinDisplay'
 export { ContributorBanner } from './ContributorLadder'
+export { ContributorLeaderboard } from './ContributorLeaderboard'
 export { GitHubInviteModal, GitHubInviteButton } from './GitHubInvite'
 export { LinkedInShareButton, LinkedInShareCard } from './LinkedInShare'
 export { RewardsPanel } from './RewardsPanel'

--- a/web/src/hooks/useLeaderboard.ts
+++ b/web/src/hooks/useLeaderboard.ts
@@ -1,0 +1,142 @@
+/**
+ * Hooks for fetching leaderboard and contributor detail data.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { BACKEND_DEFAULT_URL } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import type { LeaderboardResponse, LeaderboardEntry, ContributorStats } from '../types/rewards'
+
+const LEADERBOARD_CACHE_KEY = 'leaderboard-cache'
+const CONTRIBUTOR_CACHE_PREFIX = 'contributor-detail-'
+const DEFAULT_LEADERBOARD_LIMIT = 5
+
+function loadLeaderboardCache(): LeaderboardResponse | null {
+  try {
+    const raw = localStorage.getItem(LEADERBOARD_CACHE_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+function saveLeaderboardCache(data: LeaderboardResponse): void {
+  try {
+    localStorage.setItem(LEADERBOARD_CACHE_KEY, JSON.stringify(data))
+  } catch {
+    // quota exceeded — ignore
+  }
+}
+
+function loadContributorCache(login: string): ContributorStats | null {
+  try {
+    const raw = localStorage.getItem(`${CONTRIBUTOR_CACHE_PREFIX}${login}`)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+function saveContributorCache(login: string, data: ContributorStats): void {
+  try {
+    localStorage.setItem(`${CONTRIBUTOR_CACHE_PREFIX}${login}`, JSON.stringify(data))
+  } catch {
+    // quota exceeded — ignore
+  }
+}
+
+export function useLeaderboard(limit: number = DEFAULT_LEADERBOARD_LIMIT) {
+  const [entries, setEntries] = useState<LeaderboardEntry[]>(() => {
+    const cached = loadLeaderboardCache()
+    return cached?.entries ?? []
+  })
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchLeaderboard = useCallback(async () => {
+    const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+    if (!token) return
+
+    setIsLoading(true)
+    try {
+      const apiBase = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
+      const res = await fetch(`${apiBase}/api/rewards/leaderboard?limit=${limit}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+      if (!res.ok) throw new Error(`API error: ${res.status}`)
+      const result: LeaderboardResponse = await res.json()
+      setEntries(result.entries || [])
+      saveLeaderboardCache(result)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [limit])
+
+  useEffect(() => {
+    fetchLeaderboard()
+  }, [fetchLeaderboard])
+
+  return {
+    entries,
+    isLoading,
+    error,
+    refresh: fetchLeaderboard,
+  }
+}
+
+export function useContributorDetail(login: string | null) {
+  const [stats, setStats] = useState<ContributorStats | null>(() => {
+    if (!login) return null
+    return loadContributorCache(login)
+  })
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!login) {
+      setStats(null)
+      return
+    }
+
+    const cached = loadContributorCache(login)
+    if (cached) {
+      setStats(cached)
+    }
+
+    const fetchDetail = async () => {
+      const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+      if (!token) return
+
+      setIsLoading(true)
+      try {
+        const apiBase = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
+        const res = await fetch(`${apiBase}/api/rewards/contributor/${encodeURIComponent(login)}`, {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+        })
+        if (!res.ok) throw new Error(`API error: ${res.status}`)
+        const result: ContributorStats = await res.json()
+        setStats(result)
+        saveContributorCache(login, result)
+        setError(null)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchDetail()
+  }, [login])
+
+  return {
+    stats,
+    isLoading,
+    error,
+  }
+}

--- a/web/src/types/rewards.ts
+++ b/web/src/types/rewards.ts
@@ -39,11 +39,37 @@ export interface UserRewards {
 }
 
 export interface LeaderboardEntry {
-  userId: string
-  username: string
-  avatarUrl?: string
-  totalCoins: number
+  login: string
+  avatar_url: string
+  total_points: number
   rank: number
+  breakdown: GitHubRewardsBreakdown
+  level: string
+  level_rank: number
+}
+
+export interface LeaderboardResponse {
+  entries: LeaderboardEntry[]
+  cached_at: string
+  from_cache: boolean
+}
+
+export interface ContributorStats {
+  login: string
+  avatar_url: string
+  total_points: number
+  breakdown: GitHubRewardsBreakdown
+  level: string
+  level_rank: number
+  avg_pr_iterations: number
+  avg_pr_time_hours: number
+  first_contribution: string
+  most_active_repo: string
+  total_prs: number
+  total_issues: number
+  contributions: GitHubContribution[]
+  cached_at: string
+  from_cache: boolean
 }
 
 export interface Achievement {


### PR DESCRIPTION
## Summary
- Adds a **contributor leaderboard** to the feedback dialog's Updates tab, showing top contributors ranked by reward coins
- Two new backend endpoints: `GET /api/rewards/leaderboard` (24h cache) and `GET /api/rewards/contributor/:login` (15min cache) 
- Leaderboard UI with rank medals (gold/silver/bronze), avatars, coins, level badges, search-by-GitHub-ID, and expandable detail panels with PR stats (avg iterations, avg time, breakdown pills)

## Test plan
- [ ] `go build ./...` passes
- [ ] `npm run build` and `npm run lint` pass (no new errors)
- [ ] Open feedback dialog → Updates tab → verify leaderboard shows below contributor banner
- [ ] Click refresh button → verify spinner animation and data refresh
- [ ] Click a leaderboard row → verify detail panel expands with stats
- [ ] Toggle search → enter a GitHub username → verify detail lookup
- [ ] Search for nonexistent user → verify graceful error state
- [ ] Collapse/expand leaderboard section → verify toggle works