### PR TITLE
🐛 Fix scroll tracking to use correct scroll container

### DIFF
--- a/web/src/hooks/useDashboardScrollTracking.ts
+++ b/web/src/hooks/useDashboardScrollTracking.ts
@@ -19,13 +19,18 @@ export function useDashboardScrollTracking() {
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
+    // The dashboard uses a <main> element with overflow-y-auto as the scroll
+    // container, not the window. Listen on the actual scrollable element.
+    const scrollContainer = document.querySelector('main') as HTMLElement | null
+
     const handleScroll = () => {
       if (hasFiredDeep.current) return // Already tracked deepest level
 
       if (debounceTimer.current) clearTimeout(debounceTimer.current)
 
       debounceTimer.current = setTimeout(() => {
-        const scrollRatio = window.scrollY / window.innerHeight
+        const el = scrollContainer || document.documentElement
+        const scrollRatio = el.scrollTop / el.clientHeight
 
         if (scrollRatio >= DEEP_SCROLL_THRESHOLD && !hasFiredDeep.current) {
           hasFiredDeep.current = true
@@ -37,9 +42,10 @@ export function useDashboardScrollTracking() {
       }, SCROLL_DEBOUNCE_MS)
     }
 
-    window.addEventListener('scroll', handleScroll, { passive: true })
+    const target = scrollContainer || window
+    target.addEventListener('scroll', handleScroll, { passive: true })
     return () => {
-      window.removeEventListener('scroll', handleScroll)
+      target.removeEventListener('scroll', handleScroll)
       if (debounceTimer.current) clearTimeout(debounceTimer.current)
     }
   }, [])


### PR DESCRIPTION
## Summary
- Dashboard scroll tracking hook was listening on `window.scroll`, but the actual scrollable element is `<main>` with `overflow-y-auto`
- `window.scrollY` stayed at 0, so `ksc_dashboard_scrolled` events never fired
- Now detects the `<main>` scroll container and listens on the correct element

## Test plan
- [ ] Scroll dashboard — verify `ksc_dashboard_scrolled` events appear in GA4 realtime
- [ ] Verify shallow (< 1.5x viewport) and deep (> 1.5x viewport) thresholds work