### PR TITLE
🐛 Improve update failure UX: actionable error + retry without refresh

### DIFF
--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -298,8 +298,9 @@ func (uc *UpdateChecker) checkDeveloperChannel() {
 	if hasUncommittedChanges(repoPath) {
 		log.Println("[AutoUpdate] Uncommitted changes detected, skipping update")
 		uc.broadcast("update_progress", UpdateProgressPayload{
-			Status:  "idle",
-			Message: "Update paused: uncommitted changes",
+			Status:  "failed",
+			Message: "Update skipped: uncommitted changes detected",
+			Error:   fmt.Sprintf("Run 'cd %s && git stash' to save your changes, then retry the update", repoPath),
 		})
 		return
 	}
@@ -771,8 +772,8 @@ func (uc *UpdateChecker) executeDevReleaseUpdate(release *githubReleaseInfo) {
 		log.Println("[AutoUpdate] Uncommitted changes detected, skipping release update")
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:  "failed",
-			Message: "Update skipped: uncommitted changes in repo",
-			Error:   "Commit or stash your changes before updating",
+			Message: "Update skipped: uncommitted changes detected",
+			Error:   fmt.Sprintf("Run 'cd %s && git stash' to save your changes, then retry the update", repoPath),
 		})
 		return
 	}

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -151,10 +151,15 @@ export function UpdateSettings() {
     forceCheck()
   }, [forceCheck])
 
-  // Clear triggered state once WebSocket progress starts
+  // Clear triggered state once WebSocket progress starts or update fails
   useEffect(() => {
     if (updateProgress && triggerState === 'triggered') {
       setTriggerState('idle')
+    }
+    // Reset the double-click guard when the update finishes (success or failure)
+    // so the user can retry without refreshing
+    if (updateProgress && ['done', 'failed'].includes(updateProgress.status)) {
+      triggerGuardRef.current = false
     }
   }, [updateProgress, triggerState])
 


### PR DESCRIPTION
## Summary
Follow-up to #2041. Three improvements to the auto-update failure flow:

- **Actionable error message**: Instead of "Update paused: uncommitted changes", shows "Update skipped: uncommitted changes detected" with a specific command: `Run 'cd /path/to/repo && git stash' to save your changes, then retry the update`
- **Consistent status**: Both `checkDeveloperChannel` and `executeDevReleaseUpdate` now broadcast `status: "failed"` (the developer channel previously sent `"idle"` which confused the UI)
- **Retry without refresh**: Reset `triggerGuardRef` when update finishes (done or failed) so the "Update Now" button works again without requiring a page refresh

## Test plan
- [ ] Introduce uncommitted changes in the console repo
- [ ] Click "Update Now" in Settings
- [ ] Verify error banner shows with `git stash` instruction
- [ ] Stash the changes, click "Update Now" again — should work without page refresh