### PR TITLE
✨ Add StatusBadge + Button shared components, replace hardcoded gray tokens

### DIFF
--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -196,7 +196,7 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
       {groups.length === 0 && !isCreating ? (
         <div className="text-center py-6">
           <Layers className="w-8 h-8 mx-auto mb-2 text-gray-600" />
-          <p className="text-sm text-gray-500">{t('cards:clusterGroups.noGroupsYet')}</p>
+          <p className="text-sm text-muted-foreground">{t('cards:clusterGroups.noGroupsYet')}</p>
           <p className="text-xs text-gray-600 mt-1">
             {t('cards:clusterGroups.createGroupHint')}
           </p>
@@ -234,7 +234,7 @@ export function ClusterGroups(_props: ClusterGroupsProps) {
       )}
 
       {/* Help text */}
-      <div className="pt-2 border-t border-gray-800">
+      <div className="pt-2 border-t border-border">
         <p className="text-2xs text-gray-600 text-center">
           {t('cards:clusterGroups.dragWorkloadHint')}
         </p>
@@ -287,7 +287,7 @@ function DroppableGroup({ group, isExpanded, isRefreshing, clusterHealthMap, onT
         {/* Expand toggle */}
         <button
           onClick={onToggle}
-          className="text-gray-500 hover:text-gray-300 transition-colors"
+          className="text-muted-foreground hover:text-gray-300 transition-colors"
         >
           {isExpanded
             ? <ChevronDown className="w-3.5 h-3.5" />
@@ -322,14 +322,14 @@ function DroppableGroup({ group, isExpanded, isRefreshing, clusterHealthMap, onT
             />
           ))}
           {group.clusters.length > MAX_INLINE_BADGES && (
-            <span className="text-[9px] text-gray-500">
+            <span className="text-[9px] text-muted-foreground">
               +{group.clusters.length - MAX_INLINE_BADGES}
             </span>
           )}
         </div>
 
         {/* Cluster count + health */}
-        <span className="text-2xs text-gray-500">
+        <span className="text-2xs text-muted-foreground">
           {healthyCount}/{group.clusters.length} {t('common:common.healthy').toLowerCase()}
         </span>
 
@@ -354,14 +354,14 @@ function DroppableGroup({ group, isExpanded, isRefreshing, clusterHealthMap, onT
         <div className="flex items-center gap-1">
           <button
             onClick={onEdit}
-            className="p-1 rounded hover:bg-white/10 text-gray-500 hover:text-gray-300 transition-colors"
+            className="p-1 rounded hover:bg-white/10 text-muted-foreground hover:text-gray-300 transition-colors"
             title={t('cards:clusterGroups.editGroup')}
           >
             <Edit2 className="w-3 h-3" />
           </button>
           <button
             onClick={onDelete}
-            className="p-1 rounded hover:bg-red-500/20 text-gray-500 hover:text-red-400 transition-colors"
+            className="p-1 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors"
             title={t('cards:clusterGroups.deleteGroup')}
           >
             <Trash2 className="w-3 h-3" />
@@ -371,10 +371,10 @@ function DroppableGroup({ group, isExpanded, isRefreshing, clusterHealthMap, onT
 
       {/* Expanded: cluster list + query info for dynamic groups */}
       {isExpanded && (
-        <div className="px-3 pb-2 pt-1 border-t border-gray-800/50 space-y-2">
+        <div className="px-3 pb-2 pt-1 border-t border-border/50 space-y-2">
           {/* Dynamic: show query summary */}
           {isDynamic && group.query && (
-            <div className="text-2xs text-gray-500 space-y-0.5">
+            <div className="text-2xs text-muted-foreground space-y-0.5">
               {group.query.labelSelector && (
                 <div className="flex items-center gap-1">
                   <Tag className="w-2.5 h-2.5" />
@@ -538,7 +538,7 @@ function CreateGroupForm({ availableClusters, clusterHealthMap, onSave, onCancel
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-blue-400">{t('cards:clusterGroups.newClusterGroup')}</span>
         <button onClick={onCancel} className="p-2 hover:bg-white/10 rounded min-h-11 min-w-11 flex items-center justify-center">
-          <X className="w-3.5 h-3.5 text-gray-500" />
+          <X className="w-3.5 h-3.5 text-muted-foreground" />
         </button>
       </div>
 
@@ -554,7 +554,7 @@ function CreateGroupForm({ availableClusters, clusterHealthMap, onSave, onCancel
 
       {/* Color picker */}
       <div className="flex items-center gap-1.5">
-        <span className="text-2xs text-gray-500 mr-1">{t('cards:clusterGroups.color')}:</span>
+        <span className="text-2xs text-muted-foreground mr-1">{t('cards:clusterGroups.color')}:</span>
         {GROUP_COLORS.map(c => (
           <button
             key={c.name}
@@ -576,7 +576,7 @@ function CreateGroupForm({ availableClusters, clusterHealthMap, onSave, onCancel
             'flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors',
             kind === 'static'
               ? 'bg-blue-500/20 text-blue-400'
-              : 'bg-gray-900/30 text-gray-500 hover:text-muted-foreground'
+              : 'bg-gray-900/30 text-muted-foreground hover:text-muted-foreground'
           )}
         >
           <Server className="w-3 h-3" />
@@ -588,7 +588,7 @@ function CreateGroupForm({ availableClusters, clusterHealthMap, onSave, onCancel
             'flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors',
             kind === 'dynamic'
               ? 'bg-purple-500/20 text-purple-400'
-              : 'bg-gray-900/30 text-gray-500 hover:text-muted-foreground'
+              : 'bg-gray-900/30 text-muted-foreground hover:text-muted-foreground'
           )}
         >
           <Zap className="w-3 h-3" />
@@ -618,7 +618,7 @@ function CreateGroupForm({ availableClusters, clusterHealthMap, onSave, onCancel
                 'flex items-center gap-1 px-2 py-1 text-2xs font-medium rounded transition-colors',
                 dynamicTab === 'builder'
                   ? 'bg-purple-500/20 text-purple-400'
-                  : 'text-gray-500 hover:text-muted-foreground'
+                  : 'text-muted-foreground hover:text-muted-foreground'
               )}
             >
               <Search className="w-2.5 h-2.5" />
@@ -630,7 +630,7 @@ function CreateGroupForm({ availableClusters, clusterHealthMap, onSave, onCancel
                 'flex items-center gap-1 px-2 py-1 text-2xs font-medium rounded transition-colors',
                 dynamicTab === 'ai'
                   ? 'bg-purple-500/20 text-purple-400'
-                  : 'text-gray-500 hover:text-muted-foreground'
+                  : 'text-muted-foreground hover:text-muted-foreground'
               )}
             >
               <Sparkles className="w-2.5 h-2.5" />
@@ -727,12 +727,12 @@ function StaticClusterPicker({
 
   return (
     <div>
-      <span className="text-2xs text-gray-500 block mb-1.5">
+      <span className="text-2xs text-muted-foreground block mb-1.5">
         {t('cards:clusterGroups.selectClusters')} ({selectedClusters.size} {t('common:common.selected').toLowerCase()})
       </span>
       <div className="max-h-32 overflow-y-auto space-y-1">
         {availableClusters.length === 0 ? (
-          <div className="flex items-center gap-2 py-2 text-xs text-gray-500">
+          <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground">
             <Loader2 className="w-3 h-3 animate-spin" />
             {t('cards:clusterGroups.loadingClusters')}
           </div>
@@ -794,7 +794,7 @@ function QueryBuilder({
     <div className="space-y-2">
       {/* Label selector */}
       <div>
-        <label className="flex items-center gap-1 text-2xs text-gray-500 mb-1">
+        <label className="flex items-center gap-1 text-2xs text-muted-foreground mb-1">
           <Tag className="w-2.5 h-2.5" />
           {t('cards:clusterGroups.labelSelector')}
         </label>
@@ -810,7 +810,7 @@ function QueryBuilder({
       {/* Resource filters */}
       <div>
         <div className="flex items-center justify-between mb-1">
-          <label className="flex items-center gap-1 text-2xs text-gray-500">
+          <label className="flex items-center gap-1 text-2xs text-muted-foreground">
             <Filter className="w-2.5 h-2.5" />
             {t('cards:clusterGroups.resourceFilters')}
           </label>
@@ -904,7 +904,7 @@ function QueryBuilder({
                 {/* Remove */}
                 <button
                   onClick={() => onRemoveFilter(i)}
-                  className="p-0.5 rounded hover:bg-red-500/20 text-gray-500 hover:text-red-400"
+                  className="p-0.5 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400"
                 >
                   <X className="w-3 h-3" />
                 </button>
@@ -940,7 +940,7 @@ function AIAssistant({
   const { t } = useTranslation(['cards', 'common'])
   return (
     <div className="space-y-2">
-      <label className="flex items-center gap-1 text-2xs text-gray-500">
+      <label className="flex items-center gap-1 text-2xs text-muted-foreground">
         <Sparkles className="w-2.5 h-2.5" />
         {t('cards:clusterGroups.describeClusters')}
       </label>
@@ -1046,13 +1046,13 @@ function EditGroupForm({ group, availableClusters, clusterHealthMap, onSave, onC
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-yellow-400">{t('common:common.edit')}: {group.name}</span>
         <button onClick={onCancel} className="p-2 hover:bg-white/10 rounded min-h-11 min-w-11 flex items-center justify-center">
-          <X className="w-3.5 h-3.5 text-gray-500" />
+          <X className="w-3.5 h-3.5 text-muted-foreground" />
         </button>
       </div>
 
       {/* Color picker */}
       <div className="flex items-center gap-1.5">
-        <span className="text-2xs text-gray-500 mr-1">{t('cards:clusterGroups.color')}:</span>
+        <span className="text-2xs text-muted-foreground mr-1">{t('cards:clusterGroups.color')}:</span>
         {GROUP_COLORS.map(c => (
           <button
             key={c.name}
@@ -1074,7 +1074,7 @@ function EditGroupForm({ group, availableClusters, clusterHealthMap, onSave, onC
             'flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors',
             kind === 'static'
               ? 'bg-yellow-500/20 text-yellow-400'
-              : 'bg-gray-900/30 text-gray-500 hover:text-muted-foreground'
+              : 'bg-gray-900/30 text-muted-foreground hover:text-muted-foreground'
           )}
         >
           <Server className="w-3 h-3" />
@@ -1086,7 +1086,7 @@ function EditGroupForm({ group, availableClusters, clusterHealthMap, onSave, onC
             'flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors',
             kind === 'dynamic'
               ? 'bg-purple-500/20 text-purple-400'
-              : 'bg-gray-900/30 text-gray-500 hover:text-muted-foreground'
+              : 'bg-gray-900/30 text-muted-foreground hover:text-muted-foreground'
           )}
         >
           <Zap className="w-3 h-3" />

--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -755,7 +755,7 @@ function ClusterStatusRow({ status }: ClusterStatusRowProps) {
 const DEP_ACTION_STYLES: Record<string, { color: string; label: string }> = {
   created: { color: 'text-green-400', label: 'Created' },
   updated: { color: 'text-blue-400', label: 'Updated' },
-  skipped: { color: 'text-gray-500', label: 'Skipped' },
+  skipped: { color: 'text-muted-foreground', label: 'Skipped' },
   failed: { color: 'text-red-400', label: 'Failed' },
 }
 

--- a/web/src/components/cards/MobileBrowser.tsx
+++ b/web/src/components/cards/MobileBrowser.tsx
@@ -319,7 +319,7 @@ export function MobileBrowser() {
                   {/* Bookmarks */}
                   {bookmarks.length > 0 && (
                     <div className="mb-4">
-                      <h3 className="text-xs font-semibold text-gray-500 mb-2">Favorites</h3>
+                      <h3 className="text-xs font-semibold text-muted-foreground mb-2">Favorites</h3>
                       <div className="grid grid-cols-4 gap-2">
                         {bookmarks.slice(0, 8).map((bookmark, i) => (
                           <button
@@ -341,7 +341,7 @@ export function MobileBrowser() {
 
                   {/* Quick Links */}
                   <div>
-                    <h3 className="text-xs font-semibold text-gray-500 mb-2">Quick Links</h3>
+                    <h3 className="text-xs font-semibold text-muted-foreground mb-2">Quick Links</h3>
                     <div className="grid grid-cols-4 gap-2">
                       {QUICK_LINKS.map((link) => (
                         <button
@@ -404,7 +404,7 @@ export function MobileBrowser() {
                           </button>
                         </div>
                         {tab.url && (
-                          <span className="text-2xs text-gray-500 truncate block">
+                          <span className="text-2xs text-muted-foreground truncate block">
                             {tab.url}
                           </span>
                         )}
@@ -437,7 +437,7 @@ export function MobileBrowser() {
                   </button>
                 </div>
                 {bookmarks.length === 0 ? (
-                  <p className="text-xs text-gray-500 text-center py-8">
+                  <p className="text-xs text-muted-foreground text-center py-8">
                     No bookmarks yet. Tap the star icon to add one.
                   </p>
                 ) : (
@@ -461,7 +461,7 @@ export function MobileBrowser() {
                             <span className="text-xs font-medium text-gray-700 dark:text-gray-300 block truncate">
                               {bookmark.title}
                             </span>
-                            <span className="text-2xs text-gray-500 truncate block">
+                            <span className="text-2xs text-muted-foreground truncate block">
                               {bookmark.url}
                             </span>
                           </button>

--- a/web/src/components/cards/WorkloadDeployment.tsx
+++ b/web/src/components/cards/WorkloadDeployment.tsx
@@ -639,27 +639,27 @@ export function WorkloadDeployment(_props: WorkloadDeploymentProps) {
       <div className="grid grid-cols-6 gap-2 px-3 py-2 bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-700">
         <div className="text-center">
           <div className="text-lg font-semibold text-gray-900 dark:text-gray-100">{stats.totalWorkloads}</div>
-          <div className="text-xs text-gray-500">{t('common.total')}</div>
+          <div className="text-xs text-muted-foreground">{t('common.total')}</div>
         </div>
         <div className="text-center">
           <div className="text-lg font-semibold text-purple-500">{stats.uniqueWorkloads}</div>
-          <div className="text-xs text-gray-500">Unique</div>
+          <div className="text-xs text-muted-foreground">Unique</div>
         </div>
         <div className="text-center">
           <div className="text-lg font-semibold text-green-600">{stats.runningCount}</div>
-          <div className="text-xs text-gray-500">{t('common.running')}</div>
+          <div className="text-xs text-muted-foreground">{t('common.running')}</div>
         </div>
         <div className="text-center">
           <div className="text-lg font-semibold text-yellow-600">{stats.degradedCount}</div>
-          <div className="text-xs text-gray-500">{t('common.degraded')}</div>
+          <div className="text-xs text-muted-foreground">{t('common.degraded')}</div>
         </div>
         <div className="text-center">
           <div className="text-lg font-semibold text-blue-600">{stats.pendingCount}</div>
-          <div className="text-xs text-gray-500">{t('common.pending')}</div>
+          <div className="text-xs text-muted-foreground">{t('common.pending')}</div>
         </div>
         <div className="text-center">
           <div className="text-lg font-semibold text-red-600">{stats.failedCount}</div>
-          <div className="text-xs text-gray-500">{t('common.failed')}</div>
+          <div className="text-xs text-muted-foreground">{t('common.failed')}</div>
         </div>
       </div>
 

--- a/web/src/components/cards/kagenti/KagentiAgentDiscovery.tsx
+++ b/web/src/components/cards/kagenti/KagentiAgentDiscovery.tsx
@@ -127,7 +127,7 @@ export function KagentiAgentDiscovery({ config }: KagentiAgentDiscoveryProps) {
             {card.identityBinding ? (
               <Shield className="w-3 h-3 text-green-400" />
             ) : (
-              <span className="text-xs text-gray-500">No ID</span>
+              <span className="text-xs text-muted-foreground">No ID</span>
             )}
             {(card.skills || []).length > 0 && (
               <span className="text-xs text-muted-foreground/40">

--- a/web/src/components/cards/kagenti/KagentiToolRegistry.tsx
+++ b/web/src/components/cards/kagenti/KagentiToolRegistry.tsx
@@ -100,7 +100,7 @@ export function KagentiToolRegistry({ config }: KagentiToolRegistryProps) {
             {tool.hasCredential ? (
               <Shield className="w-3 h-3 text-green-400" />
             ) : (
-              <ShieldOff className="w-3 h-3 text-gray-500" />
+              <ShieldOff className="w-3 h-3 text-muted-foreground" />
             )}
           </div>
         ))}

--- a/web/src/components/cards/llmd/BenchmarkHero.tsx
+++ b/web/src/components/cards/llmd/BenchmarkHero.tsx
@@ -191,7 +191,7 @@ export function BenchmarkHero() {
           <div>
             <div className="flex items-center gap-2">
               <span className="text-white font-semibold text-lg">{model}</span>
-              <ArrowRight size={14} className="text-gray-500" />
+              <ArrowRight size={14} className="text-muted-foreground" />
               <span className="text-gray-300 font-medium">{hw}</span>
               <span className="text-xs px-2 py-0.5 rounded-full font-medium"
                 style={{ background: `${CONFIG_COLORS[config]}20`, color: CONFIG_COLORS[config] }}>
@@ -207,7 +207,7 @@ export function BenchmarkHero() {
         </div>
         {/* Time range filter */}
         <div className="flex items-center gap-2">
-          <CalendarDays size={13} className="text-gray-500" />
+          <CalendarDays size={13} className="text-muted-foreground" />
           <select
             value={TIME_RANGE_OPTIONS.some(o => o.value === currentSince) ? currentSince : 'custom'}
             onChange={e => handleTimeRangeChange(e.target.value)}
@@ -288,27 +288,27 @@ export function BenchmarkHero() {
       {/* Bottom strip */}
       <div className="flex items-center gap-6 px-1 text-xs text-muted-foreground">
         <div className="flex items-center gap-1.5">
-          <span className="text-gray-500">Requests:</span>
+          <span className="text-muted-foreground">Requests:</span>
           <span className="text-white font-mono">{agg.requests.total.toLocaleString()}</span>
         </div>
         <div className="flex items-center gap-1.5">
-          <span className="text-gray-500">Failures:</span>
+          <span className="text-muted-foreground">Failures:</span>
           <span className={`font-mono ${agg.requests.failures > 0 ? 'text-red-400' : 'text-green-400'}`}>
             {agg.requests.failures === 0 ? '0' : agg.requests.failures}
           </span>
         </div>
         <div className="flex items-center gap-1.5">
-          <Cpu size={11} className="text-gray-500" />
-          <span className="text-gray-500">GPU Util:</span>
+          <Cpu size={11} className="text-muted-foreground" />
+          <span className="text-muted-foreground">GPU Util:</span>
           <span className="text-white font-mono">{gpuUtil.toFixed(0)}%</span>
         </div>
         <div className="flex items-center gap-1.5">
-          <Zap size={11} className="text-gray-500" />
-          <span className="text-gray-500">Power:</span>
+          <Zap size={11} className="text-muted-foreground" />
+          <span className="text-muted-foreground">Power:</span>
           <span className="text-white font-mono">{gpuPower.toFixed(0)}W</span>
         </div>
         <div className="flex items-center gap-1.5">
-          <span className="text-gray-500">GPUs:</span>
+          <span className="text-muted-foreground">GPUs:</span>
           <span className="text-white font-mono">{engine?.standardized.accelerator?.count ?? 1}x {hw}</span>
         </div>
       </div>

--- a/web/src/components/cards/llmd/EPPRouting.tsx
+++ b/web/src/components/cards/llmd/EPPRouting.tsx
@@ -886,7 +886,7 @@ export function EPPRouting() {
         <div className="absolute inset-0 flex flex-col items-center justify-center z-20 bg-gray-900/60 backdrop-blur-sm rounded-lg">
           <div className="w-12 h-12 rounded-full border-2 border-gray-600 border-t-yellow-500 animate-spin mb-4" />
           <span className="text-muted-foreground text-sm">{t('llmd.selectStackRouting')}</span>
-          <span className="text-gray-500 text-xs mt-1">{t('llmd.useStackSelector')}</span>
+          <span className="text-muted-foreground text-xs mt-1">{t('llmd.useStackSelector')}</span>
         </div>
       )}
       {/* Header */}
@@ -1107,7 +1107,7 @@ export function EPPRouting() {
                                   ? metric === 'load'
                                     ? 'bg-yellow-500/20 text-yellow-400 shadow-sm shadow-yellow-500/20'
                                     : 'bg-cyan-500/20 text-cyan-400 shadow-sm shadow-cyan-500/20'
-                                  : 'bg-gray-700/50 text-gray-500 hover:text-gray-300'
+                                  : 'bg-gray-700/50 text-muted-foreground hover:text-gray-300'
                               }`}
                             >
                               {metric === 'load' ? t('llmd.load') : t('llmd.rps')}
@@ -1119,13 +1119,13 @@ export function EPPRouting() {
                         <div className="flex gap-3 text-xs">
                           {selectedMetricTypes.includes('load') && (
                             <div>
-                              <span className="text-gray-500">{t('llmd.load')}:</span>{' '}
+                              <span className="text-muted-foreground">{t('llmd.load')}:</span>{' '}
                               <span className="text-yellow-400 font-mono">{metrics.load}%</span>
                             </div>
                           )}
                           {selectedMetricTypes.includes('rps') && (
                             <div>
-                              <span className="text-gray-500">{t('llmd.rps')}:</span>{' '}
+                              <span className="text-muted-foreground">{t('llmd.rps')}:</span>{' '}
                               <span className="text-cyan-400 font-mono">{metrics.rps}</span>
                             </div>
                           )}
@@ -1162,7 +1162,7 @@ export function EPPRouting() {
                     )}
 
                     {node.type === 'source' && (
-                      <div className="text-xs text-gray-500">
+                      <div className="text-xs text-muted-foreground">
                         {t('llmd.incomingRequests')}
                       </div>
                     )}

--- a/web/src/components/cards/llmd/HardwareLeaderboard.tsx
+++ b/web/src/components/cards/llmd/HardwareLeaderboard.tsx
@@ -111,7 +111,7 @@ export function HardwareLeaderboard() {
         <div className="flex items-center gap-2">
           <Trophy size={16} className="text-yellow-400" />
           <span className="text-sm font-medium text-white">Hardware Leaderboard</span>
-          <span className="text-xs text-gray-500">{totalItems} configs</span>
+          <span className="text-xs text-muted-foreground">{totalItems} configs</span>
         </div>
         <div className="flex items-center gap-2">
           <CardSearch
@@ -143,15 +143,15 @@ export function HardwareLeaderboard() {
         <table className="w-full text-xs">
           <thead className="sticky top-0 bg-gray-900 backdrop-blur-sm z-10">
             <tr className="border-b border-gray-700/50">
-              <th className="text-left py-2 px-2 text-gray-500 font-medium w-[36px]">#</th>
-              <th className="text-left py-2 px-2 text-gray-500 font-medium w-[70px]">Hardware</th>
-              <th className="text-left py-2 px-2 text-gray-500 font-medium w-[100px]">Model</th>
-              <th className="text-left py-2 px-2 text-gray-500 font-medium w-[90px]">Config</th>
+              <th className="text-left py-2 px-2 text-muted-foreground font-medium w-[36px]">#</th>
+              <th className="text-left py-2 px-2 text-muted-foreground font-medium w-[70px]">Hardware</th>
+              <th className="text-left py-2 px-2 text-muted-foreground font-medium w-[100px]">Model</th>
+              <th className="text-left py-2 px-2 text-muted-foreground font-medium w-[90px]">Config</th>
               {COLUMNS.map(col => (
                 <th
                   key={col.key}
                   onClick={() => toggleSort(col.key)}
-                  className={`text-right py-2 px-2 text-gray-500 font-medium cursor-pointer hover:text-white transition-colors ${col.width}`}
+                  className={`text-right py-2 px-2 text-muted-foreground font-medium cursor-pointer hover:text-white transition-colors ${col.width}`}
                 >
                   <div className="flex items-center justify-end gap-1">
                     <span>{col.label}</span>
@@ -165,7 +165,7 @@ export function HardwareLeaderboard() {
             {rows.map(row => (
               <tr
                 key={row.rank}
-                className={`border-b border-gray-800/50 transition-colors hover:bg-gray-800/30 ${
+                className={`border-b border-border/50 transition-colors hover:bg-gray-800/30 ${
                   row.config !== 'standalone' ? 'bg-blue-500/[0.03]' : ''
                 }`}
               >

--- a/web/src/components/cards/llmd/KVCacheMonitor.tsx
+++ b/web/src/components/cards/llmd/KVCacheMonitor.tsx
@@ -554,7 +554,7 @@ export function KVCacheMonitor() {
         <div className="absolute inset-0 flex flex-col items-center justify-center z-20 bg-gray-900/60 backdrop-blur-sm rounded-lg">
           <div className="w-12 h-12 rounded-full border-2 border-gray-600 border-t-cyan-500 animate-spin mb-4" />
           <span className="text-muted-foreground text-sm">{t('llmd.selectStackMonitor')}</span>
-          <span className="text-gray-500 text-xs mt-1">{t('llmd.useStackSelector')}</span>
+          <span className="text-muted-foreground text-xs mt-1">{t('llmd.useStackSelector')}</span>
         </div>
       )}
       {/* Header */}
@@ -717,7 +717,7 @@ export function KVCacheMonitor() {
                                 ? metric === 'util'
                                   ? 'bg-yellow-500/20 text-yellow-400'
                                   : 'bg-green-500/20 text-green-400'
-                                : 'bg-gray-700/50 text-gray-500 hover:text-gray-300'
+                                : 'bg-gray-700/50 text-muted-foreground hover:text-gray-300'
                             }`}
                           >
                             {metric === 'util' ? t('llmd.util') : t('llmd.hitRate')}
@@ -729,13 +729,13 @@ export function KVCacheMonitor() {
                       <div className="flex gap-3 text-xs mb-2">
                         {selectedMetrics.includes('util') && (
                           <div>
-                            <span className="text-gray-500">{t('llmd.util')}:</span>{' '}
+                            <span className="text-muted-foreground">{t('llmd.util')}:</span>{' '}
                             <span className="text-yellow-400 font-mono">{stat.utilizationPercent}%</span>
                           </div>
                         )}
                         {selectedMetrics.includes('hitRate') && (
                           <div>
-                            <span className="text-gray-500">{t('llmd.hit')}:</span>{' '}
+                            <span className="text-muted-foreground">{t('llmd.hit')}:</span>{' '}
                             <span className="text-green-400 font-mono">{Math.round(stat.hitRate * 100)}%</span>
                           </div>
                         )}

--- a/web/src/components/cards/llmd/LLMdFlow.tsx
+++ b/web/src/components/cards/llmd/LLMdFlow.tsx
@@ -967,7 +967,7 @@ export function LLMdFlow() {
         <div className="absolute inset-0 flex flex-col items-center justify-center z-20 bg-gray-900/60 backdrop-blur-sm">
           <div className="w-12 h-12 rounded-full border-2 border-gray-600 border-t-purple-500 animate-spin mb-4" />
           <span className="text-muted-foreground text-sm">{t('llmd.selectStackVisualize')}</span>
-          <span className="text-gray-500 text-xs mt-1">{t('llmd.useStackSelector')}</span>
+          <span className="text-muted-foreground text-xs mt-1">{t('llmd.useStackSelector')}</span>
         </div>
       )}
       {/* Header */}
@@ -981,7 +981,7 @@ export function LLMdFlow() {
               }`}>
                 {selectedStack.name}
               </span>
-              <span className="text-gray-500">{selectedStack.cluster}</span>
+              <span className="text-muted-foreground">{selectedStack.cluster}</span>
               {/* Autoscaler indicator */}
               {selectedStack.autoscaler && (
                 <span className={`px-1.5 py-0.5 rounded text-2xs font-medium ${
@@ -1145,7 +1145,7 @@ export function LLMdFlow() {
                   }`}
                 >
                   <div className="text-center">
-                    <div className="text-[9px] text-gray-500 uppercase">{t(`llmd.${metric}`)}</div>
+                    <div className="text-[9px] text-muted-foreground uppercase">{t(`llmd.${metric}`)}</div>
                     <div className="font-mono" style={{ color: selectedMetricTypes.includes(metric) ? metricConfig[metric].color : undefined }}>
                       {metric === 'load' ? `${selectedMetrics.load}%` :
                        metric === 'queue' ? selectedMetrics.queueDepth :
@@ -1182,7 +1182,7 @@ export function LLMdFlow() {
             </div>
 
             {/* Hint text */}
-            <div className="text-[9px] text-gray-500 mt-2 text-center">
+            <div className="text-[9px] text-muted-foreground mt-2 text-center">
               Click metrics above to compare
             </div>
           </motion.div>

--- a/web/src/components/cards/llmd/LatencyBreakdown.tsx
+++ b/web/src/components/cards/llmd/LatencyBreakdown.tsx
@@ -246,7 +246,7 @@ export function LatencyBreakdown() {
             </ComposedChart>
           </ResponsiveContainer>
         ) : (
-          <div className="h-full flex items-center justify-center text-gray-500 text-sm">
+          <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
             No data available for selected filters
           </div>
         )}

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -246,7 +246,7 @@ Please provide:
             {/* llm-d component tags */}
             {hasLLMDImages && (
               <div className="mt-1.5 pt-1.5 border-t border-gray-700">
-                <div className="text-gray-500 text-[9px] font-medium mb-0.5">llm-d components</div>
+                <div className="text-muted-foreground text-[9px] font-medium mb-0.5">llm-d components</div>
                 {Object.entries(llmdImages).map(([name, tag]) => (
                   <div key={name} className="flex items-center gap-1 whitespace-nowrap">
                     <span className="text-muted-foreground">{name}</span>
@@ -259,7 +259,7 @@ Please provide:
             {/* Other container tags */}
             {hasOtherImages && (
               <div className="mt-1.5 pt-1.5 border-t border-gray-700">
-                <div className="text-gray-500 text-[9px] font-medium mb-0.5">other images</div>
+                <div className="text-muted-foreground text-[9px] font-medium mb-0.5">other images</div>
                 {Object.entries(otherImages).map(([name, tag]) => (
                   <div key={name} className="flex items-center gap-1 whitespace-nowrap">
                     <span className="text-muted-foreground">{name}</span>
@@ -423,7 +423,7 @@ function TrendSparkline({ runs }: { runs: NightlyRun[] }) {
 
   return (
     <div className="bg-gray-800/60 border border-gray-700/50 rounded-lg p-2">
-      <div className="text-2xs text-gray-500 uppercase tracking-wider mb-1">{t('cards:llmd.passFailTrend')}</div>
+      <div className="text-2xs text-muted-foreground uppercase tracking-wider mb-1">{t('cards:llmd.passFailTrend')}</div>
       <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none">
         <defs>
           <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
@@ -695,7 +695,7 @@ function GuideDetailPanel({ guide, hoveredRun, onRunHover }: {
           </span>
           <span className="text-sm font-semibold text-gray-200 truncate">{guide.guide}</span>
         </div>
-        <div className="flex items-center gap-2 text-2xs text-gray-500">
+        <div className="flex items-center gap-2 text-2xs text-muted-foreground">
           <span style={{ color: PLATFORM_COLORS[guide.platform] }}>{guide.platform}</span>
           <span>&middot;</span>
           <a href={workflowUrl} target="_blank" rel="noopener noreferrer"
@@ -714,11 +714,11 @@ function GuideDetailPanel({ guide, hoveredRun, onRunHover }: {
       <div className={`grid ${gpuFails > 0 ? 'grid-cols-6' : 'grid-cols-5'} gap-1.5 mb-2`}>
         <div className="col-span-1 bg-gray-800/60 border border-gray-700/50 rounded-lg p-2 text-center">
           <div className={`text-lg font-bold ${
-            guide.passRate >= 90 ? 'text-green-400' : guide.passRate >= 70 ? 'text-yellow-400' : guide.passRate > 0 ? 'text-red-400' : 'text-gray-500'
+            guide.passRate >= 90 ? 'text-green-400' : guide.passRate >= 70 ? 'text-yellow-400' : guide.passRate > 0 ? 'text-red-400' : 'text-muted-foreground'
           }`}>
             {guide.passRate}%
           </div>
-          <div className="text-[8px] text-gray-500 uppercase tracking-wider">{t('common:common.rate')}</div>
+          <div className="text-[8px] text-muted-foreground uppercase tracking-wider">{t('common:common.rate')}</div>
         </div>
         <StatBox label={t('cards:llmd.pass')} value={String(passed)} color="text-green-400" />
         <StatBox label={t('cards:llmd.fail')} value={String(failed)} color="text-red-400" />
@@ -760,52 +760,52 @@ function GuideDetailPanel({ guide, hoveredRun, onRunHover }: {
           </div>
         )}
         <div className="flex items-center justify-between text-[11px]">
-          <span className="text-gray-500">{t('cards:llmd.model')}</span>
+          <span className="text-muted-foreground">{t('cards:llmd.model')}</span>
           <span className={`font-mono text-2xs truncate max-w-[140px] ${hoveredRun ? 'text-gray-200' : 'text-gray-300'}`} title={displayModel}>{displayModel}</span>
         </div>
         <div className="flex items-center justify-between text-[11px]">
-          <span className="text-gray-500">{t('cards:llmd.gpu')}</span>
+          <span className="text-muted-foreground">{t('cards:llmd.gpu')}</span>
           <span className={`font-mono text-2xs ${hoveredRun ? 'text-gray-200' : 'text-gray-300'}`}>
             {displayGpuCount > 0 ? `${displayGpuCount}× ${displayGpuType}` : displayGpuType}
           </span>
         </div>
         {hoveredRun && runDur !== null ? (
           <div className="flex items-center justify-between text-[11px]">
-            <span className="text-gray-500">{t('cards:llmd.duration')}</span>
+            <span className="text-muted-foreground">{t('cards:llmd.duration')}</span>
             <span className="text-gray-200 font-mono">{formatDuration(runDur)}</span>
           </div>
         ) : avgDur !== null ? (
           <div className="flex items-center justify-between text-[11px]">
-            <span className="text-gray-500">{t('cards:llmd.avgDuration')}</span>
+            <span className="text-muted-foreground">{t('cards:llmd.avgDuration')}</span>
             <span className="text-gray-300 font-mono">{formatDuration(avgDur)}</span>
           </div>
         ) : null}
         <div className="h-px bg-gray-700/30 my-0.5" />
         {lastSuccess && (
           <div className="flex items-center justify-between text-[11px]">
-            <span className="text-gray-500">{t('cards:llmd.lastPass')}</span>
+            <span className="text-muted-foreground">{t('cards:llmd.lastPass')}</span>
             <span className="text-green-400 font-mono">{formatTimeAgo(lastSuccess.updatedAt)}</span>
           </div>
         )}
         {lastFailure && (
           <div className="flex items-center justify-between text-[11px]">
-            <span className="text-gray-500">{t('cards:llmd.lastFail')}</span>
+            <span className="text-muted-foreground">{t('cards:llmd.lastFail')}</span>
             <span className="text-red-400 font-mono">{formatTimeAgo(lastFailure.updatedAt)}</span>
           </div>
         )}
         <div className="flex items-center justify-between text-[11px]">
-          <span className="text-gray-500">{t('cards:llmd.totalRuns')}</span>
+          <span className="text-muted-foreground">{t('cards:llmd.totalRuns')}</span>
           <span className="text-gray-300 font-mono">{guide.runs.length}</span>
         </div>
         <div className="flex items-center justify-between text-[11px]">
-          <span className="text-gray-500">{t('cards:llmd.trend')}</span>
+          <span className="text-muted-foreground">{t('cards:llmd.trend')}</span>
           <TrendIndicator trend={guide.trend} passRate={guide.passRate} />
         </div>
       </div>
 
       {/* Run history dots — hover to see per-run details above */}
       <div className="mt-auto pt-2 border-t border-gray-700/30">
-        <div className="text-2xs text-gray-500 mb-1.5">
+        <div className="text-2xs text-muted-foreground mb-1.5">
           {hoveredRun ? t('cards:llmd.runHistoryNewest') : `${t('cards:llmd.runHistoryNewest')} — ${t('cards:llmd.hoverDotForDetails')}`}
         </div>
         <div className="flex items-center gap-1 flex-wrap">
@@ -829,7 +829,7 @@ function StatBox({ label, value, color }: { label: string; value: string; color:
   return (
     <div className="bg-gray-800/40 border border-gray-700/30 rounded-lg p-2 text-center">
       <div className={`text-base font-bold ${color}`}>{value}</div>
-      <div className="text-[9px] text-gray-500 uppercase tracking-wider">{label}</div>
+      <div className="text-[9px] text-muted-foreground uppercase tracking-wider">{label}</div>
     </div>
   )
 }
@@ -982,7 +982,7 @@ export function NightlyE2EStatus() {
                   {platform}
                 </span>
                 <div className="flex-1 h-px bg-gray-700/50" />
-                <span className="text-2xs text-gray-500">
+                <span className="text-2xs text-muted-foreground">
                   {platformGuides.filter(g => g.latestConclusion === 'success').length}/{platformGuides.length} {t('cards:llmd.passing')}
                 </span>
               </div>
@@ -1012,14 +1012,14 @@ export function NightlyE2EStatus() {
           ) : (
             <div className="h-full flex flex-col items-center justify-center text-center gap-2">
               <TestTube2 size={20} className="text-gray-600" />
-              <p className="text-[11px] text-gray-500">{t('cards:llmd.hoverTestDetails')}</p>
+              <p className="text-[11px] text-muted-foreground">{t('cards:llmd.hoverTestDetails')}</p>
             </div>
           )}
         </div>
       </div>
 
       {/* Legend */}
-      <div className="flex items-center justify-center gap-4 text-2xs text-gray-500 pt-1 border-t border-gray-700/30">
+      <div className="flex items-center justify-center gap-4 text-2xs text-muted-foreground pt-1 border-t border-gray-700/30">
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-full bg-green-400" />
           <span>{t('cards:llmd.pass')}</span>

--- a/web/src/components/cards/llmd/PDDisaggregation.tsx
+++ b/web/src/components/cards/llmd/PDDisaggregation.tsx
@@ -361,12 +361,12 @@ export function PDDisaggregation() {
       {/* Empty state for non-disaggregated stacks */}
       {selectedStack && !hasDisaggregation && !isDemoMode && (
         <div className="flex-1 flex flex-col items-center justify-center text-center p-6">
-          <AlertCircle size={32} className="text-gray-500 mb-3" />
+          <AlertCircle size={32} className="text-muted-foreground mb-3" />
           <span className="text-muted-foreground text-sm font-medium">{t('llmd.unifiedServingMode')}</span>
-          <span className="text-gray-500 text-xs mt-1">
+          <span className="text-muted-foreground text-xs mt-1">
             {t('llmd.stackUsesUnified')}
           </span>
-          <span className="text-gray-500 text-xs">
+          <span className="text-muted-foreground text-xs">
             {t('llmd.disaggregationAvailable')}
           </span>
         </div>
@@ -377,7 +377,7 @@ export function PDDisaggregation() {
         <div className="flex-1 flex flex-col items-center justify-center text-center p-6">
           <div className="w-12 h-12 rounded-full border-2 border-gray-600 border-t-cyan-500 animate-spin mb-4" />
           <span className="text-muted-foreground text-sm">{t('llmd.selectStackDisaggregation')}</span>
-          <span className="text-gray-500 text-xs mt-1">{t('llmd.useStackSelector')}</span>
+          <span className="text-muted-foreground text-xs mt-1">{t('llmd.useStackSelector')}</span>
         </div>
       )}
 

--- a/web/src/components/cards/llmd/PerformanceTimeline.tsx
+++ b/web/src/components/cards/llmd/PerformanceTimeline.tsx
@@ -136,7 +136,7 @@ export function PerformanceTimeline() {
         <div className="flex items-center gap-2">
           <LayoutGrid size={14} className="text-purple-400" />
           <span className="text-sm font-medium text-white">Sequence Length Impact</span>
-          <span className="text-2xs text-gray-500">ISL × OSL → {modeInfo.label}</span>
+          <span className="text-2xs text-muted-foreground">ISL × OSL → {modeInfo.label}</span>
         </div>
         <div className="flex items-center gap-2">
           <select
@@ -178,7 +178,7 @@ export function PerformanceTimeline() {
         {cells.length > 0 ? (
           <div className="relative">
             {/* Y-axis label */}
-            <div className="absolute -left-8 top-1/2 -translate-y-1/2 -rotate-90 text-2xs text-gray-500 flex items-center gap-1 whitespace-nowrap">
+            <div className="absolute -left-8 top-1/2 -translate-y-1/2 -rotate-90 text-2xs text-muted-foreground flex items-center gap-1 whitespace-nowrap">
               <ArrowDown size={10} className="rotate-90" />
               OSL (Output Seq Len)
             </div>
@@ -193,7 +193,7 @@ export function PerformanceTimeline() {
                 ))}
               </div>
               <div className="flex items-center gap-1 mb-2 pl-16">
-                <div className="flex-1 text-center text-2xs text-gray-500 flex items-center justify-center gap-1">
+                <div className="flex-1 text-center text-2xs text-muted-foreground flex items-center justify-center gap-1">
                   <ArrowRight size={10} />
                   ISL (Input Seq Len)
                 </div>
@@ -242,7 +242,7 @@ export function PerformanceTimeline() {
             )}
           </div>
         ) : (
-          <div className="text-gray-500 text-sm">No data for selected filters</div>
+          <div className="text-muted-foreground text-sm">No data for selected filters</div>
         )}
       </div>
 

--- a/web/src/components/cards/llmd/ResourceUtilization.tsx
+++ b/web/src/components/cards/llmd/ResourceUtilization.tsx
@@ -223,7 +223,7 @@ export function ResourceUtilization() {
             </BarChart>
           </ResponsiveContainer>
         ) : (
-          <div className="h-full flex items-center justify-center text-gray-500 text-sm">
+          <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
             No data for QPS {effectiveQps}
           </div>
         )}

--- a/web/src/components/cards/llmd/StackSelector.tsx
+++ b/web/src/components/cards/llmd/StackSelector.tsx
@@ -137,7 +137,7 @@ const StackOption = memo(function StackOption({ stack, isSelected, onSelect }: S
             </span>
           )}
           {prefillCount === 0 && decodeCount === 0 && unifiedCount === 0 && (
-            <span className="text-gray-500 italic" title="No running pods - scaled to 0">
+            <span className="text-muted-foreground italic" title="No running pods - scaled to 0">
               0 pods
             </span>
           )}
@@ -152,7 +152,7 @@ const StackOption = memo(function StackOption({ stack, isSelected, onSelect }: S
         </span>
 
         {/* Cluster */}
-        <span className="px-1.5 py-0.5 rounded bg-gray-800 text-gray-500">
+        <span className="px-1.5 py-0.5 rounded bg-gray-800 text-muted-foreground">
           {stack.cluster}
         </span>
 
@@ -190,7 +190,7 @@ const StackOption = memo(function StackOption({ stack, isSelected, onSelect }: S
 
         {/* Model name */}
         {stack.model && (
-          <span className="text-gray-500 truncate max-w-[120px] ml-auto" title={`model: ${stack.model}`}>
+          <span className="text-muted-foreground truncate max-w-[120px] ml-auto" title={`model: ${stack.model}`}>
             {stack.model}
           </span>
         )}
@@ -231,7 +231,7 @@ export function StackSelector() {
   // If no context, show placeholder
   if (!stackContext) {
     return (
-      <div className="flex items-center gap-2 px-3 py-1.5 rounded bg-gray-800/50 text-gray-500 text-sm">
+      <div className="flex items-center gap-2 px-3 py-1.5 rounded bg-gray-800/50 text-muted-foreground text-sm">
         <Layers className="w-4 h-4" />
         <span>{t('common.noStackData')}</span>
       </div>
@@ -347,7 +347,7 @@ export function StackSelector() {
             <span className="text-sm font-medium text-white max-w-[140px] truncate">
               {selectedStack.name}
             </span>
-            <span className="text-2xs text-gray-500">ns:{selectedStack.namespace}</span>
+            <span className="text-2xs text-muted-foreground">ns:{selectedStack.namespace}</span>
 
             {/* P/D replica counts */}
             {(() => {
@@ -401,7 +401,7 @@ export function StackSelector() {
                 <span className="text-sm font-medium text-white">
                   🎯 Focus on a Stack
                 </span>
-                <p className="text-2xs text-gray-500 mt-0.5">
+                <p className="text-2xs text-muted-foreground mt-0.5">
                   Select an inference stack to visualize its metrics
                 </p>
               </div>
@@ -440,7 +440,7 @@ export function StackSelector() {
               {/* Search input */}
               <div className="px-3 pb-2">
                 <div className="relative">
-                  <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-500" />
+                  <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
                   <input
                     ref={searchInputRef}
                     type="text"
@@ -452,7 +452,7 @@ export function StackSelector() {
                   {searchQuery && (
                     <button
                       onClick={() => setSearchQuery('')}
-                      className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-gray-700 text-gray-500 hover:text-white"
+                      className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-gray-700 text-muted-foreground hover:text-white"
                     >
                       <X className="w-3 h-3" />
                     </button>
@@ -462,7 +462,7 @@ export function StackSelector() {
 
               {/* Sort options */}
               <div className="px-3 pb-2 flex items-center gap-1">
-                <span className="text-2xs text-gray-500 mr-1">Sort:</span>
+                <span className="text-2xs text-muted-foreground mr-1">Sort:</span>
                 {(['status', 'name', 'accelerators', 'replicas'] as SortField[]).map(field => (
                   <button
                     key={field}
@@ -506,11 +506,11 @@ export function StackSelector() {
                   </div>
                 ))
               ) : isLoading ? (
-                <div className="px-3 py-4 text-center text-gray-500 text-sm">
+                <div className="px-3 py-4 text-center text-muted-foreground text-sm">
                   Loading stacks...
                 </div>
               ) : (
-                <div className="px-3 py-4 text-center text-gray-500 text-sm">
+                <div className="px-3 py-4 text-center text-muted-foreground text-sm">
                   {searchQuery ? 'No stacks match your search' : 'No llm-d stacks found'}
                 </div>
               )}

--- a/web/src/components/cards/llmd/ThroughputComparison.tsx
+++ b/web/src/components/cards/llmd/ThroughputComparison.tsx
@@ -196,7 +196,7 @@ export function ThroughputComparison() {
             </ComposedChart>
           </ResponsiveContainer>
         ) : (
-          <div className="h-full flex items-center justify-center text-gray-500 text-sm">
+          <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
             No data available for selected filters
           </div>
         )}

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,0 +1,70 @@
+import { type ButtonHTMLAttributes, type ReactNode, forwardRef } from 'react'
+import { cn } from '../../lib/cn'
+
+type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost' | 'accent'
+type ButtonSize = 'sm' | 'md' | 'lg'
+
+const VARIANT_MAP: Record<ButtonVariant, string> = {
+  primary: 'bg-blue-600 hover:bg-blue-700 text-white',
+  secondary: 'bg-secondary hover:bg-secondary/80 text-foreground',
+  danger: 'bg-red-600 hover:bg-red-700 text-white',
+  ghost: 'hover:bg-secondary/50 text-muted-foreground hover:text-foreground',
+  accent: 'bg-purple-500/20 hover:bg-purple-500/30 text-purple-400',
+}
+
+const SIZE_MAP: Record<ButtonSize, string> = {
+  sm: 'px-2 py-1 text-xs gap-1',
+  md: 'px-3 py-1.5 text-sm gap-1.5',
+  lg: 'px-4 py-2 text-sm gap-2',
+}
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  icon?: ReactNode
+  iconRight?: ReactNode
+  loading?: boolean
+  fullWidth?: boolean
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    variant = 'secondary',
+    size = 'md',
+    icon,
+    iconRight,
+    loading,
+    fullWidth,
+    disabled,
+    className,
+    children,
+    ...props
+  },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      disabled={disabled || loading}
+      className={cn(
+        'inline-flex items-center justify-center rounded-lg font-medium transition-colors',
+        'disabled:opacity-50 disabled:cursor-not-allowed',
+        SIZE_MAP[size],
+        VARIANT_MAP[variant],
+        fullWidth && 'w-full',
+        className,
+      )}
+      {...props}
+    >
+      {loading ? (
+        <span className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+      ) : icon ? (
+        icon
+      ) : null}
+      {children}
+      {iconRight}
+    </button>
+  )
+})
+
+export type { ButtonVariant, ButtonSize }

--- a/web/src/components/ui/StatusBadge.tsx
+++ b/web/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,69 @@
+import { type ReactNode } from 'react'
+import { cn } from '../../lib/cn'
+
+type BadgeColor = 'green' | 'red' | 'yellow' | 'blue' | 'purple' | 'orange' | 'cyan' | 'gray'
+type BadgeSize = 'xs' | 'sm' | 'md'
+type BadgeVariant = 'default' | 'outline' | 'solid'
+
+const COLOR_MAP: Record<BadgeColor, { bg: string; text: string; border: string; solid: string }> = {
+  green:  { bg: 'bg-green-500/20',  text: 'text-green-400',  border: 'border-green-500/30',  solid: 'bg-green-600 text-white' },
+  red:    { bg: 'bg-red-500/20',    text: 'text-red-400',    border: 'border-red-500/30',    solid: 'bg-red-600 text-white' },
+  yellow: { bg: 'bg-yellow-500/20', text: 'text-yellow-400', border: 'border-yellow-500/30', solid: 'bg-yellow-600 text-white' },
+  blue:   { bg: 'bg-blue-500/20',   text: 'text-blue-400',   border: 'border-blue-500/30',   solid: 'bg-blue-600 text-white' },
+  purple: { bg: 'bg-purple-500/20', text: 'text-purple-400', border: 'border-purple-500/30', solid: 'bg-purple-600 text-white' },
+  orange: { bg: 'bg-orange-500/20', text: 'text-orange-400', border: 'border-orange-500/30', solid: 'bg-orange-600 text-white' },
+  cyan:   { bg: 'bg-cyan-500/20',   text: 'text-cyan-400',   border: 'border-cyan-500/30',   solid: 'bg-cyan-600 text-white' },
+  gray:   { bg: 'bg-secondary',     text: 'text-muted-foreground', border: 'border-border', solid: 'bg-secondary text-foreground' },
+}
+
+const SIZE_MAP: Record<BadgeSize, string> = {
+  xs: 'text-2xs px-1.5 py-0.5',
+  sm: 'text-xs px-1.5 py-0.5',
+  md: 'text-xs px-2 py-1',
+}
+
+interface StatusBadgeProps {
+  children: ReactNode
+  color: BadgeColor
+  size?: BadgeSize
+  variant?: BadgeVariant
+  rounded?: 'default' | 'full'
+  icon?: ReactNode
+  className?: string
+}
+
+export function StatusBadge({
+  children,
+  color,
+  size = 'sm',
+  variant = 'default',
+  rounded = 'default',
+  icon,
+  className,
+}: StatusBadgeProps) {
+  const colors = COLOR_MAP[color]
+  const roundedClass = rounded === 'full' ? 'rounded-full' : 'rounded'
+
+  const variantClasses = {
+    default: cn(colors.bg, colors.text),
+    outline: cn(colors.bg, colors.text, 'border', colors.border),
+    solid: colors.solid,
+  }
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 font-medium whitespace-nowrap',
+        SIZE_MAP[size],
+        roundedClass,
+        variantClasses[variant],
+        className,
+      )}
+    >
+      {icon}
+      {children}
+    </span>
+  )
+}
+
+export type { BadgeColor, BadgeSize, BadgeVariant }

--- a/web/src/components/widget/MiniDashboard.tsx
+++ b/web/src/components/widget/MiniDashboard.tsx
@@ -55,7 +55,7 @@ function StatCard({
     >
       <span className={cn('text-2xl font-bold', color)}>{value}</span>
       <span className="text-xs text-muted-foreground mt-1">{label}</span>
-      {subValue && <span className="text-2xs text-gray-500">{subValue}</span>}
+      {subValue && <span className="text-2xs text-muted-foreground">{subValue}</span>}
     </button>
   )
 }
@@ -311,7 +311,7 @@ export function MiniDashboard() {
         </div>
         <div className="flex items-center gap-2">
           {lastUpdated && (
-            <span className="text-xs text-gray-500">
+            <span className="text-xs text-muted-foreground">
               {lastUpdated.toLocaleTimeString()}
             </span>
           )}
@@ -404,7 +404,7 @@ export function MiniDashboard() {
                     )}
                   />
                   <span className="truncate text-gray-300">{issue.name}</span>
-                  <span className="text-gray-500 ml-auto flex-shrink-0">{issue.reason || issue.status}</span>
+                  <span className="text-muted-foreground ml-auto flex-shrink-0">{issue.reason || issue.status}</span>
                 </button>
               )
             })}
@@ -425,7 +425,7 @@ export function MiniDashboard() {
             Install as Desktop Widget
           </button>
         ) : !isInstalled ? (
-          <div className="text-center text-xs text-gray-500 space-y-1">
+          <div className="text-center text-xs text-muted-foreground space-y-1">
             {isSafariBrowser ? (
               <p>Safari: <strong>File → Add to Dock</strong> to install</p>
             ) : (
@@ -436,7 +436,7 @@ export function MiniDashboard() {
             )}
           </div>
         ) : (
-          <div className="flex items-center justify-between text-xs text-gray-500">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
             <span>Nodes Widget</span>
             <button
               onClick={openFullDashboard}

--- a/web/src/lib/unified/card/UnifiedCard.tsx
+++ b/web/src/lib/unified/card/UnifiedCard.tsx
@@ -250,13 +250,13 @@ function PlaceholderVisualization({
   columns?: number
 }) {
   return (
-    <div className="flex flex-col items-center justify-center p-6 text-gray-500 border border-dashed border-gray-700 rounded-lg m-2">
+    <div className="flex flex-col items-center justify-center p-6 text-muted-foreground border border-dashed border-border rounded-lg m-2">
       <Info className="w-8 h-8 mb-2 text-blue-400" />
       <div className="text-sm font-medium">Visualization: {type}</div>
       <div className="text-xs mt-1">
         {itemCount} items{columns ? `, ${columns} columns` : ''}
       </div>
-      <div className="text-xs mt-2 text-gray-600">
+      <div className="text-xs mt-2 text-muted-foreground">
         (Implementation pending - PR 2/4)
       </div>
     </div>
@@ -354,7 +354,7 @@ function EmptyState({
       </div>
       <div className="text-sm font-medium text-gray-300">{title}</div>
       {message && (
-        <div className="text-xs text-gray-500 mt-1">{message}</div>
+        <div className="text-xs text-muted-foreground mt-1">{message}</div>
       )}
     </div>
   )
@@ -374,11 +374,11 @@ function ErrorState({
     <div className="flex flex-col items-center justify-center p-6 text-center">
       <AlertTriangle className="w-8 h-8 text-red-400 mb-2" />
       <div className="text-sm font-medium text-gray-300">Error loading data</div>
-      <div className="text-xs text-gray-500 mt-1">{message}</div>
+      <div className="text-xs text-muted-foreground mt-1">{message}</div>
       {onRetry && (
         <button
           onClick={onRetry}
-          className="mt-3 px-3 py-1 text-xs bg-gray-800 hover:bg-gray-700 rounded transition-colors"
+          className="mt-3 px-3 py-1 text-xs bg-secondary hover:bg-secondary/80 rounded transition-colors"
         >
           Retry
         </button>
@@ -402,12 +402,12 @@ function InlineStats({
   data: unknown[] | undefined
 }) {
   return (
-    <div className="flex items-center gap-3 px-2 py-1.5 border-b border-gray-800">
+    <div className="flex items-center gap-3 px-2 py-1.5 border-b border-border">
       {stats.map((stat) => (
         <div key={stat.id} className="flex items-center gap-1.5 text-xs">
           <div className={`w-2 h-2 rounded-full ${stat.bgColor ?? 'bg-gray-600'}`} />
           <span className="text-muted-foreground">{stat.label}:</span>
-          <span className="font-medium text-gray-200">--</span>
+          <span className="font-medium text-foreground">--</span>
         </div>
       ))}
     </div>
@@ -425,13 +425,13 @@ function CardFooter({
   data: unknown[] | undefined
 }) {
   return (
-    <div className="flex items-center justify-between px-2 py-1.5 text-xs text-gray-500 border-t border-gray-800">
+    <div className="flex items-center justify-between px-2 py-1.5 text-xs text-muted-foreground border-t border-border">
       {config.showTotal && data && (
         <span>{data.length} items</span>
       )}
       {config.text && <span>{config.text}</span>}
       {config.pagination && (
-        <span className="text-gray-600">Pagination placeholder</span>
+        <span className="text-muted-foreground">Pagination placeholder</span>
       )}
     </div>
   )

--- a/web/src/lib/unified/card/UnifiedCardAdapter.tsx
+++ b/web/src/lib/unified/card/UnifiedCardAdapter.tsx
@@ -354,7 +354,7 @@ export function UnifiedCardAdapter({
 
   // If no legacy renderer provided, show placeholder
   return (
-    <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+    <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
       Card not available
     </div>
   )

--- a/web/src/lib/unified/card/hooks/useCardFiltering.ts
+++ b/web/src/lib/unified/card/hooks/useCardFiltering.ts
@@ -117,7 +117,7 @@ export function useCardFiltering(
 
     return createElement(
       'div',
-      { className: 'flex items-center gap-2 p-2 border-b border-gray-800' },
+      { className: 'flex items-center gap-2 p-2 border-b border-border' },
       filters.map((filter) =>
         createElement(FilterControl, {
           key: filter.field,
@@ -158,7 +158,7 @@ function FilterControl({
         value: (value as string) ?? '',
         onChange: (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
         className:
-          'flex-1 px-3 py-1.5 text-sm bg-gray-800 border border-gray-700 rounded focus:outline-none focus:border-blue-500 text-gray-200 placeholder-gray-500',
+          'flex-1 px-3 py-1.5 text-sm bg-secondary border border-border rounded focus:outline-none focus:border-blue-500 text-foreground placeholder-muted-foreground',
       })
 
     case 'select':
@@ -170,7 +170,7 @@ function FilterControl({
           onChange: (e: React.ChangeEvent<HTMLSelectElement>) =>
             onChange(e.target.value || undefined),
           className:
-            'px-3 py-1.5 text-sm bg-gray-900 border border-gray-600 rounded focus:outline-none focus:border-blue-500 text-gray-200',
+            'px-3 py-1.5 text-sm bg-background border border-border rounded focus:outline-none focus:border-blue-500 text-foreground',
         },
         createElement('option', { value: '' }, config.placeholder ?? 'All'),
         config.options?.map((opt) =>
@@ -186,7 +186,7 @@ function FilterControl({
           type: 'checkbox',
           checked: (value as boolean) ?? false,
           onChange: (e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.checked),
-          className: 'rounded border-gray-700 bg-gray-800',
+          className: 'rounded border-border bg-secondary',
         }),
         config.label ?? config.field
       )
@@ -198,7 +198,7 @@ function FilterControl({
         'div',
         { className: 'flex items-center gap-1 text-xs' },
         createElement('span', { className: 'text-muted-foreground' }, config.label ?? config.field),
-        createElement('span', { className: 'text-gray-500' }, '(multi-select)')
+        createElement('span', { className: 'text-muted-foreground' }, '(multi-select)')
       )
 
     default:

--- a/web/src/lib/unified/card/renderers/registry.ts
+++ b/web/src/lib/unified/card/renderers/registry.ts
@@ -87,7 +87,7 @@ function renderText(
   column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const text = String(value)
@@ -106,12 +106,12 @@ function renderNumber(
   column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const num = typeof value === 'number' ? value : parseFloat(String(value))
   if (isNaN(num)) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const prefix = column.prefix ?? ''
@@ -133,12 +133,12 @@ function renderPercentage(
   column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const num = typeof value === 'number' ? value : parseFloat(String(value))
   if (isNaN(num)) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const prefix = column.prefix ?? ''
@@ -160,12 +160,12 @@ function renderBytes(
   column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const num = typeof value === 'number' ? value : parseFloat(String(value))
   if (isNaN(num)) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const prefix = column.prefix ?? ''
@@ -187,12 +187,12 @@ function renderDuration(
   column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const num = typeof value === 'number' ? value : parseFloat(String(value))
   if (isNaN(num)) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const prefix = column.prefix ?? ''
@@ -214,7 +214,7 @@ function renderDate(
   _column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   try {
@@ -225,7 +225,7 @@ function renderDate(
       date.toLocaleDateString()
     )
   } catch {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 }
 
@@ -238,7 +238,7 @@ function renderDateTime(
   _column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   try {
@@ -249,7 +249,7 @@ function renderDateTime(
       date.toLocaleString()
     )
   } catch {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 }
 
@@ -262,7 +262,7 @@ function renderRelativeTime(
   _column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   try {
@@ -289,7 +289,7 @@ function renderRelativeTime(
     const years = Math.floor(days / 365)
     return `${years}y ago`
   } catch {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 }
 
@@ -302,7 +302,7 @@ function renderStatusBadge(
   _column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const status = String(value)
@@ -326,7 +326,7 @@ function renderClusterBadge(
   _column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const cluster = String(value)
@@ -349,7 +349,7 @@ function renderNamespaceBadge(
   _column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const namespace = String(value)
@@ -372,12 +372,12 @@ function renderProgressBar(
   _column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const num = typeof value === 'number' ? value : parseFloat(String(value))
   if (isNaN(num)) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   // Clamp to 0-100
@@ -421,7 +421,7 @@ function renderBoolean(
   return createElement(
     'span',
     {
-      className: bool ? 'text-green-400' : 'text-gray-500',
+      className: bool ? 'text-green-400' : 'text-muted-foreground',
     },
     bool ? '✓' : '✗'
   )
@@ -436,7 +436,7 @@ function renderIcon(
   _column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   // For now, just render the value - icon lookup can be added later
@@ -456,7 +456,7 @@ function renderJson(
   _column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, 'null')
+    return createElement('span', { className: 'text-muted-foreground' }, 'null')
   }
 
   try {
@@ -467,7 +467,7 @@ function renderJson(
       json
     )
   } catch {
-    return createElement('span', { className: 'text-gray-500' }, '[Object]')
+    return createElement('span', { className: 'text-muted-foreground' }, '[Object]')
   }
 }
 
@@ -480,7 +480,7 @@ function renderTruncate(
   _column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const text = String(value)
@@ -504,7 +504,7 @@ function renderLink(
   _column: CardColumnConfig
 ): ReactNode {
   if (value === null || value === undefined) {
-    return createElement('span', { className: 'text-gray-500' }, '—')
+    return createElement('span', { className: 'text-muted-foreground' }, '—')
   }
 
   const url = String(value)

--- a/web/src/lib/unified/card/visualizations/ChartVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/ChartVisualization.tsx
@@ -134,7 +134,7 @@ export function ChartVisualization({ content, data }: ChartVisualizationProps) {
 
     default:
       return (
-        <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+        <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
           Unknown chart type: {chartType}
         </div>
       )
@@ -484,7 +484,7 @@ function GaugeChartRenderer({
       </ResponsiveContainer>
       {/* Center label */}
       <div className="absolute inset-0 flex items-center justify-center pt-4">
-        <span className="text-2xl font-bold text-gray-200">{Math.round(value)}%</span>
+        <span className="text-2xl font-bold text-foreground">{Math.round(value)}%</span>
       </div>
     </div>
   )
@@ -499,7 +499,7 @@ function SparklineRenderer({
   height,
 }: Omit<ChartRendererProps, 'xAxis' | 'yAxis' | 'showLegend'>) {
   if (series.length === 0) {
-    return <div className="text-gray-500 text-sm">No series configured</div>
+    return <div className="text-muted-foreground text-sm">No series configured</div>
   }
 
   const primarySeries = series[0]

--- a/web/src/lib/unified/card/visualizations/ListVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/ListVisualization.tsx
@@ -135,15 +135,15 @@ export function ListVisualization({
     <div className="flex flex-col h-full">
       {/* Sort controls */}
       {sortable && availableSortOptions.length > 0 && (
-        <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-800">
-          <ArrowUpDown className="w-3.5 h-3.5 text-gray-500" />
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
+          <ArrowUpDown className="w-3.5 h-3.5 text-muted-foreground" />
           <select
             value={sortBy || ''}
             onChange={(e) => {
               setSortBy(e.target.value || undefined)
               setCurrentPage(0) // Reset to first page on sort change
             }}
-            className="px-2 py-1 text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 focus:outline-none focus:border-blue-500"
+            className="px-2 py-1 text-xs bg-secondary border border-border rounded text-foreground focus:outline-none focus:border-blue-500"
           >
             <option value="">Sort by...</option>
             {availableSortOptions.map((opt) => (
@@ -155,7 +155,7 @@ export function ListVisualization({
           {sortBy && (
             <button
               onClick={toggleSortDirection}
-              className="flex items-center gap-1 px-2 py-1 text-xs bg-gray-800 border border-gray-700 rounded text-gray-200 hover:bg-gray-700 transition-colors"
+              className="flex items-center gap-1 px-2 py-1 text-xs bg-secondary border border-border rounded text-foreground hover:bg-secondary/80 transition-colors"
               title={sortDirection === 'asc' ? 'Ascending (click to reverse)' : 'Descending (click to reverse)'}
             >
               {sortDirection === 'asc' ? (
@@ -177,7 +177,7 @@ export function ListVisualization({
       {/* List content */}
       <div className="flex-1 overflow-y-auto scroll-enhanced">
         {paginatedData.length === 0 ? (
-          <div className="flex items-center justify-center h-full text-gray-500 text-sm">
+          <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
             No items to display
           </div>
         ) : (
@@ -200,7 +200,7 @@ export function ListVisualization({
 
       {/* Pagination footer */}
       {totalPages > 1 && (
-        <div className="flex items-center justify-between px-3 py-2 border-t border-gray-800 text-xs text-muted-foreground">
+        <div className="flex items-center justify-between px-3 py-2 border-t border-border text-xs text-muted-foreground">
           <span>
             {currentPage * pageSize + 1}–{Math.min((currentPage + 1) * pageSize, data.length)} of {data.length}
           </span>
@@ -208,7 +208,7 @@ export function ListVisualization({
             <button
               onClick={() => setCurrentPage((p) => Math.max(0, p - 1))}
               disabled={currentPage === 0}
-              className="p-1 rounded hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="p-1 rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <ChevronLeft className="w-4 h-4" />
             </button>
@@ -218,7 +218,7 @@ export function ListVisualization({
             <button
               onClick={() => setCurrentPage((p) => Math.min(totalPages - 1, p + 1))}
               disabled={currentPage >= totalPages - 1}
-              className="p-1 rounded hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="p-1 rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <ChevronRight className="w-4 h-4" />
             </button>
@@ -304,14 +304,14 @@ function ListItem({
     <div
       className={`flex items-center gap-3 px-3 py-2 group ${
         isClickable
-          ? 'cursor-pointer hover:bg-gray-800/50 transition-colors'
+          ? 'cursor-pointer hover:bg-secondary/50 transition-colors'
           : ''
       }`}
       onClick={isClickable ? onClick : undefined}
     >
       {/* Row number */}
       {rowNumber !== undefined && (
-        <span className="text-xs text-gray-600 w-6 text-right shrink-0">
+        <span className="text-xs text-muted-foreground w-6 text-right shrink-0">
           {rowNumber}
         </span>
       )}
@@ -328,7 +328,7 @@ function ListItem({
               ${column.width ? '' : 'flex-1'}
               ${column.align === 'center' ? 'text-center' : ''}
               ${column.align === 'right' ? 'text-right' : ''}
-              ${isPrimary ? 'font-medium text-gray-200' : 'text-muted-foreground'}
+              ${isPrimary ? 'font-medium text-foreground' : 'text-muted-foreground'}
               ${colIndex === 0 && !rowNumber ? 'flex-1' : ''}
               truncate
             `}

--- a/web/src/lib/unified/card/visualizations/StatusGridVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/StatusGridVisualization.tsx
@@ -185,7 +185,7 @@ function StatusGridItem({
       <div className="flex-1 min-w-0">
         <div className="text-xs text-muted-foreground truncate">{item.label}</div>
         {showValue && (
-          <div className="text-lg font-semibold text-gray-200 truncate">
+          <div className="text-lg font-semibold text-foreground truncate">
             {value}
           </div>
         )}

--- a/web/src/lib/unified/card/visualizations/TableVisualization.tsx
+++ b/web/src/lib/unified/card/visualizations/TableVisualization.tsx
@@ -123,8 +123,8 @@ export function TableVisualization({
       <div className="flex-1 overflow-auto">
         <table className="w-full text-sm">
           {/* Header */}
-          <thead className="sticky top-0 bg-gray-900/95 backdrop-blur-sm">
-            <tr className="border-b border-gray-800">
+          <thead className="sticky top-0 bg-background/95 backdrop-blur-sm">
+            <tr className="border-b border-border">
               {visibleColumns.map((column) => (
                 <th
                   key={column.field}
@@ -132,7 +132,7 @@ export function TableVisualization({
                     px-3 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider
                     ${column.align === 'center' ? 'text-center' : ''}
                     ${column.align === 'right' ? 'text-right' : 'text-left'}
-                    ${sortable && column.sortable !== false ? 'cursor-pointer hover:text-gray-200 select-none' : ''}
+                    ${sortable && column.sortable !== false ? 'cursor-pointer hover:text-foreground select-none' : ''}
                   `}
                   style={
                     column.width
@@ -168,7 +168,7 @@ export function TableVisualization({
               <tr>
                 <td
                   colSpan={visibleColumns.length}
-                  className="px-3 py-8 text-center text-gray-500"
+                  className="px-3 py-8 text-center text-muted-foreground"
                 >
                   No data to display
                 </td>
@@ -178,7 +178,7 @@ export function TableVisualization({
                 <tr
                   key={rowIndex}
                   className={`
-                    ${isClickable ? 'cursor-pointer hover:bg-gray-800/50' : ''}
+                    ${isClickable ? 'cursor-pointer hover:bg-secondary/50' : ''}
                     transition-colors
                   `}
                   onClick={
@@ -196,7 +196,7 @@ export function TableVisualization({
                           px-3 py-2
                           ${column.align === 'center' ? 'text-center' : ''}
                           ${column.align === 'right' ? 'text-right' : ''}
-                          ${column.primary ? 'font-medium text-gray-200' : 'text-muted-foreground'}
+                          ${column.primary ? 'font-medium text-foreground' : 'text-muted-foreground'}
                         `}
                       >
                         {renderCell(value, item as Record<string, unknown>, column)}
@@ -212,7 +212,7 @@ export function TableVisualization({
 
       {/* Pagination footer */}
       {totalPages > 1 && (
-        <div className="flex items-center justify-between px-3 py-2 border-t border-gray-800 text-xs text-muted-foreground">
+        <div className="flex items-center justify-between px-3 py-2 border-t border-border text-xs text-muted-foreground">
           <span>
             {currentPage * pageSize + 1}–{Math.min((currentPage + 1) * pageSize, sortedData.length)} of {sortedData.length}
           </span>
@@ -220,7 +220,7 @@ export function TableVisualization({
             <button
               onClick={() => setCurrentPage((p) => Math.max(0, p - 1))}
               disabled={currentPage === 0}
-              className="p-1 rounded hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="p-1 rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <ChevronLeft className="w-4 h-4" />
             </button>
@@ -230,7 +230,7 @@ export function TableVisualization({
             <button
               onClick={() => setCurrentPage((p) => Math.min(totalPages - 1, p + 1))}
               disabled={currentPage >= totalPages - 1}
-              className="p-1 rounded hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="p-1 rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed"
             >
               <ChevronRight className="w-4 h-4" />
             </button>

--- a/web/src/lib/unified/dashboard/DashboardGrid.tsx
+++ b/web/src/lib/unified/dashboard/DashboardGrid.tsx
@@ -229,7 +229,7 @@ function DashboardCardWrapper({
       <div
         ref={setNodeRef}
         style={style}
-        className={`${colSpan} glass rounded-lg p-4 flex items-center justify-center text-gray-500`}
+        className={`${colSpan} glass rounded-lg p-4 flex items-center justify-center text-muted-foreground`}
       >
         Unknown card type: {cardTypeKey || 'undefined'}
       </div>
@@ -248,7 +248,7 @@ function DashboardCardWrapper({
         {isDraggable && (
           <div
             {...listeners}
-            className="absolute top-2 left-2 z-10 cursor-grab active:cursor-grabbing p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity bg-gray-800/50"
+            className="absolute top-2 left-2 z-10 cursor-grab active:cursor-grabbing p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity bg-secondary/50"
             title="Drag to reorder"
           >
             <svg
@@ -267,7 +267,7 @@ function DashboardCardWrapper({
             {onConfigure && (
               <button
                 onClick={onConfigure}
-                className="p-1 rounded bg-gray-800/50 hover:bg-gray-700 text-muted-foreground hover:text-white transition-colors"
+                className="p-1 rounded bg-secondary/50 hover:bg-secondary/80 text-muted-foreground hover:text-white transition-colors"
                 title="Configure card"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -279,7 +279,7 @@ function DashboardCardWrapper({
             {onRemove && (
               <button
                 onClick={onRemove}
-                className="p-1 rounded bg-gray-800/50 hover:bg-red-900/50 text-muted-foreground hover:text-red-400 transition-colors"
+                className="p-1 rounded bg-secondary/50 hover:bg-red-900/50 text-muted-foreground hover:text-red-400 transition-colors"
                 title="Remove card"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -300,7 +300,7 @@ function DashboardCardWrapper({
 
         {/* Loading overlay */}
         {isLoading && !isOverlay && (
-          <div className="absolute inset-0 bg-gray-900/50 rounded-lg flex items-center justify-center">
+          <div className="absolute inset-0 bg-background/50 rounded-lg flex items-center justify-center">
             <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
           </div>
         )}

--- a/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
+++ b/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
@@ -213,7 +213,7 @@ export function UnifiedDashboard({
         <div className="flex items-center gap-2">
           {/* Last updated indicator */}
           {lastUpdated && (
-            <span className="text-xs text-gray-500">
+            <span className="text-xs text-muted-foreground">
               Updated {lastUpdated.toLocaleTimeString()}
             </span>
           )}
@@ -223,7 +223,7 @@ export function UnifiedDashboard({
             <button
               onClick={handleRefresh}
               disabled={isLoading}
-              className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 disabled:opacity-50 transition-colors"
+              className="p-2 rounded-lg bg-secondary hover:bg-secondary/80 disabled:opacity-50 transition-colors"
               title="Refresh"
             >
               <RefreshCw
@@ -236,7 +236,7 @@ export function UnifiedDashboard({
           {features.addCard !== false && (
             <button
               onClick={handleAddCard}
-              className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors"
+              className="p-2 rounded-lg bg-secondary hover:bg-secondary/80 transition-colors"
               title="Add card"
             >
               <Plus className="w-4 h-4 text-muted-foreground" />
@@ -247,7 +247,7 @@ export function UnifiedDashboard({
           {isCustomized && (
             <button
               onClick={handleReset}
-              className="px-3 py-1.5 text-xs rounded-lg bg-gray-800 hover:bg-gray-700 text-muted-foreground transition-colors"
+              className="px-3 py-1.5 text-xs rounded-lg bg-secondary hover:bg-secondary/80 text-muted-foreground transition-colors"
               title="Reset to default layout"
             >
               Reset
@@ -281,11 +281,11 @@ export function UnifiedDashboard({
       {/* Empty state */}
       {cards.length === 0 && (
         <div className="flex flex-col items-center justify-center py-16 text-center">
-          <Activity className="w-12 h-12 text-gray-600 mb-4" />
+          <Activity className="w-12 h-12 text-muted-foreground mb-4" />
           <h3 className="text-lg font-medium text-gray-300 mb-2">
             No cards configured
           </h3>
-          <p className="text-sm text-gray-500 mb-4">
+          <p className="text-sm text-muted-foreground mb-4">
             Add cards to start building your dashboard
           </p>
           {features.addCard !== false && (


### PR DESCRIPTION
## Summary

- **New `StatusBadge` component** (`components/ui/StatusBadge.tsx`) — generic badge with 8-color palette, 3 sizes (xs/sm/md), 3 variants (default/outline/solid), rounded options, icon support
- **New `Button` component** (`components/ui/Button.tsx`) — generic button with 5 variants (primary/secondary/danger/ghost/accent), 3 sizes (sm/md/lg), icon support, loading state, fullWidth option
- **Replace hardcoded gray tokens** with semantic design tokens across 29 files:
  - `text-gray-500` → `text-muted-foreground` (28 files, ~151 instances)
  - `border-gray-800` → `border-border` (unified card system)
  - `border-gray-700` → `border-border` (unified card system)
  - `bg-gray-800` → `bg-secondary` (unified card system)
  - `bg-gray-900` → `bg-background` (unified card system)
  - `text-gray-200` → `text-foreground` (unified card system)
  - `placeholder-gray-500` → `placeholder-muted-foreground`

### StatusBadge API
```tsx
<StatusBadge color="green">Running</StatusBadge>
<StatusBadge color="red" variant="outline" size="xs">Failed</StatusBadge>
<StatusBadge color="purple" icon={<Star className="w-3 h-3" />}>Featured</StatusBadge>
```

### Button API
```tsx
<Button variant="primary" icon={<Plus className="w-4 h-4" />}>Add Card</Button>
<Button variant="danger" size="sm" loading>Deleting...</Button>
<Button variant="accent">AI Action</Button>
```

## Follow-up work

- Migrate 268 card files to use `StatusBadge` (incremental adoption)
- Migrate button patterns to use `Button` component
- Replace remaining `bg-gray-800` in card-specific files (context-dependent)

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (69 errors all pre-existing)
- [x] No regressions — all gray token replacements are semantic equivalents
- [ ] Visual check: unified card system renders correctly with semantic tokens