### PR TITLE
✨ Migrate all cards to caching layer with TTL refresh and demo fallback

### DIFF
--- a/web/src/components/cards/ChartVersions.tsx
+++ b/web/src/components/cards/ChartVersions.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { Package } from 'lucide-react'
-import { useClusters, useHelmReleases } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedHelmReleases } from '../../hooks/useCachedData'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import {
   useCardData, commonComparators,
@@ -8,7 +9,6 @@ import {
 } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
-import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface ChartVersionsProps {
   config?: {
@@ -35,7 +35,6 @@ const SORT_OPTIONS = [
 export function ChartVersions({ config: _config }: ChartVersionsProps) {
   const { t } = useTranslation()
   const { isLoading: clustersLoading } = useClusters()
-  const { isDemoMode } = useDemoMode()
 
   // Fetch ALL Helm releases once - filter locally
   const {
@@ -43,7 +42,8 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
     isLoading: releasesLoading,
     isFailed,
     consecutiveFailures,
-  } = useHelmReleases()
+    isDemoFallback: isDemoData,
+  } = useCachedHelmReleases()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton, showEmptyState } = useCardLoadingState({
@@ -51,7 +51,7 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
     hasAnyData: allHelmReleases.length > 0,
     isFailed,
     consecutiveFailures,
-    isDemoData: isDemoMode,
+    isDemoData,
   })
 
   // Transform Helm releases to chart info

--- a/web/src/components/cards/ClusterComparison.tsx
+++ b/web/src/components/cards/ClusterComparison.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect } from 'react'
 import { Server, Activity, Box, Cpu, ChevronRight } from 'lucide-react'
-import { useClusters, useGPUNodes } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { Skeleton } from '../ui/Skeleton'
@@ -17,7 +18,7 @@ interface ClusterComparisonProps {
 export function ClusterComparison({ config }: ClusterComparisonProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { deduplicatedClusters: rawClusters, isLoading: clustersLoading } = useClusters()
-  const { nodes: gpuNodes } = useGPUNodes()
+  const { nodes: gpuNodes, isDemoFallback } = useCachedGPUNodes()
   const [selectedClusters, setSelectedClusters] = useState<string[]>(config?.clusters || [])
   const { isDemoMode } = useDemoMode()
 
@@ -25,7 +26,7 @@ export function ClusterComparison({ config }: ClusterComparisonProps) {
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading,
     hasAnyData: rawClusters.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || isDemoFallback,
   })
   const {
     selectedClusters: globalSelectedClusters,

--- a/web/src/components/cards/ClusterCosts.tsx
+++ b/web/src/components/cards/ClusterCosts.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect, useCallback } from 'react'
 import { Server, Cpu, HardDrive, TrendingUp, Info, ExternalLink, ChevronDown, Sparkles, Settings2, ChevronRight } from 'lucide-react'
-import { useClusters, useGPUNodes } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { Skeleton } from '../ui/Skeleton'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
@@ -194,7 +195,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
     [t]
   )
   const { deduplicatedClusters: allClusters, isLoading } = useClusters()
-  const { nodes: gpuNodes } = useGPUNodes()
+  const { nodes: gpuNodes, isDemoFallback } = useCachedGPUNodes()
   const { drillToCost } = useDrillDownActions()
   const { isDemoMode } = useDemoMode()
 
@@ -202,7 +203,7 @@ export function ClusterCosts({ config }: ClusterCostsProps) {
   useCardLoadingState({
     isLoading,
     hasAnyData: allClusters.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || isDemoFallback,
   })
 
   // Cloud provider selection

--- a/web/src/components/cards/ClusterFocus.tsx
+++ b/web/src/components/cards/ClusterFocus.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react'
 import { Activity, Box, Cpu, HardDrive, Network, AlertTriangle } from 'lucide-react'
-import { useClusters, useGPUNodes } from '../../hooks/useMCP'
-import { useCachedPodIssues, useCachedDeploymentIssues } from '../../hooks/useCachedData'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedPodIssues, useCachedDeploymentIssues, useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { Skeleton } from '../ui/Skeleton'
@@ -19,9 +19,9 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
   const { t } = useTranslation(['cards', 'common'])
   const selectedCluster = config?.cluster
   const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
-  const { nodes: gpuNodes } = useGPUNodes()
-  const { issues: podIssues } = useCachedPodIssues(selectedCluster)
-  const { issues: deploymentIssues } = useCachedDeploymentIssues(selectedCluster)
+  const { nodes: gpuNodes, isDemoFallback: gpuDemoFallback } = useCachedGPUNodes()
+  const { issues: podIssues, isDemoFallback: podsDemoFallback } = useCachedPodIssues(selectedCluster)
+  const { issues: deploymentIssues, isDemoFallback: deployDemoFallback } = useCachedDeploymentIssues(selectedCluster)
   const { drillToCluster, drillToPod, drillToDeployment } = useDrillDownActions()
   const [internalCluster, setInternalCluster] = useState<string>('')
   const { isDemoMode } = useDemoMode()
@@ -30,7 +30,7 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading,
     hasAnyData: allClusters.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || gpuDemoFallback || podsDemoFallback || deployDemoFallback,
   })
 
   const {

--- a/web/src/components/cards/ClusterHealth.tsx
+++ b/web/src/components/cards/ClusterHealth.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { CheckCircle, WifiOff, Cpu, Loader2, ExternalLink, AlertTriangle, KeyRound } from 'lucide-react'
-import { useClusters, useGPUNodes, ClusterInfo } from '../../hooks/useMCP'
+import { useClusters, ClusterInfo } from '../../hooks/useMCP'
+import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useMobile } from '../../hooks/useMobile'
 import { Skeleton, SkeletonStats, SkeletonList } from '../ui/Skeleton'
@@ -85,7 +86,7 @@ export function ClusterHealth() {
     error,
     lastRefresh,
   } = useClusters()
-  const { nodes: gpuNodes } = useGPUNodes()
+  const { nodes: gpuNodes, isDemoFallback } = useCachedGPUNodes()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { isMobile } = useMobile()
   const { isDemoMode } = useDemoMode()
@@ -142,7 +143,7 @@ export function ClusterHealth() {
     hasAnyData: hasData,
     isFailed: !!error && !hasData,
     consecutiveFailures: error ? 1 : 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || isDemoFallback,
   })
   const isLoading = showSkeleton
 

--- a/web/src/components/cards/ComputeOverview.tsx
+++ b/web/src/components/cards/ComputeOverview.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { Cpu, MemoryStick, Zap, Server, Box, Activity } from 'lucide-react'
-import { useClusters, useGPUNodes } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { formatStat, formatMemoryStat } from '../../lib/formatStats'
@@ -13,7 +14,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 export function ComputeOverview() {
   const { t } = useTranslation(['cards', 'common'])
   const { deduplicatedClusters: clusters, isLoading } = useClusters()
-  const { nodes: gpuNodes, isLoading: gpuLoading } = useGPUNodes()
+  const { nodes: gpuNodes, isLoading: gpuLoading, isDemoFallback } = useCachedGPUNodes()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { drillToResources } = useDrillDownActions()
   const { isDemoMode } = useDemoMode()
@@ -104,7 +105,7 @@ export function ComputeOverview() {
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isLoading || gpuLoading,
     hasAnyData: clusters.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || isDemoFallback,
   })
 
   if (showSkeleton) {

--- a/web/src/components/cards/GPUInventory.tsx
+++ b/web/src/components/cards/GPUInventory.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { Cpu, Server, ChevronRight } from 'lucide-react'
-import { useGPUNodes } from '../../hooks/useMCP'
+import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { CardClusterFilter } from '../../lib/cards'
@@ -12,7 +12,6 @@ import { CardSearchInput } from '../../lib/cards/CardComponents'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
-import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface GPUInventoryProps {
   config?: Record<string, unknown>
@@ -27,7 +26,7 @@ const SORT_OPTIONS = [
   { value: 'gpuType' as const, label: 'GPU Type' },
 ]
 
-type GPUNode = ReturnType<typeof useGPUNodes>['nodes'][number]
+type GPUNode = ReturnType<typeof useCachedGPUNodes>['nodes'][number]
 
 const GPU_SORT_COMPARATORS: Record<SortByOption, (a: GPUNode, b: GPUNode) => number> = {
   utilization: (a, b) => (a.gpuAllocated / a.gpuCount) - (b.gpuAllocated / b.gpuCount),
@@ -43,9 +42,9 @@ export function GPUInventory({ config }: GPUInventoryProps) {
     nodes: rawNodes,
     isLoading: hookLoading,
     error,
-  } = useGPUNodes(cluster)
+    isDemoFallback,
+  } = useCachedGPUNodes(cluster)
   const { drillToGPUNode } = useDrillDownActions()
-  const { isDemoMode } = useDemoMode()
 
   // Only show skeleton when no cached data exists
   const isLoading = hookLoading && rawNodes.length === 0
@@ -56,7 +55,7 @@ export function GPUInventory({ config }: GPUInventoryProps) {
     hasAnyData: rawNodes.length > 0,
     isFailed: !!error && rawNodes.length === 0,
     consecutiveFailures: error ? 1 : 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoFallback,
   })
 
   // Use unified card data hook for filtering, sorting, and pagination

--- a/web/src/components/cards/GPUNamespaceAllocations.tsx
+++ b/web/src/components/cards/GPUNamespaceAllocations.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { Box, ChevronRight, Server } from 'lucide-react'
-import { useGPUNodes, useAllPods } from '../../hooks/useMCP'
+import { useCachedGPUNodes, useCachedAllPods } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { StatusBadge } from '../ui/StatusBadge'
@@ -9,9 +9,8 @@ import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
 import { Skeleton } from '../ui/Skeleton'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
-import { useCardLoadingState, useForceLive } from './CardDataContext'
+import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
-import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface GPUNamespaceAllocationsProps {
   config?: Record<string, unknown>
@@ -53,18 +52,19 @@ const NAMESPACE_SORT_COMPARATORS: Record<SortByOption, (a: NamespaceGPUAllocatio
 
 export function GPUNamespaceAllocations({ config: _config }: GPUNamespaceAllocationsProps) {
   const { t } = useTranslation(['cards', 'common'])
-  const forceLive = useForceLive()
-  const { nodes: gpuNodes, isLoading: gpuLoading } = useGPUNodes()
-  const { pods: allPods, isLoading: podsLoading } = useAllPods(undefined, undefined, forceLive)
+  const { nodes: gpuNodes, isLoading: gpuLoading, isDemoFallback: gpuNodesDemoFallback } = useCachedGPUNodes()
+  const { pods: allPods, isLoading: podsLoading, isDemoFallback: podsDemoFallback } = useCachedAllPods()
   const { drillToGPUNamespace } = useDrillDownActions()
-  const { isDemoMode } = useDemoMode()
+
+  // Combine all isDemoFallback values from cached hooks
+  const isDemoData = gpuNodesDemoFallback || podsDemoFallback
 
   const isLoading = (gpuLoading && gpuNodes.length === 0) || (podsLoading && allPods.length === 0)
 
   useCardLoadingState({
     isLoading: gpuLoading || podsLoading,
     hasAnyData: gpuNodes.length > 0 || allPods.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData,
   })
 
   // Compute per-namespace GPU allocations

--- a/web/src/components/cards/GPUOverview.tsx
+++ b/web/src/components/cards/GPUOverview.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react'
-import { useGPUNodes, useClusters } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { Skeleton } from '../ui/Skeleton'
@@ -27,7 +28,8 @@ export function GPUOverview({ config: _config }: GPUOverviewProps) {
   const {
     nodes: rawNodes,
     isLoading: hookLoading,
-  } = useGPUNodes()
+    isDemoFallback,
+  } = useCachedGPUNodes()
   const { deduplicatedClusters: clusters } = useClusters()
   const { isDemoMode } = useDemoMode()
 
@@ -38,7 +40,7 @@ export function GPUOverview({ config: _config }: GPUOverviewProps) {
   const { showSkeleton } = useCardLoadingState({
     isLoading: hookLoading,
     hasAnyData: rawNodes.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || isDemoFallback,
   })
   const isLoading = showSkeleton
   const { drillToResources } = useDrillDownActions()

--- a/web/src/components/cards/GPUStatus.tsx
+++ b/web/src/components/cards/GPUStatus.tsx
@@ -1,9 +1,8 @@
 import { useState, useMemo } from 'react'
 import { Activity, ChevronRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { useGPUNodes } from '../../hooks/useMCP'
+import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { useDemoMode } from '../../hooks/useDemoMode'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { StatusBadge } from '../ui/StatusBadge'
 import { Skeleton } from '../ui/Skeleton'
@@ -37,15 +36,15 @@ export function GPUStatus({ config }: GPUStatusProps) {
   const {
     nodes: rawNodes,
     isLoading: hookLoading,
-  } = useGPUNodes(cluster)
+    isDemoFallback,
+  } = useCachedGPUNodes(cluster)
   const { drillToCluster } = useDrillDownActions()
-  const { isDemoMode: demoMode } = useDemoMode()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: hookLoading,
     hasAnyData: rawNodes.length > 0,
-    isDemoData: demoMode,
+    isDemoData: isDemoFallback,
   })
 
   // Card-specific GPU type filter (not handled by useCardData)

--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -11,7 +11,8 @@ import {
   ResponsiveContainer,
   Legend,
 } from 'recharts'
-import { useGPUNodes, useClusters } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { Skeleton, SkeletonStats } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
@@ -54,7 +55,8 @@ export function GPUUsageTrend() {
   const {
     nodes: gpuNodes,
     isLoading: hookLoading,
-  } = useGPUNodes()
+    isDemoFallback,
+  } = useCachedGPUNodes()
   const { deduplicatedClusters: clusters } = useClusters()
   const { isDemoMode } = useDemoMode()
 
@@ -66,7 +68,7 @@ export function GPUUsageTrend() {
   useCardLoadingState({
     isLoading: hookLoading,
     hasAnyData: gpuNodes.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || isDemoFallback,
   })
   const [timeRange, setTimeRange] = useState<TimeRange>('1h')
   const [localClusterFilter, setLocalClusterFilter] = useState<string[]>([])

--- a/web/src/components/cards/GPUUtilization.tsx
+++ b/web/src/components/cards/GPUUtilization.tsx
@@ -16,7 +16,8 @@ import {
   Pie,
   ReferenceLine,
 } from 'recharts'
-import { useGPUNodes, useClusters } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -50,7 +51,8 @@ export function GPUUtilization() {
   const {
     nodes: gpuNodes,
     isLoading: hookLoading,
-  } = useGPUNodes()
+    isDemoFallback,
+  } = useCachedGPUNodes()
   const { deduplicatedClusters: clusters } = useClusters()
   const { isDemoMode } = useDemoMode()
 
@@ -62,7 +64,7 @@ export function GPUUtilization() {
   useCardLoadingState({
     isLoading: hookLoading,
     hasAnyData: gpuNodes.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || isDemoFallback,
   })
   const [timeRange, setTimeRange] = useState<TimeRange>('1h')
   const [localClusterFilter, setLocalClusterFilter] = useState<string[]>([])

--- a/web/src/components/cards/GPUWorkloads.tsx
+++ b/web/src/components/cards/GPUWorkloads.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { Cpu, Box, ChevronRight, AlertTriangle, CheckCircle, Loader2, Server } from 'lucide-react'
-import { useGPUNodes, useAllPods, useClusters } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedGPUNodes, useCachedAllPods } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { CardClusterFilter, CardSearchInput, CardAIActions } from '../../lib/cards'
@@ -12,7 +13,6 @@ import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import type { PodInfo } from '../../hooks/useMCP'
 import { useTranslation } from 'react-i18next'
-import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface GPUWorkloadsProps {
   config?: Record<string, unknown>
@@ -64,11 +64,14 @@ export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
   const {
     nodes: gpuNodes,
     isLoading: gpuLoading,
-  } = useGPUNodes()
-  const { pods: allPods, isLoading: podsLoading } = useAllPods()
+    isDemoFallback: gpuNodesDemoFallback,
+  } = useCachedGPUNodes()
+  const { pods: allPods, isLoading: podsLoading, isDemoFallback: podsDemoFallback } = useCachedAllPods()
   useClusters() // Keep hook for cache warming
   const { drillToPod } = useDrillDownActions()
-  const { isDemoMode } = useDemoMode()
+
+  // Combine all isDemoFallback values from cached hooks
+  const isDemoData = gpuNodesDemoFallback || podsDemoFallback
 
   // Only show loading when no cached data exists
   const isLoading = (gpuLoading && gpuNodes.length === 0) || (podsLoading && allPods.length === 0)
@@ -77,7 +80,7 @@ export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
   useCardLoadingState({
     isLoading: gpuLoading || podsLoading,
     hasAnyData: gpuNodes.length > 0 || allPods.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData,
   })
 
   // Pre-filter pods to only GPU workloads (domain-specific logic before hook)

--- a/web/src/components/cards/GitOpsDrift.tsx
+++ b/web/src/components/cards/GitOpsDrift.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { GitBranch, AlertTriangle, Plus, Minus, RefreshCw, Loader2, ChevronRight, Server } from 'lucide-react'
-import { useGitOpsDrifts, GitOpsDrift as GitOpsDriftType } from '../../hooks/useMCP'
+import { GitOpsDrift as GitOpsDriftType } from '../../hooks/useMCP'
+import { useCachedGitOpsDrifts } from '../../hooks/useCachedData'
 import { useGlobalFilters, type SeverityLevel } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
@@ -10,7 +11,6 @@ import { useCardData, CardClusterFilter, CardSearchInput } from '../../lib/cards
 import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
-import { useDemoMode } from '../../hooks/useDemoMode'
 
 type SortByOption = 'severity' | 'type' | 'resource' | 'cluster'
 type SortTranslationKey = 'cards:gitOpsDrift.severity' | 'cards:gitOpsDrift.type' | 'cards:gitOpsDrift.resource' | 'common:common.cluster'
@@ -74,9 +74,9 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
     error,
     isFailed,
     consecutiveFailures,
-  } = useGitOpsDrifts(cluster, namespace)
+    isDemoFallback: isDemoData,
+  } = useCachedGitOpsDrifts(cluster, namespace)
   const { selectedSeverities, isAllSeveritiesSelected, customFilter } = useGlobalFilters()
-  const { isDemoMode } = useDemoMode()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton, showEmptyState } = useCardLoadingState({
@@ -84,7 +84,7 @@ export function GitOpsDrift({ config }: GitOpsDriftProps) {
     hasAnyData: drifts.length > 0,
     isFailed,
     consecutiveFailures,
-    isDemoData: isDemoMode,
+    isDemoData,
   })
 
   // Map drift severity to global SeverityLevel

--- a/web/src/components/cards/HelmHistory.tsx
+++ b/web/src/components/cards/HelmHistory.tsx
@@ -1,9 +1,9 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { CheckCircle, XCircle, RotateCcw, ArrowUp, Clock, ChevronRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { useClusters, useHelmReleases, useHelmHistory, type HelmHistoryEntry } from '../../hooks/useMCP'
+import { useClusters, type HelmHistoryEntry } from '../../hooks/useMCP'
+import { useCachedHelmReleases, useCachedHelmHistory } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
-import { useDemoMode } from '../../hooks/useDemoMode'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
@@ -46,7 +46,6 @@ export function HelmHistory({ config }: HelmHistoryProps) {
     [t]
   )
   const { deduplicatedClusters: allClusters } = useClusters()
-  const { isDemoMode: demoMode } = useDemoMode()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const [selectedRelease, setSelectedRelease] = useState<string>(config?.release || '')
 
@@ -91,11 +90,11 @@ export function HelmHistory({ config }: HelmHistoryProps) {
   }, [globalSelectedClusters, isAllClustersSelected])
 
   // Fetch ALL Helm releases from all clusters once (not per-cluster)
-  const { releases: allHelmReleases, isLoading: releasesLoading } = useHelmReleases()
+  const { releases: allHelmReleases, isLoading: releasesLoading, isDemoFallback: isDemoData } = useCachedHelmReleases()
 
   // Auto-select cluster and release in demo mode so card shows data immediately
   useEffect(() => {
-    if (demoMode && allHelmReleases.length > 0 && allClusters.length > 0) {
+    if (isDemoData && allHelmReleases.length > 0 && allClusters.length > 0) {
       if (!selectedCluster) {
         const firstCluster = allClusters[0].name
         setSelectedCluster(firstCluster)
@@ -107,7 +106,7 @@ export function HelmHistory({ config }: HelmHistoryProps) {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [demoMode, allHelmReleases, allClusters])
+  }, [isDemoData, allHelmReleases, allClusters])
 
   // Look up namespace from the selected release (required for helm history command)
   const selectedReleaseNamespace = useMemo(() => {
@@ -125,7 +124,7 @@ export function HelmHistory({ config }: HelmHistoryProps) {
     isRefreshing: historyRefreshing,
     isFailed,
     consecutiveFailures,
-  } = useHelmHistory(
+  } = useCachedHelmHistory(
     selectedCluster || undefined,
     selectedRelease || undefined,
     selectedReleaseNamespace
@@ -138,7 +137,7 @@ export function HelmHistory({ config }: HelmHistoryProps) {
     hasAnyData: rawHistory.length > 0 || !selectedRelease,
     isFailed,
     consecutiveFailures,
-    isDemoData: demoMode,
+    isDemoData,
   })
 
   // Apply global filters to clusters

--- a/web/src/components/cards/HelmReleaseStatus.tsx
+++ b/web/src/components/cards/HelmReleaseStatus.tsx
@@ -1,8 +1,8 @@
 import { useState, useMemo } from 'react'
 import { CheckCircle, AlertTriangle, XCircle, Clock, ChevronRight, Server } from 'lucide-react'
-import { useClusters, useHelmReleases } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedHelmReleases } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { useDemoMode } from '../../hooks/useDemoMode'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import {
@@ -50,7 +50,6 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
   )
   const { isLoading: clustersLoading } = useClusters()
   const { drillToHelm } = useDrillDownActions()
-  const { isDemoMode: demoMode } = useDemoMode()
 
   const [selectedNamespace, setSelectedNamespace] = useState<string>(config?.namespace || '')
 
@@ -60,7 +59,8 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
     isLoading: releasesLoading,
     isFailed,
     consecutiveFailures,
-  } = useHelmReleases()
+    isDemoFallback: isDemoData,
+  } = useCachedHelmReleases()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton, showEmptyState } = useCardLoadingState({
@@ -68,7 +68,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
     hasAnyData: allHelmReleases.length > 0,
     isFailed,
     consecutiveFailures,
-    isDemoData: demoMode,
+    isDemoData,
   })
 
   // Transform API data to display format

--- a/web/src/components/cards/HelmValuesDiff.tsx
+++ b/web/src/components/cards/HelmValuesDiff.tsx
@@ -1,10 +1,10 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { ChevronRight, Plus, Edit, Filter, ChevronDown, Server, RotateCcw } from 'lucide-react'
-import { useClusters, useHelmReleases, useHelmValues } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedHelmReleases, useCachedHelmValues } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
-import { useDemoMode } from '../../hooks/useDemoMode'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
@@ -58,14 +58,6 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const [selectedRelease, setSelectedRelease] = useState<string>(config?.release || '')
   const { drillToHelm } = useDrillDownActions()
-  const { isDemoMode: demoMode } = useDemoMode()
-
-  // Report state to CardWrapper for refresh animation
-  useCardLoadingState({
-    isLoading: clustersLoading,
-    hasAnyData: allClusters.length > 0,
-    isDemoData: demoMode,
-  })
 
   // Local cluster filter (card-specific, kept as separate state)
   const [localClusterFilter, setLocalClusterFilter] = useState<string[]>([])
@@ -137,11 +129,18 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   }, [globalSelectedClusters, isAllClustersSelected])
 
   // Fetch ALL Helm releases from all clusters once (not per-cluster)
-  const { releases: allHelmReleases, isLoading: releasesLoading } = useHelmReleases()
+  const { releases: allHelmReleases, isLoading: releasesLoading, isDemoFallback: isDemoData } = useCachedHelmReleases()
+
+  // Report state to CardWrapper for refresh animation
+  useCardLoadingState({
+    isLoading: clustersLoading,
+    hasAnyData: allClusters.length > 0,
+    isDemoData,
+  })
 
   // Auto-select first cluster and release in demo mode
   useEffect(() => {
-    if (demoMode && allHelmReleases.length > 0 && allClusters.length > 0) {
+    if (isDemoData && allHelmReleases.length > 0 && allClusters.length > 0) {
       if (!selectedCluster) {
         const firstCluster = allClusters[0].name
         setSelectedCluster(firstCluster)
@@ -153,7 +152,7 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [demoMode, allHelmReleases, allClusters])
+  }, [isDemoData, allHelmReleases, allClusters])
 
   // Look up namespace from the selected release (required for helm commands)
   const selectedReleaseNamespace = useMemo(() => {
@@ -167,14 +166,15 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   // Fetch values for selected release (hook handles caching)
   const {
     values,
-    format,
     isLoading: valuesLoading,
     isRefreshing: valuesRefreshing,
-  } = useHelmValues(
+  } = useCachedHelmValues(
     selectedCluster || undefined,
     selectedRelease || undefined,
     selectedReleaseNamespace
   )
+  // Cached hook doesn't return format; values are always JSON objects
+  const format = 'json' as string
 
   // Only show skeleton when no cached data exists
   const isLoading = (clustersLoading || releasesLoading) && allHelmReleases.length === 0

--- a/web/src/components/cards/NamespaceEvents.tsx
+++ b/web/src/components/cards/NamespaceEvents.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useEffect } from 'react'
 import { AlertTriangle, Info, AlertCircle, Clock, ChevronRight } from 'lucide-react'
-import { useClusters, useWarningEvents, useNamespaces, type ClusterEvent } from '../../hooks/useMCP'
+import { useClusters, type ClusterEvent } from '../../hooks/useMCP'
+import { useCachedWarningEvents, useCachedNamespaces } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { StatusBadge } from '../ui/StatusBadge'
@@ -47,7 +48,7 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
     [t]
   )
   const { isLoading: clustersLoading } = useClusters()
-  const { events: allEvents, isLoading: eventsLoading } = useWarningEvents()
+  const { events: allEvents, isLoading: eventsLoading, isDemoFallback: eventsDemoFallback } = useCachedWarningEvents()
   const { drillToEvents } = useDrillDownActions()
   const { isDemoMode } = useDemoMode()
 
@@ -57,7 +58,7 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: allEvents.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData: eventsDemoFallback || isDemoMode,
   })
 
   // Use cascading selection hook for cluster -> namespace
@@ -84,7 +85,7 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
   }, [])
 
   // Fetch namespaces for the selected cluster
-  const { namespaces } = useNamespaces(selectedCluster || undefined)
+  const { namespaces } = useCachedNamespaces(selectedCluster || undefined)
 
   // Pre-filter by selected cluster/namespace (card-specific cascading selection)
   const preFilteredEvents = useMemo(() => {

--- a/web/src/components/cards/NamespaceMonitor.tsx
+++ b/web/src/components/cards/NamespaceMonitor.tsx
@@ -5,16 +5,13 @@ import {
   AlertTriangle, Eye, X, Activity
 } from 'lucide-react'
 import { CardSearchInput } from '../../lib/cards'
-import {
-  useClusters, useNamespaces, useDeployments, useServices, usePVCs,
-  usePods, useConfigMaps, useSecrets, useJobs
-} from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedNamespaces, useCachedDeployments, useCachedServices, useCachedPVCs, useCachedPods, useCachedConfigMaps, useCachedSecrets, useCachedJobs } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { CardComponentProps } from './cardRegistry'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
-import { useDemoMode } from '../../hooks/useDemoMode'
 
 // Resource types to monitor
 type ResourceType = 'pods' | 'deployments' | 'services' | 'configmaps' | 'secrets' | 'pvcs' | 'jobs'
@@ -98,15 +95,6 @@ export function NamespaceMonitor({ config: _config }: CardComponentProps) {
   const { deduplicatedClusters: clusters, isLoading } = useClusters()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { drillToNamespace, drillToPod, drillToDeployment, drillToService, drillToPVC } = useDrillDownActions()
-  const { isDemoMode } = useDemoMode()
-
-  // Report loading state to CardWrapper for skeleton/refresh behavior
-  useCardLoadingState({
-    isLoading,
-    hasAnyData: clusters.length > 0,
-    isDemoData: isDemoMode,
-  })
-
   // UI state
   const [searchFilter, setSearchFilter] = useState('')
   const [expandedClusters, setExpandedClusters] = useState<Set<string>>(new Set())
@@ -144,14 +132,25 @@ export function NamespaceMonitor({ config: _config }: CardComponentProps) {
   }, [clusters, selectedClusters, isAllClustersSelected, searchFilter])
 
   // Fetch data for selected cluster
-  const { namespaces } = useNamespaces(selectedCluster || undefined)
-  const { deployments } = useDeployments(selectedCluster || undefined)
-  const { services } = useServices(selectedCluster || undefined)
-  const { pvcs } = usePVCs(selectedCluster || undefined)
-  const { pods } = usePods(selectedCluster || undefined, undefined, 'name', 500)
-  const { configmaps } = useConfigMaps(selectedCluster || undefined)
-  const { secrets } = useSecrets(selectedCluster || undefined)
-  const { jobs } = useJobs(selectedCluster || undefined)
+  const { namespaces, isDemoFallback: namespacesDemoFallback } = useCachedNamespaces(selectedCluster || undefined)
+  const { deployments, isDemoFallback: deploymentsDemoFallback } = useCachedDeployments(selectedCluster || undefined)
+  const { services, isDemoFallback: servicesDemoFallback } = useCachedServices(selectedCluster || undefined)
+  const { pvcs, isDemoFallback: pvcsDemoFallback } = useCachedPVCs(selectedCluster || undefined)
+  const { pods, isDemoFallback: podsDemoFallback } = useCachedPods(selectedCluster || undefined, undefined, { limit: 500 })
+  const { configmaps, isDemoFallback: configmapsDemoFallback } = useCachedConfigMaps(selectedCluster || undefined)
+  const { secrets, isDemoFallback: secretsDemoFallback } = useCachedSecrets(selectedCluster || undefined)
+  const { jobs, isDemoFallback: jobsDemoFallback } = useCachedJobs(selectedCluster || undefined)
+
+  // Combine all isDemoFallback values from cached hooks
+  const isDemoData = namespacesDemoFallback || deploymentsDemoFallback || servicesDemoFallback ||
+    pvcsDemoFallback || podsDemoFallback || configmapsDemoFallback || secretsDemoFallback || jobsDemoFallback
+
+  // Report loading state to CardWrapper for skeleton/refresh behavior
+  useCardLoadingState({
+    isLoading,
+    hasAnyData: clusters.length > 0,
+    isDemoData,
+  })
 
   // Build snapshots and detect changes
   useEffect(() => {

--- a/web/src/components/cards/NamespaceOverview.tsx
+++ b/web/src/components/cards/NamespaceOverview.tsx
@@ -1,7 +1,8 @@
 import { useState, useMemo, useEffect } from 'react'
 import { Layers, Box, Activity, AlertTriangle, Server } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { useClusters, useNamespaces } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedNamespaces } from '../../hooks/useCachedData'
 import { useCachedPodIssues, useCachedDeploymentIssues } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -63,7 +64,7 @@ export function NamespaceOverview({ config }: NamespaceOverviewProps) {
   const { issues: allDeploymentIssues, isDemoFallback: deploymentIssuesDemoFallback, isRefreshing: isDeploymentIssuesRefreshing, lastRefresh: deploymentIssuesLastRefresh } = useCachedDeploymentIssues(selectedCluster)
 
   // Fetch namespaces for the selected cluster
-  const { namespaces } = useNamespaces(selectedCluster || undefined)
+  const { namespaces } = useCachedNamespaces(selectedCluster || undefined)
 
   // Auto-select first namespace in demo mode once namespaces load
   useEffect(() => {

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -4,7 +4,6 @@ import { BaseModal } from '../../lib/modals'
 import { Button } from '../ui/Button'
 import {
   useClusters,
-  useNamespaces,
   useResourceQuotas,
   useLimitRanges,
   LimitRange,
@@ -14,6 +13,7 @@ import {
   COMMON_RESOURCE_TYPES,
   GPU_RESOURCE_TYPES,
 } from '../../hooks/useMCP'
+import { useCachedNamespaces } from '../../hooks/useCachedData'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useCardLoadingState } from './CardDataContext'
@@ -122,7 +122,7 @@ function QuotaModal({
   const [showGpuPresets, setShowGpuPresets] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const { namespaces: clusterNamespaces } = useNamespaces(cluster || undefined)
+  const { namespaces: clusterNamespaces } = useCachedNamespaces(cluster || undefined)
   const availableNamespaces = cluster ? clusterNamespaces : namespaces
 
   const addResource = () => {
@@ -356,7 +356,7 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
   const [deleteConfirm, setDeleteConfirm] = useState<{ cluster: string; namespace: string; name: string } | null>(null)
 
   // Fetch namespaces for the selected cluster (only when specific cluster selected)
-  const { namespaces } = useNamespaces(selectedCluster !== 'all' ? selectedCluster : undefined)
+  const { namespaces, isDemoFallback } = useCachedNamespaces(selectedCluster !== 'all' ? selectedCluster : undefined)
 
   // Filter clusters based on global filter (useCardData handles global filtering internally)
   const clusters = allClusters
@@ -379,7 +379,7 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
   useCardLoadingState({
     isLoading: isInitialLoading || isFetchingData,
     hasAnyData: allClusters.length > 0 || resourceQuotas.length > 0 || limitRanges.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || isDemoFallback,
   })
 
   // Handle save quota

--- a/web/src/components/cards/NamespaceRBAC.tsx
+++ b/web/src/components/cards/NamespaceRBAC.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect } from 'react'
 import { Users, Key, Lock, ChevronRight, AlertCircle } from 'lucide-react'
-import { useClusters, useNamespaces, useK8sRoles, useK8sRoleBindings, useK8sServiceAccounts } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedNamespaces, useCachedK8sRoles, useCachedK8sRoleBindings, useCachedK8sServiceAccounts } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { Skeleton } from '../ui/Skeleton'
@@ -10,7 +11,6 @@ import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 import { useCardLoadingState } from './CardDataContext'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
-import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
 
 interface NamespaceRBACProps {
@@ -45,46 +45,48 @@ function NamespaceRBACInternal({ config }: NamespaceRBACProps) {
   const { deduplicatedClusters: clusters, isLoading: clustersLoading, error } = useClusters()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { drillToRBAC } = useDrillDownActions()
-  const { isDemoMode: demoMode } = useDemoMode()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const [selectedNamespace, setSelectedNamespace] = useState<string>(config?.namespace || '')
   const [activeTab, setActiveTab] = useState<'roles' | 'bindings' | 'serviceaccounts'>('roles')
 
   // Fetch namespaces for the selected cluster (requires a cluster to be selected)
-  const { namespaces } = useNamespaces(selectedCluster || undefined)
+  const { namespaces, isDemoFallback: namespacesDemoFallback } = useCachedNamespaces(selectedCluster || undefined)
+
+  // Fetch RBAC data using cached hooks (requires a cluster to be selected)
+  const { roles: k8sRoles, isLoading: rolesLoading, isDemoFallback: rolesDemoFallback } = useCachedK8sRoles(
+    selectedCluster || undefined,
+    selectedNamespace || undefined
+  )
+  const { bindings: k8sBindings, isLoading: bindingsLoading, isDemoFallback: bindingsDemoFallback } = useCachedK8sRoleBindings(
+    selectedCluster || undefined,
+    selectedNamespace || undefined
+  )
+  const { serviceAccounts: k8sServiceAccounts, isLoading: sasLoading, isDemoFallback: sasDemoFallback } = useCachedK8sServiceAccounts(
+    selectedCluster || undefined,
+    selectedNamespace || undefined
+  )
+
+  // Combine all isDemoFallback values from cached hooks
+  const isDemoData = namespacesDemoFallback || rolesDemoFallback || bindingsDemoFallback || sasDemoFallback
 
   // Auto-select first cluster and namespace in demo mode
   useEffect(() => {
-    if (demoMode && clusters.length > 0 && !selectedCluster) {
+    if (isDemoData && clusters.length > 0 && !selectedCluster) {
       setSelectedCluster(clusters[0].name)
     }
-  }, [demoMode, clusters, selectedCluster])
+  }, [isDemoData, clusters, selectedCluster])
 
   useEffect(() => {
-    if (demoMode && selectedCluster && namespaces.length > 0 && !selectedNamespace) {
+    if (isDemoData && selectedCluster && namespaces.length > 0 && !selectedNamespace) {
       setSelectedNamespace(namespaces[0])
     }
-  }, [demoMode, selectedCluster, namespaces, selectedNamespace])
+  }, [isDemoData, selectedCluster, namespaces, selectedNamespace])
 
   // Filter clusters based on global filter
   const filteredClusters = useMemo(() => {
     if (isAllClustersSelected) return clusters
     return clusters.filter(c => selectedClusters.includes(c.name))
   }, [clusters, selectedClusters, isAllClustersSelected])
-
-  // Fetch RBAC data using real hooks (requires a cluster to be selected)
-  const { roles: k8sRoles, isLoading: rolesLoading } = useK8sRoles(
-    selectedCluster || undefined,
-    selectedNamespace || undefined
-  )
-  const { bindings: k8sBindings, isLoading: bindingsLoading } = useK8sRoleBindings(
-    selectedCluster || undefined,
-    selectedNamespace || undefined
-  )
-  const { serviceAccounts: k8sServiceAccounts, isLoading: sasLoading } = useK8sServiceAccounts(
-    selectedCluster || undefined,
-    selectedNamespace || undefined
-  )
 
   // Check if we're loading initial data or fetching RBAC data
   const isInitialLoading = clustersLoading
@@ -94,7 +96,7 @@ function NamespaceRBACInternal({ config }: NamespaceRBACProps) {
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isInitialLoading || !!isFetchingRBAC,
     hasAnyData: clusters.length > 0 || k8sRoles.length > 0 || k8sBindings.length > 0 || k8sServiceAccounts.length > 0,
-    isDemoData: demoMode,
+    isDemoData,
   })
 
   // Transform raw RBAC data into RBACItem arrays (no filtering/sorting — that's handled by useCardData)

--- a/web/src/components/cards/OperatorStatus.tsx
+++ b/web/src/components/cards/OperatorStatus.tsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react'
 import { CheckCircle, AlertTriangle, XCircle, RefreshCw, ArrowUpCircle, ChevronRight } from 'lucide-react'
-import { useClusters, useOperators, Operator } from '../../hooks/useMCP'
+import { useClusters, Operator } from '../../hooks/useMCP'
+import { useCachedOperators } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { useDemoMode } from '../../hooks/useDemoMode'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { StatusBadge } from '../ui/StatusBadge'
 import { Skeleton } from '../ui/Skeleton'
@@ -63,10 +63,9 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
   )
   const { isLoading: clustersLoading } = useClusters()
   const { drillToOperator } = useDrillDownActions()
-  const { isDemoMode: demoMode } = useDemoMode()
 
   // Fetch operators - pass undefined to get all clusters
-  const { operators: rawOperators, isLoading: operatorsLoading, consecutiveFailures, isFailed } = useOperators(undefined)
+  const { operators: rawOperators, isLoading: operatorsLoading, consecutiveFailures, isFailed, isDemoFallback: isDemoData } = useCachedOperators(undefined)
 
   // Report card data state
   const { showSkeleton, showEmptyState } = useCardLoadingState({
@@ -74,7 +73,7 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
     hasAnyData: rawOperators.length > 0,
     isFailed,
     consecutiveFailures,
-    isDemoData: demoMode,
+    isDemoData,
   })
 
   // Use useCardFilters for status counts (globally filtered, before local search/pagination)

--- a/web/src/components/cards/OperatorSubscriptions.tsx
+++ b/web/src/components/cards/OperatorSubscriptions.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { Clock, AlertTriangle, Settings, ChevronRight } from 'lucide-react'
-import { useClusters, useOperatorSubscriptions, OperatorSubscription } from '../../hooks/useMCP'
+import { useClusters, OperatorSubscription } from '../../hooks/useMCP'
+import { useCachedOperatorSubscriptions } from '../../hooks/useCachedData'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { StatusBadge } from '../ui/StatusBadge'
@@ -18,7 +19,6 @@ import {
   CardPaginationFooter,
 } from '../../lib/cards/CardComponents'
 import { useTranslation } from 'react-i18next'
-import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface OperatorSubscriptionsProps {
   config?: {
@@ -58,10 +58,9 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
   )
   const { isLoading: clustersLoading } = useClusters()
   const { drillToOperator } = useDrillDownActions()
-  const { isDemoMode } = useDemoMode()
 
   // Fetch subscriptions - pass undefined to get all clusters
-  const { subscriptions: rawSubscriptions, isLoading: subscriptionsLoading, consecutiveFailures, isFailed } = useOperatorSubscriptions(undefined)
+  const { subscriptions: rawSubscriptions, isLoading: subscriptionsLoading, consecutiveFailures, isFailed, isDemoFallback: isDemoData } = useCachedOperatorSubscriptions(undefined)
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton, showEmptyState } = useCardLoadingState({
@@ -69,7 +68,7 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
     hasAnyData: rawSubscriptions.length > 0,
     isFailed,
     consecutiveFailures,
-    isDemoData: isDemoMode,
+    isDemoData,
   })
 
   // Use useCardFilters for summary counts (globally filtered, before local search/pagination)

--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { CheckCircle, AlertTriangle, Clock, ChevronRight } from 'lucide-react'
-import { usePVCs } from '../../hooks/useMCP'
 import type { PVC } from '../../hooks/useMCP'
+import { useCachedPVCs } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useCardLoadingState } from './CardDataContext'
@@ -71,7 +71,7 @@ function getStatusColor(status: string) {
 
 function PVCStatusInternal() {
   const { t } = useTranslation()
-  const { pvcs, isLoading, error, consecutiveFailures, isFailed } = usePVCs()
+  const { pvcs, isLoading, error, consecutiveFailures, isFailed, isDemoFallback } = useCachedPVCs()
   const { drillToPVC } = useDrillDownActions()
   const { isDemoMode: demoMode } = useDemoMode()
 
@@ -81,7 +81,7 @@ function PVCStatusInternal() {
     hasAnyData: pvcs.length > 0,
     isFailed,
     consecutiveFailures,
-    isDemoData: demoMode,
+    isDemoData: isDemoFallback || demoMode,
   })
 
   const {

--- a/web/src/components/cards/ResourceCapacity.tsx
+++ b/web/src/components/cards/ResourceCapacity.tsx
@@ -1,7 +1,8 @@
 import { useState, useMemo } from 'react'
 import { Cpu, HardDrive, Zap } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import { useClusters, useGPUNodes, GPUNode } from '../../hooks/useMCP'
+import { useClusters, GPUNode } from '../../hooks/useMCP'
+import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { Skeleton } from '../ui/Skeleton'
@@ -39,7 +40,7 @@ const SORT_OPTIONS = [
 export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { deduplicatedClusters: allClusters, isLoading, isRefreshing, lastRefresh, isFailed, consecutiveFailures, error } = useClusters()
-  const { nodes: gpuNodes } = useGPUNodes()
+  const { nodes: gpuNodes, isDemoFallback } = useCachedGPUNodes()
   const { drillToResources } = useDrillDownActions()
   const { isDemoMode } = useDemoMode()
   const {
@@ -58,7 +59,7 @@ export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
     isFailed,
     consecutiveFailures,
     errorMessage: error ?? undefined,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || isDemoFallback,
   })
 
   // Local cluster filter

--- a/web/src/components/cards/ResourceMarshall.tsx
+++ b/web/src/components/cards/ResourceMarshall.tsx
@@ -9,7 +9,7 @@ import {
   Search,
 } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
-import { useNamespaces } from '../../hooks/useMCP'
+import { useCachedNamespaces } from '../../hooks/useCachedData'
 import { useWorkloads } from '../../hooks/useWorkloads'
 import { useResolveDependencies, type ResolvedDependency } from '../../hooks/useDependencies'
 import { cn } from '../../lib/cn'
@@ -48,15 +48,15 @@ export function ResourceMarshall() {
   const [selectedWorkload, setSelectedWorkload] = useState<string>('')
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
 
+  // Fetch namespaces for selected cluster
+  const { namespaces, isLoading: nsLoading, isDemoFallback } = useCachedNamespaces(selectedCluster || undefined)
+
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
     hasAnyData: clusters.length > 0,
-    isDemoData: demoMode,
+    isDemoData: demoMode || isDemoFallback,
   })
-
-  // Fetch namespaces for selected cluster
-  const { namespaces, isLoading: nsLoading } = useNamespaces(selectedCluster || undefined)
 
   // Fetch workloads only when both cluster and namespace are selected.
   // Passing enabled=false prevents fetching all workloads across clusters.

--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from 'react'
 import { Gauge } from '../charts'
 import { Cpu, MemoryStick, Server } from 'lucide-react'
-import { useClusters, useGPUNodes } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useChartFilters, CardClusterFilter } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
@@ -12,7 +13,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 export function ResourceUsage() {
   const { t } = useTranslation(['cards', 'common'])
   const { isLoading: clustersLoading } = useClusters()
-  const { nodes: allGPUNodes } = useGPUNodes()
+  const { nodes: allGPUNodes, isDemoFallback } = useCachedGPUNodes()
   const { drillToResources } = useDrillDownActions()
   const { isDemoMode } = useDemoMode()
 
@@ -74,7 +75,7 @@ export function ResourceUsage() {
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading,
     hasAnyData: clusters.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || isDemoFallback,
   })
 
   if (showSkeleton) {

--- a/web/src/components/cards/StorageOverview.tsx
+++ b/web/src/components/cards/StorageOverview.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { HardDrive, Database, CheckCircle, AlertTriangle, Clock, Server } from 'lucide-react'
-import { useClusters, usePVCs } from '../../hooks/useMCP'
+import { useClusters } from '../../hooks/useMCP'
+import { useCachedPVCs } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCardLoadingState } from './CardDataContext'
@@ -12,7 +13,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 export function StorageOverview() {
   const { t } = useTranslation(['cards', 'common'])
   const { deduplicatedClusters: clusters, isLoading } = useClusters()
-  const { pvcs, isLoading: pvcsLoading, consecutiveFailures, isFailed } = usePVCs()
+  const { pvcs, isLoading: pvcsLoading, consecutiveFailures, isFailed, isDemoFallback } = useCachedPVCs()
 
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { drillToPVC } = useDrillDownActions()
@@ -25,7 +26,7 @@ export function StorageOverview() {
     hasAnyData: pvcs.length > 0,
     isFailed,
     consecutiveFailures,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoFallback || isDemoMode,
   })
 
   // Local cluster filter

--- a/web/src/components/cards/buildpacks-status/BuildpacksStatus.tsx
+++ b/web/src/components/cards/buildpacks-status/BuildpacksStatus.tsx
@@ -1,7 +1,8 @@
 import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { CheckCircle, AlertTriangle, XCircle, Clock, ChevronRight, Server } from 'lucide-react'
-import { useClusters, useBuildpackImages, BuildpackImage } from '../../../hooks/useMCP'
+import { useClusters, BuildpackImage } from '../../../hooks/useMCP'
+import { useCachedBuildpackImages } from '../../../hooks/useCachedData'
 import { Skeleton } from '../../ui/Skeleton'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { useCardData, CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions } from '../../../lib/cards'
@@ -85,8 +86,8 @@ export function BuildpacksStatus({ config }: BuildpacksStatusProps) {
     isFailed,
     consecutiveFailures,
     error,
-    isDemoData,
-  } = useBuildpackImages(config?.cluster)
+    isDemoFallback: isDemoData,
+  } = useCachedBuildpackImages(config?.cluster)
 
   const { drillToBuildpack } = useDrillDownActions()
 

--- a/web/src/components/cards/cluster-resource-tree/ClusterResourceTree.tsx
+++ b/web/src/components/cards/cluster-resource-tree/ClusterResourceTree.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, useCallback, useEffect } from 'react'
 import { Server, Box, Layers, Database, Network, HardDrive, AlertTriangle, RefreshCw, Folder } from 'lucide-react'
-import { useClusters, useNodes, useNamespaces, useDeployments, useServices, usePVCs, usePods, useConfigMaps, useSecrets, useServiceAccounts, useJobs, useHPAs, useReplicaSets, useStatefulSets, useDaemonSets, useCronJobs, useIngresses, useNetworkPolicies } from '../../../hooks/useMCP'
-import { useCachedPodIssues } from '../../../hooks/useCachedData'
+import { useClusters } from '../../../hooks/useMCP'
+import { useCachedPodIssues, useCachedNodes, useCachedNamespaces, useCachedDeployments, useCachedServices, useCachedPVCs, useCachedPods, useCachedConfigMaps, useCachedSecrets, useCachedServiceAccounts, useCachedJobs, useCachedHPAs, useCachedReplicaSets, useCachedStatefulSets, useCachedDaemonSets, useCachedCronJobs, useCachedIngresses, useCachedNetworkPolicies } from '../../../hooks/useCachedData'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useCardLoadingState } from '../CardDataContext'
@@ -13,22 +13,12 @@ import { buildNamespaceResources, getVisibleNamespaces, getIssueCounts, getPodsF
 import type { ClusterResourceTreeProps, TreeLens, SortByOption, NamespaceResources, ClusterDataCache } from './types'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
-import { useDemoMode } from '../../../hooks/useDemoMode'
 
 export function ClusterResourceTree({ config: _config }: ClusterResourceTreeProps) {
   const { t } = useTranslation()
   const { deduplicatedClusters: clusters, isLoading } = useClusters()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { drillToNamespace, drillToPod, drillToCluster, drillToDeployment, drillToService, drillToPVC } = useDrillDownActions()
-  const { isDemoMode } = useDemoMode()
-
-  // Report state to CardWrapper for refresh animation
-  useCardLoadingState({
-    isLoading,
-    hasAnyData: clusters.length > 0,
-    isDemoData: isDemoMode,
-  })
-
   // Tree view state - start with clusters expanded
   const [expandedNodes, setExpandedNodes] = useState<Set<string>>(new Set(['clusters']))
   const [searchFilter, setSearchFilter] = useState('')
@@ -79,23 +69,37 @@ export function ClusterResourceTree({ config: _config }: ClusterResourceTreeProp
 
   // Fetch data for the selected cluster (only when a cluster is expanded)
   const { issues: podIssues } = useCachedPodIssues(selectedCluster || undefined)
-  const { nodes: allNodes, isLoading: nodesLoading } = useNodes(selectedCluster || undefined)
-  const { namespaces: allNamespaces, isLoading: namespacesLoading } = useNamespaces(selectedCluster || undefined)
-  const { deployments: allDeployments } = useDeployments(selectedCluster || undefined)
-  const { services: allServices } = useServices(selectedCluster || undefined)
-  const { pvcs: allPVCs } = usePVCs(selectedCluster || undefined)
-  const { pods: allPods } = usePods(selectedCluster || undefined, undefined, 'name', 500)
-  const { configmaps: allConfigMaps } = useConfigMaps(selectedCluster || undefined)
-  const { secrets: allSecrets } = useSecrets(selectedCluster || undefined)
-  const { serviceAccounts: allServiceAccounts } = useServiceAccounts(selectedCluster || undefined)
-  const { jobs: allJobs } = useJobs(selectedCluster || undefined)
-  const { hpas: allHPAs } = useHPAs(selectedCluster || undefined)
-  const { replicasets: allReplicaSets } = useReplicaSets(selectedCluster || undefined)
-  const { statefulsets: allStatefulSets } = useStatefulSets(selectedCluster || undefined)
-  const { daemonsets: allDaemonSets } = useDaemonSets(selectedCluster || undefined)
-  const { cronjobs: allCronJobs } = useCronJobs(selectedCluster || undefined)
-  const { ingresses: allIngresses } = useIngresses(selectedCluster || undefined)
-  const { networkpolicies: allNetworkPolicies } = useNetworkPolicies(selectedCluster || undefined)
+  const { nodes: allNodes, isLoading: nodesLoading, isDemoFallback: nodesDemoFallback } = useCachedNodes(selectedCluster || undefined)
+  const { namespaces: allNamespaces, isLoading: namespacesLoading, isDemoFallback: namespacesDemoFallback } = useCachedNamespaces(selectedCluster || undefined)
+  const { deployments: allDeployments, isDemoFallback: deploymentsDemoFallback } = useCachedDeployments(selectedCluster || undefined)
+  const { services: allServices, isDemoFallback: servicesDemoFallback } = useCachedServices(selectedCluster || undefined)
+  const { pvcs: allPVCs, isDemoFallback: pvcsDemoFallback } = useCachedPVCs(selectedCluster || undefined)
+  const { pods: allPods, isDemoFallback: podsDemoFallback } = useCachedPods(selectedCluster || undefined, undefined, { limit: 500 })
+  const { configmaps: allConfigMaps, isDemoFallback: configmapsDemoFallback } = useCachedConfigMaps(selectedCluster || undefined)
+  const { secrets: allSecrets, isDemoFallback: secretsDemoFallback } = useCachedSecrets(selectedCluster || undefined)
+  const { serviceAccounts: allServiceAccounts, isDemoFallback: serviceAccountsDemoFallback } = useCachedServiceAccounts(selectedCluster || undefined)
+  const { jobs: allJobs, isDemoFallback: jobsDemoFallback } = useCachedJobs(selectedCluster || undefined)
+  const { hpas: allHPAs, isDemoFallback: hpasDemoFallback } = useCachedHPAs(selectedCluster || undefined)
+  const { replicasets: allReplicaSets, isDemoFallback: replicasetsDemoFallback } = useCachedReplicaSets(selectedCluster || undefined)
+  const { statefulsets: allStatefulSets, isDemoFallback: statefulsetsDemoFallback } = useCachedStatefulSets(selectedCluster || undefined)
+  const { daemonsets: allDaemonSets, isDemoFallback: daemonsetsDemoFallback } = useCachedDaemonSets(selectedCluster || undefined)
+  const { cronjobs: allCronJobs, isDemoFallback: cronjobsDemoFallback } = useCachedCronJobs(selectedCluster || undefined)
+  const { ingresses: allIngresses, isDemoFallback: ingressesDemoFallback } = useCachedIngresses(selectedCluster || undefined)
+  const { networkpolicies: allNetworkPolicies, isDemoFallback: networkpoliciesDemoFallback } = useCachedNetworkPolicies(selectedCluster || undefined)
+
+  // Combine all isDemoFallback values from cached hooks
+  const isDemoData = nodesDemoFallback || namespacesDemoFallback || deploymentsDemoFallback ||
+    servicesDemoFallback || pvcsDemoFallback || podsDemoFallback || configmapsDemoFallback ||
+    secretsDemoFallback || serviceAccountsDemoFallback || jobsDemoFallback || hpasDemoFallback ||
+    replicasetsDemoFallback || statefulsetsDemoFallback || daemonsetsDemoFallback ||
+    cronjobsDemoFallback || ingressesDemoFallback || networkpoliciesDemoFallback
+
+  // Report state to CardWrapper for refresh animation
+  useCardLoadingState({
+    isLoading,
+    hasAnyData: clusters.length > 0,
+    isDemoData,
+  })
 
   // Cache data for the selected cluster when it changes
   useEffect(() => {

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -2,7 +2,8 @@ import { useMemo, useState, useEffect, useRef } from 'react'
 import { AlertCircle, CheckCircle, Clock, ChevronRight, TrendingUp, TrendingDown, Minus, Cpu, HardDrive, RefreshCw, Info, Sparkles, ThumbsUp, ThumbsDown, Zap, Layers, List } from 'lucide-react'
 import { useCardDemoState } from '../CardDataContext'
 import { useMissions } from '../../../hooks/useMissions'
-import { useGPUNodes, usePodIssues, useClusters } from '../../../hooks/useMCP'
+import { useClusters } from '../../../hooks/useMCP'
+import { useCachedPodIssues, useCachedGPUNodes } from '../../../hooks/useCachedData'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { usePredictionSettings } from '../../../hooks/usePredictionSettings'
@@ -221,8 +222,8 @@ function generatePredictionId(type: string, name: string, cluster?: string): str
 export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { startMission, missions } = useMissions()
-  const { nodes: gpuNodes, isLoading } = useGPUNodes()
-  const { issues: podIssues } = usePodIssues()
+  const { nodes: gpuNodes, isLoading, isDemoFallback: gpuDemoFallback } = useCachedGPUNodes()
+  const { issues: podIssues, isDemoFallback: podsDemoFallback } = useCachedPodIssues()
   const { deduplicatedClusters: clusters } = useClusters()
   const { selectedClusters, isAllClustersSelected, customFilter } = useGlobalFilters()
   const { drillToCluster, drillToNode } = useDrillDownActions()
@@ -248,7 +249,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
   useCardLoadingState({
     isLoading: isLoading && nodesLoading,
     hasAnyData: gpuNodes.length > 0 || nodesCache.length > 0 || allNodes.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || gpuDemoFallback || podsDemoFallback,
   })
 
   // Subscribe to cache updates and fetch nodes

--- a/web/src/components/cards/workload-detection/LLMInference.tsx
+++ b/web/src/components/cards/workload-detection/LLMInference.tsx
@@ -11,10 +11,10 @@ import { StatusBadge } from '../../ui/StatusBadge'
 import { Pagination } from '../../ui/Pagination'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import type { SortDirection } from '../../../lib/cards/cardHooks'
-import { useCachedLLMdServers } from '../../../hooks/useCachedData'
+import { useCachedLLMdServers, useCachedGPUNodes } from '../../../hooks/useCachedData'
 import type { LLMdServer, LLMdComponentType } from '../../../hooks/useLLMd'
 import { useLLMdClusters } from './shared'
-import { useClusters, useGPUNodes } from '../../../hooks/useMCP'
+import { useClusters } from '../../../hooks/useMCP'
 import { useCardLoadingState } from '../CardDataContext'
 import { useTranslation } from 'react-i18next'
 
@@ -45,7 +45,7 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
   const { t: _t } = useTranslation()
   // Dynamically discover LLM-d clusters instead of using static list
   const { deduplicatedClusters } = useClusters()
-  const { nodes: gpuNodes } = useGPUNodes()
+  const { nodes: gpuNodes } = useCachedGPUNodes()
   const gpuClusterNames = useMemo(() => new Set(gpuNodes.map(n => n.cluster)), [gpuNodes])
   const llmdClusters = useLLMdClusters(deduplicatedClusters, gpuClusterNames)
 

--- a/web/src/components/cards/workload-detection/LLMModels.tsx
+++ b/web/src/components/cards/workload-detection/LLMModels.tsx
@@ -5,9 +5,9 @@ import { RefreshIndicator } from '../../ui/RefreshIndicator'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { useCardData } from '../../../lib/cards/cardHooks'
 import { CardPaginationFooter, CardControlsRow, CardSearchInput } from '../../../lib/cards/CardComponents'
-import { useCachedLLMdModels } from '../../../hooks/useCachedData'
+import { useCachedLLMdModels, useCachedGPUNodes } from '../../../hooks/useCachedData'
 import { useLLMdClusters } from './shared'
-import { useClusters, useGPUNodes } from '../../../hooks/useMCP'
+import { useClusters } from '../../../hooks/useMCP'
 import type { LLMdModel } from '../../../hooks/useLLMd'
 import { useCardLoadingState } from '../CardDataContext'
 import { useTranslation } from 'react-i18next'
@@ -29,7 +29,7 @@ export function LLMModels({ config: _config }: LLMModelsProps) {
   const { t } = useTranslation()
   // Dynamically discover LLM-d clusters instead of using static list
   const { deduplicatedClusters } = useClusters()
-  const { nodes: gpuNodes } = useGPUNodes()
+  const { nodes: gpuNodes } = useCachedGPUNodes()
   const gpuClusterNames = useMemo(() => new Set(gpuNodes.map(n => n.cluster)), [gpuNodes])
   const llmdClusters = useLLMdClusters(deduplicatedClusters, gpuClusterNames)
 

--- a/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/LLMdStackMonitor.tsx
@@ -9,14 +9,14 @@ import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
 import { CardControls } from '../../ui/CardControls'
 import { CardSearchInput, CardAIActions } from '../../../lib/cards'
-import { useCachedLLMdServers } from '../../../hooks/useCachedData'
+import { useCachedLLMdServers, useCachedGPUNodes } from '../../../hooks/useCachedData'
 import { useWorkloadMonitor } from '../../../hooks/useWorkloadMonitor'
 import { useDiagnoseRepairLoop } from '../../../hooks/useDiagnoseRepairLoop'
 import { useApiKeyCheck, ApiKeyPromptModal } from '../console-missions/shared'
 import { cn } from '../../../lib/cn'
 // WorkloadMonitorAlerts replaced with inline issue cards in Issues tab
 import { useLLMdClusters } from '../workload-detection/shared'
-import { useClusters, useGPUNodes } from '../../../hooks/useMCP'
+import { useClusters } from '../../../hooks/useMCP'
 import { ClusterStatusDot, getClusterState } from '../../ui/ClusterStatusBadge'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { useCardLoadingState } from '../CardDataContext'
@@ -109,7 +109,7 @@ const STATUS_BADGE: Record<string, string> = {
 export function LLMdStackMonitor({ config: _config }: LLMdStackMonitorProps) {
   const { t } = useTranslation()
   const { deduplicatedClusters } = useClusters()
-  const { nodes: gpuNodes } = useGPUNodes()
+  const { nodes: gpuNodes } = useCachedGPUNodes()
 
   // Dynamically discover clusters that likely have llm-d stacks
   const gpuClusterNames = useMemo(() => new Set(gpuNodes.map(n => n.cluster)), [gpuNodes])

--- a/web/src/components/cards/workload-monitor/WorkloadMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/WorkloadMonitor.tsx
@@ -4,7 +4,8 @@ import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
 import { useCardData, commonComparators } from '../../../lib/cards/cardHooks'
 import type { SortDirection } from '../../../lib/cards/cardHooks'
-import { useClusters, useNamespaces } from '../../../hooks/useMCP'
+import { useClusters } from '../../../hooks/useMCP'
+import { useCachedNamespaces } from '../../../hooks/useCachedData'
 import { useWorkloads } from '../../../hooks/useWorkloads'
 import { useWorkloadMonitor } from '../../../hooks/useWorkloadMonitor'
 import { cn } from '../../../lib/cn'
@@ -43,20 +44,20 @@ export function WorkloadMonitor({ config }: WorkloadMonitorProps) {
   const [selectedNamespace, setSelectedNamespace] = useState(monitorConfig?.namespace || '')
   const [selectedWorkload, setSelectedWorkload] = useState(monitorConfig?.workload || '')
 
+  // Fetch namespaces/workloads for selectors
+  const { namespaces, isLoading: nsLoading, isDemoFallback: nsDemoFallback } = useCachedNamespaces(selectedCluster || undefined)
+
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading: clustersLoading,
     hasAnyData: clusters.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData: isDemoMode || nsDemoFallback,
   })
 
   const isPreConfigured = !!(monitorConfig?.cluster && monitorConfig?.namespace && monitorConfig?.workload)
   const activeCluster = isPreConfigured ? monitorConfig!.cluster! : selectedCluster
   const activeNamespace = isPreConfigured ? monitorConfig!.namespace! : selectedNamespace
   const activeWorkload = isPreConfigured ? monitorConfig!.workload! : selectedWorkload
-
-  // Fetch namespaces/workloads for selectors
-  const { namespaces, isLoading: nsLoading } = useNamespaces(selectedCluster || undefined)
   const hasSelection = !!selectedCluster && !!selectedNamespace
   const workloadOpts = useMemo(() => {
     if (!selectedCluster || !selectedNamespace) return undefined

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -33,6 +33,30 @@ import type {
   Service,
   SecurityIssue,
   NodeInfo,
+  GPUNode,
+  GPUNodeHealthStatus,
+  PVC,
+  Job,
+  HPA,
+  HelmRelease,
+  HelmHistoryEntry,
+  Operator,
+  OperatorSubscription,
+  GitOpsDrift,
+  BuildpackImage,
+  ConfigMap,
+  Secret,
+  ServiceAccount,
+  ReplicaSet,
+  StatefulSet,
+  DaemonSet,
+  CronJob,
+  Ingress,
+  NetworkPolicy,
+  K8sRole,
+  K8sRoleBinding,
+  K8sServiceAccountInfo,
+  GPUHealthCronJobStatus,
 } from './useMCP'
 import type { ProwJob, ProwStatus } from './useProw'
 import type { LLMdServer, LLMdStatus, LLMdModel } from './useLLMd'
@@ -182,6 +206,91 @@ async function fetchViaSSE<T>(
     // SSE failed — fall back to per-cluster REST
     return fetchFromAllClusters<T>(endpoint, resultKey, params, true, onProgress)
   }
+}
+
+/**
+ * Fetch GitOps data via SSE streaming (uses /api/gitops/ prefix).
+ */
+async function fetchViaGitOpsSSE<T>(
+  endpoint: string,
+  resultKey: string,
+  params?: Record<string, string | number | undefined>,
+  onProgress?: (partial: T[]) => void
+): Promise<T[]> {
+  const token = getToken()
+  if (!token || token === 'demo-token' || isBackendUnavailable()) {
+    return []
+  }
+
+  const accumulated: T[] = []
+  return await fetchSSE<T>({
+    url: `/api/gitops/${endpoint}/stream`,
+    params,
+    itemsKey: resultKey,
+    onClusterData: (_cluster, items) => {
+      accumulated.push(...items)
+      onProgress?.([...accumulated])
+    },
+  })
+}
+
+/**
+ * Fetch data from a GitOps REST endpoint.
+ */
+async function fetchGitOpsAPI<T>(
+  endpoint: string,
+  params?: Record<string, string | number | undefined>
+): Promise<T> {
+  const token = getToken()
+  if (!token) throw new Error('No authentication token')
+
+  const searchParams = new URLSearchParams()
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined) searchParams.append(key, String(value))
+    })
+  }
+
+  const url = `/api/gitops/${endpoint}?${searchParams}`
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
+
+  if (!response.ok) throw new Error(`API error: ${response.status}`)
+  return response.json()
+}
+
+/** RBAC timeout — roles/bindings can be slow on large clusters */
+const RBAC_FETCH_TIMEOUT_MS = 60_000
+
+/**
+ * Fetch data from an RBAC REST endpoint (/api/rbac/).
+ */
+async function fetchRbacAPI<T>(
+  endpoint: string,
+  params?: Record<string, string | number | boolean | undefined>
+): Promise<T> {
+  const token = getToken()
+  if (!token) throw new Error('No authentication token')
+
+  const searchParams = new URLSearchParams()
+  if (params) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined) searchParams.append(key, String(value))
+    })
+  }
+
+  const url = `/api/rbac/${endpoint}?${searchParams}`
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(RBAC_FETCH_TIMEOUT_MS),
+  })
+
+  if (!response.ok) throw new Error(`API error: ${response.status}`)
+  return response.json()
 }
 
 // ============================================================================
@@ -1678,8 +1787,6 @@ export function useCachedNodes(
 // GPU Node Health Cached Hooks (SSE-enabled, proactive monitoring)
 // ============================================================================
 
-import type { GPUNodeHealthStatus, GPUHealthCronJobStatus } from './useMCP'
-
 const getDemoCachedGPUNodeHealth = (): GPUNodeHealthStatus[] => [
   {
     nodeName: 'gpu-node-1', cluster: 'vllm-gpu-cluster', status: 'healthy',
@@ -2358,6 +2465,1112 @@ export function useCachedCoreDNSStatus(
 
   return {
     clusters: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+// ============================================================================
+// Additional Demo Data (for new cached hooks)
+// ============================================================================
+
+const getDemoGPUNodes = (): GPUNode[] => [
+  { name: 'gpu-node-1', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 5, acceleratorType: 'GPU', gpuMemoryMB: 81920, manufacturer: 'NVIDIA' },
+  { name: 'gpu-node-2', cluster: 'eks-prod-us-east-1', gpuType: 'NVIDIA T4', gpuCount: 4, gpuAllocated: 3, acceleratorType: 'GPU', gpuMemoryMB: 16384, manufacturer: 'NVIDIA' },
+  { name: 'gpu-node-3', cluster: 'gke-staging', gpuType: 'NVIDIA L4', gpuCount: 2, gpuAllocated: 0, acceleratorType: 'GPU', gpuMemoryMB: 24576, manufacturer: 'NVIDIA' },
+]
+
+const getDemoPVCs = (): PVC[] => [
+  { name: 'data-postgres-0', namespace: 'production', cluster: 'eks-prod-us-east-1', status: 'Bound', storageClass: 'gp3', capacity: '100Gi', accessModes: ['ReadWriteOnce'], age: '30d' },
+  { name: 'redis-data-0', namespace: 'data', cluster: 'gke-staging', status: 'Bound', storageClass: 'standard', capacity: '50Gi', accessModes: ['ReadWriteOnce'], age: '14d' },
+  { name: 'ml-scratch', namespace: 'ml-workloads', cluster: 'vllm-gpu-cluster', status: 'Pending', storageClass: 'fast-nvme', capacity: '500Gi', accessModes: ['ReadWriteMany'], age: '1h' },
+]
+
+const getDemoNamespaces = (): string[] =>
+  ['default', 'kube-system', 'kube-public', 'monitoring', 'production', 'staging', 'batch', 'data', 'ingress', 'security']
+
+const getDemoJobs = (): Job[] => [
+  { name: 'data-migration-v2', namespace: 'batch', cluster: 'eks-prod-us-east-1', status: 'Complete', completions: '1/1', duration: '5m', age: '2h' },
+  { name: 'model-training-run-42', namespace: 'ml-workloads', cluster: 'vllm-gpu-cluster', status: 'Running', completions: '0/1', age: '30m' },
+  { name: 'backup-db-daily', namespace: 'production', cluster: 'gke-staging', status: 'Failed', completions: '0/1', duration: '10m', age: '6h' },
+]
+
+const getDemoHPAs = (): HPA[] => [
+  { name: 'web-frontend', namespace: 'production', cluster: 'eks-prod-us-east-1', reference: 'Deployment/web-frontend', minReplicas: 2, maxReplicas: 10, currentReplicas: 4, targetCPU: '70%', currentCPU: '55%', age: '30d' },
+  { name: 'api-gateway', namespace: 'production', cluster: 'eks-prod-us-east-1', reference: 'Deployment/api-gateway', minReplicas: 3, maxReplicas: 20, currentReplicas: 8, targetCPU: '60%', currentCPU: '78%', age: '14d' },
+]
+
+const getDemoConfigMaps = (): ConfigMap[] => [
+  { name: 'app-config', namespace: 'production', cluster: 'eks-prod-us-east-1', dataCount: 5, age: '7d' },
+  { name: 'nginx-config', namespace: 'ingress', cluster: 'gke-staging', dataCount: 3, age: '14d' },
+]
+
+const getDemoSecrets = (): Secret[] => [
+  { name: 'db-credentials', namespace: 'production', cluster: 'eks-prod-us-east-1', type: 'Opaque', dataCount: 3, age: '30d' },
+  { name: 'tls-cert', namespace: 'ingress', cluster: 'eks-prod-us-east-1', type: 'kubernetes.io/tls', dataCount: 2, age: '90d' },
+]
+
+const getDemoServiceAccounts = (): ServiceAccount[] => [
+  { name: 'default', namespace: 'production', cluster: 'eks-prod-us-east-1', age: '90d' },
+  { name: 'prometheus', namespace: 'monitoring', cluster: 'gke-staging', age: '30d' },
+]
+
+const getDemoReplicaSets = (): ReplicaSet[] => [
+  { name: 'web-frontend-7d8f9c4b5', namespace: 'production', cluster: 'eks-prod-us-east-1', replicas: 3, readyReplicas: 3, ownerName: 'web-frontend', ownerKind: 'Deployment', age: '2d' },
+  { name: 'api-gateway-6c8d7f5e4', namespace: 'production', cluster: 'eks-prod-us-east-1', replicas: 3, readyReplicas: 1, ownerName: 'api-gateway', ownerKind: 'Deployment', age: '1d' },
+]
+
+const getDemoStatefulSets = (): StatefulSet[] => [
+  { name: 'postgres', namespace: 'production', cluster: 'eks-prod-us-east-1', replicas: 3, readyReplicas: 3, status: 'running', image: 'postgres:15', age: '30d' },
+  { name: 'redis', namespace: 'data', cluster: 'gke-staging', replicas: 3, readyReplicas: 3, status: 'running', image: 'redis:7', age: '14d' },
+]
+
+const getDemoDaemonSets = (): DaemonSet[] => [
+  { name: 'node-exporter', namespace: 'monitoring', cluster: 'eks-prod-us-east-1', desiredScheduled: 5, currentScheduled: 5, ready: 5, status: 'running', age: '60d' },
+  { name: 'fluentd', namespace: 'logging', cluster: 'gke-staging', desiredScheduled: 3, currentScheduled: 3, ready: 3, status: 'running', age: '30d' },
+]
+
+const getDemoCronJobs = (): CronJob[] => [
+  { name: 'db-backup', namespace: 'production', cluster: 'eks-prod-us-east-1', schedule: '0 2 * * *', suspend: false, active: 0, lastSchedule: new Date(Date.now() - 8 * 3600000).toISOString(), age: '60d' },
+  { name: 'log-cleanup', namespace: 'monitoring', cluster: 'gke-staging', schedule: '0 0 * * 0', suspend: false, active: 0, lastSchedule: new Date(Date.now() - 48 * 3600000).toISOString(), age: '30d' },
+]
+
+const getDemoIngresses = (): Ingress[] => [
+  { name: 'main-ingress', namespace: 'production', cluster: 'eks-prod-us-east-1', class: 'nginx', hosts: ['app.example.com', 'api.example.com'], address: '10.0.0.100', age: '30d' },
+  { name: 'staging-ingress', namespace: 'staging', cluster: 'gke-staging', class: 'nginx', hosts: ['staging.example.com'], address: '10.0.1.50', age: '14d' },
+]
+
+const getDemoNetworkPolicies = (): NetworkPolicy[] => [
+  { name: 'deny-all', namespace: 'production', cluster: 'eks-prod-us-east-1', policyTypes: ['Ingress', 'Egress'], podSelector: '{}', age: '60d' },
+  { name: 'allow-web', namespace: 'production', cluster: 'eks-prod-us-east-1', policyTypes: ['Ingress'], podSelector: 'app=web', age: '30d' },
+]
+
+const getDemoHelmReleases = (): HelmRelease[] => [
+  { name: 'prometheus', namespace: 'monitoring', revision: '5', updated: new Date(Date.now() - 2 * 3600000).toISOString(), status: 'deployed', chart: 'prometheus-25.8.0', app_version: '2.48.1', cluster: 'eks-prod-us-east-1' },
+  { name: 'grafana', namespace: 'monitoring', revision: '3', updated: new Date(Date.now() - 5 * 3600000).toISOString(), status: 'deployed', chart: 'grafana-7.0.11', app_version: '10.2.3', cluster: 'eks-prod-us-east-1' },
+  { name: 'nginx-ingress', namespace: 'ingress', revision: '8', updated: new Date(Date.now() - 24 * 3600000).toISOString(), status: 'deployed', chart: 'ingress-nginx-4.8.3', app_version: '1.9.4', cluster: 'gke-staging' },
+  { name: 'api-gateway', namespace: 'production', revision: '6', updated: new Date(Date.now() - 1 * 3600000).toISOString(), status: 'failed', chart: 'api-gateway-2.1.0', app_version: '3.5.0', cluster: 'eks-prod-us-east-1' },
+]
+
+const getDemoHelmHistory = (): HelmHistoryEntry[] => [
+  { revision: 6, updated: new Date(Date.now() - 1 * 3600000).toISOString(), status: 'failed', chart: 'api-gateway-2.1.0', app_version: '3.5.0', description: 'Upgrade failed: container crashed' },
+  { revision: 5, updated: new Date(Date.now() - 2 * 3600000).toISOString(), status: 'deployed', chart: 'prometheus-25.8.0', app_version: '2.48.1', description: 'Upgrade complete' },
+  { revision: 4, updated: new Date(Date.now() - 24 * 3600000).toISOString(), status: 'superseded', chart: 'prometheus-25.7.0', app_version: '2.48.0', description: 'Upgrade complete' },
+]
+
+const getDemoHelmValues = (): Record<string, unknown> => ({
+  replicaCount: 2,
+  image: { repository: 'prom/prometheus', tag: 'v2.48.1', pullPolicy: 'IfNotPresent' },
+  service: { type: 'ClusterIP', port: 9090 },
+  resources: { limits: { cpu: '500m', memory: '512Mi' }, requests: { cpu: '200m', memory: '256Mi' } },
+})
+
+const getDemoOperators = (): Operator[] => [
+  { name: 'prometheus-operator', namespace: 'monitoring', version: '0.72.0', status: 'Succeeded', cluster: 'eks-prod-us-east-1' },
+  { name: 'cert-manager', namespace: 'cert-manager', version: '1.14.0', status: 'Succeeded', upgradeAvailable: '1.15.0', cluster: 'eks-prod-us-east-1' },
+  { name: 'gpu-operator', namespace: 'nvidia-gpu-operator', version: '23.9.1', status: 'Succeeded', cluster: 'vllm-gpu-cluster' },
+]
+
+const getDemoOperatorSubscriptions = (): OperatorSubscription[] => [
+  { name: 'prometheus-sub', namespace: 'monitoring', channel: 'stable', source: 'community-operators', installPlanApproval: 'Automatic', currentCSV: 'prometheusoperator.0.72.0', cluster: 'eks-prod-us-east-1' },
+  { name: 'cert-manager-sub', namespace: 'cert-manager', channel: 'stable', source: 'community-operators', installPlanApproval: 'Manual', currentCSV: 'cert-manager.v1.14.0', pendingUpgrade: 'cert-manager.v1.15.0', cluster: 'eks-prod-us-east-1' },
+]
+
+const getDemoGitOpsDrifts = (): GitOpsDrift[] => [
+  { resource: 'nginx-deployment', namespace: 'production', cluster: 'eks-prod-us-east-1', kind: 'Deployment', driftType: 'modified', gitVersion: 'abc1234', details: 'replicas changed from 3 to 5', severity: 'medium' },
+  { resource: 'redis-config', namespace: 'data', cluster: 'gke-staging', kind: 'ConfigMap', driftType: 'modified', gitVersion: 'def5678', details: 'maxmemory-policy changed', severity: 'low' },
+]
+
+const getDemoBuildpackImages = (): BuildpackImage[] => [
+  { name: 'api-service', namespace: 'production', builder: 'paketo-buildpacks/builder-jammy-base', image: 'registry.example.com/api-service:latest', status: 'succeeded', updated: new Date(Date.now() - 2 * 3600000).toISOString(), cluster: 'eks-prod-us-east-1' },
+  { name: 'web-app', namespace: 'staging', builder: 'paketo-buildpacks/builder-jammy-full', image: 'registry.example.com/web-app:v2.1', status: 'building', updated: new Date(Date.now() - 300000).toISOString(), cluster: 'gke-staging' },
+]
+
+const getDemoK8sRoles = (): K8sRole[] => [
+  { name: 'pod-reader', namespace: 'production', cluster: 'eks-prod-us-east-1', isCluster: false, ruleCount: 3 },
+  { name: 'admin', cluster: 'eks-prod-us-east-1', isCluster: true, ruleCount: 15 },
+]
+
+const getDemoK8sRoleBindings = (): K8sRoleBinding[] => [
+  { name: 'pod-reader-binding', namespace: 'production', cluster: 'eks-prod-us-east-1', isCluster: false, roleName: 'pod-reader', roleKind: 'Role', subjects: [{ kind: 'User', name: 'jane' }] },
+  { name: 'admin-binding', cluster: 'eks-prod-us-east-1', isCluster: true, roleName: 'admin', roleKind: 'ClusterRole', subjects: [{ kind: 'Group', name: 'admins' }] },
+]
+
+const getDemoK8sServiceAccountsRbac = (): K8sServiceAccountInfo[] => [
+  { name: 'default', namespace: 'production', cluster: 'eks-prod-us-east-1', createdAt: new Date(Date.now() - 90 * 86400000).toISOString() },
+  { name: 'prometheus', namespace: 'monitoring', cluster: 'eks-prod-us-east-1', roles: ['prometheus-reader'], createdAt: new Date(Date.now() - 30 * 86400000).toISOString() },
+]
+
+// ============================================================================
+// Additional Cached Data Hooks
+// ============================================================================
+
+/**
+ * Hook for fetching GPU nodes with caching
+ */
+export function useCachedGPUNodes(
+  cluster?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<GPUNode[]> & { nodes: GPUNode[] } {
+  const { category = 'gpu' } = options || {}
+  const key = `gpuNodes:${cluster || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as GPUNode[],
+    demoData: getDemoGPUNodes(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ nodes: GPUNode[] }>('gpu-nodes', { cluster })
+        return (data.nodes || []).map(n => ({ ...n, cluster }))
+      }
+      return await fetchFromAllClusters<GPUNode>('gpu-nodes', 'nodes')
+    },
+    progressiveFetcher: cluster ? undefined : async (onProgress) => {
+      return await fetchViaSSE<GPUNode>('gpu-nodes', 'nodes', {}, onProgress)
+    },
+  })
+
+  return {
+    nodes: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching all pods (no namespace filter) with caching.
+ * Used by GPU cards that need all pods across clusters for allocation tracking.
+ */
+export function useCachedAllPods(
+  cluster?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<PodInfo[]> & { pods: PodInfo[] } {
+  const { category = 'pods' } = options || {}
+  const key = `allPods:${cluster || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as PodInfo[],
+    demoData: getDemoPods(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ pods: PodInfo[] }>('pods', { cluster })
+        return (data.pods || []).map(p => ({ ...p, cluster }))
+      }
+      return await fetchFromAllClusters<PodInfo>('pods', 'pods')
+    },
+    progressiveFetcher: cluster ? undefined : async (onProgress) => {
+      return await fetchViaSSE<PodInfo>('pods', 'pods', {}, onProgress)
+    },
+  })
+
+  return {
+    pods: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching PVCs with caching
+ */
+export function useCachedPVCs(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<PVC[]> & { pvcs: PVC[] } {
+  const { category = 'default' } = options || {}
+  const key = `pvcs:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as PVC[],
+    demoData: getDemoPVCs(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ pvcs: PVC[] }>('pvcs', { cluster, namespace })
+        return (data.pvcs || []).map(p => ({ ...p, cluster }))
+      }
+      return await fetchFromAllClusters<PVC>('pvcs', 'pvcs', { namespace })
+    },
+  })
+
+  return {
+    pvcs: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching namespaces with caching.
+ * Returns a list of namespace names for a given cluster.
+ */
+export function useCachedNamespaces(
+  cluster?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<string[]> & { namespaces: string[] } {
+  const { category = 'namespaces' } = options || {}
+  const key = `namespaces:${cluster || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as string[],
+    demoData: getDemoNamespaces(),
+    fetcher: async () => {
+      if (!cluster) return getDemoNamespaces()
+      // Use the dedicated /api/namespaces endpoint which returns namespace details
+      const token = getToken()
+      if (!token) throw new Error('No authentication token')
+      const response = await fetch(`/api/namespaces?cluster=${encodeURIComponent(cluster)}`, {
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+      if (!response.ok) throw new Error(`API error: ${response.status}`)
+      const data = await response.json() as Array<{ name?: string; Name?: string }>
+      return (data || []).map((ns: { name?: string; Name?: string }) => ns.name || ns.Name || '').filter(Boolean)
+    },
+  })
+
+  return {
+    namespaces: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching jobs with caching
+ */
+export function useCachedJobs(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<Job[]> & { jobs: Job[] } {
+  const { category = 'default' } = options || {}
+  const key = `jobs:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as Job[],
+    demoData: getDemoJobs(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ jobs: Job[] }>('jobs', { cluster, namespace })
+        return (data.jobs || []).map(j => ({ ...j, cluster }))
+      }
+      return await fetchFromAllClusters<Job>('jobs', 'jobs', { namespace })
+    },
+  })
+
+  return {
+    jobs: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching HPAs with caching
+ */
+export function useCachedHPAs(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<HPA[]> & { hpas: HPA[] } {
+  const { category = 'default' } = options || {}
+  const key = `hpas:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as HPA[],
+    demoData: getDemoHPAs(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ hpas: HPA[] }>('hpas', { cluster, namespace })
+        return (data.hpas || []).map(h => ({ ...h, cluster }))
+      }
+      return await fetchFromAllClusters<HPA>('hpas', 'hpas', { namespace })
+    },
+  })
+
+  return {
+    hpas: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching ConfigMaps with caching
+ */
+export function useCachedConfigMaps(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<ConfigMap[]> & { configmaps: ConfigMap[] } {
+  const { category = 'default' } = options || {}
+  const key = `configMaps:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as ConfigMap[],
+    demoData: getDemoConfigMaps(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ configmaps: ConfigMap[] }>('configmaps', { cluster, namespace })
+        return (data.configmaps || []).map(c => ({ ...c, cluster }))
+      }
+      return await fetchFromAllClusters<ConfigMap>('configmaps', 'configmaps', { namespace })
+    },
+    progressiveFetcher: cluster ? undefined : async (onProgress) => {
+      return await fetchViaSSE<ConfigMap>('configmaps', 'configmaps', { namespace }, onProgress)
+    },
+  })
+
+  return {
+    configmaps: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching Secrets with caching
+ */
+export function useCachedSecrets(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<Secret[]> & { secrets: Secret[] } {
+  const { category = 'default' } = options || {}
+  const key = `secrets:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as Secret[],
+    demoData: getDemoSecrets(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ secrets: Secret[] }>('secrets', { cluster, namespace })
+        return (data.secrets || []).map(s => ({ ...s, cluster }))
+      }
+      return await fetchFromAllClusters<Secret>('secrets', 'secrets', { namespace })
+    },
+    progressiveFetcher: cluster ? undefined : async (onProgress) => {
+      return await fetchViaSSE<Secret>('secrets', 'secrets', { namespace }, onProgress)
+    },
+  })
+
+  return {
+    secrets: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching ServiceAccounts with caching
+ */
+export function useCachedServiceAccounts(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<ServiceAccount[]> & { serviceAccounts: ServiceAccount[] } {
+  const { category = 'default' } = options || {}
+  const key = `serviceAccounts:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as ServiceAccount[],
+    demoData: getDemoServiceAccounts(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ serviceaccounts: ServiceAccount[] }>('serviceaccounts', { cluster, namespace })
+        return (data.serviceaccounts || []).map(sa => ({ ...sa, cluster }))
+      }
+      return await fetchFromAllClusters<ServiceAccount>('serviceaccounts', 'serviceaccounts', { namespace })
+    },
+  })
+
+  return {
+    serviceAccounts: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching ReplicaSets with caching
+ */
+export function useCachedReplicaSets(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<ReplicaSet[]> & { replicasets: ReplicaSet[] } {
+  const { category = 'default' } = options || {}
+  const key = `replicaSets:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as ReplicaSet[],
+    demoData: getDemoReplicaSets(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ replicasets: ReplicaSet[] }>('replicasets', { cluster, namespace })
+        return (data.replicasets || []).map(rs => ({ ...rs, cluster }))
+      }
+      return await fetchFromAllClusters<ReplicaSet>('replicasets', 'replicasets', { namespace })
+    },
+  })
+
+  return {
+    replicasets: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching StatefulSets with caching
+ */
+export function useCachedStatefulSets(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<StatefulSet[]> & { statefulsets: StatefulSet[] } {
+  const { category = 'default' } = options || {}
+  const key = `statefulSets:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as StatefulSet[],
+    demoData: getDemoStatefulSets(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ statefulsets: StatefulSet[] }>('statefulsets', { cluster, namespace })
+        return (data.statefulsets || []).map(ss => ({ ...ss, cluster }))
+      }
+      return await fetchFromAllClusters<StatefulSet>('statefulsets', 'statefulsets', { namespace })
+    },
+  })
+
+  return {
+    statefulsets: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching DaemonSets with caching
+ */
+export function useCachedDaemonSets(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<DaemonSet[]> & { daemonsets: DaemonSet[] } {
+  const { category = 'default' } = options || {}
+  const key = `daemonSets:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as DaemonSet[],
+    demoData: getDemoDaemonSets(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ daemonsets: DaemonSet[] }>('daemonsets', { cluster, namespace })
+        return (data.daemonsets || []).map(ds => ({ ...ds, cluster }))
+      }
+      return await fetchFromAllClusters<DaemonSet>('daemonsets', 'daemonsets', { namespace })
+    },
+  })
+
+  return {
+    daemonsets: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching CronJobs with caching
+ */
+export function useCachedCronJobs(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<CronJob[]> & { cronjobs: CronJob[] } {
+  const { category = 'default' } = options || {}
+  const key = `cronJobs:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as CronJob[],
+    demoData: getDemoCronJobs(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ cronjobs: CronJob[] }>('cronjobs', { cluster, namespace })
+        return (data.cronjobs || []).map(cj => ({ ...cj, cluster }))
+      }
+      return await fetchFromAllClusters<CronJob>('cronjobs', 'cronjobs', { namespace })
+    },
+  })
+
+  return {
+    cronjobs: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching Ingresses with caching
+ */
+export function useCachedIngresses(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<Ingress[]> & { ingresses: Ingress[] } {
+  const { category = 'default' } = options || {}
+  const key = `ingresses:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as Ingress[],
+    demoData: getDemoIngresses(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ ingresses: Ingress[] }>('ingresses', { cluster, namespace })
+        return (data.ingresses || []).map(i => ({ ...i, cluster }))
+      }
+      return await fetchFromAllClusters<Ingress>('ingresses', 'ingresses', { namespace })
+    },
+  })
+
+  return {
+    ingresses: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching NetworkPolicies with caching
+ */
+export function useCachedNetworkPolicies(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<NetworkPolicy[]> & { networkpolicies: NetworkPolicy[] } {
+  const { category = 'default' } = options || {}
+  const key = `networkPolicies:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as NetworkPolicy[],
+    demoData: getDemoNetworkPolicies(),
+    fetcher: async () => {
+      if (cluster) {
+        const data = await fetchAPI<{ networkpolicies: NetworkPolicy[] }>('networkpolicies', { cluster, namespace })
+        return (data.networkpolicies || []).map(np => ({ ...np, cluster }))
+      }
+      return await fetchFromAllClusters<NetworkPolicy>('networkpolicies', 'networkpolicies', { namespace })
+    },
+  })
+
+  return {
+    networkpolicies: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching Helm releases with caching (GitOps SSE endpoint)
+ */
+export function useCachedHelmReleases(
+  cluster?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<HelmRelease[]> & { releases: HelmRelease[] } {
+  const { category = 'helm' } = options || {}
+  const key = `helmReleases:${cluster || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as HelmRelease[],
+    demoData: getDemoHelmReleases(),
+    fetcher: async () => {
+      const data = await fetchGitOpsAPI<{ releases: HelmRelease[] }>('helm-releases', cluster ? { cluster } : undefined)
+      return data.releases || []
+    },
+    progressiveFetcher: cluster ? undefined : async (onProgress) => {
+      return await fetchViaGitOpsSSE<HelmRelease>('helm-releases', 'releases', {}, onProgress)
+    },
+  })
+
+  return {
+    releases: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching Helm release history with caching
+ */
+export function useCachedHelmHistory(
+  cluster?: string,
+  release?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<HelmHistoryEntry[]> & { history: HelmHistoryEntry[] } {
+  const { category = 'helm' } = options || {}
+  const key = `helmHistory:${cluster || 'none'}:${release || 'none'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as HelmHistoryEntry[],
+    demoData: getDemoHelmHistory(),
+    enabled: !!(cluster && release),
+    fetcher: async () => {
+      const data = await fetchGitOpsAPI<{ history: HelmHistoryEntry[] }>('helm-history', { cluster, release, namespace })
+      return data.history || []
+    },
+  })
+
+  return {
+    history: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching Helm release values with caching
+ */
+export function useCachedHelmValues(
+  cluster?: string,
+  release?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<Record<string, unknown>> & { values: Record<string, unknown> } {
+  const { category = 'helm' } = options || {}
+  const key = `helmValues:${cluster || 'none'}:${release || 'none'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: {} as Record<string, unknown>,
+    demoData: getDemoHelmValues(),
+    enabled: !!(cluster && release),
+    fetcher: async () => {
+      const data = await fetchGitOpsAPI<{ values: Record<string, unknown> }>('helm-values', { cluster, release, namespace })
+      return data.values || {}
+    },
+  })
+
+  return {
+    values: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching operators with caching (GitOps SSE endpoint)
+ */
+export function useCachedOperators(
+  cluster?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<Operator[]> & { operators: Operator[] } {
+  const { category = 'operators' } = options || {}
+  const key = `operators:${cluster || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as Operator[],
+    demoData: getDemoOperators(),
+    fetcher: async () => {
+      const data = await fetchGitOpsAPI<{ operators: Operator[] }>('operators', cluster ? { cluster } : undefined)
+      return data.operators || []
+    },
+    progressiveFetcher: cluster ? undefined : async (onProgress) => {
+      return await fetchViaGitOpsSSE<Operator>('operators', 'operators', {}, onProgress)
+    },
+  })
+
+  return {
+    operators: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching operator subscriptions with caching (GitOps SSE endpoint)
+ */
+export function useCachedOperatorSubscriptions(
+  cluster?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<OperatorSubscription[]> & { subscriptions: OperatorSubscription[] } {
+  const { category = 'operators' } = options || {}
+  const key = `operatorSubscriptions:${cluster || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as OperatorSubscription[],
+    demoData: getDemoOperatorSubscriptions(),
+    fetcher: async () => {
+      const data = await fetchGitOpsAPI<{ subscriptions: OperatorSubscription[] }>('operator-subscriptions', cluster ? { cluster } : undefined)
+      return data.subscriptions || []
+    },
+    progressiveFetcher: cluster ? undefined : async (onProgress) => {
+      return await fetchViaGitOpsSSE<OperatorSubscription>('operator-subscriptions', 'subscriptions', {}, onProgress)
+    },
+  })
+
+  return {
+    subscriptions: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching GitOps drift data with caching
+ */
+export function useCachedGitOpsDrifts(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<GitOpsDrift[]> & { drifts: GitOpsDrift[] } {
+  const { category = 'gitops' } = options || {}
+  const key = `gitopsDrifts:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as GitOpsDrift[],
+    demoData: getDemoGitOpsDrifts(),
+    fetcher: async () => {
+      const data = await fetchGitOpsAPI<{ drifts: GitOpsDrift[] }>('drifts', { cluster, namespace })
+      return data.drifts || []
+    },
+  })
+
+  return {
+    drifts: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching buildpack images with caching
+ */
+export function useCachedBuildpackImages(
+  cluster?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<BuildpackImage[]> & { images: BuildpackImage[] } {
+  const { category = 'default' } = options || {}
+  const key = `buildpackImages:${cluster || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as BuildpackImage[],
+    demoData: getDemoBuildpackImages(),
+    fetcher: async () => {
+      const data = await fetchGitOpsAPI<{ images: BuildpackImage[] }>('buildpack-images', cluster ? { cluster } : undefined)
+      return data.images || []
+    },
+  })
+
+  return {
+    images: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching K8s Roles with caching (RBAC endpoint)
+ */
+export function useCachedK8sRoles(
+  cluster?: string,
+  namespace?: string,
+  options?: { includeSystem?: boolean; category?: RefreshCategory }
+): CachedHookResult<K8sRole[]> & { roles: K8sRole[] } {
+  const { includeSystem = false, category = 'rbac' } = options || {}
+  const key = `k8sRoles:${cluster || 'all'}:${namespace || 'all'}:${includeSystem}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as K8sRole[],
+    demoData: getDemoK8sRoles(),
+    fetcher: async () => {
+      const data = await fetchRbacAPI<{ roles: K8sRole[] }>('roles', { cluster, namespace, includeSystem })
+      return data.roles || []
+    },
+  })
+
+  return {
+    roles: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching K8s RoleBindings with caching (RBAC endpoint)
+ */
+export function useCachedK8sRoleBindings(
+  cluster?: string,
+  namespace?: string,
+  options?: { includeSystem?: boolean; category?: RefreshCategory }
+): CachedHookResult<K8sRoleBinding[]> & { bindings: K8sRoleBinding[] } {
+  const { includeSystem = false, category = 'rbac' } = options || {}
+  const key = `k8sRoleBindings:${cluster || 'all'}:${namespace || 'all'}:${includeSystem}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as K8sRoleBinding[],
+    demoData: getDemoK8sRoleBindings(),
+    fetcher: async () => {
+      const data = await fetchRbacAPI<{ bindings: K8sRoleBinding[] }>('bindings', { cluster, namespace, includeSystem })
+      return data.bindings || []
+    },
+  })
+
+  return {
+    bindings: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/**
+ * Hook for fetching K8s ServiceAccounts with caching (RBAC endpoint)
+ */
+export function useCachedK8sServiceAccounts(
+  cluster?: string,
+  namespace?: string,
+  options?: { category?: RefreshCategory }
+): CachedHookResult<K8sServiceAccountInfo[]> & { serviceAccounts: K8sServiceAccountInfo[] } {
+  const { category = 'rbac' } = options || {}
+  const key = `k8sServiceAccounts:${cluster || 'all'}:${namespace || 'all'}`
+
+  const result = useCache({
+    key,
+    category,
+    initialData: [] as K8sServiceAccountInfo[],
+    demoData: getDemoK8sServiceAccountsRbac(),
+    fetcher: async () => {
+      const data = await fetchRbacAPI<{ serviceAccounts: K8sServiceAccountInfo[] }>('service-accounts', { cluster, namespace })
+      return data.serviceAccounts || []
+    },
+  })
+
+  return {
+    serviceAccounts: result.data,
     data: result.data,
     isLoading: result.isLoading,
     isRefreshing: result.isRefreshing,


### PR DESCRIPTION
## Summary
- Add 25 new cached hooks to `useCachedData.ts` covering GPU, Helm, Operators, GitOps, Namespaces, RBAC, Storage, and workload resources
- Migrate 36 card files from direct `useMCP` hooks to the `useCachedData` caching layer
- Each hook uses appropriate `RefreshCategory` (gpu=45s, helm=120s, operators=300s, rbac=300s, namespaces=180s, gitops=120s, etc.)
- All cards properly wire `isDemoFallback` into `useCardLoadingState` for Demo badge display
- New hooks include: `useCachedGPUNodes`, `useCachedAllPods`, `useCachedPVCs`, `useCachedNamespaces`, `useCachedJobs`, `useCachedHPAs`, `useCachedConfigMaps`, `useCachedSecrets`, `useCachedServiceAccounts`, `useCachedReplicaSets`, `useCachedStatefulSets`, `useCachedDaemonSets`, `useCachedCronJobs`, `useCachedIngresses`, `useCachedNetworkPolicies`, `useCachedHelmReleases`, `useCachedHelmHistory`, `useCachedHelmValues`, `useCachedOperators`, `useCachedOperatorSubscriptions`, `useCachedGitOpsDrifts`, `useCachedBuildpackImages`, `useCachedK8sRoles`, `useCachedK8sRoleBindings`, `useCachedK8sServiceAccounts`

## Benefits
- **TTL-based refresh** with stale-while-revalidate pattern
- **localStorage persistence** for instant loads on revisit
- **Request deduplication** prevents duplicate API calls
- **Progressive SSE loading** for multi-cluster data
- **Automatic demo fallback** with proper Demo badge tracking
- **Reduced API load** via intelligent caching and category-based refresh rates

## Test plan
- [x] `npm run build` passes clean
- [x] Verified all card categories in demo mode via CDP on localhost:8080
- [x] Dashboard, My Clusters, Deploy, AI/ML, CI/CD, Cluster Admin pages all render correctly
- [x] Demo badges appear on all cards in demo mode
- [x] Zero console errors during testing
- [x] Code review agent validated isDemoFallback wiring and RefreshCategory correctness