### PR TITLE
🐛 Include llm-d component tags in nightly E2E card tooltips

### DIFF
--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -121,6 +121,8 @@ export function useNightlyE2EData() {
                   model: g.model ?? 'Unknown',
                   gpuType: g.gpuType ?? 'Unknown',
                   gpuCount: g.gpuCount ?? 0,
+                  llmdImages: g.llmdImages,
+                  otherImages: g.otherImages,
                 }))
                 const result = { guides, isDemo: false }
                 saveCachedData(result)


### PR DESCRIPTION
## Summary
- The `useNightlyE2EData` hook was mapping API response fields to `NightlyGuideStatus` objects but **omitting `llmdImages` and `otherImages`**
- The Übersicht widget (which reads the raw API JSON) showed the tags correctly, but the dashboard card never received them
- Fix: add `llmdImages` and `otherImages` to the guide mapping (2-line fix)

## Test plan
- [ ] Open the Nightly E2E Status card on the dashboard
- [ ] Hover over a colored run dot — tooltip should show llm-d component tags (e.g., `llm-d-cuda-dev:latest`)
- [ ] Verify the Übersicht widget still shows tags as before