### PR TITLE
✨ Sidebar UX: resizable width, aligned counts, slogan, setup guide modal

### DIFF
--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useMemo, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Sparkles, Plus, Loader2, LayoutGrid, Search, Wand2, Activity, Compass } from 'lucide-react'
+import { Sparkles, Plus, Loader2, LayoutGrid, Search, Wand2, Activity } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 import { useModalState } from '../../lib/modals'
 import { CardFactoryModal } from './CardFactoryModal'
@@ -10,7 +10,6 @@ import { TechnicalAcronym } from '../shared/TechnicalAcronym'
 import { useToast } from '../ui/Toast'
 import { FOCUS_DELAY_MS, RETRY_DELAY_MS } from '../../lib/constants/network'
 import { emitAddCardModalOpened, emitAddCardModalAbandoned, emitCardCategoryBrowsed, emitRecommendedCardShown } from '../../lib/analytics'
-import { useSidebarConfig, DISCOVERABLE_DASHBOARDS } from '../../hooks/useSidebarConfig'
 
 // Helper function to wrap technical abbreviations in text with tooltips
 function wrapAbbreviations(text: string): ReactNode {
@@ -988,13 +987,6 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
     return unsub
   }, [])
 
-  // Sidebar config for "Recommended Dashboards" section
-  const { config: sidebarConfig, restoreDashboard } = useSidebarConfig()
-  const availableDashboards = useMemo(() => {
-    const sidebarIds = new Set((sidebarConfig.primaryNav || []).map(item => item.id))
-    return DISCOVERABLE_DASHBOARDS.filter(d => !sidebarIds.has(d.id))
-  }, [sidebarConfig.primaryNav])
-
   // Compute recommended cards — popular cards not already on the dashboard
   const recommendedCards = useMemo(() => {
     const existing = new Set(existingCardTypes || [])
@@ -1265,30 +1257,7 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
                   </div>
                 )}
 
-                {/* Recommended Dashboards — discoverable dashboards not in the sidebar */}
-                {!browseSearch.trim() && availableDashboards.length > 0 && (
-                  <div className="mb-4 rounded-xl border border-blue-500/20 bg-blue-500/5 p-3">
-                    <h4 className="text-xs font-medium text-blue-400 uppercase tracking-wider mb-2 flex items-center gap-1.5">
-                      <Compass className="w-3.5 h-3.5" />
-                      Recommended Dashboards
-                    </h4>
-                    <p className="text-xs text-muted-foreground mb-2">
-                      Add topic-specific dashboards to your sidebar
-                    </p>
-                    <div className="flex flex-wrap gap-2">
-                      {availableDashboards.map(dashboard => (
-                        <button
-                          key={dashboard.id}
-                          onClick={() => restoreDashboard(dashboard)}
-                          className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm bg-secondary/50 border border-border/50 hover:border-blue-500/30 hover:bg-secondary text-foreground transition-all"
-                        >
-                          <span className="font-medium text-xs">{dashboard.name}</span>
-                          <Plus className="w-3 h-3 text-blue-400" />
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                )}
+                {/* Recommended Dashboards section removed — too noisy in the Add Cards modal */}
 
                 {/* Card catalog */}
                 <div className="max-h-[40vh] overflow-y-auto space-y-3">

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -37,6 +37,7 @@ import { CardRecommendations } from './CardRecommendations'
 import { safeGetItem, safeSetItem, safeGetJSON, safeSetJSON } from '../../lib/utils/localStorage'
 import { MissionSuggestions } from './MissionSuggestions'
 import { GettingStartedBanner } from './GettingStartedBanner'
+import { SidebarCustomizer } from '../layout/SidebarCustomizer'
 import { useMissions } from '../../hooks/useMissions'
 import { TemplatesModal } from './TemplatesModal'
 import { CreateDashboardModal } from './CreateDashboardModal'
@@ -104,6 +105,7 @@ export function Dashboard() {
   const [_dragOverDashboard, setDragOverDashboard] = useState<string | null>(null)
   const { isOpen: isCreateDashboardOpen, open: openCreateDashboard, close: closeCreateDashboard } = useModalState()
   const { isOpen: isWidgetExportOpen, open: openWidgetExport, close: closeWidgetExport } = useModalState()
+  const { isOpen: isSidebarCustomizerOpen, open: openSidebarCustomizer, close: closeSidebarCustomizer } = useModalState()
 
   // Get context for modals that can be triggered from sidebar
   const {
@@ -884,7 +886,7 @@ export function Dashboard() {
       <GettingStartedBanner
         onBrowseCards={openAddCardModal}
         onTryMission={openMissionSidebar}
-        onExploreDashboards={openAddCardModal}
+        onExploreDashboards={openSidebarCustomizer}
       />
 
       {/* Demo-to-local CTA — shown on console.kubestellar.io for demo visitors */}
@@ -1080,6 +1082,11 @@ export function Dashboard() {
         sourceCluster={pendingDeploy?.sourceCluster ?? ''}
         targetClusters={pendingDeploy?.targetClusters ?? []}
         groupName={pendingDeploy?.groupName}
+      />
+
+      <SidebarCustomizer
+        isOpen={isSidebarCustomizerOpen}
+        onClose={closeSidebarCustomizer}
       />
     </div>
   )

--- a/web/src/components/dashboard/DemoToLocalCTA.tsx
+++ b/web/src/components/dashboard/DemoToLocalCTA.tsx
@@ -7,7 +7,8 @@
  */
 
 import { useState, useEffect, useRef } from 'react'
-import { Terminal, Copy, Check, ExternalLink, X } from 'lucide-react'
+import { Terminal, Copy, Check, X, Rocket } from 'lucide-react'
+import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
 import { isNetlifyDeployment } from '../../lib/demoMode'
 import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
 import {
@@ -17,7 +18,6 @@ import {
 import { emitDemoToLocalShown, emitDemoToLocalActioned } from '../../lib/analytics'
 
 const INSTALL_COMMAND = 'brew tap kubestellar/tap && brew install --head kc-agent && kc-agent'
-const DOCS_URL = 'https://docs.kubestellar.io/docs/getting-started/'
 
 /** How many seconds the "Copied!" confirmation shows */
 const COPY_FEEDBACK_MS = 2000
@@ -30,6 +30,7 @@ export function DemoToLocalCTA() {
     () => safeGetItem(STORAGE_KEY_HINTS_SUPPRESSED) === 'true'
   )
   const [copied, setCopied] = useState(false)
+  const [showSetupDialog, setShowSetupDialog] = useState(false)
   const emittedRef = useRef(false)
 
   useEffect(() => {
@@ -66,7 +67,7 @@ export function DemoToLocalCTA() {
 
   const handleDocs = () => {
     emitDemoToLocalActioned('view_docs')
-    window.open(DOCS_URL, '_blank', 'noopener')
+    setShowSetupDialog(true)
   }
 
   return (
@@ -121,9 +122,14 @@ export function DemoToLocalCTA() {
           onClick={handleDocs}
           className="flex items-center gap-1 text-blue-400 hover:text-blue-300 transition-colors"
         >
-          Full setup guide <ExternalLink className="w-3 h-3" />
+          Full setup guide <Rocket className="w-3 h-3" />
         </button>
       </div>
+
+      <SetupInstructionsDialog
+        isOpen={showSetupDialog}
+        onClose={() => setShowSetupDialog(false)}
+      />
     </div>
   )
 }

--- a/web/src/components/dashboard/GettingStartedBanner.tsx
+++ b/web/src/components/dashboard/GettingStartedBanner.tsx
@@ -79,7 +79,7 @@ export function GettingStartedBanner({
     },
     {
       id: 'explore-dashboards',
-      label: 'Explore Dashboards',
+      label: 'Explore More Dashboards',
       description: `${DASHBOARD_COUNT} topic-specific dashboards`,
       icon: Compass,
       onClick: () => handleAction('explore_dashboards', onExploreDashboards),

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -5,7 +5,7 @@ import { Box, Wifi, WifiOff, X, Settings, Rocket, RotateCcw, Check, Loader2, Ref
 import { Navbar } from './navbar/index'
 import { Sidebar } from './Sidebar'
 import { MissionSidebar, MissionSidebarToggle } from './mission-sidebar'
-import { useSidebarConfig } from '../../hooks/useSidebarConfig'
+import { useSidebarConfig, SIDEBAR_COLLAPSED_WIDTH_PX, SIDEBAR_DEFAULT_WIDTH_PX } from '../../hooks/useSidebarConfig'
 import { useMobile } from '../../hooks/useMobile'
 import { useNavigationHistory } from '../../hooks/useNavigationHistory'
 import { useLastRoute } from '../../hooks/useLastRoute'
@@ -78,6 +78,7 @@ export function Layout({ children }: LayoutProps) {
   const { t } = useTranslation()
   const { config } = useSidebarConfig()
   const { isMobile } = useMobile()
+  const sidebarWidthPx = isMobile ? 0 : (config.collapsed ? SIDEBAR_COLLAPSED_WIDTH_PX : (config.width ?? SIDEBAR_DEFAULT_WIDTH_PX))
   const { isSidebarOpen: isMissionSidebarOpen, isSidebarMinimized: isMissionSidebarMinimized, isFullScreen: isMissionFullScreen } = useMissions()
   const { isDemoMode, toggleDemoMode } = useDemoMode()
   const { status: agentStatus } = useLocalAgent()
@@ -259,11 +260,9 @@ export function Layout({ children }: LayoutProps) {
       {/* Network Disconnected Banner */}
       {showNetworkBanner && (
         <div
-          style={{ top: networkBannerTop }}
+          style={{ top: networkBannerTop, left: sidebarWidthPx }}
           className={cn(
             "fixed right-0 z-40 border-b transition-[left] duration-300",
-            // Mobile: full width
-            isMobile ? "left-0" : (config.collapsed ? "left-20" : "left-64"),
             isOnline
               ? "bg-green-500/10 border-green-500/20"
               : "bg-red-500/10 border-red-500/20",
@@ -298,11 +297,9 @@ export function Layout({ children }: LayoutProps) {
         const isAuthenticatedNoAgent = hasRealToken() && agentStatus !== 'connected'
         return (
           <div
-            style={{ top: demoBannerTop }}
+            style={{ top: demoBannerTop, left: sidebarWidthPx }}
             className={cn(
               "fixed right-0 z-30 bg-background border-b border-yellow-500/20 transition-[left] duration-300",
-              // Mobile: full width
-              isMobile ? "left-0" : (config.collapsed ? "left-20" : "left-64"),
             )}>
             <div className="flex flex-wrap items-center justify-center gap-2 md:gap-3 py-1.5 px-3 md:px-4">
               {isAuthenticatedNoAgent
@@ -352,11 +349,9 @@ export function Layout({ children }: LayoutProps) {
       {/* Offline Mode Banner - positioned in main content area only */}
       {showOfflineBanner && (
         <div
-          style={{ top: offlineBannerTop }}
+          style={{ top: offlineBannerTop, left: sidebarWidthPx }}
           className={cn(
             "fixed z-20 bg-background border-b border-orange-500/20 transition-[right] duration-300",
-            // Mobile: full width
-            isMobile ? "left-0" : (config.collapsed ? "left-20" : "left-64"),
           // Adjust right edge when mission sidebar is open (desktop only)
           !isMobile && isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen ? "right-[500px]" : "right-0",
           !isMobile && isMissionSidebarOpen && isMissionSidebarMinimized && !isMissionFullScreen && "right-12"
@@ -399,11 +394,9 @@ export function Layout({ children }: LayoutProps) {
         <Sidebar />
         <main
           id="main-content"
+          style={{ marginLeft: sidebarWidthPx }}
           className={cn(
             'relative flex-1 p-4 md:p-6 transition-[margin] duration-300 overflow-y-auto scroll-enhanced min-w-0',
-            // Mobile: no left margin (sidebar overlays)
-            // Desktop: respect collapsed state
-            isMobile ? 'ml-0' : (config.collapsed ? 'ml-20' : 'ml-64'),
             // Don't apply right margin when fullscreen is active or on mobile
             !isMobile && isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen && 'mr-[500px]',
             !isMobile && isMissionSidebarOpen && isMissionSidebarMinimized && !isMissionFullScreen && 'mr-12'

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { NavLink, useNavigate, useLocation } from 'react-router-dom'
 // NOTE: Wildcard import is required for dynamic icon resolution
@@ -8,7 +8,7 @@ import * as Icons from 'lucide-react'
 import { Plus, ChevronLeft, ChevronRight, CheckCircle2, AlertTriangle, WifiOff, GripVertical, X, User } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { SnoozedCards } from './SnoozedCards'
-import { useSidebarConfig, SidebarItem, PROTECTED_SIDEBAR_IDS } from '../../hooks/useSidebarConfig'
+import { useSidebarConfig, SidebarItem, PROTECTED_SIDEBAR_IDS, SIDEBAR_COLLAPSED_WIDTH_PX, SIDEBAR_DEFAULT_WIDTH_PX } from '../../hooks/useSidebarConfig'
 import { useMobile } from '../../hooks/useMobile'
 import { useClusters } from '../../hooks/useMCP'
 import { useDashboardContextOptional } from '../../hooks/useDashboardContext'
@@ -18,6 +18,10 @@ import type { SnoozedMission } from '../../hooks/useSnoozedMissions'
 import { useActiveUsers } from '../../hooks/useActiveUsers'
 import { ROUTES } from '../../config/routes'
 import { DASHBOARD_CONFIGS } from '../../config/dashboards/index'
+
+/** Sidebar resize limits in pixels */
+const SIDEBAR_MIN_WIDTH_PX = 180
+const SIDEBAR_MAX_WIDTH_PX = 480
 
 /** Map sidebar item href to dashboard config ID for card count display */
 const HREF_TO_DASHBOARD_ID: Record<string, string> = {
@@ -34,7 +38,7 @@ const HREF_TO_DASHBOARD_ID: Record<string, string> = {
 }
 
 export function Sidebar() {
-  const { config, toggleCollapsed, reorderItems, updateItem, removeItem, closeMobileSidebar } = useSidebarConfig()
+  const { config, toggleCollapsed, reorderItems, updateItem, removeItem, closeMobileSidebar, setWidth } = useSidebarConfig()
   const { isMobile } = useMobile()
   const { deduplicatedClusters } = useClusters()
   const dashboardContext = useDashboardContextOptional()
@@ -52,6 +56,39 @@ export function Sidebar() {
 
   // On mobile, always show expanded view; on desktop, respect collapsed state
   const isCollapsed = !isMobile && config.collapsed
+
+  // Sidebar width (resizable)
+  const sidebarWidth = isCollapsed ? SIDEBAR_COLLAPSED_WIDTH_PX : (config.width ?? SIDEBAR_DEFAULT_WIDTH_PX)
+
+  // Resize handle state
+  const [isResizing, setIsResizing] = useState(false)
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    setIsResizing(true)
+    const startX = e.clientX
+    const startWidth = config.width ?? SIDEBAR_DEFAULT_WIDTH_PX
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      const newWidth = Math.min(
+        SIDEBAR_MAX_WIDTH_PX,
+        Math.max(SIDEBAR_MIN_WIDTH_PX, startWidth + (moveEvent.clientX - startX))
+      )
+      setWidth(newWidth)
+    }
+
+    const handleMouseUp = () => {
+      setIsResizing(false)
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+    }
+
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+  }, [config.width, setWidth])
 
   // Inline rename state for custom sidebar items
   const [editingItemId, setEditingItemId] = useState<string | null>(null)
@@ -266,18 +303,18 @@ export function Sidebar() {
             title={item.isCustom && item.href.startsWith('/custom-dashboard/') ? `${item.name} — ${t('sidebar.doubleClickRename')}` : item.name}
           >
             {renderIcon(item.icon, isCollapsed ? 'w-6 h-6' : 'w-5 h-5')}
-            {!isCollapsed && <span className="flex-1 truncate">{item.name}</span>}
+            {!isCollapsed && <span className="flex-1 min-w-0">{item.name}</span>}
             {!isCollapsed && (() => {
               const dashId = HREF_TO_DASHBOARD_ID[item.href]
               const count = dashId ? DASHBOARD_CONFIGS[dashId]?.cards?.length : null
               return count != null ? (
-                <span className="text-[10px] text-muted-foreground/40 tabular-nums group-hover:hidden flex-shrink-0">
+                <span className="text-[10px] text-muted-foreground/40 tabular-nums flex-shrink-0 min-w-[1.5rem] text-right">
                   {count}
                 </span>
               ) : null
             })()}
             {!isCollapsed && (
-              <span className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0 ml-1">
+              <span className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity bg-background/80 backdrop-blur-sm rounded px-0.5">
                 {!PROTECTED_SIDEBAR_IDS.includes(item.id) && (
                   <span
                     role="button"
@@ -313,18 +350,20 @@ export function Sidebar() {
         />
       )}
 
-      <aside 
-        data-testid="sidebar" 
-        data-tour="sidebar" 
+      <aside
+        data-testid="sidebar"
+        data-tour="sidebar"
         className={cn(
-          'fixed left-0 top-16 bottom-0 glass border-r border-border/50 overflow-y-auto scroll-enhanced transition-all duration-300 z-40',
+          'fixed left-0 top-16 bottom-0 glass border-r border-border/50 overflow-y-auto scroll-enhanced z-40',
+          !isResizing && 'transition-all duration-300',
           // Desktop: respect collapsed state
-          !isMobile && (config.collapsed ? 'w-20 p-3' : 'w-64 p-4'),
-          // Mobile: always w-64 when open, slide off-screen when closed
-          isMobile && 'w-64 p-4',
+          !isMobile && (config.collapsed ? 'p-3' : 'p-4'),
+          // Mobile: slide off-screen when closed
+          isMobile && 'p-4',
           isMobile && !config.isMobileOpen && '-translate-x-full',
           isMobile && config.isMobileOpen && 'translate-x-0'
-        )}>
+        )}
+        style={{ width: isMobile ? SIDEBAR_DEFAULT_WIDTH_PX : sidebarWidth }}>
         {/* Collapse toggle - hidden on mobile */}
         <button
           data-testid="sidebar-collapse-toggle"
@@ -430,6 +469,17 @@ export function Sidebar() {
         )}
       </aside>
 
+      {/* Resize handle - drag to adjust sidebar width */}
+      {!isCollapsed && !isMobile && (
+        <div
+          onMouseDown={handleResizeStart}
+          className={cn(
+            "fixed top-16 bottom-0 cursor-col-resize z-50 hover:bg-purple-500/30 transition-colors",
+            isResizing && "bg-purple-500/50"
+          )}
+          style={{ left: sidebarWidth - 3, width: 6 }}
+        />
+      )}
     </>
   )
 }

--- a/web/src/components/layout/SidebarCustomizer.tsx
+++ b/web/src/components/layout/SidebarCustomizer.tsx
@@ -34,7 +34,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { useSidebarConfig, SidebarItem } from '../../hooks/useSidebarConfig'
+import { useSidebarConfig, SidebarItem, DISCOVERABLE_DASHBOARDS } from '../../hooks/useSidebarConfig'
 import { useDashboards, Dashboard } from '../../hooks/useDashboards'
 import { DASHBOARD_TEMPLATES, TEMPLATE_CATEGORIES, DashboardTemplate } from '../dashboard/templates'
 import { CreateDashboardModal } from '../dashboard/CreateDashboardModal'
@@ -181,6 +181,7 @@ export function SidebarCustomizer({ isOpen, onClose }: SidebarCustomizerProps) {
     toggleClusterStatus,
     resetToDefault,
     generateFromBehavior,
+    restoreDashboard,
   } = useSidebarConfig()
 
   // DnD sensors for both mouse and keyboard
@@ -598,6 +599,40 @@ export function SidebarCustomizer({ isOpen, onClose }: SidebarCustomizerProps) {
               )}
             </div>
           )}
+
+          {/* Recommended Dashboards — discoverable dashboards not yet in the sidebar */}
+          {(() => {
+            const existingHrefs = new Set([
+              ...config.primaryNav.map(item => item.href),
+              ...config.secondaryNav.map(item => item.href),
+            ])
+            const available = DISCOVERABLE_DASHBOARDS.filter(d => !existingHrefs.has(d.href))
+            if (available.length === 0) return null
+            return (
+              <div className="mb-4 rounded-xl border border-blue-500/20 bg-blue-500/5 p-3">
+                <h4 className="text-xs font-medium text-blue-400 uppercase tracking-wider mb-2 flex items-center gap-1.5">
+                  <Sparkles className="w-3.5 h-3.5" />
+                  Recommended Dashboards
+                </h4>
+                <p className="text-xs text-muted-foreground mb-2">
+                  Add topic-specific dashboards to your sidebar
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {available.map(dashboard => (
+                    <button
+                      key={dashboard.id}
+                      onClick={() => restoreDashboard(dashboard)}
+                      className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm bg-secondary/50 border border-border/50 hover:border-blue-500/30 hover:bg-secondary text-foreground transition-all"
+                    >
+                      {renderIcon(dashboard.icon, 'w-3.5 h-3.5 text-muted-foreground')}
+                      <span className="font-medium text-xs">{dashboard.name}</span>
+                      <Plus className="w-3 h-3 text-blue-400" />
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )
+          })()}
 
           {/* Primary Navigation */}
           <div className="mb-4">

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -62,7 +62,10 @@ export function Navbar() {
             alt="KubeStellar"
             className="w-8 h-8 md:w-9 md:h-9"
           />
-          <span className="text-base md:text-lg font-semibold text-foreground hidden lg:inline">KubeStellar Console</span>
+          <div className="hidden lg:flex flex-col leading-tight">
+            <span className="text-base md:text-lg font-semibold text-foreground">KubeStellar Console</span>
+            <span className="text-[10px] text-muted-foreground tracking-wide">multi-cluster first, saving time and tokens</span>
+          </div>
         </button>
       </div>
 

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -1,6 +1,11 @@
 import { useCallback, useSyncExternalStore } from 'react'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
+/** Width of the collapsed sidebar in pixels (w-20 = 5rem = 80px) */
+export const SIDEBAR_COLLAPSED_WIDTH_PX = 80
+/** Default width of the expanded sidebar in pixels (w-64 = 16rem = 256px) */
+export const SIDEBAR_DEFAULT_WIDTH_PX = 256
+
 export interface SidebarItem {
   id: string
   name: string
@@ -21,6 +26,7 @@ export interface SidebarConfig {
   showClusterStatus: boolean
   collapsed: boolean
   isMobileOpen: boolean
+  width?: number
 }
 
 // Shared state store for sidebar config
@@ -373,6 +379,10 @@ export function useSidebarConfig() {
     setConfig((prev) => ({ ...prev, showClusterStatus: !prev.showClusterStatus }))
   }, [])
 
+  const setWidth = useCallback((width: number) => {
+    setConfig((prev) => ({ ...prev, width }))
+  }, [])
+
   const toggleCollapsed = useCallback(() => {
     setConfig((prev) => ({ ...prev, collapsed: !prev.collapsed }))
   }, [])
@@ -456,6 +466,7 @@ export function useSidebarConfig() {
     reorderItems,
     restoreDashboard,
     toggleClusterStatus,
+    setWidth,
     toggleCollapsed,
     openMobileSidebar,
     closeMobileSidebar,


### PR DESCRIPTION
## Summary
- **Resizable sidebar** — drag the right edge to adjust width (180px–480px), persisted to localStorage
- **Aligned card counts** — hover actions no longer push counts out of alignment (now absolutely positioned)
- **Counts stay visible on hover** — removed `group-hover:hidden` that hid count badges
- **No more ellipsis** — full dashboard names display (e.g. "Cluster Admin" instead of "Cluster ...")
- **Navbar slogan** — "multi-cluster first, saving time and tokens" under the logo
- **Full setup guide modal** — "Full setup guide" link now opens SetupInstructionsDialog instead of a 404 URL
- **Recommended Dashboards moved** — from Add Cards modal (too noisy) to Customize Sidebar modal
- **"Explore More Dashboards"** — renamed button now opens the Customize Sidebar modal

## Test plan
- [ ] Drag sidebar right edge to resize — verify it persists across page reloads
- [ ] Check card count alignment in sidebar — all counts should be right-aligned
- [ ] Hover over sidebar items — counts should remain visible
- [ ] Verify "Cluster Admin" and other long names show fully (no ellipsis)
- [ ] Check slogan appears under logo on wide screens
- [ ] Click "Full setup guide" in the Demo-to-Local CTA — should open modal, not 404
- [ ] Click "Explore More Dashboards" in Getting Started banner — should open Customize Sidebar
- [ ] Verify Recommended Dashboards section appears in Customize Sidebar modal
- [ ] Verify Recommended Dashboards section is removed from Add Cards modal