### PR TITLE
🐛 Stop auto-adding triage/accepted to console-created issues

### DIFF
--- a/.github/workflows/console-issue-labels.yml
+++ b/.github/workflows/console-issue-labels.yml
@@ -27,7 +27,8 @@ jobs:
             const typeLabel = isBug ? 'kind/bug' : 'enhancement';
 
             // Labels that should be present on all console-created issues
-            const requiredLabels = [typeLabel, 'ai-fix-requested', 'help wanted', 'triage/accepted'];
+            // Note: triage/accepted is intentionally omitted — only humans should add it
+            const requiredLabels = [typeLabel, 'ai-fix-requested', 'help wanted'];
 
             const labelsToAdd = requiredLabels.filter(l => !existingLabels.includes(l));
 


### PR DESCRIPTION
## Summary
- `console-issue-labels.yml` was auto-adding `triage/accepted` to console-created issues
- This bypasses the human triage step — `triage/accepted` should only be added by maintainers
- Also caused a race condition: `ai-fix.yml` requires both `ai-fix-requested` + `triage/accepted`, but when `console-issue-labels.yml` added `triage/accepted` after the initial label event, the second trigger was for the wrong label

## Test plan
- [ ] Create issue via console — should NOT get `triage/accepted` auto-applied
- [ ] Manually add `triage/accepted` — should trigger `ai-fix.yml` → Copilot assignment