### PR TITLE
🌱 Rename dev setup link to "Developer Mode Setup Instructions"

### DIFF
--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -287,7 +287,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
                       className="flex items-center gap-2 text-xs text-purple-400 hover:text-purple-300 transition-colors"
                     >
                       <Rocket className="w-3.5 h-3.5" />
-                      {t('developer.setupInstructions')}
+                      {installMethod === 'dev' ? t('developer.devModeSetup') : t('developer.setupInstructions')}
                     </button>
                     {!oauthStatus.configured && oauthStatus.checked && (
                       <a

--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -587,6 +587,7 @@
     "oauthNotConfigured": "OAuth not configured",
     "checkingOauth": "Checking OAuth...",
     "setupInstructions": "Setup Instructions",
+    "devModeSetup": "Entwicklermodus-Einrichtungsanleitung",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
     "docs": "Documentation",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -587,6 +587,7 @@
     "oauthNotConfigured": "OAuth not configured",
     "checkingOauth": "Checking OAuth...",
     "setupInstructions": "Setup Instructions",
+    "devModeSetup": "Developer Mode Setup Instructions",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
     "docs": "Documentation",

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -587,6 +587,7 @@
     "oauthNotConfigured": "OAuth not configured",
     "checkingOauth": "Checking OAuth...",
     "setupInstructions": "Setup Instructions",
+    "devModeSetup": "Instrucciones de configuración del modo desarrollador",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
     "docs": "Documentation",

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -587,6 +587,7 @@
     "oauthNotConfigured": "OAuth not configured",
     "checkingOauth": "Checking OAuth...",
     "setupInstructions": "Setup Instructions",
+    "devModeSetup": "Instructions de configuration du mode développeur",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
     "docs": "Documentation",

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -587,6 +587,7 @@
     "oauthNotConfigured": "OAuth not configured",
     "checkingOauth": "Checking OAuth...",
     "setupInstructions": "Setup Instructions",
+    "devModeSetup": "डेवलपर मोड सेटअप निर्देश",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
     "docs": "Documentation",

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -587,6 +587,7 @@
     "oauthNotConfigured": "OAuth not configured",
     "checkingOauth": "Checking OAuth...",
     "setupInstructions": "Setup Instructions",
+    "devModeSetup": "Istruzioni di configurazione modalità sviluppatore",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
     "docs": "Documentation",

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -587,6 +587,7 @@
     "oauthNotConfigured": "OAuth not configured",
     "checkingOauth": "Checking OAuth...",
     "setupInstructions": "Setup Instructions",
+    "devModeSetup": "開発者モードセットアップ手順",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
     "docs": "Documentation",

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -587,6 +587,7 @@
     "oauthNotConfigured": "OAuth not configured",
     "checkingOauth": "Checking OAuth...",
     "setupInstructions": "Setup Instructions",
+    "devModeSetup": "Instruções de configuração do modo desenvolvedor",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
     "docs": "Documentation",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -587,6 +587,7 @@
     "oauthNotConfigured": "OAuth not configured",
     "checkingOauth": "Checking OAuth...",
     "setupInstructions": "Setup Instructions",
+    "devModeSetup": "开发者模式设置说明",
     "configureOauth": "Configure GitHub OAuth",
     "githubRepo": "GitHub Repository",
     "docs": "Documentation",


### PR DESCRIPTION
## Summary
- Show "Developer Mode Setup Instructions" instead of "Setup Instructions" when running in dev mode
- Non-dev installs still see "Setup Instructions"

## Test plan
- [ ] Run console in dev mode → open profile dropdown → expand Developer → verify link says "Developer Mode Setup Instructions"