### PR TITLE
✨ Add framework-level GA4 card interaction tracking

### DIFF
--- a/web/src/components/ui/CardControls.tsx
+++ b/web/src/components/ui/CardControls.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, ArrowUp, ArrowDown } from 'lucide-react'
 import { useState, useRef, useEffect } from 'react'
 import { cn } from '../../lib/cn'
+import { emitCardSortChanged, emitCardSortDirectionChanged, emitCardLimitChanged } from '../../lib/analytics'
 
 interface LimitOption {
   value: number | 'unlimited'
@@ -55,7 +56,9 @@ export function CardControls<T extends string = string>({
 
   const toggleDirection = () => {
     if (onSortDirectionChange) {
-      onSortDirectionChange(sortDirection === 'asc' ? 'desc' : 'asc')
+      const newDir = sortDirection === 'asc' ? 'desc' : 'asc'
+      onSortDirectionChange(newDir)
+      emitCardSortDirectionChanged(newDir)
     }
   }
 
@@ -93,7 +96,7 @@ export function CardControls<T extends string = string>({
               {LIMIT_OPTIONS.map(option => (
                 <button
                   key={String(option.value)}
-                  onClick={() => { onLimitChange(option.value); setLimitOpen(false) }}
+                  onClick={() => { onLimitChange(option.value); setLimitOpen(false); emitCardLimitChanged(String(option.value)) }}
                   className={cn(
                     'w-full px-3 py-1.5 text-left text-xs hover:bg-secondary/50 transition-colors',
                     limit === option.value ? 'text-primary bg-primary/10' : 'text-foreground'
@@ -123,7 +126,7 @@ export function CardControls<T extends string = string>({
                 {sortOptions.map(option => (
                   <button
                     key={option.value}
-                    onClick={() => { onSortChange(option.value); setSortOpen(false) }}
+                    onClick={() => { onSortChange(option.value); setSortOpen(false); emitCardSortChanged(option.value) }}
                     className={cn(
                       'w-full px-3 py-1.5 text-left text-xs hover:bg-secondary/50 transition-colors',
                       sortBy === option.value ? 'text-primary bg-primary/10' : 'text-foreground'

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -382,6 +382,40 @@ export function emitCardReplaced(oldType: string, newType: string) {
   send('ksc_card_replaced', { old_type: oldType, new_type: newType })
 }
 
+// ── Card Interactions (framework-level) ──────────────────────────────
+// These fire automatically from shared UI components (CardControls,
+// CardSearchInput, CardClusterFilter) so all cards get consistent
+// tracking without per-card instrumentation.
+
+/** Fired when user changes sort field in a card's controls */
+export function emitCardSortChanged(sortField: string) {
+  send('ksc_card_sort_changed', { sort_field: sortField, page_path: window.location.pathname })
+}
+
+/** Fired when user toggles sort direction in a card's controls */
+export function emitCardSortDirectionChanged(direction: string) {
+  send('ksc_card_sort_direction_changed', { direction, page_path: window.location.pathname })
+}
+
+/** Fired when user changes the item limit in a card's controls */
+export function emitCardLimitChanged(limit: string) {
+  send('ksc_card_limit_changed', { limit, page_path: window.location.pathname })
+}
+
+/** Fired when user types in a card's search input (debounced — fires once per search session) */
+export function emitCardSearchUsed(queryLength: number) {
+  send('ksc_card_search_used', { query_length: queryLength, page_path: window.location.pathname })
+}
+
+/** Fired when user changes cluster filter selection in a card */
+export function emitCardClusterFilterChanged(selectedCount: number, totalCount: number) {
+  send('ksc_card_cluster_filter_changed', {
+    selected_count: selectedCount,
+    total_count: totalCount,
+    page_path: window.location.pathname,
+  })
+}
+
 // ── AI Missions ────────────────────────────────────────────────────
 
 export function emitMissionStarted(missionType: string, agentProvider: string) {

--- a/web/src/lib/cards/CardComponents.tsx
+++ b/web/src/lib/cards/CardComponents.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '../../components/ui/Skeleton'
 import { Pagination } from '../../components/ui/Pagination'
 import { CardControls as CardControlsUI, type SortDirection } from '../../components/ui/CardControls'
 import { ClusterStatusDot, getClusterState, type ClusterState } from '../../components/ui/ClusterStatusBadge'
+import { emitCardSearchUsed, emitCardClusterFilterChanged } from '../analytics'
 import type { ClusterWithHealth } from './cardHooks'
 
 // ============================================================================
@@ -230,6 +231,14 @@ export function CardSearchInput({
     }
   }, [onChange, debounceMs])
 
+  // Fire analytics when user finishes typing (on blur) to avoid per-keystroke spam
+  const handleBlur = useCallback(() => {
+    const current = debounceMs ? localValue : value
+    if (current.length > 0) {
+      emitCardSearchUsed(current.length)
+    }
+  }, [debounceMs, localValue, value])
+
   // Cleanup timer on unmount
   useEffect(() => () => clearTimeout(timerRef.current), [])
 
@@ -240,6 +249,7 @@ export function CardSearchInput({
         type="text"
         value={debounceMs ? localValue : value}
         onChange={(e) => handleChange(e.target.value)}
+        onBlur={handleBlur}
         placeholder={placeholder}
         className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
       />
@@ -320,7 +330,7 @@ export function CardClusterFilter({
         >
           <div className="p-1">
             <button
-              onClick={onClear}
+              onClick={() => { onClear(); emitCardClusterFilterChanged(0, availableClusters.length) }}
               className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${selectedClusters.length === 0
                 ? 'bg-purple-500/20 text-purple-400'
                 : 'hover:bg-secondary text-foreground'
@@ -352,7 +362,15 @@ export function CardClusterFilter({
               return (
                 <button
                   key={cluster.name}
-                  onClick={() => !isUnreachable && onToggle(cluster.name)}
+                  onClick={() => {
+                    if (!isUnreachable) {
+                      onToggle(cluster.name)
+                      // Compute resulting count: toggling adds or removes one cluster
+                      const willBeSelected = !selectedClusters.includes(cluster.name)
+                      const newCount = willBeSelected ? selectedClusters.length + 1 : selectedClusters.length - 1
+                      emitCardClusterFilterChanged(newCount, availableClusters.length)
+                    }
+                  }}
                   disabled={isUnreachable}
                   className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors flex items-center gap-2 ${isUnreachable
                     ? 'opacity-40 cursor-not-allowed'


### PR DESCRIPTION
## Summary
- Adds 5 new GA4 events fired automatically from shared card UI components (`CardControls`, `CardSearchInput`, `CardClusterFilter`)
- All ~100+ cards get consistent interaction tracking without any per-card changes
- Events include `page_path` for dashboard-level attribution in GA4

## New Events
| Event | Source Component | Fires When |
|-------|-----------------|------------|
| `ksc_card_sort_changed` | `CardControls` | User selects a sort field |
| `ksc_card_sort_direction_changed` | `CardControls` | User toggles asc/desc |
| `ksc_card_limit_changed` | `CardControls` | User changes item limit |
| `ksc_card_search_used` | `CardSearchInput` | User finishes typing (on blur) |
| `ksc_card_cluster_filter_changed` | `CardClusterFilter` | User toggles/clears cluster filter |

## Test plan
- [ ] Verify build passes
- [ ] Open any card with sort/limit controls, change sort field → check GA4 realtime for `ksc_card_sort_changed`
- [ ] Toggle sort direction → check for `ksc_card_sort_direction_changed`
- [ ] Change limit dropdown → check for `ksc_card_limit_changed`
- [ ] Type in a card search input, click away → check for `ksc_card_search_used`
- [ ] Toggle cluster filter → check for `ksc_card_cluster_filter_changed`