### PR TITLE
✨ Add llm-d tags to widget tooltips and remove hardcoded widget URLs

### DIFF
--- a/web/src/components/settings/sections/WidgetSettingsSection.tsx
+++ b/web/src/components/settings/sections/WidgetSettingsSection.tsx
@@ -5,8 +5,13 @@ import { cn } from '../../../lib/cn'
 import { TOAST_DISMISS_MS, UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { emitWidgetDownloaded } from '../../../lib/analytics'
 
-// The widget code that gets downloaded - includes drag functionality
-const WIDGET_CODE = `/**
+/** Build the Übersicht widget code with the current console origin injected.
+ *  This avoids hardcoded URLs so the widget works regardless of deployment
+ *  (localhost, cluster-deployed, console.kubestellar.io). */
+function buildWidgetCode(consoleOrigin: string): string {
+  // kc-agent always runs on the same host as the user's browser
+  const agentUrl = 'http://127.0.0.1:8585'
+  return `/**
  * KubeStellar Console - Übersicht Widget
  *
  * Draggable desktop widget for monitoring Kubernetes clusters.
@@ -20,11 +25,11 @@ const WIDGET_CODE = `/**
 
 import { css, run } from "uebersicht";
 
-export const command = \`/usr/bin/curl -s --connect-timeout 2 http://127.0.0.1:8585/nodes 2>/dev/null || echo '{"offline":true}'\`;
+export const command = \`/usr/bin/curl -s --connect-timeout 2 ${agentUrl}/nodes?source=ubersicht-widget 2>/dev/null || echo '{"offline":true}'\`;
 
 export const refreshFrequency = 30000;
 
-const CONSOLE_URL = "http://localhost:5174";
+const CONSOLE_URL = "${consoleOrigin}";
 const STORAGE_KEY = "kubestellar-widget-position";
 
 // Drag state
@@ -110,8 +115,10 @@ const handleDragEnd = () => {
   document.removeEventListener("mouseup", handleDragEnd);
 };
 
+const WIDGET_UTM = "utm_source=widget&utm_medium=ubersicht&utm_campaign=widget-usage";
 const openUrl = (path = "") => {
-  run(\`open "\${CONSOLE_URL}\${path}"\`);
+  const sep = path.includes("?") ? "&" : "?";
+  run(\`open "\${CONSOLE_URL}\${path}\${sep}\${WIDGET_UTM}"\`);
 };
 
 const styles = {
@@ -343,8 +350,8 @@ export const render = ({ output }) => {
       </div>
     </div>
   );
-};
-`;
+};`
+}
 
 interface WidgetOption {
   id: string
@@ -392,7 +399,8 @@ export function WidgetSettingsSection() {
   }, [])
 
   const handleDownload = () => {
-    const blob = new Blob([WIDGET_CODE], { type: 'text/javascript' })
+    const widgetCode = buildWidgetCode(window.location.origin)
+    const blob = new Blob([widgetCode], { type: 'text/javascript' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url
@@ -408,7 +416,7 @@ export function WidgetSettingsSection() {
   }
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(WIDGET_CODE)
+    await navigator.clipboard.writeText(buildWidgetCode(window.location.origin))
     setCopied(true)
     clearTimeout(copiedTimerRef.current)
     copiedTimerRef.current = setTimeout(() => setCopied(false), UI_FEEDBACK_TIMEOUT_MS)

--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -37,10 +37,12 @@ export function generateCardWidget(
     throw new Error(`Unknown card type: ${cardType}`)
   }
 
-  const curlUrl = resolveWidgetEndpoint(apiEndpoint, card.apiEndpoints[0])
+  const baseUrl = resolveWidgetEndpoint(apiEndpoint, card.apiEndpoints[0])
+  /** Append source param so the backend can attribute traffic from exported widgets */
+  const curlUrl = baseUrl + (baseUrl.includes('?') ? '&' : '?') + 'source=ubersicht-widget'
   const widgetName = cardType.replace(/_/g, '-')
-  // Derive the console frontend URL from the API endpoint
-  const consoleUrl = apiEndpoint.replace(/\/api$/, '').replace(/:\d+$/, ':5174')
+  // Use the API endpoint origin as the console URL (backend serves the frontend)
+  const consoleUrl = apiEndpoint.replace(/\/api$/, '')
   const shellCode = generateWidgetShell(widgetName, consoleUrl)
 
   return `/**
@@ -293,6 +295,28 @@ ${wrapOpen}
                         );
                       })()}
                       {runs.length === 1 && <div style={{fontSize: '8px', color: '#64748b'}}>Only 1 run — no trend yet</div>}
+                      {g.llmdImages && Object.keys(g.llmdImages).length > 0 && (
+                        <div style={{marginTop: 4, paddingTop: 4, borderTop: '1px solid #334155'}}>
+                          <div style={{fontSize: '8px', fontWeight: 600, color: '#64748b', marginBottom: 2}}>llm-d components</div>
+                          {Object.entries(g.llmdImages).map(([name, tag]) => (
+                            <div key={name} style={{display: 'flex', gap: 4, whiteSpace: 'nowrap'}}>
+                              <span style={{color: '#94a3b8'}}>{name}</span>
+                              <span style={{color: '#22d3ee', fontFamily: 'monospace'}}>:{String(tag)}</span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                      {g.otherImages && Object.keys(g.otherImages).length > 0 && (
+                        <div style={{marginTop: 4, paddingTop: 4, borderTop: '1px solid #334155'}}>
+                          <div style={{fontSize: '8px', fontWeight: 600, color: '#64748b', marginBottom: 2}}>other images</div>
+                          {Object.entries(g.otherImages).map(([name, tag]) => (
+                            <div key={name} style={{display: 'flex', gap: 4, whiteSpace: 'nowrap'}}>
+                              <span style={{color: '#94a3b8'}}>{name}</span>
+                              <span style={{color: '#fb923c', fontFamily: 'monospace'}}>:{String(tag)}</span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
                     </span>
                     <span style={{fontSize: '10px', color: '#cbd5e1', display: 'inline-block', width: '90px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap'}}>{g.guide}</span>
                   </span>

--- a/web/src/lib/widgets/styleConverter.ts
+++ b/web/src/lib/widgets/styleConverter.ts
@@ -366,7 +366,11 @@ const handleDragEnd = () => {
   document.removeEventListener('mouseup', handleDragEnd);
 };
 
-const openConsole = (path = '') => { run(\`open "\${CONSOLE_URL}\${path}"\`); };
+const WIDGET_UTM = 'utm_source=widget&utm_medium=ubersicht&utm_campaign=widget-usage';
+const openConsole = (path = '') => {
+  const sep = path.includes('?') ? '&' : '?';
+  run(\`open "\${CONSOLE_URL}\${path}\${sep}\${WIDGET_UTM}"\`);
+};
 
 export const className = css\`
   position: fixed;


### PR DESCRIPTION
## Summary
- **Widget nightly E2E tooltips** now show llm-d component tags (cyan) and other image tags (orange), matching the dashboard card popup
- **All widget URLs are now dynamic** — no more hardcoded `localhost:5174` or `127.0.0.1:8585`
  - Übersicht widget template injects `window.location.origin` at download/copy time
  - Exported card widgets use the user-configured API endpoint (works for localhost, cluster-deployed, console.kubestellar.io)
  - Removed hardcoded `:5174` port derivation in codeGenerator
- **Widget API attribution**: all curl URLs include `?source=ubersicht-widget`
- **Click-through UTM tracking**: all `openConsole`/`openUrl` calls append `utm_campaign=widget-usage`

## Files changed
| File | Change |
|------|--------|
| `codeGenerator.ts` | Add llm-d/other image tags to spark-tip, add `?source=` to curl URL, fix console URL derivation |
| `styleConverter.ts` | Add UTM params to `openConsole()` click-throughs |
| `WidgetSettingsSection.tsx` | Convert static WIDGET_CODE to `buildWidgetCode(origin)` function, add UTM + source params |

## Test plan
- [ ] Export a widget from any card → verify curl URL has `?source=ubersicht-widget`
- [ ] Export from localhost → verify `CONSOLE_URL` is `http://localhost:8080`
- [ ] Export from console.kubestellar.io → verify `CONSOLE_URL` is `https://console.kubestellar.io`
- [ ] Settings → Download Übersicht widget → verify no hardcoded localhost URLs
- [ ] Hover over nightly E2E widget tooltip → verify llm-d component tags appear