### PR TITLE
🐛 Fix analytics API crash from unregistered card_id dimension

### DIFF
--- a/web/netlify/functions/analytics-dashboard.mts
+++ b/web/netlify/functions/analytics-dashboard.mts
@@ -92,7 +92,6 @@ interface DashboardData {
   featureAdoption: { feature: string; count: number; users: number }[];
   weeklyRetention: { week: string; newUsers: number; returning: number }[];
   errors: { event: string; count: number; detail: string; daily: number[] }[];
-  cardErrors: { card: string; count: number; daily: number[] }[];
   cachedAt: string;
   propertyId: string;
   dateRange: string;
@@ -272,7 +271,6 @@ async function fetchDashboardData(
     weeklyRetRows,
     errorRows,
     errorDailyRows,
-    cardErrorRows,
   ] = await Promise.all([
     // 1. Overview metrics (current period)
     runReport(propertyId, accessToken, {
@@ -581,21 +579,6 @@ async function fetchDashboardData(
       },
       orderBys: [{ dimension: { dimensionName: "date", orderType: "ALPHANUMERIC" } }],
     }),
-
-    // 20. Card-level error breakdown (by customEvent:card_id)
-    runReport(propertyId, accessToken, {
-      dateRanges: [currentRange],
-      dimensions: [{ name: "customEvent:card_id" }, { name: "date" }],
-      metrics: [{ name: "eventCount" }],
-      dimensionFilter: {
-        filter: {
-          fieldName: "eventName",
-          stringFilter: { matchType: "EXACT", value: "ksc_error" },
-        },
-      },
-      orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
-      limit: 200,
-    }),
   ]);
 
   // Parse overview
@@ -726,25 +709,7 @@ async function fetchDashboardData(
       return { event, count: metVal(r, 0), detail, daily };
     });
 
-  // Parse card-level errors with sparklines
-  const cardErrorMap = new Map<string, { count: number; dayMap: Map<string, number> }>();
-  for (const row of cardErrorRows) {
-    const card = dimVal(row, 0);
-    if (card === "(not set)") continue;
-    const date = dimVal(row, 1);
-    const count = metVal(row, 0);
-    if (!cardErrorMap.has(card)) cardErrorMap.set(card, { count: 0, dayMap: new Map() });
-    const entry = cardErrorMap.get(card)!;
-    entry.count += count;
-    entry.dayMap.set(date, (entry.dayMap.get(date) || 0) + count);
-  }
-  const cardErrors = [...cardErrorMap.entries()]
-    .map(([card, { count, dayMap }]) => ({
-      card,
-      count,
-      daily: allDates.map((d) => dayMap.get(d) || 0),
-    }))
-    .sort((a, b) => b.count - a.count);
+
 
   return {
     overview,
@@ -817,7 +782,6 @@ async function fetchDashboardData(
     featureAdoption,
     weeklyRetention,
     errors,
-    cardErrors,
     cachedAt: new Date().toISOString(),
     propertyId,
     dateRange: "Last 28 days",

--- a/web/public/analytics.html
+++ b/web/public/analytics.html
@@ -752,22 +752,6 @@
         html += '</div>';
       }
 
-      // Card Error Breakdown
-      if (data.cardErrors && data.cardErrors.length > 0) {
-        html += '<div class="section-title">Card Error Breakdown</div>';
-        html += '<div class="chart-grid">';
-        html += '<div class="chart-card"><h3>Errors by Card</h3><div class="chart-wrapper"><canvas id="cardErrorChart"></canvas></div></div>';
-        html += '<div class="table-card"><h3>Per-Card Render Errors (28 days)</h3><table><thead><tr><th>Card ID</th><th style="width:120px">Trend (28d)</th><th class="num">Errors</th></tr></thead><tbody>';
-        for (const c of data.cardErrors.slice(0, 20)) {
-          const color = c.count > 20 ? 'var(--red)' : c.count > 5 ? 'var(--yellow)' : 'var(--text)';
-          const sparkline = buildSparklineSVG(c.daily || [], color);
-          const trend = getTrend(c.daily || []);
-          html += `<tr><td><code>${c.card}</code></td><td>${sparkline}<span class="trend-indicator ${trend.dir}">${trend.label}</span></td><td class="num" style="color:${color}">${fmt(c.count)}</td></tr>`;
-        }
-        html += '</tbody></table></div>';
-        html += '</div>';
-      }
-
       container.innerHTML = html;
 
       // Render charts
@@ -792,9 +776,6 @@
       }
       if (data.errors && data.errors.length > 0) {
         renderErrorChart(data.errors.slice(0, 8));
-      }
-      if (data.cardErrors && data.cardErrors.length > 0) {
-        renderCardErrorChart(data.cardErrors.slice(0, 12));
       }
     }
 
@@ -1098,35 +1079,6 @@
           maintainAspectRatio: false,
           plugins: {
             legend: { position: 'right', labels: { boxWidth: 12, padding: 8, font: { size: 11 } } },
-          },
-        },
-      });
-      charts.push(chart);
-    }
-
-    function renderCardErrorChart(cardErrors) {
-      const ctx = document.getElementById('cardErrorChart');
-      if (!ctx) return;
-      const CARD_ERR_COLORS = ['#ef4444', '#f97316', '#eab308', '#a855f7', '#6366f1', '#3b82f6', '#06b6d4', '#22c55e'];
-      const chart = new Chart(ctx, {
-        type: 'bar',
-        data: {
-          labels: cardErrors.map(c => c.card),
-          datasets: [{
-            label: 'Errors',
-            data: cardErrors.map(c => c.count),
-            backgroundColor: CARD_ERR_COLORS.slice(0, cardErrors.length),
-            borderRadius: 4,
-          }],
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          indexAxis: 'y',
-          plugins: { legend: { display: false } },
-          scales: {
-            x: { beginAtZero: true },
-            y: { grid: { display: false }, ticks: { font: { size: 10 } } },
           },
         },
       });

--- a/web/src/components/cards/DynamicCardErrorBoundary.tsx
+++ b/web/src/components/cards/DynamicCardErrorBoundary.tsx
@@ -50,7 +50,7 @@ export class DynamicCardErrorBoundary extends Component<Props, State> {
     }
 
     console.error(`[DynamicCard:${this.props.cardId}] Render error:`, error, errorInfo)
-    emitError('card_render', error.message, this.props.cardId)
+    emitError('card_render', `[${this.props.cardId}] ${error.message}`, this.props.cardId)
     this.props.onError?.(error, errorInfo)
     // Only increment retryCount when the error happens during a retry attempt,
     // so successful retries do not consume the retry budget.


### PR DESCRIPTION
## Summary
- **HOTFIX**: Removes GA4 query using `customEvent:card_id` which isn't registered as a custom dimension, causing a 400 error that broke the entire analytics API (all data)
- Removes the card error breakdown UI (will re-add once `card_id` is registered in GA4 admin)
- Keeps `card_id` being sent as an event parameter (will collect data for when it's registered)
- Restores `[cardId]` prefix in `error_detail` for backward compatibility

## Test plan
- [ ] Verify `console.kubestellar.io/api/analytics-dashboard` returns valid data (not 502)
- [ ] Verify analytics page loads with all sections including error sparklines