### PR TITLE
🐛 Fix search results clicking doing nothing for catalog cards and non-sidebar dashboards

### DIFF
--- a/web/src/components/dashboard/FloatingDashboardActions.tsx
+++ b/web/src/components/dashboard/FloatingDashboardActions.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
 import { Plus, Layout, RotateCcw, Download, Upload, Pencil } from 'lucide-react'
 import { useModalState } from '../../lib/modals'
 import { useMissions } from '../../hooks/useMissions'
@@ -41,6 +42,7 @@ export function FloatingDashboardActions({
   const { t } = useTranslation()
   const { isSidebarOpen, isSidebarMinimized } = useMissions()
   const { isMobile } = useMobile()
+  const [searchParams, setSearchParams] = useSearchParams()
   const fabHint = useFeatureHints('fab-add')
   const menu = useModalState()
   const resetDialog = useModalState()
@@ -48,6 +50,17 @@ export function FloatingDashboardActions({
   const menuRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const { isOpen: menuIsOpen, close: closeMenu } = menu
+  const { open: openCustomizer } = customizer
+
+  // Auto-open sidebar customizer when navigated from search with ?customizeSidebar=true
+  useEffect(() => {
+    if (searchParams.get('customizeSidebar') === 'true') {
+      openCustomizer()
+      const cleaned = new URLSearchParams(searchParams)
+      cleaned.delete('customizeSidebar')
+      setSearchParams(cleaned, { replace: true })
+    }
+  }, [searchParams, setSearchParams, openCustomizer])
 
   // Close menu when clicking outside
   useEffect(() => {

--- a/web/src/components/layout/navbar/SearchDropdown.tsx
+++ b/web/src/components/layout/navbar/SearchDropdown.tsx
@@ -18,9 +18,13 @@ import {
 } from 'lucide-react'
 import { useSearchIndex, CATEGORY_ORDER, type SearchCategory, type SearchItem } from '../../../hooks/useSearchIndex'
 import { useMissions } from '../../../hooks/useMissions'
+import { useSidebarConfig, DISCOVERABLE_DASHBOARDS } from '../../../hooks/useSidebarConfig'
 import { scrollToCard } from '../../../lib/scrollToCard'
 import { useFeatureHints } from '../../../hooks/useFeatureHints'
 import { FeatureHintTooltip } from '../../ui/FeatureHintTooltip'
+
+/** Routes for dashboards that are discoverable but not shown by default in the sidebar */
+const DISCOVERABLE_ROUTES = new Set(DISCOVERABLE_DASHBOARDS.map(d => d.href))
 
 const CATEGORY_CONFIG: Record<SearchCategory, { label: string; icon: typeof Server }> = {
   page: { label: 'Pages', icon: LayoutDashboard },
@@ -42,6 +46,7 @@ export function SearchDropdown() {
   const navigate = useNavigate()
   const location = useLocation()
   const { openSidebar, setActiveMission, startMission } = useMissions()
+  const { config: sidebarConfig } = useSidebarConfig()
   const [searchQuery, setSearchQuery] = useState('')
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const [selectedIndex, setSelectedIndex] = useState(0)
@@ -85,6 +90,12 @@ export function SearchDropdown() {
   const totalSelectableItems = flatResults.length + 1
   const askAIIndex = flatResults.length // "Ask AI" is always the last item
 
+  // Check if a page route is a discoverable dashboard not currently in the sidebar
+  const sidebarHrefs = useMemo(() => {
+    if (!sidebarConfig) return new Set<string>()
+    return new Set(sidebarConfig.primaryNav.map(item => item.href))
+  }, [sidebarConfig])
+
   const handleSelect = useCallback((item: SearchItem) => {
     // Mission items open the sidebar instead of navigating
     if (item.category === 'mission' && item.href?.startsWith('#mission:')) {
@@ -97,7 +108,18 @@ export function SearchDropdown() {
       if (item.scrollTarget && location.pathname === item.href) {
         scrollToCard(item.scrollTarget)
       } else {
-        navigate(item.href)
+        // For discoverable dashboards not in the sidebar, append customizeSidebar
+        // param so the page auto-opens the sidebar customizer
+        const isDiscoverableNotInSidebar =
+          item.category === 'page' &&
+          DISCOVERABLE_ROUTES.has(item.href) &&
+          !sidebarHrefs.has(item.href)
+
+        const targetHref = isDiscoverableNotInSidebar
+          ? `${item.href}${item.href.includes('?') ? '&' : '?'}customizeSidebar=true`
+          : item.href
+
+        navigate(targetHref)
         // After navigation, scroll to the card if there's a scroll target
         if (item.scrollTarget) {
           scrollToCard(item.scrollTarget)
@@ -106,7 +128,7 @@ export function SearchDropdown() {
     }
     setSearchQuery('')
     setIsSearchOpen(false)
-  }, [navigate, location.pathname, setActiveMission, openSidebar])
+  }, [navigate, location.pathname, setActiveMission, openSidebar, sidebarHrefs])
 
   // Close dropdown when clicking outside
   useEffect(() => {

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -291,20 +291,23 @@ const SETTING_ITEMS: SearchItem[] = [
 ]
 
 // All known card types from metadata (makes every card searchable even if not placed)
+// Catalog items navigate to main dashboard and open the Add Card modal
 const CATALOG_CARD_ITEMS: SearchItem[] = Object.entries(CARD_TITLES).map(([type, title]) => ({
   id: `catalog-card-${type}`,
   name: title,
   description: CARD_DESCRIPTIONS[type] || 'Available card',
   category: 'card' as SearchCategory,
+  href: '/?addCard=true',
   keywords: [type, type.replace(/_/g, ' ')],
   meta: 'add card',
 }))
 
 // Static items that don't need localStorage scanning (stats are scanned dynamically now)
+// Note: CATALOG_CARD_ITEMS are NOT included here — they're de-duplicated against
+// placed cards at query time (see filtering logic below)
 const STATIC_ITEMS: SearchItem[] = [
   ...PAGE_ITEMS,
   ...SETTING_ITEMS,
-  ...CATALOG_CARD_ITEMS,
 ]
 
 // --- Matching ---
@@ -467,7 +470,12 @@ export function useSearchIndex(query: string) {
     // Scan placed stats from localStorage / defaults
     const placedStats = scanPlacedStats()
 
-    const allItems = [...STATIC_ITEMS, ...dynamicItems, ...placedCards, ...placedStats]
+    // De-duplicate: if a card is placed on a dashboard, prefer the placed version
+    // (which navigates + scrolls to it) over the generic catalog version
+    const placedCardTypes = new Set(placedCards.map(c => c.id.replace(/^card-/, '').replace(/-on-.*$/, '')))
+    const dedupedCatalog = CATALOG_CARD_ITEMS.filter(c => !placedCardTypes.has(c.id.replace('catalog-card-', '')))
+
+    const allItems = [...STATIC_ITEMS, ...dedupedCatalog, ...dynamicItems, ...placedCards, ...placedStats]
     const matched = allItems.filter(item => matchesQuery(item, query))
 
     // Group by category


### PR DESCRIPTION
## Summary

- **Catalog card search results** (cards not placed on any dashboard) had no `href`, so clicking them silently closed the search dropdown with no action. Now they navigate to the main dashboard and open the Add Card modal (`/?addCard=true`).
- **De-duplicates search results**: when a card is already placed on a dashboard, the placed version (which navigates + scrolls to it) is preferred over the generic catalog version.
- **Discoverable dashboards not in sidebar**: clicking a search result for a dashboard page not in the user's sidebar now navigates to the page AND auto-opens the sidebar customizer, so the user can add it to their sidebar.

## Root cause

In `useSearchIndex.ts`, `CATALOG_CARD_ITEMS` (line 294) was missing the `href` property. The click handler in `SearchDropdown.tsx` checks `if (item.href)` before navigating — catalog items fell through silently.

## Test plan

- [ ] Search for "node status" (a card not placed by default) → clicking opens the Add Card modal on the main dashboard
- [ ] Search for "node status" when the card IS placed on a dashboard → clicking navigates to that dashboard and scrolls to the card (no duplicate catalog result)
- [ ] Search for "Storage" or "GitOps" (discoverable dashboards not in default sidebar) → clicking navigates to the page and opens the sidebar customizer
- [ ] Search for "Dashboard" or "Clusters" (pages already in sidebar) → clicking navigates normally without opening the customizer
- [ ] Build passes, no new lint errors