### PR TITLE
✨ Add GA4 UTM campaign params to mission share links

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useState, useEffect } from 'react'
-import { Routes, Route, Navigate, useNavigate, useLocation, useParams } from 'react-router-dom'
+import { Routes, Route, Navigate, useNavigate, useLocation, useParams, useSearchParams } from 'react-router-dom'
 import { CardHistoryEntry } from './hooks/useCardHistory'
 import { Layout } from './components/layout/Layout'
 import { DrillDownModal } from './components/drilldown/DrillDownModal'
@@ -243,10 +243,14 @@ function SettingsSyncInit() {
   return null
 }
 
-/** Redirect /missions/:missionId → /?mission=:missionId to open MissionBrowser via deep-link */
+/** Redirect /missions/:missionId → /?mission=:missionId to open MissionBrowser via deep-link.
+ *  Preserves UTM and other query params so GA4 campaign attribution survives the redirect. */
 function MissionDeepLink() {
   const { missionId } = useParams()
-  return <Navigate to={`/?mission=${encodeURIComponent(missionId || '')}`} replace />
+  const [searchParams] = useSearchParams()
+  const params = new URLSearchParams(searchParams)
+  params.set('mission', encodeURIComponent(missionId || ''))
+  return <Navigate to={`/?${params.toString()}`} replace />
 }
 
 // Route-to-title map for GA4 page view granularity and browser tab labeling

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -133,9 +133,12 @@ export function getMissionSlug(mission: MissionExport): string {
     .replace(/^-|-$/g, '')
 }
 
-/** Build a full shareable URL for a mission */
+/** UTM parameters appended to share-button URLs for GA4 campaign attribution */
+const SHARE_UTM_PARAMS = 'utm_source=mission-explorer&utm_medium=share-link&utm_campaign=mission-sharing'
+
+/** Build a full shareable URL for a mission (includes UTM campaign params) */
 function getMissionShareUrl(mission: MissionExport): string {
-  return `${window.location.origin}${getMissionRoute(getMissionSlug(mission))}`
+  return `${window.location.origin}${getMissionRoute(getMissionSlug(mission))}?${SHARE_UTM_PARAMS}`
 }
 
 const CNCF_CATEGORIES = [


### PR DESCRIPTION
## Summary
- Share button URLs now include UTM params: `utm_source=mission-explorer&utm_medium=share-link&utm_campaign=mission-sharing`
- Enables GA4 campaign attribution to distinguish organic user shares from direct navigation and marketing campaigns
- Deep-link redirect (`/missions/:id` → `/?mission=...`) now preserves UTM params through the rewrite

## GA4 traffic buckets
| Source | Campaign |
|--------|----------|
| Share button clicks | `mission-sharing` |
| Marketing (newsletters, Slack) | Custom UTM added manually |
| Direct / bookmarks | `(none)` |

## Test plan
- [ ] Click Share on a mission card → verify copied URL contains `?utm_source=mission-explorer&utm_medium=share-link&utm_campaign=mission-sharing`
- [ ] Paste shared URL in new tab → verify mission opens correctly (UTM params don't break routing)
- [ ] Check GA4 Realtime → verify campaign=mission-sharing appears in traffic source