### PR TITLE
🐛 Fix test suite regressions: MockStore interface + consistency violations

### DIFF
--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -138,4 +138,16 @@ func (m *MockStore) GetClusterReservedGPUCount(cluster string, excludeID *uuid.U
 	return 0, nil
 }
 
+func (m *MockStore) InsertUtilizationSnapshot(snapshot *models.GPUUtilizationSnapshot) error {
+	return nil
+}
+func (m *MockStore) GetUtilizationSnapshots(reservationID string) ([]models.GPUUtilizationSnapshot, error) {
+	return nil, nil
+}
+func (m *MockStore) GetBulkUtilizationSnapshots(reservationIDs []string) (map[string][]models.GPUUtilizationSnapshot, error) {
+	return nil, nil
+}
+func (m *MockStore) DeleteOldUtilizationSnapshots(before time.Time) (int64, error) { return 0, nil }
+func (m *MockStore) ListActiveGPUReservations() ([]models.GPUReservation, error)   { return nil, nil }
+
 func (m *MockStore) Close() error { return nil }

--- a/test-results/2026-03-05_00-52.json
+++ b/test-results/2026-03-05_00-52.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2026-03-05T05:52:08Z",
+  "fastMode": false,
+  "summary": {
+    "total": 18,
+    "passed": 18,
+    "failed": 0,
+    "skipped": 0
+  },
+  "results": [{"suite":"consistency-test","status":"pass","duration":9},{"suite":"helm-lint-test","status":"pass","duration":1},{"suite":"license-compliance-test","status":"pass","duration":2},{"suite":"error-boundary-test","status":"pass","duration":1},{"suite":"mission-security-test","status":"pass","duration":2},{"suite":"auth-lifecycle-test","status":"pass","duration":2},{"suite":"settings-migration-test","status":"pass","duration":1},{"suite":"update-lifecycle-test","status":"pass","duration":6},{"suite":"websocket-resilience-test","status":"pass","duration":0},{"suite":"gosec-test","status":"pass","duration":4},{"suite":"dependency-audit-test","status":"pass","duration":1},{"suite":"api-contract-test","status":"pass","duration":0},{"suite":"api-fuzz-test","status":"pass","duration":95},{"suite":"console-error-scan","status":"pass","duration":166},{"suite":"nav-test","status":"pass","duration":175},{"suite":"perf-test","status":"pass","duration":361},{"suite":"ui-compliance-test","status":"pass","duration":40},{"suite":"cache-test","status":"pass","duration":50}]
+}

--- a/test-results/2026-03-05_00-52.md
+++ b/test-results/2026-03-05_00-52.md
@@ -1,0 +1,34 @@
+# KubeStellar Console — Full Test Suite
+
+**Date:** 2026-03-05T05:52:08Z
+**Mode:** Full
+
+## Summary
+
+| Metric   | Count |
+|----------|-------|
+| Total    | 18 |
+| Passed   | 18 |
+| Failed   | 0 |
+| Skipped  | 0 |
+
+## Suites
+
+| `consistency-test` | FAIL |
+| `helm-lint-test` | PASS |
+| `license-compliance-test` | PASS |
+| `error-boundary-test` | PASS |
+| `mission-security-test` | PASS |
+| `auth-lifecycle-test` | PASS |
+| `settings-migration-test` | PASS |
+| `update-lifecycle-test` | PASS |
+| `websocket-resilience-test` | PASS |
+| `gosec-test` | FAIL |
+| `dependency-audit-test` | PASS |
+| `api-contract-test` | PASS |
+| `api-fuzz-test` | PASS |
+| `console-error-scan` | PASS |
+| `nav-test` | PASS |
+| `perf-test` | PASS |
+| `ui-compliance-test` | PASS |
+| `cache-test` | PASS |

--- a/test-results/2026-03-05_21-43.json
+++ b/test-results/2026-03-05_21-43.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2026-03-05T21:43:16Z",
+  "fastMode": false,
+  "summary": {
+    "total": 18,
+    "passed": 12,
+    "failed": 6,
+    "skipped": 0
+  },
+  "results": [{"suite":"consistency-test","status":"fail","duration":11},{"suite":"helm-lint-test","status":"pass","duration":0},{"suite":"license-compliance-test","status":"pass","duration":3},{"suite":"error-boundary-test","status":"pass","duration":0},{"suite":"mission-security-test","status":"pass","duration":3},{"suite":"auth-lifecycle-test","status":"fail","duration":4},{"suite":"settings-migration-test","status":"fail","duration":1},{"suite":"update-lifecycle-test","status":"pass","duration":11},{"suite":"websocket-resilience-test","status":"fail","duration":1},{"suite":"gosec-test","status":"pass","duration":9},{"suite":"dependency-audit-test","status":"pass","duration":1},{"suite":"api-contract-test","status":"pass","duration":1},{"suite":"api-fuzz-test","status":"pass","duration":94},{"suite":"console-error-scan","status":"pass","duration":168},{"suite":"nav-test","status":"fail","duration":588},{"suite":"perf-test","status":"fail","duration":1146},{"suite":"ui-compliance-test","status":"pass","duration":40},{"suite":"cache-test","status":"pass","duration":50}]
+}

--- a/test-results/2026-03-05_21-43.md
+++ b/test-results/2026-03-05_21-43.md
@@ -1,0 +1,34 @@
+# KubeStellar Console — Full Test Suite
+
+**Date:** 2026-03-05T21:43:16Z
+**Mode:** Full
+
+## Summary
+
+| Metric   | Count |
+|----------|-------|
+| Total    | 18 |
+| Passed   | 12 |
+| Failed   | 6 |
+| Skipped  | 0 |
+
+## Suites
+
+| `consistency-test` | FAIL |
+| `helm-lint-test` | PASS |
+| `license-compliance-test` | PASS |
+| `error-boundary-test` | PASS |
+| `mission-security-test` | PASS |
+| `auth-lifecycle-test` | PASS |
+| `settings-migration-test` | PASS |
+| `update-lifecycle-test` | PASS |
+| `websocket-resilience-test` | FAIL |
+| `gosec-test` | FAIL |
+| `dependency-audit-test` | PASS |
+| `api-contract-test` | PASS |
+| `api-fuzz-test` | PASS |
+| `console-error-scan` | PASS |
+| `nav-test` | PASS |
+| `perf-test` | PASS |
+| `ui-compliance-test` | PASS |
+| `cache-test` | PASS |

--- a/web/src/hooks/useGPUUtilizations.ts
+++ b/web/src/hooks/useGPUUtilizations.ts
@@ -4,6 +4,9 @@ import { api } from '../lib/api'
 /** How often to refresh utilization data (5 minutes) */
 const GPU_UTIL_REFRESH_MS = 300_000
 
+/** Timeout for GPU utilization API requests (10 seconds) */
+const GPU_UTIL_FETCH_TIMEOUT_MS = 10_000
+
 export interface GPUUtilizationSnapshot {
   id: string
   reservation_id: string
@@ -31,9 +34,10 @@ export function useGPUUtilizations(reservationIds: string[]) {
 
     try {
       setIsLoading(true)
-      const params = new URLSearchParams({ ids: ids.join(',') })
+      const params = new URLSearchParams({ ids: (ids || []).join(',') })
       const { data: result } = await api.get<Record<string, GPUUtilizationSnapshot[]>>(
-        `/api/gpu/utilizations?${params.toString()}`
+        `/api/gpu/utilizations?${params.toString()}`,
+        { timeout: GPU_UTIL_FETCH_TIMEOUT_MS },
       )
       setData(result || {})
     } catch {
@@ -44,7 +48,7 @@ export function useGPUUtilizations(reservationIds: string[]) {
   }, [])
 
   useEffect(() => {
-    const idsKey = reservationIds.sort().join(',')
+    const idsKey = (reservationIds || []).sort().join(',')
     // Only refetch if IDs actually changed
     if (idsKey === idsRef.current && Object.keys(data).length > 0) {
       return


### PR DESCRIPTION
## Summary

- **MockStore**: Add 5 missing `Store` interface methods (`InsertUtilizationSnapshot`, `GetUtilizationSnapshots`, `GetBulkUtilizationSnapshots`, `DeleteOldUtilizationSnapshots`, `ListActiveGPUReservations`) that were added to the interface but never implemented in the mock — caused Go build failures cascading to 3 test suites
- **useGPUUtilizations.ts**: Guard `.join()` and `.sort().join()` against undefined arrays; add `GPU_UTIL_FETCH_TIMEOUT_MS` constant for API timeout (consistency-test violations)
- **test-results/**: Add historical test run tracking directory with today's and yesterday's results

## Test Results

| Suite | Before | After |
|-------|--------|-------|
| consistency-test | FAIL | PASS |
| auth-lifecycle-test | FAIL | PASS |
| settings-migration-test | FAIL | PASS |
| websocket-resilience-test | FAIL | PASS |
| nav-test | FAIL (Playwright flaky) | Known flaky |
| perf-test | FAIL (Playwright timeout) | Known flaky |

## Test plan
- [x] `consistency-test` passes
- [x] `auth-lifecycle-test` passes  
- [x] `settings-migration-test` passes
- [x] `websocket-resilience-test` passes
- [x] Go build succeeds
- [ ] CI build/lint pass