### PR TITLE
✨ UX cleanup: reduce sidebar clutter, recommended dashboards, cluster-admin reorder

### DIFF
--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Sparkles, Plus, Loader2, LayoutGrid, Search, Wand2, Activity } from 'lucide-react'
+import { Sparkles, Plus, Loader2, LayoutGrid, Search, Wand2, Activity, Compass } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 import { useModalState } from '../../lib/modals'
 import { CardFactoryModal } from './CardFactoryModal'
@@ -10,6 +10,7 @@ import { TechnicalAcronym } from '../shared/TechnicalAcronym'
 import { useToast } from '../ui/Toast'
 import { FOCUS_DELAY_MS, RETRY_DELAY_MS } from '../../lib/constants/network'
 import { emitAddCardModalOpened, emitAddCardModalAbandoned, emitCardCategoryBrowsed, emitRecommendedCardShown } from '../../lib/analytics'
+import { useSidebarConfig, DISCOVERABLE_DASHBOARDS } from '../../hooks/useSidebarConfig'
 
 // Helper function to wrap technical abbreviations in text with tooltips
 function wrapAbbreviations(text: string): ReactNode {
@@ -987,6 +988,13 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
     return unsub
   }, [])
 
+  // Sidebar config for "Recommended Dashboards" section
+  const { config: sidebarConfig, restoreDashboard } = useSidebarConfig()
+  const availableDashboards = useMemo(() => {
+    const sidebarIds = new Set((sidebarConfig.primaryNav || []).map(item => item.id))
+    return DISCOVERABLE_DASHBOARDS.filter(d => !sidebarIds.has(d.id))
+  }, [sidebarConfig.primaryNav])
+
   // Compute recommended cards — popular cards not already on the dashboard
   const recommendedCards = useMemo(() => {
     const existing = new Set(existingCardTypes || [])
@@ -1253,6 +1261,31 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
                           </button>
                         )
                       })}
+                    </div>
+                  </div>
+                )}
+
+                {/* Recommended Dashboards — discoverable dashboards not in the sidebar */}
+                {!browseSearch.trim() && availableDashboards.length > 0 && (
+                  <div className="mb-4 rounded-xl border border-blue-500/20 bg-blue-500/5 p-3">
+                    <h4 className="text-xs font-medium text-blue-400 uppercase tracking-wider mb-2 flex items-center gap-1.5">
+                      <Compass className="w-3.5 h-3.5" />
+                      Recommended Dashboards
+                    </h4>
+                    <p className="text-xs text-muted-foreground mb-2">
+                      Add topic-specific dashboards to your sidebar
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {availableDashboards.map(dashboard => (
+                        <button
+                          key={dashboard.id}
+                          onClick={() => restoreDashboard(dashboard)}
+                          className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm bg-secondary/50 border border-border/50 hover:border-blue-500/30 hover:bg-secondary text-foreground transition-all"
+                        >
+                          <span className="font-medium text-xs">{dashboard.name}</span>
+                          <Plus className="w-3 h-3 text-blue-400" />
+                        </button>
+                      ))}
                     </div>
                   </div>
                 )}

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -121,7 +121,7 @@ export function Dashboard() {
   } = useDashboardContext()
 
   // Missions context for Getting Started banner
-  const { openSidebar: openMissionSidebar, startMission } = useMissions()
+  const { startMission } = useMissions()
 
   // Get all dashboards for cross-dashboard dragging
   const { dashboards, moveCardToDashboard, createDashboard, exportDashboard, importDashboard } = useDashboards()
@@ -884,11 +884,7 @@ export function Dashboard() {
       {/* Getting Started banner — quick-action buttons for first-time users */}
       <GettingStartedBanner
         onBrowseCards={openAddCardModal}
-        onTryMission={openMissionSidebar}
-        onExploreDashboards={() => {
-          const sidebar = document.querySelector('[data-tour="sidebar"]')
-          sidebar?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-        }}
+        onExploreDashboards={openAddCardModal}
       />
 
       {/* Demo-to-local CTA — shown on console.kubestellar.io for demo visitors */}

--- a/web/src/components/dashboard/GettingStartedBanner.tsx
+++ b/web/src/components/dashboard/GettingStartedBanner.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useState, useEffect, useRef } from 'react'
-import { LayoutGrid, Sparkles, Compass, X } from 'lucide-react'
+import { LayoutGrid, Compass, X } from 'lucide-react'
 import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
 import {
   STORAGE_KEY_GETTING_STARTED_DISMISSED,
@@ -24,13 +24,11 @@ const DASHBOARD_COUNT = Object.keys(DASHBOARD_CONFIGS).length
 
 interface GettingStartedBannerProps {
   onBrowseCards: () => void
-  onTryMission: () => void
   onExploreDashboards: () => void
 }
 
 export function GettingStartedBanner({
   onBrowseCards,
-  onTryMission,
   onExploreDashboards,
 }: GettingStartedBannerProps) {
   const [dismissed, setDismissed] = useState(
@@ -71,13 +69,6 @@ export function GettingStartedBanner({
       onClick: () => handleAction('browse_cards', onBrowseCards),
     },
     {
-      id: 'try-mission',
-      label: 'Try a Mission',
-      description: 'Guided workflows powered by AI',
-      icon: Sparkles,
-      onClick: () => handleAction('try_mission', onTryMission),
-    },
-    {
       id: 'explore-dashboards',
       label: 'Explore Dashboards',
       description: `${DASHBOARD_COUNT} topic-specific dashboards`,
@@ -106,7 +97,7 @@ export function GettingStartedBanner({
         </button>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
         {actions.map(({ id, label, description, icon: Icon, onClick }) => (
           <button
             key={id}

--- a/web/src/config/dashboards/cluster-admin.ts
+++ b/web/src/config/dashboards/cluster-admin.ts
@@ -13,20 +13,20 @@ export const clusterAdminDashboardConfig: UnifiedDashboardConfig = {
   route: '/cluster-admin',
   statsType: 'cluster-admin',
   cards: [
-    // Row 1: Health at a glance
-    { id: 'ca-health-1', cardType: 'cluster_health', position: { w: 4, h: 3, x: 0, y: 0 } },
-    { id: 'ca-cp-1', cardType: 'control_plane_health', title: 'Control Plane', position: { w: 4, h: 3, x: 4, y: 0 } },
-    { id: 'ca-provider-1', cardType: 'provider_health', position: { w: 4, h: 3, x: 8, y: 0 } },
-    // Row 2: Resources & prediction
-    { id: 'ca-usage-1', cardType: 'resource_usage', position: { w: 4, h: 3, x: 0, y: 3 } },
-    { id: 'ca-predict-1', cardType: 'predictive_health', title: 'Predictive Health', position: { w: 8, h: 3, x: 4, y: 3 } },
-    // Row 3: Issues & events
-    { id: 'ca-pods-1', cardType: 'pod_issues', position: { w: 4, h: 3, x: 0, y: 6 } },
-    { id: 'ca-deploys-1', cardType: 'deployment_issues', position: { w: 4, h: 3, x: 4, y: 6 } },
-    { id: 'ca-warnings-1', cardType: 'warning_events', position: { w: 4, h: 3, x: 8, y: 6 } },
-    // Row 4: Operations tooling
-    { id: 'ca-kubectl-1', cardType: 'kubectl', position: { w: 6, h: 4, x: 0, y: 9 } },
-    { id: 'ca-nodedebug-1', cardType: 'node_debug', title: 'Node Debug', position: { w: 6, h: 4, x: 6, y: 9 } },
+    // Row 1: Operations tooling (most-used — top of dashboard)
+    { id: 'ca-kubectl-1', cardType: 'kubectl', position: { w: 6, h: 4, x: 0, y: 0 } },
+    { id: 'ca-nodedebug-1', cardType: 'node_debug', title: 'Node Debug', position: { w: 6, h: 4, x: 6, y: 0 } },
+    // Row 2: Health at a glance
+    { id: 'ca-health-1', cardType: 'cluster_health', position: { w: 4, h: 3, x: 0, y: 4 } },
+    { id: 'ca-cp-1', cardType: 'control_plane_health', title: 'Control Plane', position: { w: 4, h: 3, x: 4, y: 4 } },
+    { id: 'ca-provider-1', cardType: 'provider_health', position: { w: 4, h: 3, x: 8, y: 4 } },
+    // Row 3: Resources & prediction
+    { id: 'ca-usage-1', cardType: 'resource_usage', position: { w: 4, h: 3, x: 0, y: 7 } },
+    { id: 'ca-predict-1', cardType: 'predictive_health', title: 'Predictive Health', position: { w: 8, h: 3, x: 4, y: 7 } },
+    // Row 4: Issues & events
+    { id: 'ca-pods-1', cardType: 'pod_issues', position: { w: 4, h: 3, x: 0, y: 10 } },
+    { id: 'ca-deploys-1', cardType: 'deployment_issues', position: { w: 4, h: 3, x: 4, y: 10 } },
+    { id: 'ca-warnings-1', cardType: 'warning_events', position: { w: 4, h: 3, x: 8, y: 10 } },
     // Row 5: Infrastructure
     { id: 'ca-hw-1', cardType: 'hardware_health', position: { w: 6, h: 3, x: 0, y: 13 } },
     { id: 'ca-upgrade-1', cardType: 'upgrade_status', position: { w: 6, h: 3, x: 6, y: 13 } },

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -40,8 +40,8 @@ function subscribe(listener: () => void): () => void {
   return () => listeners.delete(listener)
 }
 
+// Core dashboards shown in sidebar by default (reduced from 28 to 9 to cut clutter)
 const DEFAULT_PRIMARY_NAV: SidebarItem[] = [
-  // Priority dashboards at the top
   { id: 'dashboard', name: 'Dashboard', icon: 'LayoutDashboard', href: '/', type: 'link', order: 0 },
   { id: 'clusters', name: 'My Clusters', icon: 'Server', href: '/clusters', type: 'link', order: 1 },
   { id: 'cluster-admin', name: 'Cluster Admin', icon: 'ShieldAlert', href: '/cluster-admin', type: 'link', order: 2 },
@@ -49,29 +49,36 @@ const DEFAULT_PRIMARY_NAV: SidebarItem[] = [
   { id: 'ai-ml', name: 'AI/ML', icon: 'Sparkles', href: '/ai-ml', type: 'link', order: 4 },
   { id: 'ai-agents', name: 'AI Agents', icon: 'Bot', href: '/ai-agents', type: 'link', order: 5 },
   { id: 'ci-cd', name: 'CI/CD', icon: 'GitMerge', href: '/ci-cd', type: 'link', order: 6 },
-  // All other dashboards (alphabetical)
   { id: 'alerts', name: 'Alerts', icon: 'Bell', href: '/alerts', type: 'link', order: 7 },
   { id: 'arcade', name: 'Arcade', icon: 'Gamepad2', href: '/arcade', type: 'link', order: 8 },
-  { id: 'compliance', name: 'Compliance', icon: 'ClipboardCheck', href: '/compliance', type: 'link', order: 9 },
-  { id: 'compute', name: 'Compute', icon: 'Monitor', href: '/compute', type: 'link', order: 10 },
-  { id: 'cost', name: 'Cost', icon: 'DollarSign', href: '/cost', type: 'link', order: 11 },
-  { id: 'data-compliance', name: 'Data Compliance', icon: 'Database', href: '/data-compliance', type: 'link', order: 12 },
-  { id: 'deployments', name: 'Deployments', icon: 'Layers', href: '/deployments', type: 'link', order: 13 },
-  { id: 'events', name: 'Events', icon: 'Activity', href: '/events', type: 'link', order: 14 },
-  { id: 'gitops', name: 'GitOps', icon: 'GitBranch', href: '/gitops', type: 'link', order: 15 },
-  { id: 'gpu-reservations', name: 'GPU Reservations', icon: 'Cpu', href: '/gpu-reservations', type: 'link', order: 16 },
-  { id: 'helm', name: 'Helm', icon: 'Package', href: '/helm', type: 'link', order: 17 },
-  { id: 'llm-d-benchmarks', name: 'llm-d Benchmarks', icon: 'TrendingUp', href: '/llm-d-benchmarks', type: 'link', order: 18 },
-  { id: 'logs', name: 'Logs', icon: 'FileText', href: '/logs', type: 'link', order: 19 },
-  { id: 'network', name: 'Network', icon: 'Globe', href: '/network', type: 'link', order: 20 },
-  { id: 'nodes', name: 'Nodes', icon: 'CircuitBoard', href: '/nodes', type: 'link', order: 21 },
-  { id: 'operators', name: 'Operators', icon: 'Cog', href: '/operators', type: 'link', order: 22 },
-  { id: 'pods', name: 'Pods', icon: 'Hexagon', href: '/pods', type: 'link', order: 23 },
-  { id: 'security', name: 'Security', icon: 'Shield', href: '/security', type: 'link', order: 24 },
-  { id: 'security-posture', name: 'Security Posture', icon: 'ShieldCheck', href: '/security-posture', type: 'link', order: 25 },
-  { id: 'services', name: 'Services', icon: 'Network', href: '/services', type: 'link', order: 26 },
-  { id: 'storage', name: 'Storage', icon: 'HardDrive', href: '/storage', type: 'link', order: 27 },
-  { id: 'workloads', name: 'Workloads', icon: 'Box', href: '/workloads', type: 'link', order: 28 },
+]
+
+/**
+ * Dashboards available for discovery but NOT shown in the sidebar by default.
+ * Surfaced in the "Recommended Dashboards" section of the customize modal.
+ * Users can add any of these to their sidebar via the customizer.
+ */
+export const DISCOVERABLE_DASHBOARDS: SidebarItem[] = [
+  { id: 'compliance', name: 'Compliance', icon: 'ClipboardCheck', href: '/compliance', type: 'link', order: 0 },
+  { id: 'compute', name: 'Compute', icon: 'Monitor', href: '/compute', type: 'link', order: 1 },
+  { id: 'cost', name: 'Cost', icon: 'DollarSign', href: '/cost', type: 'link', order: 2 },
+  { id: 'data-compliance', name: 'Data Compliance', icon: 'Database', href: '/data-compliance', type: 'link', order: 3 },
+  { id: 'deployments', name: 'Deployments', icon: 'Layers', href: '/deployments', type: 'link', order: 4 },
+  { id: 'events', name: 'Events', icon: 'Activity', href: '/events', type: 'link', order: 5 },
+  { id: 'gitops', name: 'GitOps', icon: 'GitBranch', href: '/gitops', type: 'link', order: 6 },
+  { id: 'gpu-reservations', name: 'GPU Reservations', icon: 'Cpu', href: '/gpu-reservations', type: 'link', order: 7 },
+  { id: 'helm', name: 'Helm', icon: 'Package', href: '/helm', type: 'link', order: 8 },
+  { id: 'llm-d-benchmarks', name: 'llm-d Benchmarks', icon: 'TrendingUp', href: '/llm-d-benchmarks', type: 'link', order: 9 },
+  { id: 'logs', name: 'Logs', icon: 'FileText', href: '/logs', type: 'link', order: 10 },
+  { id: 'network', name: 'Network', icon: 'Globe', href: '/network', type: 'link', order: 11 },
+  { id: 'nodes', name: 'Nodes', icon: 'CircuitBoard', href: '/nodes', type: 'link', order: 12 },
+  { id: 'operators', name: 'Operators', icon: 'Cog', href: '/operators', type: 'link', order: 13 },
+  { id: 'pods', name: 'Pods', icon: 'Hexagon', href: '/pods', type: 'link', order: 14 },
+  { id: 'security', name: 'Security', icon: 'Shield', href: '/security', type: 'link', order: 15 },
+  { id: 'security-posture', name: 'Security Posture', icon: 'ShieldCheck', href: '/security-posture', type: 'link', order: 16 },
+  { id: 'services', name: 'Services', icon: 'Network', href: '/services', type: 'link', order: 17 },
+  { id: 'storage', name: 'Storage', icon: 'HardDrive', href: '/storage', type: 'link', order: 18 },
+  { id: 'workloads', name: 'Workloads', icon: 'Box', href: '/workloads', type: 'link', order: 19 },
 ]
 
 const DEFAULT_SECONDARY_NAV: SidebarItem[] = [
@@ -91,8 +98,8 @@ const DEFAULT_CONFIG: SidebarConfig = {
   isMobileOpen: false,
 }
 
-const STORAGE_KEY = 'kubestellar-sidebar-config-v10'
-const OLD_STORAGE_KEY = 'kubestellar-sidebar-config-v9'
+const STORAGE_KEY = 'kubestellar-sidebar-config-v11'
+const OLD_STORAGE_KEY = 'kubestellar-sidebar-config-v10'
 
 // Routes to remove during migration (deprecated/removed routes)
 const DEPRECATED_ROUTES = ['/apps']
@@ -382,6 +389,19 @@ export function useSidebarConfig() {
     setConfig((prev) => ({ ...prev, isMobileOpen: !prev.isMobileOpen }))
   }, [])
 
+  // Add a discoverable dashboard to the sidebar with its original ID (not a generated custom ID)
+  const restoreDashboard = useCallback((dashboard: SidebarItem) => {
+    setConfig((prev) => {
+      // Skip if already present
+      if (prev.primaryNav.some((item) => item.id === dashboard.id)) return prev
+      const newItem: SidebarItem = {
+        ...dashboard,
+        order: prev.primaryNav.length,
+      }
+      return { ...prev, primaryNav: [...prev.primaryNav, newItem] }
+    })
+  }, [])
+
   const resetToDefault = useCallback(() => {
     setConfig(applyDashboardFilter(DEFAULT_CONFIG))
   }, [])
@@ -434,6 +454,7 @@ export function useSidebarConfig() {
     removeItem,
     updateItem,
     reorderItems,
+    restoreDashboard,
     toggleClusterStatus,
     toggleCollapsed,
     openMobileSidebar,


### PR DESCRIPTION
## Summary

- **Sidebar reduced from 28 to 9 core dashboards**: Dashboard, My Clusters, Cluster Admin, Deploy, AI/ML, AI Agents, CI/CD, Alerts, Arcade
- **Recommended Dashboards section** in the customize modal lets users discover and add the remaining 20 dashboards to their sidebar
- **Cluster Admin dashboard**: Moved Kubectl Terminal + Node Debug to the top (most-used cards)
- **Getting Started banner**: Removed duplicate "Try a Mission" (MissionCTA handles this), "Explore Dashboards" now opens the customize modal

### Details

| Change | File |
|--------|------|
| Sidebar defaults 28→9, `DISCOVERABLE_DASHBOARDS` export | `useSidebarConfig.ts` |
| `restoreDashboard()` function for adding discoverable items | `useSidebarConfig.ts` |
| "Recommended Dashboards" browse tab section | `AddCardModal.tsx` |
| Kubectl/Node Debug moved to row 1 | `cluster-admin.ts` |
| Remove "Try a Mission", route "Explore Dashboards" to modal | `GettingStartedBanner.tsx`, `Dashboard.tsx` |
| Storage key bumped v10→v11 | `useSidebarConfig.ts` |

## Test plan

- [ ] Clear localStorage → sidebar shows 9 items only
- [ ] Open customize modal → "Recommended Dashboards" section shows 20 discoverable dashboards
- [ ] Click a recommended dashboard → it appears in sidebar immediately
- [ ] Re-open modal → that dashboard no longer appears in recommendations
- [ ] Cluster Admin dashboard → Kubectl Terminal + Node Debug at top
- [ ] Getting Started banner → 2 buttons (Browse Cards, Explore Dashboards), no "Try a Mission"
- [ ] "Explore Dashboards" opens customize modal
- [ ] Existing users with v10 sidebar migrate to v11 defaults