### PR TITLE
🐛 Auto-stash uncommitted changes during updates instead of blocking

### DIFF
--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -295,16 +295,6 @@ func (uc *UpdateChecker) checkDeveloperChannel() {
 		return
 	}
 
-	if hasUncommittedChanges(repoPath) {
-		log.Println("[AutoUpdate] Uncommitted changes detected, skipping update")
-		uc.broadcast("update_progress", UpdateProgressPayload{
-			Status:  "failed",
-			Message: "Update skipped: uncommitted changes detected",
-			Error:   fmt.Sprintf("Run 'cd %s && git stash' to save your changes, then retry the update", repoPath),
-		})
-		return
-	}
-
 	latestSHA, err := fetchLatestMainSHAWithRepo(repoPath)
 	if err != nil {
 		log.Printf("[AutoUpdate] Failed to check main SHA: %v", err)
@@ -768,15 +758,9 @@ func (uc *UpdateChecker) executeDevReleaseUpdate(release *githubReleaseInfo) {
 	if repoPath == "" {
 		return
 	}
-	if hasUncommittedChanges(repoPath) {
-		log.Println("[AutoUpdate] Uncommitted changes detected, skipping release update")
-		uc.broadcast("update_progress", UpdateProgressPayload{
-			Status:  "failed",
-			Message: "Update skipped: uncommitted changes detected",
-			Error:   fmt.Sprintf("Run 'cd %s && git stash' to save your changes, then retry the update", repoPath),
-		})
-		return
-	}
+
+	// Stash any local changes so the checkout succeeds
+	stashed := gitStash(repoPath)
 
 	uc.broadcast("update_progress", UpdateProgressPayload{
 		Status:   "pulling",
@@ -789,6 +773,9 @@ func (uc *UpdateChecker) executeDevReleaseUpdate(release *githubReleaseInfo) {
 	cmd.Dir = repoPath
 	if err := cmd.Run(); err != nil {
 		uc.recordError(fmt.Sprintf("git fetch tag failed: %v", err))
+		if stashed {
+			gitStashPop(repoPath)
+		}
 		return
 	}
 
@@ -796,6 +783,9 @@ func (uc *UpdateChecker) executeDevReleaseUpdate(release *githubReleaseInfo) {
 	cmd.Dir = repoPath
 	if err := cmd.Run(); err != nil {
 		uc.recordError(fmt.Sprintf("git checkout failed: %v", err))
+		if stashed {
+			gitStashPop(repoPath)
+		}
 		return
 	}
 
@@ -1054,11 +1044,40 @@ func hasUncommittedChanges(repoPath string) bool {
 }
 
 func runGitPull(repoPath string) error {
-	cmd := exec.Command("git", "pull", "--rebase", "origin", "main")
+	cmd := exec.Command("git", "pull", "--rebase", "--autostash", "origin", "main")
 	cmd.Dir = repoPath
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// gitStash stashes uncommitted changes if any exist. Returns true if a stash was created.
+func gitStash(repoPath string) bool {
+	if !hasUncommittedChanges(repoPath) {
+		return false
+	}
+	log.Println("[AutoUpdate] Stashing uncommitted changes before update")
+	cmd := exec.Command("git", "stash", "push", "-m", "auto-update: stashed by kc-agent")
+	cmd.Dir = repoPath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Printf("[AutoUpdate] git stash failed: %v", err)
+		return false
+	}
+	return true
+}
+
+// gitStashPop restores previously stashed changes.
+func gitStashPop(repoPath string) {
+	log.Println("[AutoUpdate] Restoring stashed changes")
+	cmd := exec.Command("git", "stash", "pop")
+	cmd.Dir = repoPath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Printf("[AutoUpdate] git stash pop failed (changes saved in stash): %v", err)
+	}
 }
 
 func rebuildFrontend(repoPath string) error {

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -379,15 +379,6 @@ export function UpdateSettings() {
               failText={t('settings.updates.prereqInstallFail')}
               icon={<HardDrive className="w-3.5 h-3.5" />}
             />
-            {autoUpdateStatus?.hasUncommittedChanges !== undefined && (
-              <PrereqRow
-                ok={!autoUpdateStatus.hasUncommittedChanges}
-                label={t('settings.updates.prereqGitClean')}
-                okText={t('settings.updates.prereqGitCleanOk')}
-                failText={t('settings.updates.prereqGitCleanFail')}
-                icon={<GitCommitHorizontal className="w-3.5 h-3.5" />}
-              />
-            )}
           </div>
           {/* Summary line */}
           {(() => {
@@ -398,9 +389,6 @@ export function UpdateSettings() {
               hasGithubToken,
               installMethod === 'dev',
             ]
-            if (autoUpdateStatus?.hasUncommittedChanges !== undefined) {
-              checks.push(!autoUpdateStatus.hasUncommittedChanges)
-            }
             const failCount = checks.filter((c) => !c).length
             return (
               <div className={`mt-3 pt-3 border-t border-border text-xs ${failCount === 0 ? 'text-green-400' : 'text-yellow-400'}`}>
@@ -436,9 +424,9 @@ export function UpdateSettings() {
             </button>
           </div>
           {autoUpdateEnabled && isDeveloperChannel && autoUpdateStatus?.hasUncommittedChanges && (
-            <div className="mt-3 flex items-center gap-2 p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
-              <AlertTriangle className="w-4 h-4 text-yellow-400 shrink-0" />
-              <p className="text-xs text-yellow-400">{t('settings.updates.uncommittedWarning')}</p>
+            <div className="mt-3 flex items-center gap-2 p-2 rounded-lg bg-blue-500/10 border border-blue-500/20">
+              <GitCommitHorizontal className="w-4 h-4 text-blue-400 shrink-0" />
+              <p className="text-xs text-blue-400">{t('settings.updates.uncommittedAutoStash')}</p>
             </div>
           )}
         </div>

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -514,6 +514,7 @@
       "currentSHA": "Current Commit",
       "latestSHA": "Latest on main",
       "uncommittedWarning": "Uncommitted changes — auto-update paused",
+      "uncommittedAutoStash": "Local changes detected — they will be automatically stashed during updates and restored after",
       "agentRequired": "kc-agent required for auto-updates",
       "agentRequiredDesc": "Start kc-agent to enable automatic updates",
       "helmDisabled": "Auto-update not available for Helm installs",


### PR DESCRIPTION
## Summary
Follow-up to #2041 and #2042. Instead of blocking updates when uncommitted changes exist, the update now handles them automatically:

- **Developer channel**: `git pull --rebase --autostash` stashes/restores changes seamlessly
- **Release channel**: `git stash push` before checkout, `git stash pop` after (with rollback on failure)
- **UI**: Removed "uncommitted changes" from the blocking prereqs checklist. Changed the warning banner to an informational note: "Local changes detected — they will be automatically stashed during updates and restored after"
- **Retry**: Reset the trigger guard on done/failed so users can retry without refreshing

Users should never have to run terminal commands to make the Update button work.

## Test plan
- [ ] Introduce uncommitted changes in the console repo
- [ ] Click "Update Now" — update should proceed, stash changes, and restore them after
- [ ] Verify the prereqs section no longer shows uncommitted changes as a blocker
- [ ] Verify the info banner shows the auto-stash message