### PR TITLE
📖 Update CONTRIBUTING.md for agent-driven workflow, add CLAUDE.md quick start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,36 @@
-# Project Configuration
+# KubeStellar Console — Agent Guide
+
+This file is read by Claude Code, Copilot, Codex, and other coding agents working on this repo.
+
+## Quick Start
+
+```bash
+./start-dev.sh          # No OAuth, mock dev-user, backend :8080, frontend :5174
+./startup-oauth.sh      # With GitHub OAuth (requires .env with GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET)
+```
+
+Build and lint before creating PRs:
+```bash
+cd web && npm run build && npm run lint
+```
+
+## Project Layout
+
+```
+cmd/console/       Server entry point
+cmd/kc-agent/      Local agent (bridges browser to kubeconfig + MCP)
+pkg/agent/         AI providers (Claude, OpenAI, Gemini)
+pkg/api/           HTTP/WS server + handlers
+pkg/mcp/           MCP bridge to Kubernetes
+pkg/store/         SQLite database layer
+web/src/           React + TypeScript frontend
+  components/cards/  Dashboard card components
+  hooks/             Data fetching hooks (useCached*)
+  lib/               Utilities, card registry, demo data
+deploy/helm/       Helm chart
+```
+
+---
 
 ## ⚠️ MANDATORY Testing Requirements
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,35 @@
 # Contributing to KubeStellar Console
 
-Thank you for your interest in contributing! This guide covers everything you need to get started.
+## Issues Are Welcome
 
-## Development Setup
+The best way to contribute is by opening an issue. Bug reports, feature requests, UX feedback, and questions all help shape the project. Use [GitHub Issues](https://github.com/kubestellar/console/issues).
 
-### Prerequisites
+## How Development Works
 
-- Go 1.24+
-- Node.js 20+
-- A kubeconfig with at least one cluster (optional - demo mode works without clusters)
+Most code in this repo is written by coding agents — Claude Opus 4.5/4.6, Gemini, and Codex. PRs are generated, reviewed, and iterated on by these agents with human oversight.
 
-### Clone and Start (No OAuth)
+**Manual coding PRs are discouraged.** They take significantly longer to complete and review compared to agent-generated code. If you want to contribute code, use one of the supported agents:
+
+- **Claude Code** (Claude Opus 4.5 or 4.6) — primary development tool
+- **GitHub Copilot** — used for automated PR fixes
+- **Google Gemini** — supported for code generation
+- **OpenAI Codex** — supported for code generation
+
+## Test PRs Are Favored
+
+The most valuable code contributions are **tests** — Playwright E2E tests, unit tests, or integration tests submitted as PRs. Tests shape how automated code generation works by defining expected behavior. A failing test PR is more useful than a code PR, because it tells the agents exactly what to build.
+
+See the [`scripts/`](scripts/) directory for 30+ existing test scripts (API contract, security, helm lint, consistency, card registry integrity, and more). Run any of them directly:
+
+```bash
+bash scripts/api-contract-test.sh
+bash scripts/consistency-test.sh
+cd web && npx playwright test --grep "your-test"
+```
+
+## Getting Started Locally
+
+Prerequisites: Go 1.24+, Node.js 20+
 
 ```bash
 git clone https://github.com/kubestellar/console.git
@@ -18,115 +37,12 @@ cd console
 ./start-dev.sh
 ```
 
-This starts:
-- **Backend** on `http://localhost:8080` (Go)
-- **Frontend** on `http://localhost:5174` (Vite + React)
-- Uses a mock `dev-user` account - no GitHub login required
+Starts backend on `:8080` and frontend on `:5174` with a mock `dev-user` account. See [CLAUDE.md](CLAUDE.md) for development conventions and card development rules.
 
-### Clone and Start (With GitHub OAuth)
+## Commit Conventions
 
-1. Create a [GitHub OAuth App](https://github.com/settings/developers):
-   - **Application name**: `KubeStellar Console (dev)`
-   - **Homepage URL**: `http://localhost:5174`
-   - **Authorization callback URL**: `http://localhost:8080/auth/github/callback`
-
-2. Copy the Client ID and generate a Client Secret, then create a `.env` file in the project root:
-
-   ```
-   GITHUB_CLIENT_ID=your-client-id
-   GITHUB_CLIENT_SECRET=your-client-secret
-   ```
-
-3. Start with OAuth:
-
-   ```bash
-   ./startup-oauth.sh
-   ```
-
-   This starts the backend with OAuth enabled and opens the console at `http://localhost:5174`. You'll be prompted to log in with GitHub.
-
-### Frontend Only
-
-If you're only working on the frontend:
-
-```bash
-cd web
-npm install
-npm run dev
-```
-
-The frontend runs on `http://localhost:5174` and connects to the backend at `http://localhost:8080`.
-
-## Project Structure
-
-```
-console/
-  pkg/              # Go backend
-    api/            # HTTP handlers and routes
-    models/         # Data models
-    store/          # SQLite persistence
-  web/              # React frontend
-    src/
-      components/   # UI components
-        cards/      # Dashboard cards
-        layout/     # Navbar, sidebar, layout
-        setup/      # Setup dialogs
-      hooks/        # React hooks (data fetching, state)
-      lib/          # Utilities, card registry, demo data
-      locales/      # i18n translations
-  start-dev.sh      # Start without OAuth
-  startup-oauth.sh  # Start with OAuth
-```
-
-## Making Changes
-
-### Branch Naming
-
-Use descriptive branch names with a prefix:
-- `fix/` - bug fixes
-- `feature/` - new features
-- `docs/` - documentation changes
-
-### Adding a New Dashboard Card
-
-1. Create your card component in `web/src/components/cards/YourCard.tsx`
-2. Create a data hook in `web/src/hooks/useYourData.ts`
-3. Register the card in `web/src/components/cards/cardRegistry.ts`
-4. Add demo data in `web/src/lib/unified/demo/`
-
-See the [console-marketplace](https://github.com/kubestellar/console-marketplace) repo for examples and card templates.
-
-### Commit Messages
-
-- Start with an emoji prefix: `✨` feature | `🐛` bug fix | `📖` docs | `⚠️` breaking | `🌱` other
 - Sign all commits with DCO: `git commit -s`
-- Keep messages concise and focused on the "why"
-
-### Pull Requests
-
-- Keep PRs focused - one feature or fix per PR
-- Include a description of what changed and why
-- Add screenshots for UI changes
-- PRs require passing build and lint checks
-
-## Building and Testing
-
-```bash
-# Build frontend
-cd web && npm run build
-
-# Lint frontend
-cd web && npm run lint
-
-# Run Go backend tests
-go test ./...
-```
-
-## Code Style
-
-- **TypeScript/React**: Follow existing patterns in the codebase. Use functional components with hooks.
-- **Go**: Standard Go formatting (`gofmt`). Use meaningful variable names.
-- **CSS**: Tailwind CSS utility classes. Follow the existing color scheme and spacing conventions.
+- Emoji prefix: `✨` feature | `🐛` bug fix | `📖` docs | `⚠️` breaking | `🌱` other
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 AI-powered multi-cluster Kubernetes dashboard with guided install missions for 250+ CNCF projects.
 
-[**Live Demo**](https://console.kubestellar.io) | [Contributing](CONTRIBUTING.md) | [License](LICENSE)
+[**Live Demo**](https://console.kubestellar.io) | [Contributing](CONTRIBUTING.md)
 
 ![KubeStellar Console](docs/images/console-screenshot.png)
 
@@ -62,31 +62,9 @@ graph LR
 - **[console-kb](https://github.com/kubestellar/console-kb)** — Knowledge base of guided installers for 250+ CNCF projects and solutions to common Kubernetes problems
 - **[console-marketplace](https://github.com/kubestellar/console-marketplace)** — Community-contributed monitoring cards per CNCF project
 - **[kc-agent](cmd/kc-agent/)** — Local agent bridging the browser to kubeconfig, coding agents (Codex, Copilot, Claude CLI), and MCP servers (`kubestellar-ops`, `kubestellar-deploy`)
-
-```
-console/
-├── cmd/console/       # Server entry point
-├── cmd/kc-agent/      # Local agent
-├── pkg/agent/         # AI providers (Claude, OpenAI, Gemini)
-├── pkg/api/           # HTTP/WS server + handlers
-├── pkg/mcp/           # MCP bridge to Kubernetes
-├── pkg/store/         # SQLite database layer
-├── web/               # React + TypeScript frontend
-└── deploy/helm/       # Helm chart
-```
-
-## Development
-
-Requires Go 1.24+, Node.js 20+.
-
-```bash
-git clone https://github.com/kubestellar/console.git && cd console
-./start-dev.sh
-```
-
-## Related Projects
-
-[console-kb](https://github.com/kubestellar/console-kb) · [console-marketplace](https://github.com/kubestellar/console-marketplace) · [claude-plugins](https://github.com/kubestellar/claude-plugins) · [homebrew-tap](https://github.com/kubestellar/homebrew-tap) · [KubeStellar](https://kubestellar.io)
+- **[claude-plugins](https://github.com/kubestellar/claude-plugins)** — Claude Code marketplace plugins for Kubernetes
+- **[homebrew-tap](https://github.com/kubestellar/homebrew-tap)** — Homebrew formulae for KubeStellar tools
+- **[KubeStellar](https://kubestellar.io)** — Multi-cluster configuration management
 
 ## License
 


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md**: Rewrite to reflect how development actually works
  - Issues are welcome as the primary contribution path
  - PRs are mostly automated by coding agents (Claude Opus 4.5/4.6, Gemini, Codex)
  - Manual coding PRs discouraged — they take too long to complete and review
  - Test PRs are the most valuable code contribution
  - Reference `scripts/` directory with 30+ test scripts
- **CLAUDE.md**: Add quick start and project layout section so coding agents can orient themselves immediately
- **README.md**: Remove redundant License link from header, remove duplicate directory tree and Development section (both now in CLAUDE.md/CONTRIBUTING.md)

## Test plan
- [x] No code changes, docs only