### PR TITLE
🐛 Fix update-available hint tooltip overflowing viewport

### DIFF
--- a/web/src/components/layout/navbar/UpdateIndicator.tsx
+++ b/web/src/components/layout/navbar/UpdateIndicator.tsx
@@ -61,7 +61,7 @@ export function UpdateIndicator() {
         <FeatureHintTooltip
           message="An update is available — click here to see what's new and how to update"
           onDismiss={updateHint.dismiss}
-          placement="bottom"
+          placement="bottom-right"
         />
       )}
 

--- a/web/src/components/ui/FeatureHintTooltip.tsx
+++ b/web/src/components/ui/FeatureHintTooltip.tsx
@@ -7,15 +7,18 @@
 
 import { X } from 'lucide-react'
 
+type Placement = 'top' | 'bottom' | 'bottom-right' | 'left' | 'right'
+
 interface FeatureHintTooltipProps {
   message: string
   onDismiss: () => void
-  placement?: 'top' | 'bottom' | 'left' | 'right'
+  placement?: Placement
 }
 
-const PLACEMENT_CLASSES: Record<string, string> = {
+const PLACEMENT_CLASSES: Record<Placement, string> = {
   top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
   bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+  'bottom-right': 'top-full right-0 mt-2',
   left: 'right-full top-1/2 -translate-y-1/2 mr-2',
   right: 'left-full top-1/2 -translate-y-1/2 ml-2',
 }


### PR DESCRIPTION
## Summary

- Add `bottom-right` placement option to `FeatureHintTooltip` that right-aligns the tooltip instead of center-aligning
- Use `bottom-right` for the update indicator hint in the navbar, which sits near the right edge and was overflowing off-screen

## Test plan

- [ ] Clear `kc-feature-hints-dismissed` from localStorage to re-trigger hints
- [ ] With an update available, verify the hint tooltip is fully visible and right-aligned under the download button
- [ ] Build passes