### PR TITLE
📖 Add mermaid architecture diagram back to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ To enable feedback and GitHub-powered features (nightly E2E status, community ac
 
 ## Architecture
 
+```mermaid
+graph LR
+    A["KubeStellar Console"] --> B["30+ Dashboards<br/>150+ Monitoring Cards"]
+    A --> M["Marketplace<br/>(console-marketplace)"]
+    A --> D["AI Mission Explorer"]
+    D --> E["console-kb"]
+    E --> F["186 Install Missions<br/>67 Solution Missions"]
+    A --> C["AI Recommendations"]
+    A --> H["kc-agent → Codex, Copilot,<br/>Claude CLI, Kube API, MCP"]
+    click A href "https://console.kubestellar.io" _blank
+    click M href "https://github.com/kubestellar/console-marketplace" _blank
+    click E href "https://github.com/kubestellar/console-kb" _blank
+    click H href "https://github.com/kubestellar/console/tree/main/cmd/kc-agent" _blank
+```
+
 - **[console-kb](https://github.com/kubestellar/console-kb)** — Knowledge base of guided installers for 250+ CNCF projects and solutions to common Kubernetes problems
 - **[console-marketplace](https://github.com/kubestellar/console-marketplace)** — Community-contributed monitoring cards per CNCF project
 - **[kc-agent](cmd/kc-agent/)** — Local agent bridging the browser to kubeconfig, coding agents (Codex, Copilot, Claude CLI), and MCP servers (`kubestellar-ops`, `kubestellar-deploy`)


### PR DESCRIPTION
Restores the mermaid architecture graph showing console-kb, marketplace, kc-agent, and AI components.