### PR TITLE
✨ Add /issue route to open feedback modal directly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 The best way to contribute is by opening an issue. Bug reports, feature requests, UX feedback, and questions all help shape the project.
 
-The fastest way to file an issue or feature request is through the bug icon in the console's top navbar — it pre-fills context about the page you're on. Use it from your [local console](http://localhost:8080) (requires GitHub OAuth) or the [live demo](https://console.kubestellar.io). You can also use [GitHub Issues](https://github.com/kubestellar/console/issues) directly.
+The fastest way to file an issue or feature request is through the console at [localhost:8080/issue](http://localhost:8080/issue) (requires GitHub OAuth). You can also use [GitHub Issues](https://github.com/kubestellar/console/issues) directly.
 
 ## How Development Works
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -463,6 +463,9 @@ function App() {
           <Route path="/missions/:missionId" element={<MissionDeepLink />} />
         </Route>
 
+        {/* /issue opens the feedback modal on the dashboard */}
+        <Route path="/issue" element={<Navigate to={ROUTES.HOME} replace state={{ openFeedback: true }} />} />
+
         <Route path="*" element={<Navigate to={ROUTES.HOME} replace />} />
       </Routes>
       </Suspense>

--- a/web/src/components/feedback/FeatureRequestButton.tsx
+++ b/web/src/components/feedback/FeatureRequestButton.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Bug } from 'lucide-react'
+import { useLocation } from 'react-router-dom'
 import { FeatureRequestModal } from './FeatureRequestModal'
 import { useNotifications } from '../../hooks/useFeatureRequests'
 import { useTranslation } from 'react-i18next'
@@ -8,6 +9,16 @@ export function FeatureRequestButton() {
   const { t: _t } = useTranslation()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const { unreadCount } = useNotifications()
+  const location = useLocation()
+
+  // Auto-open modal when navigated from /issue route
+  useEffect(() => {
+    if ((location.state as { openFeedback?: boolean })?.openFeedback) {
+      setIsModalOpen(true)
+      // Clear the state so it doesn't re-trigger on re-renders
+      window.history.replaceState({}, '', location.pathname)
+    }
+  }, [location.state, location.pathname])
 
   const handleClick = () => {
     setIsModalOpen(true)


### PR DESCRIPTION
## Summary

- Add `/issue` route that redirects to dashboard and auto-opens the feedback modal
- `FeatureRequestButton` reads `location.state.openFeedback` to trigger the modal
- Update CONTRIBUTING.md with `localhost:8080/issue` as the direct link

## Test plan
- [x] `npm run build` passes
- [ ] Navigate to `/issue` → redirects to `/` with feedback modal open