### PR TITLE
🐛 Harden Dockerfile: non-root user, healthcheck, .dockerignore, graceful shutdown

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.github
+node_modules
+web/node_modules
+*.md
+.env
+.env.*
+data/
+tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,11 @@ COPY --from=backend-builder /app/console .
 # Copy frontend build
 COPY --from=frontend-builder /app/dist ./web/dist
 
+# Create non-root user for container security
+RUN addgroup -g 1001 -S appgroup && adduser -u 1001 -S appuser -G appgroup
+
 # Create data and settings directories
-RUN mkdir -p /app/data /app/.kc
+RUN mkdir -p /app/data /app/.kc && chown -R appuser:appgroup /app/data /app/.kc
 
 # Environment variables
 ENV PORT=8080
@@ -55,5 +58,12 @@ ENV DATABASE_PATH=/app/data/console.db
 ENV HOME=/app
 
 EXPOSE 8080
+
+# Health check for orchestrator monitoring
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:8080/health || exit 1
+
+# Run as non-root user
+USER appuser
 
 ENTRYPOINT ["./console"]

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -54,14 +54,18 @@ echo ""
 # Clear ports if in use (kill existing processes)
 if lsof -Pi :$PORT -sTCP:LISTEN -t >/dev/null 2>&1 ; then
     echo -e "${YELLOW}Port $PORT is in use, killing existing process...${NC}"
+    lsof -ti:$PORT | xargs kill -TERM 2>/dev/null || true
+    sleep 2
+    # Fall back to SIGKILL if process did not exit gracefully
     lsof -ti:$PORT | xargs kill -9 2>/dev/null || true
-    sleep 1
 fi
 
 if lsof -Pi :5174 -sTCP:LISTEN -t >/dev/null 2>&1 ; then
     echo -e "${YELLOW}Port 5174 is in use, killing existing process...${NC}"
+    lsof -ti:5174 | xargs kill -TERM 2>/dev/null || true
+    sleep 2
+    # Fall back to SIGKILL if process did not exit gracefully
     lsof -ti:5174 | xargs kill -9 2>/dev/null || true
-    sleep 1
 fi
 
 # Function to cleanup on exit

--- a/scripts/prod.sh
+++ b/scripts/prod.sh
@@ -64,8 +64,10 @@ echo ""
 for p in $PORT 5174; do
     if lsof -Pi :$p -sTCP:LISTEN -t >/dev/null 2>&1; then
         echo -e "${YELLOW}Port $p is in use, killing existing process...${NC}"
+        lsof -ti:$p | xargs kill -TERM 2>/dev/null || true
+        sleep 2
+        # Fall back to SIGKILL if process did not exit gracefully
         lsof -ti:$p | xargs kill -9 2>/dev/null || true
-        sleep 1
     fi
 done
 

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -114,8 +114,10 @@ for p in 8080 5174 8585; do
     EXISTING_PID=$(lsof -ti :$p 2>/dev/null || true)
     if [ -n "$EXISTING_PID" ]; then
         echo "Killing existing process on port $p (PID: $EXISTING_PID)..."
+        kill -TERM $EXISTING_PID 2>/dev/null || true
+        sleep 2
+        # Fall back to SIGKILL if process did not exit gracefully
         kill -9 $EXISTING_PID 2>/dev/null || true
-        sleep 1
     fi
 done
 

--- a/start.sh
+++ b/start.sh
@@ -190,8 +190,10 @@ chmod +x "$INSTALL_DIR/kc-agent" 2>/dev/null || true
 EXISTING_PID=$(lsof -ti :"$PORT" 2>/dev/null || true)
 if [ -n "$EXISTING_PID" ]; then
     echo "Killing existing process on port $PORT (PID: $EXISTING_PID)..."
+    kill -TERM "$EXISTING_PID" 2>/dev/null || true
+    sleep 2
+    # Fall back to SIGKILL if process did not exit gracefully
     kill -9 "$EXISTING_PID" 2>/dev/null || true
-    sleep 1
 fi
 # Note: kc-agent on port 8585 is managed via PID file — not force-killed here
 

--- a/startup-demo.sh
+++ b/startup-demo.sh
@@ -32,8 +32,10 @@ mkdir -p ./data
 for p in 8080 5174; do
     if lsof -Pi :$p -sTCP:LISTEN -t >/dev/null 2>&1; then
         echo -e "${YELLOW}Port $p is in use, killing existing process...${NC}"
+        lsof -ti:$p | xargs kill -TERM 2>/dev/null || true
+        sleep 2
+        # Fall back to SIGKILL if process did not exit gracefully
         lsof -ti:$p | xargs kill -9 2>/dev/null || true
-        sleep 1
     fi
 done
 

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -231,8 +231,10 @@ if [ "$USE_DEV_SERVER" = true ]; then PORTS_TO_CLEAN="8080 5174 8585"; fi
 for p in $PORTS_TO_CLEAN; do
     if lsof -Pi :$p -sTCP:LISTEN -t >/dev/null 2>&1; then
         echo -e "${YELLOW}Port $p is in use, killing existing process...${NC}"
+        lsof -ti:$p | xargs kill -TERM 2>/dev/null || true
+        sleep 2
+        # Fall back to SIGKILL if process did not exit gracefully
         lsof -ti:$p | xargs kill -9 2>/dev/null || true
-        sleep 1
     fi
 done
 


### PR DESCRIPTION
## Summary

- Add non-root `appuser` (UID 1001) with `USER` directive
- Add `HEALTHCHECK` using wget against `/health`
- Add `.dockerignore` to exclude .git, node_modules, .env, etc.
- Replace `kill -9` with graceful SIGTERM + fallback in 6 scripts

## Test plan

- [x] `docker build --check` passes
- [ ] CI build

Fixes #1926