### PR TITLE
🐛 Disable agent URLs at source on Netlify deployments

### DIFF
--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -9,11 +9,29 @@
 // URLs
 // ============================================================================
 
-/** WebSocket URL for the local kc-agent */
-export const LOCAL_AGENT_WS_URL = 'ws://127.0.0.1:8585/ws'
+/**
+ * Whether the app is running on a Netlify deployment (console.kubestellar.io, preview deploys).
+ * On Netlify, agent URLs are disabled — there is no local kc-agent.
+ * Duplicated from demoMode.ts to avoid circular imports (demoMode → constants → network).
+ */
+const _isNetlify = typeof window !== 'undefined' && (
+  import.meta.env.VITE_DEMO_MODE === 'true' ||
+  window.location.hostname.includes('netlify.app') ||
+  window.location.hostname.includes('deploy-preview-') ||
+  window.location.hostname === 'console.kubestellar.io'
+)
 
-/** HTTP URL for the local kc-agent */
-export const LOCAL_AGENT_HTTP_URL = 'http://127.0.0.1:8585'
+/**
+ * WebSocket URL for the local kc-agent.
+ * Empty on Netlify — all WebSocket consumers have try/catch so empty URL throws immediately.
+ */
+export const LOCAL_AGENT_WS_URL = _isNetlify ? '' : 'ws://127.0.0.1:8585/ws'
+
+/**
+ * HTTP URL for the local kc-agent.
+ * Empty on Netlify — fetch calls become relative URLs (e.g. '/settings'), which 404 silently.
+ */
+export const LOCAL_AGENT_HTTP_URL = _isNetlify ? '' : 'http://127.0.0.1:8585'
 
 /** Default backend URL (used as fallback when not configured) */
 export const BACKEND_DEFAULT_URL = 'http://localhost:8080'


### PR DESCRIPTION
## Summary

Comprehensive fix for ALL agent CSP violations on `console.kubestellar.io`.

Previous PRs (#1772, #1775) guarded individual hooks (`usePersistedSettings`, `useUpdateProgress`), but many more hooks make unguarded agent calls: `usePrometheusMetrics`, `useAIPredictions`, `useMissions`, all drilldown views, `useKubectl`, etc.

**This PR fixes the problem at the source** — in `network.ts` where `LOCAL_AGENT_HTTP_URL` and `LOCAL_AGENT_WS_URL` are defined. On Netlify deployments, these constants are set to `''`:

- **HTTP URL `''`** → `fetch(''+'/settings')` becomes `fetch('/settings')` — relative URL on the current origin, returns 404/HTML, caught silently by existing error handlers. No CSP violation.
- **WS URL `''`** → `new WebSocket('')` throws `SyntaxError` immediately, caught by existing try/catch blocks. No CSP violation.

This eliminates the need to guard 40+ individual consumer files.

## Test plan

- [ ] Hard-reload `console.kubestellar.io` — zero CSP violations in console
- [ ] Navigate to every sidebar route — zero agent connection attempts
- [ ] Verify local dev with kc-agent still works (URLs are only disabled on Netlify)
- [ ] Check deploy preview for the EventSource MIME type error