### PR TITLE
✨ Add static SEO landing pages for search engine crawlers

### DIFF
--- a/web/netlify/edge-functions/seo-meta.ts
+++ b/web/netlify/edge-functions/seo-meta.ts
@@ -1,12 +1,13 @@
 /**
- * Netlify Edge Function: SEO Meta Tag Injection
+ * Netlify Edge Function: SEO Meta Tag Injection + Landing Pages
  *
- * Injects per-route <title>, <meta description>, Open Graph tags, and JSON-LD
- * structured data into the HTML response. This only runs on Netlify (not on
- * localhost or cluster deployments), so the SPA remains clean for self-hosted users.
+ * Two responsibilities:
+ * 1. Injects per-route <title>, <meta description>, Open Graph tags, and JSON-LD
+ *    structured data into the HTML response for all visitors.
+ * 2. Serves static landing pages (rich HTML content) to search engine crawlers
+ *    instead of the empty SPA shell. Human visitors get the normal React app.
  *
- * Edge Functions run at the CDN level and can modify responses before they reach
- * the browser, making them ideal for injecting SEO content into an SPA's index.html.
+ * This only runs on Netlify (not on localhost or cluster deployments).
  */
 
 import type { Context } from "https://edge.netlify.com";
@@ -14,6 +15,44 @@ import type { Context } from "https://edge.netlify.com";
 const SITE_URL = "https://console.kubestellar.io";
 const SITE_NAME = "KubeStellar Console";
 const DEFAULT_IMAGE = `${SITE_URL}/kubestellar.png`;
+
+/** Known search engine crawler user-agent patterns */
+const CRAWLER_UA_PATTERNS = [
+  "googlebot",
+  "bingbot",
+  "slurp",
+  "duckduckbot",
+  "baiduspider",
+  "yandexbot",
+  "facebookexternalhit",
+  "twitterbot",
+  "linkedinbot",
+  "whatsapp",
+  "slackbot",
+  "telegrambot",
+  "discordbot",
+  "applebot",
+  "semrushbot",
+  "ahrefsbot",
+  "mj12bot",
+  "petalbot",
+];
+
+/** Routes that have static landing pages in /landing/ */
+const LANDING_PAGE_MAP: Record<string, string> = {
+  "/": "/landing/index.html",
+  "/clusters": "/landing/clusters.html",
+  "/missions": "/landing/missions.html",
+  "/gpu-reservations": "/landing/gpu.html",
+  "/deploy": "/landing/deploy.html",
+  "/security": "/landing/security.html",
+};
+
+/** Check if the user-agent belongs to a search engine crawler or social bot */
+function isCrawler(userAgent: string): boolean {
+  const ua = userAgent.toLowerCase();
+  return CRAWLER_UA_PATTERNS.some((pattern) => ua.includes(pattern));
+}
 
 /** Actual dimensions of kubestellar.png used for OG image previews */
 const OG_IMAGE_WIDTH = 2048;
@@ -250,6 +289,26 @@ export default async (request: Request, context: Context) => {
     return;
   }
 
+  // Serve static landing pages to search engine crawlers and social bots.
+  // These pages have rich, crawlable HTML content instead of the empty SPA shell.
+  const userAgent = request.headers.get("user-agent") || "";
+  const landingPath = LANDING_PAGE_MAP[pathname];
+  if (landingPath && isCrawler(userAgent)) {
+    const landingUrl = new URL(landingPath, request.url);
+    const landingResponse = await fetch(landingUrl.toString());
+    if (landingResponse.ok) {
+      return new Response(await landingResponse.text(), {
+        status: 200,
+        headers: {
+          "content-type": "text/html; charset=utf-8",
+          "cache-control": "public, max-age=3600",
+          "x-robots-tag": "index, follow",
+        },
+      });
+    }
+    // Fall through to SPA + meta injection if landing page fetch fails
+  }
+
   // Get the response from the origin (index.html via SPA redirect)
   const response = await context.next();
   const contentType = response.headers.get("content-type") || "";
@@ -296,5 +355,6 @@ export const config = {
     "/*.ico",
     "/*.json",
     "/*.woff2",
+    "/landing/*",
   ],
 };

--- a/web/public/landing/clusters.html
+++ b/web/public/landing/clusters.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Multi-Cluster Management - KubeStellar Console</title>
+  <meta name="description" content="Monitor and manage multiple Kubernetes clusters from a single dashboard. View cluster health, node status, resource utilization, and deploy workloads across clusters." />
+  <meta name="keywords" content="kubernetes multi-cluster, cluster management, kubernetes cluster monitoring, multi-cluster dashboard, kubernetes fleet management" />
+  <link rel="canonical" href="https://console.kubestellar.io/clusters" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Multi-Cluster Management - KubeStellar Console" />
+  <meta property="og:description" content="Monitor and manage multiple Kubernetes clusters from a single dashboard. View cluster health, node status, resource utilization, and deploy workloads across clusters." />
+  <meta property="og:url" content="https://console.kubestellar.io/clusters" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Multi-Cluster Management - KubeStellar Console" />
+  <meta name="twitter:description" content="Monitor and manage multiple Kubernetes clusters from a single dashboard. View cluster health, node status, resource utilization, and deploy workloads across clusters." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Multi-Cluster Management",
+    "description": "Monitor and manage multiple Kubernetes clusters from a single dashboard. View cluster health, node status, resource utilization, and deploy workloads across clusters.",
+    "url": "https://console.kubestellar.io/clusters",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Multi-cluster monitoring, Cluster health tracking, Cross-cluster search, Node management, Resource utilization, Cluster federation"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Multi-Cluster <span class="accent">Kubernetes</span> Management</h1>
+    <p class="subtitle">Monitor and manage all your Kubernetes clusters from a single dashboard. View cluster health, node status, resource utilization, and deploy workloads across your entire fleet.</p>
+    <div class="hero-actions">
+      <a href="/clusters" class="btn-primary">View Clusters</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Complete Cluster Visibility and Control</h2>
+      <p>Everything you need to monitor, manage, and scale your Kubernetes clusters from one place.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2B22;</div>
+        <h3>Unified Dashboard</h3>
+        <p>See all clusters at a glance: EKS, GKE, AKS, OpenShift, kind, k3s. One dashboard to monitor every cluster in your fleet regardless of provider or distribution.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x2764;</div>
+        <h3>Cluster Health Monitoring</h3>
+        <p>Real-time health status, node conditions, and resource metrics. Instantly identify unhealthy clusters and drill into the root cause of issues.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F50D;</div>
+        <h3>Cross-Cluster Search</h3>
+        <p>Find any resource across all connected clusters instantly. Search pods, deployments, services, and custom resources without switching contexts.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2699;</div>
+        <h3>Node Management</h3>
+        <p>Monitor node status, capacity, and scheduling across clusters. Track node readiness, resource pressure conditions, and workload distribution per node.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F4CA;</div>
+        <h3>Resource Utilization</h3>
+        <p>CPU, memory, and storage usage trends across your fleet. Visualize resource consumption over time and identify clusters that need scaling.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F517;</div>
+        <h3>Cluster Federation</h3>
+        <p>Connect any conformant Kubernetes cluster in seconds. Add new clusters to your fleet with minimal configuration and start managing them immediately.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Any</div>
+        <div class="stat-label">Cloud Provider</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Real-Time</div>
+        <div class="stat-label">Health</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Cross-Cluster</div>
+        <div class="stat-label">Search</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Zero</div>
+        <div class="stat-label">Lock-In</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>One dashboard for all your Kubernetes clusters.</h2>
+    <p>Stop juggling kubectl contexts and cloud provider consoles. See everything in one place.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/deploy.html
+++ b/web/public/landing/deploy.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Multi-Cluster Workload Deployment - KubeStellar Console</title>
+  <meta name="description" content="Deploy applications across multiple Kubernetes clusters with smart placement. Drag-and-drop deployment, Helm chart management, and GitOps integration." />
+  <meta name="keywords" content="kubernetes multi-cluster deployment, deploy across clusters, kubernetes workload placement, helm deployment dashboard" />
+  <link rel="canonical" href="https://console.kubestellar.io/deploy" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Multi-Cluster Workload Deployment - KubeStellar Console" />
+  <meta property="og:description" content="Deploy applications across multiple Kubernetes clusters with smart placement. Drag-and-drop deployment, Helm chart management, and GitOps integration." />
+  <meta property="og:url" content="https://console.kubestellar.io/deploy" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Multi-Cluster Workload Deployment - KubeStellar Console" />
+  <meta name="twitter:description" content="Deploy applications across multiple Kubernetes clusters with smart placement. Drag-and-drop deployment, Helm chart management, and GitOps integration." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Multi-Cluster Deployment",
+    "description": "Deploy applications across multiple Kubernetes clusters with smart placement. Drag-and-drop deployment, Helm chart management, and GitOps integration.",
+    "url": "https://console.kubestellar.io/deploy",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": [
+      "Smart cluster placement",
+      "Helm chart management",
+      "GitOps integration",
+      "Drag-and-drop deployment",
+      "Rolling updates across clusters",
+      "Deployment history with rollback"
+    ]
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Multi-Cluster <span class="accent">Deployment</span> Made Easy</h1>
+    <p class="subtitle">Deploy applications across multiple Kubernetes clusters with smart placement, Helm chart management, and GitOps integration. One dashboard, all your clusters.</p>
+    <div class="hero-actions">
+      <a href="/deploy" class="btn-primary">Start Deploying</a>
+      <a href="https://docs.kubestellar.io" class="btn-secondary" target="_blank" rel="noopener noreferrer">View Documentation</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Deployment Features Built for Scale</h2>
+      <p>Everything you need to deploy, manage, and monitor workloads across your entire Kubernetes fleet.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2B22;</div>
+        <h3>Smart Placement</h3>
+        <p>Automatically select optimal clusters based on resource availability and constraints. Define placement policies and let KubeStellar distribute workloads intelligently.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x2318;</div>
+        <h3>Helm Chart Management</h3>
+        <p>Deploy and manage Helm charts across clusters directly from the dashboard. Browse repositories, configure values, and install charts without touching the CLI.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x21BB;</div>
+        <h3>GitOps Integration</h3>
+        <p>Sync deployments from Git repositories with Argo CD integration. Monitor sync status, detect drift, and ensure clusters match their desired state automatically.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2630;</div>
+        <h3>Drag-and-Drop Deploy</h3>
+        <p>Visual deployment interface &mdash; drag workloads to target clusters with an intuitive UI. No YAML editing required for common deployment scenarios.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x21C4;</div>
+        <h3>Rolling Updates</h3>
+        <p>Coordinated rolling updates across multiple clusters simultaneously. Monitor rollout progress, pause on failures, and ensure zero-downtime deployments at scale.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x29D6;</div>
+        <h3>Deployment History</h3>
+        <p>Track all deployments with full audit trail and rollback capability. Compare revisions, identify regressions, and restore previous configurations with a single click.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Comparison Table -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Manual kubectl vs. KubeStellar Console</h2>
+      <p>See how KubeStellar Console streamlines multi-cluster deployment workflows.</p>
+    </div>
+    <table class="comparison-table">
+      <thead>
+        <tr>
+          <th>Task</th>
+          <th>Manual kubectl</th>
+          <th>KubeStellar Console</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Deploy to 5 clusters</td>
+          <td class="cross">5 separate commands</td>
+          <td class="check">One click</td>
+        </tr>
+        <tr>
+          <td>Rollback</td>
+          <td class="cross">Manual per cluster</td>
+          <td class="check">Coordinated rollback</td>
+        </tr>
+        <tr>
+          <td>Helm management</td>
+          <td class="cross">CLI per cluster</td>
+          <td class="check">Visual dashboard</td>
+        </tr>
+        <tr>
+          <td>Drift detection</td>
+          <td class="cross">Manual diffing</td>
+          <td class="check">Automatic alerts</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Multi-Cluster</div>
+        <div class="stat-label">Deploy across all clusters at once</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Helm &amp; Kustomize</div>
+        <div class="stat-label">Native support for both tools</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">GitOps Native</div>
+        <div class="stat-label">Built-in Argo CD integration</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">One-Click Deploy</div>
+        <div class="stat-label">From dashboard to production</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Deploy everywhere. Manage from anywhere.</h2>
+    <p>Take control of your multi-cluster deployments with a unified dashboard that scales with your infrastructure.</p>
+    <a href="/" class="btn-primary">Open Console</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/gpu.html
+++ b/web/public/landing/gpu.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Kubernetes GPU Management &amp; Namespace Allocation - KubeStellar Console</title>
+  <meta name="description" content="Manage GPU resources across Kubernetes clusters. Track GPU utilization, allocate GPUs by namespace, and optimize AI/ML workload placement.">
+  <meta name="keywords" content="kubernetes GPU management, GPU allocation kubernetes, kubernetes AI ML, GPU namespace allocation, GPU monitoring kubernetes">
+  <link rel="canonical" href="https://console.kubestellar.io/gpu-reservations">
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Kubernetes GPU Management &amp; Namespace Allocation - KubeStellar Console">
+  <meta property="og:description" content="Manage GPU resources across Kubernetes clusters. Track GPU utilization, allocate GPUs by namespace, and optimize AI/ML workload placement.">
+  <meta property="og:url" content="https://console.kubestellar.io/gpu-reservations">
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png">
+  <meta property="og:image:width" content="2048">
+  <meta property="og:image:height" content="400">
+  <meta property="og:site_name" content="KubeStellar Console">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Kubernetes GPU Management &amp; Namespace Allocation - KubeStellar Console">
+  <meta name="twitter:description" content="Manage GPU resources across Kubernetes clusters. Track GPU utilization, allocate GPUs by namespace, and optimize AI/ML workload placement.">
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png">
+
+  <link rel="stylesheet" href="/landing/style.css">
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - GPU Management",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "description": "Manage GPU resources across Kubernetes clusters. Track GPU utilization, allocate GPUs by namespace, and optimize AI/ML workload placement.",
+    "url": "https://console.kubestellar.io/gpu-reservations",
+    "image": "https://console.kubestellar.io/kubestellar.png",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "featureList": [
+      "Real-time GPU utilization dashboard",
+      "Namespace-level GPU allocation and quotas",
+      "Multi-cluster GPU inventory tracking",
+      "GPU reservation system for training jobs",
+      "GPU cost tracking by namespace and workload",
+      "Smart AI/ML workload placement"
+    ]
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav" aria-label="Main navigation">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Kubernetes <span class="accent">GPU Management</span> &amp; Allocation</h1>
+    <p class="subtitle">Track GPU utilization across clusters, allocate resources by namespace, and optimize AI/ML workload placement &mdash; all from a single dashboard.</p>
+    <div class="hero-actions">
+      <a href="/gpu-reservations" class="btn-primary">Manage GPUs</a>
+      <a href="/" class="btn-secondary">View Demo</a>
+    </div>
+  </section>
+
+  <hr class="section-divider">
+
+  <!-- Features Grid -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Complete GPU Resource Management</h2>
+      <p>Everything you need to manage GPU resources across your multi-cluster Kubernetes environment.</p>
+    </div>
+    <div class="features-grid">
+
+      <div class="feature-card">
+        <div class="feature-icon blue">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/><polyline points="6 8 10 12 14 8 18 12"/></svg>
+        </div>
+        <h3>GPU Utilization Dashboard</h3>
+        <p>Real-time GPU utilization metrics across all clusters. Monitor memory usage, compute load, and temperature for every GPU in your fleet.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-icon purple">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+        </div>
+        <h3>Namespace Allocation</h3>
+        <p>Allocate GPU quotas by namespace and team. Set limits, enforce fair-share policies, and prevent resource starvation across your organization.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-icon green">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><line x1="9" y1="2" x2="9" y2="4"/><line x1="15" y1="2" x2="15" y2="4"/><line x1="9" y1="20" x2="9" y2="22"/><line x1="15" y1="20" x2="15" y2="22"/><line x1="20" y1="9" x2="22" y2="9"/><line x1="20" y1="15" x2="22" y2="15"/><line x1="2" y1="9" x2="4" y2="9"/><line x1="2" y1="15" x2="4" y2="15"/></svg>
+        </div>
+        <h3>Multi-Cluster GPU Inventory</h3>
+        <p>See all GPUs across clusters: A100, H100, L40S, T4 and more. Full inventory with model, memory, driver version, and availability status.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-icon purple">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><rect x="7" y="14" width="4" height="4" rx="1"/></svg>
+        </div>
+        <h3>Reservation System</h3>
+        <p>Reserve GPU time slots for training jobs. Schedule large model training runs without conflicts and ensure resources are available when needed.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-icon yellow">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+        </div>
+        <h3>Cost Tracking</h3>
+        <p>Track GPU spending by namespace and workload. Understand per-job costs, identify waste, and optimize GPU spend with detailed cost attribution reports.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-icon green">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4"/><path d="M12 18v4"/><path d="M4.93 4.93l2.83 2.83"/><path d="M16.24 16.24l2.83 2.83"/><path d="M2 12h4"/><path d="M18 12h4"/><path d="M4.93 19.07l2.83-2.83"/><path d="M16.24 7.76l2.83-2.83"/></svg>
+        </div>
+        <h3>Smart Placement</h3>
+        <p>Automatically place AI/ML workloads on optimal GPU nodes. Factor in GPU type, memory, network topology, and current utilization for best performance.</p>
+      </div>
+
+    </div>
+  </section>
+
+  <hr class="section-divider">
+
+  <!-- Stats Row -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Multi-Cluster</div>
+        <div class="stat-label">Unified GPU view across all clusters</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Real-Time Metrics</div>
+        <div class="stat-label">Live GPU utilization and health data</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Namespace Quotas</div>
+        <div class="stat-label">Fair-share GPU allocation by team</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Cost Tracking</div>
+        <div class="stat-label">Per-workload GPU cost attribution</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA Section -->
+  <section class="cta-section">
+    <h2>Stop wasting GPU resources.</h2>
+    <p>Get full visibility into GPU utilization across your Kubernetes clusters and start optimizing today.</p>
+    <a href="/gpu-reservations" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://kubestellar.io">KubeStellar</a>
+      <a href="https://github.com/kubestellar">GitHub</a>
+      <a href="https://docs.kubestellar.io">Documentation</a>
+      <a href="https://kubestellar.io/community">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors. All rights reserved.</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/index.html
+++ b/web/public/landing/index.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>KubeStellar Console - Multi-Cluster Kubernetes Dashboard &amp; Management</title>
+  <meta name="description" content="Open-source multi-cluster Kubernetes management dashboard. Monitor clusters, deploy workloads, manage GPU resources, and troubleshoot with AI-powered missions." />
+  <meta name="keywords" content="kubernetes dashboard, multi-cluster kubernetes, kubernetes management, k8s dashboard, kubernetes monitoring, kubestellar" />
+  <link rel="canonical" href="https://console.kubestellar.io" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="KubeStellar Console - Multi-Cluster Kubernetes Dashboard &amp; Management" />
+  <meta property="og:description" content="Open-source multi-cluster Kubernetes management dashboard. Monitor clusters, deploy workloads, manage GPU resources, and troubleshoot with AI-powered missions." />
+  <meta property="og:url" content="https://console.kubestellar.io" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="KubeStellar Console - Multi-Cluster Kubernetes Dashboard &amp; Management" />
+  <meta name="twitter:description" content="Open-source multi-cluster Kubernetes management dashboard. Monitor clusters, deploy workloads, manage GPU resources, and troubleshoot with AI-powered missions." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console",
+    "description": "Open-source multi-cluster Kubernetes management dashboard. Monitor clusters, deploy workloads, manage GPU resources, and troubleshoot with AI-powered missions.",
+    "url": "https://console.kubestellar.io",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Multi-Cluster Kubernetes Management, <span class="accent">Simplified</span></h1>
+    <p class="subtitle">Open-source dashboard for monitoring clusters, deploying workloads, managing GPU resources, and troubleshooting with AI-powered missions across all your Kubernetes environments.</p>
+    <div class="hero-actions">
+      <a href="/" class="btn-primary">Open Console</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Everything You Need for Multi-Cluster Kubernetes</h2>
+      <p>A unified dashboard that brings visibility, control, and intelligence to your Kubernetes fleet.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2B22;</div>
+        <h3>Multi-Cluster Overview</h3>
+        <p>Monitor all your Kubernetes clusters from a single dashboard. Track health status, resource utilization, node counts, and workload distribution across every environment.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x2728;</div>
+        <h3>AI-Powered Missions</h3>
+        <p>Over 400 CNCF project installers and troubleshooting guides powered by AI. Diagnose issues, install tools, and resolve incidents with guided step-by-step missions.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x2610;</div>
+        <h3>GPU Management</h3>
+        <p>Track GPU utilization and namespace allocation across your clusters. Visualize GPU capacity, monitor workload scheduling, and optimize expensive accelerator resources.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x25B6;</div>
+        <h3>Smart Deployment</h3>
+        <p>Deploy applications across multiple clusters with an intuitive drag-and-drop interface. Define placement policies and let KubeStellar handle the distribution.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x26A0;</div>
+        <h3>Security Dashboard</h3>
+        <p>RBAC analysis, vulnerability scanning, and compliance monitoring in one place. Identify misconfigurations, audit permissions, and enforce security policies across clusters.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x21BB;</div>
+        <h3>GitOps Integration</h3>
+        <p>Argo CD sync status and drift detection built in. Monitor your GitOps pipelines, detect configuration drift, and ensure your clusters match their desired state.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">50+</div>
+        <div class="stat-label">Clusters</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">400+</div>
+        <div class="stat-label">AI Missions</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">15+</div>
+        <div class="stat-label">CNCF Projects</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">100%</div>
+        <div class="stat-label">Open Source</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Ready to simplify your Kubernetes operations?</h2>
+    <p>Get started with KubeStellar Console and take control of your multi-cluster environment today.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/missions.html
+++ b/web/public/landing/missions.html
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AI-Powered Kubernetes Troubleshooting &amp; CNCF Project Installer - KubeStellar Console</title>
+  <meta name="description" content="Browse 400+ AI-generated missions for installing CNCF projects and troubleshooting Kubernetes issues. Step-by-step guides for Prometheus, Istio, Argo, Envoy, and more.">
+  <meta name="keywords" content="kubernetes troubleshooting, CNCF project installer, kubernetes AI assistant, install prometheus kubernetes, kubernetes troubleshooting guide">
+  <link rel="canonical" href="https://console.kubestellar.io/missions">
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="AI-Powered Kubernetes Troubleshooting &amp; CNCF Project Installer - KubeStellar Console">
+  <meta property="og:description" content="Browse 400+ AI-generated missions for installing CNCF projects and troubleshooting Kubernetes issues. Step-by-step guides for Prometheus, Istio, Argo, Envoy, and more.">
+  <meta property="og:url" content="https://console.kubestellar.io/missions">
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png">
+  <meta property="og:image:width" content="2048">
+  <meta property="og:image:height" content="400">
+  <meta property="og:site_name" content="KubeStellar Console">
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="AI-Powered Kubernetes Troubleshooting &amp; CNCF Project Installer - KubeStellar Console">
+  <meta name="twitter:description" content="Browse 400+ AI-generated missions for installing CNCF projects and troubleshooting Kubernetes issues. Step-by-step guides for Prometheus, Istio, Argo, Envoy, and more.">
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png">
+
+  <link rel="stylesheet" href="/landing/style.css">
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "KubeStellar Console Missions",
+    "description": "Browse 400+ AI-generated missions for installing CNCF projects and troubleshooting Kubernetes issues. Step-by-step guides for Prometheus, Istio, Argo, Envoy, and more.",
+    "url": "https://console.kubestellar.io/missions",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "featureList": [
+      "400+ step-by-step Kubernetes missions",
+      "CNCF project installation guides",
+      "AI-generated troubleshooting workflows",
+      "Multi-cluster execution",
+      "Version tracking and quality scores",
+      "Community-contributed mission library"
+    ],
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar",
+      "url": "https://kubestellar.io"
+    }
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/landing/clusters.html">Clusters</a>
+      <a href="/landing/workloads.html">Workloads</a>
+      <a href="/landing/missions.html">Missions</a>
+      <a href="/landing/deploy.html">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>AI-Powered Kubernetes <span class="accent">Missions</span></h1>
+    <p class="subtitle">Browse 400+ step-by-step missions for installing CNCF projects and troubleshooting Kubernetes issues. From Prometheus to Istio, Argo to Envoy &mdash; get guided walkthroughs that actually work.</p>
+    <div class="hero-actions">
+      <a href="/missions" class="btn-primary">Browse Missions</a>
+      <a href="https://docs.kubestellar.io" class="btn-secondary">Learn More</a>
+    </div>
+  </section>
+
+  <hr class="section-divider">
+
+  <!-- Features Grid -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Everything You Need to Deploy with Confidence</h2>
+      <p>Missions turn complex Kubernetes operations into guided, repeatable workflows.</p>
+    </div>
+    <div class="features-grid">
+
+      <div class="feature-card">
+        <div class="feature-icon green">&#9881;</div>
+        <h3>CNCF Project Installers</h3>
+        <p>Step-by-step installation guides for 15+ CNCF projects including Prometheus, Istio, Argo CD, Envoy, Falco, and more. Each guide is tested and versioned.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-icon purple">&#10024;</div>
+        <h3>AI-Generated Steps</h3>
+        <p>Each mission has detailed, tested installation and configuration steps generated by AI and validated against real clusters. No guesswork required.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-icon blue">&#128196;</div>
+        <h3>Version Tracking</h3>
+        <p>See project versions, maturity levels, and quality scores at a glance. Know exactly which version you are installing and what to expect.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-icon purple">&#127760;</div>
+        <h3>Multi-Cluster Execution</h3>
+        <p>Run missions across any connected cluster from a single console. Deploy Prometheus to staging and production simultaneously with consistent configuration.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#128270;</div>
+        <h3>Troubleshooting Guides</h3>
+        <p>Diagnose and fix common Kubernetes issues like CrashLoopBackOff, OOMKilled, and ImagePullBackOff with step-by-step diagnosis and resolution workflows.</p>
+      </div>
+
+      <div class="feature-card">
+        <div class="feature-icon green">&#129309;</div>
+        <h3>Community Contributed</h3>
+        <p>A growing library of missions from the KubeStellar community. Share your workflows, learn from others, and build on proven patterns.</p>
+      </div>
+
+    </div>
+  </section>
+
+  <hr class="section-divider">
+
+  <!-- Comparison Table -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Before &amp; After Missions</h2>
+      <p>See how missions transform complex Kubernetes tasks into guided workflows.</p>
+    </div>
+    <table class="comparison-table">
+      <thead>
+        <tr>
+          <th>Task</th>
+          <th class="cross">Without Missions</th>
+          <th class="check">With Missions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Install Prometheus</td>
+          <td class="cross">30 min reading docs</td>
+          <td class="check">5 min guided walkthrough</td>
+        </tr>
+        <tr>
+          <td>Debug CrashLoopBackOff</td>
+          <td class="cross">Stack Overflow hunting</td>
+          <td class="check">Step-by-step diagnosis</td>
+        </tr>
+        <tr>
+          <td>Set up Istio service mesh</td>
+          <td class="cross">Complex YAML editing</td>
+          <td class="check">Automated configuration</td>
+        </tr>
+        <tr>
+          <td>Configure Argo CD GitOps</td>
+          <td class="cross">Trial and error</td>
+          <td class="check">Tested workflow</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <hr class="section-divider">
+
+  <!-- Stats Row -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">400+</div>
+        <div class="stat-label">Missions</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">15+</div>
+        <div class="stat-label">CNCF Projects</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Step-by-Step</div>
+        <div class="stat-label">Guides</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Always</div>
+        <div class="stat-label">Up-to-Date</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA Section -->
+  <section class="cta-section">
+    <h2>Stop guessing. Start deploying.</h2>
+    <p>Browse hundreds of guided missions and deploy CNCF projects to your clusters in minutes, not hours.</p>
+    <a href="/missions" class="btn-primary">Browse Missions</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://kubestellar.io">KubeStellar</a>
+      <a href="https://docs.kubestellar.io">Documentation</a>
+      <a href="https://github.com/kubestellar">GitHub</a>
+      <a href="https://kubestellar.io/community">Community</a>
+    </div>
+    <p>&copy; 2024&ndash;2026 KubeStellar Contributors. All rights reserved.</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/security.html
+++ b/web/public/landing/security.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kubernetes Security Dashboard - KubeStellar Console</title>
+  <meta name="description" content="Monitor security posture across Kubernetes clusters. RBAC analysis, vulnerability scanning, network policy management, and compliance reporting." />
+  <meta name="keywords" content="kubernetes security, kubernetes RBAC, kubernetes security dashboard, cluster security monitoring, kubernetes compliance" />
+  <link rel="canonical" href="https://console.kubestellar.io/security" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Kubernetes Security Dashboard - KubeStellar Console" />
+  <meta property="og:description" content="Monitor security posture across Kubernetes clusters. RBAC analysis, vulnerability scanning, network policy management, and compliance reporting." />
+  <meta property="og:url" content="https://console.kubestellar.io/security" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Kubernetes Security Dashboard - KubeStellar Console" />
+  <meta name="twitter:description" content="Monitor security posture across Kubernetes clusters. RBAC analysis, vulnerability scanning, network policy management, and compliance reporting." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Security Dashboard",
+    "description": "Monitor security posture across Kubernetes clusters. RBAC analysis, vulnerability scanning, network policy management, and compliance reporting.",
+    "url": "https://console.kubestellar.io/security",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Kubernetes <span class="accent">Security</span> Dashboard</h1>
+    <p class="subtitle">Monitor your security posture across all Kubernetes clusters. RBAC analysis, vulnerability scanning, network policy management, and compliance reporting in one place.</p>
+    <div class="hero-actions">
+      <a href="/security" class="btn-primary">View Security</a>
+      <a href="https://docs.kubestellar.io" class="btn-secondary" target="_blank" rel="noopener noreferrer">Learn More</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Comprehensive Security for Every Cluster</h2>
+      <p>Unified visibility into RBAC, vulnerabilities, network policies, and compliance across your entire Kubernetes fleet.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F512;</div>
+        <h3>RBAC Analysis</h3>
+        <p>Visualize and audit role bindings, permissions, and access patterns. Detect overly permissive roles, orphaned bindings, and privilege escalation paths across all clusters.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F41B;</div>
+        <h3>Vulnerability Scanning</h3>
+        <p>Identify CVEs in container images across all clusters. Prioritize critical vulnerabilities, track remediation progress, and enforce image policies before deployment.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F310;</div>
+        <h3>Network Policies</h3>
+        <p>Monitor and manage network policies across namespaces. Visualize ingress and egress rules, detect unprotected workloads, and enforce zero-trust networking.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F4CB;</div>
+        <h3>Compliance Reporting</h3>
+        <p>Generate compliance reports for SOC2, PCI-DSS, HIPAA, and more. Automated checks against industry benchmarks with exportable audit trails.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F6E1;</div>
+        <h3>Security Posture Score</h3>
+        <p>Aggregate security score across your entire fleet. Track improvements over time, compare clusters, and identify the weakest links in your security chain.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4DD;</div>
+        <h3>Audit Logging</h3>
+        <p>Track all security-relevant events and API access. Searchable audit logs with real-time alerting for suspicious activity and policy violations.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Multi-Cluster</div>
+        <div class="stat-label">RBAC</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">CVE</div>
+        <div class="stat-label">Detection</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Compliance</div>
+        <div class="stat-label">Reports</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Real-Time</div>
+        <div class="stat-label">Alerts</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Secure every cluster. Trust every deployment.</h2>
+    <p>Take control of your Kubernetes security posture with comprehensive monitoring, auditing, and compliance reporting.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/style.css
+++ b/web/public/landing/style.css
@@ -1,0 +1,215 @@
+/* KubeStellar Console Landing Pages — Shared Styles
+   These static pages are crawlable by search engines and serve as
+   "marketing front doors" to the SPA dashboard. */
+
+:root {
+  --bg: #0a0a0a;
+  --bg-card: #111113;
+  --bg-card-hover: #18181b;
+  --border: #27272a;
+  --text: #fafafa;
+  --text-muted: #a1a1aa;
+  --text-dim: #71717a;
+  --purple: #7c3aed;
+  --purple-light: #a78bfa;
+  --purple-bg: rgba(124, 58, 237, 0.1);
+  --purple-border: rgba(124, 58, 237, 0.25);
+  --green: #22c55e;
+  --green-bg: rgba(34, 197, 94, 0.1);
+  --blue: #3b82f6;
+  --blue-bg: rgba(59, 130, 246, 0.1);
+  --yellow: #eab308;
+  --yellow-bg: rgba(234, 179, 8, 0.1);
+  --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-mono: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+  --max-width: 1200px;
+  --nav-height: 64px;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { background: var(--bg); color: var(--text); font-family: var(--font); line-height: 1.6; scroll-behavior: smooth; }
+body { min-height: 100vh; }
+
+/* Navigation */
+.nav {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 50;
+  height: var(--nav-height);
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 24px;
+  background: rgba(10, 10, 10, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+.nav-brand { display: flex; align-items: center; gap: 10px; text-decoration: none; color: var(--text); font-weight: 600; font-size: 16px; }
+.nav-brand svg { width: 28px; height: 28px; }
+.nav-links { display: flex; gap: 24px; }
+.nav-links a { color: var(--text-muted); text-decoration: none; font-size: 14px; transition: color 0.2s; }
+.nav-links a:hover { color: var(--text); }
+.nav-cta {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 8px 18px; border-radius: 8px;
+  background: var(--purple); color: white;
+  font-size: 14px; font-weight: 500; text-decoration: none;
+  transition: background 0.2s;
+}
+.nav-cta:hover { background: #6d28d9; }
+
+/* Hero */
+.hero {
+  padding: calc(var(--nav-height) + 80px) 24px 80px;
+  text-align: center;
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+.hero h1 {
+  font-size: clamp(32px, 5vw, 56px);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin-bottom: 20px;
+}
+.hero h1 .accent { color: var(--purple-light); }
+.hero .subtitle {
+  font-size: clamp(16px, 2vw, 20px);
+  color: var(--text-muted);
+  max-width: 700px;
+  margin: 0 auto 32px;
+}
+.hero-actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+.btn-primary {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 12px 28px; border-radius: 10px;
+  background: var(--purple); color: white;
+  font-size: 16px; font-weight: 500; text-decoration: none;
+  transition: background 0.2s, transform 0.15s;
+}
+.btn-primary:hover { background: #6d28d9; transform: translateY(-1px); }
+.btn-secondary {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 12px 28px; border-radius: 10px;
+  background: transparent; color: var(--text-muted);
+  font-size: 16px; font-weight: 500; text-decoration: none;
+  border: 1px solid var(--border);
+  transition: border-color 0.2s, color 0.2s;
+}
+.btn-secondary:hover { border-color: var(--purple-border); color: var(--text); }
+
+/* Sections */
+.section {
+  padding: 80px 24px;
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+.section-header {
+  text-align: center;
+  margin-bottom: 48px;
+}
+.section-header h2 {
+  font-size: clamp(24px, 3vw, 36px);
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+.section-header p {
+  color: var(--text-muted);
+  font-size: 16px;
+  max-width: 600px;
+  margin: 0 auto;
+}
+.section-divider {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 0;
+}
+
+/* Feature Grid */
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+}
+.feature-card {
+  padding: 28px;
+  border-radius: 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  transition: border-color 0.2s, transform 0.15s;
+}
+.feature-card:hover { border-color: var(--purple-border); transform: translateY(-2px); }
+.feature-icon {
+  width: 44px; height: 44px;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 10px;
+  margin-bottom: 16px;
+  font-size: 22px;
+}
+.feature-icon.purple { background: var(--purple-bg); color: var(--purple-light); }
+.feature-icon.green { background: var(--green-bg); color: var(--green); }
+.feature-icon.blue { background: var(--blue-bg); color: var(--blue); }
+.feature-icon.yellow { background: var(--yellow-bg); color: var(--yellow); }
+.feature-card h3 { font-size: 18px; font-weight: 600; margin-bottom: 8px; }
+.feature-card p { color: var(--text-muted); font-size: 14px; line-height: 1.6; }
+
+/* Stats Row */
+.stats-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+  margin-bottom: 48px;
+}
+.stat-card {
+  text-align: center;
+  padding: 24px;
+  border-radius: 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+}
+.stat-value { font-size: 36px; font-weight: 700; color: var(--purple-light); }
+.stat-label { font-size: 14px; color: var(--text-muted); margin-top: 4px; }
+
+/* CTA Section */
+.cta-section {
+  text-align: center;
+  padding: 80px 24px;
+  background: linear-gradient(180deg, transparent 0%, var(--purple-bg) 100%);
+  border-top: 1px solid var(--border);
+}
+.cta-section h2 { font-size: 28px; font-weight: 700; margin-bottom: 12px; }
+.cta-section p { color: var(--text-muted); margin-bottom: 28px; max-width: 500px; margin-left: auto; margin-right: auto; }
+
+/* Comparison Table */
+.comparison-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+.comparison-table th, .comparison-table td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+.comparison-table th { color: var(--text-muted); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: 0.05em; }
+.comparison-table td:first-child { font-weight: 500; }
+.check { color: var(--green); }
+.cross { color: var(--text-dim); }
+
+/* Footer */
+.footer {
+  padding: 40px 24px;
+  text-align: center;
+  border-top: 1px solid var(--border);
+  color: var(--text-dim);
+  font-size: 13px;
+}
+.footer a { color: var(--text-muted); text-decoration: none; }
+.footer a:hover { color: var(--text); }
+.footer-links { display: flex; gap: 24px; justify-content: center; margin-bottom: 16px; }
+
+/* Responsive */
+@media (max-width: 768px) {
+  .nav-links { display: none; }
+  .features-grid { grid-template-columns: 1fr; }
+  .stats-row { grid-template-columns: repeat(2, 1fr); }
+  .hero { padding-top: calc(var(--nav-height) + 48px); padding-bottom: 48px; }
+  .section { padding: 48px 16px; }
+}


### PR DESCRIPTION
## Summary
- Adds 6 static HTML landing pages served to search engine crawlers via the seo-meta edge function
- Human visitors get the normal React SPA; crawlers (Googlebot, Bingbot, social bots, etc.) get rich, indexable HTML content
- Each page includes full SEO meta tags, Open Graph, Twitter Cards, JSON-LD structured data, and keyword-optimized content

## Landing Pages
| Route | Page | Focus |
|-------|------|-------|
| `/` | Main overview | Multi-cluster Kubernetes management |
| `/clusters` | Cluster management | Fleet monitoring & cross-cluster search |
| `/missions` | AI Missions | 400+ CNCF project installers & troubleshooting |
| `/gpu-reservations` | GPU management | GPU utilization & namespace allocation |
| `/deploy` | Deployment | Multi-cluster workload deployment |
| `/security` | Security | RBAC, vulnerability scanning, compliance |

## How it works
1. seo-meta edge function detects crawler user-agents (Googlebot, Bingbot, etc.)
2. For routes with landing pages, serves the static HTML instead of the SPA shell
3. Pages are in `web/public/landing/` and use a shared CSS stylesheet
4. Non-crawler visitors continue to get the normal React SPA with injected meta tags

## Test plan
- [ ] Build succeeds with landing pages in `dist/landing/`
- [ ] Netlify preview deploys correctly
- [ ] Verify crawler detection: `curl -A "Googlebot" https://<preview>/` returns landing page
- [ ] Verify normal user-agent returns SPA: `curl https://<preview>/` returns index.html
- [ ] Each landing page renders correctly with dark theme
- [ ] All meta tags, OG tags, and JSON-LD present in landing pages