### PR TITLE
🐛 Fix /issue route to reliably open feedback modal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 The best way to contribute is by opening an issue. Bug reports, feature requests, UX feedback, and questions all help shape the project.
 
-The fastest way to file an issue or feature request is through the console at [localhost:8080/issue](http://localhost:8080/issue) (requires GitHub OAuth). You can also use [GitHub Issues](https://github.com/kubestellar/console/issues) directly.
+The fastest way to file an issue or feature request is by navigating to [`/issue`](http://localhost:8080/issue) in your running console (requires GitHub OAuth). You can also use [GitHub Issues](https://github.com/kubestellar/console/issues) directly.
 
 ## How Development Works
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -247,6 +247,18 @@ function SettingsSyncInit() {
 /** Redirect /missions → /?browse=missions to open MissionBrowser.
  *  Redirect /missions/:missionId → /?mission=:missionId to open a specific mission.
  *  Preserves UTM and other query params so GA4 campaign attribution survives the redirect. */
+function IssueRedirect() {
+  const navigate = useNavigate()
+  useEffect(() => {
+    // Navigate to home first, then dispatch event for FeatureRequestButton
+    navigate(ROUTES.HOME, { replace: true })
+    // Use setTimeout to ensure the dashboard is mounted before firing
+    const MODAL_OPEN_DELAY_MS = 100
+    setTimeout(() => window.dispatchEvent(new CustomEvent('open-feedback')), MODAL_OPEN_DELAY_MS)
+  }, [navigate])
+  return null
+}
+
 function MissionBrowseLink() {
   const [searchParams] = useSearchParams()
   const params = new URLSearchParams(searchParams)
@@ -461,10 +473,9 @@ function App() {
               and the ?mission= param survives the OAuth round-trip. */}
           <Route path="/missions" element={<MissionBrowseLink />} />
           <Route path="/missions/:missionId" element={<MissionDeepLink />} />
+          {/* /issue opens the feedback modal on the dashboard */}
+          <Route path="/issue" element={<IssueRedirect />} />
         </Route>
-
-        {/* /issue opens the feedback modal on the dashboard */}
-        <Route path="/issue" element={<Navigate to={ROUTES.HOME} replace state={{ openFeedback: true }} />} />
 
         <Route path="*" element={<Navigate to={ROUTES.HOME} replace />} />
       </Routes>

--- a/web/src/components/feedback/FeatureRequestButton.tsx
+++ b/web/src/components/feedback/FeatureRequestButton.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { Bug } from 'lucide-react'
-import { useLocation } from 'react-router-dom'
 import { FeatureRequestModal } from './FeatureRequestModal'
 import { useNotifications } from '../../hooks/useFeatureRequests'
 import { useTranslation } from 'react-i18next'
@@ -9,16 +8,13 @@ export function FeatureRequestButton() {
   const { t: _t } = useTranslation()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const { unreadCount } = useNotifications()
-  const location = useLocation()
 
-  // Auto-open modal when navigated from /issue route
+  // Auto-open modal when navigated from /issue route (fires custom event)
   useEffect(() => {
-    if ((location.state as { openFeedback?: boolean })?.openFeedback) {
-      setIsModalOpen(true)
-      // Clear the state so it doesn't re-trigger on re-renders
-      window.history.replaceState({}, '', location.pathname)
-    }
-  }, [location.state, location.pathname])
+    const handler = () => setIsModalOpen(true)
+    window.addEventListener('open-feedback', handler)
+    return () => window.removeEventListener('open-feedback', handler)
+  }, [])
 
   const handleClick = () => {
     setIsModalOpen(true)


### PR DESCRIPTION
## Summary
- Fix `/issue` route which failed to open the feedback modal when user was already on the dashboard
- Replace `Navigate` + location state with a custom event (`open-feedback`) approach
- Move `/issue` inside `ProtectedRoute` so auth is required before redirect
- Update CONTRIBUTING.md wording for the `/issue` route

## What changed
- `App.tsx`: New `IssueRedirect` component that navigates to home and dispatches a custom event
- `FeatureRequestButton.tsx`: Listen for `open-feedback` event instead of checking `location.state`
- `CONTRIBUTING.md`: Cleaner `/issue` route description