### PR TITLE
🐛 Hoist useMissions mock spies for referential stability

### DIFF
--- a/web/src/components/cards/insights/insightRelatedResources.test.tsx
+++ b/web/src/components/cards/insights/insightRelatedResources.test.tsx
@@ -18,11 +18,15 @@ vi.mock('react-i18next', () => ({
 vi.mock('../../../lib/analytics', () => ({
   emitNavigate: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
 }))
+const mockStartMission = vi.fn()
+const mockOpenSidebar = vi.fn()
+const mockMissions: unknown[] = []
+
 vi.mock('../../../hooks/useMissions', () => ({
   useMissions: () => ({
-    startMission: vi.fn(),
-    openSidebar: vi.fn(),
-    missions: [],
+    startMission: mockStartMission,
+    openSidebar: mockOpenSidebar,
+    missions: mockMissions,
     activeMission: null,
   }),
 }))


### PR DESCRIPTION
## Summary
- Moves `vi.fn()` spy instances in `insightRelatedResources.test.tsx` out of the `useMissions` mock factory into top-level constants
- Ensures each component render receives the same spy references, preventing unnecessary rerenders and enabling reliable call assertions

Addresses Copilot review feedback on #2198.

## Test plan
- [x] `vitest run insightRelatedResources.test.tsx` — all 3 tests pass