### PR TITLE
✨ Add Docker Hub publishing alongside GHCR

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -41,6 +41,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
+  DOCKERHUB_IMAGE: kubestellar/console
   IMAGE_NAME: ${{ github.repository }}
   # Helm release name used across both clusters
   HELM_RELEASE_NAME: kc
@@ -71,11 +72,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            docker.io/${{ env.DOCKERHUB_IMAGE }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
## Summary

- Adds Docker Hub as a second container registry for the KubeStellar Console image
- On every non-PR build, the image is now pushed to **both** `ghcr.io/kubestellar/console` and `docker.io/kubestellar/console`
- Docker Hub login is conditional on `event_name != 'pull_request'` (same guard as GHCR)
- Uses `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets for authentication

This makes the console image discoverable via `docker pull kubestellar/console` on Docker Hub, in addition to the existing GHCR distribution.

## Prerequisites

Before merging, the following repository secrets must be configured:
- `DOCKERHUB_USERNAME` — Docker Hub username for the `kubestellar` organization
- `DOCKERHUB_TOKEN` — Docker Hub access token with push permissions

## Test plan

- [ ] Verify PR build succeeds (Docker Hub login is skipped on PRs, so no secrets needed)
- [ ] After adding secrets, trigger a `workflow_dispatch` build to verify dual-registry push
- [ ] Confirm image appears on Docker Hub at `kubestellar/console`