### PR TITLE
🐛 Restore CONSOLE_AUTO token in ai-fix workflow

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -23,4 +23,4 @@ jobs:
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.CONSOLE_AUTO || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The infra sync PR #2055 (merged Mar 9) replaced `secrets.CONSOLE_AUTO || secrets.GITHUB_TOKEN` with just `secrets.GITHUB_TOKEN` in `.github/workflows/ai-fix.yml`
- This broke Copilot coding agent — the default `GITHUB_TOKEN` lacks the elevated permissions needed for Copilot to push commits to PRs
- Restores the `CONSOLE_AUTO` PAT fallback, matching all other Copilot workflows (`copilot-build-check.yml`, `copilot-pr-monitor.yml`, `copilot-recovery.yml`, `copilot-review-apply.yml`)

Fixes the issue reported by Vijay on PR #2137.

## Test plan
- [ ] Close and re-open PR #2137 (or assign a new issue to Copilot) and verify Copilot can push code