### PR TITLE
🐛 Broadcast failure when auto-update aborts on uncommitted changes

### DIFF
--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -764,7 +764,16 @@ func (uc *UpdateChecker) executeDevReleaseUpdate(release *githubReleaseInfo) {
 	repoPath := uc.repoPath
 	uc.mu.Unlock()
 
-	if repoPath == "" || hasUncommittedChanges(repoPath) {
+	if repoPath == "" {
+		return
+	}
+	if hasUncommittedChanges(repoPath) {
+		log.Println("[AutoUpdate] Uncommitted changes detected, skipping release update")
+		uc.broadcast("update_progress", UpdateProgressPayload{
+			Status:  "failed",
+			Message: "Update skipped: uncommitted changes in repo",
+			Error:   "Commit or stash your changes before updating",
+		})
 		return
 	}
 


### PR DESCRIPTION
## Summary
- `executeDevReleaseUpdate()` silently returned when uncommitted changes were detected, sending no WebSocket message to the frontend
- The UI got stuck showing the progress banner indefinitely (or flashing briefly) with no error feedback
- Now broadcasts a `status: "failed"` message via WebSocket so the frontend shows the error banner and clears the progress state

## Test plan
- [ ] Set up a dev install with uncommitted changes in the repo
- [ ] Trigger an update via the Settings page
- [ ] Verify the UI shows "Update skipped: uncommitted changes in repo" error instead of silently stopping