### PR TITLE
✨ Track chunk reload recovery outcome in GA4

### DIFF
--- a/web/src/components/ChunkErrorBoundary.tsx
+++ b/web/src/components/ChunkErrorBoundary.tsx
@@ -1,8 +1,8 @@
 import { Component, type ReactNode, type ErrorInfo } from 'react'
 import { RefreshCw } from 'lucide-react'
 import i18next from 'i18next'
-import { emitError } from '../lib/analytics'
-import { isChunkLoadError } from '../lib/chunkErrors'
+import { emitError, emitChunkReloadRecoveryFailed } from '../lib/analytics'
+import { isChunkLoadError, CHUNK_RELOAD_TS_KEY } from '../lib/chunkErrors'
 
 // Reload throttle interval in milliseconds to prevent infinite reload loops
 const RELOAD_THROTTLE_MS = 30_000 // 30 seconds
@@ -46,12 +46,16 @@ export class ChunkErrorBoundary extends Component<Props, State> {
     emitError('chunk_load', error.message)
 
     // Auto-reload once. Use sessionStorage to prevent infinite loops.
-    const key = 'chunk-reload-ts'
-    const lastReload = sessionStorage.getItem(key)
+    const lastReload = sessionStorage.getItem(CHUNK_RELOAD_TS_KEY)
     const now = Date.now()
     if (!lastReload || now - parseInt(lastReload) > RELOAD_THROTTLE_MS) {
-      sessionStorage.setItem(key, String(now))
+      sessionStorage.setItem(CHUNK_RELOAD_TS_KEY, String(now))
       window.location.reload()
+    } else {
+      // Auto-reload already happened within the throttle window but chunks
+      // are still stale — recovery failed, user sees manual reload UI
+      sessionStorage.removeItem(CHUNK_RELOAD_TS_KEY)
+      emitChunkReloadRecoveryFailed(error.message)
     }
   }
 

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -11,6 +11,7 @@
  */
 
 import { STORAGE_KEY_ANALYTICS_OPT_OUT } from './constants'
+import { CHUNK_RELOAD_TS_KEY } from './chunkErrors'
 import { isDemoMode } from './demoMode'
 
 // DECOY Measurement ID — the proxy rewrites this to the real ID server-side.
@@ -557,8 +558,39 @@ export function emitError(category: string, detail: string) {
   })
 }
 
+/**
+ * Check if this page load is a recovery from a chunk-load auto-reload.
+ * If CHUNK_RELOAD_TS_KEY exists in sessionStorage, the previous page load
+ * hit a stale chunk error and triggered window.location.reload().
+ * Emit a recovery event with the outcome and clear the marker.
+ */
+function checkChunkReloadRecovery() {
+  try {
+    const reloadTs = sessionStorage.getItem(CHUNK_RELOAD_TS_KEY)
+    if (!reloadTs) return
+
+    const reloadTime = parseInt(reloadTs)
+    const recoveryMs = Date.now() - reloadTime
+
+    // Clear the marker so we don't re-emit on subsequent navigations
+    sessionStorage.removeItem(CHUNK_RELOAD_TS_KEY)
+
+    // Emit recovery event — the app loaded successfully after auto-reload
+    send('ksc_chunk_reload_recovery', {
+      recovery_result: 'success',
+      recovery_latency_ms: recoveryMs,
+      recovery_page: window.location.pathname,
+    })
+  } catch {
+    // sessionStorage may be unavailable in some contexts
+  }
+}
+
 /** Track unhandled promise rejections and runtime errors globally */
 export function startGlobalErrorTracking() {
+  // Check if we just recovered from a chunk-load auto-reload
+  checkChunkReloadRecovery()
+
   // Re-entrancy guard: if emitError() → send() triggers another error,
   // the global handler must NOT call emitError() again (infinite recursion → max call stack)
   let isEmitting = false
@@ -589,6 +621,15 @@ export function startGlobalErrorTracking() {
 
 export function emitSessionExpired() {
   send('ksc_session_expired')
+}
+
+/** Emit when auto-reload failed to fix stale chunks (user sees manual reload UI) */
+export function emitChunkReloadRecoveryFailed(errorDetail: string) {
+  send('ksc_chunk_reload_recovery', {
+    recovery_result: 'failed',
+    recovery_page: window.location.pathname,
+    error_detail: errorDetail.slice(0, ERROR_DETAIL_MAX_LEN),
+  })
 }
 
 // ── Tour ───────────────────────────────────────────────────────────

--- a/web/src/lib/chunkErrors.ts
+++ b/web/src/lib/chunkErrors.ts
@@ -6,6 +6,10 @@
  * content hashing. Browsers with cached HTML still reference old
  * chunk URLs, producing these characteristic error messages.
  */
+
+/** SessionStorage key set before auto-reload, checked after to measure recovery */
+export const CHUNK_RELOAD_TS_KEY = 'chunk-reload-ts'
+
 export function isChunkLoadError(error: Error): boolean {
   const msg = error.message || ''
   return (


### PR DESCRIPTION
## Summary

- Add `ksc_chunk_reload_recovery` GA4 event to measure whether auto-reload for stale chunks actually worked
- On success: emits `recovery_result: "success"` with `recovery_latency_ms` (time from reload trigger to app load)
- On failure: emits `recovery_result: "failed"` when chunks are still stale after reload (user sees manual reload UI)
- Extract `CHUNK_RELOAD_TS_KEY` to shared constant in `chunkErrors.ts`

Previously we emitted `ksc_error(chunk_load)` before the reload but had zero visibility into recovery outcome.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (same 63 pre-existing errors, no new ones)
- [x] Existing `ChunkErrorBoundary.test.tsx` — 4/4 tests pass
- [ ] After deploy: verify `ksc_chunk_reload_recovery` events appear in GA4 with `recovery_result` dimension