### PR TITLE
✨ Show llm-d component tags in Nightly E2E tooltip + rename widget to Nodes

### DIFF
--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -29,14 +29,16 @@ const (
 
 // NightlyWorkflow defines a GitHub Actions workflow to monitor.
 type NightlyWorkflow struct {
-	Repo         string `json:"repo"`
-	WorkflowFile string `json:"workflowFile"`
-	Guide        string `json:"guide"`
-	Acronym      string `json:"acronym"`
-	Platform     string `json:"platform"`
-	Model        string `json:"model"`
-	GPUType      string `json:"gpuType"`
-	GPUCount     int    `json:"gpuCount"`
+	Repo         string            `json:"repo"`
+	WorkflowFile string            `json:"workflowFile"`
+	Guide        string            `json:"guide"`
+	Acronym      string            `json:"acronym"`
+	Platform     string            `json:"platform"`
+	Model        string            `json:"model"`
+	GPUType      string            `json:"gpuType"`
+	GPUCount     int               `json:"gpuCount"`
+	LLMDImages   map[string]string `json:"llmdImages"`   // llm-d component → tag
+	OtherImages  map[string]string `json:"otherImages"`  // non-llm-d containers → tag
 }
 
 // NightlyRun represents a single workflow run from the GitHub Actions API.
@@ -59,18 +61,20 @@ type NightlyRun struct {
 
 // NightlyGuideStatus holds runs and computed stats for a single guide.
 type NightlyGuideStatus struct {
-	Guide            string       `json:"guide"`
-	Acronym          string       `json:"acronym"`
-	Platform         string       `json:"platform"`
-	Repo             string       `json:"repo"`
-	WorkflowFile     string       `json:"workflowFile"`
-	Runs             []NightlyRun `json:"runs"`
-	PassRate         int          `json:"passRate"`
-	Trend            string       `json:"trend"`
-	LatestConclusion *string      `json:"latestConclusion"`
-	Model            string       `json:"model"`
-	GPUType          string       `json:"gpuType"`
-	GPUCount         int          `json:"gpuCount"`
+	Guide            string            `json:"guide"`
+	Acronym          string            `json:"acronym"`
+	Platform         string            `json:"platform"`
+	Repo             string            `json:"repo"`
+	WorkflowFile     string            `json:"workflowFile"`
+	Runs             []NightlyRun      `json:"runs"`
+	PassRate         int               `json:"passRate"`
+	Trend            string            `json:"trend"`
+	LatestConclusion *string           `json:"latestConclusion"`
+	Model            string            `json:"model"`
+	GPUType          string            `json:"gpuType"`
+	GPUCount         int               `json:"gpuCount"`
+	LLMDImages       map[string]string `json:"llmdImages"`  // llm-d component → tag
+	OtherImages      map[string]string `json:"otherImages"` // non-llm-d containers → tag
 }
 
 // NightlyE2EResponse is the JSON response from the /api/nightly-e2e/runs endpoint.
@@ -106,29 +110,57 @@ type NightlyE2EHandler struct {
 	logCacheExp map[string]time.Time
 }
 
+// Component image tags used by each guide type (shared across platforms).
+// The main vLLM image (llm-d-cuda-dev:latest) is overridden nightly via image_override.
+var (
+	// imgCudaDev is the nightly-built dev image used by most guides
+	imgCudaDev = map[string]string{"llm-d-cuda-dev": "latest"}
+
+	// imgPD adds the routing sidecar to the base image set
+	imgPD = map[string]string{"llm-d-cuda-dev": "latest", "llm-d-routing-sidecar": "v0.5.0"}
+
+	// imgPPC adds the UDS tokenizer to the base image set
+	imgPPC = map[string]string{"llm-d-cuda-dev": "latest", "llm-d-uds-tokenizer": "v0.5.1-rc1"}
+
+	// imgSA uses the inference simulator instead of cuda-dev
+	imgSA = map[string]string{"llm-d-inference-sim": "v0.7.1", "llm-d-routing-sidecar": "v0.5.0"}
+
+	// imgWEP adds the routing sidecar for wide EP
+	imgWEP = map[string]string{"llm-d-cuda-dev": "latest", "llm-d-routing-sidecar": "v0.5.0"}
+
+	// imgWVA adds the workload variant autoscaler (tag is dynamic, rebuilt nightly)
+	imgWVA = map[string]string{"llm-d-cuda-dev": "latest", "llm-d-workload-variant-autoscaler": "nightly"}
+
+	// imgTPC uses only the base cuda-dev image
+	imgTPC = map[string]string{"llm-d-cuda-dev": "latest"}
+
+	// imgBM uses the base image for benchmarking
+	imgBM = map[string]string{"llm-d-cuda-dev": "latest"}
+)
+
 // nightlyWorkflows is the canonical list of nightly E2E workflows to monitor.
 // Model/GPU metadata is sourced from each workflow's YAML in GitHub Actions.
 var nightlyWorkflows = []NightlyWorkflow{
 	// OCP — all OCP guides run on H100 except WVA (A100) and SA (CPU)
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-ocp.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "OCP", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-ocp.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-precise-prefix-cache-ocp.yaml", Guide: "Precise Prefix Cache", Acronym: "PPC", Platform: "OCP", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-simulated-accelerators.yaml", Guide: "Simulated Accelerators", Acronym: "SA", Platform: "OCP", Model: "Simulated", GPUType: "CPU", GPUCount: 0},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-tiered-prefix-cache-ocp.yaml", Guide: "Tiered Prefix Cache", Acronym: "TPC", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 1},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-ocp.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-ocp.yaml", Guide: "WVA", Acronym: "WVA", Platform: "OCP", Model: "Llama-3.1-8B", GPUType: "A100", GPUCount: 2},
-	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-ocp.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "OCP", Model: "opt-125m", GPUType: "A100", GPUCount: 1},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-ocp.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "OCP", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, LLMDImages: imgCudaDev},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-ocp.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, LLMDImages: imgPD},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-precise-prefix-cache-ocp.yaml", Guide: "Precise Prefix Cache", Acronym: "PPC", Platform: "OCP", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, LLMDImages: imgPPC},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-simulated-accelerators.yaml", Guide: "Simulated Accelerators", Acronym: "SA", Platform: "OCP", Model: "Simulated", GPUType: "CPU", GPUCount: 0, LLMDImages: imgSA},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-tiered-prefix-cache-ocp.yaml", Guide: "Tiered Prefix Cache", Acronym: "TPC", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 1, LLMDImages: imgTPC},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-ocp.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, LLMDImages: imgWEP},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-ocp.yaml", Guide: "WVA", Acronym: "WVA", Platform: "OCP", Model: "Llama-3.1-8B", GPUType: "A100", GPUCount: 2, LLMDImages: imgWVA},
+	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-ocp.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "OCP", Model: "opt-125m", GPUType: "A100", GPUCount: 1, LLMDImages: imgBM},
 	// GKE — all GKE guides run on L4
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-gke.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "GKE", Model: "Qwen3-32B", GPUType: "L4", GPUCount: 2},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-gke.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "GKE", Model: "Qwen3-0.6B", GPUType: "L4", GPUCount: 2},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-gke.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "GKE", Model: "Qwen3-0.6B", GPUType: "L4", GPUCount: 2},
-	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-gke.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "GKE", Model: "opt-125m", GPUType: "L4", GPUCount: 1},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-gke.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "GKE", Model: "Qwen3-32B", GPUType: "L4", GPUCount: 2, LLMDImages: imgCudaDev},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-gke.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "GKE", Model: "Qwen3-0.6B", GPUType: "L4", GPUCount: 2, LLMDImages: imgPD},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-gke.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "GKE", Model: "Qwen3-0.6B", GPUType: "L4", GPUCount: 2, LLMDImages: imgWEP},
+	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-gke.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "GKE", Model: "opt-125m", GPUType: "L4", GPUCount: 1, LLMDImages: imgBM},
 	// CKS — all CKS guides run on H100
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-cks.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "CKS", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "CKS", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-cks.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "CKS", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-cks.yaml", Guide: "WVA", Acronym: "WVA", Platform: "CKS", Model: "Llama-3.1-8B", GPUType: "H100", GPUCount: 2},
-	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nightly-benchmark-cks.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "CKS", Model: "opt-125m", GPUType: "H100", GPUCount: 1},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-cks.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "CKS", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, LLMDImages: imgCudaDev},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "CKS", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, LLMDImages: imgPD},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-cks.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "CKS", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, LLMDImages: imgWEP},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-cks.yaml", Guide: "WVA", Acronym: "WVA", Platform: "CKS", Model: "Llama-3.1-8B", GPUType: "H100", GPUCount: 2, LLMDImages: imgWVA},
+	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nightly-benchmark-cks.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "CKS", Model: "opt-125m", GPUType: "H100", GPUCount: 1, LLMDImages: imgBM},
 }
 
 // NewNightlyE2EHandler creates a handler using the given GitHub token for API access.
@@ -248,6 +280,8 @@ func (h *NightlyE2EHandler) fetchAll() (*NightlyE2EResponse, error) {
 			Model:            wf.Model,
 			GPUType:          wf.GPUType,
 			GPUCount:         wf.GPUCount,
+			LLMDImages:       wf.LLMDImages,
+			OtherImages:      wf.OtherImages,
 		}
 	}
 

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -195,6 +195,11 @@ Please provide:
     })
   }, [guide, run, checkKeyAndRun, startMission])
 
+  const llmdImages = guide?.llmdImages
+  const otherImages = guide?.otherImages
+  const hasLLMDImages = llmdImages && Object.keys(llmdImages).length > 0
+  const hasOtherImages = otherImages && Object.keys(otherImages).length > 0
+
   return (
     <div
       ref={dotRef}
@@ -206,7 +211,6 @@ Please provide:
         href={run.htmlUrl}
         target="_blank"
         rel="noopener noreferrer"
-        title={!isFailed ? title : undefined}
         aria-label={`Run #${run.runNumber}: ${title}`}
         onClick={e => e.stopPropagation()}
       >
@@ -214,19 +218,59 @@ Please provide:
           isHighlighted ? 'ring-2 ring-white/50 scale-125' : 'group-hover:ring-2 group-hover:ring-white/30'
         } transition-all`} aria-hidden="true" />
       </a>
-      {isFailed && showPopup && popupPos && createPortal(
+      {showPopup && popupPos && createPortal(
         <div
           className="fixed z-[9999]"
           style={{ top: popupPos.top, left: popupPos.left, transform: 'translate(-50%, -100%)' }}
           onMouseEnter={cancelHide}
           onMouseLeave={scheduleHide}
         >
-          <div className="mb-1.5 bg-slate-800 border border-slate-600 rounded-lg shadow-xl px-2.5 py-1.5 whitespace-nowrap text-[10px]">
-            <div className="text-slate-300 mb-1">
-              Run #{run.runNumber} &middot; {isGPUFailure ? <span className="text-amber-400">GPU unavailable</span> : <span className="text-red-400">failed</span>} &middot; {formatTimeAgo(run.createdAt)}
+          <div className="mb-1.5 bg-slate-800 border border-slate-600 rounded-lg shadow-xl px-2.5 py-1.5 text-[10px]">
+            {/* Run status line */}
+            <div className="text-slate-300 mb-1 whitespace-nowrap">
+              Run #{run.runNumber} &middot;{' '}
+              {isRunning
+                ? <span className="text-blue-400">running</span>
+                : isGPUFailure
+                  ? <span className="text-amber-400">GPU unavailable</span>
+                  : isFailed
+                    ? <span className="text-red-400">failed</span>
+                    : run.conclusion === 'success'
+                      ? <span className="text-emerald-400">passed</span>
+                      : <span className="text-slate-400">{run.conclusion}</span>
+              }
+              {' '}&middot; {formatTimeAgo(run.createdAt)}
             </div>
-            <div className="flex items-center gap-2">
-              {guide && (
+
+            {/* llm-d component tags */}
+            {hasLLMDImages && (
+              <div className="mt-1.5 pt-1.5 border-t border-slate-700">
+                <div className="text-slate-500 text-[9px] font-medium mb-0.5">llm-d components</div>
+                {Object.entries(llmdImages).map(([name, tag]) => (
+                  <div key={name} className="flex items-center gap-1 whitespace-nowrap">
+                    <span className="text-slate-400">{name}</span>
+                    <span className="text-cyan-400 font-mono">:{tag}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Other container tags */}
+            {hasOtherImages && (
+              <div className="mt-1.5 pt-1.5 border-t border-slate-700">
+                <div className="text-slate-500 text-[9px] font-medium mb-0.5">other images</div>
+                {Object.entries(otherImages).map(([name, tag]) => (
+                  <div key={name} className="flex items-center gap-1 whitespace-nowrap">
+                    <span className="text-slate-400">{name}</span>
+                    <span className="text-orange-400 font-mono">:{tag}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Action links */}
+            <div className="flex items-center gap-2 mt-1.5 pt-1.5 border-t border-slate-700">
+              {isFailed && guide && (
                 <button
                   onClick={handleDiagnose}
                   disabled={isDiagnosing}

--- a/web/src/components/widget/MiniDashboard.tsx
+++ b/web/src/components/widget/MiniDashboard.tsx
@@ -295,7 +295,7 @@ export function MiniDashboard() {
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           <StatusDot status={overallStatus} />
-          <h1 className="text-lg font-semibold">KubeStellar Console</h1>
+          <h1 className="text-lg font-semibold">Nodes</h1>
         </div>
         <div className="flex items-center gap-2">
           {lastUpdated && (
@@ -425,7 +425,7 @@ export function MiniDashboard() {
           </div>
         ) : (
           <div className="flex items-center justify-between text-xs text-gray-500">
-            <span>KubeStellar Console Widget</span>
+            <span>Nodes Widget</span>
             <button
               onClick={openFullDashboard}
               className="flex items-center gap-1 hover:text-gray-400 transition-colors"

--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -14,6 +14,8 @@ export interface NightlyWorkflowConfig {
   model: string
   gpuType: string
   gpuCount: number
+  llmdImages?: Record<string, string>
+  otherImages?: Record<string, string>
 }
 
 export interface NightlyRun {
@@ -44,29 +46,39 @@ export interface NightlyGuideStatus {
   model: string
   gpuType: string
   gpuCount: number
+  llmdImages?: Record<string, string>  // llm-d component → tag
+  otherImages?: Record<string, string> // non-llm-d containers → tag
 }
+
+// Component image maps per guide type (shared across platforms)
+const IMG_CUDA_DEV = { 'llm-d-cuda-dev': 'latest' }
+const IMG_PD = { 'llm-d-cuda-dev': 'latest', 'llm-d-routing-sidecar': 'v0.5.0' }
+const IMG_PPC = { 'llm-d-cuda-dev': 'latest', 'llm-d-uds-tokenizer': 'v0.5.1-rc1' }
+const IMG_SA = { 'llm-d-inference-sim': 'v0.7.1', 'llm-d-routing-sidecar': 'v0.5.0' }
+const IMG_WEP = { 'llm-d-cuda-dev': 'latest', 'llm-d-routing-sidecar': 'v0.5.0' }
+const IMG_WVA = { 'llm-d-cuda-dev': 'latest', 'llm-d-workload-variant-autoscaler': 'nightly' }
 
 export const NIGHTLY_WORKFLOWS: NightlyWorkflowConfig[] = [
   // OCP — all OCP guides run on H100 except WVA (A100) and SA (CPU)
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-ocp.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'OCP', model: 'Qwen3-32B', gpuType: 'H100', gpuCount: 2 },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-ocp.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'OCP', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2 },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-precise-prefix-cache-ocp.yaml', guide: 'Precise Prefix Cache', acronym: 'PPC', platform: 'OCP', model: 'Qwen3-32B', gpuType: 'H100', gpuCount: 2 },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-simulated-accelerators.yaml', guide: 'Simulated Accelerators', acronym: 'SA', platform: 'OCP', model: 'Simulated', gpuType: 'CPU', gpuCount: 0 },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-tiered-prefix-cache-ocp.yaml', guide: 'Tiered Prefix Cache', acronym: 'TPC', platform: 'OCP', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 1 },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-ocp.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'OCP', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2 },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wva-ocp.yaml', guide: 'WVA', acronym: 'WVA', platform: 'OCP', model: 'Llama-3.1-8B', gpuType: 'A100', gpuCount: 2 },
-  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nighly-benchmark-ocp.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'OCP', model: 'opt-125m', gpuType: 'A100', gpuCount: 1 },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-ocp.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'OCP', model: 'Qwen3-32B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_CUDA_DEV },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-ocp.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'OCP', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_PD },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-precise-prefix-cache-ocp.yaml', guide: 'Precise Prefix Cache', acronym: 'PPC', platform: 'OCP', model: 'Qwen3-32B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_PPC },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-simulated-accelerators.yaml', guide: 'Simulated Accelerators', acronym: 'SA', platform: 'OCP', model: 'Simulated', gpuType: 'CPU', gpuCount: 0, llmdImages: IMG_SA },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-tiered-prefix-cache-ocp.yaml', guide: 'Tiered Prefix Cache', acronym: 'TPC', platform: 'OCP', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 1, llmdImages: IMG_CUDA_DEV },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-ocp.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'OCP', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_WEP },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wva-ocp.yaml', guide: 'WVA', acronym: 'WVA', platform: 'OCP', model: 'Llama-3.1-8B', gpuType: 'A100', gpuCount: 2, llmdImages: IMG_WVA },
+  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nighly-benchmark-ocp.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'OCP', model: 'opt-125m', gpuType: 'A100', gpuCount: 1, llmdImages: IMG_CUDA_DEV },
   // GKE — all GKE guides run on L4
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-gke.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'GKE', model: 'Qwen3-32B', gpuType: 'L4', gpuCount: 2 },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-gke.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'GKE', model: 'Qwen3-0.6B', gpuType: 'L4', gpuCount: 2 },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-gke.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'GKE', model: 'Qwen3-0.6B', gpuType: 'L4', gpuCount: 2 },
-  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nighly-benchmark-gke.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'GKE', model: 'opt-125m', gpuType: 'L4', gpuCount: 1 },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-gke.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'GKE', model: 'Qwen3-32B', gpuType: 'L4', gpuCount: 2, llmdImages: IMG_CUDA_DEV },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-gke.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'GKE', model: 'Qwen3-0.6B', gpuType: 'L4', gpuCount: 2, llmdImages: IMG_PD },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-gke.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'GKE', model: 'Qwen3-0.6B', gpuType: 'L4', gpuCount: 2, llmdImages: IMG_WEP },
+  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nighly-benchmark-gke.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'GKE', model: 'opt-125m', gpuType: 'L4', gpuCount: 1, llmdImages: IMG_CUDA_DEV },
   // CKS — all CKS guides run on H100
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-cks.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'CKS', model: 'Qwen3-32B', gpuType: 'H100', gpuCount: 2 },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-cks.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'CKS', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2 },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-cks.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'CKS', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2 },
-  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wva-cks.yaml', guide: 'WVA', acronym: 'WVA', platform: 'CKS', model: 'Llama-3.1-8B', gpuType: 'H100', gpuCount: 2 },
-  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nightly-benchmark-cks.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'CKS', model: 'opt-125m', gpuType: 'H100', gpuCount: 1 },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-inference-scheduling-cks.yaml', guide: 'Inference Scheduling', acronym: 'IS', platform: 'CKS', model: 'Qwen3-32B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_CUDA_DEV },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-pd-disaggregation-cks.yaml', guide: 'PD Disaggregation', acronym: 'PD', platform: 'CKS', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_PD },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wide-ep-lws-cks.yaml', guide: 'Wide EP + LWS', acronym: 'WEP', platform: 'CKS', model: 'Qwen3-0.6B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_WEP },
+  { repo: 'llm-d/llm-d', workflowFile: 'nightly-e2e-wva-cks.yaml', guide: 'WVA', acronym: 'WVA', platform: 'CKS', model: 'Llama-3.1-8B', gpuType: 'H100', gpuCount: 2, llmdImages: IMG_WVA },
+  { repo: 'llm-d/llm-d-benchmark', workflowFile: 'ci-nightly-benchmark-cks.yaml', guide: 'Benchmarking', acronym: 'BM', platform: 'CKS', model: 'opt-125m', gpuType: 'H100', gpuCount: 1, llmdImages: IMG_CUDA_DEV },
 ]
 
 // Seeded patterns per guide for deterministic demo data
@@ -146,6 +158,8 @@ export function generateDemoNightlyData(): NightlyGuideStatus[] {
       model: wf.model,
       gpuType: wf.gpuType,
       gpuCount: wf.gpuCount,
+      llmdImages: wf.llmdImages,
+      otherImages: wf.otherImages,
     }
   })
 }


### PR DESCRIPTION
## Summary
- **Nightly E2E tooltip**: Hovering any build dot now shows a popup with the run status, llm-d component images/tags (cyan), other images (orange), and a "View Logs" link. Previously only failed dots had popups.
- **Backend**: Added `llmdImages` and `otherImages` maps to each nightly workflow config, passing static component metadata (e.g., `llm-d-cuda-dev:latest`, `llm-d-routing-sidecar:v0.5.0`) through to the API response.
- **Widget rename**: MiniDashboard title changed from "KubeStellar Console" to "Nodes".

## Test plan
- [ ] Hover any build dot on the Nightly E2E Status card — should show status, component tags, and View Logs link
- [ ] Verify different guides show different component sets (e.g., PD shows routing-sidecar, WVA shows workload-variant-autoscaler)
- [ ] MiniDashboard widget title reads "Nodes"
- [ ] Build and lint pass