### PR TITLE
🌱 Remove parentheses from sidebar card counts

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -311,7 +311,7 @@ export function Sidebar() {
                 <span className="flex-1 min-w-0">
                   {item.name}
                   {count != null && (
-                    <span className="text-[10px] text-muted-foreground/40 tabular-nums ml-1">({count})</span>
+                    <span className="text-[10px] text-muted-foreground/40 tabular-nums ml-1">{count}</span>
                   )}
                 </span>
               )


### PR DESCRIPTION
## Summary
- Drop parentheses from inline card counts: `Dashboard 11` instead of `Dashboard (11)`

## Test plan
- [ ] Sidebar shows counts without parentheses