### PR TITLE
🌱 Upgrade globals from v15 to v17

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -53,7 +53,7 @@
         "eslint": "^9.17.0",
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.16",
-        "globals": "^15.14.0",
+        "globals": "^17.4.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.1.7",
@@ -5534,9 +5534,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "15.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
+      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/package.json
+++ b/web/package.json
@@ -86,7 +86,7 @@
     "eslint": "^9.17.0",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.16",
-    "globals": "^15.14.0",
+    "globals": "^17.4.0",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-report": "^3.0.1",
     "istanbul-reports": "^3.1.7",


### PR DESCRIPTION
## Summary
- Bumps `globals` ESLint utility package from `^15.14.0` to `^17.4.0`
- Zero-risk upgrade — `globals` only provides global variable definitions for ESLint configuration
- Build and lint verified with identical output before and after

## Test plan
- [x] `npm run build` passes
- [x] `npx eslint src/` produces identical 386 problems (54 errors, 332 warnings) — no regressions