### PR TITLE
🌱 Lowercase auth badge labels

### DIFF
--- a/web/src/components/clusters/AddClusterDialog.tsx
+++ b/web/src/components/clusters/AddClusterDialog.tsx
@@ -517,8 +517,8 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
                                   ctx.authMethod === 'certificate' ? 'bg-green-500/20 text-green-400' :
                                   'bg-blue-500/20 text-blue-400'
                                 }`}>
-                                  {ctx.authMethod === 'exec' || ctx.authMethod === 'auth-provider' ? 'IAM' :
-                                   ctx.authMethod === 'token' ? 'Token' : 'Cert'}
+                                  {ctx.authMethod === 'exec' || ctx.authMethod === 'auth-provider' ? 'iam' :
+                                   ctx.authMethod === 'token' ? 'token' : 'cert'}
                                 </span>
                               )}
                               {ctx.isNew ? (

--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -65,10 +65,10 @@ function isTokenExpired(cluster: ClusterInfo): boolean {
 
 // Auth method badge labels — intentionally subtle (muted text, no colored backgrounds)
 const AUTH_BADGE_MAP: Record<string, { label: string; color: string }> = {
-  exec: { label: 'IAM', color: 'bg-white/5 text-muted-foreground' },
-  token: { label: 'Token', color: 'bg-white/5 text-muted-foreground' },
-  certificate: { label: 'Cert', color: 'bg-white/5 text-muted-foreground' },
-  'auth-provider': { label: 'IAM', color: 'bg-white/5 text-muted-foreground' },
+  exec: { label: 'iam', color: 'bg-white/5 text-muted-foreground' },
+  token: { label: 'token', color: 'bg-white/5 text-muted-foreground' },
+  certificate: { label: 'cert', color: 'bg-white/5 text-muted-foreground' },
+  'auth-provider': { label: 'iam', color: 'bg-white/5 text-muted-foreground' },
 }
 
 // Session refresh commands per exec-plugin CLI name


### PR DESCRIPTION
## Summary
- Change auth badge labels from `IAM`/`Token`/`Cert` to `iam`/`token`/`cert` for a subtler look
- Updated in both cluster grid and import preview

## Test plan
- [ ] Cluster cards show lowercase badges
- [ ] Import preview shows lowercase badges