### PR TITLE
🐛 Fix watchdog redirect losing current page after reconnect

### DIFF
--- a/cmd/console/watchdog_html.go
+++ b/cmd/console/watchdog_html.go
@@ -83,8 +83,8 @@ async function checkNow(){
           // Beacon fallback if gtag not loaded yet
           try{navigator.sendBeacon('/api/telemetry/watchdog',JSON.stringify({event:'watchdog_reconnect',attempts:attempts,wait_seconds:waitSec}))}catch(e){}
         }
-        // Small delay to let the backend fully settle
-        setTimeout(function(){location.href='/';},500);
+        // Small delay to let the backend fully settle, then reload the original page
+        setTimeout(function(){location.reload();},500);
         return;
       }
     }


### PR DESCRIPTION
## Summary
- Watchdog was always redirecting to `/` after backend recovery, causing users to lose their current page (e.g. `/compliance` → `/`)
- Changed `location.href='/'` to `location.reload()` so the page reloads in place

## Test plan
- [ ] Kill backend (`lsof -ti :8081 | xargs kill -9`), verify watchdog screen appears
- [ ] Wait for backend to restart, verify page reloads to the same URL (not `/`)