### PR TITLE
🐛 Fix insight enrichment retry spam and OPA cache TTL

### DIFF
--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -16,8 +16,8 @@ import { PolicyDetailModal, ClusterOPAModal, CreatePolicyModal } from './opa'
 import type { Policy, GatekeeperStatus, OPAClusterItem } from './opa'
 import { useDemoMode } from '../../hooks/useDemoMode'
 
-/** Cache TTL: 60 minutes — OPA installation status rarely changes */
-const CACHE_TTL_MS = 60 * 60 * 1000
+/** Cache TTL: 5 minutes — short enough to pick up connectivity changes */
+const CACHE_TTL_MS = 5 * 60 * 1000
 
 // Sort options for clusters
 type SortByOption = 'name' | 'violations' | 'policies'
@@ -789,6 +789,11 @@ Let's start by discussing what kind of policy I need.`,
                         </>
                       )}
                     </div>
+                  </div>
+                ) : status?.error ? (
+                  <div className="flex items-center gap-1 text-xs text-yellow-400/70">
+                    <AlertTriangle className="w-3 h-3" />
+                    <span>{status.error}</span>
                   </div>
                 ) : (
                   <div className="flex items-center justify-between">

--- a/web/src/hooks/useInsightEnrichment.ts
+++ b/web/src/hooks/useInsightEnrichment.ts
@@ -28,15 +28,22 @@ const ENRICHMENT_TIMEOUT_MS = 15_000
 /** Cache TTL for enrichments (5 minutes) */
 const ENRICHMENT_CACHE_TTL_MS = 5 * 60_000
 
-/** WebSocket reconnect delay (5 seconds) */
-const WS_RECONNECT_DELAY_MS = 5_000
+/** Base WebSocket reconnect delay (5 seconds) */
+const WS_BASE_RECONNECT_DELAY_MS = 5_000
+/** Maximum WebSocket reconnect delay (2 minutes) */
+const WS_MAX_RECONNECT_DELAY_MS = 2 * 60_000
+/** Maximum WebSocket reconnect attempts before giving up */
+const MAX_WS_RECONNECT_ATTEMPTS = 5
 
 // ── Singleton state ──────────────────────────────────────────────────────
 
-let enrichments: Map<string, AIInsightEnrichment> = new Map()
+const enrichments: Map<string, AIInsightEnrichment> = new Map()
 let lastEnrichmentTime = 0
 let lastRequestHash = ''
 let wsConnection: WebSocket | null = null
+let wsReconnectAttempts = 0
+/** Set to false after receiving 404 — endpoint doesn't exist */
+let enrichmentEndpointAvailable = true
 const subscribers = new Set<() => void>()
 
 function notifySubscribers() {
@@ -59,6 +66,7 @@ function isCacheValid(): boolean {
 /** Request AI enrichment from agent */
 async function requestEnrichment(insights: MultiClusterInsight[]): Promise<void> {
   if (!isAgentConnected() || isAgentUnavailable()) return
+  if (!enrichmentEndpointAvailable) return
   if (insights.length === 0) return
 
   const hash = hashInsights(insights)
@@ -96,6 +104,9 @@ async function requestEnrichment(insights: MultiClusterInsight[]): Promise<void>
     if (response.ok) {
       const data = (await response.json()) as InsightEnrichmentResponse
       applyEnrichments(data.enrichments)
+    } else if (response.status === 404) {
+      // Endpoint not implemented — stop retrying until next page load
+      enrichmentEndpointAvailable = false
     }
   } catch {
     // Silently fail — heuristic insights remain unchanged
@@ -119,9 +130,16 @@ function applyEnrichments(newEnrichments: AIInsightEnrichment[]): void {
 function connectWebSocket(): void {
   if (wsConnection) return
   if (!isAgentConnected() || isAgentUnavailable()) return
+  if (wsReconnectAttempts >= MAX_WS_RECONNECT_ATTEMPTS) return
 
   try {
-    wsConnection = new WebSocket(`${LOCAL_AGENT_WS_URL}/ws`)
+    // LOCAL_AGENT_WS_URL already includes /ws — don't append it again
+    wsConnection = new WebSocket(LOCAL_AGENT_WS_URL)
+
+    wsConnection.onopen = () => {
+      // Reset backoff on successful connection
+      wsReconnectAttempts = 0
+    }
 
     wsConnection.onmessage = (event) => {
       try {
@@ -136,10 +154,16 @@ function connectWebSocket(): void {
 
     wsConnection.onclose = () => {
       wsConnection = null
-      // Reconnect after delay if agent is still connected
-      if (isAgentConnected() && !isAgentUnavailable()) {
-        setTimeout(connectWebSocket, WS_RECONNECT_DELAY_MS)
-      }
+      wsReconnectAttempts++
+      if (wsReconnectAttempts >= MAX_WS_RECONNECT_ATTEMPTS) return
+      if (!isAgentConnected() || isAgentUnavailable()) return
+
+      // Exponential backoff: 5s, 10s, 20s, 40s, 80s (capped at 2 min)
+      const delay = Math.min(
+        WS_BASE_RECONNECT_DELAY_MS * Math.pow(2, wsReconnectAttempts - 1),
+        WS_MAX_RECONNECT_DELAY_MS,
+      )
+      setTimeout(connectWebSocket, delay)
     }
 
     wsConnection.onerror = () => {


### PR DESCRIPTION
## Summary
- **Fix double `/ws` in WebSocket URL**: `useInsightEnrichment` was connecting to `ws://127.0.0.1:8585/ws/ws` (appending `/ws` to `LOCAL_AGENT_WS_URL` which already includes it), causing every connection to fail
- **Add exponential backoff to WebSocket reconnect**: Previously reconnected every 5 seconds forever; now uses exponential backoff (5s→10s→20s→40s→80s) with max 5 attempts
- **Stop retrying HTTP after 404**: When `/insights/enrich` returns 404, mark endpoint unavailable instead of retrying every time insights change
- **Reduce OPA cache TTL**: 60 min → 5 min so connectivity changes are detected faster
- **Show "Connection failed" for unreachable clusters**: Instead of misleading "Not installed" when OPA check fails due to network timeout

## Test plan
- [ ] Navigate to Cluster Admin dashboard — should load without console spam
- [ ] Check browser console — no infinite `POST 127.0.0.1:8585/insights/enrich 404` or WebSocket failures
- [ ] OPA card shows "Connection failed" for offline clusters, not "Not installed"
- [ ] After 5 minutes, OPA statuses are re-checked (not cached for 60 min)