### PR TITLE
🐛 Use write lock in PersistenceStore.Save() instead of read lock

### DIFF
--- a/pkg/store/persistence_config.go
+++ b/pkg/store/persistence_config.go
@@ -143,8 +143,8 @@ func (p *PersistenceStore) Load() error {
 
 // Save persists the config to disk
 func (p *PersistenceStore) Save() error {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	// Ensure directory exists
 	dir := filepath.Dir(p.configPath)


### PR DESCRIPTION
## Summary

- Change `p.mu.RLock()/RUnlock()` to `p.mu.Lock()/Unlock()` in `Save()` method
- `Save()` mutates `p.config.LastModified` and writes to disk, requiring a full write lock to prevent data races

## Test plan

- [x] `go build ./...` passes
- [x] Existing store tests pass
- [ ] CI build/lint

Fixes #1793