### PR TITLE
🐛 Use deduplicated clusters in drill-down dialogs

### DIFF
--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -171,7 +171,7 @@ function getStatusBadge(status: string) {
 
 export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSummaryDrillDownProps) {
   const { t } = useTranslation()
-  const { clusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues } = useClusterData()
+  const { clusters, deduplicatedClusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues } = useClusterData()
   const { nodes: cachedNodes } = useCachedNodes()
   const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<string>('all')
@@ -190,7 +190,8 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
   const allItems = useMemo(() => {
     switch (viewType) {
       case 'all-clusters':
-        return clusters.map(c => ({
+        // Use deduplicated clusters to avoid showing duplicate contexts for the same server
+        return (deduplicatedClusters || clusters).map(c => ({
           ...c,
           name: c.name,
           cluster: c.name,
@@ -313,7 +314,7 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
       default:
         return []
     }
-  }, [viewType, clusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues, cachedNodes])
+  }, [viewType, clusters, deduplicatedClusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues, cachedNodes])
 
   // Apply initial filter from data prop
   const preFilteredItems = useMemo(() => {

--- a/web/src/hooks/useClusterData.ts
+++ b/web/src/hooks/useClusterData.ts
@@ -6,7 +6,7 @@
 import { useClusters, usePods, useDeployments, useNamespaces, useEvents, useHelmReleases, useOperatorSubscriptions, useSecurityIssues } from './useMCP'
 
 export function useClusterData() {
-  const { clusters } = useClusters()
+  const { clusters, deduplicatedClusters } = useClusters()
   const { pods } = usePods()
   const { deployments } = useDeployments()
   const { namespaces } = useNamespaces()
@@ -17,6 +17,7 @@ export function useClusterData() {
 
   return {
     clusters,
+    deduplicatedClusters,
     pods,
     deployments,
     namespaces,


### PR DESCRIPTION
## Summary
- Dashboard stat blocks (Healthy/Unhealthy/Offline) use deduplicated cluster counts
- But clicking them opened a drill-down dialog showing raw clusters with duplicate contexts
- Now the `all-clusters` drill-down uses `deduplicatedClusters` so dialog counts match stat blocks
- Exposed `deduplicatedClusters` from `useClusterData()` hook

## Test plan
- [ ] Click "Healthy Clusters" stat → dialog shows deduplicated clusters (no duplicates for same server)
- [ ] Verify Total count in dialog matches the stat block count
- [ ] Click "Unhealthy Clusters" stat → same deduplication