### PR TITLE
✨ Funnel fixes: post-connect activation, demo CTA, kill tour auto-start

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -48,6 +48,8 @@ import type { Card, DashboardData } from './dashboardUtils'
 import { useDashboardReset } from '../../hooks/useDashboardReset'
 import { WelcomeCard } from './WelcomeCard'
 import { SmartCardSuggestions } from './SmartCardSuggestions'
+import { PostConnectBanner } from './PostConnectBanner'
+import { DemoToLocalCTA } from './DemoToLocalCTA'
 import { ContextualNudgeBanner } from './ContextualNudgeBanner'
 import { DiscoverCardsPlaceholder } from './DiscoverCardsPlaceholder'
 import { WidgetExportModal } from '../widgets/WidgetExportModal'
@@ -119,7 +121,7 @@ export function Dashboard() {
   } = useDashboardContext()
 
   // Missions context for Getting Started banner
-  const { openSidebar: openMissionSidebar } = useMissions()
+  const { openSidebar: openMissionSidebar, startMission } = useMissions()
 
   // Get all dashboards for cross-dashboard dragging
   const { dashboards, moveCardToDashboard, createDashboard, exportDashboard, importDashboard } = useDashboards()
@@ -889,6 +891,9 @@ export function Dashboard() {
         }}
       />
 
+      {/* Demo-to-local CTA — shown on console.kubestellar.io for demo visitors */}
+      <DemoToLocalCTA />
+
       {/* Getting Started guide when no clusters are connected */}
       {clusters.length === 0 && !isClustersLoading && !getDemoMode() && (
         <WelcomeCard />
@@ -899,6 +904,20 @@ export function Dashboard() {
         existingCardTypes={currentCardTypes}
         onAddCard={handleAddSingleCard}
         onAddMultipleCards={handleAddMultipleCards}
+      />
+
+      {/* Post-connect activation — bridges the 90% drop between agent connect and first mission */}
+      <PostConnectBanner
+        onRunHealthCheck={() => {
+          startMission({
+            title: 'Cluster Health Check',
+            description: 'AI-powered audit of your connected clusters',
+            type: 'custom',
+            initialPrompt: 'Run a comprehensive health check on all my connected clusters. Check for pod issues, resource constraints, and security concerns.',
+          })
+        }}
+        onExploreClusters={() => navigate(ROUTES.CLUSTERS)}
+        onSetupAlerts={() => navigate(ROUTES.ALERTS)}
       />
 
       {/* Contextual nudge banner — replaces traditional tour */}

--- a/web/src/components/dashboard/DemoToLocalCTA.tsx
+++ b/web/src/components/dashboard/DemoToLocalCTA.tsx
@@ -1,0 +1,129 @@
+/**
+ * Demo-to-Local CTA — shown on console.kubestellar.io to convert demo visitors.
+ *
+ * GA4 funnel data shows 104 users visit via console.kubestellar.io but 100%
+ * abandon at Step 2 (Agent Connected) — they can't connect an agent from
+ * the demo site. This CTA provides a clear path to a local install.
+ */
+
+import { useState, useEffect, useRef } from 'react'
+import { Terminal, Copy, Check, ExternalLink, X } from 'lucide-react'
+import { isNetlifyDeployment } from '../../lib/demoMode'
+import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
+import {
+  STORAGE_KEY_DEMO_CTA_DISMISSED,
+  STORAGE_KEY_HINTS_SUPPRESSED,
+} from '../../lib/constants/storage'
+import { emitDemoToLocalShown, emitDemoToLocalActioned } from '../../lib/analytics'
+
+const INSTALL_COMMAND = 'brew tap kubestellar/tap && brew install --head kc-agent && kc-agent'
+const DOCS_URL = 'https://docs.kubestellar.io/docs/getting-started/'
+
+/** How many seconds the "Copied!" confirmation shows */
+const COPY_FEEDBACK_MS = 2000
+
+export function DemoToLocalCTA() {
+  const [dismissed, setDismissed] = useState(
+    () => safeGetItem(STORAGE_KEY_DEMO_CTA_DISMISSED) === 'true'
+  )
+  const [hintsSuppressed] = useState(
+    () => safeGetItem(STORAGE_KEY_HINTS_SUPPRESSED) === 'true'
+  )
+  const [copied, setCopied] = useState(false)
+  const emittedRef = useRef(false)
+
+  useEffect(() => {
+    if (!dismissed && !hintsSuppressed && isNetlifyDeployment && !emittedRef.current) {
+      emittedRef.current = true
+      emitDemoToLocalShown()
+    }
+  }, [dismissed, hintsSuppressed])
+
+  if (!isNetlifyDeployment || dismissed || hintsSuppressed) return null
+
+  const handleDismiss = () => {
+    setDismissed(true)
+    safeSetItem(STORAGE_KEY_DEMO_CTA_DISMISSED, 'true')
+  }
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(INSTALL_COMMAND)
+      setCopied(true)
+      emitDemoToLocalActioned('copy_command')
+      setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
+    } catch {
+      // Clipboard API not available — select the text instead
+      const el = document.querySelector('[data-install-command]') as HTMLElement
+      if (el) {
+        const range = document.createRange()
+        range.selectNodeContents(el)
+        window.getSelection()?.removeAllRanges()
+        window.getSelection()?.addRange(range)
+      }
+    }
+  }
+
+  const handleDocs = () => {
+    emitDemoToLocalActioned('view_docs')
+    window.open(DOCS_URL, '_blank', 'noopener')
+  }
+
+  return (
+    <div className="mb-4 rounded-xl border border-blue-500/20 bg-gradient-to-br from-blue-500/5 via-cyan-500/5 to-transparent p-4 animate-in slide-in-from-top-2 duration-300">
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Terminal className="w-4 h-4 text-blue-400" />
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">
+              Connect your own clusters
+            </h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              You&apos;re viewing demo data — install kc-agent locally to see your real clusters
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={handleDismiss}
+          className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+          aria-label="Dismiss"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* Install command with copy button */}
+      <div className="flex items-center gap-2 mb-3">
+        <code
+          data-install-command
+          className="flex-1 px-3 py-2 text-xs font-mono bg-secondary/50 rounded-lg border border-border/50 text-foreground overflow-x-auto whitespace-nowrap"
+        >
+          {INSTALL_COMMAND}
+        </code>
+        <button
+          onClick={handleCopy}
+          className={`p-2 rounded-lg border transition-all flex-shrink-0 ${
+            copied
+              ? 'bg-green-500/20 border-green-500/30 text-green-400'
+              : 'bg-secondary/50 border-border/50 hover:border-blue-500/30 text-muted-foreground hover:text-foreground'
+          }`}
+          title={copied ? 'Copied!' : 'Copy install command'}
+        >
+          {copied ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+        </button>
+      </div>
+
+      <div className="flex items-center gap-3 text-xs">
+        <span className="text-muted-foreground">
+          Requires macOS or Linux with Homebrew
+        </span>
+        <button
+          onClick={handleDocs}
+          className="flex items-center gap-1 text-blue-400 hover:text-blue-300 transition-colors"
+        >
+          Full setup guide <ExternalLink className="w-3 h-3" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/dashboard/PostConnectBanner.tsx
+++ b/web/src/components/dashboard/PostConnectBanner.tsx
@@ -1,0 +1,149 @@
+/**
+ * Post-Agent-Connect Activation Banner
+ *
+ * Shown when a user first connects kc-agent to bridge the 90% drop-off
+ * between "Agent Connected" (Step 2) and "Started Mission" (Step 3).
+ *
+ * GA4 data shows 75 localhost users connect an agent but only 7 start
+ * a mission (9.33%). This banner provides immediate next-step CTAs.
+ */
+
+import { useState, useEffect, useRef } from 'react'
+import { Rocket, Activity, Server, Bell, X } from 'lucide-react'
+import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
+import {
+  STORAGE_KEY_POST_CONNECT_DISMISSED,
+  STORAGE_KEY_HINTS_SUPPRESSED,
+} from '../../lib/constants/storage'
+import { emitPostConnectShown, emitPostConnectActioned } from '../../lib/analytics'
+
+interface PostConnectBannerProps {
+  onRunHealthCheck: () => void
+  onExploreClusters: () => void
+  onSetupAlerts: () => void
+}
+
+/** How long (ms) after agent connects before showing the banner */
+const SHOW_DELAY_MS = 2000
+
+export function PostConnectBanner({
+  onRunHealthCheck,
+  onExploreClusters,
+  onSetupAlerts,
+}: PostConnectBannerProps) {
+  const { status: agentStatus, health } = useLocalAgent()
+  const [dismissed, setDismissed] = useState(
+    () => safeGetItem(STORAGE_KEY_POST_CONNECT_DISMISSED) === 'true'
+  )
+  const [hintsSuppressed] = useState(
+    () => safeGetItem(STORAGE_KEY_HINTS_SUPPRESSED) === 'true'
+  )
+  const [showBanner, setShowBanner] = useState(false)
+  const emittedRef = useRef(false)
+  const prevStatusRef = useRef(agentStatus)
+
+  // Detect transition to 'connected' and show banner after a short delay
+  useEffect(() => {
+    if (
+      agentStatus === 'connected' &&
+      prevStatusRef.current !== 'connected' &&
+      !dismissed &&
+      !hintsSuppressed
+    ) {
+      const timer = setTimeout(() => setShowBanner(true), SHOW_DELAY_MS)
+      return () => clearTimeout(timer)
+    }
+    prevStatusRef.current = agentStatus
+  }, [agentStatus, dismissed, hintsSuppressed])
+
+  // Emit analytics once when banner first renders
+  useEffect(() => {
+    if (showBanner && !emittedRef.current) {
+      emittedRef.current = true
+      emitPostConnectShown()
+    }
+  }, [showBanner])
+
+  if (!showBanner || dismissed || hintsSuppressed) return null
+
+  const clusterCount = health?.clusters ?? 0
+
+  const handleDismiss = () => {
+    setDismissed(true)
+    safeSetItem(STORAGE_KEY_POST_CONNECT_DISMISSED, 'true')
+  }
+
+  const handleAction = (action: string, callback: () => void) => {
+    emitPostConnectActioned(action)
+    callback()
+    handleDismiss()
+  }
+
+  const actions = [
+    {
+      id: 'health-check',
+      label: 'Run Health Check',
+      description: 'AI-powered cluster audit',
+      icon: Activity,
+      onClick: () => handleAction('health_check', onRunHealthCheck),
+    },
+    {
+      id: 'explore-clusters',
+      label: 'Explore Clusters',
+      description: `${clusterCount} cluster${clusterCount !== 1 ? 's' : ''} detected`,
+      icon: Server,
+      onClick: () => handleAction('explore_clusters', onExploreClusters),
+    },
+    {
+      id: 'setup-alerts',
+      label: 'Set Up Alerts',
+      description: 'Get notified of issues',
+      icon: Bell,
+      onClick: () => handleAction('setup_alerts', onSetupAlerts),
+    },
+  ]
+
+  return (
+    <div className="mb-4 rounded-xl border border-green-500/20 bg-gradient-to-br from-green-500/5 via-emerald-500/5 to-transparent p-4 animate-in slide-in-from-top-2 duration-300">
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Rocket className="w-4 h-4 text-green-400" />
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">
+              Your clusters are connected!
+            </h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              kc-agent is live — here&apos;s what you can do next
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={handleDismiss}
+          className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+          aria-label="Dismiss"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+        {actions.map(({ id, label, description, icon: Icon, onClick }) => (
+          <button
+            key={id}
+            onClick={onClick}
+            className="flex items-center gap-3 p-3 rounded-lg bg-secondary/30 border border-border/50 hover:border-green-500/30 hover:bg-secondary/50 transition-all text-left group"
+          >
+            <div className="p-2 rounded-lg bg-green-500/10 group-hover:bg-green-500/20 transition-colors flex-shrink-0">
+              <Icon className="w-4 h-4 text-green-400" />
+            </div>
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-foreground truncate">{label}</p>
+              <p className="text-xs text-muted-foreground truncate">{description}</p>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/dashboard/SmartCardSuggestions.tsx
+++ b/web/src/components/dashboard/SmartCardSuggestions.tsx
@@ -70,8 +70,8 @@ const SUGGESTION_RULES: SuggestionRule[] = [
   ['cluster_metrics', 'Performance metrics over time', (ctx) => ctx.hasMultipleClusters],
 ]
 
-/** Maximum number of suggestions to show at once */
-const MAX_SUGGESTIONS = 4
+/** Maximum number of suggestions to show — kept low to reduce decision fatigue */
+const MAX_SUGGESTIONS = 2
 
 export function SmartCardSuggestions({
   existingCardTypes,

--- a/web/src/components/onboarding/Tour.tsx
+++ b/web/src/components/onboarding/Tour.tsx
@@ -4,8 +4,6 @@ import { useTour, TourStep } from '../../hooks/useTour'
 import { cn } from '../../lib/cn'
 import { useTranslation } from 'react-i18next'
 import { TOOLTIP_POSITION_DELAY_MS } from '../../lib/constants/network'
-import { STORAGE_KEY_HINTS_SUPPRESSED } from '../../lib/constants/storage'
-import { safeGetItem } from '../../lib/utils/localStorage'
 
 // KubeStellar logo — clean, no decorative overlays
 function KubeStellarAIIcon({ className }: { className?: string }) {
@@ -460,59 +458,9 @@ export function TourTrigger() {
   )
 }
 
-// Delay (in ms) before auto-starting the tour for first-time users.
-// Gives the welcome card time to be visible as a cue before the tour begins.
-const TOUR_AUTO_START_DELAY_MS = 3000
-
-// Auto-start tour prompt for new users
+// Tour prompt removed — auto-starting the tour had a 2.5% completion rate
+// and annoyed 97.5% of users. The tour is now opt-in only via TourTrigger
+// button in the navbar. Feature hints + Getting Started banner handle onboarding.
 export function TourPrompt() {
-  const { hasCompletedTour, isActive, startTour, skipTour } = useTour()
-  const [dismissed, setDismissed] = useState(false)
-
-  // Auto-start the tour after a short delay for users who haven't seen it yet.
-  // If the user clicks "Skip" before the timer fires, hasCompletedTour or
-  // dismissed will flip and the effect cleans up.
-  // Suppressed when user disables hints in settings (manual restart via TourTrigger still works).
-  const hintsSuppressed = safeGetItem(STORAGE_KEY_HINTS_SUPPRESSED) === 'true'
-  useEffect(() => {
-    if (hasCompletedTour || isActive || dismissed || hintsSuppressed) return
-    const timer = setTimeout(() => startTour(), TOUR_AUTO_START_DELAY_MS)
-    return () => clearTimeout(timer)
-  }, [hasCompletedTour, isActive, dismissed, hintsSuppressed, startTour])
-
-  // Don't show if tour completed, dismissed, already active, or hints suppressed
-  if (hasCompletedTour || dismissed || isActive || hintsSuppressed) return null
-
-  return (
-    <div className="fixed bottom-4 left-4 z-50 w-80 p-4 glass rounded-lg border border-purple-500/30 shadow-xl animate-fade-in-up">
-      <div className="flex items-start gap-3">
-        <div className="p-2 rounded-lg bg-purple-500/20 flex-shrink-0">
-          <KubeStellarAIIcon className="w-6 h-6" />
-        </div>
-        <div className="flex-1">
-          <h3 className="font-semibold text-foreground mb-1">Welcome!</h3>
-          <p className="text-sm text-muted-foreground mb-3">
-            New here? Take a quick tour to learn about dashboards, cards, search, and AI missions. Just 6 steps!
-          </p>
-          <div className="flex gap-2">
-            <button
-              onClick={startTour}
-              className="px-3 py-1.5 rounded-lg bg-purple-500 hover:bg-purple-600 text-foreground text-sm font-medium transition-colors"
-            >
-              Start Tour
-            </button>
-            <button
-              onClick={() => {
-                setDismissed(true)
-                skipTour()
-              }}
-              className="px-3 py-1.5 rounded-lg bg-secondary hover:bg-secondary/80 text-muted-foreground hover:text-foreground text-sm transition-colors"
-            >
-              Skip
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
-  )
+  return null
 }

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -781,6 +781,30 @@ export function emitGettingStartedActioned(action: string) {
   send('ksc_getting_started_actioned', { action })
 }
 
+// ── Post-Connect Activation ──────────────────────────────────────────
+
+/** Fired when the post-agent-connect activation banner renders */
+export function emitPostConnectShown() {
+  send('ksc_post_connect_shown')
+}
+
+/** Fired when user clicks a CTA on the post-connect activation banner */
+export function emitPostConnectActioned(action: string) {
+  send('ksc_post_connect_actioned', { action })
+}
+
+// ── Demo-to-Local CTA ──────────────────────────────────────────────
+
+/** Fired when the "Try it locally" CTA renders for demo-site visitors */
+export function emitDemoToLocalShown() {
+  send('ksc_demo_to_local_shown')
+}
+
+/** Fired when a demo-site visitor clicks the install CTA */
+export function emitDemoToLocalActioned(action: string) {
+  send('ksc_demo_to_local_actioned', { action })
+}
+
 // ── UTM Tracking ───────────────────────────────────────────────────
 
 /** Maximum length for UTM parameter values to avoid oversized beacon URLs */

--- a/web/src/lib/constants/storage.ts
+++ b/web/src/lib/constants/storage.ts
@@ -51,6 +51,8 @@ export const STORAGE_KEY_VISIT_COUNT = 'kc-visit-count'
 export const STORAGE_KEY_FEATURE_HINTS_DISMISSED = 'kc-feature-hints-dismissed'
 export const STORAGE_KEY_GETTING_STARTED_DISMISSED = 'kc-getting-started-dismissed'
 export const STORAGE_KEY_HINTS_SUPPRESSED = 'kc-hints-suppressed'
+export const STORAGE_KEY_POST_CONNECT_DISMISSED = 'kc-post-connect-dismissed'
+export const STORAGE_KEY_DEMO_CTA_DISMISSED = 'kc-demo-cta-dismissed'
 
 // ── Component-specific cache ───────────────────────────────────────────
 export const STORAGE_KEY_OPA_CACHE = 'opa-statuses-cache'


### PR DESCRIPTION
## Summary

GA4 funnel data reveals 4 critical drop-offs. This PR addresses each with targeted changes:

### 1. Post-Agent-Connect Activation Banner (NEW)
- **Problem**: 90% of localhost users who connect kc-agent never start a mission (75→7)
- **Fix**: `PostConnectBanner` appears on agent connect with 3 CTAs: Run Health Check (auto-mission), Explore Clusters, Set Up Alerts
- **Tracking**: `ksc_post_connect_shown`, `ksc_post_connect_actioned`

### 2. Demo-to-Local CTA (NEW)
- **Problem**: 100% of console.kubestellar.io visitors (104 users) abandon at Step 2 — they can't connect an agent
- **Fix**: `DemoToLocalCTA` shows brew install command with copy button + docs link
- **Tracking**: `ksc_demo_to_local_shown`, `ksc_demo_to_local_actioned`

### 3. Tour Auto-Start Killed
- **Problem**: 2.5% completion rate (40 started, 1 completed on Mar 6), annoying 97.5% of users
- **Fix**: `TourPrompt` now returns null. Tour remains opt-in via TourTrigger button in navbar
- Feature hints + Getting Started banner handle onboarding instead

### 4. Smart Suggestions Reduced to 2
- **Problem**: 1.7% acceptance rate with 4 suggestions (decision fatigue)
- **Fix**: `MAX_SUGGESTIONS` changed from 4 to 2

### GA4 Baseline (7-day, pre-fix)

| Funnel Step | Users | Drop-off |
|-------------|-------|----------|
| Visited Console | 247 | — |
| Connected Agent | 88 (35.6%) | 64.4% |
| Started Mission | 9 (3.6%) | 89.8% |
| Add GH Token | 0 (0%) | 100% |

Key segment: **console.kubestellar.io** = 104 visitors, 0% Step 2 conversion (demo dead end)

## Files Changed (7 files, +330 / -59)

| File | Change |
|------|--------|
| `PostConnectBanner.tsx` | **NEW** — post-agent-connect activation |
| `DemoToLocalCTA.tsx` | **NEW** — demo-to-local install CTA |
| `Dashboard.tsx` | Integrate both new components |
| `Tour.tsx` | Remove auto-start, keep manual trigger |
| `SmartCardSuggestions.tsx` | MAX_SUGGESTIONS 4→2 |
| `analytics.ts` | 4 new emit functions |
| `constants/storage.ts` | 2 new storage keys |

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] PostConnectBanner: connect kc-agent → banner appears after 2s with 3 CTAs
- [ ] DemoToLocalCTA: visit Netlify deploy preview → install CTA visible with copy button
- [ ] Tour: clear localStorage → no auto-tour prompt, TourTrigger button still works
- [ ] Smart Suggestions: connect agent → only 2 suggestions shown (not 4)
- [ ] All banners respect "Disable hints" master toggle in Settings
- [ ] GA4: new events appear in real-time report