### PR TITLE
✨ Context-aware CTA progression + update hint tooltip

### DIFF
--- a/web/src/components/dashboard/DemoToLocalCTA.tsx
+++ b/web/src/components/dashboard/DemoToLocalCTA.tsx
@@ -7,9 +7,10 @@
  */
 
 import { useState, useEffect, useRef } from 'react'
-import { Terminal, Copy, Check, X, Rocket } from 'lucide-react'
+import { Terminal, Copy, Check, X, Rocket, KeyRound, Code2 } from 'lucide-react'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
-import { isNetlifyDeployment, getDemoMode } from '../../lib/demoMode'
+import { DeveloperSetupDialog } from '../setup/DeveloperSetupDialog'
+import { isNetlifyDeployment, getDemoMode, hasRealToken } from '../../lib/demoMode'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
 import {
@@ -19,7 +20,6 @@ import {
 import { emitDemoToLocalShown, emitDemoToLocalActioned } from '../../lib/analytics'
 
 const NETLIFY_INSTALL_COMMAND = 'curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash'
-const AGENT_INSTALL_COMMAND = 'brew tap kubestellar/tap && brew install --head kc-agent && kc-agent'
 
 /** How many seconds the "Copied!" confirmation shows */
 const COPY_FEEDBACK_MS = 2000
@@ -33,12 +33,18 @@ export function DemoToLocalCTA() {
   )
   const [copied, setCopied] = useState(false)
   const [showSetupDialog, setShowSetupDialog] = useState(false)
+  const [showDevDialog, setShowDevDialog] = useState(false)
   const emittedRef = useRef(false)
-  const { status: agentStatus } = useLocalAgent()
+  const { isConnected } = useLocalAgent()
 
-  // Show on Netlify (demo site) or on localhost when agent is disconnected and in demo mode
-  const isLocalNoAgent = !isNetlifyDeployment && agentStatus === 'disconnected' && getDemoMode()
-  const shouldShow = (isNetlifyDeployment || isLocalNoAgent) && !dismissed && !hintsSuppressed
+  // Localhost without OAuth = user ran start.sh but hasn't configured GitHub OAuth yet
+  const isLocalNoOAuth = !isNetlifyDeployment && getDemoMode() && !hasRealToken()
+  // Localhost with OAuth + agent = fully set up, offer developer setup
+  const isLocalDeveloper = !isNetlifyDeployment && hasRealToken() && isConnected
+  const shouldShow =
+    (isNetlifyDeployment || isLocalNoOAuth || isLocalDeveloper) &&
+    !dismissed &&
+    !hintsSuppressed
 
   useEffect(() => {
     if (shouldShow && isNetlifyDeployment && !emittedRef.current) {
@@ -49,9 +55,6 @@ export function DemoToLocalCTA() {
 
   if (!shouldShow) return null
 
-  // Context-aware command and copy
-  const installCommand = isNetlifyDeployment ? NETLIFY_INSTALL_COMMAND : AGENT_INSTALL_COMMAND
-
   const handleDismiss = () => {
     setDismissed(true)
     safeSetItem(STORAGE_KEY_DEMO_CTA_DISMISSED, 'true')
@@ -59,7 +62,7 @@ export function DemoToLocalCTA() {
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(installCommand)
+      await navigator.clipboard.writeText(NETLIFY_INSTALL_COMMAND)
       setCopied(true)
       emitDemoToLocalActioned('copy_command')
       setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
@@ -75,11 +78,86 @@ export function DemoToLocalCTA() {
     }
   }
 
-  const handleDocs = () => {
-    emitDemoToLocalActioned('view_docs')
+  const handleSetupOAuth = () => {
+    emitDemoToLocalActioned('setup_oauth')
     setShowSetupDialog(true)
   }
 
+  const handleDevSetup = () => {
+    emitDemoToLocalActioned('developer_setup')
+    setShowDevDialog(true)
+  }
+
+  // ── State 3: Localhost with OAuth + agent — small developer link ──
+  if (isLocalDeveloper) {
+    return (
+      <>
+        <div className="mb-4 flex items-center gap-2 text-xs animate-in fade-in duration-300">
+          <Code2 className="w-3.5 h-3.5 text-emerald-400 flex-shrink-0" />
+          <button
+            onClick={handleDevSetup}
+            className="text-emerald-400 hover:text-emerald-300 transition-colors"
+          >
+            Developer setup &amp; advanced options
+          </button>
+          <button
+            onClick={handleDismiss}
+            className="p-0.5 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors flex-shrink-0 ml-auto"
+            aria-label="Dismiss"
+          >
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+        <DeveloperSetupDialog
+          isOpen={showDevDialog}
+          onClose={() => setShowDevDialog(false)}
+        />
+      </>
+    )
+  }
+
+  // ── State 2: Localhost without OAuth — prompt to set up GitHub OAuth ──
+  if (isLocalNoOAuth) {
+    return (
+      <div className="mb-4 rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-500/5 via-blue-500/5 to-transparent p-4 animate-in slide-in-from-top-2 duration-300">
+        <div className="flex items-start justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <KeyRound className="w-4 h-4 text-purple-400" />
+            <div>
+              <h3 className="text-sm font-semibold text-foreground">
+                Set up GitHub OAuth to sign in
+              </h3>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                You&apos;re viewing demo data &mdash; configure GitHub OAuth to authenticate and connect your clusters
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={handleDismiss}
+            className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+            aria-label="Dismiss"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+
+        <button
+          onClick={handleSetupOAuth}
+          className="flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 text-sm font-medium transition-colors"
+        >
+          <Rocket className="w-4 h-4" />
+          Setup Guide
+        </button>
+
+        <SetupInstructionsDialog
+          isOpen={showSetupDialog}
+          onClose={() => setShowSetupDialog(false)}
+        />
+      </div>
+    )
+  }
+
+  // ── State 1: Netlify — prompt to install locally ──
   return (
     <div className="mb-4 rounded-xl border border-blue-500/20 bg-gradient-to-br from-blue-500/5 via-cyan-500/5 to-transparent p-4 animate-in slide-in-from-top-2 duration-300">
       <div className="flex items-start justify-between mb-3">
@@ -87,12 +165,10 @@ export function DemoToLocalCTA() {
           <Terminal className="w-4 h-4 text-blue-400" />
           <div>
             <h3 className="text-sm font-semibold text-foreground">
-              {isLocalNoAgent ? 'Connect your clusters' : 'Install KubeStellar Console locally to connect your clusters'}
+              Install KubeStellar Console locally to connect your clusters
             </h3>
             <p className="text-xs text-muted-foreground mt-0.5">
-              {isLocalNoAgent
-                ? 'Install and run kc-agent to connect your real clusters'
-                : 'You\u0027re viewing demo data \u2014 install locally to monitor your real clusters'}
+              You&apos;re viewing demo data &mdash; install locally to monitor your real clusters
             </p>
           </div>
         </div>
@@ -111,7 +187,7 @@ export function DemoToLocalCTA() {
           data-install-command
           className="flex-1 px-3 py-2 text-xs font-mono bg-secondary/50 rounded-lg border border-border/50 text-foreground overflow-x-auto whitespace-nowrap"
         >
-          {installCommand}
+          {NETLIFY_INSTALL_COMMAND}
         </code>
         <button
           onClick={handleCopy}
@@ -128,10 +204,10 @@ export function DemoToLocalCTA() {
 
       <div className="flex items-center gap-3 text-xs">
         <span className="text-muted-foreground">
-          Requires macOS, Linux, or WSL with Homebrew
+          Requires macOS, Linux, or WSL
         </span>
         <button
-          onClick={handleDocs}
+          onClick={handleSetupOAuth}
           className="flex items-center gap-1 text-blue-400 hover:text-blue-300 transition-colors"
         >
           Full setup guide <Rocket className="w-3 h-3" />

--- a/web/src/components/layout/navbar/UpdateIndicator.tsx
+++ b/web/src/components/layout/navbar/UpdateIndicator.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Download } from 'lucide-react'
 import { useVersionCheck } from '../../../hooks/useVersionCheck'
+import { useFeatureHints } from '../../../hooks/useFeatureHints'
+import { FeatureHintTooltip } from '../../ui/FeatureHintTooltip'
 import { getSettingsWithHash } from '../../../config/routes'
 
 export function UpdateIndicator() {
@@ -11,6 +13,7 @@ export function UpdateIndicator() {
   const { hasUpdate, latestRelease, channel, autoUpdateStatus, latestMainSHA, skipVersion } = useVersionCheck()
   const [showUpdateDropdown, setShowUpdateDropdown] = useState(false)
   const updateRef = useRef<HTMLDivElement>(null)
+  const updateHint = useFeatureHints('update-available')
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -42,13 +45,25 @@ export function UpdateIndicator() {
   return (
     <div className="relative" ref={updateRef}>
       <button
-        onClick={() => setShowUpdateDropdown(!showUpdateDropdown)}
+        onClick={() => {
+          setShowUpdateDropdown(!showUpdateDropdown)
+          updateHint.action()
+        }}
         className="flex items-center gap-2 px-2 py-1.5 rounded-lg bg-green-500/10 text-green-400 hover:bg-green-500/20 transition-colors"
         title={isDeveloperUpdate ? updateLabel : t('update.availableTag', { tag: latestRelease?.tag ?? '' })}
       >
         <Download className="w-4 h-4" />
         <span className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
       </button>
+
+      {/* First-time hint: show users how to update */}
+      {updateHint.isVisible && !showUpdateDropdown && (
+        <FeatureHintTooltip
+          message="An update is available — click here to see what's new and how to update"
+          onDismiss={updateHint.dismiss}
+          placement="bottom"
+        />
+      )}
 
       {showUpdateDropdown && (
         <div className="absolute top-full right-0 mt-2 w-64 bg-card border border-border rounded-lg shadow-xl z-50">

--- a/web/src/hooks/useFeatureHints.ts
+++ b/web/src/hooks/useFeatureHints.ts
@@ -9,6 +9,7 @@
  *   - 'card-drag' — "Drag cards to reorder" near card grid
  *   - 'missions'  — "Try AI Missions" near missions toggle
  *   - 'fab-add'   — shimmer ring on the floating "+" button
+ *   - 'update-available' — "Click to update" near update indicator
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react'
@@ -23,7 +24,12 @@ import {
 } from '../lib/analytics'
 import { safeGetJSON, safeSetJSON, safeGetItem } from '../lib/utils/localStorage'
 
-export type FeatureHintType = 'cmd-k' | 'card-drag' | 'missions' | 'fab-add'
+export type FeatureHintType =
+  | 'cmd-k'
+  | 'card-drag'
+  | 'missions'
+  | 'fab-add'
+  | 'update-available'
 
 /** Auto-dismiss feature hints after this duration (ms) */
 const FEATURE_HINT_AUTO_DISMISS_MS = 8_000


### PR DESCRIPTION
## Summary
- **DemoToLocalCTA** now has three context-aware states forming a natural progression:
  1. **Netlify** (console.kubestellar.io): Blue banner with curl install command
  2. **Localhost without OAuth**: Purple banner with OAuth setup guide button
  3. **Localhost with OAuth + agent**: Small emerald link to Developer Setup dialog
- **UpdateIndicator** shows a one-time `FeatureHintTooltip` when an update first appears, guiding users to click for details. Auto-dismisses after 8s or on interaction.

## Files changed
- `web/src/components/dashboard/DemoToLocalCTA.tsx` — Three-state CTA with progressive disclosure
- `web/src/components/layout/navbar/UpdateIndicator.tsx` — Feature hint on first update
- `web/src/hooks/useFeatureHints.ts` — Added `update-available` hint type

## Test plan
- [ ] Visit console.kubestellar.io → see blue curl install banner
- [ ] Run locally without OAuth → see purple OAuth setup banner
- [ ] Run locally with OAuth + agent → see small emerald developer link
- [ ] Dismiss any CTA → stays dismissed (localStorage)
- [ ] When update is available → see hint tooltip below update button
- [ ] Click update button → hint dismissed permanently
- [ ] Hint auto-dismisses after 8 seconds if not interacted with