### PR TITLE
✨ Add /mcp/workloads/stream SSE endpoint for progressive loading

### DIFF
--- a/pkg/api/handlers/demo_data.go
+++ b/pkg/api/handlers/demo_data.go
@@ -1,7 +1,10 @@
 package handlers
 
 import (
+	"time"
+
 	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/api/v1alpha1"
 	"github.com/kubestellar/console/pkg/k8s"
 )
 
@@ -458,6 +461,17 @@ func getWasmCloudActors() []fiber.Map {
 			"capabilities": []string{"wasmcloud:logging"},
 			"status":       "failed",
 		},
+	}
+}
+
+// getDemoWorkloads returns demo workload data for SSE streaming in demo mode
+func getDemoWorkloads() []v1alpha1.Workload {
+	now := time.Now()
+	return []v1alpha1.Workload{
+		{Name: "nginx-ingress", Namespace: "ingress-system", Type: "Deployment", Status: "Running", Replicas: 3, ReadyReplicas: 3, Image: "nginx/nginx-ingress:3.4.0", Labels: map[string]string{"app": "nginx-ingress"}, CreatedAt: now.Add(-30 * 24 * time.Hour)},
+		{Name: "api-gateway", Namespace: "production", Type: "Deployment", Status: "Degraded", Replicas: 5, ReadyReplicas: 3, Image: "company/api-gateway:v2.5.1", Labels: map[string]string{"app": "api-gateway"}, CreatedAt: now.Add(-14 * 24 * time.Hour)},
+		{Name: "redis-cluster", Namespace: "data", Type: "StatefulSet", Status: "Running", Replicas: 3, ReadyReplicas: 3, Image: "redis:7.2-alpine", Labels: map[string]string{"app": "redis"}, CreatedAt: now.Add(-60 * 24 * time.Hour)},
+		{Name: "monitoring-agent", Namespace: "monitoring", Type: "DaemonSet", Status: "Running", Replicas: 4, ReadyReplicas: 4, Image: "prom/node-exporter:v1.7.0", Labels: map[string]string{"app": "node-exporter"}, CreatedAt: now.Add(-90 * 24 * time.Hour)},
 	}
 }
 

--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -506,6 +506,29 @@ func (h *MCPHandlers) GetSecretsStream(c *fiber.Ctx) error {
 	})
 }
 
+// GetWorkloadsStream streams workloads per cluster via SSE.
+func (h *MCPHandlers) GetWorkloadsStream(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return streamDemoSSE(c, "workloads", getDemoWorkloads())
+	}
+	if h.k8sClient == nil {
+		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
+	}
+
+	namespace := c.Query("namespace")
+	workloadType := c.Query("type")
+	return streamClusters(c, h, sseClusterStreamConfig{
+		demoKey:        "workloads",
+		clusterTimeout: ssePerClusterTimeout,
+	}, func(ctx context.Context, cluster string) (interface{}, error) {
+		workloads, err := h.k8sClient.ListWorkloadsForCluster(ctx, cluster, namespace, workloadType)
+		if err != nil {
+			return nil, err
+		}
+		return workloads, nil
+	})
+}
+
 // GetNVIDIAOperatorStatusStream streams NVIDIA operator status per cluster via SSE.
 func (h *MCPHandlers) GetNVIDIAOperatorStatusStream(c *fiber.Ctx) error {
 	if isDemoMode(c) {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -581,6 +581,7 @@ func (s *Server) setupRoutes() {
 	api.Get("/mcp/configmaps/stream", mcpHandlers.GetConfigMapsStream)
 	api.Get("/mcp/secrets/stream", mcpHandlers.GetSecretsStream)
 	api.Get("/mcp/nvidia-operators/stream", mcpHandlers.GetNVIDIAOperatorStatusStream)
+	api.Get("/mcp/workloads/stream", mcpHandlers.GetWorkloadsStream)
 
 	// GitOps routes (drift detection and sync)
 	// SECURITY: All GitOps routes require authentication in both dev and production modes

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -1418,35 +1418,12 @@ export function useCachedWorkloads(
       return []
     },
     progressiveFetcher: async (onProgress) => {
+      // Try agent first (progressive via kc-agent)
       const agentData = await fetchWorkloadsFromAgent(onProgress)
       if (agentData) return agentData
-      // REST fallback is not progressive (single response)
-      const token = getToken()
-      const hasRealToken = token && token !== 'demo-token'
-      if (hasRealToken && !isBackendUnavailable()) {
-        const res = await fetch('/api/workloads', {
-          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
-        })
-        if (res.ok) {
-          const data = await res.json()
-          const items = (data.items || data) as Array<Record<string, unknown>>
-          return items.map(d => ({
-            name: String(d.name || ''),
-            namespace: String(d.namespace || 'default'),
-            type: (String(d.type || 'Deployment')) as Workload['type'],
-            cluster: String(d.cluster || ''),
-            targetClusters: (d.targetClusters as string[]) || (d.cluster ? [String(d.cluster)] : []),
-            replicas: Number(d.replicas || 1),
-            readyReplicas: Number(d.readyReplicas || 0),
-            status: (String(d.status || 'Running')) as Workload['status'],
-            image: String(d.image || ''),
-            labels: (d.labels as Record<string, string>) || {},
-            createdAt: String(d.createdAt || new Date().toISOString()),
-          }))
-        }
-      }
-      return []
+
+      // Fall back to SSE streaming -> progressive per-cluster
+      return await fetchViaSSE<Workload>('workloads', 'workloads', {}, onProgress)
     },
   })
 


### PR DESCRIPTION
## Summary
- Adds `GetWorkloadsStream()` SSE handler using the `streamClusters()` pattern with `ListWorkloadsForCluster()`
- Registers `/mcp/workloads/stream` route supporting `namespace` and `type` query params
- Wires `useCachedWorkloads()` progressive fetcher to use `fetchViaSSE()` instead of blocking REST fallback
- Adds `getDemoWorkloads()` for demo mode SSE streaming

The Workloads card was blocking on a single bulk `/api/workloads` REST call that waited for ALL clusters to respond before rendering anything. Now workloads stream per-cluster via SSE, matching the pattern used by pods, deployments, services, nodes, etc.

## Test plan
- [ ] Verify workloads card loads progressively (data appears as each cluster responds)
- [ ] Verify demo mode still works (shows demo workloads)
- [ ] Verify namespace/type query params filter correctly
- [ ] Verify all other dashboards still load correctly