### PR TITLE
🐛 Fix gtag.js not initializing on Netlify + GA4 counting accuracy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -60,6 +60,15 @@
   to = "/.netlify/functions/missions-browse"
   status = 200
 
+# GA4 gtag.js proxy — only exists on Go backend, not Netlify.
+# Return 404 so the browser's onerror fires and the CDN fallback loads.
+# Without this, the SPA catch-all returns index.html (HTML with nosniff),
+# which triggers onload instead of onerror, breaking the CDN fallback chain.
+[[redirects]]
+  from = "/api/gtag"
+  to = "/404.html"
+  status = 404
+
 # GA4 event collection — custom lightweight tracker sends directly to /api/m
 # (Netlify Function via Config.path, no gtag.js loaded)
 

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -40,12 +40,15 @@ let pendingEvents: Array<{ name: string; params?: Record<string, string | number
 
 // Maximum time to wait for gtag.js before falling back to proxy
 const GTAG_LOAD_TIMEOUT_MS = 5_000
+// Delay after script.onload to verify gtag.js actually initialized
+const GTAG_INIT_CHECK_MS = 100
 
 // Extend window for gtag globals
 declare global {
   interface Window {
     dataLayer: unknown[]
     gtag: (...args: unknown[]) => void
+    google_tag_manager: unknown // Defined by gtag.js when it initializes
   }
 }
 const SESSION_TIMEOUT_MS = 30 * 60 * 1000 // 30 min
@@ -455,20 +458,44 @@ function loadGtagScript() {
   // Timeout: if gtag.js hasn't loaded in GTAG_LOAD_TIMEOUT_MS, fall back to proxy
   setTimeout(() => markGtagDecided(false), GTAG_LOAD_TIMEOUT_MS)
 
+  // Helper: verify gtag.js actually initialized (not just HTTP 200 with wrong content).
+  // On Netlify, /api/gtag returns HTML (SPA fallback) with HTTP 200 — the browser
+  // fires onload but MIME-type checking prevents execution. We detect this by
+  // checking for google_tag_manager, which real gtag.js always defines.
+  const isGtagInitialized = () => typeof window.google_tag_manager !== 'undefined'
+
+  // Helper: load gtag.js from Google CDN (used as fallback)
+  const loadCdnFallback = () => {
+    const cdnScript = document.createElement('script')
+    cdnScript.async = true
+    cdnScript.src = `${GTAG_CDN_URL}?id=${mid}`
+    cdnScript.onload = () => {
+      // Small delay to let gtag.js initialize before checking
+      setTimeout(() => markGtagDecided(isGtagInitialized()), GTAG_INIT_CHECK_MS)
+    }
+    cdnScript.onerror = () => { markGtagDecided(false) } // Ad blocker blocked CDN too
+    document.head.appendChild(cdnScript)
+  }
+
   // Try first-party proxy first (Go backend serves gtag.js from same origin)
   const script = document.createElement('script')
   script.async = true
   script.src = `${GTAG_SCRIPT_PATH}?id=${mid}`
-  script.onload = () => { markGtagDecided(true) }
+  script.onload = () => {
+    // Verify the script actually initialized gtag.js — not just HTTP 200 with HTML.
+    // On Netlify the SPA catch-all returns index.html for /api/gtag, which loads
+    // (HTTP 200) but gets blocked by strict MIME type checking (nosniff).
+    setTimeout(() => {
+      if (isGtagInitialized()) {
+        markGtagDecided(true)
+      } else {
+        loadCdnFallback()
+      }
+    }, GTAG_INIT_CHECK_MS)
+  }
   script.onerror = () => {
-    // First-party proxy unavailable (Netlify deploy, or proxy error)
-    // Fall back to Google CDN directly
-    const cdnScript = document.createElement('script')
-    cdnScript.async = true
-    cdnScript.src = `${GTAG_CDN_URL}?id=${mid}`
-    cdnScript.onload = () => { markGtagDecided(true) }
-    cdnScript.onerror = () => { markGtagDecided(false) } // Ad blocker blocked both
-    document.head.appendChild(cdnScript)
+    // First-party proxy returned non-200 — try Google CDN
+    loadCdnFallback()
   }
   document.head.appendChild(script)
 }


### PR DESCRIPTION
## Summary
- **Fix gtag.js silently failing on Netlify** — The SPA catch-all returns `index.html` for `/api/gtag`, which loads (HTTP 200) but is blocked by strict MIME type checking (`nosniff`). `script.onload` fires but gtag.js never initializes, causing all console.kubestellar.io analytics to silently drop.
- **Add Netlify 404 redirect for `/api/gtag`** — Returns 404 immediately so the browser fires `onerror` and the CDN fallback loads without delay.
- **Verify gtag.js initialization** — After `onload`, check `window.google_tag_manager` exists (always defined by real gtag.js) before declaring gtag available. Falls back to CDN if the check fails.
- **From prior commit (PR #2184)**: Pass custom `client_id` to gtag, queue events during load, use explicit `gtag('set', 'user_properties', ...)` for `deployment_type` accuracy.

## Root Cause
On Netlify, `/api/gtag` has no Go backend. The SPA catch-all (`/* → /index.html`) serves HTML with:
- `Content-Type: text/html`
- `X-Content-Type-Options: nosniff`

The browser fires `onload` (HTTP 200 succeeded) but refuses to execute (wrong MIME type). Since `onload` fires, the CDN fallback in `onerror` never triggers. Events are pushed to `dataLayer` but gtag.js never processes them → zero analytics from console.kubestellar.io in GA4 Realtime.

## Test plan
- [ ] Verify console.kubestellar.io users show `deployment_type: console.kubestellar.io` in GA4 Realtime
- [ ] Verify localhost users still show correctly
- [ ] Verify CDN gtag.js loads on Netlify after /api/gtag returns 404
- [ ] Verify ad-blocker fallback still works (proxy path)