### PR TITLE
🌱 Replace non-standard emerald/rose/gray-800 with design system tokens

### DIFF
--- a/web/src/components/cards/ClusterGroups.tsx
+++ b/web/src/components/cards/ClusterGroups.tsx
@@ -666,7 +666,7 @@ function CreateGroupForm({ availableClusters, clusterHealthMap, onSave, onCancel
               className={cn(
                 'w-full flex items-center justify-center gap-1.5 py-1.5 text-xs font-medium rounded-md transition-colors',
                 (!labelSelector.trim() && filters.length === 0)
-                  ? 'bg-gray-800 text-gray-600 cursor-not-allowed'
+                  ? 'bg-secondary text-muted-foreground cursor-not-allowed'
                   : 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30'
               )}
             >
@@ -695,7 +695,7 @@ function CreateGroupForm({ availableClusters, clusterHealthMap, onSave, onCancel
             ? kind === 'dynamic'
               ? 'bg-purple-500 text-white hover:bg-purple-600'
               : 'bg-blue-500 text-white hover:bg-blue-600'
-            : 'bg-gray-800 text-gray-600 cursor-not-allowed'
+            : 'bg-secondary text-muted-foreground cursor-not-allowed'
         )}
       >
         {kind === 'dynamic' ? t('cards:clusterGroups.createDynamicGroup') : t('cards:clusterGroups.createGroup')}
@@ -958,7 +958,7 @@ function AIAssistant({
         className={cn(
           'w-full flex items-center justify-center gap-1.5 py-1.5 text-xs font-medium rounded-md transition-colors',
           loading || !prompt.trim()
-            ? 'bg-gray-800 text-gray-600 cursor-not-allowed'
+            ? 'bg-secondary text-muted-foreground cursor-not-allowed'
             : 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30'
         )}
       >
@@ -1123,7 +1123,7 @@ function EditGroupForm({ group, availableClusters, clusterHealthMap, onSave, onC
             className={cn(
               'w-full flex items-center justify-center gap-1.5 py-1.5 text-xs font-medium rounded-md transition-colors',
               (!labelSelector.trim() && filters.length === 0)
-                ? 'bg-gray-800 text-gray-600 cursor-not-allowed'
+                ? 'bg-secondary text-muted-foreground cursor-not-allowed'
                 : 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30'
             )}
           >

--- a/web/src/components/dashboard/AdopterNudge.tsx
+++ b/web/src/components/dashboard/AdopterNudge.tsx
@@ -74,7 +74,7 @@ export function AdopterNudge() {
   }
 
   return (
-    <div className="mb-4 rounded-xl border border-pink-500/20 bg-gradient-to-br from-pink-500/5 via-rose-500/5 to-transparent p-4 animate-in slide-in-from-top-2 duration-300">
+    <div className="mb-4 rounded-xl border border-pink-500/20 bg-gradient-to-br from-pink-500/5 via-pink-500/5 to-transparent p-4 animate-in slide-in-from-top-2 duration-300">
       <div className="flex items-start justify-between">
         <div className="flex items-start gap-3">
           <div className="p-2 rounded-lg bg-pink-500/10 flex-shrink-0 mt-0.5">

--- a/web/src/components/dashboard/DemoToLocalCTA.tsx
+++ b/web/src/components/dashboard/DemoToLocalCTA.tsx
@@ -93,10 +93,10 @@ export function DemoToLocalCTA() {
     return (
       <>
         <div className="mb-4 flex items-center gap-2 text-xs animate-in fade-in duration-300">
-          <Code2 className="w-3.5 h-3.5 text-emerald-400 flex-shrink-0" />
+          <Code2 className="w-3.5 h-3.5 text-green-400 flex-shrink-0" />
           <button
             onClick={handleDevSetup}
-            className="text-emerald-400 hover:text-emerald-300 transition-colors"
+            className="text-green-400 hover:text-green-300 transition-colors"
           >
             Developer setup &amp; advanced options
           </button>

--- a/web/src/components/dashboard/PostConnectBanner.tsx
+++ b/web/src/components/dashboard/PostConnectBanner.tsx
@@ -105,7 +105,7 @@ export function PostConnectBanner({
   ]
 
   return (
-    <div className="mb-4 rounded-xl border border-green-500/20 bg-gradient-to-br from-green-500/5 via-emerald-500/5 to-transparent p-4 animate-in slide-in-from-top-2 duration-300">
+    <div className="mb-4 rounded-xl border border-green-500/20 bg-gradient-to-br from-green-500/5 via-green-500/5 to-transparent p-4 animate-in slide-in-from-top-2 duration-300">
       <div className="flex items-start justify-between mb-3">
         <div className="flex items-center gap-2">
           <Rocket className="w-4 h-4 text-green-400" />


### PR DESCRIPTION
## Summary
- Replace `emerald-400/500` → `green-400/500` in PostConnectBanner and DemoToLocalCTA gradients/links
- Replace `rose-500` → `pink-500` in AdopterNudge gradient
- Replace `bg-gray-800 text-gray-600` → `bg-secondary text-muted-foreground` in ClusterGroups disabled button states (4 instances)

These were the last remaining non-standard Tailwind color tokens outside of game files.

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] PostConnectBanner gradient still looks green
- [ ] DemoToLocalCTA developer link still shows green
- [ ] AdopterNudge banner gradient still shows pink
- [ ] ClusterGroups disabled buttons render correctly with semantic tokens