### PR TITLE
✨ Add WSL to all installation directions and CTAs

### DIFF
--- a/web/src/components/dashboard/DemoToLocalCTA.tsx
+++ b/web/src/components/dashboard/DemoToLocalCTA.tsx
@@ -128,7 +128,7 @@ export function DemoToLocalCTA() {
 
       <div className="flex items-center gap-3 text-xs">
         <span className="text-muted-foreground">
-          Requires macOS or Linux with Homebrew
+          Requires macOS, Linux, or WSL with Homebrew
         </span>
         <button
           onClick={handleDocs}

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -447,15 +447,15 @@ export function useLocalAgent() {
       'To connect to your local kubeconfig and Claude Code, install the kc-agent on your machine.',
     steps: [
       {
-        title: 'Install via Homebrew (macOS)',
+        title: 'Install via Homebrew (macOS / WSL)',
         command: 'brew tap kubestellar/tap && brew install --head kc-agent && kc-agent',
       },
       {
-        title: 'Build from source (Linux — recommended)',
+        title: 'Build from source (Linux / WSL — recommended)',
         command: 'git clone https://github.com/kubestellar/console.git && cd console && go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent',
       },
       {
-        title: 'Install via Linuxbrew (Linux — alternative)',
+        title: 'Install via Linuxbrew (Linux / WSL — alternative)',
         command: '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap kubestellar/tap && brew install --head kc-agent && kc-agent',
       },
     ],

--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -1492,8 +1492,8 @@
     "keysSavedTo": "Keys saved to",
     "securityNote": "API keys are stored securely on your local machine and never sent to our servers.",
     "selectAgent": "Select AI agent",
-    "installViaHomebrewMacOS": "# Install via Homebrew (macOS)",
-    "installLinuxBuildFromSource": "# Linux: build from source (requires Go 1.24+)"
+    "installViaHomebrewMacOS": "# Install via Homebrew (macOS / WSL)",
+    "installLinuxBuildFromSource": "# Linux / WSL: build from source (requires Go 1.24+)"
   },
   "navbar": {
     "closeMenu": "Close menu",
@@ -2772,10 +2772,10 @@
     "dontShowAgain": "Don't show again",
     "continueWithDemoData": "Continue with Demo Data",
     "remindMeLater": "Remind Me Later",
-    "quickInstallMacOS": "Quick Install — macOS (Homebrew)",
-    "linuxInstructions": "Linux installation instructions",
-    "linuxBuildDesc": "Build from source (recommended for Linux). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew: brew tap kubestellar/tap && brew install --head kc-agent"
+    "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
+    "linuxInstructions": "Linux / WSL installation instructions",
+    "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1502,8 +1502,8 @@
     "keysSavedTo": "Keys saved to",
     "securityNote": "API keys are stored securely on your local machine and never sent to our servers.",
     "selectAgent": "Select AI agent",
-    "installViaHomebrewMacOS": "# Install via Homebrew (macOS)",
-    "installLinuxBuildFromSource": "# Linux: build from source (requires Go 1.24+)"
+    "installViaHomebrewMacOS": "# Install via Homebrew (macOS / WSL)",
+    "installLinuxBuildFromSource": "# Linux / WSL: build from source (requires Go 1.24+)"
   },
   "navbar": {
     "closeMenu": "Close menu",
@@ -2826,10 +2826,10 @@
     "dontShowAgain": "Don't show again",
     "continueWithDemoData": "Continue with Demo Data",
     "remindMeLater": "Remind Me Later",
-    "quickInstallMacOS": "Quick Install — macOS (Homebrew)",
-    "linuxInstructions": "Linux installation instructions",
-    "linuxBuildDesc": "Build from source (recommended for Linux). Requires Go 1.24+ only:",
-    "linuxBrewAlternative": "Alternative: install Homebrew for Linux first (https://docs.brew.sh/Homebrew-on-Linux), then: brew tap kubestellar/tap && brew install --head kc-agent"
+    "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
+    "linuxInstructions": "Linux / WSL installation instructions",
+    "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+ only:",
+    "linuxBrewAlternative": "Alternative: install Homebrew for Linux / WSL first (https://docs.brew.sh/Homebrew-on-Linux), then: brew tap kubestellar/tap && brew install --head kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -1492,8 +1492,8 @@
     "keysSavedTo": "Keys saved to",
     "securityNote": "API keys are stored securely on your local machine and never sent to our servers.",
     "selectAgent": "Select AI agent",
-    "installViaHomebrewMacOS": "# Install via Homebrew (macOS)",
-    "installLinuxBuildFromSource": "# Linux: build from source (requires Go 1.24+)"
+    "installViaHomebrewMacOS": "# Install via Homebrew (macOS / WSL)",
+    "installLinuxBuildFromSource": "# Linux / WSL: build from source (requires Go 1.24+)"
   },
   "navbar": {
     "closeMenu": "Close menu",
@@ -2772,10 +2772,10 @@
     "dontShowAgain": "Don't show again",
     "continueWithDemoData": "Continue with Demo Data",
     "remindMeLater": "Remind Me Later",
-    "quickInstallMacOS": "Quick Install — macOS (Homebrew)",
-    "linuxInstructions": "Linux installation instructions",
-    "linuxBuildDesc": "Build from source (recommended for Linux). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew: brew tap kubestellar/tap && brew install --head kc-agent"
+    "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
+    "linuxInstructions": "Linux / WSL installation instructions",
+    "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -1492,8 +1492,8 @@
     "keysSavedTo": "Keys saved to",
     "securityNote": "API keys are stored securely on your local machine and never sent to our servers.",
     "selectAgent": "Select AI agent",
-    "installViaHomebrewMacOS": "# Install via Homebrew (macOS)",
-    "installLinuxBuildFromSource": "# Linux: build from source (requires Go 1.24+)"
+    "installViaHomebrewMacOS": "# Install via Homebrew (macOS / WSL)",
+    "installLinuxBuildFromSource": "# Linux / WSL: build from source (requires Go 1.24+)"
   },
   "navbar": {
     "closeMenu": "Close menu",
@@ -2772,10 +2772,10 @@
     "dontShowAgain": "Don't show again",
     "continueWithDemoData": "Continue with Demo Data",
     "remindMeLater": "Remind Me Later",
-    "quickInstallMacOS": "Quick Install — macOS (Homebrew)",
-    "linuxInstructions": "Linux installation instructions",
-    "linuxBuildDesc": "Build from source (recommended for Linux). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew: brew tap kubestellar/tap && brew install --head kc-agent"
+    "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
+    "linuxInstructions": "Linux / WSL installation instructions",
+    "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -1492,8 +1492,8 @@
     "keysSavedTo": "Keys saved to",
     "securityNote": "API keys are stored securely on your local machine and never sent to our servers.",
     "selectAgent": "Select AI agent",
-    "installViaHomebrewMacOS": "# Install via Homebrew (macOS)",
-    "installLinuxBuildFromSource": "# Linux: build from source (requires Go 1.24+)"
+    "installViaHomebrewMacOS": "# Install via Homebrew (macOS / WSL)",
+    "installLinuxBuildFromSource": "# Linux / WSL: build from source (requires Go 1.24+)"
   },
   "navbar": {
     "closeMenu": "Close menu",
@@ -2772,10 +2772,10 @@
     "dontShowAgain": "Don't show again",
     "continueWithDemoData": "Continue with Demo Data",
     "remindMeLater": "Remind Me Later",
-    "quickInstallMacOS": "Quick Install — macOS (Homebrew)",
-    "linuxInstructions": "Linux installation instructions",
-    "linuxBuildDesc": "Build from source (recommended for Linux). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew: brew tap kubestellar/tap && brew install --head kc-agent"
+    "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
+    "linuxInstructions": "Linux / WSL installation instructions",
+    "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -1492,8 +1492,8 @@
     "keysSavedTo": "Keys saved to",
     "securityNote": "API keys are stored securely on your local machine and never sent to our servers.",
     "selectAgent": "Select AI agent",
-    "installViaHomebrewMacOS": "# Install via Homebrew (macOS)",
-    "installLinuxBuildFromSource": "# Linux: build from source (requires Go 1.24+)"
+    "installViaHomebrewMacOS": "# Install via Homebrew (macOS / WSL)",
+    "installLinuxBuildFromSource": "# Linux / WSL: build from source (requires Go 1.24+)"
   },
   "navbar": {
     "closeMenu": "Close menu",
@@ -2772,10 +2772,10 @@
     "dontShowAgain": "Don't show again",
     "continueWithDemoData": "Continue with Demo Data",
     "remindMeLater": "Remind Me Later",
-    "quickInstallMacOS": "Quick Install — macOS (Homebrew)",
-    "linuxInstructions": "Linux installation instructions",
-    "linuxBuildDesc": "Build from source (recommended for Linux). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew: brew tap kubestellar/tap && brew install --head kc-agent"
+    "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
+    "linuxInstructions": "Linux / WSL installation instructions",
+    "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -1492,8 +1492,8 @@
     "keysSavedTo": "Keys saved to",
     "securityNote": "API keys are stored securely on your local machine and never sent to our servers.",
     "selectAgent": "Select AI agent",
-    "installViaHomebrewMacOS": "# Install via Homebrew (macOS)",
-    "installLinuxBuildFromSource": "# Linux: build from source (requires Go 1.24+)"
+    "installViaHomebrewMacOS": "# Install via Homebrew (macOS / WSL)",
+    "installLinuxBuildFromSource": "# Linux / WSL: build from source (requires Go 1.24+)"
   },
   "navbar": {
     "closeMenu": "Close menu",
@@ -2772,10 +2772,10 @@
     "dontShowAgain": "Don't show again",
     "continueWithDemoData": "Continue with Demo Data",
     "remindMeLater": "Remind Me Later",
-    "quickInstallMacOS": "Quick Install — macOS (Homebrew)",
-    "linuxInstructions": "Linux installation instructions",
-    "linuxBuildDesc": "Build from source (recommended for Linux). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew: brew tap kubestellar/tap && brew install --head kc-agent"
+    "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
+    "linuxInstructions": "Linux / WSL installation instructions",
+    "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -1492,8 +1492,8 @@
     "keysSavedTo": "Keys saved to",
     "securityNote": "API keys are stored securely on your local machine and never sent to our servers.",
     "selectAgent": "Select AI agent",
-    "installViaHomebrewMacOS": "# Install via Homebrew (macOS)",
-    "installLinuxBuildFromSource": "# Linux: build from source (requires Go 1.24+)"
+    "installViaHomebrewMacOS": "# Install via Homebrew (macOS / WSL)",
+    "installLinuxBuildFromSource": "# Linux / WSL: build from source (requires Go 1.24+)"
   },
   "navbar": {
     "closeMenu": "Close menu",
@@ -2772,10 +2772,10 @@
     "dontShowAgain": "Don't show again",
     "continueWithDemoData": "Continue with Demo Data",
     "remindMeLater": "Remind Me Later",
-    "quickInstallMacOS": "Quick Install — macOS (Homebrew)",
-    "linuxInstructions": "Linux installation instructions",
-    "linuxBuildDesc": "Build from source (recommended for Linux). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew: brew tap kubestellar/tap && brew install --head kc-agent"
+    "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
+    "linuxInstructions": "Linux / WSL installation instructions",
+    "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -1492,8 +1492,8 @@
     "keysSavedTo": "Keys saved to",
     "securityNote": "API keys are stored securely on your local machine and never sent to our servers.",
     "selectAgent": "Select AI agent",
-    "installViaHomebrewMacOS": "# Install via Homebrew (macOS)",
-    "installLinuxBuildFromSource": "# Linux: build from source (requires Go 1.24+)"
+    "installViaHomebrewMacOS": "# Install via Homebrew (macOS / WSL)",
+    "installLinuxBuildFromSource": "# Linux / WSL: build from source (requires Go 1.24+)"
   },
   "navbar": {
     "closeMenu": "Close menu",
@@ -2772,10 +2772,10 @@
     "dontShowAgain": "Don't show again",
     "continueWithDemoData": "Continue with Demo Data",
     "remindMeLater": "Remind Me Later",
-    "quickInstallMacOS": "Quick Install — macOS (Homebrew)",
-    "linuxInstructions": "Linux installation instructions",
-    "linuxBuildDesc": "Build from source (recommended for Linux). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew: brew tap kubestellar/tap && brew install --head kc-agent"
+    "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
+    "linuxInstructions": "Linux / WSL installation instructions",
+    "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",


### PR DESCRIPTION
## Summary
- Adds "WSL" alongside Linux and macOS in all install instructions, banners, and agent setup dialogs
- Windows/WSL users now see they're supported everywhere install directions appear
- Updated 11 files: DemoToLocalCTA, useLocalAgent, and all 9 locale `common.json` files

## Changes
| Location | Before | After |
|----------|--------|-------|
| DemoToLocalCTA banner | "Requires macOS or Linux with Homebrew" | "Requires macOS, Linux, or WSL with Homebrew" |
| Install option titles | "Install via Homebrew (macOS)" | "Install via Homebrew (macOS / WSL)" |
| Install option titles | "Build from source (Linux — recommended)" | "Build from source (Linux / WSL — recommended)" |
| Install option titles | "Install via Linuxbrew (Linux — alternative)" | "Install via Linuxbrew (Linux / WSL — alternative)" |
| Locale keys | `installViaHomebrewMacOS`, `installLinuxBuildFromSource`, `quickInstallMacOS`, `linuxInstructions`, `linuxBuildDesc`, `linuxBrewAlternative` | All updated with "/ WSL" |

## Test plan
- [ ] Verify DemoToLocalCTA banner on console.kubestellar.io shows "macOS, Linux, or WSL"
- [ ] Verify Agent Setup Dialog shows updated macOS/WSL and Linux/WSL sections
- [ ] Verify Agent Status dropdown install instructions show updated text
- [ ] Verify all 9 locale files render correctly