### PR TITLE
✨ Wire mission versioning metadata to detail view

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -269,10 +269,13 @@ interface IndexEntry {
   installMethods?: string[]
 }
 
+/** File format version used by console-kb mission files */
+const MISSION_FILE_FORMAT_VERSION = 'kc-mission-v1'
+
 /** Convert an index entry to a MissionExport (browsing metadata only — steps loaded on demand) */
 function indexEntryToMission(entry: IndexEntry): MissionExport {
   return {
-    version: '1.0',
+    version: MISSION_FILE_FORMAT_VERSION,
     title: entry.title || '',
     description: entry.description || '',
     type: (entry.type as MissionExport['type']) || 'custom',
@@ -320,6 +323,7 @@ async function fetchMissionContent(
   // Extract steps from the nested `mission` object (console-kb file format)
   // Falls back to top-level fields if the nested structure isn't present
   const nested = parsed.mission || {}
+  const fileMeta = parsed.metadata || {}
   const merged: MissionExport = {
     ...indexMission,
     steps: nested.steps || parsed.steps || indexMission.steps,
@@ -328,6 +332,13 @@ async function fetchMissionContent(
     troubleshooting: nested.troubleshooting || parsed.troubleshooting,
     resolution: nested.resolution || parsed.resolution,
     prerequisites: parsed.prerequisites || indexMission.prerequisites,
+    metadata: {
+      ...indexMission.metadata,
+      qualityScore: fileMeta.qualityScore,
+      maturity: fileMeta.maturity,
+      projectVersion: fileMeta.projectVersion,
+      sourceUrls: fileMeta.sourceUrls,
+    },
   }
 
   return { mission: merged, raw: text }

--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -464,6 +464,28 @@ export function MissionDetailView({
                   Helm Chart
                 </a>
               )}
+              {sourceUrls.issue && (
+                <a
+                  href={sourceUrls.issue}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <ExternalLink className="w-3 h-3" />
+                  Issue
+                </a>
+              )}
+              {sourceUrls.pr && (
+                <a
+                  href={sourceUrls.pr}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <ExternalLink className="w-3 h-3" />
+                  Pull Request
+                </a>
+              )}
             </div>
           )}
 

--- a/web/src/lib/missions/types.ts
+++ b/web/src/lib/missions/types.ts
@@ -55,6 +55,8 @@ export interface MissionExport {
       docs?: string
       repo?: string
       helm?: string
+      issue?: string
+      pr?: string
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fix `fetchMissionContent()` to merge metadata fields (`qualityScore`, `maturity`, `projectVersion`, `sourceUrls`) from full mission JSON files — these were present in the data but never extracted
- Replace hardcoded version `'1.0'` with `MISSION_FILE_FORMAT_VERSION` constant (`'kc-mission-v1'`)
- Add `issue` and `pr` fields to `sourceUrls` type to match actual console-kb data
- Render Issue and Pull Request links in MissionDetailView alongside existing Repository/Docs/Helm links

## Context
The `MissionDetailView` UI already had rendering logic for maturity badges, project version, quality scores, and source URLs — but `fetchMissionContent()` wasn't extracting these fields from the full mission JSON. This wires the data through so the detail view shows all available metadata.

## Test plan
- [ ] Open AI Missions explorer, select a CNCF solution mission → verify maturity badge and quality score appear in metadata bar
- [ ] Select an install mission (e.g., Aeraki Mesh) → verify project version badge appears
- [ ] Verify Issue/Pull Request links appear for solution missions that have them
- [ ] Verify no regressions on mission browsing, import, or saved missions