### PR TITLE
🐛 Fix nilaway nil-safety violations in settings and config managers

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -58,6 +58,14 @@ func GetConfigManager() *ConfigManager {
 		// Load existing config if present
 		globalConfigManager.Load()
 	})
+	// Guard satisfies nilaway: sync.Once guarantees init but static analysis
+	// cannot prove the global is non-nil after Do().
+	if globalConfigManager == nil {
+		globalConfigManager = &ConfigManager{
+			config:      &AgentConfig{Agents: make(map[string]AgentKeyConfig)},
+			keyValidity: make(map[string]bool),
+		}
+	}
 	return globalConfigManager
 }
 

--- a/pkg/settings/manager.go
+++ b/pkg/settings/manager.go
@@ -58,6 +58,13 @@ func GetSettingsManager() *SettingsManager {
 			globalSettingsManager.settings = DefaultSettings()
 		}
 	})
+	// Guard satisfies nilaway: sync.Once guarantees init but static analysis
+	// cannot prove the global is non-nil after Do().
+	if globalSettingsManager == nil {
+		globalSettingsManager = &SettingsManager{
+			settings: DefaultSettings(),
+		}
+	}
 	return globalSettingsManager
 }
 
@@ -167,6 +174,11 @@ func (sm *SettingsManager) GetAll() (*AllSettings, error) {
 		Widget:        sm.settings.Settings.Widget,
 		APIKeys:       make(map[string]APIKeyEntry),
 		Notifications: NotificationSecrets{},
+	}
+
+	// Cannot decrypt without an encryption key (init may have failed)
+	if sm.key == nil {
+		return all, nil
 	}
 
 	// Decrypt API keys
@@ -367,11 +379,17 @@ func (sm *SettingsManager) ImportEncrypted(data []byte) error {
 
 // GetSettingsPath returns the path to the settings file
 func (m *SettingsManager) GetSettingsPath() string {
+	if m == nil {
+		return ""
+	}
 	return m.settingsPath
 }
 
 // SetSettingsPath sets the path to the settings file (for testing)
 func (m *SettingsManager) SetSettingsPath(path string) {
+	if m == nil {
+		return
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.settingsPath = path
@@ -379,6 +397,9 @@ func (m *SettingsManager) SetSettingsPath(path string) {
 
 // SetKeyPath sets the path to the encryption key file (for testing)
 func (m *SettingsManager) SetKeyPath(path string) {
+	if m == nil {
+		return
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.keyPath = path


### PR DESCRIPTION
## Summary
- Add nil guards after `sync.Once` in `GetSettingsManager()` and `GetConfigManager()` — nilaway cannot prove `sync.Once` guarantees non-nil, so an explicit check satisfies the analyzer
- Add `sm.key == nil` early return in `GetAll()` before decrypt calls (handles failed init gracefully)
- Add nil receiver checks on `GetSettingsPath()`, `SetSettingsPath()`, `SetKeyPath()`

Fixes all 13+ nilaway findings in `pkg/settings/manager.go` and `pkg/agent/config.go`.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/settings/... ./pkg/agent/...` passes
- [ ] Nil Safety CI check passes