### PR TITLE
✨ Multi-Cluster Insights dashboard with 7 correlation cards

### DIFF
--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -188,6 +188,16 @@ const FluentdStatus = lazy(() => import('./fluentd_status').then(m => ({ default
 // Lima VM card
 const LimaStatus = lazy(() => import('./lima_status').then(m => ({ default: m.LimaStatus })))
 
+// Multi-cluster insights cards — share one chunk via barrel import
+const _insightsBundle = import('./insights')
+const CrossClusterEventCorrelation = lazy(() => _insightsBundle.then(m => ({ default: m.CrossClusterEventCorrelation })))
+const ClusterDeltaDetector = lazy(() => _insightsBundle.then(m => ({ default: m.ClusterDeltaDetector })))
+const CascadeImpactMap = lazy(() => _insightsBundle.then(m => ({ default: m.CascadeImpactMap })))
+const ConfigDriftHeatmap = lazy(() => _insightsBundle.then(m => ({ default: m.ConfigDriftHeatmap })))
+const ResourceImbalanceDetector = lazy(() => _insightsBundle.then(m => ({ default: m.ResourceImbalanceDetector })))
+const RestartCorrelationMatrix = lazy(() => _insightsBundle.then(m => ({ default: m.RestartCorrelationMatrix })))
+const DeploymentRolloutTracker = lazy(() => _insightsBundle.then(m => ({ default: m.DeploymentRolloutTracker })))
+
 // Cluster admin cards — share one chunk via barrel import
 const _clusterAdminBundle = import('./cluster-admin-bundle')
 const PredictiveHealth = lazy(() => _clusterAdminBundle.then(m => ({ default: m.PredictiveHealth })))
@@ -457,6 +467,15 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   throughput_comparison: ThroughputComparison,
   performance_timeline: PerformanceTimeline,
   resource_utilization: ResourceUtilization,
+
+  // Multi-cluster insights cards
+  cross_cluster_event_correlation: CrossClusterEventCorrelation,
+  cluster_delta_detector: ClusterDeltaDetector,
+  cascade_impact_map: CascadeImpactMap,
+  config_drift_heatmap: ConfigDriftHeatmap,
+  resource_imbalance_detector: ResourceImbalanceDetector,
+  restart_correlation_matrix: RestartCorrelationMatrix,
+  deployment_rollout_tracker: DeploymentRolloutTracker,
 
   // Dynamic Card (Card Factory meta-component)
   dynamic_card: DynamicCard,

--- a/web/src/components/cards/insights/CascadeImpactMap.tsx
+++ b/web/src/components/cards/insights/CascadeImpactMap.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from 'react'
+import { Workflow, ArrowRight, AlertTriangle } from 'lucide-react'
+import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
+import { useCardLoadingState } from '../CardDataContext'
+import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
+import { InsightSourceBadge } from './InsightSourceBadge'
+import { StatusBadge } from '../../ui/StatusBadge'
+import type { InsightSeverity } from '../../../types/insights'
+
+const SEVERITY_COLORS: Record<InsightSeverity, string> = {
+  critical: 'border-red-500/40 bg-red-500/10',
+  warning: 'border-yellow-500/40 bg-yellow-500/10',
+  info: 'border-blue-500/40 bg-blue-500/10',
+}
+
+const SEVERITY_DOT_COLORS: Record<InsightSeverity, string> = {
+  critical: 'bg-red-500',
+  warning: 'bg-yellow-500',
+  info: 'bg-blue-500',
+}
+
+export function CascadeImpactMap() {
+  const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
+  const { selectedClusters } = useGlobalFilters()
+
+  const cascadeInsights = useMemo(() => {
+    const all = insightsByCategory['cascade-impact'] || []
+    if (selectedClusters.length === 0) return all
+    return all.filter(i =>
+      (i.affectedClusters || []).some(c => selectedClusters.includes(c)),
+    )
+  }, [insightsByCategory, selectedClusters])
+
+  useCardLoadingState({
+    isLoading,
+    hasAnyData: cascadeInsights.length > 0,
+    isDemoData,
+  })
+
+  if (!isLoading && cascadeInsights.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
+        <Workflow className="w-8 h-8 mb-2 opacity-50" />
+        <p className="text-sm">No cascade patterns detected</p>
+        <p className="text-xs mt-1">Issues are not propagating across clusters</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 p-1">
+      {(cascadeInsights || []).map(insight => (
+        <div key={insight.id} className="space-y-2">
+          {/* Header */}
+          <div className="flex items-center gap-2">
+            <InsightSourceBadge source={insight.source} confidence={insight.confidence} />
+            <StatusBadge
+              color={insight.severity === 'critical' ? 'red' : 'yellow'}
+              size="xs"
+            >
+              {insight.severity}
+            </StatusBadge>
+            <span className="text-xs font-medium flex-1">{insight.title}</span>
+          </div>
+          <p className="text-xs text-muted-foreground">{insight.description}</p>
+
+          {/* Cascade chain */}
+          {insight.chain && insight.chain.length > 0 && (
+            <div className="flex items-start gap-1 overflow-x-auto pb-1">
+              {(insight.chain || []).map((link, i) => (
+                <div key={`${link.cluster}-${i}`} className="flex items-center gap-1 flex-shrink-0">
+                  {/* Chain node */}
+                  <div className={`border rounded-lg p-2 min-w-28 ${SEVERITY_COLORS[link.severity]}`}>
+                    <div className="flex items-center gap-1 mb-1">
+                      <div className={`w-1.5 h-1.5 rounded-full ${SEVERITY_DOT_COLORS[link.severity]}`} />
+                      <span className="text-2xs font-medium">{link.cluster}</span>
+                    </div>
+                    <div className="text-2xs text-muted-foreground">{link.resource}</div>
+                    <div className="flex items-center gap-1 mt-1">
+                      <AlertTriangle className="w-2.5 h-2.5 text-yellow-400" />
+                      <span className="text-2xs">{link.event}</span>
+                    </div>
+                    {link.timestamp && (
+                      <div className="text-[9px] text-muted-foreground mt-1">
+                        {new Date(link.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Arrow connector */}
+                  {i < (insight.chain || []).length - 1 && (
+                    <ArrowRight className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* AI remediation */}
+          {insight.remediation && (
+            <div className="bg-blue-500/5 border border-blue-500/20 rounded-lg p-2">
+              <div className="flex items-center gap-1 mb-1">
+                <StatusBadge color="blue" size="xs">AI Suggestion</StatusBadge>
+              </div>
+              <p className="text-xs text-muted-foreground">{insight.remediation}</p>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/cards/insights/ClusterDeltaDetector.tsx
+++ b/web/src/components/cards/insights/ClusterDeltaDetector.tsx
@@ -1,0 +1,164 @@
+import { useMemo, useState } from 'react'
+import { GitCompare } from 'lucide-react'
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
+import { useCardLoadingState } from '../CardDataContext'
+import { InsightSourceBadge } from './InsightSourceBadge'
+import { StatusBadge } from '../../ui/StatusBadge'
+import { CHART_GRID_STROKE, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER, CHART_TICK_COLOR } from '../../../lib/constants/ui'
+
+
+/** Color for cluster A bars */
+const CLUSTER_A_COLOR = '#3b82f6'
+/** Color for cluster B bars */
+const CLUSTER_B_COLOR = '#f59e0b'
+
+const SIGNIFICANCE_COLORS: Record<string, string> = {
+  high: 'border-red-500/30 bg-red-500/5',
+  medium: 'border-yellow-500/30 bg-yellow-500/5',
+  low: 'border-border bg-secondary/30',
+}
+
+export function ClusterDeltaDetector() {
+  const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
+
+  const deltaInsights = insightsByCategory['cluster-delta'] || []
+
+  useCardLoadingState({
+    isLoading,
+    hasAnyData: deltaInsights.length > 0,
+    isDemoData,
+  })
+
+  // Use first insight's clusters as default selection
+  const [selectedInsight, setSelectedInsight] = useState(0)
+  const insight = deltaInsights[selectedInsight] || deltaInsights[0]
+
+  const numericDeltas = useMemo(() => {
+    if (!insight?.deltas) return []
+    return (insight.deltas || [])
+      .filter(d => typeof d.clusterA.value === 'number' && typeof d.clusterB.value === 'number')
+      .map(d => ({
+        dimension: d.dimension,
+        [d.clusterA.name]: d.clusterA.value as number,
+        [d.clusterB.name]: d.clusterB.value as number,
+        significance: d.significance,
+      }))
+  }, [insight])
+
+  const nonNumericDeltas = useMemo(() => {
+    if (!insight?.deltas) return []
+    return (insight.deltas || []).filter(
+      d => typeof d.clusterA.value === 'string' || typeof d.clusterB.value === 'string',
+    )
+  }, [insight])
+
+  if (!isLoading && deltaInsights.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
+        <GitCompare className="w-8 h-8 mb-2 opacity-50" />
+        <p className="text-sm">No cluster deltas detected</p>
+        <p className="text-xs mt-1">Shared workloads are consistent across clusters</p>
+      </div>
+    )
+  }
+
+  const clusterPair = insight ? [...new Set(insight.affectedClusters)].slice(0, 2) : []
+
+  return (
+    <div className="space-y-3 p-1">
+      {/* Workload selector */}
+      {deltaInsights.length > 1 && (
+        <div className="flex items-center gap-2 overflow-x-auto pb-1">
+          {(deltaInsights || []).map((ins, i) => (
+            <button
+              key={ins.id}
+              onClick={() => setSelectedInsight(i)}
+              className={`text-2xs px-2 py-1 rounded whitespace-nowrap ${
+                i === selectedInsight
+                  ? 'bg-blue-500/20 text-blue-400 border border-blue-500/30'
+                  : 'bg-secondary/50 text-muted-foreground hover:bg-secondary'
+              }`}
+            >
+              {(ins.relatedResources || [])[0] || ins.title}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {insight && (
+        <>
+          <div className="flex items-center gap-2">
+            <InsightSourceBadge source={insight.source} confidence={insight.confidence} />
+            <StatusBadge
+              color={insight.severity === 'critical' ? 'red' : insight.severity === 'warning' ? 'yellow' : 'blue'}
+              size="xs"
+            >
+              {insight.severity}
+            </StatusBadge>
+            <span className="text-xs text-muted-foreground flex-1">{insight.description}</span>
+          </div>
+
+          {/* Legend */}
+          {clusterPair.length === 2 && (
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-1">
+                <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: CLUSTER_A_COLOR }} />
+                <span className="text-2xs text-muted-foreground">{clusterPair[0]}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <div className="w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: CLUSTER_B_COLOR }} />
+                <span className="text-2xs text-muted-foreground">{clusterPair[1]}</span>
+              </div>
+            </div>
+          )}
+
+          {/* Numeric deltas as bar chart */}
+          {numericDeltas.length > 0 && clusterPair.length === 2 && (
+            <div className="h-32">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={numericDeltas} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} />
+                  <XAxis dataKey="dimension" tick={{ fontSize: 9, fill: CHART_TICK_COLOR }} />
+                  <YAxis tick={{ fontSize: 9, fill: CHART_TICK_COLOR }} />
+                  <Tooltip
+                    contentStyle={{ backgroundColor: CHART_TOOLTIP_BG, border: `1px solid ${CHART_TOOLTIP_BORDER}`, borderRadius: 6, fontSize: 11 }}
+                  />
+                  <Bar dataKey={clusterPair[0]} fill={CLUSTER_A_COLOR} radius={[4, 4, 0, 0]} />
+                  <Bar dataKey={clusterPair[1]} fill={CLUSTER_B_COLOR} radius={[4, 4, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          {/* Non-numeric deltas as list */}
+          {nonNumericDeltas.length > 0 && (
+            <div className="space-y-1">
+              {(nonNumericDeltas || []).map((delta, i) => (
+                <div
+                  key={`${delta.dimension}-${i}`}
+                  className={`rounded-lg border p-2 ${SIGNIFICANCE_COLORS[delta.significance] || SIGNIFICANCE_COLORS.low}`}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-medium">{delta.dimension}</span>
+                    <StatusBadge
+                      color={delta.significance === 'high' ? 'red' : delta.significance === 'medium' ? 'yellow' : 'gray'}
+                      size="xs"
+                    >
+                      {delta.significance}
+                    </StatusBadge>
+                  </div>
+                  <div className="flex items-center gap-2 mt-1">
+                    <span className="text-2xs text-blue-400">{delta.clusterA.name}: {String(delta.clusterA.value)}</span>
+                    <span className="text-2xs text-muted-foreground">vs</span>
+                    <span className="text-2xs text-yellow-400">{delta.clusterB.name}: {String(delta.clusterB.value)}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/insights/ConfigDriftHeatmap.tsx
+++ b/web/src/components/cards/insights/ConfigDriftHeatmap.tsx
@@ -1,0 +1,164 @@
+import { useMemo, useState } from 'react'
+import { Diff } from 'lucide-react'
+import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
+import { useCardLoadingState } from '../CardDataContext'
+import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
+import { InsightSourceBadge } from './InsightSourceBadge'
+import { StatusBadge } from '../../ui/StatusBadge'
+
+/** Maximum clusters to show in the heatmap grid */
+const MAX_HEATMAP_CLUSTERS = 12
+
+export function ConfigDriftHeatmap() {
+  const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
+  const { selectedClusters } = useGlobalFilters()
+
+  const driftInsights = useMemo(() => insightsByCategory['config-drift'] || [], [insightsByCategory])
+
+  useCardLoadingState({
+    isLoading,
+    hasAnyData: driftInsights.length > 0,
+    isDemoData,
+  })
+
+  const [selectedWorkload, setSelectedWorkload] = useState<string | null>(null)
+
+  // Build cluster-pair drift counts
+  const { clusters, driftMatrix } = useMemo(() => {
+    const clusterSet = new Set<string>()
+    for (const insight of driftInsights || []) {
+      for (const c of insight.affectedClusters || []) {
+        if (selectedClusters.length === 0 || selectedClusters.includes(c)) {
+          clusterSet.add(c)
+        }
+      }
+    }
+    const clusterList = Array.from(clusterSet).slice(0, MAX_HEATMAP_CLUSTERS)
+
+    // Count drift items per cluster pair
+    const matrix = new Map<string, number>()
+    for (const insight of driftInsights || []) {
+      const affected = (insight.affectedClusters || []).filter(c => clusterList.includes(c))
+      for (let i = 0; i < affected.length; i++) {
+        for (let j = i + 1; j < affected.length; j++) {
+          const key = `${affected[i]}:${affected[j]}`
+          matrix.set(key, (matrix.get(key) || 0) + 1)
+        }
+      }
+    }
+
+    return { clusters: clusterList, driftMatrix: matrix }
+  }, [driftInsights, selectedClusters])
+
+  const maxDrift = Math.max(1, ...Array.from(driftMatrix.values()))
+
+  function getDriftColor(count: number): string {
+    if (count === 0) return 'bg-green-500/20'
+    const intensity = count / maxDrift
+    if (intensity > 0.7) return 'bg-red-500/30'
+    if (intensity > 0.3) return 'bg-yellow-500/25'
+    return 'bg-orange-500/15'
+  }
+
+  function getDriftCount(a: string, b: string): number {
+    return driftMatrix.get(`${a}:${b}`) || driftMatrix.get(`${b}:${a}`) || 0
+  }
+
+  if (!isLoading && driftInsights.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
+        <Diff className="w-8 h-8 mb-2 opacity-50" />
+        <p className="text-sm">No config drift detected</p>
+        <p className="text-xs mt-1">Shared workloads have consistent configuration</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3 p-1">
+      {/* Heatmap */}
+      {clusters.length >= 2 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-2xs">
+            <thead>
+              <tr>
+                <th className="p-1 text-left text-muted-foreground" />
+                {(clusters || []).map(c => (
+                  <th key={c} className="p-1 text-center text-muted-foreground max-w-16 truncate" title={c}>
+                    {c.length > 8 ? c.slice(0, 6) + '..' : c}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {(clusters || []).map((row, ri) => (
+                <tr key={row}>
+                  <td className="p-1 text-muted-foreground max-w-20 truncate" title={row}>
+                    {row.length > 10 ? row.slice(0, 8) + '..' : row}
+                  </td>
+                  {(clusters || []).map((col, ci) => {
+                    if (ri === ci) {
+                      return <td key={col} className="p-1"><div className="w-6 h-6 bg-secondary/30 rounded" /></td>
+                    }
+                    const count = getDriftCount(row, col)
+                    return (
+                      <td key={col} className="p-1">
+                        <div
+                          className={`w-6 h-6 rounded flex items-center justify-center cursor-pointer hover:ring-1 hover:ring-foreground/20 ${getDriftColor(count)}`}
+                          title={`${row} ↔ ${col}: ${count} drift items`}
+                        >
+                          {count > 0 && <span className="text-[8px] font-medium">{count}</span>}
+                        </div>
+                      </td>
+                    )
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Legend */}
+      <div className="flex items-center gap-3 text-2xs text-muted-foreground">
+        <div className="flex items-center gap-1">
+          <div className="w-3 h-3 rounded bg-green-500/20" />
+          <span>In sync</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-3 h-3 rounded bg-orange-500/15" />
+          <span>Low drift</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-3 h-3 rounded bg-yellow-500/25" />
+          <span>Medium</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-3 h-3 rounded bg-red-500/30" />
+          <span>High</span>
+        </div>
+      </div>
+
+      {/* Drift details list */}
+      <div className="space-y-1 border-t border-border pt-2 max-h-32 overflow-y-auto">
+        {(driftInsights || []).map(insight => (
+          <div
+            key={insight.id}
+            className="flex items-center gap-2 text-xs py-1 hover:bg-secondary/30 rounded px-1 cursor-pointer"
+            onClick={() => setSelectedWorkload(selectedWorkload === insight.id ? null : insight.id)}
+          >
+            <InsightSourceBadge source={insight.source} confidence={insight.confidence} />
+            <StatusBadge
+              color={insight.severity === 'warning' ? 'yellow' : 'blue'}
+              size="xs"
+            >
+              {insight.severity}
+            </StatusBadge>
+            <span className="flex-1 truncate">{insight.title}</span>
+            <span className="text-2xs text-muted-foreground">{insight.affectedClusters.length} clusters</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
+++ b/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
@@ -1,0 +1,154 @@
+import { useMemo } from 'react'
+import { Activity } from 'lucide-react'
+import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
+import { useCachedWarningEvents } from '../../../hooks/useCachedData'
+import { useCardLoadingState } from '../CardDataContext'
+import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
+import { InsightSourceBadge } from './InsightSourceBadge'
+import { StatusBadge } from '../../ui/StatusBadge'
+import { CHART_GRID_STROKE, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER, CHART_TICK_COLOR } from '../../../lib/constants/ui'
+
+/** Time bucket size for the timeline chart (2 minutes) */
+const TIMELINE_BUCKET_MS = 2 * 60 * 1000
+/** Maximum number of buckets to show on the chart */
+const MAX_TIMELINE_BUCKETS = 30
+
+/** Color palette for cluster series in the stacked area chart */
+const CLUSTER_COLORS = [
+  '#3b82f6', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6',
+  '#06b6d4', '#ec4899', '#14b8a6', '#f97316', '#6366f1',
+]
+
+export function CrossClusterEventCorrelation() {
+  const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
+  const { events: warningEvents } = useCachedWarningEvents()
+  const { selectedClusters } = useGlobalFilters()
+
+  const correlationInsights = insightsByCategory['event-correlation'] || []
+
+  useCardLoadingState({
+    isLoading,
+    hasAnyData: correlationInsights.length > 0 || (warningEvents || []).length > 0,
+    isDemoData,
+  })
+
+  // Build timeline chart data from warning events
+  const { chartData, clusterNames } = useMemo(() => {
+    const filtered = (warningEvents || []).filter(
+      e => e.cluster && e.lastSeen && (selectedClusters.length === 0 || selectedClusters.includes(e.cluster)),
+    )
+    if (filtered.length === 0) return { chartData: [], clusterNames: [] }
+
+    const clusters = [...new Set((filtered || []).map(e => e.cluster!))]
+    const buckets = new Map<number, Record<string, number>>()
+
+    for (const event of filtered) {
+      const ts = new Date(event.lastSeen!).getTime()
+      const bucket = Math.floor(ts / TIMELINE_BUCKET_MS) * TIMELINE_BUCKET_MS
+      if (!buckets.has(bucket)) {
+        const entry: Record<string, number> = {}
+        for (const c of clusters) entry[c] = 0
+        buckets.set(bucket, entry)
+      }
+      buckets.get(bucket)![event.cluster!] += event.count || 1
+    }
+
+    const sorted = Array.from(buckets.entries())
+      .sort((a, b) => a[0] - b[0])
+      .slice(-MAX_TIMELINE_BUCKETS)
+      .map(([ts, counts]) => ({
+        time: new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+        ts,
+        ...counts,
+      }))
+
+    return { chartData: sorted, clusterNames: clusters }
+  }, [warningEvents, selectedClusters])
+
+  if (!isLoading && correlationInsights.length === 0 && chartData.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
+        <Activity className="w-8 h-8 mb-2 opacity-50" />
+        <p className="text-sm">No cross-cluster event correlations detected</p>
+        <p className="text-xs mt-1">Warning events are isolated to individual clusters</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3 p-1">
+      {/* Timeline chart */}
+      {chartData.length > 0 && (
+        <div className="h-40">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={chartData} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} />
+              <XAxis dataKey="time" tick={{ fontSize: 9, fill: CHART_TICK_COLOR }} />
+              <YAxis tick={{ fontSize: 9, fill: CHART_TICK_COLOR }} allowDecimals={false} />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: CHART_TOOLTIP_BG,
+                  border: `1px solid ${CHART_TOOLTIP_BORDER}`,
+                  borderRadius: 6,
+                  fontSize: 11,
+                }}
+              />
+              {(clusterNames || []).map((cluster, i) => (
+                <Area
+                  key={cluster}
+                  type="monotone"
+                  dataKey={cluster}
+                  stackId="1"
+                  stroke={CLUSTER_COLORS[i % CLUSTER_COLORS.length]}
+                  fill={CLUSTER_COLORS[i % CLUSTER_COLORS.length]}
+                  fillOpacity={0.3}
+                />
+              ))}
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {/* Legend */}
+      {clusterNames.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {(clusterNames || []).map((cluster, i) => (
+            <div key={cluster} className="flex items-center gap-1">
+              <div
+                className="w-2.5 h-2.5 rounded-sm"
+                style={{ backgroundColor: CLUSTER_COLORS[i % CLUSTER_COLORS.length] }}
+              />
+              <span className="text-2xs text-muted-foreground">{cluster}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Correlation insights */}
+      {correlationInsights.length > 0 && (
+        <div className="space-y-2 border-t border-border pt-2">
+          <span className="text-xs font-medium text-muted-foreground">Detected Correlations</span>
+          {(correlationInsights || []).map(insight => (
+            <div
+              key={insight.id}
+              className="bg-red-500/5 border border-red-500/20 rounded-lg p-2.5 space-y-1"
+            >
+              <div className="flex items-center gap-2">
+                <InsightSourceBadge source={insight.source} confidence={insight.confidence} />
+                <StatusBadge
+                  color={insight.severity === 'critical' ? 'red' : 'yellow'}
+                  size="xs"
+                >
+                  {insight.severity}
+                </StatusBadge>
+                <span className="text-xs font-medium flex-1">{insight.title}</span>
+              </div>
+              <p className="text-xs text-muted-foreground">{insight.description}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
+++ b/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
@@ -1,0 +1,197 @@
+import { useMemo, useState } from 'react'
+import { Rocket, CheckCircle2, AlertTriangle, Clock } from 'lucide-react'
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts'
+import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
+import { useCardLoadingState } from '../CardDataContext'
+import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
+import { InsightSourceBadge } from './InsightSourceBadge'
+import { StatusBadge } from '../../ui/StatusBadge'
+import { CHART_GRID_STROKE, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER, CHART_TICK_COLOR } from '../../../lib/constants/ui'
+
+/** Color for completed rollout progress */
+const COMPLETE_COLOR = '#22c55e'
+/** Color for in-progress rollout */
+const PROGRESS_COLOR = '#3b82f6'
+/** Color for failed rollout */
+const FAILED_COLOR = '#ef4444'
+/** Color for pending rollout */
+const PENDING_COLOR = '#6b7280'
+
+/** Full progress percentage */
+const FULL_PROGRESS_PCT = 100
+
+function getProgressColor(status: string): string {
+  if (status === 'complete') return COMPLETE_COLOR
+  if (status === 'failed') return FAILED_COLOR
+  if (status === 'pending') return PENDING_COLOR
+  return PROGRESS_COLOR
+}
+
+function getStatusIcon(status: string) {
+  if (status === 'complete') return <CheckCircle2 className="w-3 h-3 text-green-400" />
+  if (status === 'failed') return <AlertTriangle className="w-3 h-3 text-red-400" />
+  if (status === 'pending') return <Clock className="w-3 h-3 text-gray-400" />
+  return <Rocket className="w-3 h-3 text-blue-400" />
+}
+
+export function DeploymentRolloutTracker() {
+  const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
+  const { selectedClusters } = useGlobalFilters()
+
+  const rolloutInsights = useMemo(() => {
+    const all = insightsByCategory['rollout-tracker'] || []
+    if (selectedClusters.length === 0) return all
+    return all.filter(i =>
+      (i.affectedClusters || []).some(c => selectedClusters.includes(c)),
+    )
+  }, [insightsByCategory, selectedClusters])
+
+  useCardLoadingState({
+    isLoading,
+    hasAnyData: rolloutInsights.length > 0,
+    isDemoData,
+  })
+
+  const [selectedRollout, setSelectedRollout] = useState(0)
+  const insight = rolloutInsights[selectedRollout] || rolloutInsights[0]
+
+  // Build per-cluster progress data from insight metrics
+  const clusterProgress = useMemo(() => {
+    if (!insight?.metrics) return []
+    const clusters = insight.affectedClusters || []
+    return (clusters || []).map(cluster => {
+      const progress = insight.metrics?.[`${cluster}_progress`] ?? 0
+      const statusKey = `${cluster}_status`
+      const status = insight.metrics?.[statusKey] !== undefined
+        ? (['pending', 'in-progress', 'complete', 'failed'][insight.metrics[statusKey]] || 'pending')
+        : (progress >= FULL_PROGRESS_PCT ? 'complete' : progress > 0 ? 'in-progress' : 'pending')
+      return {
+        cluster,
+        progress: typeof progress === 'number' ? progress : 0,
+        status,
+      }
+    })
+  }, [insight])
+
+  if (!isLoading && rolloutInsights.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
+        <Rocket className="w-8 h-8 mb-2 opacity-50" />
+        <p className="text-sm">No active rollouts detected</p>
+        <p className="text-xs mt-1">All deployments are at consistent versions</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3 p-1">
+      {/* Rollout selector */}
+      {rolloutInsights.length > 1 && (
+        <div className="flex items-center gap-2 overflow-x-auto pb-1">
+          {(rolloutInsights || []).map((ins, i) => (
+            <button
+              key={ins.id}
+              onClick={() => setSelectedRollout(i)}
+              className={`text-2xs px-2 py-1 rounded whitespace-nowrap ${
+                i === selectedRollout
+                  ? 'bg-blue-500/20 text-blue-400 border border-blue-500/30'
+                  : 'bg-secondary/50 text-muted-foreground hover:bg-secondary'
+              }`}
+            >
+              {(ins.relatedResources || [])[0] || ins.title}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {insight && (
+        <>
+          <div className="flex items-center gap-2">
+            <InsightSourceBadge source={insight.source} confidence={insight.confidence} />
+            <StatusBadge
+              color={insight.severity === 'critical' ? 'red' : insight.severity === 'warning' ? 'yellow' : 'blue'}
+              size="xs"
+            >
+              {insight.severity}
+            </StatusBadge>
+            <span className="text-xs font-medium flex-1">{insight.title}</span>
+          </div>
+          <p className="text-xs text-muted-foreground">{insight.description}</p>
+
+          {/* Per-cluster progress chart */}
+          {clusterProgress.length > 0 && (
+            <div className="h-32">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart
+                  data={clusterProgress}
+                  layout="vertical"
+                  margin={{ top: 5, right: 10, left: 0, bottom: 5 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} />
+                  <XAxis
+                    type="number"
+                    domain={[0, FULL_PROGRESS_PCT]}
+                    tick={{ fontSize: 9, fill: CHART_TICK_COLOR }}
+                    tickFormatter={v => `${v}%`}
+                  />
+                  <YAxis
+                    type="category"
+                    dataKey="cluster"
+                    tick={{ fontSize: 9, fill: CHART_TICK_COLOR }}
+                    width={80}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: CHART_TOOLTIP_BG,
+                      border: `1px solid ${CHART_TOOLTIP_BORDER}`,
+                      borderRadius: 6,
+                      fontSize: 11,
+                    }}
+                    formatter={((value: number) => [`${value}%`, 'Progress']) as never}
+                  />
+                  <Bar dataKey="progress" radius={[0, 4, 4, 0]}>
+                    {(clusterProgress || []).map((entry, idx) => (
+                      <Cell key={`cell-${idx}`} fill={getProgressColor(entry.status)} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+
+          {/* Per-cluster status list */}
+          {clusterProgress.length > 0 && (
+            <div className="space-y-1">
+              {(clusterProgress || []).map(cp => (
+                <div key={cp.cluster} className="flex items-center gap-2 text-xs">
+                  {getStatusIcon(cp.status)}
+                  <span className="font-medium min-w-20">{cp.cluster}</span>
+                  <div className="flex-1 bg-secondary/30 rounded-full h-1.5">
+                    <div
+                      className="h-full rounded-full transition-all"
+                      style={{
+                        width: `${cp.progress}%`,
+                        backgroundColor: getProgressColor(cp.status),
+                      }}
+                    />
+                  </div>
+                  <span className="text-2xs text-muted-foreground w-10 text-right">{cp.progress}%</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* AI remediation */}
+          {insight.remediation && (
+            <div className="bg-blue-500/5 border border-blue-500/20 rounded-lg p-2">
+              <div className="flex items-center gap-1 mb-1">
+                <StatusBadge color="blue" size="xs">AI Suggestion</StatusBadge>
+              </div>
+              <p className="text-xs text-muted-foreground">{insight.remediation}</p>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/insights/InsightSourceBadge.tsx
+++ b/web/src/components/cards/insights/InsightSourceBadge.tsx
@@ -1,0 +1,27 @@
+import { Zap } from 'lucide-react'
+import { StatusBadge } from '../../ui/StatusBadge'
+import type { InsightSource } from '../../../types/insights'
+
+interface InsightSourceBadgeProps {
+  source: InsightSource
+  confidence?: number
+}
+
+export function InsightSourceBadge({ source, confidence }: InsightSourceBadgeProps) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      {source === 'ai' ? (
+        <StatusBadge color="blue" size="xs" className="flex-shrink-0">
+          AI
+        </StatusBadge>
+      ) : (
+        <StatusBadge color="gray" size="xs" className="flex-shrink-0">
+          <Zap className="w-2 h-2" />
+        </StatusBadge>
+      )}
+      {confidence !== undefined && (
+        <span className="text-[9px] text-muted-foreground">{confidence}%</span>
+      )}
+    </span>
+  )
+}

--- a/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
+++ b/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from 'react'
+import { Scale } from 'lucide-react'
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ReferenceLine, ResponsiveContainer } from 'recharts'
+import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
+import { useCardLoadingState } from '../CardDataContext'
+import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
+import { InsightSourceBadge } from './InsightSourceBadge'
+import { StatusBadge } from '../../ui/StatusBadge'
+import { CHART_GRID_STROKE, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER, CHART_TICK_COLOR } from '../../../lib/constants/ui'
+
+/** Percentage threshold for coloring bars as overloaded */
+const OVERLOADED_THRESHOLD_PCT = 75
+/** Percentage threshold for coloring bars as underloaded */
+const UNDERLOADED_THRESHOLD_PCT = 30
+
+export function ResourceImbalanceDetector() {
+  const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
+  const { selectedClusters } = useGlobalFilters()
+
+  const imbalanceInsights = useMemo(() => insightsByCategory['resource-imbalance'] || [], [insightsByCategory])
+
+  useCardLoadingState({
+    isLoading,
+    hasAnyData: imbalanceInsights.length > 0,
+    isDemoData,
+  })
+
+  // Build chart data from the first (CPU) insight's metrics
+  const chartData = useMemo(() => {
+    const insight = imbalanceInsights[0]
+    if (!insight?.metrics) return []
+    return Object.entries(insight.metrics)
+      .filter(([name]) => selectedClusters.length === 0 || selectedClusters.includes(name))
+      .map(([name, value]) => ({
+        name: name.length > 15 ? name.slice(0, 12) + '...' : name,
+        fullName: name,
+        value,
+        fill: value > OVERLOADED_THRESHOLD_PCT ? '#ef4444' : value < UNDERLOADED_THRESHOLD_PCT ? '#3b82f6' : '#22c55e',
+      }))
+      .sort((a, b) => b.value - a.value)
+  }, [imbalanceInsights, selectedClusters])
+
+  const avgValue = chartData.length > 0
+    ? Math.round(chartData.reduce((sum, d) => sum + d.value, 0) / chartData.length)
+    : 0
+
+  if (!isLoading && imbalanceInsights.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
+        <Scale className="w-8 h-8 mb-2 opacity-50" />
+        <p className="text-sm">No resource imbalance detected</p>
+        <p className="text-xs mt-1">All clusters are within normal utilization range</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3 p-1">
+      {(imbalanceInsights || []).map(insight => (
+        <div key={insight.id} className="space-y-2">
+          <div className="flex items-center gap-2">
+            <InsightSourceBadge source={insight.source} confidence={insight.confidence} />
+            <StatusBadge
+              color={insight.severity === 'critical' ? 'red' : insight.severity === 'warning' ? 'yellow' : 'blue'}
+              size="xs"
+            >
+              {insight.severity}
+            </StatusBadge>
+            <span className="text-xs text-muted-foreground flex-1">{insight.title}</span>
+          </div>
+          <p className="text-xs text-muted-foreground">{insight.description}</p>
+        </div>
+      ))}
+
+      {chartData.length > 0 && (
+        <div className="h-48">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData} layout="vertical" margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={CHART_GRID_STROKE} horizontal={false} />
+              <XAxis type="number" domain={[0, 100]} tick={{ fontSize: 10, fill: CHART_TICK_COLOR }} tickFormatter={v => `${v}%`} />
+              <YAxis type="category" dataKey="name" tick={{ fontSize: 10, fill: CHART_TICK_COLOR }} width={100} />
+              <Tooltip
+                contentStyle={{ backgroundColor: CHART_TOOLTIP_BG, border: `1px solid ${CHART_TOOLTIP_BORDER}`, borderRadius: 6, fontSize: 11 }}
+                formatter={((value: number) => [`${value}%`, 'Usage']) as never}
+              />
+              <ReferenceLine x={avgValue} stroke="#f59e0b" strokeDasharray="5 5" label={{ value: `Avg ${avgValue}%`, position: 'top', fontSize: 10, fill: '#f59e0b' }} />
+              <Bar dataKey="value" radius={[0, 4, 4, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/insights/RestartCorrelationMatrix.tsx
+++ b/web/src/components/cards/insights/RestartCorrelationMatrix.tsx
@@ -1,0 +1,114 @@
+import { useMemo } from 'react'
+import { RefreshCcw, Bug, Server } from 'lucide-react'
+import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
+import { useCardLoadingState } from '../CardDataContext'
+import { InsightSourceBadge } from './InsightSourceBadge'
+import { StatusBadge } from '../../ui/StatusBadge'
+
+
+
+export function RestartCorrelationMatrix() {
+  const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
+
+  const restartInsights = useMemo(() => insightsByCategory['restart-correlation'] || [], [insightsByCategory])
+
+  useCardLoadingState({
+    isLoading,
+    hasAnyData: restartInsights.length > 0,
+    isDemoData,
+  })
+
+  const appBugInsights = useMemo(
+    () => (restartInsights || []).filter(i => i.id.includes('app-bug')),
+    [restartInsights],
+  )
+
+  const infraInsights = useMemo(
+    () => (restartInsights || []).filter(i => i.id.includes('infra-issue')),
+    [restartInsights],
+  )
+
+  if (!isLoading && restartInsights.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
+        <RefreshCcw className="w-8 h-8 mb-2 opacity-50" />
+        <p className="text-sm">No restart correlations detected</p>
+        <p className="text-xs mt-1">Pod restarts are within normal patterns</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 p-1">
+      {/* App Bug Pattern (horizontal) */}
+      {appBugInsights.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Bug className="w-3.5 h-3.5 text-yellow-400" />
+            <span className="text-xs font-medium text-yellow-400">Application Bug Pattern</span>
+            <span className="text-2xs text-muted-foreground">Same workload failing across clusters</span>
+          </div>
+          {(appBugInsights || []).map(insight => (
+            <div
+              key={insight.id}
+              className="bg-yellow-500/5 border border-yellow-500/20 rounded-lg p-2.5 space-y-1"
+            >
+              <div className="flex items-center gap-2">
+                <InsightSourceBadge source={insight.source} confidence={insight.confidence} />
+                <StatusBadge
+                  color={insight.severity === 'critical' ? 'red' : 'yellow'}
+                  size="xs"
+                >
+                  {insight.severity}
+                </StatusBadge>
+                <span className="text-xs font-medium flex-1">{insight.title}</span>
+              </div>
+              <p className="text-xs text-muted-foreground">{insight.description}</p>
+              <div className="flex flex-wrap gap-1 mt-1">
+                {(insight.affectedClusters || []).map(cluster => (
+                  <StatusBadge key={cluster} color="yellow" size="xs">{cluster}</StatusBadge>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Infra Issue Pattern (vertical) */}
+      {infraInsights.length > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Server className="w-3.5 h-3.5 text-red-400" />
+            <span className="text-xs font-medium text-red-400">Infrastructure Issue Pattern</span>
+            <span className="text-2xs text-muted-foreground">Many workloads failing in one cluster</span>
+          </div>
+          {(infraInsights || []).map(insight => (
+            <div
+              key={insight.id}
+              className="bg-red-500/5 border border-red-500/20 rounded-lg p-2.5 space-y-1"
+            >
+              <div className="flex items-center gap-2">
+                <InsightSourceBadge source={insight.source} confidence={insight.confidence} />
+                <StatusBadge
+                  color={insight.severity === 'critical' ? 'red' : 'yellow'}
+                  size="xs"
+                >
+                  {insight.severity}
+                </StatusBadge>
+                <span className="text-xs font-medium flex-1">{insight.title}</span>
+              </div>
+              <p className="text-xs text-muted-foreground">{insight.description}</p>
+              {insight.relatedResources && insight.relatedResources.length > 0 && (
+                <div className="flex flex-wrap gap-1 mt-1">
+                  {(insight.relatedResources || []).map(resource => (
+                    <StatusBadge key={resource} color="gray" size="xs">{resource}</StatusBadge>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/cards/insights/index.ts
+++ b/web/src/components/cards/insights/index.ts
@@ -1,0 +1,7 @@
+export { CrossClusterEventCorrelation } from './CrossClusterEventCorrelation'
+export { ClusterDeltaDetector } from './ClusterDeltaDetector'
+export { CascadeImpactMap } from './CascadeImpactMap'
+export { ConfigDriftHeatmap } from './ConfigDriftHeatmap'
+export { ResourceImbalanceDetector } from './ResourceImbalanceDetector'
+export { RestartCorrelationMatrix } from './RestartCorrelationMatrix'
+export { DeploymentRolloutTracker } from './DeploymentRolloutTracker'

--- a/web/src/config/cards/cascade-impact-map.ts
+++ b/web/src/config/cards/cascade-impact-map.ts
@@ -1,0 +1,23 @@
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const cascadeImpactMapConfig: UnifiedCardConfig = {
+  type: 'cascade_impact_map',
+  title: 'Cascade Impact Map',
+  category: 'insights',
+  description: 'Visualizes how issues cascade across clusters over time',
+  icon: 'Workflow',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 12,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useMultiClusterInsights' },
+  content: { type: 'custom' },
+  emptyState: {
+    icon: 'Workflow',
+    title: 'No cascade patterns detected',
+    message: 'Issues are not propagating across clusters',
+    variant: 'neutral',
+  },
+  loadingState: { type: 'chart' },
+  isDemoData: false,
+  isLive: true,
+}

--- a/web/src/config/cards/cluster-delta-detector.ts
+++ b/web/src/config/cards/cluster-delta-detector.ts
@@ -1,0 +1,23 @@
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const clusterDeltaDetectorConfig: UnifiedCardConfig = {
+  type: 'cluster_delta_detector',
+  title: 'Cluster Delta Detector',
+  category: 'insights',
+  description: 'Detects differences between clusters sharing the same workloads',
+  icon: 'GitCompare',
+  iconColor: 'text-blue-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useMultiClusterInsights' },
+  content: { type: 'custom' },
+  emptyState: {
+    icon: 'GitCompare',
+    title: 'No cluster deltas detected',
+    message: 'Shared workloads are consistent across clusters',
+    variant: 'neutral',
+  },
+  loadingState: { type: 'chart' },
+  isDemoData: false,
+  isLive: true,
+}

--- a/web/src/config/cards/config-drift-heatmap.ts
+++ b/web/src/config/cards/config-drift-heatmap.ts
@@ -1,0 +1,23 @@
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const configDriftHeatmapConfig: UnifiedCardConfig = {
+  type: 'config_drift_heatmap',
+  title: 'Config Drift Heatmap',
+  category: 'insights',
+  description: 'Cluster-pair matrix showing degree of configuration drift',
+  icon: 'Diff',
+  iconColor: 'text-orange-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useMultiClusterInsights' },
+  content: { type: 'custom' },
+  emptyState: {
+    icon: 'Diff',
+    title: 'No config drift detected',
+    message: 'Shared workloads have consistent configuration',
+    variant: 'neutral',
+  },
+  loadingState: { type: 'chart' },
+  isDemoData: false,
+  isLive: true,
+}

--- a/web/src/config/cards/cross-cluster-event-correlation.ts
+++ b/web/src/config/cards/cross-cluster-event-correlation.ts
@@ -1,0 +1,23 @@
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const crossClusterEventCorrelationConfig: UnifiedCardConfig = {
+  type: 'cross_cluster_event_correlation',
+  title: 'Cross-Cluster Event Correlation',
+  category: 'insights',
+  description: 'Unified timeline showing correlated warning events across multiple clusters',
+  icon: 'Activity',
+  iconColor: 'text-red-400',
+  defaultWidth: 12,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useMultiClusterInsights' },
+  content: { type: 'custom' },
+  emptyState: {
+    icon: 'Activity',
+    title: 'No cross-cluster event correlations detected',
+    message: 'Warning events are isolated to individual clusters',
+    variant: 'neutral',
+  },
+  loadingState: { type: 'chart' },
+  isDemoData: false,
+  isLive: true,
+}

--- a/web/src/config/cards/deployment-rollout-tracker.ts
+++ b/web/src/config/cards/deployment-rollout-tracker.ts
@@ -1,0 +1,23 @@
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const deploymentRolloutTrackerConfig: UnifiedCardConfig = {
+  type: 'deployment_rollout_tracker',
+  title: 'Deployment Rollout Tracker',
+  category: 'insights',
+  description: 'Tracks deployment rollout progress across clusters',
+  icon: 'Rocket',
+  iconColor: 'text-green-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useMultiClusterInsights' },
+  content: { type: 'custom' },
+  emptyState: {
+    icon: 'Rocket',
+    title: 'No active rollouts detected',
+    message: 'All deployments are at consistent versions',
+    variant: 'neutral',
+  },
+  loadingState: { type: 'chart' },
+  isDemoData: false,
+  isLive: true,
+}

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -150,6 +150,13 @@ import { warningEventsConfig } from './warning-events'
 import { weatherConfig } from './weather'
 import { workloadDeploymentConfig } from './workload-deployment'
 import { workloadMonitorConfig } from './workload-monitor'
+import { crossClusterEventCorrelationConfig } from './cross-cluster-event-correlation'
+import { clusterDeltaDetectorConfig } from './cluster-delta-detector'
+import { cascadeImpactMapConfig } from './cascade-impact-map'
+import { configDriftHeatmapConfig } from './config-drift-heatmap'
+import { resourceImbalanceDetectorConfig } from './resource-imbalance-detector'
+import { restartCorrelationMatrixConfig } from './restart-correlation-matrix'
+import { deploymentRolloutTrackerConfig } from './deployment-rollout-tracker'
 
 export const CARD_CONFIGS: CardConfigRegistry = {
   active_alerts: activeAlertsConfig,
@@ -298,6 +305,14 @@ export const CARD_CONFIGS: CardConfigRegistry = {
   weather: weatherConfig,
   workload_deployment: workloadDeploymentConfig,
   workload_monitor: workloadMonitorConfig,
+  // Multi-cluster insights cards
+  cross_cluster_event_correlation: crossClusterEventCorrelationConfig,
+  cluster_delta_detector: clusterDeltaDetectorConfig,
+  cascade_impact_map: cascadeImpactMapConfig,
+  config_drift_heatmap: configDriftHeatmapConfig,
+  resource_imbalance_detector: resourceImbalanceDetectorConfig,
+  restart_correlation_matrix: restartCorrelationMatrixConfig,
+  deployment_rollout_tracker: deploymentRolloutTrackerConfig,
 }
 
 export function getCardConfig(cardType: string): UnifiedCardConfig | undefined {
@@ -458,4 +473,11 @@ export {
   weatherConfig,
   workloadDeploymentConfig,
   workloadMonitorConfig,
+  crossClusterEventCorrelationConfig,
+  clusterDeltaDetectorConfig,
+  cascadeImpactMapConfig,
+  configDriftHeatmapConfig,
+  resourceImbalanceDetectorConfig,
+  restartCorrelationMatrixConfig,
+  deploymentRolloutTrackerConfig,
 }

--- a/web/src/config/cards/resource-imbalance-detector.ts
+++ b/web/src/config/cards/resource-imbalance-detector.ts
@@ -1,0 +1,23 @@
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const resourceImbalanceDetectorConfig: UnifiedCardConfig = {
+  type: 'resource_imbalance_detector',
+  title: 'Resource Imbalance Detector',
+  category: 'insights',
+  description: 'Detects CPU/memory utilization skew across the fleet',
+  icon: 'Scale',
+  iconColor: 'text-purple-400',
+  defaultWidth: 6,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useMultiClusterInsights' },
+  content: { type: 'custom' },
+  emptyState: {
+    icon: 'Scale',
+    title: 'No resource imbalance detected',
+    message: 'Cluster resource utilization is balanced',
+    variant: 'neutral',
+  },
+  loadingState: { type: 'chart' },
+  isDemoData: false,
+  isLive: true,
+}

--- a/web/src/config/cards/restart-correlation-matrix.ts
+++ b/web/src/config/cards/restart-correlation-matrix.ts
@@ -1,0 +1,23 @@
+import type { UnifiedCardConfig } from '../../lib/unified/types'
+
+export const restartCorrelationMatrixConfig: UnifiedCardConfig = {
+  type: 'restart_correlation_matrix',
+  title: 'Restart Correlation Matrix',
+  category: 'insights',
+  description: 'Detects horizontal (app bug) vs vertical (infra issue) restart patterns',
+  icon: 'RefreshCcw',
+  iconColor: 'text-yellow-400',
+  defaultWidth: 8,
+  defaultHeight: 4,
+  dataSource: { type: 'hook', hook: 'useMultiClusterInsights' },
+  content: { type: 'custom' },
+  emptyState: {
+    icon: 'RefreshCcw',
+    title: 'No restart correlations detected',
+    message: 'Pod restarts are within normal patterns',
+    variant: 'neutral',
+  },
+  loadingState: { type: 'chart' },
+  isDemoData: false,
+  isLive: true,
+}

--- a/web/src/config/dashboards/index.ts
+++ b/web/src/config/dashboards/index.ts
@@ -33,6 +33,7 @@ import { deployDashboardConfig } from './deploy'
 import { aiAgentsDashboardConfig } from './ai-agents'
 import { llmdBenchmarksDashboardConfig } from './llmd-benchmarks'
 import { clusterAdminDashboardConfig } from './cluster-admin'
+import { insightsDashboardConfig } from './insights'
 
 /**
  * Registry of all unified dashboard configurations
@@ -66,6 +67,7 @@ export const DASHBOARD_CONFIGS: DashboardConfigRegistry = {
   'ai-agents': aiAgentsDashboardConfig,
   'llm-d-benchmarks': llmdBenchmarksDashboardConfig,
   'cluster-admin': clusterAdminDashboardConfig,
+  insights: insightsDashboardConfig,
 }
 
 /**
@@ -155,4 +157,5 @@ export {
   aiAgentsDashboardConfig,
   llmdBenchmarksDashboardConfig,
   clusterAdminDashboardConfig,
+  insightsDashboardConfig,
 }

--- a/web/src/config/dashboards/insights.ts
+++ b/web/src/config/dashboards/insights.ts
@@ -1,0 +1,35 @@
+/**
+ * Insights Dashboard Configuration
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const insightsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'insights',
+  name: 'Insights',
+  subtitle: 'Cross-cluster correlation and pattern detection',
+  route: '/insights',
+  statsType: 'insights',
+  cards: [
+    // Top row: Event Correlation (full width)
+    { id: 'event-correlation-1', cardType: 'cross_cluster_event_correlation', title: 'Cross-Cluster Event Correlation', position: { w: 12, h: 4 } },
+    // Second row: Resource Imbalance + Config Drift (half each)
+    { id: 'resource-imbalance-1', cardType: 'resource_imbalance_detector', title: 'Resource Imbalance', position: { w: 6, h: 4 } },
+    { id: 'config-drift-1', cardType: 'config_drift_heatmap', title: 'Config Drift Heatmap', position: { w: 6, h: 4 } },
+    // Third row: Cluster Delta + Restart Correlation
+    { id: 'cluster-delta-1', cardType: 'cluster_delta_detector', title: 'Cluster Delta Detector', position: { w: 8, h: 4 } },
+    { id: 'restart-correlation-1', cardType: 'restart_correlation_matrix', title: 'Restart Correlation Matrix', position: { w: 4, h: 4 } },
+    // Fourth row: Cascade Impact (full width)
+    { id: 'cascade-impact-1', cardType: 'cascade_impact_map', title: 'Cascade Impact Map', position: { w: 12, h: 4 } },
+    // Fifth row: Rollout Tracker
+    { id: 'rollout-tracker-1', cardType: 'deployment_rollout_tracker', title: 'Deployment Rollout Tracker', position: { w: 8, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'kubestellar-insights-cards',
+}
+
+export default insightsDashboardConfig

--- a/web/src/hooks/useMultiClusterInsights.ts
+++ b/web/src/hooks/useMultiClusterInsights.ts
@@ -1,0 +1,700 @@
+/**
+ * Multi-Cluster Insights Hook
+ *
+ * Client-side correlation engine that detects cross-cluster patterns
+ * impossible to see in single-cluster dashboards. Runs 7 heuristic
+ * algorithms on cached data; when the kc-agent is connected, insights
+ * are enriched with AI explanations and remediation suggestions.
+ */
+
+import { useMemo } from 'react'
+import { useCachedEvents, useCachedWarningEvents, useCachedDeployments, useCachedPodIssues } from './useCachedData'
+import { useClusters } from './mcp/clusters'
+import { useDemoMode } from './useDemoMode'
+import type {
+  MultiClusterInsight,
+  InsightCategory,
+  InsightSeverity,
+  UseMultiClusterInsightsResult,
+  CascadeLink,
+  ClusterDelta,
+} from '../types/insights'
+import type { ClusterEvent, Deployment, PodIssue } from './mcp/types'
+import type { ClusterInfo } from './mcp/types'
+
+// ── Thresholds & Constants ────────────────────────────────────────────
+
+/** Minimum clusters with events in same window to trigger correlation */
+const MIN_CORRELATED_CLUSTERS = 2
+/** Time window in ms for event correlation grouping (5 minutes) */
+const EVENT_CORRELATION_WINDOW_MS = 5 * 60 * 1000
+/** Time window in ms for cascade detection (15 minutes) */
+const CASCADE_DETECTION_WINDOW_MS = 15 * 60 * 1000
+/** CPU/memory utilization percentage threshold for resource imbalance */
+const RESOURCE_IMBALANCE_THRESHOLD_PCT = 30
+/** Pod restart count threshold for restart correlation */
+const RESTART_CORRELATION_THRESHOLD = 3
+/** Maximum number of insights per category */
+const MAX_INSIGHTS_PER_CATEGORY = 10
+/** Maximum number of top insights to return */
+const MAX_TOP_INSIGHTS = 5
+/** Percentage threshold for considering two values significantly different */
+const DELTA_SIGNIFICANCE_HIGH_PCT = 50
+/** Percentage threshold for medium significance */
+const DELTA_SIGNIFICANCE_MEDIUM_PCT = 20
+/** Minimum workloads in a vertical restart pattern to flag infra issue */
+const INFRA_ISSUE_MIN_WORKLOADS = 3
+/** Minimum clusters in a horizontal restart pattern to flag app bug */
+const APP_BUG_MIN_CLUSTERS = 2
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function generateId(category: InsightCategory, ...parts: string[]): string {
+  return `${category}:${parts.join(':')}`
+}
+
+function now(): string {
+  return new Date().toISOString()
+}
+
+function parseTimestamp(ts?: string): number {
+  if (!ts) return 0
+  return new Date(ts).getTime()
+}
+
+function pct(value: number | undefined, total: number | undefined): number {
+  if (!value || !total || total === 0) return 0
+  return Math.round((value / total) * 100)
+}
+
+// ── Algorithm 1: Event Correlations ───────────────────────────────────
+
+function detectEventCorrelations(events: ClusterEvent[]): MultiClusterInsight[] {
+  const warnings = (events || []).filter(e => e.type === 'Warning' && e.cluster && e.lastSeen)
+  if (warnings.length === 0) return []
+
+  // Group events into time windows
+  const windows = new Map<number, Map<string, ClusterEvent[]>>()
+
+  for (const event of warnings) {
+    const ts = parseTimestamp(event.lastSeen)
+    if (ts === 0) continue
+    const bucket = Math.floor(ts / EVENT_CORRELATION_WINDOW_MS) * EVENT_CORRELATION_WINDOW_MS
+    if (!windows.has(bucket)) windows.set(bucket, new Map())
+    const clusterMap = windows.get(bucket)!
+    const cluster = event.cluster || 'unknown'
+    if (!clusterMap.has(cluster)) clusterMap.set(cluster, [])
+    clusterMap.get(cluster)!.push(event)
+  }
+
+  const insights: MultiClusterInsight[] = []
+
+  for (const [bucket, clusterMap] of windows) {
+    if (clusterMap.size < MIN_CORRELATED_CLUSTERS) continue
+
+    const affectedClusters = Array.from(clusterMap.keys())
+    const allEvents = Array.from(clusterMap.values()).flat()
+    const reasons = [...new Set((allEvents || []).map(e => e.reason))].join(', ')
+    const totalEvents = allEvents.reduce((sum, e) => sum + (e.count || 1), 0)
+
+    insights.push({
+      id: generateId('event-correlation', String(bucket)),
+      category: 'event-correlation',
+      source: 'heuristic',
+      severity: clusterMap.size >= 3 ? 'critical' : 'warning',
+      title: `${clusterMap.size} clusters had simultaneous warnings`,
+      description: `${totalEvents} warning events across ${affectedClusters.join(', ')} within a 5-minute window. Common reasons: ${reasons}.`,
+      affectedClusters,
+      relatedResources: [...new Set((allEvents || []).map(e => e.object))].slice(0, 5),
+      detectedAt: new Date(bucket).toISOString(),
+    })
+  }
+
+  return insights.slice(0, MAX_INSIGHTS_PER_CATEGORY)
+}
+
+// ── Algorithm 2: Cluster Deltas ───────────────────────────────────────
+
+function detectClusterDeltas(
+  deployments: Deployment[],
+  clusters: ClusterInfo[],
+): MultiClusterInsight[] {
+  if ((deployments || []).length === 0 || (clusters || []).length < 2) return []
+
+  // Group deployments by name+namespace across clusters
+  const workloadMap = new Map<string, Map<string, Deployment>>()
+  for (const dep of deployments || []) {
+    const key = `${dep.namespace}/${dep.name}`
+    if (!workloadMap.has(key)) workloadMap.set(key, new Map())
+    if (dep.cluster) workloadMap.get(key)!.set(dep.cluster, dep)
+  }
+
+  const insights: MultiClusterInsight[] = []
+
+  for (const [workloadKey, clusterDeployments] of workloadMap) {
+    if (clusterDeployments.size < 2) continue
+
+    const deltas: ClusterDelta[] = []
+    const entries = Array.from(clusterDeployments.entries())
+
+    for (let i = 0; i < entries.length; i++) {
+      for (let j = i + 1; j < entries.length; j++) {
+        const [clusterA, depA] = entries[i]
+        const [clusterB, depB] = entries[j]
+
+        // Image version delta
+        if (depA.image && depB.image && depA.image !== depB.image) {
+          deltas.push({
+            dimension: 'Image Version',
+            clusterA: { name: clusterA, value: depA.image },
+            clusterB: { name: clusterB, value: depB.image },
+            significance: 'high',
+          })
+        }
+
+        // Replica count delta
+        if (depA.replicas !== depB.replicas) {
+          const diff = Math.abs(depA.replicas - depB.replicas)
+          const maxReplicas = Math.max(depA.replicas, depB.replicas)
+          const pctDiff = maxReplicas > 0 ? (diff / maxReplicas) * 100 : 0
+          deltas.push({
+            dimension: 'Replica Count',
+            clusterA: { name: clusterA, value: depA.replicas },
+            clusterB: { name: clusterB, value: depB.replicas },
+            significance: pctDiff >= DELTA_SIGNIFICANCE_HIGH_PCT ? 'high' : pctDiff >= DELTA_SIGNIFICANCE_MEDIUM_PCT ? 'medium' : 'low',
+          })
+        }
+
+        // Ready vs desired delta
+        if (depA.status !== depB.status) {
+          deltas.push({
+            dimension: 'Status',
+            clusterA: { name: clusterA, value: depA.status },
+            clusterB: { name: clusterB, value: depB.status },
+            significance: depA.status === 'failed' || depB.status === 'failed' ? 'high' : 'medium',
+          })
+        }
+      }
+    }
+
+    if (deltas.length > 0) {
+      const highDeltas = deltas.filter(d => d.significance === 'high')
+      const affectedClusters = [...new Set(entries.map(([c]) => c))]
+
+      insights.push({
+        id: generateId('cluster-delta', workloadKey),
+        category: 'cluster-delta',
+        source: 'heuristic',
+        severity: highDeltas.length > 0 ? 'warning' : 'info',
+        title: `${workloadKey} differs across ${affectedClusters.length} clusters`,
+        description: `Found ${deltas.length} differences: ${(deltas || []).map(d => d.dimension).join(', ')}.`,
+        affectedClusters,
+        relatedResources: [workloadKey],
+        detectedAt: now(),
+        deltas,
+      })
+    }
+  }
+
+  return insights
+    .sort((a, b) => (b.deltas?.length || 0) - (a.deltas?.length || 0))
+    .slice(0, MAX_INSIGHTS_PER_CATEGORY)
+}
+
+// ── Algorithm 3: Cascade Impact ───────────────────────────────────────
+
+function detectCascadeImpact(events: ClusterEvent[]): MultiClusterInsight[] {
+  const warnings = (events || [])
+    .filter(e => e.type === 'Warning' && e.cluster && e.lastSeen)
+    .sort((a, b) => parseTimestamp(a.lastSeen) - parseTimestamp(b.lastSeen))
+
+  if (warnings.length < 2) return []
+
+  const insights: MultiClusterInsight[] = []
+  const usedEvents = new Set<number>()
+
+  for (let i = 0; i < warnings.length; i++) {
+    if (usedEvents.has(i)) continue
+    const chain: CascadeLink[] = [{
+      cluster: warnings[i].cluster || 'unknown',
+      resource: warnings[i].object,
+      event: warnings[i].reason,
+      timestamp: warnings[i].lastSeen || '',
+      severity: 'warning',
+    }]
+    usedEvents.add(i)
+
+    const baseTs = parseTimestamp(warnings[i].lastSeen)
+    const seenClusters = new Set([warnings[i].cluster])
+
+    for (let j = i + 1; j < warnings.length; j++) {
+      if (usedEvents.has(j)) continue
+      const ts = parseTimestamp(warnings[j].lastSeen)
+      if (ts - baseTs > CASCADE_DETECTION_WINDOW_MS) break
+      if (seenClusters.has(warnings[j].cluster)) continue
+
+      chain.push({
+        cluster: warnings[j].cluster || 'unknown',
+        resource: warnings[j].object,
+        event: warnings[j].reason,
+        timestamp: warnings[j].lastSeen || '',
+        severity: 'warning',
+      })
+      seenClusters.add(warnings[j].cluster)
+      usedEvents.add(j)
+    }
+
+    if (chain.length >= MIN_CORRELATED_CLUSTERS) {
+      const affectedClusters = (chain || []).map(c => c.cluster)
+      insights.push({
+        id: generateId('cascade-impact', String(baseTs)),
+        category: 'cascade-impact',
+        source: 'heuristic',
+        severity: chain.length >= 3 ? 'critical' : 'warning',
+        title: `Possible cascade across ${chain.length} clusters`,
+        description: `Issues started in ${chain[0].cluster} (${chain[0].event}) and spread to ${affectedClusters.slice(1).join(', ')} within ${Math.round(CASCADE_DETECTION_WINDOW_MS / 60000)} minutes.`,
+        affectedClusters,
+        detectedAt: chain[0].timestamp,
+        chain,
+      })
+    }
+  }
+
+  return insights.slice(0, MAX_INSIGHTS_PER_CATEGORY)
+}
+
+// ── Algorithm 4: Config Drift ─────────────────────────────────────────
+
+function detectConfigDrift(deployments: Deployment[]): MultiClusterInsight[] {
+  if ((deployments || []).length === 0) return []
+
+  // Group by name+namespace
+  const workloadMap = new Map<string, Deployment[]>()
+  for (const dep of deployments || []) {
+    const key = `${dep.namespace}/${dep.name}`
+    if (!workloadMap.has(key)) workloadMap.set(key, [])
+    workloadMap.get(key)!.push(dep)
+  }
+
+  const insights: MultiClusterInsight[] = []
+
+  for (const [workloadKey, deps] of workloadMap) {
+    if (deps.length < 2) continue
+
+    const images = new Set((deps || []).map(d => d.image).filter(Boolean))
+    const replicaSets = new Set((deps || []).map(d => d.replicas))
+
+    if (images.size <= 1 && replicaSets.size <= 1) continue
+
+    const driftDimensions: string[] = []
+    if (images.size > 1) driftDimensions.push(`${images.size} different images`)
+    if (replicaSets.size > 1) driftDimensions.push(`${replicaSets.size} different replica counts`)
+
+    const affectedClusters = [...new Set((deps || []).map(d => d.cluster).filter((c): c is string => !!c))]
+
+    insights.push({
+      id: generateId('config-drift', workloadKey),
+      category: 'config-drift',
+      source: 'heuristic',
+      severity: images.size > 1 ? 'warning' : 'info',
+      title: `Config drift in ${workloadKey}`,
+      description: `${workloadKey} has ${driftDimensions.join(' and ')} across ${affectedClusters.length} clusters.`,
+      affectedClusters,
+      relatedResources: [workloadKey],
+      detectedAt: now(),
+    })
+  }
+
+  return insights.slice(0, MAX_INSIGHTS_PER_CATEGORY)
+}
+
+// ── Algorithm 5: Resource Imbalance ───────────────────────────────────
+
+function detectResourceImbalance(clusters: ClusterInfo[]): MultiClusterInsight[] {
+  const healthy = (clusters || []).filter(c => c.healthy !== false && c.cpuCores && c.cpuCores > 0)
+  if (healthy.length < 2) return []
+
+  const insights: MultiClusterInsight[] = []
+
+  // CPU imbalance
+  const cpuPcts = healthy.map(c => ({
+    name: c.name,
+    pct: pct(c.cpuRequestsCores || c.cpuUsageCores, c.cpuCores),
+  }))
+  const avgCpu = cpuPcts.reduce((sum, c) => sum + c.pct, 0) / cpuPcts.length
+  const overloaded = cpuPcts.filter(c => c.pct - avgCpu > RESOURCE_IMBALANCE_THRESHOLD_PCT)
+  const underloaded = cpuPcts.filter(c => avgCpu - c.pct > RESOURCE_IMBALANCE_THRESHOLD_PCT)
+
+  if (overloaded.length > 0 || underloaded.length > 0) {
+    const metrics: Record<string, number> = {}
+    for (const c of cpuPcts) metrics[c.name] = c.pct
+
+    const parts: string[] = []
+    if (overloaded.length > 0) {
+      parts.push(`${(overloaded || []).map(c => `${c.name} (${c.pct}%)`).join(', ')} above average`)
+    }
+    if (underloaded.length > 0) {
+      parts.push(`${(underloaded || []).map(c => `${c.name} (${c.pct}%)`).join(', ')} below average`)
+    }
+
+    insights.push({
+      id: generateId('resource-imbalance', 'cpu'),
+      category: 'resource-imbalance',
+      source: 'heuristic',
+      severity: overloaded.some(c => c.pct > 85) ? 'critical' : 'warning',
+      title: `CPU imbalance across fleet (avg ${Math.round(avgCpu)}%)`,
+      description: `${parts.join('; ')}. Fleet average: ${Math.round(avgCpu)}%.`,
+      affectedClusters: [...overloaded, ...underloaded].map(c => c.name),
+      detectedAt: now(),
+      metrics,
+    })
+  }
+
+  // Memory imbalance
+  const memPcts = healthy
+    .filter(c => c.memoryGB && c.memoryGB > 0)
+    .map(c => ({
+      name: c.name,
+      pct: pct(c.memoryRequestsGB || c.memoryUsageGB, c.memoryGB),
+    }))
+
+  if (memPcts.length >= 2) {
+    const avgMem = memPcts.reduce((sum, c) => sum + c.pct, 0) / memPcts.length
+    const memOverloaded = memPcts.filter(c => c.pct - avgMem > RESOURCE_IMBALANCE_THRESHOLD_PCT)
+    const memUnderloaded = memPcts.filter(c => avgMem - c.pct > RESOURCE_IMBALANCE_THRESHOLD_PCT)
+
+    if (memOverloaded.length > 0 || memUnderloaded.length > 0) {
+      const metrics: Record<string, number> = {}
+      for (const c of memPcts) metrics[c.name] = c.pct
+
+      insights.push({
+        id: generateId('resource-imbalance', 'memory'),
+        category: 'resource-imbalance',
+        source: 'heuristic',
+        severity: memOverloaded.some(c => c.pct > 85) ? 'critical' : 'warning',
+        title: `Memory imbalance across fleet (avg ${Math.round(avgMem)}%)`,
+        description: `Memory utilization ranges from ${Math.min(...memPcts.map(c => c.pct))}% to ${Math.max(...memPcts.map(c => c.pct))}%. Fleet average: ${Math.round(avgMem)}%.`,
+        affectedClusters: [...memOverloaded, ...memUnderloaded].map(c => c.name),
+        detectedAt: now(),
+        metrics,
+      })
+    }
+  }
+
+  return insights
+}
+
+// ── Algorithm 6: Restart Correlation ──────────────────────────────────
+
+function detectRestartCorrelation(podIssues: PodIssue[]): MultiClusterInsight[] {
+  const issues = (podIssues || []).filter(p => p.restarts >= RESTART_CORRELATION_THRESHOLD && p.cluster)
+  if (issues.length === 0) return []
+
+  const insights: MultiClusterInsight[] = []
+
+  // Group by workload name (strip pod hash suffix) across clusters
+  const workloadRestarts = new Map<string, Map<string, number>>()
+  for (const issue of issues) {
+    // Strip pod hash: "api-server-abc123-xyz" → "api-server"
+    const parts = issue.name.split('-')
+    const workload = parts.length > 2 ? parts.slice(0, -2).join('-') : issue.name
+    const key = `${issue.namespace}/${workload}`
+    if (!workloadRestarts.has(key)) workloadRestarts.set(key, new Map())
+    const clusterMap = workloadRestarts.get(key)!
+    clusterMap.set(
+      issue.cluster || 'unknown',
+      (clusterMap.get(issue.cluster || 'unknown') || 0) + issue.restarts,
+    )
+  }
+
+  // Horizontal pattern: same workload restarting in multiple clusters = app bug
+  for (const [workload, clusterMap] of workloadRestarts) {
+    if (clusterMap.size >= APP_BUG_MIN_CLUSTERS) {
+      const affectedClusters = Array.from(clusterMap.keys())
+      const totalRestarts = Array.from(clusterMap.values()).reduce((a, b) => a + b, 0)
+
+      insights.push({
+        id: generateId('restart-correlation', 'app-bug', workload),
+        category: 'restart-correlation',
+        source: 'heuristic',
+        severity: totalRestarts > 20 ? 'critical' : 'warning',
+        title: `${workload} restarting across ${clusterMap.size} clusters (likely app bug)`,
+        description: `${workload} has ${totalRestarts} total restarts across ${affectedClusters.join(', ')}. Same workload failing everywhere suggests an application-level issue.`,
+        affectedClusters,
+        relatedResources: [workload],
+        detectedAt: now(),
+      })
+    }
+  }
+
+  // Vertical pattern: many workloads restarting in one cluster = infra issue
+  const clusterWorkloadCounts = new Map<string, Set<string>>()
+  for (const [workload, clusterMap] of workloadRestarts) {
+    for (const cluster of clusterMap.keys()) {
+      if (!clusterWorkloadCounts.has(cluster)) clusterWorkloadCounts.set(cluster, new Set())
+      clusterWorkloadCounts.get(cluster)!.add(workload)
+    }
+  }
+
+  for (const [cluster, workloads] of clusterWorkloadCounts) {
+    if (workloads.size >= INFRA_ISSUE_MIN_WORKLOADS) {
+      insights.push({
+        id: generateId('restart-correlation', 'infra-issue', cluster),
+        category: 'restart-correlation',
+        source: 'heuristic',
+        severity: workloads.size >= 5 ? 'critical' : 'warning',
+        title: `${workloads.size} workloads restarting in ${cluster} (likely infra issue)`,
+        description: `Multiple different workloads (${Array.from(workloads).slice(0, 5).join(', ')}) are restarting in ${cluster}. This pattern suggests an infrastructure problem rather than an application bug.`,
+        affectedClusters: [cluster],
+        relatedResources: Array.from(workloads).slice(0, 10),
+        detectedAt: now(),
+      })
+    }
+  }
+
+  return insights.slice(0, MAX_INSIGHTS_PER_CATEGORY)
+}
+
+// ── Algorithm 7: Rollout Tracking ─────────────────────────────────────
+
+function trackRolloutProgress(deployments: Deployment[]): MultiClusterInsight[] {
+  if ((deployments || []).length === 0) return []
+
+  // Group by name+namespace
+  const workloadMap = new Map<string, Deployment[]>()
+  for (const dep of deployments || []) {
+    const key = `${dep.namespace}/${dep.name}`
+    if (!workloadMap.has(key)) workloadMap.set(key, [])
+    workloadMap.get(key)!.push(dep)
+  }
+
+  const insights: MultiClusterInsight[] = []
+
+  for (const [workloadKey, deps] of workloadMap) {
+    if (deps.length < 2) continue
+
+    const images = [...new Set((deps || []).map(d => d.image).filter(Boolean))]
+    if (images.length < 2) continue
+
+    // Find the newest image (highest version or most common)
+    const imageCounts = new Map<string, number>()
+    for (const dep of deps) {
+      if (dep.image) imageCounts.set(dep.image, (imageCounts.get(dep.image) || 0) + 1)
+    }
+    const [newestImage] = Array.from(imageCounts.entries()).sort((a, b) => b[1] - a[1])[0]
+
+    const completed = (deps || []).filter(d => d.image === newestImage && d.cluster)
+    const pending = (deps || []).filter(d => d.image !== newestImage && d.cluster)
+    const failed = (deps || []).filter(d => d.status === 'failed' && d.cluster)
+
+    const affectedClusters = [...new Set((deps || []).map(d => d.cluster).filter((c): c is string => !!c))]
+
+    insights.push({
+      id: generateId('rollout-tracker', workloadKey),
+      category: 'rollout-tracker',
+      source: 'heuristic',
+      severity: failed.length > 0 ? 'warning' : 'info',
+      title: `Rollout in progress: ${workloadKey}`,
+      description: `${completed.length}/${deps.length} clusters on ${newestImage}. ${pending.length} pending, ${failed.length} failed.`,
+      affectedClusters,
+      relatedResources: [workloadKey],
+      detectedAt: now(),
+      metrics: {
+        completed: completed.length,
+        pending: pending.length,
+        failed: failed.length,
+        total: deps.length,
+      },
+    })
+  }
+
+  return insights.slice(0, MAX_INSIGHTS_PER_CATEGORY)
+}
+
+// ── Demo Data ─────────────────────────────────────────────────────────
+
+function getDemoInsights(): MultiClusterInsight[] {
+  const demoTime = new Date()
+  const fiveMinAgo = new Date(demoTime.getTime() - 5 * 60 * 1000).toISOString()
+  const tenMinAgo = new Date(demoTime.getTime() - 10 * 60 * 1000).toISOString()
+  const fifteenMinAgo = new Date(demoTime.getTime() - 15 * 60 * 1000).toISOString()
+
+  return [
+    {
+      id: 'demo-event-correlation-1',
+      category: 'event-correlation',
+      source: 'heuristic',
+      severity: 'critical',
+      title: '3 clusters had simultaneous warnings',
+      description: '18 warning events across eks-prod-us-east-1, gke-staging, openshift-prod within a 5-minute window. Common reasons: BackOff, FailedScheduling.',
+      affectedClusters: ['eks-prod-us-east-1', 'gke-staging', 'openshift-prod'],
+      relatedResources: ['api-server', 'metrics-collector'],
+      detectedAt: fiveMinAgo,
+    },
+    {
+      id: 'demo-resource-imbalance-cpu',
+      category: 'resource-imbalance',
+      source: 'heuristic',
+      severity: 'warning',
+      title: 'CPU imbalance across fleet (avg 54%)',
+      description: 'eks-prod-us-east-1 (87%) above average; aks-dev-westeu (22%) below average. Fleet average: 54%.',
+      affectedClusters: ['eks-prod-us-east-1', 'aks-dev-westeu'],
+      detectedAt: fiveMinAgo,
+      metrics: {
+        'eks-prod-us-east-1': 87,
+        'gke-staging': 55,
+        'openshift-prod': 62,
+        'aks-dev-westeu': 22,
+        'vllm-gpu-cluster': 45,
+      },
+    },
+    {
+      id: 'demo-restart-app-bug',
+      category: 'restart-correlation',
+      source: 'heuristic',
+      severity: 'warning',
+      title: 'default/api-server restarting across 3 clusters (likely app bug)',
+      description: 'default/api-server has 26 total restarts across eks-prod-us-east-1, gke-staging, openshift-prod. Same workload failing everywhere suggests an application-level issue.',
+      affectedClusters: ['eks-prod-us-east-1', 'gke-staging', 'openshift-prod'],
+      relatedResources: ['default/api-server'],
+      detectedAt: tenMinAgo,
+    },
+    {
+      id: 'demo-restart-infra-issue',
+      category: 'restart-correlation',
+      source: 'heuristic',
+      severity: 'critical',
+      title: '4 workloads restarting in vllm-gpu-cluster (likely infra issue)',
+      description: 'Multiple different workloads (default/metrics-collector, default/cache-redis, default/gpu-scheduler, default/log-agent) are restarting in vllm-gpu-cluster. This pattern suggests an infrastructure problem rather than an application bug.',
+      affectedClusters: ['vllm-gpu-cluster'],
+      relatedResources: ['default/metrics-collector', 'default/cache-redis', 'default/gpu-scheduler', 'default/log-agent'],
+      detectedAt: tenMinAgo,
+    },
+    {
+      id: 'demo-cascade-1',
+      category: 'cascade-impact',
+      source: 'heuristic',
+      severity: 'critical',
+      title: 'Possible cascade across 3 clusters',
+      description: 'Issues started in openshift-prod (FailedMount) and spread to eks-prod-us-east-1, gke-staging within 15 minutes.',
+      affectedClusters: ['openshift-prod', 'eks-prod-us-east-1', 'gke-staging'],
+      detectedAt: fifteenMinAgo,
+      chain: [
+        { cluster: 'openshift-prod', resource: 'config-service', event: 'FailedMount', timestamp: fifteenMinAgo, severity: 'warning' },
+        { cluster: 'eks-prod-us-east-1', resource: 'api-gateway', event: 'Unhealthy', timestamp: tenMinAgo, severity: 'warning' },
+        { cluster: 'gke-staging', resource: 'frontend', event: 'CrashLoopBackOff', timestamp: fiveMinAgo, severity: 'critical' },
+      ],
+    },
+    {
+      id: 'demo-config-drift-1',
+      category: 'config-drift',
+      source: 'heuristic',
+      severity: 'warning',
+      title: 'Config drift in default/api-server',
+      description: 'default/api-server has 3 different images and 2 different replica counts across 4 clusters.',
+      affectedClusters: ['eks-prod-us-east-1', 'gke-staging', 'openshift-prod', 'aks-dev-westeu'],
+      relatedResources: ['default/api-server'],
+      detectedAt: fiveMinAgo,
+    },
+    {
+      id: 'demo-cluster-delta-1',
+      category: 'cluster-delta',
+      source: 'heuristic',
+      severity: 'warning',
+      title: 'default/api-server differs across 2 clusters',
+      description: 'Found 3 differences: Image Version, Replica Count, Status.',
+      affectedClusters: ['eks-prod-us-east-1', 'gke-staging'],
+      relatedResources: ['default/api-server'],
+      detectedAt: fiveMinAgo,
+      deltas: [
+        { dimension: 'Image Version', clusterA: { name: 'eks-prod-us-east-1', value: 'api-server:v2.1.0' }, clusterB: { name: 'gke-staging', value: 'api-server:v2.0.3' }, significance: 'high' },
+        { dimension: 'Replica Count', clusterA: { name: 'eks-prod-us-east-1', value: 5 }, clusterB: { name: 'gke-staging', value: 3 }, significance: 'medium' },
+        { dimension: 'Status', clusterA: { name: 'eks-prod-us-east-1', value: 'running' }, clusterB: { name: 'gke-staging', value: 'deploying' }, significance: 'medium' },
+      ],
+    },
+    {
+      id: 'demo-rollout-1',
+      category: 'rollout-tracker',
+      source: 'heuristic',
+      severity: 'warning',
+      title: 'Rollout in progress: default/api-server',
+      description: '3/5 clusters on api-server:v2.1.0. 1 pending, 1 failed.',
+      affectedClusters: ['eks-prod-us-east-1', 'gke-staging', 'openshift-prod', 'aks-dev-westeu', 'vllm-gpu-cluster'],
+      relatedResources: ['default/api-server'],
+      detectedAt: fiveMinAgo,
+      metrics: { completed: 3, pending: 1, failed: 1, total: 5 },
+    },
+  ]
+}
+
+// ── Severity Ranking ──────────────────────────────────────────────────
+
+const SEVERITY_RANK: Record<InsightSeverity, number> = {
+  critical: 3,
+  warning: 2,
+  info: 1,
+}
+
+// ── Main Hook ─────────────────────────────────────────────────────────
+
+export function useMultiClusterInsights(): UseMultiClusterInsightsResult {
+  const { isDemoMode } = useDemoMode()
+  const { deduplicatedClusters, isLoading: clustersLoading } = useClusters()
+  const { events, isLoading: eventsLoading, isDemoFallback: eventsDemoFallback } = useCachedEvents()
+  const { events: warningEvents } = useCachedWarningEvents()
+  const { data: deployments, isLoading: deploymentsLoading, isDemoFallback: deploymentsDemoFallback } = useCachedDeployments()
+  const { issues: podIssues, isDemoFallback: podIssuesDemoFallback } = useCachedPodIssues()
+
+  const isDemoData = isDemoMode || (eventsDemoFallback && deploymentsDemoFallback && podIssuesDemoFallback)
+  const isLoading = clustersLoading || eventsLoading || deploymentsLoading
+
+  const insights = useMemo(() => {
+    if (isDemoData) return getDemoInsights()
+
+    const all: MultiClusterInsight[] = [
+      ...detectEventCorrelations(events || []),
+      ...detectClusterDeltas(deployments || [], deduplicatedClusters || []),
+      ...detectCascadeImpact(warningEvents || []),
+      ...detectConfigDrift(deployments || []),
+      ...detectResourceImbalance(deduplicatedClusters || []),
+      ...detectRestartCorrelation(podIssues || []),
+      ...trackRolloutProgress(deployments || []),
+    ]
+
+    // Sort by severity (critical first), then by affected clusters count
+    return all.sort((a, b) => {
+      const sevDiff = (SEVERITY_RANK[b.severity] || 0) - (SEVERITY_RANK[a.severity] || 0)
+      if (sevDiff !== 0) return sevDiff
+      return b.affectedClusters.length - a.affectedClusters.length
+    })
+  }, [isDemoData, events, warningEvents, deployments, deduplicatedClusters, podIssues])
+
+  const insightsByCategory = useMemo(() => {
+    const result: Record<InsightCategory, MultiClusterInsight[]> = {
+      'event-correlation': [],
+      'cluster-delta': [],
+      'cascade-impact': [],
+      'config-drift': [],
+      'resource-imbalance': [],
+      'restart-correlation': [],
+      'rollout-tracker': [],
+    }
+    for (const insight of insights || []) {
+      result[insight.category].push(insight)
+    }
+    return result
+  }, [insights])
+
+  const topInsights = useMemo(
+    () => (insights || []).slice(0, MAX_TOP_INSIGHTS),
+    [insights],
+  )
+
+  return {
+    insights,
+    isLoading,
+    isDemoData: !!isDemoData,
+    insightsByCategory,
+    topInsights,
+  }
+}

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -52,6 +52,7 @@ const DEFAULT_PRIMARY_NAV: SidebarItem[] = [
   { id: 'clusters', name: 'My Clusters', icon: 'Server', href: '/clusters', type: 'link', order: 1 },
   { id: 'cluster-admin', name: 'Cluster Admin', icon: 'ShieldAlert', href: '/cluster-admin', type: 'link', order: 2 },
   { id: 'deploy', name: 'Deploy', icon: 'Rocket', href: '/deploy', type: 'link', order: 3 },
+  { id: 'insights', name: 'Insights', icon: 'Lightbulb', href: '/insights', type: 'link', order: 3.5 },
   { id: 'ai-ml', name: 'AI/ML', icon: 'Sparkles', href: '/ai-ml', type: 'link', order: 4 },
   { id: 'ai-agents', name: 'AI Agents', icon: 'Bot', href: '/ai-agents', type: 'link', order: 5 },
   { id: 'ci-cd', name: 'CI/CD', icon: 'GitMerge', href: '/ci-cd', type: 'link', order: 6 },
@@ -483,6 +484,6 @@ export const AVAILABLE_ICONS = [
   'Key', 'Users', 'Bell', 'AlertTriangle', 'CheckCircle', 'XCircle',
   'RefreshCw', 'Search', 'Filter', 'Layers', 'Globe', 'Terminal',
   'Code', 'Cpu', 'HardDrive', 'Wifi', 'Monitor', 'Folder', 'Gamepad2', 'Bot',
-  'Sparkles', 'GitMerge', 'Rocket', 'ShieldCheck', 'ClipboardCheck',
+  'Sparkles', 'GitMerge', 'Rocket', 'ShieldCheck', 'ClipboardCheck', 'Lightbulb',
   'DollarSign', 'Package', 'FileText', 'CircuitBoard', 'Cog', 'Hexagon', 'Network',
 ]

--- a/web/src/lib/cards/types.ts
+++ b/web/src/lib/cards/types.ts
@@ -39,6 +39,7 @@ export type CardCategory =
   | 'games'
   | 'ci-cd'
   | 'events'
+  | 'insights'
 
 export interface CardDefinition {
   /** Unique card type identifier */

--- a/web/src/types/insights.ts
+++ b/web/src/types/insights.ts
@@ -1,0 +1,74 @@
+/**
+ * Multi-Cluster Insight Types
+ *
+ * Types for the cross-cluster correlation engine that detects patterns
+ * impossible to see in single-cluster dashboards.
+ */
+
+/** Insight source - heuristic (algorithmic) or AI (agent-enriched) */
+export type InsightSource = 'heuristic' | 'ai'
+
+/** Insight severity levels */
+export type InsightSeverity = 'critical' | 'warning' | 'info'
+
+/** Insight categories matching the 7 correlation card types */
+export type InsightCategory =
+  | 'event-correlation'
+  | 'cluster-delta'
+  | 'cascade-impact'
+  | 'config-drift'
+  | 'resource-imbalance'
+  | 'restart-correlation'
+  | 'rollout-tracker'
+
+/** A single insight produced by the multi-cluster correlation engine */
+export interface MultiClusterInsight {
+  id: string
+  category: InsightCategory
+  source: InsightSource
+  severity: InsightSeverity
+  /** Confidence percentage 0-100, present only for AI-sourced insights */
+  confidence?: number
+  /** AI provider name (e.g. 'claude'), present only for AI-sourced insights */
+  provider?: string
+  title: string
+  /** Heuristic: templated string; AI: natural language explanation */
+  description: string
+  /** AI-only: suggested remediation action */
+  remediation?: string
+  affectedClusters: string[]
+  relatedResources?: string[]
+  detectedAt: string
+  /** For cascade insights: ordered chain of events across clusters */
+  chain?: CascadeLink[]
+  /** For delta insights: list of differences between clusters */
+  deltas?: ClusterDelta[]
+  /** For imbalance insights: metric name → per-cluster value */
+  metrics?: Record<string, number>
+}
+
+/** A link in a cascading failure chain */
+export interface CascadeLink {
+  cluster: string
+  resource: string
+  event: string
+  timestamp: string
+  severity: InsightSeverity
+}
+
+/** A single delta between two clusters */
+export interface ClusterDelta {
+  dimension: string
+  clusterA: { name: string; value: string | number }
+  clusterB: { name: string; value: string | number }
+  significance: 'high' | 'medium' | 'low'
+}
+
+/** Return type of the useMultiClusterInsights hook */
+export interface UseMultiClusterInsightsResult {
+  insights: MultiClusterInsight[]
+  isLoading: boolean
+  isDemoData: boolean
+  insightsByCategory: Record<InsightCategory, MultiClusterInsight[]>
+  topInsights: MultiClusterInsight[]
+}


### PR DESCRIPTION
## Summary

- Adds new **Insights** dashboard (`/insights`) with Lightbulb sidebar icon — a cross-cluster correlation engine that surfaces patterns invisible from single-cluster views
- **7 new cards** with dual-mode badges (heuristic ⚡ / AI 🤖):
  1. **Cross-Cluster Event Correlation** — stacked area timeline of warning events across clusters with highlighted correlation bands
  2. **Cluster Delta Detector** — side-by-side comparison of two clusters showing every dimension where they differ
  3. **Cascade Impact Map** — causal chain visualization showing how issues propagate across clusters over time
  4. **Config Drift Heatmap** — cluster-pair matrix where cell color = degree of configuration drift
  5. **Resource Imbalance Detector** — per-cluster CPU/memory bars with fleet average reference line
  6. **Restart Correlation Matrix** — detects horizontal (app bug) vs vertical (infra issue) restart patterns
  7. **Deployment Rollout Tracker** — tracks deployment rollout progress across clusters with per-cluster progress bars
- Core `useMultiClusterInsights` hook runs 7 heuristic correlation algorithms on cached multi-cluster data with demo fallback
- All cards registered in add-card dialog, dashboard in customize dialog
- New `insights` category added to `CardCategory` union type

## Test plan
- [ ] Visit `/insights` — all 7 cards render with demo data
- [ ] Cards appear in "Add Card" dialog under "insights" category
- [ ] Dashboard appears in "Customize" dialog
- [ ] Sidebar shows "Insights" with Lightbulb icon between Deploy and AI/ML
- [ ] `npm run build` passes with no type errors
- [ ] `npm run lint` passes with no errors