### PR TITLE
🐛 Fix compliance dashboard showing wrong data from Kyverno hooks

### DIFF
--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -277,35 +277,53 @@ export function PolicyViolations({ config: _config }: CardConfig) {
   const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isDemoData: kyvernoDemoData } = useKyverno()
   const { selectedClusters } = useGlobalFilters()
 
-  // Aggregate violations from Kyverno (and OPA could be added here too)
+  /** Maximum number of violation entries to display */
+  const MAX_VIOLATION_ENTRIES = 10
+
+  // Aggregate violations from Kyverno reports (policy.violations is always 0
+  // because the hook doesn't back-populate per-policy counts from PolicyReports;
+  // instead use totalViolations and reports for the real data)
   const violations = useMemo(() => {
     const result: Array<{ policy: string; count: number; tool: string; clusters: string[] }> = []
-    const policyMap = new Map<string, { count: number; tool: string; clusters: string[] }>()
+    const clusterViolations = new Map<string, { count: number; clusters: string[] }>()
 
     for (const [clusterName, status] of Object.entries(kyvernoStatuses)) {
       if (!status.installed) continue
       if (selectedClusters.length > 0 && !selectedClusters.includes(clusterName)) continue
 
-      for (const policy of (status.policies || [])) {
-        if (policy.violations === 0) continue
-        const key = `kyverno:${policy.name}`
-        if (!policyMap.has(key)) {
-          policyMap.set(key, { count: 0, tool: 'Kyverno', clusters: [] })
+      // Use reports for per-namespace breakdown when available
+      if ((status.reports || []).length > 0) {
+        for (const report of (status.reports || [])) {
+          if (report.fail === 0) continue
+          const key = report.namespace || 'cluster-scoped'
+          if (!clusterViolations.has(key)) {
+            clusterViolations.set(key, { count: 0, clusters: [] })
+          }
+          const entry = clusterViolations.get(key)!
+          entry.count += report.fail
+          if (!entry.clusters.includes(clusterName)) {
+            entry.clusters.push(clusterName)
+          }
         }
-        const entry = policyMap.get(key)!
-        entry.count += policy.violations
+      } else if (status.totalViolations > 0) {
+        // Fallback: aggregate totalViolations when reports array is empty
+        const key = 'all-policies'
+        if (!clusterViolations.has(key)) {
+          clusterViolations.set(key, { count: 0, clusters: [] })
+        }
+        const entry = clusterViolations.get(key)!
+        entry.count += status.totalViolations
         if (!entry.clusters.includes(clusterName)) {
           entry.clusters.push(clusterName)
         }
       }
     }
 
-    for (const [key, data] of policyMap.entries()) {
-      const policyName = key.split(':')[1]
-      result.push({ policy: policyName, ...data })
+    for (const [key, data] of clusterViolations.entries()) {
+      result.push({ policy: key, tool: 'Kyverno', ...data })
     }
 
-    return result.sort((a, b) => b.count - a.count).slice(0, 10)
+    return result.sort((a, b) => b.count - a.count).slice(0, MAX_VIOLATION_ENTRIES)
   }, [kyvernoStatuses, selectedClusters])
 
   const hasData = violations.length > 0 || kyvernoDemoData
@@ -371,14 +389,19 @@ export function ComplianceScore({ config: _config }: CardConfig) {
       totalPolicies += status.totalPolicies
     }
     if (totalPolicies > 0) {
-      // Compliance rate: policies with zero violations / total policies
-      let compliant = 0
+      // Compliance rate based on totalViolations from PolicyReports
+      // (individual policy.violations is always 0 — hook doesn't back-populate)
+      let totalViolations = 0
       for (const [clusterName, status] of Object.entries(kyvernoStatuses)) {
         if (!status.installed) continue
         if (selectedClusters.length > 0 && !selectedClusters.includes(clusterName)) continue
-        compliant += (status.policies || []).filter(p => p.violations === 0).length
+        totalViolations += status.totalViolations
       }
-      const rate = Math.round((compliant / totalPolicies) * 100)
+      // Score: 100% when no violations, 0% when violations >= totalPolicies
+      // Scale: each violation reduces score proportionally
+      const rate = totalViolations === 0
+        ? 100
+        : Math.max(0, Math.round(100 - (totalViolations / totalPolicies) * 100))
       scores.push({ name: 'Kyverno', value: rate })
     }
 

--- a/web/src/components/cards/CrossClusterPolicyComparison.tsx
+++ b/web/src/components/cards/CrossClusterPolicyComparison.tsx
@@ -51,9 +51,8 @@ export function CrossClusterPolicyComparison({ config: _config }: CardConfig) {
       const lower = customFilter.toLowerCase()
       result = result.filter(c => c.toLowerCase().includes(lower))
     }
-    // Only include clusters that have Kyverno data
-    const kyvernoKeys = new Set(Object.keys(kyvernoStatuses || {}))
-    result = result.filter(c => kyvernoKeys.has(c))
+    // Only include clusters where Kyverno is actually installed
+    result = result.filter(c => kyvernoStatuses?.[c]?.installed)
     return result.sort()
   }, [rawClusters, globalSelectedClusters, isAllClustersSelected, customFilter, kyvernoStatuses])
 

--- a/web/src/components/cards/FleetComplianceHeatmap.tsx
+++ b/web/src/components/cards/FleetComplianceHeatmap.tsx
@@ -166,7 +166,8 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
       if (!ks || !ks.installed) {
         kyvernoCell = { status: 'not-installed', label: 'N/A', tooltip: 'Kyverno not installed' }
       } else {
-        const violations = (ks.policies || []).reduce((sum, p) => sum + p.violations, 0)
+        // Use totalViolations from cluster status — individual policy violations aren't populated from reports
+        const violations = ks.totalViolations ?? 0
         const status: CellStatus = violations >= POLICY_CRITICAL_THRESHOLD ? 'critical'
           : violations >= POLICY_WARNING_THRESHOLD ? 'warning' : 'good'
         kyvernoCell = {

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -136,6 +136,8 @@ export function useKubescape() {
     cachedData.current?.timestamp ? new Date(cachedData.current.timestamp) : null
   )
   const initialLoadDone = useRef(!!cachedData.current)
+  /** Guard to prevent concurrent refetch calls from flooding the request queue */
+  const fetchInProgress = useRef(false)
 
   const clusters = useMemo(() =>
     allClusters.filter(c => c.reachable !== false).map(c => c.name),
@@ -147,6 +149,10 @@ export function useKubescape() {
       setIsLoading(false)
       return
     }
+
+    // Skip if a fetch is already in progress to prevent queue flooding
+    if (fetchInProgress.current) return
+    fetchInProgress.current = true
 
     if (!silent) {
       setIsRefreshing(true)
@@ -295,6 +301,7 @@ export function useKubescape() {
     initialLoadDone.current = true
     setIsLoading(false)
     setIsRefreshing(false)
+    fetchInProgress.current = false
   }, [clusters])
 
   // Demo mode

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -162,6 +162,8 @@ export function useKyverno() {
     cachedData.current?.timestamp ? new Date(cachedData.current.timestamp) : null
   )
   const initialLoadDone = useRef(!!cachedData.current)
+  /** Guard to prevent concurrent refetch calls from flooding the request queue */
+  const fetchInProgress = useRef(false)
 
   const clusters = useMemo(() =>
     allClusters.filter(c => c.reachable !== false).map(c => c.name),
@@ -173,6 +175,10 @@ export function useKyverno() {
       setIsLoading(false)
       return
     }
+
+    // Skip if a fetch is already in progress to prevent queue flooding
+    if (fetchInProgress.current) return
+    fetchInProgress.current = true
 
     if (!silent) {
       setIsRefreshing(true)
@@ -317,6 +323,7 @@ export function useKyverno() {
     initialLoadDone.current = true
     setIsLoading(false)
     setIsRefreshing(false)
+    fetchInProgress.current = false
   }, [clusters])
 
   // Demo mode

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -128,6 +128,8 @@ export function useTrivy() {
     cachedData.current?.timestamp ? new Date(cachedData.current.timestamp) : null
   )
   const initialLoadDone = useRef(!!cachedData.current)
+  /** Guard to prevent concurrent refetch calls from flooding the request queue */
+  const fetchInProgress = useRef(false)
 
   const clusters = useMemo(() =>
     allClusters.filter(c => c.reachable !== false).map(c => c.name),
@@ -139,6 +141,10 @@ export function useTrivy() {
       setIsLoading(false)
       return
     }
+
+    // Skip if a fetch is already in progress to prevent queue flooding
+    if (fetchInProgress.current) return
+    fetchInProgress.current = true
 
     if (!silent) {
       setIsRefreshing(true)
@@ -221,6 +227,7 @@ export function useTrivy() {
     initialLoadDone.current = true
     setIsLoading(false)
     setIsRefreshing(false)
+    fetchInProgress.current = false
   }, [clusters])
 
   // Demo mode


### PR DESCRIPTION
## Summary
- **Queue flooding fix**: Added `fetchInProgress` ref guard to `useKyverno`, `useKubescape`, and `useTrivy` hooks to prevent concurrent `refetch()` calls from flooding the kubectl proxy WebSocket queue (was growing to 925+ items, blocking all compliance data)
- **ComplianceScore card**: Was reading per-policy `violations` field (always 0 because the hook doesn't back-populate from PolicyReports) — now uses `totalViolations` from cluster status
- **PolicyViolations card**: Was iterating `status.policies` and skipping `violations === 0` (all of them) — now uses `status.reports` fail counts for per-namespace breakdown
- **FleetComplianceHeatmap**: Was summing per-policy `violations` (always 0) — now uses `ks.totalViolations`
- **CrossClusterPolicyComparison**: Was filtering clusters by key presence in `kyvernoStatuses` (all clusters have entries including `installed: false`) — now checks `kyvernoStatuses?.[c]?.installed`

## Test plan
- [x] Verified on localhost with CDP: Fleet Compliance Heatmap shows vllm-d with 2643 violations (red)
- [x] ComplianceScore shows 0% (correct — 2643 violations >> policy count)
- [x] PolicyViolations shows per-namespace breakdown (openshift-storage: 389, openshift-marketplace: 295, etc.)
- [x] Kyverno Policies card shows 2 real policies from vllm-d and konflux-ci
- [x] CrossClusterPolicyComparison shows only clusters with Kyverno installed
- [x] No demo cluster names appear when demo mode is off
- [x] Build passes
- [x] Lint passes (no new errors in changed files)