### PR TITLE
✨ Heatmap install CTAs, ComplianceScore demo fix, Kubescape API detection

### DIFF
--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -352,11 +352,10 @@ export function ComplianceScore({ config: _config }: CardConfig) {
   const { statuses: kyvernoStatuses, isLoading: kyLoading, isDemoData: kyDemoData } = useKyverno()
   const { selectedClusters } = useGlobalFilters()
 
-  const isDemoData = ksDemoData || kyDemoData
   const isLoading = ksLoading || kyLoading
 
   // Compute composite score from available tools
-  const { score, breakdown } = useMemo(() => {
+  const { score, breakdown, usingFallback } = useMemo(() => {
     const scores: Array<{ name: string; value: number }> = []
 
     // Kubescape score (filtered by cluster if needed)
@@ -384,7 +383,7 @@ export function ComplianceScore({ config: _config }: CardConfig) {
     }
 
     if (scores.length === 0) {
-      // Demo fallback
+      // No real compliance data — show placeholder with demo indicator
       return {
         score: 85,
         breakdown: [
@@ -392,12 +391,16 @@ export function ComplianceScore({ config: _config }: CardConfig) {
           { name: 'NSA', value: 79 },
           { name: 'PCI', value: 71 },
         ],
+        usingFallback: true,
       }
     }
 
     const avg = Math.round(scores.reduce((sum, s) => sum + s.value, 0) / scores.length)
-    return { score: avg, breakdown: scores }
+    return { score: avg, breakdown: scores, usingFallback: false }
   }, [kubescapeAgg, kyvernoStatuses, selectedClusters])
+
+  // Mark as demo data when hooks report demo OR when using hardcoded fallback values
+  const isDemoData = ksDemoData || kyDemoData || usingFallback
 
   useCardLoadingState({ isLoading, hasAnyData: true, isDemoData })
 

--- a/web/src/components/cards/FleetComplianceHeatmap.tsx
+++ b/web/src/components/cards/FleetComplianceHeatmap.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useMemo } from 'react'
+import { Info } from 'lucide-react'
 import { useCardLoadingState } from './CardDataContext'
 import { useKyverno } from '../../hooks/useKyverno'
 import { useTrivy } from '../../hooks/useTrivy'
@@ -14,6 +15,7 @@ import { useKubescape } from '../../hooks/useKubescape'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useClusters } from '../../hooks/useMCP'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import { useMissions } from '../../hooks/useMissions'
 
 interface CardConfig {
   config?: Record<string, unknown>
@@ -60,16 +62,84 @@ const STATUS_DOTS: Record<CellStatus, string> = {
   'not-installed': 'bg-zinc-500',
 }
 
+/** Install mission definitions for each compliance tool */
+const INSTALL_MISSIONS: Record<string, { title: string; description: string; prompt: string }> = {
+  kyverno: {
+    title: 'Install Kyverno',
+    description: 'Install Kyverno for Kubernetes-native policy management',
+    prompt: `I want to install Kyverno for policy management on my clusters.
+
+Please help me:
+1. Install Kyverno via Helm (audit mode only — do NOT enforce)
+2. Verify the installation is running
+3. Set up a basic audit policy (like requiring labels)
+
+Use: helm install kyverno kyverno/kyverno --namespace kyverno --create-namespace --version v1.17.1 --set admissionController.replicas=1
+
+Important: Set validationFailureAction to Audit (not Enforce) for all policies to avoid breaking workloads.
+
+Please proceed step by step.`,
+  },
+  kubescape: {
+    title: 'Install Kubescape',
+    description: 'Install Kubescape Operator for security posture management',
+    prompt: `I want to install the Kubescape Operator for security posture scanning on my clusters.
+
+Please help me:
+1. Install Kubescape Operator via Helm (scan-only, no enforcement)
+2. Verify it's running and scanning
+3. Check initial scan results
+
+Use: helm install kubescape-operator kubescape/kubescape-operator --version 1.30.5 --namespace kubescape --create-namespace --set capabilities.continuousScan=enable
+
+Please proceed step by step.`,
+  },
+  trivy: {
+    title: 'Install Trivy Operator',
+    description: 'Install Trivy Operator for container vulnerability scanning',
+    prompt: `I want to install the Trivy Operator for vulnerability scanning on my clusters.
+
+Please help me:
+1. Install Trivy Operator via Helm (scan-only mode, no enforcement)
+2. Verify the operator is running and scanning
+3. Check for initial vulnerability reports
+
+Use: helm install trivy-operator aquasecurity/trivy-operator --version 0.23.0 --namespace trivy --create-namespace
+
+Please proceed step by step.`,
+  },
+}
+
 export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
-  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isDemoData: kyvernoDemoData } = useKyverno()
-  const { statuses: trivyStatuses, isLoading: trivyLoading, isDemoData: trivyDemoData } = useTrivy()
-  const { statuses: kubescapeStatuses, isLoading: kubescapeLoading, isDemoData: kubescapeDemoData } = useKubescape()
+  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isDemoData: kyvernoDemoData, installed: kyvernoInstalled } = useKyverno()
+  const { statuses: trivyStatuses, isLoading: trivyLoading, isDemoData: trivyDemoData, installed: trivyInstalled } = useTrivy()
+  const { statuses: kubescapeStatuses, isLoading: kubescapeLoading, isDemoData: kubescapeDemoData, installed: kubescapeInstalled } = useKubescape()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { deduplicatedClusters } = useClusters()
   const { isDemoMode } = useDemoMode()
+  const { startMission } = useMissions()
 
   const isLoading = kyvernoLoading || trivyLoading || kubescapeLoading
   const isDemoData = isDemoMode || kyvernoDemoData || trivyDemoData || kubescapeDemoData
+
+  /** Whether each tool is installed on at least one cluster */
+  const toolInstalled: Record<string, boolean> = {
+    kyverno: kyvernoInstalled,
+    kubescape: kubescapeInstalled,
+    trivy: trivyInstalled,
+  }
+
+  const handleInstall = (toolKey: string) => {
+    const mission = INSTALL_MISSIONS[toolKey]
+    if (!mission) return
+    startMission({
+      title: mission.title,
+      description: mission.description,
+      type: 'deploy',
+      initialPrompt: mission.prompt,
+      context: {},
+    })
+  }
 
   useCardLoadingState({ isLoading, hasAnyData: true, isDemoData })
 
@@ -158,9 +228,24 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
       {/* Header row */}
       <div className="grid grid-cols-4 gap-1 text-xs font-medium text-muted-foreground">
         <div className="px-2 py-1">Cluster</div>
-        {tools.map(tool => (
-          <div key={tool} className="px-2 py-1 text-center">{tool}</div>
-        ))}
+        {tools.map((tool, i) => {
+          const key = toolKeys[i]
+          const installed = toolInstalled[key]
+          return (
+            <div key={tool} className="px-2 py-1 text-center">
+              <span>{tool}</span>
+              {!installed && !isLoading && (
+                <button
+                  onClick={() => handleInstall(key)}
+                  className="ml-1 inline-flex items-center gap-0.5 text-cyan-400 hover:text-cyan-300 transition-colors"
+                  title={`${tool} not detected — click to install with an AI Mission`}
+                >
+                  <Info className="w-3 h-3" />
+                </button>
+              )}
+            </div>
+          )
+        })}
       </div>
 
       {/* Data rows */}

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -157,20 +157,25 @@ export function useKubescape() {
 
     for (const cluster of (clusters || [])) {
       try {
-        // Phase 1: CRD check — Kubescape uses workloadconfigurationscansummaries
-        const crdCheck = await kubectlProxy.exec(
-          ['get', 'crd', 'workloadconfigurationscansummaries.spdx.softwarecomposition.kubescape.io', '-o', 'name'],
+        // Phase 1: API resource check — Kubescape uses workloadconfigurationscansummaries
+        // Note: Kubescape Operator serves these via API aggregation (storage pod),
+        // not as standard CRDs, so we check API availability instead of CRD existence.
+        const apiCheck = await kubectlProxy.exec(
+          ['api-resources', '--api-group=spdx.softwarecomposition.kubescape.io', '-o', 'name'],
           { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
         )
 
-        if (crdCheck.exitCode !== 0) {
-          // Try alternative CRD name (older kubescape versions)
-          const altCheck = await kubectlProxy.exec(
-            ['get', 'crd', 'configurationscansummaries.spdx.softwarecomposition.kubescape.io', '-o', 'name'],
+        const hasKubescapeApi = apiCheck.exitCode === 0 &&
+          (apiCheck.output || '').includes('workloadconfigurationscansummaries')
+
+        if (!hasKubescapeApi) {
+          // Fallback: try traditional CRD check (some installations use standard CRDs)
+          const crdCheck = await kubectlProxy.exec(
+            ['get', 'crd', 'workloadconfigurationscansummaries.spdx.softwarecomposition.kubescape.io', '-o', 'name'],
             { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
           )
 
-          if (altCheck.exitCode !== 0) {
+          if (crdCheck.exitCode !== 0) {
             newStatuses[cluster] = {
               cluster, installed: false, loading: false,
               overallScore: 0, frameworks: [],


### PR DESCRIPTION
## Summary
- Add info badge CTAs to Fleet Compliance Heatmap column headers when compliance tools (Kyverno, Kubescape, Trivy) aren't detected on any cluster, linking to AI Mission install flows
- Fix ComplianceScore card showing hardcoded fallback data (85%/CIS/NSA/PCI) without demo badge by tracking `usingFallback` in `isDemoData` computation
- Fix `useKubescape` hook to detect Kubescape via `api-resources` check first (API aggregation), falling back to CRD check for standard installations

## Test plan
- [ ] Verify heatmap column headers show info icon when tools not installed
- [ ] Verify clicking info icon launches AI Mission install flow
- [ ] Verify ComplianceScore card shows demo badge when using fallback data
- [ ] Verify ComplianceScore card shows real data when tools are installed
- [ ] Verify Kubescape detection works for API aggregation installs (Kubescape Operator)
- [ ] Verify Kubescape detection still works for standard CRD-based installs