### PR TITLE
✨ Shareable direct links for Mission Explorer cards

### DIFF
--- a/web/src/components/missions/InstallerCard.tsx
+++ b/web/src/components/missions/InstallerCard.tsx
@@ -5,7 +5,8 @@
  */
 
 import { useState } from 'react'
-import { ExternalLink, Download, Wrench, Trash2, ArrowUpCircle, AlertTriangle } from 'lucide-react'
+import { ExternalLink, Download, Wrench, Trash2, ArrowUpCircle, AlertTriangle, Link, Check } from 'lucide-react'
+import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import { cn } from '../../lib/cn'
 import {
   CNCF_CATEGORY_GRADIENTS,
@@ -159,10 +160,12 @@ interface InstallerCardProps {
   mission: MissionExport
   onImport: () => void
   onSelect: () => void
+  onCopyLink?: (e: React.MouseEvent) => void
   compact?: boolean
 }
 
-export function InstallerCard({ mission, onImport, onSelect, compact }: InstallerCardProps) {
+export function InstallerCard({ mission, onImport, onSelect, onCopyLink, compact }: InstallerCardProps) {
+  const [linkCopied, setLinkCopied] = useState(false)
   const category = mission.category ?? 'Orchestration'
   const gradient = CNCF_CATEGORY_GRADIENTS[category] ?? ['#6366f1', '#8b5cf6']
   const iconPath = CNCF_CATEGORY_ICONS[category] ?? CNCF_CATEGORY_ICONS['Orchestration']
@@ -225,6 +228,21 @@ export function InstallerCard({ mission, onImport, onSelect, compact }: Installe
         }}
       >
         <ProjectLogo cncfProject={mission.cncfProject} iconPath={iconPath} size="lg" />
+        {/* Share link button */}
+        {onCopyLink && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onCopyLink(e)
+              setLinkCopied(true)
+              setTimeout(() => setLinkCopied(false), UI_FEEDBACK_TIMEOUT_MS)
+            }}
+            className="absolute top-1.5 right-1.5 p-1 rounded bg-black/30 hover:bg-black/50 text-white/70 hover:text-white transition-colors"
+            title="Copy shareable link"
+          >
+            {linkCopied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Link className="w-3.5 h-3.5" />}
+          </button>
+        )}
         {/* Category label */}
         <span className="absolute bottom-1.5 right-2 text-[10px] font-medium text-white/70 bg-black/20 px-1.5 py-0.5 rounded">
           {category}

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -29,8 +29,11 @@ import {
   Trash2,
   ExternalLink,
   RefreshCw,
+  Link,
+  Check,
 } from 'lucide-react'
 import { cn } from '../../lib/cn'
+import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import { api } from '../../lib/api'
 import { useAuth } from '../../lib/auth'
 import { matchMissionsToCluster } from '../../lib/missions/matcher'
@@ -40,7 +43,9 @@ import {
   emitSolutionViewed,
   emitSolutionImported,
   emitSolutionGitHubLink,
+  emitSolutionLinkCopied,
 } from '../../lib/analytics'
+import { getMissionRoute } from '../../config/routes'
 import type {
   MissionExport,
   MissionMatch,
@@ -107,6 +112,31 @@ const CATEGORY_FILTERS = [
 const SIDEBAR_WIDTH = 280
 const WATCHED_REPOS_KEY = 'kc_mission_watched_repos'
 const WATCHED_PATHS_KEY = 'kc_mission_watched_paths'
+
+// ============================================================================
+// Slug generation for shareable deep-links
+// ============================================================================
+
+/**
+ * Generate a stable, URL-safe slug for any mission.
+ * - Installers with cncfProject: `install-<cncfProject>` (e.g. `install-prometheus`)
+ * - All others: slugified title (lowercase, non-alphanum → hyphens, dedupe, trim)
+ */
+export function getMissionSlug(mission: MissionExport): string {
+  if (mission.missionClass === 'install' && mission.cncfProject) {
+    return `install-${mission.cncfProject.toLowerCase()}`
+  }
+  return (mission.title || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+/** Build a full shareable URL for a mission */
+function getMissionShareUrl(mission: MissionExport): string {
+  return `${window.location.origin}${getMissionRoute(getMissionSlug(mission))}`
+}
 
 const CNCF_CATEGORIES = [
   'All', 'Observability', 'Orchestration', 'Runtime', 'Provisioning',
@@ -612,22 +642,52 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   }, [])
 
   // ============================================================================
+  // Copy shareable link for a mission
+  // ============================================================================
+
+  const handleCopyLink = useCallback((mission: MissionExport, e: React.MouseEvent) => {
+    e.stopPropagation()
+    const url = getMissionShareUrl(mission)
+    navigator.clipboard.writeText(url)
+    emitSolutionLinkCopied(mission.title, mission.cncfProject)
+  }, [])
+
+  // ============================================================================
   // Deep-link: auto-select mission by name when initialMission is set
   // ============================================================================
 
   useEffect(() => {
     if (!initialMission || !isOpen || selectedMission) return
-    const match = installerMissions.find(
-      (m) => (m.title || '').toLowerCase().includes(initialMission.toLowerCase()) ||
-             (m.cncfProject && m.cncfProject.toLowerCase() === initialMission.replace('install-', '').toLowerCase())
+    const slug = initialMission.toLowerCase()
+
+    // Search installers first (by slug match or title/cncfProject substring)
+    const installerMatch = installerMissions.find(
+      (m) => getMissionSlug(m) === slug ||
+             (m.title || '').toLowerCase().includes(slug) ||
+             (m.cncfProject && m.cncfProject.toLowerCase() === slug.replace('install-', ''))
     )
-    if (match) {
+    if (installerMatch) {
       setActiveTab('installers')
-      selectCardMission(match)
-    } else if (installerMissions.length === 0 && activeTab !== 'installers') {
+      selectCardMission(installerMatch)
+      return
+    }
+
+    // Search solutions (by slug match or title substring)
+    const solutionMatch = solutionMissions.find(
+      (m) => getMissionSlug(m) === slug ||
+             (m.title || '').toLowerCase().includes(slug)
+    )
+    if (solutionMatch) {
+      setActiveTab('solutions')
+      selectCardMission(solutionMatch)
+      return
+    }
+
+    // No match yet — switch to installers tab while data loads
+    if (installerMissions.length === 0 && solutionMissions.length === 0 && activeTab !== 'installers') {
       setActiveTab('installers')
     }
-  }, [initialMission, isOpen, installerMissions, selectedMission, activeTab, selectCardMission])
+  }, [initialMission, isOpen, installerMissions, solutionMissions, selectedMission, activeTab, selectCardMission])
 
   // ============================================================================
   // Filtered installer & solution lists
@@ -1623,6 +1683,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                   matchScore={recommendations.find(
                     (r) => r.mission.title === selectedMission.title
                   )?.matchPercent}
+                  shareUrl={getMissionShareUrl(selectedMission)}
                 />
                 {showImproveDialog && (
                   <ImproveMissionDialog
@@ -1734,6 +1795,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                             match={match}
                             onSelect={() => selectCardMission(match.mission)}
                             onImport={() => handleImport(match.mission)}
+                            onCopyLink={(e) => handleCopyLink(match.mission, e)}
                           />
                         ))}
                       </div>
@@ -1882,6 +1944,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                           compact={viewMode === 'list'}
                           onSelect={() => selectCardMission(mission)}
                           onImport={() => handleImport(mission)}
+                          onCopyLink={(e) => handleCopyLink(mission, e)}
                         />
                       ))}
                     </div>
@@ -1952,6 +2015,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                           compact={viewMode === 'list'}
                           onSelect={() => selectCardMission(mission)}
                           onImport={() => handleImport(mission)}
+                          onCopyLink={(e) => handleCopyLink(mission, e)}
                         />
                       ))}
                     </div>
@@ -2177,13 +2241,16 @@ function RecommendationCard({
   match,
   onSelect,
   onImport,
+  onCopyLink,
 }: {
   match: MissionMatch
   onSelect: () => void
   onImport: () => void
+  onCopyLink?: (e: React.MouseEvent) => void
 }) {
   const { mission, score, matchPercent, matchReasons } = match
   const isClusterMatch = score > 1
+  const [linkCopied, setLinkCopied] = useState(false)
 
   return (
     <div
@@ -2194,6 +2261,22 @@ function RecommendationCard({
         <h4 className="text-sm font-medium text-foreground line-clamp-1 group-hover:text-purple-400 transition-colors">
           {mission.title}
         </h4>
+        <div className="flex items-center gap-1 flex-shrink-0">
+          {onCopyLink && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onCopyLink(e)
+                setLinkCopied(true)
+                setTimeout(() => setLinkCopied(false), UI_FEEDBACK_TIMEOUT_MS)
+              }}
+              className="p-0.5 rounded text-muted-foreground/50 hover:text-purple-400 transition-colors"
+              title="Copy shareable link"
+            >
+              {linkCopied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Link className="w-3.5 h-3.5" />}
+            </button>
+          )}
+        </div>
         <span className={cn(
           'flex items-center gap-1 px-1.5 py-0.5 text-[10px] rounded-full flex-shrink-0 font-medium tabular-nums',
           matchPercent >= 80

--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -24,6 +24,7 @@ import {
   ExternalLink,
   Shield,
   MessageSquarePlus,
+  Link,
 } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import type { MissionExport, MissionStep } from '../../lib/missions/types'
@@ -53,6 +54,8 @@ interface MissionDetailViewProps {
   importLabel?: string
   /** Hide the "Back to listing" button (e.g. when opened from saved missions) */
   hideBackButton?: boolean
+  /** Shareable URL for this mission (e.g. http://localhost:8080/missions/install-prometheus) */
+  shareUrl?: string
 }
 
 // Extract code blocks from markdown-style description
@@ -174,7 +177,9 @@ export function MissionDetailView({
   matchScore,
   importLabel = 'Import',
   hideBackButton = false,
+  shareUrl,
 }: MissionDetailViewProps) {
+  const [linkCopied, setLinkCopied] = useState(false)
   const tabs: TabDef[] = [
     {
       id: 'install',
@@ -252,6 +257,25 @@ export function MissionDetailView({
               <Star className="w-3 h-3" />
               {matchScore}% match
             </span>
+          )}
+          {shareUrl && (
+            <button
+              onClick={() => {
+                navigator.clipboard.writeText(shareUrl)
+                setLinkCopied(true)
+                setTimeout(() => setLinkCopied(false), UI_FEEDBACK_TIMEOUT_MS)
+              }}
+              className={cn(
+                'flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg border transition-colors',
+                linkCopied
+                  ? 'border-green-500/30 text-green-400'
+                  : 'border-border text-muted-foreground hover:text-foreground'
+              )}
+              title="Copy shareable link"
+            >
+              {linkCopied ? <Check className="w-3.5 h-3.5" /> : <Link className="w-3.5 h-3.5" />}
+              {linkCopied ? 'Copied!' : 'Share'}
+            </button>
           )}
           <button
             onClick={onToggleRaw}

--- a/web/src/components/missions/SolutionCard.tsx
+++ b/web/src/components/missions/SolutionCard.tsx
@@ -3,7 +3,10 @@
  * Shows type badge, category, tags, description, and import button.
  */
 
+import { useState } from 'react'
+import { Link, Check } from 'lucide-react'
 import { cn } from '../../lib/cn'
+import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import type { MissionExport } from '../../lib/missions/types'
 
 const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
@@ -19,10 +22,12 @@ interface SolutionCardProps {
   mission: MissionExport
   onImport: () => void
   onSelect: () => void
+  onCopyLink?: (e: React.MouseEvent) => void
   compact?: boolean
 }
 
-export function SolutionCard({ mission, onImport, onSelect, compact }: SolutionCardProps) {
+export function SolutionCard({ mission, onImport, onSelect, onCopyLink, compact }: SolutionCardProps) {
+  const [linkCopied, setLinkCopied] = useState(false)
   const typeStyle = TYPE_COLORS[mission.type] ?? TYPE_COLORS.custom
 
   if (compact) {
@@ -62,9 +67,25 @@ export function SolutionCard({ mission, onImport, onSelect, compact }: SolutionC
         <h4 className="text-sm font-medium text-foreground line-clamp-1 group-hover:text-purple-400 transition-colors">
           {mission.title}
         </h4>
-        <span className={cn('flex-shrink-0 px-1.5 py-0.5 text-[10px] font-medium rounded-full', typeStyle.bg, typeStyle.color)}>
-          {mission.type}
-        </span>
+        <div className="flex items-center gap-1 flex-shrink-0">
+          {onCopyLink && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onCopyLink(e)
+                setLinkCopied(true)
+                setTimeout(() => setLinkCopied(false), UI_FEEDBACK_TIMEOUT_MS)
+              }}
+              className="p-0.5 rounded text-muted-foreground/50 hover:text-purple-400 transition-colors"
+              title="Copy shareable link"
+            >
+              {linkCopied ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Link className="w-3.5 h-3.5" />}
+            </button>
+          )}
+          <span className={cn('px-1.5 py-0.5 text-[10px] font-medium rounded-full', typeStyle.bg, typeStyle.color)}>
+            {mission.type}
+          </span>
+        </div>
       </div>
 
       <p className="text-xs text-muted-foreground line-clamp-2 mb-2">{mission.description}</p>

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -388,6 +388,10 @@ export function emitSolutionImported(title: string, cncfProject?: string) {
   send('ksc_solution_imported', { title, cncf_project: cncfProject ?? '' })
 }
 
+export function emitSolutionLinkCopied(title: string, cncfProject?: string) {
+  send('ksc_solution_link_copied', { title, cncf_project: cncfProject ?? '' })
+}
+
 export function emitSolutionGitHubLink() {
   send('ksc_solution_github_link')
 }


### PR DESCRIPTION
## Summary
- Add copy-link buttons to installer cards, solution cards, recommendation cards, and the mission detail view header
- Each mission gets a stable URL-safe slug (`install-<cncfProject>` for installers, slugified title for solutions) that works with the existing `/missions/:missionId` deep-link route
- Fix deep-link matching to search both installers AND solutions (previously only searched installers), auto-switching tabs when a solution match is found
- Add `ksc_solution_link_copied` GA4 event for tracking link shares

## Test plan
- [ ] Open Mission Explorer → hover an installer card → click link icon in top-right corner → verify clipboard has URL like `http://localhost:8080/missions/install-prometheus`
- [ ] Paste URL in new tab → verify it opens Mission Explorer with that card selected
- [ ] Repeat for a solution card → verify slug-based URL works (e.g. `/missions/troubleshoot-crashloopbackoff-in-kube-system`)
- [ ] Open a card's detail view → click "Share" button in header → verify link copied with green "Copied!" feedback
- [ ] Test deep-link with a solution mission URL → verify it auto-switches to Solutions tab
- [ ] Check network tab for `ksc_solution_link_copied` GA4 event when copying a link