### PR TITLE
🐛 Fix nightly test regression: insightRelatedResources missing MissionProvider mock

### DIFF
--- a/web/src/components/cards/insights/insightRelatedResources.test.tsx
+++ b/web/src/components/cards/insights/insightRelatedResources.test.tsx
@@ -18,6 +18,14 @@ vi.mock('react-i18next', () => ({
 vi.mock('../../../lib/analytics', () => ({
   emitNavigate: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
 }))
+vi.mock('../../../hooks/useMissions', () => ({
+  useMissions: () => ({
+    startMission: vi.fn(),
+    openSidebar: vi.fn(),
+    missions: [],
+    activeMission: null,
+  }),
+}))
 
 /** Factory for a minimal insight whose relatedResources are objects, not strings */
 function objectResourceInsight(


### PR DESCRIPTION
## Summary
- Fixes 3 failing tests in the nightly test suite (issue #2020) that regressed on March 11
- `ClusterDeltaDetector`, `DeploymentRolloutTracker`, and `RestartCorrelationMatrix` now render `InsightDetailModal` which calls `useMissions()` — the test was rendering them without a `MissionProvider`, causing `"useMissions must be used within a MissionProvider"` errors
- Adds `vi.mock` for `useMissions` to provide the required context

## Test plan
- [x] `npx vitest run insightRelatedResources.test.tsx` — all 3 tests pass
- [x] `npm run build` — passes
- [x] `npm run lint` — no new issues