### PR TITLE
🌱 Add CI guard workflow for self-update mechanism

### DIFF
--- a/.github/workflows/update-guard.yml
+++ b/.github/workflows/update-guard.yml
@@ -1,0 +1,167 @@
+name: Update Mechanism Guard
+
+# Prevents PRs from breaking the self-update mechanism.
+# Runs the full update test suite (including a 10-iteration reliability loop)
+# on every PR that touches the update code or its dependencies.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pkg/agent/update_checker.go'
+      - 'pkg/agent/update_checker_test.go'
+      - 'pkg/agent/server.go'
+      - 'web/src/hooks/useUpdateProgress.ts'
+      - 'startup-oauth.sh'
+      - 'scripts/update-lifecycle-test.sh'
+      - '.github/workflows/update-guard.yml'
+  workflow_dispatch:
+
+env:
+  GO_VERSION: "1.24"
+
+permissions:
+  contents: read
+
+jobs:
+  update-tests:
+    name: Update Mechanism Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Run update mechanism tests (10-iteration loop)
+        run: |
+          echo "=== Running full update mechanism test suite ==="
+          echo ""
+          echo "--- Phase 1: 5-iteration reliability loop ---"
+          go test ./pkg/agent/ -v -run "TestDeveloperUpdateLoop_5x" -timeout 120s
+          echo ""
+          echo "--- Phase 2: Build timeout handling ---"
+          go test ./pkg/agent/ -v -run "TestDeveloperUpdate_BuildTimeout" -timeout 30s
+          echo ""
+          echo "--- Phase 3: Build failure with output capture ---"
+          go test ./pkg/agent/ -v -run "TestDeveloperUpdate_BuildFailure" -timeout 30s
+          echo ""
+          echo "--- Phase 4: npm install retry logic ---"
+          go test ./pkg/agent/ -v -run "TestDeveloperUpdate_NpmInstallRetry" -timeout 30s
+          echo ""
+          echo "--- Phase 5: Git pull failure (early abort) ---"
+          go test ./pkg/agent/ -v -run "TestDeveloperUpdate_GitPullFailure" -timeout 30s
+          echo ""
+          echo "--- Phase 6: Heartbeat during long builds ---"
+          go test ./pkg/agent/ -v -run "TestDeveloperUpdate_HeartbeatDuringBuild" -timeout 120s
+          echo ""
+          echo "--- Phase 7: Output capture and utilities ---"
+          go test ./pkg/agent/ -v -run "TestRunBuildCmd_OutputCapture|TestTailLines|TestBuildErrorDetail|TestMockPathResolution" -timeout 30s
+
+      - name: Run concurrency safety tests
+        run: |
+          echo "=== Running concurrency safety tests ==="
+          go test ./pkg/agent/ -v -run "TestTriggerNow|TestIsUpdating|TestStatus" -timeout 30s -count=3
+
+      - name: Verify update invariants in source
+        run: |
+          echo "=== Verifying critical update invariants ==="
+          CHECKER="pkg/agent/update_checker.go"
+          ERRORS=0
+
+          # 1. Atomic flag for mutual exclusion
+          if ! grep -q "atomic.CompareAndSwapInt32" "$CHECKER"; then
+            echo "FAIL: Missing atomic.CompareAndSwapInt32 for update mutual exclusion"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "PASS: Atomic CAS for mutual exclusion present"
+          fi
+
+          # 2. Defer cleanup of updating flag
+          if ! grep -q "defer atomic.StoreInt32" "$CHECKER"; then
+            echo "FAIL: Missing defer cleanup of updating flag"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "PASS: Defer cleanup of updating flag present"
+          fi
+
+          # 3. Build timeouts defined
+          for TIMEOUT in gitPullTimeout npmInstallTimeout frontendBuildTimeout goBuildTimeout; do
+            if ! grep -q "$TIMEOUT" "$CHECKER"; then
+              echo "FAIL: Missing timeout constant: $TIMEOUT"
+              ERRORS=$((ERRORS + 1))
+            else
+              echo "PASS: Timeout constant $TIMEOUT present"
+            fi
+          done
+
+          # 4. Heartbeat interval defined
+          if ! grep -q "buildHeartbeatInterval" "$CHECKER"; then
+            echo "FAIL: Missing buildHeartbeatInterval constant"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "PASS: Heartbeat interval constant present"
+          fi
+
+          # 5. Atomic binary replacement (build-to-temp-then-rename)
+          if ! grep -q "update-tmp" "$CHECKER"; then
+            echo "FAIL: Missing atomic binary replacement (.update-tmp pattern)"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "PASS: Atomic binary replacement pattern present"
+          fi
+
+          # 6. WaitDelay for pipe cleanup
+          if ! grep -q "WaitDelay" "$CHECKER"; then
+            echo "FAIL: Missing cmd.WaitDelay for pipe cleanup after timeout"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "PASS: WaitDelay for pipe cleanup present"
+          fi
+
+          # 7. exitFunc injection for testability
+          if ! grep -q "exitFunc" "$CHECKER"; then
+            echo "FAIL: Missing exitFunc injection (needed for testing restart path)"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "PASS: exitFunc injection present"
+          fi
+
+          # 8. runBuildCmd helper with timeout+heartbeat
+          if ! grep -q "func.*runBuildCmd" "$CHECKER"; then
+            echo "FAIL: Missing runBuildCmd helper"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "PASS: runBuildCmd helper present"
+          fi
+
+          # 9. Rollback functions
+          if ! grep -q "rollbackGit" "$CHECKER"; then
+            echo "FAIL: Missing rollbackGit function"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "PASS: rollbackGit function present"
+          fi
+
+          # 10. Frontend stale detection (check TypeScript)
+          TS_FILE="web/src/hooks/useUpdateProgress.ts"
+          if ! grep -q "STALE_UPDATE_TIMEOUT_MS" "$TS_FILE"; then
+            echo "FAIL: Missing stale-state detection in frontend"
+            ERRORS=$((ERRORS + 1))
+          else
+            echo "PASS: Frontend stale-state detection present"
+          fi
+
+          echo ""
+          if [ $ERRORS -gt 0 ]; then
+            echo "FAILED: $ERRORS invariant violations found"
+            exit 1
+          else
+            echo "All update mechanism invariants verified"
+          fi

--- a/pkg/agent/update_checker_test.go
+++ b/pkg/agent/update_checker_test.go
@@ -310,11 +310,11 @@ func newTestUpdateChecker(t *testing.T, repoPath string) (*UpdateChecker, *[]Upd
 	return uc, &broadcasts
 }
 
-// TestDeveloperUpdateLoop_10x runs the full 7-step developer update 10 times
-// in a row, verifying each iteration completes all steps successfully,
-// progress increases monotonically, and the correct broadcast sequence is emitted.
-// This is the primary CI reliability test for the self-update mechanism.
-func TestDeveloperUpdateLoop_10x(t *testing.T) {
+// developerUpdateLoop runs the full 7-step developer update N times in a row,
+// verifying each iteration completes all steps successfully, progress increases
+// monotonically, and the correct broadcast sequence is emitted.
+func developerUpdateLoop(t *testing.T, iterations int) {
+	t.Helper()
 	if testing.Short() {
 		t.Skip("skipping update loop test in short mode")
 	}
@@ -322,8 +322,6 @@ func TestDeveloperUpdateLoop_10x(t *testing.T) {
 	mockBin := setupMockBin(t)
 	repoPath := setupFakeRepo(t)
 	t.Setenv("PATH", mockBin+":"+os.Getenv("PATH"))
-
-	const iterations = 10
 
 	for i := 1; i <= iterations; i++ {
 		t.Run(fmt.Sprintf("iteration_%d", i), func(t *testing.T) {
@@ -395,6 +393,20 @@ func TestDeveloperUpdateLoop_10x(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDeveloperUpdateLoop_5x runs the developer update 5 times — used by CI
+// guard workflow on every PR touching update code.
+func TestDeveloperUpdateLoop_5x(t *testing.T) {
+	const ciIterations = 5
+	developerUpdateLoop(t, ciIterations)
+}
+
+// TestDeveloperUpdateLoop_10x runs the developer update 10 times — used by
+// nightly for deeper reliability verification.
+func TestDeveloperUpdateLoop_10x(t *testing.T) {
+	const nightlyIterations = 10
+	developerUpdateLoop(t, nightlyIterations)
 }
 
 // TestDeveloperUpdate_BuildTimeout verifies that builds are killed after the

--- a/scripts/update-lifecycle-test.sh
+++ b/scripts/update-lifecycle-test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Update mechanism verification — runs Go unit tests for the update checker
-# to verify version parsing, channel switching, concurrent update rejection,
-# and status reporting.
+# Update mechanism verification — comprehensive test suite for the self-update
+# lifecycle: concurrency safety, panic recovery, build timeouts, failure
+# handling, npm retry logic, heartbeat, output capture, and source invariants.
 #
 # Usage:
 #   ./scripts/update-lifecycle-test.sh              # Run all update tests
@@ -127,7 +127,151 @@ fi
 echo ""
 
 # ============================================================================
-# Phase 4: Verify update checker source patterns
+# Phase 4: 5-iteration developer update reliability loop
+# ============================================================================
+
+echo -e "${BOLD}Phase 4: Developer update reliability loop (5 iterations)${NC}"
+
+LOOP_OUTPUT="$TMPDIR_UL/loop-tests.txt"
+LOOP_EXIT=0
+go test ./pkg/agent/... -run "TestDeveloperUpdateLoop_5x" -v -timeout 120s > "$LOOP_OUTPUT" 2>&1 || LOOP_EXIT=$?
+
+TOTAL=$((TOTAL + 1))
+if [ "$LOOP_EXIT" -eq 0 ]; then
+  echo -e "  ${GREEN}✓${NC}  5-iteration reliability loop passed"
+  PASSED=$((PASSED + 1))
+else
+  echo -e "  ${RED}❌${NC} 5-iteration reliability loop failed"
+  grep "FAIL\|Error" "$LOOP_OUTPUT" 2>/dev/null | head -5 | while IFS= read -r line; do
+    echo -e "    ${DIM}${line}${NC}"
+  done
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+
+# ============================================================================
+# Phase 5: Build timeout handling
+# ============================================================================
+
+echo -e "${BOLD}Phase 5: Build timeout handling${NC}"
+
+TIMEOUT_OUTPUT="$TMPDIR_UL/timeout-tests.txt"
+TIMEOUT_EXIT=0
+go test ./pkg/agent/... -run "TestDeveloperUpdate_BuildTimeout" -v -timeout 30s > "$TIMEOUT_OUTPUT" 2>&1 || TIMEOUT_EXIT=$?
+
+TOTAL=$((TOTAL + 1))
+if [ "$TIMEOUT_EXIT" -eq 0 ]; then
+  echo -e "  ${GREEN}✓${NC}  Build timeout handling passed"
+  PASSED=$((PASSED + 1))
+else
+  echo -e "  ${RED}❌${NC} Build timeout handling failed"
+  grep "FAIL\|Error" "$TIMEOUT_OUTPUT" 2>/dev/null | head -5 | while IFS= read -r line; do
+    echo -e "    ${DIM}${line}${NC}"
+  done
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+
+# ============================================================================
+# Phase 6: Build failure with output capture
+# ============================================================================
+
+echo -e "${BOLD}Phase 6: Build failure with output capture${NC}"
+
+BUILDFAIL_OUTPUT="$TMPDIR_UL/buildfail-tests.txt"
+BUILDFAIL_EXIT=0
+go test ./pkg/agent/... -run "TestDeveloperUpdate_BuildFailure" -v -timeout 30s > "$BUILDFAIL_OUTPUT" 2>&1 || BUILDFAIL_EXIT=$?
+
+TOTAL=$((TOTAL + 1))
+if [ "$BUILDFAIL_EXIT" -eq 0 ]; then
+  echo -e "  ${GREEN}✓${NC}  Build failure output capture passed"
+  PASSED=$((PASSED + 1))
+else
+  echo -e "  ${RED}❌${NC} Build failure output capture failed"
+  grep "FAIL\|Error" "$BUILDFAIL_OUTPUT" 2>/dev/null | head -5 | while IFS= read -r line; do
+    echo -e "    ${DIM}${line}${NC}"
+  done
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+
+# ============================================================================
+# Phase 7: npm install retry logic
+# ============================================================================
+
+echo -e "${BOLD}Phase 7: npm install retry logic${NC}"
+
+RETRY_OUTPUT="$TMPDIR_UL/retry-tests.txt"
+RETRY_EXIT=0
+go test ./pkg/agent/... -run "TestDeveloperUpdate_NpmInstallRetry" -v -timeout 30s > "$RETRY_OUTPUT" 2>&1 || RETRY_EXIT=$?
+
+TOTAL=$((TOTAL + 1))
+if [ "$RETRY_EXIT" -eq 0 ]; then
+  echo -e "  ${GREEN}✓${NC}  npm install retry logic passed"
+  PASSED=$((PASSED + 1))
+else
+  echo -e "  ${RED}❌${NC} npm install retry logic failed"
+  grep "FAIL\|Error" "$RETRY_OUTPUT" 2>/dev/null | head -5 | while IFS= read -r line; do
+    echo -e "    ${DIM}${line}${NC}"
+  done
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+
+# ============================================================================
+# Phase 8: Heartbeat during long builds
+# ============================================================================
+
+echo -e "${BOLD}Phase 8: Heartbeat during long builds${NC}"
+
+HEARTBEAT_OUTPUT="$TMPDIR_UL/heartbeat-tests.txt"
+HEARTBEAT_EXIT=0
+go test ./pkg/agent/... -run "TestDeveloperUpdate_HeartbeatDuringBuild" -v -timeout 120s > "$HEARTBEAT_OUTPUT" 2>&1 || HEARTBEAT_EXIT=$?
+
+TOTAL=$((TOTAL + 1))
+if [ "$HEARTBEAT_EXIT" -eq 0 ]; then
+  echo -e "  ${GREEN}✓${NC}  Heartbeat during long builds passed"
+  PASSED=$((PASSED + 1))
+else
+  echo -e "  ${RED}❌${NC} Heartbeat during long builds failed"
+  grep "FAIL\|Error" "$HEARTBEAT_OUTPUT" 2>/dev/null | head -5 | while IFS= read -r line; do
+    echo -e "    ${DIM}${line}${NC}"
+  done
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+
+# ============================================================================
+# Phase 9: Output capture utilities
+# ============================================================================
+
+echo -e "${BOLD}Phase 9: Output capture and utility tests${NC}"
+
+UTIL_OUTPUT="$TMPDIR_UL/util-tests.txt"
+UTIL_EXIT=0
+go test ./pkg/agent/... -run "TestRunBuildCmd_OutputCapture|TestTailLines|TestBuildErrorDetail|TestMockPathResolution" -v -timeout 30s > "$UTIL_OUTPUT" 2>&1 || UTIL_EXIT=$?
+
+TOTAL=$((TOTAL + 1))
+if [ "$UTIL_EXIT" -eq 0 ]; then
+  echo -e "  ${GREEN}✓${NC}  Output capture and utility tests passed"
+  PASSED=$((PASSED + 1))
+else
+  echo -e "  ${RED}❌${NC} Output capture and utility tests failed"
+  grep "FAIL\|Error" "$UTIL_OUTPUT" 2>/dev/null | head -5 | while IFS= read -r line; do
+    echo -e "    ${DIM}${line}${NC}"
+  done
+  FAILED=$((FAILED + 1))
+fi
+
+echo ""
+
+# ============================================================================
+# Phase 10: Verify update checker source patterns
 # ============================================================================
 
 echo -e "${BOLD}Phase 4: Update mechanism source verification${NC}"
@@ -178,7 +322,13 @@ cat > "$REPORT_JSON" << EOF
   "phases": {
     "unitTests": { "exit_code": ${TEST_EXIT}, "passed": ${GO_PASSED} },
     "stressTest": { "exit_code": ${STRESS_EXIT} },
-    "panicRecovery": { "exit_code": ${PANIC_EXIT} }
+    "panicRecovery": { "exit_code": ${PANIC_EXIT} },
+    "reliabilityLoop": { "exit_code": ${LOOP_EXIT} },
+    "buildTimeout": { "exit_code": ${TIMEOUT_EXIT} },
+    "buildFailure": { "exit_code": ${BUILDFAIL_EXIT} },
+    "npmRetry": { "exit_code": ${RETRY_EXIT} },
+    "heartbeat": { "exit_code": ${HEARTBEAT_EXIT} },
+    "utilities": { "exit_code": ${UTIL_EXIT} }
   }
 }
 EOF
@@ -201,7 +351,13 @@ cat > "$REPORT_MD" << EOF
 - **Phase 1:** Update checker unit tests — $([ "$TEST_EXIT" -eq 0 ] && echo "PASS" || echo "FAIL")
 - **Phase 2:** Concurrent rejection stress — $([ "$STRESS_EXIT" -eq 0 ] && echo "PASS" || echo "FAIL")
 - **Phase 3:** Panic recovery — $([ "$PANIC_EXIT" -eq 0 ] && echo "PASS" || echo "FAIL")
-- **Phase 4:** Source pattern verification
+- **Phase 4:** 5x reliability loop — $([ "$LOOP_EXIT" -eq 0 ] && echo "PASS" || echo "FAIL")
+- **Phase 5:** Build timeout — $([ "$TIMEOUT_EXIT" -eq 0 ] && echo "PASS" || echo "FAIL")
+- **Phase 6:** Build failure capture — $([ "$BUILDFAIL_EXIT" -eq 0 ] && echo "PASS" || echo "FAIL")
+- **Phase 7:** npm retry — $([ "$RETRY_EXIT" -eq 0 ] && echo "PASS" || echo "FAIL")
+- **Phase 8:** Heartbeat — $([ "$HEARTBEAT_EXIT" -eq 0 ] && echo "PASS" || echo "FAIL")
+- **Phase 9:** Utilities — $([ "$UTIL_EXIT" -eq 0 ] && echo "PASS" || echo "FAIL")
+- **Phase 10:** Source pattern verification
 EOF
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/update-guard.yml` — a CI workflow that runs on every PR touching update-related files (`update_checker.go`, `update_checker_test.go`, `server.go`, `useUpdateProgress.ts`, `startup-oauth.sh`, `update-lifecycle-test.sh`)
- Runs the 5-iteration developer update reliability loop, build timeout handling, build failure capture, npm retry logic, heartbeat verification, output capture utilities, concurrency safety (3x), and source invariant verification
- Expands `scripts/update-lifecycle-test.sh` from 4 to 10 phases, adding integration tests for timeout, failure, retry, heartbeat, output capture, and reliability loop
- Adds `TestDeveloperUpdateLoop_5x` (CI, faster) alongside existing `TestDeveloperUpdateLoop_10x` (nightly, deeper)

## Why

PR #2056 fixed a stuck self-update issue. This CI guard ensures no future PR can regress the update mechanism — every PR touching update code must pass the full test suite.

## Test plan

- [ ] CI workflow triggers on this PR (touches `update-lifecycle-test.sh` and `update_checker_test.go`)
- [ ] All update mechanism tests pass in CI
- [ ] Source invariant checks pass (atomic CAS, defer cleanup, timeouts, heartbeat, WaitDelay, exitFunc, rollback, stale detection)
- [ ] Nightly `run-all-tests.sh` still includes expanded `update-lifecycle-test.sh`