### PR TITLE
🐛 Fix ProwStatus Running stat color: blue → green

### DIFF
--- a/web/src/components/cards/workload-detection/ProwStatus.tsx
+++ b/web/src/components/cards/workload-detection/ProwStatus.tsx
@@ -54,7 +54,7 @@ export function ProwStatus({ config: _config }: ProwStatusProps) {
         </div>
         <div className="p-3 rounded-lg bg-secondary/30">
           <div className="flex items-center gap-2">
-            <div className="text-lg font-bold text-blue-400">{status.runningJobs}</div>
+            <div className="text-lg font-bold text-green-400">{status.runningJobs}</div>
             <span className="text-xs text-muted-foreground">running</span>
           </div>
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Follow-up to #1900. The config file (`prow-status.ts`) was fixed but the legacy `ProwStatus.tsx` component had a hardcoded `text-blue-400` for the running jobs count that was missed.

- Changed `text-blue-400` → `text-green-400` in `ProwStatus.tsx` line 57
- Running = success (green) per canonical `statusColors.ts`

## Test plan

- [x] `npm run build` — passes
- [x] Verified via CDP: running stat now renders with `text-green-400` class