### PR TITLE
🐛 Check io.ReadAll and io.Copy errors across all Go handlers

### DIFF
--- a/pkg/agent/prometheus.go
+++ b/pkg/agent/prometheus.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"time"
@@ -108,5 +109,7 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 
 	// Stream the raw Prometheus response back to the caller
 	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
+	if _, copyErr := io.Copy(w, resp.Body); copyErr != nil {
+		log.Printf("failed to stream Prometheus response: %v", copyErr)
+	}
 }

--- a/pkg/agent/provider_claude.go
+++ b/pkg/agent/provider_claude.go
@@ -89,7 +89,10 @@ func (c *ClaudeProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatRespo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
 	}
 
@@ -154,7 +157,10 @@ func (c *ClaudeProvider) StreamChat(ctx context.Context, req *ChatRequest, onChu
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
 	}
 

--- a/pkg/agent/provider_gemini.go
+++ b/pkg/agent/provider_gemini.go
@@ -95,7 +95,10 @@ func (g *GeminiProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatRespo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
 	}
 
@@ -171,7 +174,10 @@ func (g *GeminiProvider) StreamChat(ctx context.Context, req *ChatRequest, onChu
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
 	}
 

--- a/pkg/agent/provider_openai.go
+++ b/pkg/agent/provider_openai.go
@@ -82,7 +82,10 @@ func (o *OpenAIProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatRespo
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
 	}
 
@@ -144,7 +147,10 @@ func (o *OpenAIProvider) StreamChat(ctx context.Context, req *ChatRequest, onChu
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		return nil, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
 	}
 

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -3297,7 +3297,10 @@ func validateClaudeKey(ctx context.Context, apiKey string) (bool, error) {
 	if resp.StatusCode == http.StatusUnauthorized {
 		return false, nil // Invalid key - no error so it gets cached
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		body = []byte("(failed to read response body)")
+	}
 	return false, fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
 }
 
@@ -3321,7 +3324,10 @@ func validateOpenAIKey(ctx context.Context, apiKey string) (bool, error) {
 	if resp.StatusCode == http.StatusUnauthorized {
 		return false, fmt.Errorf("invalid API key")
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		body = []byte("(failed to read response body)")
+	}
 	return false, fmt.Errorf("API error: %s", string(body))
 }
 
@@ -3346,7 +3352,10 @@ func validateGeminiKey(ctx context.Context, apiKey string) (bool, error) {
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return false, fmt.Errorf("invalid API key")
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		body = []byte("(failed to read response body)")
+	}
 	return false, fmt.Errorf("API error: %s", string(body))
 }
 

--- a/pkg/api/handlers/benchmarks.go
+++ b/pkg/api/handlers/benchmarks.go
@@ -420,7 +420,10 @@ func (h *BenchmarkHandlers) driveGetWithRetry(url string) (*http.Response, error
 			continue
 		}
 		if resp.StatusCode == 403 || resp.StatusCode == 429 {
-			body, _ := io.ReadAll(resp.Body)
+			body, readErr := io.ReadAll(resp.Body)
+			if readErr != nil {
+				body = []byte("(failed to read response body)")
+			}
 			resp.Body.Close()
 			lastErr = fmt.Errorf("Drive API returned %d: %s", resp.StatusCode, string(body))
 			continue
@@ -863,7 +866,10 @@ func (h *BenchmarkHandlers) downloadDriveFile(fileID string) ([]byte, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		return nil, fmt.Errorf("Drive download returned %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -523,7 +523,10 @@ func (h *FeedbackHandler) fetchGitHubIssues(githubLogin string) ([]GitHubIssue, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		return nil, fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -732,7 +735,10 @@ func (h *FeedbackHandler) closeGitHubIssue(issueNumber int) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		log.Printf("GitHub API returned %d when closing issue: %s", resp.StatusCode, string(body))
 	}
 }
@@ -764,7 +770,10 @@ func (h *FeedbackHandler) addIssueComment(issueNumber int, comment string) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		log.Printf("GitHub API returned %d when adding comment: %s", resp.StatusCode, string(body))
 	}
 }
@@ -1351,7 +1360,10 @@ func (h *FeedbackHandler) createGitHubIssue(request *models.FeatureRequest, user
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		return 0, "", fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -1409,7 +1421,10 @@ func (h *FeedbackHandler) addPRComment(request *models.FeatureRequest, feedback 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		log.Printf("GitHub API returned %d when adding PR comment: %s", resp.StatusCode, string(body))
 	}
 }

--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -109,7 +109,10 @@ func (h *MissionsHandler) BrowseConsoleKB(c *fiber.Ctx) error {
 	defer resp.Body.Close()
 
 	limitedBody := io.LimitReader(resp.Body, missionsMaxBodyBytes)
-	body, _ := io.ReadAll(limitedBody)
+	body, err := io.ReadAll(limitedBody)
+	if err != nil {
+		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "failed to read response body"})
+	}
 	if resp.StatusCode != http.StatusOK {
 		code := "github_error"
 		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
@@ -166,7 +169,10 @@ func (h *MissionsHandler) GetMissionFile(c *fiber.Ctx) error {
 	defer resp.Body.Close()
 
 	limitedBody := io.LimitReader(resp.Body, missionsMaxBodyBytes)
-	body, _ := io.ReadAll(limitedBody)
+	body, err := io.ReadAll(limitedBody)
+	if err != nil {
+		return c.Status(http.StatusInternalServerError).JSON(fiber.Map{"error": "failed to read response body"})
+	}
 	if resp.StatusCode == http.StatusNotFound {
 		return c.Status(404).JSON(fiber.Map{"error": "file not found"})
 	}

--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -319,7 +319,10 @@ func (h *NightlyE2EHandler) fetchWorkflowRuns(wf NightlyWorkflow) ([]NightlyRun,
 		return []NightlyRun{}, nil
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		return nil, fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -723,7 +726,10 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			body = []byte("(failed to read response body)")
+		}
 		return c.Status(resp.StatusCode).JSON(fiber.Map{
 			"error": fmt.Sprintf("GitHub API returned %d: %s", resp.StatusCode, string(body)),
 		})


### PR DESCRIPTION
## Summary

- Fix ~21 locations where io.ReadAll/io.Copy errors were silently ignored
- Success-path reads (missions.go) now return proper HTTP 500 errors
- Error-path reads use fallback message instead of empty/partial data
- io.Copy error in Prometheus proxy now logged

## Files changed

missions.go, nightly_e2e.go, benchmarks.go, feedback.go, provider_gemini.go, provider_openai.go, provider_claude.go, server.go, prometheus.go

## Test plan

- [x] \`go build ./...\` passes
- [x] Pre-existing test failures only (TestMissions on main)
- [ ] CI build/lint

Fixes #1909