### PR TITLE
🐛 Fix deep-link race condition and add Share button next to Import

### DIFF
--- a/web/src/components/missions/InstallerCard.tsx
+++ b/web/src/components/missions/InstallerCard.tsx
@@ -326,16 +326,33 @@ export function InstallerCard({ mission, onImport, onSelect, onCopyLink, compact
               </a>
             )}
           </div>
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              onImport()
-            }}
-            className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors flex-shrink-0"
-          >
-            <Download className="w-3 h-3" />
-            Import
-          </button>
+          <div className="flex items-center gap-1 flex-shrink-0">
+            {onCopyLink && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onCopyLink(e)
+                  setLinkCopied(true)
+                  setTimeout(() => setLinkCopied(false), UI_FEEDBACK_TIMEOUT_MS)
+                }}
+                className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded border border-border text-muted-foreground hover:text-foreground transition-colors"
+                title="Copy shareable link"
+              >
+                {linkCopied ? <Check className="w-3 h-3 text-green-400" /> : <Link className="w-3 h-3" />}
+                {linkCopied ? 'Copied' : 'Share'}
+              </button>
+            )}
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onImport()
+              }}
+              className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+            >
+              <Download className="w-3 h-3" />
+              Import
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -653,12 +653,20 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   }, [])
 
   // ============================================================================
-  // Deep-link: auto-select mission by name when initialMission is set
+  // Deep-link: auto-select mission by name when initialMission is set.
+  // The slug is saved in a ref so it survives the URL param being removed
+  // (MissionSidebar clears ?mission= after opening, but data may not have
+  // loaded yet — the ref keeps the slug alive for later matching).
   // ============================================================================
 
+  const deepLinkSlugRef = useRef<string | null>(null)
+  if (initialMission && !deepLinkSlugRef.current) {
+    deepLinkSlugRef.current = initialMission.toLowerCase()
+  }
+
   useEffect(() => {
-    if (!initialMission || !isOpen || selectedMission) return
-    const slug = initialMission.toLowerCase()
+    const slug = deepLinkSlugRef.current
+    if (!slug || !isOpen || selectedMission) return
 
     // Search installers first (by slug match or title/cncfProject substring)
     const installerMatch = installerMissions.find(
@@ -669,6 +677,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
     if (installerMatch) {
       setActiveTab('installers')
       selectCardMission(installerMatch)
+      deepLinkSlugRef.current = null // consumed
       return
     }
 
@@ -680,6 +689,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
     if (solutionMatch) {
       setActiveTab('solutions')
       selectCardMission(solutionMatch)
+      deepLinkSlugRef.current = null // consumed
       return
     }
 

--- a/web/src/components/missions/SolutionCard.tsx
+++ b/web/src/components/missions/SolutionCard.tsx
@@ -127,15 +127,32 @@ export function SolutionCard({ mission, onImport, onSelect, onCopyLink, compact 
             <span className="text-[10px]">{mission.steps?.length ?? 0} steps</span>
           )}
         </div>
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onImport()
-          }}
-          className="px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors flex-shrink-0"
-        >
-          Import
-        </button>
+        <div className="flex items-center gap-1 flex-shrink-0">
+          {onCopyLink && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onCopyLink(e)
+                setLinkCopied(true)
+                setTimeout(() => setLinkCopied(false), UI_FEEDBACK_TIMEOUT_MS)
+              }}
+              className="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded border border-border text-muted-foreground hover:text-foreground transition-colors"
+              title="Copy shareable link"
+            >
+              {linkCopied ? <Check className="w-3 h-3 text-green-400" /> : <Link className="w-3 h-3" />}
+              {linkCopied ? 'Copied' : 'Share'}
+            </button>
+          )}
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onImport()
+            }}
+            className="px-2 py-1 text-[10px] font-medium rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+          >
+            Import
+          </button>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Fix race condition: deep-link slug is saved in a ref so it survives the `?mission=` URL param being removed before mission data loads (was causing "opens then closes" behavior)
- Move Share button next to Import in card footer for both InstallerCard and SolutionCard (more visible/discoverable)

## Test plan
- [ ] Navigate to `http://localhost:8080/missions/install-prometheus` → card should open and stay open
- [ ] Share and Import buttons visible side by side in card footer
- [ ] Click Share → verify clipboard URL, green "Copied" feedback
- [ ] Normal mission browsing still works