### PR TITLE
🐛 Fix frontend resource leaks and formatBytes edge case

### DIFF
--- a/web/src/components/missions/browser/helpers.ts
+++ b/web/src/components/missions/browser/helpers.ts
@@ -43,6 +43,7 @@ export function updateNodeInTree(
 }
 
 export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 B'
   if (bytes < 1024) return `${bytes} B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`

--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -280,6 +280,13 @@ export function useActiveUsers() {
       stateSubscribers.delete(handleStateUpdate)
       window.removeEventListener('kc-demo-mode-change', handleDemoChange)
       document.removeEventListener('visibilitychange', handleVisibility)
+
+      // Stop polling when no subscribers remain to prevent leaked intervals
+      if (subscribers.size === 0 && pollInterval) {
+        clearInterval(pollInterval)
+        pollInterval = null
+        pollStarted = false
+      }
     }
   }, [])
 

--- a/web/src/hooks/useNetworkStatus.ts
+++ b/web/src/hooks/useNetworkStatus.ts
@@ -5,21 +5,36 @@ const RECONNECTED_DISPLAY_MS = 3000 // Show "reconnected" state for 3 seconds
 // Global state for network status to ensure consistency across components
 let globalOnline = typeof navigator !== 'undefined' ? navigator.onLine : true
 const listeners = new Set<(online: boolean) => void>()
+let globalListenersAttached = false
 
 function notifyListeners() {
   listeners.forEach(listener => listener(globalOnline))
 }
 
-// Initialize browser online/offline listeners at module load
-if (typeof window !== 'undefined') {
-  window.addEventListener('online', () => {
-    globalOnline = true
-    notifyListeners()
-  })
-  window.addEventListener('offline', () => {
-    globalOnline = false
-    notifyListeners()
-  })
+// Named handlers so they can be removed with removeEventListener
+function handleOnline() {
+  globalOnline = true
+  notifyListeners()
+}
+
+function handleOffline() {
+  globalOnline = false
+  notifyListeners()
+}
+
+// Attach global browser listeners only while there are active subscribers
+function attachGlobalListeners() {
+  if (globalListenersAttached || typeof window === 'undefined') return
+  globalListenersAttached = true
+  window.addEventListener('online', handleOnline)
+  window.addEventListener('offline', handleOffline)
+}
+
+function detachGlobalListeners() {
+  if (!globalListenersAttached || typeof window === 'undefined') return
+  globalListenersAttached = false
+  window.removeEventListener('online', handleOnline)
+  window.removeEventListener('offline', handleOffline)
 }
 
 /**
@@ -56,6 +71,7 @@ export function useNetworkStatus() {
       }
     }
 
+    attachGlobalListeners()
     listeners.add(handleChange)
     setIsOnline(globalOnline)
 
@@ -63,6 +79,10 @@ export function useNetworkStatus() {
       listeners.delete(handleChange)
       if (wasOfflineTimerRef.current) {
         clearTimeout(wasOfflineTimerRef.current)
+      }
+      // Remove global event listeners when no subscribers remain
+      if (listeners.size === 0) {
+        detachGlobalListeners()
       }
     }
   }, [])

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -50,7 +50,7 @@ function parseK8sQuantity(value: string): number {
  * Format bytes to human-readable string (GB, TB, MB, etc.)
  */
 export function formatBytes(bytes: number, decimals = 1): string {
-  if (bytes === 0) return '0 B'
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
 
   const k = 1024
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']

--- a/web/src/lib/stats/types.ts
+++ b/web/src/lib/stats/types.ts
@@ -273,6 +273,7 @@ export function formatStatNumber(value: number): string {
  * Format memory/storage values
  */
 export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
   if (bytes >= 1024 * 1024 * 1024 * 1024) {
     return `${(bytes / (1024 * 1024 * 1024 * 1024)).toFixed(1)} TB`
   }

--- a/web/src/lib/unified/stats/valueResolvers.ts
+++ b/web/src/lib/unified/stats/valueResolvers.ts
@@ -340,7 +340,7 @@ export function formatNumber(value: number): string | number {
  * Format bytes to human-readable
  */
 export function formatBytes(bytes: number): string {
-  if (bytes === 0) return '0 B'
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
 
   const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
   const exp = Math.floor(Math.log(bytes) / Math.log(1024))


### PR DESCRIPTION
## Summary

- **useActiveUsers**: Clean up polling interval when last subscriber unmounts
- **useNetworkStatus**: Refactor to named handlers with attach/detach; remove listeners on last unmount
- **formatBytes**: Guard against negative, NaN, and non-finite input in 4 implementations

## Test plan

- [x] `npm run build` passes
- [ ] CI build/lint

Fixes #1916