### PR TITLE
✨ Add Developer Setup dialog for running from source with OAuth

### DIFF
--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -8,6 +8,7 @@ import { languages } from '../../lib/i18n'
 import { isDemoModeForced } from '../../lib/demoMode'
 import { checkOAuthConfigured } from '../../lib/api'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
+import { DeveloperSetupDialog } from '../setup/DeveloperSetupDialog'
 import { FeatureRequestModal } from '../feedback/FeatureRequestModal'
 
 interface UserProfileDropdownProps {
@@ -26,6 +27,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
   const [isOpen, setIsOpen] = useState(false)
   const [showLanguageSubmenu, setShowLanguageSubmenu] = useState(false)
   const [showSetupDialog, setShowSetupDialog] = useState(false)
+  const [showDevSetupDialog, setShowDevSetupDialog] = useState(false)
   const [showRewards, setShowRewards] = useState(false)
   const [showFeedbackModal, setShowFeedbackModal] = useState(false)
   const [showDevPanel, setShowDevPanel] = useState(false)
@@ -277,6 +279,16 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
                       <Rocket className="w-3.5 h-3.5" />
                       {t('developer.setupInstructions')}
                     </button>
+                    <button
+                      onClick={() => {
+                        setIsOpen(false)
+                        setShowDevSetupDialog(true)
+                      }}
+                      className="flex items-center gap-2 text-xs text-purple-400 hover:text-purple-300 transition-colors"
+                    >
+                      <Code2 className="w-3.5 h-3.5" />
+                      {t('developer.developerSetup')}
+                    </button>
                     {!oauthStatus.configured && oauthStatus.checked && (
                       <a
                         href="https://github.com/settings/developers"
@@ -379,6 +391,12 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
       <SetupInstructionsDialog
         isOpen={showSetupDialog}
         onClose={() => setShowSetupDialog(false)}
+      />
+
+      {/* Developer setup dialog — dev-focused instructions with OAuth */}
+      <DeveloperSetupDialog
+        isOpen={showDevSetupDialog}
+        onClose={() => setShowDevSetupDialog(false)}
       />
 
       {/* Rewards panel — opens feedback dialog to GitHub contributions tab */}

--- a/web/src/components/setup/DeveloperSetupDialog.tsx
+++ b/web/src/components/setup/DeveloperSetupDialog.tsx
@@ -1,0 +1,231 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { Code2, Copy, Check, GitBranch, RefreshCw, ExternalLink, ChevronDown, ChevronRight } from 'lucide-react'
+import { BaseModal } from '../../lib/modals'
+import { useTranslation } from 'react-i18next'
+import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
+
+interface DeveloperSetupDialogProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const REPO_URL = 'https://github.com/kubestellar/console'
+
+const DEV_CLONE_CMD = `git clone ${REPO_URL}.git && cd console`
+const DEV_START_OAUTH_CMD = 'bash startup-oauth.sh'
+
+const ENV_TEMPLATE = `GITHUB_CLIENT_ID=<your-client-id>
+GITHUB_CLIENT_SECRET=<your-client-secret>`
+
+/** Unique keys for clipboard copy feedback per code block */
+const COPY_KEY_CLONE = 1
+const COPY_KEY_ENV = 2
+const COPY_KEY_START = 3
+
+export function DeveloperSetupDialog({ isOpen, onClose }: DeveloperSetupDialogProps) {
+  const { t } = useTranslation()
+  const [copiedStep, setCopiedStep] = useState<number | null>(null)
+  const [showUpdateChannel, setShowUpdateChannel] = useState(false)
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout>>()
+
+  useEffect(() => {
+    return () => clearTimeout(copiedTimerRef.current)
+  }, [])
+
+  const copyToClipboard = async (text: string, stepKey: number) => {
+    await navigator.clipboard.writeText(text)
+    setCopiedStep(stepKey)
+    clearTimeout(copiedTimerRef.current)
+    copiedTimerRef.current = setTimeout(() => setCopiedStep(null), UI_FEEDBACK_TIMEOUT_MS)
+  }
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="md">
+      <BaseModal.Header
+        title={t('developerSetup.title')}
+        description={t('developerSetup.description')}
+        icon={Code2}
+        onClose={onClose}
+        showBack={false}
+      />
+
+      <BaseModal.Content>
+        <div className="space-y-4">
+          {/* Prerequisites */}
+          <div className="rounded-lg border border-border/50 bg-secondary/30 p-3">
+            <h3 className="text-sm font-medium text-foreground mb-2">{t('developerSetup.prerequisites')}</h3>
+            <div className="grid grid-cols-2 gap-2 text-xs">
+              <div className="flex items-center gap-2">
+                <span className="w-2 h-2 rounded-full bg-green-500" />
+                <span className="text-muted-foreground">Go 1.24+</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="w-2 h-2 rounded-full bg-green-500" />
+                <span className="text-muted-foreground">Node.js 20+</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="w-2 h-2 rounded-full bg-green-500" />
+                <span className="text-muted-foreground">Git</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="w-2 h-2 rounded-full bg-blue-500" />
+                <span className="text-muted-foreground">kubeconfig (optional)</span>
+              </div>
+            </div>
+          </div>
+
+          {/* Step 1: Clone */}
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <StepBadge step={1} />
+              <span className="text-sm font-medium text-foreground">{t('developerSetup.cloneRepo')}</span>
+            </div>
+            <div className="flex items-center gap-2 ml-7">
+              <code className="flex-1 rounded bg-muted px-3 py-1.5 text-xs font-mono text-foreground select-all overflow-x-auto">
+                {DEV_CLONE_CMD}
+              </code>
+              <CopyButton copied={copiedStep === COPY_KEY_CLONE} onClick={() => copyToClipboard(DEV_CLONE_CMD, COPY_KEY_CLONE)} />
+            </div>
+          </div>
+
+          {/* Step 2: Configure GitHub OAuth */}
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <StepBadge step={2} />
+              <span className="text-sm font-medium text-foreground">{t('developerSetup.configureOAuth')}</span>
+            </div>
+            <div className="ml-7 space-y-2">
+              <ol className="text-xs text-muted-foreground space-y-1.5 list-decimal list-inside">
+                <li>
+                  {t('developerSetup.oauthStep1')}{' '}
+                  <a href="https://github.com/settings/developers" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline">
+                    GitHub Developer Settings
+                  </a>
+                </li>
+                <li>{t('developerSetup.oauthStep2')}</li>
+              </ol>
+              <div className="rounded-lg border border-border/30 bg-muted/30 p-2.5 space-y-1 text-xs">
+                <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground/70 shrink-0">Homepage URL:</span>
+                  <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-foreground">http://localhost:8080</code>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-muted-foreground/70 shrink-0">Callback URL:</span>
+                  <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-foreground">http://localhost:8080/auth/github/callback</code>
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">{t('developerSetup.oauthStep3')}</p>
+              <p className="text-xs text-muted-foreground">{t('developerSetup.envFile')}</p>
+              <div className="flex items-center gap-2">
+                <pre className="flex-1 rounded bg-muted px-3 py-1.5 text-xs font-mono text-foreground select-all overflow-x-auto whitespace-pre">
+                  {ENV_TEMPLATE}
+                </pre>
+                <CopyButton copied={copiedStep === COPY_KEY_ENV} onClick={() => copyToClipboard(ENV_TEMPLATE, COPY_KEY_ENV)} />
+              </div>
+            </div>
+          </div>
+
+          {/* Step 3: Start with OAuth */}
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <StepBadge step={3} />
+              <span className="text-sm font-medium text-foreground">{t('developerSetup.startDev')}</span>
+            </div>
+            <div className="flex items-center gap-2 ml-7">
+              <code className="flex-1 rounded bg-muted px-3 py-1.5 text-xs font-mono text-foreground select-all overflow-x-auto">
+                {DEV_START_OAUTH_CMD}
+              </code>
+              <CopyButton copied={copiedStep === COPY_KEY_START} onClick={() => copyToClipboard(DEV_START_OAUTH_CMD, COPY_KEY_START)} />
+            </div>
+            <p className="text-xs text-muted-foreground ml-7">
+              {t('developerSetup.startDevDesc')}
+            </p>
+          </div>
+
+          {/* What you get */}
+          <div className="rounded-lg border border-purple-500/20 bg-purple-950 p-3 ml-7">
+            <div className="font-mono text-[11px] text-foreground/70 leading-relaxed space-y-0.5">
+              <div><span className="text-purple-400">Frontend</span> {'\u2192'} <span className="text-muted-foreground">http://localhost:5174 (Vite HMR)</span></div>
+              <div><span className="text-purple-400">Backend</span> {'  \u2192'} <span className="text-muted-foreground">http://localhost:8080</span></div>
+              <div><span className="text-purple-400">kc-agent</span> {'\u2192'} <span className="text-muted-foreground">http://localhost:8585</span></div>
+            </div>
+          </div>
+
+          {/* Developer update channel (collapsible) */}
+          <div className="border-t border-border/30 pt-3">
+            <button
+              onClick={() => setShowUpdateChannel(!showUpdateChannel)}
+              className="flex items-center gap-1.5 text-xs text-purple-400 hover:text-purple-300 transition-colors"
+            >
+              {showUpdateChannel ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+              <RefreshCw className="w-3.5 h-3.5" />
+              {t('developerSetup.updateChannelTitle')}
+            </button>
+            {showUpdateChannel && (
+              <div className="mt-2 rounded-lg border border-purple-500/20 bg-purple-950 p-3 space-y-1.5">
+                <p className="text-xs text-muted-foreground">
+                  {t('developerSetup.updateChannelDesc')}
+                </p>
+                <div className="flex items-center gap-2 text-xs">
+                  <GitBranch className="w-3.5 h-3.5 text-orange-400" />
+                  <span className="text-foreground font-medium">Settings</span>
+                  <span className="text-muted-foreground">{'\u2192'}</span>
+                  <span className="text-foreground font-medium">Updates</span>
+                  <span className="text-muted-foreground">{'\u2192'}</span>
+                  <span className="text-orange-400 font-medium">Developer</span>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {t('developerSetup.updateChannelNote')}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </BaseModal.Content>
+
+      <BaseModal.Footer showKeyboardHints={false}>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-purple-400 hover:text-purple-300 transition-colors"
+          >
+            <ExternalLink className="w-3 h-3" />
+            GitHub
+          </a>
+        </div>
+        <div className="flex-1" />
+        <button
+          onClick={onClose}
+          className="rounded border px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+        >
+          {t('common.close')}
+        </button>
+      </BaseModal.Footer>
+    </BaseModal>
+  )
+}
+
+function StepBadge({ step }: { step: number }) {
+  return (
+    <span className="flex-shrink-0 w-5 h-5 rounded-full bg-purple-500/20 flex items-center justify-center text-xs font-bold text-purple-400">
+      {step}
+    </span>
+  )
+}
+
+function CopyButton({ copied, onClick }: { copied: boolean; onClick: () => void }) {
+  const { t } = useTranslation()
+  return (
+    <button
+      onClick={onClick}
+      className="shrink-0 p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+      title={t('common.copy')}
+    >
+      {copied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
+    </button>
+  )
+}

--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -589,7 +589,24 @@
     "setupInstructions": "Setup Instructions",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
-    "docs": "Documentation"
+    "docs": "Documentation",
+    "developerSetup": "Developer Setup"
+  },
+  "developerSetup": {
+    "title": "Developer Setup",
+    "description": "Run the console from source with GitHub OAuth",
+    "prerequisites": "Prerequisites",
+    "cloneRepo": "Clone the repository",
+    "configureOAuth": "Configure GitHub OAuth",
+    "oauthStep1": "Create a new OAuth app at",
+    "oauthStep2": "Fill in the app details:",
+    "oauthStep3": "Click \"Register application\", then copy the Client ID and generate a Client Secret.",
+    "envFile": "Create a .env file in the project root:",
+    "startDev": "Start the console",
+    "startDevDesc": "Compiles backend + agent from source, starts Vite dev server with hot reload.",
+    "updateChannelTitle": "Developer update channel",
+    "updateChannelDesc": "Dev installs can track the main branch for automatic updates via commit SHA.",
+    "updateChannelNote": "Checks for updates every 5 minutes and auto-rebuilds from source."
   },
   "language": {
     "select": "Select Language"

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -589,7 +589,24 @@
     "setupInstructions": "Setup Instructions",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
-    "docs": "Documentation"
+    "docs": "Documentation",
+    "developerSetup": "Developer Setup"
+  },
+  "developerSetup": {
+    "title": "Developer Setup",
+    "description": "Run the console from source with GitHub OAuth",
+    "prerequisites": "Prerequisites",
+    "cloneRepo": "Clone the repository",
+    "configureOAuth": "Configure GitHub OAuth",
+    "oauthStep1": "Create a new OAuth app at",
+    "oauthStep2": "Fill in the app details:",
+    "oauthStep3": "Click \"Register application\", then copy the Client ID and generate a Client Secret.",
+    "envFile": "Create a .env file in the project root:",
+    "startDev": "Start the console",
+    "startDevDesc": "Compiles backend + agent from source, starts Vite dev server with hot reload.",
+    "updateChannelTitle": "Developer update channel",
+    "updateChannelDesc": "Dev installs can track the main branch for automatic updates via commit SHA.",
+    "updateChannelNote": "Checks for updates every 5 minutes and auto-rebuilds from source."
   },
   "language": {
     "select": "Select Language"

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -589,7 +589,24 @@
     "setupInstructions": "Setup Instructions",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
-    "docs": "Documentation"
+    "docs": "Documentation",
+    "developerSetup": "Developer Setup"
+  },
+  "developerSetup": {
+    "title": "Developer Setup",
+    "description": "Run the console from source with GitHub OAuth",
+    "prerequisites": "Prerequisites",
+    "cloneRepo": "Clone the repository",
+    "configureOAuth": "Configure GitHub OAuth",
+    "oauthStep1": "Create a new OAuth app at",
+    "oauthStep2": "Fill in the app details:",
+    "oauthStep3": "Click \"Register application\", then copy the Client ID and generate a Client Secret.",
+    "envFile": "Create a .env file in the project root:",
+    "startDev": "Start the console",
+    "startDevDesc": "Compiles backend + agent from source, starts Vite dev server with hot reload.",
+    "updateChannelTitle": "Developer update channel",
+    "updateChannelDesc": "Dev installs can track the main branch for automatic updates via commit SHA.",
+    "updateChannelNote": "Checks for updates every 5 minutes and auto-rebuilds from source."
   },
   "language": {
     "select": "Select Language"

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -589,7 +589,24 @@
     "setupInstructions": "Setup Instructions",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
-    "docs": "Documentation"
+    "docs": "Documentation",
+    "developerSetup": "Developer Setup"
+  },
+  "developerSetup": {
+    "title": "Developer Setup",
+    "description": "Run the console from source with GitHub OAuth",
+    "prerequisites": "Prerequisites",
+    "cloneRepo": "Clone the repository",
+    "configureOAuth": "Configure GitHub OAuth",
+    "oauthStep1": "Create a new OAuth app at",
+    "oauthStep2": "Fill in the app details:",
+    "oauthStep3": "Click \"Register application\", then copy the Client ID and generate a Client Secret.",
+    "envFile": "Create a .env file in the project root:",
+    "startDev": "Start the console",
+    "startDevDesc": "Compiles backend + agent from source, starts Vite dev server with hot reload.",
+    "updateChannelTitle": "Developer update channel",
+    "updateChannelDesc": "Dev installs can track the main branch for automatic updates via commit SHA.",
+    "updateChannelNote": "Checks for updates every 5 minutes and auto-rebuilds from source."
   },
   "language": {
     "select": "Select Language"

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -589,7 +589,24 @@
     "setupInstructions": "Setup Instructions",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
-    "docs": "Documentation"
+    "docs": "Documentation",
+    "developerSetup": "Developer Setup"
+  },
+  "developerSetup": {
+    "title": "Developer Setup",
+    "description": "Run the console from source with GitHub OAuth",
+    "prerequisites": "Prerequisites",
+    "cloneRepo": "Clone the repository",
+    "configureOAuth": "Configure GitHub OAuth",
+    "oauthStep1": "Create a new OAuth app at",
+    "oauthStep2": "Fill in the app details:",
+    "oauthStep3": "Click \"Register application\", then copy the Client ID and generate a Client Secret.",
+    "envFile": "Create a .env file in the project root:",
+    "startDev": "Start the console",
+    "startDevDesc": "Compiles backend + agent from source, starts Vite dev server with hot reload.",
+    "updateChannelTitle": "Developer update channel",
+    "updateChannelDesc": "Dev installs can track the main branch for automatic updates via commit SHA.",
+    "updateChannelNote": "Checks for updates every 5 minutes and auto-rebuilds from source."
   },
   "language": {
     "select": "Select Language"

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -589,7 +589,24 @@
     "setupInstructions": "Setup Instructions",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
-    "docs": "Documentation"
+    "docs": "Documentation",
+    "developerSetup": "Developer Setup"
+  },
+  "developerSetup": {
+    "title": "Developer Setup",
+    "description": "Run the console from source with GitHub OAuth",
+    "prerequisites": "Prerequisites",
+    "cloneRepo": "Clone the repository",
+    "configureOAuth": "Configure GitHub OAuth",
+    "oauthStep1": "Create a new OAuth app at",
+    "oauthStep2": "Fill in the app details:",
+    "oauthStep3": "Click \"Register application\", then copy the Client ID and generate a Client Secret.",
+    "envFile": "Create a .env file in the project root:",
+    "startDev": "Start the console",
+    "startDevDesc": "Compiles backend + agent from source, starts Vite dev server with hot reload.",
+    "updateChannelTitle": "Developer update channel",
+    "updateChannelDesc": "Dev installs can track the main branch for automatic updates via commit SHA.",
+    "updateChannelNote": "Checks for updates every 5 minutes and auto-rebuilds from source."
   },
   "language": {
     "select": "Select Language"

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -589,7 +589,24 @@
     "setupInstructions": "Setup Instructions",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
-    "docs": "Documentation"
+    "docs": "Documentation",
+    "developerSetup": "Developer Setup"
+  },
+  "developerSetup": {
+    "title": "Developer Setup",
+    "description": "Run the console from source with GitHub OAuth",
+    "prerequisites": "Prerequisites",
+    "cloneRepo": "Clone the repository",
+    "configureOAuth": "Configure GitHub OAuth",
+    "oauthStep1": "Create a new OAuth app at",
+    "oauthStep2": "Fill in the app details:",
+    "oauthStep3": "Click \"Register application\", then copy the Client ID and generate a Client Secret.",
+    "envFile": "Create a .env file in the project root:",
+    "startDev": "Start the console",
+    "startDevDesc": "Compiles backend + agent from source, starts Vite dev server with hot reload.",
+    "updateChannelTitle": "Developer update channel",
+    "updateChannelDesc": "Dev installs can track the main branch for automatic updates via commit SHA.",
+    "updateChannelNote": "Checks for updates every 5 minutes and auto-rebuilds from source."
   },
   "language": {
     "select": "Select Language"

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -589,7 +589,24 @@
     "setupInstructions": "Setup Instructions",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
-    "docs": "Documentation"
+    "docs": "Documentation",
+    "developerSetup": "Developer Setup"
+  },
+  "developerSetup": {
+    "title": "Developer Setup",
+    "description": "Run the console from source with GitHub OAuth",
+    "prerequisites": "Prerequisites",
+    "cloneRepo": "Clone the repository",
+    "configureOAuth": "Configure GitHub OAuth",
+    "oauthStep1": "Create a new OAuth app at",
+    "oauthStep2": "Fill in the app details:",
+    "oauthStep3": "Click \"Register application\", then copy the Client ID and generate a Client Secret.",
+    "envFile": "Create a .env file in the project root:",
+    "startDev": "Start the console",
+    "startDevDesc": "Compiles backend + agent from source, starts Vite dev server with hot reload.",
+    "updateChannelTitle": "Developer update channel",
+    "updateChannelDesc": "Dev installs can track the main branch for automatic updates via commit SHA.",
+    "updateChannelNote": "Checks for updates every 5 minutes and auto-rebuilds from source."
   },
   "language": {
     "select": "Select Language"

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -589,7 +589,24 @@
     "setupInstructions": "Setup Instructions",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
-    "docs": "Documentation"
+    "docs": "Documentation",
+    "developerSetup": "Developer Setup"
+  },
+  "developerSetup": {
+    "title": "Developer Setup",
+    "description": "Run the console from source with GitHub OAuth",
+    "prerequisites": "Prerequisites",
+    "cloneRepo": "Clone the repository",
+    "configureOAuth": "Configure GitHub OAuth",
+    "oauthStep1": "Create a new OAuth app at",
+    "oauthStep2": "Fill in the app details:",
+    "oauthStep3": "Click \"Register application\", then copy the Client ID and generate a Client Secret.",
+    "envFile": "Create a .env file in the project root:",
+    "startDev": "Start the console",
+    "startDevDesc": "Compiles backend + agent from source, starts Vite dev server with hot reload.",
+    "updateChannelTitle": "Developer update channel",
+    "updateChannelDesc": "Dev installs can track the main branch for automatic updates via commit SHA.",
+    "updateChannelNote": "Checks for updates every 5 minutes and auto-rebuilds from source."
   },
   "language": {
     "select": "Select Language"


### PR DESCRIPTION
## Summary
- New **Developer Setup** link in the Developer section of the user profile dropdown, alongside existing "Setup Instructions"
- Opens a dedicated modal with developer-focused instructions:
  1. Clone the repository
  2. Configure GitHub OAuth (create OAuth app, set up `.env` with client ID/secret)
  3. Start with `bash startup-oauth.sh`
- Shows ports for Frontend (5174), Backend (8080), kc-agent (8585)
- Collapsible section about the developer update channel (Settings → Updates → Developer)
- i18n keys added to all 9 locale files

## Test plan
- [ ] Open user profile dropdown → Developer section → click "Developer Setup"
- [ ] Verify modal shows 3-step flow: clone, OAuth config, start
- [ ] Verify copy buttons work for all code blocks
- [ ] Verify collapsible "Developer update channel" section works
- [ ] Verify modal has solid background (no bleed-through)
- [ ] Test in light theme