### PR TITLE
✨ Add Artifact Hub metadata for Helm chart discovery

### DIFF
--- a/deploy/helm/kubestellar-console/Chart.yaml
+++ b/deploy/helm/kubestellar-console/Chart.yaml
@@ -6,12 +6,38 @@ version: 0.0.0
 appVersion: "0.0.0"
 keywords:
   - kubernetes
-  - multi-cluster
   - dashboard
+  - monitoring
+  - cncf
+  - ai
+  - missions
   - kubestellar
+  - multi-cluster
 home: https://kubestellar.io/docs/console
 sources:
   - https://github.com/kubestellar/console
+icon: https://raw.githubusercontent.com/kubestellar/console/main/web/public/kubestellar-logo.svg
 maintainers:
-  - name: KubeStellar
-    url: https://github.com/kubestellar
+  - name: Andy Anderson
+    email: andy@clubanderson.com
+    url: https://github.com/clubanderson
+annotations:
+  artifacthub.io/description: >-
+    Kubernetes dashboard with 30+ dashboards, 150+ monitoring cards,
+    AI-guided install missions for 186 CNCF projects, and an AI mission
+    explorer. Connects to live clusters via kubeconfig.
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Website
+      url: https://kubestellar.io
+    - name: Source
+      url: https://github.com/kubestellar/console
+    - name: Live Demo
+      url: https://console.kubestellar.io
+    - name: Documentation
+      url: https://kubestellar.io/docs/console
+  artifacthub.io/maintainers: |
+    - name: Andy Anderson
+      email: andy@clubanderson.com
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/containsSecurityUpdates: "false"

--- a/deploy/helm/kubestellar-console/artifacthub-repo.yml
+++ b/deploy/helm/kubestellar-console/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+# Artifact Hub repository metadata
+# See https://artifacthub.io/docs/topics/repositories/helm-charts/
+repositoryID: kubestellar-console
+owners:
+  - name: Andy Anderson
+    email: andy@clubanderson.com


### PR DESCRIPTION
## Summary

- Add `artifacthub-repo.yml` to the Helm chart directory with repository ownership metadata
- Update `Chart.yaml` with Artifact Hub annotations: description, license, links, maintainers
- Add `icon` field pointing to the KubeStellar SVG logo
- Expand `keywords` for better discoverability (monitoring, cncf, ai, missions)
- Update `maintainers` with contact email and GitHub profile URL

This enables the KubeStellar Console Helm chart to be discovered via `helm search hub kubestellar-console` and listed on [artifacthub.io](https://artifacthub.io) once the repository is registered there.

## Test plan

- [ ] Verify `helm lint deploy/helm/kubestellar-console/` passes with updated Chart.yaml
- [ ] After merging, register the repository on artifacthub.io and confirm the chart appears