### PR TITLE
🐛 Fix CSP blocking Chart.js on /analytics page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -93,7 +93,7 @@
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
     X-XSS-Protection = "1; mode=block"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.google-analytics.com https://*.googleapis.com https://api.github.com wss:; frame-ancestors 'none'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.google-analytics.com https://*.googleapis.com https://api.github.com wss:; frame-ancestors 'none'"
 
 [[headers]]
   for = "/assets/*"


### PR DESCRIPTION
## Summary
- Add `https://cdn.jsdelivr.net` to `script-src` in Content Security Policy
- Fixes `analytics.html` loading Chart.js from CDN being blocked by CSP

## Root cause
The `/analytics` page loads Chart.js via `<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js">` but the CSP `script-src` directive only allowed `'self'`, `'unsafe-inline'`, `'unsafe-eval'`, and `https://www.googletagmanager.com`.

## Test plan
- [ ] Visit https://console.kubestellar.io/analytics — charts should render without CSP errors