### PR TITLE
🐛 Add console-kb repo to rewards/leaderboard scope

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -925,7 +925,7 @@ func LoadConfigFromEnv() Config {
 		FeedbackRepoOwner:   getEnvOrDefault("FEEDBACK_REPO_OWNER", "kubestellar"),
 		FeedbackRepoName:    getEnvOrDefault("FEEDBACK_REPO_NAME", "console"),
 		// GitHub activity rewards
-		RewardsGitHubOrgs: getEnvOrDefault("REWARDS_GITHUB_ORGS", "repo:kubestellar/console repo:kubestellar/console-marketplace"),
+		RewardsGitHubOrgs: getEnvOrDefault("REWARDS_GITHUB_ORGS", "repo:kubestellar/console repo:kubestellar/console-marketplace repo:kubestellar/console-kb"),
 		// Skip onboarding questionnaire for new users
 		SkipOnboarding: os.Getenv("SKIP_ONBOARDING") == "true",
 		// Benchmark data from Google Drive


### PR DESCRIPTION
## Summary
- Add `kubestellar/console-kb` to the default `REWARDS_GITHUB_ORGS` config
- Leaderboard, token count, and PR/issue lists now cover all 3 console repos: `console`, `console-marketplace`, `console-kb`

## Test plan
- [ ] Restart console, open Updates tab — verify leaderboard shows contributors from all 3 repos
- [ ] Verify token count includes contributions from console-kb