### PR TITLE
🐛 Fix Fleet Compliance Heatmap blank state and install CTA text

### DIFF
--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -128,7 +128,7 @@ Please proceed step by step.`,
             <p className="text-muted-foreground">
               Install Trivy Operator for vulnerability scanning.{' '}
               <button onClick={handleInstall} className="text-cyan-400 hover:underline">
-                Install with AI →
+                Install with an AI Mission →
               </button>
             </p>
           </div>
@@ -226,7 +226,7 @@ Please proceed step by step.`,
             <p className="text-muted-foreground">
               Install Kubescape for security posture management.{' '}
               <button onClick={handleInstall} className="text-green-400 hover:underline">
-                Install with AI →
+                Install with an AI Mission →
               </button>
             </p>
           </div>

--- a/web/src/components/cards/FleetComplianceHeatmap.tsx
+++ b/web/src/components/cards/FleetComplianceHeatmap.tsx
@@ -12,6 +12,8 @@ import { useKyverno } from '../../hooks/useKyverno'
 import { useTrivy } from '../../hooks/useTrivy'
 import { useKubescape } from '../../hooks/useKubescape'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
+import { useClusters } from '../../hooks/useMCP'
+import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface CardConfig {
   config?: Record<string, unknown>
@@ -63,18 +65,22 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
   const { statuses: trivyStatuses, isLoading: trivyLoading, isDemoData: trivyDemoData } = useTrivy()
   const { statuses: kubescapeStatuses, isLoading: kubescapeLoading, isDemoData: kubescapeDemoData } = useKubescape()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
+  const { deduplicatedClusters } = useClusters()
+  const { isDemoMode } = useDemoMode()
 
   const isLoading = kyvernoLoading || trivyLoading || kubescapeLoading
-  const isDemoData = kyvernoDemoData || trivyDemoData || kubescapeDemoData
+  const isDemoData = isDemoMode || kyvernoDemoData || trivyDemoData || kubescapeDemoData
 
   useCardLoadingState({ isLoading, hasAnyData: true, isDemoData })
 
   const rows = useMemo((): HeatmapRow[] => {
-    // Collect all cluster names from all hooks
+    // Collect all cluster names from compliance hooks + useClusters fallback
     const clusterSet = new Set<string>()
     for (const name of Object.keys(kyvernoStatuses || {})) clusterSet.add(name)
     for (const name of Object.keys(trivyStatuses || {})) clusterSet.add(name)
     for (const name of Object.keys(kubescapeStatuses || {})) clusterSet.add(name)
+    // Fallback: include clusters from useClusters so the grid is always populated
+    for (const c of (deduplicatedClusters || [])) clusterSet.add(c.name)
 
     let clusterNames = Array.from(clusterSet).sort()
 
@@ -134,7 +140,7 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
 
       return { cluster, kyverno: kyvernoCell, kubescape: kubescapeCell, trivy: trivyCell }
     })
-  }, [kyvernoStatuses, trivyStatuses, kubescapeStatuses, selectedClusters, isAllClustersSelected])
+  }, [kyvernoStatuses, trivyStatuses, kubescapeStatuses, deduplicatedClusters, selectedClusters, isAllClustersSelected])
 
   if (rows.length === 0) {
     return (

--- a/web/src/components/cards/KyvernoPolicies.tsx
+++ b/web/src/components/cards/KyvernoPolicies.tsx
@@ -139,7 +139,7 @@ Please proceed step by step.`,
             <p className="text-muted-foreground">
               Install Kyverno for Kubernetes-native policy management.{' '}
               <button onClick={handleInstall} className="text-purple-400 hover:underline">
-                Install with AI →
+                Install with an AI Mission →
               </button>
             </p>
           </div>

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -805,7 +805,7 @@ Let's start by discussing what kind of policy I need.`,
                       }}
                       className="text-xs text-purple-400 hover:text-purple-300 cursor-pointer"
                     >
-                      Install with AI →
+                      Install with an AI Mission →
                     </span>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- Fix Fleet Compliance Heatmap showing "No clusters available" when MCP bridge is unavailable — now uses `useClusters()` as fallback for cluster names so the grid always populates
- Add `useDemoMode()` for correct `isDemoData` wiring on the heatmap
- Update CTA text from "Install with AI →" to "Install with an AI Mission →" in Trivy, Kubescape, Kyverno, and OPA cards

## Test plan
- [x] Build passes
- [ ] CI build/lint pass