### PR TITLE
🐛 Replace as-any casts with proper type assertions

### DIFF
--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -8,11 +8,11 @@ import { useTranslation } from 'react-i18next'
 
 type TimeRange = '15m' | '1h' | '6h' | '24h'
 
-const TIME_RANGE_KEYS: { value: TimeRange; labelKey: string; points: number; intervalMs: number }[] = [
-  { value: '15m', labelKey: 'clusterMetrics.timeRange15m', points: 15, intervalMs: 60000 },
-  { value: '1h', labelKey: 'clusterMetrics.timeRange1h', points: 20, intervalMs: 180000 },
-  { value: '6h', labelKey: 'clusterMetrics.timeRange6h', points: 24, intervalMs: 900000 },
-  { value: '24h', labelKey: 'clusterMetrics.timeRange24h', points: 24, intervalMs: 3600000 },
+const TIME_RANGE_KEYS = [
+  { value: '15m' as const, labelKey: 'clusterMetrics.timeRange15m' as const, points: 15, intervalMs: 60000 },
+  { value: '1h' as const, labelKey: 'clusterMetrics.timeRange1h' as const, points: 20, intervalMs: 180000 },
+  { value: '6h' as const, labelKey: 'clusterMetrics.timeRange6h' as const, points: 24, intervalMs: 900000 },
+  { value: '24h' as const, labelKey: 'clusterMetrics.timeRange24h' as const, points: 24, intervalMs: 3600000 },
 ]
 
 
@@ -20,10 +20,10 @@ type MetricType = 'cpu' | 'memory' | 'pods' | 'nodes'
 type ChartMode = 'total' | 'per-cluster'
 
 const metricConfigBase = {
-  cpu: { labelKey: 'clusterMetrics.cpuCores', color: '#9333ea', unit: '', baseValue: 65, variance: 30 },
-  memory: { labelKey: 'clusterMetrics.memory', color: '#3b82f6', unit: ' GB', baseValue: 72, variance: 20 },
-  pods: { labelKey: 'clusterMetrics.pods', color: '#10b981', unit: '', baseValue: 150, variance: 100 },
-  nodes: { labelKey: 'clusterMetrics.nodes', color: '#f59e0b', unit: '', baseValue: 10, variance: 5 },
+  cpu: { labelKey: 'clusterMetrics.cpuCores' as const, color: '#9333ea', unit: '', baseValue: 65, variance: 30 },
+  memory: { labelKey: 'clusterMetrics.memory' as const, color: '#3b82f6', unit: ' GB', baseValue: 72, variance: 20 },
+  pods: { labelKey: 'clusterMetrics.pods' as const, color: '#10b981', unit: '', baseValue: 150, variance: 100 },
+  nodes: { labelKey: 'clusterMetrics.nodes' as const, color: '#f59e0b', unit: '', baseValue: 10, variance: 5 },
 }
 
 interface ClusterMetricValues {
@@ -58,15 +58,13 @@ export function ClusterMetrics() {
   const metricConfig = useMemo(() => {
     const result: Record<MetricType, { label: string; color: string; unit: string; baseValue: number; variance: number }> = {} as typeof result
     for (const [key, val] of Object.entries(metricConfigBase)) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      result[key as MetricType] = { ...val, label: t(val.labelKey as any) as string }
+      result[key as MetricType] = { ...val, label: String(t(val.labelKey)) }
     }
     return result
   }, [t])
 
   const TIME_RANGE_OPTIONS = useMemo(() =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    TIME_RANGE_KEYS.map(opt => ({ ...opt, label: t(opt.labelKey as any) as string })),
+    TIME_RANGE_KEYS.map(opt => ({ ...opt, label: String(t(opt.labelKey)) })),
     [t]
   )
 

--- a/web/src/components/cards/OperatorSubscriptions.tsx
+++ b/web/src/components/cards/OperatorSubscriptions.tsx
@@ -27,10 +27,10 @@ interface OperatorSubscriptionsProps {
 type SortByOption = 'pending' | 'name' | 'approval' | 'channel'
 
 const SORT_OPTIONS_KEYS = [
-  { value: 'pending' as const, labelKey: 'operatorSubscriptions.pendingFirst' },
-  { value: 'name' as const, labelKey: 'common.name' },
-  { value: 'approval' as const, labelKey: 'operatorSubscriptions.approval' },
-  { value: 'channel' as const, labelKey: 'operatorSubscriptions.channel' },
+  { value: 'pending' as const, labelKey: 'operatorSubscriptions.pendingFirst' as const },
+  { value: 'name' as const, labelKey: 'common:common.name' as const },
+  { value: 'approval' as const, labelKey: 'operatorSubscriptions.approval' as const },
+  { value: 'channel' as const, labelKey: 'operatorSubscriptions.channel' as const },
 ]
 
 const SUBSCRIPTION_SORT_COMPARATORS = {
@@ -51,8 +51,7 @@ const FILTER_CONFIG = {
 export function OperatorSubscriptions({ config: _config }: OperatorSubscriptionsProps) {
   const { t } = useTranslation(['cards', 'common'])
   const SORT_OPTIONS = useMemo(() =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey as any)) })),
+    SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) })),
     [t]
   )
   const { isLoading: clustersLoading } = useClusters()

--- a/web/src/components/cards/ProviderHealth.tsx
+++ b/web/src/components/cards/ProviderHealth.tsx
@@ -17,12 +17,12 @@ const STATUS_COLORS: Record<ProviderHealthInfo['status'], string> = {
   unknown: 'bg-gray-400',
 }
 
-const STATUS_LABEL_KEYS: Record<ProviderHealthInfo['status'], string> = {
+const STATUS_LABEL_KEYS = {
   operational: 'providerHealth.operational',
   degraded: 'providerHealth.degraded',
   down: 'providerHealth.down',
-  unknown: 'common.unknown',
-}
+  unknown: 'common:common.unknown',
+} as const satisfies Record<ProviderHealthInfo['status'], string>
 
 function ProviderRow({ provider, onConfigure }: { provider: ProviderHealthInfo; onConfigure?: () => void }) {
   const { t } = useTranslation(['cards', 'common'])
@@ -48,8 +48,7 @@ function ProviderRow({ provider, onConfigure }: { provider: ProviderHealthInfo; 
       {/* Status dot + label */}
       <div className="flex items-center gap-1.5 shrink-0">
         <div className={cn('w-2 h-2 rounded-full', STATUS_COLORS[provider.status])} />
-        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-        <span className="text-xs text-muted-foreground">{String(t(STATUS_LABEL_KEYS[provider.status] as any))}</span>
+        <span className="text-xs text-muted-foreground">{String(t(STATUS_LABEL_KEYS[provider.status]))}</span>
         {!provider.configured && (
           <span className="text-2xs text-yellow-500 bg-yellow-500/10 px-1.5 py-0.5 rounded-full font-medium">
             {t('providerHealth.noKey')}

--- a/web/src/components/cards/ServiceExports.tsx
+++ b/web/src/components/cards/ServiceExports.tsx
@@ -100,9 +100,9 @@ const getStatusColors = (status: ServiceExportStatus) => {
 type SortByOption = 'name' | 'status' | 'cluster'
 
 const SORT_OPTIONS_KEYS = [
-  { value: 'name' as const, labelKey: 'common.name' },
-  { value: 'status' as const, labelKey: 'common.status' },
-  { value: 'cluster' as const, labelKey: 'common.cluster' },
+  { value: 'name' as const, labelKey: 'common:common.name' as const },
+  { value: 'status' as const, labelKey: 'common:common.status' as const },
+  { value: 'cluster' as const, labelKey: 'common:common.cluster' as const },
 ]
 
 const statusOrder: Record<string, number> = { Failed: 0, Pending: 1, Ready: 2 }
@@ -120,8 +120,7 @@ interface ServiceExportsProps {
 export function ServiceExports({ config: _config }: ServiceExportsProps) {
   const { t } = useTranslation(['cards', 'common'])
   const SORT_OPTIONS = useMemo(() =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey as any)) })),
+    SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) })),
     [t]
   )
   // Demo data - always available, never loading/erroring

--- a/web/src/components/cards/wasmcloud_status/useWasmCloudStatus.test.ts
+++ b/web/src/components/cards/wasmcloud_status/useWasmCloudStatus.test.ts
@@ -23,7 +23,7 @@ describe('useWasmCloudStatus', () => {
     })
 
     it('uses default API endpoints and no custom refresh interval when no config is provided', async () => {
-        ; (useCache as any).mockReturnValue({
+        vi.mocked(useCache).mockReturnValue({
             data: { totalHosts: 0 },
             isLoading: true,
             isRefreshing: false,
@@ -39,10 +39,10 @@ describe('useWasmCloudStatus', () => {
             refreshInterval: undefined,
         }))
 
-        const cacheOptions = (useCache as any).mock.calls[0][0]
+        const cacheOptions = vi.mocked(useCache).mock.calls[0][0]
         const fetcher = cacheOptions.fetcher
 
-            ; (api.get as any).mockResolvedValue({ data: { hosts: [], actors: [] } })
+        vi.mocked(api.get).mockResolvedValue({ data: { hosts: [], actors: [] } })
 
         await fetcher()
 
@@ -51,7 +51,7 @@ describe('useWasmCloudStatus', () => {
     })
 
     it('uses custom API endpoints and refresh interval from config', async () => {
-        ; (useCache as any).mockReturnValue({
+        vi.mocked(useCache).mockReturnValue({
             data: { totalHosts: 0 },
             isLoading: true,
             isRefreshing: false,
@@ -73,10 +73,10 @@ describe('useWasmCloudStatus', () => {
             refreshInterval: 60000,
         }))
 
-        const cacheOptions = (useCache as any).mock.calls[0][0]
+        const cacheOptions = vi.mocked(useCache).mock.calls[0][0]
         const fetcher = cacheOptions.fetcher
 
-            ; (api.get as any).mockResolvedValue({ data: { hosts: [], actors: [] } })
+        vi.mocked(api.get).mockResolvedValue({ data: { hosts: [], actors: [] } })
 
         await fetcher()
 

--- a/web/src/components/settings/Settings.tsx
+++ b/web/src/components/settings/Settings.tsx
@@ -50,45 +50,45 @@ const SYNC_ICONS: Record<SyncStatus, { icon: typeof CheckCircle; className: stri
 // Labels use i18n keys resolved at render time
 const SETTINGS_NAV = [
   {
-    groupKey: 'settings.groups.aiIntelligence',
+    groupKey: 'settings.groups.aiIntelligence' as const,
     items: [
-      { id: 'ai-mode-settings', labelKey: 'settings.nav.aiMode', icon: Cpu },
-      { id: 'prediction-settings', labelKey: 'settings.nav.predictions', icon: TrendingUp },
-      { id: 'agent-settings', labelKey: 'settings.nav.localAgent', icon: Plug },
-      { id: 'api-keys-settings', labelKey: 'settings.nav.apiKeys', icon: Key },
-      { id: 'token-usage-settings', labelKey: 'settings.nav.tokenUsage', icon: Coins },
+      { id: 'ai-mode-settings', labelKey: 'settings.nav.aiMode' as const, icon: Cpu },
+      { id: 'prediction-settings', labelKey: 'settings.nav.predictions' as const, icon: TrendingUp },
+      { id: 'agent-settings', labelKey: 'settings.nav.localAgent' as const, icon: Plug },
+      { id: 'api-keys-settings', labelKey: 'settings.nav.apiKeys' as const, icon: Key },
+      { id: 'token-usage-settings', labelKey: 'settings.nav.tokenUsage' as const, icon: Coins },
     ],
   },
   {
-    groupKey: 'settings.groups.integrations',
+    groupKey: 'settings.groups.integrations' as const,
     items: [
-      { id: 'github-token-settings', labelKey: 'settings.nav.github', icon: Github },
-      { id: 'widget-settings', labelKey: 'settings.nav.desktopWidget', icon: LayoutGrid },
-      { id: 'persistence-settings', labelKey: 'settings.nav.deployPersistence', icon: Database },
+      { id: 'github-token-settings', labelKey: 'settings.nav.github' as const, icon: Github },
+      { id: 'widget-settings', labelKey: 'settings.nav.desktopWidget' as const, icon: LayoutGrid },
+      { id: 'persistence-settings', labelKey: 'settings.nav.deployPersistence' as const, icon: Database },
     ],
   },
   {
-    groupKey: 'settings.groups.userAlerts',
+    groupKey: 'settings.groups.userAlerts' as const,
     items: [
-      { id: 'profile-settings', labelKey: 'settings.nav.profile', icon: User },
-      { id: 'notifications-settings', labelKey: 'settings.nav.notifications', icon: Bell },
+      { id: 'profile-settings', labelKey: 'settings.nav.profile' as const, icon: User },
+      { id: 'notifications-settings', labelKey: 'settings.nav.notifications' as const, icon: Bell },
     ],
   },
   {
-    groupKey: 'settings.groups.appearance',
+    groupKey: 'settings.groups.appearance' as const,
     items: [
-      { id: 'theme-settings', labelKey: 'settings.nav.theme', icon: Palette },
-      { id: 'accessibility-settings', labelKey: 'settings.nav.accessibility', icon: Eye },
+      { id: 'theme-settings', labelKey: 'settings.nav.theme' as const, icon: Palette },
+      { id: 'accessibility-settings', labelKey: 'settings.nav.accessibility' as const, icon: Eye },
     ],
   },
   {
-    groupKey: 'settings.groups.utilities',
+    groupKey: 'settings.groups.utilities' as const,
     items: [
-      { id: 'settings-backup', labelKey: 'settings.nav.backupSync', icon: HardDrive },
-      { id: 'local-clusters-settings', labelKey: 'settings.nav.localClusters', icon: Container },
-      { id: 'permissions-settings', labelKey: 'settings.nav.permissions', icon: Shield },
-      { id: 'analytics-settings', labelKey: 'settings.nav.analytics', icon: BarChart3 },
-      { id: 'system-updates-settings', labelKey: 'settings.nav.updates', icon: Download },
+      { id: 'settings-backup', labelKey: 'settings.nav.backupSync' as const, icon: HardDrive },
+      { id: 'local-clusters-settings', labelKey: 'settings.nav.localClusters' as const, icon: Container },
+      { id: 'permissions-settings', labelKey: 'settings.nav.permissions' as const, icon: Shield },
+      { id: 'analytics-settings', labelKey: 'settings.nav.analytics' as const, icon: BarChart3 },
+      { id: 'system-updates-settings', labelKey: 'settings.nav.updates' as const, icon: Download },
     ],
   },
 ]
@@ -244,8 +244,7 @@ export function Settings() {
           {SETTINGS_NAV.map((group) => (
             <div key={group.groupKey}>
               <h3 className="text-2xs uppercase tracking-wider text-muted-foreground font-semibold mb-1 px-2">
-                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                {t(group.groupKey as any)}
+                {t(group.groupKey)}
               </h3>
               <div className="space-y-0.5">
                 {group.items.map((item) => {
@@ -263,8 +262,7 @@ export function Settings() {
                       )}
                     >
                       <Icon className={cn('w-4 h-4 shrink-0', isActive ? 'text-purple-400' : 'text-muted-foreground')} />
-                      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-                      <span className="truncate">{t(item.labelKey as any)}</span>
+                      <span className="truncate">{t(item.labelKey)}</span>
                     </button>
                   )
                 })}

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -23,22 +23,26 @@ Object.defineProperty(window, 'matchMedia', {
 })
 
 // Mock IntersectionObserver
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-;(globalThis as any).IntersectionObserver = class IntersectionObserver {
-  constructor() {}
-  disconnect() {}
-  observe() {}
-  takeRecords() {
-    return []
-  }
-  unobserve() {}
-}
+Object.defineProperty(globalThis, 'IntersectionObserver', {
+  writable: true,
+  value: class IntersectionObserver {
+    constructor() {}
+    disconnect() {}
+    observe() {}
+    takeRecords() {
+      return []
+    }
+    unobserve() {}
+  },
+})
 
 // Mock ResizeObserver
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-;(globalThis as any).ResizeObserver = class ResizeObserver {
-  constructor() {}
-  disconnect() {}
-  observe() {}
-  unobserve() {}
-}
+Object.defineProperty(globalThis, 'ResizeObserver', {
+  writable: true,
+  value: class ResizeObserver {
+    constructor() {}
+    disconnect() {}
+    observe() {}
+    unobserve() {}
+  },
+})


### PR DESCRIPTION
## Summary

- **Test setup**: Use `Object.defineProperty` for globalThis polyfills instead of `as any`
- **Test mocks**: Use `vi.mocked()` instead of casting to `any`
- **i18n keys**: Use proper type parameter instead of `as any`
- Removes associated `eslint-disable` comments that are no longer needed

## Test plan

- [x] `npm run build` passes
- [x] `vitest run` passes
- [ ] CI build/lint

Fixes #1893