### PR TITLE
✨ GPU Reservations live data when in-cluster with OAuth

### DIFF
--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -33,7 +33,8 @@ import {
 } from '../../hooks/useMCP'
 import type { GPUNode } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
-import { useDemoMode } from '../../hooks/useDemoMode'
+import { useDemoMode, hasRealToken } from '../../hooks/useDemoMode'
+import { useBackendHealth } from '../../hooks/useBackendHealth'
 import { useAuth } from '../../lib/auth'
 import { useToast } from '../ui/Toast'
 import { DonutChart } from '../charts/PieChart'
@@ -171,7 +172,6 @@ const STATUS_COLORS: Record<string, string> = {
 export function GPUReservations() {
   const { t } = useTranslation(['cards', 'common'])
   const { nodes: rawNodes, isLoading: nodesLoading, refetch: refetchGPUNodes } = useGPUNodes()
-  const { resourceQuotas } = useResourceQuotas()
   const { refetch: refetchClusters } = useClusters()
 
   // Refresh indicator for dashboard tab — refreshes GPU nodes + clusters
@@ -182,7 +182,16 @@ export function GPUReservations() {
   const { showIndicator: isRefreshingDashboard, triggerRefresh } = useRefreshIndicator(refetchAll)
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { isDemoMode: demoMode } = useDemoMode()
-  const { user } = useAuth()
+  const { isInClusterMode } = useBackendHealth()
+  const { user, isAuthenticated } = useAuth()
+
+  // GPU Reservations bypasses demo mode when running in-cluster with a real OAuth token.
+  // Other pages can remain in demo mode — this exception ensures authenticated users
+  // on cluster deployments always get live GPU reservation data.
+  const gpuLiveMode = isInClusterMode && isAuthenticated && hasRealToken()
+  const effectiveDemoMode = demoMode && !gpuLiveMode
+
+  const { resourceQuotas } = useResourceQuotas(undefined, undefined, gpuLiveMode)
   const { showToast } = useToast()
   const [activeTab, setActiveTab] = useState<ViewTab>('overview')
   const [currentMonth, setCurrentMonth] = useState(new Date())
@@ -567,7 +576,7 @@ export function GPUReservations() {
       <div className="mb-6">
         <div className="flex items-center gap-3">
           <h1 className="text-2xl font-bold text-foreground">{t('gpuReservations.title')}</h1>
-          {demoMode && (
+          {effectiveDemoMode && (
             <span className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-full bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
               <FlaskConical className="w-3 h-3" />
               {t('gpuReservations.demo')}
@@ -657,7 +666,7 @@ export function GPUReservations() {
         <div className="space-y-6">
           {/* Quick Stats */}
           <div className="grid grid-cols-4 gap-4">
-            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
+            <div className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
               <div className="flex items-center gap-3">
                 <div className="p-2 rounded-lg bg-purple-500/20">
                   <Zap className="w-5 h-5 text-purple-400" />
@@ -668,7 +677,7 @@ export function GPUReservations() {
                 </div>
               </div>
             </div>
-            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
+            <div className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
               <div className="flex items-center gap-3">
                 <div className="p-2 rounded-lg bg-green-500/20">
                   <CheckCircle2 className="w-5 h-5 text-green-400" />
@@ -679,7 +688,7 @@ export function GPUReservations() {
                 </div>
               </div>
             </div>
-            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
+            <div className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
               <div className="flex items-center gap-3">
                 <div className="p-2 rounded-lg bg-blue-500/20">
                   <Settings2 className="w-5 h-5 text-blue-400" />
@@ -690,7 +699,7 @@ export function GPUReservations() {
                 </div>
               </div>
             </div>
-            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
+            <div className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
               <div className="flex items-center gap-3">
                 <div className="p-2 rounded-lg bg-yellow-500/20">
                   <AlertTriangle className="w-5 h-5 text-yellow-400" />
@@ -706,7 +715,7 @@ export function GPUReservations() {
           {/* Charts Row */}
           <div className="grid grid-cols-3 gap-4">
             {/* Utilization */}
-            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
+            <div className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
               <h3 className="text-sm font-medium text-muted-foreground mb-4">{t('gpuReservations.charts.gpuUtilization')}</h3>
               <div className="flex items-center justify-center">
                 <div className="relative w-32 h-32">
@@ -732,7 +741,7 @@ export function GPUReservations() {
             </div>
 
             {/* GPU Types */}
-            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
+            <div className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
               <h3 className="text-sm font-medium text-muted-foreground mb-4">{t('common:common.gpuTypes')}</h3>
               {stats.typeChartData.length > 0 ? (
                 <DonutChart data={stats.typeChartData} size={150} thickness={20} showLegend={true} />
@@ -742,7 +751,7 @@ export function GPUReservations() {
             </div>
 
             {/* Usage by Namespace */}
-            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
+            <div className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
               <h3 className="text-sm font-medium text-muted-foreground mb-4">{t('gpuReservations.charts.gpuUsageByNamespace')}</h3>
               {stats.usageByNamespace.length > 0 ? (
                 <DonutChart data={stats.usageByNamespace} size={150} thickness={20} showLegend={true} />
@@ -754,14 +763,14 @@ export function GPUReservations() {
 
           {/* Cluster Allocation */}
           {stats.clusterUsage.length > 0 && (
-            <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
+            <div className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
               <h3 className="text-sm font-medium text-muted-foreground mb-4">{t('gpuReservations.charts.gpuAllocationByCluster')}</h3>
               <BarChart data={stats.clusterUsage} height={200} color={getChartColorByName('primary')} showGrid={true} />
             </div>
           )}
 
           {/* Active Reservations */}
-          <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
+          <div className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
             <h3 className="text-sm font-medium text-muted-foreground mb-4">
               {showOnlyMine ? t('gpuReservations.overview.myGpuReservations') : t('gpuReservations.overview.activeGpuReservations')}
             </h3>
@@ -806,7 +815,7 @@ export function GPUReservations() {
       {/* Calendar Tab */}
       {activeTab === 'calendar' && (
         <div className="space-y-6">
-          <div className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
+          <div className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
             <div className="flex items-center justify-center gap-4 mb-4">
               {(['prev', 'heading', 'next'] as const).map(item => {
                 if (item === 'heading') return (
@@ -966,7 +975,7 @@ export function GPUReservations() {
             {filteredReservations.map(r => {
               const isExpanded = expandedReservationId === r.id
               return (
-                <div key={r.id} className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
+                <div key={r.id} className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
                   <div className="flex items-center justify-between mb-3">
                     <div className="flex items-center gap-3">
                       <div className="p-2 rounded-lg bg-purple-500/20">
@@ -1116,7 +1125,7 @@ export function GPUReservations() {
           {gpuClusters.map(cluster => {
             const clusterNodes = nodes.filter(n => n.cluster === cluster.name)
             return (
-              <div key={cluster.name} className={cn('glass p-4 rounded-lg', demoMode && 'border-2 border-yellow-500/50')}>
+              <div key={cluster.name} className={cn('glass p-4 rounded-lg', effectiveDemoMode && 'border-2 border-yellow-500/50')}>
                 <div className="flex items-center justify-between mb-4">
                   <div className="flex items-center gap-3">
                     <ClusterBadge cluster={cluster.name} size="sm" />

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -414,14 +414,16 @@ export function usePVs(cluster?: string) {
 }
 
 // Hook to get ResourceQuotas
-export function useResourceQuotas(cluster?: string, namespace?: string) {
+// When forceLive is true, skip demo mode fallback and always query the real API.
+// Used by GPU Reservations to show live data when running in-cluster with OAuth.
+export function useResourceQuotas(cluster?: string, namespace?: string, forceLive = false) {
   const [resourceQuotas, setResourceQuotas] = useState<ResourceQuota[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   const refetch = useCallback(async () => {
-    // If demo mode is enabled, use demo data
-    if (isDemoMode()) {
+    // If demo mode is enabled, use demo data (unless forceLive overrides)
+    if (!forceLive && isDemoMode()) {
       const demoQuotas = getDemoResourceQuotas().filter(q =>
         (!cluster || q.cluster === cluster) && (!namespace || q.namespace === namespace)
       )
@@ -446,7 +448,7 @@ export function useResourceQuotas(cluster?: string, namespace?: string) {
     } finally {
       setIsLoading(false)
     }
-  }, [cluster, namespace])
+  }, [cluster, namespace, forceLive])
 
   useEffect(() => {
     refetch()

--- a/web/src/hooks/useGPUReservations.ts
+++ b/web/src/hooks/useGPUReservations.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { api } from '../lib/api'
-import { useDemoMode } from './useDemoMode'
+import { useDemoMode, hasRealToken } from './useDemoMode'
+import { isInClusterMode } from './useBackendHealth'
 
 const REFRESH_INTERVAL_MS = 30000
 
@@ -122,6 +123,10 @@ export function useGPUReservations(onlyMine = false) {
   const { isDemoMode: demoMode } = useDemoMode()
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
+  // GPU Reservations bypasses demo mode when running in-cluster with a real OAuth token.
+  // This ensures authenticated users on cluster deployments always see live reservation data.
+  const effectiveDemo = demoMode && !(isInClusterMode() && hasRealToken())
+
   const fetchReservations = useCallback(async (silent = false) => {
     if (!silent) setIsLoading(true)
     try {
@@ -129,7 +134,7 @@ export function useGPUReservations(onlyMine = false) {
       const { data } = await api.get<GPUReservation[]>(`/api/gpu/reservations${query}`)
       const safeData = Array.isArray(data) ? data : []
       // In demo mode, use demo data when the DB is empty (localhost with no reservations)
-      if (demoMode && safeData.length === 0) {
+      if (effectiveDemo && safeData.length === 0) {
         setReservations(DEMO_RESERVATIONS)
       } else {
         setReservations(safeData)
@@ -137,7 +142,7 @@ export function useGPUReservations(onlyMine = false) {
       setError(null)
     } catch (err) {
       // API unreachable — fall back to demo data when in demo mode
-      if (demoMode) {
+      if (effectiveDemo) {
         setReservations(DEMO_RESERVATIONS)
         setError(null)
       } else if (!silent) {
@@ -146,7 +151,7 @@ export function useGPUReservations(onlyMine = false) {
     } finally {
       if (!silent) setIsLoading(false)
     }
-  }, [onlyMine, demoMode])
+  }, [onlyMine, effectiveDemo])
 
   // Re-fetches when demo mode toggles, ensuring correct data source.
   // On cluster deployments the API succeeds and data stays live.


### PR DESCRIPTION
## Summary
- GPU Reservations page now bypasses demo mode when the console is running in-cluster and the user is authenticated via OAuth
- Other pages remain in demo mode as before — this is a targeted exception for GPU Reservations only
- Adds `forceLive` parameter to `useResourceQuotas()` so GPU Reservations can force real API calls even when demo mode is globally enabled

## Context
When deployed to pok-prod-01 or vllm-d, demo mode auto-enables because no kc-agent is connected. This caused GPU Reservations to show demo data with yellow "Demo" borders even for authenticated users. Operators need live GPU reservation data to manage cluster resources.

## Test plan
- [ ] TypeScript passes (`npx tsc --noEmit`)
- [ ] Build passes (`npm run build`)
- [ ] Verify on pok-prod-01: OAuth user sees live GPU Reservations (no yellow borders, no Demo badge)
- [ ] Verify on vllm-d: same behavior
- [ ] Verify localhost with demo mode ON: GPU Reservations still shows demo data (no in-cluster detection)
- [ ] Verify other pages (Clusters, Workloads) still show demo mode as expected