### PR TITLE
🐛 Fix compliance hooks to always poll when clusters exist

### DIFF
--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -321,15 +321,14 @@ export function useKubescape() {
     }
   }, [clusters.length, isDemoMode]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Auto-refresh
+  // Auto-refresh — always poll when clusters exist so we detect tools
+  // that get installed later or clusters that become reachable
   useEffect(() => {
-    if (isDemoMode) return
-    const hasInstalled = Object.values(statuses).some(s => s.installed)
-    if (!hasInstalled) return
+    if (isDemoMode || clusters.length === 0) return
 
     const interval = setInterval(() => refetch(true), REFRESH_INTERVAL_MS)
     return () => clearInterval(interval)
-  }, [statuses, refetch, isDemoMode])
+  }, [clusters.length, refetch, isDemoMode])
 
   const isDemoData = isDemoMode
   const installed = Object.values(statuses).some(s => s.installed)

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -343,15 +343,14 @@ export function useKyverno() {
     }
   }, [clusters.length, isDemoMode]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Auto-refresh
+  // Auto-refresh — always poll when clusters exist so we detect tools
+  // that get installed later or clusters that become reachable
   useEffect(() => {
-    if (isDemoMode) return
-    const hasInstalled = Object.values(statuses).some(s => s.installed)
-    if (!hasInstalled) return
+    if (isDemoMode || clusters.length === 0) return
 
     const interval = setInterval(() => refetch(true), REFRESH_INTERVAL_MS)
     return () => clearInterval(interval)
-  }, [statuses, refetch, isDemoMode])
+  }, [clusters.length, refetch, isDemoMode])
 
   const isDemoData = isDemoMode
   const installed = Object.values(statuses).some(s => s.installed)

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -247,15 +247,14 @@ export function useTrivy() {
     }
   }, [clusters.length, isDemoMode]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Auto-refresh
+  // Auto-refresh — always poll when clusters exist so we detect tools
+  // that get installed later or clusters that become reachable
   useEffect(() => {
-    if (isDemoMode) return
-    const hasInstalled = Object.values(statuses).some(s => s.installed)
-    if (!hasInstalled) return
+    if (isDemoMode || clusters.length === 0) return
 
     const interval = setInterval(() => refetch(true), REFRESH_INTERVAL_MS)
     return () => clearInterval(interval)
-  }, [statuses, refetch, isDemoMode])
+  }, [clusters.length, refetch, isDemoMode])
 
   const isDemoData = isDemoMode
   const installed = Object.values(statuses).some(s => s.installed)


### PR DESCRIPTION
## Summary
- Fix auto-refresh in `useKyverno`, `useKubescape`, and `useTrivy` to always poll every 2 minutes when clusters are connected
- Previously, auto-refresh only ran when at least one tool was detected as installed — if the initial fetch failed (cluster unreachable), hooks would never retry
- This caused the Fleet Compliance Heatmap to show permanent N/A even after clusters became reachable again

## Test plan
- [ ] Install compliance tools on a cluster, then restart console — heatmap should detect tools within 2 minutes
- [ ] Start console when a cluster is temporarily unreachable — heatmap should auto-populate once cluster comes back
- [ ] Demo mode still works correctly (no polling in demo mode)