### PR TITLE
🐛 Wrap unprotected JSON.parse calls in try-catch across frontend

### DIFF
--- a/web/src/components/drilldown/views/CRDDrillDown.tsx
+++ b/web/src/components/drilldown/views/CRDDrillDown.tsx
@@ -157,9 +157,13 @@ export function CRDDrillDown({ data }: Props) {
         }))
       }
       ws.onmessage = (event) => {
-        const msg = JSON.parse(event.data)
-        if (msg.id === requestId && msg.payload?.output) {
-          output = msg.payload.output
+        try {
+          const msg = JSON.parse(event.data)
+          if (msg.id === requestId && msg.payload?.output) {
+            output = msg.payload.output
+          }
+        } catch (e) {
+          console.error('Failed to parse WebSocket message:', e)
         }
         clearTimeout(timeout)
         ws.close()

--- a/web/src/components/drilldown/views/KustomizationDrillDown.tsx
+++ b/web/src/components/drilldown/views/KustomizationDrillDown.tsx
@@ -146,9 +146,13 @@ export function KustomizationDrillDown({ data }: Props) {
         }))
       }
       ws.onmessage = (event) => {
-        const msg = JSON.parse(event.data)
-        if (msg.id === requestId && msg.payload?.output) {
-          output = msg.payload.output
+        try {
+          const msg = JSON.parse(event.data)
+          if (msg.id === requestId && msg.payload?.output) {
+            output = msg.payload.output
+          }
+        } catch (e) {
+          console.error('Failed to parse WebSocket message:', e)
         }
         clearTimeout(timeout)
         ws.close()

--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -177,37 +177,41 @@ export function PodDrillDown({ data }: { data: Record<string, unknown> }) {
       }
 
       ws.onmessage = (event) => {
-        const msg = JSON.parse(event.data)
-        if (msg.id === requestId && msg.payload?.output) {
-          setDescribeOutput(msg.payload.output)
-          // Parse labels and annotations from describe output if not already set
-          if (!labels || !annotations) {
-            const output = msg.payload.output as string
-            const labelsMatch = output.match(/Labels:\s*([\s\S]*?)(?=Annotations:|$)/i)
-            const annotationsMatch = output.match(/Annotations:\s*([\s\S]*?)(?=Status:|Controlled By:|$)/i)
+        try {
+          const msg = JSON.parse(event.data)
+          if (msg.id === requestId && msg.payload?.output) {
+            setDescribeOutput(msg.payload.output)
+            // Parse labels and annotations from describe output if not already set
+            if (!labels || !annotations) {
+              const output = msg.payload.output as string
+              const labelsMatch = output.match(/Labels:\s*([\s\S]*?)(?=Annotations:|$)/i)
+              const annotationsMatch = output.match(/Annotations:\s*([\s\S]*?)(?=Status:|Controlled By:|$)/i)
 
-            if (labelsMatch && !labels) {
-              const parsed: Record<string, string> = {}
-              labelsMatch[1].trim().split('\n').forEach(line => {
-                const [key, ...valueParts] = line.trim().split('=')
-                if (key && key !== '<none>') parsed[key] = valueParts.join('=')
-              })
-              if (Object.keys(parsed).length > 0) setLabels(parsed)
-            }
+              if (labelsMatch && !labels) {
+                const parsed: Record<string, string> = {}
+                labelsMatch[1].trim().split('\n').forEach(line => {
+                  const [key, ...valueParts] = line.trim().split('=')
+                  if (key && key !== '<none>') parsed[key] = valueParts.join('=')
+                })
+                if (Object.keys(parsed).length > 0) setLabels(parsed)
+              }
 
-            if (annotationsMatch && !annotations) {
-              const parsed: Record<string, string> = {}
-              annotationsMatch[1].trim().split('\n').forEach(line => {
-                const colonIdx = line.indexOf(':')
-                if (colonIdx > 0) {
-                  const key = line.substring(0, colonIdx).trim()
-                  const value = line.substring(colonIdx + 1).trim()
-                  if (key && key !== '<none>') parsed[key] = value
-                }
-              })
-              if (Object.keys(parsed).length > 0) setAnnotations(parsed)
+              if (annotationsMatch && !annotations) {
+                const parsed: Record<string, string> = {}
+                annotationsMatch[1].trim().split('\n').forEach(line => {
+                  const colonIdx = line.indexOf(':')
+                  if (colonIdx > 0) {
+                    const key = line.substring(0, colonIdx).trim()
+                    const value = line.substring(colonIdx + 1).trim()
+                    if (key && key !== '<none>') parsed[key] = value
+                  }
+                })
+                if (Object.keys(parsed).length > 0) setAnnotations(parsed)
+              }
             }
           }
+        } catch (e) {
+          console.error('Failed to parse WebSocket message:', e)
         }
         ws.close()
         setDescribeLoading(false)
@@ -240,9 +244,13 @@ export function PodDrillDown({ data }: { data: Record<string, unknown> }) {
       }
 
       ws.onmessage = (event) => {
-        const msg = JSON.parse(event.data)
-        if (msg.id === requestId && msg.payload?.output) {
-          setLogsOutput(msg.payload.output)
+        try {
+          const msg = JSON.parse(event.data)
+          if (msg.id === requestId && msg.payload?.output) {
+            setLogsOutput(msg.payload.output)
+          }
+        } catch (e) {
+          console.error('Failed to parse WebSocket message:', e)
         }
         ws.close()
         setLogsLoading(false)
@@ -275,9 +283,13 @@ export function PodDrillDown({ data }: { data: Record<string, unknown> }) {
       }
 
       ws.onmessage = (event) => {
-        const msg = JSON.parse(event.data)
-        if (msg.id === requestId && msg.payload?.output) {
-          setEventsOutput(msg.payload.output)
+        try {
+          const msg = JSON.parse(event.data)
+          if (msg.id === requestId && msg.payload?.output) {
+            setEventsOutput(msg.payload.output)
+          }
+        } catch (e) {
+          console.error('Failed to parse WebSocket message:', e)
         }
         ws.close()
         setEventsLoading(false)
@@ -318,9 +330,13 @@ export function PodDrillDown({ data }: { data: Record<string, unknown> }) {
             }))
           }
           ws.onmessage = (event) => {
-            const msg = JSON.parse(event.data)
-            if (msg.id === requestId && msg.payload?.output) {
-              output = msg.payload.output
+            try {
+              const msg = JSON.parse(event.data)
+              if (msg.id === requestId && msg.payload?.output) {
+                output = msg.payload.output
+              }
+            } catch (e) {
+              console.error('Failed to parse WebSocket message:', e)
             }
             clearTimeout(timeout)
             ws.close()
@@ -453,15 +469,19 @@ Be specific and reference actual values from the data. Keep response to 3-4 sent
       }
 
       ws.onmessage = (event) => {
-        const msg = JSON.parse(event.data)
-        if (msg.id === requestId) {
-          if (msg.payload?.content) {
-            setAiAnalysis(msg.payload.content)
-          } else if (msg.payload?.error || msg.payload?.message) {
-            setAiAnalysis(`Analysis unavailable: ${msg.payload.error || msg.payload.message}`)
-          } else {
-            setAiAnalysis('Analysis complete - no specific issues identified.')
+        try {
+          const msg = JSON.parse(event.data)
+          if (msg.id === requestId) {
+            if (msg.payload?.content) {
+              setAiAnalysis(msg.payload.content)
+            } else if (msg.payload?.error || msg.payload?.message) {
+              setAiAnalysis(`Analysis unavailable: ${msg.payload.error || msg.payload.message}`)
+            } else {
+              setAiAnalysis('Analysis complete - no specific issues identified.')
+            }
           }
+        } catch (e) {
+          console.error('Failed to parse WebSocket message:', e)
         }
         ws.close()
         setAiAnalysisLoading(false)
@@ -496,9 +516,13 @@ Be specific and reference actual values from the data. Keep response to 3-4 sent
       }
 
       ws.onmessage = (event) => {
-        const msg = JSON.parse(event.data)
-        if (msg.id === requestId && msg.payload?.output) {
-          setPodStatusOutput(msg.payload.output)
+        try {
+          const msg = JSON.parse(event.data)
+          if (msg.id === requestId && msg.payload?.output) {
+            setPodStatusOutput(msg.payload.output)
+          }
+        } catch (e) {
+          console.error('Failed to parse WebSocket message:', e)
         }
         ws.close()
         setPodStatusLoading(false)
@@ -531,9 +555,13 @@ Be specific and reference actual values from the data. Keep response to 3-4 sent
       }
 
       ws.onmessage = (event) => {
-        const msg = JSON.parse(event.data)
-        if (msg.id === requestId && msg.payload?.output) {
-          setYamlOutput(msg.payload.output)
+        try {
+          const msg = JSON.parse(event.data)
+          if (msg.id === requestId && msg.payload?.output) {
+            setYamlOutput(msg.payload.output)
+          }
+        } catch (e) {
+          console.error('Failed to parse WebSocket message:', e)
         }
         ws.close()
         setYamlLoading(false)
@@ -685,14 +713,18 @@ Please proceed step by step and ask for confirmation before making any changes.`
       }
 
       ws.onmessage = (event) => {
-        const msg = JSON.parse(event.data)
-        if (msg.id === requestId) {
-          if (msg.type === 'error' || msg.payload?.exitCode !== 0) {
-            setDeleteError(msg.payload?.error || 'Failed to delete pod')
-          } else {
-            // Success - close the drill down
-            closeDrillDown()
+        try {
+          const msg = JSON.parse(event.data)
+          if (msg.id === requestId) {
+            if (msg.type === 'error' || msg.payload?.exitCode !== 0) {
+              setDeleteError(msg.payload?.error || 'Failed to delete pod')
+            } else {
+              // Success - close the drill down
+              closeDrillDown()
+            }
           }
+        } catch (e) {
+          console.error('Failed to parse WebSocket message:', e)
         }
         ws.close()
         setDeletingPod(false)
@@ -740,15 +772,22 @@ Please proceed step by step and ask for confirmation before making any changes.`
             }))
           }
           ws.onmessage = (event) => {
-            const msg = JSON.parse(event.data)
-            if (msg.id === requestId) {
+            try {
+              const msg = JSON.parse(event.data)
+              if (msg.id === requestId) {
+                clearTimeout(timeout)
+                ws.close()
+                if (msg.payload?.exitCode === 0 || msg.payload?.output) {
+                  resolve({ success: true })
+                } else {
+                  resolve({ success: false, error: msg.payload?.error || 'Unknown error' })
+                }
+              }
+            } catch (e) {
+              console.error('Failed to parse WebSocket message:', e)
               clearTimeout(timeout)
               ws.close()
-              if (msg.payload?.exitCode === 0 || msg.payload?.output) {
-                resolve({ success: true })
-              } else {
-                resolve({ success: false, error: msg.payload?.error || 'Unknown error' })
-              }
+              resolve({ success: false, error: 'Failed to parse response' })
             }
           }
           ws.onerror = () => {
@@ -867,15 +906,22 @@ Please proceed step by step and ask for confirmation before making any changes.`
             }))
           }
           ws.onmessage = (event) => {
-            const msg = JSON.parse(event.data)
-            if (msg.id === requestId) {
+            try {
+              const msg = JSON.parse(event.data)
+              if (msg.id === requestId) {
+                clearTimeout(timeout)
+                ws.close()
+                if (msg.payload?.exitCode === 0 || msg.payload?.output) {
+                  resolve({ success: true })
+                } else {
+                  resolve({ success: false, error: msg.payload?.error || 'Unknown error' })
+                }
+              }
+            } catch (e) {
+              console.error('Failed to parse WebSocket message:', e)
               clearTimeout(timeout)
               ws.close()
-              if (msg.payload?.exitCode === 0 || msg.payload?.output) {
-                resolve({ success: true })
-              } else {
-                resolve({ success: false, error: msg.payload?.error || 'Unknown error' })
-              }
+              resolve({ success: false, error: 'Failed to parse response' })
             }
           }
           ws.onerror = () => {
@@ -994,9 +1040,13 @@ Please proceed step by step and ask for confirmation before making any changes.`
             }))
           }
           ws.onmessage = (event) => {
-            const msg = JSON.parse(event.data)
-            if (msg.id === requestId && msg.payload?.output) {
-              output = msg.payload.output
+            try {
+              const msg = JSON.parse(event.data)
+              if (msg.id === requestId && msg.payload?.output) {
+                output = msg.payload.output
+              }
+            } catch (e) {
+              console.error('Failed to parse WebSocket message:', e)
             }
             clearTimeout(timeout)
             ws.close()

--- a/web/src/hooks/useDeployMissions.ts
+++ b/web/src/hooks/useDeployMissions.ts
@@ -27,12 +27,17 @@ async function fetchDeployEventsViaProxy(
     { context, timeout: 10000 },
   )
   if (response.exitCode !== 0) return []
-  const data = JSON.parse(response.output)
   interface KubeEvent {
     lastTimestamp?: string
     reason?: string
     message?: string
     involvedObject?: { name?: string }
+  }
+  let data: { items?: KubeEvent[] }
+  try {
+    data = JSON.parse(response.output)
+  } catch {
+    return []
   }
   const prefix = workload + '-'
   const relevant = (data.items || []).filter((e: KubeEvent) => {

--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -275,7 +275,12 @@ class KubectlProxy {
     if (response.exitCode !== 0) {
       throw new Error(response.error || 'Failed to get nodes')
     }
-    const data = JSON.parse(response.output)
+    let data: { items?: KubeNode[] }
+    try {
+      data = JSON.parse(response.output)
+    } catch {
+      throw new Error('Failed to parse kubectl output as JSON')
+    }
     const nodes = (data.items || []).map((node: KubeNode) => {
       // Parse allocatable resources (prefer allocatable over capacity)
       const alloc = node.status?.allocatable || node.status?.capacity || {}
@@ -310,7 +315,12 @@ class KubectlProxy {
     if (response.exitCode !== 0) {
       throw new Error(response.error || 'Failed to get pods')
     }
-    const data = JSON.parse(response.output)
+    let data: { items?: Array<{ spec?: { containers?: Array<{ resources?: { requests?: { cpu?: string; memory?: string } } }> } }> }
+    try {
+      data = JSON.parse(response.output)
+    } catch {
+      throw new Error('Failed to parse kubectl output as JSON')
+    }
     const pods = data.items || []
 
     // Sum resource requests from all containers in all pods
@@ -369,7 +379,12 @@ class KubectlProxy {
     if (response.exitCode !== 0) {
       throw new Error(response.error || 'Failed to get services')
     }
-    const data = JSON.parse(response.output)
+    let data: { items?: Array<{ metadata: { name: string; namespace: string }; spec: { type: string; clusterIP: string; ports?: { port: number; protocol: string }[] } }> }
+    try {
+      data = JSON.parse(response.output)
+    } catch {
+      throw new Error('Failed to parse kubectl output as JSON')
+    }
     return (data.items || []).map((svc: { metadata: { name: string; namespace: string }; spec: { type: string; clusterIP: string; ports?: { port: number; protocol: string }[] } }) => ({
       name: svc.metadata.name,
       namespace: svc.metadata.namespace,
@@ -388,7 +403,12 @@ class KubectlProxy {
     if (response.exitCode !== 0) {
       throw new Error(response.error || 'Failed to get PVCs')
     }
-    const data = JSON.parse(response.output)
+    let data: { items?: Array<{ metadata: { name: string; namespace: string }; status: { phase: string; capacity?: { storage: string } }; spec: { storageClassName?: string } }> }
+    try {
+      data = JSON.parse(response.output)
+    } catch {
+      throw new Error('Failed to parse kubectl output as JSON')
+    }
     return (data.items || []).map((pvc: { metadata: { name: string; namespace: string }; status: { phase: string; capacity?: { storage: string } }; spec: { storageClassName?: string } }) => ({
       name: pvc.metadata.name,
       namespace: pvc.metadata.namespace,
@@ -530,7 +550,13 @@ class KubectlProxy {
       throw new Error(response.error || 'Failed to get pods')
     }
 
-    const data = JSON.parse(response.output)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let data: { items?: any[] }
+    try {
+      data = JSON.parse(response.output)
+    } catch {
+      throw new Error('Failed to parse kubectl output as JSON')
+    }
     const issues: PodIssue[] = []
 
     for (const pod of data.items || []) {
@@ -604,7 +630,12 @@ class KubectlProxy {
       throw new Error(response.error || 'Failed to get events')
     }
 
-    const data = JSON.parse(response.output)
+    let data: { items?: KubeEvent[] }
+    try {
+      data = JSON.parse(response.output)
+    } catch {
+      throw new Error('Failed to parse kubectl output as JSON')
+    }
     const events: ClusterEvent[] = (data.items || []).slice(-limit).reverse().map((e: KubeEvent) => ({
       type: e.type,
       reason: e.reason,
@@ -631,7 +662,12 @@ class KubectlProxy {
       throw new Error(response.error || 'Failed to get deployments')
     }
 
-    const data = JSON.parse(response.output)
+    let data: { items?: KubeDeployment[] }
+    try {
+      data = JSON.parse(response.output)
+    } catch {
+      throw new Error('Failed to parse kubectl output as JSON')
+    }
     return (data.items || []).map((d: KubeDeployment) => {
       const status = d.status
       const spec = d.spec


### PR DESCRIPTION
## Summary

- Wrap ~20 unprotected `JSON.parse` calls in try-catch blocks
- WebSocket `onmessage` handlers: catch parse errors, close WS, resolve with fallback
- kubectlProxy methods: catch parse errors, throw descriptive errors
- useDeployMissions: catch parse errors, return empty array fallback

## Files changed

PodDrillDown.tsx, CRDDrillDown.tsx, KustomizationDrillDown.tsx, useDeployMissions.ts, kubectlProxy.ts

## Test plan

- [x] `npm run build` passes
- [ ] CI build/lint

Fixes #1910