### PR TITLE
🐛 Fix React Error #31: coerce relatedResources to strings

### DIFF
--- a/web/src/components/cards/insights/ClusterDeltaDetector.tsx
+++ b/web/src/components/cards/insights/ClusterDeltaDetector.tsx
@@ -98,7 +98,7 @@ export function ClusterDeltaDetector() {
                   : 'bg-secondary/50 text-muted-foreground hover:bg-secondary'
               }`}
             >
-              {(ins.relatedResources || [])[0] || ins.title}
+              {String((ins.relatedResources || [])[0] || ins.title)}
             </button>
           ))}
         </div>

--- a/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
+++ b/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
@@ -116,7 +116,7 @@ export function DeploymentRolloutTracker() {
                   : 'bg-secondary/50 text-muted-foreground hover:bg-secondary'
               }`}
             >
-              {(ins.relatedResources || [])[0] || ins.title}
+              {String((ins.relatedResources || [])[0] || ins.title)}
             </button>
           ))}
         </div>

--- a/web/src/components/cards/insights/RestartCorrelationMatrix.tsx
+++ b/web/src/components/cards/insights/RestartCorrelationMatrix.tsx
@@ -131,7 +131,7 @@ export function RestartCorrelationMatrix() {
               {insight.relatedResources && insight.relatedResources.length > 0 && (
                 <div className="flex flex-wrap gap-1 mt-1">
                   {(insight.relatedResources || []).map(resource => (
-                    <StatusBadge key={resource} color="gray" size="xs">{resource}</StatusBadge>
+                    <StatusBadge key={String(resource)} color="gray" size="xs">{String(resource)}</StatusBadge>
                   ))}
                 </div>
               )}

--- a/web/src/components/cards/insights/insightRelatedResources.test.tsx
+++ b/web/src/components/cards/insights/insightRelatedResources.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * Tests that insight cards don't crash (React Error #31) when
+ * relatedResources contains objects instead of plain strings.
+ *
+ * Background: Kubernetes event objects can be non-string references.
+ * Without String() coercion, rendering them as React children throws
+ * "Objects are not valid as a React child".
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import type { MultiClusterInsight } from '../../../types/insights'
+
+// ----- shared mocks -----
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}))
+vi.mock('../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+}))
+
+/** Factory for a minimal insight whose relatedResources are objects, not strings */
+function objectResourceInsight(
+  category: MultiClusterInsight['category'],
+  overrides: Partial<MultiClusterInsight> = {},
+): MultiClusterInsight {
+  return {
+    id: `test-${category}`,
+    category,
+    source: 'heuristic',
+    severity: 'warning',
+    title: 'Test insight',
+    description: 'Insight with object relatedResources',
+    affectedClusters: ['cluster-a', 'cluster-b'],
+    // Cast objects to string[] to simulate the runtime scenario
+    // where Kubernetes object references slip through the type system
+    relatedResources: [
+      { kind: 'Pod', name: 'nginx-abc' } as unknown as string,
+      { kind: 'Deployment', name: 'api-server' } as unknown as string,
+    ],
+    detectedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+// ============================================================
+// ClusterDeltaDetector
+// ============================================================
+vi.mock('../../../hooks/useMultiClusterInsights', () => ({
+  useMultiClusterInsights: vi.fn(),
+}))
+vi.mock('../CardDataContext', () => ({
+  useCardLoadingState: vi.fn(),
+}))
+vi.mock('../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({
+    selectedClusters: [], isAllClustersSelected: true,
+    customFilter: '', filterByCluster: (items: unknown[]) => items,
+    filterBySeverity: (items: unknown[]) => items,
+  }),
+}))
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  BarChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Bar: () => <div />,
+  XAxis: () => <div />,
+  YAxis: () => <div />,
+  CartesianGrid: () => <div />,
+  Tooltip: () => <div />,
+  Cell: () => <div />,
+}))
+
+import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
+import { ClusterDeltaDetector } from './ClusterDeltaDetector'
+import { DeploymentRolloutTracker } from './DeploymentRolloutTracker'
+import { RestartCorrelationMatrix } from './RestartCorrelationMatrix'
+
+const mockInsights = vi.mocked(useMultiClusterInsights)
+
+describe('Insight cards handle object relatedResources without crashing', () => {
+  it('ClusterDeltaDetector renders String() for object relatedResources', () => {
+    const insight = objectResourceInsight('cluster-delta', {
+      deltas: [{
+        dimension: 'cpu',
+        significance: 'high' as const,
+        clusterA: { name: 'cluster-a', value: 100 },
+        clusterB: { name: 'cluster-b', value: 200 },
+      }],
+    })
+    // Provide two insights so the selector renders relatedResources[0]
+    mockInsights.mockReturnValue({
+      insightsByCategory: { 'cluster-delta': [insight, { ...insight, id: 'test-2' }] },
+      isLoading: false,
+      isDemoData: false,
+    } as ReturnType<typeof useMultiClusterInsights>)
+
+    expect(() => render(<ClusterDeltaDetector />)).not.toThrow()
+  })
+
+  it('DeploymentRolloutTracker renders String() for object relatedResources', () => {
+    const insight = objectResourceInsight('rollout-tracker', {
+      metrics: { 'cluster-a_progress': 50, 'cluster-b_progress': 100 },
+    })
+    mockInsights.mockReturnValue({
+      insightsByCategory: { 'rollout-tracker': [insight, { ...insight, id: 'test-2' }] },
+      isLoading: false,
+      isDemoData: false,
+    } as ReturnType<typeof useMultiClusterInsights>)
+
+    expect(() => render(<DeploymentRolloutTracker />)).not.toThrow()
+  })
+
+  it('RestartCorrelationMatrix renders String() for object relatedResources in infra list', () => {
+    const insight = objectResourceInsight('restart-correlation', {
+      id: 'test-infra-issue',
+    })
+    mockInsights.mockReturnValue({
+      insightsByCategory: { 'restart-correlation': [insight] },
+      isLoading: false,
+      isDemoData: false,
+    } as ReturnType<typeof useMultiClusterInsights>)
+
+    expect(() => render(<RestartCorrelationMatrix />)).not.toThrow()
+  })
+})

--- a/web/src/hooks/useMultiClusterInsights.ts
+++ b/web/src/hooks/useMultiClusterInsights.ts
@@ -122,7 +122,7 @@ function detectEventCorrelations(events: ClusterEvent[]): MultiClusterInsight[] 
       title: `${clusterMap.size} clusters had simultaneous warnings`,
       description: `${totalEvents} warning events across ${affectedClusters.join(', ')} within a 5-minute window. Common reasons: ${reasons}.`,
       affectedClusters,
-      relatedResources: [...new Set((allEvents || []).map(e => e.object))].slice(0, 5),
+      relatedResources: [...new Set((allEvents || []).map(e => String(e.object || '')))].slice(0, 5),
       detectedAt: new Date(bucket).toISOString(),
     })
   }


### PR DESCRIPTION
## Summary

- Fix production React Error #31 ("Objects are not valid as a React child") found via GA4 error tracking
- Kubernetes event `object` references can be non-string types that crash when rendered as JSX children
- Wrap `relatedResources` values with `String()` at the data source (`useMultiClusterInsights.ts`) and all 3 render sites (`ClusterDeltaDetector`, `DeploymentRolloutTracker`, `RestartCorrelationMatrix`)
- Add unit test verifying all 3 cards render without crashing when `relatedResources` contains objects

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] New unit test (`insightRelatedResources.test.tsx`) passes — 3/3 tests green
- [ ] Verify no React Error #31 in GA4 error logs after deploy