### PR TITLE
✨ Per-run container image metadata in nightly E2E tooltips

### DIFF
--- a/web/netlify/functions/nightly-e2e.mts
+++ b/web/netlify/functions/nightly-e2e.mts
@@ -9,13 +9,16 @@
  * GitHub API and is never exposed to the client.
  */
 import { getStore } from "@netlify/blobs";
+import { unzipSync } from "fflate";
 
 const CACHE_STORE = "nightly-e2e";
 const CACHE_KEY = "runs";
 const IMAGE_CACHE_KEY = "guide-images";
+const RUN_IMAGE_CACHE_KEY = "run-images"; // per-run artifact image metadata
 const CACHE_IDLE_TTL_MS = 5 * 60 * 1000;   // 5 minutes
 const CACHE_ACTIVE_TTL_MS = 2 * 60 * 1000; // 2 minutes when jobs running
 const IMAGE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes for image tags
+const ARTIFACT_FETCH_TIMEOUT_MS = 10_000;   // timeout for individual artifact downloads
 const RUNS_PER_PAGE = 7;
 const GITHUB_API = "https://api.github.com";
 const IMAGE_REPO = "llm-d/llm-d";
@@ -43,6 +46,15 @@ interface ImageCacheEntry {
   expiresAt: number;
 }
 
+interface RunImageMetadata {
+  llmdImages: Record<string, string>;
+  otherImages: Record<string, string>;
+}
+
+interface RunImageCache {
+  runs: Record<string, RunImageMetadata | null>; // run ID → metadata (null = no artifact)
+}
+
 interface NightlyRun {
   id: number;
   status: string;
@@ -56,6 +68,8 @@ interface NightlyRun {
   gpuType: string;
   gpuCount: number;
   event: string;
+  llmdImages?: Record<string, string>;
+  otherImages?: Record<string, string>;
 }
 
 interface NightlyGuideStatus {
@@ -309,6 +323,138 @@ async function fetchGuideImages(
 }
 
 // ---------------------------------------------------------------------------
+// Per-run image metadata from workflow artifacts
+// ---------------------------------------------------------------------------
+
+/** Fetch all image-metadata artifacts for a repo (single API call per repo) */
+async function fetchRepoArtifacts(
+  repo: string,
+  token: string,
+): Promise<Map<number, number>> {
+  const url = `${GITHUB_API}/repos/${repo}/actions/artifacts?name=image-metadata&per_page=100`;
+  const headers: Record<string, string> = { Accept: "application/vnd.github.v3+json" };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const res = await fetch(url, { headers, signal: AbortSignal.timeout(ARTIFACT_FETCH_TIMEOUT_MS) });
+  if (!res.ok) return new Map();
+
+  const data = await res.json();
+  const result = new Map<number, number>(); // runId → artifactId
+  for (const artifact of data.artifacts ?? []) {
+    if (artifact.workflow_run?.id) {
+      result.set(artifact.workflow_run.id, artifact.id);
+    }
+  }
+  return result;
+}
+
+/** Download and unzip a single artifact, returning parsed image metadata */
+async function downloadArtifact(
+  repo: string,
+  artifactId: number,
+  token: string,
+): Promise<RunImageMetadata | null> {
+  try {
+    const url = `${GITHUB_API}/repos/${repo}/actions/artifacts/${artifactId}/zip`;
+    const headers: Record<string, string> = { Accept: "application/vnd.github.v3+json" };
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+
+    const res = await fetch(url, { headers, redirect: "follow", signal: AbortSignal.timeout(ARTIFACT_FETCH_TIMEOUT_MS) });
+    if (!res.ok) return null;
+
+    const buffer = await res.arrayBuffer();
+    const unzipped = unzipSync(new Uint8Array(buffer));
+    const jsonFile = Object.values(unzipped)[0];
+    if (!jsonFile) return null;
+
+    const text = new TextDecoder().decode(jsonFile);
+    const metadata = JSON.parse(text);
+    return {
+      llmdImages: metadata.llmdImages || {},
+      otherImages: metadata.otherImages || {},
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Enrich completed runs with per-run image metadata from workflow artifacts.
+ * Uses a persistent cache so only new runs trigger artifact downloads.
+ */
+async function enrichRunsWithImages(
+  allGuides: { repo: string; runs: NightlyRun[] }[],
+  token: string,
+  store: ReturnType<typeof getStore>,
+): Promise<void> {
+  // Load cached run images
+  let cache: RunImageCache = { runs: {} };
+  try {
+    const cached = await store.get(RUN_IMAGE_CACHE_KEY, { type: "text" });
+    if (cached) cache = JSON.parse(cached);
+  } catch { /* cache miss */ }
+
+  // Find completed runs that aren't cached yet
+  const uncachedRuns: { repo: string; run: NightlyRun }[] = [];
+  for (const guide of allGuides) {
+    for (const run of guide.runs) {
+      if (run.status !== "completed") continue;
+      if (String(run.id) in cache.runs) {
+        // Apply cached metadata
+        const meta = cache.runs[String(run.id)];
+        if (meta) {
+          run.llmdImages = meta.llmdImages;
+          run.otherImages = meta.otherImages;
+        }
+        continue;
+      }
+      uncachedRuns.push({ repo: guide.repo, run });
+    }
+  }
+
+  if (uncachedRuns.length === 0) return;
+
+  // Fetch artifact listings per repo (deduplicated)
+  const repos = [...new Set(uncachedRuns.map(r => r.repo))];
+  const artifactMaps = new Map<string, Map<number, number>>();
+  await Promise.all(
+    repos.map(async (repo) => {
+      artifactMaps.set(repo, await fetchRepoArtifacts(repo, token));
+    })
+  );
+
+  // Download artifacts for uncached runs (parallel, with concurrency limit)
+  let cacheUpdated = false;
+  await Promise.all(
+    uncachedRuns.map(async ({ repo, run }) => {
+      const artifacts = artifactMaps.get(repo);
+      const artifactId = artifacts?.get(run.id);
+
+      if (!artifactId) {
+        // No artifact for this run — cache null so we don't retry
+        cache.runs[String(run.id)] = null;
+        cacheUpdated = true;
+        return;
+      }
+
+      const metadata = await downloadArtifact(repo, artifactId, token);
+      cache.runs[String(run.id)] = metadata;
+      cacheUpdated = true;
+
+      if (metadata) {
+        run.llmdImages = metadata.llmdImages;
+        run.otherImages = metadata.otherImages;
+      }
+    })
+  );
+
+  // Persist updated cache (best-effort)
+  if (cacheUpdated) {
+    store.set(RUN_IMAGE_CACHE_KEY, JSON.stringify(cache)).catch(() => {});
+  }
+}
+
+// ---------------------------------------------------------------------------
 // GitHub API fetchers
 // ---------------------------------------------------------------------------
 
@@ -420,7 +566,7 @@ async function fetchAll(
     fetchGuideImages(token, store),
   ]);
 
-  return NIGHTLY_WORKFLOWS.map((wf, i) => {
+  const guides = NIGHTLY_WORKFLOWS.map((wf, i) => {
     const result = results[i];
     const runs =
       result.status === "fulfilled" ? result.value : [];
@@ -430,7 +576,7 @@ async function fetchAll(
       latestConclusion = runs[0].conclusion ?? runs[0].status;
     }
 
-    // Use dynamically fetched images for this guide
+    // Guide-level images as fallback for runs without per-run artifacts
     const llmdImages = wf.guidePath ? (guideImages[wf.guidePath] ?? {}) : {};
 
     return {
@@ -450,6 +596,11 @@ async function fetchAll(
       otherImages: wf.otherImages,
     };
   });
+
+  // Enrich individual runs with per-run image metadata from workflow artifacts
+  await enrichRunsWithImages(guides, token, store);
+
+  return guides;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -19,6 +19,7 @@
         "clsx": "^2.1.1",
         "echarts": "^6.0.0",
         "echarts-for-react": "^3.0.6",
+        "fflate": "^0.8.2",
         "framer-motion": "^12.31.0",
         "i18next": "^25.7.4",
         "i18next-browser-languagedetector": "^8.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -51,6 +51,7 @@
     "clsx": "^2.1.1",
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.6",
+    "fflate": "^0.8.2",
     "framer-motion": "^12.31.0",
     "i18next": "^25.7.4",
     "i18next-browser-languagedetector": "^8.2.0",

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -195,8 +195,9 @@ Please provide:
     })
   }, [guide, run, checkKeyAndRun, startMission])
 
-  const llmdImages = guide?.llmdImages
-  const otherImages = guide?.otherImages
+  // Prefer per-run images (from workflow artifact) over guide-level fallback
+  const llmdImages = run.llmdImages ?? guide?.llmdImages
+  const otherImages = run.otherImages ?? guide?.otherImages
   const hasLLMDImages = llmdImages && Object.keys(llmdImages).length > 0
   const hasOtherImages = otherImages && Object.keys(otherImages).length > 0
 

--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -114,6 +114,8 @@ export function useNightlyE2EData() {
                       gpuType: r.gpuType ?? g.gpuType ?? 'Unknown',
                       gpuCount: r.gpuCount ?? g.gpuCount ?? 0,
                       event: r.event ?? 'schedule',
+                      llmdImages: r.llmdImages,
+                      otherImages: r.otherImages,
                     })
                   ),
                   passRate: g.passRate,

--- a/web/src/lib/llmd/nightlyE2EDemoData.ts
+++ b/web/src/lib/llmd/nightlyE2EDemoData.ts
@@ -31,6 +31,8 @@ export interface NightlyRun {
   gpuType: string
   gpuCount: number
   event: string
+  llmdImages?: Record<string, string>   // per-run resolved images (from workflow artifact)
+  otherImages?: Record<string, string>  // per-run non-llm-d images
 }
 
 export interface NightlyGuideStatus {

--- a/web/src/lib/widgets/codeGenerator.ts
+++ b/web/src/lib/widgets/codeGenerator.ts
@@ -324,13 +324,45 @@ ${wrapOpen}
                     {runs.map((r, i) => {
                       const isGpu = r.conclusion === 'failure' && r.failureReason === 'gpu_unavailable';
                       const isFailed = r.conclusion === 'failure';
-                      const dotLabel = (r.conclusion || r.status) + (isGpu ? ' (GPU)' : '') + ' — ' + timeAgo(r.updatedAt || r.createdAt);
-                      const dotColor = r.status !== 'completed' ? '#60a5fa' : isGpu ? '#f59e0b' : (conclusionColors[r.conclusion] || '#6b7280');
+                      const isRunning = r.status !== 'completed';
+                      const statusColor = isRunning ? '#60a5fa' : r.conclusion === 'success' ? '#22c55e' : isGpu ? '#f59e0b' : isFailed ? '#ef4444' : '#94a3b8';
+                      const statusText = isRunning ? 'running' : isGpu ? 'GPU unavailable' : isFailed ? 'failed' : r.conclusion === 'success' ? 'passed' : (r.conclusion || r.status);
+                      const dotColor = isRunning ? '#60a5fa' : isGpu ? '#f59e0b' : (conclusionColors[r.conclusion] || '#6b7280');
+                      const dotLLMD = r.llmdImages || g.llmdImages;
+                      const dotOther = r.otherImages || g.otherImages;
+                      const hasLLMD = dotLLMD && Object.keys(dotLLMD).length > 0;
+                      const hasOther = dotOther && Object.keys(dotOther).length > 0;
                       return (
-                      <span key={i} className={'dot-tip-wrap' + (isFailed ? ' has-links' : '')} onClick={() => r.htmlUrl && run(\`open "\${r.htmlUrl}"\`)}>
+                      <span key={i} className={'dot-tip-wrap' + ((isFailed || hasLLMD) ? ' has-links' : '')} onClick={() => r.htmlUrl && run(\`open "\${r.htmlUrl}"\`)}>
                         <span className="tip">
-                          {dotLabel}
-                          {isFailed && r.htmlUrl && <span><br/><a href={r.htmlUrl + '#logs'} onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}#logs"\`); }}>View Logs</a></span>}
+                          <div style={{color: '#cbd5e1', marginBottom: hasLLMD || hasOther ? 3 : 0}}>
+                            {r.runNumber ? 'Run #' + r.runNumber + ' · ' : ''}
+                            <span style={{color: statusColor}}>{statusText}</span>
+                            {' · '}{timeAgo(r.updatedAt || r.createdAt)}
+                          </div>
+                          {hasLLMD && (
+                            <div style={{borderTop: '1px solid #334155', paddingTop: 3, marginTop: 2}}>
+                              <div style={{fontSize: '8px', fontWeight: 600, color: '#64748b', marginBottom: 1}}>llm-d components</div>
+                              {Object.entries(dotLLMD).map(([name, tag]) => (
+                                <div key={name} style={{display: 'flex', gap: 4}}>
+                                  <span style={{color: '#94a3b8'}}>{name}</span>
+                                  <span style={{color: '#22d3ee', fontFamily: 'monospace'}}>:{String(tag)}</span>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                          {hasOther && (
+                            <div style={{borderTop: '1px solid #334155', paddingTop: 3, marginTop: 2}}>
+                              <div style={{fontSize: '8px', fontWeight: 600, color: '#64748b', marginBottom: 1}}>other images</div>
+                              {Object.entries(dotOther).map(([name, tag]) => (
+                                <div key={name} style={{display: 'flex', gap: 4}}>
+                                  <span style={{color: '#94a3b8'}}>{name}</span>
+                                  <span style={{color: '#fb923c', fontFamily: 'monospace'}}>:{String(tag)}</span>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                          {r.htmlUrl && <div style={{borderTop: '1px solid #334155', paddingTop: 3, marginTop: 2}}><a href={r.htmlUrl + '#logs'} onClick={(e) => { e.stopPropagation(); run(\`open "\${r.htmlUrl}#logs"\`); }} style={{color: '#60a5fa', fontSize: '9px'}}>View Logs</a></div>}
                         </span>
                         <span style={{
                           width: 7, height: 7, borderRadius: '50%', display: 'inline-block', cursor: 'pointer',


### PR DESCRIPTION
## Summary

- Fetches image metadata artifacts (from llm-d-infra PR #78) via GitHub Actions API and attaches resolved container image tags to each individual nightly E2E run
- Dot tooltips now show the **actual images used for that specific run** instead of guide-level defaults shared across all dots
- Uses `r.llmdImages || g.llmdImages` fallback pattern — per-run images when available, guide-level for older runs without artifacts

## Changes

- **`web/package.json`**: Add `fflate` (8KB) for zip decompression of GitHub artifacts
- **`web/netlify/functions/nightly-e2e.mts`**: Fetch and cache per-repo `image-metadata` artifacts from GitHub Actions API, enrich each `NightlyRun` with `llmdImages`/`otherImages`
- **`web/src/lib/llmd/nightlyE2EDemoData.ts`**: Add optional `llmdImages` and `otherImages` fields to `NightlyRun` interface
- **`web/src/hooks/useNightlyE2EData.ts`**: Pass through per-run image fields from API response
- **`web/src/components/cards/llmd/NightlyE2EStatus.tsx`**: Prefer `run.llmdImages` over `guide.llmdImages` in dot tooltips
- **`web/src/lib/widgets/codeGenerator.ts`**: Use `r.llmdImages || g.llmdImages` fallback for dot tooltips with rich image detail

## Dependencies

- Requires [llm-d-infra PR #78](https://github.com/llm-d/llm-d-infra/pull/78) (merged) — adds image metadata artifact emission to all 4 reusable nightly E2E workflows

## Test plan

- [ ] Verify build passes (`npm run build`)
- [ ] Verify lint passes (`npm run lint`)
- [ ] After tonight's nightly runs, verify per-run images appear in dot tooltips on console.kubestellar.io
- [ ] Verify Übersicht widget dot tooltips match card tooltips (synced in this PR)
- [ ] Verify older runs without artifacts gracefully fall back to guide-level images