### PR TITLE
✨ Add star treatment to KubeStellar logo

### DIFF
--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -6,6 +6,7 @@ import { checkOAuthConfigured } from '../../lib/api'
 import { ROUTES } from '../../config/routes'
 import { useTranslation } from 'react-i18next'
 import { emitLogin } from '../../lib/analytics'
+import { LogoWithStar } from '../ui/LogoWithStar'
 
 // Lazy load the heavy Three.js globe animation
 const GlobeAnimation = lazy(() => import('../animations/globe').then(m => ({ default: m.GlobeAnimation })))
@@ -134,11 +135,7 @@ export function Login() {
           {/* Logo */}
           <div className="flex justify-center mb-8">
             <div className="flex items-center gap-3">
-              <img
-                src="/kubestellar-logo.svg"
-                alt="KubeStellar logo"
-                className="w-14 h-14"
-              />
+              <LogoWithStar className="w-14 h-14" alt="KubeStellar logo" />
               <div>
                 <h1 className="text-2xl font-bold text-foreground">KubeStellar</h1>
                 <p className="text-sm text-muted-foreground">KubeStellar Console</p>

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -7,6 +7,7 @@ import { useSidebarConfig } from '../../../hooks/useSidebarConfig'
 import { useTheme } from '../../../hooks/useTheme'
 import { useMobile } from '../../../hooks/useMobile'
 import { TourTrigger } from '../../onboarding/Tour'
+import { LogoWithStar } from '../../ui/LogoWithStar'
 import { UserProfileDropdown } from '../UserProfileDropdown'
 import { AlertBadge } from '../../ui/AlertBadge'
 import { FeatureRequestButton } from '../../feedback'
@@ -57,11 +58,7 @@ export function Navbar() {
           className="flex items-center gap-2 md:gap-3 p-2 -m-2 min-w-[44px] min-h-[44px] hover:opacity-80 transition-opacity"
           aria-label={t('navbar.goHome')}
         >
-          <img
-            src="/kubestellar-logo.svg"
-            alt="KubeStellar"
-            className="w-8 h-8 md:w-9 md:h-9"
-          />
+          <LogoWithStar className="w-8 h-8 md:w-9 md:h-9" />
         </button>
         <a
           href="https://kubestellar.io/docs/console/readme"

--- a/web/src/components/onboarding/Tour.tsx
+++ b/web/src/components/onboarding/Tour.tsx
@@ -4,17 +4,7 @@ import { useTour, TourStep } from '../../hooks/useTour'
 import { cn } from '../../lib/cn'
 import { useTranslation } from 'react-i18next'
 import { TOOLTIP_POSITION_DELAY_MS } from '../../lib/constants/network'
-
-// KubeStellar logo — clean, no decorative overlays
-function KubeStellarAIIcon({ className }: { className?: string }) {
-  return (
-    <img
-      src="/kubestellar-logo.svg"
-      alt=""
-      className={cn('w-full h-full', className)}
-    />
-  )
-}
+import { LogoWithStar } from '../ui/LogoWithStar'
 
 interface TooltipPosition {
   top?: number
@@ -364,7 +354,7 @@ export function TourOverlay() {
         <div className="flex items-start justify-between mb-3">
           <div className="flex items-center gap-2">
             <div className="p-1.5 rounded-lg bg-purple-500/20">
-              <KubeStellarAIIcon className="w-5 h-5" />
+              <LogoWithStar className="w-5 h-5" />
             </div>
             <h3 className="font-semibold text-foreground">{currentStep.title}</h3>
           </div>
@@ -452,7 +442,7 @@ export function TourTrigger() {
       )}
       title="Take a tour"
     >
-      <KubeStellarAIIcon className="w-5 h-5" />
+      <LogoWithStar className="w-5 h-5" />
       {!hasCompletedTour && <span>Take the tour</span>}
     </button>
   )

--- a/web/src/components/ui/ConsoleAIIcon.tsx
+++ b/web/src/components/ui/ConsoleAIIcon.tsx
@@ -1,4 +1,5 @@
 import { cn } from '../../lib/cn'
+import { LogoWithStar } from './LogoWithStar'
 
 interface ConsoleAIIconProps {
   className?: string
@@ -6,7 +7,7 @@ interface ConsoleAIIconProps {
 }
 
 /**
- * KubeStellar Console AI icon — clean logo without decorative overlays.
+ * KubeStellar Console AI icon with star treatment.
  */
 export function ConsoleAIIcon({ className, size = 'md' }: ConsoleAIIconProps) {
   const sizeClasses = {
@@ -16,10 +17,9 @@ export function ConsoleAIIcon({ className, size = 'md' }: ConsoleAIIconProps) {
   }
 
   return (
-    <img
-      src="/kubestellar-logo.svg"
-      alt="Console AI"
+    <LogoWithStar
       className={cn(sizeClasses[size], className)}
+      alt="Console AI"
     />
   )
 }

--- a/web/src/components/ui/LogoWithStar.tsx
+++ b/web/src/components/ui/LogoWithStar.tsx
@@ -1,0 +1,57 @@
+import { cn } from '../../lib/cn'
+
+interface LogoWithStarProps {
+  className?: string
+  /** Size of the logo image itself */
+  logoClassName?: string
+  alt?: string
+}
+
+/**
+ * KubeStellar logo with the "star treatment" — a 4-pointed sparkle star
+ * and two flanking plus signs in purple, positioned at the upper-right.
+ */
+export function LogoWithStar({ className, logoClassName, alt = 'KubeStellar' }: LogoWithStarProps) {
+  return (
+    <div className={cn('relative inline-flex items-center justify-center', className)}>
+      <img
+        src="/kubestellar-logo.svg"
+        alt={alt}
+        className={cn('w-full h-full', logoClassName)}
+      />
+      {/* Star treatment overlay — positioned at upper-right of the logo */}
+      <svg
+        className="absolute -top-[15%] -right-[20%] w-[55%] h-[55%] pointer-events-none"
+        viewBox="0 0 40 40"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        {/* 4-pointed sparkle star — center of the overlay */}
+        <path
+          d="M20 8 L22.5 17.5 L32 20 L22.5 22.5 L20 32 L17.5 22.5 L8 20 L17.5 17.5 Z"
+          fill="none"
+          stroke="url(#starGradient)"
+          strokeWidth="2"
+          strokeLinejoin="round"
+        />
+        {/* Large plus sign — upper-right of star */}
+        <line x1="33" y1="5" x2="33" y2="11" stroke="url(#plusGradient)" strokeWidth="1.5" strokeLinecap="round" />
+        <line x1="30" y1="8" x2="36" y2="8" stroke="url(#plusGradient)" strokeWidth="1.5" strokeLinecap="round" />
+        {/* Small plus sign — lower-left of star, near logo edge */}
+        <line x1="6" y1="13" x2="6" y2="17" stroke="url(#plusGradient)" strokeWidth="1" strokeLinecap="round" />
+        <line x1="4" y1="15" x2="8" y2="15" stroke="url(#plusGradient)" strokeWidth="1" strokeLinecap="round" />
+        <defs>
+          <linearGradient id="starGradient" x1="8" y1="8" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stopColor="#a855f7" />
+            <stop offset="100%" stopColor="#7c3aed" />
+          </linearGradient>
+          <linearGradient id="plusGradient" x1="0" y1="0" x2="40" y2="40" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stopColor="#c084fc" />
+            <stop offset="100%" stopColor="#a855f7" />
+          </linearGradient>
+        </defs>
+      </svg>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- New `LogoWithStar` component adds a 4-pointed sparkle star + two flanking plus signs (purple gradient) as an SVG overlay on the KubeStellar logo
- Applied to: navbar logo, tour trigger, tour tooltip, login page, and `ConsoleAIIcon` component
- Matches the branding treatment shown in the reference image

## Test plan
- [ ] Navbar logo (top-left) shows star + plus overlay
- [ ] Tour trigger icon (top-right) shows star treatment
- [ ] Login page logo shows star treatment
- [ ] Verify star renders correctly in both light and dark themes
- [ ] Star overlay scales properly at all logo sizes (sm/md/lg)