### PR TITLE
🐛 Add token validation to agent settings and secrets endpoints

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -1005,6 +1005,13 @@ func (s *Server) handleSecretsHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+
+	// SECURITY: Validate token for secrets endpoint
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	if s.k8sClient == nil {
 		json.NewEncoder(w).Encode(map[string]interface{}{"secrets": []interface{}{}, "error": "k8s client not initialized"})
 		return
@@ -2862,6 +2869,12 @@ func (s *Server) handleSettingsKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SECURITY: Validate token for settings keys endpoint
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	switch r.Method {
 	case "GET":
 		s.handleGetKeysStatus(w, r)
@@ -2886,6 +2899,12 @@ func (s *Server) handleSettingsKeyByProvider(w http.ResponseWriter, r *http.Requ
 
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// SECURITY: Validate token for settings key deletion endpoint
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -2944,6 +2963,12 @@ func (s *Server) handleSettingsAll(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// SECURITY: Validate token for settings endpoint
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -3006,6 +3031,13 @@ func (s *Server) handleSettingsExport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// SECURITY: Validate token for settings export endpoint
+	if !s.validateToken(r) {
+		w.Header().Set("Content-Type", "application/json")
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
 	if r.Method != "POST" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -3041,6 +3073,12 @@ func (s *Server) handleSettingsImport(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method == "OPTIONS" {
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// SECURITY: Validate token for settings import endpoint
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 

--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -42,6 +42,7 @@ type Hub struct {
 	mu           sync.RWMutex
 	done         chan struct{}
 	jwtSecret    string // JWT secret for WebSocket auth
+	devMode      bool   // when true, demo-token bypass is allowed
 }
 
 type broadcastMessage struct {
@@ -65,6 +66,11 @@ func NewHub() *Hub {
 // SetJWTSecret sets the JWT secret for WebSocket authentication
 func (h *Hub) SetJWTSecret(secret string) {
 	h.jwtSecret = secret
+}
+
+// SetDevMode enables or disables dev mode (controls demo-token bypass)
+func (h *Hub) SetDevMode(devMode bool) {
+	h.devMode = devMode
 }
 
 // Run starts the hub
@@ -223,11 +229,17 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 	}
 
 	// Validate token
-	if authMsg.Token == "demo-token" {
+	if authMsg.Token == "demo-token" && h.devMode {
 		// Demo mode: accept connection for presence tracking (count only, no user data)
+		// SECURITY: Only allowed when DEV_MODE=true to prevent unauthenticated access in production
 		userID = uuid.Nil
 		authenticated = true
-		log.Printf("Demo-mode WebSocket connection for presence tracking")
+		log.Printf("Demo-mode WebSocket connection for presence tracking (dev mode)")
+	} else if authMsg.Token == "demo-token" && !h.devMode {
+		log.Printf("SECURITY: Rejected demo-token WebSocket connection (dev mode not enabled)")
+		conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "demo-token not allowed in production"}})
+		conn.Close()
+		return
 	} else if h.jwtSecret != "" {
 		claims, err := middleware.ValidateJWT(authMsg.Token, h.jwtSecret)
 		if err != nil {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -141,6 +141,7 @@ func NewServer(cfg Config) (*Server, error) {
 	// WebSocket hub
 	hub := handlers.NewHub()
 	hub.SetJWTSecret(cfg.JWTSecret)
+	hub.SetDevMode(cfg.DevMode)
 	go hub.Run()
 
 	// Initialize Kubernetes multi-cluster client


### PR DESCRIPTION
## Summary

- Add `validateToken()` checks to 6 unprotected agent endpoints: `/secrets`, `/settings/keys`, `/settings`, `/settings/export`, `/settings/import`
- Restrict WebSocket demo-token bypass to dev mode only (`DEV_MODE=true`)
- Wire `devMode` flag from server config to WebSocket hub

## Test plan

- [x] `go build ./...` passes
- [ ] CI build/lint

Fixes #1923