### PR TITLE
✨ GA4 analytics dashboard with live data at /analytics

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -49,6 +49,19 @@
 # GA4 event collection — custom lightweight tracker sends directly to /api/m
 # (Netlify Function via Config.path, no gtag.js loaded)
 
+# Analytics dashboard API — proxy to Netlify Function
+# Serves live GA4 Data API data (GA4_SERVICE_ACCOUNT_JSON + GA4_PROPERTY_ID in Netlify dashboard)
+[[redirects]]
+  from = "/api/analytics-dashboard"
+  to = "/.netlify/functions/analytics-dashboard"
+  status = 200
+
+# Analytics dashboard page — serve static HTML
+[[redirects]]
+  from = "/analytics"
+  to = "/analytics.html"
+  status = 200
+
 # SPA routing - redirect all routes to index.html (only if file doesn't exist)
 [[redirects]]
   from = "/*"

--- a/web/netlify/functions/analytics-dashboard.mts
+++ b/web/netlify/functions/analytics-dashboard.mts
@@ -1,0 +1,619 @@
+/**
+ * Netlify Function: GA4 Analytics Dashboard API
+ *
+ * Queries the GA4 Data API using a service account to provide
+ * real-time analytics data for the KubeStellar Console dashboard.
+ *
+ * Required Netlify env vars:
+ *   GA4_SERVICE_ACCOUNT_JSON — base64-encoded service account key JSON
+ *   GA4_PROPERTY_ID          — GA4 property ID (numeric, e.g. "525401563")
+ */
+
+import { getStore } from "@netlify/blobs";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_STORE = "analytics-dashboard";
+const CACHE_KEY = "dashboard-data";
+const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const TOKEN_CACHE_KEY = "access-token";
+const GA4_DATA_API = "https://analyticsdata.googleapis.com/v1beta";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const JWT_EXPIRY_SECONDS = 3600;
+const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000; // refresh 5 min before expiry
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ServiceAccountKey {
+  client_email: string;
+  private_key: string;
+  project_id: string;
+}
+
+interface TokenCache {
+  accessToken: string;
+  expiresAt: number;
+}
+
+interface GA4Row {
+  dimensionValues: { value: string }[];
+  metricValues: { value: string }[];
+}
+
+interface DashboardData {
+  overview: {
+    activeUsers: number;
+    sessions: number;
+    pageViews: number;
+    avgEngagementTime: number;
+    bounceRate: number;
+    eventsPerSession: number;
+  };
+  overviewPrevious: {
+    activeUsers: number;
+    sessions: number;
+    pageViews: number;
+    avgEngagementTime: number;
+    bounceRate: number;
+    eventsPerSession: number;
+  };
+  dailyUsers: { date: string; users: number; sessions: number }[];
+  topPages: { page: string; views: number; avgTime: number }[];
+  topEvents: { event: string; count: number; users: number }[];
+  countries: { country: string; users: number; sessions: number }[];
+  trafficSources: { source: string; medium: string; sessions: number; users: number }[];
+  devices: { category: string; users: number }[];
+  funnel: {
+    landing: number;
+    login: number;
+    agentConnected: number;
+    solutionViewed: number;
+    missionStarted: number;
+  };
+  cncfOutreach: {
+    project: string;
+    sessions: number;
+    users: number;
+    events: number;
+  }[];
+  engagementByPage: {
+    page: string;
+    avgEngagement: number;
+    bounceRate: number;
+    views: number;
+  }[];
+  newVsReturning: { type: string; users: number; sessions: number }[];
+  cachedAt: string;
+  propertyId: string;
+  dateRange: string;
+}
+
+// ---------------------------------------------------------------------------
+// JWT / OAuth helpers (no external deps — uses Web Crypto API)
+// ---------------------------------------------------------------------------
+
+function base64url(data: Uint8Array): string {
+  return btoa(String.fromCharCode(...data))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function textToBase64url(text: string): string {
+  return base64url(new TextEncoder().encode(text));
+}
+
+/** Import a PEM private key for RS256 signing */
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const pemContents = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/, "")
+    .replace(/-----END PRIVATE KEY-----/, "")
+    .replace(/\n/g, "");
+  const binaryDer = Uint8Array.from(atob(pemContents), (c) => c.charCodeAt(0));
+
+  return crypto.subtle.importKey(
+    "pkcs8",
+    binaryDer,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+}
+
+/** Create a signed JWT for Google OAuth2 */
+async function createSignedJWT(
+  serviceAccount: ServiceAccountKey
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = {
+    iss: serviceAccount.client_email,
+    sub: serviceAccount.client_email,
+    aud: GOOGLE_TOKEN_URL,
+    iat: now,
+    exp: now + JWT_EXPIRY_SECONDS,
+    scope: "https://www.googleapis.com/auth/analytics.readonly",
+  };
+
+  const headerB64 = textToBase64url(JSON.stringify(header));
+  const payloadB64 = textToBase64url(JSON.stringify(payload));
+  const signingInput = `${headerB64}.${payloadB64}`;
+
+  const key = await importPrivateKey(serviceAccount.private_key);
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    new TextEncoder().encode(signingInput)
+  );
+
+  return `${signingInput}.${base64url(new Uint8Array(signature))}`;
+}
+
+/** Get an access token (with caching) */
+async function getAccessToken(
+  serviceAccount: ServiceAccountKey,
+  store: ReturnType<typeof getStore>
+): Promise<string> {
+  // Check token cache
+  try {
+    const cached = await store.get(TOKEN_CACHE_KEY, { type: "text" });
+    if (cached) {
+      const entry: TokenCache = JSON.parse(cached);
+      if (Date.now() < entry.expiresAt - TOKEN_REFRESH_BUFFER_MS) {
+        return entry.accessToken;
+      }
+    }
+  } catch {
+    // Cache miss
+  }
+
+  const jwt = await createSignedJWT(serviceAccount);
+  const resp = await fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: jwt,
+    }),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Token exchange failed (${resp.status}): ${body}`);
+  }
+
+  const data = await resp.json();
+  const accessToken = data.access_token;
+  const expiresIn = data.expires_in || JWT_EXPIRY_SECONDS;
+
+  // Cache token
+  const cacheEntry: TokenCache = {
+    accessToken,
+    expiresAt: Date.now() + expiresIn * 1000,
+  };
+  store.set(TOKEN_CACHE_KEY, JSON.stringify(cacheEntry)).catch(() => {});
+
+  return accessToken;
+}
+
+// ---------------------------------------------------------------------------
+// GA4 Data API queries
+// ---------------------------------------------------------------------------
+
+async function runReport(
+  propertyId: string,
+  accessToken: string,
+  body: Record<string, unknown>
+): Promise<GA4Row[]> {
+  const resp = await fetch(
+    `${GA4_DATA_API}/properties/${propertyId}:runReport`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    }
+  );
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`GA4 API ${resp.status}: ${text}`);
+  }
+
+  const data = await resp.json();
+  return data.rows || [];
+}
+
+function dimVal(row: GA4Row, idx: number): string {
+  return (row.dimensionValues || [])[idx]?.value || "(not set)";
+}
+
+function metVal(row: GA4Row, idx: number): number {
+  return parseFloat((row.metricValues || [])[idx]?.value || "0");
+}
+
+/** Fetch all dashboard data in parallel */
+async function fetchDashboardData(
+  propertyId: string,
+  accessToken: string
+): Promise<DashboardData> {
+  const currentRange = { startDate: "28daysAgo", endDate: "today" };
+  const previousRange = { startDate: "56daysAgo", endDate: "29daysAgo" };
+
+  const [
+    overviewRows,
+    overviewPrevRows,
+    dailyRows,
+    pageRows,
+    eventRows,
+    countryRows,
+    sourceRows,
+    deviceRows,
+    funnelRows,
+    cncfRows,
+    engagementRows,
+    newReturnRows,
+  ] = await Promise.all([
+    // 1. Overview metrics (current period)
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      metrics: [
+        { name: "activeUsers" },
+        { name: "sessions" },
+        { name: "screenPageViews" },
+        { name: "averageSessionDuration" },
+        { name: "bounceRate" },
+        { name: "eventCount" },
+      ],
+    }),
+
+    // 2. Overview metrics (previous period for comparison)
+    runReport(propertyId, accessToken, {
+      dateRanges: [previousRange],
+      metrics: [
+        { name: "activeUsers" },
+        { name: "sessions" },
+        { name: "screenPageViews" },
+        { name: "averageSessionDuration" },
+        { name: "bounceRate" },
+        { name: "eventCount" },
+      ],
+    }),
+
+    // 3. Daily users/sessions
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "date" }],
+      metrics: [{ name: "activeUsers" }, { name: "sessions" }],
+      orderBys: [{ dimension: { dimensionName: "date", orderType: "ALPHANUMERIC" } }],
+    }),
+
+    // 4. Top pages
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "pageTitle" }],
+      metrics: [
+        { name: "screenPageViews" },
+        { name: "averageSessionDuration" },
+      ],
+      orderBys: [{ metric: { metricName: "screenPageViews" }, desc: true }],
+      limit: 15,
+    }),
+
+    // 5. Top events
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "eventName" }],
+      metrics: [{ name: "eventCount" }, { name: "totalUsers" }],
+      orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
+      limit: 20,
+    }),
+
+    // 6. Countries
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "country" }],
+      metrics: [{ name: "activeUsers" }, { name: "sessions" }],
+      orderBys: [{ metric: { metricName: "activeUsers" }, desc: true }],
+      limit: 15,
+    }),
+
+    // 7. Traffic sources
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [
+        { name: "sessionSource" },
+        { name: "sessionMedium" },
+      ],
+      metrics: [{ name: "sessions" }, { name: "totalUsers" }],
+      orderBys: [{ metric: { metricName: "sessions" }, desc: true }],
+      limit: 10,
+    }),
+
+    // 8. Devices
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "deviceCategory" }],
+      metrics: [{ name: "activeUsers" }],
+      orderBys: [{ metric: { metricName: "activeUsers" }, desc: true }],
+    }),
+
+    // 9. Funnel events (custom KSC events)
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "eventName" }],
+      metrics: [{ name: "totalUsers" }],
+      dimensionFilter: {
+        orGroup: {
+          expressions: [
+            "ksc_utm_landing",
+            "login",
+            "ksc_agent_connected",
+            "ksc_solution_viewed",
+            "ksc_mission_started",
+            "page_view",
+            "first_visit",
+          ].map((ev) => ({
+            filter: {
+              fieldName: "eventName",
+              stringFilter: { matchType: "EXACT", value: ev },
+            },
+          })),
+        },
+      },
+    }),
+
+    // 10. CNCF outreach (by utm_term = project slug)
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "sessionManualTerm" }],
+      metrics: [
+        { name: "sessions" },
+        { name: "totalUsers" },
+        { name: "eventCount" },
+      ],
+      dimensionFilter: {
+        filter: {
+          fieldName: "sessionCampaignName",
+          stringFilter: { matchType: "EXACT", value: "cncf_outreach" },
+        },
+      },
+      orderBys: [{ metric: { metricName: "sessions" }, desc: true }],
+      limit: 30,
+    }),
+
+    // 11. Engagement by page
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "pageTitle" }],
+      metrics: [
+        { name: "userEngagementDuration" },
+        { name: "bounceRate" },
+        { name: "screenPageViews" },
+        { name: "activeUsers" },
+      ],
+      orderBys: [{ metric: { metricName: "screenPageViews" }, desc: true }],
+      limit: 15,
+    }),
+
+    // 12. New vs returning users
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "newVsReturning" }],
+      metrics: [{ name: "activeUsers" }, { name: "sessions" }],
+    }),
+  ]);
+
+  // Parse overview
+  const ov = overviewRows[0];
+  const ovp = overviewPrevRows[0];
+  const overview = ov
+    ? {
+        activeUsers: metVal(ov, 0),
+        sessions: metVal(ov, 1),
+        pageViews: metVal(ov, 2),
+        avgEngagementTime: metVal(ov, 3),
+        bounceRate: metVal(ov, 4),
+        eventsPerSession:
+          metVal(ov, 1) > 0 ? metVal(ov, 5) / metVal(ov, 1) : 0,
+      }
+    : {
+        activeUsers: 0,
+        sessions: 0,
+        pageViews: 0,
+        avgEngagementTime: 0,
+        bounceRate: 0,
+        eventsPerSession: 0,
+      };
+
+  const overviewPrevious = ovp
+    ? {
+        activeUsers: metVal(ovp, 0),
+        sessions: metVal(ovp, 1),
+        pageViews: metVal(ovp, 2),
+        avgEngagementTime: metVal(ovp, 3),
+        bounceRate: metVal(ovp, 4),
+        eventsPerSession:
+          metVal(ovp, 1) > 0 ? metVal(ovp, 5) / metVal(ovp, 1) : 0,
+      }
+    : {
+        activeUsers: 0,
+        sessions: 0,
+        pageViews: 0,
+        avgEngagementTime: 0,
+        bounceRate: 0,
+        eventsPerSession: 0,
+      };
+
+  // Parse funnel
+  const funnelMap: Record<string, number> = {};
+  for (const row of funnelRows) {
+    funnelMap[dimVal(row, 0)] = metVal(row, 0);
+  }
+
+  return {
+    overview,
+    overviewPrevious,
+    dailyUsers: dailyRows.map((r) => ({
+      date: dimVal(r, 0),
+      users: metVal(r, 0),
+      sessions: metVal(r, 1),
+    })),
+    topPages: pageRows.map((r) => ({
+      page: dimVal(r, 0),
+      views: metVal(r, 0),
+      avgTime: metVal(r, 1),
+    })),
+    topEvents: eventRows.map((r) => ({
+      event: dimVal(r, 0),
+      count: metVal(r, 0),
+      users: metVal(r, 1),
+    })),
+    countries: countryRows.map((r) => ({
+      country: dimVal(r, 0),
+      users: metVal(r, 0),
+      sessions: metVal(r, 1),
+    })),
+    trafficSources: sourceRows.map((r) => ({
+      source: dimVal(r, 0),
+      medium: dimVal(r, 1),
+      sessions: metVal(r, 0),
+      users: metVal(r, 1),
+    })),
+    devices: deviceRows.map((r) => ({
+      category: dimVal(r, 0),
+      users: metVal(r, 0),
+    })),
+    funnel: {
+      landing: funnelMap["page_view"] || funnelMap["first_visit"] || 0,
+      login: funnelMap["login"] || 0,
+      agentConnected: funnelMap["ksc_agent_connected"] || 0,
+      solutionViewed: funnelMap["ksc_solution_viewed"] || 0,
+      missionStarted: funnelMap["ksc_mission_started"] || 0,
+    },
+    cncfOutreach: cncfRows
+      .filter((r) => dimVal(r, 0) !== "(not set)")
+      .map((r) => ({
+        project: dimVal(r, 0),
+        sessions: metVal(r, 0),
+        users: metVal(r, 1),
+        events: metVal(r, 2),
+      })),
+    engagementByPage: engagementRows.map((r) => ({
+      page: dimVal(r, 0),
+      avgEngagement:
+        metVal(r, 3) > 0 ? metVal(r, 0) / metVal(r, 3) : 0,
+      bounceRate: metVal(r, 1),
+      views: metVal(r, 2),
+    })),
+    newVsReturning: newReturnRows.map((r) => ({
+      type: dimVal(r, 0),
+      users: metVal(r, 0),
+      sessions: metVal(r, 1),
+    })),
+    cachedAt: new Date().toISOString(),
+    propertyId,
+    dateRange: "Last 28 days",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export default async (req: Request) => {
+  const corsHeaders: Record<string, string> = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+    "Cache-Control": "public, max-age=900", // 15 min browser cache
+  };
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  // Load service account credentials
+  const saJsonB64 =
+    Netlify.env.get("GA4_SERVICE_ACCOUNT_JSON") ||
+    process.env.GA4_SERVICE_ACCOUNT_JSON;
+  const propertyId =
+    Netlify.env.get("GA4_PROPERTY_ID") || process.env.GA4_PROPERTY_ID;
+
+  if (!saJsonB64 || !propertyId) {
+    return new Response(
+      JSON.stringify({
+        error: "Missing configuration",
+        hint: "Set GA4_SERVICE_ACCOUNT_JSON (base64) and GA4_PROPERTY_ID in Netlify env vars",
+      }),
+      {
+        status: 503,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+
+  let serviceAccount: ServiceAccountKey;
+  try {
+    serviceAccount = JSON.parse(atob(saJsonB64));
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Invalid GA4_SERVICE_ACCOUNT_JSON — must be base64-encoded JSON" }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+
+  // Check blob cache
+  const store = getStore(CACHE_STORE);
+  try {
+    const cached = await store.get(CACHE_KEY, { type: "text" });
+    if (cached) {
+      const entry = JSON.parse(cached);
+      if (Date.now() < entry.expiresAt) {
+        return new Response(JSON.stringify({ ...entry.data, fromCache: true }), {
+          status: 200,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
+    }
+  } catch {
+    // Cache miss
+  }
+
+  // Fetch fresh data
+  try {
+    const accessToken = await getAccessToken(serviceAccount, store);
+    const data = await fetchDashboardData(propertyId, accessToken);
+
+    // Cache result
+    store
+      .set(
+        CACHE_KEY,
+        JSON.stringify({ data, expiresAt: Date.now() + CACHE_TTL_MS })
+      )
+      .catch(() => {});
+
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch analytics data", message }),
+      {
+        status: 502,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+};

--- a/web/public/analytics.html
+++ b/web/public/analytics.html
@@ -1,0 +1,849 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>KubeStellar Console Analytics</title>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  <style>
+    :root {
+      --bg: #0f1117;
+      --surface: #1a1d27;
+      --surface-hover: #242736;
+      --border: #2a2d3a;
+      --text: #e4e4e7;
+      --text-muted: #9ca3af;
+      --accent: #6366f1;
+      --accent-light: #818cf8;
+      --green: #22c55e;
+      --red: #ef4444;
+      --yellow: #eab308;
+      --blue: #3b82f6;
+      --purple: #a855f7;
+      --orange: #f97316;
+      --cyan: #06b6d4;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+      min-height: 100vh;
+    }
+
+    .header {
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      padding: 16px 24px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      backdrop-filter: blur(12px);
+    }
+
+    .header-left {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .header h1 {
+      font-size: 18px;
+      font-weight: 600;
+      background: linear-gradient(135deg, var(--accent-light), var(--cyan));
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    .header-right {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-size: 13px;
+      color: var(--text-muted);
+    }
+
+    .status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--green);
+      display: inline-block;
+      animation: pulse 2s infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+
+    .refresh-btn {
+      background: var(--surface-hover);
+      border: 1px solid var(--border);
+      color: var(--text);
+      padding: 6px 12px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 13px;
+      transition: all 0.2s;
+    }
+
+    .refresh-btn:hover { background: var(--accent); border-color: var(--accent); }
+    .refresh-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    .container {
+      max-width: 1440px;
+      margin: 0 auto;
+      padding: 24px;
+    }
+
+    /* Loading state */
+    .loading-overlay {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 60vh;
+      gap: 16px;
+    }
+
+    .spinner {
+      width: 40px;
+      height: 40px;
+      border: 3px solid var(--border);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    .error-box {
+      background: rgba(239, 68, 68, 0.1);
+      border: 1px solid rgba(239, 68, 68, 0.3);
+      border-radius: 8px;
+      padding: 16px 20px;
+      color: var(--red);
+      max-width: 600px;
+      margin: 40px auto;
+    }
+
+    /* KPI Cards */
+    .kpi-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+
+    .kpi-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 20px;
+      transition: border-color 0.2s;
+    }
+
+    .kpi-card:hover { border-color: var(--accent); }
+
+    .kpi-label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--text-muted);
+      margin-bottom: 4px;
+    }
+
+    .kpi-value {
+      font-size: 28px;
+      font-weight: 700;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .kpi-change {
+      font-size: 13px;
+      margin-top: 4px;
+      font-weight: 500;
+    }
+
+    .kpi-change.up { color: var(--green); }
+    .kpi-change.down { color: var(--red); }
+    .kpi-change.flat { color: var(--text-muted); }
+
+    /* Chart grid */
+    .chart-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 20px;
+      margin-bottom: 24px;
+    }
+
+    .chart-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 20px;
+    }
+
+    .chart-card.full-width {
+      grid-column: 1 / -1;
+    }
+
+    .chart-card h3 {
+      font-size: 14px;
+      font-weight: 600;
+      margin-bottom: 16px;
+      color: var(--text);
+    }
+
+    .chart-wrapper {
+      position: relative;
+      height: 280px;
+    }
+
+    /* Tables */
+    .table-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 20px;
+      overflow-x: auto;
+    }
+
+    .table-card h3 {
+      font-size: 14px;
+      font-weight: 600;
+      margin-bottom: 12px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+
+    th {
+      text-align: left;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--border);
+      color: var(--text-muted);
+      font-weight: 500;
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    td {
+      padding: 8px 12px;
+      border-bottom: 1px solid rgba(42, 45, 58, 0.5);
+    }
+
+    tr:hover td { background: var(--surface-hover); }
+
+    .num { text-align: right; font-variant-numeric: tabular-nums; }
+
+    /* Funnel */
+    .funnel-container {
+      display: flex;
+      align-items: flex-end;
+      gap: 2px;
+      height: 220px;
+      padding: 20px 0;
+    }
+
+    .funnel-step {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .funnel-bar {
+      width: 100%;
+      border-radius: 6px 6px 0 0;
+      min-height: 4px;
+      transition: height 0.5s ease;
+    }
+
+    .funnel-label {
+      font-size: 11px;
+      text-align: center;
+      color: var(--text-muted);
+      line-height: 1.3;
+    }
+
+    .funnel-value {
+      font-size: 16px;
+      font-weight: 700;
+    }
+
+    .funnel-pct {
+      font-size: 11px;
+      color: var(--text-muted);
+    }
+
+    /* Responsive */
+    @media (max-width: 768px) {
+      .chart-grid { grid-template-columns: 1fr; }
+      .kpi-grid { grid-template-columns: repeat(2, 1fr); }
+      .container { padding: 16px; }
+    }
+
+    /* Insight cards */
+    .insights-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+
+    .insight-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 16px 20px;
+      border-left: 3px solid var(--accent);
+    }
+
+    .insight-card.warning { border-left-color: var(--yellow); }
+    .insight-card.success { border-left-color: var(--green); }
+    .insight-card.danger { border-left-color: var(--red); }
+
+    .insight-title {
+      font-size: 13px;
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+
+    .insight-body {
+      font-size: 12px;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+
+    /* Section headings */
+    .section-title {
+      font-size: 16px;
+      font-weight: 600;
+      margin: 32px 0 16px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    /* Back link */
+    .back-link {
+      color: var(--accent-light);
+      text-decoration: none;
+      font-size: 13px;
+    }
+
+    .back-link:hover { text-decoration: underline; }
+
+    /* TODO banner */
+    .todo-banner {
+      background: rgba(234, 179, 8, 0.1);
+      border: 1px solid rgba(234, 179, 8, 0.3);
+      border-radius: 8px;
+      padding: 12px 16px;
+      margin-bottom: 24px;
+      font-size: 13px;
+      color: var(--yellow);
+    }
+
+    .todo-banner strong { color: var(--text); }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="header-left">
+      <a href="/" class="back-link">&larr; Console</a>
+      <h1>KubeStellar Console Analytics</h1>
+    </div>
+    <div class="header-right">
+      <span id="cache-status"></span>
+      <span class="status-dot" id="status-dot"></span>
+      <button class="refresh-btn" id="refresh-btn" onclick="loadData(true)">Refresh</button>
+    </div>
+  </div>
+
+  <div class="container" id="content">
+    <div class="loading-overlay" id="loading">
+      <div class="spinner"></div>
+      <div style="color: var(--text-muted); font-size: 14px;">Loading analytics data...</div>
+    </div>
+  </div>
+
+  <script>
+    const API_URL = '/api/analytics-dashboard';
+    const CHART_COLORS = ['#6366f1', '#06b6d4', '#22c55e', '#f97316', '#a855f7', '#ef4444', '#eab308', '#3b82f6'];
+    const FUNNEL_COLORS = ['#6366f1', '#818cf8', '#3b82f6', '#06b6d4', '#22c55e'];
+
+    Chart.defaults.color = '#9ca3af';
+    Chart.defaults.borderColor = 'rgba(42, 45, 58, 0.8)';
+    Chart.defaults.font.family = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
+
+    let charts = [];
+
+    function fmt(n) {
+      if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+      if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
+      return Math.round(n).toLocaleString();
+    }
+
+    function fmtTime(seconds) {
+      if (seconds < 60) return Math.round(seconds) + 's';
+      const m = Math.floor(seconds / 60);
+      const s = Math.round(seconds % 60);
+      return m + 'm ' + s + 's';
+    }
+
+    function fmtPct(n) {
+      return (n * 100).toFixed(1) + '%';
+    }
+
+    function pctChange(current, previous) {
+      if (previous === 0) return current > 0 ? { value: '+100%', dir: 'up' } : { value: '0%', dir: 'flat' };
+      const change = ((current - previous) / previous) * 100;
+      const dir = change > 2 ? 'up' : change < -2 ? 'down' : 'flat';
+      const sign = change > 0 ? '+' : '';
+      return { value: sign + change.toFixed(1) + '%', dir };
+    }
+
+    function formatDate(dateStr) {
+      // GA4 date format: YYYYMMDD
+      const y = dateStr.slice(0, 4);
+      const m = dateStr.slice(4, 6);
+      const d = dateStr.slice(6, 8);
+      return m + '/' + d;
+    }
+
+    function destroyCharts() {
+      charts.forEach(c => c.destroy());
+      charts = [];
+    }
+
+    function generateInsights(data) {
+      const insights = [];
+      const ov = data.overview;
+      const ovp = data.overviewPrevious;
+
+      // User growth
+      const userGrowth = ovp.activeUsers > 0 ? ((ov.activeUsers - ovp.activeUsers) / ovp.activeUsers) * 100 : 0;
+      if (userGrowth > 20) {
+        insights.push({ type: 'success', title: 'Strong User Growth', body: `Active users up ${userGrowth.toFixed(0)}% vs previous period (${fmt(ovp.activeUsers)} → ${fmt(ov.activeUsers)}). Momentum is building.` });
+      } else if (userGrowth < -10) {
+        insights.push({ type: 'danger', title: 'User Decline', body: `Active users down ${Math.abs(userGrowth).toFixed(0)}% vs previous period. Investigate traffic sources and recent changes.` });
+      }
+
+      // Bounce rate
+      if (ov.bounceRate > 0.6) {
+        insights.push({ type: 'warning', title: 'High Bounce Rate', body: `${fmtPct(ov.bounceRate)} bounce rate suggests users aren't finding what they need. Consider improving landing page content and navigation.` });
+      }
+
+      // Funnel analysis
+      if (data.funnel.landing > 0 && data.funnel.login > 0) {
+        const loginRate = data.funnel.login / data.funnel.landing;
+        if (loginRate < 0.3) {
+          insights.push({ type: 'warning', title: 'Low Login Conversion', body: `Only ${fmtPct(loginRate)} of visitors log in. Consider reducing friction in the auth flow or improving the value proposition on the landing page.` });
+        }
+      }
+
+      if (data.funnel.agentConnected > 0 && data.funnel.missionStarted > 0) {
+        const missionRate = data.funnel.missionStarted / data.funnel.agentConnected;
+        if (missionRate < 0.2) {
+          insights.push({ type: 'warning', title: 'Agent → Mission Drop-off', body: `Only ${fmtPct(missionRate)} of users who connect an agent go on to start a mission. The missions discovery experience may need improvement.` });
+        }
+      }
+
+      // Top page engagement
+      if (data.engagementByPage.length > 0) {
+        const stickiest = [...data.engagementByPage].sort((a, b) => b.avgEngagement - a.avgEngagement)[0];
+        if (stickiest && stickiest.avgEngagement > 30) {
+          insights.push({ type: 'success', title: 'Stickiest Page', body: `"${stickiest.page}" has the highest engagement at ${fmtTime(stickiest.avgEngagement)} per user. Users find real value here.` });
+        }
+      }
+
+      // CNCF outreach
+      if (data.cncfOutreach.length > 0) {
+        const total = data.cncfOutreach.reduce((sum, r) => sum + r.sessions, 0);
+        insights.push({ type: 'success', title: 'CNCF Outreach Active', body: `${data.cncfOutreach.length} CNCF projects driving ${total} sessions. Track per-project conversion below.` });
+      }
+
+      // New vs returning
+      const returning = data.newVsReturning.find(r => r.type === 'returning');
+      const newUsers = data.newVsReturning.find(r => r.type === 'new');
+      if (returning && newUsers && newUsers.users > 0) {
+        const retentionRate = returning.users / (returning.users + newUsers.users);
+        if (retentionRate > 0.3) {
+          insights.push({ type: 'success', title: 'Good Retention', body: `${fmtPct(retentionRate)} returning users indicates the product delivers ongoing value.` });
+        } else {
+          insights.push({ type: 'warning', title: 'Low Retention', body: `Only ${fmtPct(retentionRate)} returning users. Focus on activation and "aha moment" to improve retention.` });
+        }
+      }
+
+      return insights;
+    }
+
+    function renderDashboard(data) {
+      destroyCharts();
+      const container = document.getElementById('content');
+      const ov = data.overview;
+      const ovp = data.overviewPrevious;
+
+      // Generate insights
+      const insights = generateInsights(data);
+
+      let html = '';
+
+      // TODO banner for error rate
+      html += `<div class="todo-banner">
+        <strong>TODO:</strong> Address error rate — The "error rate" in analytics refers to the ratio of failed event hits
+        (HTTP 4xx/5xx responses from the analytics proxy) to total event hits. A high error rate means analytics data is being
+        lost — events fired by the browser are not reaching GA4. Common causes: ad blockers (mitigated by our proxy),
+        network timeouts, or proxy misconfiguration. Current proxy: <code>/api/m</code> → GA4.
+        Check Netlify Function logs for <code>analytics-collect</code> errors.
+      </div>`;
+
+      // KPI cards
+      const kpis = [
+        { label: 'Active Users', value: fmt(ov.activeUsers), change: pctChange(ov.activeUsers, ovp.activeUsers) },
+        { label: 'Sessions', value: fmt(ov.sessions), change: pctChange(ov.sessions, ovp.sessions) },
+        { label: 'Page Views', value: fmt(ov.pageViews), change: pctChange(ov.pageViews, ovp.pageViews) },
+        { label: 'Avg Engagement', value: fmtTime(ov.avgEngagementTime), change: pctChange(ov.avgEngagementTime, ovp.avgEngagementTime) },
+        { label: 'Bounce Rate', value: fmtPct(ov.bounceRate), change: pctChange(ov.bounceRate, ovp.bounceRate) },
+        { label: 'Events / Session', value: ov.eventsPerSession.toFixed(1), change: pctChange(ov.eventsPerSession, ovp.eventsPerSession) },
+      ];
+
+      // Invert bounce rate direction (lower is better)
+      kpis[4].change.dir = kpis[4].change.dir === 'up' ? 'down' : kpis[4].change.dir === 'down' ? 'up' : 'flat';
+
+      html += '<div class="kpi-grid">';
+      for (const kpi of kpis) {
+        html += `<div class="kpi-card">
+          <div class="kpi-label">${kpi.label}</div>
+          <div class="kpi-value">${kpi.value}</div>
+          <div class="kpi-change ${kpi.change.dir}">${kpi.change.dir === 'up' ? '&#9650;' : kpi.change.dir === 'down' ? '&#9660;' : '&#8212;'} ${kpi.change.value} vs prev 28d</div>
+        </div>`;
+      }
+      html += '</div>';
+
+      // Insights
+      if (insights.length > 0) {
+        html += '<div class="section-title">Actionable Insights</div>';
+        html += '<div class="insights-grid">';
+        for (const ins of insights) {
+          html += `<div class="insight-card ${ins.type}">
+            <div class="insight-title">${ins.title}</div>
+            <div class="insight-body">${ins.body}</div>
+          </div>`;
+        }
+        html += '</div>';
+      }
+
+      // Charts row 1: Daily Users + Adoption Funnel
+      html += '<div class="chart-grid">';
+      html += '<div class="chart-card"><h3>Daily Active Users & Sessions</h3><div class="chart-wrapper"><canvas id="dailyChart"></canvas></div></div>';
+
+      // Funnel
+      const funnel = data.funnel;
+      const funnelSteps = [
+        { label: 'Page View', value: funnel.landing, color: FUNNEL_COLORS[0] },
+        { label: 'Login', value: funnel.login, color: FUNNEL_COLORS[1] },
+        { label: 'Agent Connected', value: funnel.agentConnected, color: FUNNEL_COLORS[2] },
+        { label: 'Solution Viewed', value: funnel.solutionViewed, color: FUNNEL_COLORS[3] },
+        { label: 'Mission Started', value: funnel.missionStarted, color: FUNNEL_COLORS[4] },
+      ];
+      const maxFunnel = Math.max(...funnelSteps.map(s => s.value), 1);
+
+      html += '<div class="chart-card"><h3>Adoption Funnel (28 days)</h3><div class="funnel-container">';
+      for (const step of funnelSteps) {
+        const heightPct = (step.value / maxFunnel) * 100;
+        const pct = funnel.landing > 0 ? ((step.value / funnel.landing) * 100).toFixed(1) + '%' : '—';
+        html += `<div class="funnel-step">
+          <div class="funnel-value">${fmt(step.value)}</div>
+          <div class="funnel-bar" style="height: ${Math.max(heightPct, 2)}%; background: ${step.color};"></div>
+          <div class="funnel-label">${step.label}</div>
+          <div class="funnel-pct">${pct}</div>
+        </div>`;
+      }
+      html += '</div></div>';
+
+      // Charts row 2: Events + Countries
+      html += '<div class="chart-card"><h3>Top Events</h3><div class="chart-wrapper"><canvas id="eventsChart"></canvas></div></div>';
+      html += '<div class="chart-card"><h3>Users by Country</h3><div class="chart-wrapper"><canvas id="countryChart"></canvas></div></div>';
+
+      // Charts row 3: Traffic Sources + Devices
+      html += '<div class="chart-card"><h3>Traffic Sources</h3><div class="chart-wrapper"><canvas id="sourceChart"></canvas></div></div>';
+      html += '<div class="chart-card"><h3>Device Categories</h3><div class="chart-wrapper"><canvas id="deviceChart"></canvas></div></div>';
+
+      html += '</div>'; // end chart-grid
+
+      // Tables
+      html += '<div class="section-title">Page Performance</div>';
+      html += '<div class="chart-grid">';
+
+      // Top Pages table
+      html += '<div class="table-card"><h3>Top Pages</h3><table><thead><tr><th>Page</th><th class="num">Views</th><th class="num">Avg Time</th></tr></thead><tbody>';
+      for (const p of data.topPages) {
+        html += `<tr><td>${p.page}</td><td class="num">${fmt(p.views)}</td><td class="num">${fmtTime(p.avgTime)}</td></tr>`;
+      }
+      html += '</tbody></table></div>';
+
+      // Engagement by Page
+      html += '<div class="table-card"><h3>Page Engagement</h3><table><thead><tr><th>Page</th><th class="num">Avg Engagement</th><th class="num">Bounce Rate</th><th class="num">Views</th></tr></thead><tbody>';
+      for (const p of data.engagementByPage) {
+        html += `<tr><td>${p.page}</td><td class="num">${fmtTime(p.avgEngagement)}</td><td class="num">${fmtPct(p.bounceRate)}</td><td class="num">${fmt(p.views)}</td></tr>`;
+      }
+      html += '</tbody></table></div>';
+
+      html += '</div>'; // end chart-grid
+
+      // Events table
+      html += '<div class="section-title">Events</div>';
+      html += '<div class="table-card"><h3>All Events (28 days)</h3><table><thead><tr><th>Event Name</th><th class="num">Count</th><th class="num">Users</th></tr></thead><tbody>';
+      for (const e of data.topEvents) {
+        html += `<tr><td><code>${e.event}</code></td><td class="num">${fmt(e.count)}</td><td class="num">${fmt(e.users)}</td></tr>`;
+      }
+      html += '</tbody></table></div>';
+
+      // CNCF Outreach
+      if (data.cncfOutreach.length > 0) {
+        html += '<div class="section-title">CNCF Outreach Campaign</div>';
+        html += '<div class="table-card"><h3>Per-Project Performance</h3><table><thead><tr><th>Project</th><th class="num">Sessions</th><th class="num">Users</th><th class="num">Events</th></tr></thead><tbody>';
+        for (const p of data.cncfOutreach) {
+          html += `<tr><td>${p.project}</td><td class="num">${p.sessions}</td><td class="num">${p.users}</td><td class="num">${p.events}</td></tr>`;
+        }
+        html += '</tbody></table></div>';
+      }
+
+      // New vs Returning
+      html += '<div class="section-title">Audience</div>';
+      html += '<div class="chart-grid">';
+      html += '<div class="table-card"><h3>New vs Returning Users</h3><table><thead><tr><th>Type</th><th class="num">Users</th><th class="num">Sessions</th></tr></thead><tbody>';
+      for (const r of data.newVsReturning) {
+        html += `<tr><td style="text-transform: capitalize;">${r.type}</td><td class="num">${fmt(r.users)}</td><td class="num">${fmt(r.sessions)}</td></tr>`;
+      }
+      html += '</tbody></table></div>';
+
+      // Traffic sources table
+      html += '<div class="table-card"><h3>Traffic Sources</h3><table><thead><tr><th>Source</th><th>Medium</th><th class="num">Sessions</th><th class="num">Users</th></tr></thead><tbody>';
+      for (const s of data.trafficSources) {
+        html += `<tr><td>${s.source}</td><td>${s.medium}</td><td class="num">${s.sessions}</td><td class="num">${s.users}</td></tr>`;
+      }
+      html += '</tbody></table></div>';
+      html += '</div>'; // end chart-grid
+
+      container.innerHTML = html;
+
+      // Render charts
+      renderDailyChart(data.dailyUsers);
+      renderEventsChart(data.topEvents.slice(0, 10));
+      renderCountryChart(data.countries.slice(0, 8));
+      renderSourceChart(data.trafficSources.slice(0, 6));
+      renderDeviceChart(data.devices);
+    }
+
+    function renderDailyChart(dailyUsers) {
+      const ctx = document.getElementById('dailyChart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: dailyUsers.map(d => formatDate(d.date)),
+          datasets: [
+            {
+              label: 'Users',
+              data: dailyUsers.map(d => d.users),
+              borderColor: '#6366f1',
+              backgroundColor: 'rgba(99, 102, 241, 0.1)',
+              fill: true,
+              tension: 0.3,
+              pointRadius: 2,
+            },
+            {
+              label: 'Sessions',
+              data: dailyUsers.map(d => d.sessions),
+              borderColor: '#06b6d4',
+              backgroundColor: 'rgba(6, 182, 212, 0.05)',
+              fill: true,
+              tension: 0.3,
+              pointRadius: 2,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          interaction: { intersect: false, mode: 'index' },
+          plugins: { legend: { position: 'top', labels: { boxWidth: 12, padding: 16 } } },
+          scales: {
+            x: { grid: { display: false } },
+            y: { beginAtZero: true },
+          },
+        },
+      });
+      charts.push(chart);
+    }
+
+    function renderEventsChart(events) {
+      const ctx = document.getElementById('eventsChart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: events.map(e => e.event),
+          datasets: [{
+            label: 'Event Count',
+            data: events.map(e => e.count),
+            backgroundColor: CHART_COLORS.slice(0, events.length),
+            borderRadius: 4,
+          }],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: 'y',
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { beginAtZero: true },
+            y: { grid: { display: false }, ticks: { font: { size: 11 } } },
+          },
+        },
+      });
+      charts.push(chart);
+    }
+
+    function renderCountryChart(countries) {
+      const ctx = document.getElementById('countryChart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'doughnut',
+        data: {
+          labels: countries.map(c => c.country),
+          datasets: [{
+            data: countries.map(c => c.users),
+            backgroundColor: CHART_COLORS,
+            borderWidth: 0,
+          }],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { position: 'right', labels: { boxWidth: 12, padding: 8, font: { size: 11 } } },
+          },
+        },
+      });
+      charts.push(chart);
+    }
+
+    function renderSourceChart(sources) {
+      const ctx = document.getElementById('sourceChart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: sources.map(s => s.source + ' / ' + s.medium),
+          datasets: [{
+            label: 'Sessions',
+            data: sources.map(s => s.sessions),
+            backgroundColor: '#6366f1',
+            borderRadius: 4,
+          }, {
+            label: 'Users',
+            data: sources.map(s => s.users),
+            backgroundColor: '#06b6d4',
+            borderRadius: 4,
+          }],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: { legend: { position: 'top', labels: { boxWidth: 12 } } },
+          scales: {
+            x: { grid: { display: false }, ticks: { font: { size: 10 } } },
+            y: { beginAtZero: true },
+          },
+        },
+      });
+      charts.push(chart);
+    }
+
+    function renderDeviceChart(devices) {
+      const ctx = document.getElementById('deviceChart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'doughnut',
+        data: {
+          labels: devices.map(d => d.category),
+          datasets: [{
+            data: devices.map(d => d.users),
+            backgroundColor: ['#6366f1', '#06b6d4', '#22c55e', '#f97316'],
+            borderWidth: 0,
+          }],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { position: 'right', labels: { boxWidth: 12, padding: 12 } },
+          },
+        },
+      });
+      charts.push(chart);
+    }
+
+    async function loadData(forceRefresh = false) {
+      const btn = document.getElementById('refresh-btn');
+      const status = document.getElementById('cache-status');
+      const dot = document.getElementById('status-dot');
+
+      btn.disabled = true;
+      btn.textContent = 'Loading...';
+
+      try {
+        const url = forceRefresh ? API_URL + '?bust=' + Date.now() : API_URL;
+        const resp = await fetch(url);
+        if (!resp.ok) {
+          const err = await resp.json().catch(() => ({ error: resp.statusText }));
+          throw new Error(err.message || err.error || resp.statusText);
+        }
+        const data = await resp.json();
+
+        renderDashboard(data);
+
+        const cached = data.fromCache ? 'Cached' : 'Fresh';
+        const time = new Date(data.cachedAt).toLocaleTimeString();
+        status.textContent = `${cached} · ${time}`;
+        dot.style.background = '#22c55e';
+      } catch (err) {
+        document.getElementById('content').innerHTML = `
+          <div class="error-box">
+            <strong>Failed to load analytics data</strong><br>
+            ${err.message}<br><br>
+            <small>Ensure GA4_SERVICE_ACCOUNT_JSON and GA4_PROPERTY_ID are set in Netlify env vars.</small>
+          </div>`;
+        dot.style.background = '#ef4444';
+        status.textContent = 'Error';
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Refresh';
+      }
+    }
+
+    // Auto-refresh every 15 minutes
+    const AUTO_REFRESH_MS = 15 * 60 * 1000;
+    setInterval(() => loadData(true), AUTO_REFRESH_MS);
+
+    // Initial load
+    loadData();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a **dynamic analytics dashboard** at `console.kubestellar.io/analytics`
- Netlify Function (`analytics-dashboard.mts`) queries GA4 Data API using a service account
- Beautiful dark-mode dashboard with Chart.js visualizations
- Auto-refreshes every 15 minutes, data cached in Netlify Blobs

## What's included

| Section | Description |
|---------|-------------|
| KPI Cards | Active users, sessions, page views, avg engagement, bounce rate, events/session — all with 28d vs prev 28d comparison |
| Daily Trend | Line chart of daily active users and sessions |
| Adoption Funnel | Page view → Login → Agent Connected → Solution Viewed → Mission Started |
| Top Pages | Most viewed pages with avg session duration |
| Top Events | All GA4 events ranked by count |
| Countries | Doughnut chart of user geography |
| Traffic Sources | Bar chart of source/medium combinations |
| Devices | Desktop vs mobile vs tablet breakdown |
| Page Engagement | Per-page avg engagement time and bounce rate |
| CNCF Outreach | Per-project campaign tracking (utm_term) |
| New vs Returning | User retention metrics |
| Insights | Auto-generated actionable insights based on the data |

## Configuration

Two Netlify env vars (already set):
- `GA4_SERVICE_ACCOUNT_JSON` — base64-encoded GCP service account key
- `GA4_PROPERTY_ID` — GA4 property ID (`525401563`)

## Test plan

- [ ] Verify Netlify preview deploy builds successfully
- [ ] Visit `<preview-url>/analytics` and confirm dashboard loads with real data
- [ ] Verify charts render correctly
- [ ] Verify auto-refresh works (15 min interval)
- [ ] Test error state by temporarily removing env vars