### PR TITLE
✨ Watchdog reverse proxy for zero-downtime updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,18 +52,23 @@ RUN addgroup -g 1001 -S appgroup && adduser -u 1001 -S appuser -G appgroup
 # Create data and settings directories
 RUN mkdir -p /app/data /app/.kc && chown -R appuser:appgroup /app/data /app/.kc
 
+# Copy entrypoint script for watchdog + backend
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
+
 # Environment variables
 ENV PORT=8080
+ENV BACKEND_PORT=8081
 ENV DATABASE_PATH=/app/data/console.db
 ENV HOME=/app
 
 EXPOSE 8080
 
-# Health check for orchestrator monitoring
+# Health check hits the watchdog, which always responds
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget -qO- http://localhost:8080/health || exit 1
+  CMD wget -qO- http://localhost:8080/watchdog/health || exit 1
 
 # Run as non-root user
 USER appuser
 
-ENTRYPOINT ["./console"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -19,7 +19,25 @@ func main() {
 	devMode := flag.Bool("dev", false, "Run in development mode")
 	port := flag.Int("port", 0, "Server port (default: 8080)")
 	dbPath := flag.String("db", "", "Database path (default: ./data/console.db)")
+	watchdog := flag.Bool("watchdog", false, "Run as watchdog reverse proxy (serves fallback page when backend is down)")
+	backendPort := flag.Int("backend-port", watchdogDefaultBackendPort, "Backend port for watchdog to proxy to")
 	flag.Parse()
+
+	// Watchdog mode: lightweight reverse proxy, no DB/k8s/MCP initialization
+	if *watchdog {
+		listenPort := watchdogDefaultListenPort
+		if *port > 0 {
+			listenPort = *port
+		}
+		cfg := WatchdogConfig{
+			ListenPort:  listenPort,
+			BackendPort: *backendPort,
+		}
+		if err := runWatchdog(cfg); err != nil {
+			log.Fatalf("Watchdog error: %v", err)
+		}
+		return
+	}
 
 	// Load config from environment
 	cfg := api.LoadConfigFromEnv()

--- a/cmd/console/watchdog.go
+++ b/cmd/console/watchdog.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+const (
+	watchdogHealthPollInterval  = 2 * time.Second
+	watchdogShutdownTimeout     = 5 * time.Second
+	watchdogHealthTimeout       = 2 * time.Second
+	watchdogProxyHeaderTimeout  = 30 * time.Second // generous for SSE/slow endpoints
+	watchdogReadHeaderTimeout   = 10 * time.Second
+	watchdogReadTimeout         = 30 * time.Second
+	watchdogWriteTimeout        = 5 * time.Minute // match backend for large static assets
+	watchdogIdleTimeout         = 2 * time.Minute
+	watchdogMaxIdleConns        = 100
+	watchdogMaxIdleConnsPerHost = 20
+	watchdogIdleConnTimeout     = 90 * time.Second
+	watchdogPidFile             = "/tmp/.kc-watchdog.pid"
+	watchdogPidFilePerms        = 0600
+	watchdogDefaultBackendPort  = 8081
+	watchdogDefaultListenPort   = 8080
+)
+
+// WatchdogConfig holds configuration for the watchdog reverse proxy.
+type WatchdogConfig struct {
+	ListenPort  int
+	BackendPort int
+}
+
+// runWatchdog starts the watchdog reverse proxy. It proxies all traffic to the
+// backend and serves a branded "Reconnecting..." page when the backend is down.
+// The watchdog survives startup-oauth.sh restart cycles via a PID file.
+func runWatchdog(cfg WatchdogConfig) error {
+	// Write PID file so startup-oauth.sh can detect us
+	if err := writePidFile(watchdogPidFile); err != nil {
+		log.Printf("[Watchdog] Warning: could not write PID file: %v", err)
+	}
+	defer os.Remove(watchdogPidFile)
+
+	backendURL := &url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("127.0.0.1:%d", cfg.BackendPort),
+	}
+
+	// Track backend health with atomic for lock-free reads
+	var backendHealthy int32 // 0 = unhealthy, 1 = healthy
+	var fallbacksServed int64 // count of fallback pages served (for observability)
+
+	// Create reverse proxy
+	proxy := httputil.NewSingleHostReverseProxy(backendURL)
+
+	// Custom transport with managed connection pool and timeouts
+	proxy.Transport = &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout: watchdogHealthTimeout,
+		}).DialContext,
+		ResponseHeaderTimeout: watchdogProxyHeaderTimeout,
+		MaxIdleConns:          watchdogMaxIdleConns,
+		MaxIdleConnsPerHost:   watchdogMaxIdleConnsPerHost,
+		IdleConnTimeout:       watchdogIdleConnTimeout,
+	}
+
+	// Custom error handler: serve fallback page instead of 502 when backend dies mid-request
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		log.Printf("[Watchdog] Proxy error: %v", err)
+		atomic.StoreInt32(&backendHealthy, 0)
+		serveFallback(w, r)
+	}
+
+	// Cancellable context for background goroutines
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Background health poller
+	go pollBackendHealth(ctx, backendURL.String(), &backendHealthy)
+
+	// Request handler
+	mux := http.NewServeMux()
+
+	// Watchdog's own health endpoint — always responds 200 (liveness), never proxied
+	mux.HandleFunc("/watchdog/health", func(w http.ResponseWriter, r *http.Request) {
+		status := "down"
+		if atomic.LoadInt32(&backendHealthy) == 1 {
+			status = "ok"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":           "watchdog",
+			"backend":          status,
+			"fallbacks_served": atomic.LoadInt64(&fallbacksServed),
+		})
+	})
+
+	// Readiness endpoint — returns 503 when backend is down (for K8s traffic routing)
+	mux.HandleFunc("/watchdog/ready", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if atomic.LoadInt32(&backendHealthy) == 1 {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]string{"status": "not_ready"})
+		}
+	})
+
+	// All other requests: proxy or fallback
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if atomic.LoadInt32(&backendHealthy) == 1 {
+			proxy.ServeHTTP(w, r)
+			return
+		}
+		atomic.AddInt64(&fallbacksServed, 1)
+		serveFallback(w, r)
+	})
+
+	addr := fmt.Sprintf(":%d", cfg.ListenPort)
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: watchdogReadHeaderTimeout,
+		ReadTimeout:       watchdogReadTimeout,
+		WriteTimeout:      watchdogWriteTimeout,
+		IdleTimeout:       watchdogIdleTimeout,
+	}
+
+	// Graceful shutdown
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		<-sigCh
+		log.Println("[Watchdog] Shutting down...")
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), watchdogShutdownTimeout)
+		defer shutdownCancel()
+		srv.Shutdown(shutdownCtx)
+	}()
+
+	log.Printf("[Watchdog] Listening on %s, proxying to %s", addr, backendURL.String())
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("watchdog listen error: %w", err)
+	}
+	return nil
+}
+
+// checkBackendHealth performs a single health check against the backend.
+// Returns true only if the backend responds with {"status": "ok"}.
+func checkBackendHealth(client *http.Client, healthURL string) bool {
+	resp, err := client.Get(healthURL)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return false
+	}
+	return body["status"] == "ok"
+}
+
+// pollBackendHealth polls the backend's /health endpoint and updates the atomic flag.
+// Only status "ok" counts as healthy — "starting" and "shutting_down" are treated as unhealthy.
+func pollBackendHealth(ctx context.Context, backendBase string, healthy *int32) {
+	client := &http.Client{Timeout: watchdogHealthTimeout}
+	healthURL := backendBase + "/health"
+
+	for {
+		wasHealthy := atomic.LoadInt32(healthy) == 1
+		isHealthy := checkBackendHealth(client, healthURL)
+
+		if isHealthy {
+			if !wasHealthy {
+				log.Printf("[Watchdog] Backend is healthy")
+			}
+			atomic.StoreInt32(healthy, 1)
+		} else {
+			if wasHealthy {
+				log.Printf("[Watchdog] Backend unreachable")
+			}
+			atomic.StoreInt32(healthy, 0)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(watchdogHealthPollInterval):
+		}
+	}
+}
+
+// serveFallback serves the appropriate response when the backend is down.
+// HTML requests get the branded reconnecting page; API requests get a 503 JSON response.
+func serveFallback(w http.ResponseWriter, r *http.Request) {
+	accept := r.Header.Get("Accept")
+	if strings.Contains(accept, "text/html") || accept == "" || accept == "*/*" {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(watchdogFallbackHTML))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	json.NewEncoder(w).Encode(map[string]string{
+		"error":  "backend_unavailable",
+		"status": "watchdog",
+	})
+}
+
+// writePidFile writes the current process ID to the given file path.
+func writePidFile(path string) error {
+	return os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), watchdogPidFilePerms)
+}

--- a/cmd/console/watchdog_html.go
+++ b/cmd/console/watchdog_html.go
@@ -1,0 +1,106 @@
+package main
+
+// watchdogFallbackHTML is served when the backend is unreachable.
+// It matches the KubeStellar Console branding (dark theme + star field)
+// and auto-reloads when the backend becomes healthy.
+const watchdogFallbackHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>KubeStellar Console — Reconnecting</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{background:#0a0a1a;color:#e2e8f0;font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;overflow:hidden}
+.wrap{text-align:center;max-width:420px;padding:2rem}
+.ring-wrap{position:relative;width:80px;height:80px;margin:0 auto 1.5rem}
+.ring{width:80px;height:80px;border:3px solid rgba(99,102,241,.15);border-top-color:#6366f1;border-radius:50%;animation:spin 1s linear infinite}
+@keyframes spin{to{transform:rotate(360deg)}}
+.countdown{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:1.5rem;font-weight:600;color:#6366f1}
+h1{font-size:1.25rem;font-weight:500;margin-bottom:.5rem}
+p{color:#94a3b8;font-size:.875rem;line-height:1.5}
+.status{margin-top:1rem;font-size:.8rem;color:#64748b}
+.retry-btn{display:inline-block;margin-top:1.25rem;padding:.5rem 1.25rem;background:rgba(99,102,241,.15);color:#818cf8;border:1px solid rgba(99,102,241,.3);border-radius:.5rem;font-size:.875rem;cursor:pointer;text-decoration:none;transition:all .2s}
+.retry-btn:hover{background:rgba(99,102,241,.25);border-color:rgba(99,102,241,.5)}
+.stars{position:fixed;inset:0;pointer-events:none}
+.star{position:absolute;width:2px;height:2px;background:#fff;border-radius:50%;opacity:.3;animation:twinkle 3s ease-in-out infinite}
+@keyframes twinkle{0%,100%{opacity:.2}50%{opacity:.6}}
+</style>
+</head>
+<body>
+<div class="stars" id="stars"></div>
+<div class="wrap">
+<div class="ring-wrap">
+<div class="ring"></div>
+<div class="countdown" id="cd">—</div>
+</div>
+<h1>Reconnecting to KubeStellar Console</h1>
+<p>The console is restarting or updating. This page will reload automatically when it's ready.</p>
+<div class="status" id="status">Checking connection…</div>
+<a href="/" class="retry-btn" id="retry" onclick="checkNow();return false;">Retry now</a>
+</div>
+<script>
+// Star field
+(function(){var s=document.getElementById('stars');for(var i=0;i<30;i++){var d=document.createElement('div');d.className='star';d.style.left=Math.random()*100+'%';d.style.top=Math.random()*100+'%';d.style.animationDelay=Math.random()*3+'s';s.appendChild(d)}})();
+
+var POLL_INTERVAL_MS=2000;
+var attempts=0;
+var startTime=Date.now();
+var cdEl=document.getElementById('cd');
+var statusEl=document.getElementById('status');
+var countdownSec=Math.floor(POLL_INTERVAL_MS/1000);
+
+// Countdown display between polls
+var cdTimer=setInterval(function(){
+  countdownSec--;
+  if(countdownSec<0)countdownSec=0;
+  cdEl.textContent=countdownSec;
+},1000);
+
+function elapsedStr(){
+  var s=Math.floor((Date.now()-startTime)/1000);
+  if(s<60)return s+'s';
+  return Math.floor(s/60)+'m '+s%60+'s';
+}
+
+async function checkNow(){
+  attempts++;
+  cdEl.textContent='…';
+  statusEl.textContent='Checking connection… (attempt '+attempts+')';
+  try{
+    var r=await fetch('/watchdog/health',{cache:'no-store'});
+    if(r.ok){
+      var d=await r.json();
+      if(d.backend==='ok'){
+        statusEl.textContent='Backend is ready! Reloading…';
+        clearInterval(cdTimer);
+        clearInterval(pollTimer);
+        // Send GA4 event so we can track watchdog usage
+        var waitSec=Math.floor((Date.now()-startTime)/1000);
+        if(typeof gtag==='function'){
+          gtag('event','watchdog_reconnect',{attempts:attempts,wait_seconds:waitSec});
+        }else{
+          // Beacon fallback if gtag not loaded yet
+          try{navigator.sendBeacon('/api/telemetry/watchdog',JSON.stringify({event:'watchdog_reconnect',attempts:attempts,wait_seconds:waitSec}))}catch(e){}
+        }
+        // Small delay to let the backend fully settle
+        setTimeout(function(){location.href='/';},500);
+        return;
+      }
+    }
+  }catch(e){}
+  if(attempts>15){
+    statusEl.textContent='Still reconnecting… ('+attempts+' attempts, '+elapsedStr()+')';
+  }else{
+    statusEl.textContent='Waiting for backend… (attempt '+attempts+')';
+  }
+  countdownSec=Math.floor(POLL_INTERVAL_MS/1000);
+}
+
+// Poll on interval
+var pollTimer=setInterval(checkNow,POLL_INTERVAL_MS);
+// First check immediately
+checkNow();
+</script>
+</body>
+</html>`

--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -44,13 +44,13 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ if .Values.watchdog.enabled }}/watchdog/health{{ else }}/health{{ end }}
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /health
+              path: {{ if .Values.watchdog.enabled }}/watchdog/ready{{ else }}/health{{ end }}
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -59,6 +59,10 @@ spec:
           env:
             - name: PORT
               value: "8080"
+            {{- if .Values.watchdog.enabled }}
+            - name: BACKEND_PORT
+              value: "8081"
+            {{- end }}
             - name: DATABASE_PATH
               value: {{ .Values.database.sqlitePath | quote }}
             {{- if .Values.route.enabled }}

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -165,5 +165,9 @@ podDisruptionBudget:
   enabled: false
   minAvailable: 1
 
+# Watchdog reverse proxy — serves a branded "Reconnecting..." page when backend is down
+watchdog:
+  enabled: true
+
 # Additional environment variables
 extraEnv: []

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Container entrypoint: starts backend on port 8081 with watchdog on port 8080.
+# The watchdog serves a "Reconnecting..." page if the backend crashes or restarts.
+# The shell stays as PID 1 so the signal trap can cleanly stop both processes.
+
+BACKEND_PORT=${BACKEND_PORT:-8081}
+
+# Start backend in the background
+BACKEND_PORT=$BACKEND_PORT ./console &
+BACKEND_PID=$!
+
+# Start watchdog in the background
+./console --watchdog --backend-port "$BACKEND_PORT" &
+WATCHDOG_PID=$!
+
+# Trap signals to forward to children and clean up
+cleanup() {
+    kill $WATCHDOG_PID 2>/dev/null
+    kill $BACKEND_PID 2>/dev/null
+    wait $WATCHDOG_PID 2>/dev/null
+    wait $BACKEND_PID 2>/dev/null
+    exit 0
+}
+trap cleanup SIGINT SIGTERM
+
+# Wait for either process to exit, then clean up both
+wait -n $BACKEND_PID $WATCHDOG_PID 2>/dev/null || wait $BACKEND_PID
+cleanup

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -73,6 +74,8 @@ type Config struct {
 	BenchmarkFolderID          string // Google Drive folder ID containing benchmark results
 	// Sidebar configuration
 	EnabledDashboards string // Comma-separated list of dashboard IDs to show in sidebar (empty = all)
+	// Watchdog support: when set, the backend listens on this port instead of Port
+	BackendPort int
 }
 
 // Server represents the API server
@@ -117,7 +120,12 @@ func NewServer(cfg Config) (*Server, error) {
 
 	// Start a temporary loading page server immediately so the user
 	// sees a loading screen instead of "connection refused" during init.
-	addr := fmt.Sprintf(":%d", cfg.Port)
+	// When BackendPort is set (watchdog mode), listen on that port instead.
+	listenPort := cfg.Port
+	if cfg.BackendPort > 0 {
+		listenPort = cfg.BackendPort
+	}
+	addr := fmt.Sprintf(":%d", listenPort)
 	loadingSrv := startLoadingServer(addr)
 
 	// --- Heavy initialization (loading page is already being served) ---
@@ -847,7 +855,12 @@ func (s *Server) Start() error {
 		time.Sleep(serverStartupDelay)
 	}
 
-	addr := fmt.Sprintf(":%d", s.config.Port)
+	// When BackendPort is set (watchdog mode), listen on that port instead
+	listenPort := s.config.Port
+	if s.config.BackendPort > 0 {
+		listenPort = s.config.BackendPort
+	}
+	addr := fmt.Sprintf(":%d", listenPort)
 	log.Printf("Starting server on %s (dev=%v)", addr, s.config.DevMode)
 	return s.app.Listen(addr)
 }
@@ -894,6 +907,15 @@ func LoadConfigFromEnv() Config {
 	port := 8080
 	if p := os.Getenv("PORT"); p != "" {
 		fmt.Sscanf(p, "%d", &port)
+	}
+
+	var backendPort int
+	if p := os.Getenv("BACKEND_PORT"); p != "" {
+		if v, err := strconv.Atoi(p); err != nil {
+			log.Printf("WARNING: invalid BACKEND_PORT %q, ignoring: %v", p, err)
+		} else {
+			backendPort = v
+		}
 	}
 
 	dbPath := "./data/console.db"
@@ -945,6 +967,8 @@ func LoadConfigFromEnv() Config {
 		BenchmarkFolderID:          getEnvOrDefault("BENCHMARK_FOLDER_ID", "1r2Z2Xp1L0KonUlvQHvEzed8AO9Xj8IPm"),
 		// Sidebar dashboard filter
 		EnabledDashboards: os.Getenv("ENABLED_DASHBOARDS"),
+		// Watchdog backend port override
+		BackendPort: backendPort,
 	}
 }
 

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -225,16 +225,40 @@ else
 fi
 echo ""
 
-# Port cleanup
-PORTS_TO_CLEAN="8080 8585"
-if [ "$USE_DEV_SERVER" = true ]; then PORTS_TO_CLEAN="8080 5174 8585"; fi
+# Watchdog-aware port cleanup
+# The watchdog on port 8080 survives restarts so users never see "connection refused".
+# Backend runs on port 8081 when watchdog is active.
+WATCHDOG_PID_FILE="/tmp/.kc-watchdog.pid"
+WATCHDOG_RUNNING=false
+BACKEND_LISTEN_PORT=8081
+
+# Check if watchdog is already alive on port 8080
+if [ -f "$WATCHDOG_PID_FILE" ]; then
+    WD_PID=$(cat "$WATCHDOG_PID_FILE" 2>/dev/null)
+    if [ -n "$WD_PID" ] && kill -0 "$WD_PID" 2>/dev/null; then
+        echo -e "${GREEN}Watchdog (pid $WD_PID) is alive on port 8080, preserving it${NC}"
+        WATCHDOG_RUNNING=true
+    else
+        echo -e "${YELLOW}Stale watchdog PID file, will clean up${NC}"
+        rm -f "$WATCHDOG_PID_FILE"
+    fi
+fi
+
+# Clean ports — skip 8080 if watchdog is alive
+PORTS_TO_CLEAN="$BACKEND_LISTEN_PORT 8585"
+if [ "$WATCHDOG_RUNNING" = false ]; then
+    PORTS_TO_CLEAN="8080 $BACKEND_LISTEN_PORT 8585"
+fi
+if [ "$USE_DEV_SERVER" = true ]; then PORTS_TO_CLEAN="$PORTS_TO_CLEAN 5174"; fi
 for p in $PORTS_TO_CLEAN; do
     if lsof -Pi :$p -sTCP:LISTEN -t >/dev/null 2>&1; then
         echo -e "${YELLOW}Port $p is in use, killing existing process...${NC}"
-        lsof -ti:$p | xargs kill -TERM 2>/dev/null || true
+        # Only kill LISTENING processes — not processes with outgoing connections
+        # (the watchdog has outgoing connections to the backend port)
+        lsof -ti:$p -sTCP:LISTEN | xargs kill -TERM 2>/dev/null || true
         sleep 2
         # Fall back to SIGKILL if process did not exit gracefully
-        lsof -ti:$p | xargs kill -9 2>/dev/null || true
+        lsof -ti:$p -sTCP:LISTEN | xargs kill -9 2>/dev/null || true
     fi
 done
 
@@ -247,6 +271,7 @@ cleanup() {
     kill $FRONTEND_PID 2>/dev/null || true
     kill $AGENT_LOOP_PID 2>/dev/null || true
     kill $AGENT_PID 2>/dev/null || true
+    kill $WATCHDOG_PID 2>/dev/null || true
     rm -f "$SHUTDOWN_FLAG"
     exit 0
 }
@@ -306,10 +331,18 @@ if [ "$USE_DEV_SERVER" = true ]; then
     if [ ! -d "web/node_modules" ]; then
         safe_npm_install web
     fi
-    echo -e "${GREEN}Starting backend (OAuth mode)...${NC}"
-    GOWORK=off go run ./cmd/console &
+    echo -e "${GREEN}Starting backend on port $BACKEND_LISTEN_PORT (OAuth mode)...${NC}"
+    BACKEND_PORT=$BACKEND_LISTEN_PORT GOWORK=off go run ./cmd/console &
     BACKEND_PID=$!
     sleep 2
+
+    # Start watchdog if not already running
+    if [ "$WATCHDOG_RUNNING" = false ]; then
+        echo -e "${GREEN}Starting watchdog on port 8080...${NC}"
+        GOWORK=off go run ./cmd/console --watchdog --backend-port "$BACKEND_LISTEN_PORT" &
+        WATCHDOG_PID=$!
+        sleep 1
+    fi
 
     echo -e "${GREEN}Starting Vite dev server...${NC}"
     (cd web && npm run dev -- --port 5174) &
@@ -319,7 +352,8 @@ if [ "$USE_DEV_SERVER" = true ]; then
     echo -e "${GREEN}=== Console is running in OAUTH + DEV mode ===${NC}"
     echo ""
     echo -e "  Frontend: ${CYAN}http://localhost:5174${NC}  (Vite HMR)"
-    echo -e "  Backend:  ${CYAN}http://localhost:8080${NC}"
+    echo -e "  Watchdog: ${CYAN}http://localhost:8080${NC}  (reverse proxy)"
+    echo -e "  Backend:  ${CYAN}http://localhost:$BACKEND_LISTEN_PORT${NC}"
     echo -e "  Agent:    ${CYAN}http://localhost:8585${NC}"
     echo -e "  Auth:     GitHub OAuth (real login)"
 else
@@ -331,18 +365,27 @@ else
     (cd web && npm run build)
     echo -e "${GREEN}Frontend built successfully${NC}"
 
-    # Start backend — serves both API and frontend static files from ./web/dist
-    echo -e "${GREEN}Starting backend (OAuth mode)...${NC}"
-    GOWORK=off go run ./cmd/console &
+    # Start backend on port 8081 — watchdog on 8080 proxies to it
+    echo -e "${GREEN}Starting backend on port $BACKEND_LISTEN_PORT (OAuth mode)...${NC}"
+    BACKEND_PORT=$BACKEND_LISTEN_PORT GOWORK=off go run ./cmd/console &
     BACKEND_PID=$!
     sleep 2
+
+    # Start watchdog if not already running
+    if [ "$WATCHDOG_RUNNING" = false ]; then
+        echo -e "${GREEN}Starting watchdog on port 8080...${NC}"
+        GOWORK=off go run ./cmd/console --watchdog --backend-port "$BACKEND_LISTEN_PORT" &
+        WATCHDOG_PID=$!
+        sleep 1
+    fi
 
     echo ""
     echo -e "${GREEN}=== Console is running in OAUTH mode ===${NC}"
     echo ""
-    echo -e "  Console: ${CYAN}http://localhost:8080${NC}"
-    echo -e "  Agent:   ${CYAN}http://localhost:8585${NC}"
-    echo -e "  Auth:    GitHub OAuth (real login)"
+    echo -e "  Console:  ${CYAN}http://localhost:8080${NC}  (via watchdog)"
+    echo -e "  Backend:  ${CYAN}http://localhost:$BACKEND_LISTEN_PORT${NC}"
+    echo -e "  Agent:    ${CYAN}http://localhost:8585${NC}"
+    echo -e "  Auth:     GitHub OAuth (real login)"
 fi
 echo ""
 echo "Press Ctrl+C to stop"


### PR DESCRIPTION
## Summary

- Adds a lightweight watchdog reverse proxy that sits on port 8080 and proxies to the backend on port 8081
- When the backend is down (crash, restart, update), the watchdog serves a branded "Reconnecting to KubeStellar Console..." page with auto-retry
- The watchdog **survives `startup-oauth.sh` restart cycles** via PID file detection — users never see "connection refused" during updates
- Includes Docker entrypoint, Helm chart updates, and GA4 tracking (`watchdog_reconnect` event)

### Architecture
```
User Browser → [Watchdog :8080] → [Backend :8081]
                    ↓ (backend down)
              "Reconnecting..." HTML with countdown + auto-retry
```

### Files
| File | Change |
|------|--------|
| `cmd/console/watchdog.go` | Core reverse proxy, health poller, fallback handler |
| `cmd/console/watchdog_html.go` | Branded reconnecting page (dark theme, star field, countdown) |
| `cmd/console/main.go` | `--watchdog` and `--backend-port` CLI flags |
| `pkg/api/server.go` | `BACKEND_PORT` env var support |
| `startup-oauth.sh` | Watchdog-aware port cleanup, backend on 8081 |
| `Dockerfile` + `entrypoint.sh` | Container support with signal forwarding |
| Helm deployment + values | Liveness (`/watchdog/health`) and readiness (`/watchdog/ready`) probes |

### Observability
- `/watchdog/health` — always responds: `{"status":"watchdog","backend":"ok|down","fallbacks_served":N}`
- `/watchdog/ready` — returns 503 when backend is down (K8s readiness)
- GA4 `watchdog_reconnect` event fires when backend recovers (tracks attempts + wait time)

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./cmd/console/...` passes
- [x] Frontend `npm run build` passes (no frontend changes)
- [x] **12/12 automated resilience cycles passed** — watchdog survives repeated backend kill/restart cycles without dying (single PID maintained throughout)
- [x] Code review: all 9 issues identified by reviewer have been fixed (server timeouts, connection pool management, goroutine cancellation, readiness probe separation, PID file permissions, BACKEND_PORT validation, entrypoint signal forwarding, resp.Body leak prevention, ResponseHeaderTimeout for SSE)
- [ ] Manual test with `startup-oauth.sh` (OAuth mode)
- [ ] Docker build and test