### PR TITLE
🐛 Fix search results clicking doing nothing for catalog cards and non-sidebar dashboards

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
-import { useLocation, useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import {
   DndContext,
   closestCenter,
@@ -90,6 +90,7 @@ export function Dashboard() {
   const [isLoading, setIsLoading] = useState(false) // Cards are pre-populated from localStorage/defaults — never block
   const location = useLocation()
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const { isOpen: isConfigureCardOpen, open: openConfigureCard, close: closeConfigureCard } = useModalState()
   const [selectedCard, setSelectedCard] = useState<Card | null>(null)
   const [localCards, setLocalCards] = useState<Card[]>(() => {
@@ -501,6 +502,16 @@ export function Dashboard() {
       setPendingOpenAddCardModal(false)
     }
   }, [pendingOpenAddCardModal, isLoading, openAddCardModal, setPendingOpenAddCardModal])
+
+  // Handle addCard URL param from search — open modal and clear param
+  useEffect(() => {
+    if (searchParams.get('addCard') === 'true') {
+      openAddCardModal()
+      const cleaned = new URLSearchParams(searchParams)
+      cleaned.delete('addCard')
+      setSearchParams(cleaned, { replace: true })
+    }
+  }, [searchParams, setSearchParams, openAddCardModal])
 
   // Helper to check if a card ID is a local-only (not persisted) card
   const isLocalOnlyCard = (cardId: string) => {

--- a/web/src/components/layout/navbar/SearchDropdown.tsx
+++ b/web/src/components/layout/navbar/SearchDropdown.tsx
@@ -105,7 +105,8 @@ export function SearchDropdown() {
     } else if (item.href) {
       // If we're already on the target route and there's a scroll target,
       // just scroll directly without navigating
-      if (item.scrollTarget && location.pathname === item.href) {
+      const baseHref = item.href.split('?')[0]
+      if (item.scrollTarget && location.pathname === baseHref) {
         scrollToCard(item.scrollTarget)
       } else {
         // For discoverable dashboards not in the sidebar, append customizeSidebar
@@ -115,11 +116,21 @@ export function SearchDropdown() {
           DISCOVERABLE_ROUTES.has(item.href) &&
           !sidebarHrefs.has(item.href)
 
-        const targetHref = isDiscoverableNotInSidebar
-          ? `${item.href}${item.href.includes('?') ? '&' : '?'}customizeSidebar=true`
-          : item.href
+        // Dashboard search results should open the sidebar customizer
+        const isDashboardResult = item.category === 'dashboard'
 
-        navigate(targetHref)
+        let targetHref = item.href
+        if (isDiscoverableNotInSidebar || isDashboardResult) {
+          targetHref = `${item.href}${item.href.includes('?') ? '&' : '?'}customizeSidebar=true`
+        }
+
+        // If already on the same path, force navigation by using replace
+        // so ?addCard=true or ?customizeSidebar=true params are picked up
+        if (location.pathname === baseHref) {
+          navigate(targetHref, { replace: true })
+        } else {
+          navigate(targetHref)
+        }
         // After navigation, scroll to the card if there's a scroll target
         if (item.scrollTarget) {
           scrollToCard(item.scrollTarget)


### PR DESCRIPTION
## Summary

- **Catalog card search results** (e.g. searching "node status" when the card isn't placed on any dashboard) navigated to `/?addCard=true` but the main Dashboard component never read that param — nothing happened on click
- **Dashboard search results** (custom dashboards) navigated to the page but didn't open any dialog
- **Same-route navigation** didn't trigger `useEffect` for search params when already on the target path

## Changes

- `Dashboard.tsx`: Add `?addCard=true` URL param handler (matching the pattern in `DashboardPage.tsx`, `Clusters.tsx`, `Compute.tsx`, etc.)
- `SearchDropdown.tsx`: Use `navigate(href, { replace: true })` when already on the same path so search params are picked up
- `SearchDropdown.tsx`: Append `?customizeSidebar=true` for dashboard category search results so the sidebar customizer opens

## Test plan

- [ ] Search "node status" → click result → add card modal opens on main dashboard
- [ ] Search for a custom dashboard name → click result → navigates and opens sidebar customizer
- [ ] Search for a card already placed on a dashboard → click → scrolls to it
- [ ] Verify Cmd+K → Enter keyboard flow still works