### PR TITLE
🐛 Blur untriaged request title until triage accepted

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -576,7 +576,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
                                 <>
                                   {isOwnedByUser ? (
                                     <>
-                                      <p className="text-sm font-medium text-foreground mt-1 truncate">
+                                      <p className="text-sm font-medium text-foreground mt-1 truncate blur-sm select-none">
                                         {request.request_type === 'bug' ? '🐛 ' : '✨ '}{request.title}
                                       </p>
                                       <div className="flex items-center gap-2 mt-1.5 flex-wrap">


### PR DESCRIPTION
## Summary
- Request titles in the Contribute modal were visible in plain text before triage was accepted
- Now applies `blur-sm select-none` to owned untriaged request titles, matching the existing behavior for non-owned items

## Test plan
- [ ] Submit a bug report or feature request
- [ ] Check the Updates tab — title should be blurred with "Needs Triage" badge
- [ ] After triage is accepted, title should become visible