### PR TITLE
✨ Add GA4 telemetry for detected coding agent providers

### DIFF
--- a/pkg/agent/protocol/messages.go
+++ b/pkg/agent/protocol/messages.go
@@ -33,12 +33,20 @@ type Message struct {
 
 // HealthPayload is the response for health checks
 type HealthPayload struct {
-	Status        string      `json:"status"`
-	Version       string      `json:"version"`
-	Clusters      int         `json:"clusters"`
-	HasClaude     bool        `json:"hasClaude"`
-	Claude        *ClaudeInfo `json:"claude,omitempty"`
-	InstallMethod string      `json:"install_method,omitempty"`
+	Status             string            `json:"status"`
+	Version            string            `json:"version"`
+	Clusters           int               `json:"clusters"`
+	HasClaude          bool              `json:"hasClaude"`
+	Claude             *ClaudeInfo       `json:"claude,omitempty"`
+	InstallMethod      string            `json:"install_method,omitempty"`
+	AvailableProviders []ProviderSummary `json:"availableProviders,omitempty"`
+}
+
+// ProviderSummary is a lightweight view of a detected AI provider for telemetry
+type ProviderSummary struct {
+	Name         string `json:"name"`
+	DisplayName  string `json:"displayName"`
+	Capabilities int    `json:"capabilities"` // bitmask: 1=chat, 2=toolExec
 }
 
 // ClaudeInfo contains information about the local Claude Code installation

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -446,13 +446,24 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	clusters, _ := s.kubectl.ListContexts()
 	hasClaude := s.checkClaudeAvailable()
 
+	// Build lightweight provider summaries for telemetry
+	var providerSummaries []protocol.ProviderSummary
+	for _, p := range s.registry.ListAvailable() {
+		providerSummaries = append(providerSummaries, protocol.ProviderSummary{
+			Name:         p.Name,
+			DisplayName:  p.DisplayName,
+			Capabilities: p.Capabilities,
+		})
+	}
+
 	payload := protocol.HealthPayload{
-		Status:        "ok",
-		Version:       Version,
-		Clusters:      len(clusters),
-		HasClaude:     hasClaude,
-		Claude:        s.getClaudeInfo(),
-		InstallMethod: detectAgentInstallMethod(),
+		Status:             "ok",
+		Version:            Version,
+		Clusters:           len(clusters),
+		HasClaude:          hasClaude,
+		Claude:             s.getClaudeInfo(),
+		InstallMethod:      detectAgentInstallMethod(),
+		AvailableProviders: providerSummaries,
 	}
 
 	json.NewEncoder(w).Encode(payload)

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -2,9 +2,15 @@ import { useState, useEffect, useCallback } from 'react'
 import { isDemoModeForced } from './useDemoMode'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, TRANSITION_DELAY_MS } from '../lib/constants/network'
-import { emitAgentConnected, emitAgentDisconnected, emitConversionStep } from '../lib/analytics'
+import { emitAgentConnected, emitAgentDisconnected, emitAgentProvidersDetected, emitConversionStep } from '../lib/analytics'
 import { safeGetItem, safeSetItem } from '../lib/utils/localStorage'
 import { STORAGE_KEY_FIRST_AGENT_CONNECT } from '../lib/constants/storage'
+
+export interface ProviderSummary {
+  name: string
+  displayName: string
+  capabilities: number // bitmask: 1=chat, 2=toolExec
+}
 
 export interface AgentHealth {
   status: string
@@ -12,6 +18,7 @@ export interface AgentHealth {
   clusters: number
   hasClaude: boolean
   install_method?: string
+  availableProviders?: ProviderSummary[]
   claude?: {
     installed: boolean
     path?: string
@@ -228,6 +235,7 @@ class AgentManager {
             error: null,
           })
           emitAgentConnected(data.version || 'unknown', data.clusters || 0)
+          emitAgentProvidersDetected(data.availableProviders || [])
         } else if (wasConnecting) {
           // Initial connection - connect immediately on first success
           this.addEvent('connected', `Connected to local agent v${data.version || 'unknown'}`)
@@ -238,6 +246,7 @@ class AgentManager {
             error: null,
           })
           emitAgentConnected(data.version || 'unknown', data.clusters || 0)
+          emitAgentProvidersDetected(data.availableProviders || [])
           // Stamp the first-ever agent connection for time-based nudges
           if (!safeGetItem(STORAGE_KEY_FIRST_AGENT_CONNECT)) {
             safeSetItem(STORAGE_KEY_FIRST_AGENT_CONNECT, String(Date.now()))

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -622,6 +622,44 @@ export function emitAgentDisconnected() {
   send('ksc_agent_disconnected')
 }
 
+// ── Agent Provider Detection ────────────────────────────────────
+// Emitted once per agent connection to track which coding agent CLIs
+// and API keys are configured on the user's machine.
+
+/** Capability bitmask values matching Go ProviderCapability constants */
+const CAPABILITY_CHAT = 1
+const CAPABILITY_TOOL_EXEC = 2
+
+interface ProviderSummary {
+  name: string
+  displayName: string
+  capabilities: number
+}
+
+/**
+ * Fired when kc-agent connects with the list of available AI providers.
+ * Categorizes providers into CLI (tool-exec capable) and API (chat-only)
+ * so GA4 reports show which coding agents users have installed.
+ */
+export function emitAgentProvidersDetected(providers: ProviderSummary[]) {
+  if (!providers || providers.length === 0) return
+
+  const cliProviders = (providers || [])
+    .filter(p => (p.capabilities & CAPABILITY_TOOL_EXEC) !== 0)
+    .map(p => p.name)
+  const apiProviders = (providers || [])
+    .filter(p => (p.capabilities & CAPABILITY_TOOL_EXEC) === 0 && (p.capabilities & CAPABILITY_CHAT) !== 0)
+    .map(p => p.name)
+
+  send('ksc_agent_providers_detected', {
+    provider_count: providers.length,
+    cli_providers: cliProviders.join(',') || 'none',
+    api_providers: apiProviders.join(',') || 'none',
+    cli_count: cliProviders.length,
+    api_count: apiProviders.length,
+  })
+}
+
 // ── API Key Configuration ───────────────────────────────────────
 
 export function emitApiKeyConfigured(provider: string) {


### PR DESCRIPTION
## Summary
- Adds `availableProviders` field to the `/health` endpoint response, containing each detected provider's name, display name, and capability bitmask
- Emits new `ksc_agent_providers_detected` GA4 event on every agent connect/reconnect with:
  - `cli_providers` — comma-joined names of tool-exec capable agents (Claude Code, Codex, Copilot CLI, etc.)
  - `api_providers` — comma-joined names of chat-only API agents (OpenAI, Anthropic, Google, etc.)
  - `cli_count` / `api_count` — numeric counts per category
  - `provider_count` — total available providers

## Motivation
We had no visibility into which coding agent CLIs and API keys users have configured when running kc-agent locally. This data helps us understand the developer tooling landscape of our user base and prioritize provider integrations.

## Files changed
- `pkg/agent/protocol/messages.go` — Add `ProviderSummary` type and `AvailableProviders` field to `HealthPayload`
- `pkg/agent/server.go` — Populate `AvailableProviders` from `registry.ListAvailable()` in health handler
- `web/src/lib/analytics.ts` — Add `emitAgentProvidersDetected()` function
- `web/src/hooks/useLocalAgent.ts` — Add `ProviderSummary` interface to `AgentHealth`, emit event on connect

## Test plan
- [ ] Run kc-agent locally, verify `/health` returns `availableProviders` array
- [ ] Open console in browser, verify `ksc_agent_providers_detected` fires in GA4 debug view
- [ ] Verify event contains correct `cli_providers` and `api_providers` values
- [ ] Verify no event fires when no providers are available (empty array)
- [ ] Build passes (`go build ./...` + `npm run build`)