### PR TITLE
🐛 Fix pill dropdown clipped in Recommended Cards/Actions sections

### DIFF
--- a/web/src/components/dashboard/CardRecommendations.tsx
+++ b/web/src/components/dashboard/CardRecommendations.tsx
@@ -144,7 +144,7 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
   }
 
   return (
-    <div data-tour="recommendations" className="mb-4 glass rounded-xl border border-border/50 overflow-hidden">
+    <div data-tour="recommendations" className="mb-4 glass rounded-xl border border-border/50">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">
         <div className="flex items-center gap-2">

--- a/web/src/components/dashboard/MissionSuggestions.tsx
+++ b/web/src/components/dashboard/MissionSuggestions.tsx
@@ -219,7 +219,7 @@ export function MissionSuggestions() {
   }
 
   return (
-    <div data-tour="mission-suggestions" className="mb-4 glass rounded-xl border border-border/50 overflow-hidden">
+    <div data-tour="mission-suggestions" className="mb-4 glass rounded-xl border border-border/50">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Pill dropdowns in "Recommended Cards for your clusters" and "Recommended Actions for your clusters" were getting cut off because the parent container had `overflow-hidden`
- Removed `overflow-hidden` from the interactive containers so absolutely-positioned dropdowns render correctly
- Skeleton loading state keeps `overflow-hidden` (no dropdowns to clip)

## Test plan
- [ ] Click a pill in "Recommended Cards for your clusters" — dropdown should appear fully below the pill
- [ ] Click a pill in "Recommended Actions for your clusters" — same behavior
- [ ] Verify rounded corners still look correct on both sections