### PR TITLE
✨ Add nightly dashboard health check workflow

### DIFF
--- a/.github/workflows/nightly-dashboard-health.yml
+++ b/.github/workflows/nightly-dashboard-health.yml
@@ -1,0 +1,278 @@
+name: Nightly Dashboard Health
+
+# Runs every night at 4:30 UTC (11:30 PM EST).
+# Tests all 30+ dashboard routes in demo mode for:
+#   - Console errors / unhandled exceptions
+#   - Card rendering (not blank pages)
+#   - Demo mode indicators
+#
+# On failure, creates a GitHub issue with diagnostics and assigns to Copilot.
+
+on:
+  schedule:
+    - cron: '45 4 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_issue_creation:
+        description: 'Skip creating issues for failures'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  CI: true
+  NODE_VERSION: '20'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: nightly-dashboard-health
+  cancel-in-progress: true
+
+jobs:
+  health-check:
+    name: Dashboard Health Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build production bundle
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run dashboard health tests
+        id: tests
+        run: |
+          set +e
+          npx playwright test \
+            e2e/nightly/dashboard-health.spec.ts \
+            -c e2e/nightly/nightly.config.ts \
+            --reporter=list,json 2>&1 | tee /tmp/test-output.txt
+          TEST_EXIT=$?
+          echo "exit_code=$TEST_EXIT" >> "$GITHUB_OUTPUT"
+
+          # Extract the JSON report from test output
+          if grep -q '__NIGHTLY_REPORT_JSON__' /tmp/test-output.txt; then
+            sed -n '/__NIGHTLY_REPORT_JSON__/,/__NIGHTLY_REPORT_JSON_END__/p' /tmp/test-output.txt \
+              | grep -v '__NIGHTLY_REPORT_JSON' > /tmp/nightly-report.json
+            echo "has_report=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_report=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          exit $TEST_EXIT
+        env:
+          PLAYWRIGHT_BASE_URL: ''
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-dashboard-results
+          path: |
+            web/test-results/nightly-dashboard-results.json
+            web/nightly-report/
+          retention-days: 14
+
+      - name: Upload screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-screenshots
+          path: web/test-results/nightly/
+          retention-days: 7
+
+      # ── Issue Creation ──────────────────────────────────────────────
+
+      - name: Create issue for failures
+        if: failure() && inputs.skip_issue_creation != true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CONSOLE_AUTO || secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const sha = context.sha.substring(0, 7);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const now = new Date().toISOString().split('T')[0];
+
+            // Parse the JSON report if available
+            let report = null;
+            try {
+              const raw = fs.readFileSync('/tmp/nightly-report.json', 'utf8');
+              report = JSON.parse(raw);
+            } catch {
+              core.warning('Could not parse nightly report JSON');
+            }
+
+            // Build the issue body
+            let failedDashboards = [];
+            let warnedDashboards = [];
+            let details = '';
+
+            if (report) {
+              failedDashboards = (report.results || []).filter(r => r.status === 'fail');
+              warnedDashboards = (report.results || []).filter(r => r.status === 'warn');
+
+              details += `## Results\n\n`;
+              details += `| Dashboard | Status | Cards | Loaded | Demo | Errors | Details |\n`;
+              details += `|-----------|--------|-------|--------|------|--------|---------|\n`;
+
+              for (const r of (report.results || [])) {
+                const icon = r.status === 'pass' ? '✅' : r.status === 'warn' ? '⚠️' : '❌';
+                details += `| ${r.name} | ${icon} | ${r.cardCount} | ${r.contentLoadedCount} | ${r.demoBadgeCount} | ${r.consoleErrors.length + r.pageErrors.length} | ${r.details} |\n`;
+              }
+
+              if (failedDashboards.length > 0) {
+                details += `\n## Failed Dashboards\n\n`;
+                for (const r of failedDashboards) {
+                  details += `### ${r.name} (\`${r.path}\`)\n\n`;
+                  if (r.pageErrors.length > 0) {
+                    details += `**Unhandled Exceptions:**\n`;
+                    for (const e of r.pageErrors) {
+                      details += `- \`${e.substring(0, 200)}\`\n`;
+                    }
+                  }
+                  if (r.consoleErrors.length > 0) {
+                    details += `**Console Errors:**\n`;
+                    for (const e of r.consoleErrors.slice(0, 5)) {
+                      details += `- \`${e.substring(0, 200)}\`\n`;
+                    }
+                    if (r.consoleErrors.length > 5) {
+                      details += `- ... and ${r.consoleErrors.length - 5} more\n`;
+                    }
+                  }
+                  if (!r.hasContent) {
+                    details += `**Page appears blank** (no meaningful text content)\n`;
+                  }
+                  details += '\n';
+                }
+              }
+            } else {
+              details = 'Test output could not be parsed. See the workflow run for details.';
+            }
+
+            const failCount = failedDashboards.length;
+            const warnCount = warnedDashboards.length;
+            const total = report ? report.total : '?';
+
+            const title = `[Nightly Health] ${failCount} dashboard(s) failing (${now})`;
+
+            const body = [
+              `## Nightly Dashboard Health Check — ${now}`,
+              '',
+              `**Commit:** \`${sha}\``,
+              `**Run:** [View workflow](${runUrl})`,
+              `**Total:** ${total} dashboards | **Failed:** ${failCount} | **Warnings:** ${warnCount}`,
+              '',
+              details,
+              '',
+              '## Fix Guidance',
+              '',
+              '1. Check the failed dashboard routes locally: `npm run dev` → navigate to the failing path',
+              '2. Open browser DevTools console to see the error',
+              '3. Common fixes:',
+              '   - **Unhandled exceptions**: Check for undefined data in hooks (guard with `|| []`)',
+              '   - **Blank pages**: Check lazy loading / Suspense boundaries',
+              '   - **Console errors**: Check API call error handling',
+              '',
+              '## Reproduction',
+              '',
+              '```bash',
+              'cd web',
+              'npx playwright test e2e/nightly/dashboard-health.spec.ts -c e2e/nightly/nightly.config.ts --headed',
+              '```',
+            ].join('\n');
+
+            // Check for duplicate open issues
+            const { data: openIssues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'auto-qa,nightly-health',
+              per_page: 10,
+            });
+
+            // Close stale nightly health issues (older than 3 days)
+            const threeDaysAgo = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+            for (const existing of openIssues) {
+              if (new Date(existing.created_at) < threeDaysAgo) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: existing.number,
+                  state: 'closed',
+                  state_reason: 'not_planned',
+                });
+                core.info(`Closed stale issue #${existing.number}`);
+              }
+            }
+
+            // Skip if a recent issue already exists for the same failure pattern
+            const recentDuplicate = openIssues.find(i => {
+              const created = new Date(i.created_at);
+              return created > threeDaysAgo && i.title.includes('dashboard(s) failing');
+            });
+
+            if (recentDuplicate) {
+              // Update the existing issue instead of creating a new one
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: recentDuplicate.number,
+                body: `## Updated: ${now}\n\n${details}\n\n**Run:** [View workflow](${runUrl})`,
+              });
+              core.info(`Updated existing issue #${recentDuplicate.number} with latest results`);
+              return;
+            }
+
+            // Create new issue
+            const { data: issue } = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['bug', 'auto-qa', 'nightly-health', 'ai-fix-requested', 'help wanted', 'triage/accepted'],
+            });
+
+            core.info(`Created issue #${issue.number}: ${title}`);
+
+            // Assign Copilot coding agent
+            const repo = `${context.repo.owner}/${context.repo.repo}`;
+            try {
+              await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                assignees: ['copilot-swe-agent[bot]'],
+                agent_assignment: {
+                  target_repo: repo,
+                  base_branch: 'main',
+                },
+              });
+              core.info(`Assigned Copilot to #${issue.number}`);
+            } catch (e) {
+              const hint = e.status === 401
+                ? ' — CONSOLE_AUTO PAT may be expired (check repo secrets)'
+                : e.status === 403
+                ? ' — token may lack repo scope or Copilot agent is not enabled'
+                : '';
+              core.warning(`Could not assign Copilot to #${issue.number}: ${e.message}${hint}`);
+            }

--- a/web/e2e/nightly/dashboard-health.spec.ts
+++ b/web/e2e/nightly/dashboard-health.spec.ts
@@ -1,0 +1,278 @@
+import { test, expect, type Page, type ConsoleMessage } from '@playwright/test'
+
+/**
+ * Nightly Dashboard Health Check
+ *
+ * Validates that ALL dashboard routes load correctly in demo mode:
+ *   1. No unexpected console errors
+ *   2. Cards render (not blank pages)
+ *   3. Demo badge visible where expected
+ *   4. No crashes or unhandled exceptions
+ *
+ * On failure, the CI workflow creates a GitHub issue assigned to Copilot.
+ *
+ * Run locally: npx playwright test e2e/nightly/dashboard-health.spec.ts -c e2e/nightly/nightly.config.ts
+ */
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/** Time to wait after navigation for cards to settle (ms) */
+const CARD_SETTLE_MS = 3_000
+
+/** Time to wait for networkidle after navigation (ms) */
+const NETWORK_IDLE_TIMEOUT_MS = 20_000
+
+/** Minimum text length to consider a page "not blank" */
+const MIN_PAGE_TEXT_LENGTH = 50
+
+/** Expected console errors to ignore (demo mode, known warnings) */
+const EXPECTED_ERROR_PATTERNS = [
+  /Failed to fetch/i,
+  /WebSocket/i,
+  /ResizeObserver/i,
+  /validateDOMNesting/i,
+  /act\(\)/i,
+  /Cannot read.*undefined/i,
+  /ChunkLoadError/i,
+  /Loading chunk/i,
+  /demo-token/i,
+  /localhost:8585/i,
+  /ERR_CONNECTION_REFUSED/i,
+  /net::ERR_/i,
+  /AbortError/i,
+  /signal is aborted/i,
+  /Hydration/i,
+  /flushSync was called/i,
+  /can't access property/i,
+]
+
+/** All dashboard routes to test (from App.tsx) */
+const DASHBOARD_ROUTES: Array<{ path: string; name: string; expectCards: boolean }> = [
+  { path: '/', name: 'Home Dashboard', expectCards: true },
+  { path: '/clusters', name: 'Clusters', expectCards: true },
+  { path: '/workloads', name: 'Workloads', expectCards: true },
+  { path: '/nodes', name: 'Nodes', expectCards: true },
+  { path: '/deployments', name: 'Deployments', expectCards: true },
+  { path: '/pods', name: 'Pods', expectCards: true },
+  { path: '/services', name: 'Services', expectCards: true },
+  { path: '/operators', name: 'Operators', expectCards: true },
+  { path: '/helm', name: 'Helm Releases', expectCards: true },
+  { path: '/logs', name: 'Logs', expectCards: true },
+  { path: '/compute', name: 'Compute', expectCards: true },
+  { path: '/compute/compare', name: 'Cluster Comparison', expectCards: true },
+  { path: '/storage', name: 'Storage', expectCards: true },
+  { path: '/network', name: 'Network', expectCards: true },
+  { path: '/events', name: 'Events', expectCards: true },
+  { path: '/security', name: 'Security', expectCards: true },
+  { path: '/gitops', name: 'GitOps', expectCards: true },
+  { path: '/alerts', name: 'Alerts', expectCards: true },
+  { path: '/cost', name: 'Cost', expectCards: true },
+  { path: '/security-posture', name: 'Compliance', expectCards: true },
+  { path: '/data-compliance', name: 'Data Compliance', expectCards: true },
+  { path: '/gpu-reservations', name: 'GPU Reservations', expectCards: true },
+  { path: '/namespaces', name: 'Namespaces', expectCards: true },
+  { path: '/deploy', name: 'Deploy', expectCards: true },
+  { path: '/ai-ml', name: 'AI/ML', expectCards: true },
+  { path: '/ai-agents', name: 'AI Agents', expectCards: true },
+  { path: '/llm-d-benchmarks', name: 'LLM-d Benchmarks', expectCards: true },
+  { path: '/cluster-admin', name: 'Cluster Admin', expectCards: true },
+  { path: '/ci-cd', name: 'CI/CD', expectCards: true },
+  { path: '/insights', name: 'Insights', expectCards: true },
+  { path: '/marketplace', name: 'Marketplace', expectCards: true },
+  { path: '/arcade', name: 'Arcade', expectCards: false },
+  { path: '/settings', name: 'Settings', expectCards: false },
+  { path: '/history', name: 'Card History', expectCards: false },
+  { path: '/users', name: 'User Management', expectCards: false },
+]
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface DashboardResult {
+  path: string
+  name: string
+  status: 'pass' | 'fail' | 'warn'
+  consoleErrors: string[]
+  pageErrors: string[]
+  cardCount: number
+  contentLoadedCount: number
+  demoBadgeCount: number
+  hasContent: boolean
+  details: string
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function isExpectedError(message: string): boolean {
+  return EXPECTED_ERROR_PATTERNS.some(pattern => pattern.test(message))
+}
+
+function setupErrorCollector(page: Page): { errors: string[]; pageErrors: string[] } {
+  const errors: string[] = []
+  const pageErrors: string[] = []
+
+  page.on('console', (msg: ConsoleMessage) => {
+    const text = msg.text()
+    if (msg.type() === 'error' && !isExpectedError(text)) {
+      errors.push(text)
+    }
+  })
+
+  page.on('pageerror', (err) => {
+    if (!isExpectedError(err.message)) {
+      pageErrors.push(err.message)
+    }
+  })
+
+  return { errors, pageErrors }
+}
+
+async function setupDemoMode(page: Page) {
+  await page.goto('/login')
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'demo-token')
+    localStorage.setItem('kc-demo-mode', 'true')
+    localStorage.setItem('demo-user-onboarded', 'true')
+  })
+}
+
+async function getDashboardMetrics(page: Page): Promise<{
+  cardCount: number
+  contentLoadedCount: number
+  demoBadgeCount: number
+  hasContent: boolean
+}> {
+  return page.evaluate((minTextLen) => {
+    const cards = document.querySelectorAll('[data-card-id]')
+    const contentLoaded = document.querySelectorAll('.content-loaded')
+    const demoBadges = document.querySelectorAll('[data-testid="demo-badge"]')
+    const bodyText = (document.body.textContent || '').trim()
+
+    return {
+      cardCount: cards.length,
+      contentLoadedCount: contentLoaded.length,
+      demoBadgeCount: demoBadges.length,
+      hasContent: bodyText.length > minTextLen,
+    }
+  }, MIN_PAGE_TEXT_LENGTH)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Nightly Dashboard Health', () => {
+  const results: DashboardResult[] = []
+
+  test.beforeAll(async ({ browser }) => {
+    // Verify browser can launch
+    const page = await browser.newPage()
+    await page.close()
+  })
+
+  for (const route of DASHBOARD_ROUTES) {
+    test(`${route.name} (${route.path})`, async ({ page }) => {
+      await setupDemoMode(page)
+      const { errors, pageErrors } = setupErrorCollector(page)
+
+      // Navigate to the dashboard
+      await page.goto(route.path)
+      try {
+        await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS })
+      } catch {
+        // networkidle may not fire if SSE streams are open — continue anyway
+      }
+
+      // Wait for cards to settle
+      await page.waitForTimeout(CARD_SETTLE_MS)
+
+      // Collect metrics
+      const metrics = await getDashboardMetrics(page)
+
+      // Build result
+      const result: DashboardResult = {
+        path: route.path,
+        name: route.name,
+        status: 'pass',
+        consoleErrors: [...errors],
+        pageErrors: [...pageErrors],
+        ...metrics,
+        details: '',
+      }
+
+      // Evaluate status
+      const issues: string[] = []
+
+      // Check for page errors (unhandled exceptions — always critical)
+      if (pageErrors.length > 0) {
+        issues.push(`${pageErrors.length} unhandled exception(s)`)
+        result.status = 'fail'
+      }
+
+      // Check for console errors (warnings only, not failures)
+      if (errors.length > 0) {
+        issues.push(`${errors.length} console error(s)`)
+        if (result.status !== 'fail') result.status = 'warn'
+      }
+
+      // Check for blank page
+      if (!metrics.hasContent) {
+        issues.push('Page appears blank')
+        result.status = 'fail'
+      }
+
+      // Check cards rendered (only for dashboards that should have cards)
+      if (route.expectCards && metrics.cardCount === 0) {
+        issues.push('No cards detected')
+        if (result.status !== 'fail') result.status = 'warn'
+      }
+
+      result.details = issues.length > 0 ? issues.join('; ') : 'OK'
+      results.push(result)
+
+      // Log for CI visibility
+      const statusIcon = result.status === 'pass' ? '✓' : result.status === 'warn' ? '⚠' : '✗'
+      console.log(
+        `[Dashboard Health] ${statusIcon} ${route.name}: cards=${metrics.cardCount} loaded=${metrics.contentLoadedCount} demo=${metrics.demoBadgeCount} errors=${errors.length} ${result.details}`
+      )
+
+      // Assertions
+      expect(pageErrors, `Unhandled exceptions on ${route.path}: ${pageErrors.join('; ')}`).toHaveLength(0)
+      expect(metrics.hasContent, `${route.path} appears blank (text length < ${MIN_PAGE_TEXT_LENGTH})`).toBe(true)
+    })
+  }
+
+  test.afterAll(async () => {
+    // Print summary
+    const passed = results.filter(r => r.status === 'pass').length
+    const warned = results.filter(r => r.status === 'warn').length
+    const failed = results.filter(r => r.status === 'fail').length
+    const total = results.length
+
+    console.log('\n' + '═'.repeat(60))
+    console.log('NIGHTLY DASHBOARD HEALTH SUMMARY')
+    console.log('═'.repeat(60))
+    console.log(`Total: ${total} | Pass: ${passed} | Warn: ${warned} | Fail: ${failed}`)
+    console.log('─'.repeat(60))
+
+    for (const r of results) {
+      const icon = r.status === 'pass' ? '✓' : r.status === 'warn' ? '⚠' : '✗'
+      const cardsInfo = `cards=${r.cardCount} loaded=${r.contentLoadedCount} demo=${r.demoBadgeCount}`
+      console.log(`${icon} ${r.name.padEnd(25)} ${cardsInfo} ${r.details}`)
+    }
+
+    console.log('═'.repeat(60))
+
+    // Write JSON report for CI issue creation
+    const report = {
+      timestamp: new Date().toISOString(),
+      total,
+      passed,
+      warned,
+      failed,
+      results,
+    }
+
+    // Write to stdout as JSON for workflow parsing
+    console.log('\n__NIGHTLY_REPORT_JSON__')
+    console.log(JSON.stringify(report))
+    console.log('__NIGHTLY_REPORT_JSON_END__')
+  })
+})

--- a/web/e2e/nightly/nightly.config.ts
+++ b/web/e2e/nightly/nightly.config.ts
@@ -1,0 +1,65 @@
+import { defineConfig } from '@playwright/test'
+
+/**
+ * Playwright configuration for nightly dashboard health testing.
+ *
+ * Tests all 30+ dashboard routes for:
+ *   - Console errors (unexpected JS errors)
+ *   - Card rendering (content-loaded, visible cards)
+ *   - Demo mode indicators (Demo badge)
+ *   - No blank pages / crashes
+ *
+ * Uses production build (vite preview) by default.
+ * Override with PLAYWRIGHT_BASE_URL for an already-running server.
+ */
+
+const PREVIEW_PORT = 4175
+const DEV_PORT = 5174
+const useDevServer = !!process.env.PERF_DEV
+const IS_CI = !!process.env.CI
+
+function getWebServer() {
+  if (process.env.PLAYWRIGHT_BASE_URL) return undefined
+
+  if (useDevServer) {
+    return {
+      command: `npm run dev -- --port ${DEV_PORT} --host`,
+      url: `http://127.0.0.1:${DEV_PORT}`,
+      reuseExistingServer: true,
+      timeout: 120_000,
+    }
+  }
+
+  return {
+    command: `test -d dist || npm run build; npx vite preview --port ${PREVIEW_PORT} --host`,
+    url: `http://127.0.0.1:${PREVIEW_PORT}`,
+    reuseExistingServer: true,
+    timeout: 180_000,
+  }
+}
+
+const port = useDevServer ? DEV_PORT : PREVIEW_PORT
+
+export default defineConfig({
+  testDir: '.',
+  timeout: IS_CI ? 300_000 : 180_000, // 5 min CI, 3 min local
+  expect: { timeout: IS_CI ? 30_000 : 15_000 },
+  retries: IS_CI ? 1 : 0,
+  workers: 1, // Sequential — shares demo mode state
+  reporter: [
+    ['json', { outputFile: '../test-results/nightly-dashboard-results.json' }],
+    ['html', { open: 'never', outputFolder: '../nightly-report' }],
+    ['list'],
+  ],
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${port}`,
+    viewport: { width: 1280, height: 900 },
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+  ],
+  webServer: getWebServer(),
+  outputDir: '../test-results/nightly',
+})

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "test:e2e:interaction-compliance": "playwright test --config e2e/compliance/compliance.config.ts e2e/compliance/interaction-compliance.spec.ts",
     "test:e2e:error-resilience": "playwright test --config e2e/compliance/compliance.config.ts e2e/compliance/error-resilience.spec.ts",
     "test:e2e:all-compliance": "playwright test --config e2e/compliance/compliance.config.ts",
+    "test:e2e:nightly-health": "playwright test e2e/nightly/dashboard-health.spec.ts -c e2e/nightly/nightly.config.ts",
     "test:e2e:coverage": "./scripts/run-e2e-coverage.sh",
     "test:consistency": "bash ../scripts/consistency-test.sh",
     "test:consistency:strict": "bash ../scripts/consistency-test.sh --strict",


### PR DESCRIPTION
## Summary
- Adds a nightly Playwright test that validates all 35 dashboard routes in demo mode
- Checks for: unhandled exceptions, console errors, blank pages, card rendering, demo badges
- On failure, creates a GitHub issue with a diagnostic table (per-dashboard status, card counts, error details) and assigns to Copilot for automated fixing
- Deduplicates issues (updates existing open issue instead of creating new ones) and auto-closes stale issues older than 3 days

## New Files
| File | Purpose |
|------|---------|
| `web/e2e/nightly/dashboard-health.spec.ts` | Playwright test spec — tests all 35 routes |
| `web/e2e/nightly/nightly.config.ts` | Playwright config — uses `vite preview` for production-like testing |
| `.github/workflows/nightly-dashboard-health.yml` | GitHub Actions workflow — runs at 4:45 UTC daily |

## Run Locally
```bash
cd web
npm run test:e2e:nightly-health
```

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (no new errors)
- [x] Code review (magic numbers, patterns, security)
- [ ] Playwright test runs successfully in CI
- [ ] Manual trigger via workflow_dispatch works