### PR TITLE
✨ Add per-card error breakdown to analytics dashboard

### DIFF
--- a/web/netlify/functions/analytics-dashboard.mts
+++ b/web/netlify/functions/analytics-dashboard.mts
@@ -92,6 +92,7 @@ interface DashboardData {
   featureAdoption: { feature: string; count: number; users: number }[];
   weeklyRetention: { week: string; newUsers: number; returning: number }[];
   errors: { event: string; count: number; detail: string; daily: number[] }[];
+  cardErrors: { card: string; count: number; daily: number[] }[];
   cachedAt: string;
   propertyId: string;
   dateRange: string;
@@ -271,6 +272,7 @@ async function fetchDashboardData(
     weeklyRetRows,
     errorRows,
     errorDailyRows,
+    cardErrorRows,
   ] = await Promise.all([
     // 1. Overview metrics (current period)
     runReport(propertyId, accessToken, {
@@ -579,6 +581,21 @@ async function fetchDashboardData(
       },
       orderBys: [{ dimension: { dimensionName: "date", orderType: "ALPHANUMERIC" } }],
     }),
+
+    // 20. Card-level error breakdown (by customEvent:card_id)
+    runReport(propertyId, accessToken, {
+      dateRanges: [currentRange],
+      dimensions: [{ name: "customEvent:card_id" }, { name: "date" }],
+      metrics: [{ name: "eventCount" }],
+      dimensionFilter: {
+        filter: {
+          fieldName: "eventName",
+          stringFilter: { matchType: "EXACT", value: "ksc_error" },
+        },
+      },
+      orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
+      limit: 200,
+    }),
   ]);
 
   // Parse overview
@@ -709,6 +726,26 @@ async function fetchDashboardData(
       return { event, count: metVal(r, 0), detail, daily };
     });
 
+  // Parse card-level errors with sparklines
+  const cardErrorMap = new Map<string, { count: number; dayMap: Map<string, number> }>();
+  for (const row of cardErrorRows) {
+    const card = dimVal(row, 0);
+    if (card === "(not set)") continue;
+    const date = dimVal(row, 1);
+    const count = metVal(row, 0);
+    if (!cardErrorMap.has(card)) cardErrorMap.set(card, { count: 0, dayMap: new Map() });
+    const entry = cardErrorMap.get(card)!;
+    entry.count += count;
+    entry.dayMap.set(date, (entry.dayMap.get(date) || 0) + count);
+  }
+  const cardErrors = [...cardErrorMap.entries()]
+    .map(([card, { count, dayMap }]) => ({
+      card,
+      count,
+      daily: allDates.map((d) => dayMap.get(d) || 0),
+    }))
+    .sort((a, b) => b.count - a.count);
+
   return {
     overview,
     overviewPrevious,
@@ -780,6 +817,7 @@ async function fetchDashboardData(
     featureAdoption,
     weeklyRetention,
     errors,
+    cardErrors,
     cachedAt: new Date().toISOString(),
     propertyId,
     dateRange: "Last 28 days",

--- a/web/public/analytics.html
+++ b/web/public/analytics.html
@@ -752,6 +752,22 @@
         html += '</div>';
       }
 
+      // Card Error Breakdown
+      if (data.cardErrors && data.cardErrors.length > 0) {
+        html += '<div class="section-title">Card Error Breakdown</div>';
+        html += '<div class="chart-grid">';
+        html += '<div class="chart-card"><h3>Errors by Card</h3><div class="chart-wrapper"><canvas id="cardErrorChart"></canvas></div></div>';
+        html += '<div class="table-card"><h3>Per-Card Render Errors (28 days)</h3><table><thead><tr><th>Card ID</th><th style="width:120px">Trend (28d)</th><th class="num">Errors</th></tr></thead><tbody>';
+        for (const c of data.cardErrors.slice(0, 20)) {
+          const color = c.count > 20 ? 'var(--red)' : c.count > 5 ? 'var(--yellow)' : 'var(--text)';
+          const sparkline = buildSparklineSVG(c.daily || [], color);
+          const trend = getTrend(c.daily || []);
+          html += `<tr><td><code>${c.card}</code></td><td>${sparkline}<span class="trend-indicator ${trend.dir}">${trend.label}</span></td><td class="num" style="color:${color}">${fmt(c.count)}</td></tr>`;
+        }
+        html += '</tbody></table></div>';
+        html += '</div>';
+      }
+
       container.innerHTML = html;
 
       // Render charts
@@ -776,6 +792,9 @@
       }
       if (data.errors && data.errors.length > 0) {
         renderErrorChart(data.errors.slice(0, 8));
+      }
+      if (data.cardErrors && data.cardErrors.length > 0) {
+        renderCardErrorChart(data.cardErrors.slice(0, 12));
       }
     }
 
@@ -1079,6 +1098,35 @@
           maintainAspectRatio: false,
           plugins: {
             legend: { position: 'right', labels: { boxWidth: 12, padding: 8, font: { size: 11 } } },
+          },
+        },
+      });
+      charts.push(chart);
+    }
+
+    function renderCardErrorChart(cardErrors) {
+      const ctx = document.getElementById('cardErrorChart');
+      if (!ctx) return;
+      const CARD_ERR_COLORS = ['#ef4444', '#f97316', '#eab308', '#a855f7', '#6366f1', '#3b82f6', '#06b6d4', '#22c55e'];
+      const chart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: cardErrors.map(c => c.card),
+          datasets: [{
+            label: 'Errors',
+            data: cardErrors.map(c => c.count),
+            backgroundColor: CARD_ERR_COLORS.slice(0, cardErrors.length),
+            borderRadius: 4,
+          }],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          indexAxis: 'y',
+          plugins: { legend: { display: false } },
+          scales: {
+            x: { beginAtZero: true },
+            y: { grid: { display: false }, ticks: { font: { size: 10 } } },
           },
         },
       });

--- a/web/src/components/cards/DynamicCardErrorBoundary.tsx
+++ b/web/src/components/cards/DynamicCardErrorBoundary.tsx
@@ -50,7 +50,7 @@ export class DynamicCardErrorBoundary extends Component<Props, State> {
     }
 
     console.error(`[DynamicCard:${this.props.cardId}] Render error:`, error, errorInfo)
-    emitError('card_render', `[${this.props.cardId}] ${error.message}`)
+    emitError('card_render', error.message, this.props.cardId)
     this.props.onError?.(error, errorInfo)
     // Only increment retryCount when the error happens during a retry attempt,
     // so successful retries do not consume the retry budget.

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -550,11 +550,12 @@ export function emitFeedbackSubmitted(type: string) {
 // Maximum length for error detail strings to avoid oversized payloads
 const ERROR_DETAIL_MAX_LEN = 100
 
-export function emitError(category: string, detail: string) {
+export function emitError(category: string, detail: string, cardId?: string) {
   send('ksc_error', {
     error_category: category,
     error_detail: detail.slice(0, ERROR_DETAIL_MAX_LEN),
     error_page: window.location.pathname,
+    ...(cardId && { card_id: cardId }),
   })
 }
 


### PR DESCRIPTION
## Summary
- Separates `card_id` into its own GA4 event parameter (was previously embedded in `error_detail` string as `[cardId] message`)
- Adds a new GA4 query (query 20) that breaks down `ksc_error` events by `customEvent:card_id` with daily granularity
- Renders a new "Card Error Breakdown" section on the analytics page:
  - Horizontal bar chart showing errors per card
  - Table with card ID, sparkline trend (28 days), and error count
- This will start populating data going forward as the new `card_id` parameter gets sent

## Context
The analytics dashboard showed 102 `card_render` errors over 28 days but couldn't tell us which specific cards were failing. Now each card's error boundary sends a dedicated `card_id` parameter, and the analytics page shows a per-card breakdown with trends.

## Test plan
- [ ] Verify build passes
- [ ] Verify analytics page loads with new "Card Error Breakdown" section
- [ ] Verify sparklines render in the card error table
- [ ] Verify the bar chart shows per-card error counts
- [ ] Note: `card_id` data will be empty initially until new errors are sent with the updated parameter