### PR TITLE
✨ Dashboard engagement: smart suggestions, contextual nudges, discover slot

### DIFF
--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -8,6 +8,7 @@ import { getAllDynamicCards, onRegistryChange } from '../../lib/dynamic-cards'
 import { TechnicalAcronym } from '../shared/TechnicalAcronym'
 import { useToast } from '../ui/Toast'
 import { FOCUS_DELAY_MS, RETRY_DELAY_MS } from '../../lib/constants/network'
+import { emitAddCardModalOpened, emitAddCardModalAbandoned } from '../../lib/analytics'
 
 // Helper function to wrap technical abbreviations in text with tooltips
 function wrapAbbreviations(text: string): ReactNode {
@@ -951,11 +952,23 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
     return unsub
   }, [])
 
+  // Track whether cards were added during this modal session
+  const didAddCards = useRef(false)
+
   useEffect(() => {
-    if (isOpen && activeTab === 'browse') {
-      // Delay slightly to ensure modal is rendered
-      const timer = setTimeout(() => searchInputRef.current?.focus(), FOCUS_DELAY_MS)
-      return () => clearTimeout(timer)
+    if (isOpen) {
+      didAddCards.current = false
+      emitAddCardModalOpened()
+      if (activeTab === 'browse') {
+        // Delay slightly to ensure modal is rendered
+        const timer = setTimeout(() => searchInputRef.current?.focus(), FOCUS_DELAY_MS)
+        return () => clearTimeout(timer)
+      }
+    } else {
+      // Modal just closed — if no cards were added, it was abandoned
+      if (!didAddCards.current) {
+        emitAddCardModalAbandoned()
+      }
     }
   }, [isOpen, activeTab])
 
@@ -1043,6 +1056,7 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
 
   const handleAddCards = () => {
     const cardsToAdd = suggestions.filter((_, i) => selectedCards.has(i))
+    didAddCards.current = cardsToAdd.length > 0
     onAddCards(cardsToAdd)
     onClose()
     setQuery('')
@@ -1086,6 +1100,7 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
       }
     }
     try {
+      didAddCards.current = cardsToAdd.length > 0
       onAddCards(cardsToAdd)
     } catch (error) {
       console.error('Error adding cards:', error)

--- a/web/src/components/dashboard/ContextualNudgeBanner.tsx
+++ b/web/src/components/dashboard/ContextualNudgeBanner.tsx
@@ -1,0 +1,103 @@
+/**
+ * Contextual Nudge Banner — non-intrusive hint shown at the right moment.
+ *
+ * Replaces the traditional tour with context-aware nudges:
+ *   - 'customize' — suggest customizing the dashboard after 3+ visits
+ *   - 'pwa-install' — suggest installing the PWA after 3+ sessions
+ */
+
+import { useTranslation } from 'react-i18next'
+import { Palette, Download, X } from 'lucide-react'
+import type { NudgeType } from '../../hooks/useContextualNudges'
+
+interface ContextualNudgeBannerProps {
+  nudgeType: NudgeType
+  onAction: () => void
+  onDismiss: () => void
+}
+
+const NUDGE_CONFIG: Record<NudgeType, {
+  icon: typeof Palette
+  titleKey: string
+  titleFallback: string
+  descriptionKey: string
+  descriptionFallback: string
+  actionKey: string
+  actionFallback: string
+  accentClass: string
+}> = {
+  customize: {
+    icon: Palette,
+    titleKey: 'nudge.customize.title',
+    titleFallback: 'Make it yours',
+    descriptionKey: 'nudge.customize.description',
+    descriptionFallback: 'Drag cards to rearrange, click + to add new ones, or try a template.',
+    actionKey: 'nudge.customize.action',
+    actionFallback: 'Add a card',
+    accentClass: 'border-blue-500/30 bg-blue-500/5',
+  },
+  'pwa-install': {
+    icon: Download,
+    titleKey: 'nudge.pwa.title',
+    titleFallback: 'Quick access',
+    descriptionKey: 'nudge.pwa.description',
+    descriptionFallback: 'Install the KubeStellar widget for instant cluster status from your desktop.',
+    actionKey: 'nudge.pwa.action',
+    actionFallback: 'Install widget',
+    accentClass: 'border-purple-500/30 bg-purple-500/5',
+  },
+  // drag-hint is handled by CSS animation, not a banner
+  'drag-hint': {
+    icon: Palette,
+    titleKey: '',
+    titleFallback: '',
+    descriptionKey: '',
+    descriptionFallback: '',
+    actionKey: '',
+    actionFallback: '',
+    accentClass: '',
+  },
+}
+
+export function ContextualNudgeBanner({ nudgeType, onAction, onDismiss }: ContextualNudgeBannerProps) {
+  const { t } = useTranslation()
+
+  // drag-hint is handled differently (CSS animation on cards)
+  if (nudgeType === 'drag-hint') return null
+
+  const config = NUDGE_CONFIG[nudgeType]
+  const Icon = config.icon
+
+  return (
+    <div className={`mb-4 rounded-xl border ${config.accentClass} px-4 py-3 animate-in slide-in-from-top-2 duration-300`}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Icon className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+          <div>
+            <span className="text-sm font-medium text-foreground">
+              {t(config.titleKey, config.titleFallback)}
+            </span>
+            <span className="text-sm text-muted-foreground ml-2">
+              {t(config.descriptionKey, config.descriptionFallback)}
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0 ml-4">
+          <button
+            onClick={onAction}
+            className="text-xs font-medium text-purple-400 hover:text-purple-300 transition-colors px-3 py-1.5 rounded-lg hover:bg-purple-500/10"
+          >
+            {t(config.actionKey, config.actionFallback)}
+          </button>
+          <button
+            onClick={onDismiss}
+            className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+            title={t('common.dismiss', 'Dismiss')}
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -45,8 +45,13 @@ import { SortableCard, DragPreviewCard } from './SharedSortableCard'
 import type { Card, DashboardData } from './dashboardUtils'
 import { useDashboardReset } from '../../hooks/useDashboardReset'
 import { WelcomeCard } from './WelcomeCard'
+import { SmartCardSuggestions } from './SmartCardSuggestions'
+import { ContextualNudgeBanner } from './ContextualNudgeBanner'
+import { DiscoverCardsPlaceholder } from './DiscoverCardsPlaceholder'
 import { getDemoMode } from '../../hooks/useDemoMode'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
+import { useContextualNudges } from '../../hooks/useContextualNudges'
+import { useDashboardScrollTracking } from '../../hooks/useDashboardScrollTracking'
 import { DashboardHeader } from '../shared/DashboardHeader'
 import { StatsOverview, StatBlockValue } from '../ui/StatsOverview'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
@@ -129,6 +134,15 @@ export function Dashboard() {
     setCards: setLocalCards,
     cards: localCards,
   })
+
+  // Contextual nudges (replaces traditional tour with in-context hints)
+  const { activeNudge, showDragHint, dismissNudge, actionNudge, recordVisit } = useContextualNudges(isCustomized)
+
+  // Track dashboard scroll depth for "almost" engagement analytics
+  useDashboardScrollTracking()
+
+  // Record dashboard visit for nudge thresholds
+  useEffect(() => { recordVisit() }, [recordVisit])
 
   // Universal stats for cross-dashboard stat blocks
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
@@ -740,6 +754,49 @@ export function Dashboard() {
     showToast(`Applied "${template.name}" template with ${newCards.length} cards`, 'success')
   }, [dashboard, recordCardAdded, showToast])
 
+  // Handle single card addition from smart suggestions or discover placeholder
+  const handleAddSingleCard = useCallback((cardType: string) => {
+    const size = getDefaultCardSize(cardType)
+    const newCard: Card = {
+      id: `rec-${Date.now()}`,
+      card_type: cardType,
+      config: {},
+      position: { x: 0, y: 0, ...size },
+    }
+    recordCardAdded(newCard.id, cardType, undefined, {}, dashboard?.id, dashboard?.name)
+    emitCardAdded(cardType, 'smart_suggestion')
+    setLocalCards((prev) => [newCard, ...prev])
+  }, [dashboard, recordCardAdded])
+
+  // Handle adding multiple cards from smart suggestions "Add all"
+  const handleAddMultipleCards = useCallback((cardTypes: string[]) => {
+    const newCards: Card[] = cardTypes.map((cardType, index) => {
+      const size = getDefaultCardSize(cardType)
+      return {
+        id: `rec-${Date.now()}-${index}`,
+        card_type: cardType,
+        config: {},
+        position: { x: 0, y: 0, ...size },
+      }
+    })
+    newCards.forEach((card) => {
+      recordCardAdded(card.id, card.card_type, undefined, {}, dashboard?.id, dashboard?.name)
+      emitCardAdded(card.card_type, 'smart_suggestion_all')
+    })
+    setLocalCards((prev) => [...newCards, ...prev])
+  }, [dashboard, recordCardAdded])
+
+  // Handle nudge CTA actions
+  const handleNudgeAction = useCallback(() => {
+    if (activeNudge === 'customize') {
+      openAddCardModal()
+    } else if (activeNudge === 'pwa-install') {
+      // Navigate to widget settings or trigger PWA install
+      navigate('/settings#widget-settings')
+    }
+    actionNudge()
+  }, [activeNudge, actionNudge, openAddCardModal, navigate])
+
   const currentCardTypes = localCards.map(c => {
     if (c.card_type === 'dynamic_card' && c.config?.dynamicCardId) {
       return `dynamic_card::${c.config.dynamicCardId as string}`
@@ -820,6 +877,22 @@ export function Dashboard() {
         <WelcomeCard />
       )}
 
+      {/* Smart Card Suggestions — shown after kc-agent connects */}
+      <SmartCardSuggestions
+        existingCardTypes={currentCardTypes}
+        onAddCard={handleAddSingleCard}
+        onAddMultipleCards={handleAddMultipleCards}
+      />
+
+      {/* Contextual nudge banner — replaces traditional tour */}
+      {activeNudge && activeNudge !== 'drag-hint' && (
+        <ContextualNudgeBanner
+          nudgeType={activeNudge}
+          onAction={handleNudgeAction}
+          onDismiss={dismissNudge}
+        />
+      )}
+
       {/* AI Recommendations & Actions - both rows wrapped for tour highlight */}
       <div data-tour="recommendations">
         <CardRecommendations
@@ -851,7 +924,13 @@ export function Dashboard() {
         onDragCancel={handleDragCancel}
       >
         <SortableContext items={localCards.map(c => c.id)} strategy={rectSortingStrategy}>
-          <div data-testid="dashboard-cards-grid" data-tour="dashboard" role="grid" aria-label="Dashboard cards" className="grid grid-cols-1 md:grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
+          <div
+            data-testid="dashboard-cards-grid"
+            data-tour="dashboard"
+            role="grid"
+            aria-label="Dashboard cards"
+            className={`grid grid-cols-1 md:grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)] ${showDragHint ? 'animate-shimmy' : ''}`}
+          >
             {localCards.map((card) => (
               <SortableCard
                 key={card.id}
@@ -868,6 +947,15 @@ export function Dashboard() {
                 registerExpandTrigger={(expand) => { expandTriggersRef.current.set(card.id, expand) }}
               />
             ))}
+
+            {/* Discover Cards Placeholder — intentional empty slot with card carousel */}
+            {!isCustomized && (
+              <DiscoverCardsPlaceholder
+                existingCardTypes={currentCardTypes}
+                onAddCard={handleAddSingleCard}
+                onOpenCatalog={openAddCardModal}
+              />
+            )}
           </div>
         </SortableContext>
 

--- a/web/src/components/dashboard/DiscoverCardsPlaceholder.tsx
+++ b/web/src/components/dashboard/DiscoverCardsPlaceholder.tsx
@@ -1,0 +1,132 @@
+/**
+ * Discover Cards Placeholder — an intentional empty slot in the dashboard grid.
+ *
+ * Shows a carousel of available card previews with one-click add.
+ * Creates visual "pull" toward dashboard customization by making
+ * the default layout feel intentionally incomplete.
+ */
+
+import { useState, useEffect } from 'react'
+import { Plus, ChevronLeft, ChevronRight } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { formatCardTitle } from '../../lib/formatCardTitle'
+
+interface DiscoverCardsPlaceholderProps {
+  existingCardTypes: string[]
+  onAddCard: (cardType: string) => void
+  onOpenCatalog: () => void
+}
+
+/** Cards to preview in the carousel, ordered by general usefulness */
+const DISCOVERABLE_CARDS = [
+  { type: 'gpu_overview', description: 'GPU utilization across clusters' },
+  { type: 'node_status', description: 'Node health and capacity' },
+  { type: 'security_issues', description: 'Security audit findings' },
+  { type: 'nightly_e2e_status', description: 'Nightly test results' },
+  { type: 'helm_releases', description: 'Helm release status' },
+  { type: 'namespace_overview', description: 'Namespace resource usage' },
+  { type: 'workload_deployment', description: 'Multi-cluster deployments' },
+  { type: 'cost_overview', description: 'Resource cost breakdown' },
+]
+
+/** Interval between auto-rotating cards in the carousel */
+const CAROUSEL_INTERVAL_MS = 4000
+
+export function DiscoverCardsPlaceholder({
+  existingCardTypes,
+  onAddCard,
+  onOpenCatalog,
+}: DiscoverCardsPlaceholderProps) {
+  const { t } = useTranslation()
+
+  // Filter out cards the user already has
+  const available = DISCOVERABLE_CARDS.filter(c => !existingCardTypes.includes(c.type))
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [isHovering, setIsHovering] = useState(false)
+
+  // Auto-rotate carousel when not hovering
+  useEffect(() => {
+    if (available.length <= 1 || isHovering) return
+    const timer = setInterval(() => {
+      setCurrentIndex(prev => (prev + 1) % available.length)
+    }, CAROUSEL_INTERVAL_MS)
+    return () => clearInterval(timer)
+  }, [available.length, isHovering])
+
+  // Nothing to suggest
+  if (available.length === 0) return null
+
+  const current = available[currentIndex % available.length]
+
+  return (
+    <div
+      className="h-full glass rounded-xl border-2 border-dashed border-border/50 hover:border-purple-500/40 transition-all group"
+      style={{ gridColumn: 'span 4', gridRow: 'span 3' }}
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
+    >
+      <div className="flex flex-col items-center justify-center h-full p-4 text-center gap-3">
+        {/* Carousel card preview */}
+        <div className="w-full flex items-center justify-between gap-2">
+          {available.length > 1 && (
+            <button
+              onClick={() => setCurrentIndex(prev => (prev - 1 + available.length) % available.length)}
+              className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover:opacity-100"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+          )}
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium text-foreground truncate">
+              {formatCardTitle(current.type)}
+            </div>
+            <div className="text-xs text-muted-foreground mt-0.5">
+              {current.description}
+            </div>
+          </div>
+          {available.length > 1 && (
+            <button
+              onClick={() => setCurrentIndex(prev => (prev + 1) % available.length)}
+              className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover:opacity-100"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+
+        {/* Carousel dots */}
+        {available.length > 1 && (
+          <div className="flex gap-1">
+            {available.slice(0, 6).map((_, i) => (
+              <div
+                key={i}
+                className={`w-1.5 h-1.5 rounded-full transition-colors ${
+                  i === currentIndex % available.length
+                    ? 'bg-purple-400'
+                    : 'bg-muted-foreground/30'
+                }`}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex gap-2 mt-1">
+          <button
+            onClick={() => onAddCard(current.type)}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 text-xs font-medium transition-colors"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            {t('dashboard.discover.addThis', 'Add this card')}
+          </button>
+          <button
+            onClick={onOpenCatalog}
+            className="px-3 py-1.5 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground text-xs transition-colors"
+          >
+            {t('dashboard.discover.browseCatalog', 'Browse all')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/dashboard/SmartCardSuggestions.tsx
+++ b/web/src/components/dashboard/SmartCardSuggestions.tsx
@@ -1,0 +1,221 @@
+/**
+ * Smart Card Suggestions — shown after kc-agent connects.
+ *
+ * Analyzes connected cluster capabilities and suggests relevant cards
+ * the user doesn't already have. One-click to add individual cards
+ * or "Add all" for the full set.
+ */
+
+import { useState, useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Sparkles, Plus, X, CheckCircle2 } from 'lucide-react'
+import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { useClusters } from '../../hooks/useMCP'
+import {
+  emitSmartSuggestionsShown,
+  emitSmartSuggestionAccepted,
+  emitSmartSuggestionsAddAll,
+} from '../../lib/analytics'
+import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
+import { STORAGE_KEY_SMART_SUGGESTIONS_DISMISSED } from '../../lib/constants/storage'
+import { formatCardTitle } from '../../lib/formatCardTitle'
+
+interface SmartCardSuggestionsProps {
+  existingCardTypes: string[]
+  onAddCard: (cardType: string) => void
+  onAddMultipleCards: (cardTypes: string[]) => void
+}
+
+/** Card suggestion with the reason it's recommended */
+interface Suggestion {
+  cardType: string
+  reason: string
+}
+
+/** How long to show the "Added!" confirmation before hiding the suggestion */
+const ADDED_FEEDBACK_MS = 1500
+
+/**
+ * Maps cluster capabilities to recommended card types.
+ * Each entry: [cardType, reason, condition function].
+ */
+type SuggestionRule = [
+  cardType: string,
+  reason: string,
+  condition: (ctx: ClusterContext) => boolean,
+]
+
+interface ClusterContext {
+  hasGpu: boolean
+  clusterCount: number
+  hasMultipleClusters: boolean
+  hasPrometheus: boolean
+  hasArgo: boolean
+  totalPods: number
+  totalNodes: number
+}
+
+const SUGGESTION_RULES: SuggestionRule[] = [
+  ['gpu_overview', 'GPU nodes detected in your clusters', (ctx) => ctx.hasGpu],
+  ['gpu_namespace_allocations', 'Track GPU usage across namespaces', (ctx) => ctx.hasGpu],
+  ['resource_usage', 'Monitor resource consumption across clusters', (ctx) => ctx.clusterCount > 0],
+  ['pod_issues', 'Spot problematic pods early', (ctx) => ctx.totalPods > 0],
+  ['deployment_status', 'Track deployment health', (ctx) => ctx.totalPods > 0],
+  ['node_status', 'Monitor node health across clusters', (ctx) => ctx.totalNodes > 0],
+  ['event_stream', 'Watch cluster events in real time', (ctx) => ctx.clusterCount > 0],
+  ['security_issues', 'Security audit for your clusters', (ctx) => ctx.clusterCount > 0],
+  ['cluster_metrics', 'Performance metrics over time', (ctx) => ctx.hasMultipleClusters],
+]
+
+/** Maximum number of suggestions to show at once */
+const MAX_SUGGESTIONS = 4
+
+export function SmartCardSuggestions({
+  existingCardTypes,
+  onAddCard,
+  onAddMultipleCards,
+}: SmartCardSuggestionsProps) {
+  const { t } = useTranslation()
+  const { status: agentStatus, health } = useLocalAgent()
+  const { deduplicatedClusters: clusters } = useClusters()
+  const [dismissed, setDismissed] = useState(() =>
+    safeGetItem(STORAGE_KEY_SMART_SUGGESTIONS_DISMISSED) === 'true'
+  )
+  const [addedCards, setAddedCards] = useState<Set<string>>(new Set())
+  const [hasEmittedShown, setHasEmittedShown] = useState(false)
+
+  // Build cluster context from live data
+  const clusterContext: ClusterContext = useMemo(() => {
+    const clusterList = clusters || []
+    // Detect GPU presence via namespace hints (gpu-operator, nvidia-gpu-operator)
+    const hasGpu = clusterList.some(c =>
+      (c.namespaces || []).some(ns =>
+        ns.includes('gpu') || ns.includes('nvidia')
+      )
+    )
+    return {
+      hasGpu,
+      clusterCount: clusterList.length,
+      hasMultipleClusters: clusterList.length > 1,
+      hasPrometheus: clusterList.some(c => (c.namespaces || []).some(ns => ns.includes('monitoring') || ns.includes('prometheus'))),
+      hasArgo: clusterList.some(c => (c.namespaces || []).some(ns => ns.includes('argocd') || ns.includes('argo'))),
+      totalPods: clusterList.reduce((sum, c) => sum + (c.podCount || 0), 0),
+      totalNodes: clusterList.reduce((sum, c) => sum + (c.nodeCount || 0), 0),
+    }
+  }, [clusters])
+
+  // Generate suggestions based on cluster context, excluding existing cards
+  const suggestions: Suggestion[] = useMemo(() => {
+    const existing = new Set(existingCardTypes)
+    return SUGGESTION_RULES
+      .filter(([cardType, , condition]) => !existing.has(cardType) && condition(clusterContext))
+      .map(([cardType, reason]) => ({ cardType, reason }))
+      .slice(0, MAX_SUGGESTIONS)
+  }, [existingCardTypes, clusterContext])
+
+  // Emit analytics when suggestions are first shown
+  useEffect(() => {
+    if (suggestions.length > 0 && !hasEmittedShown && !dismissed) {
+      emitSmartSuggestionsShown(suggestions.length)
+      setHasEmittedShown(true)
+    }
+  }, [suggestions.length, hasEmittedShown, dismissed])
+
+  // Don't show if agent not connected, or no suggestions, or dismissed
+  if (agentStatus !== 'connected' || suggestions.length === 0 || dismissed) {
+    return null
+  }
+
+  // Filter out already-added cards
+  const visibleSuggestions = suggestions.filter(s => !addedCards.has(s.cardType))
+  if (visibleSuggestions.length === 0) return null
+
+  const handleAdd = (cardType: string) => {
+    onAddCard(cardType)
+    emitSmartSuggestionAccepted(cardType)
+    setAddedCards(prev => new Set(prev).add(cardType))
+    // Auto-hide after feedback
+    setTimeout(() => {
+      setAddedCards(prev => {
+        const next = new Set(prev)
+        next.delete(cardType)
+        return next
+      })
+    }, ADDED_FEEDBACK_MS)
+  }
+
+  const handleAddAll = () => {
+    const types = visibleSuggestions.map(s => s.cardType)
+    onAddMultipleCards(types)
+    emitSmartSuggestionsAddAll(types.length)
+    handleDismiss()
+  }
+
+  const handleDismiss = () => {
+    setDismissed(true)
+    safeSetItem(STORAGE_KEY_SMART_SUGGESTIONS_DISMISSED, 'true')
+  }
+
+  return (
+    <div className="mb-4 glass rounded-xl border border-purple-500/30 overflow-hidden animate-in slide-in-from-top-2 duration-300">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">
+        <div className="flex items-center gap-2">
+          <Sparkles className="w-4 h-4 text-purple-400" />
+          <span className="text-sm font-medium text-foreground">
+            {t('dashboard.smartSuggestions.title', 'Recommended for your clusters')}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {health?.clusters ?? 0} {t('dashboard.smartSuggestions.clustersConnected', 'clusters connected')}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleAddAll}
+            className="text-xs text-purple-400 hover:text-purple-300 transition-colors px-2 py-1 rounded hover:bg-purple-500/10"
+          >
+            {t('dashboard.smartSuggestions.addAll', 'Add all')}
+          </button>
+          <button
+            onClick={handleDismiss}
+            className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+            title={t('common.dismiss', 'Dismiss')}
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Suggestion cards */}
+      <div className="flex flex-wrap gap-2 p-3">
+        {visibleSuggestions.map(({ cardType, reason }) => {
+          const justAdded = addedCards.has(cardType)
+          return (
+            <button
+              key={cardType}
+              onClick={() => !justAdded && handleAdd(cardType)}
+              disabled={justAdded}
+              className={`
+                flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-all
+                ${justAdded
+                  ? 'bg-green-500/20 border border-green-500/30 text-green-400'
+                  : 'bg-secondary/50 border border-border/50 hover:border-purple-500/40 hover:bg-purple-500/10 text-foreground'
+                }
+              `}
+            >
+              {justAdded ? (
+                <CheckCircle2 className="w-3.5 h-3.5" />
+              ) : (
+                <Plus className="w-3.5 h-3.5 text-purple-400" />
+              )}
+              <span className="font-medium">{formatCardTitle(cardType)}</span>
+              <span className="text-xs text-muted-foreground hidden sm:inline">
+                {reason}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/src/hooks/useContextualNudges.ts
+++ b/web/src/hooks/useContextualNudges.ts
@@ -1,0 +1,136 @@
+/**
+ * Contextual Nudges — replaces the traditional step-by-step tour with
+ * context-aware hints that appear at the right moment.
+ *
+ * Nudge types:
+ *   - 'customize'   — after 3+ visits with no card changes, suggest customization
+ *   - 'drag-hint'   — on first visit, briefly animate cards to show they're draggable
+ *   - 'pwa-install' — after 3+ sessions, suggest installing the PWA widget
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import {
+  STORAGE_KEY_NUDGE_DISMISSED,
+  STORAGE_KEY_DRAG_HINT_SHOWN,
+  STORAGE_KEY_PWA_PROMPT_DISMISSED,
+  STORAGE_KEY_SESSION_COUNT,
+  STORAGE_KEY_VISIT_COUNT,
+} from '../lib/constants/storage'
+import { emitNudgeShown, emitNudgeDismissed, emitNudgeActioned } from '../lib/analytics'
+import { safeGetItem, safeSetItem, safeGetJSON, safeSetJSON } from '../lib/utils/localStorage'
+
+export type NudgeType = 'customize' | 'drag-hint' | 'pwa-install'
+
+/** Number of dashboard visits before showing the "customize" nudge */
+const CUSTOMIZE_NUDGE_VISIT_THRESHOLD = 3
+/** Number of sessions before showing the PWA install nudge */
+const PWA_NUDGE_SESSION_THRESHOLD = 3
+
+interface NudgeState {
+  /** Which nudge (if any) should currently be shown */
+  activeNudge: NudgeType | null
+  /** Whether the drag-hint shimmy animation should play */
+  showDragHint: boolean
+  /** Dismiss the active nudge */
+  dismissNudge: () => void
+  /** Mark the active nudge as actioned (user clicked the CTA) */
+  actionNudge: () => void
+  /** Increment the visit counter (call on dashboard mount) */
+  recordVisit: () => void
+}
+
+function getDismissedNudges(): Set<string> {
+  const raw = safeGetJSON<string[]>(STORAGE_KEY_NUDGE_DISMISSED)
+  return new Set(raw || [])
+}
+
+function dismissNudgeInStorage(nudgeType: string) {
+  const dismissed = getDismissedNudges()
+  dismissed.add(nudgeType)
+  safeSetJSON(STORAGE_KEY_NUDGE_DISMISSED, Array.from(dismissed))
+}
+
+export function useContextualNudges(hasCustomizedDashboard: boolean): NudgeState {
+  const [activeNudge, setActiveNudge] = useState<NudgeType | null>(null)
+  const [showDragHint, setShowDragHint] = useState(false)
+
+  // Increment session count on first mount of the app
+  useEffect(() => {
+    const current = Number(safeGetItem(STORAGE_KEY_SESSION_COUNT) || '0')
+    safeSetItem(STORAGE_KEY_SESSION_COUNT, String(current + 1))
+  }, [])
+
+  const recordVisit = useCallback(() => {
+    const current = Number(safeGetItem(STORAGE_KEY_VISIT_COUNT) || '0')
+    safeSetItem(STORAGE_KEY_VISIT_COUNT, String(current + 1))
+  }, [])
+
+  // Determine which nudge to show
+  useEffect(() => {
+    const dismissed = getDismissedNudges()
+    const visitCount = Number(safeGetItem(STORAGE_KEY_VISIT_COUNT) || '0')
+    const sessionCount = Number(safeGetItem(STORAGE_KEY_SESSION_COUNT) || '0')
+
+    // Priority 1: Drag hint on first visit (auto-dismiss, no user action needed)
+    if (!safeGetItem(STORAGE_KEY_DRAG_HINT_SHOWN)) {
+      setShowDragHint(true)
+      safeSetItem(STORAGE_KEY_DRAG_HINT_SHOWN, 'true')
+      // Auto-hide shimmy after animation completes
+      const SHIMMY_DURATION_MS = 2000
+      const timer = setTimeout(() => setShowDragHint(false), SHIMMY_DURATION_MS)
+      return () => clearTimeout(timer)
+    }
+
+    // Priority 2: Customize nudge after 3+ visits with no changes
+    if (
+      visitCount >= CUSTOMIZE_NUDGE_VISIT_THRESHOLD &&
+      !hasCustomizedDashboard &&
+      !dismissed.has('customize')
+    ) {
+      setActiveNudge('customize')
+      emitNudgeShown('customize')
+      return
+    }
+
+    // Priority 3: PWA install nudge after 3+ sessions
+    if (
+      sessionCount >= PWA_NUDGE_SESSION_THRESHOLD &&
+      !dismissed.has('pwa-install') &&
+      !safeGetItem(STORAGE_KEY_PWA_PROMPT_DISMISSED) &&
+      !isStandalonePwa()
+    ) {
+      setActiveNudge('pwa-install')
+      emitNudgeShown('pwa-install')
+      return
+    }
+
+    setActiveNudge(null)
+  }, [hasCustomizedDashboard])
+
+  const dismissNudge = useCallback(() => {
+    if (activeNudge) {
+      emitNudgeDismissed(activeNudge)
+      dismissNudgeInStorage(activeNudge)
+      if (activeNudge === 'pwa-install') {
+        safeSetItem(STORAGE_KEY_PWA_PROMPT_DISMISSED, 'true')
+      }
+      setActiveNudge(null)
+    }
+  }, [activeNudge])
+
+  const actionNudge = useCallback(() => {
+    if (activeNudge) {
+      emitNudgeActioned(activeNudge)
+      dismissNudgeInStorage(activeNudge)
+      setActiveNudge(null)
+    }
+  }, [activeNudge])
+
+  return { activeNudge, showDragHint, dismissNudge, actionNudge, recordVisit }
+}
+
+/** Check if the app is already running as a standalone PWA */
+function isStandalonePwa(): boolean {
+  return window.matchMedia('(display-mode: standalone)').matches ||
+    (navigator as unknown as Record<string, unknown>).standalone === true
+}

--- a/web/src/hooks/useDashboardScrollTracking.ts
+++ b/web/src/hooks/useDashboardScrollTracking.ts
@@ -1,0 +1,46 @@
+/**
+ * Dashboard Scroll Tracking — tracks how far users scroll the card grid.
+ *
+ * Fires a debounced analytics event with 'shallow' or 'deep' depth
+ * to help understand whether cards below the fold are being seen.
+ */
+
+import { useEffect, useRef } from 'react'
+import { emitDashboardScrolled } from '../lib/analytics'
+
+/** Debounce delay before firing the scroll event */
+const SCROLL_DEBOUNCE_MS = 2000
+/** Percentage of viewport height to consider "deep" scrolling */
+const DEEP_SCROLL_THRESHOLD = 1.5
+
+export function useDashboardScrollTracking() {
+  const hasFiredShallow = useRef(false)
+  const hasFiredDeep = useRef(false)
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (hasFiredDeep.current) return // Already tracked deepest level
+
+      if (debounceTimer.current) clearTimeout(debounceTimer.current)
+
+      debounceTimer.current = setTimeout(() => {
+        const scrollRatio = window.scrollY / window.innerHeight
+
+        if (scrollRatio >= DEEP_SCROLL_THRESHOLD && !hasFiredDeep.current) {
+          hasFiredDeep.current = true
+          emitDashboardScrolled('deep')
+        } else if (scrollRatio > 0 && !hasFiredShallow.current) {
+          hasFiredShallow.current = true
+          emitDashboardScrolled('shallow')
+        }
+      }, SCROLL_DEBOUNCE_MS)
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', handleScroll)
+      if (debounceTimer.current) clearTimeout(debounceTimer.current)
+    }
+  }, [])
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1636,6 +1636,19 @@
   margin: 0 -4px;
 }
 
+/* Drag hint shimmy — briefly wiggles cards to indicate they're draggable */
+@keyframes card-shimmy {
+  0%, 100% { transform: rotate(0deg); }
+  20% { transform: rotate(-0.5deg); }
+  40% { transform: rotate(0.5deg); }
+  60% { transform: rotate(-0.3deg); }
+  80% { transform: rotate(0.3deg); }
+}
+
+.animate-shimmy > * {
+  animation: card-shimmy 0.6s ease-in-out 2;
+}
+
 /* Respect OS-level reduced motion preference */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -614,6 +614,67 @@ export function emitWidgetDownloaded(widgetType: 'uebersicht' | 'browser') {
   send('ksc_widget_downloaded', { widget_type: widgetType })
 }
 
+// ── Engagement Nudges ────────────────────────────────────────────────
+
+/** Fired when contextual nudge is shown to user */
+export function emitNudgeShown(nudgeType: string) {
+  send('ksc_nudge_shown', { nudge_type: nudgeType })
+}
+
+/** Fired when user dismisses a contextual nudge */
+export function emitNudgeDismissed(nudgeType: string) {
+  send('ksc_nudge_dismissed', { nudge_type: nudgeType })
+}
+
+/** Fired when user acts on a contextual nudge (e.g. clicks "Add card") */
+export function emitNudgeActioned(nudgeType: string) {
+  send('ksc_nudge_actioned', { nudge_type: nudgeType })
+}
+
+/** Fired when smart card suggestions are shown after agent connects */
+export function emitSmartSuggestionsShown(cardCount: number) {
+  send('ksc_smart_suggestions_shown', { card_count: cardCount })
+}
+
+/** Fired when user adds a card from smart suggestions */
+export function emitSmartSuggestionAccepted(cardType: string) {
+  send('ksc_smart_suggestion_accepted', { card_type: cardType })
+}
+
+/** Fired when user adds all suggested cards at once */
+export function emitSmartSuggestionsAddAll(cardCount: number) {
+  send('ksc_smart_suggestions_add_all', { card_count: cardCount })
+}
+
+// ── "Almost" Action Tracking ────────────────────────────────────────
+// These track user intent signals — users who almost engaged but didn't.
+// Helps distinguish discovery problems from conversion problems.
+
+/** Fired when add-card modal is opened (tracks intent to add) */
+export function emitAddCardModalOpened() {
+  send('ksc_add_card_modal_opened')
+}
+
+/** Fired when add-card modal is closed without adding any cards */
+export function emitAddCardModalAbandoned() {
+  send('ksc_add_card_modal_abandoned')
+}
+
+/** Fired when user scrolls the dashboard card grid (debounced) */
+export function emitDashboardScrolled(depth: 'shallow' | 'deep') {
+  send('ksc_dashboard_scrolled', { depth })
+}
+
+/** Fired when PWA install prompt is shown */
+export function emitPwaPromptShown() {
+  send('ksc_pwa_prompt_shown')
+}
+
+/** Fired when PWA install prompt is dismissed */
+export function emitPwaPromptDismissed() {
+  send('ksc_pwa_prompt_dismissed')
+}
+
 // ── UTM Tracking ───────────────────────────────────────────────────
 
 let utmParams: Record<string, string> = {}

--- a/web/src/lib/constants/storage.ts
+++ b/web/src/lib/constants/storage.ts
@@ -41,6 +41,14 @@ export const STORAGE_KEY_CLUSTER_PROVIDER_OVERRIDES = 'kubestellar-cluster-provi
 export const STORAGE_KEY_MISSIONS_ACTIVE = 'kubestellar-missions-active'
 export const STORAGE_KEY_MISSIONS_HISTORY = 'kubestellar-missions-history'
 
+// ── Engagement / Nudges ───────────────────────────────────────────────
+export const STORAGE_KEY_NUDGE_DISMISSED = 'kc-nudge-dismissed'
+export const STORAGE_KEY_SMART_SUGGESTIONS_DISMISSED = 'kc-smart-suggestions-dismissed'
+export const STORAGE_KEY_DRAG_HINT_SHOWN = 'kc-drag-hint-shown'
+export const STORAGE_KEY_PWA_PROMPT_DISMISSED = 'kc-pwa-prompt-dismissed'
+export const STORAGE_KEY_SESSION_COUNT = 'kc-session-count'
+export const STORAGE_KEY_VISIT_COUNT = 'kc-visit-count'
+
 // ── Component-specific cache ───────────────────────────────────────────
 export const STORAGE_KEY_OPA_CACHE = 'opa-statuses-cache'
 export const STORAGE_KEY_OPA_CACHE_TIME = 'opa-statuses-cache-time'

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -844,6 +844,15 @@
       "exampleOperatorStatus": "Operator status and CRDs",
       "exampleKustomizeGitOps": "Kustomize and GitOps status"
     },
+    "smartSuggestions": {
+      "title": "Recommended for your clusters",
+      "clustersConnected": "clusters connected",
+      "addAll": "Add all"
+    },
+    "discover": {
+      "addThis": "Add this card",
+      "browseCatalog": "Browse all"
+    },
     "dropZone": {
       "moveToDashboard": "Move to Dashboard",
       "noOtherDashboards": "No other dashboards available",
@@ -2907,6 +2916,18 @@
       "featureConfigurationModal": "<strong>Configuration modal</strong> - Both have settings to show/hide stats",
       "featureDemoIndicator": "<strong>Demo indicator</strong> - Both show demo badge when data.isDemo=true",
       "gapConfigSource": "<strong>Config source</strong> - Unified uses converted configs, legacy uses raw definitions"
+    }
+  },
+  "nudge": {
+    "customize": {
+      "title": "Make it yours",
+      "description": "Drag cards to rearrange, click + to add new ones, or try a template.",
+      "action": "Add a card"
+    },
+    "pwa": {
+      "title": "Quick access",
+      "description": "Install the KubeStellar widget for instant cluster status from your desktop.",
+      "action": "Install widget"
     }
   }
 }


### PR DESCRIPTION
## Summary

GA4 data (Feb 5 – Mar 4) shows 221 users with excellent login conversion (84%) but near-zero dashboard customization: 4 card adds, 0 drags, 0 widget installs, and a 12% tour completion rate.

This PR adds 7 engagement features to bridge the gap between "connected agent" and "customized dashboard":

### New Components
- **SmartCardSuggestions** — after kc-agent connects, suggests cards matching cluster capabilities (GPU nodes, monitoring, ArgoCD) with one-click add or "Add all"
- **ContextualNudgeBanner** — replaces the traditional tour with context-aware hints that appear at the right moment (customize after 3+ visits, PWA install after 3+ sessions)
- **DiscoverCardsPlaceholder** — intentional empty slot in the default dashboard grid with a rotating card carousel and one-click add, creating visual "pull" toward customization

### Behavioral Changes
- **Drag hint shimmy** — on first visit, cards briefly wiggle (0.6s x 2 iterations) to signal they're draggable. Respects prefers-reduced-motion. Auto-dismisses.
- **Tour preserved** — the existing tour system is untouched; contextual nudges supplement it

### Analytics ("Almost" Actions)
New events to distinguish discovery vs conversion problems:
- ksc_add_card_modal_opened / ksc_add_card_modal_abandoned
- ksc_dashboard_scrolled (shallow/deep)
- ksc_nudge_shown / ksc_nudge_dismissed / ksc_nudge_actioned
- ksc_smart_suggestions_shown / ksc_smart_suggestion_accepted / ksc_smart_suggestions_add_all
- ksc_pwa_prompt_shown / ksc_pwa_prompt_dismissed

## Test plan
- [ ] Build passes
- [ ] Lint passes
- [ ] Smart suggestions appear when agent is connected with clusters
- [ ] Discover card placeholder shows in default (non-customized) dashboard
- [ ] Shimmy animation plays on first visit only
- [ ] Contextual nudge banner appears after 3+ dashboard visits without customization
- [ ] AddCardModal open/abandon events fire in GA4 Realtime view