### PR TITLE
✨ Add adopter nudge — prompt engaged users to join ADOPTERS.MD

### DIFF
--- a/web/src/components/dashboard/AdopterNudge.tsx
+++ b/web/src/components/dashboard/AdopterNudge.tsx
@@ -1,0 +1,109 @@
+/**
+ * Adopter Nudge — shown after a user has been using the console for 3+ days.
+ *
+ * Prompts engaged users to add their company/project to ADOPTERS.MD.
+ * Only shows for localhost users who have connected kc-agent at least
+ * ADOPTER_NUDGE_DELAY_DAYS ago.
+ */
+
+import { useState, useEffect, useRef } from 'react'
+import { Heart, ExternalLink, X } from 'lucide-react'
+import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
+import {
+  STORAGE_KEY_ADOPTER_NUDGE_DISMISSED,
+  STORAGE_KEY_FIRST_AGENT_CONNECT,
+  STORAGE_KEY_HINTS_SUPPRESSED,
+} from '../../lib/constants/storage'
+import {
+  emitAdopterNudgeShown,
+  emitAdopterNudgeActioned,
+  emitConversionStep,
+} from '../../lib/analytics'
+import { isNetlifyDeployment } from '../../lib/demoMode'
+
+const ADOPTERS_EDIT_URL =
+  'https://github.com/kubestellar/console/edit/main/ADOPTERS.MD'
+
+/** Number of days after first agent connection before showing the nudge */
+const ADOPTER_NUDGE_DELAY_DAYS = 3
+const MS_PER_DAY = 86_400_000
+
+export function AdopterNudge() {
+  const { isConnected } = useLocalAgent()
+  const [dismissed, setDismissed] = useState(
+    () => safeGetItem(STORAGE_KEY_ADOPTER_NUDGE_DISMISSED) === 'true'
+  )
+  const [hintsSuppressed] = useState(
+    () => safeGetItem(STORAGE_KEY_HINTS_SUPPRESSED) === 'true'
+  )
+  const emittedRef = useRef(false)
+
+  // Check if enough time has passed since first agent connection
+  const firstConnect = safeGetItem(STORAGE_KEY_FIRST_AGENT_CONNECT)
+  const daysSinceFirstConnect = firstConnect
+    ? (Date.now() - parseInt(firstConnect, 10)) / MS_PER_DAY
+    : 0
+
+  const shouldShow =
+    !isNetlifyDeployment &&
+    isConnected &&
+    !dismissed &&
+    !hintsSuppressed &&
+    daysSinceFirstConnect >= ADOPTER_NUDGE_DELAY_DAYS
+
+  useEffect(() => {
+    if (shouldShow && !emittedRef.current) {
+      emittedRef.current = true
+      emitAdopterNudgeShown()
+    }
+  }, [shouldShow])
+
+  if (!shouldShow) return null
+
+  const handleDismiss = () => {
+    setDismissed(true)
+    safeSetItem(STORAGE_KEY_ADOPTER_NUDGE_DISMISSED, 'true')
+  }
+
+  const handleAddOrg = () => {
+    emitAdopterNudgeActioned('add_org')
+    emitConversionStep(7, 'adopter_cta')
+    window.open(ADOPTERS_EDIT_URL, '_blank', 'noopener')
+    handleDismiss()
+  }
+
+  return (
+    <div className="mb-4 rounded-xl border border-pink-500/20 bg-gradient-to-br from-pink-500/5 via-rose-500/5 to-transparent p-4 animate-in slide-in-from-top-2 duration-300">
+      <div className="flex items-start justify-between">
+        <div className="flex items-start gap-3">
+          <div className="p-2 rounded-lg bg-pink-500/10 flex-shrink-0 mt-0.5">
+            <Heart className="w-4 h-4 text-pink-400" />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-foreground">
+              Enjoying KubeStellar Console?
+            </h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Add your company or project to our adopters list and help grow the community.
+            </p>
+            <button
+              onClick={handleAddOrg}
+              className="mt-2 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-pink-500/10 border border-pink-500/20 text-pink-400 hover:bg-pink-500/20 hover:text-pink-300 text-xs font-medium transition-all"
+            >
+              Add your organization
+              <ExternalLink className="w-3 h-3" />
+            </button>
+          </div>
+        </div>
+        <button
+          onClick={handleDismiss}
+          className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors flex-shrink-0"
+          aria-label="Dismiss"
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -49,6 +49,7 @@ import { useDashboardReset } from '../../hooks/useDashboardReset'
 import { WelcomeCard } from './WelcomeCard'
 import { SmartCardSuggestions } from './SmartCardSuggestions'
 import { PostConnectBanner } from './PostConnectBanner'
+import { AdopterNudge } from './AdopterNudge'
 import { DemoToLocalCTA } from './DemoToLocalCTA'
 import { ContextualNudgeBanner } from './ContextualNudgeBanner'
 import { DiscoverCardsPlaceholder } from './DiscoverCardsPlaceholder'
@@ -917,6 +918,9 @@ export function Dashboard() {
         onExploreClusters={() => navigate(ROUTES.CLUSTERS)}
         onSetupAlerts={() => navigate(ROUTES.ALERTS)}
       />
+
+      {/* Adopter nudge — shows after 3+ days of usage to encourage ADOPTERS.MD contribution */}
+      <AdopterNudge />
 
       {/* Contextual nudge banner — replaces traditional tour */}
       {activeNudge && activeNudge !== 'drag-hint' && (

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -3,6 +3,8 @@ import { isDemoModeForced } from './useDemoMode'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, TRANSITION_DELAY_MS } from '../lib/constants/network'
 import { emitAgentConnected, emitAgentDisconnected, emitConversionStep } from '../lib/analytics'
+import { safeGetItem, safeSetItem } from '../lib/utils/localStorage'
+import { STORAGE_KEY_FIRST_AGENT_CONNECT } from '../lib/constants/storage'
 
 export interface AgentHealth {
   status: string
@@ -236,6 +238,10 @@ class AgentManager {
             error: null,
           })
           emitAgentConnected(data.version || 'unknown', data.clusters || 0)
+          // Stamp the first-ever agent connection for time-based nudges
+          if (!safeGetItem(STORAGE_KEY_FIRST_AGENT_CONNECT)) {
+            safeSetItem(STORAGE_KEY_FIRST_AGENT_CONNECT, String(Date.now()))
+          }
           emitConversionStep(3, 'agent', { agent_version: data.version || 'unknown' })
           if ((data.clusters || 0) > 0) {
             emitConversionStep(4, 'clusters', { cluster_count: String(data.clusters) })

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -552,6 +552,7 @@ export function emitApiKeyRemoved(provider: string) {
 //   4 = clusters      (real clusters detected)
 //   5 = api_key       (AI API key configured)
 //   6 = github_token  (GitHub token configured)
+//   7 = adopter_cta   (clicked "Join Adopters" to edit ADOPTERS.MD)
 
 export function emitConversionStep(
   step: number,
@@ -803,6 +804,18 @@ export function emitDemoToLocalShown() {
 /** Fired when a demo-site visitor clicks the install CTA */
 export function emitDemoToLocalActioned(action: string) {
   send('ksc_demo_to_local_actioned', { action })
+}
+
+// ── Adopter Nudge ─────────────────────────────────────────────────
+
+/** Fired when the adopter nudge banner renders */
+export function emitAdopterNudgeShown() {
+  send('ksc_adopter_nudge_shown')
+}
+
+/** Fired when user clicks the adopter nudge CTA */
+export function emitAdopterNudgeActioned(action: string) {
+  send('ksc_adopter_nudge_actioned', { action })
 }
 
 // ── UTM Tracking ───────────────────────────────────────────────────

--- a/web/src/lib/constants/storage.ts
+++ b/web/src/lib/constants/storage.ts
@@ -53,6 +53,8 @@ export const STORAGE_KEY_GETTING_STARTED_DISMISSED = 'kc-getting-started-dismiss
 export const STORAGE_KEY_HINTS_SUPPRESSED = 'kc-hints-suppressed'
 export const STORAGE_KEY_POST_CONNECT_DISMISSED = 'kc-post-connect-dismissed'
 export const STORAGE_KEY_DEMO_CTA_DISMISSED = 'kc-demo-cta-dismissed'
+export const STORAGE_KEY_ADOPTER_NUDGE_DISMISSED = 'kc-adopter-nudge-dismissed'
+export const STORAGE_KEY_FIRST_AGENT_CONNECT = 'kc-first-agent-connect'
 
 // ── Component-specific cache ───────────────────────────────────────────
 export const STORAGE_KEY_OPA_CACHE = 'opa-statuses-cache'


### PR DESCRIPTION
## Summary
- Adds a time-delayed nudge banner that appears after 3+ days of connected agent usage
- Prompts users: "Enjoying KubeStellar Console? Add your company or project to our adopters list"
- Clicking "Add your organization" opens the GitHub edit page for `ADOPTERS.MD` in a new tab
- Tracks conversion step 7 (`adopter_cta`) in GA4 funnel

## How it works
1. On first agent connection, `kc-first-agent-connect` timestamp is saved to localStorage
2. After 3+ days (`ADOPTER_NUDGE_DELAY_DAYS`), the `AdopterNudge` banner appears on the main dashboard
3. User can dismiss permanently (X button) or click through to GitHub
4. Respects the master "hints suppressed" toggle in settings

## Files changed
| File | Change |
|------|--------|
| `AdopterNudge.tsx` | **New** — the nudge banner component |
| `Dashboard.tsx` | Import + render AdopterNudge after PostConnectBanner |
| `useLocalAgent.ts` | Stamp first-connect timestamp on initial connection |
| `analytics.ts` | Add `emitAdopterNudgeShown/Actioned` + conversion step 7 |
| `storage.ts` | Add `STORAGE_KEY_ADOPTER_NUDGE_DISMISSED` and `STORAGE_KEY_FIRST_AGENT_CONNECT` |

## GA4 events
- `ksc_adopter_nudge_shown` — banner rendered
- `ksc_adopter_nudge_actioned` — user clicked "Add your organization"
- `ksc_conversion_step` step=7, step_name=`adopter_cta`

## Test plan
- [ ] Clear localStorage, connect agent, verify nudge does NOT appear (< 3 days)
- [ ] Set `kc-first-agent-connect` to 4 days ago in localStorage, reload — nudge appears
- [ ] Click "Add your organization" — opens GitHub edit page for ADOPTERS.MD
- [ ] Dismiss via X — does not reappear on reload
- [ ] Toggle "hints suppressed" in settings — nudge hidden