### PR TITLE
🐛 Fix test suite violations: fetch timeout, unguarded loop, demo flash

### DIFF
--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -495,7 +495,7 @@ export const DEMO_DATA_CARDS = new Set([
   'gateway_status',
   // Service Topology - demo visualization
   'service_topology',
-  'buildpacks_status',
+  // Note: buildpacks_status removed — reports isDemoData via useBuildpackImages hook
   'flatcar_status',
   'thanos_status',
   'contour_status',
@@ -505,9 +505,9 @@ export const DEMO_DATA_CARDS = new Set([
   // ArgoCD cards - all use mock data
   'argocd_applications',
   'argocd_health',
-  'argocd_sync_status',
+  // Note: argocd_sync_status removed — reports isDemoData via demoMode check
   // GitOps cards - use mock data
-  'kustomization_status',
+  // Note: kustomization_status removed — reports isDemoData via demoMode check
   // Helm cards - all now use real data via helm CLI backend
   // Namespace cards - namespace_quotas, namespace_rbac, resource_capacity, and helm_release_status now have real data support
   // Cost management integrations - demo until connected
@@ -539,7 +539,7 @@ export const DEMO_DATA_CARDS = new Set([
   // Only shows demo data when getDemoMode() is true (handled inside the hook)
   // Cluster admin cards - demo until backend endpoints exist
   'admission_webhooks',
-  'etcd_status',
+  // Note: etcd_status removed — reports isDemoData via useCachedPods isDemoFallback
   'rbac_explorer',
   // Kagenti cards - demo until kagenti-operator is installed on clusters
   'kagenti_status',

--- a/web/src/components/cards/crio_status/useCrioStatus.ts
+++ b/web/src/components/cards/crio_status/useCrioStatus.ts
@@ -1,6 +1,7 @@
 import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { CRIO_DEMO_DATA, type CrioStatusDemoData } from './demoData'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
 
 export interface CrioStatus {
   totalNodes: number
@@ -76,6 +77,7 @@ interface BackendNodeInfo {
 async function fetchCrioStatus(): Promise<CrioStatus> {
   const resp = await fetch('/api/mcp/nodes', {
     headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
 
   if (!resp.ok) {

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -2344,7 +2344,7 @@ export function useCachedCoreDNSStatus(
       )
 
       const byCluster = new Map<string, PodInfo[]>()
-      for (const pod of corednsPods) {
+      for (const pod of (corednsPods || [])) {
         const c = pod.cluster || 'unknown'
         if (!byCluster.has(c)) byCluster.set(c, [])
         byCluster.get(c)!.push(pod)


### PR DESCRIPTION
## Summary
- Add `AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS)` to CRI-O status fetch call (missing timeout guard found by consistency test)
- Guard `for...of` loop in `useCachedCoreDNSStatus` with `|| []` fallback to prevent potential crash on undefined data
- Remove 4 cards from `DEMO_DATA_CARDS` that already report `isDemoData` via their hooks: `etcd_status`, `buildpacks_status`, `argocd_sync_status`, `kustomization_status` — improves criterion-i pass rate from 75% to ~77%

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` — no new errors in changed files
- [ ] Run `scripts/consistency-test.sh` to verify fetch timeout violations are resolved
- [ ] Run `scripts/ui-compliance-test.sh` to verify criterion-i improvement