### PR TITLE
🌱 Move GitHub cards to top of CI/CD dashboard

### DIFF
--- a/web/src/config/dashboards/ci-cd.ts
+++ b/web/src/config/dashboards/ci-cd.ts
@@ -10,14 +10,15 @@ export const ciCdDashboardConfig: UnifiedDashboardConfig = {
   route: '/ci-cd',
   statsType: 'ci-cd',
   cards: [
-    // Top row: Prow overview cards
+    // Top row: GitHub integration
+    { id: 'github-ci-monitor-1', cardType: 'github_ci_monitor', title: 'GitHub CI Monitor', position: { w: 6, h: 4 } },
+    { id: 'github-activity-1', cardType: 'github_activity', title: 'GitHub Activity', position: { w: 5, h: 4 } },
+    // Second row: Prow overview cards
     { id: 'prow-status-1', cardType: 'prow_status', title: 'Prow Status', position: { w: 4, h: 3 } },
     { id: 'prow-jobs-1', cardType: 'prow_jobs', title: 'Prow Jobs', position: { w: 5, h: 4 } },
     { id: 'prow-ci-monitor-1', cardType: 'prow_ci_monitor', title: 'Prow CI Monitor', position: { w: 6, h: 4 } },
-    // Second row: History and GitHub integration
+    // Third row: History
     { id: 'prow-history-1', cardType: 'prow_history', title: 'Prow History', position: { w: 4, h: 3 } },
-    { id: 'github-ci-monitor-1', cardType: 'github_ci_monitor', title: 'GitHub CI Monitor', position: { w: 6, h: 4 } },
-    { id: 'github-activity-1', cardType: 'github_activity', title: 'GitHub Activity', position: { w: 5, h: 4 } },
   ],
   features: {
     dragDrop: true,


### PR DESCRIPTION
## Summary
- Moves GitHub CI Monitor and GitHub Activity cards from the bottom to the top of the CI/CD dashboard
- Prow cards shift to the second and third rows

## Context
These GitHub cards are the most relevant for users visiting the CI/CD dashboard — they should be immediately visible without scrolling.

## Note
Existing users who have customized their CI/CD dashboard layout (saved in localStorage) will keep their current arrangement. This change affects new users and reset layouts.

## Test plan
- [ ] Navigate to CI/CD dashboard — GitHub CI Monitor and GitHub Activity appear in the top row
- [ ] Prow Status, Prow Jobs, and Prow CI Monitor appear in the second row
- [ ] Prow History appears in the third row