### PR TITLE
🐛 Always show cluster name badges on compliance cards

### DIFF
--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -234,7 +234,7 @@ Please proceed step by step.`,
       )}
 
       {/* Per-cluster badges — click to open detail modal */}
-      {installed && Object.values(statuses).filter(s => s.installed).length > 1 && (
+      {installed && Object.values(statuses).some(s => s.installed) && (
         <div className="flex flex-wrap gap-1">
           {Object.values(statuses).filter(s => s.installed).map(s => (
             <button key={s.cluster} onClick={() => setModalCluster(s.cluster)} className="cursor-pointer">
@@ -413,7 +413,7 @@ Please proceed step by step.`,
       )}
 
       {/* Per-cluster scores — click to open detail modal */}
-      {installed && Object.values(statuses).filter(s => s.installed).length > 1 && (
+      {installed && Object.values(statuses).some(s => s.installed) && (
         <div className="flex flex-wrap gap-1">
           {Object.values(statuses).filter(s => s.installed).map(s => (
             <button key={s.cluster} onClick={() => setModalCluster(s.cluster)} className="cursor-pointer">

--- a/web/src/components/cards/KyvernoPolicies.tsx
+++ b/web/src/components/cards/KyvernoPolicies.tsx
@@ -184,7 +184,7 @@ Please proceed step by step.`,
       )}
 
       {/* Per-cluster badges — click to open detail modal */}
-      {installed && Object.values(statuses).filter(s => s.installed).length > 1 && (
+      {installed && Object.values(statuses).some(s => s.installed) && (
         <div className="flex flex-wrap gap-1 mb-3">
           {Object.values(statuses).filter(s => s.installed).map(s => (
             <button key={s.cluster} onClick={() => setModalCluster(s.cluster)} className="cursor-pointer">
@@ -271,9 +271,7 @@ Please proceed step by step.`,
               <span className={getCategoryColor(policy.category)}>{policy.category}</span>
               <div className="flex items-center gap-2 text-muted-foreground">
                 <span>{policy.kind}</span>
-                {Object.values(statuses).filter(s => s.installed).length > 1 && (
-                  <span className="text-2xs">{policy.cluster}</span>
-                )}
+                <span className="text-2xs">{policy.cluster}</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Cluster name badges on Kyverno Policies, Trivy Scan, and Kubescape Scan cards were only shown when **multiple** clusters had the tool installed (`length > 1`)
- Changed to always show badges when **at least one** cluster is installed (`.some()`)
- Also removed the `> 1` guard on per-policy cluster name in Kyverno rows — the cluster name now always appears

## Test plan
- [ ] With a single cluster running Kyverno, verify the cluster badge appears on the Kyverno Policies card
- [ ] With a single cluster running Trivy, verify the cluster badge appears on the Trivy Scan card  
- [ ] With a single cluster running Kubescape, verify the cluster badge appears on the Kubescape Scan card
- [ ] With multiple clusters, verify badges still render correctly for each
- [ ] Verify demo mode shows badges for all demo clusters