### PR TITLE
🐛 Fix ignored json.Marshal errors and add recover to goroutines

### DIFF
--- a/pkg/agent/prediction_worker.go
+++ b/pkg/agent/prediction_worker.go
@@ -488,7 +488,11 @@ func (w *PredictionWorker) buildAnalysisPrompt(data *ClusterAnalysisData) string
 	filteredData.GPUNodes = data.GPUNodes
 	filteredData.OfflineNodes = data.OfflineNodes
 
-	dataJSON, _ := json.MarshalIndent(filteredData, "", "  ")
+	dataJSON, err := json.MarshalIndent(filteredData, "", "  ")
+	if err != nil {
+		log.Printf("[PredictionWorker] Failed to marshal filtered data: %v", err)
+		return ""
+	}
 
 	return fmt.Sprintf(`You are a Kubernetes cluster health analyzer. Analyze the provided metrics for HEALTHY clusters and predict potential failures BEFORE they occur.
 

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -559,6 +559,11 @@ func (s *Server) handleGPUNodesHTTP(w http.ResponseWriter, r *http.Request) {
 			wg.Add(1)
 			go func(clusterName string) {
 				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("[GPUNodes] recovered from panic for cluster %s: %v", clusterName, r)
+					}
+				}()
 				clusterCtx, clusterCancel := context.WithTimeout(ctx, agentDefaultTimeout)
 				defer clusterCancel()
 				nodes, err := s.k8sClient.GetGPUNodes(clusterCtx, clusterName)
@@ -624,6 +629,11 @@ func (s *Server) handleNodesHTTP(w http.ResponseWriter, r *http.Request) {
 			wg.Add(1)
 			go func(clusterName string) {
 				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("[Nodes] recovered from panic for cluster %s: %v", clusterName, r)
+					}
+				}()
 				clusterCtx, clusterCancel := context.WithTimeout(ctx, agentDefaultTimeout)
 				defer clusterCancel()
 				nodes, err := s.k8sClient.GetNodes(clusterCtx, clusterName)
@@ -1328,6 +1338,11 @@ func (s *Server) startBackendProcess() error {
 
 	// Reap process in background to avoid zombies
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("[Backend] recovered from panic in process reaper: %v", r)
+			}
+		}()
 		cmd.Wait()
 		s.backendMux.Lock()
 		if s.backendCmd == cmd {
@@ -1808,6 +1823,11 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 				forceAgent = "claude"
 			}
 			go func(m protocol.Message, fa string) {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("[Chat] recovered from panic in streaming handler: %v", r)
+					}
+				}()
 				s.handleChatMessageStreaming(conn, m, fa, &writeMu, &closed)
 			}(msg, forceAgent)
 		} else if msg.Type == protocol.TypeCancelChat {
@@ -1817,6 +1837,11 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			// Handle kubectl messages concurrently so one slow cluster
 			// doesn't block the entire WebSocket message loop.
 			go func(m protocol.Message) {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("[Kubectl] recovered from panic in message handler: %v", r)
+					}
+				}()
 				response := s.handleMessage(m)
 				if closed.Load() {
 					return
@@ -2174,11 +2199,18 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 
 // handleCancelChat cancels an in-progress chat session by calling its context cancel function
 func (s *Server) handleCancelChat(conn *websocket.Conn, msg protocol.Message, writeMu *sync.Mutex) {
-	payloadBytes, _ := json.Marshal(msg.Payload)
+	payloadBytes, err := json.Marshal(msg.Payload)
+	if err != nil {
+		log.Printf("[Chat] Failed to marshal cancel chat payload: %v", err)
+		return
+	}
 	var req struct {
 		SessionID string `json:"sessionId"`
 	}
-	json.Unmarshal(payloadBytes, &req)
+	if err := json.Unmarshal(payloadBytes, &req); err != nil {
+		log.Printf("[Chat] Failed to unmarshal cancel chat request: %v", err)
+		return
+	}
 
 	s.activeChatCtxsMu.Lock()
 	cancelFn, ok := s.activeChatCtxs[req.SessionID]
@@ -3411,6 +3443,11 @@ func (s *Server) handleProvidersHealth(w http.ResponseWriter, r *http.Request) {
 		wg.Add(1)
 		go func(providerID, url string) {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("[ProviderHealth] recovered from panic checking %s: %v", providerID, r)
+				}
+			}()
 			status := checkStatuspageHealth(client, url)
 			mu.Lock()
 			results = append(results, ProviderHealthStatus{ID: providerID, Status: status})
@@ -3423,6 +3460,11 @@ func (s *Server) handleProvidersHealth(w http.ResponseWriter, r *http.Request) {
 		wg.Add(1)
 		go func(providerID, url string) {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("[ProviderHealth] recovered from panic pinging %s: %v", providerID, r)
+				}
+			}()
 			status := checkPingHealth(client, url)
 			mu.Lock()
 			results = append(results, ProviderHealthStatus{ID: providerID, Status: status})
@@ -3821,6 +3863,11 @@ func (s *Server) sendNativeNotification(alerts []DeviceAlert) {
 
 	// Use osascript for macOS notifications (non-blocking)
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("[DeviceTracker] recovered from panic in notification: %v", r)
+			}
+		}()
 		script := fmt.Sprintf(`display notification "%s" with title "%s" sound name "Glass"`,
 			message, title)
 		cmd := exec.Command("osascript", "-e", script)
@@ -3934,6 +3981,11 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 
 		// Create cluster in background and return immediately
 		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("[LocalClusters] recovered from panic creating cluster %s: %v", req.Name, r)
+				}
+			}()
 			if err := s.localClusters.CreateCluster(req.Tool, req.Name); err != nil {
 				log.Printf("[LocalClusters] Failed to create cluster %s with %s: %v", req.Name, req.Tool, err)
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
@@ -3985,6 +4037,11 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 
 		// Delete cluster in background
 		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("[LocalClusters] recovered from panic deleting cluster %s: %v", name, r)
+				}
+			}()
 			if err := s.localClusters.DeleteCluster(tool, name); err != nil {
 				log.Printf("[LocalClusters] Failed to delete cluster %s: %v", name, err)
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{

--- a/pkg/api/handlers/benchmarks.go
+++ b/pkg/api/handlers/benchmarks.go
@@ -496,7 +496,10 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 		c.Set("Content-Type", "text/event-stream")
 		c.Set("Cache-Control", "no-cache")
 		c.Set("Connection", "keep-alive")
-		batch, _ := json.Marshal(reports)
+		batch, err := json.Marshal(reports)
+		if err != nil {
+			return fiber.NewError(fiber.StatusInternalServerError, "failed to marshal benchmark reports")
+		}
 		fmt.Fprintf(c, "event: batch\ndata: %s\n\n", batch)
 		fmt.Fprintf(c, "event: done\ndata: {\"total\":%d,\"source\":\"cache\"}\n\n", len(reports))
 		return nil
@@ -526,7 +529,11 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 			if len(pendingBatch) == 0 {
 				return
 			}
-			batch, _ := json.Marshal(pendingBatch)
+			batch, err := json.Marshal(pendingBatch)
+			if err != nil {
+				log.Printf("[benchmarks] Failed to marshal batch: %v", err)
+				return
+			}
 			fmt.Fprintf(w, "event: batch\ndata: %s\n\n", batch)
 			w.Flush()
 			log.Printf("[benchmarks] Flushed batch of %d (total: %d)", len(pendingBatch), totalSent)

--- a/pkg/api/handlers/events.go
+++ b/pkg/api/handlers/events.go
@@ -47,7 +47,10 @@ func (h *EventHandler) RecordEvent(c *fiber.Ctx) error {
 	}
 
 	if input.Metadata != nil {
-		metadata, _ := json.Marshal(input.Metadata)
+		metadata, err := json.Marshal(input.Metadata)
+		if err != nil {
+			return fiber.NewError(fiber.StatusInternalServerError, "failed to marshal event metadata")
+		}
 		event.Metadata = metadata
 	}
 

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -708,7 +708,11 @@ func (h *FeedbackHandler) RequestUpdate(c *fiber.Ctx) error {
 // closeGitHubIssue closes an issue on GitHub
 func (h *FeedbackHandler) closeGitHubIssue(issueNumber int) {
 	payload := map[string]string{"state": "closed"}
-	jsonData, _ := json.Marshal(payload)
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("Failed to marshal close issue payload: %v", err)
+		return
+	}
 
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d",
 		h.repoOwner, h.repoName, issueNumber)
@@ -740,7 +744,11 @@ func (h *FeedbackHandler) closeGitHubIssue(issueNumber int) {
 // addIssueComment adds a comment to a GitHub issue
 func (h *FeedbackHandler) addIssueComment(issueNumber int, comment string) {
 	payload := map[string]string{"body": comment}
-	jsonData, _ := json.Marshal(payload)
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("Failed to marshal issue comment payload: %v", err)
+		return
+	}
 
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d/comments",
 		h.repoOwner, h.repoName, issueNumber)
@@ -1331,7 +1339,10 @@ func (h *FeedbackHandler) createGitHubIssue(request *models.FeatureRequest, user
 		"labels": labels,
 	}
 
-	jsonData, _ := json.Marshal(payload)
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to marshal issue payload: %w", err)
+	}
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues", h.repoOwner, h.repoName)
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
@@ -1385,7 +1396,11 @@ func (h *FeedbackHandler) addPRComment(request *models.FeatureRequest, feedback 
 	}
 
 	payload := map[string]string{"body": commentBody}
-	jsonData, _ := json.Marshal(payload)
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("Failed to marshal PR comment payload: %v", err)
+		return
+	}
 
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d/comments",
 		h.repoOwner, h.repoName, *request.PRNumber)

--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -247,7 +247,10 @@ func (h *MissionsHandler) ShareToSlack(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "text is required"})
 	}
 
-	payload, _ := json.Marshal(map[string]string{"text": req.Text})
+	payload, err := json.Marshal(map[string]string{"text": req.Text})
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to marshal payload"})
+	}
 	httpReq, err := http.NewRequest("POST", req.WebhookURL, bytes.NewReader(payload))
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": "failed to build request"})
@@ -344,10 +347,13 @@ func (h *MissionsHandler) ShareToGitHub(c *fiber.Ctx) error {
 	}
 
 	refURL := fmt.Sprintf("%s/repos/%s/git/refs", h.githubAPIURL, forkFullName)
-	refPayload, _ := json.Marshal(map[string]string{
+	refPayload, err := json.Marshal(map[string]string{
 		"ref": "refs/heads/" + req.Branch,
 		"sha": headSHA,
 	})
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to marshal branch ref payload"})
+	}
 	refReq, err := http.NewRequest("POST", refURL, bytes.NewReader(refPayload))
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": "failed to build branch ref request"})
@@ -358,11 +364,14 @@ func (h *MissionsHandler) ShareToGitHub(c *fiber.Ctx) error {
 
 	// Step 3: Create/update file (commit)
 	fileURL := fmt.Sprintf("%s/repos/%s/contents/%s", h.githubAPIURL, forkFullName, req.FilePath)
-	filePayload, _ := json.Marshal(map[string]string{
+	filePayload, err := json.Marshal(map[string]string{
 		"message": req.Message,
 		"content": req.Content,
 		"branch":  req.Branch,
 	})
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to marshal file commit payload"})
+	}
 	fileReq, err := http.NewRequest("PUT", fileURL, bytes.NewReader(filePayload))
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": "failed to build file commit request"})
@@ -377,12 +386,15 @@ func (h *MissionsHandler) ShareToGitHub(c *fiber.Ctx) error {
 
 	// Step 4: Create PR
 	prURL := fmt.Sprintf("%s/repos/%s/pulls", h.githubAPIURL, req.Repo)
-	prPayload, _ := json.Marshal(map[string]interface{}{
+	prPayload, err := json.Marshal(map[string]interface{}{
 		"title": req.Message,
 		"head":  strings.Split(forkFullName, "/")[0] + ":" + req.Branch,
 		"base":  "main",
 		"body":  "Mission shared via KubeStellar Console",
 	})
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{"error": "failed to marshal PR payload"})
+	}
 	prReq, err := http.NewRequest("POST", prURL, bytes.NewReader(prPayload))
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{"error": "failed to build PR request"})

--- a/pkg/api/handlers/onboarding.go
+++ b/pkg/api/handlers/onboarding.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/google/uuid"
@@ -160,7 +161,11 @@ func generateDefaultCards(responses []models.OnboardingResponse) []models.Card {
 	// GPU workloads
 	if respMap["gpu_workloads"] == "Yes" {
 		// Add config for GPU filtering
-		gpuConfig, _ := json.Marshal(map[string]string{"resource_type": "gpu"})
+		gpuConfig, err := json.Marshal(map[string]string{"resource_type": "gpu"})
+		if err != nil {
+			log.Printf("Failed to marshal GPU config: %v", err)
+			gpuConfig = []byte(`{"resource_type":"gpu"}`)
+		}
 		cards = append(cards, models.Card{
 			ID:       uuid.New(),
 			CardType: models.CardTypeResourceCapacity,

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -623,27 +623,33 @@ func (s *SQLiteStore) CreateCard(card *models.Card) error {
 	}
 	card.CreatedAt = time.Now()
 
-	positionJSON, _ := json.Marshal(card.Position)
+	positionJSON, err := json.Marshal(card.Position)
+	if err != nil {
+		return fmt.Errorf("failed to marshal card position: %w", err)
+	}
 	var configStr *string
 	if card.Config != nil {
 		str := string(card.Config)
 		configStr = &str
 	}
 
-	_, err := s.db.Exec(`INSERT INTO cards (id, dashboard_id, card_type, config, position, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
+	_, err = s.db.Exec(`INSERT INTO cards (id, dashboard_id, card_type, config, position, created_at) VALUES (?, ?, ?, ?, ?, ?)`,
 		card.ID.String(), card.DashboardID.String(), string(card.CardType), configStr, string(positionJSON), card.CreatedAt)
 	return err
 }
 
 func (s *SQLiteStore) UpdateCard(card *models.Card) error {
-	positionJSON, _ := json.Marshal(card.Position)
+	positionJSON, err := json.Marshal(card.Position)
+	if err != nil {
+		return fmt.Errorf("failed to marshal card position: %w", err)
+	}
 	var configStr *string
 	if card.Config != nil {
 		str := string(card.Config)
 		configStr = &str
 	}
 
-	_, err := s.db.Exec(`UPDATE cards SET card_type = ?, config = ?, position = ? WHERE id = ?`,
+	_, err = s.db.Exec(`UPDATE cards SET card_type = ?, config = ?, position = ? WHERE id = ?`,
 		string(card.CardType), configStr, string(positionJSON), card.ID.String())
 	return err
 }


### PR DESCRIPTION
## Summary

- Fix 13 ignored `json.Marshal`/`MarshalIndent` errors across 8 files
- Add `recover()` to all 10 unprotected goroutines in server.go
- Note: 165 unchecked `json.NewEncoder().Encode()` calls deferred (needs helper pattern)

## Test plan

- [x] `go build ./...` passes
- [x] Pre-existing test failures only
- [ ] CI build/lint

Fixes #1915