### PR TITLE
✨ Backend: IAM auth method detection + cloud CLI status endpoint

### DIFF
--- a/pkg/agent/kubectl.go
+++ b/pkg/agent/kubectl.go
@@ -52,9 +52,11 @@ func (k *KubectlProxy) ListContexts() ([]protocol.ClusterInfo, string) {
 		if cluster != nil {
 			server = cluster.Server
 		}
+		authMethod := detectAuthMethod(k.config.AuthInfos[ctx.AuthInfo])
 		clusters = append(clusters, protocol.ClusterInfo{
 			Name: name, Context: name, Server: server,
-			User: ctx.AuthInfo, Namespace: ctx.Namespace, IsCurrent: name == current,
+			User: ctx.AuthInfo, Namespace: ctx.Namespace,
+			AuthMethod: authMethod, IsCurrent: name == current,
 		})
 	}
 	return clusters, current
@@ -583,4 +585,26 @@ func (k *KubectlProxy) TestClusterConnection(req TestConnectionRequest) (*TestCo
 		Reachable:     true,
 		ServerVersion: version.GitVersion,
 	}, nil
+}
+
+// detectAuthMethod examines a kubeconfig AuthInfo entry and returns the auth
+// method in use: "exec" (IAM/cloud CLI), "token", "certificate",
+// "auth-provider", or "unknown".
+func detectAuthMethod(ai *api.AuthInfo) string {
+	if ai == nil {
+		return "unknown"
+	}
+	if ai.Exec != nil {
+		return "exec"
+	}
+	if ai.Token != "" || ai.TokenFile != "" {
+		return "token"
+	}
+	if len(ai.ClientCertificateData) > 0 || ai.ClientCertificate != "" {
+		return "certificate"
+	}
+	if ai.AuthProvider != nil {
+		return "auth-provider"
+	}
+	return "unknown"
 }

--- a/pkg/agent/protocol/messages.go
+++ b/pkg/agent/protocol/messages.go
@@ -70,12 +70,13 @@ type ClustersPayload struct {
 
 // ClusterInfo represents a kubeconfig context
 type ClusterInfo struct {
-	Name      string `json:"name"`
-	Context   string `json:"context"`
-	Server    string `json:"server"`
-	User      string `json:"user,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	IsCurrent bool   `json:"isCurrent"`
+	Name       string `json:"name"`
+	Context    string `json:"context"`
+	Server     string `json:"server"`
+	User       string `json:"user,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	AuthMethod string `json:"authMethod,omitempty"` // exec, token, certificate, auth-provider, unknown
+	IsCurrent  bool   `json:"isCurrent"`
 }
 
 // KubectlRequest is the payload for kubectl commands

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -323,6 +323,9 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/kagenti/tools", s.handleKagentiTools)
 	mux.HandleFunc("/kagenti/summary", s.handleKagentiSummary)
 
+	// Cloud CLI status (detects installed cloud CLIs for IAM auth guidance)
+	mux.HandleFunc("/cloud-cli-status", s.handleCloudCLIStatus)
+
 	// Local cluster management endpoints
 	mux.HandleFunc("/local-cluster-tools", s.handleLocalClusterTools)
 	mux.HandleFunc("/local-clusters", s.handleLocalClusters)
@@ -3821,6 +3824,49 @@ func (s *Server) sendNativeNotification(alerts []DeviceAlert) {
 			log.Printf("[DeviceTracker] Failed to send notification: %v", err)
 		}
 	}()
+}
+
+// cloudCLI describes a cloud provider CLI binary and its purpose.
+type cloudCLI struct {
+	Name     string `json:"name"`     // Binary name (e.g. "aws")
+	Provider string `json:"provider"` // Cloud provider label
+	Found    bool   `json:"found"`    // Whether the binary is on PATH
+	Path     string `json:"path,omitempty"`
+}
+
+// handleCloudCLIStatus detects installed cloud CLIs (aws, gcloud, az, oc)
+// so the frontend can show provider-specific IAM auth guidance.
+func (s *Server) handleCloudCLIStatus(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	clis := []cloudCLI{
+		{Name: "aws", Provider: "AWS EKS"},
+		{Name: "gcloud", Provider: "Google GKE"},
+		{Name: "az", Provider: "Azure AKS"},
+		{Name: "oc", Provider: "OpenShift"},
+	}
+
+	for i := range clis {
+		if p, err := exec.LookPath(clis[i].Name); err == nil {
+			clis[i].Found = true
+			clis[i].Path = p
+		}
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"clis": clis,
+	})
 }
 
 // handleLocalClusterTools returns detected local cluster tools

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -148,16 +148,17 @@ func (m *MultiClusterClient) Reload() error {
 
 // ClusterInfo represents basic cluster information
 type ClusterInfo struct {
-	Name      string `json:"name"`
-	Context   string `json:"context"`
-	Server    string `json:"server,omitempty"`
-	User      string `json:"user,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
-	Healthy   bool   `json:"healthy"`
-	Source    string `json:"source,omitempty"`
-	NodeCount int    `json:"nodeCount,omitempty"`
-	PodCount  int    `json:"podCount,omitempty"`
-	IsCurrent bool   `json:"isCurrent,omitempty"`
+	Name       string `json:"name"`
+	Context    string `json:"context"`
+	Server     string `json:"server,omitempty"`
+	User       string `json:"user,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	AuthMethod string `json:"authMethod,omitempty"` // exec, token, certificate, auth-provider, unknown
+	Healthy    bool   `json:"healthy"`
+	Source     string `json:"source,omitempty"`
+	NodeCount  int    `json:"nodeCount,omitempty"`
+	PodCount   int    `json:"podCount,omitempty"`
+	IsCurrent  bool   `json:"isCurrent,omitempty"`
 }
 
 // ClusterHealth represents cluster health status
@@ -929,13 +930,29 @@ func (m *MultiClusterClient) ListClusters(ctx context.Context) ([]ClusterInfo, e
 			// Get the user name from the AuthInfo reference
 			user := contextInfo.AuthInfo
 
+			// Detect auth method from kubeconfig AuthInfo
+			authMethod := "unknown"
+			if ai, ok := rawConfig.AuthInfos[contextInfo.AuthInfo]; ok && ai != nil {
+				switch {
+				case ai.Exec != nil:
+					authMethod = "exec"
+				case ai.Token != "" || ai.TokenFile != "":
+					authMethod = "token"
+				case len(ai.ClientCertificateData) > 0 || ai.ClientCertificate != "":
+					authMethod = "certificate"
+				case ai.AuthProvider != nil:
+					authMethod = "auth-provider"
+				}
+			}
+
 			clusters = append(clusters, ClusterInfo{
-				Name:      contextName,
-				Context:   contextName,
-				Server:    server,
-				User:      user,
-				Source:    "kubeconfig",
-				IsCurrent: contextName == currentContext,
+				Name:       contextName,
+				Context:    contextName,
+				Server:     server,
+				User:       user,
+				AuthMethod: authMethod,
+				Source:     "kubeconfig",
+				IsCurrent:  contextName == currentContext,
 			})
 		}
 	}
@@ -1262,14 +1279,17 @@ func classifyError(errMsg string) string {
 		return "timeout"
 	}
 
-	// Auth errors
+	// Auth errors (includes exec-plugin / IAM failures)
 	if strings.Contains(lowerMsg, "401") ||
 		strings.Contains(lowerMsg, "403") ||
 		strings.Contains(lowerMsg, "unauthorized") ||
 		strings.Contains(lowerMsg, "forbidden") ||
 		strings.Contains(lowerMsg, "authentication") ||
 		strings.Contains(lowerMsg, "invalid token") ||
-		strings.Contains(lowerMsg, "token expired") {
+		strings.Contains(lowerMsg, "token expired") ||
+		strings.Contains(lowerMsg, "exec plugin") ||
+		strings.Contains(lowerMsg, "getting credentials") ||
+		(strings.Contains(lowerMsg, "executable") && strings.Contains(lowerMsg, "not found")) {
 		return "auth"
 	}
 


### PR DESCRIPTION
## Summary
- Adds `authMethod` field to `ClusterInfo` structs (both agent protocol and backend k8s) to expose which authentication method each cluster uses: `exec` (IAM/cloud CLI), `token`, `certificate`, `auth-provider`, or `unknown`
- Adds `detectAuthMethod()` helper that inspects kubeconfig `AuthInfo` entries to determine the auth method
- Improves `classifyError()` to recognize exec-plugin failures (missing binary, credential errors, getting credentials) as `auth` errors — enabling actionable frontend error messages
- Adds `/cloud-cli-status` endpoint that detects installed cloud CLIs (`aws`, `gcloud`, `az`, `oc`) so the frontend can show provider-specific IAM auth guidance

## Context
Operators on multi-cloud environments (AWS EKS, GKE, AKS, OpenShift) need IAM authentication support. Since `client-go` already handles exec plugins transparently via kubeconfig `exec:` blocks, the gap is purely UX — this PR provides the backend data needed for the frontend to show auth method badges, provider-specific error guidance, and cloud CLI availability.

## Test plan
- [ ] `go build ./...` passes
- [ ] Clusters with exec-plugin auth show `authMethod: "exec"` in `/clusters` response
- [ ] Clusters with token auth show `authMethod: "token"`
- [ ] `/cloud-cli-status` returns detected CLIs with paths
- [ ] Exec-plugin errors (missing binary, expired credentials) classified as `auth` error type