### PR TITLE
🐛 Fix transparent AI card suggestion dropdown

### DIFF
--- a/web/src/components/dashboard/CardRecommendations.tsx
+++ b/web/src/components/dashboard/CardRecommendations.tsx
@@ -138,7 +138,7 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
                 <div
                   ref={dropdownRef}
                   role="menu"
-                  className={`absolute top-full left-0 mt-1 z-50 w-72 rounded-lg border ${style.border} ${style.bg} backdrop-blur-sm shadow-xl`}
+                  className={`absolute top-full left-0 mt-1 z-50 w-72 rounded-lg border ${style.border} bg-card shadow-xl`}
                   onKeyDown={(e) => {
                     if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
                     e.preventDefault()


### PR DESCRIPTION
## Summary
- AI card recommendation dropdown was using semi-transparent `bg-red-500/20` + `backdrop-blur-sm`, making cards behind it bleed through
- Changed to solid `bg-card` background

## Test plan
- [x] Verified dropdown is now opaque via CDP screenshot