### PR TITLE
✨ Add GA4 campaign tracking for widget usage

### DIFF
--- a/web/src/components/settings/sections/WidgetSettingsSection.tsx
+++ b/web/src/components/settings/sections/WidgetSettingsSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Monitor, Download, Copy, Check, ExternalLink, Smartphone, Globe, Apple, Chrome } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import { TOAST_DISMISS_MS, UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
+import { emitWidgetDownloaded } from '../../../lib/analytics'
 
 // The widget code that gets downloaded - includes drag functionality
 const WIDGET_CODE = `/**
@@ -400,6 +401,7 @@ export function WidgetSettingsSection() {
     a.click()
     document.body.removeChild(a)
     URL.revokeObjectURL(url)
+    emitWidgetDownloaded('uebersicht')
     setDownloaded(true)
     clearTimeout(downloadedTimerRef.current)
     downloadedTimerRef.current = setTimeout(() => setDownloaded(false), TOAST_DISMISS_MS)
@@ -498,6 +500,7 @@ export function WidgetSettingsSection() {
             href="/widget"
             target="_blank"
             rel="noopener noreferrer"
+            onClick={() => emitWidgetDownloaded('browser')}
             className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium transition-colors"
           >
             <ExternalLink className="w-4 h-4" />

--- a/web/src/components/widget/MiniDashboard.tsx
+++ b/web/src/components/widget/MiniDashboard.tsx
@@ -14,6 +14,10 @@ import { cn } from '../../lib/cn'
 import { useTranslation } from 'react-i18next'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 import { POLL_INTERVAL_MS } from '../../lib/constants/network'
+import { emitWidgetLoaded, emitWidgetNavigation, emitWidgetInstalled } from '../../lib/analytics'
+
+/** UTM params appended to click-through URLs for GA4 widget campaign attribution */
+const WIDGET_UTM_PARAMS = 'utm_source=widget&utm_medium=pwa&utm_campaign=widget-usage'
 
 // Node data type from agent
 interface NodeData {
@@ -146,8 +150,9 @@ export function MiniDashboard() {
   // Track previous offline count for notifications
   const prevOfflineCountRef = useRef<number>(0)
 
-  // Request notification permission on mount
+  // Track widget load in GA4 and request notification permission
   useEffect(() => {
+    emitWidgetLoaded(isStandalone() ? 'standalone' : 'browser')
     if ('Notification' in window && Notification.permission === 'default') {
       Notification.requestPermission()
     }
@@ -172,17 +177,20 @@ export function MiniDashboard() {
         notification.onclick = () => {
           window.focus()
           if (firstOfflineNode) {
-            // Build deep link URL to node drilldown
+            // Build deep link URL to node drilldown with widget campaign attribution
             const params = new URLSearchParams({
               drilldown: 'node',
               cluster: firstOfflineNode.cluster || 'unknown',
               node: firstOfflineNode.name,
               issue: 'Node went offline',
+              utm_source: 'widget',
+              utm_medium: 'notification',
+              utm_campaign: 'widget-usage',
             })
             window.location.href = `${window.location.origin}/?${params.toString()}`
           } else {
             // Fallback to main dashboard
-            window.location.href = window.location.origin + '/'
+            window.location.href = `${window.location.origin}/?${WIDGET_UTM_PARAMS}`
           }
           notification.close()
         }
@@ -248,15 +256,16 @@ export function MiniDashboard() {
     await installPrompt.prompt()
     const result = await installPrompt.userChoice
     if (result.outcome === 'accepted') {
+      emitWidgetInstalled('pwa-prompt')
       setIsInstalled(true)
       setInstallPrompt(null)
     }
   }
 
-  // Open URL in system browser (not in PWA)
-  // Use a different origin (127.0.0.1 vs localhost) to force browser window
+  // Open URL in system browser (not in PWA) with GA4 widget campaign attribution.
+  // Swaps localhost <-> 127.0.0.1 to force Chrome to open in a browser window.
   const openInBrowser = useCallback((path: string) => {
-    // Swap localhost <-> 127.0.0.1 to force Chrome to open in browser
+    emitWidgetNavigation(path)
     const currentHost = window.location.host
     let targetOrigin = window.location.origin
 
@@ -266,7 +275,8 @@ export function MiniDashboard() {
       targetOrigin = window.location.origin.replace('127.0.0.1', 'localhost')
     }
 
-    window.open(`${targetOrigin}${path}`, '_blank')
+    const separator = path.includes('?') ? '&' : '?'
+    window.open(`${targetOrigin}${path}${separator}${WIDGET_UTM_PARAMS}`, '_blank')
   }, [])
 
   // Open full dashboard in new window

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -567,6 +567,28 @@ export function emitClusterStatsDrillDown(statType: string) {
   send('ksc_cluster_stats_drill_down', { stat_type: statType })
 }
 
+// ── Widget Tracking ─────────────────────────────────────────────────
+
+/** Fired once when the PWA mini-dashboard mounts (tracks active widget users) */
+export function emitWidgetLoaded(mode: 'standalone' | 'browser') {
+  send('ksc_widget_loaded', { mode })
+}
+
+/** Fired when a user clicks a stat card in the widget to open the full console */
+export function emitWidgetNavigation(targetPath: string) {
+  send('ksc_widget_navigation', { target_path: targetPath })
+}
+
+/** Fired when the PWA install prompt is accepted */
+export function emitWidgetInstalled(method: 'pwa-prompt' | 'safari-dock') {
+  send('ksc_widget_installed', { method })
+}
+
+/** Fired when the Übersicht widget JSX file is downloaded from settings */
+export function emitWidgetDownloaded(widgetType: 'uebersicht' | 'browser') {
+  send('ksc_widget_downloaded', { widget_type: widgetType })
+}
+
 // ── UTM Tracking ───────────────────────────────────────────────────
 
 let utmParams: Record<string, string> = {}


### PR DESCRIPTION
## Summary
- Adds 4 new GA4 events for widget lifecycle tracking: `ksc_widget_loaded`, `ksc_widget_navigation`, `ksc_widget_installed`, `ksc_widget_downloaded`
- All widget click-throughs to the full console include UTM params (`utm_campaign=widget-usage`) for campaign attribution
- Notification deep-links use `utm_medium=notification` to distinguish from direct widget clicks (`utm_medium=pwa`)
- Übersicht widget downloads and browser widget opens from Settings are tracked via `ksc_widget_downloaded`

## GA4 events

| Event | When | Key params |
|-------|------|------------|
| `ksc_widget_loaded` | PWA widget mounts | `mode`: standalone/browser |
| `ksc_widget_navigation` | User clicks a stat to open full console | `target_path`: e.g. /clusters |
| `ksc_widget_installed` | PWA install prompt accepted | `method`: pwa-prompt |
| `ksc_widget_downloaded` | Übersicht JSX downloaded or browser widget opened from Settings | `widget_type`: uebersicht/browser |

## Campaign attribution

| Source | utm_source | utm_medium | utm_campaign |
|--------|-----------|------------|--------------|
| Widget stat click | widget | pwa | widget-usage |
| Widget notification | widget | notification | widget-usage |
| Share button (missions) | mission-explorer | share-link | mission-sharing |

## Test plan
- [ ] Open `/widget` → check GA4 Realtime for `ksc_widget_loaded` event
- [ ] Click any stat card in widget → verify new browser tab URL has `utm_campaign=widget-usage`
- [ ] Settings → Widget → Download Übersicht → check for `ksc_widget_downloaded`
- [ ] Settings → Widget → Open Browser Widget → check for `ksc_widget_downloaded`