### PR TITLE
🐛 Fix OAuth status showing "not configured" false positive

### DIFF
--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -31,11 +31,10 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
   const [showRewards, setShowRewards] = useState(false)
   const [showFeedbackModal, setShowFeedbackModal] = useState(false)
   const [showDevPanel, setShowDevPanel] = useState(false)
-  // If user is logged in via GitHub, OAuth is obviously configured
   const [oauthStatus, setOauthStatus] = useState<{ checked: boolean; configured: boolean; backendUp: boolean }>({
-    checked: !!user?.github_login,
-    configured: !!user?.github_login,
-    backendUp: !!user?.github_login,
+    checked: false,
+    configured: false,
+    backendUp: false,
   })
   const dropdownRef = useRef<HTMLDivElement>(null)
   const { totalCoins, awardCoins } = useRewards()
@@ -56,7 +55,14 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
     setIsOpen(false)
   }
 
-  // Check OAuth status when dropdown opens (covers dev panel visibility)
+  // Check OAuth status eagerly on mount so it's ready before dropdown opens
+  useEffect(() => {
+    checkOAuthConfigured().then(({ backendUp, oauthConfigured }) => {
+      setOauthStatus({ checked: true, configured: oauthConfigured, backendUp })
+    })
+  }, [])
+
+  // Re-check when dropdown opens (status may have changed)
   useEffect(() => {
     if (isOpen) {
       checkOAuthConfigured().then(({ backendUp, oauthConfigured }) => {


### PR DESCRIPTION
## Summary
- Fix OAuth status in Developer panel always showing "not configured" despite OAuth being properly configured
- Root cause: `useState` initializer using `user?.github_login` only runs once on mount — if `user` prop is null at mount time, the initial state is `{checked: false, configured: false}` and never reinitializes
- Now checks OAuth status eagerly on component mount via `/health` endpoint, so status is ready before the dropdown is ever opened
- Also re-checks on each dropdown open for freshness

## Test plan
- [ ] Start console with OAuth configured (`bash startup-oauth.sh`)
- [ ] Open user profile dropdown → expand Developer section
- [ ] Verify OAuth shows green "Configured" instead of yellow "Not configured"