### PR TITLE
✨ Add Submit to KB option for saved resolutions

### DIFF
--- a/web/src/components/missions/ResolutionHistoryPanel.tsx
+++ b/web/src/components/missions/ResolutionHistoryPanel.tsx
@@ -8,6 +8,7 @@
 import { useState, useEffect, useRef } from 'react'
 import {
   BookMarked,
+  BookUp,
   Star,
   Building2,
   ChevronDown,
@@ -23,6 +24,7 @@ import {
 import { useResolutions, type Resolution } from '../../hooks/useResolutions'
 import { cn } from '../../lib/cn'
 import { ShareMissionDialog } from './ShareMissionDialog'
+import { SubmitToKBDialog } from './SubmitToKBDialog'
 import { useTranslation } from 'react-i18next'
 import { DELETE_CONFIRM_TIMEOUT_MS } from '../../lib/constants/network'
 
@@ -38,6 +40,7 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
   const [showShared, setShowShared] = useState(true)
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
   const [exportResolution, setExportResolution] = useState<Resolution | null>(null)
+  const [submitKBResolution, setSubmitKBResolution] = useState<Resolution | null>(null)
   const deleteConfirmTimerRef = useRef<ReturnType<typeof setTimeout>>()
 
   useEffect(() => {
@@ -123,6 +126,7 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
                     onDelete={() => handleDelete(resolution.id)}
                     onShare={() => handleShare(resolution.id)}
                     onExport={() => setExportResolution(resolution)}
+                    onSubmitToKB={() => setSubmitKBResolution(resolution)}
                     isDeleteConfirm={deleteConfirmId === resolution.id}
                     canShare
                   />
@@ -154,6 +158,7 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
                     onApply={onApplyResolution ? () => onApplyResolution(resolution) : undefined}
                     onDelete={() => handleDelete(resolution.id)}
                     onExport={() => setExportResolution(resolution)}
+                    onSubmitToKB={() => setSubmitKBResolution(resolution)}
                     isDeleteConfirm={deleteConfirmId === resolution.id}
                     showSharedBy
                   />
@@ -172,6 +177,15 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
           onClose={() => setExportResolution(null)}
         />
       )}
+
+      {/* Submit to KB dialog */}
+      {submitKBResolution && (
+        <SubmitToKBDialog
+          resolution={submitKBResolution}
+          isOpen={true}
+          onClose={() => setSubmitKBResolution(null)}
+        />
+      )}
     </div>
   )
 }
@@ -184,6 +198,7 @@ interface ResolutionCardProps {
   onDelete: () => void
   onShare?: () => void
   onExport?: () => void
+  onSubmitToKB?: () => void
   isDeleteConfirm: boolean
   showSharedBy?: boolean
   canShare?: boolean
@@ -197,6 +212,7 @@ function ResolutionCard({
   onDelete,
   onShare,
   onExport,
+  onSubmitToKB,
   isDeleteConfirm,
   showSharedBy,
   canShare,
@@ -319,6 +335,18 @@ function ResolutionCard({
                   title="Export mission"
                 >
                   <Download className="w-3 h-3" />
+                </button>
+              )}
+              {onSubmitToKB && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onSubmitToKB()
+                  }}
+                  className="flex items-center justify-center gap-1 px-2 py-1.5 text-2xs bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 border border-purple-500/30 rounded transition-colors"
+                  title="Submit to console-kb"
+                >
+                  <BookUp className="w-3 h-3" />
                 </button>
               )}
               <button

--- a/web/src/components/missions/SubmitToKBDialog.tsx
+++ b/web/src/components/missions/SubmitToKBDialog.tsx
@@ -1,0 +1,386 @@
+/**
+ * Submit to KB Dialog
+ *
+ * Converts a saved resolution into a console-kb compatible mission file
+ * and opens GitHub's file creation UI to submit it as a PR to kubestellar/console-kb.
+ */
+
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
+import {
+  X,
+  BookUp,
+  ExternalLink,
+  Shield,
+  Loader2,
+  AlertTriangle,
+  CheckCircle,
+  FileJson,
+  Tag,
+} from 'lucide-react'
+import type { Resolution } from '../../hooks/useResolutions'
+import type { MissionExport, MissionClass, FileScanResult } from '../../lib/missions/types'
+import { fullScan } from '../../lib/missions/scanner/index'
+import { cn } from '../../lib/cn'
+
+/** GitHub repo for the knowledge base */
+const CONSOLE_KB_REPO = 'kubestellar/console-kb'
+
+/** Default branch for new file PRs */
+const CONSOLE_KB_BRANCH = 'master'
+
+/** Max URL length for GitHub new-file links (browsers typically support ~8000) */
+const MAX_GITHUB_URL_LENGTH = 7500
+
+interface SubmitToKBDialogProps {
+  resolution: Resolution
+  isOpen: boolean
+  onClose: () => void
+}
+
+/**
+ * Convert a Resolution into the console-kb nested file format.
+ * console-kb uses: { mission: { steps, ... }, metadata: { ... } }
+ */
+function resolutionToKBFormat(
+  resolution: Resolution,
+  missionClass: MissionClass,
+  cncfProject: string,
+): Record<string, unknown> {
+  const steps = resolution.resolution.steps.map((step, i) => ({
+    title: `Step ${i + 1}`,
+    description: step,
+  }))
+
+  const mission: Record<string, unknown> = {
+    steps,
+  }
+
+  // Add troubleshooting section for solution-class missions
+  if (missionClass === 'solution' && resolution.resolution.summary) {
+    mission.troubleshooting = [
+      {
+        title: resolution.issueSignature.type,
+        description: resolution.resolution.summary,
+      },
+    ]
+  }
+
+  // Add resolution data
+  if (resolution.resolution.summary || resolution.resolution.steps.length > 0) {
+    mission.resolution = {
+      summary: resolution.resolution.summary,
+      steps: resolution.resolution.steps,
+      ...(resolution.resolution.yaml ? { yaml: resolution.resolution.yaml } : {}),
+    }
+  }
+
+  return {
+    version: 'kc-mission-v1',
+    title: resolution.title,
+    description: resolution.resolution.summary || resolution.title,
+    type: missionClass === 'install' ? 'deploy' : 'troubleshoot',
+    missionClass,
+    tags: [
+      resolution.issueSignature.type,
+      ...(resolution.issueSignature.resourceKind ? [resolution.issueSignature.resourceKind] : []),
+      ...(cncfProject ? [cncfProject] : []),
+    ].filter(Boolean),
+    category: missionClass === 'install' ? 'installation' : 'troubleshooting',
+    ...(cncfProject ? { cncfProject } : {}),
+    ...(resolution.issueSignature.resourceKind ? { resourceKind: resolution.issueSignature.resourceKind } : {}),
+    mission,
+    metadata: {
+      author: resolution.sharedBy || resolution.userId,
+      source: 'kubestellar-console',
+      createdAt: resolution.createdAt,
+      updatedAt: resolution.updatedAt,
+    },
+  }
+}
+
+/** Generate a filesystem-safe filename from the resolution title */
+function generateFilename(title: string, missionClass: MissionClass): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 60)
+  const prefix = missionClass === 'install' ? 'install' : 'solution'
+  return `${prefix}-${slug}.json`
+}
+
+/** Build the GitHub "new file" URL that opens the file creation UI */
+function buildGitHubNewFileUrl(
+  filepath: string,
+  content: string,
+  description: string,
+): string {
+  // GitHub new file URL: /new/{branch}/{path}?filename=...&value=...&message=...
+  const directory = filepath.includes('/') ? filepath.substring(0, filepath.lastIndexOf('/')) : 'solutions'
+  const filename = filepath.includes('/') ? filepath.substring(filepath.lastIndexOf('/') + 1) : filepath
+
+  const params = new URLSearchParams({
+    filename,
+    value: content,
+    message: `Add ${filename}: ${description}`,
+    description: `Submitted from KubeStellar Console resolution history.\n\n${description}`,
+  })
+
+  return `https://github.com/${CONSOLE_KB_REPO}/new/${CONSOLE_KB_BRANCH}/${directory}?${params.toString()}`
+}
+
+export function SubmitToKBDialog({ resolution, isOpen, onClose }: SubmitToKBDialogProps) {
+  const [missionClass, setMissionClass] = useState<MissionClass>('solution')
+  const [cncfProject, setCncfProject] = useState('')
+  const [filename, setFilename] = useState('')
+  const [scanResult, setScanResult] = useState<FileScanResult | null>(null)
+  const [scanning, setScanning] = useState(false)
+  const scanRanRef = useRef(false)
+
+  // Generate default filename when inputs change
+  useEffect(() => {
+    if (isOpen) {
+      setFilename(generateFilename(resolution.title, missionClass))
+      setScanResult(null)
+      scanRanRef.current = false
+    }
+  }, [isOpen, resolution.title, missionClass])
+
+  // Build the console-kb formatted JSON
+  const kbContent = useMemo(
+    () => resolutionToKBFormat(resolution, missionClass, cncfProject),
+    [resolution, missionClass, cncfProject],
+  )
+
+  const jsonString = useMemo(
+    () => JSON.stringify(kbContent, null, 2),
+    [kbContent],
+  )
+
+  // Determine the target directory based on mission class
+  const targetDir = missionClass === 'install' ? 'solutions/cncf-install' : 'solutions/troubleshoot'
+  const fullPath = `${targetDir}/${filename}`
+
+  // Run security scan
+  const runScan = useCallback(() => {
+    setScanning(true)
+    try {
+      const result = fullScan(kbContent as unknown as MissionExport)
+      setScanResult(result)
+    } catch {
+      setScanResult(null)
+    } finally {
+      setScanning(false)
+      scanRanRef.current = true
+    }
+  }, [kbContent])
+
+  // Auto-scan on first open
+  useEffect(() => {
+    if (isOpen && !scanRanRef.current) {
+      runScan()
+    }
+  }, [isOpen, runScan])
+
+  const hasWarnings = scanResult?.findings.some(f => f.severity === 'warning' || f.severity === 'error')
+
+  const handleSubmit = () => {
+    const description = resolution.resolution.summary || resolution.title
+    const url = buildGitHubNewFileUrl(fullPath, jsonString, description)
+
+    // Check URL length — GitHub has limits
+    if (url.length > MAX_GITHUB_URL_LENGTH) {
+      // Fall back to opening an issue with the content instead
+      const issueParams = new URLSearchParams({
+        title: `New ${missionClass}: ${resolution.title}`,
+        body: [
+          `## New ${missionClass === 'install' ? 'Install Mission' : 'Solution'}`,
+          '',
+          `**Title:** ${resolution.title}`,
+          `**Issue Type:** ${resolution.issueSignature.type}`,
+          cncfProject ? `**CNCF Project:** ${cncfProject}` : '',
+          '',
+          '## Mission JSON',
+          '',
+          '```json',
+          jsonString,
+          '```',
+          '',
+          '---',
+          '_Submitted from KubeStellar Console resolution history._',
+        ].filter(Boolean).join('\n'),
+        labels: ['new-mission', missionClass].join(','),
+      })
+
+      window.open(
+        `https://github.com/${CONSOLE_KB_REPO}/issues/new?${issueParams.toString()}`,
+        '_blank',
+        'noopener,noreferrer',
+      )
+    } else {
+      window.open(url, '_blank', 'noopener,noreferrer')
+    }
+
+    onClose()
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-2xl">
+      <div className="bg-card border border-border rounded-lg shadow-xl w-full max-w-lg mx-4 max-h-[85vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-border">
+          <div className="flex items-center gap-2">
+            <BookUp className="w-5 h-5 text-purple-400" />
+            <h3 className="text-sm font-semibold text-foreground">Submit to Knowledge Base</h3>
+          </div>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground transition-colors">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          {/* Resolution preview */}
+          <div className="p-3 rounded-lg bg-secondary/50 border border-border">
+            <p className="text-xs font-medium text-foreground truncate">{resolution.title}</p>
+            <p className="text-2xs text-muted-foreground mt-1">
+              {resolution.issueSignature.type}
+              {resolution.issueSignature.resourceKind && ` · ${resolution.issueSignature.resourceKind}`}
+              {' · '}{resolution.resolution.steps.length} steps
+            </p>
+          </div>
+
+          {/* Mission Class */}
+          <div>
+            <label className="text-sm font-medium text-foreground mb-2 block">
+              Mission Type
+            </label>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setMissionClass('solution')}
+                className={cn(
+                  'flex-1 flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg border transition-colors',
+                  missionClass === 'solution'
+                    ? 'bg-purple-500/20 border-purple-500/50 text-purple-400'
+                    : 'bg-secondary/50 border-border text-muted-foreground hover:text-foreground',
+                )}
+              >
+                <Tag className="w-4 h-4" />
+                <div className="text-left">
+                  <span className="text-sm font-medium block">Solution</span>
+                  <span className="text-2xs opacity-70">Troubleshooting fix</span>
+                </div>
+              </button>
+              <button
+                onClick={() => setMissionClass('install')}
+                className={cn(
+                  'flex-1 flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg border transition-colors',
+                  missionClass === 'install'
+                    ? 'bg-blue-500/20 border-blue-500/50 text-blue-400'
+                    : 'bg-secondary/50 border-border text-muted-foreground hover:text-foreground',
+                )}
+              >
+                <BookUp className="w-4 h-4" />
+                <div className="text-left">
+                  <span className="text-sm font-medium block">Install Mission</span>
+                  <span className="text-2xs opacity-70">Setup / deploy guide</span>
+                </div>
+              </button>
+            </div>
+          </div>
+
+          {/* CNCF Project (optional) */}
+          <div>
+            <label className="text-sm font-medium text-foreground mb-1.5 block">
+              CNCF Project <span className="text-muted-foreground font-normal">(optional)</span>
+            </label>
+            <input
+              type="text"
+              value={cncfProject}
+              onChange={(e) => setCncfProject(e.target.value)}
+              placeholder="e.g., Istio, Argo CD, Prometheus..."
+              className="w-full px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500"
+            />
+          </div>
+
+          {/* Filename */}
+          <div>
+            <label className="text-sm font-medium text-foreground flex items-center gap-2 mb-1.5">
+              <FileJson className="w-4 h-4 text-muted-foreground" />
+              Filename
+            </label>
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-muted-foreground whitespace-nowrap">{targetDir}/</span>
+              <input
+                type="text"
+                value={filename}
+                onChange={(e) => setFilename(e.target.value)}
+                className="flex-1 px-3 py-2 text-sm font-mono bg-secondary/50 border border-border rounded-lg text-foreground focus:outline-none focus:ring-1 focus:ring-purple-500"
+              />
+            </div>
+          </div>
+
+          {/* Security scan */}
+          <div className="px-3 py-2.5 rounded-lg border border-border bg-secondary/30">
+            {scanning ? (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="w-3 h-3 animate-spin" />
+                Scanning for sensitive data...
+              </div>
+            ) : scanResult ? (
+              <div className={cn('flex items-center gap-2 text-xs', hasWarnings ? 'text-yellow-400' : 'text-green-400')}>
+                {hasWarnings ? <AlertTriangle className="w-3 h-3" /> : <CheckCircle className="w-3 h-3" />}
+                {hasWarnings
+                  ? `${scanResult.findings.filter(f => f.severity !== 'info').length} finding(s) — review before submitting`
+                  : 'No sensitive data detected'}
+              </div>
+            ) : (
+              <button
+                onClick={runScan}
+                className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <Shield className="w-3 h-3" />
+                Run security scan
+              </button>
+            )}
+          </div>
+
+          {/* JSON preview */}
+          <details className="group">
+            <summary className="text-xs text-muted-foreground cursor-pointer hover:text-foreground transition-colors">
+              Preview JSON ({jsonString.length} chars)
+            </summary>
+            <pre className="mt-2 p-3 rounded-lg bg-secondary/50 border border-border text-2xs font-mono text-foreground overflow-x-auto max-h-48 overflow-y-auto">
+              {jsonString}
+            </pre>
+          </details>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-between p-4 border-t border-border">
+          <p className="text-2xs text-muted-foreground">
+            Opens a PR on {CONSOLE_KB_REPO}
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onClose}
+              className="px-3 py-1.5 text-sm rounded-lg border border-border text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={!filename.trim()}
+              className="flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium rounded-lg bg-purple-600 hover:bg-purple-500 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ExternalLink className="w-3.5 h-3.5" />
+              Submit to KB
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds a purple **Submit to KB** button (BookUp icon) on each resolution card in the Resolution History panel
- New `SubmitToKBDialog` lets users submit saved resolutions to `kubestellar/console-kb` as either a **Solution** (troubleshooting fix) or **Install Mission** (setup guide)
- Converts resolutions to the console-kb nested file format (`{ mission: { steps, ... }, metadata: { ... } }`)
- Includes CNCF project field, editable filename, security scan, and JSON preview
- Opens GitHub's file creation UI to submit as a PR — falls back to GitHub issue if URL exceeds browser limits

## How It Works

1. User expands a saved resolution in the Resolution History panel
2. Clicks the purple KB button (between export and delete)
3. Dialog opens with:
   - Mission class selector (Solution / Install Mission)
   - Optional CNCF project name
   - Auto-generated filename (e.g., `solution-fix-kubevuln-crash-looping.json`)
   - Security scan result
   - Collapsible JSON preview
4. "Submit to KB" opens GitHub's new-file UI on `kubestellar/console-kb` with pre-filled content
5. User creates a PR directly from GitHub

## Test plan

- [ ] Save a resolution from a completed mission
- [ ] Click the purple KB button on the resolution card
- [ ] Verify dialog shows correct content, filename, and security scan
- [ ] Switch between Solution and Install Mission — filename prefix changes
- [ ] Click "Submit to KB" — GitHub opens with pre-filled file content
- [ ] Verify the JSON matches console-kb's expected nested format
- [ ] `npm run build` and `npm run lint` pass