### PR TITLE
🐛 Fix minimatch ReDoS vulnerability (HIGH)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7431,16 +7431,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
-      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"


### PR DESCRIPTION
## Summary
- Upgrade minimatch to fix ReDoS vulnerability (HIGH severity)
- GHSA-7r86-cg39-jmmj and GHSA-23c5-xmqv-rm74
- Applied via `npm audit fix`

## Test plan
- [ ] `cd web && npm audit` shows 0 vulnerabilities
- [ ] `cd web && npm run build` passes
- [ ] `scripts/dependency-audit-test.sh` passes