### PR TITLE
🐛 Add focus trapping, error boundary, and aria improvements

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ import { AlertsProvider } from './contexts/AlertsContext'
 import { RewardsProvider } from './hooks/useRewards'
 import { UnifiedDemoProvider } from './lib/unified/demo'
 import { ChunkErrorBoundary } from './components/ChunkErrorBoundary'
+import { AppErrorBoundary } from './components/AppErrorBoundary'
 import { ROUTES } from './config/routes'
 import { usePersistedSettings } from './hooks/usePersistedSettings'
 import { prefetchCardData } from './lib/prefetchCardData'
@@ -361,6 +362,7 @@ function App() {
       <DashboardProvider>
       <DrillDownProvider>
       <DrillDownModal />
+      <AppErrorBoundary>
       <ChunkErrorBoundary>
       <Suspense fallback={<LoadingFallback />}>
       <Routes>
@@ -428,6 +430,7 @@ function App() {
       </Routes>
       </Suspense>
       </ChunkErrorBoundary>
+      </AppErrorBoundary>
       </DrillDownProvider>
       </DashboardProvider>
       </AlertsProvider>

--- a/web/src/components/AppErrorBoundary.tsx
+++ b/web/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,87 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react'
+import { AlertTriangle, RefreshCw } from 'lucide-react'
+import i18next from 'i18next'
+import { emitError } from '../lib/analytics'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+/**
+ * Generic error boundary that catches any unhandled React runtime errors.
+ *
+ * Wraps the app outside ChunkErrorBoundary. ChunkErrorBoundary handles stale
+ * chunk errors specifically (auto-reload). This boundary catches everything
+ * else — null references, bad API response shapes, rendering bugs — and
+ * shows a recovery UI instead of a white screen.
+ */
+export class AppErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('[AppErrorBoundary] Uncaught error:', error, errorInfo)
+    emitError('uncaught_render', error.message)
+  }
+
+  handleReload = () => {
+    window.location.reload()
+  }
+
+  handleRecover = () => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center bg-background">
+          <div className="text-center p-8 max-w-md" role="alert">
+            <AlertTriangle className="w-12 h-12 text-yellow-400 mx-auto mb-4" aria-hidden="true" />
+            <h2 className="text-lg font-semibold text-foreground mb-2">
+              {i18next.t('common:appError.title', 'Something went wrong')}
+            </h2>
+            <p className="text-sm text-muted-foreground mb-6">
+              {i18next.t('common:appError.description', 'An unexpected error occurred. You can try recovering or reload the page.')}
+            </p>
+            {this.state.error && (
+              <p className="text-xs text-muted-foreground/70 font-mono mb-6 break-all">
+                {this.state.error.message}
+              </p>
+            )}
+            <div className="flex items-center justify-center gap-3">
+              <button
+                onClick={this.handleRecover}
+                className="px-4 py-2 bg-secondary hover:bg-secondary/80 text-foreground rounded-lg text-sm font-medium transition-colors"
+                aria-label={i18next.t('common:appError.tryAgain', 'Try again')}
+              >
+                {i18next.t('common:appError.tryAgain', 'Try again')}
+              </button>
+              <button
+                onClick={this.handleReload}
+                className="px-4 py-2 bg-purple-500 hover:bg-purple-600 text-white rounded-lg text-sm font-medium transition-colors flex items-center gap-2"
+                aria-label={i18next.t('common:appError.reloadPage', 'Reload page')}
+              >
+                <RefreshCw className="w-4 h-4" aria-hidden="true" />
+                {i18next.t('common:appError.reloadPage', 'Reload page')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -79,7 +79,12 @@ function ToastContainer({ toasts, onRemove }: ToastContainerProps) {
   if (toasts.length === 0) return null
 
   return (
-    <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[100] flex flex-col items-center space-y-2">
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="false"
+      className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[100] flex flex-col items-center space-y-2"
+    >
       {toasts.map((toast) => (
         <ToastItem key={toast.id} toast={toast} onRemove={() => onRemove(toast.id)} />
       ))}
@@ -126,8 +131,9 @@ function ToastItem({ toast, onRemove }: ToastItemProps) {
       <button
         onClick={onRemove}
         className="p-1 rounded hover:bg-white/10 text-muted-foreground hover:text-foreground"
+        aria-label="Dismiss notification"
       >
-        <X className="w-3 h-3" />
+        <X className="w-3 h-3" aria-hidden="true" />
       </button>
     </div>
   )

--- a/web/src/lib/modals/BaseModal.tsx
+++ b/web/src/lib/modals/BaseModal.tsx
@@ -37,7 +37,7 @@
 import { ReactNode, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { X, ChevronLeft } from 'lucide-react'
-import { useModalNavigation } from './useModalNavigation'
+import { useModalNavigation, useModalFocusTrap } from './useModalNavigation'
 import {
   BaseModalProps,
   ModalHeaderProps,
@@ -81,6 +81,7 @@ export function BaseModal({
   closeOnEscape = true,
 }: BaseModalProps) {
   const backdropRef = useRef<HTMLDivElement>(null)
+  const modalRef = useRef<HTMLDivElement>(null)
 
   // Set up keyboard navigation (ESC and Space/Backspace to close)
   useModalNavigation({
@@ -90,6 +91,9 @@ export function BaseModal({
     enableBackspace: true,
     disableBodyScroll: true,
   })
+
+  // Trap focus within modal so Tab cannot escape to background content
+  useModalFocusTrap(modalRef, isOpen)
 
   if (!isOpen) return null
 
@@ -113,6 +117,7 @@ export function BaseModal({
         onClick={handleBackdropClick}
       >
         <div
+          ref={modalRef}
           role="dialog"
           aria-modal="true"
           className={`glass w-full ${SIZE_CLASSES[size]} ${HEIGHT_CLASSES[size]} rounded-xl flex flex-col overflow-hidden ${className}`}
@@ -152,8 +157,9 @@ function ModalHeader({
               onClick={onBack}
               className="p-2 rounded-lg hover:bg-card/50 text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
               title="Go back (Backspace)"
+              aria-label="Go back"
             >
-              <ChevronLeft className="w-5 h-5" />
+              <ChevronLeft className="w-5 h-5" aria-hidden="true" />
             </button>
           )}
 
@@ -194,8 +200,9 @@ function ModalHeader({
               onClick={onClose}
               className="p-2 rounded-lg hover:bg-card/50 text-muted-foreground hover:text-foreground transition-colors"
               title="Close (Esc)"
+              aria-label="Close modal"
             >
-              <X className="w-5 h-5" />
+              <X className="w-5 h-5" aria-hidden="true" />
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary
Three safety-net changes from the UI analysis — all additive, cannot break existing behavior:

- **Focus trapping in BaseModal** — enables the existing `useModalFocusTrap` hook so Tab key cycles within the modal instead of escaping to background content. Adds `aria-label` to back/close buttons.
- **Toast aria-live** — adds `role="status"` and `aria-live="polite"` to the toast container so screen readers announce notifications. Adds `aria-label` to the dismiss button.
- **AppErrorBoundary** — catches any unhandled React runtime error and shows a recovery UI ("Try again" / "Reload page") instead of a white screen. Wraps `ChunkErrorBoundary` which only handles stale chunk errors.

## Why these are safe
- Focus trap: uses existing code that was already implemented but disabled. No behavior change for mouse users.
- Toast aria: HTML attributes only — no rendering, styling, or behavior impact for sighted users.
- Error boundary: does nothing until an error occurs. Purely a safety net.

## Test plan
- [ ] Open any modal (e.g., card expand) → Tab should cycle within the modal, not escape to background
- [ ] Trigger a toast notification → verify screen reader announces it (or inspect DOM for `aria-live`)
- [ ] Verify app loads normally (error boundary is transparent when no errors occur)