### PR TITLE
🐛 Fix self-update resilience: timeouts, heartbeats, stale detection

### DIFF
--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -24,6 +25,19 @@ const (
 	healthCheckDelay       = 2 * time.Second
 	githubMainRefURL       = "https://api.github.com/repos/kubestellar/console/git/ref/heads/main"
 	githubReleasesURL      = "https://api.github.com/repos/kubestellar/console/releases"
+
+	// Timeouts for each build step — prevents updates from hanging indefinitely
+	gitPullTimeout      = 2 * time.Minute
+	npmInstallTimeout   = 5 * time.Minute
+	frontendBuildTimeout = 5 * time.Minute
+	goBuildTimeout      = 5 * time.Minute
+
+	// Heartbeat interval — periodic progress broadcasts during long builds
+	// so the frontend knows the agent is still alive
+	buildHeartbeatInterval = 15 * time.Second
+
+	// Max lines of build output to include in error messages sent to the frontend
+	buildOutputTailLines = 20
 )
 
 // UpdateChecker periodically checks for updates and applies them.
@@ -42,6 +56,10 @@ type UpdateChecker struct {
 	lastUpdateError string
 	cancel          context.CancelFunc
 	updating        int32 // atomic: 1 = update in progress, 0 = idle
+
+	// exitFunc terminates the process after spawning the restart script.
+	// Defaults to os.Exit. Overridden in tests to prevent the test runner from exiting.
+	exitFunc func(code int)
 }
 
 // UpdateCheckerConfig holds initialization parameters.
@@ -337,7 +355,7 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 		TotalSteps: total,
 	})
 
-	if err := runGitPull(repoPath); err != nil {
+	if err := runGitPullWithTimeout(repoPath, gitPullTimeout); err != nil {
 		log.Printf("[AutoUpdate] FAILED at step 1 (git pull) after %s: %v", time.Since(start), err)
 		uc.recordError(fmt.Sprintf("git pull failed: %v", err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
@@ -361,7 +379,7 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 	})
 
 	stepStart := time.Now()
-	if err := uc.resilientNpmInstall(webDir, 2, total); err != nil {
+	if err := uc.resilientNpmInstall(webDir, 2, total, npmInstallTimeout); err != nil {
 		log.Printf("[AutoUpdate] FAILED at step 2 (npm install) after %s: %v", time.Since(start), err)
 		uc.recordError(fmt.Sprintf("npm install failed: %v", err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
@@ -386,17 +404,15 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 	})
 
 	stepStart = time.Now()
-	npmBuild := exec.Command("npm", "run", "build")
-	npmBuild.Dir = webDir
-	npmBuild.Stdout = os.Stdout
-	npmBuild.Stderr = os.Stderr
-	if err := npmBuild.Run(); err != nil {
-		log.Printf("[AutoUpdate] FAILED at step 3 (frontend build) after %s: %v", time.Since(start), err)
-		uc.recordError(fmt.Sprintf("frontend build failed: %v", err))
+	res := uc.runBuildCmd(frontendBuildTimeout, "Building frontend with Vite", 3, total, 30,
+		"npm", []string{"run", "build"}, webDir, nil)
+	if res.err != nil {
+		log.Printf("[AutoUpdate] FAILED at step 3 (frontend build) after %s: %v", time.Since(start), res.err)
+		uc.recordError(fmt.Sprintf("frontend build failed: %v", res.err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:  "failed",
 			Message: "Frontend build failed, rolling back...",
-			Error:   err.Error(),
+			Error:   buildErrorDetail(res.err, res.output),
 		})
 		rollbackGit(repoPath, previousSHA)
 		rebuildFrontend(repoPath) //nolint:errcheck
@@ -417,25 +433,30 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 	stepStart = time.Now()
 	consolePath, err := exec.LookPath("console")
 	if err != nil {
-		consolePath = "./console"
+		consolePath = filepath.Join(repoPath, "console")
 	}
-	consoleBuild := exec.Command("go", "build", "-o", consolePath, "./cmd/console")
-	consoleBuild.Dir = repoPath
-	consoleBuild.Env = append(os.Environ(), "GOWORK=off")
-	consoleBuild.Stdout = os.Stdout
-	consoleBuild.Stderr = os.Stderr
-	if err := consoleBuild.Run(); err != nil {
-		log.Printf("[AutoUpdate] FAILED at step 4 (console build) after %s: %v", time.Since(start), err)
-		uc.recordError(fmt.Sprintf("go build console failed: %v", err))
+	// Build to a temp file first, then atomically rename to the final path.
+	// This prevents a half-written binary if the build is killed or times out.
+	consoleTmp := consolePath + ".update-tmp"
+	res = uc.runBuildCmd(goBuildTimeout, "Building console binary", 4, total, 45,
+		"go", []string{"build", "-o", consoleTmp, "./cmd/console"}, repoPath, []string{"GOWORK=off"})
+	if res.err != nil {
+		os.Remove(consoleTmp) // clean up partial build
+		log.Printf("[AutoUpdate] FAILED at step 4 (console build) after %s: %v", time.Since(start), res.err)
+		uc.recordError(fmt.Sprintf("go build console failed: %v", res.err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:  "failed",
 			Message: "Console build failed, rolling back...",
-			Error:   err.Error(),
+			Error:   buildErrorDetail(res.err, res.output),
 		})
 		rollbackGit(repoPath, previousSHA)
 		rebuildFrontend(repoPath)   //nolint:errcheck
 		rebuildGoBinaries(repoPath) //nolint:errcheck
 		return
+	}
+	if err := os.Rename(consoleTmp, consolePath); err != nil {
+		log.Printf("[AutoUpdate] Failed to move console binary: %v", err)
+		os.Remove(consoleTmp)
 	}
 	log.Printf("[AutoUpdate] Step 4/%d complete (console binary) in %s", total, time.Since(stepStart))
 
@@ -452,25 +473,29 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 	stepStart = time.Now()
 	agentPath, err := exec.LookPath("kc-agent")
 	if err != nil {
-		agentPath = "./kc-agent"
+		agentPath = filepath.Join(repoPath, "kc-agent")
 	}
-	agentBuild := exec.Command("go", "build", "-o", agentPath, "./cmd/kc-agent")
-	agentBuild.Dir = repoPath
-	agentBuild.Env = append(os.Environ(), "GOWORK=off")
-	agentBuild.Stdout = os.Stdout
-	agentBuild.Stderr = os.Stderr
-	if err := agentBuild.Run(); err != nil {
-		log.Printf("[AutoUpdate] FAILED at step 5 (kc-agent build) after %s: %v", time.Since(start), err)
-		uc.recordError(fmt.Sprintf("go build kc-agent failed: %v", err))
+	// Build to a temp file first, then atomically rename.
+	agentTmp := agentPath + ".update-tmp"
+	res = uc.runBuildCmd(goBuildTimeout, "Building kc-agent binary", 5, total, 58,
+		"go", []string{"build", "-o", agentTmp, "./cmd/kc-agent"}, repoPath, []string{"GOWORK=off"})
+	if res.err != nil {
+		os.Remove(agentTmp) // clean up partial build
+		log.Printf("[AutoUpdate] FAILED at step 5 (kc-agent build) after %s: %v", time.Since(start), res.err)
+		uc.recordError(fmt.Sprintf("go build kc-agent failed: %v", res.err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:  "failed",
 			Message: "kc-agent build failed, rolling back...",
-			Error:   err.Error(),
+			Error:   buildErrorDetail(res.err, res.output),
 		})
 		rollbackGit(repoPath, previousSHA)
 		rebuildFrontend(repoPath)   //nolint:errcheck
 		rebuildGoBinaries(repoPath) //nolint:errcheck
 		return
+	}
+	if err := os.Rename(agentTmp, agentPath); err != nil {
+		log.Printf("[AutoUpdate] Failed to move kc-agent binary: %v", err)
+		os.Remove(agentTmp)
 	}
 	log.Printf("[AutoUpdate] Step 5/%d complete (kc-agent binary) in %s", total, time.Since(stepStart))
 
@@ -558,7 +583,11 @@ func (uc *UpdateChecker) restartViaStartupScript(repoPath string) {
 	}
 
 	// Exit this process — startup-oauth.sh will start fresh instances
-	os.Exit(0)
+	exit := uc.exitFunc
+	if exit == nil {
+		exit = os.Exit
+	}
+	exit(0)
 }
 
 // selfUpdateFallback rebuilds the kc-agent binary and replaces the running
@@ -842,23 +871,21 @@ const npmInstallMaxRetries = 3 // Max retries for npm install with cache recover
 // resilientNpmInstall runs npm install with automatic recovery from cache corruption.
 // On failure it runs npm cache clean --force and retries. On 2nd+ failure it also
 // removes node_modules for a completely clean install. Broadcasts progress via WebSocket.
-func (uc *UpdateChecker) resilientNpmInstall(webDir string, step, totalSteps int) error {
+// Each attempt has a hard timeout to prevent indefinite hangs.
+func (uc *UpdateChecker) resilientNpmInstall(webDir string, step, totalSteps int, timeout time.Duration) error {
 	for attempt := 1; attempt <= npmInstallMaxRetries; attempt++ {
 		// Remove stale lockfiles that can block concurrent installs
 		os.Remove(webDir + "/package-lock.json.lock")
 		os.Remove(webDir + "/.package-lock.json")
 
-		npmInstall := exec.Command("npm", "install", "--prefer-offline")
-		npmInstall.Dir = webDir
-		npmInstall.Stdout = os.Stdout
-		npmInstall.Stderr = os.Stderr
-
-		if err := npmInstall.Run(); err == nil {
+		res := uc.runBuildCmd(timeout, fmt.Sprintf("Installing npm dependencies (attempt %d/%d)", attempt, npmInstallMaxRetries),
+			step, totalSteps, 18, "npm", []string{"install", "--prefer-offline"}, webDir, nil)
+		if res.err == nil {
 			return nil // success
 		}
 
 		if attempt == npmInstallMaxRetries {
-			return fmt.Errorf("npm install failed after %d attempts", npmInstallMaxRetries)
+			return fmt.Errorf("npm install failed after %d attempts: %s", npmInstallMaxRetries, buildErrorDetail(res.err, res.output))
 		}
 
 		// Broadcast retry status
@@ -1051,6 +1078,23 @@ func runGitPull(repoPath string) error {
 	return cmd.Run()
 }
 
+// runGitPullWithTimeout runs git pull with a hard timeout to prevent hanging on network issues.
+func runGitPullWithTimeout(repoPath string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "pull", "--rebase", "--autostash", "origin", "main")
+	cmd.Dir = repoPath
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("timed out after %s", timeout)
+	}
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
 // gitStash stashes uncommitted changes if any exist. Returns true if a stash was created.
 func gitStash(repoPath string) bool {
 	if !hasUncommittedChanges(repoPath) {
@@ -1124,7 +1168,7 @@ func rebuildGoBinaries(repoPath string) error {
 	// Build console binary
 	consolePath, err := exec.LookPath("console")
 	if err != nil {
-		consolePath = "./console"
+		consolePath = filepath.Join(repoPath, "console")
 	}
 	consoleBuild := exec.Command("go", "build", "-o", consolePath, "./cmd/console")
 	consoleBuild.Dir = repoPath
@@ -1138,7 +1182,7 @@ func rebuildGoBinaries(repoPath string) error {
 	// Build kc-agent binary
 	agentPath, err := exec.LookPath("kc-agent")
 	if err != nil {
-		agentPath = "./kc-agent"
+		agentPath = filepath.Join(repoPath, "kc-agent")
 	}
 	agentBuild := exec.Command("go", "build", "-o", agentPath, "./cmd/kc-agent")
 	agentBuild.Dir = repoPath
@@ -1206,4 +1250,107 @@ func short(sha string) string {
 		return sha[:7]
 	}
 	return sha
+}
+
+// --- Build execution with timeout, heartbeat, and output capture ---
+
+// buildResult holds the outcome of a build command.
+type buildResult struct {
+	err    error
+	output string // combined stdout+stderr (last buildOutputTailLines lines)
+}
+
+// runBuildCmd executes an external command with:
+//   - A hard timeout so builds can never hang indefinitely
+//   - Periodic heartbeat broadcasts so the frontend knows the agent is still alive
+//   - Captured stderr/stdout so error messages include the actual build output
+//
+// The heartbeat sends a WebSocket progress message every buildHeartbeatInterval
+// with an updated elapsed-time string.
+func (uc *UpdateChecker) runBuildCmd(
+	timeout time.Duration,
+	stepLabel string,
+	step, totalSteps, progressPct int,
+	name string, args []string,
+	dir string,
+	env []string,
+) buildResult {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	// After the context cancels and the process is killed, give I/O pipes
+	// this long to drain before force-closing them. Without this, cmd.Wait()
+	// can hang indefinitely waiting on pipe-reader goroutines.
+	const waitDelayAfterKill = 3 * time.Second
+	cmd.WaitDelay = waitDelayAfterKill
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
+
+	// Capture combined output for error reporting
+	var buf strings.Builder
+	cmd.Stdout = io.MultiWriter(os.Stdout, &buf)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &buf)
+
+	// Start the command
+	if err := cmd.Start(); err != nil {
+		return buildResult{err: err}
+	}
+
+	// Heartbeat goroutine — sends periodic "still building..." messages
+	done := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(buildHeartbeatInterval)
+		defer ticker.Stop()
+		start := time.Now()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				elapsed := time.Since(start).Truncate(time.Second)
+				uc.broadcast("update_progress", UpdateProgressPayload{
+					Status:     "building",
+					Message:    fmt.Sprintf("%s (%s elapsed)...", stepLabel, elapsed),
+					Progress:   progressPct,
+					Step:       step,
+					TotalSteps: totalSteps,
+				})
+			}
+		}
+	}()
+
+	err := cmd.Wait()
+	close(done)
+
+	// Extract the tail of the output for error messages
+	output := tailLines(buf.String(), buildOutputTailLines)
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return buildResult{
+			err:    fmt.Errorf("timed out after %s", timeout),
+			output: output,
+		}
+	}
+	return buildResult{err: err, output: output}
+}
+
+// tailLines returns the last n lines of s. If s has fewer than n lines, returns all of s.
+func tailLines(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) <= n {
+		return s
+	}
+	return strings.Join(lines[len(lines)-n:], "\n")
+}
+
+// buildErrorDetail formats an error message that includes both the Go error and
+// the tail of the build output, giving the user actionable information.
+func buildErrorDetail(err error, output string) string {
+	if output == "" {
+		return err.Error()
+	}
+	return fmt.Sprintf("%v\n---\n%s", err, output)
 }

--- a/pkg/agent/update_checker_test.go
+++ b/pkg/agent/update_checker_test.go
@@ -1,6 +1,11 @@
 package agent
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -192,4 +197,569 @@ func TestStatusIncludesUpdateInProgress(t *testing.T) {
 	}
 
 	atomic.StoreInt32(&uc.updating, 0)
+}
+
+// =============================================================================
+// Integration tests — full update flow with mock commands
+// =============================================================================
+
+// --- Mock script helpers ---
+
+// writeMockScript creates an executable shell script in dir with the given name and body.
+func writeMockScript(t *testing.T, dir, name, body string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/bash\n"+body), 0755); err != nil {
+		t.Fatalf("failed to write mock script %s: %v", name, err)
+	}
+}
+
+// setupMockBin creates a temporary directory with mock versions of go, npm, and git.
+// These mock scripts simulate successful operations without doing any real work.
+func setupMockBin(t *testing.T) string {
+	t.Helper()
+	mockBin := t.TempDir()
+
+	// Mock 'go' — when called with "build -o <path> ...", creates an empty executable
+	writeMockScript(t, mockBin, "go", `
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-o" ]; then
+    touch "$arg"
+    chmod 755 "$arg"
+  fi
+  prev="$arg"
+done
+exit 0
+`)
+
+	// Mock 'npm' — always succeeds (handles install, run build, cache clean)
+	writeMockScript(t, mockBin, "npm", `exit 0`)
+
+	// Mock 'git' — handles the subcommands used by the updater
+	writeMockScript(t, mockBin, "git", `
+case "$1" in
+  pull)      exit 0 ;;
+  fetch)     exit 0 ;;
+  rev-parse)
+    case "$2" in
+      --show-toplevel) pwd ;;
+      HEAD)            echo "abc1234567890" ;;
+      origin/main)     echo "def7890123456" ;;
+      *)               echo "unknown" ;;
+    esac
+    exit 0 ;;
+  status)    echo "" ; exit 0 ;;
+  reset)     exit 0 ;;
+  stash)     exit 0 ;;
+  *)         exit 0 ;;
+esac
+`)
+
+	return mockBin
+}
+
+// setupFakeRepo creates a minimal repo directory structure that the updater expects.
+func setupFakeRepo(t *testing.T) string {
+	t.Helper()
+	repoDir := t.TempDir()
+
+	webDir := filepath.Join(repoDir, "web")
+	if err := os.MkdirAll(webDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(webDir, "package.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, "data"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Create a no-op startup-oauth.sh so restartViaStartupScript finds it.
+	// The test overrides exitFunc to prevent actual os.Exit.
+	if err := os.WriteFile(filepath.Join(repoDir, "startup-oauth.sh"),
+		[]byte("#!/bin/bash\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	return repoDir
+}
+
+// newTestUpdateChecker creates an UpdateChecker configured for testing.
+// The broadcast function records all payloads. exitFunc is a no-op.
+func newTestUpdateChecker(t *testing.T, repoPath string) (*UpdateChecker, *[]UpdateProgressPayload) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var broadcasts []UpdateProgressPayload
+
+	uc := &UpdateChecker{
+		repoPath:   repoPath,
+		currentSHA: "oldsha1234567",
+		broadcast: func(_ string, payload interface{}) {
+			if p, ok := payload.(UpdateProgressPayload); ok {
+				mu.Lock()
+				broadcasts = append(broadcasts, p)
+				mu.Unlock()
+			}
+		},
+		restartBackend: func() error { return nil },
+		killBackend:    func() bool { return true },
+		exitFunc:       func(_ int) { /* no-op in tests */ },
+	}
+
+	return uc, &broadcasts
+}
+
+// TestDeveloperUpdateLoop_10x runs the full 7-step developer update 10 times
+// in a row, verifying each iteration completes all steps successfully,
+// progress increases monotonically, and the correct broadcast sequence is emitted.
+// This is the primary CI reliability test for the self-update mechanism.
+func TestDeveloperUpdateLoop_10x(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping update loop test in short mode")
+	}
+
+	mockBin := setupMockBin(t)
+	repoPath := setupFakeRepo(t)
+	t.Setenv("PATH", mockBin+":"+os.Getenv("PATH"))
+
+	const iterations = 10
+
+	for i := 1; i <= iterations; i++ {
+		t.Run(fmt.Sprintf("iteration_%d", i), func(t *testing.T) {
+			uc, broadcasts := newTestUpdateChecker(t, repoPath)
+
+			newSHA := fmt.Sprintf("newsha%07d", i)
+			uc.executeDeveloperUpdate(newSHA)
+
+			msgs := *broadcasts
+
+			// Must have at least 7 broadcasts (one per step)
+			if len(msgs) < devUpdateTotalSteps {
+				t.Fatalf("expected at least %d broadcasts, got %d: %+v",
+					devUpdateTotalSteps, len(msgs), msgs)
+			}
+
+			// Verify all 7 steps were broadcast
+			seenSteps := make(map[int]bool)
+			for _, m := range msgs {
+				if m.Step > 0 {
+					seenSteps[m.Step] = true
+				}
+			}
+			for s := 1; s <= devUpdateTotalSteps; s++ {
+				if !seenSteps[s] {
+					t.Errorf("missing broadcast for step %d", s)
+				}
+			}
+
+			// Verify progress is monotonically non-decreasing
+			maxProgress := 0
+			for _, m := range msgs {
+				if m.Progress < maxProgress {
+					t.Errorf("progress decreased: %d -> %d at step %d (%s)",
+						maxProgress, m.Progress, m.Step, m.Message)
+				}
+				if m.Progress > maxProgress {
+					maxProgress = m.Progress
+				}
+			}
+
+			// Verify no "failed" status
+			for _, m := range msgs {
+				if m.Status == "failed" {
+					t.Fatalf("unexpected failure: step=%d message=%q error=%q",
+						m.Step, m.Message, m.Error)
+				}
+			}
+
+			// Verify final broadcast is "restarting" (step 7)
+			last := msgs[len(msgs)-1]
+			if last.Status != "restarting" {
+				t.Errorf("expected last status 'restarting', got %q", last.Status)
+			}
+			if last.Step != devUpdateTotalSteps {
+				t.Errorf("expected last step %d, got %d", devUpdateTotalSteps, last.Step)
+			}
+
+			// Verify SHA was updated
+			uc.mu.Lock()
+			currentSHA := uc.currentSHA
+			lastErr := uc.lastUpdateError
+			uc.mu.Unlock()
+			if currentSHA != newSHA {
+				t.Errorf("expected currentSHA=%q, got %q", newSHA, currentSHA)
+			}
+			if lastErr != "" {
+				t.Errorf("unexpected lastUpdateError: %q", lastErr)
+			}
+		})
+	}
+}
+
+// TestDeveloperUpdate_BuildTimeout verifies that builds are killed after the
+// timeout expires and an appropriate error is reported.
+func TestDeveloperUpdate_BuildTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timeout test in short mode")
+	}
+
+	mockBin := t.TempDir()
+	// Mock 'go' to sleep forever (simulating a hung build)
+	writeMockScript(t, mockBin, "go", `sleep 3600`)
+	t.Setenv("PATH", mockBin+":"+os.Getenv("PATH"))
+
+	uc, _ := newTestUpdateChecker(t, t.TempDir())
+
+	shortTimeout := 2 * time.Second
+	start := time.Now()
+	res := uc.runBuildCmd(shortTimeout, "test build", 1, 1, 50,
+		"go", []string{"build", "-o", "/dev/null", "."}, t.TempDir(), nil)
+	elapsed := time.Since(start)
+
+	if res.err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(res.err.Error(), "timed out") {
+		t.Errorf("expected timeout error, got: %v", res.err)
+	}
+
+	// Should have been killed close to the timeout + WaitDelay (3s for pipe drain)
+	const pipeWaitDelay = 3 * time.Second
+	const timingSlack = 2 * time.Second
+	maxExpected := shortTimeout + pipeWaitDelay + timingSlack
+	if elapsed > maxExpected {
+		t.Errorf("command took %s, expected <%s (timeout=%s + pipe_drain=%s + slack=%s)",
+			elapsed, maxExpected, shortTimeout, pipeWaitDelay, timingSlack)
+	}
+}
+
+// TestDeveloperUpdate_BuildFailure verifies that build failures include the
+// actual build output in the error broadcast.
+func TestDeveloperUpdate_BuildFailure(t *testing.T) {
+	mockBin := t.TempDir()
+	repoPath := setupFakeRepo(t)
+
+	writeMockScript(t, mockBin, "git", `
+case "$1" in
+  pull)      exit 0 ;;
+  rev-parse) echo "abc1234" ; exit 0 ;;
+  status)    echo "" ; exit 0 ;;
+  reset)     exit 0 ;;
+  *)         exit 0 ;;
+esac
+`)
+	writeMockScript(t, mockBin, "npm", `exit 0`)
+	// Mock 'go' to fail with a compile error
+	writeMockScript(t, mockBin, "go", `
+echo "# cmd/console" >&2
+echo "./main.go:42:5: undefined: SomeNewFunction" >&2
+exit 1
+`)
+	t.Setenv("PATH", mockBin+":"+os.Getenv("PATH"))
+
+	uc, broadcasts := newTestUpdateChecker(t, repoPath)
+	uc.executeDeveloperUpdate("newsha_fail")
+
+	msgs := *broadcasts
+
+	var failMsg *UpdateProgressPayload
+	for i := range msgs {
+		if msgs[i].Status == "failed" {
+			failMsg = &msgs[i]
+			break
+		}
+	}
+	if failMsg == nil {
+		t.Fatal("expected a 'failed' broadcast, got none")
+	}
+	// Error should contain the actual compiler output
+	if !strings.Contains(failMsg.Error, "undefined: SomeNewFunction") {
+		t.Errorf("expected build output in error, got: %q", failMsg.Error)
+	}
+}
+
+// TestDeveloperUpdate_NpmInstallRetry verifies npm install retry logic
+// with cache cleaning.
+func TestDeveloperUpdate_NpmInstallRetry(t *testing.T) {
+	mockBin := t.TempDir()
+	repoPath := setupFakeRepo(t)
+
+	writeMockScript(t, mockBin, "git", `
+case "$1" in
+  pull)      exit 0 ;;
+  rev-parse) echo "abc1234" ; exit 0 ;;
+  status)    echo "" ; exit 0 ;;
+  reset)     exit 0 ;;
+  *)         exit 0 ;;
+esac
+`)
+
+	// npm — fail first install attempt, succeed on second
+	counterFile := filepath.Join(t.TempDir(), "npm_attempt")
+	os.WriteFile(counterFile, []byte("0"), 0644) //nolint:errcheck
+
+	writeMockScript(t, mockBin, "npm", fmt.Sprintf(`
+COUNTER_FILE="%s"
+case "$1" in
+  install)
+    count=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
+    count=$((count + 1))
+    echo "$count" > "$COUNTER_FILE"
+    if [ "$count" -le 1 ]; then
+      echo "npm ERR! EACCES: permission denied" >&2
+      exit 1
+    fi
+    exit 0 ;;
+  cache) exit 0 ;;
+  run)   exit 0 ;;
+  *)     exit 0 ;;
+esac
+`, counterFile))
+
+	writeMockScript(t, mockBin, "go", `
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-o" ]; then
+    touch "$arg"
+    chmod 755 "$arg"
+  fi
+  prev="$arg"
+done
+exit 0
+`)
+	t.Setenv("PATH", mockBin+":"+os.Getenv("PATH"))
+
+	uc, broadcasts := newTestUpdateChecker(t, repoPath)
+	uc.executeDeveloperUpdate("newsha_retry")
+
+	msgs := *broadcasts
+
+	// Should NOT have failed (npm retried and succeeded)
+	for _, m := range msgs {
+		if m.Status == "failed" {
+			t.Fatalf("unexpected failure: %q (error: %q)", m.Message, m.Error)
+		}
+	}
+
+	// Should have a retry message
+	hasRetryMsg := false
+	for _, m := range msgs {
+		if strings.Contains(m.Message, "cache") || strings.Contains(m.Message, "attempt") {
+			hasRetryMsg = true
+			break
+		}
+	}
+	if !hasRetryMsg {
+		t.Error("expected a retry/cache-cleaning broadcast message")
+	}
+
+	// Should have completed
+	last := msgs[len(msgs)-1]
+	if last.Status != "restarting" {
+		t.Errorf("expected final status 'restarting', got %q", last.Status)
+	}
+}
+
+// TestDeveloperUpdate_GitPullFailure verifies git pull failure stops the update.
+func TestDeveloperUpdate_GitPullFailure(t *testing.T) {
+	mockBin := t.TempDir()
+	repoPath := setupFakeRepo(t)
+
+	writeMockScript(t, mockBin, "git", `
+case "$1" in
+  pull)
+    echo "error: cannot pull with rebase" >&2
+    exit 1 ;;
+  rev-parse) echo "abc1234" ; exit 0 ;;
+  status)    echo "" ; exit 0 ;;
+  reset)     exit 0 ;;
+  *)         exit 0 ;;
+esac
+`)
+	writeMockScript(t, mockBin, "npm", `exit 0`)
+	writeMockScript(t, mockBin, "go", `exit 0`)
+	t.Setenv("PATH", mockBin+":"+os.Getenv("PATH"))
+
+	uc, broadcasts := newTestUpdateChecker(t, repoPath)
+	uc.executeDeveloperUpdate("newsha_gitfail")
+
+	msgs := *broadcasts
+
+	if len(msgs) < 2 {
+		t.Fatalf("expected at least 2 broadcasts, got %d", len(msgs))
+	}
+
+	// First should be pulling
+	if msgs[0].Status != "pulling" {
+		t.Errorf("expected first status 'pulling', got %q", msgs[0].Status)
+	}
+
+	// Should have a failed broadcast
+	var failMsg *UpdateProgressPayload
+	for i := range msgs {
+		if msgs[i].Status == "failed" {
+			failMsg = &msgs[i]
+			break
+		}
+	}
+	if failMsg == nil {
+		t.Fatal("expected a 'failed' broadcast after git pull failure")
+	}
+
+	// Should NOT have any build step broadcasts (steps 2+)
+	for _, m := range msgs {
+		if m.Step > 1 {
+			t.Errorf("unexpected step %d broadcast after git pull failure", m.Step)
+		}
+	}
+}
+
+// TestDeveloperUpdate_HeartbeatDuringBuild verifies heartbeat messages are
+// sent during long-running builds.
+func TestDeveloperUpdate_HeartbeatDuringBuild(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping heartbeat test in short mode")
+	}
+
+	mockBin := t.TempDir()
+	repoPath := setupFakeRepo(t)
+
+	writeMockScript(t, mockBin, "git", `
+case "$1" in
+  pull)      exit 0 ;;
+  rev-parse) echo "abc1234" ; exit 0 ;;
+  *)         exit 0 ;;
+esac
+`)
+	writeMockScript(t, mockBin, "npm", `exit 0`)
+	// Mock 'go' — sleep long enough for at least one heartbeat (>15s)
+	writeMockScript(t, mockBin, "go", `
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-o" ]; then
+    OUTPUT="$arg"
+  fi
+  prev="$arg"
+done
+sleep 18
+if [ -n "$OUTPUT" ]; then
+  touch "$OUTPUT"
+  chmod 755 "$OUTPUT"
+fi
+exit 0
+`)
+	t.Setenv("PATH", mockBin+":"+os.Getenv("PATH"))
+
+	uc, broadcasts := newTestUpdateChecker(t, repoPath)
+
+	start := time.Now()
+	uc.executeDeveloperUpdate("newsha_heartbeat")
+	elapsed := time.Since(start)
+
+	msgs := *broadcasts
+
+	if elapsed < 15*time.Second {
+		t.Errorf("expected build to take >15s, took %s", elapsed)
+	}
+
+	// Should have heartbeat messages containing "elapsed"
+	heartbeats := 0
+	for _, m := range msgs {
+		if strings.Contains(m.Message, "elapsed") {
+			heartbeats++
+		}
+	}
+	if heartbeats == 0 {
+		t.Error("expected at least one heartbeat message with elapsed time")
+	}
+	t.Logf("received %d heartbeat messages over %s", heartbeats, elapsed)
+}
+
+// TestRunBuildCmd_OutputCapture verifies build output is captured in errors.
+func TestRunBuildCmd_OutputCapture(t *testing.T) {
+	mockBin := t.TempDir()
+
+	writeMockScript(t, mockBin, "failbuild", `
+echo "compiling package main..."
+echo "ERROR: cannot find module 'foo'" >&2
+exit 1
+`)
+	t.Setenv("PATH", mockBin+":"+os.Getenv("PATH"))
+
+	uc, _ := newTestUpdateChecker(t, t.TempDir())
+	res := uc.runBuildCmd(30*time.Second, "test", 1, 1, 50,
+		filepath.Join(mockBin, "failbuild"), nil, t.TempDir(), nil)
+
+	if res.err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(res.output, "cannot find module") {
+		t.Errorf("expected stderr in output, got: %q", res.output)
+	}
+	if !strings.Contains(res.output, "compiling package main") {
+		t.Errorf("expected stdout in output, got: %q", res.output)
+	}
+}
+
+// TestTailLines verifies the tailLines utility.
+func TestTailLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		n        int
+		expected string
+	}{
+		{"fewer lines than n", "a\nb\nc", 5, "a\nb\nc"},
+		{"exact n lines", "a\nb\nc", 3, "a\nb\nc"},
+		{"more lines than n", "a\nb\nc\nd\ne", 2, "d\ne"},
+		{"single line", "hello", 3, "hello"},
+		{"empty string", "", 3, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tailLines(tt.input, tt.n)
+			if got != tt.expected {
+				t.Errorf("tailLines(%q, %d) = %q, want %q", tt.input, tt.n, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestBuildErrorDetail verifies error detail formatting.
+func TestBuildErrorDetail(t *testing.T) {
+	err := fmt.Errorf("exit status 1")
+
+	detail := buildErrorDetail(err, "line1\nline2")
+	if !strings.Contains(detail, "exit status 1") || !strings.Contains(detail, "line2") {
+		t.Errorf("unexpected detail: %q", detail)
+	}
+
+	detail = buildErrorDetail(err, "")
+	if detail != "exit status 1" {
+		t.Errorf("expected just error, got: %q", detail)
+	}
+}
+
+// TestMockPathResolution is a sanity check that the mock PATH approach works.
+func TestMockPathResolution(t *testing.T) {
+	mockBin := setupMockBin(t)
+	t.Setenv("PATH", mockBin+":"+os.Getenv("PATH"))
+
+	goPath, err := exec.LookPath("go")
+	if err != nil {
+		t.Fatalf("failed to find mock go: %v", err)
+	}
+	if !strings.HasPrefix(goPath, mockBin) {
+		t.Errorf("expected mock go at %s/go, found: %s", mockBin, goPath)
+	}
+
+	npmPath, err := exec.LookPath("npm")
+	if err != nil {
+		t.Fatalf("failed to find mock npm: %v", err)
+	}
+	if !strings.HasPrefix(npmPath, mockBin) {
+		t.Errorf("expected mock npm at %s/npm, found: %s", mockBin, npmPath)
+	}
 }

--- a/web/src/hooks/useUpdateProgress.ts
+++ b/web/src/hooks/useUpdateProgress.ts
@@ -7,6 +7,11 @@ const WS_RECONNECT_MS = 5000  // Reconnect interval after WebSocket disconnect
 const BACKEND_POLL_MS = 2000  // Poll interval when waiting for backend to come up
 const BACKEND_POLL_MAX = 90   // Max attempts (~3 min) before giving up
 
+// Stale detection: if WebSocket has been disconnected for this long during an
+// active update (status is "pulling", "building", or "restarting"), we assume
+// the kc-agent died and show a failure message instead of leaving the UI stuck.
+const STALE_UPDATE_TIMEOUT_MS = 45_000  // 45 seconds without a WebSocket message
+
 /** Known update step labels for developer channel (7-step update) */
 const DEV_UPDATE_STEP_LABELS: Record<number, string> = {
   1: 'Git pull',
@@ -18,16 +23,28 @@ const DEV_UPDATE_STEP_LABELS: Record<number, string> = {
   7: 'Restart',
 }
 
+/** Statuses that indicate an update is actively running */
+const ACTIVE_UPDATE_STATUSES = new Set(['pulling', 'building', 'restarting'])
+
 /**
  * Hook that listens for update_progress WebSocket broadcasts from kc-agent.
  * Uses a separate WebSocket connection to avoid interfering with the shared one.
  * Also tracks step history for detailed progress display.
+ *
+ * Includes stale-state detection: if the WebSocket disconnects during an active
+ * update and stays disconnected for STALE_UPDATE_TIMEOUT_MS, the hook
+ * automatically transitions to a "failed" state with a helpful error message.
  */
 export function useUpdateProgress() {
   const [progress, setProgress] = useState<UpdateProgress | null>(null)
   const [stepHistory, setStepHistory] = useState<UpdateStepEntry[]>([])
   const wsRef = useRef<WebSocket | null>(null)
   const progressRef = useRef<UpdateProgress | null>(null)
+
+  // Track the last time we received a WebSocket message during an active update.
+  // Used for stale-state detection.
+  const lastMessageTimeRef = useRef<number>(0)
+  const staleTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   // Keep ref in sync so the connect closure always sees the latest value
   progressRef.current = progress
@@ -67,6 +84,48 @@ export function useUpdateProgress() {
       }
       return entries
     })
+  }, [])
+
+  // Start or stop the stale-state detection timer based on current progress.
+  // When an update is active, we check periodically whether the WebSocket
+  // has gone silent for too long — which means the kc-agent process likely died.
+  const startStaleDetection = useCallback(() => {
+    // Clear any existing timer
+    if (staleTimerRef.current) {
+      clearInterval(staleTimerRef.current)
+      staleTimerRef.current = null
+    }
+
+    const STALE_CHECK_INTERVAL_MS = 5000  // Check every 5 seconds
+    staleTimerRef.current = setInterval(() => {
+      const cur = progressRef.current
+      if (!cur || !ACTIVE_UPDATE_STATUSES.has(cur.status)) {
+        // Not in an active update — stop checking
+        if (staleTimerRef.current) {
+          clearInterval(staleTimerRef.current)
+          staleTimerRef.current = null
+        }
+        return
+      }
+
+      const elapsed = Date.now() - lastMessageTimeRef.current
+      if (elapsed > STALE_UPDATE_TIMEOUT_MS && !wsRef.current) {
+        // WebSocket disconnected during active update for too long — agent likely died
+        setProgress({
+          status: 'failed',
+          message: 'Update agent stopped responding — the kc-agent process may have crashed during the build.',
+          progress: cur.progress,
+          error: 'No response from kc-agent for ' + Math.round(elapsed / 1000) + 's. '
+            + 'Try restarting manually: cd <repo> && bash startup-oauth.sh',
+        })
+
+        // Stop the timer
+        if (staleTimerRef.current) {
+          clearInterval(staleTimerRef.current)
+          staleTimerRef.current = null
+        }
+      }
+    }, STALE_CHECK_INTERVAL_MS)
   }, [])
 
   useEffect(() => {
@@ -131,6 +190,9 @@ export function useUpdateProgress() {
         wsRef.current = ws
 
         ws.onopen = () => {
+          // Reset stale timer on successful connection
+          lastMessageTimeRef.current = Date.now()
+
           // If we reconnected while showing "restarting", kc-agent is back —
           // but backend may still be building. Wait for it.
           const cur = progressRef.current
@@ -140,12 +202,29 @@ export function useUpdateProgress() {
         }
 
         ws.onmessage = (event) => {
+          // Update last-message timestamp for stale detection
+          lastMessageTimeRef.current = Date.now()
+
           try {
             const msg = JSON.parse(event.data)
             if (msg.type === 'update_progress' && msg.payload) {
               const p = msg.payload as UpdateProgress
+
+              // Start stale detection when an active update begins
+              if (ACTIVE_UPDATE_STATUSES.has(p.status) && !staleTimerRef.current) {
+                startStaleDetection()
+              }
+
               setProgress(p)
               updateStepHistory(p)
+
+              // Stop stale detection when update is done or failed
+              if (p.status === 'done' || p.status === 'failed') {
+                if (staleTimerRef.current) {
+                  clearInterval(staleTimerRef.current)
+                  staleTimerRef.current = null
+                }
+              }
             }
           } catch {
             // Ignore parse errors
@@ -174,12 +253,16 @@ export function useUpdateProgress() {
 
     return () => {
       clearTimeout(reconnectTimer)
+      if (staleTimerRef.current) {
+        clearInterval(staleTimerRef.current)
+        staleTimerRef.current = null
+      }
       if (wsRef.current) {
         wsRef.current.close()
         wsRef.current = null
       }
     }
-  }, [updateStepHistory])
+  }, [updateStepHistory, startStaleDetection])
 
   const dismiss = () => {
     setProgress(null)


### PR DESCRIPTION
## Summary

- Fix self-update mechanism getting permanently stuck when kc-agent dies mid-build — the UI showed "Building kc-agent binary..." forever with no error or recovery
- Add hard timeouts on all build commands (git pull 2m, npm install/builds 5m each) so builds can never hang indefinitely
- Add heartbeat goroutine during builds that sends periodic WebSocket progress updates so the frontend knows the agent is alive
- Capture build stdout/stderr so error messages include actual compiler output instead of just "exit status 1"
- Build Go binaries to a temp file then atomic rename to prevent corrupt/half-written binaries
- Add frontend stale-state detection: if WebSocket disconnects for >45s during an active update, auto-transition to failed state with actionable error message
- Add comprehensive CI test suite: 10-iteration reliability loop, timeout/failure/retry/heartbeat tests

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/ -run TestDeveloperUpdateLoop_10x` — 10/10 iterations pass
- [x] `go test ./pkg/agent/ -run TestDeveloperUpdate_BuildTimeout` — process killed after deadline
- [x] `go test ./pkg/agent/ -run TestDeveloperUpdate_BuildFailure` — compiler output in error
- [x] `go test ./pkg/agent/ -run TestDeveloperUpdate_NpmInstallRetry` — retry with cache clean works
- [x] `go test ./pkg/agent/ -run TestDeveloperUpdate_GitPullFailure` — immediate abort, no build steps
- [x] `go test ./pkg/agent/ -run TestDeveloperUpdate_HeartbeatDuringBuild` — heartbeat messages received
- [x] All existing tests still pass (no regressions)
- [x] Frontend build passes
- [ ] CI build/lint/Go tests pass