### PR TITLE
✨ Add card_type + page_path to GA4 card interaction events

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -96,6 +96,16 @@ export function useCardExpanded() {
   return useContext(CardExpandedContext)
 }
 
+// Context to expose cardType to descendant shared components (CardControls,
+// CardSearchInput, CardClusterFilter) so GA4 events can identify which card
+// the user interacted with — no prop threading required.
+const CardTypeContext = createContext<string>('')
+
+/** Hook for shared UI components to read the cardType of their parent CardWrapper */
+export function useCardType() {
+  return useContext(CardTypeContext)
+}
+
 // Note: Lazy mounting and eager mount scheduling have been removed.
 // Cards now render immediately to show cached data without delay.
 // This trades some initial render performance for better UX with cached data.
@@ -678,6 +688,7 @@ export function CardWrapper({
   void setLocalMessages
 
   return (
+    <CardTypeContext.Provider value={cardType}>
     <CardExpandedContext.Provider value={{ isExpanded }}>
       <ForceLiveContext.Provider value={!!forceLive}>
       <CardDataReportContext.Provider value={reportCtx}>
@@ -1079,5 +1090,6 @@ export function CardWrapper({
       </CardDataReportContext.Provider>
       </ForceLiveContext.Provider>
     </CardExpandedContext.Provider>
+    </CardTypeContext.Provider>
   )
 }

--- a/web/src/components/ui/CardControls.tsx
+++ b/web/src/components/ui/CardControls.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, ArrowUp, ArrowDown } from 'lucide-react'
 import { useState, useRef, useEffect } from 'react'
 import { cn } from '../../lib/cn'
 import { emitCardSortChanged, emitCardSortDirectionChanged, emitCardLimitChanged } from '../../lib/analytics'
+import { useCardType } from '../cards/CardWrapper'
 
 interface LimitOption {
   value: number | 'unlimited'
@@ -49,6 +50,7 @@ export function CardControls<T extends string = string>({
   showLimit = true,
   showSort = true,
 }: CardControlsProps<T>) {
+  const cardType = useCardType()
   const [limitOpen, setLimitOpen] = useState(false)
   const [sortOpen, setSortOpen] = useState(false)
   const limitRef = useRef<HTMLDivElement>(null)
@@ -58,7 +60,7 @@ export function CardControls<T extends string = string>({
     if (onSortDirectionChange) {
       const newDir = sortDirection === 'asc' ? 'desc' : 'asc'
       onSortDirectionChange(newDir)
-      emitCardSortDirectionChanged(newDir)
+      emitCardSortDirectionChanged(newDir, cardType)
     }
   }
 
@@ -96,7 +98,7 @@ export function CardControls<T extends string = string>({
               {LIMIT_OPTIONS.map(option => (
                 <button
                   key={String(option.value)}
-                  onClick={() => { onLimitChange(option.value); setLimitOpen(false); emitCardLimitChanged(String(option.value)) }}
+                  onClick={() => { onLimitChange(option.value); setLimitOpen(false); emitCardLimitChanged(String(option.value), cardType) }}
                   className={cn(
                     'w-full px-3 py-1.5 text-left text-xs hover:bg-secondary/50 transition-colors',
                     limit === option.value ? 'text-primary bg-primary/10' : 'text-foreground'
@@ -126,7 +128,7 @@ export function CardControls<T extends string = string>({
                 {sortOptions.map(option => (
                   <button
                     key={option.value}
-                    onClick={() => { onSortChange(option.value); setSortOpen(false); emitCardSortChanged(option.value) }}
+                    onClick={() => { onSortChange(option.value); setSortOpen(false); emitCardSortChanged(option.value, cardType) }}
                     className={cn(
                       'w-full px-3 py-1.5 text-left text-xs hover:bg-secondary/50 transition-colors',
                       sortBy === option.value ? 'text-primary bg-primary/10' : 'text-foreground'

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -388,30 +388,31 @@ export function emitCardReplaced(oldType: string, newType: string) {
 // tracking without per-card instrumentation.
 
 /** Fired when user changes sort field in a card's controls */
-export function emitCardSortChanged(sortField: string) {
-  send('ksc_card_sort_changed', { sort_field: sortField, page_path: window.location.pathname })
+export function emitCardSortChanged(sortField: string, cardType: string) {
+  send('ksc_card_sort_changed', { sort_field: sortField, card_type: cardType, page_path: window.location.pathname })
 }
 
 /** Fired when user toggles sort direction in a card's controls */
-export function emitCardSortDirectionChanged(direction: string) {
-  send('ksc_card_sort_direction_changed', { direction, page_path: window.location.pathname })
+export function emitCardSortDirectionChanged(direction: string, cardType: string) {
+  send('ksc_card_sort_direction_changed', { direction, card_type: cardType, page_path: window.location.pathname })
 }
 
 /** Fired when user changes the item limit in a card's controls */
-export function emitCardLimitChanged(limit: string) {
-  send('ksc_card_limit_changed', { limit, page_path: window.location.pathname })
+export function emitCardLimitChanged(limit: string, cardType: string) {
+  send('ksc_card_limit_changed', { limit, card_type: cardType, page_path: window.location.pathname })
 }
 
 /** Fired when user types in a card's search input (debounced — fires once per search session) */
-export function emitCardSearchUsed(queryLength: number) {
-  send('ksc_card_search_used', { query_length: queryLength, page_path: window.location.pathname })
+export function emitCardSearchUsed(queryLength: number, cardType: string) {
+  send('ksc_card_search_used', { query_length: queryLength, card_type: cardType, page_path: window.location.pathname })
 }
 
 /** Fired when user changes cluster filter selection in a card */
-export function emitCardClusterFilterChanged(selectedCount: number, totalCount: number) {
+export function emitCardClusterFilterChanged(selectedCount: number, totalCount: number, cardType: string) {
   send('ksc_card_cluster_filter_changed', {
     selected_count: selectedCount,
     total_count: totalCount,
+    card_type: cardType,
     page_path: window.location.pathname,
   })
 }

--- a/web/src/lib/cards/CardComponents.tsx
+++ b/web/src/lib/cards/CardComponents.tsx
@@ -8,6 +8,7 @@ import { Pagination } from '../../components/ui/Pagination'
 import { CardControls as CardControlsUI, type SortDirection } from '../../components/ui/CardControls'
 import { ClusterStatusDot, getClusterState, type ClusterState } from '../../components/ui/ClusterStatusBadge'
 import { emitCardSearchUsed, emitCardClusterFilterChanged } from '../analytics'
+import { useCardType } from '../../components/cards/CardWrapper'
 import type { ClusterWithHealth } from './cardHooks'
 
 // ============================================================================
@@ -213,6 +214,7 @@ export function CardSearchInput({
   className = '',
   debounceMs,
 }: CardSearchInputProps) {
+  const cardType = useCardType()
   const [localValue, setLocalValue] = useState(value)
   const timerRef = useRef<ReturnType<typeof setTimeout>>()
 
@@ -235,9 +237,9 @@ export function CardSearchInput({
   const handleBlur = useCallback(() => {
     const current = debounceMs ? localValue : value
     if (current.length > 0) {
-      emitCardSearchUsed(current.length)
+      emitCardSearchUsed(current.length, cardType)
     }
-  }, [debounceMs, localValue, value])
+  }, [debounceMs, localValue, value, cardType])
 
   // Cleanup timer on unmount
   useEffect(() => () => clearTimeout(timerRef.current), [])
@@ -290,6 +292,7 @@ export function CardClusterFilter({
   containerRef,
   minClusters = 2,
 }: CardClusterFilterProps) {
+  const cardType = useCardType()
   const buttonRef = useRef<HTMLButtonElement>(null)
   const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number } | null>(null)
 
@@ -330,7 +333,7 @@ export function CardClusterFilter({
         >
           <div className="p-1">
             <button
-              onClick={() => { onClear(); emitCardClusterFilterChanged(0, availableClusters.length) }}
+              onClick={() => { onClear(); emitCardClusterFilterChanged(0, availableClusters.length, cardType) }}
               className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${selectedClusters.length === 0
                 ? 'bg-purple-500/20 text-purple-400'
                 : 'hover:bg-secondary text-foreground'
@@ -368,7 +371,7 @@ export function CardClusterFilter({
                       // Compute resulting count: toggling adds or removes one cluster
                       const willBeSelected = !selectedClusters.includes(cluster.name)
                       const newCount = willBeSelected ? selectedClusters.length + 1 : selectedClusters.length - 1
-                      emitCardClusterFilterChanged(newCount, availableClusters.length)
+                      emitCardClusterFilterChanged(newCount, availableClusters.length, cardType)
                     }
                   }}
                   disabled={isUnreachable}


### PR DESCRIPTION
## Summary
- Adds `CardTypeContext` in `CardWrapper` so shared UI components automatically know which card they're inside
- All 5 card interaction GA4 events now include both `card_type` and `page_path`
- Zero prop threading needed — the context is read automatically by `CardControls`, `CardSearchInput`, and `CardClusterFilter`

## What GA4 events now report
| Event | Parameters |
|-------|-----------|
| `ksc_card_sort_changed` | `sort_field`, `card_type`, `page_path` |
| `ksc_card_sort_direction_changed` | `direction`, `card_type`, `page_path` |
| `ksc_card_limit_changed` | `limit`, `card_type`, `page_path` |
| `ksc_card_search_used` | `query_length`, `card_type`, `page_path` |
| `ksc_card_cluster_filter_changed` | `selected_count`, `total_count`, `card_type`, `page_path` |

Example: When a user changes the sort on the Warning Events card on the Insights dashboard, GA4 receives:
```
ksc_card_sort_changed { sort_field: "severity", card_type: "warning_events", page_path: "/insights" }
```

## Test plan
- [ ] Build passes
- [ ] Interact with card controls → verify `card_type` appears in GA4 realtime
- [ ] Same card on different dashboards → verify `page_path` differs