### PR TITLE
🐛 Use deduplicated clusters across all pages and contexts

### DIFF
--- a/web/src/components/aiml/AIML.tsx
+++ b/web/src/components/aiml/AIML.tsx
@@ -17,7 +17,7 @@ const DEFAULT_AIML_CARDS = getDefaultCards('ai-ml')
 
 export function AIML() {
   const { t } = useTranslation('common')
-  const { clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error } = useClusters()
   const { nodes: gpuNodes, isLoading: gpuLoading } = useGPUNodes()
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
 

--- a/web/src/components/nodes/Nodes.tsx
+++ b/web/src/components/nodes/Nodes.tsx
@@ -16,7 +16,7 @@ const DEFAULT_NODES_CARDS = getDefaultCards('nodes')
 
 export function Nodes() {
   const { t } = useTranslation(['cards', 'common'])
-  const { clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error: clustersError } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error: clustersError } = useClusters()
   const { nodes: gpuNodes } = useGPUNodes()
   const error = clustersError
 

--- a/web/src/components/operators/Operators.tsx
+++ b/web/src/components/operators/Operators.tsx
@@ -16,7 +16,7 @@ const DEFAULT_OPERATORS_CARDS = getDefaultCards('operators')
 
 export function Operators() {
   const { t } = useTranslation(['cards', 'common'])
-  const { clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error: clustersError } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error: clustersError } = useClusters()
   const { subscriptions: operatorSubs, refetch: refetchSubs, error: subsError } = useOperatorSubscriptions()
   const { operators: allOperators, refetch: refetchOps, error: opsError } = useOperators()
   const error = clustersError || subsError || opsError

--- a/web/src/components/widget/MiniDashboard.tsx
+++ b/web/src/components/widget/MiniDashboard.tsx
@@ -89,7 +89,7 @@ export function MiniDashboard() {
   const [isSafariBrowser] = useState(() => isSafari())
 
   // Fetch data from MCP hooks
-  const { clusters, isLoading: clustersLoading, refetch: refetchClusters } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading, refetch: refetchClusters } = useClusters()
   const { nodes: gpuNodes, isLoading: gpuLoading, refetch: refetchGPU } = useGPUNodes()
 
   // Fetch nodes from local agent for offline detection

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -95,7 +95,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
 
   const { nodes: gpuNodes, isLoading: isGPULoading, error: gpuError } = useGPUNodes()
   const { issues: podIssues, isLoading: isPodIssuesLoading, error: podIssuesError } = usePodIssues()
-  const { clusters, isLoading: isClustersLoading, error: clustersError } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading: isClustersLoading, error: clustersError } = useClusters()
   const { startMission } = useMissions()
   const { isDemoMode } = useDemoMode()
   const previousDemoMode = useRef(isDemoMode)


### PR DESCRIPTION
## Summary
- Multiple pages were using raw `clusters` instead of `deduplicatedClusters`, causing inflated counts from duplicate contexts pointing to the same server
- Fixed in: MiniDashboard, Operators, AI/ML, Nodes, AlertsContext
- CanIChecker intentionally left on raw clusters (RBAC checks are context-specific)

## Files changed
- `web/src/components/widget/MiniDashboard.tsx` — PWA widget cluster counts
- `web/src/components/operators/Operators.tsx` — cluster stats block
- `web/src/components/aiml/AIML.tsx` — LLM-d cluster discovery
- `web/src/components/nodes/Nodes.tsx` — node/CPU/memory aggregation
- `web/src/contexts/AlertsContext.tsx` — alert evaluation & CronJob fetches

## Test plan
- [ ] Check cluster counts on each affected page match deduplicated count
- [ ] Verify PWA widget shows correct cluster count
- [ ] Verify Nodes page stats don't double-count from duplicate contexts