### PR TITLE
🐛 Fix AI Disabled false positive from zero-value token settings

### DIFF
--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -299,14 +299,12 @@ export function useTokenUsage() {
   const updateSettings = useCallback(
     (settings: Partial<Omit<TokenUsage, 'used' | 'resetDate'>>) => {
       const newSettings = {
-        limit: settings.limit ?? sharedUsage.limit,
-        warningThreshold: settings.warningThreshold ?? sharedUsage.warningThreshold,
-        criticalThreshold: settings.criticalThreshold ?? sharedUsage.criticalThreshold,
-        // Always preserve stopThreshold at 100% — not user-configurable, prevents corruption
+        // Use || (not ??) so that 0 falls back to defaults — 0 is never a valid threshold
+        limit: settings.limit || sharedUsage.limit || DEFAULT_SETTINGS.limit,
+        warningThreshold: settings.warningThreshold || sharedUsage.warningThreshold || DEFAULT_SETTINGS.warningThreshold,
+        criticalThreshold: settings.criticalThreshold || sharedUsage.criticalThreshold || DEFAULT_SETTINGS.criticalThreshold,
         stopThreshold: DEFAULT_SETTINGS.stopThreshold,
       }
-      // Ensure limit is always positive
-      if (newSettings.limit <= 0) newSettings.limit = DEFAULT_SETTINGS.limit
       updateSharedUsage(newSettings)
       localStorage.setItem(SETTINGS_KEY, JSON.stringify(newSettings))
       window.dispatchEvent(new Event(SETTINGS_CHANGED_EVENT))


### PR DESCRIPTION
## Summary
- `updateSettings` used `??` (nullish coalescing) which treats `0` as a valid value
- When localStorage had `{"limit":0,"warningThreshold":0,"criticalThreshold":0,"stopThreshold":0}`, `stopThreshold: 0` caused any usage >= 0% to show "AI Disabled"
- Changed to `||` so that `0` falls back to defaults since 0 is never a valid limit or threshold

## Test plan
- [ ] Set token settings to all zeros in localStorage, verify "AI Disabled" does NOT appear
- [ ] Verify normal token usage display works correctly
- [ ] Verify settings page saves valid values