### PR TITLE
✨ Add shimmer loading skeleton for mission detail view

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -441,6 +441,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   const [rawContent, setRawContent] = useState<string | null>(null)
   const [showRaw, setShowRaw] = useState(false)
   const [loading, setLoading] = useState(false)
+  const [isMissionLoading, setIsMissionLoading] = useState(false)
 
   // Recommendations
   const [recommendations, setRecommendations] = useState<MissionMatch[]>([])
@@ -627,6 +628,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   const selectCardMission = useCallback(async (mission: MissionExport) => {
     // Show index metadata immediately for instant feedback
     setSelectedMission(mission)
+    setIsMissionLoading(true)
     setRawContent(JSON.stringify(mission, null, 2))
     setShowRaw(false)
 
@@ -638,6 +640,8 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       setRawContent((current) => current === JSON.stringify(mission, null, 2) ? raw : current)
     } catch {
       // Silently keep the index metadata — steps will show as empty
+    } finally {
+      setIsMissionLoading(false)
     }
   }, [])
 
@@ -1682,6 +1686,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                   mission={selectedMission}
                   rawContent={rawContent}
                   showRaw={showRaw}
+                  loading={isMissionLoading}
                   onToggleRaw={() => setShowRaw(!showRaw)}
                   onImport={() => handleImport(selectedMission, rawContent ?? undefined)}
                   onBack={() => {

--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -41,6 +41,9 @@ interface TabDef {
   color: string
 }
 
+/** Number of shimmer skeleton rows shown while full mission content loads */
+const LOADING_SKELETON_COUNT = 3
+
 interface MissionDetailViewProps {
   mission: MissionExport
   rawContent: string | null
@@ -56,6 +59,8 @@ interface MissionDetailViewProps {
   hideBackButton?: boolean
   /** Shareable URL for this mission (e.g. http://localhost:8080/missions/install-prometheus) */
   shareUrl?: string
+  /** Show shimmer skeleton while full mission content is being fetched */
+  loading?: boolean
 }
 
 // Extract code blocks from markdown-style description
@@ -178,6 +183,7 @@ export function MissionDetailView({
   importLabel = 'Import',
   hideBackButton = false,
   shareUrl,
+  loading = false,
 }: MissionDetailViewProps) {
   const [linkCopied, setLinkCopied] = useState(false)
   const tabs: TabDef[] = [
@@ -493,7 +499,20 @@ export function MissionDetailView({
 
           {/* Tab content */}
           <div className="space-y-3">
-            {activeTabDef.steps.length > 0 ? (
+            {loading ? (
+              /* Shimmer skeleton placeholders while full mission content loads */
+              Array.from({ length: LOADING_SKELETON_COUNT }).map((_, i) => (
+                <div key={i} className="flex gap-3 p-4 rounded-lg bg-secondary/50 border border-border">
+                  <div className="flex-shrink-0 w-7 h-7 rounded-full animate-shimmer" />
+                  <div className="flex-1 space-y-2">
+                    <div className="h-4 w-1/3 rounded animate-shimmer" />
+                    <div className="h-3 w-full rounded animate-shimmer" />
+                    <div className="h-3 w-2/3 rounded animate-shimmer" />
+                    <div className="h-16 w-full rounded animate-shimmer" />
+                  </div>
+                </div>
+              ))
+            ) : activeTabDef.steps.length > 0 ? (
               activeTabDef.steps.map((step, i) => (
                 <StepCard
                   key={`${activeTab}-${i}`}


### PR DESCRIPTION
## Summary
- Shows animated shimmer skeleton placeholders in the mission detail view while full mission content loads asynchronously
- Prevents the brief "No install steps available" flash when opening a card via deep-link or click
- Uses existing `animate-shimmer` CSS class consistent with other loading states in the console

## Test plan
- [ ] Open Mission Explorer → click any installer card → verify shimmer appears briefly before steps load
- [ ] Test with deep-link URL (e.g. `/missions/install-prometheus`) → verify shimmer shows during load
- [ ] Verify steps render correctly after loading completes
- [ ] Verify "No install steps available" still shows for tabs that genuinely have no content