### PR TITLE
🐛 Auto-label issues created from KubeStellar Console

### DIFF
--- a/.github/workflows/console-issue-labels.yml
+++ b/.github/workflows/console-issue-labels.yml
@@ -1,0 +1,45 @@
+name: Label Console-Created Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    if: >-
+      contains(github.event.issue.body, 'automatically created from the KubeStellar Console') ||
+      contains(github.event.issue.body, 'Submitted via KubeStellar Console')
+    steps:
+      - name: Apply labels to console-submitted issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+            const existingLabels = issue.labels.map(l => l.name);
+
+            // Determine issue type from body
+            const isBug = body.includes('**Type:** bug') || body.includes('## Bug Report');
+            const typeLabel = isBug ? 'kind/bug' : 'enhancement';
+
+            // Labels that should be present on all console-created issues
+            const requiredLabels = [typeLabel, 'ai-fix-requested', 'help wanted', 'triage/accepted'];
+
+            const labelsToAdd = requiredLabels.filter(l => !existingLabels.includes(l));
+
+            if (labelsToAdd.length === 0) {
+              core.info('All required labels already present');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: labelsToAdd
+            });
+            core.info(`Added labels: ${labelsToAdd.join(', ')}`);


### PR DESCRIPTION
## Summary
- Issues submitted through the console's feedback form arrive without labels when the `FEEDBACK_GITHUB_TOKEN` lacks label permissions (e.g., issue #1674)
- Adds a workflow that triggers on `issues: [opened]` and detects the console signature in the body
- Applies `kind/bug` or `enhancement`, `ai-fix-requested`, `help wanted`, and `triage/accepted` labels automatically
- Matches both backend (`automatically created from the KubeStellar Console`) and frontend (`Submitted via KubeStellar Console`) paths

## Test plan
- [ ] Create a test issue with the console signature text — verify labels are auto-applied
- [ ] Create a normal issue without the signature — verify no labels are added