### PR TITLE
🐛 Guard authHeader slice to prevent panic on short Authorization headers

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -338,6 +338,10 @@ func (h *AuthHandler) RefreshToken(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusUnauthorized, "Missing authorization")
 	}
 
+	if !strings.HasPrefix(authHeader, "Bearer ") {
+		return fiber.NewError(fiber.StatusUnauthorized, "Invalid authorization format")
+	}
+
 	tokenString := authHeader[7:] // Remove "Bearer "
 	token, err := jwt.ParseWithClaims(tokenString, &middleware.UserClaims{}, func(token *jwt.Token) (interface{}, error) {
 		return []byte(h.jwtSecret), nil


### PR DESCRIPTION
## Summary

- Add `strings.HasPrefix(authHeader, "Bearer ")` check before slicing `authHeader[7:]` in `RefreshToken` handler
- Prevents index-out-of-bounds panic when Authorization header is present but not a Bearer token (e.g. "Basic")

## Test plan

- [x] `go build ./...` passes
- [x] Existing handler tests pass
- [ ] CI build/lint

Fixes #1785