### PR TITLE
🐛 Fix backend startup command in development script

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -162,7 +162,7 @@ fi
 
 # Start backend
 echo "Starting backend..."
-go run ./cmd/console/main.go --dev &
+go run ./cmd/console/ --dev &
 BACKEND_PID=$!
 sleep 2
 


### PR DESCRIPTION
Running `make dev` started Vite on port 5174 successfully, but the Go backend exited immediately without binding to port 8080. This caused every proxied request from Vite to fail with ECONNREFUSED.

### 📌 Fixes

Fixes #2138 
---

### 📝 Summary of Changes

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated  `Makefile`, ensuring watchdog go files also run, which fixes the errors.
---

### Checklist

Please ensure the following before submitting your PR:

- [ ] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
