### PR TITLE
🐛 Add NetworkPolicy, PDB, and securityContext defaults to Helm chart

### DIFF
--- a/deploy/helm/kubestellar-console/templates/networkpolicy.yaml
+++ b/deploy/helm/kubestellar-console/templates/networkpolicy.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kubestellar-console.fullname" . }}
+  labels:
+    {{- include "kubestellar-console.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kubestellar-console.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: {{ .Values.service.port | default 8080 }}
+          protocol: TCP
+{{- end }}

--- a/deploy/helm/kubestellar-console/templates/pdb.yaml
+++ b/deploy/helm/kubestellar-console/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kubestellar-console.fullname" . }}
+  labels:
+    {{- include "kubestellar-console.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "kubestellar-console.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -26,7 +26,12 @@ podLabels: {}
 
 podSecurityContext: {}
 
-securityContext: {}
+securityContext:
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
 
 service:
   type: ClusterIP
@@ -152,6 +157,13 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+networkPolicy:
+  enabled: false
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
 
 # Additional environment variables
 extraEnv: []


### PR DESCRIPTION
## Summary

- Add NetworkPolicy template (disabled by default via `networkPolicy.enabled`)
- Add PodDisruptionBudget template (disabled by default via `podDisruptionBudget.enabled`)
- Set securityContext defaults: `runAsNonRoot`, `readOnlyRootFilesystem`, drop ALL capabilities

## Test plan

- [x] `helm lint` passes
- [ ] CI build

Fixes #1913