### PR TITLE
🐛 Fix analytics page crash: CSP blocks Chart.js CDN

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -93,7 +93,7 @@
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
     X-XSS-Protection = "1; mode=block"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.google-analytics.com https://*.googleapis.com https://api.github.com https://api.dicebear.com https://fonts.gstatic.com wss:; frame-ancestors 'none'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://*.google-analytics.com https://*.googleapis.com https://api.github.com https://api.dicebear.com https://fonts.gstatic.com https://cdn.jsdelivr.net wss:; frame-ancestors 'none'"
 
 [[headers]]
   for = "/assets/*"

--- a/web/public/analytics.html
+++ b/web/public/analytics.html
@@ -373,6 +373,11 @@
     const CHART_COLORS = ['#6366f1', '#06b6d4', '#22c55e', '#f97316', '#a855f7', '#ef4444', '#eab308', '#3b82f6'];
     const FUNNEL_COLORS = ['#6366f1', '#818cf8', '#3b82f6', '#06b6d4', '#22c55e'];
 
+    if (typeof Chart === 'undefined') {
+      document.getElementById('content').innerHTML = '<div class="error-box"><strong>Chart.js failed to load</strong><br>The charting library could not be loaded. This may be due to a Content Security Policy restriction or network issue. Try refreshing the page.</div>';
+      throw new Error('Chart.js not loaded — CDN may be blocked by CSP');
+    }
+
     Chart.defaults.color = '#9ca3af';
     Chart.defaults.borderColor = 'rgba(42, 45, 58, 0.8)';
     Chart.defaults.font.family = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';


### PR DESCRIPTION
## Summary
- Adds `https://cdn.jsdelivr.net` to CSP `connect-src` in `netlify.toml` — the mockServiceWorker intercepts `<script>` loads as `fetch()` requests, which get checked against `connect-src` instead of `script-src`, causing Chart.js to fail to load
- Adds a guard in `analytics.html` that shows a helpful error message if Chart.js fails to load for any reason, instead of an opaque "Cannot access 'charts' before initialization" crash

## Test plan
- [ ] Verify `console.kubestellar.io/analytics` loads without errors after deploy
- [ ] Verify all charts render correctly (daily users, events, countries, sources, devices, missions, cards, features, retention, errors)
- [ ] Verify the guard message appears if CDN is manually blocked