### PR TITLE
🐛 fix: nightly E2E cold-start shows demo data instead of skeleton

### DIFF
--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -70,6 +70,7 @@ export function useNightlyE2EData() {
     demoData: { guides: DEMO_DATA, isDemo: true },
     persist: true,
     refreshInterval,
+    demoWhenEmpty: true, // Show demo data immediately during cold start instead of skeleton loading
     liveInDemoMode: isNetlifyDeployment, // Only fetch live in demo mode on console.kubestellar.io
     fetcher: async () => {
       // Try authenticated endpoint first, then public fallback
@@ -156,10 +157,12 @@ export function useNightlyE2EData() {
 
   return {
     guides,
-    // Don't report demo fallback while still loading — the initial demo data is a
-    // loading placeholder, not confirmed demo mode. Showing the Demo badge during
-    // cache hydration is misleading and fails cache compliance tests.
-    isDemoFallback: cacheResult.isLoading ? false : isDemo,
+    // Use the cache's own isDemoFallback which correctly handles:
+    // 1. Optimistic demo during cold-start loading (showOptimisticDemo)
+    // 2. Normal demo mode when disabled
+    // 3. demoWhenEmpty fallback after fetch returns empty
+    // Don't suppress during loading — demoWhenEmpty already handles this properly.
+    isDemoFallback: cacheResult.isDemoFallback || (!cacheResult.isLoading && isDemo),
     isLoading: hasCachedInitial ? false : cacheResult.isLoading,
     isRefreshing: cacheResult.isRefreshing || (hasCachedInitial && cacheResult.isLoading),
     isFailed: cacheResult.isFailed,


### PR DESCRIPTION
## Summary
- Adds `demoWhenEmpty: true` to the nightly E2E `useCache` call, enabling the cache's optimistic demo mode
- On cold start (no localStorage cache), demo data renders immediately while live fetch runs in background
- Eliminates the multi-minute skeleton loading caused by exponential backoff (5min → 10min intervals)

## Root cause
When `nightly-e2e-cache` localStorage is empty (first visit or after clearing), the `useCache` hook starts with empty initial data and fetches from the API. If the first fetch fails or times out, the exponential backoff doubles the 5-minute refresh interval to 10 minutes before retrying. With `MAX_FAILURES=3`, the card could be stuck in skeleton loading for up to 25 minutes.

## Fix
`demoWhenEmpty: true` activates the cache's `showOptimisticDemo` path — demo data is shown immediately (with Demo badge + refresh indicator) while the live fetch runs asynchronously. Once the fetch succeeds, real data replaces the demo seamlessly.

## Test plan
- [ ] Clear `nightly-e2e-cache` from localStorage
- [ ] Reload page — card should show demo data immediately (not skeleton)
- [ ] Demo badge should appear during loading
- [ ] Once live data loads, demo badge disappears and real data shows
- [ ] Normal flow (with cache) unchanged — shows cached data instantly