### PR TITLE
🐛 Fix GA4 0s engagement time and blocked OpenShift analytics

### DIFF
--- a/pkg/api/handlers/analytics_proxy.go
+++ b/pkg/api/handlers/analytics_proxy.go
@@ -125,12 +125,17 @@ func GA4CollectProxy(c *fiber.Ctx) error {
 }
 
 // isAllowedOrigin checks if the request comes from an allowed hostname.
+// In addition to the explicit allowlist, same-origin requests are always
+// permitted — this ensures OpenShift and other dynamic deployments work
+// without maintaining an exhaustive hostname list.
 func isAllowedOrigin(c *fiber.Ctx) bool {
+	requestHost := stripPort(c.Hostname())
+
 	origin := c.Get("Origin")
 	if origin != "" {
 		if u, err := url.Parse(origin); err == nil {
 			host := stripPort(u.Hostname())
-			if allowedOrigins[host] || strings.HasSuffix(host, ".netlify.app") {
+			if allowedOrigins[host] || strings.HasSuffix(host, ".netlify.app") || host == requestHost {
 				return true
 			}
 		}
@@ -140,7 +145,7 @@ func isAllowedOrigin(c *fiber.Ctx) bool {
 	if referer != "" {
 		if u, err := url.Parse(referer); err == nil {
 			host := stripPort(u.Hostname())
-			if allowedOrigins[host] || strings.HasSuffix(host, ".netlify.app") {
+			if allowedOrigins[host] || strings.HasSuffix(host, ".netlify.app") || host == requestHost {
 				return true
 			}
 		}

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -87,6 +87,7 @@ function startEngagementTracking() {
         accumulatedEngagementMs += Date.now() - engagementStartMs
         isUserActive = false
       }
+      emitUserEngagement() // Flush engagement to GA4 before tab goes away
     } else {
       markActive()
     }
@@ -104,6 +105,25 @@ function stopEngagementTracking() {
   if (heartbeatTimer) {
     clearInterval(heartbeatTimer)
     heartbeatTimer = null
+  }
+}
+
+/**
+ * Emit a user_engagement event to GA4 with accumulated engagement time.
+ * GA4 calculates Average Engagement Time exclusively from this event type —
+ * the _et parameter on other events (page_view, custom events) is ignored
+ * for engagement metrics.
+ *
+ * Note: We do NOT call getAndResetEngagementMs() here because send() already
+ * calls it internally to set the _et parameter. Calling it here would reset
+ * the accumulator before send() reads it, resulting in _et=0.
+ */
+function emitUserEngagement() {
+  // Check if there's accumulated engagement without resetting.
+  // send() will handle getting and resetting the actual value via _et.
+  const hasEngagement = accumulatedEngagementMs > 0 || (isUserActive && Date.now() - engagementStartMs > 0)
+  if (hasEngagement) {
+    send('user_engagement', {})
   }
 }
 
@@ -263,6 +283,9 @@ export function initAnalytics() {
   // Start tracking user engagement for GA4 engagement time metrics
   startEngagementTracking()
 
+  // Flush engagement on page close (Safari doesn't always fire visibilitychange)
+  window.addEventListener('beforeunload', emitUserEngagement)
+
   // Track unhandled errors globally for error categorization
   startGlobalErrorTracking()
 
@@ -319,6 +342,8 @@ export function isAnalyticsOptedOut(): boolean {
 // ── Page views ─────────────────────────────────────────────────────
 
 export function emitPageView(path: string) {
+  emitUserEngagement() // Flush previous page's engagement time before new page_view
+  pageId = rand()      // New page ID for the new page
   send('page_view', { page_path: path, ksc_demo_mode: isDemoMode() ? 'true' : 'false' })
 }
 


### PR DESCRIPTION
## Summary
- **Fix 0s Average Engagement Time**: GA4 calculates engagement time exclusively from `user_engagement` events. Our custom analytics tracked time correctly but never emitted this event type. Now emits `user_engagement` on tab hide, page unload, and SPA navigation.
- **Unblock OpenShift analytics**: Origin validation only whitelisted `localhost`, `127.0.0.1`, `console.kubestellar.io`, and `*.netlify.app`. OpenShift hostnames (vllm-d, pok-prod) were rejected with 403. Added same-origin check so any self-hosted deployment accepts its own analytics.

## Test plan
- [ ] Start console locally, navigate between pages
- [ ] Open DevTools → Network → filter `/api/m`
- [ ] Switch to another tab and back — verify `en=user_engagement` with `_et` > 0 in decoded payload
- [ ] Verify page_view events still fire on navigation
- [ ] After deploy: GA4 Average Engagement Time should be >0s within 24-48h