### PR TITLE
🐛 Security hardening: sanitize error messages, fix target=_blank, remove console.log

### DIFF
--- a/pkg/agent/kagenti.go
+++ b/pkg/agent/kagenti.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"time"
 
@@ -137,7 +138,8 @@ func (s *Server) handleKagentiAgents(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]any{"agents": []any{}, "error": err.Error()})
+		log.Printf("error fetching agents: %v", err)
+		json.NewEncoder(w).Encode(map[string]any{"agents": []any{}, "error": "internal server error"})
 		return
 	}
 
@@ -213,7 +215,8 @@ func (s *Server) handleKagentiBuilds(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]any{"builds": []any{}, "error": err.Error()})
+		log.Printf("error fetching builds: %v", err)
+		json.NewEncoder(w).Encode(map[string]any{"builds": []any{}, "error": "internal server error"})
 		return
 	}
 
@@ -284,7 +287,8 @@ func (s *Server) handleKagentiCards(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]any{"cards": []any{}, "error": err.Error()})
+		log.Printf("error fetching cards: %v", err)
+		json.NewEncoder(w).Encode(map[string]any{"cards": []any{}, "error": "internal server error"})
 		return
 	}
 
@@ -347,7 +351,8 @@ func (s *Server) handleKagentiTools(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]any{"tools": []any{}, "error": err.Error()})
+		log.Printf("error fetching tools: %v", err)
+		json.NewEncoder(w).Encode(map[string]any{"tools": []any{}, "error": "internal server error"})
 		return
 	}
 
@@ -413,10 +418,11 @@ func (s *Server) handleKagentiSummary(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
+		log.Printf("error fetching kagenti summary: %v", err)
 		json.NewEncoder(w).Encode(map[string]any{
 			"agentCount": 0, "readyAgents": 0, "buildCount": 0,
 			"activeBuilds": 0, "toolCount": 0, "cardCount": 0,
-			"frameworks": map[string]int{}, "error": err.Error(),
+			"frameworks": map[string]int{}, "error": "internal server error",
 		})
 		return
 	}

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -541,7 +541,8 @@ func (s *Server) handleGPUNodesHTTP(w http.ResponseWriter, r *http.Request) {
 	if cluster != "" {
 		nodes, err := s.k8sClient.GetGPUNodes(ctx, cluster)
 		if err != nil {
-			json.NewEncoder(w).Encode(map[string]interface{}{"nodes": []interface{}{}, "error": err.Error()})
+			log.Printf("error fetching nodes: %v", err)
+			json.NewEncoder(w).Encode(map[string]interface{}{"nodes": []interface{}{}, "error": "internal server error"})
 			return
 		}
 		allNodes = nodes
@@ -549,7 +550,8 @@ func (s *Server) handleGPUNodesHTTP(w http.ResponseWriter, r *http.Request) {
 		// Query all clusters
 		clusters, err := s.k8sClient.ListClusters(ctx)
 		if err != nil {
-			json.NewEncoder(w).Encode(map[string]interface{}{"nodes": []interface{}{}, "error": err.Error()})
+			log.Printf("error fetching nodes: %v", err)
+			json.NewEncoder(w).Encode(map[string]interface{}{"nodes": []interface{}{}, "error": "internal server error"})
 			return
 		}
 
@@ -610,7 +612,8 @@ func (s *Server) handleNodesHTTP(w http.ResponseWriter, r *http.Request) {
 		// Query specific cluster
 		nodes, err := s.k8sClient.GetNodes(ctx, cluster)
 		if err != nil {
-			json.NewEncoder(w).Encode(map[string]interface{}{"nodes": []interface{}{}, "error": err.Error()})
+			log.Printf("error fetching nodes: %v", err)
+			json.NewEncoder(w).Encode(map[string]interface{}{"nodes": []interface{}{}, "error": "internal server error"})
 			return
 		}
 		allNodes = nodes
@@ -618,7 +621,8 @@ func (s *Server) handleNodesHTTP(w http.ResponseWriter, r *http.Request) {
 		// Query all clusters
 		clusters, err := s.k8sClient.ListClusters(ctx)
 		if err != nil {
-			json.NewEncoder(w).Encode(map[string]interface{}{"nodes": []interface{}{}, "error": err.Error()})
+			log.Printf("error fetching nodes: %v", err)
+			json.NewEncoder(w).Encode(map[string]interface{}{"nodes": []interface{}{}, "error": "internal server error"})
 			return
 		}
 
@@ -693,7 +697,8 @@ func (s *Server) handleEventsHTTP(w http.ResponseWriter, r *http.Request) {
 	// Get events from the cluster
 	events, err := s.k8sClient.GetEvents(ctx, cluster, namespace, limit)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"events": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching events: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"events": []interface{}{}, "error": "internal server error"})
 		return
 	}
 
@@ -737,7 +742,8 @@ func (s *Server) handleNamespacesHTTP(w http.ResponseWriter, r *http.Request) {
 
 	namespaces, err := s.k8sClient.ListNamespacesWithDetails(ctx, cluster)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"namespaces": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching namespaces: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"namespaces": []interface{}{}, "error": "internal server error"})
 		return
 	}
 
@@ -776,7 +782,8 @@ func (s *Server) handleDeploymentsHTTP(w http.ResponseWriter, r *http.Request) {
 
 	deployments, err := s.k8sClient.GetDeployments(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"deployments": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching deployments: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"deployments": []interface{}{}, "error": "internal server error"})
 		return
 	}
 
@@ -805,7 +812,8 @@ func (s *Server) handleReplicaSetsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	replicasets, err := s.k8sClient.GetReplicaSets(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"replicasets": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching replicasets: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"replicasets": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"replicasets": replicasets, "source": "agent"})
@@ -833,7 +841,8 @@ func (s *Server) handleStatefulSetsHTTP(w http.ResponseWriter, r *http.Request) 
 	defer cancel()
 	statefulsets, err := s.k8sClient.GetStatefulSets(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"statefulsets": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching statefulsets: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"statefulsets": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"statefulsets": statefulsets, "source": "agent"})
@@ -861,7 +870,8 @@ func (s *Server) handleDaemonSetsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	daemonsets, err := s.k8sClient.GetDaemonSets(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"daemonsets": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching daemonsets: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"daemonsets": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"daemonsets": daemonsets, "source": "agent"})
@@ -889,7 +899,8 @@ func (s *Server) handleCronJobsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	cronjobs, err := s.k8sClient.GetCronJobs(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"cronjobs": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching cronjobs: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"cronjobs": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"cronjobs": cronjobs, "source": "agent"})
@@ -917,7 +928,8 @@ func (s *Server) handleIngressesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	ingresses, err := s.k8sClient.GetIngresses(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"ingresses": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching ingresses: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"ingresses": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"ingresses": ingresses, "source": "agent"})
@@ -945,7 +957,8 @@ func (s *Server) handleNetworkPoliciesHTTP(w http.ResponseWriter, r *http.Reques
 	defer cancel()
 	policies, err := s.k8sClient.GetNetworkPolicies(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"networkpolicies": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching networkpolicies: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"networkpolicies": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"networkpolicies": policies, "source": "agent"})
@@ -973,7 +986,8 @@ func (s *Server) handleServicesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	services, err := s.k8sClient.GetServices(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"services": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching services: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"services": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"services": services, "source": "agent"})
@@ -1001,7 +1015,8 @@ func (s *Server) handleConfigMapsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	configmaps, err := s.k8sClient.GetConfigMaps(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"configmaps": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching configmaps: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"configmaps": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"configmaps": configmaps, "source": "agent"})
@@ -1036,7 +1051,8 @@ func (s *Server) handleSecretsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	secrets, err := s.k8sClient.GetSecrets(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"secrets": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching secrets: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"secrets": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"secrets": secrets, "source": "agent"})
@@ -1064,7 +1080,8 @@ func (s *Server) handleServiceAccountsHTTP(w http.ResponseWriter, r *http.Reques
 	defer cancel()
 	serviceaccounts, err := s.k8sClient.GetServiceAccounts(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"serviceaccounts": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching serviceaccounts: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"serviceaccounts": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"serviceaccounts": serviceaccounts, "source": "agent"})
@@ -1092,7 +1109,8 @@ func (s *Server) handleJobsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	jobs, err := s.k8sClient.GetJobs(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"jobs": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching jobs: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"jobs": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"jobs": jobs, "source": "agent"})
@@ -1120,7 +1138,8 @@ func (s *Server) handleHPAsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	hpas, err := s.k8sClient.GetHPAs(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"hpas": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching hpas: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"hpas": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"hpas": hpas, "source": "agent"})
@@ -1148,7 +1167,8 @@ func (s *Server) handlePVCsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	pvcs, err := s.k8sClient.GetPVCs(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"pvcs": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching pvcs: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"pvcs": []interface{}{}, "error": "internal server error"})
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]interface{}{"pvcs": pvcs, "source": "agent"})
@@ -1186,7 +1206,8 @@ func (s *Server) handlePodsHTTP(w http.ResponseWriter, r *http.Request) {
 
 	pods, err := s.k8sClient.GetPods(ctx, cluster, namespace)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"pods": []interface{}{}, "error": err.Error()})
+		log.Printf("error fetching pods: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"pods": []interface{}{}, "error": "internal server error"})
 		return
 	}
 
@@ -1227,7 +1248,8 @@ func (s *Server) handleClusterHealthHTTP(w http.ResponseWriter, r *http.Request)
 
 	health, err := s.k8sClient.GetClusterHealth(ctx, cluster)
 	if err != nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{"error": err.Error()})
+		log.Printf("request error: %v", err)
+		json.NewEncoder(w).Encode(map[string]interface{}{"error": "internal server error"})
 		return
 	}
 
@@ -1282,7 +1304,7 @@ func (s *Server) handleRestartBackend(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"success": false,
-			"message": err.Error(),
+			"message": "operation failed",
 		})
 		return
 	}
@@ -1546,8 +1568,9 @@ func (s *Server) handleRenameContextHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := s.kubectl.RenameContext(req.OldName, req.NewName); err != nil {
+		log.Printf("rename context error: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "rename_failed", Message: err.Error()})
+		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "rename_failed", Message: "failed to rename context"})
 		return
 	}
 
@@ -1615,8 +1638,9 @@ func (s *Server) handleKubeconfigPreviewHTTP(w http.ResponseWriter, r *http.Requ
 
 	entries, err := s.kubectl.PreviewKubeconfig(req.Kubeconfig)
 	if err != nil {
+		log.Printf("kubeconfig preview error: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "preview_failed", Message: err.Error()})
+		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "preview_failed", Message: "invalid kubeconfig"})
 		return
 	}
 
@@ -1665,8 +1689,9 @@ func (s *Server) handleKubeconfigImportHTTP(w http.ResponseWriter, r *http.Reque
 
 	added, skipped, err := s.kubectl.ImportKubeconfig(req.Kubeconfig)
 	if err != nil {
+		log.Printf("kubeconfig import error: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(kubeconfigImportResponse{Success: false, Error: err.Error()})
+		json.NewEncoder(w).Encode(kubeconfigImportResponse{Success: false, Error: "failed to import kubeconfig"})
 		return
 	}
 
@@ -1715,8 +1740,9 @@ func (s *Server) handleKubeconfigAddHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := s.kubectl.AddCluster(req); err != nil {
+		log.Printf("add cluster error: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(kubeconfigAddResponse{Success: false, Error: err.Error()})
+		json.NewEncoder(w).Encode(kubeconfigAddResponse{Success: false, Error: "failed to add cluster"})
 		return
 	}
 
@@ -1760,8 +1786,9 @@ func (s *Server) handleKubeconfigTestHTTP(w http.ResponseWriter, r *http.Request
 
 	result, err := s.kubectl.TestClusterConnection(req)
 	if err != nil {
+		log.Printf("test connection error: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(TestConnectionResult{Reachable: false, Error: err.Error()})
+		json.NewEncoder(w).Encode(TestConnectionResult{Reachable: false, Error: "connection test failed"})
 		return
 	}
 
@@ -2138,7 +2165,8 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 				log.Printf("[Chat] Session %s cancelled", req.SessionID)
 				return
 			}
-			safeWrite(ctx, s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s: %s", agentName, err.Error())))
+			log.Printf("[Chat] streaming execution error for %s: %v", agentName, err)
+			safeWrite(ctx, s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s", agentName)))
 			return
 		}
 
@@ -2154,7 +2182,8 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 				log.Printf("[Chat] Session %s cancelled", req.SessionID)
 				return
 			}
-			safeWrite(ctx, s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s: %s", agentName, err.Error())))
+			log.Printf("[Chat] execution error for %s: %v", agentName, err)
+			safeWrite(ctx, s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s", agentName)))
 			return
 		}
 	}
@@ -2351,7 +2380,8 @@ func (s *Server) handleChatMessage(msg protocol.Message, forceAgent string) prot
 
 	resp, err := provider.Chat(context.Background(), chatReq)
 	if err != nil {
-		return s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s: %s", agentName, err.Error()))
+		log.Printf("[Chat] execution error for %s: %v", agentName, err)
+		return s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s", agentName))
 	}
 
 	if resp == nil {
@@ -2439,7 +2469,8 @@ func (s *Server) handleSelectAgentMessage(msg protocol.Message) protocol.Message
 	// For now, update the default agent
 	previousAgent := s.registry.GetDefaultName()
 	if err := s.registry.SetDefault(req.Agent); err != nil {
-		return s.errorResponse(msg.ID, "invalid_agent", err.Error())
+		log.Printf("set default agent error: %v", err)
+		return s.errorResponse(msg.ID, "invalid_agent", "invalid agent selection")
 	}
 
 	log.Printf("Agent selected: %s (was: %s)", req.Agent, previousAgent)
@@ -2967,8 +2998,9 @@ func (s *Server) handleSettingsKeyByProvider(w http.ResponseWriter, r *http.Requ
 	}
 
 	if err := cm.RemoveAPIKey(provider); err != nil {
+		log.Printf("delete API key error: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "delete_failed", Message: err.Error()})
+		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "delete_failed", Message: "failed to delete API key"})
 		return
 	}
 
@@ -3132,7 +3164,7 @@ func (s *Server) handleSettingsImport(w http.ResponseWriter, r *http.Request) {
 	if err := sm.ImportEncrypted(body); err != nil {
 		log.Printf("[settings] Import error: %v", err)
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "import_failed", Message: err.Error()})
+		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "import_failed", Message: "failed to import settings"})
 		return
 	}
 
@@ -3192,7 +3224,8 @@ func (s *Server) handleGetKeysStatus(w http.ResponseWriter, r *http.Request) {
 			// Cache the validity for IsAvailable() checks
 			cm.SetKeyValidity(p.name, valid)
 			if err != nil {
-				status.Error = err.Error()
+				log.Printf("API key validation error for %s: %v", p.name, err)
+				status.Error = "validation failed"
 			}
 		}
 
@@ -3230,11 +3263,10 @@ func (s *Server) handleSetKey(w http.ResponseWriter, r *http.Request) {
 	valid, validationErr := s.validateAPIKeyValue(req.Provider, req.APIKey)
 	if !valid {
 		w.WriteHeader(http.StatusBadRequest)
-		errMsg := "Invalid API key"
 		if validationErr != nil {
-			errMsg = validationErr.Error()
+			log.Printf("API key validation error: %v", validationErr)
 		}
-		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "invalid_key", Message: errMsg})
+		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "invalid_key", Message: "Invalid API key"})
 		return
 	}
 
@@ -3242,8 +3274,9 @@ func (s *Server) handleSetKey(w http.ResponseWriter, r *http.Request) {
 
 	// Save the key
 	if err := cm.SetAPIKey(req.Provider, req.APIKey); err != nil {
+		log.Printf("save API key error: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "save_failed", Message: err.Error()})
+		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "save_failed", Message: "failed to save API key"})
 		return
 	}
 
@@ -3649,7 +3682,8 @@ func (s *Server) handlePredictionsAnalyze(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := s.predictionWorker.TriggerAnalysis(req.Providers); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Printf("prediction analysis error: %v", err)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
 
@@ -4039,14 +4073,14 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 					"tool":     req.Tool,
 					"name":     req.Name,
 					"status":   "failed",
-					"message":  err.Error(),
+					"message":  "operation failed",
 					"progress": 0,
 				})
 				// Keep backwards-compat event
 				s.BroadcastToClients("local_cluster_error", map[string]string{
 					"tool":  req.Tool,
 					"name":  req.Name,
-					"error": err.Error(),
+					"error": "internal server error",
 				})
 			} else {
 				log.Printf("[LocalClusters] Created cluster %s with %s", req.Name, req.Tool)
@@ -4095,14 +4129,14 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 					"tool":     tool,
 					"name":     name,
 					"status":   "failed",
-					"message":  err.Error(),
+					"message":  "operation failed",
 					"progress": 0,
 				})
 				// Keep backwards-compat event
 				s.BroadcastToClients("local_cluster_error", map[string]string{
 					"tool":  tool,
 					"name":  name,
-					"error": err.Error(),
+					"error": "internal server error",
 				})
 			} else {
 				log.Printf("[LocalClusters] Deleted cluster %s", name)

--- a/pkg/api/handlers/benchmarks.go
+++ b/pkg/api/handlers/benchmarks.go
@@ -467,9 +467,9 @@ func (h *BenchmarkHandlers) GetReports(c *fiber.Ctx) error {
 		stale := h.cache.reports
 		h.cache.mu.RUnlock()
 		if stale != nil {
-			return c.JSON(fiber.Map{"reports": stale, "source": "stale-cache", "error": err.Error()})
+			return c.JSON(fiber.Map{"reports": stale, "source": "stale-cache", "error": "failed to refresh benchmark data"})
 		}
-		return c.Status(502).JSON(fiber.Map{"error": fmt.Sprintf("failed to fetch benchmark data: %v", err)})
+		return c.Status(502).JSON(fiber.Map{"error": "failed to fetch benchmark data"})
 	}
 
 	h.cache.set(reports, since)
@@ -566,7 +566,8 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 
 		topLevel, err := h.listDriveFolder(h.folderID)
 		if err != nil {
-			fmt.Fprintf(w, "event: error\ndata: {\"error\":%q}\n\n", err.Error())
+			log.Printf("error listing drive folder: %v", err)
+			fmt.Fprintf(w, "event: error\ndata: {\"error\":\"failed to fetch benchmark data\"}\n\n")
 			w.Flush()
 			return
 		}

--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -145,7 +145,8 @@ func (h *ConsolePersistenceHandlers) UpdateConfig(c *fiber.Ctx) error {
 	}
 
 	if err := h.persistenceStore.UpdateConfig(config); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("bad request: %v", err)
+		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 
 	if err := h.persistenceStore.Save(); err != nil {
@@ -179,7 +180,8 @@ func (h *ConsolePersistenceHandlers) GetStatus(c *fiber.Ctx) error {
 func (h *ConsolePersistenceHandlers) ListManagedWorkloads(c *fiber.Ctx) error {
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
@@ -187,7 +189,8 @@ func (h *ConsolePersistenceHandlers) ListManagedWorkloads(c *fiber.Ctx) error {
 
 	workloads, err := persistence.ListManagedWorkloads(c.Context(), namespace)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(workloads)
@@ -200,7 +203,8 @@ func (h *ConsolePersistenceHandlers) GetManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
@@ -208,7 +212,8 @@ func (h *ConsolePersistenceHandlers) GetManagedWorkload(c *fiber.Ctx) error {
 
 	workload, err := persistence.GetManagedWorkload(c.Context(), namespace, name)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(workload)
@@ -224,7 +229,8 @@ func (h *ConsolePersistenceHandlers) CreateManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
@@ -242,7 +248,8 @@ func (h *ConsolePersistenceHandlers) CreateManagedWorkload(c *fiber.Ctx) error {
 
 	created, err := persistence.CreateManagedWorkload(c.Context(), &workload)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.Status(201).JSON(created)
@@ -260,7 +267,8 @@ func (h *ConsolePersistenceHandlers) UpdateManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
@@ -272,7 +280,8 @@ func (h *ConsolePersistenceHandlers) UpdateManagedWorkload(c *fiber.Ctx) error {
 
 	updated, err := persistence.UpdateManagedWorkload(c.Context(), &workload)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(updated)
@@ -285,14 +294,16 @@ func (h *ConsolePersistenceHandlers) DeleteManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
 	persistence := k8s.NewConsolePersistence(client)
 
 	if err := persistence.DeleteManagedWorkload(c.Context(), namespace, name); err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.SendStatus(204)
@@ -307,7 +318,8 @@ func (h *ConsolePersistenceHandlers) DeleteManagedWorkload(c *fiber.Ctx) error {
 func (h *ConsolePersistenceHandlers) ListClusterGroups(c *fiber.Ctx) error {
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
@@ -315,7 +327,8 @@ func (h *ConsolePersistenceHandlers) ListClusterGroups(c *fiber.Ctx) error {
 
 	groups, err := persistence.ListClusterGroups(c.Context(), namespace)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(groups)
@@ -328,7 +341,8 @@ func (h *ConsolePersistenceHandlers) GetClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
@@ -336,7 +350,8 @@ func (h *ConsolePersistenceHandlers) GetClusterGroup(c *fiber.Ctx) error {
 
 	group, err := persistence.GetClusterGroup(c.Context(), namespace, name)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(group)
@@ -352,7 +367,8 @@ func (h *ConsolePersistenceHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
@@ -376,7 +392,8 @@ func (h *ConsolePersistenceHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 
 	created, err := persistence.CreateClusterGroup(c.Context(), &group)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.Status(201).JSON(created)
@@ -394,7 +411,8 @@ func (h *ConsolePersistenceHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
@@ -412,7 +430,8 @@ func (h *ConsolePersistenceHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 
 	updated, err := persistence.UpdateClusterGroup(c.Context(), &group)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(updated)
@@ -425,14 +444,16 @@ func (h *ConsolePersistenceHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
 	persistence := k8s.NewConsolePersistence(client)
 
 	if err := persistence.DeleteClusterGroup(c.Context(), namespace, name); err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.SendStatus(204)
@@ -582,7 +603,8 @@ func clusterFilterNeedsNodes(filters []v1alpha1.ClusterFilter) bool {
 func (h *ConsolePersistenceHandlers) ListWorkloadDeployments(c *fiber.Ctx) error {
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
@@ -590,7 +612,8 @@ func (h *ConsolePersistenceHandlers) ListWorkloadDeployments(c *fiber.Ctx) error
 
 	deployments, err := persistence.ListWorkloadDeployments(c.Context(), namespace)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(deployments)
@@ -603,7 +626,8 @@ func (h *ConsolePersistenceHandlers) GetWorkloadDeployment(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
@@ -611,7 +635,8 @@ func (h *ConsolePersistenceHandlers) GetWorkloadDeployment(c *fiber.Ctx) error {
 
 	deployment, err := persistence.GetWorkloadDeployment(c.Context(), namespace, name)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(deployment)
@@ -627,7 +652,8 @@ func (h *ConsolePersistenceHandlers) CreateWorkloadDeployment(c *fiber.Ctx) erro
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
@@ -650,7 +676,8 @@ func (h *ConsolePersistenceHandlers) CreateWorkloadDeployment(c *fiber.Ctx) erro
 
 	created, err := persistence.CreateWorkloadDeployment(c.Context(), &deployment)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	// Trigger deployment reconciliation asynchronously
@@ -671,7 +698,8 @@ func (h *ConsolePersistenceHandlers) UpdateWorkloadDeploymentStatus(c *fiber.Ctx
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
@@ -680,7 +708,8 @@ func (h *ConsolePersistenceHandlers) UpdateWorkloadDeploymentStatus(c *fiber.Ctx
 	// Get existing deployment
 	deployment, err := persistence.GetWorkloadDeployment(c.Context(), namespace, name)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	// Update status
@@ -688,7 +717,8 @@ func (h *ConsolePersistenceHandlers) UpdateWorkloadDeploymentStatus(c *fiber.Ctx
 
 	updated, err := persistence.UpdateWorkloadDeploymentStatus(c.Context(), deployment)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(updated)
@@ -701,14 +731,16 @@ func (h *ConsolePersistenceHandlers) DeleteWorkloadDeployment(c *fiber.Ctx) erro
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("service unavailable: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	namespace := h.persistenceStore.GetNamespace()
 	persistence := k8s.NewConsolePersistence(client)
 
 	if err := persistence.DeleteWorkloadDeployment(c.Context(), namespace, name); err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.SendStatus(204)

--- a/pkg/api/handlers/gateway.go
+++ b/pkg/api/handlers/gateway.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"log"
 	"github.com/gofiber/fiber/v2"
 	"github.com/kubestellar/console/pkg/k8s"
 )
@@ -34,7 +35,8 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 		// Get gateways for specific cluster
 		gateways, err := h.k8sClient.ListGatewaysForCluster(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{
 			"items":      gateways,
@@ -46,7 +48,8 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 	// Get gateways across all clusters
 	list, err := h.k8sClient.ListGateways(c.Context())
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(list)
@@ -67,7 +70,8 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 		// Get routes for specific cluster
 		routes, err := h.k8sClient.ListHTTPRoutesForCluster(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{
 			"items":      routes,
@@ -79,7 +83,8 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 	// Get routes across all clusters
 	list, err := h.k8sClient.ListHTTPRoutes(c.Context())
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(list)
@@ -94,7 +99,8 @@ func (h *GatewayHandlers) GetGatewayAPIStatus(c *fiber.Ctx) error {
 
 	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	type clusterGatewayStatus struct {
@@ -129,7 +135,8 @@ func (h *GatewayHandlers) GetGateway(c *fiber.Ctx) error {
 
 	gateways, err := h.k8sClient.ListGatewaysForCluster(c.Context(), cluster, namespace)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	for _, gw := range gateways {
@@ -154,7 +161,8 @@ func (h *GatewayHandlers) GetHTTPRoute(c *fiber.Ctx) error {
 
 	routes, err := h.k8sClient.ListHTTPRoutesForCluster(c.Context(), cluster, namespace)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	for _, route := range routes {

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -166,7 +166,8 @@ func (h *GitOpsHandlers) ListHelmReleases(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error(), "releases": []HelmRelease{}})
+			log.Printf("error listing healthy clusters for releases: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "releases": []HelmRelease{}})
 		}
 
 		var wg sync.WaitGroup
@@ -248,7 +249,8 @@ func (h *GitOpsHandlers) ListKustomizations(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error(), "kustomizations": []Kustomization{}})
+			log.Printf("error listing healthy clusters for kustomizations: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "kustomizations": []Kustomization{}})
 		}
 
 		var wg sync.WaitGroup
@@ -413,7 +415,8 @@ func (h *GitOpsHandlers) ListOperators(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error(), "operators": []Operator{}})
+			log.Printf("error listing healthy clusters for operators: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "operators": []Operator{}})
 		}
 
 		var wg sync.WaitGroup
@@ -485,7 +488,8 @@ func (h *GitOpsHandlers) StreamOperators(c *fiber.Ctx) error {
 
 	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	c.Set("Content-Type", "text/event-stream")
@@ -673,7 +677,8 @@ func (h *GitOpsHandlers) ListOperatorSubscriptions(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error(), "subscriptions": []OperatorSubscription{}})
+			log.Printf("error listing healthy clusters for subscriptions: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "subscriptions": []OperatorSubscription{}})
 		}
 
 		var wg sync.WaitGroup
@@ -740,7 +745,8 @@ func (h *GitOpsHandlers) StreamOperatorSubscriptions(c *fiber.Ctx) error {
 
 	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	c.Set("Content-Type", "text/event-stream")
@@ -873,7 +879,8 @@ func (h *GitOpsHandlers) StreamHelmReleases(c *fiber.Ctx) error {
 
 	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	c.Set("Content-Type", "text/event-stream")
@@ -958,7 +965,8 @@ func (h *GitOpsHandlers) DetectDrift(c *fiber.Ctx) error {
 	// Fall back to kubectl diff
 	result, err := h.detectDriftViaKubectl(c.Context(), req)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(result)
@@ -1119,7 +1127,8 @@ func (h *GitOpsHandlers) Sync(c *fiber.Ctx) error {
 	// Fall back to kubectl apply
 	result, err := h.syncViaKubectl(c.Context(), req)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(result)

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -117,7 +117,8 @@ func (h *MCPHandlers) ListClusters(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, err := h.k8sClient.ListClusters(c.Context())
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 
 		// Enrich with cached health data only — never block on live health
@@ -167,7 +168,8 @@ func (h *MCPHandlers) GetClusterHealth(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		health, err := h.k8sClient.GetClusterHealth(c.Context(), cluster)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(health)
 	}
@@ -186,7 +188,8 @@ func (h *MCPHandlers) GetAllClusterHealth(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		health, err := h.k8sClient.GetAllClusterHealth(c.Context())
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"health": health})
 	}
@@ -220,7 +223,8 @@ func (h *MCPHandlers) GetPods(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -250,7 +254,8 @@ func (h *MCPHandlers) GetPods(c *fiber.Ctx) error {
 
 		pods, err := h.k8sClient.GetPods(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"pods": pods, "source": "k8s"})
 	}
@@ -283,7 +288,8 @@ func (h *MCPHandlers) FindPodIssues(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -313,7 +319,8 @@ func (h *MCPHandlers) FindPodIssues(c *fiber.Ctx) error {
 
 		issues, err := h.k8sClient.FindPodIssues(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"issues": issues, "source": "k8s"})
 	}
@@ -335,7 +342,8 @@ func (h *MCPHandlers) GetGPUNodes(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -365,7 +373,8 @@ func (h *MCPHandlers) GetGPUNodes(c *fiber.Ctx) error {
 
 		nodes, err := h.k8sClient.GetGPUNodes(c.Context(), cluster)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"nodes": nodes, "source": "k8s"})
 	}
@@ -385,7 +394,8 @@ func (h *MCPHandlers) GetGPUNodeHealth(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -415,7 +425,8 @@ func (h *MCPHandlers) GetGPUNodeHealth(c *fiber.Ctx) error {
 
 		nodes, err := h.k8sClient.GetGPUNodeHealth(c.Context(), cluster)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"nodes": nodes, "source": "k8s"})
 	}
@@ -440,7 +451,8 @@ func (h *MCPHandlers) GetGPUHealthCronJobStatus(c *fiber.Ctx) error {
 
 	status, err := h.k8sClient.GetGPUHealthCronJobStatus(c.Context(), cluster)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.JSON(fiber.Map{"status": status})
 }
@@ -469,7 +481,8 @@ func (h *MCPHandlers) InstallGPUHealthCronJob(c *fiber.Ctx) error {
 	}
 
 	if err := h.k8sClient.InstallGPUHealthCronJob(c.Context(), body.Cluster, body.Namespace, body.Schedule, body.Tier); err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(fiber.Map{"success": true, "message": fmt.Sprintf("GPU health CronJob installed on %s (tier %d)", body.Cluster, body.Tier)})
@@ -497,7 +510,8 @@ func (h *MCPHandlers) UninstallGPUHealthCronJob(c *fiber.Ctx) error {
 	}
 
 	if err := h.k8sClient.UninstallGPUHealthCronJob(c.Context(), body.Cluster, body.Namespace); err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(fiber.Map{"success": true, "message": fmt.Sprintf("GPU health CronJob removed from %s", body.Cluster)})
@@ -521,7 +535,8 @@ func (h *MCPHandlers) GetGPUHealthCronJobResults(c *fiber.Ctx) error {
 
 	status, err := h.k8sClient.GetGPUHealthCronJobStatus(c.Context(), cluster)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.JSON(fiber.Map{"results": status.LastResults, "cluster": cluster})
 }
@@ -540,7 +555,8 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatus(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -570,7 +586,8 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatus(c *fiber.Ctx) error {
 
 		status, err := h.k8sClient.GetNVIDIAOperatorStatus(c.Context(), cluster)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"operator": status, "source": "k8s"})
 	}
@@ -592,7 +609,8 @@ func (h *MCPHandlers) GetNodes(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -622,7 +640,8 @@ func (h *MCPHandlers) GetNodes(c *fiber.Ctx) error {
 
 		nodes, err := h.k8sClient.GetNodes(c.Context(), cluster)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"nodes": nodes, "source": "k8s"})
 	}
@@ -646,7 +665,8 @@ func (h *MCPHandlers) FindDeploymentIssues(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -676,7 +696,8 @@ func (h *MCPHandlers) FindDeploymentIssues(c *fiber.Ctx) error {
 
 		issues, err := h.k8sClient.FindDeploymentIssues(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"issues": issues, "source": "k8s"})
 	}
@@ -699,7 +720,8 @@ func (h *MCPHandlers) GetDeployments(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -729,7 +751,8 @@ func (h *MCPHandlers) GetDeployments(c *fiber.Ctx) error {
 
 		deployments, err := h.k8sClient.GetDeployments(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"deployments": deployments, "source": "k8s"})
 	}
@@ -751,7 +774,8 @@ func (h *MCPHandlers) GetServices(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -781,7 +805,8 @@ func (h *MCPHandlers) GetServices(c *fiber.Ctx) error {
 
 		services, err := h.k8sClient.GetServices(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"services": services, "source": "k8s"})
 	}
@@ -803,7 +828,8 @@ func (h *MCPHandlers) GetJobs(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -833,7 +859,8 @@ func (h *MCPHandlers) GetJobs(c *fiber.Ctx) error {
 
 		jobs, err := h.k8sClient.GetJobs(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"jobs": jobs, "source": "k8s"})
 	}
@@ -855,7 +882,8 @@ func (h *MCPHandlers) GetHPAs(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -885,7 +913,8 @@ func (h *MCPHandlers) GetHPAs(c *fiber.Ctx) error {
 
 		hpas, err := h.k8sClient.GetHPAs(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"hpas": hpas, "source": "k8s"})
 	}
@@ -907,7 +936,8 @@ func (h *MCPHandlers) GetConfigMaps(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -937,7 +967,8 @@ func (h *MCPHandlers) GetConfigMaps(c *fiber.Ctx) error {
 
 		configmaps, err := h.k8sClient.GetConfigMaps(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"configmaps": configmaps, "source": "k8s"})
 	}
@@ -959,7 +990,8 @@ func (h *MCPHandlers) GetSecrets(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -989,7 +1021,8 @@ func (h *MCPHandlers) GetSecrets(c *fiber.Ctx) error {
 
 		secrets, err := h.k8sClient.GetSecrets(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"secrets": secrets, "source": "k8s"})
 	}
@@ -1011,7 +1044,8 @@ func (h *MCPHandlers) GetServiceAccounts(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -1041,7 +1075,8 @@ func (h *MCPHandlers) GetServiceAccounts(c *fiber.Ctx) error {
 
 		serviceAccounts, err := h.k8sClient.GetServiceAccounts(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"serviceAccounts": serviceAccounts, "source": "k8s"})
 	}
@@ -1063,7 +1098,8 @@ func (h *MCPHandlers) GetPVCs(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -1093,7 +1129,8 @@ func (h *MCPHandlers) GetPVCs(c *fiber.Ctx) error {
 
 		pvcs, err := h.k8sClient.GetPVCs(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"pvcs": pvcs, "source": "k8s"})
 	}
@@ -1114,7 +1151,8 @@ func (h *MCPHandlers) GetPVs(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -1144,7 +1182,8 @@ func (h *MCPHandlers) GetPVs(c *fiber.Ctx) error {
 
 		pvs, err := h.k8sClient.GetPVs(c.Context(), cluster)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"pvs": pvs, "source": "k8s"})
 	}
@@ -1166,7 +1205,8 @@ func (h *MCPHandlers) GetResourceQuotas(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -1196,7 +1236,8 @@ func (h *MCPHandlers) GetResourceQuotas(c *fiber.Ctx) error {
 
 		quotas, err := h.k8sClient.GetResourceQuotas(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"resourceQuotas": quotas, "source": "k8s"})
 	}
@@ -1218,7 +1259,8 @@ func (h *MCPHandlers) GetLimitRanges(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -1248,7 +1290,8 @@ func (h *MCPHandlers) GetLimitRanges(c *fiber.Ctx) error {
 
 		ranges, err := h.k8sClient.GetLimitRanges(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"limitRanges": ranges, "source": "k8s"})
 	}
@@ -1284,7 +1327,8 @@ func (h *MCPHandlers) CreateOrUpdateResourceQuota(c *fiber.Ctx) error {
 		// Auto-create namespace if requested (used by GPU reservation flow)
 		if req.EnsureNamespace {
 			if err := h.k8sClient.EnsureNamespaceExists(c.Context(), req.Cluster, req.Namespace); err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": "Failed to create namespace: " + err.Error()})
+				log.Printf("failed to create namespace: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 		}
 
@@ -1298,7 +1342,8 @@ func (h *MCPHandlers) CreateOrUpdateResourceQuota(c *fiber.Ctx) error {
 
 		quota, err := h.k8sClient.CreateOrUpdateResourceQuota(c.Context(), req.Cluster, spec)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 
 		return c.JSON(fiber.Map{"resourceQuota": quota, "source": "k8s"})
@@ -1320,7 +1365,8 @@ func (h *MCPHandlers) DeleteResourceQuota(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		err := h.k8sClient.DeleteResourceQuota(c.Context(), cluster, namespace, name)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 
 		return c.JSON(fiber.Map{"deleted": true, "name": name, "namespace": namespace, "cluster": cluster})
@@ -1349,7 +1395,8 @@ func (h *MCPHandlers) GetPodLogs(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		logs, err := h.k8sClient.GetPodLogs(c.Context(), cluster, namespace, pod, container, int64(tailLines))
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"logs": logs, "source": "k8s"})
 	}
@@ -1385,7 +1432,8 @@ func (h *MCPHandlers) GetEvents(c *fiber.Ctx) error {
 			// via multiple kubeconfig contexts (e.g. "vllm-d" and its long OpenShift name)
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			perClusterLimit := limit / len(clusters)
@@ -1426,7 +1474,8 @@ func (h *MCPHandlers) GetEvents(c *fiber.Ctx) error {
 
 		events, err := h.k8sClient.GetEvents(c.Context(), cluster, namespace, limit)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"events": events, "source": "k8s", "cluster": cluster})
 	}
@@ -1460,7 +1509,8 @@ func (h *MCPHandlers) GetWarningEvents(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			perClusterLimit := limit / len(clusters)
@@ -1500,7 +1550,8 @@ func (h *MCPHandlers) GetWarningEvents(c *fiber.Ctx) error {
 
 		events, err := h.k8sClient.GetWarningEvents(c.Context(), cluster, namespace, limit)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"events": events, "source": "k8s", "cluster": cluster})
 	}
@@ -1524,7 +1575,8 @@ func (h *MCPHandlers) CheckSecurityIssues(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+				log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 
 			var wg sync.WaitGroup
@@ -1554,7 +1606,8 @@ func (h *MCPHandlers) CheckSecurityIssues(c *fiber.Ctx) error {
 
 		issues, err := h.k8sClient.CheckSecurityIssues(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{"issues": issues, "source": "k8s"})
 	}
@@ -1695,7 +1748,8 @@ func (h *MCPHandlers) CallOpsTool(c *fiber.Ctx) error {
 
 	result, err := h.bridge.CallOpsTool(c.Context(), req.Name, req.Arguments)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(result)
@@ -1719,7 +1773,8 @@ func (h *MCPHandlers) CallDeployTool(c *fiber.Ctx) error {
 
 	result, err := h.bridge.CallDeployTool(c.Context(), req.Name, req.Arguments)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(result)

--- a/pkg/api/handlers/mcs.go
+++ b/pkg/api/handlers/mcs.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"log"
 	"github.com/gofiber/fiber/v2"
 	"github.com/kubestellar/console/pkg/k8s"
 )
@@ -34,7 +35,8 @@ func (h *MCSHandlers) ListServiceExports(c *fiber.Ctx) error {
 		// Get exports for specific cluster
 		exports, err := h.k8sClient.ListServiceExportsForCluster(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{
 			"items":      exports,
@@ -46,7 +48,8 @@ func (h *MCSHandlers) ListServiceExports(c *fiber.Ctx) error {
 	// Get exports across all clusters
 	list, err := h.k8sClient.ListServiceExports(c.Context())
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(list)
@@ -67,7 +70,8 @@ func (h *MCSHandlers) ListServiceImports(c *fiber.Ctx) error {
 		// Get imports for specific cluster
 		imports, err := h.k8sClient.ListServiceImportsForCluster(c.Context(), cluster, namespace)
 		if err != nil {
-			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
 		return c.JSON(fiber.Map{
 			"items":      imports,
@@ -79,7 +83,8 @@ func (h *MCSHandlers) ListServiceImports(c *fiber.Ctx) error {
 	// Get imports across all clusters
 	list, err := h.k8sClient.ListServiceImports(c.Context())
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(list)
@@ -94,7 +99,8 @@ func (h *MCSHandlers) GetMCSStatus(c *fiber.Ctx) error {
 
 	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	type clusterMCSStatus struct {
@@ -129,7 +135,8 @@ func (h *MCSHandlers) GetServiceExport(c *fiber.Ctx) error {
 
 	exports, err := h.k8sClient.ListServiceExportsForCluster(c.Context(), cluster, namespace)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	for _, export := range exports {
@@ -154,7 +161,8 @@ func (h *MCSHandlers) GetServiceImport(c *fiber.Ctx) error {
 
 	imports, err := h.k8sClient.ListServiceImportsForCluster(c.Context(), cluster, namespace)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	for _, imp := range imports {
@@ -182,7 +190,8 @@ func (h *MCSHandlers) CreateServiceExport(c *fiber.Ctx) error {
 
 	var req CreateServiceExportRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body: " + err.Error()})
+		log.Printf("invalid request body: %v", err)
+		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 
 	// Validate required fields
@@ -198,7 +207,8 @@ func (h *MCSHandlers) CreateServiceExport(c *fiber.Ctx) error {
 
 	// Create the ServiceExport
 	if err := h.k8sClient.CreateServiceExport(c.Context(), req.Cluster, req.Namespace, req.ServiceName); err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "Failed to create ServiceExport: " + err.Error()})
+		log.Printf("failed to create serviceexport: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.Status(201).JSON(fiber.Map{
@@ -221,7 +231,8 @@ func (h *MCSHandlers) DeleteServiceExport(c *fiber.Ctx) error {
 	name := c.Params("name")
 
 	if err := h.k8sClient.DeleteServiceExport(c.Context(), cluster, namespace, name); err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "Failed to delete ServiceExport: " + err.Error()})
+		log.Printf("failed to delete serviceexport: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(fiber.Map{

--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -211,7 +211,7 @@ func (h *MissionsHandler) ValidateMission(c *fiber.Ctx) error {
 
 	var mission MissionSpec
 	if err := json.Unmarshal(body, &mission); err != nil {
-		return c.Status(400).JSON(fiber.Map{"valid": false, "errors": []string{"invalid JSON: " + err.Error()}})
+		return c.Status(400).JSON(fiber.Map{"valid": false, "errors": []string{"invalid JSON format"}})
 	}
 
 	var errs []string

--- a/pkg/api/handlers/namespaces.go
+++ b/pkg/api/handlers/namespaces.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"log"
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/kubestellar/console/pkg/api/middleware"
@@ -34,7 +35,8 @@ func (h *NamespaceHandler) ListNamespaces(c *fiber.Ctx) error {
 	ctx := c.Context()
 	namespaces, err := h.k8sClient.ListNamespacesWithDetails(ctx, cluster)
 	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list namespaces: "+err.Error())
+		log.Printf("failed to list namespaces: %v", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
 	return c.JSON(namespaces)
@@ -72,7 +74,8 @@ func (h *NamespaceHandler) CreateNamespace(c *fiber.Ctx) error {
 
 	ns, err := h.k8sClient.CreateNamespace(ctx, req.Cluster, req.Name, req.Labels)
 	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create namespace: "+err.Error())
+		log.Printf("failed to create namespace: %v", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
 	return c.JSON(fiber.Map{
@@ -109,7 +112,8 @@ func (h *NamespaceHandler) DeleteNamespace(c *fiber.Ctx) error {
 	}
 
 	if err := h.k8sClient.DeleteNamespace(ctx, cluster, name); err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "Failed to delete namespace: "+err.Error())
+		log.Printf("failed to delete namespace: %v", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
 	return c.JSON(fiber.Map{"success": true})
@@ -130,7 +134,8 @@ func (h *NamespaceHandler) GetNamespaceAccess(c *fiber.Ctx) error {
 	ctx := c.Context()
 	bindings, err := h.k8sClient.ListRoleBindings(ctx, cluster, name)
 	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list role bindings: "+err.Error())
+		log.Printf("failed to list role bindings: %v", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
 	// Convert to access list format
@@ -197,7 +202,8 @@ func (h *NamespaceHandler) GrantNamespaceAccess(c *fiber.Ctx) error {
 
 	bindingName, err := h.k8sClient.GrantNamespaceAccess(ctx, req.Cluster, namespace, req)
 	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "Failed to grant access: "+err.Error())
+		log.Printf("failed to grant access: %v", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
 	return c.JSON(fiber.Map{
@@ -236,7 +242,8 @@ func (h *NamespaceHandler) RevokeNamespaceAccess(c *fiber.Ctx) error {
 	}
 
 	if err := h.k8sClient.DeleteRoleBinding(ctx, cluster, namespace, bindingName, false); err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "Failed to revoke access: "+err.Error())
+		log.Printf("failed to revoke access: %v", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
 	return c.JSON(fiber.Map{"success": true})

--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"regexp"
 	"strings"
@@ -712,7 +713,8 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 
 	req, err := http.NewRequest("GET", jobsURL, nil)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	if h.githubToken != "" {
@@ -721,7 +723,8 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 
 	resp, err := h.httpClient.Do(req)
 	if err != nil {
-		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("bad gateway: %v", err)
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": "bad gateway"})
 	}
 	defer resp.Body.Close()
 
@@ -743,7 +746,8 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 		} `json:"jobs"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&jobData); err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	// Fetch logs for failed jobs concurrently (limit concurrency)

--- a/pkg/api/handlers/notifications.go
+++ b/pkg/api/handlers/notifications.go
@@ -55,7 +55,7 @@ func (h *NotificationHandler) TestNotification(c *fiber.Ctx) error {
 		log.Printf("Notification test failed: %v", err)
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error":   "Notification test failed",
-			"message": err.Error(),
+			"message": "notification test failed",
 		})
 	}
 
@@ -81,7 +81,7 @@ func (h *NotificationHandler) SendAlertNotification(c *fiber.Ctx) error {
 		log.Printf("Failed to send alert notification: %v", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error":   "Failed to send notification",
-			"message": err.Error(),
+			"message": "failed to send notification",
 		})
 	}
 

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"log"
 	"context"
 	"time"
 
@@ -168,7 +169,8 @@ func (h *RBACHandler) ListK8sServiceAccounts(c *fiber.Ctx) error {
 		// Get SAs from specific cluster
 		sas, err := h.k8sClient.ListServiceAccounts(ctx, cluster, namespace)
 		if err != nil {
-			return fiber.NewError(fiber.StatusInternalServerError, "Failed to list service accounts: "+err.Error())
+			log.Printf("failed to list service accounts: %v", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 		}
 		return c.JSON(sas)
 	}
@@ -310,7 +312,8 @@ func (h *RBACHandler) CreateServiceAccount(c *fiber.Ctx) error {
 
 	sa, err := h.k8sClient.CreateServiceAccount(ctx, req.Cluster, req.Namespace, req.Name)
 	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create service account: "+err.Error())
+		log.Printf("failed to create service account: %v", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
 	return c.JSON(sa)
@@ -340,7 +343,8 @@ func (h *RBACHandler) CreateRoleBinding(c *fiber.Ctx) error {
 	}
 
 	if err := h.k8sClient.CreateRoleBinding(ctx, req); err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "Failed to create role binding: "+err.Error())
+		log.Printf("failed to create role binding: %v", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
 	return c.JSON(fiber.Map{"success": true})
@@ -383,7 +387,8 @@ func (h *RBACHandler) ListOpenShiftUsers(c *fiber.Ctx) error {
 
 	users, err := h.k8sClient.ListOpenShiftUsers(ctx, cluster)
 	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list OpenShift users: "+err.Error())
+		log.Printf("failed to list openshift users: %v", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
 	return c.JSON(users)
@@ -398,7 +403,8 @@ func (h *RBACHandler) GetPermissionsSummary(c *fiber.Ctx) error {
 	ctx := c.Context()
 	summaries, err := h.k8sClient.GetAllPermissionsSummaries(ctx)
 	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "Failed to get permissions summary: "+err.Error())
+		log.Printf("failed to get permissions summary: %v", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
 	// Convert to map format for API response
@@ -439,7 +445,8 @@ func (h *RBACHandler) CheckCanI(c *fiber.Ctx) error {
 	ctx := c.Context()
 	result, err := h.k8sClient.CheckCanI(ctx, req.Cluster, req)
 	if err != nil {
-		return fiber.NewError(fiber.StatusInternalServerError, "Failed to check permission: "+err.Error())
+		log.Printf("failed to check permission: %v", err)
+		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
 	return c.JSON(models.CanIResponse{

--- a/pkg/api/handlers/settings.go
+++ b/pkg/api/handlers/settings.go
@@ -83,7 +83,7 @@ func (h *SettingsHandler) ImportSettings(c *fiber.Ctx) error {
 		log.Printf("[settings] Import error: %v", err)
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error":   "Failed to import settings",
-			"message": err.Error(),
+			"message": "invalid settings data",
 		})
 	}
 

--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -90,7 +90,8 @@ func streamClusters(
 ) error {
 	healthy, offline, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	c.Set("Content-Type", "text/event-stream")

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"log"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -54,7 +55,8 @@ func (h *WorkloadHandlers) ListWorkloads(c *fiber.Ctx) error {
 
 	workloads, err := h.k8sClient.ListWorkloads(c.Context(), cluster, namespace, workloadType)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(workloads)
@@ -73,7 +75,8 @@ func (h *WorkloadHandlers) GetWorkload(c *fiber.Ctx) error {
 
 	workload, err := h.k8sClient.GetWorkload(c.Context(), cluster, namespace, name)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	if workload == nil {
@@ -101,7 +104,8 @@ func (h *WorkloadHandlers) DeployWorkload(c *fiber.Ctx) error {
 
 	var req DeployRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body: " + err.Error()})
+		log.Printf("invalid request body: %v", err)
+		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 
 	// Validate required fields
@@ -128,7 +132,8 @@ func (h *WorkloadHandlers) DeployWorkload(c *fiber.Ctx) error {
 
 	result, err := h.k8sClient.DeployWorkload(c.Context(), req.SourceCluster, req.Namespace, req.WorkloadName, req.TargetClusters, req.Replicas, opts)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(result)
@@ -148,9 +153,11 @@ func (h *WorkloadHandlers) ResolveDependencies(c *fiber.Ctx) error {
 	workloadKind, bundle, err := h.k8sClient.ResolveWorkloadDependencies(c.Context(), cluster, namespace, name)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			return c.Status(404).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("not found: %v", err)
+		return c.Status(404).JSON(fiber.Map{"error": "not found"})
 		}
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	type depDTO struct {
@@ -201,9 +208,11 @@ func (h *WorkloadHandlers) MonitorWorkload(c *fiber.Ctx) error {
 	result, err := h.k8sClient.MonitorWorkload(c.Context(), cluster, namespace, name)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			return c.Status(404).JSON(fiber.Map{"error": err.Error()})
+			log.Printf("not found: %v", err)
+		return c.Status(404).JSON(fiber.Map{"error": "not found"})
 		}
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(result)
@@ -222,7 +231,8 @@ func (h *WorkloadHandlers) GetDeployStatus(c *fiber.Ctx) error {
 
 	workload, err := h.k8sClient.GetWorkload(c.Context(), cluster, namespace, name)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	if workload == nil {
@@ -296,7 +306,8 @@ func (h *WorkloadHandlers) ListClusterGroups(c *fiber.Ctx) error {
 func (h *WorkloadHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 	var group ClusterGroup
 	if err := c.BodyParser(&group); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body: " + err.Error()})
+		log.Printf("invalid request body: %v", err)
+		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 	if group.Name == "" {
 		return c.Status(400).JSON(fiber.Map{"error": "name is required"})
@@ -329,7 +340,8 @@ func (h *WorkloadHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 
 	var group ClusterGroup
 	if err := c.BodyParser(&group); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body: " + err.Error()})
+		log.Printf("invalid request body: %v", err)
+		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 	group.Name = name
 
@@ -412,7 +424,8 @@ func (h *WorkloadHandlers) EvaluateClusterQuery(c *fiber.Ctx) error {
 
 	var query ClusterGroupQuery
 	if err := c.BodyParser(&query); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "Invalid query: " + err.Error()})
+		log.Printf("invalid query: %v", err)
+		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), workloadListTimeout)
@@ -423,7 +436,8 @@ func (h *WorkloadHandlers) EvaluateClusterQuery(c *fiber.Ctx) error {
 	// We only want one result per unique server URL.
 	dedupClusters, _, err := h.k8sClient.HealthyClusters(ctx)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "Failed to list clusters: " + err.Error()})
+		log.Printf("failed to list clusters: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 	primaryNames := make(map[string]bool, len(dedupClusters))
 	for _, cl := range dedupClusters {
@@ -433,7 +447,8 @@ func (h *WorkloadHandlers) EvaluateClusterQuery(c *fiber.Ctx) error {
 	// Get all cluster health data and keep only deduplicated entries
 	allHealth, err := h.k8sClient.GetAllClusterHealth(ctx)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "Failed to get cluster health: " + err.Error()})
+		log.Printf("failed to get cluster health: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 	healthData := make([]k8s.ClusterHealth, 0, len(dedupClusters))
 	for _, h := range allHealth {
@@ -670,7 +685,8 @@ func (h *WorkloadHandlers) GenerateClusterQuery(c *fiber.Ctx) error {
 	registry := agent.GetRegistry()
 	provider, err := registry.GetDefault()
 	if err != nil {
-		return c.Status(503).JSON(fiber.Map{"error": "No AI provider available: " + err.Error()})
+		log.Printf("no ai provider available: %v", err)
+		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
 	systemPrompt := `You are a Kubernetes cluster query generator. Given a natural language description, generate a structured JSON query for selecting clusters from a multi-cluster environment.
@@ -712,7 +728,8 @@ If the user's request doesn't need label selectors, omit the labelSelector field
 
 	resp, err := provider.Chat(c.Context(), chatReq)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": "AI query generation failed: " + err.Error()})
+		log.Printf("ai query generation failed: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	// Try to parse the AI response as structured JSON
@@ -728,9 +745,10 @@ If the user's request doesn't need label selectors, omit the labelSelector field
 		Query         ClusterGroupQuery `json:"query"`
 	}
 	if err := json.Unmarshal([]byte(content), &result); err != nil {
+		log.Printf("could not parse AI response as structured query: %v", err)
 		return c.JSON(fiber.Map{
 			"raw":   resp.Content,
-			"error": "Could not parse AI response as structured query: " + err.Error(),
+			"error": "could not parse AI response as structured query",
 		})
 	}
 
@@ -769,7 +787,8 @@ func (h *WorkloadHandlers) ScaleWorkload(c *fiber.Ctx) error {
 
 	var req ScaleRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body: " + err.Error()})
+		log.Printf("invalid request body: %v", err)
+		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 
 	// Validate required fields
@@ -782,7 +801,8 @@ func (h *WorkloadHandlers) ScaleWorkload(c *fiber.Ctx) error {
 
 	result, err := h.k8sClient.ScaleWorkload(c.Context(), req.Namespace, req.WorkloadName, req.TargetClusters, req.Replicas)
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(result)
@@ -800,7 +820,8 @@ func (h *WorkloadHandlers) DeleteWorkload(c *fiber.Ctx) error {
 	name := c.Params("name")
 
 	if err := h.k8sClient.DeleteWorkload(c.Context(), cluster, namespace, name); err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(fiber.Map{
@@ -820,7 +841,8 @@ func (h *WorkloadHandlers) GetClusterCapabilities(c *fiber.Ctx) error {
 
 	capabilities, err := h.k8sClient.GetClusterCapabilities(c.Context())
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(capabilities)
@@ -835,7 +857,8 @@ func (h *WorkloadHandlers) ListBindingPolicies(c *fiber.Ctx) error {
 
 	policies, err := h.k8sClient.ListBindingPolicies(c.Context())
 	if err != nil {
-		return c.Status(500).JSON(fiber.Map{"error": err.Error()})
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.JSON(policies)

--- a/web/src/hooks/useLLMd.ts
+++ b/web/src/hooks/useLLMd.ts
@@ -337,8 +337,6 @@ export function useLLMdServers(clusters: string[] = ['vllm-d', 'platform-eval'])
             )
           })
 
-          console.log(`[useLLMdServers] Filtered to ${llmdDeployments.length} llm-d deployments on ${cluster}`)
-
           // Build namespace status maps for gateway and prometheus
           const namespaceGatewayStatus = new Map<string, { status: 'running' | 'stopped' | 'unknown', type: LLMdServer['gatewayType'] }>()
           const namespacePrometheusStatus = new Map<string, 'running' | 'stopped' | 'unknown'>()
@@ -395,7 +393,6 @@ export function useLLMdServers(clusters: string[] = ['vllm-d', 'platform-eval'])
 
           // Progressive loading: update state after each cluster
           if (clusterServers.length > 0) {
-            console.log(`[useLLMdServers] Progressive update: adding ${clusterServers.length} servers from ${cluster}`)
             setServers(prev => [...prev, ...clusterServers])
             // Clear loading state after first batch of data arrives
             if (!initialLoadDone.current) {
@@ -428,7 +425,6 @@ export function useLLMdServers(clusters: string[] = ['vllm-d', 'platform-eval'])
         setError(err instanceof Error ? err.message : 'Failed to fetch LLM-d servers')
       }
     } finally {
-      console.log('[useLLMdServers] refetch finally block')
       setIsLoading(false)
       setIsRefreshing(false)
     }
@@ -436,13 +432,11 @@ export function useLLMdServers(clusters: string[] = ['vllm-d', 'platform-eval'])
   }, [(clusters || []).join(',')])
 
   useEffect(() => {
-    console.log('[useLLMdServers] useEffect mounting, starting initial fetch')
     refetch(false).catch(err => {
       console.error('[useLLMdServers] Initial fetch error:', err)
     })
     const interval = setInterval(() => refetch(true), REFRESH_INTERVAL_MS)
     return () => {
-      console.log('[useLLMdServers] useEffect cleanup')
       clearInterval(interval)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -495,8 +489,6 @@ export function useLLMdModels(clusters: string[] = ['vllm-d', 'platform-eval']) 
       return
     }
 
-    console.log(`[useLLMdModels] refetch called, silent=${silent}, clusters=${clusters.join(',')}`)
-
     // Progressive loading: reset state
     if (!silent) {
       setIsRefreshing(true)
@@ -542,7 +534,6 @@ export function useLLMdModels(clusters: string[] = ['vllm-d', 'platform-eval']) 
 
           // Progressive loading: update state after each cluster
           if (clusterModels.length > 0) {
-            console.log(`[useLLMdModels] Progressive update: adding ${clusterModels.length} models from ${cluster}`)
             setModels(prev => [...prev, ...clusterModels])
             // Clear loading state after first batch of data arrives
             if (!initialLoadDone.current) {

--- a/web/src/hooks/useRewards.tsx
+++ b/web/src/hooks/useRewards.tsx
@@ -122,7 +122,6 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
 
     // Check if one-time reward already earned
     if (rewardConfig.oneTime && hasEarnedAction(action)) {
-      console.log(`[useRewards] One-time reward already earned: ${action}`)
       return false
     }
 
@@ -154,7 +153,6 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
     setRewards(updated)
     saveRewards(user.id, updated)
 
-    console.log(`[useRewards] Awarded ${rewardConfig.coins} coins for ${action}`)
     return true
   }, [rewards, user?.id, hasEarnedAction])
 


### PR DESCRIPTION
## Summary

- Replace internal error messages in HTTP responses with generic messages
- Add `rel="noopener noreferrer"` to `target="_blank"` links
- Remove `console.log` statements from production hook code

Partial fix for #1911 (CSP and rate limiting deferred to separate PRs)

## Test plan

- [x] `go build ./...` passes
- [x] `npm run build` passes
- [ ] CI build/lint

Partial fix for #1911