### PR TITLE
🐛 Fix GA4 analytics: abandoned modal bug + wire 3 missing events

### DIFF
--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -4,6 +4,7 @@ import { BaseModal } from '../../lib/modals'
 import { useClusterHealth, usePodIssues, useDeploymentIssues, useGPUNodes, useNodes, useNamespaceStats, useDeployments, useClusters } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
+import { emitClusterAction } from '../../lib/analytics'
 import { Gauge } from '../charts/Gauge'
 import { NodeListItem } from './NodeListItem'
 import { NodeDetailPanel } from './NodeDetailPanel'
@@ -161,6 +162,7 @@ export function ClusterDetailModal({ clusterName, clusterUser, onClose, onRename
 
   // AI diagnose/repair handlers
   const handleDiagnose = () => {
+    emitClusterAction('diagnose', clusterName)
     const issuesSummary = [
       ...podIssues.map(p => `Pod ${p.name} in ${p.namespace}: ${p.status}`),
       ...clusterDeploymentIssues.map(d => `Deployment ${d.name} in ${d.namespace}: ${d.readyReplicas}/${d.replicas} ready`)
@@ -199,6 +201,7 @@ Please analyze this cluster and provide:
   }
 
   const handleRepair = () => {
+    emitClusterAction('repair', clusterName)
     const issuesList = [
       ...podIssues.slice(0, 5).map(p => `- Pod "${p.name}" in namespace "${p.namespace}": ${p.status} (${p.restarts} restarts)`),
       ...clusterDeploymentIssues.slice(0, 5).map(d => `- Deployment "${d.name}" in namespace "${d.namespace}": ${d.readyReplicas}/${d.replicas} ready - ${d.reason || 'Unknown reason'}`)
@@ -368,6 +371,7 @@ After I approve, help me execute the repairs step by step.`,
             </button>
             <button
               onClick={() => {
+                emitClusterAction('ask', clusterName)
                 startMission({
                   title: `Ask about ${clusterName.split('/').pop()}`,
                   description: 'Custom question about the cluster',

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -42,6 +42,7 @@ const CLUSTERS_CARDS_KEY = 'kubestellar-clusters-cards'
 const DEFAULT_CLUSTERS_CARDS = getDefaultCards('clusters')
 
 import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { emitClusterStatsDrillDown } from '../../lib/analytics'
 import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
@@ -413,15 +414,16 @@ export function Clusters() {
             <StatsOverview
               stats={stats}
               onFilterByStatus={(status) => {
+                emitClusterStatsDrillDown('cluster_health_status')
                 setFilter(status)
                 setShowClusterGrid(true) // Ensure cluster grid is visible
               }}
-              onCPUClick={() => window.location.href = '/compute'}
-              onMemoryClick={() => window.location.href = '/compute'}
-              onStorageClick={() => window.location.href = '/storage'}
-              onGPUClick={() => setShowGPUModal(true)}
-              onNodesClick={() => window.location.href = '/compute'}
-              onPodsClick={() => window.location.href = '/workloads'}
+              onCPUClick={() => { emitClusterStatsDrillDown('cpu'); window.location.href = '/compute' }}
+              onMemoryClick={() => { emitClusterStatsDrillDown('memory'); window.location.href = '/compute' }}
+              onStorageClick={() => { emitClusterStatsDrillDown('storage'); window.location.href = '/storage' }}
+              onGPUClick={() => { emitClusterStatsDrillDown('gpu'); setShowGPUModal(true) }}
+              onNodesClick={() => { emitClusterStatsDrillDown('nodes'); window.location.href = '/compute' }}
+              onPodsClick={() => { emitClusterStatsDrillDown('pods'); window.location.href = '/workloads' }}
             />
           )
         )}

--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -956,21 +956,28 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
 
   // Track whether cards were added during this modal session
   const didAddCards = useRef(false)
+  // Guard: only fire "abandoned" after the modal has actually been opened
+  const wasOpened = useRef(false)
 
   useEffect(() => {
     if (isOpen) {
       didAddCards.current = false
+      wasOpened.current = true
       emitAddCardModalOpened()
-      if (activeTab === 'browse') {
-        // Delay slightly to ensure modal is rendered
-        const timer = setTimeout(() => searchInputRef.current?.focus(), FOCUS_DELAY_MS)
-        return () => clearTimeout(timer)
-      }
-    } else {
+    } else if (wasOpened.current) {
       // Modal just closed — if no cards were added, it was abandoned
+      wasOpened.current = false
       if (!didAddCards.current) {
         emitAddCardModalAbandoned()
       }
+    }
+  }, [isOpen])
+
+  // Auto-focus search input when browse tab is active
+  useEffect(() => {
+    if (isOpen && activeTab === 'browse') {
+      const timer = setTimeout(() => searchInputRef.current?.focus(), FOCUS_DELAY_MS)
+      return () => clearTimeout(timer)
     }
   }, [isOpen, activeTab])
 

--- a/web/src/components/llmd-benchmarks/LLMdBenchmarks.tsx
+++ b/web/src/components/llmd-benchmarks/LLMdBenchmarks.tsx
@@ -1,10 +1,16 @@
+import { useEffect } from 'react'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
+import { emitBenchmarkViewed } from '../../lib/analytics'
 
 const BENCHMARKS_CARDS_KEY = 'kubestellar-llmd-benchmarks-cards'
 const DEFAULT_BENCHMARKS_CARDS = getDefaultCards('llm-d-benchmarks')
 
 export function LLMdBenchmarks() {
+  useEffect(() => {
+    emitBenchmarkViewed('llm-d')
+  }, [])
+
   return (
     <DashboardPage
       title="llm-d Benchmarks"


### PR DESCRIPTION
## Summary

GA4 audit revealed several analytics issues — one data-corrupting bug and multiple unwired events on high-traffic pages.

### Bug Fix: `ksc_add_card_modal_abandoned` inflated 71x
- **427 abandoned events vs 6 opened** — the `useEffect` in `AddCardModal.tsx` fired `emitAddCardModalAbandoned()` on component mount (when `isOpen` is initially `false`) and on every `activeTab` change while closed
- Added a `wasOpened` ref guard so abandoned only fires after the modal has actually been opened then closed
- Split the `[isOpen, activeTab]` effect into two separate effects to prevent cross-triggering

### Wiring: 3 unwired events on high-traffic pages
| Event | Page | Pageviews | Was Tracked |
|-------|------|-----------|-------------|
| `ksc_benchmark_viewed` | /llm-d-benchmarks | 153 | 0 |
| `ksc_cluster_action` | Cluster detail modal | 152 (clusters) | 0 |
| `ksc_cluster_stats_drill_down` | /clusters stats | 152 (clusters) | 0 |

- `emitBenchmarkViewed('llm-d')` — called on mount in `LLMdBenchmarks.tsx`
- `emitClusterAction(action, clusterName)` — called for diagnose/repair/ask in `ClusterDetailModal.tsx`
- `emitClusterStatsDrillDown(statType)` — called for all 6 StatsOverview click handlers (CPU, memory, storage, GPU, nodes, pods)

### Not wired (expected zeros)
- `emitComplianceFilterChanged` — compliance page has no filter UI yet (dead code waiting for feature)
- `emitCardReplaced`, `emitDemoModeToggled`, `emitApiProviderConnected`, `emitPwaPrompt*` — features not used on console.kubestellar.io

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Reset localStorage, open add-card modal, close without adding → exactly 1 opened + 1 abandoned event (not 71x)
- [ ] Page load without opening modal → 0 abandoned events
- [ ] Visit /llm-d-benchmarks → `ksc_benchmark_viewed` fires in GA4 DebugView
- [ ] Click Diagnose/Repair/Ask in cluster detail → `ksc_cluster_action` fires
- [ ] Click CPU/Memory/GPU stats → `ksc_cluster_stats_drill_down` fires