### PR TITLE
🌱 Add Google Search Console verification file

### DIFF
--- a/web/public/google76fedc310dc4bbdd.html
+++ b/web/public/google76fedc310dc4bbdd.html
@@ -1,0 +1,1 @@
+google-site-verification: google76fedc310dc4bbdd.html


### PR DESCRIPTION
## Summary
- Adds `google76fedc310dc4bbdd.html` to `web/public/` for Google Search Console ownership verification
- Required before we can submit the sitemap.xml and request indexing of console.kubestellar.io
- File is served as a static asset — Netlify's SPA catch-all has `force = false` so it won't intercept existing files

## Test plan
- [ ] Verify file deploys to `https://console.kubestellar.io/google76fedc310dc4bbdd.html`
- [ ] Verify Google Search Console ownership verification succeeds
- [ ] Submit sitemap at `https://console.kubestellar.io/sitemap.xml`