### PR TITLE
🐛 Add fetchInProgress guard to useCertManager and useLLMd hooks

### DIFF
--- a/web/src/hooks/useCertManager.ts
+++ b/web/src/hooks/useCertManager.ts
@@ -220,6 +220,8 @@ export function useCertManager() {
     cachedData.current?.timestamp ? new Date(cachedData.current.timestamp) : null
   )
   const initialLoadDone = useRef(!!cachedData.current)
+  /** Guard to prevent concurrent refetch calls from flooding the request queue */
+  const fetchInProgress = useRef(false)
 
   // Filter to reachable clusters
   const clusters = useMemo(() =>
@@ -232,6 +234,10 @@ export function useCertManager() {
       setIsLoading(false)
       return
     }
+
+    // Skip if a fetch is already in progress to prevent queue flooding
+    if (fetchInProgress.current) return
+    fetchInProgress.current = true
 
     if (!silent) {
       setIsRefreshing(true)
@@ -372,6 +378,7 @@ export function useCertManager() {
     } finally {
       setIsLoading(false)
       setIsRefreshing(false)
+      fetchInProgress.current = false
     }
   }, [clusters])
 

--- a/web/src/hooks/useLLMd.ts
+++ b/web/src/hooks/useLLMd.ts
@@ -207,6 +207,8 @@ export function useLLMdServers(clusters: string[] = ['vllm-d', 'platform-eval'])
   const [consecutiveFailures, setConsecutiveFailures] = useState(0)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
   const initialLoadDone = useRef(false)
+  /** Guard to prevent concurrent refetch calls from flooding the request queue */
+  const fetchInProgress = useRef(false)
 
   const refetch = useCallback(async (silent = false) => {
     // Skip fetching in demo mode — no agent available
@@ -214,6 +216,10 @@ export function useLLMdServers(clusters: string[] = ['vllm-d', 'platform-eval'])
       setIsLoading(false)
       return
     }
+
+    // Skip if a fetch is already in progress to prevent queue flooding
+    if (fetchInProgress.current) return
+    fetchInProgress.current = true
 
     // Progressive loading: reset state
     if (!silent) {
@@ -427,6 +433,7 @@ export function useLLMdServers(clusters: string[] = ['vllm-d', 'platform-eval'])
     } finally {
       setIsLoading(false)
       setIsRefreshing(false)
+      fetchInProgress.current = false
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [(clusters || []).join(',')])
@@ -481,6 +488,8 @@ export function useLLMdModels(clusters: string[] = ['vllm-d', 'platform-eval']) 
   const [consecutiveFailures, setConsecutiveFailures] = useState(0)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
   const initialLoadDone = useRef(false)
+  /** Guard to prevent concurrent refetch calls from flooding the request queue */
+  const fetchInProgress = useRef(false)
 
   const refetch = useCallback(async (silent = false) => {
     // Skip fetching in demo mode — no agent available
@@ -488,6 +497,10 @@ export function useLLMdModels(clusters: string[] = ['vllm-d', 'platform-eval']) 
       setIsLoading(false)
       return
     }
+
+    // Skip if a fetch is already in progress to prevent queue flooding
+    if (fetchInProgress.current) return
+    fetchInProgress.current = true
 
     // Progressive loading: reset state
     if (!silent) {
@@ -563,6 +576,7 @@ export function useLLMdModels(clusters: string[] = ['vllm-d', 'platform-eval']) 
     } finally {
       setIsLoading(false)
       setIsRefreshing(false)
+      fetchInProgress.current = false
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [(clusters || []).join(',')])


### PR DESCRIPTION
## Summary
- Applies the same `fetchInProgress` ref guard from PR #2124 to `useCertManager`, `useLLMdServers`, and `useLLMdModels`
- These hooks loop over clusters making multiple `kubectlProxy.exec` calls per refetch, and lacked re-entrancy protection
- Without the guard, concurrent refetch calls (from auto-refresh timers, React StrictMode double-mounts, effect dependency changes) flood the kubectl proxy WebSocket queue

## Test plan
- [x] Build passes
- [x] No new lint errors
- [x] Pattern matches existing guards in useKyverno, useKubescape, useTrivy (PR #2124)