### PR TITLE
✨ Expand nightly test coverage from 25 to 32 suites

### DIFF
--- a/scripts/a11y-test.sh
+++ b/scripts/a11y-test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Run accessibility compliance tests (WCAG, keyboard nav, ARIA)
+#
+# Usage:
+#   ./scripts/a11y-test.sh              # Full a11y audit (production build)
+#   ./scripts/a11y-test.sh --dev        # Use Vite dev server
+#
+# Tests all dashboards for:
+#   - axe-core WCAG 2.1 AA violations
+#   - Keyboard navigation (Tab, Enter, Escape)
+#   - ARIA attributes and roles
+#   - Focus management
+#   - Color contrast
+#
+# Prerequisites:
+#   - npm install done in web/
+#
+# Output:
+#   web/e2e/test-results/a11y-compliance-report.json
+#   web/e2e/test-results/a11y-compliance-summary.md
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../web"
+
+EXTRA_ENV=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dev) EXTRA_ENV="PERF_DEV=1"; echo "Using Vite dev server..." ;;
+  esac
+done
+
+if [[ -z "$EXTRA_ENV" ]]; then
+  echo "Running accessibility compliance tests against production build..."
+fi
+
+env $EXTRA_ENV npx playwright test \
+  --config e2e/compliance/compliance.config.ts \
+  e2e/compliance/a11y-compliance.spec.ts
+
+echo ""
+echo "Reports:"
+echo "  JSON:    web/e2e/test-results/a11y-compliance-report.json"
+echo "  Summary: web/e2e/test-results/a11y-compliance-summary.md"

--- a/scripts/error-resilience-test.sh
+++ b/scripts/error-resilience-test.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Run error resilience tests — verify graceful degradation on failures
+#
+# Usage:
+#   ./scripts/error-resilience-test.sh              # Production build
+#   ./scripts/error-resilience-test.sh --dev        # Use Vite dev server
+#
+# Tests all dashboards for:
+#   - Error boundary activation on component crashes
+#   - Graceful fallback when APIs return errors
+#   - Recovery after transient failures
+#   - No blank screens or unhandled exceptions
+#
+# Prerequisites:
+#   - npm install done in web/
+#
+# Output:
+#   web/e2e/test-results/error-resilience-report.json
+#   web/e2e/test-results/error-resilience-summary.md
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../web"
+
+EXTRA_ENV=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dev) EXTRA_ENV="PERF_DEV=1"; echo "Using Vite dev server..." ;;
+  esac
+done
+
+if [[ -z "$EXTRA_ENV" ]]; then
+  echo "Running error resilience tests against production build..."
+fi
+
+env $EXTRA_ENV npx playwright test \
+  --config e2e/compliance/compliance.config.ts \
+  e2e/compliance/error-resilience.spec.ts
+
+echo ""
+echo "Reports:"
+echo "  JSON:    web/e2e/test-results/error-resilience-report.json"
+echo "  Summary: web/e2e/test-results/error-resilience-summary.md"

--- a/scripts/i18n-test.sh
+++ b/scripts/i18n-test.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Run internationalization compliance tests
+#
+# Usage:
+#   ./scripts/i18n-test.sh              # Production build
+#   ./scripts/i18n-test.sh --dev        # Use Vite dev server
+#
+# Tests all dashboards for:
+#   - Hardcoded English strings that should use i18n
+#   - Date/time formatting consistency
+#   - Number formatting (locale-aware)
+#   - Text truncation and overflow handling
+#   - RTL layout readiness
+#
+# Prerequisites:
+#   - npm install done in web/
+#
+# Output:
+#   web/e2e/test-results/i18n-compliance-report.json
+#   web/e2e/test-results/i18n-compliance-summary.md
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../web"
+
+EXTRA_ENV=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dev) EXTRA_ENV="PERF_DEV=1"; echo "Using Vite dev server..." ;;
+  esac
+done
+
+if [[ -z "$EXTRA_ENV" ]]; then
+  echo "Running i18n compliance tests against production build..."
+fi
+
+env $EXTRA_ENV npx playwright test \
+  --config e2e/compliance/compliance.config.ts \
+  e2e/compliance/i18n-compliance.spec.ts
+
+echo ""
+echo "Reports:"
+echo "  JSON:    web/e2e/test-results/i18n-compliance-report.json"
+echo "  Summary: web/e2e/test-results/i18n-compliance-summary.md"

--- a/scripts/interaction-test.sh
+++ b/scripts/interaction-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Run interaction compliance tests — verify UI responsiveness
+#
+# Usage:
+#   ./scripts/interaction-test.sh              # Production build
+#   ./scripts/interaction-test.sh --dev        # Use Vite dev server
+#
+# Tests all dashboards for:
+#   - Button/link click responsiveness
+#   - Form input handling
+#   - Drag and drop operations
+#   - Modal open/close behavior
+#   - Tooltip and popover display
+#   - Scroll and resize handling
+#
+# Prerequisites:
+#   - npm install done in web/
+#
+# Output:
+#   web/e2e/test-results/interaction-compliance-report.json
+#   web/e2e/test-results/interaction-compliance-summary.md
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../web"
+
+EXTRA_ENV=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dev) EXTRA_ENV="PERF_DEV=1"; echo "Using Vite dev server..." ;;
+  esac
+done
+
+if [[ -z "$EXTRA_ENV" ]]; then
+  echo "Running interaction compliance tests against production build..."
+fi
+
+env $EXTRA_ENV npx playwright test \
+  --config e2e/compliance/compliance.config.ts \
+  e2e/compliance/interaction-compliance.spec.ts
+
+echo ""
+echo "Reports:"
+echo "  JSON:    web/e2e/test-results/interaction-compliance-report.json"
+echo "  Summary: web/e2e/test-results/interaction-compliance-summary.md"

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -58,6 +58,8 @@ declare -a FAST_SCRIPTS=(
   "scripts/license-compliance-test.sh"
   "scripts/error-boundary-test.sh"
   "scripts/mission-security-test.sh"
+  "scripts/card-registry-integrity-test.sh"
+  "scripts/unit-test.sh"
 )
 
 # Scripts that run Go tests
@@ -173,6 +175,11 @@ declare -a PLAYWRIGHT_SCRIPTS=(
   "scripts/cache-test.sh"
   "scripts/benchmark-test.sh"
   "scripts/ai-ml-test.sh"
+  "scripts/a11y-test.sh"
+  "scripts/error-resilience-test.sh"
+  "scripts/i18n-test.sh"
+  "scripts/interaction-test.sh"
+  "scripts/security-e2e-test.sh"
 )
 
 PREVIEW_PORT=4174

--- a/scripts/security-e2e-test.sh
+++ b/scripts/security-e2e-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Run security compliance tests via Playwright (runtime security checks)
+#
+# Usage:
+#   ./scripts/security-e2e-test.sh              # Production build
+#   ./scripts/security-e2e-test.sh --dev        # Use Vite dev server
+#
+# Tests all dashboards for:
+#   - XSS vector injection resistance
+#   - Content Security Policy enforcement
+#   - Sensitive data exposure in DOM
+#   - localStorage/sessionStorage security
+#   - Cookie security attributes
+#   - Open redirect prevention
+#
+# Prerequisites:
+#   - npm install done in web/
+#
+# Output:
+#   web/e2e/test-results/security-compliance-report.json
+#   web/e2e/test-results/security-compliance-summary.md
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../web"
+
+EXTRA_ENV=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --dev) EXTRA_ENV="PERF_DEV=1"; echo "Using Vite dev server..." ;;
+  esac
+done
+
+if [[ -z "$EXTRA_ENV" ]]; then
+  echo "Running security compliance tests against production build..."
+fi
+
+env $EXTRA_ENV npx playwright test \
+  --config e2e/compliance/compliance.config.ts \
+  e2e/compliance/security-compliance.spec.ts
+
+echo ""
+echo "Reports:"
+echo "  JSON:    web/e2e/test-results/security-compliance-report.json"
+echo "  Summary: web/e2e/test-results/security-compliance-summary.md"

--- a/scripts/unit-test.sh
+++ b/scripts/unit-test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Run all Vitest unit tests (React components, hooks, utilities)
+#
+# Usage:
+#   ./scripts/unit-test.sh              # Run all unit tests
+#   ./scripts/unit-test.sh --coverage   # Run with coverage reporting
+#
+# Covers 98+ test files across:
+#   - React components (rendering, props, state, interactions)
+#   - Custom hooks (useCachedData, useMissions, etc.)
+#   - Utility libraries (mission sanitizer, matcher, etc.)
+#
+# Prerequisites:
+#   - npm install done in web/
+#
+# Output:
+#   Console output with pass/fail counts
+#   Coverage reports in web/coverage/ (with --coverage flag)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../web"
+
+EXTRA_ARGS=""
+
+for arg in "$@"; do
+  case "$arg" in
+    --coverage) EXTRA_ARGS="--coverage" ;;
+  esac
+done
+
+echo "Running Vitest unit tests..."
+npx vitest run $EXTRA_ARGS --reporter=verbose

--- a/web/e2e/compliance/a11y-compliance.spec.ts
+++ b/web/e2e/compliance/a11y-compliance.spec.ts
@@ -66,7 +66,9 @@ const ROUTES_TO_AUDIT = [
   { name: 'Workloads', path: '/workloads' },
 ]
 
-const PAGE_LOAD_TIMEOUT_MS = 15_000
+const IS_CI = !!process.env.CI
+const CI_TIMEOUT_MULTIPLIER = 2
+const PAGE_LOAD_TIMEOUT_MS = IS_CI ? 30_000 : 15_000
 const ROUTE_SETTLE_MS = 2_000
 
 // ---------------------------------------------------------------------------
@@ -95,7 +97,8 @@ function addCheck(result: A11yCheckResult) {
 }
 
 test('a11y compliance — WCAG 2.1 AA multi-route audit', async ({ page }, testInfo) => {
-  testInfo.setTimeout(300_000) // 5 minutes for 15 routes
+  const A11Y_AUDIT_TIMEOUT_MS = 300_000 // 5 minutes for 15 routes
+  testInfo.setTimeout(IS_CI ? A11Y_AUDIT_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : A11Y_AUDIT_TIMEOUT_MS)
 
   // Phase 1: Setup
   console.log('[A11y] Phase 1: Setting up live mode with mocks')

--- a/web/e2e/compliance/compliance.config.ts
+++ b/web/e2e/compliance/compliance.config.ts
@@ -16,6 +16,8 @@ import { defineConfig } from '@playwright/test'
 const PREVIEW_PORT = 4174
 const DEV_PORT = 5174
 const useDevServer = !!process.env.PERF_DEV
+const IS_CI = !!process.env.CI
+const CI_TIMEOUT_MULTIPLIER = 2
 
 function getWebServer() {
   if (process.env.PLAYWRIGHT_BASE_URL) return undefined
@@ -41,8 +43,8 @@ const port = useDevServer ? DEV_PORT : PREVIEW_PORT
 
 export default defineConfig({
   testDir: '.',
-  timeout: 1_200_000, // 20 minutes — cold + warm phases across all batches
-  expect: { timeout: 30_000 },
+  timeout: IS_CI ? 1_200_000 * CI_TIMEOUT_MULTIPLIER : 1_200_000, // 20 min local, 40 min CI
+  expect: { timeout: IS_CI ? 60_000 : 30_000 },
   retries: 0,
   workers: 1,
   reporter: [

--- a/web/e2e/compliance/error-resilience.spec.ts
+++ b/web/e2e/compliance/error-resilience.spec.ts
@@ -41,7 +41,9 @@ interface ResilienceReport {
 // Constants
 // ---------------------------------------------------------------------------
 
-const PAGE_LOAD_TIMEOUT_MS = 15_000
+const IS_CI = !!process.env.CI
+const CI_TIMEOUT_MULTIPLIER = 2
+const PAGE_LOAD_TIMEOUT_MS = IS_CI ? 30_000 : 15_000
 const SETTLE_MS = 2_000
 
 // ---------------------------------------------------------------------------
@@ -79,7 +81,8 @@ test.describe('Error Resilience', () => {
 
   test('API 500 errors — cards show error state, not blank', async ({ page }) => {
     const start = Date.now()
-    test.setTimeout(60_000)
+    const API_ERROR_TIMEOUT_MS = 60_000
+    test.setTimeout(IS_CI ? API_ERROR_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : API_ERROR_TIMEOUT_MS)
 
     try {
       await setupAuth(page)
@@ -165,7 +168,8 @@ test.describe('Error Resilience', () => {
 
   test('network timeout — cards handle slow responses', async ({ page }) => {
     const start = Date.now()
-    test.setTimeout(90_000)
+    const NETWORK_TIMEOUT_MS = 90_000
+    test.setTimeout(IS_CI ? NETWORK_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : NETWORK_TIMEOUT_MS)
 
     try {
       await setupAuth(page)
@@ -239,7 +243,8 @@ test.describe('Error Resilience', () => {
 
   test('partial failure — healthy endpoints show data', async ({ page }) => {
     const start = Date.now()
-    test.setTimeout(60_000)
+    const PARTIAL_FAIL_TIMEOUT_MS = 60_000
+    test.setTimeout(IS_CI ? PARTIAL_FAIL_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PARTIAL_FAIL_TIMEOUT_MS)
 
     try {
       await setupAuth(page)
@@ -311,7 +316,8 @@ test.describe('Error Resilience', () => {
 
   test('SSE disconnect — cards handle stream interruption', async ({ page }) => {
     const start = Date.now()
-    test.setTimeout(60_000)
+    const SSE_DISCONNECT_TIMEOUT_MS = 60_000
+    test.setTimeout(IS_CI ? SSE_DISCONNECT_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : SSE_DISCONNECT_TIMEOUT_MS)
 
     try {
       // Start with normal mocks
@@ -370,7 +376,8 @@ test.describe('Error Resilience', () => {
 
   test('auth token expiry — handles 401 gracefully', async ({ page }) => {
     const start = Date.now()
-    test.setTimeout(60_000)
+    const AUTH_EXPIRY_TIMEOUT_MS = 60_000
+    test.setTimeout(IS_CI ? AUTH_EXPIRY_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : AUTH_EXPIRY_TIMEOUT_MS)
 
     try {
       // Setup normally first

--- a/web/e2e/compliance/i18n-compliance.spec.ts
+++ b/web/e2e/compliance/i18n-compliance.spec.ts
@@ -33,6 +33,10 @@ interface I18nReport {
   }
 }
 
+const IS_CI = !!process.env.CI
+const CI_TIMEOUT_MULTIPLIER = 2
+const PAGE_LOAD_TIMEOUT_MS = IS_CI ? 30_000 : 15_000
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -362,7 +366,7 @@ test('i18n compliance — internationalization audit', async ({ page }) => {
 
   await setupAuth(page)
   await setupMockServer(page)
-  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: 30_000 })
+  await page.goto('/', { waitUntil: 'domcontentloaded', timeout: IS_CI ? 60_000 : 30_000 })
   await page.waitForTimeout(3_000)
 
   // Check 3.1: No raw translation keys visible in DOM
@@ -611,7 +615,7 @@ test('i18n compliance — internationalization audit', async ({ page }) => {
 
   for (const { route, checks: expectedTexts } of spotCheckRoutes) {
     try {
-      await page.goto(route, { waitUntil: 'domcontentloaded', timeout: 10_000 })
+      await page.goto(route, { waitUntil: 'domcontentloaded', timeout: IS_CI ? 20_000 : 10_000 })
       await page.waitForTimeout(1_500)
 
       const bodyText = await page.evaluate(() => document.body.innerText || '')
@@ -644,7 +648,7 @@ test('i18n compliance — internationalization audit', async ({ page }) => {
   let pagesWithRawKeys = 0
 
   for (const pagePath of pages) {
-    await page.goto(pagePath, { waitUntil: 'domcontentloaded', timeout: 15_000 })
+    await page.goto(pagePath, { waitUntil: 'domcontentloaded', timeout: PAGE_LOAD_TIMEOUT_MS })
     await page.waitForTimeout(1_500)
 
     const rawKeys = await page.evaluate(() => {

--- a/web/e2e/compliance/interaction-compliance.spec.ts
+++ b/web/e2e/compliance/interaction-compliance.spec.ts
@@ -41,7 +41,9 @@ interface InteractionReport {
 // Constants
 // ---------------------------------------------------------------------------
 
-const PAGE_LOAD_TIMEOUT_MS = 15_000
+const IS_CI = !!process.env.CI
+const CI_TIMEOUT_MULTIPLIER = 2
+const PAGE_LOAD_TIMEOUT_MS = IS_CI ? 30_000 : 15_000
 const SETTLE_MS = 2_000
 
 // ---------------------------------------------------------------------------
@@ -239,7 +241,8 @@ test.describe('Interaction Compliance', () => {
   })
 
   test('card expand/collapse', async ({ page }) => {
-    test.setTimeout(30_000)
+    const CARD_EXPAND_TIMEOUT_MS = 30_000
+    test.setTimeout(IS_CI ? CARD_EXPAND_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : CARD_EXPAND_TIMEOUT_MS)
     const start = Date.now()
     await setupPage(page)
     await navigateAndSettle(page, '/')

--- a/web/e2e/compliance/security-compliance.spec.ts
+++ b/web/e2e/compliance/security-compliance.spec.ts
@@ -33,6 +33,9 @@ interface SecurityReport {
   }
 }
 
+const IS_CI = !!process.env.CI
+const CI_TIMEOUT_MULTIPLIER = 2
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -131,7 +134,8 @@ async function setupAuth(page: Page) {
 test.describe.configure({ mode: 'serial' })
 
 test('security compliance — frontend security audit', async ({ page }, testInfo) => {
-  testInfo.setTimeout(120_000) // multi-page navigation + auth bypass check needs extra time
+  const SECURITY_AUDIT_TIMEOUT_MS = 120_000 // multi-page navigation + auth bypass check
+  testInfo.setTimeout(IS_CI ? SECURITY_AUDIT_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : SECURITY_AUDIT_TIMEOUT_MS)
   const checks: SecurityCheck[] = []
 
   function addCheck(


### PR DESCRIPTION
## Summary

- Adds **7 new test suites** to the nightly runner (`run-all-tests.sh`), expanding coverage from 25 to 32 suites
- Wires in `unit-test.sh` (vitest, 98 test files) and `card-registry-integrity-test.sh` as fast scripts
- Adds 5 new Playwright compliance scripts: a11y, error-resilience, i18n, interaction, security
- All compliance specs get **CI-aware timeouts** (2x multiplier via `process.env.CI`) to prevent false failures on GitHub Actions runners
- Compliance config gets CI-scaled global timeout (20 min local → 40 min CI) and expect timeout (30s → 60s)

### New suites added

| Suite | Type | What it tests |
|-------|------|---------------|
| `unit-test` | vitest | 98 existing unit test files |
| `card-registry-integrity-test` | fast script | Card registry validation |
| `a11y-test` | Playwright | WCAG 2.1 AA, keyboard nav, ARIA, focus |
| `error-resilience-test` | Playwright | API errors, timeouts, SSE disconnect, auth expiry |
| `i18n-test` | Playwright | Hardcoded strings, date/number formatting, RTL |
| `interaction-test` | Playwright | Clicks, search, theme toggle, card expand |
| `security-e2e-test` | Playwright | XSS, CSP, sensitive data exposure, cookies |

## Test plan

- [ ] Nightly workflow runs with all 32 suites
- [ ] CI-aware timeouts prevent false failures
- [ ] Existing 25 suites remain unaffected