### PR TITLE
🐛 Fix onboarding tour with accurate content for production

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -716,7 +716,7 @@ export function MissionSidebarToggle() {
   return (
     <button
       onClick={openSidebar}
-      data-tour="ai-missions"
+      data-tour="ai-missions-toggle"
       className={cn(
         'fixed flex items-center gap-2 rounded-full shadow-lg transition-all z-50',
         // Mobile: smaller padding, bottom right

--- a/web/src/components/onboarding/Tour.tsx
+++ b/web/src/components/onboarding/Tour.tsx
@@ -1,10 +1,9 @@
 import { useEffect, useState, useRef } from 'react'
 import { X, ChevronLeft, ChevronRight } from 'lucide-react'
 import { useTour, TourStep } from '../../hooks/useTour'
-import { useMissions } from '../../hooks/useMissions'
 import { cn } from '../../lib/cn'
 import { useTranslation } from 'react-i18next'
-import { TOOLTIP_POSITION_DELAY_MS, SHORT_DELAY_MS } from '../../lib/constants/network'
+import { TOOLTIP_POSITION_DELAY_MS } from '../../lib/constants/network'
 
 // KubeStellar logo — clean, no decorative overlays
 function KubeStellarAIIcon({ className }: { className?: string }) {
@@ -239,8 +238,6 @@ export function TourOverlay() {
     prevStep,
     skipTour,
   } = useTour()
-  const { openSidebar: openMissionSidebar, closeSidebar: closeMissionSidebar } = useMissions()
-
   const [tooltipPosition, setTooltipPosition] = useState<TooltipPosition>({})
   const [targetRect, setTargetRect] = useState<DOMRect | null>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
@@ -293,12 +290,6 @@ export function TourOverlay() {
       }
     }, 100))
 
-    // For steps that may have layout shifts (e.g., after sidebar closes),
-    // reposition after a longer delay to catch the final layout
-    if (currentStep.id === 'add-card' || currentStep.id === 'templates') {
-      timeoutIds.push(setTimeout(positionTooltip, SHORT_DELAY_MS))
-    }
-
     // Reposition on window resize
     const handleResize = () => positionTooltip()
     window.addEventListener('resize', handleResize)
@@ -327,22 +318,6 @@ export function TourOverlay() {
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [isActive, nextStep, prevStep, skipTour])
-
-  // Open mission sidebar when on the AI Missions step
-  useEffect(() => {
-    if (!isActive || !currentStep) return
-
-    if (currentStep.id === 'ai-missions') {
-      openMissionSidebar()
-    }
-
-    return () => {
-      // Close sidebar when leaving the AI Missions step
-      if (currentStep.id === 'ai-missions') {
-        closeMissionSidebar()
-      }
-    }
-  }, [isActive, currentStep, openMissionSidebar, closeMissionSidebar])
 
   if (!isActive || !currentStep) return null
 
@@ -513,7 +488,7 @@ export function TourPrompt() {
         <div className="flex-1">
           <h3 className="font-semibold text-foreground mb-1">Welcome!</h3>
           <p className="text-sm text-muted-foreground mb-3">
-            Would you like a quick tour of the console? Learn about AI features, drill-down navigation, and more.
+            New here? Take a quick tour to learn about dashboards, cards, search, and AI missions.
           </p>
           <div className="flex gap-2">
             <button

--- a/web/src/hooks/useTour.tsx
+++ b/web/src/hooks/useTour.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState, useEffect, useCallback, ReactNode 
 import { useMobile } from './useMobile'
 import { SETTINGS_CHANGED_EVENT, SETTINGS_RESTORED_EVENT } from '../lib/settingsSync'
 import { emitTourStarted, emitTourCompleted, emitTourSkipped } from '../lib/analytics'
+import { STORAGE_KEY_TOUR_COMPLETED } from '../lib/constants/storage'
 
 export interface TourStep {
   id: string
@@ -13,21 +14,25 @@ export interface TourStep {
 }
 
 /**
- * Onboarding tour steps — kept short (4 steps) for high completion rates.
+ * Onboarding tour steps — kept short (5 steps) for high completion rates.
  *
  * The original 13-step tour had very low completion; most users skipped
- * after step 2-3. These 4 steps cover the essential "aha moments":
+ * after step 2-3. These 5 steps cover the essential "aha moments":
  *   1. Welcome — what this product is
- *   2. Sidebar — how to navigate
+ *   2. Sidebar — how to navigate 30+ dashboards
  *   3. Dashboard cards — the core interaction model
- *   4. AI features — the key differentiator (search + recommendations)
+ *   4. Search — command palette (Cmd+K)
+ *   5. AI Missions — guided multi-step operations
+ *
+ * All text must be accurate on both console.kubestellar.io (demo mode)
+ * and localhost with a live backend.
  */
 const TOUR_STEPS: TourStep[] = [
   {
     id: 'welcome',
     target: '[data-tour="navbar"]',
     title: 'Welcome to KubeStellar Console',
-    content: 'Your AI-powered multi-cluster Kubernetes dashboard. Claude AI helps you monitor, troubleshoot, and manage clusters — let\'s take a quick look around.',
+    content: 'Your multi-cluster Kubernetes dashboard. Monitor, troubleshoot, and manage clusters across any infrastructure \u2014 let\u2019s take a quick look around.',
     placement: 'bottom',
     highlight: true,
   },
@@ -35,7 +40,7 @@ const TOUR_STEPS: TourStep[] = [
     id: 'sidebar',
     target: '[data-tour="sidebar"]',
     title: 'Navigation',
-    content: 'Switch between dashboards (Clusters, Deploy, Security, GitOps) in the top section. Each view is fully customizable — add or remove cards to fit your workflow. The bottom section has Settings, Marketplace, and snoozed AI suggestions.',
+    content: 'Browse 30+ dashboards organized by topic \u2014 Clusters, Deploy, AI/ML, Security, GitOps, Cost, and more. Drag items to reorder or hide ones you don\u2019t need. Settings and Marketplace are at the bottom.',
     placement: 'right',
     highlight: true,
   },
@@ -43,21 +48,27 @@ const TOUR_STEPS: TourStep[] = [
     id: 'dashboard-cards',
     target: '[data-tour="card-header"]',
     title: 'Dashboard Cards',
-    content: 'Cards show real-time cluster data. Drag to reorder, click the menu (⋮) to configure with natural language, or click "+" at the bottom to add more cards from the catalog.',
+    content: 'Cards show cluster data at a glance. Drag to reorder, click the \u22ee menu to configure or resize, and expand any card for detailed drill-downs. Use the floating + button (bottom-right) or the sidebar to add cards from the catalog.',
     placement: 'bottom',
     highlight: true,
   },
   {
-    id: 'ai-features',
+    id: 'search',
     target: '[data-tour="search"]',
-    title: 'AI-Powered Features',
-    content: 'Press ⌘K to search across all clusters with natural language. Above the cards, AI recommendations suggest useful cards and Actions offer one-click fixes for detected issues. Try the AI Missions panel for complex multi-step operations.',
+    title: 'Search & Commands',
+    content: 'Press \u2318K (or Ctrl+K) to open the command palette. Search across dashboards, cards, clusters, and missions \u2014 or type a question to get AI-powered answers.',
     placement: 'bottom',
     highlight: true,
   },
+  {
+    id: 'ai-missions',
+    target: '[data-tour="ai-missions-toggle"]',
+    title: 'AI Missions',
+    content: 'Open the Missions panel to launch guided multi-step operations \u2014 install platforms, troubleshoot issues, and more. Choose your preferred AI provider in the navbar. In demo mode, missions run with sample data.',
+    placement: 'left',
+    highlight: true,
+  },
 ]
-
-const TOUR_STORAGE_KEY = 'kubestellar-console-tour-completed'
 
 interface TourContextValue {
   isActive: boolean
@@ -84,7 +95,7 @@ export function TourProvider({ children }: { children: ReactNode }) {
   // Check localStorage on mount and when settings are restored from file
   useEffect(() => {
     const readFromStorage = () => {
-      const completed = localStorage.getItem(TOUR_STORAGE_KEY)
+      const completed = localStorage.getItem(STORAGE_KEY_TOUR_COMPLETED)
       setHasCompletedTour(completed === 'true')
     }
     readFromStorage()
@@ -116,7 +127,7 @@ export function TourProvider({ children }: { children: ReactNode }) {
       // Tour complete
       setIsActive(false)
       setHasCompletedTour(true)
-      localStorage.setItem(TOUR_STORAGE_KEY, 'true')
+      localStorage.setItem(STORAGE_KEY_TOUR_COMPLETED, 'true')
       window.dispatchEvent(new Event(SETTINGS_CHANGED_EVENT))
       emitTourCompleted(TOUR_STEPS.length)
     }
@@ -132,12 +143,12 @@ export function TourProvider({ children }: { children: ReactNode }) {
     emitTourSkipped(currentStepIndex)
     setIsActive(false)
     setHasCompletedTour(true)
-    localStorage.setItem(TOUR_STORAGE_KEY, 'true')
+    localStorage.setItem(STORAGE_KEY_TOUR_COMPLETED, 'true')
     window.dispatchEvent(new Event(SETTINGS_CHANGED_EVENT))
   }, [currentStepIndex])
 
   const resetTour = useCallback(() => {
-    localStorage.removeItem(TOUR_STORAGE_KEY)
+    localStorage.removeItem(STORAGE_KEY_TOUR_COMPLETED)
     setHasCompletedTour(false)
     window.dispatchEvent(new Event(SETTINGS_CHANGED_EVENT))
   }, [])


### PR DESCRIPTION
## Summary
- **Rewrite all 5 tour steps** to be factually accurate on both `console.kubestellar.io` (Netlify/demo mode) and localhost with live backend
- **Remove "Claude AI" reference** — system supports Anthropic, OpenAI, Google, GitHub Copilot, and more
- **Fix dashboard count** — "30+ dashboards" instead of listing only 4 (Clusters, Deploy, Security, GitOps)
- **Fix card step** — accurate + button location (floating FAB / sidebar), remove misleading "natural language" config claim
- **Add Search & Commands step** (Cmd+K / Ctrl+K) — previously buried in AI Features step
- **Add AI Missions step** — targets the toggle button, honest about demo mode behavior
- **Remove dead code** — `add-card`/`templates`/`ai-missions` step handlers that referenced non-existent steps from the old 13-step tour
- **Remove mission sidebar auto-open** — it hid the toggle button target, breaking tooltip positioning
- **Disambiguate `data-tour` selector** — MissionSidebar toggle button gets `ai-missions-toggle` to avoid matching the off-screen panel div
- **Deduplicate storage key** — import `STORAGE_KEY_TOUR_COMPLETED` from shared constants instead of local duplicate

## Files Changed
| File | Change |
|------|--------|
| `web/src/hooks/useTour.tsx` | Rewrite TOUR_STEPS (4 to 5), import shared storage key |
| `web/src/components/onboarding/Tour.tsx` | Remove 3 dead code blocks, unused imports, update TourPrompt text |
| `web/src/components/layout/mission-sidebar/MissionSidebar.tsx` | Rename toggle `data-tour` to `ai-missions-toggle` |

## Test plan
- [ ] Reset tour: `localStorage.removeItem('kubestellar-console-tour-completed')` then refresh
- [ ] Walk through all 5 steps — verify each tooltip highlights the correct element
- [ ] Step 1: No "Claude AI" mention, targets navbar
- [ ] Step 2: Mentions "30+ dashboards", targets sidebar
- [ ] Step 3: Accurate card interaction description, targets card header
- [ ] Step 4: Cmd+K and Ctrl+K mentioned, targets search
- [ ] Step 5: AI Missions toggle button highlighted (bottom-right), mentions demo mode
- [ ] Keyboard nav: arrow-right advance, arrow-left back, Esc skip
- [ ] Tour completion persists across refresh
- [ ] TourTrigger button restarts tour
- [ ] Build passes: `npm run build`
- [ ] Lint passes: `npm run lint` (0 new errors)