### PR TITLE
🐛 Fix GPU Reservations demo bypass: dashboard cards, namespaces, tab switch

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -144,6 +144,9 @@ interface CardWrapperProps {
   isDemoData?: boolean
   /** Whether this card is showing live/real-time data (for time-series/trend cards) */
   isLive?: boolean
+  /** Force live mode — suppress demo badge even when global demo mode is on.
+   *  Used by GPU Reservations when running in-cluster with OAuth. */
+  forceLive?: boolean
   /** Whether data refresh has failed 3+ times consecutively */
   isFailed?: boolean
   /** Number of consecutive refresh failures */
@@ -860,6 +863,7 @@ export function CardWrapper({
   lastUpdated,
   isDemoData,
   isLive,
+  forceLive,
   isFailed,
   consecutiveFailures,
   cardWidth,
@@ -1021,7 +1025,7 @@ export function CardWrapper({
   const { isDemoMode: globalDemoMode } = useDemoMode()
   const isModeSwitching = useIsModeSwitching()
   const isDemoExempt = DEMO_EXEMPT_CARDS.has(cardType)
-  const isDemoMode = globalDemoMode && !isDemoExempt
+  const isDemoMode = globalDemoMode && !isDemoExempt && !forceLive
 
   // Agent offline detection removed — cards render immediately regardless of agent state
   const menuContainerRef = useRef<HTMLDivElement>(null)

--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -101,6 +101,7 @@ const SortableGpuCard = memo(function SortableGpuCard({
   onWidthChange,
   onRefresh,
   isRefreshing,
+  forceLive,
 }: {
   id: string
   card: GpuDashCard
@@ -109,6 +110,7 @@ const SortableGpuCard = memo(function SortableGpuCard({
   onWidthChange: (w: number) => void
   onRefresh?: () => void
   isRefreshing?: boolean
+  forceLive?: boolean
 }) {
   const {
     attributes,
@@ -138,6 +140,7 @@ const SortableGpuCard = memo(function SortableGpuCard({
           title={CARD_TITLES[card.type] ?? card.type.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
           cardType={card.type}
           cardWidth={card.width}
+          forceLive={forceLive}
           onRemove={onRemove}
           onWidthChange={onWidthChange}
           onRefresh={onRefresh}
@@ -644,7 +647,11 @@ export function GPUReservations() {
               <input
                 type="checkbox"
                 checked={showOnlyMine}
-                onChange={() => setShowOnlyMine(!showOnlyMine)}
+                onChange={() => {
+                  setShowOnlyMine(!showOnlyMine)
+                  // Switch to Reservations tab so filtered results are visible
+                  if (!showOnlyMine) setActiveTab('quotas')
+                }}
                 className="sr-only"
               />
               {showOnlyMine ? <User className="w-4 h-4" /> : <Filter className="w-4 h-4" />}
@@ -1209,6 +1216,7 @@ export function GPUReservations() {
                     id={dashCardIds[index]}
                     card={card}
                     index={index}
+                    forceLive={gpuLiveMode}
                     onRemove={() => handleRemoveDashboardCard(index)}
                     onWidthChange={(newWidth) => handleDashCardWidthChange(index, newWidth)}
                     onRefresh={triggerRefresh}
@@ -1250,6 +1258,7 @@ export function GPUReservations() {
         allNodes={rawNodes}
         user={user}
         prefillDate={prefillDate}
+        forceLive={gpuLiveMode}
         onSave={async (input) => {
           if (editingReservation) {
             await apiUpdateReservation(editingReservation.id, input as UpdateGPUReservationInput)
@@ -1303,6 +1312,7 @@ function ReservationFormModal({
   allNodes,
   user,
   prefillDate,
+  forceLive,
   onSave,
   onActivate,
   onSaved,
@@ -1315,6 +1325,8 @@ function ReservationFormModal({
   allNodes: GPUNode[]
   user: { github_login: string; email?: string } | null
   prefillDate?: string | null
+  /** When true, skip demo mode fallback for namespace list */
+  forceLive?: boolean
   onSave: (input: CreateGPUReservationInput | UpdateGPUReservationInput) => Promise<string | void>
   onActivate: (id: string) => Promise<void>
   onSaved: () => void
@@ -1344,7 +1356,7 @@ function ReservationFormModal({
     onClose()
   }
 
-  const { namespaces: rawNamespaces } = useNamespaces(cluster || undefined)
+  const { namespaces: rawNamespaces } = useNamespaces(cluster || undefined, forceLive)
 
   // Filter out system namespaces from the dropdown
   const FILTERED_NS_PREFIXES = ['openshift-', 'kube-']

--- a/web/src/hooks/mcp/namespaces.ts
+++ b/web/src/hooks/mcp/namespaces.ts
@@ -10,7 +10,9 @@ import type { PodInfo, NamespaceStats } from './types'
 // Use a generous timeout to avoid aborting valid but slow requests.
 const NAMESPACE_FETCH_TIMEOUT_MS = 45000
 
-export function useNamespaces(cluster?: string) {
+// When forceLive is true, skip demo mode fallback and always query the real API.
+// Used by GPU Reservations to show live namespaces when running in-cluster with OAuth.
+export function useNamespaces(cluster?: string, forceLive = false) {
   const [namespaces, setNamespaces] = useState<string[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -43,8 +45,8 @@ export function useNamespaces(cluster?: string) {
       return
     }
 
-    // Demo mode returns synthetic namespaces immediately
-    if (isDemoMode()) {
+    // Demo mode returns synthetic namespaces immediately (unless forceLive overrides)
+    if (!forceLive && isDemoMode()) {
       setNamespaces(['default', 'kube-system', 'kube-public', 'monitoring', 'production', 'staging', 'batch', 'data', 'ingress', 'security'])
       setIsLoading(false)
       setError(null)
@@ -127,7 +129,7 @@ export function useNamespaces(cluster?: string) {
     } finally {
       setIsLoading(false)
     }
-  }, [cluster])
+  }, [cluster, forceLive])
 
   useEffect(() => {
     refetch()


### PR DESCRIPTION
## Summary
- **Dashboard cards Demo badge**: Added `forceLive` prop to `CardWrapper` that suppresses Demo badge when `gpuLiveMode` is true (in-cluster + OAuth'd). Threaded through `SortableGpuCard` so all GPU dashboard cards benefit.
- **Namespace list showing demo data**: Added `forceLive` parameter to `useNamespaces()` hook. When true, skips the `isDemoMode()` early-return that returns hardcoded demo namespaces. Passed through `ReservationFormModal` so the Create Reservation form shows real cluster namespaces.
- **My Reservations tab switch**: Clicking "My Reservations" checkbox now also switches to the Reservations tab so filtered results are immediately visible.

Follow-up to #1700 (GPU Reservations live mode).

## Test plan
- [ ] Deploy to vllm-d and pok-prod-01 clusters
- [ ] Verify GPU Reservations Dashboard tab cards show NO Demo badge when OAuth'd
- [ ] Verify Create Reservation form shows real cluster namespaces (not demo ones like monitoring, production, staging)
- [ ] Verify clicking "My Reservations" switches to Reservations tab
- [ ] Verify other pages still show demo mode as expected