### PR TITLE
🐛 Fix empty states showing during compliance hook loading

### DIFF
--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useState, useMemo } from 'react'
-import { AlertTriangle, AlertCircle, Shield, ExternalLink, Info } from 'lucide-react'
+import { AlertTriangle, AlertCircle, Shield, ExternalLink, Info, Loader2 } from 'lucide-react'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
@@ -199,8 +199,8 @@ Please proceed step by step.`,
 
   return (
     <div className="space-y-3">
-      {/* Install prompt when not detected */}
-      {!installed && (
+      {/* Install prompt when not detected (only after scanning completes) */}
+      {!installed && !isLoading && !isRefreshing && (
         <div className="flex items-start gap-2 p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-xs">
           <AlertCircle className="w-4 h-4 text-cyan-400 flex-shrink-0 mt-0.5" />
           <div>
@@ -378,8 +378,8 @@ Please proceed step by step.`,
 
   return (
     <div className="space-y-3">
-      {/* Install prompt when not detected */}
-      {!installed && (
+      {/* Install prompt when not detected (only after scanning completes) */}
+      {!installed && !isLoading && !isRefreshing && (
         <div className="flex items-start gap-2 p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-xs">
           <AlertCircle className="w-4 h-4 text-green-400 flex-shrink-0 mt-0.5" />
           <div>
@@ -615,6 +615,18 @@ export function PolicyViolations({ config: _config }: CardConfig) {
   useCardLoadingState({ isLoading: kyvernoLoading, hasAnyData: hasData, isDemoData: kyvernoDemoData })
 
   if (violations.length === 0 && !kyvernoDemoData) {
+    // Still scanning — show loading state instead of definitive empty state
+    if (kyvernoLoading || kyvernoRefreshing) {
+      return (
+        <div className="space-y-3">
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
+            <Loader2 className="w-8 h-8 mb-2 opacity-50 animate-spin" />
+            <p className="text-sm">Scanning for policy violations...</p>
+            <p className="text-xs mt-1">Checking Kyverno reports across clusters</p>
+          </div>
+        </div>
+      )
+    }
     return (
       <div className="space-y-3">
         {/* Degraded state: installed but no policies */}

--- a/web/src/components/cards/ComplianceDrift.tsx
+++ b/web/src/components/cards/ComplianceDrift.tsx
@@ -150,8 +150,8 @@ export function ComplianceDrift({ config: _config }: CardConfig) {
     return result
   }, [kyvernoStatuses, trivyStatuses, kubescapeStatuses, selectedClusters, isAllClustersSelected])
 
-  // Empty state: all clusters within baseline
-  if (!isLoading && drifts.length === 0) {
+  // Empty state: all clusters within baseline (only show after all hooks finish)
+  if (!isLoading && !isRefreshing && drifts.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-2 text-center p-4">
         <CheckCircle2 className="w-8 h-8 text-green-400" />

--- a/web/src/components/cards/CrossClusterPolicyComparison.tsx
+++ b/web/src/components/cards/CrossClusterPolicyComparison.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useState, useMemo } from 'react'
-import { CheckCircle2, XCircle, Minus, Info } from 'lucide-react'
+import { CheckCircle2, XCircle, Minus, Info, Loader2 } from 'lucide-react'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardLoadingState } from './CardDataContext'
 import { useKyverno } from '../../hooks/useKyverno'
@@ -138,6 +138,15 @@ export function CrossClusterPolicyComparison({ config: _config }: CardConfig) {
   }
 
   if (allClusters.length === 0) {
+    // Still scanning — show loading state instead of definitive empty state
+    if (isLoading || isRefreshing) {
+      return (
+        <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm p-4 gap-2">
+          <Loader2 className="w-6 h-6 animate-spin opacity-50" />
+          <p>Scanning clusters for Kyverno...</p>
+        </div>
+      )
+    }
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground text-sm p-4">
         No clusters with Kyverno detected

--- a/web/src/components/cards/FleetComplianceHeatmap.tsx
+++ b/web/src/components/cards/FleetComplianceHeatmap.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useState, useMemo } from 'react'
-import { Info } from 'lucide-react'
+import { Info, Loader2 } from 'lucide-react'
 import { useCardLoadingState } from './CardDataContext'
 import { useKyverno } from '../../hooks/useKyverno'
 import { useTrivy } from '../../hooks/useTrivy'
@@ -257,6 +257,15 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
   }, [kyvernoStatuses, trivyStatuses, kubescapeStatuses, deduplicatedClusters, selectedClusters, isAllClustersSelected])
 
   if (rows.length === 0) {
+    // Still scanning — show loading state instead of definitive empty state
+    if (isLoading || isRefreshing) {
+      return (
+        <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm gap-2">
+          <Loader2 className="w-6 h-6 animate-spin opacity-50" />
+          <p>Scanning clusters...</p>
+        </div>
+      )
+    }
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
         No clusters available
@@ -294,7 +303,7 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
           return (
             <div key={tool} className="px-2 py-1 text-center">
               <span>{tool}</span>
-              {!installed && !isLoading && (
+              {!installed && !isLoading && !isRefreshing && (
                 <button
                   onClick={() => handleInstall(key)}
                   className="ml-1 inline-flex items-center gap-0.5 text-cyan-400 hover:text-cyan-300 transition-colors"

--- a/web/src/components/cards/KyvernoPolicies.tsx
+++ b/web/src/components/cards/KyvernoPolicies.tsx
@@ -167,8 +167,8 @@ Please proceed step by step.`,
         </a>
       </div>
 
-      {/* Install prompt when not detected */}
-      {!installed && (
+      {/* Install prompt when not detected (only after scanning completes) */}
+      {!installed && !isLoading && !isRefreshing && (
         <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-xs">
           <AlertCircle className="w-4 h-4 text-cyan-400 flex-shrink-0 mt-0.5" />
           <div>

--- a/web/src/components/cards/RecommendedPolicies.tsx
+++ b/web/src/components/cards/RecommendedPolicies.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useMemo, useState } from 'react'
-import { Sparkles, Shield, ChevronRight, CheckCircle2, AlertTriangle, Zap } from 'lucide-react'
+import { Sparkles, Shield, ChevronRight, CheckCircle2, AlertTriangle, Zap, Loader2 } from 'lucide-react'
 import { useCardLoadingState } from './CardDataContext'
 import { useKyverno } from '../../hooks/useKyverno'
 import { useKubescape } from '../../hooks/useKubescape'
@@ -254,9 +254,9 @@ Deploy to ALL clusters with Kyverno installed. Proceed step by step.`,
 // ─── Component ──────────────────────────────────────────────────────
 
 function RecommendedPoliciesInternal({ config: _config }: CardConfig) {
-  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, installed: kyvernoInstalled, isDemoData: kyvernoDemoData } = useKyverno()
-  const { isLoading: kubescapeLoading, installed: kubescapeInstalled, isDemoData: kubescapeDemoData } = useKubescape()
-  const { isLoading: trivyLoading, installed: trivyInstalled, isDemoData: trivyDemoData } = useTrivy()
+  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, installed: kyvernoInstalled, isDemoData: kyvernoDemoData } = useKyverno()
+  const { isLoading: kubescapeLoading, isRefreshing: kubescapeRefreshing, installed: kubescapeInstalled, isDemoData: kubescapeDemoData } = useKubescape()
+  const { isLoading: trivyLoading, isRefreshing: trivyRefreshing, installed: trivyInstalled, isDemoData: trivyDemoData } = useTrivy()
   const { deduplicatedClusters } = useClusters()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
@@ -264,6 +264,7 @@ function RecommendedPoliciesInternal({ config: _config }: CardConfig) {
   const [expandedCategory, setExpandedCategory] = useState<RecommendationCategory | null>(null)
 
   const isLoading = kyvernoLoading || kubescapeLoading || trivyLoading
+  const isRefreshing = kyvernoRefreshing || kubescapeRefreshing || trivyRefreshing
   const isDemoData = isDemoMode || kyvernoDemoData || kubescapeDemoData || trivyDemoData
 
   // Build recommendations from real cluster data
@@ -385,8 +386,22 @@ Deploy each policy to every cluster where it's missing. Proceed cluster by clust
     })
   }
 
-  // No tools installed — prompt to get started
+  // No tools installed — prompt to get started (but only after scanning is complete)
   if (!kyvernoInstalled && !kubescapeInstalled && !trivyInstalled && !isDemoData) {
+    // Still scanning — show loading state instead of definitive empty state
+    if (isLoading || isRefreshing) {
+      return (
+        <div className="space-y-3">
+          <div className="flex flex-col items-center justify-center py-6 text-center">
+            <Loader2 className="w-8 h-8 text-muted-foreground/50 mb-3 animate-spin" />
+            <p className="text-sm font-medium text-foreground">Scanning clusters...</p>
+            <p className="text-xs text-muted-foreground mt-1 max-w-[250px]">
+              Checking for compliance tools across your fleet
+            </p>
+          </div>
+        </div>
+      )
+    }
     return (
       <div className="space-y-3">
         <div className="flex flex-col items-center justify-center py-6 text-center">

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -144,7 +144,7 @@ interface WorkloadConfigScanResource {
 
 export function useKubescape() {
   const { isDemoMode } = useDemoMode()
-  const { clusters: allClusters } = useClusters()
+  const { clusters: allClusters, isLoading: clustersLoading } = useClusters()
 
   const cachedData = useRef(loadFromCache())
   const [statuses, setStatuses] = useState<Record<string, KubescapeClusterStatus>>(
@@ -372,10 +372,12 @@ export function useKubescape() {
 
     if (clusters.length > 0) {
       refetch()
-    } else {
+    } else if (!clustersLoading) {
+      // Only clear loading when cluster list has actually been fetched
+      // (prevents premature empty state while useClusters is still resolving)
       setIsLoading(false)
     }
-  }, [clusters.length, isDemoMode]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [clusters.length, isDemoMode, clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Auto-refresh — always poll when clusters exist so we detect tools
   // that get installed later or clusters that become reachable

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -150,7 +150,7 @@ interface PolicyReportResource {
 
 export function useKyverno() {
   const { isDemoMode } = useDemoMode()
-  const { clusters: allClusters } = useClusters()
+  const { clusters: allClusters, isLoading: clustersLoading } = useClusters()
 
   const cachedData = useRef(loadFromCache())
   const [statuses, setStatuses] = useState<Record<string, KyvernoClusterStatus>>(
@@ -359,10 +359,12 @@ export function useKyverno() {
 
     if (clusters.length > 0) {
       refetch()
-    } else {
+    } else if (!clustersLoading) {
+      // Only clear loading when cluster list has actually been fetched
+      // (prevents premature empty state while useClusters is still resolving)
       setIsLoading(false)
     }
-  }, [clusters.length, isDemoMode]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [clusters.length, isDemoMode, clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Auto-refresh — always poll when clusters exist so we detect tools
   // that get installed later or clusters that become reachable

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -140,7 +140,7 @@ interface VulnerabilityReportResource {
 
 export function useTrivy() {
   const { isDemoMode } = useDemoMode()
-  const { clusters: allClusters } = useClusters()
+  const { clusters: allClusters, isLoading: clustersLoading } = useClusters()
 
   const cachedData = useRef(loadFromCache())
   const [statuses, setStatuses] = useState<Record<string, TrivyClusterStatus>>(
@@ -305,10 +305,12 @@ export function useTrivy() {
 
     if (clusters.length > 0) {
       refetch()
-    } else {
+    } else if (!clustersLoading) {
+      // Only clear loading when cluster list has actually been fetched
+      // (prevents premature empty state while useClusters is still resolving)
       setIsLoading(false)
     }
-  }, [clusters.length, isDemoMode]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [clusters.length, isDemoMode, clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Auto-refresh — always poll when clusters exist so we detect tools
   // that get installed later or clusters that become reachable


### PR DESCRIPTION
## Summary
- Guard all compliance card empty states against premature display while hooks are still scanning clusters
- Fix race condition where compliance hooks set `isLoading=false` before `useClusters()` resolves, causing flash of "No tools detected" empty states
- Show "Scanning clusters..." with spinner instead of definitive empty states while hooks are loading/refreshing

## Root Causes Fixed

**1. Cards show empty states while still scanning:**
Cards like RecommendedPolicies, PolicyViolations, CrossClusterPolicyComparison showed "No Compliance Tools Detected" / "No policy violations" / "No clusters with Kyverno detected" while the refresh spinner was still running. All empty-state conditions now check `isLoading || isRefreshing` and render a scanning indicator instead.

**2. Premature `isLoading=false` in hooks:**
useKyverno, useTrivy, useKubescape all had `else { setIsLoading(false) }` when `clusters.length === 0`. Since `useClusters()` starts with an empty array before resolving, this caused a brief window where `isLoading` was false with no data — triggering empty states. Fixed by checking `clustersLoading` from useClusters before clearing loading state.

## Affected Files
- `RecommendedPolicies.tsx` — "No Compliance Tools Detected" → "Scanning clusters..."
- `ComplianceCards.tsx` (PolicyViolations) — "No policy violations" → "Scanning for policy violations..."
- `ComplianceCards.tsx` (TrivyScan, KubescapeScan) — Install prompts hidden during scanning
- `CrossClusterPolicyComparison.tsx` — "No clusters with Kyverno" → "Scanning clusters for Kyverno..."
- `ComplianceDrift.tsx` — Also check `isRefreshing` before showing "all within baseline"
- `FleetComplianceHeatmap.tsx` — "No clusters available" → "Scanning clusters..."
- `KyvernoPolicies.tsx` — Install prompt hidden during scanning
- `useKyverno.ts`, `useTrivy.ts`, `useKubescape.ts` — Check `clustersLoading` before clearing `isLoading`

## Test plan
- [ ] Navigate to Compliance dashboard with empty localStorage cache
- [ ] Verify cards show "Scanning clusters..." instead of empty states during initial load
- [ ] Verify cards eventually show real data or proper empty states after scanning completes
- [ ] Verify demo mode still works correctly
- [ ] Verify background refresh (2min interval) doesn't flash empty states