### PR TITLE
🐛 Fix review findings: try/finally guards and cross-cluster pass/fail

### DIFF
--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -21,6 +21,9 @@ interface CardConfig {
   config?: Record<string, unknown>
 }
 
+/** Maximum number of violation entries to display in PolicyViolations card */
+const MAX_VIOLATION_ENTRIES = 10
+
 // ── Falco (still static — no hook yet) ──────────────────────────────────
 
 export function FalcoAlerts({ config: _config }: CardConfig) {
@@ -277,9 +280,6 @@ export function PolicyViolations({ config: _config }: CardConfig) {
   const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isDemoData: kyvernoDemoData } = useKyverno()
   const { selectedClusters } = useGlobalFilters()
 
-  /** Maximum number of violation entries to display */
-  const MAX_VIOLATION_ENTRIES = 10
-
   // Aggregate violations from Kyverno reports (policy.violations is always 0
   // because the hook doesn't back-populate per-policy counts from PolicyReports;
   // instead use totalViolations and reports for the real data)
@@ -397,8 +397,9 @@ export function ComplianceScore({ config: _config }: CardConfig) {
         if (selectedClusters.length > 0 && !selectedClusters.includes(clusterName)) continue
         totalViolations += status.totalViolations
       }
-      // Score: 100% when no violations, 0% when violations >= totalPolicies
-      // Scale: each violation reduces score proportionally
+      // Score: 100% when no violations, clamped to 0% when violations >= totalPolicies.
+      // Note: multiple resources can violate the same policy, so totalViolations
+      // often exceeds totalPolicies — the score floors at 0% in that case.
       const rate = totalViolations === 0
         ? 100
         : Math.max(0, Math.round(100 - (totalViolations / totalPolicies) * 100))

--- a/web/src/components/cards/CrossClusterPolicyComparison.tsx
+++ b/web/src/components/cards/CrossClusterPolicyComparison.tsx
@@ -85,6 +85,12 @@ export function CrossClusterPolicyComparison({ config: _config }: CardConfig) {
       const cs = kyvernoStatuses?.[cluster]
       if (!cs) continue
 
+      // Note: per-policy violations are not populated by the hook (always 0).
+      // Use cluster-level totalViolations as a signal: if the cluster has
+      // violations, audit-mode policies are marked 'fail' since they may
+      // be contributing; enforcing policies always pass (violations are blocked).
+      const clusterHasViolations = cs.totalViolations > 0
+
       for (const policy of (cs.policies || [])) {
         const key = `${policy.kind}/${policy.name}`
         if (!policyMap.has(key)) {
@@ -96,7 +102,8 @@ export function CrossClusterPolicyComparison({ config: _config }: CardConfig) {
           })
         }
         const row = policyMap.get(key)!
-        row.statuses[cluster] = policy.violations > 0 ? 'fail' : 'pass'
+        const isAudit = policy.status === 'audit'
+        row.statuses[cluster] = (clusterHasViolations && isAudit) ? 'fail' : 'pass'
       }
     }
 

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -154,6 +154,7 @@ export function useKubescape() {
     if (fetchInProgress.current) return
     fetchInProgress.current = true
 
+    try {
     if (!silent) {
       setIsRefreshing(true)
       if (!initialLoadDone.current) setIsLoading(true)
@@ -301,7 +302,9 @@ export function useKubescape() {
     initialLoadDone.current = true
     setIsLoading(false)
     setIsRefreshing(false)
-    fetchInProgress.current = false
+    } finally {
+      fetchInProgress.current = false
+    }
   }, [clusters])
 
   // Demo mode

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -180,6 +180,7 @@ export function useKyverno() {
     if (fetchInProgress.current) return
     fetchInProgress.current = true
 
+    try {
     if (!silent) {
       setIsRefreshing(true)
       if (!initialLoadDone.current) setIsLoading(true)
@@ -323,7 +324,9 @@ export function useKyverno() {
     initialLoadDone.current = true
     setIsLoading(false)
     setIsRefreshing(false)
-    fetchInProgress.current = false
+    } finally {
+      fetchInProgress.current = false
+    }
   }, [clusters])
 
   // Demo mode

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -146,6 +146,7 @@ export function useTrivy() {
     if (fetchInProgress.current) return
     fetchInProgress.current = true
 
+    try {
     if (!silent) {
       setIsRefreshing(true)
       if (!initialLoadDone.current) setIsLoading(true)
@@ -227,7 +228,9 @@ export function useTrivy() {
     initialLoadDone.current = true
     setIsLoading(false)
     setIsRefreshing(false)
-    fetchInProgress.current = false
+    } finally {
+      fetchInProgress.current = false
+    }
   }, [clusters])
 
   // Demo mode


### PR DESCRIPTION
## Summary
Follow-up from code review of PR #2124:
- **try/finally on fetchInProgress**: Without this, if an unexpected error occurs after setting the flag (e.g., `setStatuses` throws during unmount), the flag stays permanently stuck at `true` and no further fetches will ever execute
- **CrossClusterPolicyComparison pass/fail**: Was using `policy.violations` (always 0) to determine cell color — same root cause as the other cards fixed in #2124. Now uses `totalViolations > 0` + audit mode as a cluster-level signal
- **MAX_VIOLATION_ENTRIES**: Hoisted to module-level constant per project conventions
- **ComplianceScore comment**: Documented the cliff effect where violations > policies floors at 0%

## Test plan
- [x] Build passes
- [x] Production build verified on localhost:8080 — all compliance cards show real data
- [x] Kyverno 2643 violations correctly displayed across all cards