### PR TITLE
🌱 Upgrade @dnd-kit/sortable from v8 to v9

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
-        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/sortable": "^9.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@netlify/blobs": "^10.6.0",
         "@react-three/drei": "^9.120.4",
@@ -639,16 +639,16 @@
       }
     },
     "node_modules/@dnd-kit/sortable": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
-      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-9.0.0.tgz",
+      "integrity": "sha512-3/9r8Mmba0nKTbo8kPnVSFZKf/VSy94nXZ3aUwzPEh78j/LooQ/EFKRZENak4PHKBkN53mgTF/z+Sd8H+FcAnQ==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
-        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/core": "^6.2.0",
         "react": ">=16.8.0"
       }
     },

--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/sortable": "^9.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@netlify/blobs": "^10.6.0",
     "@react-three/drei": "^9.120.4",


### PR DESCRIPTION
## Summary
- Bumps `@dnd-kit/sortable` from `^8.0.0` to `^9.0.0`
- Step 1 of 2 — v9 → v10 will follow in a separate PR
- No source code changes required

## Test plan
- [x] `npm run build` passes with identical output
- [x] No API changes affecting current usage