### PR TITLE
🌱 Migrate remaining 62 inline badge spans to StatusBadge

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -265,9 +265,9 @@ export function ActiveAlerts() {
             {showAcknowledged ? <Eye className="w-3 h-3" /> : <EyeOff className="w-3 h-3" />}
             <span>{t('activeAlerts.ackd')}</span>
             {acknowledgedAlerts.length > 0 && (
-              <span className="ml-0.5 px-1 py-0 text-2xs rounded-full bg-green-500/30">
+              <StatusBadge color="green" size="xs" rounded="full" className="ml-0.5">
                 {acknowledgedAlerts.length}
-              </span>
+              </StatusBadge>
             )}
           </button>
           {/* 2. Cluster Filter */}

--- a/web/src/components/cards/ArgoCDApplications.tsx
+++ b/web/src/components/cards/ArgoCDApplications.tsx
@@ -4,6 +4,7 @@ import { ClusterBadge } from '../ui/ClusterBadge'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { Skeleton } from '../ui/Skeleton'
 import { useArgoCDApplications, useArgoCDTriggerSync, type ArgoApplication } from '../../hooks/useArgoCD'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import {
   useCardData,
@@ -180,9 +181,9 @@ function ArgoCDApplicationsInternal({ config }: ArgoCDApplicationsProps) {
       {/* Header with controls */}
       <div className="flex items-center justify-between mb-3 flex-shrink-0">
         <div className="flex items-center gap-2">
-          <span className="text-xs px-1.5 py-0.5 rounded bg-orange-500/20 text-orange-400">
+          <StatusBadge color="orange">
             {t('argoCDApplications.appsCount', { count: totalItems })}
-          </span>
+          </StatusBadge>
         </div>
         <div className="flex items-center gap-2">
           <CardControlsRow

--- a/web/src/components/cards/ClusterChangelog.tsx
+++ b/web/src/components/cards/ClusterChangelog.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCachedEvents } from '../../hooks/useCachedData'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 
 const CHANGE_REASONS = new Set([
@@ -108,7 +109,7 @@ export function ClusterChangelog() {
                       {event.reason}
                     </span>
                     {event.cluster && (
-                      <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-400">{event.cluster}</span>
+                      <StatusBadge color="purple">{event.cluster}</StatusBadge>
                     )}
                     {ts && <span className="text-xs text-muted-foreground">{formatTime(ts)}</span>}
                   </div>

--- a/web/src/components/cards/ClusterHealth.tsx
+++ b/web/src/components/cards/ClusterHealth.tsx
@@ -9,6 +9,7 @@ import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions }
 import { ClusterDetailModal } from '../clusters/ClusterDetailModal'
 import { CloudProviderIcon, detectCloudProvider, getProviderLabel, CloudProvider } from '../ui/CloudProviderIcon'
 import { isClusterUnreachable, isClusterTokenExpired } from '../clusters/utils'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -236,9 +237,9 @@ export function ClusterHealth() {
       {/* Header with controls */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400" title={t('clusterHealth.totalClustersTitle', { count: rawClusters.length })}>
+          <StatusBadge color="purple" title={t('clusterHealth.totalClustersTitle', { count: rawClusters.length })}>
             {rawClusters.length} {t('clusterHealth.clustersLabel')}
-          </span>
+          </StatusBadge>
         </div>
         <CardControlsRow
           clusterIndicator={

--- a/web/src/components/cards/DeploymentIssues.tsx
+++ b/web/src/components/cards/DeploymentIssues.tsx
@@ -6,6 +6,7 @@ import type { DeploymentIssue } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { LimitedAccessWarning } from '../ui/LimitedAccessWarning'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import {
@@ -151,9 +152,9 @@ function DeploymentIssuesInternal({ config }: DeploymentIssuesProps) {
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400" title={t('deploymentIssues.issuesTitle', { count: rawIssues.length })}>
+          <StatusBadge color="red" title={t('deploymentIssues.issuesTitle', { count: rawIssues.length })}>
             {t('deploymentIssues.nIssues', { count: rawIssues.length })}
-          </span>
+          </StatusBadge>
         </div>
         <CardControlsRow
           clusterIndicator={{
@@ -214,9 +215,9 @@ function DeploymentIssuesInternal({ config }: DeploymentIssuesProps) {
                   </div>
                   <p className="text-sm font-medium text-foreground truncate" title={issue.name}>{issue.name}</p>
                   <div className="flex items-center gap-2 mt-2 flex-wrap">
-                    <span className="text-xs px-2 py-0.5 rounded bg-red-500/20 text-red-400" title={`Issue: ${issue.reason || 'Unknown'}`}>
+                    <StatusBadge color="red" size="md" title={`Issue: ${issue.reason || 'Unknown'}`}>
                       {issue.reason || 'Issue'}
-                    </span>
+                    </StatusBadge>
                     <span className="text-xs text-muted-foreground" title={t('deploymentIssues.replicasReady', { ready: issue.readyReplicas, total: issue.replicas })}>
                       {issue.readyReplicas}/{issue.replicas} {t('common:common.ready')}
                     </span>

--- a/web/src/components/cards/GPUInventory.tsx
+++ b/web/src/components/cards/GPUInventory.tsx
@@ -9,6 +9,7 @@ import { Pagination } from '../ui/Pagination'
 import { Skeleton } from '../ui/Skeleton'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput } from '../../lib/cards/CardComponents'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -151,9 +152,9 @@ export function GPUInventory({ config }: GPUInventoryProps) {
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <span className="text-xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400">
+          <StatusBadge color="green">
             {t('gpuInventory.gpuCount', { count: stats.totalGPUs })}
-          </span>
+          </StatusBadge>
         </div>
         <div className="flex items-center gap-2">
           {/* Cluster count indicator */}

--- a/web/src/components/cards/GPUWorkloads.tsx
+++ b/web/src/components/cards/GPUWorkloads.tsx
@@ -8,6 +8,7 @@ import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { Skeleton } from '../ui/Skeleton'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import type { PodInfo } from '../../hooks/useMCP'
 import { useTranslation } from 'react-i18next'
@@ -223,9 +224,9 @@ export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
       {/* Controls */}
       <div className="flex items-center justify-between mb-3">
         {summary.failed > 0 ? (
-          <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400">
+          <StatusBadge color="red">
             {t('gpuWorkloads.failedCount', { count: summary.failed })}
-          </span>
+          </StatusBadge>
         ) : <div />}
         <div className="flex items-center gap-2">
           {/* Cluster count indicator */}

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -14,6 +14,7 @@ import {
 import { useCardLoadingState } from './CardDataContext'
 import type { SortDirection } from '../../lib/cards'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../ui/StatusBadge'
 
 // Types for GitHub activity data
 interface GitHubPR {
@@ -715,9 +716,9 @@ export const GitHubActivity = forwardRef<GitHubActivityRef, { config?: GitHubAct
       <div className="h-full flex flex-col content-loaded">
         {/* Header with inline repo editor */}
         <div className="flex items-center justify-between mb-3">
-          <span className="px-2 py-0.5 text-xs rounded-full bg-red-500/20 text-red-400 border border-red-500/30">
+          <StatusBadge color="red" variant="outline" rounded="full">
             {t('common:common.error')}
-          </span>
+          </StatusBadge>
           <button
             onClick={() => setIsEditingRepos(!isEditingRepos)}
             className={cn(
@@ -1134,10 +1135,10 @@ function PRItem({ pr }: { pr: GitHubPR }) {
               {statusText}
             </span>
             {pr.draft && (
-              <span className="text-xs px-2 py-0.5 rounded bg-gray-500/20 text-muted-foreground shrink-0">{t('cards:github.draft')}</span>
+              <StatusBadge color="gray" size="md" className="shrink-0">{t('cards:github.draft')}</StatusBadge>
             )}
             {isStaleItem && (
-              <span className="text-xs px-2 py-0.5 rounded bg-yellow-500/20 text-yellow-400 shrink-0">{t('cards:github.stale')}</span>
+              <StatusBadge color="yellow" size="md" className="shrink-0">{t('cards:github.stale')}</StatusBadge>
             )}
           </div>
           <div className="flex items-center gap-3 text-xs text-muted-foreground">
@@ -1194,7 +1195,7 @@ function IssueItem({ issue }: { issue: GitHubIssue }) {
               {isOpen ? t('cards:github.open') : t('cards:github.closed')}
             </span>
             {isStaleItem && (
-              <span className="text-xs px-2 py-0.5 rounded bg-yellow-500/20 text-yellow-400 shrink-0">{t('cards:github.stale')}</span>
+              <StatusBadge color="yellow" size="md" className="shrink-0">{t('cards:github.stale')}</StatusBadge>
             )}
           </div>
           <div className="flex items-center gap-3 text-xs text-muted-foreground">
@@ -1233,7 +1234,7 @@ function ReleaseItem({ release }: { release: GitHubRelease }) {
           <div className="flex items-center gap-2 mb-1">
             <span className="text-sm font-medium">{release.name || release.tag_name}</span>
             {release.prerelease && (
-              <span className="text-xs px-2 py-0.5 rounded bg-orange-500/20 text-orange-400">{t('cards:github.preRelease')}</span>
+              <StatusBadge color="orange" size="md">{t('cards:github.preRelease')}</StatusBadge>
             )}
           </div>
           <div className="flex items-center gap-3 text-xs text-muted-foreground">

--- a/web/src/components/cards/GitOpsDrift.tsx
+++ b/web/src/components/cards/GitOpsDrift.tsx
@@ -7,6 +7,7 @@ import { ClusterBadge } from '../ui/ClusterBadge'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { useCardData, CardClusterFilter, CardSearchInput } from '../../lib/cards'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -212,10 +213,9 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
             </span>
           )}
           {highSeverityCount > 0 && (
-            <span className="text-xs px-2 py-0.5 rounded bg-red-500/20 text-red-400 flex items-center gap-1">
-              <AlertTriangle className="w-3 h-3" />
+            <StatusBadge color="red" size="md" className="flex items-center gap-1" icon={<AlertTriangle className="w-3 h-3" />}>
               {t('gitOpsDrift.nCritical', { count: highSeverityCount })}
-            </span>
+            </StatusBadge>
           )}
           {totalDrifts > 0 && (
             <span className="text-xs px-2 py-0.5 rounded bg-secondary text-muted-foreground">

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../lib/cn'
 import { useCardLoadingState } from './CardDataContext'
 import { CardControlsRow, CardSearchInput, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedHardwareHealth, type DeviceAlert, type NodeDeviceInventory, type DeviceCounts } from '../../hooks/useCachedData'
@@ -775,19 +776,19 @@ export function HardwareHealthCard() {
                         )}
                         {/* Status indicators */}
                         {node.devices.sriovCapable && (
-                          <span className="px-1 py-0.5 text-[9px] bg-blue-500/20 text-blue-400 rounded">SR-IOV</span>
+                          <StatusBadge color="blue" size="xs">SR-IOV</StatusBadge>
                         )}
                         {node.devices.rdmaAvailable && (
-                          <span className="px-1 py-0.5 text-[9px] bg-purple-500/20 text-purple-400 rounded">RDMA</span>
+                          <StatusBadge color="purple" size="xs">RDMA</StatusBadge>
                         )}
                         {node.devices.mellanoxPresent && (
-                          <span className="px-1 py-0.5 text-[9px] bg-orange-500/20 text-orange-400 rounded">Mellanox</span>
+                          <StatusBadge color="orange" size="xs">Mellanox</StatusBadge>
                         )}
                         {node.devices.mofedReady && (
-                          <span className="px-1 py-0.5 text-[9px] bg-green-500/20 text-green-400 rounded">MOFED</span>
+                          <StatusBadge color="green" size="xs">MOFED</StatusBadge>
                         )}
                         {node.devices.gpuDriverReady && (
-                          <span className="px-1 py-0.5 text-[9px] bg-green-500/20 text-green-400 rounded">GPU Driver</span>
+                          <StatusBadge color="green" size="xs">GPU Driver</StatusBadge>
                         )}
                         {getTotalDevices(node.devices) === 0 && (
                           <span className="text-2xs text-muted-foreground italic">No devices detected</span>

--- a/web/src/components/cards/KubeKart.tsx
+++ b/web/src/components/cards/KubeKart.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { Play, RotateCcw, Pause, Trophy, Flag, Timer, Gauge } from 'lucide-react'
 
 import { useCardExpanded } from './CardWrapper'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 
@@ -584,9 +585,9 @@ export function KubeKart() {
               <h3 className="text-2xl font-bold text-blue-400 mb-2">Kube Kart</h3>
               <p className="text-sm text-muted-foreground mb-4">Arrow keys or WASD to drive</p>
               <div className="flex gap-2 mb-4 text-xs">
-                <span className="px-2 py-1 rounded bg-cyan-500/30 text-cyan-400">Boost</span>
-                <span className="px-2 py-1 rounded bg-purple-500/30 text-purple-400">Shield</span>
-                <span className="px-2 py-1 rounded bg-orange-500/30 text-orange-400">Slow Others</span>
+                <StatusBadge color="cyan" size="md">Boost</StatusBadge>
+                <StatusBadge color="purple" size="md">Shield</StatusBadge>
+                <StatusBadge color="orange" size="md">Slow Others</StatusBadge>
               </div>
               <button
                 onClick={startGame}

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -27,6 +27,7 @@ import {
   type SortDirection,
 } from '../../lib/cards'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../ui/StatusBadge'
 
 interface NamespaceQuotasProps {
   config?: {
@@ -579,9 +580,9 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400">
+          <StatusBadge color="yellow">
             {activeTab === 'quotas' ? `${totalQuotas} quotas` : `${totalLimits} limits`}
-          </span>
+          </StatusBadge>
         </div>
         <div className="flex items-center gap-2">
           <CardControlsRow
@@ -668,13 +669,13 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
         {/* Scope badge */}
         <div className="flex items-center gap-2 mb-4 min-w-0 overflow-hidden">
           {selectedCluster === 'all' ? (
-            <span className="text-xs px-2 py-0.5 rounded bg-blue-500/20 text-blue-400 shrink-0">All Clusters</span>
+            <StatusBadge color="blue" size="md" className="shrink-0">All Clusters</StatusBadge>
           ) : (
             <div className="shrink-0"><ClusterBadge cluster={selectedCluster} /></div>
           )}
           <span className="text-muted-foreground shrink-0">/</span>
           {selectedNamespace === 'all' ? (
-            <span className="text-xs px-2 py-0.5 rounded bg-purple-500/20 text-purple-400 shrink-0">All Namespaces</span>
+            <StatusBadge color="purple" size="md" className="shrink-0">All Namespaces</StatusBadge>
           ) : (
             <span className="text-sm text-foreground truncate min-w-0">{selectedNamespace}</span>
           )}
@@ -817,9 +818,9 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
                       <div className="flex items-center gap-2">
                         <Gauge className="w-4 h-4 text-blue-400" />
                         <span className="text-sm text-foreground">{item.name}</span>
-                        <span className="text-xs px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-400">
+                        <StatusBadge color="blue">
                           {item.type}
-                        </span>
+                        </StatusBadge>
                       </div>
                       <ChevronRight className="w-4 h-4 text-muted-foreground" />
                     </div>

--- a/web/src/components/cards/NodeConditions.tsx
+++ b/web/src/components/cards/NodeConditions.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCachedNodes } from '../../hooks/useCachedData'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useKubectl } from '../../hooks/useKubectl'
 
 type ConditionFilter = 'all' | 'healthy' | 'cordoned' | 'pressure'
@@ -131,7 +132,7 @@ export function NodeConditions() {
               </div>
               <div className="flex items-center gap-1 shrink-0">
                 {node.unschedulable && (
-                  <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/10 text-yellow-400">{t('nodeConditions.cordoned')}</span>
+                  <StatusBadge color="yellow">{t('nodeConditions.cordoned')}</StatusBadge>
                 )}
                 {pressures.map(p => (
                   <span key={p.type} className="text-xs px-1.5 py-0.5 rounded bg-red-500/10 text-red-400">

--- a/web/src/components/cards/OverlayComparison.tsx
+++ b/web/src/components/cards/OverlayComparison.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../ui/StatusBadge'
 
 interface OverlayComparisonProps {
   config?: {
@@ -134,9 +135,9 @@ export function OverlayComparison({ config }: OverlayComparisonProps) {
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
           {diffs.length > 0 && (
-            <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+            <StatusBadge color="purple">
               {diffs.length} changes
-            </span>
+            </StatusBadge>
           )}
         </div>
       </div>

--- a/web/src/components/cards/PodIssues.tsx
+++ b/web/src/components/cards/PodIssues.tsx
@@ -4,6 +4,7 @@ import type { PodIssue } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { LimitedAccessWarning } from '../ui/LimitedAccessWarning'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import {
   useCardData, commonComparators, getStatusColors,
@@ -127,9 +128,9 @@ export function PodIssues() {
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2">
-          <span className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400" title={`${rawIssues.length} pods with issues`}>
+          <StatusBadge color="red" title={`${rawIssues.length} pods with issues`}>
             {rawIssues.length} issues
-          </span>
+          </StatusBadge>
         </div>
         <CardControlsRow
           clusterIndicator={{

--- a/web/src/components/cards/PredictiveHealth.tsx
+++ b/web/src/components/cards/PredictiveHealth.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCachedNodes, useCachedPods } from '../../hooks/useCachedData'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 
 interface Prediction {
@@ -159,7 +160,7 @@ export function PredictiveHealth() {
                     </div>
                   </div>
                   <div className="flex flex-col items-end gap-0.5 shrink-0">
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-400">{pred.cluster}</span>
+                    <StatusBadge color="purple">{pred.cluster}</StatusBadge>
                     {pred.timeToExhaustion && (
                       <span className={`text-xs ${style.text}`}>{pred.timeToExhaustion}</span>
                     )}

--- a/web/src/components/cards/ProviderHealth.tsx
+++ b/web/src/components/cards/ProviderHealth.tsx
@@ -9,6 +9,7 @@ import { cn } from '../../lib/cn'
 import { useCardLoadingState } from './CardDataContext'
 import { ROUTES } from '../../config/routes'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useDemoMode } from '../../hooks/useDemoMode'
 
 const STATUS_COLORS: Record<ProviderHealthInfo['status'], string> = {
@@ -51,9 +52,9 @@ function ProviderRow({ provider, onConfigure }: { provider: ProviderHealthInfo; 
         <div className={cn('w-2 h-2 rounded-full', STATUS_COLORS[provider.status])} />
         <span className="text-xs text-muted-foreground">{String(t(STATUS_LABEL_KEYS[provider.status]))}</span>
         {!provider.configured && (
-          <span className="text-2xs text-yellow-500 bg-yellow-500/10 px-1.5 py-0.5 rounded-full font-medium">
+          <StatusBadge color="yellow" size="xs" rounded="full">
             {t('providerHealth.noKey')}
-          </span>
+          </StatusBadge>
         )}
       </div>
 

--- a/web/src/components/cards/RBACExplorer.tsx
+++ b/web/src/components/cards/RBACExplorer.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 
 interface RBACFinding {
@@ -67,7 +68,7 @@ export function RBACExplorer() {
                   <span className="text-sm font-medium truncate">{finding.subject}</span>
                   <span className="text-xs text-muted-foreground">({finding.subjectKind})</span>
                 </div>
-                <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-400 shrink-0">{finding.cluster}</span>
+                <StatusBadge color="purple" className="shrink-0">{finding.cluster}</StatusBadge>
               </div>
               <div className="text-xs text-muted-foreground mt-0.5">{finding.description}</div>
               <div className="text-xs text-muted-foreground/60 mt-0.5 truncate">{finding.binding}</div>

--- a/web/src/components/cards/UserManagement.tsx
+++ b/web/src/components/cards/UserManagement.tsx
@@ -24,6 +24,7 @@ import type { ConsoleUser, UserRole, OpenShiftUser } from '../../types/users'
 import { Skeleton } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../ui/StatusBadge'
 import { useToast } from '../ui/Toast'
 import { useDemoMode } from '../../hooks/useDemoMode'
 
@@ -753,9 +754,9 @@ function ClusterUsersTab({
                     <span className="text-muted-foreground text-xs">({user.fullName})</span>
                   )}
                   {showClusterBadge && (
-                    <span className="px-1.5 py-0.5 rounded text-xs bg-cyan-500/20 text-cyan-400 border border-cyan-500/30">
+                    <StatusBadge color="cyan" variant="outline">
                       {user.cluster}
-                    </span>
+                    </StatusBadge>
                   )}
                 </div>
                 <ChevronRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
@@ -881,9 +882,9 @@ function ServiceAccountsTab({
                 <div className="flex items-center gap-2">
                   <span className="text-foreground font-medium group-hover:text-purple-400">{sa.name}</span>
                   {showClusterBadge && (
-                    <span className="px-1.5 py-0.5 rounded text-xs bg-cyan-500/20 text-cyan-400 border border-cyan-500/30">
+                    <StatusBadge color="cyan" variant="outline">
                       {sa.cluster}
-                    </span>
+                    </StatusBadge>
                   )}
                 </div>
                 <div className="flex items-center gap-2">

--- a/web/src/components/cards/WarningEvents.tsx
+++ b/web/src/components/cards/WarningEvents.tsx
@@ -9,6 +9,7 @@ import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
 import type { ClusterEvent } from '../../hooks/useMCP'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../ui/StatusBadge'
 
 function getTimeAgo(timestamp: string | undefined): string {
   if (!timestamp) return 'Unknown'
@@ -193,9 +194,9 @@ export function WarningEvents() {
                 <AlertTriangle className="w-3.5 h-3.5 text-yellow-400 mt-0.5 flex-shrink-0" />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-1.5 flex-wrap">
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400 font-medium">
+                    <StatusBadge color="yellow">
                       {event.reason}
-                    </span>
+                    </StatusBadge>
                     <span className="text-xs text-foreground truncate">{event.object}</span>
                     {event.count > 1 && (
                       <span className="text-xs px-1 py-0.5 rounded bg-card text-muted-foreground">

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -16,6 +16,7 @@ import { useCardLoadingState } from '../CardDataContext'
 import type { PredictedRisk, TrendDirection } from '../../../types/predictions'
 import { CardControlsRow, CardSearchInput, CardPaginationFooter, CardAIActions } from '../../../lib/cards/CardComponents'
 import { ClusterBadge } from '../../ui/ClusterBadge'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { useTranslation } from 'react-i18next'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { POLL_INTERVAL_MS } from '../../../lib/constants/network'
@@ -1148,9 +1149,9 @@ TASK:
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-1.5 flex-wrap">
                     <span className="font-medium text-foreground truncate">{node.name}</span>
-                    <span className="flex-shrink-0 px-1 py-0.5 text-[9px] font-medium bg-red-500/20 text-red-400 rounded">
+                    <StatusBadge color="red" size="xs" className="flex-shrink-0">
                       {rootCause?.cause || t('cards:consoleOfflineDetection.offline')}
-                    </span>
+                    </StatusBadge>
                     {node.cluster && (
                       <ClusterBadge cluster={node.cluster} size="sm" />
                     )}
@@ -1184,9 +1185,9 @@ TASK:
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-1.5 flex-wrap">
                     <span className="font-medium text-foreground truncate">{issue.nodeName}</span>
-                    <span className="flex-shrink-0 px-1 py-0.5 text-[9px] font-medium bg-yellow-500/20 text-yellow-400 rounded">
+                    <StatusBadge color="yellow" size="xs" className="flex-shrink-0">
                       GPU
-                    </span>
+                    </StatusBadge>
                     <ClusterBadge cluster={issue.cluster} size="sm" />
                   </div>
                   <div className="text-yellow-400 truncate mt-0.5">0 GPUs available</div>
@@ -1237,13 +1238,13 @@ TASK:
                         <span className="font-medium text-foreground truncate">{risk.name}</span>
                         {/* Source Badge */}
                         {risk.source === 'ai' ? (
-                          <span className="flex-shrink-0 px-1 py-0.5 text-[9px] font-medium bg-blue-500/20 text-blue-400 rounded">
+                          <StatusBadge color="blue" size="xs" className="flex-shrink-0">
                             AI
-                          </span>
+                          </StatusBadge>
                         ) : (
-                          <span className="flex-shrink-0 px-1 py-0.5 text-[9px] font-medium bg-blue-500/20 text-blue-400 rounded flex items-center gap-0.5">
+                          <StatusBadge color="blue" size="xs" className="flex-shrink-0">
                             <Zap className="w-2 h-2" />
-                          </span>
+                          </StatusBadge>
                         )}
                         {/* Confidence */}
                         {risk.confidence !== undefined && (
@@ -1253,9 +1254,9 @@ TASK:
                         {risk.trend && <TrendIcon trend={risk.trend} />}
                         {/* Namespace Badge */}
                         {risk.namespace && (
-                          <span className="flex-shrink-0 px-1 py-0.5 text-[9px] font-medium bg-gray-500/20 text-muted-foreground rounded truncate max-w-[80px]" title={`namespace: ${risk.namespace}`}>
+                          <StatusBadge color="gray" size="xs" className="flex-shrink-0 truncate max-w-[80px]" title={`namespace: ${risk.namespace}`}>
                             {risk.namespace}
-                          </span>
+                          </StatusBadge>
                         )}
                         {/* Cluster Badge */}
                         {risk.cluster && (

--- a/web/src/components/cards/llmd/EPPRouting.tsx
+++ b/web/src/components/cards/llmd/EPPRouting.tsx
@@ -16,6 +16,7 @@ import { usePrometheusMetrics } from '../../../hooks/usePrometheusMetrics'
 import { useCardExpanded } from '../CardWrapper'
 import { useTranslation } from 'react-i18next'
 import { POLL_INTERVAL_FAST_MS } from '../../../lib/constants/network'
+import { StatusBadge } from '../../ui/StatusBadge'
 
 type MetricType = 'load' | 'rps'
 type ViewMode = 'default' | 'horseshoe'
@@ -908,7 +909,7 @@ export function EPPRouting() {
                 {selectedStack.name}
               </span>
               {isDemoMode && (
-                <span className="px-1 py-0.5 rounded bg-yellow-500/10 text-yellow-400 text-2xs">{t('common:common.demo')}</span>
+                <StatusBadge color="yellow" size="xs">{t('common:common.demo')}</StatusBadge>
               )}
             </div>
           )}

--- a/web/src/components/cards/llmd/KVCacheMonitor.tsx
+++ b/web/src/components/cards/llmd/KVCacheMonitor.tsx
@@ -18,6 +18,7 @@ import { usePrometheusMetrics } from '../../../hooks/usePrometheusMetrics'
 import { useCardExpanded } from '../CardWrapper'
 import { useTranslation } from 'react-i18next'
 import { KV_CACHE_UPDATE_INTERVAL_MS } from '../../../lib/constants/network'
+import { StatusBadge } from '../../ui/StatusBadge'
 
 // Premium gauge with glowing arcs and ambient lighting
 interface PremiumGaugeProps {
@@ -576,7 +577,7 @@ export function KVCacheMonitor() {
                 {selectedStack.name}
               </span>
               {isDemoMode && (
-                <span className="px-1 py-0.5 rounded bg-yellow-500/10 text-yellow-400 text-2xs">{t('common:common.demo')}</span>
+                <StatusBadge color="yellow" size="xs">{t('common:common.demo')}</StatusBadge>
               )}
             </div>
           )}

--- a/web/src/components/cards/llmd/LLMdFlow.tsx
+++ b/web/src/components/cards/llmd/LLMdFlow.tsx
@@ -17,6 +17,7 @@ import { usePrometheusMetrics } from '../../../hooks/usePrometheusMetrics'
 import { useCardExpanded } from '../CardWrapper'
 import { useTranslation } from 'react-i18next'
 import { POLL_INTERVAL_FAST_MS } from '../../../lib/constants/network'
+import { StatusBadge } from '../../ui/StatusBadge'
 
 type ViewMode = 'default' | 'horseshoe'
 
@@ -999,7 +1000,7 @@ export function LLMdFlow() {
                 </span>
               )}
               {isDemoMode && (
-                <span className="px-1 py-0.5 rounded bg-yellow-500/10 text-yellow-400 text-2xs">{t('common:common.demo')}</span>
+                <StatusBadge color="yellow" size="xs">{t('common:common.demo')}</StatusBadge>
               )}
             </div>
           )}

--- a/web/src/components/cards/llmd/LatencyBreakdown.tsx
+++ b/web/src/components/cards/llmd/LatencyBreakdown.tsx
@@ -22,6 +22,7 @@ import {
   type ScalingPoint,
 } from '../../../lib/llmd/benchmarkDataUtils'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../../ui/StatusBadge'
 
 type MetricTab = 'ttftP50Ms' | 'tpotP50Ms' | 'p99LatencyMs' | 'itlP50Ms' | 'requestLatencyMs'
 
@@ -135,10 +136,10 @@ export function LatencyBreakdown() {
           <Clock size={14} className="text-yellow-400" />
           <span className="text-sm font-medium text-white">Latency Under Load</span>
           {degradationWarning && (
-            <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-2xs font-medium bg-red-500/15 text-red-400">
+            <StatusBadge color="red" size="xs" rounded="full">
               <AlertTriangle size={10} />
               {degradationWarning.variant}: +{degradationWarning.increase.toFixed(0)}% at peak
-            </span>
+            </StatusBadge>
           )}
         </div>
         <div className="flex items-center gap-2">

--- a/web/src/components/cards/llmd/ResourceUtilization.tsx
+++ b/web/src/components/cards/llmd/ResourceUtilization.tsx
@@ -20,6 +20,7 @@ import {
   CONFIG_TYPE_COLORS,
 } from '../../../lib/llmd/benchmarkDataUtils'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../../ui/StatusBadge'
 
 type MetricMode = 'throughput' | 'ttftP50Ms' | 'tpotP50Ms' | 'p99LatencyMs'
 
@@ -135,10 +136,10 @@ export function ResourceUtilization() {
           <BarChart3 size={14} className="text-green-400" />
           <span className="text-sm font-medium text-white">Experiment Comparison</span>
           {bestVariant && (
-            <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-2xs font-medium bg-green-500/15 text-green-400">
+            <StatusBadge color="green" size="xs" rounded="full">
               <Trophy size={10} />
               Best: {bestVariant} ({bestValue.toLocaleString(undefined, { maximumFractionDigits: 1 })} {modeInfo.unit})
-            </span>
+            </StatusBadge>
           )}
         </div>
         <div className="flex items-center gap-2">

--- a/web/src/components/cards/llmd/StackSelector.tsx
+++ b/web/src/components/cards/llmd/StackSelector.tsx
@@ -10,6 +10,7 @@ import { ChevronDown, ChevronUp, Server, Layers, RefreshCw, Cpu, Search, X } fro
 import { useOptionalStack } from '../../../contexts/StackContext'
 import type { LLMdStack } from '../../../hooks/useStackDiscovery'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../../ui/StatusBadge'
 
 const STATUS_COLORS = {
   healthy: 'bg-green-500',
@@ -377,7 +378,7 @@ export function StackSelector() {
             )}
 
             {isDemoMode && (
-              <span className="text-[9px] px-1 py-0.5 rounded bg-yellow-500/20 text-yellow-400">{t('common.demo')}</span>
+              <StatusBadge color="yellow" size="xs">{t('common.demo')}</StatusBadge>
             )}
           </>
         ) : (

--- a/web/src/components/cards/llmd/ThroughputComparison.tsx
+++ b/web/src/components/cards/llmd/ThroughputComparison.tsx
@@ -22,6 +22,7 @@ import {
   type ExperimentGroup,
 } from '../../../lib/llmd/benchmarkDataUtils'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../../ui/StatusBadge'
 
 interface ChartRow {
   qps: number
@@ -111,10 +112,10 @@ export function ThroughputComparison() {
           <Zap size={14} className="text-blue-400" />
           <span className="text-sm font-medium text-white">Throughput Scaling</span>
           {peakInfo && (
-            <span className="flex items-center gap-1 px-2 py-0.5 rounded-full text-2xs font-medium bg-blue-500/15 text-blue-400">
+            <StatusBadge color="blue" size="xs" rounded="full">
               <TrendingUp size={10} />
               Peak: {peakInfo.value.toLocaleString(undefined, { maximumFractionDigits: 0 })} tok/s
-            </span>
+            </StatusBadge>
           )}
         </div>
         <div className="flex items-center gap-2">

--- a/web/src/components/cards/workload-detection/LLMInference.tsx
+++ b/web/src/components/cards/workload-detection/LLMInference.tsx
@@ -117,9 +117,9 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
       case 'scaling':
         return <StatusBadge color="blue" icon={<RefreshCw className="w-2.5 h-2.5 animate-spin" />}>Scaling</StatusBadge>
       case 'stopped':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-gray-500/20 text-muted-foreground flex items-center gap-1"><Pause className="w-2.5 h-2.5" /> Stopped</span>
+        return <StatusBadge color="gray" icon={<Pause className="w-2.5 h-2.5" />}>Stopped</StatusBadge>
       default:
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-gray-500/20 text-muted-foreground">{status}</span>
+        return <StatusBadge color="gray">{status}</StatusBadge>
     }
   }
 

--- a/web/src/components/cards/workload-detection/LLMModels.tsx
+++ b/web/src/components/cards/workload-detection/LLMModels.tsx
@@ -79,11 +79,11 @@ export function LLMModels({ config: _config }: LLMModelsProps) {
       case 'downloading':
         return <StatusBadge color="blue" icon={<RefreshCw className="w-2.5 h-2.5 animate-spin" />}>Downloading</StatusBadge>
       case 'stopped':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-gray-500/20 text-muted-foreground">Stopped</span>
+        return <StatusBadge color="gray">Stopped</StatusBadge>
       case 'error':
         return <StatusBadge color="red">{t('common.error')}</StatusBadge>
       default:
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-gray-500/20 text-muted-foreground">{status}</span>
+        return <StatusBadge color="gray">{status}</StatusBadge>
     }
   }
 

--- a/web/src/components/cards/workload-detection/MLJobs.tsx
+++ b/web/src/components/cards/workload-detection/MLJobs.tsx
@@ -69,7 +69,7 @@ export function MLJobs({ config: _config }: MLJobsProps) {
       case 'failed':
         return <StatusBadge color="red" icon={<XCircle className="w-2.5 h-2.5" />}>Failed</StatusBadge>
       default:
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-gray-500/20 text-muted-foreground">{status}</span>
+        return <StatusBadge color="gray">{status}</StatusBadge>
     }
   }
 

--- a/web/src/components/cards/workload-detection/MLNotebooks.tsx
+++ b/web/src/components/cards/workload-detection/MLNotebooks.tsx
@@ -56,9 +56,9 @@ export function MLNotebooks({ config: _config }: MLNotebooksProps) {
       case 'idle':
         return <StatusBadge color="yellow">Idle</StatusBadge>
       case 'stopped':
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-gray-500/20 text-muted-foreground">Stopped</span>
+        return <StatusBadge color="gray">Stopped</StatusBadge>
       default:
-        return <span className="text-xs px-1.5 py-0.5 rounded bg-gray-500/20 text-muted-foreground">{status}</span>
+        return <StatusBadge color="gray">{status}</StatusBadge>
     }
   }
 

--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -319,9 +319,7 @@ const FullClusterCard = memo(function FullClusterCard({
               </span>
             )}
             {!permissionsLoading && !isClusterAdmin && !unreachable && (
-              <span className="flex items-center px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400" title="You have limited permissions on this cluster">
-                <ShieldAlert className="w-3.5 h-3.5" />
-              </span>
+              <StatusBadge color="yellow" title="You have limited permissions on this cluster" icon={<ShieldAlert className="w-3.5 h-3.5" />} />
             )}
           </div>
         </div>

--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -10,6 +10,7 @@ import { cn } from '../../../lib/cn'
 import { Button } from '../../ui/Button'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import {
   getIssueSeverity,
@@ -1743,7 +1744,7 @@ Please proceed step by step and ask for confirmation before making any changes.`
                       <Box className="w-4 h-4" />
                       <span className="text-xs text-cyan-300">{t('common.pod')}</span>
                       <span className="font-semibold">{podName}</span>
-                      <span className="text-xs px-1.5 py-0.5 rounded bg-cyan-500/30 text-cyan-300">current</span>
+                      <StatusBadge color="cyan">current</StatusBadge>
                     </div>
                   </div>
                 </div>
@@ -1914,7 +1915,7 @@ Please proceed step by step and ask for confirmation before making any changes.`
                       <Box className="w-4 h-4" />
                       <span className="text-xs text-cyan-300">{t('common.pod')}</span>
                       <span className="font-semibold">{podName}</span>
-                      <span className="text-xs px-1.5 py-0.5 rounded bg-cyan-500/30 text-cyan-300">current</span>
+                      <StatusBadge color="cyan">current</StatusBadge>
                     </div>
                     <p className="text-muted-foreground text-sm mt-3">{t('drilldown.empty.noRelatedResourcesDiscovered')}</p>
                   </div>

--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -27,6 +27,7 @@ import {
   Link,
 } from 'lucide-react'
 import { cn } from '../../lib/cn'
+import { StatusBadge } from '../ui/StatusBadge'
 import type { MissionExport, MissionStep } from '../../lib/missions/types'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 
@@ -280,10 +281,10 @@ export function MissionDetailView({
         </div>
         <div className="flex items-center gap-2 flex-shrink-0">
           {matchScore != null && matchScore > 0 && (
-            <span className="flex items-center gap-1 px-2 py-1 text-xs rounded-full bg-purple-500/10 text-purple-400 border border-purple-500/20">
+            <StatusBadge color="purple" size="md" variant="outline" rounded="full">
               <Star className="w-3 h-3" />
               {matchScore}% match
-            </span>
+            </StatusBadge>
           )}
           {shareUrl && (
             <button
@@ -360,14 +361,14 @@ export function MissionDetailView({
               </span>
             )}
             {mission.cncfProject && (
-              <span className="px-2.5 py-1 text-xs rounded-full bg-blue-500/10 text-blue-400 border border-blue-500/20">
+              <StatusBadge color="blue" size="md" variant="outline" rounded="full">
                 {mission.cncfProject}
-              </span>
+              </StatusBadge>
             )}
             {mission.difficulty && (
-              <span className="px-2.5 py-1 text-xs rounded-full bg-purple-500/10 text-purple-400 border border-purple-500/20">
+              <StatusBadge color="purple" size="md" variant="outline" rounded="full">
                 {mission.difficulty}
-              </span>
+              </StatusBadge>
             )}
             {maturity && (
               <span

--- a/web/src/components/missions/SolutionCard.tsx
+++ b/web/src/components/missions/SolutionCard.tsx
@@ -6,6 +6,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { Link, Check } from 'lucide-react'
 import { cn } from '../../lib/cn'
+import { StatusBadge } from '../ui/StatusBadge'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import type { MissionExport } from '../../lib/missions/types'
 
@@ -50,9 +51,9 @@ export function SolutionCard({ mission, onImport, onSelect, onCopyLink, compact 
           {mission.title}
         </h4>
         {mission.category && (
-          <span className="px-1.5 py-0.5 text-2xs rounded bg-purple-500/10 text-purple-400 border border-purple-500/20 flex-shrink-0">
+          <StatusBadge color="purple" size="xs" variant="outline" className="flex-shrink-0">
             {mission.category}
-          </span>
+          </StatusBadge>
         )}
         <span className="text-2xs text-muted-foreground flex-shrink-0">{mission.steps?.length ?? 0} steps</span>
         <button
@@ -101,9 +102,9 @@ export function SolutionCard({ mission, onImport, onSelect, onCopyLink, compact 
       {/* Tags */}
       <div className="flex flex-wrap gap-1 mb-2 mt-auto">
         {mission.category && (
-          <span className="px-1.5 py-0.5 text-2xs rounded bg-purple-500/10 text-purple-400 border border-purple-500/20">
+          <StatusBadge color="purple" size="xs" variant="outline">
             {mission.category}
-          </span>
+          </StatusBadge>
         )}
         {mission.tags?.slice(0, 3).map(tag => (
           <span key={tag} className="px-1.5 py-0.5 text-2xs rounded bg-secondary text-muted-foreground">

--- a/web/src/components/missions/browser/RecommendationCard.tsx
+++ b/web/src/components/missions/browser/RecommendationCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { CheckCircle, Check, Link } from 'lucide-react'
 import { cn } from '../../../lib/cn'
+import { StatusBadge } from '../../ui/StatusBadge'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import type { MissionMatch } from '../../../lib/missions/types'
 
@@ -80,9 +81,9 @@ export function RecommendationCard({
             {mission.type}
           </span>
           {mission.metadata?.projectVersion && (
-            <span className="px-1.5 py-0.5 text-2xs rounded bg-blue-500/10 text-blue-400 border border-blue-500/20 font-medium">
+            <StatusBadge color="blue" size="xs" variant="outline">
               v{mission.metadata.projectVersion}
-            </span>
+            </StatusBadge>
           )}
           {mission.metadata?.maturity && (
             <span className={cn(


### PR DESCRIPTION
## Summary
- Migrate 62 remaining inline `<span>` badge elements to the shared `StatusBadge` component across 37 files
- Covers cards, drilldown views, cluster components, and mission views
- Completes the badge migration effort started in PR #1937 (67 files)

**Total StatusBadge adoption after this PR: ~130 files**

### Badge categories migrated
- Card stat/count badges (red, yellow, green, purple, orange)
- Cluster/namespace scope badges (blue, purple)  
- Status badges in workload detection cards (gray)
- Demo badges in llm-d cards (yellow)
- Hardware capability badges (blue, purple, orange, green)
- Mission/solution category badges (purple, blue outline)
- Game item badges in KubeKart (cyan, purple, orange)

## Test plan
- [x] `npm run build` passes (zero TypeScript errors)
- [ ] Visual spot-check: badge colors and sizes render identically
- [ ] No logic changes — purely presentational migration