### PR TITLE
🐛 Fix small touch targets for mobile UI (WCAG 2.5.5)

### DIFF
--- a/web/src/components/cards/workload-detection/ProwHistory.tsx
+++ b/web/src/components/cards/workload-detection/ProwHistory.tsx
@@ -135,7 +135,7 @@ export function ProwHistory({ config: _config }: ProwHistoryProps) {
                 <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
                   <span>{job.duration}</span>
                   {job.url && (
-                    <a href={job.url} target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline flex items-center gap-1">
+                    <a href={job.url} target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline inline-flex items-center gap-1 min-h-11 py-1">
                       Logs <ExternalLink className="w-3 h-3" />
                     </a>
                   )}

--- a/web/src/components/cards/workload-detection/ProwJobs.tsx
+++ b/web/src/components/cards/workload-detection/ProwJobs.tsx
@@ -211,7 +211,7 @@ export function ProwJobs({ config: _config }: ProwJobsProps) {
               {job.pr && <span>PR: #{job.pr}</span>}
               <span>Duration: {job.duration}</span>
               {job.url && (
-                <a href={job.url} target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline flex items-center gap-1">
+                <a href={job.url} target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline inline-flex items-center gap-1 min-h-11 py-1">
                   Logs <ExternalLink className="w-3 h-3" />
                 </a>
               )}

--- a/web/src/components/cards/workload-detection/ProwStatus.tsx
+++ b/web/src/components/cards/workload-detection/ProwStatus.tsx
@@ -83,7 +83,7 @@ export function ProwStatus({ config: _config }: ProwStatusProps) {
 
       {/* Footer */}
       <div className="mt-4 pt-3 border-t border-border/50 text-xs text-muted-foreground">
-        <a href="https://prow2.kubestellar.io" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline flex items-center gap-1">
+        <a href="https://prow2.kubestellar.io" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline inline-flex items-center gap-1 min-h-11 py-1">
           Open Prow Dashboard <ExternalLink className="w-3 h-3" />
         </a>
       </div>

--- a/web/src/components/missions/ClusterSelectionDialog.tsx
+++ b/web/src/components/missions/ClusterSelectionDialog.tsx
@@ -48,7 +48,7 @@ export function ClusterSelectionDialog({ open, missionTitle, onSelect, onCancel 
             <h3 className="text-sm font-semibold text-foreground">Select Target Cluster</h3>
             <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-[320px]">{missionTitle}</p>
           </div>
-          <Button variant="ghost" onClick={onCancel} className="p-1 rounded-md" icon={<X className="w-4 h-4" />} />
+          <Button variant="ghost" onClick={onCancel} className="p-2 min-h-11 min-w-11 rounded-md" icon={<X className="w-4 h-4" />} />
         </div>
 
         {/* Cluster list */}

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -1295,8 +1295,8 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                         autoFocus
                         onKeyDown={(e) => { if (e.key === 'Escape') { setAddingRepo(false); setNewRepoValue('') } }}
                       />
-                      <button type="submit" className="p-1 text-xs text-green-400 hover:text-green-300"><CheckCircle className="w-3.5 h-3.5" /></button>
-                      <button type="button" onClick={() => { setAddingRepo(false); setNewRepoValue('') }} className="p-1 text-xs text-muted-foreground hover:text-foreground"><X className="w-3.5 h-3.5" /></button>
+                      <button type="submit" className="p-2 min-h-11 min-w-11 inline-flex items-center justify-center text-xs text-green-400 hover:text-green-300"><CheckCircle className="w-3.5 h-3.5" /></button>
+                      <button type="button" onClick={() => { setAddingRepo(false); setNewRepoValue('') }} className="p-2 min-h-11 min-w-11 inline-flex items-center justify-center text-xs text-muted-foreground hover:text-foreground"><X className="w-3.5 h-3.5" /></button>
                     </form>
                   </div>
                 )}
@@ -1324,8 +1324,8 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                         autoFocus
                         onKeyDown={(e) => { if (e.key === 'Escape') { setAddingPath(false); setNewPathValue('') } }}
                       />
-                      <button type="submit" className="p-1 text-xs text-green-400 hover:text-green-300"><CheckCircle className="w-3.5 h-3.5" /></button>
-                      <button type="button" onClick={() => { setAddingPath(false); setNewPathValue('') }} className="p-1 text-xs text-muted-foreground hover:text-foreground"><X className="w-3.5 h-3.5" /></button>
+                      <button type="submit" className="p-2 min-h-11 min-w-11 inline-flex items-center justify-center text-xs text-green-400 hover:text-green-300"><CheckCircle className="w-3.5 h-3.5" /></button>
+                      <button type="button" onClick={() => { setAddingPath(false); setNewPathValue('') }} className="p-2 min-h-11 min-w-11 inline-flex items-center justify-center text-xs text-muted-foreground hover:text-foreground"><X className="w-3.5 h-3.5" /></button>
                     </form>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- Ensures interactive elements meet the **44x44px minimum touch target** size per WCAG 2.5.5
- Prow log links (ProwJobs, ProwHistory, ProwStatus): added `min-h-11 py-1` for adequate tap area
- MissionBrowser add/cancel icon buttons: enlarged from `p-1` to `p-2 min-h-11 min-w-11`
- ClusterSelectionDialog close button: enlarged from `p-1` to `p-2 min-h-11 min-w-11`
- Elements that already had proper sizing (WorkloadDeployment, NamespaceResources, ResourceBadges) were left unchanged

Fixes #2105

## Test plan
- [ ] Verify Prow card log links are easily tappable on mobile
- [ ] Verify MissionBrowser add repo/path form buttons have adequate touch area
- [ ] Verify ClusterSelectionDialog close button is easily tappable
- [ ] Visual regression: buttons shouldn't look oversized on desktop