### PR TITLE
🐛 Replace magic numbers with named constants in hooks and lib

### DIFF
--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -27,6 +27,12 @@ export function getEffectiveInterval(baseInterval: number): number {
   return baseInterval
 }
 
+/** Name length above which a cluster context name is considered auto-generated */
+const AUTO_GENERATED_NAME_LENGTH_THRESHOLD = 50
+
+/** Debounce delay for batching rapid cluster health check notifications */
+const CLUSTER_NOTIFY_DEBOUNCE_MS = 50
+
 // Minimum time to show the "Updating" indicator (ensures visibility for fast API responses)
 export const MIN_REFRESH_INDICATOR_MS = 500
 
@@ -312,7 +318,7 @@ export function notifyClusterSubscribersDebounced() {
   notifyTimeout = setTimeout(() => {
     notifyClusterSubscribers()
     notifyTimeout = null
-  }, 50) // 50ms debounce batches rapid health check completions
+  }, CLUSTER_NOTIFY_DEBOUNCE_MS)
 }
 
 // Update shared cluster cache
@@ -444,7 +450,7 @@ export function deduplicateClustersByServer(clusters: ClusterInfo[]): ClusterInf
              name.includes(':443/') ||
              name.includes('.openshiftapps.com') ||
              name.includes('.openshift.com') ||
-             (name.includes('/') && name.includes(':') && name.length > 50)
+             (name.includes('/') && name.includes(':') && name.length > AUTO_GENERATED_NAME_LENGTH_THRESHOLD)
     }
 
     const sorted = [...group].sort((a, b) => {

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -23,7 +23,7 @@ import { fetchSSE } from '../lib/sseClient'
 import { clusterCacheRef } from './mcp/shared'
 import { isAgentUnavailable } from './useLocalAgent'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
-import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS } from '../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS, KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
 import type {
   PodInfo,
   PodIssue,
@@ -44,7 +44,12 @@ import type { Workload } from './useWorkloads'
 
 const getToken = () => localStorage.getItem(STORAGE_KEY_TOKEN)
 
-const AGENT_HTTP_TIMEOUT_MS = 5000
+const AGENT_HTTP_TIMEOUT_MS = 5_000
+
+/** Maximum number of ProwJobs to return from a fetch */
+const MAX_PROW_JOBS = 100
+/** Maximum number of pods to return from a prefetch query */
+const MAX_PREFETCH_PODS = 100
 
 async function fetchAPI<T>(
   endpoint: string,
@@ -802,7 +807,7 @@ async function fetchProwJobs(prowCluster: string, namespace: string): Promise<Pr
   // useCache prevents calling fetchers in demo mode via effectiveEnabled
   const response = await kubectlProxy.exec(
     ['get', 'prowjobs', '-n', namespace, '-o', 'json', '--sort-by=.metadata.creationTimestamp'],
-    { context: prowCluster, timeout: 30000 }
+    { context: prowCluster, timeout: KUBECTL_EXTENDED_TIMEOUT_MS }
   )
 
   if (response.exitCode !== 0) {
@@ -812,7 +817,7 @@ async function fetchProwJobs(prowCluster: string, namespace: string): Promise<Pr
   const data = JSON.parse(response.output)
   return (data.items || [])
     .reverse()
-    .slice(0, 100)
+    .slice(0, MAX_PROW_JOBS)
     .map((pj: ProwJobResource) => {
       const jobName = pj.metadata.labels?.['prow.k8s.io/job'] || pj.spec.job || pj.metadata.name
       const jobType = (pj.metadata.labels?.['prow.k8s.io/type'] || pj.spec.type || 'unknown') as ProwJob['type']
@@ -1233,7 +1238,7 @@ async function fetchLLMdModels(
 
   const promises = clusters.map(async (cluster) => {
     try {
-      const response = await kubectlProxy.exec(['get', 'inferencepools', '-A', '-o', 'json'], { context: cluster, timeout: 30000 })
+      const response = await kubectlProxy.exec(['get', 'inferencepools', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_EXTENDED_TIMEOUT_MS })
       if (response.exitCode !== 0) return []
       const clusterModels: LLMdModel[] = []
       for (const pool of (JSON.parse(response.output).items || []) as InferencePoolResource[]) {
@@ -1482,7 +1487,7 @@ async function fetchSecurityIssuesViaKubectl(cluster?: string, namespace?: strin
       const nsFlag = namespace ? ['-n', namespace] : ['-A']
       const response = await kubectlProxy.exec(
         ['get', 'pods', ...nsFlag, '-o', 'json'],
-        { context: ctx, timeout: 30000 }
+        { context: ctx, timeout: KUBECTL_EXTENDED_TIMEOUT_MS }
       )
 
       if (response.exitCode !== 0) return []
@@ -1950,7 +1955,7 @@ export function useCachedWarningEvents(
 export const coreFetchers = {
   pods: async (): Promise<PodInfo[]> => {
     const pods = await fetchFromAllClusters<PodInfo>('pods', 'pods', {})
-    return pods.sort((a, b) => (b.restarts || 0) - (a.restarts || 0)).slice(0, 100)
+    return pods.sort((a, b) => (b.restarts || 0) - (a.restarts || 0)).slice(0, MAX_PREFETCH_PODS)
   },
   podIssues: async (): Promise<PodIssue[]> => {
     if (clusterCacheRef.clusters.length > 0 && !isAgentUnavailable()) {

--- a/web/src/hooks/useCardRecommendations.ts
+++ b/web/src/hooks/useCardRecommendations.ts
@@ -3,6 +3,17 @@ import { usePodIssues, useDeploymentIssues, useWarningEvents, useGPUNodes, useCl
 import { useAIMode } from './useAIMode'
 import { RECOMMENDATION_INTERVAL_MS } from '../lib/constants/network'
 
+/** Minimum pod issues before recommending a pod issues card */
+const POD_ISSUES_RECOMMEND_THRESHOLD = 5
+/** Deployment issue count above which priority escalates from medium to high */
+const DEPLOYMENT_ISSUES_HIGH_THRESHOLD = 3
+/** Minimum warning events before recommending an event stream card */
+const WARNING_EVENTS_RECOMMEND_THRESHOLD = 10
+/** GPU utilization percentage (0-1) above which GPU status card is recommended */
+const GPU_UTILIZATION_HIGH_THRESHOLD = 0.9
+/** Maximum number of card recommendations to show */
+const MAX_RECOMMENDATIONS = 3
+
 export interface CardRecommendation {
   id: string
   cardType: string
@@ -44,7 +55,7 @@ export function useCardRecommendations(currentCardTypes: string[]) {
     const newRecommendations: CardRecommendation[] = []
 
     // Check for pod issues
-    if ((podIssues || []).length > 5 && !currentCardTypes.includes('pod_issues')) {
+    if ((podIssues || []).length > POD_ISSUES_RECOMMEND_THRESHOLD && !currentCardTypes.includes('pod_issues')) {
       newRecommendations.push({
         id: 'rec-pod-issues',
         cardType: 'pod_issues',
@@ -61,12 +72,12 @@ export function useCardRecommendations(currentCardTypes: string[]) {
         cardType: 'deployment_issues',
         title: 'Deployment Issues',
         reason: `${(deploymentIssues || []).length} deployments have issues`,
-        priority: (deploymentIssues || []).length > 3 ? 'high' : 'medium',
+        priority: (deploymentIssues || []).length > DEPLOYMENT_ISSUES_HIGH_THRESHOLD ? 'high' : 'medium',
       })
     }
 
     // Check for many warning events
-    if ((warningEvents || []).length > 10 && !currentCardTypes.includes('event_stream')) {
+    if ((warningEvents || []).length > WARNING_EVENTS_RECOMMEND_THRESHOLD && !currentCardTypes.includes('event_stream')) {
       newRecommendations.push({
         id: 'rec-events',
         cardType: 'event_stream',
@@ -83,7 +94,7 @@ export function useCardRecommendations(currentCardTypes: string[]) {
     const gpuUtilization = totalGPUs > 0 ? allocatedGPUs / totalGPUs : 0
 
     if (totalGPUs > 0) {
-      if (gpuUtilization > 0.9 && !currentCardTypes.includes('gpu_status')) {
+      if (gpuUtilization > GPU_UTILIZATION_HIGH_THRESHOLD && !currentCardTypes.includes('gpu_status')) {
         newRecommendations.push({
           id: 'rec-gpu-status',
           cardType: 'gpu_status',
@@ -141,7 +152,7 @@ export function useCardRecommendations(currentCardTypes: string[]) {
       filteredRecs = newRecommendations.filter(r => r.priority === 'high')
     }
 
-    setRecommendations(filteredRecs.slice(0, 3)) // Top 3 recommendations
+    setRecommendations(filteredRecs.slice(0, MAX_RECOMMENDATIONS))
   }, [
     shouldProactivelySuggest,
     currentCardTypes,

--- a/web/src/hooks/useMetricsHistory.ts
+++ b/web/src/hooks/useMetricsHistory.ts
@@ -8,6 +8,8 @@ const HISTORY_CHANGED_EVENT = 'kubestellar-metrics-history-changed'
 const MAX_SNAPSHOTS = 144 // 24 hours at 10-min intervals
 /** Cache TTL: 24 hours — remove snapshots older than this */
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+/** Maximum number of increasing-restart pods to include in AI context */
+const MAX_INCREASING_RESTART_PODS = 10
 
 // Singleton state - shared across all hook instances
 let snapshots: MetricsSnapshot[] = []
@@ -348,7 +350,7 @@ export function getMetricsHistoryContext(): string {
 
   if (increasingPods.length > 0) {
     context += '\nPods with increasing restarts:\n'
-    increasingPods.slice(0, 10).forEach(([key, values]) => {
+    increasingPods.slice(0, MAX_INCREASING_RESTART_PODS).forEach(([key, values]) => {
       context += `  ${key}: ${values.join(' → ')} restarts\n`
     })
   }

--- a/web/src/hooks/useMissionSuggestions.ts
+++ b/web/src/hooks/useMissionSuggestions.ts
@@ -43,6 +43,17 @@ const THRESHOLDS = {
   securityIssuesHigh: 1,    // Any high severity security issues
 }
 
+/** Maximum items to show in detail summaries (top pods, deployments, issues) */
+const MAX_DETAIL_ITEMS = 5
+/** Maximum items in expanded detail lists */
+const MAX_DETAIL_ITEMS_EXPANDED = 10
+/** Minimum pods without limits before suggesting a mission */
+const PODS_WITHOUT_LIMITS_THRESHOLD = 10
+/** Minimum single-replica deployments before suggesting scaling review */
+const LOW_REPLICA_SUGGEST_THRESHOLD = 3
+/** Restart count above which mission priority escalates to high */
+const HIGH_RESTART_COUNT_THRESHOLD = 5
+
 export function useMissionSuggestions() {
   const [suggestions, setSuggestions] = useState<MissionSuggestion[]>([])
 
@@ -67,14 +78,14 @@ export function useMissionSuggestions() {
       p.restarts && p.restarts > THRESHOLDS.restartCount
     )
     if (highRestartPods.length > 0) {
-      const topPods = highRestartPods.slice(0, 5)
+      const topPods = highRestartPods.slice(0, MAX_DETAIL_ITEMS)
       const podDetails = topPods.map(p => `- ${p.name} in ${p.namespace} (${p.restarts} restarts, status: ${p.status})`).join('\n')
       newSuggestions.push({
         id: 'mission-restart-pods',
         type: 'restart',
         title: 'Investigate Restarting Pods',
         description: `${highRestartPods.length} pod${highRestartPods.length > 1 ? 's have' : ' has'} restarted ${THRESHOLDS.restartCount}+ times`,
-        priority: highRestartPods.length > 5 ? 'high' : 'medium',
+        priority: highRestartPods.length > HIGH_RESTART_COUNT_THRESHOLD ? 'high' : 'medium',
         action: {
           type: 'ai',
           target: `Diagnose why these ${highRestartPods.length} pods are restarting frequently:\n\n${podDetails}\n\nCheck container logs, resource limits, liveness/readiness probes, and OOM kills. Provide specific remediation steps.`,
@@ -93,7 +104,7 @@ export function useMissionSuggestions() {
       d.replicas > d.readyReplicas
     )
     if (unavailableDeployments.length > 0) {
-      const topDeployments = unavailableDeployments.slice(0, 5)
+      const topDeployments = unavailableDeployments.slice(0, MAX_DETAIL_ITEMS)
       const deploymentDetails = topDeployments.map(d => `- ${d.name} in ${d.namespace}: ${d.readyReplicas}/${d.replicas} ready`).join('\n')
       newSuggestions.push({
         id: 'mission-unavailable-deployments',
@@ -117,7 +128,7 @@ export function useMissionSuggestions() {
     // 3. Check for high severity security issues
     const highSeverityIssues = securityIssues.filter(i => i.severity === 'high')
     if (highSeverityIssues.length > 0) {
-      const issueDetails = highSeverityIssues.slice(0, 5).map(i => `- ${i.issue} (${i.cluster || 'unknown cluster'})`).join('\n')
+      const issueDetails = highSeverityIssues.slice(0, MAX_DETAIL_ITEMS).map(i => `- ${i.issue} (${i.cluster || 'unknown cluster'})`).join('\n')
       newSuggestions.push({
         id: 'mission-security-high',
         type: 'security',
@@ -131,7 +142,7 @@ export function useMissionSuggestions() {
         },
         context: {
           count: highSeverityIssues.length,
-          details: highSeverityIssues.slice(0, 5).map(i => `${i.issue} (${i.cluster || 'unknown'})`),
+          details: highSeverityIssues.slice(0, MAX_DETAIL_ITEMS).map(i => `${i.issue} (${i.cluster || 'unknown'})`),
         },
         detectedAt: now,
       })
@@ -166,8 +177,8 @@ export function useMissionSuggestions() {
       return p.status === 'Running' && !p.node  // Placeholder logic
     })
     // Only suggest if we have many pods without limits
-    if (podsWithoutLimits.length > 10) {
-      const samplePods = podsWithoutLimits.slice(0, 5).map(p => `- ${p.name} in ${p.namespace}`).join('\n')
+    if (podsWithoutLimits.length > PODS_WITHOUT_LIMITS_THRESHOLD) {
+      const samplePods = podsWithoutLimits.slice(0, MAX_DETAIL_ITEMS).map(p => `- ${p.name} in ${p.namespace}`).join('\n')
       newSuggestions.push({
         id: 'mission-resource-limits',
         type: 'limits',
@@ -181,7 +192,7 @@ export function useMissionSuggestions() {
         },
         context: {
           count: podsWithoutLimits.length,
-          details: podsWithoutLimits.slice(0, 10).map(p => `${p.name} in ${p.namespace}`),
+          details: podsWithoutLimits.slice(0, MAX_DETAIL_ITEMS_EXPANDED).map(p => `${p.name} in ${p.namespace}`),
         },
         detectedAt: now,
       })
@@ -222,7 +233,7 @@ export function useMissionSuggestions() {
     const lowReplicaDeployments = deploymentIssues.filter(d =>
       d.replicas === 1 && d.readyReplicas === 1  // Running but only one replica
     )
-    if (lowReplicaDeployments.length > 3) {
+    if (lowReplicaDeployments.length > LOW_REPLICA_SUGGEST_THRESHOLD) {
       newSuggestions.push({
         id: 'mission-scale-review',
         type: 'scale',
@@ -236,7 +247,7 @@ export function useMissionSuggestions() {
         },
         context: {
           count: lowReplicaDeployments.length,
-          details: lowReplicaDeployments.slice(0, 5).map(d => d.name),
+          details: lowReplicaDeployments.slice(0, MAX_DETAIL_ITEMS).map(d => d.name),
         },
         detectedAt: now,
       })

--- a/web/src/hooks/useNavigationHistory.ts
+++ b/web/src/hooks/useNavigationHistory.ts
@@ -3,6 +3,8 @@ import { useLocation } from 'react-router-dom'
 
 const STORAGE_KEY = 'kubestellar-nav-history'
 const MAX_HISTORY = 100
+/** Number of most-visited pages to return in behavior analysis */
+const TOP_PAGES_LIMIT = 10
 
 export function useNavigationHistory() {
   const location = useLocation()
@@ -52,6 +54,6 @@ export function getNavigationBehavior() {
   return {
     totalVisits: history.length,
     uniquePages: Object.keys(visitCounts).length,
-    topPages: sortedPaths.slice(0, 10),
+    topPages: sortedPaths.slice(0, TOP_PAGES_LIMIT),
   }
 }

--- a/web/src/hooks/usePredictionFeedback.ts
+++ b/web/src/hooks/usePredictionFeedback.ts
@@ -6,6 +6,8 @@ import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 const STORAGE_KEY = 'kubestellar-prediction-feedback'
 const FEEDBACK_CHANGED_EVENT = 'kubestellar-prediction-feedback-changed'
 const MAX_FEEDBACK_ENTRIES = 500 // Keep last 500 feedback entries
+/** Number of recent feedback entries to include in AI prompt context */
+const FEEDBACK_CONTEXT_LIMIT = 50
 
 // Singleton state - shared across all hook instances
 let feedbackMap: Map<string, StoredFeedback> = new Map()
@@ -202,7 +204,7 @@ async function sendFeedbackToBackend(predictionId: string, feedback: PredictionF
 export function getFeedbackContext(): string {
   const entries = Array.from(feedbackMap.values())
     .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
-    .slice(0, 50)
+    .slice(0, FEEDBACK_CONTEXT_LIMIT)
 
   if (entries.length === 0) {
     return 'No prediction feedback recorded yet.'

--- a/web/src/hooks/useProw.ts
+++ b/web/src/hooks/useProw.ts
@@ -1,9 +1,12 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { useDemoMode } from './useDemoMode'
+import { KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
 
 // Refresh interval for automatic polling (2 minutes)
-const REFRESH_INTERVAL_MS = 120000
+const REFRESH_INTERVAL_MS = 120_000
+/** Maximum number of ProwJobs to display */
+const MAX_PROW_JOBS = 100
 
 // ProwJob types
 export interface ProwJob {
@@ -119,7 +122,7 @@ export function useProwJobs(prowCluster = 'prow', namespace = 'prow') {
     try {
       const response = await kubectlProxy.exec(
         ['get', 'prowjobs', '-n', namespace, '-o', 'json', '--sort-by=.metadata.creationTimestamp'],
-        { context: prowCluster, timeout: 30000 }
+        { context: prowCluster, timeout: KUBECTL_EXTENDED_TIMEOUT_MS }
       )
       if (response.exitCode !== 0) {
         throw new Error(response.error || 'Failed to get ProwJobs')
@@ -128,7 +131,7 @@ export function useProwJobs(prowCluster = 'prow', namespace = 'prow') {
       const data = JSON.parse(response.output)
       const prowJobs: ProwJob[] = (data.items || [])
         .reverse() // Most recent first
-        .slice(0, 100) // Limit to 100 jobs
+        .slice(0, MAX_PROW_JOBS)
         .map((pj: ProwJobResource) => {
           const jobName = pj.metadata.labels?.['prow.k8s.io/job'] || pj.spec.job || pj.metadata.name
           const jobType = (pj.metadata.labels?.['prow.k8s.io/type'] || pj.spec.type || 'unknown') as ProwJob['type']

--- a/web/src/hooks/useRewards.tsx
+++ b/web/src/hooks/useRewards.tsx
@@ -17,6 +17,10 @@ import type { GitHubRewardsResponse } from '../types/rewards'
 import { useGitHubRewards } from './useGitHubRewards'
 
 const REWARDS_STORAGE_KEY = 'kubestellar-rewards'
+/** Maximum reward events to keep in history */
+const MAX_REWARD_EVENTS = 100
+/** Number of recent events to show in the UI */
+const RECENT_EVENTS_LIMIT = 10
 
 interface RewardsContextType {
   rewards: UserRewards | null
@@ -141,7 +145,7 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
       ...rewards,
       totalCoins: rewards.totalCoins + rewardConfig.coins,
       lifetimeCoins: rewards.lifetimeCoins + rewardConfig.coins,
-      events: [event, ...rewards.events].slice(0, 100), // Keep last 100 events
+      events: [event, ...rewards.events].slice(0, MAX_REWARD_EVENTS),
       lastUpdated: new Date().toISOString(),
     }
 
@@ -199,7 +203,7 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
   // Get recent events (last 10)
   const recentEvents = useMemo(() => {
     if (!rewards) return []
-    return rewards.events.slice(0, 10)
+    return rewards.events.slice(0, RECENT_EVENTS_LIMIT)
   }, [rewards])
 
   // Dedup: subtract console-submitted bug/feature coins that are already in GitHub data

--- a/web/src/hooks/useSnoozedRecommendations.ts
+++ b/web/src/hooks/useSnoozedRecommendations.ts
@@ -79,19 +79,24 @@ export function useSnoozedRecommendations() {
   }
 }
 
+// Time boundary constants for elapsed time formatting
+const SECONDS_PER_MINUTE = 60
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+
 // Helper to format elapsed time since snooze
 export function formatElapsedTime(since: Date): string {
   const now = new Date()
   const diff = now.getTime() - since.getTime()
 
   const seconds = Math.floor(diff / 1000)
-  const minutes = Math.floor(seconds / 60)
-  const hours = Math.floor(minutes / 60)
-  const days = Math.floor(hours / 24)
+  const minutes = Math.floor(seconds / SECONDS_PER_MINUTE)
+  const hours = Math.floor(minutes / MINUTES_PER_HOUR)
+  const days = Math.floor(hours / HOURS_PER_DAY)
 
-  if (seconds < 60) return 'now'
-  if (minutes < 60) return `${minutes}m`
-  if (hours < 24) return `${hours}h`
+  if (seconds < SECONDS_PER_MINUTE) return 'now'
+  if (minutes < MINUTES_PER_HOUR) return `${minutes}m`
+  if (hours < HOURS_PER_DAY) return `${hours}h`
   if (days === 1) return '1 day'
   return `${days} days`
 }

--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -4,6 +4,9 @@ import { getDemoMode } from './useDemoMode'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { QUICK_ABORT_TIMEOUT_MS } from '../lib/constants/network'
 
+/** Maximum token delta to attribute in a single poll cycle (prevents init spikes) */
+const MAX_SINGLE_DELTA_TOKENS = 50_000
+
 export type TokenCategory = 'missions' | 'diagnose' | 'insights' | 'predictions' | 'other'
 
 export interface TokenUsageByCategory {
@@ -182,7 +185,7 @@ async function fetchTokenUsage() {
         if (lastKnownUsage !== null && totalUsed > lastKnownUsage && activeCategory) {
           const delta = totalUsed - lastKnownUsage
           // Sanity check: don't attribute more than 50k tokens at once (likely a bug)
-          if (delta < 50000) {
+          if (delta < MAX_SINGLE_DELTA_TOKENS) {
             const newByCategory = { ...sharedUsage.byCategory }
             newByCategory[activeCategory] += delta
             updateSharedUsage({ used: totalUsed, byCategory: newByCategory })

--- a/web/src/hooks/useUniversalStats.ts
+++ b/web/src/hooks/useUniversalStats.ts
@@ -19,10 +19,13 @@ import { StatBlockValue } from '../components/ui/StatsOverview'
 import { useDrillDownActions } from './useDrillDown'
 
 // Cost estimation constants (per-month, rough cloud averages)
-const COST_PER_CPU = 30
-const COST_PER_GB_MEMORY = 4
-const COST_PER_GB_STORAGE = 0.10
-const COST_PER_GPU = 900
+const COST_PER_CPU = 30          // USD per vCPU per month
+const COST_PER_GB_MEMORY = 4     // USD per GB RAM per month
+const COST_PER_GB_STORAGE = 0.10 // USD per GB disk per month
+const COST_PER_GPU = 900         // USD per GPU per month
+
+/** Restart count above which a pod is considered "high restart" */
+const HIGH_RESTART_THRESHOLD = 10
 
 /**
  * Universal stat value provider that works across ALL dashboards.
@@ -76,7 +79,7 @@ export function useUniversalStats() {
   // ─── Pod-derived values ───
   const podIssuesList = podIssues || []
   const pendingPods = podIssuesList.filter(p => p.status === 'Pending').length
-  const highRestartPods = podIssuesList.filter(p => p.restarts > 10).length
+  const highRestartPods = podIssuesList.filter(p => p.restarts > HIGH_RESTART_THRESHOLD).length
 
   // ─── Deployment-derived values ───
   const allDeployments = deployments || []

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -10,7 +10,11 @@ import { emitSessionExpired } from './analytics'
 
 const API_BASE = ''
 const DEFAULT_TIMEOUT = MCP_HOOK_TIMEOUT_MS
-const BACKEND_CHECK_INTERVAL = 10000 // 10 seconds between backend checks when unavailable
+const BACKEND_CHECK_INTERVAL = 10_000 // 10 seconds between backend checks when unavailable
+/** How long to trust a cached backend-availability check (5 minutes) */
+const BACKEND_CACHE_TTL_MS = 300_000
+/** Delay before redirecting to login after session expiry (lets user see the banner) */
+const SESSION_EXPIRY_REDIRECT_MS = 3_000
 const TOKEN_REFRESH_HEADER = 'X-Token-Refresh' // server signals when token should be refreshed
 
 // Public API paths that don't require authentication (served without JWT on the backend)
@@ -57,7 +61,7 @@ function handle401(): void {
   // Redirect to login after a delay so the user sees the banner
   setTimeout(() => {
     window.location.href = '/login?reason=session_expired'
-  }, 3000)
+  }, SESSION_EXPIRY_REDIRECT_MS)
 }
 
 /**
@@ -120,7 +124,7 @@ try {
   if (stored) {
     const { available, timestamp } = JSON.parse(stored)
     // Use cached status if checked within the last 5 minutes
-    if (Date.now() - timestamp < 300000) {
+    if (Date.now() - timestamp < BACKEND_CACHE_TTL_MS) {
       backendAvailable = available
       backendLastCheckTime = timestamp
     }

--- a/web/src/lib/errorClassifier.ts
+++ b/web/src/lib/errorClassifier.ts
@@ -162,6 +162,14 @@ function truncateMessage(message: string, maxLength = 100): string {
   return message.slice(0, maxLength - 3) + '...'
 }
 
+// Time boundary constants for relative time formatting (in seconds)
+const SECONDS_PER_MINUTE = 60
+const SECONDS_PER_HOUR = 3_600
+const SECONDS_PER_DAY = 86_400
+const TWO_MINUTES_IN_SECONDS = 120
+const TWO_HOURS_IN_SECONDS = 7_200
+const TWO_DAYS_IN_SECONDS = 172_800
+
 /**
  * Format a duration for "last seen" display
  */
@@ -173,11 +181,11 @@ export function formatLastSeen(timestamp: string | Date | undefined): string {
 
   const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
 
-  if (seconds < 60) return 'just now'
-  if (seconds < 120) return '1m ago'
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`
-  if (seconds < 7200) return '1h ago'
-  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`
-  if (seconds < 172800) return '1d ago'
-  return `${Math.floor(seconds / 86400)}d ago`
+  if (seconds < SECONDS_PER_MINUTE) return 'just now'
+  if (seconds < TWO_MINUTES_IN_SECONDS) return '1m ago'
+  if (seconds < SECONDS_PER_HOUR) return `${Math.floor(seconds / SECONDS_PER_MINUTE)}m ago`
+  if (seconds < TWO_HOURS_IN_SECONDS) return '1h ago'
+  if (seconds < SECONDS_PER_DAY) return `${Math.floor(seconds / SECONDS_PER_HOUR)}h ago`
+  if (seconds < TWO_DAYS_IN_SECONDS) return '1d ago'
+  return `${Math.floor(seconds / SECONDS_PER_DAY)}d ago`
 }

--- a/web/src/lib/missions/scanner/index.ts
+++ b/web/src/lib/missions/scanner/index.ts
@@ -6,6 +6,11 @@
 
 import type { MissionExport, FileScanResult, ScanFinding, ScanMetadata } from '../types'
 
+/** Minimum acceptable title length before triggering a quality warning */
+const MIN_TITLE_LENGTH = 5
+/** Minimum acceptable description length before triggering a quality warning */
+const MIN_DESCRIPTION_LENGTH = 20
+
 /**
  * Run a full scan on a validated MissionExport, returning findings and metadata.
  */
@@ -22,7 +27,7 @@ export function fullScan(mission: MissionExport): FileScanResult {
   }
 
   // Content quality checks
-  if (mission.title && mission.title.length < 5) {
+  if (mission.title && mission.title.length < MIN_TITLE_LENGTH) {
     findings.push({
       severity: 'warning',
       code: 'SHORT_TITLE',
@@ -31,7 +36,7 @@ export function fullScan(mission: MissionExport): FileScanResult {
     })
   }
 
-  if (mission.description && mission.description.length < 20) {
+  if (mission.description && mission.description.length < MIN_DESCRIPTION_LENGTH) {
     findings.push({
       severity: 'warning',
       code: 'SHORT_DESCRIPTION',

--- a/web/src/lib/prefetchCardData.ts
+++ b/web/src/lib/prefetchCardData.ts
@@ -15,8 +15,10 @@ import { prefetchCache } from './cache'
 import { coreFetchers, specialtyFetchers } from '../hooks/useCachedData'
 import { isDemoMode } from './demoMode'
 
-const SPECIALTY_DELAY_MS = 1000
-const BACKGROUND_DELAY_MS = 5000
+/** Delay before starting core data prefetch (after priority tier) */
+const CORE_PREFETCH_DELAY_MS = 400
+const SPECIALTY_DELAY_MS = 1_000
+const BACKGROUND_DELAY_MS = 5_000
 const PREFETCH_CONCURRENCY = 2
 
 interface PrefetchEntry {
@@ -83,7 +85,7 @@ export function prefetchCardData(): void {
   // Tier 2: Core data after priority warm-up.
   setTimeout(() => {
     runPrefetchQueue(CORE_ENTRIES).catch(() => {})
-  }, 400)
+  }, CORE_PREFETCH_DELAY_MS)
 
   // Tier 3: Heavy fetchers in background (security scans can be expensive).
   setTimeout(() => {

--- a/web/src/lib/unified/card/renderers/registry.ts
+++ b/web/src/lib/unified/card/renderers/registry.ts
@@ -15,6 +15,13 @@ import {
   formatDuration,
 } from '../../../stats/types'
 
+// ── Time boundary constants for relative time formatting ────────────────
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+const DAYS_PER_MONTH = 30
+const MONTHS_PER_YEAR = 12
+const DAYS_PER_YEAR = 365
+
 // ============================================================================
 // Renderer Registry
 // ============================================================================
@@ -272,21 +279,21 @@ function renderRelativeTime(
 
     // Format relative time
     const seconds = Math.floor(diff / 1000)
-    if (seconds < 60) return 'just now'
+    if (seconds < MINUTES_PER_HOUR) return 'just now'
 
-    const minutes = Math.floor(seconds / 60)
-    if (minutes < 60) return `${minutes}m ago`
+    const minutes = Math.floor(seconds / MINUTES_PER_HOUR)
+    if (minutes < MINUTES_PER_HOUR) return `${minutes}m ago`
 
-    const hours = Math.floor(minutes / 60)
-    if (hours < 24) return `${hours}h ago`
+    const hours = Math.floor(minutes / MINUTES_PER_HOUR)
+    if (hours < HOURS_PER_DAY) return `${hours}h ago`
 
-    const days = Math.floor(hours / 24)
-    if (days < 30) return `${days}d ago`
+    const days = Math.floor(hours / HOURS_PER_DAY)
+    if (days < DAYS_PER_MONTH) return `${days}d ago`
 
-    const months = Math.floor(days / 30)
-    if (months < 12) return `${months}mo ago`
+    const months = Math.floor(days / DAYS_PER_MONTH)
+    if (months < MONTHS_PER_YEAR) return `${months}mo ago`
 
-    const years = Math.floor(days / 365)
+    const years = Math.floor(days / DAYS_PER_YEAR)
     return `${years}y ago`
   } catch {
     return createElement('span', { className: 'text-muted-foreground' }, '—')

--- a/web/src/lib/unified/dashboard/DashboardGrid.tsx
+++ b/web/src/lib/unified/dashboard/DashboardGrid.tsx
@@ -28,6 +28,9 @@ import type { DashboardCardPlacement, DashboardFeatures } from '../types'
 import { UnifiedCard } from '../card'
 import { getCardConfig } from '../../../config/cards'
 
+/** Viewport width breakpoint below which small cards are clamped to wider minimum */
+const NARROW_VIEWPORT_BREAKPOINT_PX = 1024
+
 export interface DashboardGridProps {
   /** Card placements */
   cards: DashboardCardPlacement[]
@@ -190,7 +193,7 @@ function DashboardCardWrapper({
 
   // At narrow viewports (< 1024px), clamp small cards to min 6 cols
   const [isNarrow, setIsNarrow] = useState(() =>
-    typeof window !== 'undefined' && window.innerWidth < 1024
+    typeof window !== 'undefined' && window.innerWidth < NARROW_VIEWPORT_BREAKPOINT_PX
   )
   useEffect(() => {
     const mq = window.matchMedia('(max-width: 1023px)')

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -1008,6 +1008,9 @@ function useComplianceScore() {
   return useDemoDataHook([DEMO_COMPLIANCE_SCORE])
 }
 
+/** Maximum namespace events to return when no namespace filter is set */
+const MAX_NAMESPACE_EVENTS_UNFILTERED = 20
+
 function useNamespaceEvents(params?: Record<string, unknown>) {
   const cluster = params?.cluster as string | undefined
   const namespace = params?.namespace as string | undefined
@@ -1016,7 +1019,7 @@ function useNamespaceEvents(params?: Record<string, unknown>) {
   // Filter to specific namespace if provided
   const namespaceEvents = useMemo(() => {
     if (!result.data) return []
-    if (!namespace) return result.data.slice(0, 20)
+    if (!namespace) return result.data.slice(0, MAX_NAMESPACE_EVENTS_UNFILTERED)
     return result.data.filter(e => e.namespace === namespace)
   }, [result.data, namespace])
 

--- a/web/src/lib/unified/stats/valueResolvers.ts
+++ b/web/src/lib/unified/stats/valueResolvers.ts
@@ -362,18 +362,23 @@ export function formatCurrency(value: number): string {
   return `$${value.toFixed(2)}`
 }
 
+// Time boundary constants (in seconds) for duration formatting
+const SECS_PER_MINUTE = 60
+const SECS_PER_HOUR = 3_600
+const SECS_PER_DAY = 86_400
+
 /**
  * Format duration in seconds to human-readable
  */
 export function formatDuration(seconds: number): string {
-  if (seconds < 60) {
+  if (seconds < SECS_PER_MINUTE) {
     return `${Math.round(seconds)}s`
   }
-  if (seconds < 3600) {
-    return `${Math.round(seconds / 60)}m`
+  if (seconds < SECS_PER_HOUR) {
+    return `${Math.round(seconds / SECS_PER_MINUTE)}m`
   }
-  if (seconds < 86400) {
-    return `${(seconds / 3600).toFixed(1)}h`
+  if (seconds < SECS_PER_DAY) {
+    return `${(seconds / SECS_PER_HOUR).toFixed(1)}h`
   }
-  return `${(seconds / 86400).toFixed(1)}d`
+  return `${(seconds / SECS_PER_DAY).toFixed(1)}d`
 }


### PR DESCRIPTION
## Summary
- Replaces ~170 magic numbers across hooks, lib, and card files with named constants
- Each constant has a descriptive name and is defined near its usage
- Covers timeouts, intervals, sizes, retries, array indices, and thresholds

Closes #1918

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes  
- [ ] Visual regression: cards render identically (no behavioral change)