### PR TITLE
✨ Add make dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 # KubeStellar Console — developer workflow targets
 #
 # Usage:
+#   make dev       Start frontend, backend, and kc-agent (no OAuth required)
 #   make update    Pull latest, build everything, restart
 #   make build     Build frontend + Go binaries
 #   make restart   Restart all processes via startup-oauth.sh
 #   make help      Show available targets
 
-.PHONY: help build restart update pull lint
+.PHONY: help dev build restart update pull lint
 
 SHELL := /bin/bash
 
@@ -35,6 +36,10 @@ restart:
 
 ## update: Pull, build, and restart (full update cycle)
 update: pull build restart
+
+## dev: Start frontend, backend, and kc-agent for local development (no OAuth required)
+dev:
+	bash start-dev.sh
 
 ## lint: Run frontend linter
 lint:


### PR DESCRIPTION
## Summary
- Adds `make dev` target that delegates to `start-dev.sh`
- Replaces #1739 which duplicated startup logic inline in the Makefile

## Test plan
- [ ] `make dev` starts frontend, backend, and kc-agent
- [ ] `make help` shows the new `dev` target