### PR TITLE
✨ Filter localhost dev traffic from analytics dashboard

### DIFF
--- a/web/netlify/functions/analytics-dashboard.mts
+++ b/web/netlify/functions/analytics-dashboard.mts
@@ -16,7 +16,7 @@ import { getStore } from "@netlify/blobs";
 // ---------------------------------------------------------------------------
 
 const CACHE_STORE = "analytics-dashboard";
-const CACHE_KEY = "dashboard-data";
+const CACHE_KEY_PREFIX = "dashboard-data"; // suffixed with filter mode
 const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
 const TOKEN_CACHE_KEY = "access-token";
 const GA4_DATA_API = "https://analyticsdata.googleapis.com/v1beta";
@@ -243,10 +243,44 @@ function metVal(row: GA4Row, idx: number): number {
   return parseFloat((row.metricValues || [])[idx]?.value || "0");
 }
 
+type FilterMode = "production" | "all";
+
+/** Exclusion filter: NOT (deployment_type = "localhost") */
+const LOCALHOST_EXCLUSION = {
+  notExpression: {
+    filter: {
+      fieldName: "customUser:deployment_type",
+      stringFilter: { matchType: "EXACT" as const, value: "localhost" },
+    },
+  },
+};
+
+/**
+ * Wrap a GA4 query body with localhost exclusion when in production filter mode.
+ * Merges with any existing dimensionFilter using andGroup.
+ */
+function withFilter(
+  body: Record<string, unknown>,
+  mode: FilterMode
+): Record<string, unknown> {
+  if (mode === "all") return body;
+  const existing = body.dimensionFilter as Record<string, unknown> | undefined;
+  if (!existing) {
+    return { ...body, dimensionFilter: LOCALHOST_EXCLUSION };
+  }
+  return {
+    ...body,
+    dimensionFilter: {
+      andGroup: { expressions: [existing, LOCALHOST_EXCLUSION] },
+    },
+  };
+}
+
 /** Fetch all dashboard data in parallel */
 async function fetchDashboardData(
   propertyId: string,
-  accessToken: string
+  accessToken: string,
+  filterMode: FilterMode = "production"
 ): Promise<DashboardData> {
   const currentRange = { startDate: "28daysAgo", endDate: "today" };
   const previousRange = { startDate: "56daysAgo", endDate: "29daysAgo" };
@@ -273,7 +307,7 @@ async function fetchDashboardData(
     errorDailyRows,
   ] = await Promise.all([
     // 1. Overview metrics (current period)
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       metrics: [
         { name: "activeUsers" },
@@ -283,10 +317,10 @@ async function fetchDashboardData(
         { name: "bounceRate" },
         { name: "eventCount" },
       ],
-    }),
+    }, filterMode)),
 
     // 2. Overview metrics (previous period for comparison)
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [previousRange],
       metrics: [
         { name: "activeUsers" },
@@ -296,18 +330,18 @@ async function fetchDashboardData(
         { name: "bounceRate" },
         { name: "eventCount" },
       ],
-    }),
+    }, filterMode)),
 
     // 3. Daily users/sessions
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "date" }],
       metrics: [{ name: "activeUsers" }, { name: "sessions" }],
       orderBys: [{ dimension: { dimensionName: "date", orderType: "ALPHANUMERIC" } }],
-    }),
+    }, filterMode)),
 
     // 4. Top pages
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "pageTitle" }],
       metrics: [
@@ -316,28 +350,28 @@ async function fetchDashboardData(
       ],
       orderBys: [{ metric: { metricName: "screenPageViews" }, desc: true }],
       limit: 15,
-    }),
+    }, filterMode)),
 
     // 5. Top events
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "eventName" }],
       metrics: [{ name: "eventCount" }, { name: "totalUsers" }],
       orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
       limit: 20,
-    }),
+    }, filterMode)),
 
     // 6. Countries
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "country" }],
       metrics: [{ name: "activeUsers" }, { name: "sessions" }],
       orderBys: [{ metric: { metricName: "activeUsers" }, desc: true }],
       limit: 15,
-    }),
+    }, filterMode)),
 
     // 7. Traffic sources
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [
         { name: "sessionSource" },
@@ -346,18 +380,18 @@ async function fetchDashboardData(
       metrics: [{ name: "sessions" }, { name: "totalUsers" }],
       orderBys: [{ metric: { metricName: "sessions" }, desc: true }],
       limit: 10,
-    }),
+    }, filterMode)),
 
     // 8. Devices
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "deviceCategory" }],
       metrics: [{ name: "activeUsers" }],
       orderBys: [{ metric: { metricName: "activeUsers" }, desc: true }],
-    }),
+    }, filterMode)),
 
     // 9. Funnel events (custom KSC events)
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "eventName" }],
       metrics: [{ name: "totalUsers" }],
@@ -379,10 +413,10 @@ async function fetchDashboardData(
           })),
         },
       },
-    }),
+    }, filterMode)),
 
     // 10. CNCF outreach (by utm_term = project slug)
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "sessionManualTerm" }],
       metrics: [
@@ -398,10 +432,10 @@ async function fetchDashboardData(
       },
       orderBys: [{ metric: { metricName: "sessions" }, desc: true }],
       limit: 30,
-    }),
+    }, filterMode)),
 
     // 11. Engagement by page
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "pageTitle" }],
       metrics: [
@@ -412,17 +446,17 @@ async function fetchDashboardData(
       ],
       orderBys: [{ metric: { metricName: "screenPageViews" }, desc: true }],
       limit: 15,
-    }),
+    }, filterMode)),
 
     // 12. New vs returning users
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "newVsReturning" }],
       metrics: [{ name: "activeUsers" }, { name: "sessions" }],
-    }),
+    }, filterMode)),
 
     // 13. Mission events (started/completed/error/rated)
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "eventName" }],
       metrics: [{ name: "eventCount" }, { name: "totalUsers" }],
@@ -441,10 +475,10 @@ async function fetchDashboardData(
           })),
         },
       },
-    }),
+    }, filterMode)),
 
     // 14. Mission types breakdown (by customEvent:mission_type)
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "customEvent:mission_type" }],
       metrics: [{ name: "eventCount" }],
@@ -456,10 +490,10 @@ async function fetchDashboardData(
       },
       orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
       limit: 15,
-    }),
+    }, filterMode)),
 
     // 15. Card popularity (added/expanded/clicked by card_type)
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [
         { name: "customEvent:card_type" },
@@ -482,10 +516,10 @@ async function fetchDashboardData(
       },
       orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
       limit: 100,
-    }),
+    }, filterMode)),
 
     // 16. Feature adoption events
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "eventName" }],
       metrics: [{ name: "eventCount" }, { name: "totalUsers" }],
@@ -519,18 +553,18 @@ async function fetchDashboardData(
       },
       orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
       limit: 20,
-    }),
+    }, filterMode)),
 
     // 17. Weekly retention (new vs returning by week)
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "week" }, { name: "newVsReturning" }],
       metrics: [{ name: "activeUsers" }],
       orderBys: [{ dimension: { dimensionName: "week", orderType: "ALPHANUMERIC" } }],
-    }),
+    }, filterMode)),
 
     // 18. Error events
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "eventName" }, { name: "customEvent:error_category" }],
       metrics: [{ name: "eventCount" }],
@@ -553,10 +587,10 @@ async function fetchDashboardData(
       },
       orderBys: [{ metric: { metricName: "eventCount" }, desc: true }],
       limit: 30,
-    }),
+    }, filterMode)),
 
     // 19. Daily error trends (for sparklines)
-    runReport(propertyId, accessToken, {
+    runReport(propertyId, accessToken, withFilter({
       dateRanges: [currentRange],
       dimensions: [{ name: "date" }, { name: "eventName" }, { name: "customEvent:error_category" }],
       metrics: [{ name: "eventCount" }],
@@ -578,7 +612,7 @@ async function fetchDashboardData(
         },
       },
       orderBys: [{ dimension: { dimensionName: "date", orderType: "ALPHANUMERIC" } }],
-    }),
+    }, filterMode)),
   ]);
 
   // Parse overview
@@ -837,14 +871,20 @@ export default async (req: Request) => {
     );
   }
 
+  // Parse filter mode: ?filter=production (default) or ?filter=all
+  const url = new URL(req.url);
+  const filterParam = url.searchParams.get("filter");
+  const filterMode: FilterMode = filterParam === "all" ? "all" : "production";
+  const cacheKey = `${CACHE_KEY_PREFIX}-${filterMode}`;
+
   // Check blob cache
   const store = getStore(CACHE_STORE);
   try {
-    const cached = await store.get(CACHE_KEY, { type: "text" });
+    const cached = await store.get(cacheKey, { type: "text" });
     if (cached) {
       const entry = JSON.parse(cached);
       if (Date.now() < entry.expiresAt) {
-        return new Response(JSON.stringify({ ...entry.data, fromCache: true }), {
+        return new Response(JSON.stringify({ ...entry.data, fromCache: true, filterMode }), {
           status: 200,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
         });
@@ -857,17 +897,17 @@ export default async (req: Request) => {
   // Fetch fresh data
   try {
     const accessToken = await getAccessToken(serviceAccount, store);
-    const data = await fetchDashboardData(propertyId, accessToken);
+    const data = await fetchDashboardData(propertyId, accessToken, filterMode);
 
     // Cache result
     store
       .set(
-        CACHE_KEY,
+        cacheKey,
         JSON.stringify({ data, expiresAt: Date.now() + CACHE_TTL_MS })
       )
       .catch(() => {});
 
-    return new Response(JSON.stringify(data), {
+    return new Response(JSON.stringify({ ...data, filterMode }), {
       status: 200,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });

--- a/web/public/analytics.html
+++ b/web/public/analytics.html
@@ -367,6 +367,10 @@
       <h1>KubeStellar Console Analytics</h1>
     </div>
     <div class="header-right">
+      <label style="display:flex;align-items:center;gap:6px;cursor:pointer;user-select:none" title="Include dev traffic from localhost (Vite HMR inflates user counts)">
+        <input type="checkbox" id="include-localhost" style="accent-color:var(--accent);cursor:pointer">
+        <span style="font-size:12px;color:var(--text-muted)">Include localhost</span>
+      </label>
       <span id="cache-status"></span>
       <span class="status-dot" id="status-dot"></span>
       <button class="refresh-btn" id="refresh-btn" onclick="loadData(true)">Refresh</button>
@@ -1085,6 +1089,10 @@
       charts.push(chart);
     }
 
+    function getFilterMode() {
+      return document.getElementById('include-localhost').checked ? 'all' : 'production';
+    }
+
     async function loadData(forceRefresh = false) {
       const btn = document.getElementById('refresh-btn');
       const status = document.getElementById('cache-status');
@@ -1094,7 +1102,10 @@
       btn.textContent = 'Loading...';
 
       try {
-        const url = forceRefresh ? API_URL + '?bust=' + Date.now() : API_URL;
+        const filter = getFilterMode();
+        const params = new URLSearchParams({ filter });
+        if (forceRefresh) params.set('bust', String(Date.now()));
+        const url = API_URL + '?' + params.toString();
         const resp = await fetch(url);
         if (!resp.ok) {
           const err = await resp.json().catch(() => ({ error: resp.statusText }));
@@ -1106,7 +1117,8 @@
 
         const cached = data.fromCache ? 'Cached' : 'Fresh';
         const time = new Date(data.cachedAt).toLocaleTimeString();
-        status.textContent = `${cached} · ${time}`;
+        const modeLabel = filter === 'all' ? ' (all traffic)' : ' (production only)';
+        status.textContent = `${cached} · ${time}${modeLabel}`;
         dot.style.background = '#22c55e';
       } catch (err) {
         document.getElementById('content').innerHTML = `
@@ -1122,6 +1134,9 @@
         btn.textContent = 'Refresh';
       }
     }
+
+    // Reload when filter toggle changes
+    document.getElementById('include-localhost').addEventListener('change', () => loadData(true));
 
     // Auto-refresh every 15 minutes
     const AUTO_REFRESH_MS = 15 * 60 * 1000;


### PR DESCRIPTION
## Problem

Localhost dev traffic from Vite HMR inflates analytics user counts ~400x (1,943 "users" from localhost vs 5 real production users today). This makes the analytics dashboard unusable for understanding actual user behavior.

## Solution

- **API**: Add `?filter=production` (default) / `?filter=all` query param
- **Backend**: Wrap all 19 GA4 queries with `NOT(customUser:deployment_type = localhost)` exclusion filter
- **Caching**: Separate blob cache keys per filter mode so toggling doesn't wait for cache expiry
- **UI**: Add "Include localhost" checkbox toggle in analytics.html header
- Shows filter mode label in status bar ("production only" / "all traffic")

## How it works

The `deployment_type` user property is already set by the analytics client (`analytics.ts`) and registered as a GA4 custom dimension (#2 event-scoped, #22 user-scoped). The filter uses `customUser:deployment_type` which covers all events for that user session.

## Before/After

| Metric | Before (all traffic) | After (production only) |
|--------|---------------------|------------------------|
| Active Users | 1,943 | ~5 |
| Sessions | 2,230 | ~5 |

The toggle allows switching to "all traffic" view when dev data is needed for debugging.