### PR TITLE
🐛 Fix OAuth status check and Setup Instructions for dev mode

### DIFF
--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -56,14 +56,14 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
     setIsOpen(false)
   }
 
-  // Re-check OAuth status each time dev panel is opened
+  // Check OAuth status when dropdown opens (covers dev panel visibility)
   useEffect(() => {
-    if (showDevPanel) {
+    if (isOpen) {
       checkOAuthConfigured().then(({ backendUp, oauthConfigured }) => {
         setOauthStatus({ checked: true, configured: oauthConfigured, backendUp })
       })
     }
-  }, [showDevPanel])
+  }, [isOpen])
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -272,22 +272,16 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
                     <button
                       onClick={() => {
                         setIsOpen(false)
-                        setShowSetupDialog(true)
+                        if (installMethod === 'dev') {
+                          setShowDevSetupDialog(true)
+                        } else {
+                          setShowSetupDialog(true)
+                        }
                       }}
                       className="flex items-center gap-2 text-xs text-purple-400 hover:text-purple-300 transition-colors"
                     >
                       <Rocket className="w-3.5 h-3.5" />
                       {t('developer.setupInstructions')}
-                    </button>
-                    <button
-                      onClick={() => {
-                        setIsOpen(false)
-                        setShowDevSetupDialog(true)
-                      }}
-                      className="flex items-center gap-2 text-xs text-purple-400 hover:text-purple-300 transition-colors"
-                    >
-                      <Code2 className="w-3.5 h-3.5" />
-                      {t('developer.developerSetup')}
                     </button>
                     {!oauthStatus.configured && oauthStatus.checked && (
                       <a


### PR DESCRIPTION
## Summary
- **OAuth not configured false positive**: Moved OAuth check from dev panel toggle to dropdown open, so the status is fetched before the Developer section renders. Previously it showed "not configured" briefly because the async check hadn't completed yet.
- **Setup Instructions for dev mode**: When `installMethod === 'dev'`, clicking "Setup Instructions" now opens the Developer Setup dialog (with source/OAuth instructions) instead of the non-developer modal (nightly/stable build instructions).
- Removed separate "Developer Setup" link — it's now unified into "Setup Instructions" which is context-aware based on install method.

## Test plan
- [ ] Open profile dropdown → Developer section → verify OAuth shows "configured" (green) immediately
- [ ] Click "Setup Instructions" in dev mode → verify Developer Setup dialog opens (not the curl/nightly one)
- [ ] In non-dev mode, "Setup Instructions" should still open the standard modal