### PR TITLE
🐛 Fix mission sidebar content and input overflow

### DIFF
--- a/web/src/components/layout/mission-sidebar/MemoizedMessage.tsx
+++ b/web/src/components/layout/mission-sidebar/MemoizedMessage.tsx
@@ -75,10 +75,22 @@ export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent
     ul: ({ children }: { children?: React.ReactNode }) => <ul className="my-4 ml-4 list-disc space-y-2">{children}</ul>,
     ol: ({ children }: { children?: React.ReactNode }) => <ol className="my-4 ml-4 list-decimal space-y-2">{children}</ol>,
     li: ({ children }: { children?: React.ReactNode }) => <li className="my-1 leading-relaxed">{children}</li>,
+    table: ({ children }: { children?: React.ReactNode }) => (
+      <div className="overflow-x-auto w-full my-4 rounded border border-border">
+        <table className="min-w-full border-collapse text-sm">{children}</table>
+      </div>
+    ),
+    thead: ({ children }: { children?: React.ReactNode }) => <thead className="bg-secondary/50">{children}</thead>,
+    th: ({ children }: { children?: React.ReactNode }) => (
+      <th className="px-3 py-2 text-left text-xs font-semibold text-foreground border-b border-border whitespace-nowrap">{children}</th>
+    ),
+    td: ({ children }: { children?: React.ReactNode }) => (
+      <td className="px-3 py-2 text-xs text-muted-foreground border-b border-border/50 max-w-[200px] break-words">{children}</td>
+    ),
   }), [fontSize])
 
   const proseClasses = cn(
-    "prose dark:prose-invert max-w-none overflow-hidden",
+    "prose dark:prose-invert max-w-none overflow-x-auto overflow-y-hidden",
     "prose-pre:my-5 prose-pre:bg-transparent prose-pre:p-0 prose-pre:overflow-x-auto",
     "prose-code:text-purple-700 dark:prose-code:text-purple-300 prose-code:bg-black/5 dark:prose-code:bg-black/20 prose-code:px-1 prose-code:rounded prose-code:break-all",
     "prose-hr:my-6",

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -252,7 +252,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
 
   return (
     <>
-    <div className={cn("flex flex-1 min-h-0", isFullScreen && "gap-4")}>
+    <div className={cn("flex flex-1 min-h-0 min-w-0", isFullScreen && "gap-4")}>
       {/* Left panel for resolutions (fullscreen only) */}
       {isFullScreen && (
         <div className="flex flex-col">
@@ -402,7 +402,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
       <div
         ref={messagesContainerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto scroll-enhanced p-4 space-y-4 min-h-0"
+        className="flex-1 overflow-y-auto scroll-enhanced p-4 space-y-4 min-h-0 min-w-0"
       >
         {mission.messages.map((msg, index) => {
           // Find if this is the last assistant message
@@ -458,7 +458,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
       </div>
 
       {/* Input / Actions */}
-      <div className="p-4 border-t border-border flex-shrink-0 bg-card">
+      <div className="p-4 border-t border-border flex-shrink-0 bg-card min-w-0">
         {mission.status === 'running' ? (
           <div className="flex flex-col gap-2">
             <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- Adds `table`, `thead`, `th`, `td` markdown component overrides with a horizontal scroll wrapper so tables don't get clipped in the 500px sidebar
- Changes prose container from `overflow-hidden` to `overflow-x-auto` for wide content
- Adds `min-w-0` to flex containers (root, messages, input area) so children properly constrain to parent width — fixes the input field overflowing the sidebar

## Test plan
- [ ] Open a mission with a table response → table scrolls horizontally instead of being clipped
- [ ] Input field fits within sidebar width (no overflow)
- [ ] Long text content wraps properly
- [ ] Vertical scrolling still works for long conversations