### PR TITLE
✨ Add mission, card, feature, retention & error analytics sections

### DIFF
--- a/web/netlify/functions/analytics-dashboard.mts
+++ b/web/netlify/functions/analytics-dashboard.mts
@@ -87,6 +87,11 @@ interface DashboardData {
     views: number;
   }[];
   newVsReturning: { type: string; users: number; sessions: number }[];
+  missions: { started: number; completed: number; errored: number; rated: number; topTypes: { type: string; count: number }[] };
+  cardPopularity: { card: string; added: number; expanded: number; clicked: number }[];
+  featureAdoption: { feature: string; count: number; users: number }[];
+  weeklyRetention: { week: string; newUsers: number; returning: number }[];
+  errors: { event: string; count: number; detail: string }[];
   cachedAt: string;
   propertyId: string;
   dateRange: string;
@@ -259,6 +264,12 @@ async function fetchDashboardData(
     cncfRows,
     engagementRows,
     newReturnRows,
+    missionEventRows,
+    missionTypeRows,
+    cardPopRows,
+    featureRows,
+    weeklyRetRows,
+    errorRows,
   ] = await Promise.all([
     // 1. Overview metrics (current period)
     runReport(propertyId, accessToken, {
@@ -408,6 +419,140 @@ async function fetchDashboardData(
       dimensions: [{ name: "newVsReturning" }],
       metrics: [{ name: "activeUsers" }, { name: "sessions" }],
     }),
+
+    // 13. Mission events (started/completed/error/rated)
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "eventName" }],
+      metrics: [{ name: "eventCount" }, { name: "totalUsers" }],
+      dimensionFilter: {
+        orGroup: {
+          expressions: [
+            "ksc_mission_started",
+            "ksc_mission_completed",
+            "ksc_mission_error",
+            "ksc_mission_rated",
+          ].map((ev) => ({
+            filter: {
+              fieldName: "eventName",
+              stringFilter: { matchType: "EXACT", value: ev },
+            },
+          })),
+        },
+      },
+    }),
+
+    // 14. Mission types breakdown (by customEvent:mission_type)
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "customEvent:mission_type" }],
+      metrics: [{ name: "eventCount" }],
+      dimensionFilter: {
+        filter: {
+          fieldName: "eventName",
+          stringFilter: { matchType: "EXACT", value: "ksc_mission_started" },
+        },
+      },
+      orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
+      limit: 15,
+    }),
+
+    // 15. Card popularity (added/expanded/clicked by card_type)
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [
+        { name: "customEvent:card_type" },
+        { name: "eventName" },
+      ],
+      metrics: [{ name: "eventCount" }],
+      dimensionFilter: {
+        orGroup: {
+          expressions: [
+            "ksc_card_added",
+            "ksc_card_expanded",
+            "ksc_card_list_item_clicked",
+          ].map((ev) => ({
+            filter: {
+              fieldName: "eventName",
+              stringFilter: { matchType: "EXACT", value: ev },
+            },
+          })),
+        },
+      },
+      orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
+      limit: 100,
+    }),
+
+    // 16. Feature adoption events
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "eventName" }],
+      metrics: [{ name: "eventCount" }, { name: "totalUsers" }],
+      dimensionFilter: {
+        orGroup: {
+          expressions: [
+            "ksc_global_search_opened",
+            "ksc_global_search_queried",
+            "ksc_theme_changed",
+            "ksc_language_changed",
+            "ksc_demo_mode_toggled",
+            "ksc_dashboard_created",
+            "ksc_data_exported",
+            "ksc_marketplace_install",
+            "ksc_drill_down_opened",
+            "ksc_card_refreshed",
+            "ksc_tour_started",
+            "ksc_tour_completed",
+            "ksc_feedback_submitted",
+            "ksc_linkedin_share",
+            "ksc_pwa_prompt_shown",
+            "ksc_sidebar_navigated",
+            "ksc_add_card_modal_opened",
+          ].map((ev) => ({
+            filter: {
+              fieldName: "eventName",
+              stringFilter: { matchType: "EXACT", value: ev },
+            },
+          })),
+        },
+      },
+      orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
+      limit: 20,
+    }),
+
+    // 17. Weekly retention (new vs returning by week)
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "week" }, { name: "newVsReturning" }],
+      metrics: [{ name: "activeUsers" }],
+      orderBys: [{ dimension: { dimensionName: "week", orderType: "ALPHANUMERIC" } }],
+    }),
+
+    // 18. Error events
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "eventName" }, { name: "customEvent:error_category" }],
+      metrics: [{ name: "eventCount" }],
+      dimensionFilter: {
+        orGroup: {
+          expressions: [
+            "ksc_error",
+            "ksc_mission_error",
+            "ksc_update_failed",
+            "ksc_chunk_reload_recovery_failed",
+            "ksc_marketplace_install_failed",
+            "ksc_update_stalled",
+          ].map((ev) => ({
+            filter: {
+              fieldName: "eventName",
+              stringFilter: { matchType: "EXACT", value: ev },
+            },
+          })),
+        },
+      },
+      orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
+      limit: 30,
+    }),
   ]);
 
   // Parse overview
@@ -456,6 +601,67 @@ async function fetchDashboardData(
   for (const row of funnelRows) {
     funnelMap[dimVal(row, 0)] = metVal(row, 0);
   }
+
+  // Parse mission events
+  const missionMap: Record<string, number> = {};
+  for (const row of missionEventRows) {
+    missionMap[dimVal(row, 0)] = metVal(row, 0);
+  }
+
+  // Parse mission types
+  const missionTopTypes = missionTypeRows
+    .filter((r) => dimVal(r, 0) !== "(not set)")
+    .map((r) => ({ type: dimVal(r, 0), count: metVal(r, 0) }));
+
+  // Parse card popularity — pivot by card_type
+  const cardMap = new Map<string, { added: number; expanded: number; clicked: number }>();
+  for (const row of cardPopRows) {
+    const card = dimVal(row, 0);
+    const event = dimVal(row, 1);
+    const count = metVal(row, 0);
+    if (card === "(not set)") continue;
+    if (!cardMap.has(card)) cardMap.set(card, { added: 0, expanded: 0, clicked: 0 });
+    const entry = cardMap.get(card)!;
+    if (event === "ksc_card_added") entry.added += count;
+    else if (event === "ksc_card_expanded") entry.expanded += count;
+    else if (event === "ksc_card_list_item_clicked") entry.clicked += count;
+  }
+  const cardPopularity = [...cardMap.entries()]
+    .map(([card, stats]) => ({ card, ...stats }))
+    .sort((a, b) => (b.added + b.expanded + b.clicked) - (a.added + a.expanded + a.clicked));
+
+  // Parse feature adoption
+  const featureAdoption = featureRows
+    .filter((r) => dimVal(r, 0) !== "(not set)")
+    .map((r) => ({
+      feature: dimVal(r, 0).replace("ksc_", "").replace(/_/g, " "),
+      count: metVal(r, 0),
+      users: metVal(r, 1),
+    }));
+
+  // Parse weekly retention
+  const weekMap = new Map<string, { newUsers: number; returning: number }>();
+  for (const row of weeklyRetRows) {
+    const week = dimVal(row, 0);
+    const type = dimVal(row, 1);
+    const users = metVal(row, 0);
+    if (!weekMap.has(week)) weekMap.set(week, { newUsers: 0, returning: 0 });
+    const entry = weekMap.get(week)!;
+    if (type === "new") entry.newUsers = users;
+    else if (type === "returning") entry.returning = users;
+  }
+  const weeklyRetention = [...weekMap.entries()]
+    .map(([week, data]) => ({ week, ...data }))
+    .sort((a, b) => a.week.localeCompare(b.week));
+
+  // Parse errors
+  const errors = errorRows
+    .filter((r) => dimVal(r, 0) !== "(not set)")
+    .map((r) => ({
+      event: dimVal(r, 0).replace("ksc_", "").replace(/_/g, " "),
+      count: metVal(r, 0),
+      detail: dimVal(r, 1),
+    }));
 
   return {
     overview,
@@ -517,6 +723,17 @@ async function fetchDashboardData(
       users: metVal(r, 0),
       sessions: metVal(r, 1),
     })),
+    missions: {
+      started: missionMap["ksc_mission_started"] || 0,
+      completed: missionMap["ksc_mission_completed"] || 0,
+      errored: missionMap["ksc_mission_error"] || 0,
+      rated: missionMap["ksc_mission_rated"] || 0,
+      topTypes: missionTopTypes,
+    },
+    cardPopularity,
+    featureAdoption,
+    weeklyRetention,
+    errors,
     cachedAt: new Date().toISOString(),
     propertyId,
     dateRange: "Last 28 days",

--- a/web/public/analytics.html
+++ b/web/public/analytics.html
@@ -619,6 +619,85 @@
       html += '</tbody></table></div>';
       html += '</div>'; // end chart-grid
 
+      // Mission Completion Rate
+      if (data.missions && data.missions.started > 0) {
+        html += '<div class="section-title">AI Missions</div>';
+        html += '<div class="chart-grid">';
+
+        // Mission KPIs
+        const m = data.missions;
+        const completionRate = m.started > 0 ? (m.completed / m.started * 100).toFixed(1) : '0';
+        const errorRate = m.started > 0 ? (m.errored / m.started * 100).toFixed(1) : '0';
+        const ratedPct = m.completed > 0 ? (m.rated / m.completed * 100).toFixed(1) : '0';
+
+        html += '<div class="chart-card"><h3>Mission Performance</h3>';
+        html += '<div class="kpi-grid" style="margin-bottom:0">';
+        html += `<div class="kpi-card"><div class="kpi-label">Started</div><div class="kpi-value">${fmt(m.started)}</div></div>`;
+        html += `<div class="kpi-card"><div class="kpi-label">Completed</div><div class="kpi-value" style="color:var(--green)">${fmt(m.completed)}</div><div class="kpi-change up">${completionRate}% completion</div></div>`;
+        html += `<div class="kpi-card"><div class="kpi-label">Errors</div><div class="kpi-value" style="color:${m.errored > 0 ? 'var(--red)' : 'var(--text)'}">${fmt(m.errored)}</div><div class="kpi-change ${m.errored > 0 ? 'down' : 'flat'}">${errorRate}% error rate</div></div>`;
+        html += `<div class="kpi-card"><div class="kpi-label">Rated</div><div class="kpi-value">${fmt(m.rated)}</div><div class="kpi-change flat">${ratedPct}% of completed</div></div>`;
+        html += '</div></div>';
+
+        // Mission types breakdown
+        if (m.topTypes && m.topTypes.length > 0) {
+          html += '<div class="chart-card"><h3>Mission Types</h3><div class="chart-wrapper"><canvas id="missionTypesChart"></canvas></div></div>';
+        }
+
+        html += '</div>';
+      }
+
+      // Card Popularity
+      if (data.cardPopularity && data.cardPopularity.length > 0) {
+        html += '<div class="section-title">Card Popularity</div>';
+        html += '<div class="chart-grid">';
+        html += '<div class="chart-card"><h3>Most Popular Cards</h3><div class="chart-wrapper"><canvas id="cardPopChart"></canvas></div></div>';
+        html += '<div class="table-card"><h3>Card Interactions (28 days)</h3><table><thead><tr><th>Card</th><th class="num">Added</th><th class="num">Expanded</th><th class="num">Clicked</th><th class="num">Total</th></tr></thead><tbody>';
+        for (const c of data.cardPopularity.slice(0, 20)) {
+          const total = c.added + c.expanded + c.clicked;
+          html += `<tr><td><code>${c.card}</code></td><td class="num">${fmt(c.added)}</td><td class="num">${fmt(c.expanded)}</td><td class="num">${fmt(c.clicked)}</td><td class="num"><strong>${fmt(total)}</strong></td></tr>`;
+        }
+        html += '</tbody></table></div>';
+        html += '</div>';
+      }
+
+      // Feature Adoption
+      if (data.featureAdoption && data.featureAdoption.length > 0) {
+        html += '<div class="section-title">Feature Adoption</div>';
+        html += '<div class="chart-grid">';
+        html += '<div class="chart-card"><h3>Feature Usage</h3><div class="chart-wrapper"><canvas id="featureChart"></canvas></div></div>';
+        html += '<div class="table-card"><h3>Feature Events (28 days)</h3><table><thead><tr><th>Feature</th><th class="num">Events</th><th class="num">Users</th></tr></thead><tbody>';
+        for (const f of data.featureAdoption) {
+          html += `<tr><td style="text-transform:capitalize">${f.feature}</td><td class="num">${fmt(f.count)}</td><td class="num">${fmt(f.users)}</td></tr>`;
+        }
+        html += '</tbody></table></div>';
+        html += '</div>';
+      }
+
+      // Weekly Retention
+      if (data.weeklyRetention && data.weeklyRetention.length > 0) {
+        html += '<div class="section-title">Retention Cohorts</div>';
+        html += '<div class="chart-grid">';
+        html += '<div class="chart-card full-width"><h3>Weekly New vs Returning Users</h3><div class="chart-wrapper"><canvas id="retentionChart"></canvas></div></div>';
+        html += '</div>';
+      }
+
+      // Error Tracking
+      if (data.errors && data.errors.length > 0) {
+        const totalErrors = data.errors.reduce((sum, e) => sum + e.count, 0);
+        html += '<div class="section-title">Error Tracking</div>';
+        html += '<div class="chart-grid">';
+        html += `<div class="chart-card"><h3>Error Summary</h3>`;
+        html += `<div class="kpi-grid" style="margin-bottom:16px"><div class="kpi-card"><div class="kpi-label">Total Errors</div><div class="kpi-value" style="color:${totalErrors > 50 ? 'var(--red)' : totalErrors > 10 ? 'var(--yellow)' : 'var(--green)'}">${fmt(totalErrors)}</div></div></div>`;
+        html += '<div class="chart-wrapper"><canvas id="errorChart"></canvas></div></div>';
+        html += '<div class="table-card"><h3>Error Details (28 days)</h3><table><thead><tr><th>Error Type</th><th>Category</th><th class="num">Count</th></tr></thead><tbody>';
+        for (const e of data.errors) {
+          const color = e.count > 20 ? 'var(--red)' : e.count > 5 ? 'var(--yellow)' : 'var(--text)';
+          html += `<tr><td style="text-transform:capitalize">${e.event}</td><td><code>${e.detail !== '(not set)' ? e.detail : '—'}</code></td><td class="num" style="color:${color}">${fmt(e.count)}</td></tr>`;
+        }
+        html += '</tbody></table></div>';
+        html += '</div>';
+      }
+
       container.innerHTML = html;
 
       // Render charts
@@ -627,6 +706,23 @@
       renderCountryChart(data.countries.slice(0, 8));
       renderSourceChart(data.trafficSources.slice(0, 6));
       renderDeviceChart(data.devices);
+
+      // New charts
+      if (data.missions && data.missions.topTypes && data.missions.topTypes.length > 0) {
+        renderMissionTypesChart(data.missions.topTypes);
+      }
+      if (data.cardPopularity && data.cardPopularity.length > 0) {
+        renderCardPopChart(data.cardPopularity.slice(0, 12));
+      }
+      if (data.featureAdoption && data.featureAdoption.length > 0) {
+        renderFeatureChart(data.featureAdoption.slice(0, 10));
+      }
+      if (data.weeklyRetention && data.weeklyRetention.length > 0) {
+        renderRetentionChart(data.weeklyRetention);
+      }
+      if (data.errors && data.errors.length > 0) {
+        renderErrorChart(data.errors.slice(0, 8));
+      }
     }
 
     function renderDailyChart(dailyUsers) {
@@ -773,6 +869,162 @@
           maintainAspectRatio: false,
           plugins: {
             legend: { position: 'right', labels: { boxWidth: 12, padding: 12 } },
+          },
+        },
+      });
+      charts.push(chart);
+    }
+
+    function renderMissionTypesChart(topTypes) {
+      const ctx = document.getElementById('missionTypesChart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: topTypes.map(t => t.type),
+          datasets: [{
+            label: 'Missions Started',
+            data: topTypes.map(t => t.count),
+            backgroundColor: CHART_COLORS.slice(0, topTypes.length),
+            borderRadius: 4,
+          }],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: 'y',
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { beginAtZero: true },
+            y: { grid: { display: false }, ticks: { font: { size: 11 } } },
+          },
+        },
+      });
+      charts.push(chart);
+    }
+
+    function renderCardPopChart(cards) {
+      const ctx = document.getElementById('cardPopChart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: cards.map(c => c.card),
+          datasets: [
+            { label: 'Added', data: cards.map(c => c.added), backgroundColor: '#6366f1', borderRadius: 4 },
+            { label: 'Expanded', data: cards.map(c => c.expanded), backgroundColor: '#06b6d4', borderRadius: 4 },
+            { label: 'Clicked', data: cards.map(c => c.clicked), backgroundColor: '#22c55e', borderRadius: 4 },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: 'y',
+          plugins: { legend: { position: 'top', labels: { boxWidth: 12 } } },
+          scales: {
+            x: { beginAtZero: true, stacked: true },
+            y: { stacked: true, grid: { display: false }, ticks: { font: { size: 10 } } },
+          },
+        },
+      });
+      charts.push(chart);
+    }
+
+    function renderFeatureChart(features) {
+      const ctx = document.getElementById('featureChart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: features.map(f => f.feature),
+          datasets: [
+            { label: 'Events', data: features.map(f => f.count), backgroundColor: '#a855f7', borderRadius: 4 },
+            { label: 'Users', data: features.map(f => f.users), backgroundColor: '#06b6d4', borderRadius: 4 },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: 'y',
+          plugins: { legend: { position: 'top', labels: { boxWidth: 12 } } },
+          scales: {
+            x: { beginAtZero: true },
+            y: { grid: { display: false }, ticks: { font: { size: 10 }, callback: function(val) { const l = this.getLabelForValue(val); return l.length > 20 ? l.slice(0, 18) + '...' : l; } } },
+          },
+        },
+      });
+      charts.push(chart);
+    }
+
+    function renderRetentionChart(weeks) {
+      const ctx = document.getElementById('retentionChart');
+      if (!ctx) return;
+      const chart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: weeks.map(w => 'W' + w.week),
+          datasets: [
+            {
+              label: 'New Users',
+              data: weeks.map(w => w.newUsers),
+              backgroundColor: '#6366f1',
+              borderRadius: 4,
+              stack: 'stack0',
+            },
+            {
+              label: 'Returning Users',
+              data: weeks.map(w => w.returning),
+              backgroundColor: '#22c55e',
+              borderRadius: 4,
+              stack: 'stack0',
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { position: 'top', labels: { boxWidth: 12 } },
+            tooltip: {
+              callbacks: {
+                afterBody: function(items) {
+                  const idx = items[0].dataIndex;
+                  const w = weeks[idx];
+                  const total = w.newUsers + w.returning;
+                  const retPct = total > 0 ? (w.returning / total * 100).toFixed(1) : '0';
+                  return 'Retention: ' + retPct + '%';
+                }
+              }
+            }
+          },
+          scales: {
+            x: { stacked: true, grid: { display: false } },
+            y: { stacked: true, beginAtZero: true },
+          },
+        },
+      });
+      charts.push(chart);
+    }
+
+    function renderErrorChart(errors) {
+      const ctx = document.getElementById('errorChart');
+      if (!ctx) return;
+      const ERROR_COLORS = ['#ef4444', '#f97316', '#eab308', '#a855f7', '#6366f1', '#3b82f6', '#06b6d4', '#22c55e'];
+      const chart = new Chart(ctx, {
+        type: 'doughnut',
+        data: {
+          labels: errors.map(e => e.event),
+          datasets: [{
+            data: errors.map(e => e.count),
+            backgroundColor: ERROR_COLORS.slice(0, errors.length),
+            borderWidth: 0,
+          }],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { position: 'right', labels: { boxWidth: 12, padding: 8, font: { size: 11 } } },
           },
         },
       });


### PR DESCRIPTION
## Summary
- Adds **5 new sections** to the analytics dashboard at `console.kubestellar.io/analytics`
- **AI Missions**: Started/completed/errored/rated KPIs with completion rate, plus mission types breakdown chart
- **Card Popularity**: Stacked bar chart + table showing which cards are most added/expanded/clicked
- **Feature Adoption**: Bar chart + table tracking search, themes, exports, marketplace, tours, feedback, etc.
- **Retention Cohorts**: Weekly new vs returning users stacked bar chart with retention % in tooltips
- **Error Tracking**: Doughnut chart + detail table for `ksc_error`, `ksc_mission_error`, `ksc_update_failed`, etc.

All 6 new GA4 queries run in parallel with existing 12 queries. Sections only render when data exists (graceful empty state).

## Test plan
- [ ] Visit `console.kubestellar.io/analytics` after deploy
- [ ] Verify Mission Performance section shows with KPI cards and types chart
- [ ] Verify Card Popularity section shows stacked bar + interaction table
- [ ] Verify Feature Adoption section shows bar chart + events table
- [ ] Verify Retention Cohorts section shows weekly stacked bars
- [ ] Verify Error Tracking section shows doughnut + detail table
- [ ] Verify all existing sections still render correctly
- [ ] Verify 15-minute cache still works (data.fromCache indicator)