### PR TITLE
✨ Polish mission sidebar: solid backgrounds, wider layout, fix overflow

### DIFF
--- a/web/src/components/layout/mission-sidebar/MemoizedMessage.tsx
+++ b/web/src/components/layout/mission-sidebar/MemoizedMessage.tsx
@@ -126,9 +126,12 @@ export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent
         )}
       </div>
       <div className={cn(
-        'flex-1 rounded-lg p-3 overflow-hidden min-w-0',
-        isFullScreen ? 'max-w-[98%]' : 'max-w-[85%]',
-        msg.role === 'user' ? 'bg-primary/10 ml-auto' : msg.role === 'assistant' ? 'bg-secondary/50' : 'bg-yellow-500/10'
+        'flex-1 rounded-lg p-3 min-w-0',
+        msg.role === 'user'
+          ? cn('bg-secondary ml-auto overflow-hidden', isFullScreen ? 'max-w-[85%]' : 'max-w-[80%]')
+          : msg.role === 'assistant'
+            ? 'bg-card border border-border overflow-x-auto'
+            : 'bg-yellow-950 border border-yellow-500/30 overflow-x-auto'
       )}>
         {msg.role === 'assistant' || msg.role === 'system' ? (
           parsedContent ? (

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -461,7 +461,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
       <div className="p-4 border-t border-border flex-shrink-0 bg-card min-w-0">
         {mission.status === 'running' ? (
           <div className="flex flex-col gap-2">
-            <div className="flex gap-2">
+            <div className="flex gap-2 min-w-0">
               <input
                 ref={inputRef}
                 type="text"
@@ -469,7 +469,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={t('missionChat.typeNextMessage')}
-                className="flex-1 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                className="flex-1 min-w-0 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
               />
               <button
                 onClick={handleSend}
@@ -578,7 +578,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               <span className={cn(config.color)}>{config.label}</span>
               <span className="text-muted-foreground">{t('missionChat.switchAgentRetry')}</span>
             </div>
-            <div className="flex gap-2">
+            <div className="flex gap-2 min-w-0">
               <input
                 ref={inputRef}
                 type="text"
@@ -586,7 +586,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={t('missionChat.retryWithMessage')}
-                className="flex-1 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+                className="flex-1 min-w-0 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
               />
               <button
                 onClick={handleSend}
@@ -598,7 +598,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
             </div>
           </div>
         ) : (
-          <div className="flex gap-2">
+          <div className="flex gap-2 min-w-0">
             <input
               ref={inputRef}
               type="text"
@@ -606,7 +606,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder={t('missionChat.typeMessage')}
-              className="flex-1 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+              className="flex-1 min-w-0 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
             />
             <button
               onClick={handleSend}

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -229,7 +229,7 @@ export function MissionSidebar() {
           isMobile && isSidebarOpen && "translate-y-0",
           // Desktop: right sidebar
           !isMobile && isFullScreen && "inset-0 top-16 border-l-0 rounded-none",
-          !isMobile && !isFullScreen && "top-16 right-0 bottom-0 w-[500px] border-l shadow-xl",
+          !isMobile && !isFullScreen && "top-16 right-0 bottom-0 w-[580px] border-l shadow-xl",
           !isMobile && !isSidebarOpen && "translate-x-full pointer-events-none"
         )}
       >


### PR DESCRIPTION
## Summary
- **Solid backgrounds** for message bubbles: assistant = `bg-card` + border, user = `bg-secondary`, system = `bg-yellow-950` + yellow border (replaces transparent `/10` and `/50` opacity values)
- **Wider sidebar**: 500px → 580px for better content readability
- **Fix text clipping**: removed `max-w-[85%]` on assistant messages — text now uses full width and wraps properly
- **Fix input overflow**: added `min-w-0` to all input wrappers and input elements across all states (running, failed, default)
- User messages keep `max-w-[80%]` for chat bubble appearance

## Test plan
- [ ] Open mission sidebar → messages have solid backgrounds with visible borders
- [ ] Assistant messages use full width, text wraps without clipping
- [ ] User messages appear as narrower bubbles aligned right
- [ ] Input field fits within sidebar (no overflow on right edge)
- [ ] Sidebar is noticeably wider (580px vs 500px)