### PR TITLE
🐛 Fix pin button state not syncing across KeepAlive navigation

### DIFF
--- a/web/src/components/shared/DashboardHeader.tsx
+++ b/web/src/components/shared/DashboardHeader.tsx
@@ -59,11 +59,18 @@ export function DashboardHeader({
 }: DashboardHeaderProps) {
   const { t } = useTranslation()
   const location = useLocation()
-  const [rememberPosition, setRememberPositionState] = useState(() => getRememberPosition(location.pathname))
+  // Capture this dashboard's path on mount — KeepAlive keeps us mounted even
+  // when the user navigates to a different dashboard, so location.pathname
+  // changes to other dashboards' paths. Only sync pin state for our own path.
+  const ownPathRef = useRef(location.pathname)
+  const [rememberPosition, setRememberPositionState] = useState(() => getRememberPosition(ownPathRef.current))
 
-  // Re-sync pin state whenever the path changes (e.g. navigating between dashboards)
+  // Re-sync pin state only when returning to THIS dashboard's path
   useEffect(() => {
-    setRememberPositionState(getRememberPosition(location.pathname))
+    const ownPath = ownPathRef.current
+    if (location.pathname === ownPath) {
+      setRememberPositionState(getRememberPosition(ownPath))
+    }
   }, [location.pathname])
 
   // Self-managed timestamp: updates when isFetching goes true → false
@@ -126,7 +133,7 @@ export function DashboardHeader({
               checked={rememberPosition}
               onChange={(e) => {
                 setRememberPositionState(e.target.checked)
-                setRememberPosition(location.pathname, e.target.checked)
+                setRememberPosition(ownPathRef.current, e.target.checked)
               }}
               className="rounded border-border w-3.5 h-3.5"
             />


### PR DESCRIPTION
## Summary
- Fixes pin checkbox syncing to wrong dashboard's state when KeepAlive keeps multiple dashboards mounted
- Uses `useRef` to capture the component's own path on mount, then guards the `useEffect` to only sync pin state when `location.pathname` matches the component's own path
- Also fixes the `onChange` handler to write to `ownPathRef.current` instead of `location.pathname`

## Root Cause
KeepAlive preserves mounted components across navigation. When navigating from Dashboard-1 to Dashboard-2, Dashboard-1's `DashboardHeader` stays mounted and its `useEffect` fires with Dashboard-2's `location.pathname`, overwriting Dashboard-1's pin state with Dashboard-2's value.

## Fix
```tsx
const ownPathRef = useRef(location.pathname) // captured once on mount

useEffect(() => {
  const ownPath = ownPathRef.current
  if (location.pathname === ownPath) {
    setRememberPositionState(getRememberPosition(ownPath))
  }
}, [location.pathname])
```

Fixes #1743