### PR TITLE
⚠️ Design system critical fixes: accessibility, color consistency, status dedup

### DIFF
--- a/web/src/components/cards/ArgoCDApplications.tsx
+++ b/web/src/components/cards/ArgoCDApplications.tsx
@@ -247,22 +247,30 @@ function ArgoCDApplicationsInternal({ config }: ArgoCDApplicationsProps) {
       {/* Stats */}
       <div className="grid grid-cols-4 gap-2 mb-3">
         <div className="text-center p-2 rounded-lg bg-green-500/10 cursor-pointer hover:bg-green-500/20"
-             onClick={() => setSelectedFilter('all')}>
+             role="button" tabIndex={0}
+             onClick={() => setSelectedFilter('all')}
+             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedFilter('all') } }}>
           <p className="text-lg font-bold text-green-400">{stats.synced}</p>
           <p className="text-xs text-muted-foreground">{t('argoCDApplications.synced')}</p>
         </div>
         <div className="text-center p-2 rounded-lg bg-yellow-500/10 cursor-pointer hover:bg-yellow-500/20"
-             onClick={() => setSelectedFilter('outOfSync')}>
+             role="button" tabIndex={0}
+             onClick={() => setSelectedFilter('outOfSync')}
+             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedFilter('outOfSync') } }}>
           <p className="text-lg font-bold text-yellow-400">{stats.outOfSync}</p>
           <p className="text-xs text-muted-foreground">{t('argoCDApplications.outOfSync')}</p>
         </div>
         <div className="text-center p-2 rounded-lg bg-green-500/10 cursor-pointer hover:bg-green-500/20"
-             onClick={() => setSelectedFilter('all')}>
+             role="button" tabIndex={0}
+             onClick={() => setSelectedFilter('all')}
+             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedFilter('all') } }}>
           <p className="text-lg font-bold text-green-400">{stats.healthy}</p>
           <p className="text-xs text-muted-foreground">{t('argoCDApplications.healthy')}</p>
         </div>
         <div className="text-center p-2 rounded-lg bg-red-500/10 cursor-pointer hover:bg-red-500/20"
-             onClick={() => setSelectedFilter('unhealthy')}>
+             role="button" tabIndex={0}
+             onClick={() => setSelectedFilter('unhealthy')}
+             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedFilter('unhealthy') } }}>
           <p className="text-lg font-bold text-red-400">{stats.unhealthy}</p>
           <p className="text-xs text-muted-foreground">{t('argoCDApplications.unhealthy')}</p>
         </div>

--- a/web/src/components/cards/cluster-resource-tree/ClusterResourceTree.tsx
+++ b/web/src/components/cards/cluster-resource-tree/ClusterResourceTree.tsx
@@ -731,9 +731,9 @@ export function ClusterResourceTree({ config: _config }: ClusterResourceTreeProp
                                       id={`${nsId}:job:${job.name}`}
                                       label={job.name}
                                       icon={ResourceIcon.job}
-                                      iconColor={isComplete ? 'text-green-400' : isRunning ? 'text-amber-400' : 'text-red-400'}
+                                      iconColor={isComplete ? 'text-green-400' : isRunning ? 'text-green-400' : 'text-red-400'}
                                       badge={`${job.status} (${job.completions})`}
-                                      badgeColor={isComplete ? 'bg-green-500/20 text-green-400' : isRunning ? 'bg-amber-500/20 text-amber-400' : 'bg-red-500/20 text-red-400'}
+                                      badgeColor={isComplete ? 'bg-green-500/20 text-green-400' : isRunning ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'}
                                       indent={5}
                                       expandedNodes={expandedNodes}
                                       toggleNode={toggleNode}

--- a/web/src/components/cards/cluster-resource-tree/TreeRenderer.tsx
+++ b/web/src/components/cards/cluster-resource-tree/TreeRenderer.tsx
@@ -3,6 +3,11 @@ import { StatusIndicator } from '../../charts/StatusIndicator'
 import type { TreeNodeProps } from './types'
 import { useTranslation } from 'react-i18next'
 
+/** Pixels of horizontal indent per tree nesting level */
+const INDENT_PER_LEVEL_PX = 16
+/** Base left padding for tree nodes */
+const BASE_PADDING_LEFT_PX = 8
+
 interface TreeNodeInternalProps extends TreeNodeProps {
   expandedNodes: Set<string>
   toggleNode: (nodeId: string) => void
@@ -32,7 +37,7 @@ export function TreeNode({
     <div className="select-none">
       <div
         className={`flex items-center gap-1.5 py-1.5 px-2 rounded-md hover:bg-secondary/50 transition-colors group`}
-        style={{ paddingLeft: `${indent * 16 + 8}px` }}
+        style={{ paddingLeft: `${indent * INDENT_PER_LEVEL_PX + BASE_PADDING_LEFT_PX}px` }}
       >
         {/* Chevron + Icon - handles expand/collapse */}
         {hasChildren ? (
@@ -60,6 +65,11 @@ export function TreeNode({
             e.stopPropagation()
             onClick?.()
           }}
+          {...(onClick ? {
+            role: 'button' as const,
+            tabIndex: 0,
+            onKeyDown: (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } },
+          } : {})}
           className={`text-sm text-foreground truncate ${onClick ? 'cursor-pointer hover:text-purple-400' : ''}`}
         >
           {label}
@@ -75,7 +85,7 @@ export function TreeNode({
         )}
       </div>
       {hasChildren && isExpanded && (
-        <div className="border-l border-border/50 ml-3" style={{ marginLeft: `${indent * 16 + 16}px` }}>
+        <div className="border-l border-border/50 ml-3" style={{ marginLeft: `${indent * INDENT_PER_LEVEL_PX + INDENT_PER_LEVEL_PX}px` }}>
           {children}
         </div>
       )}

--- a/web/src/components/cards/rss/RSSFeed.tsx
+++ b/web/src/components/cards/rss/RSSFeed.tsx
@@ -1307,7 +1307,7 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
                 {item.thumbnail && item.thumbnail.startsWith('http') && (
                   <img
                     src={item.thumbnail}
-                    alt=""
+                    alt={item.title || 'Feed thumbnail'}
                     className="w-16 h-16 object-cover rounded flex-shrink-0"
                     onError={(e) => (e.currentTarget.style.display = 'none')}
                   />

--- a/web/src/components/clusters/components/NamespaceResources.tsx
+++ b/web/src/components/clusters/components/NamespaceResources.tsx
@@ -136,7 +136,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
       name: job.name,
       namespace: job.namespace,
       status: job.status,
-      statusColor: job.status === 'Complete' ? 'green' : job.status === 'Running' ? 'blue' : 'red',
+      statusColor: job.status === 'Complete' ? 'green' : job.status === 'Running' ? 'green' : 'red',
       detail: job.completions,
       data: { status: job.status, completions: job.completions, duration: job.duration, age: job.age }
     }))
@@ -461,7 +461,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
                       >
                         <Briefcase className="w-3 h-3 text-amber-400" />
                         <span className="text-foreground truncate max-w-[200px]" title={job.name}>{job.name}</span>
-                        <span className={job.status === 'Complete' ? 'text-green-400' : job.status === 'Running' ? 'text-blue-400' : 'text-red-400'}>{job.status}</span>
+                        <span className={job.status === 'Complete' ? 'text-green-400' : job.status === 'Running' ? 'text-green-400' : 'text-red-400'}>{job.status}</span>
                         <span className="text-muted-foreground">{job.completions}</span>
                         <ChevronRight className="w-3 h-3 text-primary ml-auto" />
                       </div>

--- a/web/src/components/drilldown/RemediationConsole.tsx
+++ b/web/src/components/drilldown/RemediationConsole.tsx
@@ -441,14 +441,14 @@ Labels:       app=${resourceName.split('-')[0]}
                           <span className="text-red-400">❌</span>
                         )}
                         {log.type === 'info' && (
-                          <span className="text-gray-400">ℹ️</span>
+                          <span className="text-muted-foreground">ℹ️</span>
                         )}
                         <span className={cn(
                           log.type === 'thinking' && 'text-purple-300',
                           log.type === 'action' && 'text-blue-300',
                           log.type === 'result' && 'text-green-300',
                           log.type === 'error' && 'text-red-300',
-                          log.type === 'info' && 'text-gray-300',
+                          log.type === 'info' && 'text-muted-foreground',
                         )}>
                           {log.message}
                         </span>
@@ -503,7 +503,7 @@ Labels:       app=${resourceName.split('-')[0]}
                     ) : log.type === 'error' ? (
                       <pre className="text-red-400 whitespace-pre-wrap">{log.message}</pre>
                     ) : (
-                      <pre className="text-gray-300 whitespace-pre-wrap">{log.message}</pre>
+                      <pre className="text-muted-foreground whitespace-pre-wrap">{log.message}</pre>
                     )}
                   </div>
                 ))

--- a/web/src/components/drilldown/views/AlertDrillDown.tsx
+++ b/web/src/components/drilldown/views/AlertDrillDown.tsx
@@ -52,7 +52,7 @@ const getStateStyle = (state: string) => {
   if (lower === 'resolved' || lower === 'inactive') {
     return { bg: 'bg-green-500/20', text: 'text-green-400' }
   }
-  return { bg: 'bg-gray-500/20', text: 'text-gray-400' }
+  return { bg: 'bg-secondary', text: 'text-muted-foreground' }
 }
 
 export function AlertDrillDown({ data }: Props) {

--- a/web/src/components/drilldown/views/ArgoAppDrillDown.tsx
+++ b/web/src/components/drilldown/views/ArgoAppDrillDown.tsx
@@ -37,7 +37,7 @@ const getSyncStatusStyle = (status: string) => {
     return { bg: 'bg-yellow-500/20', text: 'text-yellow-400', border: 'border-yellow-500/30', icon: AlertTriangle }
   }
   if (lower === 'unknown') {
-    return { bg: 'bg-gray-500/20', text: 'text-gray-400', border: 'border-gray-500/30', icon: AlertTriangle }
+    return { bg: 'bg-secondary', text: 'text-muted-foreground', border: 'border-border', icon: AlertTriangle }
   }
   return { bg: 'bg-blue-500/20', text: 'text-blue-400', border: 'border-blue-500/30', icon: RefreshCw }
 }
@@ -60,7 +60,7 @@ const getHealthStatusStyle = (status: string) => {
   if (lower === 'missing') {
     return { bg: 'bg-orange-500/20', text: 'text-orange-400', border: 'border-orange-500/30' }
   }
-  return { bg: 'bg-gray-500/20', text: 'text-gray-400', border: 'border-gray-500/30' }
+  return { bg: 'bg-secondary', text: 'text-muted-foreground', border: 'border-border' }
 }
 
 interface ArgoResource {

--- a/web/src/components/drilldown/views/DriftDrillDown.tsx
+++ b/web/src/components/drilldown/views/DriftDrillDown.tsx
@@ -39,7 +39,7 @@ const getDriftSeverityStyle = (severity: string) => {
   if (lower === 'high' || lower === 'critical' || lower === 'drifted') {
     return { bg: 'bg-red-500/20', text: 'text-red-400', border: 'border-red-500/30', icon: XCircle }
   }
-  return { bg: 'bg-gray-500/20', text: 'text-gray-400', border: 'border-gray-500/30', icon: AlertTriangle }
+  return { bg: 'bg-secondary', text: 'text-muted-foreground', border: 'border-border', icon: AlertTriangle }
 }
 
 // Change type styles
@@ -54,7 +54,7 @@ const getChangeTypeStyle = (changeType: string) => {
   if (lower === 'deleted' || lower === 'remove') {
     return { bg: 'bg-red-500/20', text: 'text-red-400', label: 'Deleted' }
   }
-  return { bg: 'bg-gray-500/20', text: 'text-gray-400', label: changeType }
+  return { bg: 'bg-secondary', text: 'text-muted-foreground', label: changeType }
 }
 
 interface DriftChange {

--- a/web/src/components/drilldown/views/HelmReleaseDrillDown.tsx
+++ b/web/src/components/drilldown/views/HelmReleaseDrillDown.tsx
@@ -478,7 +478,7 @@ Please:
                           ? 'bg-green-500/10 border border-green-500/30 text-green-400 hover:bg-green-500/20'
                           : resource.kind === 'Service'
                           ? 'bg-cyan-500/10 border border-cyan-500/30 text-cyan-400 hover:bg-cyan-500/20'
-                          : 'bg-gray-500/10 border border-gray-500/30 text-gray-400'
+                          : 'bg-secondary border border-border text-muted-foreground'
                       )}
                     >
                       <span>{resource.kind}:</span>

--- a/web/src/components/drilldown/views/KustomizationDrillDown.tsx
+++ b/web/src/components/drilldown/views/KustomizationDrillDown.tsx
@@ -39,7 +39,7 @@ const getStatusStyle = (status: string) => {
   if (lower === 'stalled' || lower === 'suspended') {
     return { bg: 'bg-yellow-500/20', text: 'text-yellow-400', border: 'border-yellow-500/30', icon: AlertTriangle }
   }
-  return { bg: 'bg-gray-500/20', text: 'text-gray-400', border: 'border-gray-500/30', icon: AlertTriangle }
+  return { bg: 'bg-secondary', text: 'text-muted-foreground', border: 'border-border', icon: AlertTriangle }
 }
 
 interface AppliedResource {

--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -145,8 +145,8 @@ function getViewConfig(viewType: DrillDownViewType) {
     default:
       return {
         icon: Layers,
-        color: 'text-gray-400',
-        bgColor: 'bg-gray-500/20',
+        color: 'text-muted-foreground',
+        bgColor: 'bg-secondary',
         dataKey: 'items',
         nameKey: 'name',
         getStatus: () => 'unknown',
@@ -166,7 +166,7 @@ function getStatusBadge(status: string) {
   if (['failed', 'error', 'unhealthy', 'notready', 'critical', 'crashloopbackoff', 'imagepullbackoff'].includes(lower)) {
     return { icon: XCircle, color: 'text-red-400', bg: 'bg-red-500/20' }
   }
-  return { icon: AlertCircle, color: 'text-gray-400', bg: 'bg-gray-500/20' }
+  return { icon: AlertCircle, color: 'text-muted-foreground', bg: 'bg-secondary' }
 }
 
 export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSummaryDrillDownProps) {

--- a/web/src/components/drilldown/views/OperatorDrillDown.tsx
+++ b/web/src/components/drilldown/views/OperatorDrillDown.tsx
@@ -40,7 +40,7 @@ const getPhaseStyle = (phase: string) => {
   if (lower === 'upgrading' || lower === 'replacing') {
     return { bg: 'bg-yellow-500/20', text: 'text-yellow-400', border: 'border-yellow-500/30', icon: RefreshCw }
   }
-  return { bg: 'bg-gray-500/20', text: 'text-gray-400', border: 'border-gray-500/30', icon: AlertTriangle }
+  return { bg: 'bg-secondary', text: 'text-muted-foreground', border: 'border-border', icon: AlertTriangle }
 }
 
 interface CSVInfo {

--- a/web/src/components/drilldown/views/PolicyDrillDown.tsx
+++ b/web/src/components/drilldown/views/PolicyDrillDown.tsx
@@ -37,7 +37,7 @@ const getStatusStyle = (status: string) => {
   if (lower === 'failed' || lower === 'error' || lower === 'inactive') {
     return { bg: 'bg-red-500/20', text: 'text-red-400', border: 'border-red-500/30', icon: XCircle }
   }
-  return { bg: 'bg-gray-500/20', text: 'text-gray-400', border: 'border-gray-500/30', icon: AlertCircle }
+  return { bg: 'bg-secondary', text: 'text-muted-foreground', border: 'border-border', icon: AlertCircle }
 }
 
 interface Violation {

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -257,7 +257,9 @@ export function Sidebar() {
                 {!PROTECTED_SIDEBAR_IDS.includes(item.id) && (
                   <span
                     role="button"
+                    tabIndex={0}
                     onClick={(e) => { e.preventDefault(); e.stopPropagation(); removeItem(item.id) }}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); removeItem(item.id) } }}
                     className="p-0.5 rounded hover:bg-red-500/20 hover:text-red-400 text-muted-foreground/50 transition-colors"
                     title={t('sidebar.removeFromSidebar')}
                   >

--- a/web/src/components/modals/sections/ResourceBadges.tsx
+++ b/web/src/components/modals/sections/ResourceBadges.tsx
@@ -223,6 +223,11 @@ export function NamespaceBadge({
       className={`inline-flex items-center gap-1 rounded border font-medium bg-indigo-500/20 text-indigo-400 border-indigo-500/30 ${sizeClasses[size]} ${onClick ? 'cursor-pointer hover:opacity-80' : 'cursor-default'} ${className}`}
       title={`Namespace: ${namespace}`}
       onClick={onClick}
+      {...(onClick ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        onKeyDown: (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } },
+      } : {})}
     >
       {showIcon && <FolderTree className={iconSizes[size]} />}
       {namespace}
@@ -265,6 +270,11 @@ export function ResourceKindBadge({
       className={`inline-flex items-center gap-1 rounded border font-medium ${colors.bg} ${colors.text} ${colors.border} ${sizeClasses[size]} ${onClick ? 'cursor-pointer hover:opacity-80' : 'cursor-default'} ${className}`}
       title={`Resource: ${kind}`}
       onClick={onClick}
+      {...(onClick ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        onKeyDown: (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } },
+      } : {})}
     >
       {showIcon && <Icon className={iconSizes[size]} />}
       {kind}

--- a/web/src/components/modals/types/modal.types.ts
+++ b/web/src/components/modals/types/modal.types.ts
@@ -400,42 +400,12 @@ export const RESOURCE_KIND_ICONS: Record<ResourceKind, string> = {
 }
 
 // ============================================================================
-// Status colors
+// Status colors — delegates to canonical statusColors.ts
 // ============================================================================
 
-export const STATUS_COLORS: Record<string, { bg: string; text: string; border: string }> = {
-  // Success states
-  Running: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-  Succeeded: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-  Healthy: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-  Ready: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-  Active: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-  Synced: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-  Deployed: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-  Bound: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-
-  // Warning states
-  Pending: { bg: 'bg-yellow-500/10', text: 'text-yellow-400', border: 'border-yellow-500/20' },
-  Progressing: { bg: 'bg-yellow-500/10', text: 'text-yellow-400', border: 'border-yellow-500/20' },
-  Waiting: { bg: 'bg-yellow-500/10', text: 'text-yellow-400', border: 'border-yellow-500/20' },
-  Unknown: { bg: 'bg-yellow-500/10', text: 'text-yellow-400', border: 'border-yellow-500/20' },
-  OutOfSync: { bg: 'bg-yellow-500/10', text: 'text-yellow-400', border: 'border-yellow-500/20' },
-
-  // Error states
-  Failed: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/20' },
-  Error: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/20' },
-  CrashLoopBackOff: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/20' },
-  ImagePullBackOff: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/20' },
-  Unhealthy: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/20' },
-  Degraded: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/20' },
-  Firing: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/20' },
-
-  // Info states
-  Terminated: { bg: 'bg-gray-500/10', text: 'text-gray-400', border: 'border-gray-500/20' },
-  Completed: { bg: 'bg-gray-500/10', text: 'text-gray-400', border: 'border-gray-500/20' },
-  Offline: { bg: 'bg-gray-500/10', text: 'text-gray-400', border: 'border-gray-500/20' },
-}
+import { getStatusColors as getCanonicalStatusColors } from '../../../lib/cards/statusColors'
 
 export function getStatusColors(status: string): { bg: string; text: string; border: string } {
-  return STATUS_COLORS[status] || { bg: 'bg-gray-500/10', text: 'text-gray-400', border: 'border-gray-500/20' }
+  const c = getCanonicalStatusColors(status)
+  return { bg: c.bg, text: c.text, border: c.border }
 }

--- a/web/src/config/cards/events-timeline.ts
+++ b/web/src/config/cards/events-timeline.ts
@@ -14,7 +14,7 @@ export const eventsTimelineConfig: UnifiedCardConfig = {
 
   // Appearance
   icon: 'Clock',
-  iconColor: 'text-amber-400',
+  iconColor: 'text-yellow-400',
   defaultWidth: 6,
   defaultHeight: 3,
 
@@ -29,8 +29,8 @@ export const eventsTimelineConfig: UnifiedCardConfig = {
     {
       id: 'totalEvents',
       icon: 'Bell',
-      color: 'text-amber-400',
-      bgColor: 'bg-amber-500/10',
+      color: 'text-yellow-400',
+      bgColor: 'bg-yellow-500/10',
       label: 'Total',
       valueSource: { type: 'computed', expression: 'sum:count' },
     },

--- a/web/src/config/cards/gpu-node-health.ts
+++ b/web/src/config/cards/gpu-node-health.ts
@@ -12,7 +12,7 @@ export const gpuNodeHealthConfig: UnifiedCardConfig = {
   category: 'cluster-health',
   description: 'Proactive health monitoring for GPU nodes — checks node readiness, GPU operator pods, stuck pods, and GPU reset events',
   icon: 'Activity',
-  iconColor: 'text-emerald-400',
+  iconColor: 'text-green-400',
   defaultWidth: 6,
   defaultHeight: 3,
   dataSource: { type: 'hook', hook: 'useGPUNodeHealth' },

--- a/web/src/config/cards/namespace-overview.ts
+++ b/web/src/config/cards/namespace-overview.ts
@@ -9,7 +9,7 @@ export const namespaceOverviewConfig: UnifiedCardConfig = {
   category: 'namespaces',
   description: 'Namespace resource summary',
   icon: 'FolderOpen',
-  iconColor: 'text-sky-400',
+  iconColor: 'text-blue-400',
   defaultWidth: 6,
   defaultHeight: 3,
   dataSource: { type: 'hook', hook: 'useNamespaceOverview' },

--- a/web/src/config/cards/namespace-quotas.ts
+++ b/web/src/config/cards/namespace-quotas.ts
@@ -9,7 +9,7 @@ export const namespaceQuotasConfig: UnifiedCardConfig = {
   category: 'namespaces',
   description: 'Resource quota usage by namespace',
   icon: 'Gauge',
-  iconColor: 'text-amber-400',
+  iconColor: 'text-yellow-400',
   defaultWidth: 5,
   defaultHeight: 3,
   dataSource: { type: 'hook', hook: 'useNamespaceQuotas' },

--- a/web/src/config/cards/namespace-status.ts
+++ b/web/src/config/cards/namespace-status.ts
@@ -14,7 +14,7 @@ export const namespaceStatusConfig: UnifiedCardConfig = {
 
   // Appearance
   icon: 'FolderOpen',
-  iconColor: 'text-sky-400',
+  iconColor: 'text-blue-400',
   defaultWidth: 6,
   defaultHeight: 3,
 

--- a/web/src/config/cards/nightly-e2e-status.ts
+++ b/web/src/config/cards/nightly-e2e-status.ts
@@ -9,7 +9,7 @@ export const nightlyE2eStatusConfig: UnifiedCardConfig = {
   category: 'ci-cd',
   description: 'llm-d nightly E2E workflow status across OCP and GKE platforms',
   icon: 'TestTube2',
-  iconColor: 'text-emerald-400',
+  iconColor: 'text-green-400',
   defaultWidth: 12,
   defaultHeight: 5,
   dataSource: { type: 'hook', hook: 'useNightlyE2EData' },

--- a/web/src/config/cards/provider-health.ts
+++ b/web/src/config/cards/provider-health.ts
@@ -9,7 +9,7 @@ export const providerHealthConfig: UnifiedCardConfig = {
   category: 'cluster-health',
   description: 'Cloud and AI provider status',
   icon: 'Cloud',
-  iconColor: 'text-sky-400',
+  iconColor: 'text-blue-400',
   defaultWidth: 6,
   defaultHeight: 3,
   dataSource: { type: 'hook', hook: 'useProviderHealth' },

--- a/web/src/config/cards/prow-status.ts
+++ b/web/src/config/cards/prow-status.ts
@@ -16,7 +16,7 @@ export const prowStatusConfig: UnifiedCardConfig = {
   content: {
     type: 'stats-grid',
     stats: [
-      { field: 'running', label: 'Running', color: 'blue' },
+      { field: 'running', label: 'Running', color: 'green' },
       { field: 'passed', label: 'Passed', color: 'green' },
       { field: 'failed', label: 'Failed', color: 'red' },
       { field: 'pending', label: 'Pending', color: 'yellow' },

--- a/web/src/config/cards/pv-status.ts
+++ b/web/src/config/cards/pv-status.ts
@@ -14,7 +14,7 @@ export const pvStatusConfig: UnifiedCardConfig = {
 
   // Appearance
   icon: 'HardDrive',
-  iconColor: 'text-amber-400',
+  iconColor: 'text-yellow-400',
   defaultWidth: 6,
   defaultHeight: 3,
 

--- a/web/src/config/cards/role-status.ts
+++ b/web/src/config/cards/role-status.ts
@@ -14,7 +14,7 @@ export const roleStatusConfig: UnifiedCardConfig = {
 
   // Appearance
   icon: 'Key',
-  iconColor: 'text-amber-400',
+  iconColor: 'text-yellow-400',
   defaultWidth: 6,
   defaultHeight: 3,
 

--- a/web/src/config/cards/service-account-status.ts
+++ b/web/src/config/cards/service-account-status.ts
@@ -14,7 +14,7 @@ export const serviceAccountStatusConfig: UnifiedCardConfig = {
 
   // Appearance
   icon: 'UserCircle',
-  iconColor: 'text-emerald-400',
+  iconColor: 'text-green-400',
   defaultWidth: 6,
   defaultHeight: 3,
 

--- a/web/src/config/cards/weather.ts
+++ b/web/src/config/cards/weather.ts
@@ -9,7 +9,7 @@ export const weatherConfig: UnifiedCardConfig = {
   category: 'utility',
   description: 'Current weather conditions',
   icon: 'Cloud',
-  iconColor: 'text-sky-400',
+  iconColor: 'text-blue-400',
   defaultWidth: 6,
   defaultHeight: 3,
   dataSource: { type: 'hook', hook: 'useWeather' },

--- a/web/src/lib/cards/CardComponents.tsx
+++ b/web/src/lib/cards/CardComponents.tsx
@@ -479,6 +479,11 @@ export function CardListItem({
       className={`p-3 rounded-lg ${bg} border ${border} ${onClick ? 'cursor-pointer hover:opacity-80' : ''
         } transition-all group`}
       onClick={onClick}
+      {...(onClick ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        onKeyDown: (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } },
+      } : {})}
       title={title}
     >
       <div className="flex items-start gap-3">

--- a/web/src/lib/modals/ModalSections.tsx
+++ b/web/src/lib/modals/ModalSections.tsx
@@ -289,6 +289,10 @@ export function TableSection<T extends Record<string, unknown>>({
                 onRowClick ? 'cursor-pointer hover:bg-secondary/50' : ''
               }`}
               onClick={() => onRowClick?.(row)}
+              {...(onRowClick ? {
+                tabIndex: 0,
+                onKeyDown: (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onRowClick(row) } },
+              } : {})}
             >
               {columns.map((column) => (
                 <td
@@ -487,6 +491,11 @@ export function BadgesSection({ badges, className = '' }: BadgesSectionProps) {
         <span
           key={index}
           onClick={badge.onClick}
+          {...(badge.onClick ? {
+            role: 'button' as const,
+            tabIndex: 0,
+            onKeyDown: (e: React.KeyboardEvent) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); badge.onClick!() } },
+          } : {})}
           className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium ${
             badge.color || 'bg-secondary text-muted-foreground'
           } ${badge.onClick ? 'cursor-pointer hover:opacity-80' : ''}`}

--- a/web/src/lib/modals/types.ts
+++ b/web/src/lib/modals/types.ts
@@ -371,8 +371,10 @@ export interface UseModalNavigationResult {
 }
 
 // ============================================================================
-// Status Helpers
+// Status Helpers — delegates to canonical statusColors.ts
 // ============================================================================
+
+import { getStatusColors as getCanonicalStatusColors } from '../cards/statusColors'
 
 export interface StatusColors {
   bg: string
@@ -380,32 +382,7 @@ export interface StatusColors {
   border: string
 }
 
-export const STATUS_COLORS: Record<string, StatusColors> = {
-  // Success states
-  Running: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-  Succeeded: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-  Healthy: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-  Ready: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-  Active: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-  Bound: { bg: 'bg-green-500/10', text: 'text-green-400', border: 'border-green-500/20' },
-
-  // Warning states
-  Pending: { bg: 'bg-yellow-500/10', text: 'text-yellow-400', border: 'border-yellow-500/20' },
-  Progressing: { bg: 'bg-yellow-500/10', text: 'text-yellow-400', border: 'border-yellow-500/20' },
-  Waiting: { bg: 'bg-yellow-500/10', text: 'text-yellow-400', border: 'border-yellow-500/20' },
-  Unknown: { bg: 'bg-yellow-500/10', text: 'text-yellow-400', border: 'border-yellow-500/20' },
-
-  // Error states
-  Failed: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/20' },
-  Error: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/20' },
-  CrashLoopBackOff: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/20' },
-  Unhealthy: { bg: 'bg-red-500/10', text: 'text-red-400', border: 'border-red-500/20' },
-
-  // Info states
-  Terminated: { bg: 'bg-gray-500/10', text: 'text-gray-400', border: 'border-gray-500/20' },
-  Completed: { bg: 'bg-gray-500/10', text: 'text-gray-400', border: 'border-gray-500/20' },
-}
-
 export function getStatusColors(status: string): StatusColors {
-  return STATUS_COLORS[status] || { bg: 'bg-gray-500/10', text: 'text-gray-400', border: 'border-gray-500/20' }
+  const c = getCanonicalStatusColors(status)
+  return { bg: c.bg, text: c.text, border: c.border }
 }


### PR DESCRIPTION
## Summary

Comprehensive design system fixes addressing critical issues across accessibility, color consistency, and typography compliance. All changes are safe, additive, or mechanical replacements.

### 1. Accessibility — Keyboard support for clickable elements
- Added `role="button"`, `tabIndex={0}`, and `onKeyDown` (Enter/Space) handlers to interactive `<div>`/`<span>` elements in:
  - **ArgoCDApplications** — 4 stat-filter divs
  - **Sidebar** — remove-item button (already had `role`, added `tabIndex` + `onKeyDown`)
  - **TreeRenderer** — clickable label spans (conditional, only when `onClick` is provided)
  - **CardListItem** — shared primitive used by all cards (conditional)
  - **ModalSections** — `BadgesSection` badge clicks, `TableSection` row clicks (conditional)
  - **ResourceBadges** — `NamespaceBadge` and `ResourceKindBadge` (conditional)

### 2. Accessibility — Image alt text
- **RSSFeed.tsx** — Changed empty `alt=""` to `alt={item.title || 'Feed thumbnail'}`

### 3. Accessibility — Low contrast text in drilldown views
- Replaced `text-gray-400` / `bg-gray-500/20` / `border-gray-500/30` fallback status colors with semantic tokens (`text-muted-foreground` / `bg-secondary` / `border-border`) in 9 drilldown files + RemediationConsole

### 4. Status color deduplication
- Eliminated two duplicate `STATUS_COLORS` objects (in `lib/modals/types.ts` and `modals/types/modal.types.ts`) that conflicted with canonical `statusColors.ts`
- Both now delegate to the canonical `getStatusColors()` via a thin adapter
- Consumers (`ModalSections.tsx`, `BreadcrumbNav.tsx`) unchanged — same import paths

### 5. "Running" status color consistency
- Fixed "Running" shown as blue/amber instead of canonical green in:
  - `prow-status.ts`, `NamespaceResources.tsx`, `ClusterResourceTree.tsx`
- **Not changed**: `mission-sidebar/types.ts` (blue is semantically correct for "AI agent executing")

### 6. Non-standard Tailwind colors in config files
- `emerald-400` → `green-400` (3 files)
- `sky-400` → `blue-400` (4 files)
- `amber-400` → `yellow-400` (4 files)

### 7. TreeRenderer magic numbers
- Replaced hardcoded `16` and `8` pixel values with named constants `INDENT_PER_LEVEL_PX` and `BASE_PADDING_LEFT_PX`

## Test plan

- [x] `npm run build` — passes
- [x] `npm run lint` — passes (69 pre-existing errors, 0 new)
- [ ] Manual: Tab through ArgoCD Applications stats, press Enter/Space — should activate filter
- [ ] Visual: Prow Status "Running" shows green (not blue)
- [ ] Visual: ClusterResourceTree job nodes show green (not amber)
- [ ] Visual: Drilldown fallback status badges use semantic token colors