### PR TITLE
🐛 Blur untriaged titles with safe default during loading

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -576,7 +576,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
                                 <>
                                   {isOwnedByUser ? (
                                     <>
-                                      <p className="text-sm font-medium text-foreground mt-1 truncate">
+                                      <p className="text-sm font-medium text-foreground mt-1 truncate blur-sm select-none">
                                         {request.request_type === 'bug' ? '🐛 ' : '✨ '}{request.title}
                                       </p>
                                       <div className="flex items-center gap-2 mt-1.5 flex-wrap">
@@ -991,7 +991,22 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
                           <p className="text-xs">No contributions found — open issues or PRs to earn points</p>
                         </div>
                       ) : (
-                        githubRewards.contributions.map((contrib: GitHubContribution, idx: number) => (
+                        (() => {
+                          // Blur titles of contributions that match untriaged feedback requests.
+                          // While requests are still loading, blur all issue-type contributions
+                          // from console repos as a safe default to prevent title leak.
+                          const requestsReady = !requestsLoading && requests.length > 0
+                          const untriagedIssueNumbers = new Set(
+                            (requests || [])
+                              .filter(r => !isTriaged(r.status) && r.github_issue_number)
+                              .map(r => r.github_issue_number)
+                          )
+                          return githubRewards.contributions.map((contrib: GitHubContribution, idx: number) => {
+                          const isConsoleIssue = contrib.type.startsWith('issue_') && contrib.repo?.includes('console')
+                          const isUntriaged = requestsReady
+                            ? untriagedIssueNumbers.has(contrib.number)
+                            : isConsoleIssue
+                          return (
                           <a
                             key={`${contrib.repo}-${contrib.number}-${contrib.type}-${idx}`}
                             href={contrib.url}
@@ -1002,7 +1017,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
                             <div className="flex items-center gap-2.5 min-w-0 flex-1">
                               <GitHubContributionIcon type={contrib.type} />
                               <div className="min-w-0 flex-1">
-                                <p className="text-sm text-foreground truncate group-hover:text-blue-400 transition-colors">
+                                <p className={`text-sm text-foreground truncate group-hover:text-blue-400 transition-colors ${isUntriaged ? 'blur-sm select-none' : ''}`}>
                                   {contrib.title}
                                 </p>
                                 <p className="text-xs text-muted-foreground">
@@ -1015,7 +1030,9 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
                               <ExternalLink className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
                             </div>
                           </a>
-                        ))
+                          )
+                        })
+                        })()
                       )}
 
                     {githubRewards?.from_cache && (


### PR DESCRIPTION
## Summary
- Follow-up to #1637 — contributions section loaded before requests, so untriaged titles were briefly visible
- Now blurs all console issue contributions by default until requests data loads, then narrows to only untriaged items
- Uses `contrib.type.startsWith('issue_')` to match `issue_bug`, `issue_feature`, `issue_other` types

## Test plan
- [ ] Open Updates tab — contributions section should blur console issue titles immediately
- [ ] After requests load, only untriaged items stay blurred
- [ ] Triaged/accepted items show title in plain text