### PR TITLE
🐛 Fix stack overflow on Arcade page + chunk error detection

### DIFF
--- a/web/src/components/arcade/Arcade.tsx
+++ b/web/src/components/arcade/Arcade.tsx
@@ -217,8 +217,8 @@ export function Arcade() {
   }, [removeCard])
 
   const handleConfigureCard = useCallback((cardId: string) => {
-    openConfigureCard(cardId, cards)
-  }, [openConfigureCard, cards])
+    openConfigureCard(cardId)
+  }, [openConfigureCard])
 
   const handleSaveCardConfig = useCallback((cardId: string, config: Record<string, unknown>) => {
     configureCard(cardId, config)

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -1517,8 +1517,8 @@ export function Clusters() {
   }, [removeCard])
 
   const handleConfigureCard = useCallback((cardId: string) => {
-    openConfigureCard(cardId, cards)
-  }, [openConfigureCard, cards])
+    openConfigureCard(cardId)
+  }, [openConfigureCard])
 
   const handleSaveCardConfig = useCallback((cardId: string, config: Record<string, unknown>) => {
     configureCard(cardId, config)

--- a/web/src/components/deploy/Deploy.tsx
+++ b/web/src/components/deploy/Deploy.tsx
@@ -414,8 +414,8 @@ export function Deploy() {
   }, [removeCard])
 
   const handleConfigureCard = useCallback((cardId: string) => {
-    openConfigureCard(cardId, cards)
-  }, [openConfigureCard, cards])
+    openConfigureCard(cardId)
+  }, [openConfigureCard])
 
   const handleSaveCardConfig = useCallback((cardId: string, config: Record<string, unknown>) => {
     configureCard(cardId, config)

--- a/web/src/lib/chunkErrors.ts
+++ b/web/src/lib/chunkErrors.ts
@@ -15,6 +15,8 @@ export function isChunkLoadError(error: Error): boolean {
     msg.includes('dynamically imported module') ||
     msg.includes('error loading dynamically imported module') ||
     // Vite-specific preload error
-    msg.includes('Unable to preload CSS')
+    msg.includes('Unable to preload CSS') ||
+    // Server returned HTML instead of JS (404 → SPA fallback for missing chunk)
+    msg.includes('is not a valid JavaScript MIME type')
   )
 }

--- a/web/src/lib/dashboards/DashboardPage.tsx
+++ b/web/src/lib/dashboards/DashboardPage.tsx
@@ -173,8 +173,8 @@ export function DashboardPage({
   }, [removeCard])
 
   const handleConfigureCard = useCallback((cardId: string) => {
-    openConfigureCard(cardId, cards)
-  }, [openConfigureCard, cards])
+    openConfigureCard(cardId)
+  }, [openConfigureCard])
 
   const handleSaveCardConfig = useCallback((cardId: string, config: Record<string, unknown>) => {
     configureCard(cardId, config)

--- a/web/src/lib/dashboards/DashboardRuntime.tsx
+++ b/web/src/lib/dashboards/DashboardRuntime.tsx
@@ -353,7 +353,7 @@ export function DashboardRuntime({
                     <SortableDashboardCard
                       key={card.id}
                       card={card}
-                      onConfigure={() => openConfigureCard(card.id, cards)}
+                      onConfigure={() => openConfigureCard(card.id)}
                       onRemove={() => removeCard(card.id)}
                       onWidthChange={(w) => updateCardWidth(card.id, w)}
                       isDragging={dnd.activeId === card.id}

--- a/web/src/lib/dashboards/dashboardHooks.ts
+++ b/web/src/lib/dashboards/dashboardHooks.ts
@@ -322,10 +322,12 @@ export interface UseDashboardModalsResult {
   /** Card being configured */
   configuringCard: DashboardCard | null
   setConfiguringCard: (card: DashboardCard | null) => void
-  /** Open configure modal for a card */
-  openConfigureCard: (cardId: string, cards: DashboardCard[]) => void
+  /** Open configure modal for a card (uses internal ref — no cards param needed) */
+  openConfigureCard: (cardId: string) => void
   /** Close configure modal and optionally save */
   closeConfigureCard: () => void
+  /** Set the cards ref (called by useDashboard to wire cards without deps) */
+  _setCardsRef: (cards: DashboardCard[]) => void
 }
 
 export function useDashboardModals(): UseDashboardModalsResult {
@@ -333,8 +335,15 @@ export function useDashboardModals(): UseDashboardModalsResult {
   const [showTemplates, setShowTemplates] = useState(false)
   const [configuringCard, setConfiguringCard] = useState<DashboardCard | null>(null)
 
-  const openConfigureCard = useCallback((cardId: string, cards: DashboardCard[]) => {
-    const card = cards.find(c => c.id === cardId)
+  // Use a ref so openConfigureCard is stable (no cards in deps)
+  const cardsRef = useRef<DashboardCard[]>([])
+
+  const _setCardsRef = useCallback((cards: DashboardCard[]) => {
+    cardsRef.current = cards
+  }, [])
+
+  const openConfigureCard = useCallback((cardId: string) => {
+    const card = cardsRef.current.find(c => c.id === cardId)
     if (card) setConfiguringCard(card)
   }, [])
 
@@ -351,6 +360,7 @@ export function useDashboardModals(): UseDashboardModalsResult {
     setConfiguringCard,
     openConfigureCard,
     closeConfigureCard,
+    _setCardsRef,
   }
 }
 
@@ -439,6 +449,9 @@ export function useDashboard(options: UseDashboardOptions): UseDashboardResult {
 
   // Modals
   const modals = useDashboardModals()
+
+  // Keep the modals cards ref in sync so openConfigureCard doesn't need cards as a dep
+  modals._setCardsRef(cardState.cards)
 
   // Card visibility
   const showCardsState = useDashboardShowCards(storageKey)


### PR DESCRIPTION
## Summary

- **Fix stack overflow on Arcade page** — `handleConfigureCard` had `cards` in its dependency array, causing all 21 game card callbacks to recreate on every card state change, triggering cascading re-renders that exhausted the call stack
- **Improve chunk error detection** — Add MIME type mismatch detection for stale chunk 404s

## Root cause

GA4 analytics showed **27 "Maximum call stack size exceeded" errors** concentrated on the Arcade page (44 total `ksc_error` events on Mar 4 alone). The pattern:

```
openConfigureCard(cardId, cards)  ← cards in dependency array
```

Every card add/remove/configure/reorder updated `cards` → recreated `handleConfigureCard` → propagated new callbacks to all 21 `SortableArcadeCard` components → cascading re-renders → stack overflow.

Same bug existed in Deploy, Clusters, DashboardPage, and DashboardRuntime.

## Fix

Changed `openConfigureCard` in `useDashboardModals` to use an internal `useRef` for the cards array. The ref is wired by `useDashboard` — callers just pass `cardId`, no `cards` param needed. The callback is now **completely stable** (empty deps).

## Test plan

- [ ] Build passes
- [ ] Open Arcade page — should render without stack overflow
- [ ] Configure a card — modal should open correctly
- [ ] Drag-reorder cards — should work without cascading re-renders
- [ ] Verify same fix works on Dashboard, Deploy, Clusters pages