### PR TITLE
✨ Add unified controls to all 7 Insights dashboard cards

### DIFF
--- a/web/src/components/cards/insights/CascadeImpactMap.tsx
+++ b/web/src/components/cards/insights/CascadeImpactMap.tsx
@@ -5,6 +5,8 @@ import { useCardLoadingState } from '../CardDataContext'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
 import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
+import { CardControlsRow } from '../../../lib/cards/CardComponents'
+import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
 import type { InsightSeverity } from '../../../types/insights'
 
 const SEVERITY_COLORS: Record<InsightSeverity, string> = {
@@ -23,21 +25,25 @@ export function CascadeImpactMap() {
   const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
   const { selectedClusters } = useGlobalFilters()
 
-  const cascadeInsights = useMemo(() => {
+  const cascadeInsightsRaw = useMemo(() => {
     const all = insightsByCategory['cascade-impact'] || []
     if (selectedClusters.length === 0) return all
     return all.filter(i =>
       (i.affectedClusters || []).some(c => selectedClusters.includes(c)),
     )
   }, [insightsByCategory, selectedClusters])
+  const {
+    sorted: cascadeInsights,
+    sortBy, setSortBy, sortDirection, setSortDirection, limit, setLimit,
+  } = useInsightSort(cascadeInsightsRaw)
 
   useCardLoadingState({
     isLoading,
-    hasAnyData: cascadeInsights.length > 0,
+    hasAnyData: cascadeInsightsRaw.length > 0,
     isDemoData,
   })
 
-  if (!isLoading && cascadeInsights.length === 0) {
+  if (!isLoading && cascadeInsightsRaw.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
         <Workflow className="w-8 h-8 mb-2 opacity-50" />
@@ -49,6 +55,18 @@ export function CascadeImpactMap() {
 
   return (
     <div className="space-y-4 p-1">
+      <CardControlsRow
+        cardControls={{
+          limit,
+          onLimitChange: setLimit,
+          sortBy,
+          sortOptions: INSIGHT_SORT_OPTIONS,
+          onSortChange: (v) => setSortBy(v as InsightSortField),
+          sortDirection,
+          onSortDirectionChange: setSortDirection,
+        }}
+      />
+
       {(cascadeInsights || []).map(insight => (
         <div key={insight.id} className="space-y-2">
           {/* Header */}

--- a/web/src/components/cards/insights/ClusterDeltaDetector.tsx
+++ b/web/src/components/cards/insights/ClusterDeltaDetector.tsx
@@ -5,6 +5,8 @@ import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
 import { useCardLoadingState } from '../CardDataContext'
 import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
+import { CardControlsRow } from '../../../lib/cards/CardComponents'
+import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
 import { CHART_GRID_STROKE, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER, CHART_TICK_COLOR } from '../../../lib/constants/ui'
 
 
@@ -22,11 +24,15 @@ const SIGNIFICANCE_COLORS: Record<string, string> = {
 export function ClusterDeltaDetector() {
   const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
 
-  const deltaInsights = insightsByCategory['cluster-delta'] || []
+  const deltaInsightsRaw = insightsByCategory['cluster-delta'] || []
+  const {
+    sorted: deltaInsights,
+    sortBy, setSortBy, sortDirection, setSortDirection, limit, setLimit,
+  } = useInsightSort(deltaInsightsRaw)
 
   useCardLoadingState({
     isLoading,
-    hasAnyData: deltaInsights.length > 0,
+    hasAnyData: deltaInsightsRaw.length > 0,
     isDemoData,
   })
 
@@ -53,7 +59,7 @@ export function ClusterDeltaDetector() {
     )
   }, [insight])
 
-  if (!isLoading && deltaInsights.length === 0) {
+  if (!isLoading && deltaInsightsRaw.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
         <GitCompare className="w-8 h-8 mb-2 opacity-50" />
@@ -67,6 +73,18 @@ export function ClusterDeltaDetector() {
 
   return (
     <div className="space-y-3 p-1">
+      <CardControlsRow
+        cardControls={{
+          limit,
+          onLimitChange: setLimit,
+          sortBy,
+          sortOptions: INSIGHT_SORT_OPTIONS,
+          onSortChange: (v) => setSortBy(v as InsightSortField),
+          sortDirection,
+          onSortDirectionChange: setSortDirection,
+        }}
+      />
+
       {/* Workload selector */}
       {deltaInsights.length > 1 && (
         <div className="flex items-center gap-2 overflow-x-auto pb-1">

--- a/web/src/components/cards/insights/ConfigDriftHeatmap.tsx
+++ b/web/src/components/cards/insights/ConfigDriftHeatmap.tsx
@@ -5,6 +5,8 @@ import { useCardLoadingState } from '../CardDataContext'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
 import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
+import { CardControlsRow } from '../../../lib/cards/CardComponents'
+import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
 
 /** Maximum clusters to show in the heatmap grid */
 const MAX_HEATMAP_CLUSTERS = 12
@@ -13,11 +15,15 @@ export function ConfigDriftHeatmap() {
   const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
   const { selectedClusters } = useGlobalFilters()
 
-  const driftInsights = useMemo(() => insightsByCategory['config-drift'] || [], [insightsByCategory])
+  const driftInsightsRaw = useMemo(() => insightsByCategory['config-drift'] || [], [insightsByCategory])
+  const {
+    sorted: driftInsights,
+    sortBy, setSortBy, sortDirection, setSortDirection, limit, setLimit,
+  } = useInsightSort(driftInsightsRaw)
 
   useCardLoadingState({
     isLoading,
-    hasAnyData: driftInsights.length > 0,
+    hasAnyData: driftInsightsRaw.length > 0,
     isDemoData,
   })
 
@@ -64,7 +70,7 @@ export function ConfigDriftHeatmap() {
     return driftMatrix.get(`${a}:${b}`) || driftMatrix.get(`${b}:${a}`) || 0
   }
 
-  if (!isLoading && driftInsights.length === 0) {
+  if (!isLoading && driftInsightsRaw.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
         <Diff className="w-8 h-8 mb-2 opacity-50" />
@@ -76,6 +82,18 @@ export function ConfigDriftHeatmap() {
 
   return (
     <div className="space-y-3 p-1">
+      <CardControlsRow
+        cardControls={{
+          limit,
+          onLimitChange: setLimit,
+          sortBy,
+          sortOptions: INSIGHT_SORT_OPTIONS,
+          onSortChange: (v) => setSortBy(v as InsightSortField),
+          sortDirection,
+          onSortDirectionChange: setSortDirection,
+        }}
+      />
+
       {/* Heatmap */}
       {clusters.length >= 2 && (
         <div className="overflow-x-auto">

--- a/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
+++ b/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
@@ -7,6 +7,8 @@ import { useCardLoadingState } from '../CardDataContext'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
 import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
+import { CardControlsRow } from '../../../lib/cards/CardComponents'
+import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
 import { CHART_GRID_STROKE, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER, CHART_TICK_COLOR } from '../../../lib/constants/ui'
 
 /** Time bucket size for the timeline chart (2 minutes) */
@@ -25,11 +27,15 @@ export function CrossClusterEventCorrelation() {
   const { events: warningEvents } = useCachedWarningEvents()
   const { selectedClusters } = useGlobalFilters()
 
-  const correlationInsights = insightsByCategory['event-correlation'] || []
+  const correlationInsightsRaw = insightsByCategory['event-correlation'] || []
+  const {
+    sorted: correlationInsights,
+    sortBy, setSortBy, sortDirection, setSortDirection, limit, setLimit,
+  } = useInsightSort(correlationInsightsRaw)
 
   useCardLoadingState({
     isLoading,
-    hasAnyData: correlationInsights.length > 0 || (warningEvents || []).length > 0,
+    hasAnyData: correlationInsightsRaw.length > 0 || (warningEvents || []).length > 0,
     isDemoData,
   })
 
@@ -66,7 +72,7 @@ export function CrossClusterEventCorrelation() {
     return { chartData: sorted, clusterNames: clusters }
   }, [warningEvents, selectedClusters])
 
-  if (!isLoading && correlationInsights.length === 0 && chartData.length === 0) {
+  if (!isLoading && correlationInsightsRaw.length === 0 && chartData.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
         <Activity className="w-8 h-8 mb-2 opacity-50" />
@@ -78,6 +84,18 @@ export function CrossClusterEventCorrelation() {
 
   return (
     <div className="space-y-3 p-1">
+      <CardControlsRow
+        cardControls={{
+          limit,
+          onLimitChange: setLimit,
+          sortBy,
+          sortOptions: INSIGHT_SORT_OPTIONS,
+          onSortChange: (v) => setSortBy(v as InsightSortField),
+          sortDirection,
+          onSortDirectionChange: setSortDirection,
+        }}
+      />
+
       {/* Timeline chart */}
       {chartData.length > 0 && (
         <div className="h-40">

--- a/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
+++ b/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
@@ -6,6 +6,8 @@ import { useCardLoadingState } from '../CardDataContext'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
 import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
+import { CardControlsRow } from '../../../lib/cards/CardComponents'
+import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
 import { CHART_GRID_STROKE, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER, CHART_TICK_COLOR } from '../../../lib/constants/ui'
 
 /** Color for completed rollout progress */
@@ -38,17 +40,21 @@ export function DeploymentRolloutTracker() {
   const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
   const { selectedClusters } = useGlobalFilters()
 
-  const rolloutInsights = useMemo(() => {
+  const rolloutInsightsRaw = useMemo(() => {
     const all = insightsByCategory['rollout-tracker'] || []
     if (selectedClusters.length === 0) return all
     return all.filter(i =>
       (i.affectedClusters || []).some(c => selectedClusters.includes(c)),
     )
   }, [insightsByCategory, selectedClusters])
+  const {
+    sorted: rolloutInsights,
+    sortBy, setSortBy, sortDirection, setSortDirection, limit, setLimit,
+  } = useInsightSort(rolloutInsightsRaw)
 
   useCardLoadingState({
     isLoading,
-    hasAnyData: rolloutInsights.length > 0,
+    hasAnyData: rolloutInsightsRaw.length > 0,
     isDemoData,
   })
 
@@ -73,7 +79,7 @@ export function DeploymentRolloutTracker() {
     })
   }, [insight])
 
-  if (!isLoading && rolloutInsights.length === 0) {
+  if (!isLoading && rolloutInsightsRaw.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
         <Rocket className="w-8 h-8 mb-2 opacity-50" />
@@ -85,6 +91,18 @@ export function DeploymentRolloutTracker() {
 
   return (
     <div className="space-y-3 p-1">
+      <CardControlsRow
+        cardControls={{
+          limit,
+          onLimitChange: setLimit,
+          sortBy,
+          sortOptions: INSIGHT_SORT_OPTIONS,
+          onSortChange: (v) => setSortBy(v as InsightSortField),
+          sortDirection,
+          onSortDirectionChange: setSortDirection,
+        }}
+      />
+
       {/* Rollout selector */}
       {rolloutInsights.length > 1 && (
         <div className="flex items-center gap-2 overflow-x-auto pb-1">

--- a/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
+++ b/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
@@ -6,6 +6,8 @@ import { useCardLoadingState } from '../CardDataContext'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
 import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
+import { CardControlsRow } from '../../../lib/cards/CardComponents'
+import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
 import { CHART_GRID_STROKE, CHART_TOOLTIP_BG, CHART_TOOLTIP_BORDER, CHART_TICK_COLOR } from '../../../lib/constants/ui'
 
 /** Percentage threshold for coloring bars as overloaded */
@@ -17,11 +19,15 @@ export function ResourceImbalanceDetector() {
   const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
   const { selectedClusters } = useGlobalFilters()
 
-  const imbalanceInsights = useMemo(() => insightsByCategory['resource-imbalance'] || [], [insightsByCategory])
+  const imbalanceInsightsRaw = useMemo(() => insightsByCategory['resource-imbalance'] || [], [insightsByCategory])
+  const {
+    sorted: imbalanceInsights,
+    sortBy, setSortBy, sortDirection, setSortDirection, limit, setLimit,
+  } = useInsightSort(imbalanceInsightsRaw)
 
   useCardLoadingState({
     isLoading,
-    hasAnyData: imbalanceInsights.length > 0,
+    hasAnyData: imbalanceInsightsRaw.length > 0,
     isDemoData,
   })
 
@@ -44,7 +50,7 @@ export function ResourceImbalanceDetector() {
     ? Math.round(chartData.reduce((sum, d) => sum + d.value, 0) / chartData.length)
     : 0
 
-  if (!isLoading && imbalanceInsights.length === 0) {
+  if (!isLoading && imbalanceInsightsRaw.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
         <Scale className="w-8 h-8 mb-2 opacity-50" />
@@ -56,6 +62,18 @@ export function ResourceImbalanceDetector() {
 
   return (
     <div className="space-y-3 p-1">
+      <CardControlsRow
+        cardControls={{
+          limit,
+          onLimitChange: setLimit,
+          sortBy,
+          sortOptions: INSIGHT_SORT_OPTIONS,
+          onSortChange: (v) => setSortBy(v as InsightSortField),
+          sortDirection,
+          onSortDirectionChange: setSortDirection,
+        }}
+      />
+
       {(imbalanceInsights || []).map(insight => (
         <div key={insight.id} className="space-y-2">
           <div className="flex items-center gap-2">

--- a/web/src/components/cards/insights/RestartCorrelationMatrix.tsx
+++ b/web/src/components/cards/insights/RestartCorrelationMatrix.tsx
@@ -4,17 +4,23 @@ import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
 import { useCardLoadingState } from '../CardDataContext'
 import { InsightSourceBadge } from './InsightSourceBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
+import { CardControlsRow } from '../../../lib/cards/CardComponents'
+import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
 
 
 
 export function RestartCorrelationMatrix() {
   const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
 
-  const restartInsights = useMemo(() => insightsByCategory['restart-correlation'] || [], [insightsByCategory])
+  const restartInsightsRaw = useMemo(() => insightsByCategory['restart-correlation'] || [], [insightsByCategory])
+  const {
+    sorted: restartInsights,
+    sortBy, setSortBy, sortDirection, setSortDirection, limit, setLimit,
+  } = useInsightSort(restartInsightsRaw)
 
   useCardLoadingState({
     isLoading,
-    hasAnyData: restartInsights.length > 0,
+    hasAnyData: restartInsightsRaw.length > 0,
     isDemoData,
   })
 
@@ -28,7 +34,7 @@ export function RestartCorrelationMatrix() {
     [restartInsights],
   )
 
-  if (!isLoading && restartInsights.length === 0) {
+  if (!isLoading && restartInsightsRaw.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
         <RefreshCcw className="w-8 h-8 mb-2 opacity-50" />
@@ -40,6 +46,18 @@ export function RestartCorrelationMatrix() {
 
   return (
     <div className="space-y-4 p-1">
+      <CardControlsRow
+        cardControls={{
+          limit,
+          onLimitChange: setLimit,
+          sortBy,
+          sortOptions: INSIGHT_SORT_OPTIONS,
+          onSortChange: (v) => setSortBy(v as InsightSortField),
+          sortDirection,
+          onSortDirectionChange: setSortDirection,
+        }}
+      />
+
       {/* App Bug Pattern (horizontal) */}
       {appBugInsights.length > 0 && (
         <div className="space-y-2">

--- a/web/src/components/cards/insights/insightSortUtils.ts
+++ b/web/src/components/cards/insights/insightSortUtils.ts
@@ -1,0 +1,64 @@
+import { useState, useMemo } from 'react'
+import type { MultiClusterInsight, InsightSeverity } from '../../../types/insights'
+import type { SortDirection } from '../../ui/CardControls'
+
+/** Numeric ordering for insight severity levels */
+const INSIGHT_SEVERITY_ORDER: Record<InsightSeverity, number> = {
+  critical: 0,
+  warning: 1,
+  info: 2,
+}
+
+/** Default number of insight items to display */
+const DEFAULT_INSIGHT_LIMIT = 5
+
+export type InsightSortField = 'severity' | 'clusters' | 'time' | 'title'
+
+export const INSIGHT_SORT_OPTIONS: { value: InsightSortField; label: string }[] = [
+  { value: 'severity', label: 'Severity' },
+  { value: 'clusters', label: 'Clusters' },
+  { value: 'time', label: 'Time' },
+  { value: 'title', label: 'Title' },
+]
+
+const insightComparators: Record<InsightSortField, (a: MultiClusterInsight, b: MultiClusterInsight) => number> = {
+  severity: (a, b) =>
+    (INSIGHT_SEVERITY_ORDER[a.severity] ?? 3) - (INSIGHT_SEVERITY_ORDER[b.severity] ?? 3),
+  clusters: (a, b) =>
+    (a.affectedClusters?.length ?? 0) - (b.affectedClusters?.length ?? 0),
+  time: (a, b) =>
+    new Date(a.detectedAt).getTime() - new Date(b.detectedAt).getTime(),
+  title: (a, b) => a.title.localeCompare(b.title),
+}
+
+/**
+ * Hook that provides sort/limit state and sorted+limited insights array.
+ * Used by all Insights dashboard cards for unified controls.
+ */
+export function useInsightSort(
+  insights: MultiClusterInsight[],
+  defaultSort: InsightSortField = 'severity',
+  defaultDirection: SortDirection = 'asc',
+) {
+  const [sortBy, setSortBy] = useState<InsightSortField>(defaultSort)
+  const [sortDirection, setSortDirection] = useState<SortDirection>(defaultDirection)
+  const [limit, setLimit] = useState<number | 'unlimited'>(DEFAULT_INSIGHT_LIMIT)
+
+  const sorted = useMemo(() => {
+    const cmp = insightComparators[sortBy]
+    const dirMul = sortDirection === 'asc' ? 1 : -1
+    const result = [...insights].sort((a, b) => dirMul * cmp(a, b))
+    if (limit === 'unlimited') return result
+    return result.slice(0, limit)
+  }, [insights, sortBy, sortDirection, limit])
+
+  return {
+    sorted,
+    sortBy,
+    setSortBy,
+    sortDirection,
+    setSortDirection,
+    limit,
+    setLimit,
+  }
+}


### PR DESCRIPTION
## Summary
- Add sort and limit controls (CardControlsRow) to all 7 Insights dashboard cards
- Shared sort logic in `insightSortUtils.ts` — supports severity, clusters, time, title sorting with configurable direction and limit
- Cards updated: CrossClusterEventCorrelation, ResourceImbalanceDetector, ConfigDriftHeatmap, ClusterDeltaDetector, RestartCorrelationMatrix, CascadeImpactMap, DeploymentRolloutTracker

## Test plan
- [ ] Navigate to Insights dashboard
- [ ] Verify each card shows sort dropdown (Severity, Clusters, Time, Title) and limit dropdown
- [ ] Change sort field and direction — verify insights reorder correctly
- [ ] Change limit — verify number of displayed insights is capped
- [ ] Verify empty states still display correctly when no insights exist
- [ ] Verify charts/visualizations still render alongside controls