### PR TITLE
🐛 Fix feedback error message not showing actual backend error

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -233,10 +233,10 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
     } catch (err) {
       // Show the actual backend error message if available
       const message = err instanceof Error ? err.message : ''
-      // Try to parse JSON error from backend (Fiber returns {message: "..."})
+      // Try to parse JSON error from backend (Fiber returns {error: "..."})
       try {
         const parsed = JSON.parse(message)
-        setError(parsed.message || t('feedback.submitFailed'))
+        setError(parsed.error || parsed.message || t('feedback.submitFailed'))
       } catch {
         setError(message || t('feedback.submitFailed'))
       }


### PR DESCRIPTION
## Summary
- The Fiber error handler returns `{"error": "..."}` but the frontend only checked `parsed.message`, so every submission failure showed the generic "Unable to submit — GitHub login may be required" instead of the actual error (e.g., "FEEDBACK_GITHUB_TOKEN is not configured").
- Now checks `parsed.error || parsed.message` so developers running locally see the real issue.

## Test plan
- [ ] Run console without `FEEDBACK_GITHUB_TOKEN` in `.env`, try to submit a bug report — should see "Issue submission is not available: FEEDBACK_GITHUB_TOKEN is not configured..."
- [ ] Run with valid token, submit — should work normally