### PR TITLE
🐛 Wire isDemoData for 5 AI/ML cards missing demo badge

### DIFF
--- a/web/src/components/cards/GPUOverview.tsx
+++ b/web/src/components/cards/GPUOverview.tsx
@@ -9,6 +9,7 @@ import { useCardLoadingState } from './CardDataContext'
 import { Activity } from 'lucide-react'
 import { ClusterStatusDot } from '../ui/ClusterStatusBadge'
 import { useTranslation } from 'react-i18next'
+import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface GPUOverviewProps {
   config?: Record<string, unknown>
@@ -28,13 +29,16 @@ export function GPUOverview({ config: _config }: GPUOverviewProps) {
     isLoading: hookLoading,
   } = useGPUNodes()
   const { deduplicatedClusters: clusters } = useClusters()
+  const { isDemoMode } = useDemoMode()
 
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
 
   // Report state to CardWrapper for refresh animation
+  // useGPUNodes falls back to demo data when isDemoMode is true and no live data is available
   const { showSkeleton } = useCardLoadingState({
     isLoading: hookLoading,
     hasAnyData: rawNodes.length > 0,
+    isDemoData: isDemoMode,
   })
   const isLoading = showSkeleton
   const { drillToResources } = useDrillDownActions()

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -70,6 +70,7 @@ export function HardwareHealthCard() {
     isLoading,
     isFailed,
     consecutiveFailures,
+    isDemoFallback,
     error: fetchError,
     refetch,
   } = useCachedHardwareHealth()
@@ -116,6 +117,7 @@ export function HardwareHealthCard() {
   useCardLoadingState({
     isLoading,
     hasAnyData: alerts.length > 0 || inventory.length > 0 || nodeCount > 0,
+    isDemoData: isDemoFallback,
     isFailed,
     consecutiveFailures,
   })

--- a/web/src/components/cards/llmd/LLMdConfigurator.tsx
+++ b/web/src/components/cards/llmd/LLMdConfigurator.tsx
@@ -153,8 +153,8 @@ export function LLMdConfigurator() {
   const presets = useMemo(() => getConfiguratorPresets(), [])
   const [selectedPresetId, setSelectedPresetId] = useState<string>(presets[0]?.id || '')
 
-  // Report to CardWrapper that this static card is ready
-  useReportCardDataState({ isFailed: false, consecutiveFailures: 0, hasData: true })
+  // Report to CardWrapper that this static card is ready (never demo — uses local mock data)
+  useReportCardDataState({ isFailed: false, consecutiveFailures: 0, hasData: true, isDemoData: false })
   const [customParams, setCustomParams] = useState<Record<string, unknown>>({})
   const [copied, setCopied] = useState(false)
 

--- a/web/src/components/cards/workload-detection/LLMInference.tsx
+++ b/web/src/components/cards/workload-detection/LLMInference.tsx
@@ -48,12 +48,13 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
   const gpuClusterNames = useMemo(() => new Set(gpuNodes.map(n => n.cluster)), [gpuNodes])
   const llmdClusters = useLLMdClusters(deduplicatedClusters, gpuClusterNames)
 
-  const { servers, isLoading, isRefreshing, lastRefresh, refetch, isFailed, consecutiveFailures, error } = useCachedLLMdServers(llmdClusters)
+  const { servers, isLoading, isRefreshing, lastRefresh, refetch, isFailed, consecutiveFailures, isDemoFallback, error } = useCachedLLMdServers(llmdClusters)
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
     hasAnyData: servers.length > 0,
+    isDemoData: isDemoFallback,
     isFailed,
     consecutiveFailures,
   })

--- a/web/src/components/cards/workload-detection/LLMModels.tsx
+++ b/web/src/components/cards/workload-detection/LLMModels.tsx
@@ -32,12 +32,13 @@ export function LLMModels({ config: _config }: LLMModelsProps) {
   const gpuClusterNames = useMemo(() => new Set(gpuNodes.map(n => n.cluster)), [gpuNodes])
   const llmdClusters = useLLMdClusters(deduplicatedClusters, gpuClusterNames)
 
-  const { models, isLoading, isRefreshing, lastRefresh } = useCachedLLMdModels(llmdClusters)
+  const { models, isLoading, isRefreshing, lastRefresh, isDemoFallback } = useCachedLLMdModels(llmdClusters)
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
     hasAnyData: models.length > 0,
+    isDemoData: isDemoFallback,
   })
 
   const {


### PR DESCRIPTION
## Summary

- 5 AI/ML dashboard cards were showing demo data without the Demo badge or yellow outline
- E2E tests confirmed: **before fix: 0 demo badges** when all cards display demo data; **after fix: 12 demo badges** (2 always-demo + 10 correctly detected)
- Root cause: cards didn't destructure `isDemoFallback` from their `useCached*` hooks or pass `isDemoData` to `useCardLoadingState()`/`useReportCardDataState()`

## Cards fixed

| Card | File | Fix |
|------|------|-----|
| LLMdConfigurator | `llmd/LLMdConfigurator.tsx` | Add `isDemoData: false` (static card, never demo) |
| LLMInference | `workload-detection/LLMInference.tsx` | Destructure `isDemoFallback` from `useCachedLLMdServers` |
| LLMModels | `workload-detection/LLMModels.tsx` | Destructure `isDemoFallback` from `useCachedLLMdModels` |
| HardwareHealth | `HardwareHealthCard.tsx` | Destructure `isDemoFallback` from `useCachedHardwareHealth` |
| GPUOverview | `GPUOverview.tsx` | Import `useDemoMode`, pass `isDemoMode` as `isDemoData` |

## Test plan

- [x] `npm run build` passes
- [x] Lint clean on all 5 modified files (0 new errors)
- [x] AI/ML E2E test "page loads with all 13 AI/ML cards" passes (13 cards rendered)
- [x] AI/ML E2E test "no cards show demo badge" now correctly detects 12 demo badges (was 0)