### PR TITLE
✨ Consolidate mission CTA into Getting Started banner

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -36,7 +36,6 @@ import { ConfigureCardModal } from './ConfigureCardModal'
 import { CardRecommendations } from './CardRecommendations'
 import { safeGetItem, safeSetItem, safeGetJSON, safeSetJSON } from '../../lib/utils/localStorage'
 import { MissionSuggestions } from './MissionSuggestions'
-import { MissionCTA } from './MissionCTA'
 import { GettingStartedBanner } from './GettingStartedBanner'
 import { useMissions } from '../../hooks/useMissions'
 import { TemplatesModal } from './TemplatesModal'
@@ -120,8 +119,8 @@ export function Dashboard() {
     clearPendingRestoreCard,
   } = useDashboardContext()
 
-  // Missions context for Getting Started banner
-  const { startMission } = useMissions()
+  // Missions context for Getting Started banner + PostConnectBanner
+  const { openSidebar: openMissionSidebar, startMission } = useMissions()
 
   // Get all dashboards for cross-dashboard dragging
   const { dashboards, moveCardToDashboard, createDashboard, exportDashboard, importDashboard } = useDashboards()
@@ -884,6 +883,7 @@ export function Dashboard() {
       {/* Getting Started banner — quick-action buttons for first-time users */}
       <GettingStartedBanner
         onBrowseCards={openAddCardModal}
+        onTryMission={openMissionSidebar}
         onExploreDashboards={openAddCardModal}
       />
 
@@ -934,9 +934,6 @@ export function Dashboard() {
         {/* Mission Suggestions - actionable items like scaling, restarts, security issues */}
         <MissionSuggestions />
       </div>
-
-      {/* Mission CTA - encourage users who haven't tried missions yet */}
-      <MissionCTA />
 
       {/* Dashboard drop zone (shows when dragging) */}
       <DashboardDropZone

--- a/web/src/components/dashboard/GettingStartedBanner.tsx
+++ b/web/src/components/dashboard/GettingStartedBanner.tsx
@@ -4,14 +4,14 @@
  * Contains 3 quick-action buttons that funnel users to key features:
  *   1. "Browse Cards" — opens the add card modal
  *   2. "Try a Mission" — opens the mission sidebar
- *   3. "Explore Dashboards" — scrolls the sidebar into view
+ *   3. "Explore Dashboards" — opens the customize modal
  *
  * Dismissed permanently via localStorage. Suppressed when user disables
- * hints in settings. Does NOT replace the existing MissionCTA banner.
+ * hints in settings. Replaces the separate MissionCTA banner.
  */
 
 import { useState, useEffect, useRef } from 'react'
-import { LayoutGrid, Compass, X } from 'lucide-react'
+import { LayoutGrid, Compass, Sparkles, X } from 'lucide-react'
 import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
 import {
   STORAGE_KEY_GETTING_STARTED_DISMISSED,
@@ -24,11 +24,13 @@ const DASHBOARD_COUNT = Object.keys(DASHBOARD_CONFIGS).length
 
 interface GettingStartedBannerProps {
   onBrowseCards: () => void
+  onTryMission: () => void
   onExploreDashboards: () => void
 }
 
 export function GettingStartedBanner({
   onBrowseCards,
+  onTryMission,
   onExploreDashboards,
 }: GettingStartedBannerProps) {
   const [dismissed, setDismissed] = useState(
@@ -69,6 +71,13 @@ export function GettingStartedBanner({
       onClick: () => handleAction('browse_cards', onBrowseCards),
     },
     {
+      id: 'try-mission',
+      label: 'Try a Mission',
+      description: 'Guided workflows for scaling, security & more',
+      icon: Sparkles,
+      onClick: () => handleAction('try_mission', onTryMission),
+    },
+    {
       id: 'explore-dashboards',
       label: 'Explore Dashboards',
       description: `${DASHBOARD_COUNT} topic-specific dashboards`,
@@ -97,7 +106,7 @@ export function GettingStartedBanner({
         </button>
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
         {actions.map(({ id, label, description, icon: Icon, onClick }) => (
           <button
             key={id}


### PR DESCRIPTION
## Summary

- Add "Try a Mission" back to the Getting Started banner (now 3 actions: Browse Cards, Try a Mission, Explore Dashboards)
- Remove the separate `<MissionCTA />` component from Dashboard — single onboarding banner handles everything
- 3-column grid layout on desktop

## Test plan

- [ ] Getting Started banner shows 3 action buttons
- [ ] "Try a Mission" opens the mission sidebar
- [ ] No separate MissionCTA banner below the card grid