### PR TITLE
🐛 Fix kubectlProxy blocking agent connection in dev mode

### DIFF
--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -5,7 +5,7 @@
  * which has access to the user's kubeconfig.
  */
 
-import { getDemoMode } from '../hooks/useDemoMode'
+import { isNetlifyDeployment } from './demoMode'
 import {
   LOCAL_AGENT_WS_URL,
   WS_CONNECT_TIMEOUT_MS,
@@ -70,9 +70,9 @@ class KubectlProxy {
    * Ensure WebSocket is connected
    */
   private async ensureConnected(): Promise<void> {
-    // In demo mode, skip WebSocket connection to avoid console errors
-    if (getDemoMode()) {
-      throw new Error('Agent unavailable in demo mode')
+    // On Netlify there is no local agent — skip WebSocket entirely
+    if (isNetlifyDeployment) {
+      throw new Error('Agent unavailable on Netlify deployment')
     }
 
     if (this.ws?.readyState === WebSocket.OPEN) {


### PR DESCRIPTION
## Summary
- `kubectlProxy.ensureConnected()` called `getDemoMode()` which returns `true` when the auth token is `"demo-token"` (default in dev mode), even when the user explicitly toggled demo mode off via the UI
- This prevented ALL kubectl commands from executing through the WebSocket, breaking compliance hooks (Kyverno, Trivy, Kubescape) and other cluster data fetching in local dev mode
- Replace `getDemoMode()` with `isNetlifyDeployment` — the guard only needs to prevent WebSocket attempts on Netlify (where no local agent exists). In local environments, the agent should be allowed to connect regardless of token type

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Verified via CDP: Trivy hook successfully fetches real data from `vllm-d` cluster in dev mode
- [x] Verified WebSocket connects to kc-agent and processes kubectl commands
- [x] Netlify deployments still blocked (uses `isNetlifyDeployment` constant)