### PR TITLE
🐛 Fix tour truncation and add 'Add Cards' step

### DIFF
--- a/web/src/components/dashboard/FloatingDashboardActions.tsx
+++ b/web/src/components/dashboard/FloatingDashboardActions.tsx
@@ -209,6 +209,7 @@ export function FloatingDashboardActions({
 
         {/* FAB toggle - smaller on mobile */}
         <button
+          data-tour="fab-button"
           onClick={menu.toggle}
           className={`flex items-center justify-center rounded-full shadow-lg transition-all duration-200 ${
             isMobile ? 'w-8 h-8' : 'w-10 h-10'

--- a/web/src/components/onboarding/Tour.tsx
+++ b/web/src/components/onboarding/Tour.tsx
@@ -488,7 +488,7 @@ export function TourPrompt() {
         <div className="flex-1">
           <h3 className="font-semibold text-foreground mb-1">Welcome!</h3>
           <p className="text-sm text-muted-foreground mb-3">
-            New here? Take a quick tour to learn about dashboards, cards, search, and AI missions.
+            New here? Take a quick tour to learn about dashboards, cards, search, and AI missions. Just 6 steps!
           </p>
           <div className="flex gap-2">
             <button

--- a/web/src/hooks/useTour.tsx
+++ b/web/src/hooks/useTour.tsx
@@ -14,15 +14,16 @@ export interface TourStep {
 }
 
 /**
- * Onboarding tour steps — kept short (5 steps) for high completion rates.
+ * Onboarding tour steps — kept short (6 steps) for high completion rates.
  *
  * The original 13-step tour had very low completion; most users skipped
- * after step 2-3. These 5 steps cover the essential "aha moments":
+ * after step 2-3. These 6 steps cover the essential "aha moments":
  *   1. Welcome — what this product is
  *   2. Sidebar — how to navigate 30+ dashboards
  *   3. Dashboard cards — the core interaction model
  *   4. Search — command palette (Cmd+K)
- *   5. AI Missions — guided multi-step operations
+ *   5. Add Cards — the floating + button for adding/managing cards
+ *   6. AI Missions — guided multi-step operations
  *
  * All text must be accurate on both console.kubestellar.io (demo mode)
  * and localhost with a live backend.
@@ -48,7 +49,7 @@ const TOUR_STEPS: TourStep[] = [
     id: 'dashboard-cards',
     target: '[data-tour="card-header"]',
     title: 'Dashboard Cards',
-    content: 'Cards show cluster data at a glance. Drag to reorder, click the \u22ee menu to configure or resize, and expand any card for detailed drill-downs. Use the floating + button (bottom-right) or the sidebar to add cards from the catalog.',
+    content: 'Cards show cluster data at a glance. Drag to reorder, click the \u22ee menu to configure or resize, and expand any card for detailed drill-downs.',
     placement: 'bottom',
     highlight: true,
   },
@@ -61,11 +62,19 @@ const TOUR_STEPS: TourStep[] = [
     highlight: true,
   },
   {
+    id: 'add-cards',
+    target: '[data-tour="fab-button"]',
+    title: 'Add & Manage Cards',
+    content: 'Click this button to add cards from the catalog, apply dashboard templates, export or import layouts, and customize the sidebar.',
+    placement: 'top',
+    highlight: true,
+  },
+  {
     id: 'ai-missions',
     target: '[data-tour="ai-missions-toggle"]',
     title: 'AI Missions',
-    content: 'Open the Missions panel to launch guided multi-step operations \u2014 install platforms, troubleshoot issues, and more. Choose your preferred AI provider in the navbar. In demo mode, missions run with sample data.',
-    placement: 'left',
+    content: 'Open the Missions panel for guided multi-step operations \u2014 install platforms, troubleshoot issues, and more. Choose your AI provider in the navbar.',
+    placement: 'top',
     highlight: true,
   },
 ]


### PR DESCRIPTION
## Summary
- Fixes AI Missions tooltip being truncated at the bottom by changing placement from `left` to `top`
- Adds new "Add & Manage Cards" tour step (step 5) targeting the floating + FAB button
- Shortens AI Missions content text and removes redundant FAB mention from dashboard-cards step
- Tour is now 6 steps (was 5)

## Changes
| File | Change |
|------|--------|
| `FloatingDashboardActions.tsx` | Add `data-tour="fab-button"` to FAB button |
| `useTour.tsx` | Add step 5, change AI Missions to `placement: 'top'`, shorten text |
| `Tour.tsx` | Update TourPrompt to say "Just 6 steps!" |

## Test plan
- [ ] Reset tour: `localStorage.removeItem('kubestellar-console-tour-completed')` + refresh
- [ ] Walk through all 6 steps — verify no truncation on AI Missions step
- [ ] Verify "Add & Manage Cards" step highlights the purple + FAB button
- [ ] Test on console.kubestellar.io after deploy