### PR TITLE
🐛 Fix chunk load errors after deploys (137 errors, +272%)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -100,6 +100,17 @@
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
 
+# HTML files must always revalidate to pick up new chunk references after deploys
+[[headers]]
+  for = "/*.html"
+  [headers.values]
+    Cache-Control = "no-cache"
+
+[[headers]]
+  for = "/index.html"
+  [headers.values]
+    Cache-Control = "no-cache"
+
 # Context-specific settings
 [context.production]
   # Production builds (main branch) - still use demo mode for now

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -23,6 +23,24 @@ import { loadDynamicCards, getAllDynamicCards, loadDynamicStats } from './lib/dy
 import { STORAGE_KEY_SQLITE_MIGRATED } from './lib/constants'
 import { initAnalytics } from './lib/analytics'
 
+// ── Chunk load error recovery ─────────────────────────────────────────────
+// When a new build is deployed, chunk filenames change (content hashes).
+// Browsers with cached HTML reference old chunks that no longer exist.
+// Vite fires `vite:preloadError` before React error boundaries see the error.
+// Auto-reload once to pick up fresh HTML with correct chunk references.
+const CHUNK_RELOAD_KEY = 'chunk-reload-ts'
+const CHUNK_RELOAD_COOLDOWN_MS = 30_000
+window.addEventListener('vite:preloadError', (event) => {
+  const lastReload = sessionStorage.getItem(CHUNK_RELOAD_KEY)
+  const now = Date.now()
+  if (!lastReload || now - parseInt(lastReload) > CHUNK_RELOAD_COOLDOWN_MS) {
+    sessionStorage.setItem(CHUNK_RELOAD_KEY, String(now))
+    // Prevent the error from propagating to error boundaries
+    event.preventDefault()
+    window.location.reload()
+  }
+})
+
 // Suppress recharts dimension warnings (these occur when charts render before container is sized)
 const originalWarn = console.warn
 console.warn = (...args) => {


### PR DESCRIPTION
## Summary
- Add `vite:preloadError` handler in `main.tsx` that auto-reloads the page with a 30s cooldown when stale chunks fail to load after a new deploy
- Add `Cache-Control: no-cache` headers for `/*.html` and `/index.html` in `netlify.toml` so browsers always fetch fresh HTML with correct chunk references
- Works alongside the existing `ChunkErrorBoundary` React error boundary as a defense-in-depth approach

## Context
GA4 analytics showed 137 `chunk_load` errors with a +272% trend over 28 days. Root cause: after Netlify deploys, chunk filenames change (content hashes) but browsers with cached HTML still reference the old chunks that no longer exist on the CDN.

## Three-layer defense
1. **`vite:preloadError` handler** (NEW) — catches errors before React sees them, auto-reloads once
2. **Netlify `no-cache` headers** (NEW) — prevents HTML from being cached, so fresh chunk references are always served
3. **`ChunkErrorBoundary`** (existing) — React error boundary fallback if the above miss

## Test plan
- [ ] `npm run build` passes
- [ ] Deploy preview serves `Cache-Control: no-cache` on HTML responses
- [ ] Simulate stale chunk by manually requesting a non-existent chunk hash — page auto-reloads
- [ ] Monitor GA4 `chunk_load` error count over next 7 days — should trend toward zero