### PR TITLE
🐛 Fix update settings stall and OAuth spinner

### DIFF
--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -328,6 +328,12 @@ func (uc *UpdateChecker) checkDeveloperChannel() {
 	}
 
 	if latestSHA == currentSHA || currentSHA == "" {
+		log.Printf("[AutoUpdate] Already up to date (%s), no update needed", short(currentSHA))
+		uc.broadcast("update_progress", UpdateProgressPayload{
+			Status:   "done",
+			Message:  "Already up to date — no changes on main",
+			Progress: 100,
+		})
 		return
 	}
 
@@ -640,6 +646,12 @@ func (uc *UpdateChecker) checkReleaseChannel(channel string) {
 	}
 
 	if latest == nil || latest.TagName == currentVersion {
+		log.Printf("[AutoUpdate] Already on latest %s release (%s)", channel, currentVersion)
+		uc.broadcast("update_progress", UpdateProgressPayload{
+			Status:   "done",
+			Message:  fmt.Sprintf("Already up to date — running latest %s release", channel),
+			Progress: 100,
+		})
 		return
 	}
 

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -26,7 +26,7 @@ import {
 import { useVersionCheck } from '../../hooks/useVersionCheck'
 import { useUpdateProgress } from '../../hooks/useUpdateProgress'
 import { Button } from '../ui/Button'
-import { checkOAuthConfigured } from '../../lib/api'
+import { useAuth } from '../../lib/auth'
 import { STORAGE_KEY_GITHUB_TOKEN } from '../../lib/constants'
 import type { UpdateChannel } from '../../types/updates'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
@@ -41,11 +41,11 @@ const INITIAL_PROGRESS_PCT = 5
 /** Estimated total update duration in seconds (pull + install + build + restart) */
 const ESTIMATED_UPDATE_SECS = 180
 
+/** Timeout (ms) for the trigger to receive a WebSocket progress message before auto-failing */
+const TRIGGER_STALL_TIMEOUT_MS = 30_000
+
 /** Countdown tick interval in milliseconds */
 const COUNTDOWN_TICK_MS = 1000
-
-/** Retry interval (ms) when polling OAuth status while backend is starting */
-const OAUTH_RETRY_MS = 5000
 
 /** Scroll to a settings section by ID (mirrors Settings.tsx logic) */
 function scrollToSettingsSection(sectionId: string) {
@@ -87,6 +87,10 @@ export function UpdateSettings() {
   // WebSocket-driven update progress from kc-agent
   const { progress: updateProgress, stepHistory, dismiss: dismissProgress } = useUpdateProgress()
 
+  // OAuth is configured if the user is authenticated (no backend call needed)
+  const { isAuthenticated } = useAuth()
+  const oauthConfigured = isAuthenticated
+
   const CHANNEL_OPTIONS: { value: UpdateChannel; label: string; description: string; devOnly?: boolean }[] = [
     {
       value: 'stable',
@@ -114,7 +118,6 @@ export function UpdateSettings() {
   const [showReleaseNotes, setShowReleaseNotes] = useState(false)
   const [copiedCommand, setCopiedCommand] = useState<string | null>(null)
   const [channelDropdownOpen, setChannelDropdownOpen] = useState(false)
-  const [oauthConfigured, setOauthConfigured] = useState<boolean | null>(null)
   const [triggerState, setTriggerState] = useState<'idle' | 'triggered' | 'error'>('idle')
   const [triggerError, setTriggerError] = useState<string | null>(null)
   const [countdown, setCountdown] = useState(ESTIMATED_UPDATE_SECS)
@@ -163,22 +166,19 @@ export function UpdateSettings() {
     }
   }, [updateProgress, triggerState])
 
-  // Fetch OAuth status on mount — retry if backend was down
+  // Auto-fail the triggered state if no WebSocket progress arrives within timeout.
+  // This prevents the UI from being stuck forever on "Starting update — please wait..."
+  // when kc-agent accepts the trigger but never sends progress messages (e.g. no update needed).
   useEffect(() => {
-    let retryTimer: ReturnType<typeof setTimeout>
-    function check() {
-      checkOAuthConfigured().then(({ backendUp, oauthConfigured: configured }) => {
-        if (backendUp) {
-          setOauthConfigured(configured)
-        } else {
-          // Backend not ready yet — retry in 5s
-          retryTimer = setTimeout(check, OAUTH_RETRY_MS)
-        }
-      })
-    }
-    check()
-    return () => clearTimeout(retryTimer)
-  }, [])
+    if (triggerState !== 'triggered') return
+    const timer = setTimeout(() => {
+      setTriggerState('error')
+      setTriggerError('No response from kc-agent — the update may not have started. Check if an update is actually available.')
+      triggerGuardRef.current = false
+    }, TRIGGER_STALL_TIMEOUT_MS)
+    return () => clearTimeout(timer)
+  }, [triggerState])
+
 
   // Re-check GitHub token when settings change (e.g. env token auto-detected by GitHubTokenSection)
   useEffect(() => {
@@ -356,8 +356,7 @@ export function UpdateSettings() {
               icon={<Bot className="w-3.5 h-3.5" />}
             />
             <PrereqRow
-              ok={oauthConfigured === true}
-              loading={oauthConfigured === null}
+              ok={oauthConfigured}
               label={t('settings.updates.prereqOAuth')}
               okText={t('settings.updates.prereqOAuthOk')}
               failText={t('settings.updates.prereqOAuthFail')}
@@ -385,7 +384,7 @@ export function UpdateSettings() {
             const checks = [
               agentConnected,
               hasCodingAgent,
-              oauthConfigured === true,
+              oauthConfigured,
               hasGithubToken,
               installMethod === 'dev',
             ]

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -322,6 +322,8 @@ function useVersionCheckCore() {
         const data = (await resp.json()) as AutoUpdateStatus
         console.debug('[version-check] Auto-update status:', data)
         setAutoUpdateStatus(data)
+        // Clear any stale error from a previous failed check
+        setError(null)
         // Update latestMainSHA and lastChecked from agent response
         if (data.latestSHA) {
           setLatestMainSHA(data.latestSHA)


### PR DESCRIPTION
## Summary
- **Backend**: kc-agent now broadcasts "Already up to date" WebSocket message when trigger finds no update, instead of silently returning — prevents the frontend from being stuck forever on "Starting update — please wait..."
- **Frontend**: 30-second stall timeout auto-fails the triggered state if no WebSocket progress arrives
- **Frontend**: OAuth prereq check replaced with instant `useAuth().isAuthenticated` — no more infinite retry loop polling the Go backend
- **Frontend**: `fetchAutoUpdateStatus` clears stale errors on success (fixes persistent "Could not reach kc-agent" after recovery)

## Test plan
- [x] `npm run build` — no type errors
- [x] `go build ./...` — no errors
- [x] `npx playwright test UpdateSettings.spec.ts --project=chromium` — 9/9 pass
- [x] Manual CDP test: OAuth shows "Configured" instantly, no spinner
- [x] Manual CDP test: no stale session false positive after refresh