### PR TITLE
🐛 Fix main content not shrinking for 580px mission sidebar

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -395,7 +395,7 @@ export function Layout({ children }: LayoutProps) {
           className={cn(
             "fixed z-20 bg-background border-b border-orange-500/20 transition-[right] duration-300",
           // Adjust right edge when mission sidebar is open (desktop only)
-          !isMobile && isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen ? "right-[500px]" : "right-0",
+          !isMobile && isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen ? "right-[580px]" : "right-0",
           !isMobile && isMissionSidebarOpen && isMissionSidebarMinimized && !isMissionFullScreen && "right-12"
         )}>
           <div className="flex flex-wrap items-center justify-between gap-2 py-1.5 px-3 md:px-4">
@@ -440,7 +440,7 @@ export function Layout({ children }: LayoutProps) {
           className={cn(
             'relative flex-1 p-4 md:p-6 transition-[margin] duration-300 overflow-y-auto scroll-enhanced min-w-0',
             // Don't apply right margin when fullscreen is active or on mobile
-            !isMobile && isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen && 'mr-[500px]',
+            !isMobile && isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen && 'mr-[580px]',
             !isMobile && isMissionSidebarOpen && isMissionSidebarMinimized && !isMissionFullScreen && 'mr-12'
           )}>
           <NavigationProgress />


### PR DESCRIPTION
## Summary
- The mission sidebar was widened to 580px in #1612 but the Layout.tsx main content `margin-right` and offline banner `right` offset were still using the old 500px value
- This caused the sidebar to overlap dashboard cards when opened
- Updated both values from `mr-[500px]`/`right-[500px]` to `mr-[580px]`/`right-[580px]`

## Test plan
- [ ] Open any dashboard page
- [ ] Click "AI Missions" to open the sidebar
- [ ] Verify cards shrink and don't overlap with the sidebar
- [ ] Verify offline banner (if visible) also respects the sidebar width