### PR TITLE
✨ Migrate ~88 inline buttons to shared Button component

### DIFF
--- a/web/src/components/alerts/AlertDetail.tsx
+++ b/web/src/components/alerts/AlertDetail.tsx
@@ -17,6 +17,7 @@ import { useMissions } from '../../hooks/useMissions'
 import { getSeverityIcon, getSeverityColor } from '../../types/alerts'
 import type { Alert } from '../../types/alerts'
 import { useToast } from '../ui/Toast'
+import { Button } from '../ui/Button'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { RETRY_DELAY_MS, TOAST_DISMISS_MS } from '../../lib/constants/network'
@@ -208,23 +209,15 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
               <span className="text-sm font-medium text-foreground">{t('alerts.aiDiagnosis')}</span>
             </div>
             {!alert.aiDiagnosis?.missionId && (
-              <button
+              <Button
+                variant="accent"
+                size="sm"
                 onClick={handleRunDiagnosis}
                 disabled={isRunningDiagnosis}
-                className="px-3 py-1 text-xs rounded-lg bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 transition-colors flex items-center gap-1 disabled:opacity-50"
+                icon={isRunningDiagnosis ? <RefreshCw className="w-3 h-3 animate-spin" /> : <Bot className="w-3 h-3" />}
               >
-                {isRunningDiagnosis ? (
-                  <>
-                    <RefreshCw className="w-3 h-3 animate-spin" />
-                    {t('alerts.analyzing')}
-                  </>
-                ) : (
-                  <>
-                    <Bot className="w-3 h-3" />
-                    {t('alerts.runDiagnosis')}
-                  </>
-                )}
-              </button>
+                {isRunningDiagnosis ? t('alerts.analyzing') : t('alerts.runDiagnosis')}
+              </Button>
             )}
           </div>
 
@@ -284,15 +277,16 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
             </div>
             <div className="flex flex-wrap gap-2">
               {webhooks.map(webhook => (
-                <button
+                <Button
                   key={webhook.id}
+                  variant="secondary"
+                  size="sm"
                   onClick={() => handleSendSlack(webhook.id)}
                   disabled={isSendingSlack}
-                  className="px-3 py-1.5 text-xs rounded-lg bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1 disabled:opacity-50"
+                  icon={<Send className="w-3 h-3" />}
                 >
-                  <Send className="w-3 h-3" />
                   {webhook.name}
-                </button>
+                </Button>
               ))}
             </div>
             {slackSent && (
@@ -308,12 +302,13 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
       <div className="p-4 border-t border-border flex items-center justify-between">
         <div className="flex items-center gap-2">
           {!alert.acknowledgedAt && alert.status === 'firing' && (
-            <button
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={handleAcknowledge}
-              className="px-3 py-1.5 text-sm rounded-lg bg-secondary hover:bg-secondary/80 text-foreground transition-colors"
             >
               {t('alerts.acknowledge')}
-            </button>
+            </Button>
           )}
           {alert.status === 'firing' && (
             <button
@@ -325,12 +320,13 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
           )}
         </div>
         {onClose && (
-          <button
+          <Button
+            variant="secondary"
+            size="sm"
             onClick={onClose}
-            className="px-3 py-1.5 text-sm rounded-lg bg-secondary hover:bg-secondary/80 text-foreground transition-colors"
           >
             {t('actions.close')}
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -17,6 +17,7 @@ import { useDrillDown } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
 import { getSeverityIcon } from '../../types/alerts'
 import type { Alert, AlertSeverity } from '../../types/alerts'
+import { Button } from '../ui/Button'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { useCardData, CardClusterFilter, CardSearchInput, CardAIActions } from '../../lib/cards'
@@ -357,24 +358,28 @@ export function ActiveAlerts() {
               {/* Quick Actions */}
               <div className="flex items-center gap-2 mt-2 pt-2 border-t border-border/30">
                 {!alert.acknowledgedAt && (
-                  <button
+                  <Button
+                    variant="secondary"
+                    size="sm"
                     onClick={e => handleAcknowledge(e, alert.id)}
-                    className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors"
+                    className="rounded"
                   >
                     {t('activeAlerts.acknowledge')}
-                  </button>
+                  </Button>
                 )}
                 {(() => {
                   const mission = getMissionForAlert(alert)
                   if (mission) {
                     return (
-                      <button
+                      <Button
+                        variant="accent"
+                        size="sm"
                         onClick={e => handleOpenMission(e, alert)}
-                        className="px-2 py-1 text-xs rounded bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 transition-colors flex items-center gap-1"
+                        icon={<ExternalLink className="w-3 h-3" />}
+                        className="rounded"
                       >
-                        <ExternalLink className="w-3 h-3" />
                         {t('activeAlerts.viewDiagnosis')}
-                      </button>
+                      </Button>
                     )
                   } else {
                     return (

--- a/web/src/components/cards/AlertRules.tsx
+++ b/web/src/components/cards/AlertRules.tsx
@@ -9,6 +9,7 @@ import {
 import { useAlertRules } from '../../hooks/useAlerts'
 import { formatCondition } from '../../types/alerts'
 import type { AlertRule, AlertSeverity } from '../../types/alerts'
+import { Button } from '../ui/Button'
 import { AlertRuleEditor } from '../alerts/AlertRuleEditor'
 import { StatusBadge } from '../ui/StatusBadge'
 import {
@@ -194,13 +195,15 @@ export function AlertRulesCard() {
           <div className="h-full flex flex-col items-center justify-center text-muted-foreground text-sm">
             <Bell className="w-8 h-8 mb-2" />
             <span>{t('alertRules.noRulesConfigured')}</span>
-            <button
+            <Button
+              variant="accent"
+              size="sm"
               onClick={handleCreateNew}
-              className="mt-2 px-3 py-1.5 text-xs rounded-lg bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 transition-colors flex items-center gap-1"
+              icon={<Plus className="w-3 h-3" />}
+              className="mt-2"
             >
-              <Plus className="w-3 h-3" />
               {t('alertRules.createRule')}
-            </button>
+            </Button>
           </div>
         ) : (
           displayedRules.map((rule: AlertRule) => (

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -8,6 +8,7 @@ import { CARD_TITLES, CARD_DESCRIPTIONS } from './cardMetadata'
 import { CARD_ICONS } from './cardIcons'
 import { BaseModal } from '../../lib/modals'
 import { cn } from '../../lib/cn'
+import { Button } from '../ui/Button'
 import { useCardCollapse } from '../../lib/cards'
 import { useSnoozedCards } from '../../hooks/useSnoozedCards'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -988,27 +989,33 @@ export function CardWrapper({
                 </div>
                 <p className="text-xs text-muted-foreground mt-1">{pendingSwap.reason}</p>
                 <div className="flex gap-2 mt-2">
-                  <button
+                  <Button
+                    variant="secondary"
+                    size="sm"
                     onClick={() => handleSnooze(3600000)}
-                    className="text-xs px-2 py-1 rounded bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground"
+                    className="rounded"
                     title={t('cardWrapper.snoozeTooltip')}
                   >
                     {t('common:buttons.snoozeHour')}
-                  </button>
-                  <button
+                  </Button>
+                  <Button
+                    variant="accent"
+                    size="sm"
                     onClick={handleSwapNow}
-                    className="text-xs px-2 py-1 rounded bg-purple-500/20 hover:bg-purple-500/30 text-purple-300"
+                    className="rounded"
                     title={t('cardWrapper.swapNowTooltip')}
                   >
                     {t('common:buttons.swapNow')}
-                  </button>
-                  <button
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
                     onClick={() => onSwapCancel?.()}
-                    className="text-xs px-2 py-1 rounded hover:bg-secondary/50 text-muted-foreground"
+                    className="rounded"
                     title={t('cardWrapper.keepThisTooltip')}
                   >
                     {t('common:buttons.keepThis')}
-                  </button>
+                  </Button>
                 </div>
               </div>
             )}

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react'
 import { GitPullRequest, GitBranch, Star, Users, Package, TrendingUp, AlertCircle, Clock, CheckCircle, XCircle, GitMerge, Settings, X, Plus, Check } from 'lucide-react'
 import { STORAGE_KEY_GITHUB_TOKEN, FETCH_EXTERNAL_TIMEOUT_MS } from '../../lib/constants'
+import { Button } from '../ui/Button'
 import { Skeleton } from '../ui/Skeleton'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { cn } from '../../lib/cn'
@@ -823,12 +824,14 @@ export const GitHubActivity = forwardRef<GitHubActivityRef, { config?: GitHubAct
           <AlertCircle className="w-8 h-8 text-red-400 mb-3" />
           <p className="text-sm text-foreground mb-2">{t('cards:github.fetchError')}</p>
           <p className="text-xs text-muted-foreground mb-4 max-w-xs">{error}</p>
-          <button
+          <Button
+            variant="primary"
+            size="lg"
             onClick={refetch}
-            className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+            className="bg-primary hover:bg-primary/90 text-primary-foreground"
           >
             {t('common:common.retry')}
-          </button>
+          </Button>
           <p className="mt-4 text-xs text-muted-foreground/70 max-w-xs">
             {t('cards:github.configureToken')}
           </p>

--- a/web/src/components/cards/Kubectl.tsx
+++ b/web/src/components/cards/Kubectl.tsx
@@ -4,6 +4,7 @@ import { STORAGE_KEY_KUBECTL_HISTORY } from '../../lib/constants'
 import { TRANSITION_DELAY_MS } from '../../lib/constants/network'
 import { useKubectl } from '../../hooks/useKubectl'
 import { useClusters } from '../../hooks/useMCP'
+import { Button } from '../ui/Button'
 import { cn } from '../../lib/cn'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
@@ -542,20 +543,23 @@ data:
             className="w-full px-3 py-2 text-sm bg-secondary rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
           />
           <div className="flex gap-2 mt-2">
-            <button
+            <Button
+              variant="accent"
+              size="sm"
               onClick={generateCommand}
               disabled={isExecuting || !aiPrompt.trim()}
-              className="px-3 py-1.5 text-xs rounded-lg bg-purple-500/20 hover:bg-purple-500/30 text-purple-300 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {t('cards:kubectl.generateCommand')}
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="accent"
+              size="sm"
               onClick={generateYAML}
               disabled={isExecuting || !aiPrompt.trim()}
-              className="px-3 py-1.5 text-xs rounded-lg bg-blue-500/20 hover:bg-blue-500/30 text-blue-300 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-blue-500/20 hover:bg-blue-500/30 text-blue-300"
             >
               {t('cards:kubectl.generateYAML')}
-            </button>
+            </Button>
           </div>
         </div>
       )}
@@ -622,22 +626,25 @@ data:
             </div>
           )}
           <div className="flex gap-2 mt-2">
-            <button
+            <Button
+              variant="accent"
+              size="sm"
               onClick={applyYAML}
               disabled={isExecuting || !yamlContent.trim() || !!yamlError}
-              className="px-3 py-1.5 text-xs rounded-lg bg-blue-500/20 hover:bg-blue-500/30 text-blue-300 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="bg-blue-500/20 hover:bg-blue-500/30 text-blue-300"
             >
               {isExecuting ? t('cards:kubectl.applying') : isDryRun ? t('cards:kubectl.dryRunApply') : t('common:common.apply')}
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => {
                 setYamlContent('')
                 setYamlError(null)
               }}
-              className="px-3 py-1.5 text-xs rounded-lg hover:bg-secondary/50 text-muted-foreground"
             >
               {t('common:common.clear')}
-            </button>
+            </Button>
           </div>
 
           {/* Saved Manifests */}

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
-import { Gauge, Cpu, HardDrive, Box, Loader2, ChevronRight, Plus, Pencil, Trash2, Zap } from 'lucide-react'
+import { Gauge, Cpu, HardDrive, Box, ChevronRight, Plus, Pencil, Trash2, Zap } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
+import { Button } from '../ui/Button'
 import {
   useClusters,
   useNamespaces,
@@ -238,13 +239,15 @@ function QuotaModal({
               <label className="text-sm font-medium text-muted-foreground">{t('namespaceQuotas.resourceLimits')}</label>
               <div className="flex items-center gap-2">
                 <div className="relative">
-                  <button
+                  <Button
+                    variant="accent"
+                    size="sm"
+                    icon={<Zap className="w-3 h-3" />}
                     onClick={() => setShowGpuPresets(!showGpuPresets)}
-                    className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-purple-500/20 text-purple-400 hover:bg-purple-500/30"
+                    className="rounded"
                   >
-                    <Zap className="w-3 h-3" />
                     GPU
-                  </button>
+                  </Button>
                   {showGpuPresets && (
                     <div className="absolute right-0 top-full mt-1 w-56 bg-popover border border-border rounded-lg shadow-lg z-10">
                       {GPU_RESOURCE_TYPES.map(rt => (
@@ -315,20 +318,22 @@ function QuotaModal({
       <BaseModal.Footer>
         <div className="flex-1" />
         <div className="flex items-center gap-2">
-          <button
+          <Button
+            variant="secondary"
+            size="lg"
             onClick={onClose}
-            className="px-4 py-2 text-sm rounded-lg bg-secondary text-foreground hover:bg-secondary/80"
           >
             {t('common:common.cancel')}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="primary"
+            size="lg"
             onClick={handleSave}
             disabled={isLoading}
-            className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+            loading={isLoading}
           >
-            {isLoading && <Loader2 className="w-4 h-4 animate-spin" />}
             {editingQuota ? t('common:common.update') : t('common:common.create')}
-          </button>
+          </Button>
         </div>
       </BaseModal.Footer>
     </BaseModal>
@@ -904,20 +909,22 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
         <BaseModal.Footer>
           <div className="flex-1" />
           <div className="flex items-center gap-2">
-            <button
+            <Button
+              variant="secondary"
+              size="lg"
               onClick={() => setDeleteConfirm(null)}
-              className="px-4 py-2 text-sm rounded-lg bg-secondary text-foreground hover:bg-secondary/80"
             >
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="danger"
+              size="lg"
               onClick={() => deleteConfirm && handleDeleteQuota(deleteConfirm.cluster, deleteConfirm.namespace, deleteConfirm.name)}
               disabled={isSaving}
-              className="flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+              loading={isSaving}
             >
-              {isSaving && <Loader2 className="w-4 h-4 animate-spin" />}
               Delete
-            </button>
+            </Button>
           </div>
         </BaseModal.Footer>
       </BaseModal>

--- a/web/src/components/cards/ServiceTopology.tsx
+++ b/web/src/components/cards/ServiceTopology.tsx
@@ -4,6 +4,7 @@ import { ClusterBadge } from '../ui/ClusterBadge'
 import { StatusBadge } from '../ui/StatusBadge'
 import type { TopologyNode, TopologyEdge, TopologyHealthStatus } from '../../types/topology'
 import { useReportCardDataState } from './CardDataContext'
+import { Button } from '../ui/Button'
 import { useTranslation } from 'react-i18next'
 
 // Demo topology data
@@ -130,27 +131,30 @@ export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
       {/* Header */}
       <div className="flex items-center justify-end mb-2">
         <div className="flex items-center gap-1">
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={<ZoomOut className="w-3.5 h-3.5" />}
             onClick={handleZoomOut}
-            className="p-1 hover:bg-secondary rounded transition-colors text-muted-foreground hover:text-foreground"
             title={t('serviceTopology.zoomOut')}
-          >
-            <ZoomOut className="w-3.5 h-3.5" />
-          </button>
-          <button
+            className="p-1 hover:bg-secondary rounded"
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={<Maximize2 className="w-3.5 h-3.5" />}
             onClick={handleResetZoom}
-            className="p-1 hover:bg-secondary rounded transition-colors text-muted-foreground hover:text-foreground"
             title={t('serviceTopology.resetZoom')}
-          >
-            <Maximize2 className="w-3.5 h-3.5" />
-          </button>
-          <button
+            className="p-1 hover:bg-secondary rounded"
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={<ZoomIn className="w-3.5 h-3.5" />}
             onClick={handleZoomIn}
-            className="p-1 hover:bg-secondary rounded transition-colors text-muted-foreground hover:text-foreground"
             title={t('serviceTopology.zoomIn')}
-          >
-            <ZoomIn className="w-3.5 h-3.5" />
-          </button>
+            className="p-1 hover:bg-secondary rounded"
+          />
         </div>
       </div>
 

--- a/web/src/components/cards/opa/ClusterOPAModal.tsx
+++ b/web/src/components/cards/opa/ClusterOPAModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { Shield, AlertTriangle, CheckCircle, ExternalLink, Plus, Edit3, Trash2, FileCode, LayoutTemplate, Sparkles, Copy } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { Button } from '../../ui/Button'
 import { BaseModal } from '../../../lib/modals'
 import { kubectlProxy } from '../../../lib/kubectlProxy'
 import { useToast } from '../../ui/Toast'
@@ -259,13 +260,14 @@ Please proceed with applying this policy.`,
 
             {/* Create Policy Button */}
             <div ref={createMenuRef} className="relative">
-              <button
+              <Button
+                variant="accent"
+                size="md"
+                icon={<Plus className="w-4 h-4" />}
                 onClick={() => setShowCreateMenu(!showCreateMenu)}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-colors"
               >
-                <Plus className="w-4 h-4" />
                 Create Policy
-              </button>
+              </Button>
               {showCreateMenu && (
                 <div className="absolute right-0 top-full mt-1 w-56 bg-card border border-border rounded-lg shadow-lg z-50 py-1">
                   <button
@@ -449,12 +451,13 @@ Please proceed with applying this policy.`,
             <ExternalLink className="w-3 h-3" />
           </a>
           <div className="flex-1" />
-          <button
+          <Button
+            variant="secondary"
+            size="lg"
             onClick={onClose}
-            className="px-4 py-2 bg-secondary text-foreground rounded-lg hover:bg-secondary/80 transition-colors"
           >
             Close
-          </button>
+          </Button>
         </BaseModal.Footer>
       </BaseModal>
 
@@ -517,12 +520,13 @@ Please proceed with applying this policy.`,
           </div>
         </BaseModal.Content>
         <BaseModal.Footer>
-          <button
+          <Button
+            variant="ghost"
+            size="lg"
             onClick={() => setShowYamlEditor(false)}
-            className="px-4 py-2 text-muted-foreground hover:text-foreground transition-colors"
           >
             Cancel
-          </button>
+          </Button>
           <div className="flex-1" />
           <button
             onClick={handleApplyYaml}
@@ -562,12 +566,13 @@ Please proceed with applying this policy.`,
           </div>
         </BaseModal.Content>
         <BaseModal.Footer>
-          <button
+          <Button
+            variant="ghost"
+            size="lg"
             onClick={() => setDeleteConfirm(null)}
-            className="px-4 py-2 text-muted-foreground hover:text-foreground transition-colors"
           >
             Cancel
-          </button>
+          </Button>
           <div className="flex-1" />
           <button
             onClick={() => deleteConfirm && handleDelete(deleteConfirm)}

--- a/web/src/components/cards/opa/CreatePolicyModal.tsx
+++ b/web/src/components/cards/opa/CreatePolicyModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
 import { Shield, FileCode, LayoutTemplate, Sparkles, Copy, MessageSquareText, ScanSearch, Loader2 } from 'lucide-react'
+import { Button } from '../../ui/Button'
 import { BaseModal } from '../../../lib/modals'
 import { kubectlProxy } from '../../../lib/kubectlProxy'
 import { useToast } from '../../ui/Toast'
@@ -229,7 +230,9 @@ Please proceed with applying this policy.`,
             <Shield className="w-10 h-10 mx-auto mb-3 opacity-40" />
             <p className="text-sm font-medium mb-1">No clusters have OPA Gatekeeper installed</p>
             <p className="text-xs mb-4">Install Gatekeeper on a cluster first, then create policies.</p>
-            <button
+            <Button
+              variant="accent"
+              size="lg"
               onClick={() => {
                 onClose()
                 const firstCluster = Object.keys(statuses)[0]
@@ -245,10 +248,9 @@ Please proceed with applying this policy.`,
                 }
               }}
               disabled={Object.keys(statuses).length === 0}
-              className="px-4 py-2 bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-colors text-sm disabled:opacity-50"
             >
               Install Gatekeeper with AI
-            </button>
+            </Button>
           </div>
         ) : (
           <div className="space-y-4">
@@ -447,12 +449,13 @@ Please proceed with applying this policy.`,
       </BaseModal.Content>
 
       <BaseModal.Footer>
-        <button
+        <Button
+          variant="ghost"
+          size="lg"
           onClick={onClose}
-          className="px-4 py-2 text-muted-foreground hover:text-foreground transition-colors text-sm"
         >
           Cancel
-        </button>
+        </Button>
         <div className="flex-1" />
       </BaseModal.Footer>
     </BaseModal>

--- a/web/src/components/cards/rss/RSSFeed.tsx
+++ b/web/src/components/cards/rss/RSSFeed.tsx
@@ -4,6 +4,7 @@ import {
   Clock, ArrowUp, ChevronDown, Star, Filter, Pencil
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
+import { Button } from '../../ui/Button'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../../lib/cards/CardComponents'
 import { useCardLoadingState } from '../CardDataContext'
@@ -903,15 +904,17 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
                 {t('cards:rssFeed.applyFilter')}
               </button>
               {activeFeed?.filter && (
-                <button
+                <Button
+                  variant="secondary"
+                  size="sm"
                   onClick={() => {
                     updateFeedFilter(activeFeedIndex, undefined)
                     setShowFilterEditor(false)
                   }}
-                  className="px-3 py-1 text-xs bg-secondary text-foreground rounded hover:bg-secondary/80 transition-colors"
+                  className="rounded"
                 >
                   {t('cards:rssFeed.clearFilter')}
-                </button>
+                </Button>
               )}
             </div>
           </div>
@@ -1210,7 +1213,9 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
                     {editingAggregateIndex !== null ? t('common:common.update') : t('common:common.create')} Aggregate ({selectedSourceUrls.length} sources)
                   </button>
                   {editingAggregateIndex !== null && (
-                    <button
+                    <Button
+                      variant="secondary"
+                      size="sm"
                       onClick={() => {
                         setShowAggregateCreator(false)
                         setEditingAggregateIndex(null)
@@ -1219,10 +1224,10 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
                         setAggregateIncludeTerms('')
                         setAggregateExcludeTerms('')
                       }}
-                      className="px-3 py-1.5 text-xs bg-secondary text-foreground rounded hover:bg-secondary/80 transition-colors"
+                      className="rounded"
                     >
                       {t('common:common.cancel')}
-                    </button>
+                    </Button>
                   )}
                 </div>
               </div>

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -4,6 +4,7 @@ import {
   Clock, Loader2, ExternalLink, Key, Settings, Plus, X, Check,
 } from 'lucide-react'
 import { STORAGE_KEY_GITHUB_TOKEN, FETCH_EXTERNAL_TIMEOUT_MS } from '../../../lib/constants'
+import { Button } from '../../ui/Button'
 import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
 import { CardControls } from '../../ui/CardControls'
@@ -375,21 +376,23 @@ export const GitHubCIMonitor = forwardRef<GitHubCIMonitorRef, GitHubCIMonitorPro
               placeholder="owner/repo (e.g., facebook/react)"
               className="flex-1 px-2 py-1 text-xs rounded bg-secondary border border-border text-foreground"
             />
-            <button
+            <Button
+              variant="accent"
+              size="sm"
+              icon={<Plus className="w-3.5 h-3.5" />}
               onClick={handleAddRepo}
               disabled={!newRepoInput.trim()}
-              className="p-1 rounded bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 disabled:opacity-50 disabled:cursor-not-allowed"
               title="Add repo"
-            >
-              <Plus className="w-3.5 h-3.5" />
-            </button>
-            <button
+              className="p-1 rounded"
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<Check className="w-3.5 h-3.5" />}
               onClick={() => setIsEditingRepos(false)}
-              className="p-1 rounded hover:bg-secondary text-muted-foreground"
               title="Done"
-            >
-              <Check className="w-3.5 h-3.5" />
-            </button>
+              className="p-1 rounded hover:bg-secondary"
+            />
           </div>
           <div className="flex flex-wrap gap-1.5">
             {repos.map((repo) => (

--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -13,6 +13,7 @@ import { CPUDetailModal, MemoryDetailModal, StorageDetailModal, GPUDetailModal }
 import { CloudProviderIcon, detectCloudProvider as detectCloudProviderShared, getProviderLabel, CloudProvider as CloudProviderType } from '../ui/CloudProviderIcon'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../ui/StatusBadge'
+import { Button } from '../ui/Button'
 
 // Cloud provider types
 type CloudProvider = 'eks' | 'gke' | 'aks' | 'openshift' | 'oci' | 'alibaba' | 'digitalocean' | 'rancher' | 'coreweave' | 'kind' | 'minikube' | 'k3s' | 'unknown'
@@ -364,7 +365,9 @@ After I approve, help me execute the repairs step by step.`,
                 </StatusBadge>
               )}
             </button>
-            <button
+            <Button
+              variant="accent"
+              size="sm"
               onClick={() => {
                 emitClusterAction('ask', clusterName)
                 startMission({
@@ -378,12 +381,11 @@ After I approve, help me execute the repairs step by step.`,
                 onClose()
               }}
               disabled={isUnreachable}
-              className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              icon={<Wand2 className="w-3.5 h-3.5" />}
               title={t('clusterDetail.askTitle')}
             >
-              <Wand2 className="w-3.5 h-3.5" />
               {t('clusterDetail.ask')}
-            </button>
+            </Button>
           </div>
         </div>
 

--- a/web/src/components/compute/Compute.tsx
+++ b/web/src/components/compute/Compute.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useRef, useState } from 'react'
 import { useSearchParams, useLocation, useNavigate } from 'react-router-dom'
 import { GitCompare, CheckSquare, Square, ChevronDown, ChevronRight, AlertCircle } from 'lucide-react'
+import { Button } from '../ui/Button'
 import { useClusters, useGPUNodes } from '../../hooks/useMCP'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -195,13 +196,14 @@ export function Compute() {
               Clear
             </button>
             {selectedForComparison.length >= 2 && (
-              <button
+              <Button
+                variant="accent"
+                size="sm"
                 onClick={handleCompare}
-                className="flex items-center gap-2 px-3 py-1.5 bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 rounded-lg transition-colors text-sm font-medium"
+                icon={<GitCompare className="w-4 h-4" />}
               >
-                <GitCompare className="w-4 h-4" />
                 Compare ({selectedForComparison.length})
-              </button>
+              </Button>
             )}
           </div>
         )}

--- a/web/src/components/dashboard/CreateDashboardModal.tsx
+++ b/web/src/components/dashboard/CreateDashboardModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LayoutDashboard, FileText, Layout, ChevronRight, Check, ChevronDown } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
+import { Button } from '../ui/Button'
 import { DASHBOARD_TEMPLATES, TEMPLATE_CATEGORIES, DashboardTemplate } from './templates'
 import { FOCUS_DELAY_MS } from '../../lib/constants/network'
 
@@ -223,19 +224,21 @@ export function CreateDashboardModal({
       </BaseModal.Content>
 
       <BaseModal.Footer>
-        <button
+        <Button
+          variant="ghost"
+          size="lg"
           onClick={onClose}
-          className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           {t('actions.cancel')}
-        </button>
-        <button
+        </Button>
+        <Button
+          variant="accent"
+          size="lg"
+          iconRight={<ChevronRight className="w-4 h-4" />}
           onClick={handleCreate}
-          className="flex items-center gap-2 px-4 py-2 bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-colors"
         >
           {t('dashboard.create.title')}
-          <ChevronRight className="w-4 h-4" />
-        </button>
+        </Button>
       </BaseModal.Footer>
     </BaseModal>
   )

--- a/web/src/components/dashboard/DashboardCards.tsx
+++ b/web/src/components/dashboard/DashboardCards.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Plus, LayoutGrid, ChevronDown, ChevronRight, Layout } from 'lucide-react'
 import { useModalState } from '../../lib/modals'
+import { Button } from '../ui/Button'
 import { CardWrapper } from '../cards/CardWrapper'
 import { CARD_COMPONENTS, DEMO_DATA_CARDS, LIVE_DATA_CARDS } from '../cards/cardRegistry'
 import { AddCardModal } from './AddCardModal'
@@ -120,20 +121,22 @@ export function DashboardCards({
 
         {showCards && (
           <div className="flex items-center gap-2">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<Layout className="w-3.5 h-3.5" />}
               onClick={templatesModal.open}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-secondary/50 rounded-lg transition-colors"
             >
-              <Layout className="w-3.5 h-3.5" />
               {t('dashboard.actions.templates')}
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="accent"
+              size="sm"
+              icon={<Plus className="w-3.5 h-3.5" />}
               onClick={addCardModal.open}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 rounded-lg transition-colors"
             >
-              <Plus className="w-3.5 h-3.5" />
               {t('dashboard.actions.addCard')}
-            </button>
+            </Button>
           </div>
         )}
       </div>
@@ -148,13 +151,14 @@ export function DashboardCards({
               <p className="text-muted-foreground text-sm max-w-md mx-auto mb-4">
                 {emptyDescription}
               </p>
-              <button
+              <Button
+                variant="accent"
+                size="lg"
+                icon={<Plus className="w-4 h-4" />}
                 onClick={addCardModal.open}
-                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 rounded-lg transition-colors"
               >
-                <Plus className="w-4 h-4" />
                 {t('dashboard.addCard.addCards')}
-              </button>
+              </Button>
             </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/web/src/components/dashboard/DiscoverCardsPlaceholder.tsx
+++ b/web/src/components/dashboard/DiscoverCardsPlaceholder.tsx
@@ -10,6 +10,7 @@ import { useState, useEffect } from 'react'
 import { Plus, ChevronLeft, ChevronRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { formatCardTitle } from '../../lib/formatCardTitle'
+import { Button } from '../ui/Button'
 
 interface DiscoverCardsPlaceholderProps {
   existingCardTypes: string[]
@@ -112,19 +113,21 @@ export function DiscoverCardsPlaceholder({
 
         {/* Actions */}
         <div className="flex gap-2 mt-1">
-          <button
+          <Button
+            variant="accent"
+            size="sm"
+            icon={<Plus className="w-3.5 h-3.5" />}
             onClick={() => onAddCard(current.type)}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 text-xs font-medium transition-colors"
           >
-            <Plus className="w-3.5 h-3.5" />
             {t('dashboard.discover.addThis', 'Add this card')}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={onOpenCatalog}
-            className="px-3 py-1.5 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground text-xs transition-colors"
           >
             {t('dashboard.discover.browseCatalog', 'Browse all')}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/web/src/components/dashboard/ReplaceCardModal.tsx
+++ b/web/src/components/dashboard/ReplaceCardModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Sparkles, Loader2, RefreshCw, ToggleLeft, Box } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { BaseModal } from '../../lib/modals'
+import { Button } from '../ui/Button'
 import { CARD_CONFIGS } from '../../config/cards'
 import { NAV_AFTER_ANIMATION_MS } from '../../lib/constants/network'
 
@@ -330,12 +331,13 @@ export function ReplaceCardModal({ isOpen, card, onClose, onReplace }: ReplaceCa
         <BaseModal.Footer showKeyboardHints>
           <div className="flex-1" />
           <div className="flex items-center gap-3">
-            <button
+            <Button
+              variant="ghost"
+              size="lg"
               onClick={onClose}
-              className="px-4 py-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary/50"
             >
               {t('actions.cancel')}
-            </button>
+            </Button>
             {activeTab === 'select' && (
               <button
                 onClick={handleSelectReplace}

--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -7,6 +7,7 @@ import { useCanI } from '../../../hooks/usePermissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { FileText, Terminal, Zap, Code, Info, Tag, ChevronDown, ChevronUp, Loader2, Copy, Check, Box, Layers, Server, AlertTriangle, Pencil, Trash2, Plus, Save, X, RefreshCw, Stethoscope, Wrench, Sparkles } from 'lucide-react'
 import { cn } from '../../../lib/cn'
+import { Button } from '../../ui/Button'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import { useTranslation } from 'react-i18next'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
@@ -1419,13 +1420,14 @@ Please proceed step by step and ask for confirmation before making any changes.`
                         )}
                         {t('drilldown.actions.saveChanges')}
                       </button>
-                      <button
+                      <Button
+                        variant="secondary"
+                        size="sm"
                         onClick={cancelLabelEdit}
                         disabled={labelSaving}
-                        className="px-3 py-1.5 rounded-lg bg-secondary text-foreground text-sm hover:bg-secondary/80 disabled:opacity-50"
                       >
                         {t('common.cancel')}
-                      </button>
+                      </Button>
                     </div>
                   </div>
                 ) : labelEntries.length > 0 ? (
@@ -1595,13 +1597,14 @@ Please proceed step by step and ask for confirmation before making any changes.`
                         )}
                         {t('drilldown.actions.saveChanges')}
                       </button>
-                      <button
+                      <Button
+                        variant="secondary"
+                        size="sm"
                         onClick={cancelAnnotationEdit}
                         disabled={annotationSaving}
-                        className="px-3 py-1.5 rounded-lg bg-secondary text-foreground text-sm hover:bg-secondary/80 disabled:opacity-50"
                       >
                         {t('common.cancel')}
-                      </button>
+                      </Button>
                     </div>
                   </div>
                 ) : annotationEntries.length > 0 ? (
@@ -1921,13 +1924,14 @@ Please proceed step by step and ask for confirmation before making any changes.`
               {/* Refresh button */}
               {agentConnected && (
                 <div className="pt-4 border-t border-border mt-4">
-                  <button
+                  <Button
+                    variant="secondary"
+                    size="sm"
                     onClick={() => fetchRelatedResources(true)}
-                    className="px-3 py-1.5 rounded-lg bg-secondary text-foreground text-sm hover:bg-secondary/80 flex items-center gap-2"
+                    icon={<Loader2 className={cn('w-4 h-4', relatedLoading && 'animate-spin')} />}
                   >
-                    <Loader2 className={cn('w-4 h-4', relatedLoading && 'animate-spin')} />
                     Refresh
-                  </button>
+                  </Button>
                 </div>
               )}
 

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { X, Bug, Sparkles, Loader2, ExternalLink, Bell, Check, Clock, GitPullRequest, GitMerge, Eye, RefreshCw, MessageSquare, Settings, Github, Coins, Lightbulb, AlertCircle, Linkedin, Trophy } from 'lucide-react'
+import { Button } from '../ui/Button'
 import { StatusBadge } from '../ui/StatusBadge'
 import { BaseModal } from '../../lib/modals'
 import {
@@ -281,12 +282,14 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
                   {t('feedback.loginDemoExplanation')}
                 </p>
                 <div className="flex justify-end gap-2">
-                  <button
+                  <Button
+                    variant="secondary"
+                    size="lg"
                     onClick={() => setShowLoginPrompt(false)}
-                    className="px-4 py-2 text-sm rounded-lg border border-border text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"
+                    className="border border-border"
                   >
                     Cancel
-                  </button>
+                  </Button>
                   <button
                     onClick={handleLoginRedirect}
                     className="px-4 py-2 text-sm rounded-lg bg-purple-500 hover:bg-purple-600 text-white transition-colors"
@@ -350,12 +353,14 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
                 {/* Actions */}
                 <div className="flex flex-col gap-2">
                   <div className="flex gap-2">
-                    <button
+                    <Button
+                      variant="secondary"
+                      size="lg"
                       onClick={() => setShowLoginPrompt(false)}
-                      className="px-4 py-2 text-sm rounded-lg border border-border text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"
+                      className="border border-border"
                     >
                       Cancel
-                    </button>
+                    </Button>
                     <a
                       href="https://github.com/kubestellar/console/issues/new"
                       target="_blank"
@@ -1191,14 +1196,16 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
         <div className="flex items-center gap-2">
         {activeTab === 'submit' && !success ? (
           <>
-            <button
+            <Button
+              variant="secondary"
+              size="lg"
               type="button"
               onClick={handleClose}
               disabled={isSubmitting}
-              className="px-4 py-2 text-sm rounded-lg border border-border text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors disabled:opacity-50"
+              className="border border-border"
             >
               Cancel
-            </button>
+            </Button>
             {canPerformActions ? (
               <button
                 type="submit"
@@ -1232,13 +1239,15 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialContex
             )}
           </>
         ) : (
-          <button
+          <Button
+            variant="secondary"
+            size="lg"
             type="button"
             onClick={handleClose}
-            className="px-4 py-2 text-sm rounded-lg border border-border text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"
+            className="border border-border"
           >
             Close
-          </button>
+          </Button>
         )}
         </div>
       </div>

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode, Suspense, useState, useEffect, useRef, useCallback } from 'r
 import { useTranslation } from 'react-i18next'
 import { Link, useLocation } from 'react-router-dom'
 import { Box, Wifi, WifiOff, X, Settings, Rocket, RotateCcw, Check, Loader2, RefreshCw, Plug } from 'lucide-react'
+import { Button } from '../ui/Button'
 import { Navbar } from './navbar/index'
 import { Sidebar } from './Sidebar'
 import { MissionSidebar, MissionSidebarToggle } from './mission-sidebar'
@@ -315,9 +316,11 @@ export function Layout({ children }: LayoutProps) {
                   : 'Showing sample data only — install locally to monitor your real clusters'
                 }
               </span>
-              <button
+              <Button
+                variant="accent"
+                size="sm"
                 onClick={() => setShowSetupDialog(true)}
-                className="hidden sm:flex ml-2 items-center gap-1.5 px-3 py-1 bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 rounded-full text-xs font-medium transition-colors"
+                className="hidden sm:flex ml-2 rounded-full"
               >
                 {isAuthenticatedNoAgent ? (
                   <>
@@ -332,7 +335,7 @@ export function Layout({ children }: LayoutProps) {
                     <span className="lg:hidden">Get Console</span>
                   </>
                 )}
-              </button>
+              </Button>
               <button
                 onClick={() => isDemoModeForced ? setShowSetupDialog(true) : toggleDemoMode()}
                 className="ml-1 md:ml-2 p-2 min-h-11 min-w-11 hover:bg-yellow-500/20 rounded transition-colors"
@@ -486,12 +489,14 @@ export function Layout({ children }: LayoutProps) {
           <div className="flex items-center gap-3 px-4 py-3 rounded-lg border shadow-lg text-sm bg-blue-950/90 border-blue-800/50 text-blue-200">
             <RefreshCw className="w-4 h-4 text-blue-400" />
             <span>A new version is available</span>
-            <button
+            <Button
+              variant="primary"
+              size="sm"
               onClick={() => window.location.reload()}
-              className="ml-1 px-2.5 py-1 bg-blue-600 hover:bg-blue-500 text-white rounded text-xs font-medium transition-colors"
+              className="ml-1 rounded"
             >
               Reload
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/web/src/components/layout/SidebarCustomizer.tsx
+++ b/web/src/components/layout/SidebarCustomizer.tsx
@@ -39,6 +39,7 @@ import { useDashboards, Dashboard } from '../../hooks/useDashboards'
 import { DASHBOARD_TEMPLATES, TEMPLATE_CATEGORIES, DashboardTemplate } from '../dashboard/templates'
 import { CreateDashboardModal } from '../dashboard/CreateDashboardModal'
 import { StatusBadge } from '../ui/StatusBadge'
+import { Button } from '../ui/Button'
 import { cn } from '../../lib/cn'
 import { formatCardTitle } from '../../lib/formatCardTitle'
 import { STORAGE_KEY_NAV_HISTORY } from '../../lib/constants'
@@ -395,13 +396,13 @@ export function SidebarCustomizer({ isOpen, onClose }: SidebarCustomizerProps) {
       <BaseModal.Content className="max-h-[60vh]">
           {/* Quick Actions */}
           <div className="flex flex-wrap gap-2 mb-6">
-            <button
+            <Button
+              variant="accent"
               onClick={() => setShowAddForm(!showAddForm)}
-              className="flex items-center gap-2 px-3 py-2 rounded-lg bg-purple-500/20 text-purple-400 hover:bg-purple-500/30"
+              icon={<Plus className="w-4 h-4" />}
             >
-              <Plus className="w-4 h-4" />
               {t('sidebar.customizer.addItem')}
-            </button>
+            </Button>
             <button
               onClick={() => setIsCreateDashboardOpen(true)}
               className="flex items-center gap-2 px-3 py-2 rounded-lg bg-green-500/20 text-green-400 hover:bg-green-500/30"
@@ -409,25 +410,25 @@ export function SidebarCustomizer({ isOpen, onClose }: SidebarCustomizerProps) {
               <FolderPlus className="w-4 h-4" />
               {t('sidebar.customizer.newDashboard')}
             </button>
-            <button
+            <Button
+              variant="ghost"
               onClick={resetToDefault}
-              className="flex items-center gap-2 px-3 py-2 rounded-lg bg-secondary/50 text-muted-foreground hover:text-foreground"
+              icon={<RotateCcw className="w-4 h-4" />}
             >
-              <RotateCcw className="w-4 h-4" />
               {t('sidebar.customizer.reset')}
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="ghost"
               onClick={handleGenerateFromBehavior}
               disabled={isGenerating}
-              className="flex items-center gap-2 px-3 py-2 rounded-lg bg-secondary/50 text-muted-foreground hover:text-foreground disabled:opacity-50"
-            >
-              {isGenerating ? (
+              icon={isGenerating ? (
                 <Loader2 className="w-4 h-4 animate-spin" />
               ) : (
                 <Sparkles className="w-4 h-4" />
               )}
+            >
               {isGenerating ? t('sidebar.customizer.analyzing') : t('sidebar.customizer.generateFromBehavior')}
-            </button>
+            </Button>
           </div>
 
           {/* Generation Result */}
@@ -781,7 +782,9 @@ export function SidebarCustomizer({ isOpen, onClose }: SidebarCustomizerProps) {
                             {isInSidebar ? (
                               <StatusBadge color="green">{t('sidebar.customizer.added')}</StatusBadge>
                             ) : (
-                              <button
+                              <Button
+                                variant="accent"
+                                size="sm"
                                 onClick={() => {
                                   addItem({
                                     name: template.name,
@@ -790,10 +793,10 @@ export function SidebarCustomizer({ isOpen, onClose }: SidebarCustomizerProps) {
                                     type: 'link',
                                   }, 'primary')
                                 }}
-                                className="text-xs px-2 py-0.5 rounded bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 whitespace-nowrap"
+                                className="whitespace-nowrap rounded"
                               >
                                 {t('sidebar.customizer.add')}
-                              </button>
+                              </Button>
                             )}
                           </div>
                         )

--- a/web/src/components/layout/navbar/ClusterFilterPanel.tsx
+++ b/web/src/components/layout/navbar/ClusterFilterPanel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Search, Server, Activity, Filter, Check, AlertTriangle, Plus, Folder, X, Trash2, WifiOff } from 'lucide-react'
 import { AlertCircle, CheckCircle2 } from 'lucide-react'
 import { useGlobalFilters, SEVERITY_LEVELS, SEVERITY_CONFIG, STATUS_LEVELS, STATUS_CONFIG } from '../../../hooks/useGlobalFilters'
+import { Button } from '../../ui/Button'
 import { cn } from '../../../lib/cn'
 
 export function ClusterFilterPanel() {
@@ -76,19 +77,20 @@ export function ClusterFilterPanel() {
     <>
       {/* Clear Filters Button - shows when filters active */}
       {isFiltered && (
-        <button
+        <Button
+          variant="accent"
+          size="sm"
           onClick={() => {
             selectAllClusters()
             selectAllSeverities()
             selectAllStatuses()
             clearCustomFilter()
           }}
-          className="flex items-center gap-1.5 px-2 py-1 rounded-lg bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 transition-colors text-xs font-medium"
+          icon={<X className="w-3 h-3" />}
           title={t('common:filters.clearAll', 'Clear all filters')}
         >
-          <X className="w-3 h-3" />
           <span className="hidden sm:inline">{t('common:filters.clear', 'Clear')}</span>
-        </button>
+        </Button>
       )}
 
       {/* Global Filters */}

--- a/web/src/components/missions/ClusterSelectionDialog.tsx
+++ b/web/src/components/missions/ClusterSelectionDialog.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from 'react'
 import { X, Server, Check } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { useClusters } from '../../hooks/mcp/clusters'
+import { Button } from '../ui/Button'
 
 /** Delay before auto-selecting a single online cluster (ms) */
 const AUTO_SELECT_DELAY_MS = 600
@@ -47,9 +48,7 @@ export function ClusterSelectionDialog({ open, missionTitle, onSelect, onCancel 
             <h3 className="text-sm font-semibold text-foreground">Select Target Cluster</h3>
             <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-[320px]">{missionTitle}</p>
           </div>
-          <button onClick={onCancel} className="p-1 rounded hover:bg-secondary transition-colors">
-            <X className="w-4 h-4 text-muted-foreground" />
-          </button>
+          <Button variant="ghost" onClick={onCancel} className="p-1 rounded-md" icon={<X className="w-4 h-4" />} />
         </div>
 
         {/* Cluster list */}
@@ -114,12 +113,13 @@ export function ClusterSelectionDialog({ open, missionTitle, onSelect, onCancel 
 
         {/* Actions */}
         <div className="flex items-center justify-between px-4 py-3 border-t border-border">
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => onSelect('')}
-            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
             Skip (use current context)
-          </button>
+          </Button>
           <button
             onClick={() => selected && onSelect(selected)}
             disabled={!selected}

--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -16,6 +16,7 @@ import {
   Server,
   WifiOff
 } from 'lucide-react'
+import { Button } from '../ui/Button'
 import { useClusters } from '../../hooks/useMCP'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
 import { BaseModal } from '../../lib/modals'
@@ -387,13 +388,13 @@ export function NamespaceManager() {
         onRefresh={triggerRefresh}
         lastUpdated={lastUpdated}
         rightExtra={
-          <button
+          <Button
+            variant="primary"
             onClick={() => setShowCreateModal(true)}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-500/80 text-white text-sm hover:bg-blue-500 transition-colors"
+            icon={<Plus className="w-3.5 h-3.5" />}
           >
-            <Plus className="w-3.5 h-3.5" />
             Create
-          </button>
+          </Button>
         }
       />
 
@@ -864,19 +865,21 @@ function DeleteConfirmModal({ namespace, onClose, onConfirm }: DeleteConfirmModa
       <BaseModal.Footer>
         <div className="flex-1" />
         <div className="flex gap-3">
-          <button
+          <Button
+            variant="ghost"
+            size="lg"
             onClick={onClose}
-            className="px-4 py-2 rounded-lg text-muted-foreground hover:text-white transition-colors"
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="danger"
+            size="lg"
             onClick={handleDelete}
             disabled={!canDelete || deleting}
-            className="px-4 py-2 rounded-lg bg-red-500 text-white hover:bg-red-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {deleting ? 'Deleting...' : 'Delete Namespace'}
-          </button>
+          </Button>
         </div>
       </BaseModal.Footer>
     </BaseModal>
@@ -1070,13 +1073,13 @@ function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNamespaceM
                 )}
               </div>
               <div className="relative">
-                <button
+                <Button
+                  variant="accent"
                   onClick={() => setShowGroupDropdown(!showGroupDropdown)}
-                  className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 transition-colors text-sm"
+                  icon={<Shield className="w-4 h-4" />}
                 >
-                  <Shield className="w-4 h-4" />
                   Add Group
-                </button>
+                </Button>
                 {showGroupDropdown && availableGroups.length > 0 && (
                   <div
                     role="listbox"
@@ -1170,19 +1173,21 @@ function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNamespaceM
       <BaseModal.Footer>
         <div className="flex-1" />
         <div className="flex gap-3">
-          <button
+          <Button
+            variant="ghost"
+            size="lg"
             onClick={handleClose}
-            className="px-4 py-2 rounded-lg text-muted-foreground hover:text-white transition-colors"
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="primary"
+            size="lg"
             onClick={handleCreate}
             disabled={!name || !cluster || creating}
-            className="px-4 py-2 rounded-lg bg-blue-500 text-white hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {creating ? 'Creating...' : 'Create'}
-          </button>
+          </Button>
         </div>
       </BaseModal.Footer>
     </BaseModal>
@@ -1394,19 +1399,21 @@ function GrantAccessModal({ namespace, existingAccess, onClose, onGranted }: Gra
       <BaseModal.Footer>
         <div className="flex-1" />
         <div className="flex gap-3">
-          <button
+          <Button
+            variant="ghost"
+            size="lg"
             onClick={handleClose}
-            className="px-4 py-2 rounded-lg text-muted-foreground hover:text-white transition-colors"
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="primary"
+            size="lg"
             onClick={handleGrant}
             disabled={!subjectName || granting}
-            className="px-4 py-2 rounded-lg bg-blue-500 text-white hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {granting ? 'Granting...' : 'Grant Access'}
-          </button>
+          </Button>
         </div>
       </BaseModal.Footer>
     </BaseModal>

--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo } from 'react'
 import { Shield, Check, X, Loader2, AlertCircle, ChevronDown } from 'lucide-react'
 import { useCanI } from '../../hooks/usePermissions'
 import { useClusters, useNamespaces } from '../../hooks/useMCP'
+import { Button } from '../ui/Button'
 import { useTranslation } from 'react-i18next'
 
 const COMMON_VERBS = ['get', 'list', 'create', 'update', 'delete', 'watch', 'patch']
@@ -393,13 +394,14 @@ export function CanIChecker() {
               placeholder="Add custom group..."
               className="flex-1 p-2 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
-            <button
+            <Button
+              variant="primary"
+              size="lg"
               onClick={addCustomUserGroup}
               disabled={!customUserGroup.trim()}
-              className="px-3 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {t('rbac.add')}
-            </button>
+            </Button>
           </div>
           <p className="mt-1 text-xs text-muted-foreground">
             {t('rbac.addGroupsDesc')}
@@ -430,32 +432,26 @@ export function CanIChecker() {
 
         {/* Check Button */}
         <div className="flex gap-2">
-          <button
+          <Button
+            variant="primary"
+            size="lg"
             onClick={handleCheck}
             disabled={checking || clusters.length === 0}
-            className="flex-1 flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            icon={checking ? <Loader2 className="w-4 h-4 animate-spin" /> : <Shield className="w-4 h-4" />}
+            className="flex-1"
             data-testid="can-i-check"
           >
-            {checking ? (
-              <>
-                <Loader2 className="w-4 h-4 animate-spin" />
-                {t('rbac.checking')}
-              </>
-            ) : (
-              <>
-                <Shield className="w-4 h-4" />
-                {t('rbac.checkPermission')}
-              </>
-            )}
-          </button>
+            {checking ? t('rbac.checking') : t('rbac.checkPermission')}
+          </Button>
           {result && (
-            <button
+            <Button
+              variant="secondary"
+              size="lg"
               onClick={handleReset}
-              className="px-4 py-2 rounded-lg bg-secondary hover:bg-secondary/80 text-foreground font-medium transition-colors"
               data-testid="can-i-reset"
             >
               {t('rbac.reset')}
-            </button>
+            </Button>
           )}
         </div>
 

--- a/web/src/components/rewards/LinkedInShare.tsx
+++ b/web/src/components/rewards/LinkedInShare.tsx
@@ -5,6 +5,7 @@
 import { useState } from 'react'
 import { Linkedin, Share2, Coins, CheckCircle2 } from 'lucide-react'
 import { StatusBadge } from '../ui/StatusBadge'
+import { Button } from '../ui/Button'
 import { useRewards } from '../../hooks/useRewards'
 import { useTranslation } from 'react-i18next'
 import { emitLinkedInShare } from '../../lib/analytics'
@@ -67,18 +68,22 @@ export function LinkedInShareButton() {
               </div>
 
               <div className="flex gap-2">
-                <button
+                <Button
+                  variant="secondary"
+                  size="lg"
                   onClick={() => setShowConfirm(false)}
-                  className="flex-1 px-4 py-2 rounded-lg bg-secondary hover:bg-secondary/80 text-foreground text-sm transition-colors"
+                  className="flex-1"
                 >
                   Not yet
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="primary"
+                  size="lg"
                   onClick={handleConfirmShare}
-                  className="flex-1 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium transition-colors"
+                  className="flex-1"
                 >
                   Yes, I shared!
-                </button>
+                </Button>
               </div>
 
               {shareCount > 0 && (

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react'
 import { useVersionCheck } from '../../hooks/useVersionCheck'
 import { useUpdateProgress } from '../../hooks/useUpdateProgress'
+import { Button } from '../ui/Button'
 import { checkOAuthConfigured } from '../../lib/api'
 import { STORAGE_KEY_GITHUB_TOKEN } from '../../lib/constants'
 import type { UpdateChannel } from '../../types/updates'
@@ -260,14 +261,15 @@ export function UpdateSettings() {
                t('settings.updates.helmMode')}
             </span>
           )}
-          <button
+          <Button
+            variant="ghost"
+            size="md"
+            icon={<RefreshCw className={`w-4 h-4 ${isVisuallySpinning ? 'animate-spin-min text-blue-400' : ''}`} />}
             onClick={() => { emitUpdateChecked(); forceCheck() }}
             disabled={isChecking || isVisuallySpinning}
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 disabled:opacity-50"
           >
-            <RefreshCw className={`w-4 h-4 ${isVisuallySpinning ? 'animate-spin-min text-blue-400' : ''}`} />
             {t('settings.updates.checkNow')}
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/web/src/components/settings/sections/AgentSection.tsx
+++ b/web/src/components/settings/sections/AgentSection.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Plug, RefreshCw, Check, X, Copy, Cpu } from 'lucide-react'
+import { Button } from '../../ui/Button'
 import type { AgentHealth } from '../../../hooks/useLocalAgent'
 import { UI_FEEDBACK_TIMEOUT_MS, RETRY_DELAY_MS } from '../../../lib/constants/network'
 
@@ -55,14 +56,15 @@ export function AgentSection({ isConnected, health, refresh }: AgentSectionProps
             <p className="text-sm text-muted-foreground">{t('settings.agent.subtitle')}</p>
           </div>
         </div>
-        <button
+        <Button
+          variant="ghost"
+          size="md"
+          icon={<RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />}
           onClick={handleRefresh}
           disabled={isRefreshing}
-          className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 disabled:opacity-50"
         >
-          <RefreshCw className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`} />
           {t('settings.agent.refresh')}
-        </button>
+        </Button>
       </div>
 
       {/* Connection Status */}

--- a/web/src/components/settings/sections/LocalClustersSection.tsx
+++ b/web/src/components/settings/sections/LocalClustersSection.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Container, RefreshCw, Plus, Trash2, Check, AlertCircle, AlertTriangle, Loader2, X } from 'lucide-react'
+import { Button } from '../../ui/Button'
 import { useLocalClusterTools } from '../../../hooks/useLocalClusterTools'
 import { CLUSTER_PROGRESS_AUTO_DISMISS_MS } from '../../../hooks/useClusterProgress'
 import { emitLocalClusterCreated } from '../../../lib/analytics'
@@ -176,14 +177,15 @@ export function LocalClustersSection() {
           </div>
         </div>
         {(isConnected || isDemoMode) && (
-          <button
+          <Button
+            variant="ghost"
+            size="md"
+            icon={<RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />}
             onClick={refresh}
             disabled={isLoading}
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 disabled:opacity-50"
           >
-            <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
             Refresh
-          </button>
+          </Button>
         )}
       </div>
 

--- a/web/src/components/settings/sections/PredictionSettingsSection.tsx
+++ b/web/src/components/settings/sections/PredictionSettingsSection.tsx
@@ -4,6 +4,7 @@ import { TrendingUp, Save, RotateCcw, Sparkles, Clock, Percent, Layers, Info } f
 import type { PredictionSettings } from '../../../types/predictions'
 import { usePredictionFeedback } from '../../../hooks/usePredictionFeedback'
 import { CollapsibleSection } from '../../ui/CollapsibleSection'
+import { Button } from '../../ui/Button'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 
 interface PredictionSettingsSectionProps {
@@ -72,14 +73,15 @@ export function PredictionSettingsSection({
             <p className="text-sm text-muted-foreground">{t('settings.predictions.subtitle')}</p>
           </div>
         </div>
-        <button
+        <Button
+          variant="ghost"
+          size="md"
+          icon={<RotateCcw className="w-4 h-4" />}
           onClick={resetSettings}
-          className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50"
           title="Reset to defaults"
         >
-          <RotateCcw className="w-4 h-4" />
           {t('settings.predictions.reset')}
-        </button>
+        </Button>
       </div>
 
       <div className="space-y-6">

--- a/web/src/components/settings/sections/TokenUsageSection.tsx
+++ b/web/src/components/settings/sections/TokenUsageSection.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Save, Coins, RefreshCw } from 'lucide-react'
 import { StatusBadge } from '../../../components/ui/StatusBadge'
+import { Button } from '../../../components/ui/Button'
 import type { TokenUsage } from '../../../hooks/useTokenUsage'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 
@@ -54,13 +55,14 @@ export function TokenUsageSection({ usage, updateSettings, resetUsage, isDemoDat
             <p className="text-sm text-muted-foreground">{t('settings.tokens.subtitle')}</p>
           </div>
         </div>
-        <button
+        <Button
+          variant="ghost"
+          size="md"
+          icon={<RefreshCw className="w-4 h-4" />}
           onClick={resetUsage}
-          className="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50"
         >
-          <RefreshCw className="w-4 h-4" />
           {t('settings.tokens.resetUsage')}
-        </button>
+        </Button>
       </div>
 
       {isDemoData && (

--- a/web/src/components/ui/AlertBadge.tsx
+++ b/web/src/components/ui/AlertBadge.tsx
@@ -12,6 +12,7 @@ import { CardAIActions } from '../../lib/cards/CardComponents'
 import { ROUTES } from '../../config/routes'
 import { TRANSITION_DELAY_MS } from '../../lib/constants/network'
 import { useModalState } from '../../lib/modals'
+import { Button } from './Button'
 
 // Animated counter component for the badge - exported for future use
 export function AnimatedCounter({ value, className }: { value: number; className?: string }) {
@@ -460,25 +461,29 @@ export function AlertBadge() {
                   {/* Quick Actions */}
                   <div className="flex items-center gap-2 mt-2">
                     {!alert.acknowledgedAt && (
-                      <button
+                      <Button
+                        variant="secondary"
+                        size="sm"
                         onClick={e => handleAcknowledge(e, alert.id)}
-                        className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors"
+                        className="rounded-md"
                       >
                         Acknowledge
-                      </button>
+                      </Button>
                     )}
                     {(() => {
                       const mission = getMissionForAlert(alert)
                       if (mission) {
                         // Mission exists - show link to view it
                         return (
-                          <button
+                          <Button
+                            variant="accent"
+                            size="sm"
                             onClick={e => handleOpenMission(e, alert)}
-                            className="px-2 py-1 text-xs rounded bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 transition-colors flex items-center gap-1"
+                            className="rounded-md"
+                            icon={<ExternalLink className="w-3 h-3" />}
                           >
-                            <ExternalLink className="w-3 h-3" />
                             View Diagnosis
-                          </button>
+                          </Button>
                         )
                       } else {
                         // No mission or mission was deleted - show diagnose button

--- a/web/src/components/ui/CardSearch.tsx
+++ b/web/src/components/ui/CardSearch.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Search, X } from 'lucide-react'
 import { cn } from '../../lib/cn'
+import { Button } from './Button'
 
 interface CardSearchProps {
   /** Current search value */
@@ -88,16 +89,13 @@ export function CardSearch({
 
   if (!isExpanded) {
     return (
-      <button
+      <Button
+        variant="ghost"
         onClick={() => setIsExpanded(true)}
-        className={cn(
-          'p-1.5 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors',
-          className
-        )}
+        className={cn('p-1.5', className)}
         title={t('common.search')}
-      >
-        <Search className={iconSize} />
-      </button>
+        icon={<Search className={iconSize} />}
+      />
     )
   }
 

--- a/web/src/lib/modals/ConfirmDialog.tsx
+++ b/web/src/lib/modals/ConfirmDialog.tsx
@@ -20,6 +20,7 @@
 
 import { AlertTriangle, AlertCircle, Info, Loader2 } from 'lucide-react'
 import { BaseModal } from './BaseModal'
+import { Button } from '../../components/ui/Button'
 
 export interface ConfirmDialogProps {
   /** Whether dialog is open */
@@ -91,13 +92,15 @@ export function ConfirmDialog({
 
         {/* Actions */}
         <div className="flex gap-3">
-          <button
+          <Button
+            variant="secondary"
+            size="lg"
             onClick={onClose}
             disabled={isLoading}
-            className="flex-1 px-4 py-2 text-sm rounded-lg bg-secondary text-foreground hover:bg-secondary/80 transition-colors disabled:opacity-50"
+            className="flex-1"
           >
             {cancelLabel}
-          </button>
+          </Button>
           <button
             onClick={onConfirm}
             disabled={isLoading}

--- a/web/src/lib/modals/ModalSections.tsx
+++ b/web/src/lib/modals/ModalSections.tsx
@@ -26,6 +26,7 @@ import { ReactNode, useState, useEffect, useRef } from 'react'
 import { Copy, Check, ChevronDown, ChevronRight, ExternalLink, AlertCircle } from 'lucide-react'
 import { getStatusColors, NavigationTarget } from './types'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../constants/network'
+import { Button } from '../../components/ui/Button'
 
 // ============================================================================
 // Key-Value Section
@@ -166,17 +167,17 @@ function KeyValueItem({
       <dd className="text-sm text-foreground flex items-center gap-2">
         {renderValue()}
         {(item.copyable || item.render === 'copyable') && (
-          <button
+          <Button
+            variant="ghost"
             onClick={handleCopy}
-            className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+            className="p-1 rounded-md"
             title="Copy to clipboard"
-          >
-            {copied ? (
+            icon={copied ? (
               <Check className="w-3 h-3 text-green-400" />
             ) : (
               <Copy className="w-3 h-3" />
             )}
-          </button>
+          />
         )}
       </dd>
     </div>
@@ -434,12 +435,13 @@ export function EmptySection({
         <p className="text-sm text-muted-foreground mb-4">{message}</p>
       )}
       {action && (
-        <button
+        <Button
+          variant="accent"
+          size="lg"
           onClick={action.onClick}
-          className="px-4 py-2 bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 rounded-lg text-sm font-medium transition-colors"
         >
           {action.label}
-        </button>
+        </Button>
       )}
     </div>
   )

--- a/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
+++ b/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect } from 'react'
 import { Activity, RefreshCw, Plus } from 'lucide-react'
+import { Button } from '../../../components/ui/Button'
 import type {
   UnifiedDashboardProps,
   DashboardCardPlacement,
@@ -220,27 +221,27 @@ export function UnifiedDashboard({
 
           {/* Refresh button */}
           {features.autoRefresh !== false && (
-            <button
+            <Button
+              variant="secondary"
               onClick={handleRefresh}
               disabled={isLoading}
-              className="p-2 rounded-lg bg-secondary hover:bg-secondary/80 disabled:opacity-50 transition-colors"
+              className="p-2"
               title="Refresh"
-            >
-              <RefreshCw
+              icon={<RefreshCw
                 className={`w-4 h-4 text-muted-foreground ${isLoading ? 'animate-spin' : ''}`}
-              />
-            </button>
+              />}
+            />
           )}
 
           {/* Add card button */}
           {features.addCard !== false && (
-            <button
+            <Button
+              variant="secondary"
               onClick={handleAddCard}
-              className="p-2 rounded-lg bg-secondary hover:bg-secondary/80 transition-colors"
+              className="p-2"
               title="Add card"
-            >
-              <Plus className="w-4 h-4 text-muted-foreground" />
-            </button>
+              icon={<Plus className="w-4 h-4 text-muted-foreground" />}
+            />
           )}
 
           {/* Reset button (if customized) */}
@@ -289,12 +290,13 @@ export function UnifiedDashboard({
             Add cards to start building your dashboard
           </p>
           {features.addCard !== false && (
-            <button
+            <Button
+              variant="primary"
+              size="lg"
               onClick={handleAddCard}
-              className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm font-medium transition-colors"
             >
               Add your first card
-            </button>
+            </Button>
           )}
         </div>
       )}

--- a/web/src/lib/unified/stats/UnifiedStatsSection.tsx
+++ b/web/src/lib/unified/stats/UnifiedStatsSection.tsx
@@ -7,6 +7,7 @@
 
 import { useState, useMemo, useCallback } from 'react'
 import { Activity, ChevronDown, ChevronRight, Settings, FlaskConical } from 'lucide-react'
+import { Button } from '../../../components/ui/Button'
 import { StatusBadge } from '../../../components/ui/StatusBadge'
 import type { UnifiedStatsSectionProps, UnifiedStatBlockConfig, StatBlockValue } from '../types'
 import { UnifiedStatBlock } from './UnifiedStatBlock'
@@ -161,13 +162,13 @@ export function UnifiedStatsSection({
 
         {/* Configure button */}
         {config.showConfigButton !== false && isExpanded && (
-          <button
+          <Button
+            variant="ghost"
             onClick={() => setIsConfigOpen(true)}
-            className="p-1 text-muted-foreground hover:text-foreground hover:bg-secondary rounded transition-colors"
+            className="p-1 rounded-md"
             title="Configure stats"
-          >
-            <Settings className="w-4 h-4" />
-          </button>
+            icon={<Settings className="w-4 h-4" />}
+          />
         )}
       </div>
 
@@ -274,19 +275,20 @@ function StatsConfigModal({
 
         {/* Actions */}
         <div className="flex items-center justify-between">
-          <button
+          <Button
+            variant="ghost"
             onClick={handleReset}
-            className="text-sm text-muted-foreground hover:text-foreground"
           >
             Reset to default
-          </button>
+          </Button>
           <div className="flex gap-2">
-            <button
+            <Button
+              variant="secondary"
               onClick={onClose}
-              className="px-3 py-1.5 text-sm rounded bg-secondary hover:bg-secondary/80"
+              className="rounded-md"
             >
               Cancel
-            </button>
+            </Button>
             <button
               onClick={handleSave}
               className="px-3 py-1.5 text-sm rounded bg-primary text-primary-foreground hover:bg-primary/90"


### PR DESCRIPTION
## Summary

- Migrates **~88 inline `<button>` elements** across **38 files** to use the shared `Button` component (introduced in PR #1934)
- Covers all 5 variants: `primary`, `secondary`, `danger`, `ghost`, `accent`
- Removes unused `Loader2` import (replaced by Button's `loading` prop)

### Categories migrated

| Category | Files | Buttons |
|----------|-------|---------|
| Card components (kubectl, alerts, OPA, quotas, helm, costs, etc.) | 12 | ~30 |
| Layout (sidebar, navbar, version banner) | 3 | 7 |
| Dashboard (cards, modals, discover placeholder) | 5 | 8 |
| Drilldown/cluster views (pod, cluster detail) | 3 | 8 |
| Settings (token usage, predictions, clusters, agent) | 5 | 6 |
| Modals (confirm, OPA, cluster selection) | 4 | 8 |
| Feedback/rewards (feature requests, LinkedIn) | 3 | 8 |
| Other (missions, compute, RBAC) | 4 | ~13 |

### Before/After

```tsx
// Before — inline Tailwind button
<button
  onClick={handleSave}
  disabled={loading}
  className="inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-blue-600 hover:bg-blue-700 text-white transition-colors disabled:opacity-50"
>
  {loading && <Loader2 className="w-4 h-4 animate-spin" />}
  Save
</button>

// After — shared component
<Button variant="primary" onClick={handleSave} loading={loading}>
  Save
</Button>
```

### Intentionally skipped
- Buttons with complex conditional ternaries (tab/toggle states)
- Game-specific buttons (KubePong, KubeKart, etc.)
- Buttons with non-standard color schemes (custom green, orange, theme primary)
- Tiny icon-only buttons with custom padding

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — passes
- [ ] Visual check: buttons render with correct variants, sizes, and states
- [ ] Interaction check: onClick, disabled, loading states all work correctly