### PR TITLE
🐛 Fix Copilot assignment token and improve error diagnostics

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -23,4 +23,4 @@ jobs:
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.CONSOLE_AUTO || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -4231,7 +4231,12 @@ jobs:
                 });
                 core.info(`Assigned Copilot to #${issue.number}`);
               } catch (e) {
-                core.warning(`Could not assign Copilot to #${issue.number}: ${e.message}`);
+                const hint = e.status === 401
+                  ? ' — CONSOLE_AUTO PAT may be expired (check repo secrets)'
+                  : e.status === 403
+                  ? ' — token may lack repo scope or Copilot agent is not enabled'
+                  : '';
+                core.warning(`Could not assign Copilot to #${issue.number}: ${e.message}${hint}`);
               }
               created++;
 


### PR DESCRIPTION
## Summary
- **ai-fix.yml**: Use `CONSOLE_AUTO` PAT instead of `GITHUB_TOKEN` for Copilot coding agent assignment. The built-in `GITHUB_TOKEN` lacks permission to assign bot actors, causing repeated "Forbidden" comment spam on every auto-QA issue.
- **auto-qa.yml**: Add diagnostic hints to Copilot assignment failure warnings — distinguishes expired PAT (401) from permission issues (403) so future token expiry is immediately diagnosable.

## Root Cause
The `CONSOLE_AUTO` PAT expired ~Feb 28 (was set Jan 29 with 30-day expiry). All auto-qa runs since Mar 2 failed with `Bad credentials (401)`. The token has been rotated with a 365-day expiry.

Additionally, `ai-fix.yml` was using `secrets.GITHUB_TOKEN` which never had permission to assign Copilot — this caused "Forbidden" comment spam on every auto-QA issue even when auto-qa itself succeeded.

## Test plan
- [x] Created new 365-day PAT and updated `CONSOLE_AUTO` secret
- [x] Verified PAT scopes: `admin:org`, `repo`, `workflow`
- [x] Manually tested issue creation + Copilot assignment with new PAT (issue #1678)
- [x] Triggered auto-qa workflow — run #22721386438 succeeded, created 3 issues (#1680-1682), all assigned to Copilot
- [ ] After merge, verify next auto-qa run produces no Forbidden comments