### PR TITLE
🐛 Fix CSP violations on console.kubestellar.io

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -93,7 +93,7 @@
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
     X-XSS-Protection = "1; mode=block"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.google-analytics.com https://*.googleapis.com https://api.github.com wss:; frame-ancestors 'none'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.google-analytics.com https://*.googleapis.com https://api.github.com https://api.dicebear.com https://fonts.gstatic.com wss:; frame-ancestors 'none'"
 
 [[headers]]
   for = "/assets/*"

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -10,7 +10,7 @@ import type {
 } from '../types/alerts'
 import type { GPUHealthCheckResult } from '../hooks/mcp/types'
 import type { NightlyGuideStatus } from '../lib/llmd/nightlyE2EDemoData'
-import { BACKEND_DEFAULT_URL, STORAGE_KEY_AUTH_TOKEN, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants'
+import { STORAGE_KEY_AUTH_TOKEN, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants'
 import { INITIAL_FETCH_DELAY_MS, POLL_INTERVAL_SLOW_MS, SECONDARY_FETCH_DELAY_MS } from '../lib/constants/network'
 import { PRESET_ALERT_RULES } from '../types/alerts'
 import { sendNotificationWithDeepLink } from '../hooks/useDeepLink'
@@ -167,7 +167,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
       const currentClusters = clustersRef.current
       if (!currentClusters.length) return
 
-      const API_BASE = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
+      const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
       const results: Record<string, GPUHealthCheckResult[]> = {}
 
       await Promise.allSettled(
@@ -206,7 +206,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     const fetchNightlyE2E = async () => {
       try {
-        const API_BASE = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
+        const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
         const resp = await fetch(`${API_BASE}/api/public/nightly-e2e/runs`, {
           signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
         })
@@ -463,7 +463,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
       // Skip notification if not authenticated - notifications require login
       if (!token) return
 
-      const API_BASE = import.meta.env.VITE_API_BASE_URL || BACKEND_DEFAULT_URL
+      const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
 
       const response = await fetch(`${API_BASE}/api/notifications/send`, {
         method: 'POST',

--- a/web/src/hooks/usePersistedSettings.ts
+++ b/web/src/hooks/usePersistedSettings.ts
@@ -9,6 +9,7 @@ import {
 } from '../lib/settingsSync'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { isNetlifyDeployment } from '../lib/demoMode'
 
 const DEBOUNCE_MS = 1000
 
@@ -131,8 +132,10 @@ export function usePersistedSettings() {
   useEffect(() => {
     mountedRef.current = true
 
-    if (!isAuthenticated) {
-      // Not logged in yet — wait for auth to complete
+    if (!isAuthenticated || isNetlifyDeployment) {
+      // Not logged in yet or on Netlify (no local agent) — skip agent sync
+      setSyncStatus(isNetlifyDeployment ? 'offline' : 'idle')
+      setLoaded(true)
       return () => { mountedRef.current = false }
     }
 

--- a/web/src/hooks/useUpdateProgress.ts
+++ b/web/src/hooks/useUpdateProgress.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import type { UpdateProgress, UpdateStepEntry } from '../types/updates'
 import { LOCAL_AGENT_WS_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { isNetlifyDeployment } from '../lib/demoMode'
 
 const WS_RECONNECT_MS = 5000  // Reconnect interval after WebSocket disconnect
 const BACKEND_POLL_MS = 2000  // Poll interval when waiting for backend to come up
@@ -165,6 +166,9 @@ export function useUpdateProgress() {
         reconnectTimer = setTimeout(connect, WS_RECONNECT_MS)
       }
     }
+
+    // Skip agent WebSocket on Netlify deployments (no local agent available)
+    if (isNetlifyDeployment) return
 
     connect()
 


### PR DESCRIPTION
## Summary

Fixes multiple Content Security Policy errors on `console.kubestellar.io`:

- **Agent guard (useUpdateProgress)** — WebSocket to `ws://127.0.0.1:8585/ws` was attempted on every page load via `Layout.tsx`, even on Netlify where no local agent exists. Added `isNetlifyDeployment` guard.
- **Agent guard (usePersistedSettings)** — Settings fetch to `http://127.0.0.1:8585/settings` was attempted unconditionally on mount. Added `isNetlifyDeployment` guard to skip agent sync and use localStorage-only mode.
- **Nightly E2E URL (AlertsContext)** — Fallback URL was `http://localhost:8080` which violates CSP on production. Changed to relative URL (`''`) since Netlify Functions handle `/api/` routes via redirects.
- **CSP connect-src (netlify.toml)** — Added `https://api.dicebear.com` (avatar generation) and `https://fonts.gstatic.com` (font loading via MSW passthrough) to the `connect-src` directive.

## Test plan

- [ ] Verify no CSP errors in browser console on `console.kubestellar.io` after deploy
- [ ] Verify settings sync still works when running locally with kc-agent
- [ ] Verify nightly E2E card loads data on production (via Netlify Function)
- [ ] Verify dicebear avatars and Google Fonts load without CSP errors