### PR TITLE
✨ Auto-collapse recommendation panels, GA4 analytics, remove SmartCardSuggestions

### DIFF
--- a/web/src/components/dashboard/CardRecommendations.tsx
+++ b/web/src/components/dashboard/CardRecommendations.tsx
@@ -1,15 +1,19 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Clock, ChevronDown, ChevronUp, X, Plus, AlertTriangle, Info, Lightbulb } from 'lucide-react'
+import { Clock, ChevronDown, ChevronUp, X, Plus, AlertTriangle, Info, Lightbulb, Timer } from 'lucide-react'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useCardRecommendations, CardRecommendation } from '../../hooks/useCardRecommendations'
 import { useSnoozedRecommendations } from '../../hooks/useSnoozedRecommendations'
 import { AI_THINKING_DELAY_MS } from '../../lib/constants/network'
+import { emitCardRecommendationsShown, emitCardRecommendationActioned } from '../../lib/analytics'
 
 interface Props {
   currentCardTypes: string[]
   onAddCard: (cardType: string, config?: Record<string, unknown>) => void
 }
+
+/** Seconds before the panel auto-collapses */
+const AUTO_COLLAPSE_SECONDS = 20
 
 const PRIORITY_STYLES = {
   high: {
@@ -37,10 +41,55 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
   const [expandedRec, setExpandedRec] = useState<string | null>(null)
   const [addingCard, setAddingCard] = useState<string | null>(null)
   const [minimized, setMinimized] = useState(false)
+  const [countdown, setCountdown] = useState(AUTO_COLLAPSE_SECONDS)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const analyticsEmittedRef = useRef(false)
 
   // Force dependency on snoozedRecommendations for reactivity
   void snoozedRecommendations
+
+  // Start / stop countdown timer
+  const startCountdown = useCallback(() => {
+    if (countdownRef.current) clearInterval(countdownRef.current)
+    countdownRef.current = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          if (countdownRef.current) clearInterval(countdownRef.current)
+          countdownRef.current = null
+          setMinimized(true)
+          return AUTO_COLLAPSE_SECONDS
+        }
+        return prev - 1
+      })
+    }, 1000)
+  }, [])
+
+  // Manage countdown lifecycle based on minimized state
+  useEffect(() => {
+    if (!minimized) {
+      setCountdown(AUTO_COLLAPSE_SECONDS)
+      startCountdown()
+    } else if (countdownRef.current) {
+      clearInterval(countdownRef.current)
+      countdownRef.current = null
+    }
+    return () => {
+      if (countdownRef.current) clearInterval(countdownRef.current)
+    }
+  }, [minimized, startCountdown])
+
+  // Pause countdown on hover, resume on leave
+  const handleMouseEnter = useCallback(() => {
+    if (countdownRef.current) {
+      clearInterval(countdownRef.current)
+      countdownRef.current = null
+    }
+  }, [])
+
+  const handleMouseLeave = useCallback(() => {
+    if (!minimized) startCountdown()
+  }, [minimized, startCountdown])
 
   // Close dropdown when clicking outside or pressing Escape
   useEffect(() => {
@@ -75,6 +124,7 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
     setAddingCard(rec.id)
     await new Promise(resolve => setTimeout(resolve, AI_THINKING_DELAY_MS))
     onAddCard(rec.cardType, rec.config)
+    emitCardRecommendationActioned(rec.cardType, rec.priority)
     setAddingCard(null)
     setExpandedRec(null)
     dismissRecommendation(rec.id) // Permanently hide tile after adding card
@@ -93,6 +143,14 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
 
   // Filter out snoozed and dismissed recommendations
   const visibleRecommendations = recommendations.filter(rec => !isSnoozed(rec.id) && !isDismissed(rec.id))
+
+  // Emit analytics once when panel first renders with visible recommendations
+  useEffect(() => {
+    if (!analyticsEmittedRef.current && visibleRecommendations.length > 0) {
+      analyticsEmittedRef.current = true
+      emitCardRecommendationsShown(visibleRecommendations.length, highPriorityCount)
+    }
+  }, [visibleRecommendations.length, highPriorityCount])
 
   if (!hasRecommendations || visibleRecommendations.length === 0) return null
 
@@ -145,7 +203,12 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
   }
 
   return (
-    <div data-tour="recommendations" className="mb-4 glass rounded-xl border border-border/50">
+    <div
+      data-tour="recommendations"
+      className="mb-4 glass rounded-xl border border-border/50"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">
         <div className="flex items-center gap-2">
@@ -164,13 +227,19 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
             </span>
           )}
         </div>
-        <button
-          onClick={() => setMinimized(true)}
-          className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
-          title="Minimize"
-        >
-          <ChevronUp className="w-3.5 h-3.5" />
-        </button>
+        <div className="flex items-center gap-2">
+          <span className="flex items-center gap-1 text-2xs text-muted-foreground/60 tabular-nums">
+            <Timer className="w-3 h-3" />
+            {countdown}s
+          </span>
+          <button
+            onClick={() => setMinimized(true)}
+            className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+            title="Minimize"
+          >
+            <ChevronUp className="w-3.5 h-3.5" />
+          </button>
+        </div>
       </div>
 
       {/* Recommendation chips */}

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -47,7 +47,7 @@ import { SortableCard, DragPreviewCard } from './SharedSortableCard'
 import type { Card, DashboardData } from './dashboardUtils'
 import { useDashboardReset } from '../../hooks/useDashboardReset'
 import { WelcomeCard } from './WelcomeCard'
-import { SmartCardSuggestions } from './SmartCardSuggestions'
+
 import { PostConnectBanner } from './PostConnectBanner'
 import { AdopterNudge } from './AdopterNudge'
 import { DemoToLocalCTA } from './DemoToLocalCTA'
@@ -780,24 +780,6 @@ export function Dashboard() {
     setLocalCards((prev) => [newCard, ...prev])
   }, [dashboard, recordCardAdded])
 
-  // Handle adding multiple cards from smart suggestions "Add all"
-  const handleAddMultipleCards = useCallback((cardTypes: string[]) => {
-    const newCards: Card[] = cardTypes.map((cardType, index) => {
-      const size = getDefaultCardSize(cardType)
-      return {
-        id: `rec-${Date.now()}-${index}`,
-        card_type: cardType,
-        config: {},
-        position: { x: 0, y: 0, ...size },
-      }
-    })
-    newCards.forEach((card) => {
-      recordCardAdded(card.id, card.card_type, undefined, {}, dashboard?.id, dashboard?.name)
-      emitCardAdded(card.card_type, 'smart_suggestion_all')
-    })
-    setLocalCards((prev) => [...newCards, ...prev])
-  }, [dashboard, recordCardAdded])
-
   // Handle nudge CTA actions
   const handleNudgeAction = useCallback(() => {
     if (activeNudge === 'customize') {
@@ -897,13 +879,6 @@ export function Dashboard() {
       {clusters.length === 0 && !isClustersLoading && !getDemoMode() && (
         <WelcomeCard />
       )}
-
-      {/* Smart Card Suggestions — shown after kc-agent connects */}
-      <SmartCardSuggestions
-        existingCardTypes={currentCardTypes}
-        onAddCard={handleAddSingleCard}
-        onAddMultipleCards={handleAddMultipleCards}
-      />
 
       {/* Post-connect activation — bridges the 90% drop between agent connect and first mission */}
       <PostConnectBanner

--- a/web/src/components/dashboard/MissionSuggestions.tsx
+++ b/web/src/components/dashboard/MissionSuggestions.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useRef, startTransition } from 'react'
+import { useState, useEffect, useRef, useCallback, startTransition } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import { Lightbulb, Clock, X, ChevronDown, ChevronUp, Zap, AlertTriangle, Shield, Server, Scale, Activity, Wrench, Stethoscope } from 'lucide-react'
+import { Lightbulb, Clock, X, ChevronDown, ChevronUp, Zap, AlertTriangle, Shield, Server, Scale, Activity, Wrench, Stethoscope, Timer } from 'lucide-react'
 import { useMissionSuggestions, MissionSuggestion, MissionType } from '../../hooks/useMissionSuggestions'
 import { useSnoozedMissions, formatTimeRemaining } from '../../hooks/useSnoozedMissions'
 import { useMissions } from '../../hooks/useMissions'
@@ -10,6 +10,10 @@ import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { Skeleton } from '../ui/Skeleton'
 import { StatusBadge } from '../ui/StatusBadge'
+import { emitMissionSuggestionsShown, emitMissionSuggestionActioned } from '../../lib/analytics'
+
+/** Seconds before the panel auto-collapses */
+const AUTO_COLLAPSE_SECONDS = 20
 
 const MISSION_ICONS: Record<MissionType, typeof Zap> = {
   scale: Scale,
@@ -58,7 +62,10 @@ export function MissionSuggestions() {
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [processingId, setProcessingId] = useState<string | null>(null)
   const [minimized, setMinimized] = useState(false)
+  const [countdown, setCountdown] = useState(AUTO_COLLAPSE_SECONDS)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const analyticsEmittedRef = useRef(false)
 
   // Check agent status for offline skeleton display
   const { status: agentStatus } = useLocalAgent()
@@ -68,6 +75,56 @@ export function MissionSuggestions() {
 
   // Force dependency on snoozedMissions for reactivity
   void snoozedMissions
+
+  // Start / stop countdown timer
+  const startCountdown = useCallback(() => {
+    if (countdownRef.current) clearInterval(countdownRef.current)
+    countdownRef.current = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          if (countdownRef.current) clearInterval(countdownRef.current)
+          countdownRef.current = null
+          setMinimized(true)
+          return AUTO_COLLAPSE_SECONDS
+        }
+        return prev - 1
+      })
+    }, 1000)
+  }, [])
+
+  // Manage countdown lifecycle based on minimized state
+  useEffect(() => {
+    if (!minimized && hasSuggestions) {
+      setCountdown(AUTO_COLLAPSE_SECONDS)
+      startCountdown()
+    } else if (countdownRef.current) {
+      clearInterval(countdownRef.current)
+      countdownRef.current = null
+    }
+    return () => {
+      if (countdownRef.current) clearInterval(countdownRef.current)
+    }
+  }, [minimized, hasSuggestions, startCountdown])
+
+  // Pause countdown on hover, resume on leave
+  const handleMouseEnter = useCallback(() => {
+    if (countdownRef.current) {
+      clearInterval(countdownRef.current)
+      countdownRef.current = null
+    }
+  }, [])
+
+  const handleMouseLeave = useCallback(() => {
+    if (!minimized) startCountdown()
+  }, [minimized, startCountdown])
+
+  // Emit analytics once when panel first renders with suggestions
+  useEffect(() => {
+    if (!analyticsEmittedRef.current && hasSuggestions && suggestions.length > 0) {
+      analyticsEmittedRef.current = true
+      emitMissionSuggestionsShown(suggestions.length, stats.critical)
+    }
+  }, [hasSuggestions, suggestions.length, stats.critical])
 
   // Close dropdown when clicking outside or pressing Escape
   useEffect(() => {
@@ -102,6 +159,8 @@ export function MissionSuggestions() {
     e.stopPropagation()
     e.preventDefault()
 
+    emitMissionSuggestionActioned(suggestion.type, suggestion.priority, 'investigate')
+
     // Batch state updates to prevent flicker
     startTransition(() => {
       setExpandedId(null)
@@ -128,6 +187,8 @@ export function MissionSuggestions() {
   const handleRepair = (e: React.MouseEvent, suggestion: MissionSuggestion) => {
     e.stopPropagation()
     e.preventDefault()
+
+    emitMissionSuggestionActioned(suggestion.type, suggestion.priority, 'repair')
 
     // Batch state updates to prevent flicker
     startTransition(() => {
@@ -220,7 +281,12 @@ export function MissionSuggestions() {
   }
 
   return (
-    <div data-tour="mission-suggestions" className="mb-4 glass rounded-xl border border-border/50">
+    <div
+      data-tour="mission-suggestions"
+      className="mb-4 glass rounded-xl border border-border/50"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">
         <div className="flex items-center gap-2">
@@ -244,13 +310,19 @@ export function MissionSuggestions() {
             </span>
           )}
         </div>
-        <button
-          onClick={() => setMinimized(true)}
-          className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
-          title="Minimize"
-        >
-          <ChevronUp className="w-3.5 h-3.5" />
-        </button>
+        <div className="flex items-center gap-2">
+          <span className="flex items-center gap-1 text-2xs text-muted-foreground/60 tabular-nums">
+            <Timer className="w-3 h-3" />
+            {countdown}s
+          </span>
+          <button
+            onClick={() => setMinimized(true)}
+            className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+            title="Minimize"
+          >
+            <ChevronUp className="w-3.5 h-3.5" />
+          </button>
+        </div>
       </div>
 
       {/* Action chips */}

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -656,6 +656,30 @@ export function emitSmartSuggestionsAddAll(cardCount: number) {
   send('ksc_smart_suggestions_add_all', { card_count: cardCount })
 }
 
+// ── Card Recommendations (dashboard panel) ──────────────────────────
+
+/** Fired when the "Recommended Cards for your clusters" panel renders */
+export function emitCardRecommendationsShown(cardCount: number, highPriorityCount: number) {
+  send('ksc_card_recommendations_shown', { card_count: cardCount, high_priority_count: highPriorityCount })
+}
+
+/** Fired when user adds a card from the recommendations panel */
+export function emitCardRecommendationActioned(cardType: string, priority: string) {
+  send('ksc_card_recommendation_actioned', { card_type: cardType, priority })
+}
+
+// ── Mission Suggestions (dashboard panel) ───────────────────────────
+
+/** Fired when the "Recommended Actions for your clusters" panel renders */
+export function emitMissionSuggestionsShown(count: number, criticalCount: number) {
+  send('ksc_mission_suggestions_shown', { suggestion_count: count, critical_count: criticalCount })
+}
+
+/** Fired when user starts an action from the mission suggestions panel */
+export function emitMissionSuggestionActioned(missionType: string, priority: string, action: string) {
+  send('ksc_mission_suggestion_actioned', { mission_type: missionType, priority, action })
+}
+
 // ── "Almost" Action Tracking ────────────────────────────────────────
 // These track user intent signals — users who almost engaged but didn't.
 // Helps distinguish discovery problems from conversion problems.


### PR DESCRIPTION
## Summary

- **Remove SmartCardSuggestions** from Dashboard — redundant now that CardRecommendations and MissionSuggestions provide the same functionality
- **Add 20s auto-collapse countdown timer** to both "Recommended Cards" and "Recommended Actions" panels — timer is visible in the header, pauses on hover, resumes on mouse leave
- **Add GA4 analytics** for recommendation panels: `ksc_card_recommendations_shown`, `ksc_card_recommendation_actioned`, `ksc_mission_suggestions_shown`, `ksc_mission_suggestion_actioned`

## Motivation

GA4 data shows smart suggestions had very low conversion (155 shown, 5 accepted). The two recommendation panels already serve this purpose better. Auto-collapse reduces visual clutter for returning users while keeping recommendations discoverable. New analytics events close the gap in funnel tracking for recommendation engagement.

## Test plan

- [ ] Verify SmartCardSuggestions no longer renders on dashboard
- [ ] Both recommendation panels show countdown timer (20s) in header
- [ ] Hovering pauses the countdown; leaving resumes it
- [ ] Panel auto-collapses to minimized view when timer reaches 0
- [ ] Clicking expand on minimized view resets the timer
- [ ] GA4 events fire: `ksc_card_recommendations_shown` on render, `ksc_card_recommendation_actioned` on add
- [ ] GA4 events fire: `ksc_mission_suggestions_shown` on render, `ksc_mission_suggestion_actioned` on action/repair
- [ ] Build and lint pass