### PR TITLE
🌱 Reduce mission index cache TTL to 15 minutes

### DIFF
--- a/web/netlify/functions/missions-file.mts
+++ b/web/netlify/functions/missions-file.mts
@@ -18,8 +18,8 @@ const MAX_BODY_BYTES = 10 * 1024 * 1024;
 /** Request timeout in milliseconds */
 const FETCH_TIMEOUT_MS = 30_000;
 
-/** Cache TTL: serve cached content for 1 hour before re-fetching from GitHub */
-const CACHE_TTL_MS = 60 * 60 * 1000;
+/** Cache TTL: serve cached content for 15 minutes before re-fetching from GitHub */
+const CACHE_TTL_MS = 15 * 60 * 1000;
 
 /** CDN edge cache: tell Netlify CDN to cache successful responses for 10 minutes */
 const CDN_CACHE_MAX_AGE_S = 600;


### PR DESCRIPTION
## Summary
- Reduces Netlify Blob cache TTL for `missions-file` function from 1 hour to 15 minutes
- New missions added to `kubestellar/console-kb` now appear on console.kubestellar.io within ~15 minutes instead of ~1 hour
- Safe because `raw.githubusercontent.com` doesn't count against GitHub API rate limits, and Netlify's CDN edge cache (10 min) absorbs concurrent requests

## Test plan
- [ ] Deploy to Netlify preview, verify `X-Cache: MISS` header after 15 min
- [ ] Add a mission to console-kb, confirm it appears on production within 15 min