### PR TITLE
✨ Add GPU reservation utilization tracking with sparkline graphs

### DIFF
--- a/pkg/api/gpu_utilization_worker.go
+++ b/pkg/api/gpu_utilization_worker.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"context"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/kubestellar/console/pkg/k8s"
+	"github.com/kubestellar/console/pkg/models"
+	"github.com/kubestellar/console/pkg/store"
+)
+
+const (
+	// defaultUtilPollIntervalMs is the default polling interval for GPU utilization (1 hour)
+	defaultUtilPollIntervalMs = 3_600_000
+	// snapshotRetentionDays is how long to keep utilization snapshots before cleanup
+	snapshotRetentionDays = 90
+	// fullUtilizationPct is the utilization percentage used when GPUs are active but no metrics API exists
+	fullUtilizationPct = 100.0
+)
+
+// GPUUtilizationWorker periodically collects GPU utilization data for active reservations
+type GPUUtilizationWorker struct {
+	store     store.Store
+	k8sClient *k8s.MultiClusterClient
+	interval  time.Duration
+	stopCh    chan struct{}
+}
+
+// NewGPUUtilizationWorker creates a new GPU utilization worker
+func NewGPUUtilizationWorker(s store.Store, k8sClient *k8s.MultiClusterClient) *GPUUtilizationWorker {
+	intervalMs := defaultUtilPollIntervalMs
+	if envVal := os.Getenv("GPU_UTIL_POLL_INTERVAL_MS"); envVal != "" {
+		if parsed, err := strconv.Atoi(envVal); err == nil && parsed > 0 {
+			intervalMs = parsed
+		}
+	}
+
+	return &GPUUtilizationWorker{
+		store:     s,
+		k8sClient: k8sClient,
+		interval:  time.Duration(intervalMs) * time.Millisecond,
+		stopCh:    make(chan struct{}),
+	}
+}
+
+// Start begins the background polling loop
+func (w *GPUUtilizationWorker) Start() {
+	go func() {
+		// Cleanup old snapshots on startup
+		w.cleanupOldSnapshots()
+
+		// Run an initial collection immediately
+		w.collectUtilization()
+
+		ticker := time.NewTicker(w.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				w.collectUtilization()
+			case <-w.stopCh:
+				return
+			}
+		}
+	}()
+	log.Printf("GPU utilization worker started (interval: %v)", w.interval)
+}
+
+// Stop signals the worker to stop
+func (w *GPUUtilizationWorker) Stop() {
+	close(w.stopCh)
+}
+
+// collectUtilization queries active reservations and records utilization snapshots
+func (w *GPUUtilizationWorker) collectUtilization() {
+	if w.k8sClient == nil {
+		return
+	}
+
+	reservations, err := w.store.ListActiveGPUReservations()
+	if err != nil {
+		log.Printf("GPU utilization worker: failed to list active reservations: %v", err)
+		return
+	}
+
+	if len(reservations) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), w.interval/2)
+	defer cancel()
+
+	for i := range reservations {
+		w.collectForReservation(ctx, &reservations[i])
+	}
+}
+
+// collectForReservation collects utilization for a single reservation
+func (w *GPUUtilizationWorker) collectForReservation(ctx context.Context, reservation *models.GPUReservation) {
+	cluster := reservation.Cluster
+	namespace := reservation.Namespace
+
+	// Get pods in this namespace/cluster
+	pods, err := w.k8sClient.GetPods(ctx, cluster, namespace)
+	if err != nil {
+		log.Printf("GPU utilization worker: failed to get pods for %s/%s: %v", cluster, namespace, err)
+		return
+	}
+
+	// Get GPU nodes for this cluster to know which nodes have GPUs
+	gpuNodes, err := w.k8sClient.GetGPUNodes(ctx, cluster)
+	if err != nil {
+		log.Printf("GPU utilization worker: failed to get GPU nodes for %s: %v", cluster, err)
+		return
+	}
+
+	gpuNodeNames := make(map[string]bool)
+	for _, node := range gpuNodes {
+		gpuNodeNames[node.Name] = true
+	}
+
+	// Count pods on GPU nodes and GPU resource requests
+	var activeGPUCount int
+	for _, pod := range pods {
+		if pod.Status != "Running" {
+			continue
+		}
+		// Check if pod requests GPUs or is on a GPU node
+		podGPUs := 0
+		for _, c := range pod.Containers {
+			podGPUs += c.GPURequested
+		}
+		if podGPUs > 0 {
+			activeGPUCount += podGPUs
+		} else if gpuNodeNames[pod.Node] {
+			// Pod on a GPU node but no explicit GPU request — count as 1 GPU in use
+			activeGPUCount++
+		}
+	}
+
+	// Cap active count to reservation total
+	totalGPUs := reservation.GPUCount
+	if activeGPUCount > totalGPUs {
+		activeGPUCount = totalGPUs
+	}
+
+	// Compute utilization percentage (binary: active vs reserved)
+	// Without metrics-server, we use pod presence as a proxy for utilization
+	var gpuUtilPct float64
+	if totalGPUs > 0 {
+		gpuUtilPct = (float64(activeGPUCount) / float64(totalGPUs)) * fullUtilizationPct
+	}
+
+	snapshot := &models.GPUUtilizationSnapshot{
+		ID:                   uuid.New().String(),
+		ReservationID:        reservation.ID.String(),
+		Timestamp:            time.Now(),
+		GPUUtilizationPct:    gpuUtilPct,
+		MemoryUtilizationPct: gpuUtilPct, // Use same value when no memory metrics available
+		ActiveGPUCount:       activeGPUCount,
+		TotalGPUCount:        totalGPUs,
+	}
+
+	if err := w.store.InsertUtilizationSnapshot(snapshot); err != nil {
+		log.Printf("GPU utilization worker: failed to insert snapshot for reservation %s: %v", reservation.ID, err)
+	}
+}
+
+// cleanupOldSnapshots removes snapshots older than the retention period
+func (w *GPUUtilizationWorker) cleanupOldSnapshots() {
+	cutoff := time.Now().AddDate(0, 0, -snapshotRetentionDays)
+	deleted, err := w.store.DeleteOldUtilizationSnapshots(cutoff)
+	if err != nil {
+		log.Printf("GPU utilization worker: failed to cleanup old snapshots: %v", err)
+		return
+	}
+	if deleted > 0 {
+		log.Printf("GPU utilization worker: cleaned up %d old snapshots", deleted)
+	}
+}

--- a/pkg/api/handlers/gpu.go
+++ b/pkg/api/handlers/gpu.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
@@ -242,4 +243,51 @@ func (h *GPUHandler) DeleteReservation(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(fiber.Map{"status": "ok"})
+}
+
+// GetReservationUtilization returns utilization snapshots for a single reservation
+func (h *GPUHandler) GetReservationUtilization(c *fiber.Ctx) error {
+	id := c.Params("id")
+	if _, err := uuid.Parse(id); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "Invalid reservation ID")
+	}
+
+	snapshots, err := h.store.GetUtilizationSnapshots(id)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to get utilization data")
+	}
+	if snapshots == nil {
+		snapshots = []models.GPUUtilizationSnapshot{}
+	}
+
+	return c.JSON(snapshots)
+}
+
+// GetBulkUtilizations returns utilization snapshots for multiple reservations
+func (h *GPUHandler) GetBulkUtilizations(c *fiber.Ctx) error {
+	idsParam := c.Query("ids")
+	if idsParam == "" {
+		return c.JSON(map[string][]models.GPUUtilizationSnapshot{})
+	}
+
+	ids := strings.Split(idsParam, ",")
+	// Validate all IDs
+	for _, id := range ids {
+		if _, err := uuid.Parse(strings.TrimSpace(id)); err != nil {
+			return fiber.NewError(fiber.StatusBadRequest, fmt.Sprintf("Invalid reservation ID: %s", id))
+		}
+	}
+
+	// Trim spaces
+	trimmedIDs := make([]string, len(ids))
+	for i, id := range ids {
+		trimmedIDs[i] = strings.TrimSpace(id)
+	}
+
+	result, err := h.store.GetBulkUtilizationSnapshots(trimmedIDs)
+	if err != nil {
+		return fiber.NewError(fiber.StatusInternalServerError, "Failed to get utilization data")
+	}
+
+	return c.JSON(result)
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -87,6 +87,7 @@ type Server struct {
 	persistenceStore    *store.PersistenceStore
 	loadingSrv          *http.Server // temporary loading screen server
 	shuttingDown        int32        // atomic flag: 1 during graceful shutdown
+	gpuUtilWorker       *GPUUtilizationWorker
 }
 
 // NewServer creates a new API server. It starts a temporary loading page
@@ -226,6 +227,12 @@ func NewServer(cfg Config) (*Server, error) {
 
 	server.setupMiddleware()
 	server.setupRoutes()
+
+	// Start GPU utilization background worker (collects hourly snapshots)
+	if k8sClient != nil {
+		server.gpuUtilWorker = NewGPUUtilizationWorker(db, k8sClient)
+		server.gpuUtilWorker.Start()
+	}
 
 	log.Println("Server initialization complete")
 
@@ -681,6 +688,8 @@ func (s *Server) setupRoutes() {
 	api.Get("/gpu/reservations/:id", gpuHandler.GetReservation)
 	api.Put("/gpu/reservations/:id", gpuHandler.UpdateReservation)
 	api.Delete("/gpu/reservations/:id", gpuHandler.DeleteReservation)
+	api.Get("/gpu/reservations/:id/utilization", gpuHandler.GetReservationUtilization)
+	api.Get("/gpu/utilizations", gpuHandler.GetBulkUtilizations)
 
 	// Alert notification routes
 	notificationHandler := handlers.NewNotificationHandler(s.store, s.notificationService)
@@ -846,6 +855,9 @@ func (s *Server) Start() error {
 // before services are torn down, giving the frontend time to notice.
 func (s *Server) Shutdown() error {
 	atomic.StoreInt32(&s.shuttingDown, 1)
+	if s.gpuUtilWorker != nil {
+		s.gpuUtilWorker.Stop()
+	}
 	s.hub.Close()
 	if s.k8sClient != nil {
 		s.k8sClient.StopWatching()

--- a/pkg/models/gpu.go
+++ b/pkg/models/gpu.go
@@ -53,6 +53,17 @@ type CreateGPUReservationInput struct {
 	MaxClusterGPUs int    `json:"max_cluster_gpus"`
 }
 
+// GPUUtilizationSnapshot records a point-in-time GPU usage measurement for a reservation
+type GPUUtilizationSnapshot struct {
+	ID                   string    `json:"id"`
+	ReservationID        string    `json:"reservation_id"`
+	Timestamp            time.Time `json:"timestamp"`
+	GPUUtilizationPct    float64   `json:"gpu_utilization_pct"`
+	MemoryUtilizationPct float64   `json:"memory_utilization_pct"`
+	ActiveGPUCount       int       `json:"active_gpu_count"`
+	TotalGPUCount        int       `json:"total_gpu_count"`
+}
+
 // UpdateGPUReservationInput is the input for updating a GPU reservation
 type UpdateGPUReservationInput struct {
 	Title          *string            `json:"title,omitempty"`

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -182,6 +182,19 @@ func (s *SQLiteStore) migrate() error {
 	);
 	CREATE INDEX IF NOT EXISTS idx_gpu_reservations_user ON gpu_reservations(user_id);
 	CREATE INDEX IF NOT EXISTS idx_gpu_reservations_status ON gpu_reservations(status);
+
+	-- GPU utilization snapshots (hourly measurements per reservation)
+	CREATE TABLE IF NOT EXISTS gpu_utilization_snapshots (
+		id TEXT PRIMARY KEY,
+		reservation_id TEXT NOT NULL,
+		timestamp DATETIME NOT NULL,
+		gpu_utilization_pct REAL NOT NULL,
+		memory_utilization_pct REAL NOT NULL,
+		active_gpu_count INTEGER NOT NULL,
+		total_gpu_count INTEGER NOT NULL,
+		FOREIGN KEY (reservation_id) REFERENCES gpu_reservations(id) ON DELETE CASCADE
+	);
+	CREATE INDEX IF NOT EXISTS idx_utilization_reservation ON gpu_utilization_snapshots(reservation_id, timestamp);
 	`
 	_, err := s.db.Exec(schema)
 	if err != nil {
@@ -1357,6 +1370,107 @@ func (s *SQLiteStore) scanGPUReservationRow(rows *sql.Rows) (*models.GPUReservat
 		r.UpdatedAt = &updatedAt.Time
 	}
 	return &r, nil
+}
+
+// --- GPU Utilization Snapshots ---
+
+func (s *SQLiteStore) InsertUtilizationSnapshot(snapshot *models.GPUUtilizationSnapshot) error {
+	_, err := s.db.Exec(
+		`INSERT INTO gpu_utilization_snapshots (id, reservation_id, timestamp, gpu_utilization_pct, memory_utilization_pct, active_gpu_count, total_gpu_count) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		snapshot.ID, snapshot.ReservationID, snapshot.Timestamp,
+		snapshot.GPUUtilizationPct, snapshot.MemoryUtilizationPct,
+		snapshot.ActiveGPUCount, snapshot.TotalGPUCount,
+	)
+	return err
+}
+
+func (s *SQLiteStore) GetUtilizationSnapshots(reservationID string) ([]models.GPUUtilizationSnapshot, error) {
+	rows, err := s.db.Query(
+		`SELECT id, reservation_id, timestamp, gpu_utilization_pct, memory_utilization_pct, active_gpu_count, total_gpu_count FROM gpu_utilization_snapshots WHERE reservation_id = ? ORDER BY timestamp ASC`,
+		reservationID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var snapshots []models.GPUUtilizationSnapshot
+	for rows.Next() {
+		var snap models.GPUUtilizationSnapshot
+		if err := rows.Scan(&snap.ID, &snap.ReservationID, &snap.Timestamp,
+			&snap.GPUUtilizationPct, &snap.MemoryUtilizationPct,
+			&snap.ActiveGPUCount, &snap.TotalGPUCount); err != nil {
+			return nil, err
+		}
+		snapshots = append(snapshots, snap)
+	}
+	return snapshots, rows.Err()
+}
+
+func (s *SQLiteStore) GetBulkUtilizationSnapshots(reservationIDs []string) (map[string][]models.GPUUtilizationSnapshot, error) {
+	result := make(map[string][]models.GPUUtilizationSnapshot)
+	if len(reservationIDs) == 0 {
+		return result, nil
+	}
+
+	// Build parameterized query with placeholders
+	placeholders := ""
+	args := make([]interface{}, len(reservationIDs))
+	for i, id := range reservationIDs {
+		if i > 0 {
+			placeholders += ", "
+		}
+		placeholders += "?"
+		args[i] = id
+	}
+
+	rows, err := s.db.Query(
+		fmt.Sprintf(`SELECT id, reservation_id, timestamp, gpu_utilization_pct, memory_utilization_pct, active_gpu_count, total_gpu_count FROM gpu_utilization_snapshots WHERE reservation_id IN (%s) ORDER BY timestamp ASC`, placeholders),
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var snap models.GPUUtilizationSnapshot
+		if err := rows.Scan(&snap.ID, &snap.ReservationID, &snap.Timestamp,
+			&snap.GPUUtilizationPct, &snap.MemoryUtilizationPct,
+			&snap.ActiveGPUCount, &snap.TotalGPUCount); err != nil {
+			return nil, err
+		}
+		result[snap.ReservationID] = append(result[snap.ReservationID], snap)
+	}
+	return result, rows.Err()
+}
+
+func (s *SQLiteStore) DeleteOldUtilizationSnapshots(before time.Time) (int64, error) {
+	res, err := s.db.Exec(`DELETE FROM gpu_utilization_snapshots WHERE timestamp < ?`, before)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+func (s *SQLiteStore) ListActiveGPUReservations() ([]models.GPUReservation, error) {
+	rows, err := s.db.Query(
+		`SELECT id, user_id, user_name, title, description, cluster, namespace, gpu_count, gpu_type, start_date, duration_hours, notes, status, quota_name, quota_enforced, created_at, updated_at FROM gpu_reservations WHERE status IN ('active', 'pending') ORDER BY start_date DESC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var reservations []models.GPUReservation
+	for rows.Next() {
+		r, err := s.scanGPUReservationRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		reservations = append(reservations, *r)
+	}
+	return reservations, rows.Err()
 }
 
 // Helper functions

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -91,6 +91,13 @@ type Store interface {
 	DeleteGPUReservation(id uuid.UUID) error
 	GetClusterReservedGPUCount(cluster string, excludeID *uuid.UUID) (int, error)
 
+	// GPU Utilization Snapshots
+	InsertUtilizationSnapshot(snapshot *models.GPUUtilizationSnapshot) error
+	GetUtilizationSnapshots(reservationID string) ([]models.GPUUtilizationSnapshot, error)
+	GetBulkUtilizationSnapshots(reservationIDs []string) (map[string][]models.GPUUtilizationSnapshot, error)
+	DeleteOldUtilizationSnapshots(before time.Time) (int64, error)
+	ListActiveGPUReservations() ([]models.GPUReservation, error)
+
 	// Lifecycle
 	Close() error
 }

--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -45,6 +45,9 @@ import { cn } from '../../lib/cn'
 import { TechnicalAcronym } from '../shared/TechnicalAcronym'
 import { getChartColor, getChartColorByName } from '../../lib/chartColors'
 import { useGPUReservations } from '../../hooks/useGPUReservations'
+import { useGPUUtilizations } from '../../hooks/useGPUUtilizations'
+import type { GPUUtilizationSnapshot } from '../../hooks/useGPUUtilizations'
+import { Sparkline } from '../charts/Sparkline'
 import type { GPUReservation, CreateGPUReservationInput, UpdateGPUReservationInput } from '../../hooks/useGPUReservations'
 import { CARD_COMPONENTS, getDefaultCardWidth } from '../cards/cardRegistry'
 import { CardWrapper, CARD_TITLES } from '../cards/CardWrapper'
@@ -73,6 +76,11 @@ import { CSS } from '@dnd-kit/utilities'
 const UTILIZATION_HIGH_THRESHOLD = 80
 const UTILIZATION_MEDIUM_THRESHOLD = 50
 
+// Sparkline utilization color thresholds
+const SPARKLINE_HIGH_UTIL_PCT = 70    // Green: well-utilized
+const SPARKLINE_LOW_UTIL_PCT = 30     // Red: underutilized
+const SPARKLINE_HEIGHT_PX = 28        // Height of sparkline chart
+
 // Display settings
 const MAX_NAME_DISPLAY_LENGTH = 12 // Maximum characters to display before truncating cluster names
 
@@ -80,6 +88,31 @@ type ViewTab = 'overview' | 'calendar' | 'quotas' | 'inventory' | 'dashboard'
 
 // GPU resource keys used to identify GPU quotas
 const GPU_KEYS = ['nvidia.com/gpu', 'amd.com/gpu', 'gpu.intel.com/i915']
+
+/** Get sparkline color based on average utilization */
+function getUtilizationColor(avgPct: number): string {
+  if (avgPct >= SPARKLINE_HIGH_UTIL_PCT) return '#22c55e' // green-500
+  if (avgPct >= SPARKLINE_LOW_UTIL_PCT) return '#eab308'  // yellow-500
+  return '#ef4444' // red-500
+}
+
+/** Count unique days where GPUs were actively used */
+function countActiveDays(snapshots: GPUUtilizationSnapshot[]): number {
+  const activeDates = new Set<string>()
+  for (const snap of snapshots) {
+    if (snap.active_gpu_count > 0) {
+      activeDates.add(snap.timestamp.split('T')[0])
+    }
+  }
+  return activeDates.size
+}
+
+/** Compute average GPU utilization across all snapshots */
+function computeAvgUtilization(snapshots: GPUUtilizationSnapshot[]): number {
+  if (snapshots.length === 0) return 0
+  const sum = snapshots.reduce((acc, s) => acc + s.gpu_utilization_pct, 0)
+  return Math.round(sum / snapshots.length)
+}
 
 // GPU cluster info for dropdown
 interface GPUClusterInfo {
@@ -308,6 +341,13 @@ export function GPUReservations() {
     }
     return filtered
   }, [allReservations, showOnlyMine, user, selectedClusters, isAllClustersSelected])
+
+  // Fetch utilization data for visible reservations
+  const visibleReservationIds = useMemo(
+    () => (filteredReservations || []).map(r => r.id),
+    [filteredReservations]
+  )
+  const { utilizations } = useGPUUtilizations(visibleReservationIds)
 
   // Clusters with GPU info for the dropdown
   const gpuClusters = useMemo((): GPUClusterInfo[] => {
@@ -783,33 +823,66 @@ export function GPUReservations() {
               {showOnlyMine ? t('gpuReservations.overview.myGpuReservations') : t('gpuReservations.overview.activeGpuReservations')}
             </h3>
             <div className="space-y-3">
-              {filteredReservations.slice(0, 5).map(r => (
+              {filteredReservations.slice(0, 5).map(r => {
+                const snapshots = (utilizations || {})[r.id] || []
+                const avgUtil = computeAvgUtilization(snapshots)
+                const activeDays = countActiveDays(snapshots)
+                const sparkColor = snapshots.length > 0 ? getUtilizationColor(avgUtil) : '#9333ea'
+                return (
                 <div key={r.id}
-                  className="flex items-center justify-between p-3 rounded-lg bg-purple-500/10 border border-purple-500/20"
+                  className="p-3 rounded-lg bg-purple-500/10 border border-purple-500/20"
                 >
-                  <div className="flex items-center gap-4">
-                    <div className="p-2 rounded-lg bg-purple-500/20">
-                      <Zap className="w-4 h-4 text-purple-400" />
-                    </div>
-                    <div>
-                      <div className="font-medium text-foreground">{r.title}</div>
-                      <div className="text-sm text-muted-foreground">
-                        {r.namespace} · {r.user_name}
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-4">
+                      <div className="p-2 rounded-lg bg-purple-500/20">
+                        <Zap className="w-4 h-4 text-purple-400" />
+                      </div>
+                      <div>
+                        <div className="font-medium text-foreground">{r.title}</div>
+                        <div className="text-sm text-muted-foreground">
+                          {r.namespace} · {r.user_name}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                  <div className="flex items-center gap-4">
-                    <div className="text-right">
-                      <div className="font-medium text-foreground">{r.gpu_count} <TechnicalAcronym term="GPU">{t('common:common.gpus')}</TechnicalAcronym></div>
-                      <div className="text-sm text-muted-foreground">{t('gpuReservations.overview.durationHours', { hours: r.duration_hours })}</div>
+                    <div className="flex items-center gap-4">
+                      <div className="text-right">
+                        <div className="font-medium text-foreground">{r.gpu_count} <TechnicalAcronym term="GPU">{t('common:common.gpus')}</TechnicalAcronym></div>
+                        <div className="text-sm text-muted-foreground">{t('gpuReservations.overview.durationHours', { hours: r.duration_hours })}</div>
+                      </div>
+                      <span className={cn('px-2 py-0.5 text-xs rounded-full border', STATUS_COLORS[r.status] || STATUS_COLORS.pending)}>
+                        {r.status}
+                      </span>
+                      <ClusterBadge cluster={r.cluster} size="sm" />
                     </div>
-                    <span className={cn('px-2 py-0.5 text-xs rounded-full border', STATUS_COLORS[r.status] || STATUS_COLORS.pending)}>
-                      {r.status}
-                    </span>
-                    <ClusterBadge cluster={r.cluster} size="sm" />
                   </div>
+                  {/* GPU Utilization Sparkline */}
+                  {snapshots.length > 0 ? (
+                    <div className="mt-2 pt-2 border-t border-purple-500/10">
+                      <Sparkline
+                        data={snapshots.map(s => s.gpu_utilization_pct)}
+                        color={sparkColor}
+                        height={SPARKLINE_HEIGHT_PX}
+                        fill
+                      />
+                      <div className="flex items-center justify-between text-xs mt-1">
+                        <span style={{ color: sparkColor }}>
+                          {t('gpuReservations.utilization.avgGpu', `Avg {{pct}}% GPU`, { pct: avgUtil })}
+                        </span>
+                        <span className="text-muted-foreground">
+                          {t('gpuReservations.utilization.activeDays', `{{count}} active days`, { count: activeDays })}
+                        </span>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="mt-2 pt-2 border-t border-purple-500/10">
+                      <div className="text-xs text-muted-foreground text-center py-1">
+                        {t('gpuReservations.utilization.noData', 'No usage data yet')}
+                      </div>
+                    </div>
+                  )}
                 </div>
-              ))}
+                )
+              })}
               {filteredReservations.length === 0 && (
                 <div className="text-center py-4 text-muted-foreground">
                   {showOnlyMine ? t('gpuReservations.overview.noReservationsUser') : t('gpuReservations.overview.noReservationsYet')}
@@ -1061,6 +1134,39 @@ export function GPUReservations() {
                       <div className="text-sm font-medium text-foreground">{r.duration_hours}h</div>
                     </div>
                   </div>
+
+                  {/* GPU Utilization Sparkline */}
+                  {(() => {
+                    const snaps = (utilizations || {})[r.id] || []
+                    if (snaps.length === 0) return (
+                      <div className="mt-3 pt-3 border-t border-border/50">
+                        <div className="text-xs text-muted-foreground text-center py-1">
+                          {t('gpuReservations.utilization.noData', 'No usage data yet')}
+                        </div>
+                      </div>
+                    )
+                    const avg = computeAvgUtilization(snaps)
+                    const days = countActiveDays(snaps)
+                    const color = getUtilizationColor(avg)
+                    return (
+                      <div className="mt-3 pt-3 border-t border-border/50">
+                        <Sparkline
+                          data={snaps.map(s => s.gpu_utilization_pct)}
+                          color={color}
+                          height={SPARKLINE_HEIGHT_PX}
+                          fill
+                        />
+                        <div className="flex items-center justify-between text-xs mt-1">
+                          <span style={{ color }}>
+                            {t('gpuReservations.utilization.avgGpu', `Avg {{pct}}% GPU`, { pct: avg })}
+                          </span>
+                          <span className="text-muted-foreground">
+                            {t('gpuReservations.utilization.activeDays', `{{count}} active days`, { count: days })}
+                          </span>
+                        </div>
+                      </div>
+                    )
+                  })()}
 
                   {/* Description and notes */}
                   {(r.description || r.notes) && (

--- a/web/src/hooks/useGPUUtilizations.ts
+++ b/web/src/hooks/useGPUUtilizations.ts
@@ -1,0 +1,67 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+/** How often to refresh utilization data (5 minutes) */
+const GPU_UTIL_REFRESH_MS = 300_000
+
+export interface GPUUtilizationSnapshot {
+  id: string
+  reservation_id: string
+  timestamp: string
+  gpu_utilization_pct: number
+  memory_utilization_pct: number
+  active_gpu_count: number
+  total_gpu_count: number
+}
+
+/**
+ * Bulk-fetch GPU utilization snapshots for multiple reservations.
+ * Polls every GPU_UTIL_REFRESH_MS. Skips fetch if no IDs provided.
+ */
+export function useGPUUtilizations(reservationIds: string[]) {
+  const [data, setData] = useState<Record<string, GPUUtilizationSnapshot[]>>({})
+  const [isLoading, setIsLoading] = useState(false)
+  const idsRef = useRef<string>('')
+
+  const fetchData = useCallback(async (ids: string[]) => {
+    if (ids.length === 0) {
+      setData({})
+      return
+    }
+
+    try {
+      setIsLoading(true)
+      const params = new URLSearchParams({ ids: ids.join(',') })
+      const response = await fetch(`/api/gpu/utilizations?${params.toString()}`)
+      if (!response.ok) {
+        return
+      }
+      const result = await response.json()
+      setData(result || {})
+    } catch {
+      // Silently fail — utilization is supplementary data
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    const idsKey = reservationIds.sort().join(',')
+    // Only refetch if IDs actually changed
+    if (idsKey === idsRef.current && Object.keys(data).length > 0) {
+      return
+    }
+    idsRef.current = idsKey
+
+    fetchData(reservationIds)
+
+    if (reservationIds.length === 0) return
+
+    const interval = setInterval(() => {
+      fetchData(reservationIds)
+    }, GPU_UTIL_REFRESH_MS)
+
+    return () => clearInterval(interval)
+  }, [reservationIds, fetchData]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { utilizations: data, isLoading }
+}


### PR DESCRIPTION
## Summary
- Adds hourly background worker that tracks GPU utilization per active reservation by checking pod status on GPU nodes
- New SQLite table `gpu_utilization_snapshots` with cascade delete and 90-day automatic cleanup
- Bulk utilization API endpoint for efficient sparkline data loading
- Each reservation card now shows a color-coded sparkline (green >70%, yellow 30-70%, red <30%) with average GPU % and active days count
- Sparklines appear on both Overview and Reservations tabs

## Test plan
- [ ] Verify Go build passes (`go build ./...`)
- [ ] Verify TypeScript/lint passes (`npx tsc --noEmit && npm run build`)
- [ ] Create a GPU reservation and verify "No usage data yet" appears initially
- [ ] After worker runs (1 hour, or set `GPU_UTIL_POLL_INTERVAL_MS=10000` for testing), verify sparkline appears with utilization data
- [ ] Verify sparkline color coding: green for high utilization, yellow for medium, red for low
- [ ] Verify active days count reflects days with GPU usage
- [ ] Deploy to cluster and verify utilization data populates over time