### PR TITLE
🐛 Set HTTP client timeouts for AI provider integrations

### DIFF
--- a/pkg/agent/provider_claude.go
+++ b/pkg/agent/provider_claude.go
@@ -30,7 +30,7 @@ func NewClaudeProvider() *ClaudeProvider {
 	return &ClaudeProvider{
 		apiKey: cm.GetAPIKey("claude"),
 		model:  cm.GetModel("claude", defaultClaudeModel),
-		client: &http.Client{},
+		client: newAIProviderHTTPClient(),
 	}
 }
 

--- a/pkg/agent/provider_gemini.go
+++ b/pkg/agent/provider_gemini.go
@@ -29,7 +29,7 @@ func NewGeminiProvider() *GeminiProvider {
 	return &GeminiProvider{
 		apiKey: cm.GetAPIKey("gemini"),
 		model:  cm.GetModel("gemini", defaultGeminiModel),
-		client: &http.Client{},
+		client: newAIProviderHTTPClient(),
 	}
 }
 

--- a/pkg/agent/provider_helpers.go
+++ b/pkg/agent/provider_helpers.go
@@ -1,6 +1,18 @@
 package agent
 
-import "strings"
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+const aiProviderHTTPTimeout = 120 * time.Second // timeout for AI provider API calls
+
+// newAIProviderHTTPClient creates an HTTP client configured with the standard
+// timeout for AI provider API calls.
+func newAIProviderHTTPClient() *http.Client {
+	return &http.Client{Timeout: aiProviderHTTPTimeout}
+}
 
 // buildPromptWithHistoryGeneric creates a prompt string from a ChatRequest
 // including system prompt and conversation history.

--- a/pkg/agent/provider_openai.go
+++ b/pkg/agent/provider_openai.go
@@ -29,7 +29,7 @@ func NewOpenAIProvider() *OpenAIProvider {
 	return &OpenAIProvider{
 		apiKey: cm.GetAPIKey("openai"),
 		model:  cm.GetModel("openai", defaultOpenAIModel),
-		client: &http.Client{},
+		client: newAIProviderHTTPClient(),
 	}
 }
 

--- a/pkg/agent/provider_openai_compat.go
+++ b/pkg/agent/provider_openai_compat.go
@@ -39,7 +39,7 @@ func chatViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKey,
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := newAIProviderHTTPClient().Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("API request failed: %w", err)
 	}
@@ -112,7 +112,7 @@ func streamViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKe
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := newAIProviderHTTPClient().Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("API request failed: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Add `aiProviderHTTPTimeout = 120s` constant and `newAIProviderHTTPClient()` factory
- Replace bare `&http.Client{}` and `http.DefaultClient` in Claude, OpenAI, Gemini, and OpenAI-compat providers

## Test plan

- [x] `go build ./...` passes
- [ ] CI build/lint

Fixes #1924