### PR TITLE
🐛 Fix UTM campaign attribution not reaching GA4

### DIFF
--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -250,6 +250,15 @@ function send(
     p.set('uid', userId)
   }
 
+  // Campaign attribution — GA4 MP v2 requires explicit campaign params.
+  // gtag.js extracts these from the URL automatically, but when using the
+  // Measurement Protocol directly we must set cs/cm/cn/ck/cc ourselves.
+  if (utmParams.utm_source) p.set('cs', utmParams.utm_source)
+  if (utmParams.utm_medium) p.set('cm', utmParams.utm_medium)
+  if (utmParams.utm_campaign) p.set('cn', utmParams.utm_campaign)
+  if (utmParams.utm_term) p.set('ck', utmParams.utm_term)
+  if (utmParams.utm_content) p.set('cc', utmParams.utm_content)
+
   // Encode the entire payload as base64 so network-level filters
   // can't match on GA4 parameter patterns (tid=G-*, en=, cid=, etc.)
   const encoded = btoa(p.toString())


### PR DESCRIPTION
## Summary
- CNCF outreach issues link to console.kubestellar.io with proper UTM params (`utm_source=github&utm_medium=issue&utm_campaign=cncf_outreach&utm_term=<project>`)
- But GA4 showed zero campaign traffic — all sessions were "Direct" or "Unassigned"
- Root cause: When using Measurement Protocol v2 directly (not gtag.js), GA4 does **not** auto-extract UTM params from the `dl` (document location) URL
- Fix: Explicitly set GA4 campaign parameters (`cs`, `cm`, `cn`, `ck`, `cc`) on every event from the captured UTM params

## Test plan
- [ ] Visit `https://console.kubestellar.io?utm_source=github&utm_medium=issue&utm_campaign=cncf_outreach&utm_term=test`
- [ ] In GA4 Realtime, verify the session shows source=github, medium=issue, campaign=cncf_outreach
- [ ] Verify existing events still fire correctly (page_view, ksc_card_added, etc.)