### PR TITLE
✨ Nightly E2E: dynamically fetch component image versions from guide YAML files

### DIFF
--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -2,10 +2,12 @@
 package handlers
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -14,8 +16,9 @@ import (
 )
 
 const (
-	nightlyCacheIdleTTL   = 5 * time.Minute // cache when no jobs running
-	nightlyCacheActiveTTL = 2 * time.Minute // cache when jobs are in progress
+	nightlyCacheIdleTTL   = 5 * time.Minute  // cache when no jobs running
+	nightlyCacheActiveTTL = 2 * time.Minute  // cache when jobs are in progress
+	imageCacheTTL         = 30 * time.Minute // image tags change less frequently
 	nightlyRunsPerPage    = 7
 	githubAPIBase         = "https://api.github.com"
 
@@ -25,7 +28,18 @@ const (
 	maxLogBytes     = 200_000          // 200KB tail per job log
 	logCacheTTL     = 10 * time.Minute // immutable once run completes
 	maxLogFetchJobs = 5                // limit concurrent job log fetches
+
+	// imageRepo is the GitHub repo whose guide directories contain image references
+	imageRepo = "llm-d/llm-d"
 )
+
+// imageRe matches direct image references: ghcr.io/llm-d/<name>:<tag>
+var imageRe = regexp.MustCompile(`ghcr\.io/llm-d/([\w][\w.-]*?):([\w][\w.+-]*)`)
+
+// hubRe matches the hub/name/tag EPP pattern (hub: ghcr.io/llm-d)
+var hubRe = regexp.MustCompile(`(?i)hub:\s*ghcr\.io/llm-d\b`)
+var nameRe = regexp.MustCompile(`(?i)name:\s*([\w][\w.-]*)`)
+var tagRe = regexp.MustCompile(`(?i)tag:\s*([\w][\w.+-]*)`)
 
 // NightlyWorkflow defines a GitHub Actions workflow to monitor.
 type NightlyWorkflow struct {
@@ -37,7 +51,8 @@ type NightlyWorkflow struct {
 	Model        string            `json:"model"`
 	GPUType      string            `json:"gpuType"`
 	GPUCount     int               `json:"gpuCount"`
-	LLMDImages   map[string]string `json:"llmdImages"`   // llm-d component → tag
+	GuidePath    string            `json:"-"`            // directory under guides/ in llm-d/llm-d repo
+	LLMDImages   map[string]string `json:"llmdImages"`   // llm-d component → tag (populated dynamically)
 	OtherImages  map[string]string `json:"otherImages"`  // non-llm-d containers → tag
 }
 
@@ -108,59 +123,36 @@ type NightlyE2EHandler struct {
 	logMu       sync.RWMutex
 	logCache    map[string]*RunLogsResponse // key: "repo/runId"
 	logCacheExp map[string]time.Time
+
+	imgMu       sync.RWMutex
+	imgCache    map[string]map[string]string // guidePath → image name → tag
+	imgCacheExp time.Time
 }
 
-// Component image tags used by each guide type (shared across platforms).
-// The main vLLM image (llm-d-cuda-dev:latest) is overridden nightly via image_override.
-var (
-	// imgCudaDev is the nightly-built dev image used by most guides
-	imgCudaDev = map[string]string{"llm-d-cuda-dev": "latest"}
-
-	// imgPD adds the routing sidecar to the base image set
-	imgPD = map[string]string{"llm-d-cuda-dev": "latest", "llm-d-routing-sidecar": "v0.5.0"}
-
-	// imgPPC adds the UDS tokenizer to the base image set
-	imgPPC = map[string]string{"llm-d-cuda-dev": "latest", "llm-d-uds-tokenizer": "v0.5.1-rc1"}
-
-	// imgSA uses the inference simulator instead of cuda-dev
-	imgSA = map[string]string{"llm-d-inference-sim": "v0.7.1", "llm-d-routing-sidecar": "v0.5.0"}
-
-	// imgWEP adds the routing sidecar for wide EP
-	imgWEP = map[string]string{"llm-d-cuda-dev": "latest", "llm-d-routing-sidecar": "v0.5.0"}
-
-	// imgWVA adds the workload variant autoscaler (tag is dynamic, rebuilt nightly)
-	imgWVA = map[string]string{"llm-d-cuda-dev": "latest", "llm-d-workload-variant-autoscaler": "nightly"}
-
-	// imgTPC uses only the base cuda-dev image
-	imgTPC = map[string]string{"llm-d-cuda-dev": "latest"}
-
-	// imgBM uses the base image for benchmarking
-	imgBM = map[string]string{"llm-d-cuda-dev": "latest"}
-)
-
 // nightlyWorkflows is the canonical list of nightly E2E workflows to monitor.
-// Model/GPU metadata is sourced from each workflow's YAML in GitHub Actions.
+// GuidePath maps to the directory under guides/ in llm-d/llm-d whose YAML files
+// contain the image references. LLMDImages is populated dynamically at runtime.
 var nightlyWorkflows = []NightlyWorkflow{
 	// OCP — all OCP guides run on H100 except WVA (A100) and SA (CPU)
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-ocp.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "OCP", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, LLMDImages: imgCudaDev},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-ocp.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, LLMDImages: imgPD},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-precise-prefix-cache-ocp.yaml", Guide: "Precise Prefix Cache", Acronym: "PPC", Platform: "OCP", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, LLMDImages: imgPPC},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-simulated-accelerators.yaml", Guide: "Simulated Accelerators", Acronym: "SA", Platform: "OCP", Model: "Simulated", GPUType: "CPU", GPUCount: 0, LLMDImages: imgSA},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-tiered-prefix-cache-ocp.yaml", Guide: "Tiered Prefix Cache", Acronym: "TPC", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 1, LLMDImages: imgTPC},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-ocp.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, LLMDImages: imgWEP},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-ocp.yaml", Guide: "WVA", Acronym: "WVA", Platform: "OCP", Model: "Llama-3.1-8B", GPUType: "A100", GPUCount: 2, LLMDImages: imgWVA},
-	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-ocp.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "OCP", Model: "opt-125m", GPUType: "A100", GPUCount: 1, LLMDImages: imgBM},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-ocp.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "OCP", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, GuidePath: "inference-scheduling"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-ocp.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, GuidePath: "pd-disaggregation"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-precise-prefix-cache-ocp.yaml", Guide: "Precise Prefix Cache", Acronym: "PPC", Platform: "OCP", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, GuidePath: "precise-prefix-cache-aware"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-simulated-accelerators.yaml", Guide: "Simulated Accelerators", Acronym: "SA", Platform: "OCP", Model: "Simulated", GPUType: "CPU", GPUCount: 0, GuidePath: "simulated-accelerators"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-tiered-prefix-cache-ocp.yaml", Guide: "Tiered Prefix Cache", Acronym: "TPC", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 1, GuidePath: "tiered-prefix-cache"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-ocp.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "OCP", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, GuidePath: "wide-ep-lws"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-ocp.yaml", Guide: "WVA", Acronym: "WVA", Platform: "OCP", Model: "Llama-3.1-8B", GPUType: "A100", GPUCount: 2, GuidePath: "workload-autoscaling"},
+	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-ocp.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "OCP", Model: "opt-125m", GPUType: "A100", GPUCount: 1},
 	// GKE — all GKE guides run on L4
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-gke.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "GKE", Model: "Qwen3-32B", GPUType: "L4", GPUCount: 2, LLMDImages: imgCudaDev},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-gke.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "GKE", Model: "Qwen3-0.6B", GPUType: "L4", GPUCount: 2, LLMDImages: imgPD},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-gke.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "GKE", Model: "Qwen3-0.6B", GPUType: "L4", GPUCount: 2, LLMDImages: imgWEP},
-	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-gke.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "GKE", Model: "opt-125m", GPUType: "L4", GPUCount: 1, LLMDImages: imgBM},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-gke.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "GKE", Model: "Qwen3-32B", GPUType: "L4", GPUCount: 2, GuidePath: "inference-scheduling"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-gke.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "GKE", Model: "Qwen3-0.6B", GPUType: "L4", GPUCount: 2, GuidePath: "pd-disaggregation"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-gke.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "GKE", Model: "Qwen3-0.6B", GPUType: "L4", GPUCount: 2, GuidePath: "wide-ep-lws"},
+	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nighly-benchmark-gke.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "GKE", Model: "opt-125m", GPUType: "L4", GPUCount: 1},
 	// CKS — all CKS guides run on H100
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-cks.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "CKS", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, LLMDImages: imgCudaDev},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "CKS", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, LLMDImages: imgPD},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-cks.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "CKS", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, LLMDImages: imgWEP},
-	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-cks.yaml", Guide: "WVA", Acronym: "WVA", Platform: "CKS", Model: "Llama-3.1-8B", GPUType: "H100", GPUCount: 2, LLMDImages: imgWVA},
-	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nightly-benchmark-cks.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "CKS", Model: "opt-125m", GPUType: "H100", GPUCount: 1, LLMDImages: imgBM},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-inference-scheduling-cks.yaml", Guide: "Inference Scheduling", Acronym: "IS", Platform: "CKS", Model: "Qwen3-32B", GPUType: "H100", GPUCount: 2, GuidePath: "inference-scheduling"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", Guide: "PD Disaggregation", Acronym: "PD", Platform: "CKS", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, GuidePath: "pd-disaggregation"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wide-ep-lws-cks.yaml", Guide: "Wide EP + LWS", Acronym: "WEP", Platform: "CKS", Model: "Qwen3-0.6B", GPUType: "H100", GPUCount: 2, GuidePath: "wide-ep-lws"},
+	{Repo: "llm-d/llm-d", WorkflowFile: "nightly-e2e-wva-cks.yaml", Guide: "WVA", Acronym: "WVA", Platform: "CKS", Model: "Llama-3.1-8B", GPUType: "H100", GPUCount: 2, GuidePath: "workload-autoscaling"},
+	{Repo: "llm-d/llm-d-benchmark", WorkflowFile: "ci-nightly-benchmark-cks.yaml", Guide: "Benchmarking", Acronym: "BM", Platform: "CKS", Model: "opt-125m", GPUType: "H100", GPUCount: 1},
 }
 
 // NewNightlyE2EHandler creates a handler using the given GitHub token for API access.
@@ -171,6 +163,7 @@ func NewNightlyE2EHandler(githubToken string) *NightlyE2EHandler {
 		httpClient:  &http.Client{Timeout: 30 * time.Second},
 		logCache:    make(map[string]*RunLogsResponse),
 		logCacheExp: make(map[string]time.Time),
+		imgCache:    make(map[string]map[string]string),
 	}
 	go h.prewarm()
 	return h
@@ -234,6 +227,7 @@ func (h *NightlyE2EHandler) fetchAll() (*NightlyE2EResponse, error) {
 		err  error
 	}
 
+	// Fetch workflow runs and guide images concurrently
 	ch := make(chan result, len(nightlyWorkflows))
 	for i, wf := range nightlyWorkflows {
 		go func(idx int, wf NightlyWorkflow) {
@@ -242,6 +236,9 @@ func (h *NightlyE2EHandler) fetchAll() (*NightlyE2EResponse, error) {
 		}(i, wf)
 	}
 
+	// Fetch dynamic image tags (cached separately with longer TTL)
+	guideImages := h.getGuideImages()
+
 	// Collect results
 	runsByIdx := make(map[int][]NightlyRun, len(nightlyWorkflows))
 	for range nightlyWorkflows {
@@ -249,7 +246,6 @@ func (h *NightlyE2EHandler) fetchAll() (*NightlyE2EResponse, error) {
 		if r.err == nil {
 			runsByIdx[r.idx] = r.runs
 		}
-		// Workflows that 404 (not yet created) just get empty runs
 	}
 
 	guides := make([]NightlyGuideStatus, len(nightlyWorkflows))
@@ -267,6 +263,13 @@ func (h *NightlyE2EHandler) fetchAll() (*NightlyE2EResponse, error) {
 				latest = &s
 			}
 		}
+
+		// Use dynamically fetched images for this guide
+		images := guideImages[wf.GuidePath]
+		if images == nil {
+			images = map[string]string{}
+		}
+
 		guides[i] = NightlyGuideStatus{
 			Guide:            wf.Guide,
 			Acronym:          wf.Acronym,
@@ -280,7 +283,7 @@ func (h *NightlyE2EHandler) fetchAll() (*NightlyE2EResponse, error) {
 			Model:            wf.Model,
 			GPUType:          wf.GPUType,
 			GPUCount:         wf.GPUCount,
-			LLMDImages:       wf.LLMDImages,
+			LLMDImages:       images,
 			OtherImages:      wf.OtherImages,
 		}
 	}
@@ -425,6 +428,249 @@ func (h *NightlyE2EHandler) detectGPUFailure(repo string, runID int64) string {
 		}
 	}
 	return failureReasonTest
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic image tag fetching from guide YAML files
+// ---------------------------------------------------------------------------
+
+// getGuideImages returns cached image maps or fetches fresh ones from GitHub.
+func (h *NightlyE2EHandler) getGuideImages() map[string]map[string]string {
+	h.imgMu.RLock()
+	if h.imgCache != nil && time.Now().Before(h.imgCacheExp) {
+		result := h.imgCache
+		h.imgMu.RUnlock()
+		return result
+	}
+	h.imgMu.RUnlock()
+
+	images := h.fetchAllGuideImages()
+
+	h.imgMu.Lock()
+	h.imgCache = images
+	h.imgCacheExp = time.Now().Add(imageCacheTTL)
+	h.imgMu.Unlock()
+
+	return images
+}
+
+// fetchAllGuideImages fetches image tags for all unique guide paths by scanning
+// YAML files in the llm-d/llm-d repo's guides/ directory via the Git Trees API.
+func (h *NightlyE2EHandler) fetchAllGuideImages() map[string]map[string]string {
+	result := make(map[string]map[string]string)
+
+	// Collect unique guide paths
+	seen := make(map[string]bool)
+	var guidePaths []string
+	for _, wf := range nightlyWorkflows {
+		if wf.GuidePath != "" && !seen[wf.GuidePath] {
+			seen[wf.GuidePath] = true
+			guidePaths = append(guidePaths, wf.GuidePath)
+		}
+	}
+
+	// Fetch the repo tree once (single API call for all file paths)
+	yamlFiles := h.fetchGuideYAMLFiles()
+
+	// For each guide, find relevant files and fetch their contents in parallel
+	type guideResult struct {
+		path   string
+		images map[string]string
+	}
+	ch := make(chan guideResult, len(guidePaths))
+
+	for _, gp := range guidePaths {
+		go func(guidePath string) {
+			prefix := "guides/" + guidePath + "/"
+			images := make(map[string]string)
+
+			// Find YAML files under this guide's directory
+			var files []treeEntry
+			for _, f := range yamlFiles {
+				if strings.HasPrefix(f.Path, prefix) {
+					files = append(files, f)
+				}
+			}
+
+			// Fetch each file and parse images (sequentially per guide to limit API calls)
+			for _, f := range files {
+				content := h.fetchBlob(f.SHA)
+				if content == "" {
+					continue
+				}
+				for k, v := range parseImagesFromYAML(content) {
+					images[k] = v
+				}
+			}
+
+			ch <- guideResult{path: guidePath, images: images}
+		}(gp)
+	}
+
+	for range guidePaths {
+		gr := <-ch
+		if len(gr.images) > 0 {
+			result[gr.path] = gr.images
+		}
+	}
+
+	return result
+}
+
+// treeEntry holds a file path and its blob SHA from the Git Trees API.
+type treeEntry struct {
+	Path string
+	SHA  string
+}
+
+// fetchGuideYAMLFiles fetches the repo tree and returns YAML files under guides/
+// that are likely to contain image references (values.yaml, decode.yaml, etc.).
+func (h *NightlyE2EHandler) fetchGuideYAMLFiles() []treeEntry {
+	url := fmt.Sprintf("%s/repos/%s/git/trees/main?recursive=1", githubAPIBase, imageRepo)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	if h.githubToken != "" {
+		req.Header.Set("Authorization", "Bearer "+h.githubToken)
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	var tree struct {
+		Tree []struct {
+			Path string `json:"path"`
+			Type string `json:"type"`
+			SHA  string `json:"sha"`
+		} `json:"tree"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tree); err != nil {
+		return nil
+	}
+
+	var results []treeEntry
+	for _, entry := range tree.Tree {
+		if entry.Type != "blob" {
+			continue
+		}
+		if !strings.HasPrefix(entry.Path, "guides/") {
+			continue
+		}
+		if !strings.HasSuffix(entry.Path, ".yaml") {
+			continue
+		}
+		// Only scan files likely to contain image references
+		name := entry.Path[strings.LastIndex(entry.Path, "/")+1:]
+		if name == "values.yaml" || name == "decode.yaml" || name == "prefill.yaml" ||
+			strings.Contains(name, "inferencepool") {
+			results = append(results, treeEntry{Path: entry.Path, SHA: entry.SHA})
+		}
+	}
+
+	return results
+}
+
+// fetchBlob fetches a git blob's content by SHA and returns it decoded.
+func (h *NightlyE2EHandler) fetchBlob(sha string) string {
+	url := fmt.Sprintf("%s/repos/%s/git/blobs/%s", githubAPIBase, imageRepo, sha)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	if h.githubToken != "" {
+		req.Header.Set("Authorization", "Bearer "+h.githubToken)
+	}
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+
+	var blob struct {
+		Content  string `json:"content"`
+		Encoding string `json:"encoding"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&blob); err != nil {
+		return ""
+	}
+
+	if blob.Encoding == "base64" {
+		decoded, err := base64.StdEncoding.DecodeString(blob.Content)
+		if err != nil {
+			return ""
+		}
+		return string(decoded)
+	}
+
+	return blob.Content
+}
+
+// parseImagesFromYAML extracts ghcr.io/llm-d image references from YAML content.
+// Handles two patterns:
+//  1. Direct: image: ghcr.io/llm-d/<name>:<tag>
+//  2. Hub/name/tag (EPP): hub: ghcr.io/llm-d + name: <name> + tag: <tag>
+func parseImagesFromYAML(content string) map[string]string {
+	images := make(map[string]string)
+
+	// Pattern 1: direct image references
+	for _, match := range imageRe.FindAllStringSubmatch(content, -1) {
+		images[match[1]] = match[2]
+	}
+
+	// Pattern 2: hub/name/tag (EPP images)
+	// Scan lines for "hub: ghcr.io/llm-d" and look for nearby name/tag
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if !hubRe.MatchString(line) {
+			continue
+		}
+		// Search nearby lines (±5) for name and tag
+		const searchRadius = 5
+		var name, tag string
+		start := i - searchRadius
+		if start < 0 {
+			start = 0
+		}
+		end := i + searchRadius
+		if end >= len(lines) {
+			end = len(lines) - 1
+		}
+		for j := start; j <= end; j++ {
+			trimmed := strings.TrimSpace(lines[j])
+			// Skip commented-out lines
+			if strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			if m := nameRe.FindStringSubmatch(lines[j]); m != nil && name == "" {
+				name = m[1]
+			}
+			if m := tagRe.FindStringSubmatch(lines[j]); m != nil && tag == "" {
+				tag = m[1]
+			}
+		}
+		if name != "" && tag != "" {
+			images[name] = tag
+		}
+	}
+
+	return images
 }
 
 // isGPUStep returns true if the step name indicates a GPU availability check.

--- a/web/netlify/functions/nightly-e2e.mts
+++ b/web/netlify/functions/nightly-e2e.mts
@@ -12,10 +12,14 @@ import { getStore } from "@netlify/blobs";
 
 const CACHE_STORE = "nightly-e2e";
 const CACHE_KEY = "runs";
+const IMAGE_CACHE_KEY = "guide-images";
 const CACHE_IDLE_TTL_MS = 5 * 60 * 1000;   // 5 minutes
 const CACHE_ACTIVE_TTL_MS = 2 * 60 * 1000; // 2 minutes when jobs running
+const IMAGE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes for image tags
 const RUNS_PER_PAGE = 7;
 const GITHUB_API = "https://api.github.com";
+const IMAGE_REPO = "llm-d/llm-d";
+const SEARCH_RADIUS = 5; // lines to search around hub: for name/tag
 
 // ---------------------------------------------------------------------------
 // Types
@@ -30,8 +34,13 @@ interface NightlyWorkflow {
   model: string;
   gpuType: string;
   gpuCount: number;
-  llmdImages: Record<string, string>;
+  guidePath?: string;  // directory under guides/ in llm-d/llm-d repo
   otherImages?: Record<string, string>;
+}
+
+interface ImageCacheEntry {
+  images: Record<string, Record<string, string>>; // guidePath → imageName → tag
+  expiresAt: number;
 }
 
 interface NightlyRun {
@@ -73,58 +82,30 @@ interface CacheEntry {
 }
 
 // ---------------------------------------------------------------------------
-// Component image tags — must match Go handler (pkg/api/handlers/nightly_e2e.go)
-// ---------------------------------------------------------------------------
-
-/** Nightly-built dev image used by most guides */
-const IMG_CUDA_DEV: Record<string, string> = { "llm-d-cuda-dev": "latest" };
-
-/** PD adds the routing sidecar */
-const IMG_PD: Record<string, string> = { "llm-d-cuda-dev": "latest", "llm-d-routing-sidecar": "v0.5.0" };
-
-/** PPC adds the UDS tokenizer */
-const IMG_PPC: Record<string, string> = { "llm-d-cuda-dev": "latest", "llm-d-uds-tokenizer": "v0.5.1-rc1" };
-
-/** SA uses the inference simulator instead of cuda-dev */
-const IMG_SA: Record<string, string> = { "llm-d-inference-sim": "v0.7.1", "llm-d-routing-sidecar": "v0.5.0" };
-
-/** Wide EP adds the routing sidecar */
-const IMG_WEP: Record<string, string> = { "llm-d-cuda-dev": "latest", "llm-d-routing-sidecar": "v0.5.0" };
-
-/** WVA adds the workload variant autoscaler (tag is dynamic, rebuilt nightly) */
-const IMG_WVA: Record<string, string> = { "llm-d-cuda-dev": "latest", "llm-d-workload-variant-autoscaler": "nightly" };
-
-/** TPC uses only the base cuda-dev image */
-const IMG_TPC: Record<string, string> = { "llm-d-cuda-dev": "latest" };
-
-/** Benchmarking uses the base image */
-const IMG_BM: Record<string, string> = { "llm-d-cuda-dev": "latest" };
-
-// ---------------------------------------------------------------------------
-// Workflow definitions — must match Go handler and frontend demo data
+// Workflow definitions — image tags are fetched dynamically from guide YAML files
 // ---------------------------------------------------------------------------
 
 const NIGHTLY_WORKFLOWS: NightlyWorkflow[] = [
   // OCP
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-inference-scheduling-ocp.yaml", guide: "Inference Scheduling", acronym: "IS", platform: "OCP", model: "Qwen3-32B", gpuType: "H100", gpuCount: 2, llmdImages: IMG_CUDA_DEV },
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-pd-disaggregation-ocp.yaml", guide: "PD Disaggregation", acronym: "PD", platform: "OCP", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2, llmdImages: IMG_PD },
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-precise-prefix-cache-ocp.yaml", guide: "Precise Prefix Cache", acronym: "PPC", platform: "OCP", model: "Qwen3-32B", gpuType: "H100", gpuCount: 2, llmdImages: IMG_PPC },
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-simulated-accelerators.yaml", guide: "Simulated Accelerators", acronym: "SA", platform: "OCP", model: "Simulated", gpuType: "CPU", gpuCount: 0, llmdImages: IMG_SA },
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-tiered-prefix-cache-ocp.yaml", guide: "Tiered Prefix Cache", acronym: "TPC", platform: "OCP", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 1, llmdImages: IMG_TPC },
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wide-ep-lws-ocp.yaml", guide: "Wide EP + LWS", acronym: "WEP", platform: "OCP", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2, llmdImages: IMG_WEP },
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wva-ocp.yaml", guide: "WVA", acronym: "WVA", platform: "OCP", model: "Llama-3.1-8B", gpuType: "A100", gpuCount: 2, llmdImages: IMG_WVA },
-  { repo: "llm-d/llm-d-benchmark", workflowFile: "ci-nighly-benchmark-ocp.yaml", guide: "Benchmarking", acronym: "BM", platform: "OCP", model: "opt-125m", gpuType: "A100", gpuCount: 1, llmdImages: IMG_BM },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-inference-scheduling-ocp.yaml", guide: "Inference Scheduling", acronym: "IS", platform: "OCP", model: "Qwen3-32B", gpuType: "H100", gpuCount: 2, guidePath: "inference-scheduling" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-pd-disaggregation-ocp.yaml", guide: "PD Disaggregation", acronym: "PD", platform: "OCP", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2, guidePath: "pd-disaggregation" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-precise-prefix-cache-ocp.yaml", guide: "Precise Prefix Cache", acronym: "PPC", platform: "OCP", model: "Qwen3-32B", gpuType: "H100", gpuCount: 2, guidePath: "precise-prefix-cache-aware" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-simulated-accelerators.yaml", guide: "Simulated Accelerators", acronym: "SA", platform: "OCP", model: "Simulated", gpuType: "CPU", gpuCount: 0, guidePath: "simulated-accelerators" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-tiered-prefix-cache-ocp.yaml", guide: "Tiered Prefix Cache", acronym: "TPC", platform: "OCP", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 1, guidePath: "tiered-prefix-cache" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wide-ep-lws-ocp.yaml", guide: "Wide EP + LWS", acronym: "WEP", platform: "OCP", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2, guidePath: "wide-ep-lws" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wva-ocp.yaml", guide: "WVA", acronym: "WVA", platform: "OCP", model: "Llama-3.1-8B", gpuType: "A100", gpuCount: 2, guidePath: "workload-autoscaling" },
+  { repo: "llm-d/llm-d-benchmark", workflowFile: "ci-nighly-benchmark-ocp.yaml", guide: "Benchmarking", acronym: "BM", platform: "OCP", model: "opt-125m", gpuType: "A100", gpuCount: 1 },
   // GKE
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-inference-scheduling-gke.yaml", guide: "Inference Scheduling", acronym: "IS", platform: "GKE", model: "Qwen3-32B", gpuType: "L4", gpuCount: 2, llmdImages: IMG_CUDA_DEV },
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-pd-disaggregation-gke.yaml", guide: "PD Disaggregation", acronym: "PD", platform: "GKE", model: "Qwen3-0.6B", gpuType: "L4", gpuCount: 2, llmdImages: IMG_PD },
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wide-ep-lws-gke.yaml", guide: "Wide EP + LWS", acronym: "WEP", platform: "GKE", model: "Qwen3-0.6B", gpuType: "L4", gpuCount: 2, llmdImages: IMG_WEP },
-  { repo: "llm-d/llm-d-benchmark", workflowFile: "ci-nighly-benchmark-gke.yaml", guide: "Benchmarking", acronym: "BM", platform: "GKE", model: "opt-125m", gpuType: "L4", gpuCount: 1, llmdImages: IMG_BM },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-inference-scheduling-gke.yaml", guide: "Inference Scheduling", acronym: "IS", platform: "GKE", model: "Qwen3-32B", gpuType: "L4", gpuCount: 2, guidePath: "inference-scheduling" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-pd-disaggregation-gke.yaml", guide: "PD Disaggregation", acronym: "PD", platform: "GKE", model: "Qwen3-0.6B", gpuType: "L4", gpuCount: 2, guidePath: "pd-disaggregation" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wide-ep-lws-gke.yaml", guide: "Wide EP + LWS", acronym: "WEP", platform: "GKE", model: "Qwen3-0.6B", gpuType: "L4", gpuCount: 2, guidePath: "wide-ep-lws" },
+  { repo: "llm-d/llm-d-benchmark", workflowFile: "ci-nighly-benchmark-gke.yaml", guide: "Benchmarking", acronym: "BM", platform: "GKE", model: "opt-125m", gpuType: "L4", gpuCount: 1 },
   // CKS
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-inference-scheduling-cks.yaml", guide: "Inference Scheduling", acronym: "IS", platform: "CKS", model: "Qwen3-32B", gpuType: "H100", gpuCount: 2, llmdImages: IMG_CUDA_DEV },
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", guide: "PD Disaggregation", acronym: "PD", platform: "CKS", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2, llmdImages: IMG_PD },
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wide-ep-lws-cks.yaml", guide: "Wide EP + LWS", acronym: "WEP", platform: "CKS", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2, llmdImages: IMG_WEP },
-  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wva-cks.yaml", guide: "WVA", acronym: "WVA", platform: "CKS", model: "Llama-3.1-8B", gpuType: "H100", gpuCount: 2, llmdImages: IMG_WVA },
-  { repo: "llm-d/llm-d-benchmark", workflowFile: "ci-nightly-benchmark-cks.yaml", guide: "Benchmarking", acronym: "BM", platform: "CKS", model: "opt-125m", gpuType: "H100", gpuCount: 1, llmdImages: IMG_BM },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-inference-scheduling-cks.yaml", guide: "Inference Scheduling", acronym: "IS", platform: "CKS", model: "Qwen3-32B", gpuType: "H100", gpuCount: 2, guidePath: "inference-scheduling" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-pd-disaggregation-cks.yaml", guide: "PD Disaggregation", acronym: "PD", platform: "CKS", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2, guidePath: "pd-disaggregation" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wide-ep-lws-cks.yaml", guide: "Wide EP + LWS", acronym: "WEP", platform: "CKS", model: "Qwen3-0.6B", gpuType: "H100", gpuCount: 2, guidePath: "wide-ep-lws" },
+  { repo: "llm-d/llm-d", workflowFile: "nightly-e2e-wva-cks.yaml", guide: "WVA", acronym: "WVA", platform: "CKS", model: "Llama-3.1-8B", gpuType: "H100", gpuCount: 2, guidePath: "workload-autoscaling" },
+  { repo: "llm-d/llm-d-benchmark", workflowFile: "ci-nightly-benchmark-cks.yaml", guide: "Benchmarking", acronym: "BM", platform: "CKS", model: "opt-125m", gpuType: "H100", gpuCount: 1 },
 ];
 
 // ---------------------------------------------------------------------------
@@ -168,6 +149,163 @@ function hasInProgressRuns(guides: NightlyGuideStatus[]): boolean {
 function isGPUStep(name: string): boolean {
   const lower = name.toLowerCase();
   return lower.includes("gpu") && lower.includes("availab");
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic image tag fetching from guide YAML files
+// ---------------------------------------------------------------------------
+
+/** Regex for direct image refs: ghcr.io/llm-d/<name>:<tag> */
+const IMAGE_RE = /ghcr\.io\/llm-d\/([\w][\w.-]*?):([\w][\w.+-]*)/g;
+/** Regex for hub: ghcr.io/llm-d pattern (EPP images) */
+const HUB_RE = /hub:\s*ghcr\.io\/llm-d\b/i;
+const NAME_RE = /name:\s*([\w][\w.-]*)/i;
+const TAG_RE = /tag:\s*([\w][\w.+-]*)/i;
+
+/** Parse ghcr.io/llm-d image references from YAML content */
+function parseImagesFromYAML(content: string): Record<string, string> {
+  const images: Record<string, string> = {};
+
+  // Pattern 1: direct image references
+  for (const match of content.matchAll(IMAGE_RE)) {
+    images[match[1]] = match[2];
+  }
+
+  // Pattern 2: hub/name/tag (EPP images)
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    if (!HUB_RE.test(lines[i])) continue;
+
+    let name = "";
+    let tag = "";
+    const start = Math.max(0, i - SEARCH_RADIUS);
+    const end = Math.min(lines.length - 1, i + SEARCH_RADIUS);
+
+    for (let j = start; j <= end; j++) {
+      const trimmed = lines[j].trim();
+      if (trimmed.startsWith("#")) continue;
+      if (!name) {
+        const nm = NAME_RE.exec(lines[j]);
+        if (nm) name = nm[1];
+      }
+      if (!tag) {
+        const tg = TAG_RE.exec(lines[j]);
+        if (tg) tag = tg[1];
+      }
+    }
+    if (name && tag) images[name] = tag;
+  }
+
+  return images;
+}
+
+interface TreeEntry {
+  path: string;
+  sha: string;
+}
+
+/** Fetch the repo tree and return YAML files under guides/ likely to contain image refs */
+async function fetchGuideYAMLFiles(token: string): Promise<TreeEntry[]> {
+  const url = `${GITHUB_API}/repos/${IMAGE_REPO}/git/trees/main?recursive=1`;
+  const headers: Record<string, string> = { Accept: "application/vnd.github.v3+json" };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const res = await fetch(url, { headers });
+  if (!res.ok) return [];
+
+  const data = await res.json();
+  const results: TreeEntry[] = [];
+
+  for (const entry of data.tree ?? []) {
+    if (entry.type !== "blob") continue;
+    if (!entry.path.startsWith("guides/")) continue;
+    if (!entry.path.endsWith(".yaml")) continue;
+
+    const name = entry.path.substring(entry.path.lastIndexOf("/") + 1);
+    if (name === "values.yaml" || name === "decode.yaml" || name === "prefill.yaml" ||
+        name.includes("inferencepool")) {
+      results.push({ path: entry.path, sha: entry.sha });
+    }
+  }
+
+  return results;
+}
+
+/** Fetch a git blob's content by SHA */
+async function fetchBlob(sha: string, token: string): Promise<string> {
+  const url = `${GITHUB_API}/repos/${IMAGE_REPO}/git/blobs/${sha}`;
+  const headers: Record<string, string> = { Accept: "application/vnd.github.v3+json" };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const res = await fetch(url, { headers });
+  if (!res.ok) return "";
+
+  const blob = await res.json();
+  if (blob.encoding === "base64") {
+    return atob(blob.content);
+  }
+  return blob.content ?? "";
+}
+
+/** Fetch image tags for all guide paths, with Netlify Blob caching */
+async function fetchGuideImages(
+  token: string,
+  store: ReturnType<typeof getStore>,
+): Promise<Record<string, Record<string, string>>> {
+  // Check image cache
+  try {
+    const cached = await store.get(IMAGE_CACHE_KEY, { type: "text" });
+    if (cached) {
+      const entry: ImageCacheEntry = JSON.parse(cached);
+      if (Date.now() < entry.expiresAt) {
+        return entry.images;
+      }
+    }
+  } catch {
+    // Cache miss — proceed to fetch
+  }
+
+  // Collect unique guide paths
+  const guidePaths = [...new Set(
+    NIGHTLY_WORKFLOWS.map((wf) => wf.guidePath).filter(Boolean) as string[]
+  )];
+
+  // Fetch the repo tree (single API call)
+  const yamlFiles = await fetchGuideYAMLFiles(token);
+
+  // For each guide, find relevant files and fetch their contents
+  const result: Record<string, Record<string, string>> = {};
+
+  await Promise.all(
+    guidePaths.map(async (guidePath) => {
+      const prefix = `guides/${guidePath}/`;
+      const files = yamlFiles.filter((f) => f.path.startsWith(prefix));
+      const images: Record<string, string> = {};
+
+      // Fetch blobs in parallel for this guide
+      const contents = await Promise.all(
+        files.map((f) => fetchBlob(f.sha, token))
+      );
+
+      for (const content of contents) {
+        if (!content) continue;
+        Object.assign(images, parseImagesFromYAML(content));
+      }
+
+      if (Object.keys(images).length > 0) {
+        result[guidePath] = images;
+      }
+    })
+  );
+
+  // Cache result (best-effort)
+  const cacheEntry: ImageCacheEntry = {
+    images: result,
+    expiresAt: Date.now() + IMAGE_CACHE_TTL_MS,
+  };
+  store.set(IMAGE_CACHE_KEY, JSON.stringify(cacheEntry)).catch(() => {});
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -271,11 +409,16 @@ async function detectGPUFailure(
 }
 
 async function fetchAll(
-  token: string
+  token: string,
+  store: ReturnType<typeof getStore>,
 ): Promise<NightlyGuideStatus[]> {
-  const results = await Promise.allSettled(
-    NIGHTLY_WORKFLOWS.map((wf) => fetchWorkflowRuns(wf, token))
-  );
+  // Fetch workflow runs and guide images concurrently
+  const [results, guideImages] = await Promise.all([
+    Promise.allSettled(
+      NIGHTLY_WORKFLOWS.map((wf) => fetchWorkflowRuns(wf, token))
+    ),
+    fetchGuideImages(token, store),
+  ]);
 
   return NIGHTLY_WORKFLOWS.map((wf, i) => {
     const result = results[i];
@@ -286,6 +429,9 @@ async function fetchAll(
     if (runs.length > 0) {
       latestConclusion = runs[0].conclusion ?? runs[0].status;
     }
+
+    // Use dynamically fetched images for this guide
+    const llmdImages = wf.guidePath ? (guideImages[wf.guidePath] ?? {}) : {};
 
     return {
       guide: wf.guide,
@@ -300,7 +446,7 @@ async function fetchAll(
       model: wf.model,
       gpuType: wf.gpuType,
       gpuCount: wf.gpuCount,
-      llmdImages: wf.llmdImages,
+      llmdImages,
       otherImages: wf.otherImages,
     };
   });
@@ -356,7 +502,7 @@ export default async (req: Request) => {
 
   // Fetch fresh data from GitHub
   try {
-    const guides = await fetchAll(token);
+    const guides = await fetchAll(token, store);
     const now = new Date().toISOString();
     const ttl = hasInProgressRuns(guides)
       ? CACHE_ACTIVE_TTL_MS


### PR DESCRIPTION
## Summary

- Replaces hardcoded image tag maps (which were already stale — showing `v0.5.0` when the actual routing-sidecar is `v0.6.0`) with runtime fetching from the `llm-d/llm-d` repo's guide YAML files
- Uses GitHub Git Trees API (single call) to discover relevant YAML files, then fetches blobs in parallel to extract `ghcr.io/llm-d/*` image references
- Handles both direct `image: ghcr.io/llm-d/<name>:<tag>` refs and the EPP `hub/name/tag` pattern
- Image data cached for 30 minutes (separate from the 2-5 min run data cache) since versions change less frequently
- Applied to both Go backend (`pkg/api/handlers/nightly_e2e.go`) and Netlify function (`web/netlify/functions/nightly-e2e.mts`)

## Test plan

- [ ] Verify tooltip on Nightly E2E card shows current image tags (e.g., `llm-d-routing-sidecar:v0.6.0`)
- [ ] Verify image data is cached (subsequent requests don't re-fetch from GitHub)
- [ ] Verify graceful fallback when GitHub API is unavailable (empty image map, no crash)
- [ ] Verify on console.kubestellar.io (Netlify deployment) after merge