### PR TITLE
🐛 Nodes Tracked click switches to inventory tab

### DIFF
--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -412,12 +412,15 @@ export function HardwareHealthCard() {
             Warning
           </div>
         </div>
-        <div className="p-2 rounded-lg border bg-muted/20 border-muted/30">
+        <button
+          onClick={() => setViewMode('inventory')}
+          className="p-2 rounded-lg border bg-muted/20 border-muted/30 hover:bg-muted/40 transition-colors cursor-pointer text-left"
+        >
           <div className="text-xl font-bold text-foreground">{deduplicatedNodeCount}</div>
           <div className="text-[10px] text-muted-foreground">
             Nodes Tracked
           </div>
-        </div>
+        </button>
       </div>
 
       {/* View Mode Toggle */}


### PR DESCRIPTION
## Summary
- Makes the "Nodes Tracked" stat block in the Hardware Health card clickable
- Clicking it switches the view from Alerts to the Inventory tab
- Converted from `<div>` to `<button>` with hover styling for discoverability

## Test plan
- [ ] Open Hardware Health card with Alerts tab active
- [ ] Click "Nodes Tracked" stat → should switch to Inventory tab
- [ ] Verify hover state shows the element is clickable