### PR TITLE
✨ Migrate 152 inline badge spans to StatusBadge component

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -11,6 +11,7 @@ import {
   ExternalLink,
 } from 'lucide-react'
 import { useAlerts } from '../../hooks/useAlerts'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useGlobalFilters, type SeverityLevel } from '../../hooks/useGlobalFilters'
 import { useDrillDown } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
@@ -234,9 +235,9 @@ export function ActiveAlerts() {
       <div className="flex items-center justify-between mb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           {stats.firing > 0 && (
-            <span className="px-1.5 py-0.5 text-xs font-medium rounded-full bg-red-500/20 text-red-400 border border-red-500/30">
+            <StatusBadge color="red" variant="outline" rounded="full">
               {t('activeAlerts.firingCount', { count: stats.firing })}
-            </span>
+            </StatusBadge>
           )}
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">

--- a/web/src/components/cards/AlertRules.tsx
+++ b/web/src/components/cards/AlertRules.tsx
@@ -10,6 +10,7 @@ import { useAlertRules } from '../../hooks/useAlerts'
 import { formatCondition } from '../../types/alerts'
 import type { AlertRule, AlertSeverity } from '../../types/alerts'
 import { AlertRuleEditor } from '../alerts/AlertRuleEditor'
+import { StatusBadge } from '../ui/StatusBadge'
 import {
   useCardData,
   commonComparators,
@@ -223,9 +224,9 @@ export function AlertRulesCard() {
                       {rule.name}
                     </span>
                     {rule.aiDiagnose && (
-                      <span className="px-1 py-0.5 text-2xs rounded bg-purple-500/20 text-purple-400">
+                      <StatusBadge color="purple" size="xs">
                         AI
-                      </span>
+                      </StatusBadge>
                     )}
                   </div>
                   <p className="text-xs text-muted-foreground mt-0.5">

--- a/web/src/components/cards/ClusterCosts.tsx
+++ b/web/src/components/cards/ClusterCosts.tsx
@@ -6,6 +6,7 @@ import { Skeleton } from '../ui/Skeleton'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 import { CloudProviderIcon, type CloudProvider as IconProvider } from '../ui/CloudProviderIcon'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 
@@ -513,7 +514,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
                       </span>
                       <span className="flex-1">{CLOUD_PRICING[provider].name}</span>
                       {provider === detectedProvider && (
-                        <span className="text-[9px] px-1 py-0.5 rounded bg-yellow-500/20 text-yellow-400">{t('cards:clusterCosts.detected')}</span>
+                        <StatusBadge color="yellow" size="xs">{t('cards:clusterCosts.detected')}</StatusBadge>
                       )}
                     </button>
                   ))}
@@ -607,9 +608,9 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
                         {t('common:common.cpu')} ${p.cpu.toFixed(3)} • {t('common:common.memory')} ${p.memory.toFixed(4)} • {t('cards:clusterCosts.gpu')} ${p.gpu.toFixed(2)}
                       </span>
                       {count > 0 && (
-                        <span className="text-[9px] px-1 py-0.5 rounded bg-purple-500/20 text-purple-400">
+                        <StatusBadge color="purple" size="xs">
                           {count}
-                        </span>
+                        </StatusBadge>
                       )}
                       {p.pricingUrl && (
                         <a

--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -33,6 +33,7 @@ import { useClusters } from '../../hooks/useMCP'
 import { useCardLoadingState } from './CardDataContext'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../ui/StatusBadge'
 
 interface ClusterGroupsProps {
   config?: Record<string, unknown>
@@ -302,10 +303,9 @@ function DroppableGroup({ group, isExpanded, isRefreshing, clusterHealthMap, onT
         <span className={cn('text-sm font-medium flex-1 flex items-center gap-1.5', color.text)}>
           {group.name}
           {isDynamic && (
-            <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[9px] font-medium rounded-full bg-purple-500/20 text-purple-400 border border-purple-500/30">
-              <Zap className="w-2.5 h-2.5" />
+            <StatusBadge color="purple" size="xs" variant="outline" rounded="full" icon={<Zap className="w-2.5 h-2.5" />}>
               {t('cards:clusterGroups.dynamic')}
-            </span>
+            </StatusBadge>
           )}
         </span>
 

--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -4,6 +4,7 @@
  */
 
 import { AlertTriangle, AlertCircle } from 'lucide-react'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 
@@ -196,9 +197,9 @@ export function PolicyViolations({ config: _config }: CardConfig) {
               <p className="text-sm font-medium text-foreground">{v.policy}</p>
               <p className="text-xs text-muted-foreground">{v.tool}</p>
             </div>
-            <span className="px-2 py-1 rounded bg-orange-500/20 text-orange-400 text-xs font-medium">
+            <StatusBadge color="orange" size="md">
               {v.count}
-            </span>
+            </StatusBadge>
           </div>
         ))}
       </div>

--- a/web/src/components/cards/DataComplianceCards.tsx
+++ b/web/src/components/cards/DataComplianceCards.tsx
@@ -6,6 +6,7 @@
  */
 
 import { Shield, CheckCircle2, AlertTriangle, Clock, AlertCircle } from 'lucide-react'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCertManager } from '../../hooks/useCertManager'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
@@ -262,14 +263,14 @@ export function CertManager({ config: _config }: CardConfig) {
       {(status.pending > 0 || status.failed > 0) && (
         <div className="flex items-center gap-2 text-xs">
           {status.pending > 0 && (
-            <span className="px-2 py-0.5 rounded-full bg-blue-500/20 text-blue-400">
+            <StatusBadge color="blue" rounded="full">
               {status.pending} pending
-            </span>
+            </StatusBadge>
           )}
           {status.failed > 0 && (
-            <span className="px-2 py-0.5 rounded-full bg-red-500/20 text-red-400">
+            <StatusBadge color="red" rounded="full">
               {status.failed} failed
-            </span>
+            </StatusBadge>
           )}
         </div>
       )}

--- a/web/src/components/cards/GPUNamespaceAllocations.tsx
+++ b/web/src/components/cards/GPUNamespaceAllocations.tsx
@@ -3,6 +3,7 @@ import { Box, ChevronRight, Server } from 'lucide-react'
 import { useGPUNodes, useAllPods } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { StatusBadge } from '../ui/StatusBadge'
 import { CardClusterFilter, CardSearchInput } from '../../lib/cards'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
@@ -166,9 +167,9 @@ export function GPUNamespaceAllocations({ config: _config }: GPUNamespaceAllocat
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+          <StatusBadge color="purple">
             {t('gpuNamespaceAllocations.gpusAcrossNamespaces', { gpus: totalGPUs, count: namespaceAllocations.length })}
-          </span>
+          </StatusBadge>
         </div>
         <div className="flex items-center gap-2">
           {filters.localClusterFilter && filters.localClusterFilter.length > 0 && (

--- a/web/src/components/cards/GPUStatus.tsx
+++ b/web/src/components/cards/GPUStatus.tsx
@@ -5,6 +5,7 @@ import { useGPUNodes } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { StatusBadge } from '../ui/StatusBadge'
 import { Skeleton } from '../ui/Skeleton'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
@@ -168,9 +169,9 @@ export function GPUStatus({ config }: GPUStatusProps) {
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+          <StatusBadge color="purple">
             {t('gpuStatus.clusterCount', { count: totalItems })}
-          </span>
+          </StatusBadge>
         </div>
         <CardControlsRow
           clusterIndicator={{

--- a/web/src/components/cards/HelmHistory.tsx
+++ b/web/src/components/cards/HelmHistory.tsx
@@ -7,6 +7,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { StatusBadge } from '../ui/StatusBadge'
 import {
   useCardData,
   CardSearchInput, CardControlsRow, CardPaginationFooter,
@@ -271,9 +272,9 @@ export function HelmHistory({ config }: HelmHistoryProps) {
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           {totalItems > 0 && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+            <StatusBadge color="purple">
               {t('helmHistory.nRevisions', { count: totalItems })}
-            </span>
+            </StatusBadge>
           )}
         </div>
         <CardControlsRow
@@ -410,9 +411,9 @@ export function HelmHistory({ config }: HelmHistoryProps) {
                             <div className="flex items-center gap-2">
                               <span className="text-sm font-medium text-foreground">{t('helmHistory.rev', { revision: entry.revision })}</span>
                               {isCurrent && (
-                                <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">
+                                <StatusBadge color="green">
                                   {t('helmHistory.current')}
-                                </span>
+                                </StatusBadge>
                               )}
                             </div>
                             <div className="flex items-center gap-2">

--- a/web/src/components/cards/Missions.tsx
+++ b/web/src/components/cards/Missions.tsx
@@ -13,6 +13,7 @@ import {
   Package,
 } from 'lucide-react'
 import { cn } from '../../lib/cn'
+import { StatusBadge } from '../ui/StatusBadge'
 import { ClusterBadge, getClusterInfo } from '../ui/ClusterBadge'
 import { useDeployMissions } from '../../hooks/useDeployMissions'
 import { useClusters } from '../../hooks/useMCP'
@@ -358,9 +359,9 @@ Please:
       <div className="flex items-center justify-between mb-2 shrink-0">
         <div className="flex items-center gap-2">
           {activeMissions.length > 0 ? (
-            <span className="text-2xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 font-medium">
+            <StatusBadge color="blue" size="xs">
               {activeMissions.length} active
-            </span>
+            </StatusBadge>
           ) : (
             <span className="text-2xs text-muted-foreground">No active</span>
           )}

--- a/web/src/components/cards/NamespaceEvents.tsx
+++ b/web/src/components/cards/NamespaceEvents.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, Info, AlertCircle, Clock, ChevronRight } from 'lucide-re
 import { useClusters, useWarningEvents, useNamespaces, type ClusterEvent } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { StatusBadge } from '../ui/StatusBadge'
 import {
   useCardData, useCascadingSelection, commonComparators,
   CardSkeleton, CardSearchInput, CardControlsRow, CardPaginationFooter,
@@ -177,9 +178,9 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           {totalItems > 0 && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400">
+            <StatusBadge color="orange">
               {t('namespaceEvents.nEvents', { count: totalItems })}
-            </span>
+            </StatusBadge>
           )}
         </div>
         <CardControlsRow

--- a/web/src/components/cards/NamespaceOverview.tsx
+++ b/web/src/components/cards/NamespaceOverview.tsx
@@ -7,6 +7,7 @@ import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { StatusBadge } from '../ui/StatusBadge'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardLoadingState } from './CardDataContext'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -243,9 +244,9 @@ export function NamespaceOverview({ config }: NamespaceOverviewProps) {
                     <div className="flex items-center gap-2 min-w-0">
                       <AlertTriangle className="w-4 h-4 text-red-400 shrink-0" />
                       <span className="text-sm text-foreground truncate min-w-0 flex-1">{issue.name}</span>
-                      <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 shrink-0">
+                      <StatusBadge color="red" className="shrink-0">
                         {issue.status}
-                      </span>
+                      </StatusBadge>
                     </div>
                   </div>
                 ))}

--- a/web/src/components/cards/NamespaceRBAC.tsx
+++ b/web/src/components/cards/NamespaceRBAC.tsx
@@ -5,6 +5,7 @@ import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 import { useCardLoadingState } from './CardDataContext'
@@ -205,9 +206,9 @@ function NamespaceRBACInternal({ config }: NamespaceRBACProps) {
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+          <StatusBadge color="purple">
             {activeTab === 'roles' ? t('namespaceRBAC.nRoles', { count: rbacRoles.length }) : activeTab === 'bindings' ? t('namespaceRBAC.nBindings', { count: rbacBindings.length }) : t('namespaceRBAC.nServiceAccounts', { count: rbacServiceAccounts.length })}
-          </span>
+          </StatusBadge>
         </div>
         <CardControlsRow
           clusterIndicator={{

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -6,6 +6,7 @@ import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardSkeleton } 
 import { useClusters } from '../../hooks/useMCP'
 import { useMissions } from '../../hooks/useMissions'
 import { kubectlProxy } from '../../lib/kubectlProxy'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState, useCardDemoState } from './CardDataContext'
 import { isDemoMode as checkIsDemoMode } from '../../lib/demoMode'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
@@ -618,9 +619,9 @@ Let's start by discussing what kind of policy I need.`,
       {/* Controls */}
       <div className="flex items-center justify-between mb-3">
         {installedCount > 0 ? (
-          <span className="px-1.5 py-0.5 text-2xs rounded bg-green-500/20 text-green-400">
+          <StatusBadge color="green" size="xs">
             {installedCount} cluster{installedCount !== 1 ? 's' : ''}
-          </span>
+          </StatusBadge>
         ) : <div />}
         <CardControlsRow
           clusterFilter={{

--- a/web/src/components/cards/OperatorStatus.tsx
+++ b/web/src/components/cards/OperatorStatus.tsx
@@ -4,6 +4,7 @@ import { useClusters, useOperators, Operator } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { StatusBadge } from '../ui/StatusBadge'
 import { Skeleton } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
@@ -179,9 +180,9 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           {totalItems > 0 && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+            <StatusBadge color="purple">
               {t('operatorStatus.nOperators', { count: totalItems })}
-            </span>
+            </StatusBadge>
           )}
         </div>
         <CardControlsRow
@@ -218,13 +219,13 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
             {localClusterFilter.length === 1 ? (
               <ClusterBadge cluster={localClusterFilter[0]} />
             ) : localClusterFilter.length > 1 ? (
-              <span className="text-xs px-2 py-1 rounded-full bg-purple-500/20 text-purple-400">
+              <StatusBadge color="purple" size="md" rounded="full">
                 {t('operatorStatus.nClustersSelected', { count: localClusterFilter.length })}
-              </span>
+              </StatusBadge>
             ) : (
-              <span className="text-xs px-2 py-1 rounded-full bg-purple-500/20 text-purple-400">
+              <StatusBadge color="purple" size="md" rounded="full">
                 {t('operatorStatus.allClusters', { count: availableClusters.length })}
-              </span>
+              </StatusBadge>
             )}
           </div>
 

--- a/web/src/components/cards/OperatorSubscriptions.tsx
+++ b/web/src/components/cards/OperatorSubscriptions.tsx
@@ -3,6 +3,7 @@ import { Clock, AlertTriangle, Settings, ChevronRight } from 'lucide-react'
 import { useClusters, useOperatorSubscriptions, OperatorSubscription } from '../../hooks/useMCP'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCardLoadingState } from './CardDataContext'
 import {
@@ -151,9 +152,9 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           {pendingCount > 0 && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400">
+            <StatusBadge color="orange">
               {t('operatorSubscriptions.nPending', { count: pendingCount })}
-            </span>
+            </StatusBadge>
           )}
         </div>
         <CardControlsRow
@@ -190,13 +191,13 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
             {localClusterFilter.length === 1 ? (
               <ClusterBadge cluster={localClusterFilter[0]} />
             ) : localClusterFilter.length > 1 ? (
-              <span className="text-xs px-2 py-1 rounded-full bg-blue-500/20 text-blue-400">
+              <StatusBadge color="blue" size="md" rounded="full">
                 {t('operatorSubscriptions.nClustersSelected', { count: localClusterFilter.length })}
-              </span>
+              </StatusBadge>
             ) : (
-              <span className="text-xs px-2 py-1 rounded-full bg-blue-500/20 text-blue-400">
+              <StatusBadge color="blue" size="md" rounded="full">
                 {t('operatorSubscriptions.allClusters', { count: availableClusters.length })}
-              </span>
+              </StatusBadge>
             )}
           </div>
 

--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -4,6 +4,7 @@ import type { SecurityIssue } from '../../hooks/useMCP'
 import { useCachedSecurityIssues } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { StatusBadge } from '../ui/StatusBadge'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { LimitedAccessWarning } from '../ui/LimitedAccessWarning'
@@ -238,14 +239,14 @@ export function SecurityIssues({ config }: SecurityIssuesProps) {
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
           {highCount > 0 && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400" title={t('securityIssues.highSeverityTitle', { count: highCount })}>
+            <StatusBadge color="red" title={t('securityIssues.highSeverityTitle', { count: highCount })}>
               {highCount} {t('securityIssues.highLabel')}
-            </span>
+            </StatusBadge>
           )}
           {mediumCount > 0 && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400" title={t('securityIssues.mediumSeverityTitle', { count: mediumCount })}>
+            <StatusBadge color="orange" title={t('securityIssues.mediumSeverityTitle', { count: mediumCount })}>
               {mediumCount} {t('securityIssues.medLabel')}
-            </span>
+            </StatusBadge>
           )}
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">

--- a/web/src/components/cards/ServiceTopology.tsx
+++ b/web/src/components/cards/ServiceTopology.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useCallback } from 'react'
 import { ZoomIn, ZoomOut, Maximize2, ArrowRight } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { StatusBadge } from '../ui/StatusBadge'
 import type { TopologyNode, TopologyEdge, TopologyHealthStatus } from '../../types/topology'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
@@ -363,15 +364,15 @@ export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
           {selectedNodeData.metadata && (
             <div className="flex flex-wrap gap-1 mt-1">
               {selectedNodeData.metadata.exported && (
-                <span className="px-1.5 py-0.5 rounded bg-cyan-500/20 text-cyan-400 text-[9px]">{t('serviceTopology.exported')}</span>
+                <StatusBadge color="cyan" size="xs">{t('serviceTopology.exported')}</StatusBadge>
               )}
               {selectedNodeData.metadata.imported && (
-                <span className="px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 text-[9px]">{t('serviceTopology.imported')}</span>
+                <StatusBadge color="blue" size="xs">{t('serviceTopology.imported')}</StatusBadge>
               )}
               {selectedNodeData.metadata.gatewayClass && (
-                <span className="px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400 text-[9px]">
+                <StatusBadge color="purple" size="xs">
                   {selectedNodeData.metadata.gatewayClass as string}
-                </span>
+                </StatusBadge>
               )}
               {typeof selectedNodeData.metadata.endpoints === 'number' && (
                 <span className="px-1.5 py-0.5 rounded bg-secondary text-muted-foreground text-[9px]">

--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -8,6 +8,7 @@ import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { LOCAL_AGENT_WS_URL } from '../../lib/constants'
 import { useTranslation } from 'react-i18next'
@@ -554,9 +555,9 @@ Please proceed step by step and ask for confirmation before making any changes.`
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
           {pendingUpgrades > 0 && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">
+            <StatusBadge color="yellow">
               {pendingUpgrades} upgrades available
-            </span>
+            </StatusBadge>
           )}
         </div>
         <CardControlsRow

--- a/web/src/components/cards/cluster-resource-tree/ClusterResourceTree.tsx
+++ b/web/src/components/cards/cluster-resource-tree/ClusterResourceTree.tsx
@@ -12,6 +12,7 @@ import { ResourceIcon, SORT_OPTIONS } from './types'
 import { buildNamespaceResources, getVisibleNamespaces, getIssueCounts, getPodsForDeployment } from './TreeBuilder'
 import type { ClusterResourceTreeProps, TreeLens, SortByOption, NamespaceResources, ClusterDataCache } from './types'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../../ui/StatusBadge'
 
 export function ClusterResourceTree({ config: _config }: ClusterResourceTreeProps) {
   const { t } = useTranslation()
@@ -331,9 +332,9 @@ export function ClusterResourceTree({ config: _config }: ClusterResourceTreeProp
               <lens.icon className="w-3.5 h-3.5" />
               {lens.label}
               {lens.count !== undefined && lens.count > 0 && (
-                <span className="ml-0.5 px-1.5 py-0.5 rounded-full text-2xs bg-red-500/20 text-red-400">
+                <StatusBadge color="red" size="xs" rounded="full" className="ml-0.5">
                   {lens.count}
-                </span>
+                </StatusBadge>
               )}
             </button>
           ))}

--- a/web/src/components/cards/crossplane-status/CrossplaneManagedResources.tsx
+++ b/web/src/components/cards/crossplane-status/CrossplaneManagedResources.tsx
@@ -4,6 +4,7 @@ import { SkeletonStats, SkeletonList } from '../../ui/Skeleton'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import { CardSearchInput,CardControlsRow,CardPaginationFooter,CardAIActions } from '../../../lib/cards/CardComponents'
 import { useCardLoadingState } from '../CardDataContext'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { useCrossplaneManagedResources, type CrossplaneManagedResource } from '../../../hooks/mcp/crossplane'
 
 type ManagedResourceView = {
@@ -142,9 +143,9 @@ export function CrossplaneManagedResources() {
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
-        <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+        <StatusBadge color="purple">
           {t('crossplaneManagedResources.resourceCount', { count: rawResources.length })}
-        </span>
+        </StatusBadge>
         {isRefreshing && (
           <Loader2 className="w-3 h-3 animate-spin text-muted-foreground" />
         )}

--- a/web/src/components/cards/llmd/LLMdAIInsights.tsx
+++ b/web/src/components/cards/llmd/LLMdAIInsights.tsx
@@ -7,6 +7,7 @@
 import { useState, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Brain, Lightbulb, AlertTriangle, TrendingUp, Gauge, MessageSquare, ChevronRight, Sparkles, Settings2, Zap } from 'lucide-react'
+import { StatusBadge } from '../../../components/ui/StatusBadge'
 import { useOptionalStack } from '../../../contexts/StackContext'
 import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
 import { generateAIInsights, type AIInsight } from '../../../lib/llmd/mockData'
@@ -418,15 +419,14 @@ export function LLMdAIInsights() {
 
         <div className="flex items-center gap-2">
           {selectedStack && !shouldUseDemoData && (
-            <span className="px-2 py-0.5 bg-purple-500/20 text-purple-400 text-xs rounded truncate max-w-[100px]" title={selectedStack.name}>
+            <StatusBadge color="purple" className="truncate max-w-[100px]" title={selectedStack.name}>
               {selectedStack.name}
-            </span>
+            </StatusBadge>
           )}
           {showDemoBadge && (
-            <span className="px-2 py-0.5 bg-yellow-500/20 text-yellow-400 text-xs rounded flex items-center gap-1">
-              <Sparkles size={10} />
+            <StatusBadge color="yellow" icon={<Sparkles size={10} />}>
               {t('common:common.demo')}
-            </span>
+            </StatusBadge>
           )}
         </div>
       </div>

--- a/web/src/components/cards/llmd/PDDisaggregation.tsx
+++ b/web/src/components/cards/llmd/PDDisaggregation.tsx
@@ -9,6 +9,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { Split, ArrowRight, Cpu, Zap, Clock, Activity, AlertCircle } from 'lucide-react'
+import { StatusBadge } from '../../../components/ui/StatusBadge'
 import { Acronym } from './shared/PortalTooltip'
 import { useOptionalStack } from '../../../contexts/StackContext'
 import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
@@ -351,9 +352,9 @@ export function PDDisaggregation() {
             </span>
           )}
           {isDemoMode && (
-            <span className="px-2 py-0.5 bg-yellow-500/20 text-yellow-400 text-xs rounded">
+            <StatusBadge color="yellow">
               {t('common:common.demo')}
-            </span>
+            </StatusBadge>
           )}
         </div>
       </div>

--- a/web/src/components/cards/workload-detection/LLMInference.tsx
+++ b/web/src/components/cards/workload-detection/LLMInference.tsx
@@ -7,6 +7,7 @@ import { CardClusterFilter, CardSearchInput } from '../../../lib/cards'
 import { Skeleton } from '../../ui/Skeleton'
 import { CardControls } from '../../ui/CardControls'
 import { RefreshIndicator } from '../../ui/RefreshIndicator'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { Pagination } from '../../ui/Pagination'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import type { SortDirection } from '../../../lib/cards/cardHooks'
@@ -112,9 +113,9 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
   const getStatusBadge = (status: string) => {
     switch (status) {
       case 'running':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400 flex items-center gap-1"><Play className="w-2.5 h-2.5" /> Running</span>
+        return <StatusBadge color="green" icon={<Play className="w-2.5 h-2.5" />}>Running</StatusBadge>
       case 'scaling':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 flex items-center gap-1"><RefreshCw className="w-2.5 h-2.5 animate-spin" /> Scaling</span>
+        return <StatusBadge color="blue" icon={<RefreshCw className="w-2.5 h-2.5 animate-spin" />}>Scaling</StatusBadge>
       case 'stopped':
         return <span className="text-xs px-1.5 py-0.5 rounded bg-gray-500/20 text-muted-foreground flex items-center gap-1"><Pause className="w-2.5 h-2.5" /> Stopped</span>
       default:
@@ -190,9 +191,9 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
               {COMPONENT_FILTERS.find(f => f.value === componentFilter)?.label}
             </span>
           )}
-          <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+          <StatusBadge color="purple">
             {items.filter(s => s.status === 'running').length} running
-          </span>
+          </StatusBadge>
         </div>
         <div className="flex items-center gap-2">
           {/* Component type filter */}
@@ -311,9 +312,9 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
                   )}
                   {/* Autoscaler badge */}
                   {server.hasAutoscaler && (
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400 flex-shrink-0" title={server.autoscalerType === 'va' ? 'VariantAutoscaling' : server.autoscalerType === 'both' ? 'HPA + VariantAutoscaling' : 'HorizontalPodAutoscaler'}>
+                    <StatusBadge color="orange" className="flex-shrink-0" title={server.autoscalerType === 'va' ? 'VariantAutoscaling' : server.autoscalerType === 'both' ? 'HPA + VariantAutoscaling' : 'HorizontalPodAutoscaler'}>
                       {server.autoscalerType === 'va' ? 'VA' : server.autoscalerType === 'both' ? 'HPA+VA' : 'HPA'}
-                    </span>
+                    </StatusBadge>
                   )}
                 </div>
                 {getStatusBadge(server.status)}

--- a/web/src/components/cards/workload-detection/LLMModels.tsx
+++ b/web/src/components/cards/workload-detection/LLMModels.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { Layers, AlertCircle, RefreshCw } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { RefreshIndicator } from '../../ui/RefreshIndicator'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { useCardData } from '../../../lib/cards/cardHooks'
 import { CardPaginationFooter, CardControlsRow, CardSearchInput } from '../../../lib/cards/CardComponents'
 import { useCachedLLMdModels } from '../../../hooks/useCachedData'
@@ -74,13 +75,13 @@ export function LLMModels({ config: _config }: LLMModelsProps) {
   const getStatusBadge = (status: string) => {
     switch (status) {
       case 'loaded':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">Loaded</span>
+        return <StatusBadge color="green">Loaded</StatusBadge>
       case 'downloading':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 flex items-center gap-1"><RefreshCw className="w-2.5 h-2.5 animate-spin" /> Downloading</span>
+        return <StatusBadge color="blue" icon={<RefreshCw className="w-2.5 h-2.5 animate-spin" />}>Downloading</StatusBadge>
       case 'stopped':
         return <span className="text-xs px-1.5 py-0.5 rounded bg-gray-500/20 text-muted-foreground">Stopped</span>
       case 'error':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400">{t('common.error')}</span>
+        return <StatusBadge color="red">{t('common.error')}</StatusBadge>
       default:
         return <span className="text-xs px-1.5 py-0.5 rounded bg-gray-500/20 text-muted-foreground">{status}</span>
     }
@@ -108,9 +109,9 @@ export function LLMModels({ config: _config }: LLMModelsProps) {
             showLabel={true}
             staleThresholdMinutes={5}
           />
-          <span className="text-xs px-1.5 py-0.5 rounded bg-cyan-500/20 text-cyan-400">
+          <StatusBadge color="cyan">
             {models.filter(m => m.status === 'loaded').length} loaded
-          </span>
+          </StatusBadge>
         </div>
         <CardControlsRow
           clusterIndicator={

--- a/web/src/components/cards/workload-detection/MLJobs.tsx
+++ b/web/src/components/cards/workload-detection/MLJobs.tsx
@@ -3,6 +3,7 @@ import {
   AlertCircle, Play, Server
 } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { CardClusterFilter, CardSearchInput } from '../../../lib/cards'
 import { Pagination } from '../../ui/Pagination'
 import { CardControls } from '../../ui/CardControls'
@@ -59,13 +60,13 @@ export function MLJobs({ config: _config }: MLJobsProps) {
   const getStatusBadge = (status: string) => {
     switch (status) {
       case 'running':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400 flex items-center gap-1"><Play className="w-2.5 h-2.5" /> Running</span>
+        return <StatusBadge color="green" icon={<Play className="w-2.5 h-2.5" />}>Running</StatusBadge>
       case 'queued':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400 flex items-center gap-1"><Clock className="w-2.5 h-2.5" /> Queued</span>
+        return <StatusBadge color="yellow" icon={<Clock className="w-2.5 h-2.5" />}>Queued</StatusBadge>
       case 'completed':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 flex items-center gap-1"><CheckCircle className="w-2.5 h-2.5" /> Done</span>
+        return <StatusBadge color="blue" icon={<CheckCircle className="w-2.5 h-2.5" />}>Done</StatusBadge>
       case 'failed':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 flex items-center gap-1"><XCircle className="w-2.5 h-2.5" /> Failed</span>
+        return <StatusBadge color="red" icon={<XCircle className="w-2.5 h-2.5" />}>Failed</StatusBadge>
       default:
         return <span className="text-xs px-1.5 py-0.5 rounded bg-gray-500/20 text-muted-foreground">{status}</span>
     }
@@ -92,9 +93,9 @@ export function MLJobs({ config: _config }: MLJobsProps) {
               {filters.localClusterFilter.length}/{filters.availableClusters.length}
             </span>
           )}
-          <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">
+          <StatusBadge color="yellow">
             {jobs.filter(j => j.status === 'running').length} running
-          </span>
+          </StatusBadge>
         </div>
         <div className="flex items-center gap-2">
           <CardClusterFilter

--- a/web/src/components/cards/workload-detection/MLNotebooks.tsx
+++ b/web/src/components/cards/workload-detection/MLNotebooks.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink, AlertCircle } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { useCardData } from '../../../lib/cards/cardHooks'
 import { CardPaginationFooter, CardControlsRow, CardSearchInput } from '../../../lib/cards/CardComponents'
 import { DEMO_NOTEBOOKS, useDemoData } from './shared'
@@ -50,9 +51,9 @@ export function MLNotebooks({ config: _config }: MLNotebooksProps) {
   const getStatusBadge = (status: string) => {
     switch (status) {
       case 'running':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">{t('common.active')}</span>
+        return <StatusBadge color="green">{t('common.active')}</StatusBadge>
       case 'idle':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">Idle</span>
+        return <StatusBadge color="yellow">Idle</StatusBadge>
       case 'stopped':
         return <span className="text-xs px-1.5 py-0.5 rounded bg-gray-500/20 text-muted-foreground">Stopped</span>
       default:
@@ -74,9 +75,9 @@ export function MLNotebooks({ config: _config }: MLNotebooksProps) {
     <div className="h-full flex flex-col min-h-card">
       {/* Header controls */}
       <div className="flex items-center justify-between mb-3">
-        <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400">
+        <StatusBadge color="blue">
           {notebooks.filter(n => n.status === 'running').length} active
-        </span>
+        </StatusBadge>
         <CardControlsRow
           cardControls={{
             limit: itemsPerPage,

--- a/web/src/components/cards/workload-detection/ProwHistory.tsx
+++ b/web/src/components/cards/workload-detection/ProwHistory.tsx
@@ -4,6 +4,7 @@ import {
 } from 'lucide-react'
 import { Skeleton } from '../../ui/Skeleton'
 import { CardControls } from '../../ui/CardControls'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { CardSearchInput } from '../../../lib/cards'
 import { Pagination } from '../../ui/Pagination'
 import { useCachedProwJobs } from '../../../hooks/useCachedData'
@@ -85,9 +86,9 @@ export function ProwHistory({ config: _config }: ProwHistoryProps) {
     <div className="h-full flex flex-col min-h-card">
       {/* Controls */}
       <div className="flex items-center justify-between mb-4">
-        <span className="text-xs px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400">
+        <StatusBadge color="orange">
           {totalItems} revisions
-        </span>
+        </StatusBadge>
         <div className="flex items-center gap-2">
           <CardControls
             limit={itemsPerPage}

--- a/web/src/components/cards/workload-detection/ProwJobs.tsx
+++ b/web/src/components/cards/workload-detection/ProwJobs.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../ui/Skeleton'
 import { CardControls } from '../../ui/CardControls'
 import { RefreshIndicator } from '../../ui/RefreshIndicator'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { CardSearchInput, CardAIActions } from '../../../lib/cards'
 import { Pagination } from '../../ui/Pagination'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
@@ -135,14 +136,13 @@ export function ProwJobs({ config: _config }: ProwJobsProps) {
             showLabel={true}
             staleThresholdMinutes={5}
           />
-          <span className="text-xs px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400">
+          <StatusBadge color="orange">
             {totalItems} jobs
-          </span>
+          </StatusBadge>
           {jobs.filter(j => j.state === 'running').length > 0 && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 flex items-center gap-1">
-              <Play className="w-3 h-3" />
+            <StatusBadge color="blue" icon={<Play className="w-3 h-3" />}>
               {jobs.filter(j => j.state === 'running').length} running
-            </span>
+            </StatusBadge>
           )}
         </div>
         <div className="flex items-center gap-2">

--- a/web/src/components/cards/workload-monitor/ClusterHealthMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/ClusterHealthMonitor.tsx
@@ -9,6 +9,7 @@ import { useClusters } from '../../../hooks/useMCP'
 import { useCachedPodIssues, useCachedDeploymentIssues } from '../../../hooks/useCachedData'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
 import { cn } from '../../../lib/cn'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { useCardLoadingState } from '../CardDataContext'
 import { WorkloadMonitorAlerts } from './WorkloadMonitorAlerts'
 import { WorkloadMonitorDiagnose } from './WorkloadMonitorDiagnose'
@@ -305,9 +306,9 @@ export function ClusterHealthMonitor({ config: _config }: ClusterHealthMonitorPr
                           <XCircle className="w-3 h-3 text-red-400 shrink-0" />
                           <span className="text-xs text-foreground truncate flex-1">{p.name}</span>
                           <span className="text-2xs text-muted-foreground shrink-0">{p.namespace}</span>
-                          <span className="text-2xs px-1 py-0.5 rounded bg-red-500/20 text-red-400 shrink-0">
+                          <StatusBadge color="red" size="xs" className="shrink-0">
                             {p.status || 'error'}
-                          </span>
+                          </StatusBadge>
                         </div>
                       ))}
                       {clusterPodIssues.length > 5 && (
@@ -332,9 +333,9 @@ export function ClusterHealthMonitor({ config: _config }: ClusterHealthMonitorPr
                           <AlertTriangle className="w-3 h-3 text-yellow-400 shrink-0" />
                           <span className="text-xs text-foreground truncate flex-1">{d.name}</span>
                           <span className="text-2xs text-muted-foreground shrink-0">{d.namespace}</span>
-                          <span className="text-2xs px-1 py-0.5 rounded bg-yellow-500/20 text-yellow-400 shrink-0">
+                          <StatusBadge color="yellow" size="xs" className="shrink-0">
                             {d.readyReplicas ?? 0}/{d.replicas ?? 0}
-                          </span>
+                          </StatusBadge>
                         </div>
                       ))}
                       {clusterDeployIssues.length > 5 && (

--- a/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
@@ -18,6 +18,7 @@ import { cn } from '../../../lib/cn'
 import { useLLMdClusters } from '../workload-detection/shared'
 import { useClusters, useGPUNodes } from '../../../hooks/useMCP'
 import { ClusterStatusDot, getClusterState } from '../../ui/ClusterStatusBadge'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { useCardLoadingState } from '../CardDataContext'
 import type { MonitorIssue, MonitoredResource } from '../../../types/workloadMonitor'
 import { useTranslation } from 'react-i18next'
@@ -719,9 +720,9 @@ export function LLMdStackMonitor({ config: _config }: LLMdStackMonitorProps) {
                           <div className={cn('w-1.5 h-1.5 rounded-full shrink-0', STATUS_DOT[item.status] || 'bg-gray-400')} />
                           <span className="text-xs text-foreground truncate flex-1">{item.name}</span>
                           {item.namespace && (
-                            <span className="text-2xs px-1 py-0.5 rounded bg-purple-500/20 text-purple-400 shrink-0">
+                            <StatusBadge color="purple" size="xs" className="shrink-0">
                               {item.namespace}
-                            </span>
+                            </StatusBadge>
                           )}
                           {item.detail && (
                             <span className="text-2xs text-muted-foreground shrink-0 truncate max-w-[150px]">
@@ -829,9 +830,9 @@ export function LLMdStackMonitor({ config: _config }: LLMdStackMonitorProps) {
                         )}
                         <div className="flex items-center gap-2 mt-2 flex-wrap">
                           {issue.resource?.namespace && (
-                            <span className="text-2xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+                            <StatusBadge color="purple" size="xs">
                               {issue.resource.namespace}
-                            </span>
+                            </StatusBadge>
                           )}
                           {issue.resource?.cluster && (
                             <span className="text-2xs px-1.5 py-0.5 rounded bg-secondary text-muted-foreground">

--- a/web/src/components/cards/workload-monitor/WorkloadMonitorAlerts.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitorAlerts.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, AlertCircle, Info, ChevronDown, ChevronRight } from 'luc
 import { useState } from 'react'
 import type { MonitorIssue } from '../../../types/workloadMonitor'
 import { CardAIActions } from '../../../lib/cards/CardComponents'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { useTranslation } from 'react-i18next'
 
 interface AlertsProps {
@@ -52,13 +53,13 @@ export function WorkloadMonitorAlerts({ issues, monitorType: _monitorType, expan
           <AlertTriangle className="w-3.5 h-3.5 text-yellow-400" />
           <span>Issues ({issues.length})</span>
           {criticalCount > 0 && (
-            <span className="text-2xs px-1 py-0.5 rounded bg-red-500/20 text-red-400">{criticalCount} critical</span>
+            <StatusBadge color="red" size="xs">{criticalCount} critical</StatusBadge>
           )}
           {warningCount > 0 && (
-            <span className="text-2xs px-1 py-0.5 rounded bg-yellow-500/20 text-yellow-400">{warningCount} warning</span>
+            <StatusBadge color="yellow" size="xs">{warningCount} warning</StatusBadge>
           )}
           {infoCount > 0 && (
-            <span className="text-2xs px-1 py-0.5 rounded bg-blue-500/20 text-blue-400">{infoCount} info</span>
+            <StatusBadge color="blue" size="xs">{infoCount} info</StatusBadge>
           )}
         </button>
       )}
@@ -67,13 +68,13 @@ export function WorkloadMonitorAlerts({ issues, monitorType: _monitorType, expan
       {forcedExpanded && (
         <div className="flex items-center gap-2 mb-3 px-1">
           {criticalCount > 0 && (
-            <span className="text-xs px-2 py-1 rounded bg-red-500/20 text-red-400">{criticalCount} critical</span>
+            <StatusBadge color="red" size="md">{criticalCount} critical</StatusBadge>
           )}
           {warningCount > 0 && (
-            <span className="text-xs px-2 py-1 rounded bg-yellow-500/20 text-yellow-400">{warningCount} warning</span>
+            <StatusBadge color="yellow" size="md">{warningCount} warning</StatusBadge>
           )}
           {infoCount > 0 && (
-            <span className="text-xs px-2 py-1 rounded bg-blue-500/20 text-blue-400">{infoCount} info</span>
+            <StatusBadge color="blue" size="md">{infoCount} info</StatusBadge>
           )}
         </div>
       )}

--- a/web/src/components/cards/workload-monitor/WorkloadMonitorToolbar.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitorToolbar.tsx
@@ -1,5 +1,6 @@
 import { Search, List, GitBranch } from 'lucide-react'
 import { CardControls } from '../../ui/CardControls'
+import { StatusBadge } from '../../ui/StatusBadge'
 import type { MonitorViewMode, ResourceCategory, ResourceHealthStatus } from '../../../types/workloadMonitor'
 import { useTranslation } from 'react-i18next'
 
@@ -54,13 +55,13 @@ export function WorkloadMonitorToolbar({
       {/* Top row: summary + controls */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+          <StatusBadge color="purple">
             {totalItems} resources
-          </span>
+          </StatusBadge>
           {issueCount > 0 && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400">
+            <StatusBadge color="red">
               {issueCount} issue{issueCount !== 1 ? 's' : ''}
-            </span>
+            </StatusBadge>
           )}
         </div>
         <div className="flex items-center gap-2">

--- a/web/src/components/clusters/AddClusterDialog.tsx
+++ b/web/src/components/clusters/AddClusterDialog.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import { CloudProviderIcon } from '../ui/CloudProviderIcon'
+import { StatusBadge } from '../ui/StatusBadge'
 
 interface AddClusterDialogProps {
   open: boolean
@@ -393,7 +394,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
                           <div className="flex items-center gap-2 mb-2">
                             <CloudProviderIcon provider={providerKey} size={16} />
                             <span className="text-sm font-medium text-foreground">{cli.provider}</span>
-                            <span className="text-2xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">detected</span>
+                            <StatusBadge color="green" size="xs">detected</StatusBadge>
                           </div>
                           <div className="flex items-start justify-between gap-2">
                             <code className="text-xs text-muted-foreground font-mono break-all">{cmds.register || cmds.auth}</code>
@@ -522,9 +523,9 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
                                 </span>
                               )}
                               {ctx.isNew ? (
-                                <span className="bg-green-500/20 text-green-400 text-xs px-2 py-0.5 rounded">
+                                <StatusBadge color="green">
                                   {t('cluster.importNew')}
-                                </span>
+                                </StatusBadge>
                               ) : (
                                 <span className="bg-white/10 text-muted-foreground text-xs px-2 py-0.5 rounded">
                                   {t('cluster.importExists')}

--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -12,6 +12,7 @@ import { NamespaceResources } from './components'
 import { CPUDetailModal, MemoryDetailModal, StorageDetailModal, GPUDetailModal } from './ResourceDetailModals'
 import { CloudProviderIcon, detectCloudProvider as detectCloudProviderShared, getProviderLabel, CloudProvider as CloudProviderType } from '../ui/CloudProviderIcon'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../ui/StatusBadge'
 
 // Cloud provider types
 type CloudProvider = 'eks' | 'gke' | 'aks' | 'openshift' | 'oci' | 'alibaba' | 'digitalocean' | 'rancher' | 'coreweave' | 'kind' | 'minikube' | 'k3s' | 'unknown'
@@ -265,17 +266,11 @@ After I approve, help me execute the repairs step by step.`,
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center gap-3">
             {isUnreachable ? (
-              <span className="flex items-center gap-1.5 px-2 py-1 rounded bg-yellow-500/20 text-yellow-400" title={t('clusterDetail.offlineStatus')}>
-                <WifiOff className="w-4 h-4" />
-              </span>
+              <StatusBadge color="yellow" icon={<WifiOff className="w-4 h-4" />} className="px-2 py-1" />
             ) : isHealthy ? (
-              <span className="flex items-center gap-1.5 px-2 py-1 rounded bg-green-500/20 text-green-400" title={t('clusterDetail.healthy')}>
-                <CheckCircle className="w-4 h-4" />
-              </span>
+              <StatusBadge color="green" icon={<CheckCircle className="w-4 h-4" />} className="px-2 py-1" />
             ) : (
-              <span className="flex items-center gap-1.5 px-2 py-1 rounded bg-red-500/20 text-red-400" title={t('clusterDetail.unhealthy')}>
-                <AlertTriangle className="w-4 h-4" />
-              </span>
+              <StatusBadge color="red" icon={<AlertTriangle className="w-4 h-4" />} className="px-2 py-1" />
             )}
             <div className="flex flex-col">
               <h2 className="text-xl font-semibold text-foreground">{clusterName.split('/').pop()}</h2>
@@ -364,9 +359,9 @@ After I approve, help me execute the repairs step by step.`,
               <Wrench className="w-3.5 h-3.5" />
               {t('clusterDetail.repair')}
               {(podIssues.length > 0 || clusterDeploymentIssues.length > 0) && (
-                <span className="px-1.5 py-0.5 rounded bg-red-500/30 text-xs">
+                <StatusBadge color="red" size="xs">
                   {podIssues.length + clusterDeploymentIssues.length}
-                </span>
+                </StatusBadge>
               )}
             </button>
             <button
@@ -603,7 +598,7 @@ After I approve, help me execute the repairs step by step.`,
                       >
                         <div className="flex items-center gap-2">
                           {isExpanded ? <ChevronDown className="w-4 h-4 text-muted-foreground" /> : <ChevronRight className="w-4 h-4 text-muted-foreground" />}
-                          <span className="flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 font-medium"><FolderOpen className="w-3 h-3" />{t('clusterDetail.ns')}</span>
+                          <StatusBadge color="blue" size="xs" icon={<FolderOpen className="w-3 h-3" />}>{t('clusterDetail.ns')}</StatusBadge>
                           <span className="font-mono text-sm text-foreground">{ns.name}</span>
                         </div>
                         <div className="flex items-center gap-4 text-sm">
@@ -675,14 +670,12 @@ After I approve, help me execute the repairs step by step.`,
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2 flex-1 min-w-0">
-                      <span className="flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 font-medium flex-shrink-0">
-                        <Box className="w-3 h-3" />{t('clusterDetail.pod')}
-                      </span>
+                      <StatusBadge color="blue" size="xs" icon={<Box className="w-3 h-3" />} className="flex-shrink-0">{t('clusterDetail.pod')}</StatusBadge>
                       <span className="font-medium text-foreground truncate">{issue.name}</span>
                       <span className="text-xs text-muted-foreground flex-shrink-0">({issue.namespace})</span>
                     </div>
                     <div className="flex items-center gap-2 flex-shrink-0 ml-2">
-                      <span className="text-xs px-2 py-1 rounded bg-red-500/20 text-red-400">{issue.status}</span>
+                      <StatusBadge color="red" size="xs">{issue.status}</StatusBadge>
                       <ChevronRight className="w-4 h-4 text-muted-foreground" />
                     </div>
                   </div>
@@ -698,16 +691,14 @@ After I approve, help me execute the repairs step by step.`,
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2 flex-1 min-w-0">
-                      <span className="flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400 font-medium flex-shrink-0">
-                        <Layers className="w-3 h-3" />{t('clusterDetail.deploy')}
-                      </span>
+                      <StatusBadge color="purple" size="xs" icon={<Layers className="w-3 h-3" />} className="flex-shrink-0">{t('clusterDetail.deploy')}</StatusBadge>
                       <span className="font-medium text-foreground truncate">{issue.name}</span>
                       <span className="text-xs text-muted-foreground flex-shrink-0">({issue.namespace})</span>
                     </div>
                     <div className="flex items-center gap-2 flex-shrink-0 ml-2">
-                      <span className="text-xs px-2 py-1 rounded bg-red-500/20 text-red-400">
+                      <StatusBadge color="red" size="xs">
                         {issue.readyReplicas}/{issue.replicas} ready
-                      </span>
+                      </StatusBadge>
                       <ChevronRight className="w-4 h-4 text-muted-foreground" />
                     </div>
                   </div>

--- a/web/src/components/clusters/NodeDetailPanel.tsx
+++ b/web/src/components/clusters/NodeDetailPanel.tsx
@@ -6,6 +6,7 @@ import { useMissions } from '../../hooks/useMissions'
 import { cn } from '../../lib/cn'
 import { formatK8sMemory, formatK8sStorage } from '../../lib/formatters'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../ui/StatusBadge'
 
 interface NodeDetailPanelProps {
   node: NodeInfo
@@ -75,9 +76,7 @@ Please proceed step by step and ask for confirmation before making any changes.`
       {/* Header */}
       <div className="p-3 flex items-center justify-between border-b border-border/30">
         <div className="flex items-center gap-2">
-          <span className="flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-cyan-500/20 text-cyan-400 font-medium">
-            <Server className="w-3 h-3" />Node
-          </span>
+          <StatusBadge color="cyan" icon={<Server className="w-3 h-3" />}>Node</StatusBadge>
           <span className="font-medium text-foreground">{node.name}</span>
           {node.roles.map(role => (
             <span key={role} className="text-xs px-1.5 py-0.5 rounded bg-secondary text-muted-foreground">
@@ -147,9 +146,9 @@ Please proceed step by step and ask for confirmation before making any changes.`
             <span className="text-muted-foreground">Taints:</span>
             <div className="flex flex-wrap gap-2 mt-1">
               {node.taints.map((taint, i) => (
-                <span key={i} className="text-xs px-2 py-1 rounded bg-yellow-500/20 text-yellow-400">
+                <StatusBadge key={i} color="yellow" size="md">
                   {taint}
-                </span>
+                </StatusBadge>
               ))}
             </div>
           </div>
@@ -175,9 +174,9 @@ Please proceed step by step and ask for confirmation before making any changes.`
             </div>
             <div className="flex flex-wrap gap-2 mt-1">
               {displayedLabels.map(([k, v]) => (
-                <span key={k} className="text-xs px-2 py-1 rounded bg-blue-500/10 text-blue-400 font-mono">
+                <StatusBadge key={k} color="blue" size="md" className="font-mono">
                   {k}={v}
-                </span>
+                </StatusBadge>
               ))}
             </div>
           </div>

--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -6,6 +6,7 @@ import { StatusIndicator } from '../../charts/StatusIndicator'
 import { isClusterUnreachable, isClusterLoading } from '../utils'
 import { CloudProviderIcon, detectCloudProvider, getProviderLabel, getProviderColor, getConsoleUrl } from '../../ui/CloudProviderIcon'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../../ui/StatusBadge'
 
 // Guarantees spinner runs for at least 1 full rotation (1s) even if data returns faster.
 // Uses refs for condition checks to avoid stale closure issues when refreshing
@@ -258,11 +259,10 @@ const FullClusterCard = memo(function FullClusterCard({
                   </span>
                 )}
                 {cluster.aliases && cluster.aliases.length > 0 && (
-                  <span
-                    className="text-2xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400 flex-shrink-0"
-                    title={`Also known as: ${cluster.aliases.join(', ')}`}
-                  >
-                    +{cluster.aliases.length} alias{cluster.aliases.length > 1 ? 'es' : ''}
+                  <span title={`Also known as: ${cluster.aliases.join(', ')}`}>
+                    <StatusBadge color="purple" size="xs" className="flex-shrink-0">
+                      +{cluster.aliases.length} alias{cluster.aliases.length > 1 ? 'es' : ''}
+                    </StatusBadge>
                   </span>
                 )}
                 {isConnected && (cluster.source === 'kubeconfig' || !cluster.source) && (
@@ -466,11 +466,10 @@ const ListClusterCard = memo(function ListClusterCard({
               </span>
             )}
             {cluster.aliases && cluster.aliases.length > 0 && (
-              <span
-                className="text-2xs px-1 py-0.5 rounded bg-purple-500/20 text-purple-400 flex-shrink-0"
-                title={`Also known as: ${cluster.aliases.join(', ')}`}
-              >
-                +{cluster.aliases.length}
+              <span title={`Also known as: ${cluster.aliases.join(', ')}`}>
+                <StatusBadge color="purple" size="xs" className="flex-shrink-0">
+                  +{cluster.aliases.length}
+                </StatusBadge>
               </span>
             )}
             {cluster.isCurrent && (
@@ -605,11 +604,10 @@ const CompactClusterCard = memo(function CompactClusterCard({
             {cluster.context || cluster.name.split('/').pop()}
           </span>
           {cluster.aliases && cluster.aliases.length > 0 && (
-            <span
-              className="text-[8px] px-1 rounded bg-purple-500/20 text-purple-400 flex-shrink-0"
-              title={`Also known as: ${cluster.aliases.join(', ')}`}
-            >
-              +{cluster.aliases.length}
+            <span title={`Also known as: ${cluster.aliases.join(', ')}`}>
+              <StatusBadge color="purple" size="xs" className="flex-shrink-0">
+                +{cluster.aliases.length}
+              </StatusBadge>
             </span>
           )}
           {cluster.isCurrent && (

--- a/web/src/components/clusters/components/GPUDetailModal.tsx
+++ b/web/src/components/clusters/components/GPUDetailModal.tsx
@@ -3,6 +3,7 @@ import { Zap, Server, Layers, RefreshCw, Cpu, AlertCircle, HardDrive, CircuitBoa
 import { GPUNode, NVIDIAOperatorStatus } from '../../../hooks/useMCP'
 import { BaseModal } from '../../../lib/modals'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../../ui/StatusBadge'
 
 interface GPUDetailModalProps {
   gpuNodes: GPUNode[]
@@ -453,7 +454,7 @@ export function GPUDetailModal({ isOpen = true, gpuNodes, isLoading, error, onRe
                             <div className="flex items-center gap-1">
                               {node.name}
                               {node.migCapable && (
-                                <span className="px-1 py-0.5 rounded bg-purple-500/20 text-purple-400 text-2xs">MIG</span>
+                                <StatusBadge color="purple" size="xs">MIG</StatusBadge>
                               )}
                             </div>
                           </td>

--- a/web/src/components/clusters/components/NamespaceResources.tsx
+++ b/web/src/components/clusters/components/NamespaceResources.tsx
@@ -3,6 +3,7 @@ import { ChevronRight, ChevronDown, Box, Layers, Network, List, GitBranch, Activ
 import { usePods, useDeployments, useServices, useJobs, useHPAs, useConfigMaps, useSecrets, useServiceAccounts, usePVCs } from '../../../hooks/useMCP'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../../ui/StatusBadge'
 
 type ResourceKind = 'Pod' | 'Deployment' | 'Service' | 'Job' | 'HPA' | 'ConfigMap' | 'Secret' | 'ServiceAccount' | 'PVC'
 
@@ -338,7 +339,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
               <div className="mb-1">
                 <button onClick={() => toggleType('deployments')} className="flex items-center gap-1.5 py-2 hover:bg-card/30 rounded px-2 w-full text-left min-h-11">
                   {expandedTypes.has('deployments') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <span className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400 font-medium"><Layers className="w-3 h-3" />Deploy</span>
+                  <StatusBadge color="purple" icon={<Layers className="w-3 h-3" />}>Deploy</StatusBadge>
                   <span className="text-muted-foreground">({deployments.length})</span>
                 </button>
                 {expandedTypes.has('deployments') && (
@@ -391,7 +392,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
               <div className="mb-1">
                 <button onClick={() => toggleType('pods')} className="flex items-center gap-1.5 py-2 hover:bg-card/30 rounded px-2 w-full text-left min-h-11">
                   {expandedTypes.has('pods') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <span className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400 font-medium"><Box className="w-3 h-3" />{t('common.pod')}</span>
+                  <StatusBadge color="blue" icon={<Box className="w-3 h-3" />}>{t('common.pod')}</StatusBadge>
                   <span className="text-muted-foreground">Standalone ({podsByDeployment.standalone.length})</span>
                 </button>
                 {expandedTypes.has('pods') && (
@@ -418,7 +419,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
               <div className="mb-1">
                 <button onClick={() => toggleType('services')} className="flex items-center gap-1.5 py-2 hover:bg-card/30 rounded px-2 w-full text-left min-h-11">
                   {expandedTypes.has('services') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <span className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-cyan-500/20 text-cyan-400 font-medium"><Network className="w-3 h-3" />Svc</span>
+                  <StatusBadge color="cyan" icon={<Network className="w-3 h-3" />}>Svc</StatusBadge>
                   <span className="text-muted-foreground">({services.length})</span>
                 </button>
                 {expandedTypes.has('services') && (
@@ -445,7 +446,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
               <div className="mb-1">
                 <button onClick={() => toggleType('jobs')} className="flex items-center gap-1.5 py-2 hover:bg-card/30 rounded px-2 w-full text-left min-h-11">
                   {expandedTypes.has('jobs') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <span className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400 font-medium"><Briefcase className="w-3 h-3" />Job</span>
+                  <StatusBadge color="yellow" icon={<Briefcase className="w-3 h-3" />}>Job</StatusBadge>
                   <span className="text-muted-foreground">({jobs.length})</span>
                 </button>
                 {expandedTypes.has('jobs') && (
@@ -472,7 +473,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
               <div className="mb-1">
                 <button onClick={() => toggleType('hpas')} className="flex items-center gap-1.5 py-2 hover:bg-card/30 rounded px-2 w-full text-left min-h-11">
                   {expandedTypes.has('hpas') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <span className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400 font-medium"><Activity className="w-3 h-3" />HPA</span>
+                  <StatusBadge color="purple" icon={<Activity className="w-3 h-3" />}>HPA</StatusBadge>
                   <span className="text-muted-foreground">({hpas.length})</span>
                 </button>
                 {expandedTypes.has('hpas') && (
@@ -499,7 +500,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
               <div className="mb-1">
                 <button onClick={() => toggleType('serviceaccounts')} className="flex items-center gap-1.5 py-2 hover:bg-card/30 rounded px-2 w-full text-left min-h-11">
                   {expandedTypes.has('serviceaccounts') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <span className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-cyan-500/20 text-cyan-400 font-medium"><User className="w-3 h-3" />SA</span>
+                  <StatusBadge color="cyan" icon={<User className="w-3 h-3" />}>SA</StatusBadge>
                   <span className="text-muted-foreground">({serviceAccounts.length})</span>
                 </button>
                 {expandedTypes.has('serviceaccounts') && (
@@ -526,7 +527,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
               <div className="mb-1">
                 <button onClick={() => toggleType('pvcs')} className="flex items-center gap-1.5 py-2 hover:bg-card/30 rounded px-2 w-full text-left min-h-11">
                   {expandedTypes.has('pvcs') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <span className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-green-500/20 text-green-400 font-medium"><HardDrive className="w-3 h-3" />PVC</span>
+                  <StatusBadge color="green" icon={<HardDrive className="w-3 h-3" />}>PVC</StatusBadge>
                   <span className="text-muted-foreground">({pvcs.length})</span>
                 </button>
                 {expandedTypes.has('pvcs') && (
@@ -554,7 +555,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
               <div className="mb-1">
                 <button onClick={() => toggleType('configmaps')} className="flex items-center gap-1.5 py-2 hover:bg-card/30 rounded px-2 w-full text-left min-h-11">
                   {expandedTypes.has('configmaps') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <span className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400 font-medium"><Settings className="w-3 h-3" />CM</span>
+                  <StatusBadge color="orange" icon={<Settings className="w-3 h-3" />}>CM</StatusBadge>
                   <span className="text-muted-foreground">({configmaps.length})</span>
                 </button>
                 {expandedTypes.has('configmaps') && (
@@ -581,7 +582,7 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
               <div className="mb-1">
                 <button onClick={() => toggleType('secrets')} className="flex items-center gap-1.5 py-2 hover:bg-card/30 rounded px-2 w-full text-left min-h-11">
                   {expandedTypes.has('secrets') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <span className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400 font-medium"><Lock className="w-3 h-3" />Secret</span>
+                  <StatusBadge color="purple" icon={<Lock className="w-3 h-3" />}>Secret</StatusBadge>
                   <span className="text-muted-foreground">({secrets.length})</span>
                 </button>
                 {expandedTypes.has('secrets') && (

--- a/web/src/components/dashboard/CardFactoryModal.tsx
+++ b/web/src/components/dashboard/CardFactoryModal.tsx
@@ -20,6 +20,7 @@ import { InlineAIAssist } from './InlineAIAssist'
 import { CARD_T1_SYSTEM_PROMPT, CARD_T2_SYSTEM_PROMPT, CARD_INLINE_ASSIST_PROMPT, CODE_INLINE_ASSIST_PROMPT } from '../../lib/ai/prompts'
 import { generateSampleData, detectFieldFormat } from '../../lib/ai/sampleData'
 import { useAIMode } from '../../hooks/useAIMode'
+import { StatusBadge } from '../ui/StatusBadge'
 
 interface CardFactoryModalProps {
   isOpen: boolean
@@ -1230,9 +1231,9 @@ function T1Preview({ result }: { result: AiCardT1Result }) {
       <div className="flex items-center gap-2 mb-3">
         <Layers className="w-4 h-4 text-purple-400" />
         <span className="text-sm font-medium text-foreground">{result.title}</span>
-        <span className="text-2xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400">
+        <StatusBadge color="blue" size="xs">
           {result.layout}
-        </span>
+        </StatusBadge>
       </div>
       {result.description && (
         <p className="text-xs text-muted-foreground mb-3">{result.description}</p>
@@ -1278,9 +1279,9 @@ function T2Preview({ result }: { result: AiCardT2Result }) {
       <div className="flex items-center gap-2 mb-3">
         <Code className="w-4 h-4 text-purple-400" />
         <span className="text-sm font-medium text-foreground">{result.title}</span>
-        <span className="text-2xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+        <StatusBadge color="purple" size="xs">
           Custom Code
-        </span>
+        </StatusBadge>
       </div>
       {result.description && (
         <p className="text-xs text-muted-foreground mb-2">{result.description}</p>

--- a/web/src/components/dashboard/CardRecommendations.tsx
+++ b/web/src/components/dashboard/CardRecommendations.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Clock, ChevronDown, ChevronUp, X, Plus, AlertTriangle, Info, Lightbulb } from 'lucide-react'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardRecommendations, CardRecommendation } from '../../hooks/useCardRecommendations'
 import { useSnoozedRecommendations } from '../../hooks/useSnoozedRecommendations'
 import { AI_THINKING_DELAY_MS } from '../../lib/constants/network'
@@ -134,9 +135,9 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
             )
           })}
           {highPriorityCount > 0 && (
-            <span className="px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-400 text-2xs">
+            <StatusBadge color="red" size="xs" rounded="full">
               {t('dashboard.recommendations.critical', { count: highPriorityCount })}
-            </span>
+            </StatusBadge>
           )}
         </div>
       </div>
@@ -153,9 +154,9 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
             {t('dashboard.recommendations.ai')}
           </span>
           {highPriorityCount > 0 && (
-            <span className="px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-400 text-2xs">
+            <StatusBadge color="red" size="xs" rounded="full">
               {t('dashboard.recommendations.critical', { count: highPriorityCount })}
-            </span>
+            </StatusBadge>
           )}
           {visibleRecommendations.length > 6 && (
             <span className="text-2xs text-muted-foreground">

--- a/web/src/components/dashboard/MissionSuggestions.tsx
+++ b/web/src/components/dashboard/MissionSuggestions.tsx
@@ -9,6 +9,7 @@ import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { Skeleton } from '../ui/Skeleton'
+import { StatusBadge } from '../ui/StatusBadge'
 
 const MISSION_ICONS: Record<MissionType, typeof Zap> = {
   scale: Scale,
@@ -209,9 +210,9 @@ export function MissionSuggestions() {
             )
           })}
           {stats.critical > 0 && (
-            <span className="px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-400 text-2xs">
+            <StatusBadge color="red" size="xs" rounded="full">
               {t('dashboard.missions.critical', { count: stats.critical })}
-            </span>
+            </StatusBadge>
           )}
         </div>
       </div>
@@ -228,14 +229,14 @@ export function MissionSuggestions() {
             {t('dashboard.missions.actions')}
           </span>
           {stats.critical > 0 && (
-            <span className="px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-400 text-2xs">
+            <StatusBadge color="red" size="xs" rounded="full">
               {t('dashboard.missions.critical', { count: stats.critical })}
-            </span>
+            </StatusBadge>
           )}
           {stats.high > 0 && stats.critical === 0 && (
-            <span className="px-1.5 py-0.5 rounded-full bg-orange-500/20 text-orange-400 text-2xs">
+            <StatusBadge color="orange" size="xs" rounded="full">
               {t('dashboard.missions.high', { count: stats.high })}
-            </span>
+            </StatusBadge>
           )}
           {suggestions.length > 6 && (
             <span className="text-2xs text-muted-foreground">

--- a/web/src/components/dashboard/StatBlockFactoryModal.tsx
+++ b/web/src/components/dashboard/StatBlockFactoryModal.tsx
@@ -25,6 +25,7 @@ import { AiGenerationPanel } from './AiGenerationPanel'
 import { InlineAIAssist } from './InlineAIAssist'
 import { STAT_BLOCK_SYSTEM_PROMPT, STAT_INLINE_ASSIST_PROMPT } from '../../lib/ai/prompts'
 import { useAIMode } from '../../hooks/useAIMode'
+import { StatusBadge } from '../ui/StatusBadge'
 
 // Demo/preview constants
 const DEMO_STAT_VALUE = 42 // Placeholder value shown in stat block previews
@@ -662,9 +663,9 @@ export function StatBlockFactoryModal({ isOpen, onClose, onStatsCreated }: StatB
                   <div className="flex items-center gap-1.5">
                     <Eye className="w-3 h-3 text-muted-foreground" />
                     <span className="text-2xs font-medium text-muted-foreground uppercase tracking-wide">{t('dashboard.preview.header')}</span>
-                    <span className="text-[9px] px-1 py-0.5 rounded bg-purple-500/10 text-purple-400/70">
+                    <StatusBadge color="purple" size="xs">
                       {t('dashboard.preview.sampleValues')}
-                    </span>
+                    </StatusBadge>
                   </div>
                   <div className="flex items-center gap-0.5">
                     <button
@@ -773,9 +774,9 @@ export function StatBlockFactoryModal({ isOpen, onClose, onStatsCreated }: StatB
                     <div className="flex items-center gap-2">
                       <Activity className="w-4 h-4 text-purple-400 shrink-0" />
                       <span className="text-sm font-medium text-foreground">{stats.title || stats.type}</span>
-                      <span className="text-2xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+                      <StatusBadge color="purple" size="xs">
                         {t('dashboard.statFactory.blocksCount', { count: stats.blocks.length })}
-                      </span>
+                      </StatusBadge>
                     </div>
                     <p className="text-xs text-muted-foreground mt-0.5">
                       Type: {stats.type}

--- a/web/src/components/drilldown/views/CRDDrillDown.tsx
+++ b/web/src/components/drilldown/views/CRDDrillDown.tsx
@@ -9,6 +9,7 @@ import {
   FileText, Code, Database, List
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
@@ -492,10 +493,10 @@ Please:
                       <div className="flex items-center gap-2">
                         <span className="text-sm font-medium text-foreground">{version.name}</span>
                         {version.storage && (
-                          <span className="px-2 py-0.5 rounded text-xs bg-blue-500/20 text-blue-400">{t('common.storage')}</span>
+                          <StatusBadge color="blue" size="xs">{t('common.storage')}</StatusBadge>
                         )}
                         {version.deprecated && (
-                          <span className="px-2 py-0.5 rounded text-xs bg-yellow-500/20 text-yellow-400">Deprecated</span>
+                          <StatusBadge color="yellow" size="xs">Deprecated</StatusBadge>
                         )}
                       </div>
                       <span className={cn(

--- a/web/src/components/drilldown/views/ClusterDrillDown.tsx
+++ b/web/src/components/drilldown/views/ClusterDrillDown.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { ChevronRight, ChevronDown, Server, Box, Layers, Database, Network, HardDrive, Search, AlertTriangle, XCircle } from 'lucide-react'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { useClusterHealth, usePodIssues, useDeploymentIssues, useGPUNodes, useNodes, useNamespaces, useDeployments, useServices, usePVCs, useEvents } from '../../../hooks/useMCP'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { StatusIndicator } from '../../charts/StatusIndicator'
@@ -372,7 +373,7 @@ export function ClusterDrillDown({ data }: Props) {
                         )}
                       </div>
                       <div className="flex items-center gap-2 flex-shrink-0 ml-2">
-                        <span className="text-xs px-2 py-1 rounded bg-red-500/20 text-red-400">{issue.status}</span>
+                        <StatusBadge color="red" size="xs">{issue.status}</StatusBadge>
                         <ChevronRight className="w-4 h-4 text-muted-foreground" />
                       </div>
                     </div>
@@ -402,9 +403,9 @@ export function ClusterDrillDown({ data }: Props) {
                         )}
                       </div>
                       <div className="flex items-center gap-2 flex-shrink-0 ml-2">
-                        <span className="text-xs px-2 py-1 rounded bg-orange-500/20 text-orange-400">
+                        <StatusBadge color="orange" size="xs">
                           {issue.readyReplicas}/{issue.replicas} ready
-                        </span>
+                        </StatusBadge>
                         <ChevronRight className="w-4 h-4 text-muted-foreground" />
                       </div>
                     </div>
@@ -485,9 +486,9 @@ export function ClusterDrillDown({ data }: Props) {
             <Layers className="w-5 h-5 text-purple-400" />
             Resource Tree
             {issueCounts.total > 0 && (
-              <span className="ml-2 px-2 py-0.5 text-xs rounded-full bg-red-500/20 text-red-400">
+              <StatusBadge color="red" size="xs" rounded="full" className="ml-2">
                 {issueCounts.total} issues
-              </span>
+              </StatusBadge>
             )}
           </button>
         </div>
@@ -575,9 +576,9 @@ export function ClusterDrillDown({ data }: Props) {
                           <span className="text-sm font-medium text-foreground">{t('common.nodes')}</span>
                           <span className="text-xs text-muted-foreground">({filteredNodes.length})</span>
                           {issueCounts.nodes > 0 && (
-                            <span className="ml-1 px-1.5 py-0.5 rounded-full text-2xs bg-red-500/20 text-red-400">
+                            <StatusBadge color="red" size="xs" rounded="full" className="ml-1">
                               {issueCounts.nodes} not ready
-                            </span>
+                            </StatusBadge>
                           )}
                         </div>
 
@@ -641,9 +642,9 @@ export function ClusterDrillDown({ data }: Props) {
                                     {expandedSections.has(nsKey) ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
                                     <span className="text-sm text-foreground">{ns}</span>
                                     {totalIssues > 0 && (
-                                      <span className="ml-1 px-1.5 py-0.5 rounded-full text-2xs bg-red-500/20 text-red-400">
+                                      <StatusBadge color="red" size="xs" rounded="full" className="ml-1">
                                         {totalIssues}
-                                      </span>
+                                      </StatusBadge>
                                     )}
                                   </div>
 
@@ -711,9 +712,9 @@ export function ClusterDrillDown({ data }: Props) {
                           {expandedSections.has('deployment-issues') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
                           <AlertTriangle className="w-4 h-4 text-orange-400" />
                           <span className="text-sm font-medium text-foreground">Deployment Issues</span>
-                          <span className="px-1.5 py-0.5 rounded-full text-2xs bg-orange-500/20 text-orange-400">
+                          <StatusBadge color="orange" size="xs" rounded="full">
                             {issueCounts.deployments}
-                          </span>
+                          </StatusBadge>
                         </div>
 
                         {expandedSections.has('deployment-issues') && (
@@ -746,9 +747,9 @@ export function ClusterDrillDown({ data }: Props) {
                           {expandedSections.has('pod-issues') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
                           <AlertTriangle className="w-4 h-4 text-red-400" />
                           <span className="text-sm font-medium text-foreground">Pod Issues</span>
-                          <span className="px-1.5 py-0.5 rounded-full text-2xs bg-red-500/20 text-red-400">
+                          <StatusBadge color="red" size="xs" rounded="full">
                             {issueCounts.pods}
-                          </span>
+                          </StatusBadge>
                         </div>
 
                         {expandedSections.has('pod-issues') && (
@@ -788,9 +789,9 @@ export function ClusterDrillDown({ data }: Props) {
                           <span className="text-sm font-medium text-foreground">{t('common.pvcs')}</span>
                           <span className="text-xs text-muted-foreground">({filteredPVCs.length})</span>
                           {issueCounts.pvcs > 0 && (
-                            <span className="ml-1 px-1.5 py-0.5 rounded-full text-2xs bg-yellow-500/20 text-yellow-400">
+                            <StatusBadge color="yellow" size="xs" rounded="full" className="ml-1">
                               {issueCounts.pvcs} pending
-                            </span>
+                            </StatusBadge>
                           )}
                         </div>
 
@@ -846,7 +847,7 @@ export function ClusterDrillDown({ data }: Props) {
                                 <Network className="w-3 h-3 text-blue-400" />
                                 <span className="text-sm text-foreground">{svc.name}</span>
                                 <span className="text-xs text-muted-foreground">{svc.namespace}</span>
-                                <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400">{svc.type}</span>
+                                <StatusBadge color="blue" size="xs">{svc.type}</StatusBadge>
                                 <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
                               </div>
                             ))}

--- a/web/src/components/drilldown/views/KustomizationDrillDown.tsx
+++ b/web/src/components/drilldown/views/KustomizationDrillDown.tsx
@@ -9,6 +9,7 @@ import {
   FileText, GitBranch, Clock, Package
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
@@ -312,9 +313,9 @@ Please:
           {/* Status badges */}
           <div className="flex items-center gap-2">
             {suspended && (
-              <span className="px-2.5 py-1 rounded-lg text-xs font-medium bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
+              <StatusBadge color="yellow" variant="outline">
                 Suspended
-              </span>
+              </StatusBadge>
             )}
             <span className={cn('px-2.5 py-1 rounded-lg text-xs font-medium flex items-center gap-1', statusStyle.bg, statusStyle.text, 'border', statusStyle.border)}>
               <StatusIcon className="w-3 h-3" />

--- a/web/src/components/drilldown/views/NamespaceDrillDown.tsx
+++ b/web/src/components/drilldown/views/NamespaceDrillDown.tsx
@@ -3,6 +3,7 @@ import { ChevronRight } from 'lucide-react'
 import { usePodIssues, useDeploymentIssues, useEvents } from '../../../hooks/useMCP'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { StatusIndicator } from '../../charts/StatusIndicator'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
@@ -78,9 +79,9 @@ export function NamespaceDrillDown({ data }: Props) {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1">
                       <span className="font-semibold text-foreground">{issue.name}</span>
-                      <span className="text-xs px-2 py-0.5 rounded bg-orange-500/20 text-orange-400">
+                      <StatusBadge color="orange" size="xs">
                         {issue.readyReplicas}/{issue.replicas} ready
-                      </span>
+                      </StatusBadge>
                     </div>
                     {issue.reason && (
                       <div className="text-sm text-muted-foreground">Reason: {issue.reason}</div>
@@ -112,9 +113,9 @@ export function NamespaceDrillDown({ data }: Props) {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1">
                       <span className="font-semibold text-foreground">{issue.name}</span>
-                      <span className="text-xs px-2 py-0.5 rounded bg-red-500/20 text-red-400">
+                      <StatusBadge color="red" size="xs">
                         {issue.status}
-                      </span>
+                      </StatusBadge>
                     </div>
                     <div className="flex items-center gap-4 text-sm text-muted-foreground">
                       <span>{issue.restarts} restarts</span>
@@ -123,9 +124,9 @@ export function NamespaceDrillDown({ data }: Props) {
                     {issue.issues.length > 0 && (
                       <div className="flex flex-wrap gap-1 mt-2">
                         {issue.issues.map((iss, j) => (
-                          <span key={j} className="text-xs px-2 py-0.5 rounded bg-red-500/20 text-red-400">
+                          <StatusBadge key={j} color="red" size="xs">
                             {iss}
-                          </span>
+                          </StatusBadge>
                         ))}
                       </div>
                     )}

--- a/web/src/components/drilldown/views/PolicyDrillDown.tsx
+++ b/web/src/components/drilldown/views/PolicyDrillDown.tsx
@@ -10,6 +10,7 @@ import {
   FileText, AlertCircle
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
@@ -440,8 +441,8 @@ Please:
                     <div key={i} className="p-3 rounded-lg bg-secondary/50 flex items-center justify-between">
                       <span className="text-sm font-medium text-foreground">{rule.name}</span>
                       <div className="flex gap-2">
-                        {rule.validate && <span className="px-2 py-0.5 rounded text-xs bg-blue-500/20 text-blue-400">Validate</span>}
-                        {rule.mutate && <span className="px-2 py-0.5 rounded text-xs bg-purple-500/20 text-purple-400">Mutate</span>}
+                        {rule.validate && <StatusBadge color="blue" size="xs">Validate</StatusBadge>}
+                        {rule.mutate && <StatusBadge color="purple" size="xs">Mutate</StatusBadge>}
                       </div>
                     </div>
                   ))}

--- a/web/src/components/drilldown/views/ReplicaSetDrillDown.tsx
+++ b/web/src/components/drilldown/views/ReplicaSetDrillDown.tsx
@@ -5,6 +5,7 @@ import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { FileText, Code, Info, Tag, Zap, Loader2, Copy, Check, Layers, Server, Box } from 'lucide-react'
 import { cn } from '../../../lib/cn'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { StatusIndicator } from '../../charts/StatusIndicator'
 import { Gauge } from '../../charts/Gauge'
@@ -288,9 +289,9 @@ export function ReplicaSetDrillDown({ data }: Props) {
                 </h3>
                 <div className="flex flex-wrap gap-2">
                   {Object.entries(labels).slice(0, 8).map(([key, value]) => (
-                    <span key={key} className="text-xs px-2 py-1 rounded bg-blue-500/10 text-blue-400 font-mono">
+                    <StatusBadge key={key} color="blue" size="xs" className="font-mono">
                       {key}={value}
-                    </span>
+                    </StatusBadge>
                   ))}
                   {Object.keys(labels).length > 8 && (
                     <span className="text-xs text-muted-foreground">+{Object.keys(labels).length - 8} more</span>

--- a/web/src/components/events/Events.tsx
+++ b/web/src/components/events/Events.tsx
@@ -14,6 +14,7 @@ import { StatBlockValue } from '../ui/StatsOverview'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
 import { getChartColor, getChartColorByName } from '../../lib/chartColors'
+import { StatusBadge } from '../ui/StatusBadge'
 
 // Event-related constants
 const EVENT_LIMIT = 100 // Maximum number of events to fetch
@@ -335,7 +336,7 @@ export function Events() {
                     <AlertTriangle className="w-4 h-4 text-yellow-400 flex-shrink-0" />
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
-                        <span className="text-xs px-2 py-0.5 rounded bg-yellow-500/20 text-yellow-400 font-medium">{event.reason}</span>
+                        <StatusBadge color="yellow">{event.reason}</StatusBadge>
                         <span className="text-sm text-foreground truncate">{event.object}</span>
                       </div>
                       <div className="text-xs text-muted-foreground truncate mt-0.5">{event.message}</div>

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { X, Bug, Sparkles, Loader2, ExternalLink, Bell, Check, Clock, GitPullRequest, GitMerge, Eye, RefreshCw, MessageSquare, Settings, Github, Coins, Lightbulb, AlertCircle, Linkedin, Trophy } from 'lucide-react'
+import { StatusBadge } from '../ui/StatusBadge'
 import { BaseModal } from '../../lib/modals'
 import {
   useFeatureRequests,
@@ -406,9 +407,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
             </p>
           </div>
           {!canPerformActions && (
-            <span className="px-1.5 py-0.5 text-2xs font-medium rounded bg-yellow-500/20 text-yellow-400 uppercase tracking-wider">
-              {t('feedback.demo')}
-            </span>
+            <StatusBadge color="yellow" size="xs" className="uppercase tracking-wider">{t('feedback.demo')}</StatusBadge>
           )}
         </div>
         <button
@@ -460,9 +459,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
                   ? t('feedback.loginBannerDemo')
                   : t('feedback.loginBannerLocal')}
               </span>
-          <span className="text-xs px-2 py-1 rounded bg-yellow-500/20 text-yellow-400">
-            {isDemoModeForced ? t('feedback.loginWithGitHub') : t('feedback.setupOAuth')}
-          </span>
+          <StatusBadge color="yellow">{isDemoModeForced ? t('feedback.loginWithGitHub') : t('feedback.setupOAuth')}</StatusBadge>
         </button>
       )}
 
@@ -562,9 +559,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
                                   </span>
                                 )}
                                 {isOwnedByUser && (
-                                  <span className="px-1.5 py-0.5 text-2xs font-medium rounded bg-blue-500/20 text-blue-400">
-                                    Yours
-                                  </span>
+                                  <StatusBadge color="blue" size="xs">Yours</StatusBadge>
                                 )}
                                 {/* Unread updates badge with clear button */}
                                 {requestUnreadCount > 0 && (
@@ -959,34 +954,29 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
                         <div className="px-3 py-2 border-b border-border/50 flex-shrink-0">
                           <div className="flex flex-wrap gap-1.5">
                             {githubRewards.breakdown.prs_merged > 0 && (
-                              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-purple-500/20 text-purple-400 text-2xs">
-                                <GitMerge className="w-2.5 h-2.5" />
+                              <StatusBadge color="purple" size="xs" rounded="full" icon={<GitMerge className="w-2.5 h-2.5" />}>
                                 {githubRewards.breakdown.prs_merged} Merged
-                              </span>
+                              </StatusBadge>
                             )}
                             {githubRewards.breakdown.prs_opened > 0 && (
-                              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-green-500/20 text-green-400 text-2xs">
-                                <GitPullRequest className="w-2.5 h-2.5" />
+                              <StatusBadge color="green" size="xs" rounded="full" icon={<GitPullRequest className="w-2.5 h-2.5" />}>
                                 {githubRewards.breakdown.prs_opened} PRs
-                              </span>
+                              </StatusBadge>
                             )}
                             {githubRewards.breakdown.bug_issues > 0 && (
-                              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-400 text-2xs">
-                                <Bug className="w-2.5 h-2.5" />
+                              <StatusBadge color="red" size="xs" rounded="full" icon={<Bug className="w-2.5 h-2.5" />}>
                                 {githubRewards.breakdown.bug_issues} Bugs
-                              </span>
+                              </StatusBadge>
                             )}
                             {githubRewards.breakdown.feature_issues > 0 && (
-                              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-yellow-500/20 text-yellow-400 text-2xs">
-                                <Lightbulb className="w-2.5 h-2.5" />
+                              <StatusBadge color="yellow" size="xs" rounded="full" icon={<Lightbulb className="w-2.5 h-2.5" />}>
                                 {githubRewards.breakdown.feature_issues} Features
-                              </span>
+                              </StatusBadge>
                             )}
                             {githubRewards.breakdown.other_issues > 0 && (
-                              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-gray-500/20 text-muted-foreground text-2xs">
-                                <AlertCircle className="w-2.5 h-2.5" />
+                              <StatusBadge color="purple" size="xs" rounded="full" className="!bg-gray-500/20 !text-muted-foreground" icon={<AlertCircle className="w-2.5 h-2.5" />}>
                                 {githubRewards.breakdown.other_issues} Issues
-                              </span>
+                              </StatusBadge>
                             )}
                           </div>
                         </div>

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { createPortal } from 'react-dom'
 import { X, Bug, Lightbulb, Send, CheckCircle2, ExternalLink, Linkedin } from 'lucide-react'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useRewards, REWARD_ACTIONS } from '../../hooks/useRewards'
 import { useToast } from '../ui/Toast'
 import { emitFeedbackSubmitted, emitLinkedInShare } from '../../lib/analytics'
@@ -175,9 +176,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                 >
                   <Bug className="w-4 h-4" />
                   <span className="text-sm font-medium">Bug Report</span>
-                  <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">
-                    +{REWARD_ACTIONS.bug_report.coins}
-                  </span>
+                  <StatusBadge color="yellow">+{REWARD_ACTIONS.bug_report.coins}</StatusBadge>
                 </button>
                 <button
                   type="button"
@@ -190,9 +189,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                 >
                   <Lightbulb className="w-4 h-4" />
                   <span className="text-sm font-medium">Feature Request</span>
-                  <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">
-                    +{REWARD_ACTIONS.feature_suggestion.coins}
-                  </span>
+                  <StatusBadge color="yellow">+{REWARD_ACTIONS.feature_suggestion.coins}</StatusBadge>
                 </button>
               </div>
 
@@ -293,9 +290,7 @@ export function LinkedInShareButton({ onShare, compact = false }: { onShare?: ()
       >
         <Linkedin className="w-4 h-4" />
         <span>{t('feedback.share')}</span>
-        <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">
-          +{REWARD_ACTIONS.linkedin_share.coins}
-        </span>
+        <StatusBadge color="yellow">+{REWARD_ACTIONS.linkedin_share.coins}</StatusBadge>
       </button>
     )
   }

--- a/web/src/components/feedback/NotificationBadge.tsx
+++ b/web/src/components/feedback/NotificationBadge.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Bell, X, Check, Clock, Bug, Sparkles, GitPullRequest, Eye } from 'lucide-react'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useNotifications, type Notification, type NotificationType } from '../../hooks/useFeatureRequests'
 import { useTranslation } from 'react-i18next'
 
@@ -132,9 +133,7 @@ export function NotificationBadge() {
                 <Bell className="w-4 h-4 text-purple-400" />
                 <span className="font-medium text-foreground">Notifications</span>
                 {unreadCount > 0 && (
-                  <span className="px-1.5 py-0.5 text-xs rounded bg-purple-500/20 text-purple-400">
-                    {unreadCount} new
-                  </span>
+                  <StatusBadge color="purple">{unreadCount} new</StatusBadge>
                 )}
               </div>
               <div className="flex items-center gap-1">

--- a/web/src/components/gitops/GitOps.tsx
+++ b/web/src/components/gitops/GitOps.tsx
@@ -15,6 +15,7 @@ import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
 import { PortalTooltip } from '../cards/llmd/shared/PortalTooltip'
 import { STATUS_TOOLTIPS } from '../shared/TechnicalAcronym'
+import { StatusBadge } from '../ui/StatusBadge'
 
 // GitOps app configuration (repos to monitor)
 interface GitOpsAppConfig {
@@ -291,7 +292,7 @@ export function GitOps() {
       {/* Apps List */}
       <div className="flex items-center gap-2 mb-3">
         <span className="text-sm font-medium text-muted-foreground">{t('gitops.applications')}</span>
-        <span className="text-2xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">{t('common:common.demo')}</span>
+        <StatusBadge color="yellow" size="xs">{t('common:common.demo')}</StatusBadge>
       </div>
       {filteredApps.length === 0 ? (
         <div className="text-center py-12">

--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -48,6 +48,7 @@ import type { GPUUtilizationSnapshot } from '../../hooks/useGPUUtilizations'
 import { Sparkline } from '../charts/Sparkline'
 import type { GPUReservation, CreateGPUReservationInput, UpdateGPUReservationInput } from '../../hooks/useGPUReservations'
 import { CARD_COMPONENTS, getDefaultCardWidth } from '../cards/cardRegistry'
+import { StatusBadge } from '../ui/StatusBadge'
 import { CardWrapper, CARD_TITLES } from '../cards/CardWrapper'
 import { AddCardModal } from '../dashboard/AddCardModal'
 import { safeGetJSON, safeSetJSON } from '../../lib/utils/localStorage'
@@ -625,10 +626,9 @@ export function GPUReservations() {
         <div className="flex items-center gap-3">
           <h1 className="text-2xl font-bold text-foreground">{t('gpuReservations.title')}</h1>
           {effectiveDemoMode && (
-            <span className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-full bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
-              <FlaskConical className="w-3 h-3" />
+            <StatusBadge color="yellow" variant="outline" rounded="full" icon={<FlaskConical className="w-3 h-3" />}>
               {t('gpuReservations.demo')}
-            </span>
+            </StatusBadge>
           )}
         </div>
         <div className="text-muted-foreground">{t('gpuReservations.subtitle')}</div>
@@ -670,9 +670,9 @@ export function GPUReservations() {
               <Icon className="w-4 h-4" aria-hidden="true" />
               {tab.label}
               {tab.count !== undefined && tab.count > 0 && (
-                <span className="px-1.5 py-0.5 text-xs rounded-full bg-purple-500/20 text-purple-400">
+                <StatusBadge color="purple" rounded="full">
                   {tab.count}
-                </span>
+                </StatusBadge>
               )}
             </button>
           )

--- a/web/src/components/layout/SidebarCustomizer.tsx
+++ b/web/src/components/layout/SidebarCustomizer.tsx
@@ -38,6 +38,7 @@ import { useSidebarConfig, SidebarItem } from '../../hooks/useSidebarConfig'
 import { useDashboards, Dashboard } from '../../hooks/useDashboards'
 import { DASHBOARD_TEMPLATES, TEMPLATE_CATEGORIES, DashboardTemplate } from '../dashboard/templates'
 import { CreateDashboardModal } from '../dashboard/CreateDashboardModal'
+import { StatusBadge } from '../ui/StatusBadge'
 import { cn } from '../../lib/cn'
 import { formatCardTitle } from '../../lib/formatCardTitle'
 import { STORAGE_KEY_NAV_HISTORY } from '../../lib/constants'
@@ -569,7 +570,7 @@ export function SidebarCustomizer({ isOpen, onClose }: SidebarCustomizerProps) {
                                     {route.name}
                                   </span>
                                   {isAlreadyAdded && (
-                                    <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400 flex-shrink-0 ml-auto">{t('sidebar.customizer.added')}</span>
+                                    <StatusBadge color="green" className="flex-shrink-0 ml-auto">{t('sidebar.customizer.added')}</StatusBadge>
                                   )}
                                 </div>
                               </button>
@@ -668,9 +669,7 @@ export function SidebarCustomizer({ isOpen, onClose }: SidebarCustomizerProps) {
                         <LayoutDashboard className="w-3.5 h-3.5 text-muted-foreground" />
                         {dashboard.name}
                         {dashboard.is_default && (
-                          <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
-                            {t('sidebar.customizer.default')}
-                          </span>
+                          <StatusBadge color="purple">{t('sidebar.customizer.default')}</StatusBadge>
                         )}
                       </div>
                       {dashboard.cards && dashboard.cards.length > 0 ? (
@@ -745,9 +744,7 @@ export function SidebarCustomizer({ isOpen, onClose }: SidebarCustomizerProps) {
                               <div className="text-xs text-muted-foreground truncate">{template.description}</div>
                             </div>
                             {isInSidebar ? (
-                              <span className="text-xs px-2 py-0.5 rounded bg-green-500/20 text-green-400 whitespace-nowrap">
-                                {t('sidebar.customizer.added')}
-                              </span>
+                              <StatusBadge color="green">{t('sidebar.customizer.added')}</StatusBadge>
                             ) : (
                               <button
                                 onClick={() => {

--- a/web/src/components/layout/SnoozedCards.tsx
+++ b/web/src/components/layout/SnoozedCards.tsx
@@ -5,6 +5,7 @@ import { useSnoozedCards, formatTimeRemaining, SnoozedSwap } from '../../hooks/u
 import { useSnoozedRecommendations, formatElapsedTime, SnoozedRecommendation } from '../../hooks/useSnoozedRecommendations'
 import { useSnoozedMissions, SnoozedMission, formatTimeRemaining as formatMissionTimeRemaining } from '../../hooks/useSnoozedMissions'
 import { MissionType } from '../../hooks/useMissionSuggestions'
+import { StatusBadge } from '../ui/StatusBadge'
 import { cn } from '../../lib/cn'
 import { POLL_INTERVAL_SLOW_MS } from '../../lib/constants/network'
 
@@ -93,9 +94,7 @@ export function SnoozedCards({ onApplySwap, onApplyRecommendation, onApplyMissio
         <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
           {t('sidebar.snoozedActions')}
         </h4>
-        <span className="ml-auto text-xs bg-purple-500/20 text-purple-400 px-1.5 py-0.5 rounded">
-          {snoozedMissions.length}
-        </span>
+        <StatusBadge color="purple" className="ml-auto">{snoozedMissions.length}</StatusBadge>
       </div>
       <div className="space-y-2">
         {snoozedMissions.map((mission) => (
@@ -118,9 +117,7 @@ export function SnoozedCards({ onApplySwap, onApplyRecommendation, onApplyMissio
         <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
           {t('sidebar.snoozedRecommendations')}
         </h4>
-        <span className="ml-auto text-xs bg-yellow-500/20 text-yellow-400 px-1.5 py-0.5 rounded">
-          {snoozedRecommendations.length}
-        </span>
+        <StatusBadge color="yellow" className="ml-auto">{snoozedRecommendations.length}</StatusBadge>
       </div>
       <div className="space-y-2">
         {snoozedRecommendations.map((rec) => (
@@ -143,9 +140,7 @@ export function SnoozedCards({ onApplySwap, onApplyRecommendation, onApplyMissio
         <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
           {t('sidebar.snoozedSwaps')}
         </h4>
-        <span className="ml-auto text-xs bg-purple-500/20 text-purple-400 px-1.5 py-0.5 rounded">
-          {snoozedSwaps.length}
-        </span>
+        <StatusBadge color="purple" className="ml-auto">{snoozedSwaps.length}</StatusBadge>
       </div>
       <div className="space-y-2">
         {snoozedSwaps.map((swap) => (

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -24,6 +24,7 @@ import {
 import { useSearchParams } from 'react-router-dom'
 import { useMissions } from '../../../hooks/useMissions'
 import { useMobile } from '../../../hooks/useMobile'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { cn } from '../../../lib/cn'
 import { AgentSelector } from '../../agent/AgentSelector'
 import { AgentIcon } from '../../agent/AgentIcon'
@@ -248,9 +249,7 @@ export function MissionSidebar() {
           <AgentIcon provider={getAgentProvider(selectedAgent)} className="w-5 h-5" />
           <h2 className="font-semibold text-foreground text-sm md:text-base">{t('missionSidebar.aiMissions')}</h2>
           {needsAttention > 0 && (
-            <span className="px-1.5 py-0.5 text-xs bg-purple-500/20 text-purple-400 rounded-full">
-              {needsAttention}
-            </span>
+            <StatusBadge color="purple" rounded="full">{needsAttention}</StatusBadge>
           )}
         </div>
         {/* Agent Selector */}
@@ -461,7 +460,7 @@ export function MissionSidebar() {
               <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
                 <Bookmark className="w-4 h-4 text-yellow-500" />
                 <span className="text-xs font-semibold text-foreground">Saved Missions</span>
-                <span className="text-2xs bg-yellow-500/20 text-yellow-400 px-1.5 py-0.5 rounded-full ml-auto">{savedMissions.length}</span>
+                <StatusBadge color="yellow" size="xs" rounded="full" className="ml-auto">{savedMissions.length}</StatusBadge>
               </div>
               <div className="flex-1 overflow-y-auto scroll-enhanced p-1.5 space-y-1">
                 {savedMissions.map(m => (
@@ -536,7 +535,7 @@ export function MissionSidebar() {
               <div className="flex items-center gap-2 px-2 py-1.5 mb-1">
                 <Bookmark className="w-4 h-4 text-yellow-500" />
                 <span className="text-xs font-semibold text-foreground">Saved Missions</span>
-                <span className="text-2xs bg-yellow-500/20 text-yellow-400 px-1.5 py-0.5 rounded-full">{savedMissions.length}</span>
+                <StatusBadge color="yellow" size="xs" rounded="full">{savedMissions.length}</StatusBadge>
               </div>
               <div className="space-y-1.5">
                 {savedMissions.map(m => (

--- a/web/src/components/layout/navbar/TokenUsageWidget.tsx
+++ b/web/src/components/layout/navbar/TokenUsageWidget.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Coins, Rocket, Stethoscope, Lightbulb, TrendingUp, MoreHorizontal } from 'lucide-react'
 import { useTokenUsage, type TokenCategory } from '../../../hooks/useTokenUsage'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { cn } from '../../../lib/cn'
 import { getSettingsWithHash } from '../../../config/routes'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
@@ -66,7 +67,7 @@ export function TokenUsageWidget() {
       >
         <Coins className={cn("w-4 h-4 transition-transform", tokenAnimating && "animate-bounce text-yellow-400 scale-125")} />
         {isDemoData && (
-          <span className="text-xs font-medium px-1.5 py-0.5 bg-yellow-500/20 text-yellow-400 rounded" role="img" aria-label="Demo mode active">Demo</span>
+          <StatusBadge color="yellow" role="img" aria-label="Demo mode active">Demo</StatusBadge>
         )}
         <span className="text-xs font-medium hidden sm:inline">{percentage.toFixed(0)}%</span>
         <div className="w-12 h-1.5 bg-secondary rounded-full overflow-hidden hidden sm:block">
@@ -91,9 +92,7 @@ export function TokenUsageWidget() {
           <div className="flex items-center justify-between mb-3">
             <h4 className="text-sm font-medium text-foreground">Token Usage</h4>
             {isDemoData && (
-              <span className="text-xs px-2 py-0.5 bg-yellow-500/20 text-yellow-400 rounded border border-yellow-500/20">
-                Demo Data
-              </span>
+              <StatusBadge color="yellow" variant="outline">Demo Data</StatusBadge>
             )}
           </div>
           {isDemoData && (

--- a/web/src/components/rewards/GitHubInvite.tsx
+++ b/web/src/components/rewards/GitHubInvite.tsx
@@ -4,6 +4,7 @@
 
 import { useState } from 'react'
 import { Github, Send, Coins, CheckCircle2, X, ExternalLink } from 'lucide-react'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useRewards } from '../../hooks/useRewards'
 import { useTranslation } from 'react-i18next'
 
@@ -208,7 +209,7 @@ export function GitHubInviteButton({ onClick }: { onClick: () => void }) {
     >
       <Github className="w-4 h-4" />
       Invite Friend
-      <span className="px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400 text-xs">+500</span>
+      <StatusBadge color="yellow">+500</StatusBadge>
     </button>
   )
 }

--- a/web/src/components/rewards/LinkedInShare.tsx
+++ b/web/src/components/rewards/LinkedInShare.tsx
@@ -4,6 +4,7 @@
 
 import { useState } from 'react'
 import { Linkedin, Share2, Coins, CheckCircle2 } from 'lucide-react'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useRewards } from '../../hooks/useRewards'
 import { useTranslation } from 'react-i18next'
 import { emitLinkedInShare } from '../../lib/analytics'
@@ -42,7 +43,7 @@ export function LinkedInShareButton() {
       >
         <Linkedin className="w-4 h-4" />
         Share on LinkedIn
-        <span className="px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400 text-xs">+200</span>
+        <StatusBadge color="yellow">+200</StatusBadge>
       </button>
 
       {/* Confirmation Modal */}

--- a/web/src/components/rewards/RewardsPanel.tsx
+++ b/web/src/components/rewards/RewardsPanel.tsx
@@ -4,6 +4,7 @@
 
 import { useState } from 'react'
 import { Coins, Trophy, Gift, Github, Bug, Lightbulb, Star, ChevronRight, GitPullRequest, GitMerge, RefreshCw, ExternalLink, AlertCircle } from 'lucide-react'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useRewards, REWARD_ACTIONS, ACHIEVEMENTS } from '../../hooks/useRewards'
 import { GitHubInviteModal, GitHubInviteButton } from './GitHubInvite'
 import { LinkedInShareCard } from './LinkedInShare'
@@ -86,9 +87,7 @@ export function RewardsPanel() {
               <div className="flex-1">
                 <div className="flex items-center justify-between mb-1">
                   <h4 className="font-medium text-foreground">Report Bugs</h4>
-                  <span className="px-2 py-0.5 rounded bg-yellow-500/20 text-yellow-400 text-xs">
-                    +{REWARD_ACTIONS.bug_report.coins} each
-                  </span>
+                  <StatusBadge color="yellow">+{REWARD_ACTIONS.bug_report.coins} each</StatusBadge>
                 </div>
                 <p className="text-sm text-muted-foreground">
                   Found a bug? Report it on GitHub to earn coins!
@@ -109,9 +108,7 @@ export function RewardsPanel() {
               <div className="flex-1">
                 <div className="flex items-center justify-between mb-1">
                   <h4 className="font-medium text-foreground">Suggest Features</h4>
-                  <span className="px-2 py-0.5 rounded bg-yellow-500/20 text-yellow-400 text-xs">
-                    +{REWARD_ACTIONS.feature_suggestion.coins} each
-                  </span>
+                  <StatusBadge color="yellow">+{REWARD_ACTIONS.feature_suggestion.coins} each</StatusBadge>
                 </div>
                 <p className="text-sm text-muted-foreground">
                   Have an idea? Submit feature requests to earn coins!
@@ -151,34 +148,29 @@ export function RewardsPanel() {
             </div>
             <div className="flex flex-wrap gap-2">
               {githubRewards.breakdown.prs_merged > 0 && (
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-purple-500/20 text-purple-400 text-xs">
-                  <GitMerge className="w-3 h-3" />
+                <StatusBadge color="purple" rounded="full" icon={<GitMerge className="w-3 h-3" />}>
                   {githubRewards.breakdown.prs_merged} Merged
-                </span>
+                </StatusBadge>
               )}
               {githubRewards.breakdown.prs_opened > 0 && (
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-500/20 text-green-400 text-xs">
-                  <GitPullRequest className="w-3 h-3" />
+                <StatusBadge color="green" rounded="full" icon={<GitPullRequest className="w-3 h-3" />}>
                   {githubRewards.breakdown.prs_opened} PRs
-                </span>
+                </StatusBadge>
               )}
               {githubRewards.breakdown.bug_issues > 0 && (
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-red-500/20 text-red-400 text-xs">
-                  <Bug className="w-3 h-3" />
+                <StatusBadge color="red" rounded="full" icon={<Bug className="w-3 h-3" />}>
                   {githubRewards.breakdown.bug_issues} Bugs
-                </span>
+                </StatusBadge>
               )}
               {githubRewards.breakdown.feature_issues > 0 && (
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-yellow-500/20 text-yellow-400 text-xs">
-                  <Lightbulb className="w-3 h-3" />
+                <StatusBadge color="yellow" rounded="full" icon={<Lightbulb className="w-3 h-3" />}>
                   {githubRewards.breakdown.feature_issues} Features
-                </span>
+                </StatusBadge>
               )}
               {githubRewards.breakdown.other_issues > 0 && (
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-500/20 text-muted-foreground text-xs">
-                  <AlertCircle className="w-3 h-3" />
+                <StatusBadge color="purple" rounded="full" className="!bg-gray-500/20 !text-muted-foreground" icon={<AlertCircle className="w-3 h-3" />}>
                   {githubRewards.breakdown.other_issues} Issues
-                </span>
+                </StatusBadge>
               )}
             </div>
           </div>

--- a/web/src/components/settings/sections/ThemeSection.tsx
+++ b/web/src/components/settings/sections/ThemeSection.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Moon, Sun, Check, Palette, ChevronDown, Trash2 } from 'lucide-react'
+import { StatusBadge } from '../../../components/ui/StatusBadge'
 import type { Theme } from '../../../lib/themes'
 import { themeGroups, getCustomThemes, removeCustomTheme } from '../../../lib/themes'
 import { ConfirmDialog } from '../../../lib/modals'
@@ -311,19 +312,19 @@ export function ThemeSection({ themeId, setTheme, themes, currentTheme }: ThemeS
         {/* Theme Features */}
         <div className="flex flex-wrap gap-2 pt-2">
           {currentTheme.starField && (
-            <span className="px-2 py-1 text-xs rounded bg-purple-500/20 text-purple-400">
-              ✨ Star Field
-            </span>
+            <StatusBadge color="purple">
+              Star Field
+            </StatusBadge>
           )}
           {currentTheme.glowEffects && (
-            <span className="px-2 py-1 text-xs rounded bg-blue-500/20 text-blue-400">
-              💫 Glow Effects
-            </span>
+            <StatusBadge color="blue">
+              Glow Effects
+            </StatusBadge>
           )}
           {currentTheme.gradientAccents && (
-            <span className="px-2 py-1 text-xs rounded bg-purple-500/20 text-purple-400">
-              🌈 Gradients
-            </span>
+            <StatusBadge color="purple">
+              Gradients
+            </StatusBadge>
           )}
           <span className="px-2 py-1 text-xs rounded bg-secondary text-muted-foreground">
             Font: {currentTheme.font.family.split(',')[0].replace(/'/g, '')}

--- a/web/src/components/settings/sections/TokenUsageSection.tsx
+++ b/web/src/components/settings/sections/TokenUsageSection.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Save, Coins, RefreshCw } from 'lucide-react'
+import { StatusBadge } from '../../../components/ui/StatusBadge'
 import type { TokenUsage } from '../../../hooks/useTokenUsage'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 
@@ -45,9 +46,9 @@ export function TokenUsageSection({ usage, updateSettings, resetUsage, isDemoDat
             <div className="flex items-center gap-2">
               <h2 className="text-lg font-medium text-foreground">{t('settings.tokens.title')}</h2>
               {isDemoData && (
-                <span className="text-xs px-2 py-0.5 bg-yellow-500/20 text-yellow-400 rounded border border-yellow-500/20" role="img" aria-label="Demo mode active">
+                <StatusBadge color="yellow" variant="outline" role="img" aria-label="Demo mode active">
                   Demo Data
-                </span>
+                </StatusBadge>
               )}
             </div>
             <p className="text-sm text-muted-foreground">{t('settings.tokens.subtitle')}</p>

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -8,6 +8,7 @@ import {
   ShieldAlert, ShieldOff, User, Info, Percent, ClipboardList, Sparkles, Activity,
   List, DollarSign, ChevronDown, ChevronRight, FlaskConical,
 } from 'lucide-react'
+import { StatusBadge } from './StatusBadge'
 import { StatBlockConfig, DashboardStatsType } from './StatsBlockDefinitions'
 import { StatsConfigModal, useStatsConfig } from './StatsConfig'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
@@ -220,10 +221,9 @@ export function StatsOverview({
             </div>
           )}
           {isDemoData && (
-            <span className="flex items-center gap-1 px-1.5 py-0.5 text-2xs font-medium rounded-full bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
-              <FlaskConical className="w-2.5 h-2.5" />
+            <StatusBadge color="yellow" size="xs" variant="outline" rounded="full" icon={<FlaskConical className="w-2.5 h-2.5" />}>
               {t('statsOverview.demo')}
-            </span>
+            </StatusBadge>
           )}
           {lastUpdated && (
             <span className="text-xs text-muted-foreground/60">

--- a/web/src/components/ui/StatusBadge.tsx
+++ b/web/src/components/ui/StatusBadge.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react'
+import { type HTMLAttributes, type ReactNode } from 'react'
 import { cn } from '../../lib/cn'
 
 type BadgeColor = 'green' | 'red' | 'yellow' | 'blue' | 'purple' | 'orange' | 'cyan' | 'gray'
@@ -22,14 +22,13 @@ const SIZE_MAP: Record<BadgeSize, string> = {
   md: 'text-xs px-2 py-1',
 }
 
-interface StatusBadgeProps {
-  children: ReactNode
+interface StatusBadgeProps extends Omit<HTMLAttributes<HTMLSpanElement>, 'color'> {
+  children?: ReactNode
   color: BadgeColor
   size?: BadgeSize
   variant?: BadgeVariant
   rounded?: 'default' | 'full'
   icon?: ReactNode
-  className?: string
 }
 
 export function StatusBadge({
@@ -40,6 +39,7 @@ export function StatusBadge({
   rounded = 'default',
   icon,
   className,
+  ...props
 }: StatusBadgeProps) {
   const colors = COLOR_MAP[color]
   const roundedClass = rounded === 'full' ? 'rounded-full' : 'rounded'
@@ -59,6 +59,7 @@ export function StatusBadge({
         variantClasses[variant],
         className,
       )}
+      {...props}
     >
       {icon}
       {children}

--- a/web/src/lib/unified/stats/UnifiedStatsSection.tsx
+++ b/web/src/lib/unified/stats/UnifiedStatsSection.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useMemo, useCallback } from 'react'
 import { Activity, ChevronDown, ChevronRight, Settings, FlaskConical } from 'lucide-react'
+import { StatusBadge } from '../../../components/ui/StatusBadge'
 import type { UnifiedStatsSectionProps, UnifiedStatBlockConfig, StatBlockValue } from '../types'
 import { UnifiedStatBlock } from './UnifiedStatBlock'
 import { resolveStatValue } from './valueResolvers'
@@ -145,10 +146,9 @@ export function UnifiedStatsSection({
 
           {/* Demo indicator */}
           {isDemoData && (
-            <span className="flex items-center gap-1 px-1.5 py-0.5 text-2xs font-medium rounded-full bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
-              <FlaskConical className="w-2.5 h-2.5" />
+            <StatusBadge color="yellow" size="xs" variant="outline" rounded="full" icon={<FlaskConical className="w-2.5 h-2.5" />}>
               Demo
-            </span>
+            </StatusBadge>
           )}
 
           {/* Last updated */}


### PR DESCRIPTION
## Summary

- Migrates **152 inline badge `<span>` elements** across **67 files** to use the shared `StatusBadge` component (introduced in PR #1934)
- Updates `StatusBadge` to accept standard HTML span attributes (`title`, `role`, `aria-label`) and optional `children` (icon-only badges)
- Dynamic/conditional badges (ternary color selection, runtime lookups) were intentionally skipped — they need case-by-case handling

### Categories migrated

| Category | Files | Badges |
|----------|-------|--------|
| Card components (operator, security, compliance, GPU, helm, etc.) | 25 | 52 |
| Workload monitor/detection (alerts, health, CI, ML jobs) | 10 | 31 |
| Drilldown views (cluster, policy, namespace, CRD, replica set) | 7 | 26 |
| Layout (sidebar, snoozed cards, mission sidebar, navbar) | 6 | 28 |
| Dashboard (recommendations, factory modals, suggestions) | 7 | 16 |
| Clusters (detail modal, grid, nodes, namespaces, GPU) | 8 | 22 |
| Other (feedback, rewards, settings, onboarding) | 4 | varies |

### Before/After

```tsx
// Before — inline Tailwind badge
<span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-xs font-medium rounded bg-green-500/20 text-green-400">
  Running
</span>

// After — shared component
<StatusBadge color="green">Running</StatusBadge>
```

### StatusBadge enhancements

- `children` is now optional (supports icon-only badges)
- Extends `HTMLAttributes<HTMLSpanElement>` for native props (`title`, `role`, `aria-label`, etc.)

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — passes
- [x] `npm run lint` — no new errors (69 pre-existing, all unrelated)
- [ ] Visual check: badges render identically (same colors, sizes, rounding)
- [ ] Keyboard/a11y: badges with `role`/`aria-label` still accessible