### PR TITLE
🐛 Fix AddCard modal stacking with KeepAlive navigation

### DIFF
--- a/web/src/components/arcade/Arcade.tsx
+++ b/web/src/components/arcade/Arcade.tsx
@@ -193,13 +193,15 @@ export function Arcade() {
     defaultCards: DEFAULT_ARCADE_CARDS,
   })
 
-  // Handle addCard URL param - open modal and clear param
+  // Handle addCard URL param - open modal and clear param.
+  // Guard: KeepAlive keeps hidden dashboards mounted; only process on active route.
   useEffect(() => {
+    if (location.pathname !== '/arcade') return
     if (searchParams.get('addCard') === 'true') {
       setShowAddCard(true)
       setSearchParams({}, { replace: true })
     }
-  }, [searchParams, setSearchParams, setShowAddCard])
+  }, [searchParams, setSearchParams, setShowAddCard, location.pathname])
 
   // Track location for any navigation effects
   useEffect(() => {

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -153,14 +153,16 @@ export function Clusters() {
     onRefresh: refetch,
   })
 
-  // Handle addCard URL param - open modal and clear param
+  // Handle addCard URL param - open modal and clear param.
+  // Guard: KeepAlive keeps hidden dashboards mounted; only process on active route.
   useEffect(() => {
+    if (location.pathname !== '/clusters') return
     if (searchParams.get('addCard') === 'true') {
       setShowAddCard(true)
       searchParams.delete('addCard')
       setSearchParams(searchParams, { replace: true })
     }
-  }, [searchParams, setSearchParams, setShowAddCard])
+  }, [searchParams, setSearchParams, setShowAddCard, location.pathname])
 
   // Trigger refresh when navigating to this page (location.key changes on each navigation)
   useEffect(() => {

--- a/web/src/components/compute/Compute.tsx
+++ b/web/src/components/compute/Compute.tsx
@@ -36,12 +36,14 @@ export function Compute() {
   const [selectedForComparison, setSelectedForComparison] = useState<string[]>([])
   const [showClusterList, setShowClusterList] = useState(false)
 
-  // Handle addCard URL param - open modal and clear param
+  // Handle addCard URL param - open modal and clear param.
+  // Guard: KeepAlive keeps hidden dashboards mounted; only process on active route.
   useEffect(() => {
+    if (location.pathname !== '/compute') return
     if (searchParams.get('addCard') === 'true') {
       setSearchParams({}, { replace: true })
     }
-  }, [searchParams, setSearchParams])
+  }, [searchParams, setSearchParams, location.pathname])
 
   // Trigger refresh when navigating to this page (location.key changes on each navigation)
   useEffect(() => {

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -503,9 +503,12 @@ export function Dashboard() {
     }
   }, [pendingOpenAddCardModal, isLoading, openAddCardModal, setPendingOpenAddCardModal])
 
-  // Handle addCard URL param from search — open modal and clear param
+  // Handle addCard URL param from search — open modal and clear param.
+  // Guard with pathname check: KeepAlive keeps hidden dashboards mounted,
+  // so all of them see the same searchParams. Only process when active.
   const [addCardSearch, setAddCardSearch] = useState('')
   useEffect(() => {
+    if (location.pathname !== '/' && location.pathname !== '') return
     if (searchParams.get('addCard') === 'true') {
       setAddCardSearch(searchParams.get('cardSearch') || '')
       openAddCardModal()
@@ -514,7 +517,7 @@ export function Dashboard() {
       cleaned.delete('cardSearch')
       setSearchParams(cleaned, { replace: true })
     }
-  }, [searchParams, setSearchParams, openAddCardModal])
+  }, [searchParams, setSearchParams, openAddCardModal, location.pathname])
 
   // Helper to check if a card ID is a local-only (not persisted) card
   const isLocalOnlyCard = (cardId: string) => {

--- a/web/src/components/deploy/Deploy.tsx
+++ b/web/src/components/deploy/Deploy.tsx
@@ -390,13 +390,15 @@ export function Deploy() {
     }
   }, [pendingDeploy, publishCardEvent, deployWorkload, shouldPersist, createManagedWorkload, createWorkloadDeployment, showToast])
 
-  // Handle addCard URL param - open modal and clear param
+  // Handle addCard URL param - open modal and clear param.
+  // Guard: KeepAlive keeps hidden dashboards mounted; only process on active route.
   useEffect(() => {
+    if (location.pathname !== '/deploy') return
     if (searchParams.get('addCard') === 'true') {
       setShowAddCard(true)
       setSearchParams({}, { replace: true })
     }
-  }, [searchParams, setSearchParams, setShowAddCard])
+  }, [searchParams, setSearchParams, setShowAddCard, location.pathname])
 
   // Track location for any navigation effects
   useEffect(() => {

--- a/web/src/components/security/Security.tsx
+++ b/web/src/components/security/Security.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useCallback } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams, useLocation } from 'react-router-dom'
 import { Shield, ShieldAlert, ShieldCheck, ShieldX, Users, Key, Lock, Eye, Clock, AlertTriangle, CheckCircle2, XCircle, ChevronRight } from 'lucide-react'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
@@ -36,6 +36,7 @@ type ViewTab = 'overview' | 'issues' | 'rbac' | 'compliance'
 export function Security() {
   const { t } = useTranslation(['cards', 'common'])
   const [searchParams, setSearchParams] = useSearchParams()
+  const location = useLocation()
   const {
     selectedClusters: globalSelectedClusters,
     isAllClustersSelected,
@@ -81,12 +82,14 @@ export function Security() {
     }
   }, [])
 
-  // Handle addCard URL param - open modal and clear param
+  // Handle addCard URL param - open modal and clear param.
+  // Guard: KeepAlive keeps hidden dashboards mounted; only process on active route.
   useEffect(() => {
+    if (location.pathname !== '/security') return
     if (searchParams.get('addCard') === 'true') {
       setSearchParams({}, { replace: true })
     }
-  }, [searchParams, setSearchParams])
+  }, [searchParams, setSearchParams, location.pathname])
 
   // Trigger refresh on mount (ensures data is fresh when navigating to this page)
   useEffect(() => {

--- a/web/src/lib/dashboards/DashboardPage.tsx
+++ b/web/src/lib/dashboards/DashboardPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback, ReactNode } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useState, useEffect, useCallback, useRef, ReactNode } from 'react'
+import { useSearchParams, useLocation } from 'react-router-dom'
 import { Plus, LayoutGrid, ChevronDown, ChevronRight } from 'lucide-react'
 // NOTE: Wildcard import is required for dynamic icon resolution
 // Dashboard page resolves icon names from dashboard definitions at runtime
@@ -106,6 +106,10 @@ export function DashboardPage({
   isDemoData = false,
 }: DashboardPageProps) {
   const [searchParams, setSearchParams] = useSearchParams()
+  const location = useLocation()
+  // Capture the route path at mount time — KeepAlive keeps this component alive
+  // across navigations, so we need to know which route we belong to.
+  const mountedRouteRef = useRef(location.pathname)
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
   const Icon = getIcon(icon)
 
@@ -153,15 +157,18 @@ export function DashboardPage({
   const isRefreshing = externalRefreshing || showIndicator
   const isFetching = isLoading || isRefreshing
 
-  // Handle addCard URL param - open modal and clear param
+  // Handle addCard URL param - open modal and clear param.
+  // Guard with mounted route: KeepAlive keeps hidden dashboards mounted,
+  // so all of them see the same searchParams. Only process when active.
   const [addCardSearch, setAddCardSearch] = useState('')
   useEffect(() => {
+    if (location.pathname !== mountedRouteRef.current) return
     if (searchParams.get('addCard') === 'true') {
       setAddCardSearch(searchParams.get('cardSearch') || '')
       setShowAddCard(true)
       setSearchParams({}, { replace: true })
     }
-  }, [searchParams, setSearchParams, setShowAddCard])
+  }, [searchParams, setSearchParams, setShowAddCard, location.pathname])
 
   // Card handlers
   const handleAddCards = useCallback((newCards: Array<{ type: string; title: string; config: Record<string, unknown> }>) => {


### PR DESCRIPTION
## Summary

- **Bug**: Searching for a card (e.g. "node status") and clicking the result opens 2-4 stacked AddCard modals instead of one
- **Root cause**: KeepAlive preserves previously-visited dashboard components in the DOM with `display:none`. When navigating to `/?addCard=true`, `useSearchParams` fires in ALL cached components simultaneously, each opening its own AddCardModal
- **Fix**: Guard each component's `addCard` useEffect with a `location.pathname` check so only the active route processes the URL parameter. For the generic `DashboardPage`, capture mount-time pathname via `useRef`

## Files changed
- `Dashboard.tsx` — guard with `location.pathname !== '/'`
- `Clusters.tsx` — guard with `location.pathname !== '/clusters'`
- `Compute.tsx` — guard with `location.pathname !== '/compute'`
- `Security.tsx` — guard with `location.pathname !== '/security'`
- `Deploy.tsx` — guard with `location.pathname !== '/deploy'`
- `Arcade.tsx` — guard with `location.pathname !== '/arcade'`
- `DashboardPage.tsx` — guard with `mountedRouteRef` (captures route at mount time)

## Test plan
- [x] Navigate to multiple dashboards (clusters, deploy, arcade) to warm KeepAlive cache
- [x] Search "node status" and click result
- [x] Verify only 1 AddCard modal opens (was 4 before fix)
- [x] Verify modal closes cleanly with ESC
- [x] Build passes
- [x] Lint passes (no new errors)