### PR TITLE
✨ Add Netlify Function to proxy gtag.js for GA4 Realtime

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -60,14 +60,10 @@
   to = "/.netlify/functions/missions-browse"
   status = 200
 
-# GA4 gtag.js proxy — only exists on Go backend, not Netlify.
-# Return 404 so the browser's onerror fires and the CDN fallback loads.
-# Without this, the SPA catch-all returns index.html (HTML with nosniff),
-# which triggers onload instead of onerror, breaking the CDN fallback chain.
-[[redirects]]
-  from = "/api/gtag"
-  to = "/404.html"
-  status = 404
+# GA4 gtag.js proxy — Netlify Function serves gtag.js from same origin,
+# bypassing domain-based ad blockers. This is the Netlify equivalent of
+# the Go backend's GA4ScriptProxy. Route handled by gtag-proxy.mts via
+# Config.path, so no redirect needed here.
 
 # GA4 event collection — custom lightweight tracker sends directly to /api/m
 # (Netlify Function via Config.path, no gtag.js loaded)

--- a/web/netlify/functions/gtag-proxy.mts
+++ b/web/netlify/functions/gtag-proxy.mts
@@ -1,0 +1,58 @@
+/**
+ * Netlify Function: GA4 gtag.js Proxy
+ *
+ * Serves gtag.js from the console's own domain (/api/gtag) so that
+ * domain-based ad blockers don't block it. This is the Netlify equivalent
+ * of the Go backend's GA4ScriptProxy handler.
+ *
+ * Without this, Netlify visitors fall back to the Google CDN
+ * (googletagmanager.com) which is on virtually every ad blocker's
+ * blocklist. When gtag.js can't load, events go through the custom
+ * proxy (/api/m) which only appears in standard reports — NOT Realtime.
+ *
+ * With this function, gtag.js loads from console.kubestellar.io/api/gtag
+ * (same origin), events go directly from browser to GA4, and visitors
+ * appear in GA4 Realtime reports with accurate deployment_type.
+ */
+
+import type { Config } from "@netlify/functions"
+
+const GTAG_BASE_URL = "https://www.googletagmanager.com/gtag/js"
+const CACHE_MAX_AGE_SECS = 3600 // 1 hour — matches Go backend
+
+export default async (req: Request) => {
+  const url = new URL(req.url)
+  const queryString = url.search || ""
+
+  // Proxy the request to Google Tag Manager, preserving query params (e.g. ?id=G-...)
+  const targetUrl = `${GTAG_BASE_URL}${queryString}`
+
+  try {
+    const resp = await fetch(targetUrl, {
+      headers: {
+        "User-Agent": req.headers.get("user-agent") || "",
+      },
+    })
+
+    if (!resp.ok) {
+      return new Response(null, { status: resp.status })
+    }
+
+    const body = await resp.text()
+
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/javascript; charset=utf-8",
+        "Cache-Control": `public, max-age=${CACHE_MAX_AGE_SECS}`,
+        "X-Content-Type-Options": "nosniff",
+      },
+    })
+  } catch {
+    return new Response(null, { status: 502 })
+  }
+}
+
+export const config: Config = {
+  path: "/api/gtag",
+}


### PR DESCRIPTION
## Summary
- Adds `gtag-proxy.mts` Netlify Function that proxies gtag.js from `googletagmanager.com` through the console's own domain (`/api/gtag`)
- Removes the 404 redirect for `/api/gtag` in `netlify.toml` — the Netlify Function now handles it via `Config.path`
- This is the Netlify equivalent of the Go backend's `GA4ScriptProxy` handler

## Problem
GA4 standard reports show 163 `console.kubestellar.io` users (past 7 days) via the proxy path, but GA4 **Realtime** shows zero — because:
1. `/api/gtag` returned 404 on Netlify (added in PR #2186)
2. CDN fallback (`googletagmanager.com`) is blocked by virtually all ad blockers
3. Events fall through to the custom proxy (`/api/m`), which only populates standard reports (24-48h delay), not Realtime

## Solution
Serve gtag.js from the same origin (`console.kubestellar.io/api/gtag`) via a Netlify Function, bypassing domain-based ad blockers. This makes the first-party proxy work on **both** platforms:
- **Localhost**: Go backend proxies gtag.js (existing)
- **console.kubestellar.io**: Netlify Function proxies gtag.js (new)

## Test plan
- [ ] Verify Netlify preview deploys successfully
- [ ] Visit preview URL → confirm gtag.js loads from `/api/gtag` (Network tab shows 200 with JS content)
- [ ] After merge, monitor GA4 Realtime for `deployment_type: console.kubestellar.io` entries
- [ ] Verify existing localhost analytics continue working (no regression)