### PR TITLE
✨ SEO: Add landing pages for all 29 dashboard routes to accelerate Google indexing

### DIFF
--- a/web/netlify/edge-functions/seo-meta.ts
+++ b/web/netlify/edge-functions/seo-meta.ts
@@ -51,6 +51,29 @@ const LANDING_PAGE_MAP: Record<string, string> = {
   "/gpu-reservations": "/landing/gpu.html",
   "/deploy": "/landing/deploy.html",
   "/security": "/landing/security.html",
+  "/workloads": "/landing/workloads.html",
+  "/llm-d-benchmarks": "/landing/llm-d-benchmarks.html",
+  "/gitops": "/landing/gitops.html",
+  "/marketplace": "/landing/marketplace.html",
+  "/ai-agents": "/landing/ai-agents.html",
+  "/cost": "/landing/cost.html",
+  "/ai-ml": "/landing/ai-ml.html",
+  "/nodes": "/landing/nodes.html",
+  "/deployments": "/landing/deployments.html",
+  "/pods": "/landing/pods.html",
+  "/services": "/landing/services.html",
+  "/operators": "/landing/operators.html",
+  "/helm": "/landing/helm.html",
+  "/events": "/landing/events.html",
+  "/logs": "/landing/logs.html",
+  "/compute": "/landing/compute.html",
+  "/storage": "/landing/storage.html",
+  "/network": "/landing/network.html",
+  "/alerts": "/landing/alerts.html",
+  "/security-posture": "/landing/security-posture.html",
+  "/data-compliance": "/landing/data-compliance.html",
+  "/ci-cd": "/landing/ci-cd.html",
+  "/arcade": "/landing/arcade.html",
 };
 
 /** Check if the user-agent belongs to a search engine crawler or social bot */
@@ -211,6 +234,193 @@ const ROUTE_META: Record<string, RouteMeta> = {
       "kubernetes cost optimization",
       "cluster cost tracking",
       "kubernetes FinOps",
+    ],
+  },
+  "/ai-ml": {
+    title: "AI/ML Workload Management on Kubernetes - KubeStellar Console",
+    description:
+      "Manage AI and machine learning workloads across Kubernetes clusters. GPU scheduling, model serving, training job orchestration, and inference optimization.",
+    keywords: [
+      "kubernetes AI ML",
+      "kubernetes machine learning",
+      "GPU workload management",
+      "kubernetes model serving",
+    ],
+  },
+  "/nodes": {
+    title: "Kubernetes Node Management - KubeStellar Console",
+    description:
+      "Monitor and manage Kubernetes nodes across clusters. Node health, capacity planning, resource pressure conditions, and scheduling status.",
+    keywords: [
+      "kubernetes node management",
+      "kubernetes node monitoring",
+      "node capacity planning",
+      "kubernetes node health",
+    ],
+  },
+  "/deployments": {
+    title: "Kubernetes Deployment Management - KubeStellar Console",
+    description:
+      "Manage Kubernetes deployments across clusters. Rolling updates, rollback history, replica scaling, and deployment health monitoring.",
+    keywords: [
+      "kubernetes deployment management",
+      "kubernetes rolling update",
+      "deployment scaling",
+      "kubernetes deployment monitoring",
+    ],
+  },
+  "/pods": {
+    title: "Kubernetes Pod Monitoring - KubeStellar Console",
+    description:
+      "Monitor pods across all Kubernetes clusters. Real-time pod status, container logs, resource usage, and debugging tools.",
+    keywords: [
+      "kubernetes pod monitoring",
+      "kubernetes pod logs",
+      "pod debugging",
+      "kubernetes pod status",
+    ],
+  },
+  "/services": {
+    title: "Kubernetes Service Management - KubeStellar Console",
+    description:
+      "Manage Kubernetes services across clusters. Service discovery, endpoint health, load balancing configuration, and ingress management.",
+    keywords: [
+      "kubernetes service management",
+      "kubernetes service discovery",
+      "kubernetes load balancing",
+      "kubernetes ingress",
+    ],
+  },
+  "/operators": {
+    title: "Kubernetes Operator Management - KubeStellar Console",
+    description:
+      "Manage Kubernetes operators and custom resources across clusters. OLM integration, operator lifecycle, CRD management, and operator health monitoring.",
+    keywords: [
+      "kubernetes operators",
+      "kubernetes OLM",
+      "custom resource management",
+      "operator lifecycle",
+    ],
+  },
+  "/helm": {
+    title: "Helm Chart Management - KubeStellar Console",
+    description:
+      "Manage Helm releases across Kubernetes clusters. Chart repository browsing, release history, upgrade management, and values configuration.",
+    keywords: [
+      "helm chart management",
+      "kubernetes helm dashboard",
+      "helm release management",
+      "helm repository",
+    ],
+  },
+  "/events": {
+    title: "Kubernetes Event Monitoring - KubeStellar Console",
+    description:
+      "Monitor Kubernetes events across all clusters in real-time. Warning detection, event correlation, and automated alerting for cluster issues.",
+    keywords: [
+      "kubernetes events",
+      "kubernetes event monitoring",
+      "kubernetes warning events",
+      "cluster event alerting",
+    ],
+  },
+  "/logs": {
+    title: "Kubernetes Log Aggregation - KubeStellar Console",
+    description:
+      "Centralized log viewing across all Kubernetes clusters. Container logs, pod logs, and cluster-wide log search with filtering and streaming.",
+    keywords: [
+      "kubernetes logs",
+      "kubernetes log aggregation",
+      "container log viewer",
+      "kubernetes log search",
+    ],
+  },
+  "/compute": {
+    title: "Kubernetes Compute Resources - KubeStellar Console",
+    description:
+      "Manage compute resources across Kubernetes clusters. CPU and memory utilization, resource quotas, limit ranges, and capacity planning.",
+    keywords: [
+      "kubernetes compute resources",
+      "kubernetes resource management",
+      "kubernetes capacity planning",
+      "CPU memory utilization",
+    ],
+  },
+  "/storage": {
+    title: "Kubernetes Storage Management - KubeStellar Console",
+    description:
+      "Manage storage across Kubernetes clusters. Persistent volumes, storage classes, PVC monitoring, and storage capacity tracking.",
+    keywords: [
+      "kubernetes storage management",
+      "kubernetes persistent volumes",
+      "kubernetes PVC",
+      "kubernetes storage class",
+    ],
+  },
+  "/network": {
+    title: "Kubernetes Network Management - KubeStellar Console",
+    description:
+      "Manage network policies and service mesh across Kubernetes clusters. Network policy visualization, traffic flow analysis, and connectivity debugging.",
+    keywords: [
+      "kubernetes network policy",
+      "kubernetes service mesh",
+      "kubernetes networking",
+      "network policy management",
+    ],
+  },
+  "/alerts": {
+    title: "Kubernetes Alert Management - KubeStellar Console",
+    description:
+      "Manage alerts across Kubernetes clusters. Prometheus and Alertmanager integration, alert routing, silencing, and incident management.",
+    keywords: [
+      "kubernetes alerts",
+      "kubernetes prometheus alerts",
+      "kubernetes alertmanager",
+      "kubernetes incident management",
+    ],
+  },
+  "/security-posture": {
+    title: "Kubernetes Security Posture Assessment - KubeStellar Console",
+    description:
+      "Assess security posture across Kubernetes clusters. CIS benchmarks, pod security standards, image vulnerability scanning, and compliance scoring.",
+    keywords: [
+      "kubernetes security posture",
+      "kubernetes CIS benchmark",
+      "kubernetes compliance",
+      "pod security standards",
+    ],
+  },
+  "/data-compliance": {
+    title: "Kubernetes Data Compliance - KubeStellar Console",
+    description:
+      "Monitor data compliance across Kubernetes clusters. GDPR, HIPAA, SOC 2 compliance tracking, data residency policies, and audit reporting.",
+    keywords: [
+      "kubernetes compliance",
+      "kubernetes GDPR",
+      "kubernetes data governance",
+      "kubernetes audit",
+    ],
+  },
+  "/ci-cd": {
+    title: "CI/CD Pipeline Monitoring - KubeStellar Console",
+    description:
+      "Monitor CI/CD pipelines across Kubernetes clusters. Build status tracking, deployment frequency, lead time metrics, and pipeline health dashboards.",
+    keywords: [
+      "kubernetes CI CD",
+      "kubernetes pipeline monitoring",
+      "kubernetes deployment frequency",
+      "CI CD dashboard",
+    ],
+  },
+  "/arcade": {
+    title: "Kubernetes Learning Arcade - KubeStellar Console",
+    description:
+      "Interactive games and challenges for learning Kubernetes concepts. Practice cluster operations, debugging scenarios, and resource management in a safe environment.",
+    keywords: [
+      "kubernetes learning",
+      "kubernetes training",
+      "kubernetes interactive tutorial",
+      "kubernetes practice",
     ],
   },
 };

--- a/web/public/landing/ai-agents.html
+++ b/web/public/landing/ai-agents.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI-Powered Kubernetes Operations Agents - KubeStellar Console</title>
+  <meta name="description" content="Automate Kubernetes operations with AI agents. Intelligent troubleshooting, capacity planning, incident response, and optimization powered by large language models." />
+  <meta name="keywords" content="kubernetes ai agents, ai kubernetes operations, intelligent kubernetes automation, llm kubernetes, aiops kubernetes, automated troubleshooting kubernetes" />
+  <link rel="canonical" href="https://console.kubestellar.io/ai-agents" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="AI-Powered Kubernetes Operations Agents - KubeStellar Console" />
+  <meta property="og:description" content="Automate Kubernetes operations with AI agents. Intelligent troubleshooting, capacity planning, incident response, and optimization powered by large language models." />
+  <meta property="og:url" content="https://console.kubestellar.io/ai-agents" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="AI-Powered Kubernetes Operations Agents - KubeStellar Console" />
+  <meta name="twitter:description" content="Automate Kubernetes operations with AI agents. Intelligent troubleshooting, capacity planning, incident response, and optimization." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - AI Operations Agents",
+    "description": "Automate Kubernetes operations with AI agents. Intelligent troubleshooting, capacity planning, incident response, and optimization powered by large language models.",
+    "url": "https://console.kubestellar.io/ai-agents",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "AI troubleshooting, Capacity planning agent, Incident response automation, Cost optimization agent, Security scanning agent, Natural language operations"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>AI-Powered <span class="accent">Kubernetes</span> Operations</h1>
+    <p class="subtitle">Deploy intelligent agents that monitor, troubleshoot, and optimize your Kubernetes clusters autonomously. Reduce toil with LLM-powered operations that understand your infrastructure context.</p>
+    <div class="hero-actions">
+      <a href="/ai-agents" class="btn-primary">Explore AI Agents</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Intelligent Automation for Modern Infrastructure</h2>
+      <p>AI agents that go beyond simple alerting to actively investigate, diagnose, and resolve issues across your multi-cluster environment.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F9E0;</div>
+        <h3>Intelligent Troubleshooting</h3>
+        <p>AI agents analyze pod failures, OOMKills, CrashLoopBackOff events, and networking issues. They correlate events across clusters and provide root cause analysis with remediation steps.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4CA;</div>
+        <h3>Capacity Planning</h3>
+        <p>Predictive analytics that forecast resource needs based on historical usage patterns. Get recommendations for right-sizing clusters, adding nodes, or redistributing workloads before issues arise.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F6A8;</div>
+        <h3>Incident Response</h3>
+        <p>Automated incident investigation that begins the moment an alert fires. Agents gather logs, events, metrics, and recent changes to build a timeline and suggest remediation actions.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4AC;</div>
+        <h3>Natural Language Queries</h3>
+        <p>Ask questions about your infrastructure in plain English. &ldquo;Which pods restarted in the last hour?&rdquo; &ldquo;Show me clusters with high memory pressure.&rdquo; No kubectl needed.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F50C;</div>
+        <h3>Custom Agent Missions</h3>
+        <p>Create custom AI missions that automate your specific operational workflows. Chain together inspection, analysis, and action steps to build agents tailored to your environment.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F6E1;</div>
+        <h3>Security Scanning Agent</h3>
+        <p>Continuous security assessment that scans for misconfigurations, vulnerable images, exposed secrets, and RBAC issues. Prioritizes findings by risk and provides fix-forward guidance.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">LLM</div>
+        <div class="stat-label">Powered</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">24/7</div>
+        <div class="stat-label">Monitoring</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Natural</div>
+        <div class="stat-label">Language</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Autonomous</div>
+        <div class="stat-label">Operations</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Let AI handle the toil so you can focus on building.</h2>
+    <p>Deploy intelligent agents that know your clusters, understand your workloads, and act before problems become incidents.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/ai-ml.html
+++ b/web/public/landing/ai-ml.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI/ML Workload Management on Kubernetes - KubeStellar Console</title>
+  <meta name="description" content="Manage AI and machine learning workloads on Kubernetes. Monitor training jobs, inference services, GPU allocation, model serving, and MLOps pipelines across clusters." />
+  <meta name="keywords" content="ai ml kubernetes, machine learning kubernetes, gpu workload management, model serving kubernetes, mlops dashboard, training job monitoring, inference kubernetes" />
+  <link rel="canonical" href="https://console.kubestellar.io/ai-ml" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="AI/ML Workload Management on Kubernetes - KubeStellar Console" />
+  <meta property="og:description" content="Manage AI and machine learning workloads on Kubernetes. Monitor training jobs, inference services, GPU allocation, model serving, and MLOps pipelines across clusters." />
+  <meta property="og:url" content="https://console.kubestellar.io/ai-ml" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="AI/ML Workload Management on Kubernetes - KubeStellar Console" />
+  <meta name="twitter:description" content="Manage AI and machine learning workloads on Kubernetes. Monitor training jobs, inference services, GPU allocation, and MLOps pipelines." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - AI/ML Workload Management",
+    "description": "Manage AI and machine learning workloads on Kubernetes. Monitor training jobs, inference services, GPU allocation, model serving, and MLOps pipelines across clusters.",
+    "url": "https://console.kubestellar.io/ai-ml",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "GPU workload management, Training job monitoring, Model serving dashboard, MLOps pipeline tracking, Inference scaling, Multi-cluster GPU scheduling"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>AI/ML <span class="accent">Workloads</span> on Kubernetes</h1>
+    <p class="subtitle">A purpose-built dashboard for managing machine learning workloads across Kubernetes clusters. Track training jobs, monitor inference endpoints, allocate GPU resources, and streamline your MLOps pipeline.</p>
+    <div class="hero-actions">
+      <a href="/ai-ml" class="btn-primary">View AI/ML Dashboard</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Built for Machine Learning Teams</h2>
+      <p>From model training to production inference, manage every stage of the ML lifecycle on Kubernetes with full GPU visibility.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4BB;</div>
+        <h3>GPU Resource Management</h3>
+        <p>Visualize GPU allocation across nodes and namespaces. See which training jobs and inference pods consume GPU resources, identify fragmentation, and optimize scheduling across clusters.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F3CB;</div>
+        <h3>Training Job Monitoring</h3>
+        <p>Track distributed training jobs across multiple nodes and GPUs. Monitor epoch progress, loss curves, checkpointing, and resource consumption in real time with multi-cluster support.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F680;</div>
+        <h3>Model Serving Dashboard</h3>
+        <p>Monitor inference endpoints powered by vLLM, TGI, Triton, and KServe. Track request latency, throughput, queue depth, and auto-scaling decisions across serving clusters.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F504;</div>
+        <h3>MLOps Pipeline View</h3>
+        <p>Visualize end-to-end ML pipelines from data preparation through model deployment. Track pipeline runs, stage durations, and failure points with integration for Kubeflow and Argo Workflows.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F4C8;</div>
+        <h3>Auto-Scaling Analytics</h3>
+        <p>Monitor Horizontal Pod Autoscaler and custom metrics scaling for inference workloads. Visualize scaling events, queue buildup, and request patterns to fine-tune scaling policies.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4BE;</div>
+        <h3>Model Registry Integration</h3>
+        <p>Connect to model registries to track which model versions are deployed where. View model lineage, compare serving performance across versions, and manage canary deployments.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Multi-GPU</div>
+        <div class="stat-label">Visibility</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Real-Time</div>
+        <div class="stat-label">Training Metrics</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">vLLM</div>
+        <div class="stat-label">Integration</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Full</div>
+        <div class="stat-label">MLOps Pipeline</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>From training to inference, one dashboard for your ML platform.</h2>
+    <p>Give your ML engineering team the visibility they need to build, deploy, and scale models on Kubernetes with confidence.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/alerts.html
+++ b/web/public/landing/alerts.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Alert Management &amp; Prometheus Integration - KubeStellar Console</title>
+  <meta name="description" content="Manage Kubernetes alerts from Prometheus, Alertmanager, and Thanos across clusters. View firing alerts, silences, and routing rules from a unified multi-cluster alert dashboard." />
+  <meta name="keywords" content="kubernetes alerts, prometheus alerting, alertmanager dashboard, kubernetes monitoring alerts, multi-cluster alerts, thanos alerting, prometheus integration" />
+  <link rel="canonical" href="https://console.kubestellar.io/alerts" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Alert Management &amp; Prometheus Integration - KubeStellar Console" />
+  <meta property="og:description" content="Manage Kubernetes alerts from Prometheus, Alertmanager, and Thanos across clusters. View firing alerts, silences, and routing rules from a unified dashboard." />
+  <meta property="og:url" content="https://console.kubestellar.io/alerts" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Alert Management &amp; Prometheus Integration - KubeStellar Console" />
+  <meta name="twitter:description" content="Manage Kubernetes alerts from Prometheus and Alertmanager across clusters. View firing alerts, silences, and routing rules." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Alert Management",
+    "description": "Manage Kubernetes alerts from Prometheus, Alertmanager, and Thanos across clusters. View firing alerts, silences, and routing rules from a unified multi-cluster alert dashboard.",
+    "url": "https://console.kubestellar.io/alerts",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Prometheus alert integration, Alertmanager dashboard, Firing alert tracking, Silence management, Alert routing rules, Multi-cluster alert aggregation"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Multi-Cluster <span class="accent">Alert</span> Management</h1>
+    <p class="subtitle">Aggregate alerts from Prometheus, Alertmanager, and Thanos across your entire Kubernetes fleet. See every firing alert, manage silences, review routing rules, and reduce alert fatigue from one dashboard.</p>
+    <div class="hero-actions">
+      <a href="/alerts" class="btn-primary">View Alerts</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Alerting That Scales With Your Fleet</h2>
+      <p>As your cluster count grows, so does alert noise. Cut through the noise with aggregation, deduplication, and intelligent grouping.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F6A8;</div>
+        <h3>Firing Alert Dashboard</h3>
+        <p>See all currently firing alerts across every cluster. Prioritize by severity (critical, warning, info), group by alert name or cluster, and drill into the metrics that triggered each alert.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F515;</div>
+        <h3>Silence Management</h3>
+        <p>Create, extend, and expire silences across multiple Alertmanager instances. Apply silences during maintenance windows and track which alerts are currently suppressed fleet-wide.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F4E8;</div>
+        <h3>Routing Rule Viewer</h3>
+        <p>Inspect Alertmanager routing trees across clusters. See which alerts go to which receivers (Slack, PagerDuty, email) and identify misconfigured routes that may be dropping alerts.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4CA;</div>
+        <h3>Alert Trends</h3>
+        <p>Track alert frequency over time to identify noisy rules and alert storms. See which clusters generate the most alerts, which alert names fire most often, and how patterns change week over week.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F501;</div>
+        <h3>Alert Deduplication</h3>
+        <p>Identify duplicate alerts firing across multiple clusters for the same root cause. Group related alerts to reduce noise and focus on distinct issues rather than duplicated notifications.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x2699;</div>
+        <h3>PrometheusRule Tracking</h3>
+        <p>Browse and compare PrometheusRule resources across clusters. Detect rule version drift, identify missing rules in specific clusters, and ensure consistent alerting policies fleet-wide.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Prometheus</div>
+        <div class="stat-label">Native</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">All Clusters</div>
+        <div class="stat-label">Aggregated</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Silence</div>
+        <div class="stat-label">Management</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Reduced</div>
+        <div class="stat-label">Alert Fatigue</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>One alert dashboard to rule them all.</h2>
+    <p>Aggregate, deduplicate, and manage alerts from every Prometheus instance in your fleet without switching between Alertmanager UIs.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/arcade.html
+++ b/web/public/landing/arcade.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Interactive Kubernetes Learning Arcade - KubeStellar Console</title>
+  <meta name="description" content="Learn Kubernetes through interactive games and challenges. Practice cluster management, pod scheduling, network policies, and troubleshooting in a safe, gamified environment." />
+  <meta name="keywords" content="kubernetes learning, kubernetes games, interactive kubernetes training, kubernetes practice, kubernetes challenges, learn kubernetes online, kubernetes education, gamified learning" />
+  <link rel="canonical" href="https://console.kubestellar.io/arcade" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Interactive Kubernetes Learning Arcade - KubeStellar Console" />
+  <meta property="og:description" content="Learn Kubernetes through interactive games and challenges. Practice cluster management, pod scheduling, and troubleshooting in a gamified environment." />
+  <meta property="og:url" content="https://console.kubestellar.io/arcade" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Interactive Kubernetes Learning Arcade - KubeStellar Console" />
+  <meta name="twitter:description" content="Learn Kubernetes through interactive games and challenges. Practice cluster management, scheduling, and troubleshooting." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Kubernetes Learning Arcade",
+    "description": "Learn Kubernetes through interactive games and challenges. Practice cluster management, pod scheduling, network policies, and troubleshooting in a safe, gamified environment.",
+    "url": "https://console.kubestellar.io/arcade",
+    "applicationCategory": "EducationalApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Interactive Kubernetes games, Pod scheduling challenges, Network policy puzzles, Troubleshooting scenarios, Achievement system, Leaderboard"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Kubernetes <span class="accent">Learning</span> Arcade</h1>
+    <p class="subtitle">Master Kubernetes concepts through interactive games and challenges. Schedule pods, configure network policies, troubleshoot failures, and compete on leaderboards in a safe, gamified environment embedded in your console.</p>
+    <div class="hero-actions">
+      <a href="/arcade" class="btn-primary">Play Now</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Learn by Playing, Not Just Reading</h2>
+      <p>Interactive challenges that build real Kubernetes skills. No sandbox cluster required. Play directly in your console and learn at your own pace.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F3AE;</div>
+        <h3>Pod Scheduling Game</h3>
+        <p>Place pods on nodes while respecting resource constraints, node affinity, taints, and tolerations. Race against the clock to schedule workloads efficiently and earn a high score.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F6E1;</div>
+        <h3>Network Policy Puzzle</h3>
+        <p>Build network policies to allow or deny traffic between services. Each level introduces new concepts: namespace isolation, port restrictions, CIDR blocks, and egress rules.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F527;</div>
+        <h3>Troubleshooting Scenarios</h3>
+        <p>Diagnose and fix broken deployments with only the clues a real cluster would give you. Investigate events, logs, and resource status to resolve CrashLoopBackOff, ImagePullBackOff, and more.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F3C6;</div>
+        <h3>Achievement System</h3>
+        <p>Unlock achievements as you master Kubernetes concepts. From &ldquo;First Pod&rdquo; to &ldquo;Multi-Cluster Master,&rdquo; track your progress and showcase your skills with badges on your profile.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F4C8;</div>
+        <h3>Skill Progression</h3>
+        <p>Challenges are organized by difficulty and topic. Start with basic pod concepts and progress through deployments, services, RBAC, storage, and advanced scheduling as your skills grow.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F465;</div>
+        <h3>Team Leaderboard</h3>
+        <p>Compete with colleagues and the community on global leaderboards. Track speed, accuracy, and total challenges completed. Great for team training sessions and onboarding new engineers.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Interactive</div>
+        <div class="stat-label">Challenges</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Progressive</div>
+        <div class="stat-label">Difficulty</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Achievements</div>
+        <div class="stat-label">&amp; Badges</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Team</div>
+        <div class="stat-label">Leaderboards</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>The most fun way to learn Kubernetes.</h2>
+    <p>Build real skills through interactive challenges, not just documentation. Play games that teach you how Kubernetes actually works.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/ci-cd.html
+++ b/web/public/landing/ci-cd.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CI/CD Pipeline Monitoring - KubeStellar Console</title>
+  <meta name="description" content="Monitor CI/CD pipelines and build status across Kubernetes clusters. Track GitHub Actions, Tekton, and Argo Workflows. View build history, deployment gates, and delivery metrics." />
+  <meta name="keywords" content="kubernetes ci cd, pipeline monitoring, github actions kubernetes, tekton dashboard, argo workflows, build status monitoring, delivery metrics, deployment pipeline" />
+  <link rel="canonical" href="https://console.kubestellar.io/ci-cd" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="CI/CD Pipeline Monitoring - KubeStellar Console" />
+  <meta property="og:description" content="Monitor CI/CD pipelines and build status across Kubernetes clusters. Track GitHub Actions, Tekton, and Argo Workflows with delivery metrics." />
+  <meta property="og:url" content="https://console.kubestellar.io/ci-cd" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="CI/CD Pipeline Monitoring - KubeStellar Console" />
+  <meta name="twitter:description" content="Monitor CI/CD pipelines and build status across Kubernetes clusters. Track GitHub Actions, Tekton, and Argo Workflows." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - CI/CD Pipeline Monitoring",
+    "description": "Monitor CI/CD pipelines and build status across Kubernetes clusters. Track GitHub Actions, Tekton, and Argo Workflows. View build history, deployment gates, and delivery metrics.",
+    "url": "https://console.kubestellar.io/ci-cd",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Pipeline monitoring, Build status tracking, GitHub Actions integration, Tekton pipeline view, Deployment gates, DORA metrics"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>CI/CD <span class="accent">Pipeline</span> Monitoring</h1>
+    <p class="subtitle">Track continuous integration and delivery pipelines from code commit to production deployment. Monitor build status, test results, deployment gates, and delivery velocity across your Kubernetes fleet.</p>
+    <div class="hero-actions">
+      <a href="/ci-cd" class="btn-primary">View Pipelines</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>From Commit to Production, Fully Visible</h2>
+      <p>Connect your build systems to your deployment targets and see the full picture of software delivery in your organization.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F6A6;</div>
+        <h3>Pipeline Status Board</h3>
+        <p>See all pipelines across repositories and clusters on one screen. Green, yellow, and red indicators show pipeline health at a glance. Click through to see individual stage results and logs.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x2699;</div>
+        <h3>Multi-Framework Support</h3>
+        <p>Unified view of GitHub Actions workflows, Tekton Pipelines, Argo Workflows, and Jenkins jobs. No matter which CI/CD tools you use, see them all in one place.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F6D1;</div>
+        <h3>Deployment Gates</h3>
+        <p>Track deployment gate status between environments. See which builds are approved for staging, which are waiting for production sign-off, and who approved each promotion.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4CA;</div>
+        <h3>DORA Metrics</h3>
+        <p>Track the four key DORA metrics: deployment frequency, lead time for changes, change failure rate, and time to restore service. Benchmark your teams against industry performance levels.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F9EA;</div>
+        <h3>Test Results Tracking</h3>
+        <p>View test suite results for every pipeline run. Track test pass rates, identify flaky tests, and see which tests are blocking deployments most frequently across your repositories.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4C5;</div>
+        <h3>Build History &amp; Trends</h3>
+        <p>Analyze build duration trends, success rates, and failure patterns over time. Identify builds that are getting slower, pipelines that fail most often, and the root causes of delivery delays.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Multi-CI</div>
+        <div class="stat-label">Integration</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">DORA</div>
+        <div class="stat-label">Metrics</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Gate</div>
+        <div class="stat-label">Management</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">End-to-End</div>
+        <div class="stat-label">Visibility</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>See every build, every test, every deployment.</h2>
+    <p>Connect your CI/CD pipelines to your Kubernetes dashboard and gain end-to-end visibility from code commit to production cluster.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/compute.html
+++ b/web/public/landing/compute.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Compute Resource Management - KubeStellar Console</title>
+  <meta name="description" content="Manage and optimize Kubernetes compute resources across clusters. Monitor CPU, memory, and GPU allocation. Right-size workloads, manage resource quotas, and prevent over-provisioning." />
+  <meta name="keywords" content="kubernetes compute resources, resource management kubernetes, cpu memory management, kubernetes resource quota, compute optimization, kubernetes capacity management" />
+  <link rel="canonical" href="https://console.kubestellar.io/compute" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Compute Resource Management - KubeStellar Console" />
+  <meta property="og:description" content="Manage and optimize Kubernetes compute resources across clusters. Monitor CPU, memory, and GPU allocation. Right-size workloads and prevent over-provisioning." />
+  <meta property="og:url" content="https://console.kubestellar.io/compute" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Compute Resource Management - KubeStellar Console" />
+  <meta name="twitter:description" content="Manage and optimize Kubernetes compute resources across clusters. Monitor CPU, memory, GPU allocation and prevent over-provisioning." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Compute Resource Management",
+    "description": "Manage and optimize Kubernetes compute resources across clusters. Monitor CPU, memory, and GPU allocation. Right-size workloads, manage resource quotas, and prevent over-provisioning.",
+    "url": "https://console.kubestellar.io/compute",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "CPU utilization tracking, Memory allocation analysis, GPU resource management, Resource quota monitoring, Right-sizing recommendations, Compute capacity planning"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Compute <span class="accent">Resource</span> Management</h1>
+    <p class="subtitle">Optimize CPU, memory, and GPU utilization across your Kubernetes fleet. Prevent over-provisioning, enforce resource quotas, and ensure workloads have exactly the resources they need to perform.</p>
+    <div class="hero-actions">
+      <a href="/compute" class="btn-primary">View Compute Resources</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Right-Size Every Workload Across Every Cluster</h2>
+      <p>Gain precise control over compute allocation with tools that show exactly how resources are requested, consumed, and wasted.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4BB;</div>
+        <h3>CPU Utilization Dashboard</h3>
+        <p>Compare CPU requests versus actual usage for every pod and namespace. Identify containers that request 2 cores but use 200 millicores, and right-size them to free up capacity.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4BE;</div>
+        <h3>Memory Analysis</h3>
+        <p>Track memory requests, limits, and actual working set size. Detect containers approaching their memory limits before OOMKills occur, and spot over-allocated memory across the fleet.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F3AE;</div>
+        <h3>GPU Allocation View</h3>
+        <p>Visualize GPU allocation per node, namespace, and workload. See which GPUs are idle, partially utilized, or fully committed. Plan GPU capacity across clusters for AI/ML workloads.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4CF;</div>
+        <h3>Resource Quota Monitoring</h3>
+        <p>Track namespace resource quota usage across clusters. See which namespaces are approaching their limits, which have excess headroom, and enforce consistent quota policies fleet-wide.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F4A1;</div>
+        <h3>Right-Sizing Recommendations</h3>
+        <p>AI-driven recommendations for CPU and memory requests based on observed usage patterns. Apply suggestions in bulk across clusters to eliminate waste without risking performance.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4CA;</div>
+        <h3>Capacity Forecasting</h3>
+        <p>Project future compute needs based on historical growth trends. Know when clusters will run out of capacity and plan node additions or workload redistribution before it happens.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">CPU + Memory</div>
+        <div class="stat-label">Tracking</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">GPU</div>
+        <div class="stat-label">Allocation View</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Automated</div>
+        <div class="stat-label">Right-Sizing</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Capacity</div>
+        <div class="stat-label">Forecasting</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Every core, every gigabyte, accounted for.</h2>
+    <p>Stop guessing how much compute your workloads need. Use data-driven insights to right-size every container in your fleet.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/cost.html
+++ b/web/public/landing/cost.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kubernetes Cost Management &amp; FinOps - KubeStellar Console</title>
+  <meta name="description" content="Kubernetes cost management and FinOps dashboard. Track cloud spending per cluster, namespace, and workload. Identify waste, right-size resources, and optimize GPU costs." />
+  <meta name="keywords" content="kubernetes cost management, finops kubernetes, kubernetes cost optimization, cloud cost tracking, gpu cost management, kubernetes resource waste, multi-cluster cost" />
+  <link rel="canonical" href="https://console.kubestellar.io/cost" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Kubernetes Cost Management &amp; FinOps - KubeStellar Console" />
+  <meta property="og:description" content="Kubernetes cost management and FinOps dashboard. Track cloud spending per cluster, namespace, and workload. Identify waste, right-size resources, and optimize GPU costs." />
+  <meta property="og:url" content="https://console.kubestellar.io/cost" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Kubernetes Cost Management &amp; FinOps - KubeStellar Console" />
+  <meta name="twitter:description" content="Kubernetes cost management and FinOps dashboard. Track cloud spending, identify waste, and optimize GPU costs across clusters." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Cost Management",
+    "description": "Kubernetes cost management and FinOps dashboard. Track cloud spending per cluster, namespace, and workload. Identify waste, right-size resources, and optimize GPU costs.",
+    "url": "https://console.kubestellar.io/cost",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Cost allocation, Resource waste detection, GPU cost tracking, Namespace cost breakdown, Right-sizing recommendations, Multi-cloud cost comparison"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Kubernetes <span class="accent">Cost</span> Management</h1>
+    <p class="subtitle">Track, allocate, and optimize cloud spending across your entire Kubernetes fleet. Identify resource waste, right-size workloads, and reduce GPU costs with actionable FinOps insights.</p>
+    <div class="hero-actions">
+      <a href="/cost" class="btn-primary">View Cost Dashboard</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>FinOps for Multi-Cluster Kubernetes</h2>
+      <p>Know exactly where every dollar goes. Break down costs by cluster, namespace, team, and individual workload with full chargeback support.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4B0;</div>
+        <h3>Cost Allocation</h3>
+        <p>Attribute infrastructure costs to specific teams, projects, and namespaces. Generate chargeback and showback reports that map Kubernetes resource consumption to actual cloud spend.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4C9;</div>
+        <h3>Waste Detection</h3>
+        <p>Identify idle workloads, over-provisioned containers, and unused persistent volumes. Get specific recommendations to reclaim resources and reduce monthly costs by up to 40%.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F4BB;</div>
+        <h3>GPU Cost Tracking</h3>
+        <p>Track GPU utilization and cost per workload for AI/ML teams. Identify expensive GPU instances running at low utilization and optimize scheduling to maximize GPU efficiency.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4CA;</div>
+        <h3>Spending Trends</h3>
+        <p>Visualize cost trends over time with daily, weekly, and monthly breakdowns. Set budget alerts and forecast future spending based on current consumption patterns and growth rates.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x2696;</div>
+        <h3>Right-Sizing Engine</h3>
+        <p>Automated recommendations for CPU and memory requests based on actual usage. Reduce over-provisioning without risking OOM kills by analyzing percentile-based resource consumption.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x2601;</div>
+        <h3>Multi-Cloud Comparison</h3>
+        <p>Compare costs across AWS EKS, Google GKE, Azure AKS, and bare metal. See which provider delivers the best price-performance for your specific workload profiles.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Per-Pod</div>
+        <div class="stat-label">Cost Tracking</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Up to 40%</div>
+        <div class="stat-label">Savings Found</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">GPU</div>
+        <div class="stat-label">Cost Visibility</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Multi-Cloud</div>
+        <div class="stat-label">Support</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Stop overpaying for Kubernetes infrastructure.</h2>
+    <p>Gain full visibility into where your cloud dollars go and get actionable recommendations to cut waste and optimize spending.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/data-compliance.html
+++ b/web/public/landing/data-compliance.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Data Compliance Monitoring - KubeStellar Console</title>
+  <meta name="description" content="Monitor data compliance across Kubernetes clusters. Track data residency, encryption status, access controls, and regulatory compliance for GDPR, HIPAA, SOC 2, and PCI DSS." />
+  <meta name="keywords" content="kubernetes compliance, data compliance kubernetes, gdpr kubernetes, hipaa kubernetes, soc2 compliance, pci dss kubernetes, data residency, regulatory compliance" />
+  <link rel="canonical" href="https://console.kubestellar.io/data-compliance" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Data Compliance Monitoring - KubeStellar Console" />
+  <meta property="og:description" content="Monitor data compliance across Kubernetes clusters. Track data residency, encryption, and regulatory compliance for GDPR, HIPAA, SOC 2, and PCI DSS." />
+  <meta property="og:url" content="https://console.kubestellar.io/data-compliance" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Data Compliance Monitoring - KubeStellar Console" />
+  <meta name="twitter:description" content="Monitor data compliance across Kubernetes clusters. Track data residency, encryption, and regulatory compliance." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Data Compliance Monitoring",
+    "description": "Monitor data compliance across Kubernetes clusters. Track data residency, encryption status, access controls, and regulatory compliance for GDPR, HIPAA, SOC 2, and PCI DSS.",
+    "url": "https://console.kubestellar.io/data-compliance",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "GDPR compliance monitoring, HIPAA controls, SOC 2 reporting, Data residency tracking, Encryption status audit, Access control review"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Data <span class="accent">Compliance</span> Monitoring</h1>
+    <p class="subtitle">Ensure your Kubernetes infrastructure meets regulatory requirements. Monitor data residency, encryption status, access controls, and compliance posture for GDPR, HIPAA, SOC 2, and PCI DSS across every cluster.</p>
+    <div class="hero-actions">
+      <a href="/data-compliance" class="btn-primary">View Compliance</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Compliance at Scale for Multi-Cluster Kubernetes</h2>
+      <p>Regulatory compliance does not stop at the cluster boundary. Track and enforce data compliance policies across your entire fleet.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F30D;</div>
+        <h3>Data Residency Tracking</h3>
+        <p>Map where data lives across your multi-cluster, multi-region fleet. Ensure workloads processing EU citizen data run in EU-based clusters and track data flows that cross geographic boundaries.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F512;</div>
+        <h3>Encryption Audit</h3>
+        <p>Verify encryption at rest and in transit across all clusters. Check etcd encryption configuration, TLS certificate status, secret encryption providers, and mTLS coverage for service mesh traffic.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F4CB;</div>
+        <h3>Framework Mapping</h3>
+        <p>Map Kubernetes controls to specific compliance framework requirements. See which GDPR articles, HIPAA safeguards, SOC 2 criteria, or PCI DSS requirements each control satisfies.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F464;</div>
+        <h3>Access Control Review</h3>
+        <p>Audit who can access what data across your clusters. Track RBAC bindings, namespace isolation policies, and service account permissions to ensure data access follows compliance requirements.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F4D1;</div>
+        <h3>Audit Log Analysis</h3>
+        <p>Monitor Kubernetes audit logs for compliance-relevant events. Track API access to sensitive resources, detect unauthorized access attempts, and generate evidence for compliance auditors.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4C4;</div>
+        <h3>Compliance Reporting</h3>
+        <p>Generate compliance reports on demand or on a schedule. Export evidence of controls, remediation actions, and compliance posture changes for audit teams and regulatory submissions.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">GDPR</div>
+        <div class="stat-label">Compliance</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">HIPAA</div>
+        <div class="stat-label">Controls</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">SOC 2</div>
+        <div class="stat-label">Reporting</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">PCI DSS</div>
+        <div class="stat-label">Tracking</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Compliance is continuous. Your monitoring should be too.</h2>
+    <p>Stay audit-ready with real-time compliance monitoring that covers data residency, encryption, access controls, and regulatory frameworks.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/deployments.html
+++ b/web/public/landing/deployments.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Deployment Management &amp; Rollouts - KubeStellar Console</title>
+  <meta name="description" content="Manage Kubernetes deployments across multiple clusters. Monitor rollout status, track replica sets, perform canary deployments, and scale workloads from a unified dashboard." />
+  <meta name="keywords" content="kubernetes deployments, deployment management, rolling updates kubernetes, canary deployment, kubernetes rollback, multi-cluster deployment, replica management" />
+  <link rel="canonical" href="https://console.kubestellar.io/deployments" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Deployment Management &amp; Rollouts - KubeStellar Console" />
+  <meta property="og:description" content="Manage Kubernetes deployments across multiple clusters. Monitor rollout status, track replica sets, perform canary deployments, and scale workloads." />
+  <meta property="og:url" content="https://console.kubestellar.io/deployments" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Deployment Management &amp; Rollouts - KubeStellar Console" />
+  <meta name="twitter:description" content="Manage Kubernetes deployments across multiple clusters. Monitor rollout status, track replica sets, and scale workloads." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Deployment Management",
+    "description": "Manage Kubernetes deployments across multiple clusters. Monitor rollout status, track replica sets, perform canary deployments, and scale workloads from a unified dashboard.",
+    "url": "https://console.kubestellar.io/deployments",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Deployment monitoring, Rolling update tracking, Canary deployments, Replica management, Rollback support, Multi-cluster scaling"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Deployment <span class="accent">Rollout</span> Management</h1>
+    <p class="subtitle">Track and control Kubernetes deployments across your fleet. Monitor rolling updates in real time, manage replica counts, execute canary releases, and roll back instantly when needed.</p>
+    <div class="hero-actions">
+      <a href="/deployments" class="btn-primary">View Deployments</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Full Deployment Lifecycle Control</h2>
+      <p>From initial rollout to production scaling, manage every aspect of your Kubernetes deployments with confidence.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F504;</div>
+        <h3>Rollout Progress</h3>
+        <p>Watch rolling updates propagate across clusters in real time. See new and old replica set counts, track surge and unavailable pods, and know exactly when a rollout completes.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4C4;</div>
+        <h3>Revision History</h3>
+        <p>View every revision of a deployment with the changes that triggered it. Compare container images, environment variables, and resource limits between any two revisions side by side.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F3AF;</div>
+        <h3>Canary Releases</h3>
+        <p>Execute canary deployments by controlling traffic split between old and new versions. Monitor error rates and latency per version before promoting the new release fleet-wide.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2194;</div>
+        <h3>Horizontal Scaling</h3>
+        <p>Scale deployments across clusters with a single action. View current vs. desired replicas, HPA configurations, and scaling events to ensure workloads meet demand without over-provisioning.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x26A0;</div>
+        <h3>Stalled Rollout Detection</h3>
+        <p>Automatically detect deployments stuck in a rollout due to image pull errors, insufficient resources, or failing readiness probes. Get alerted before stalled deployments impact availability.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x21A9;</div>
+        <h3>Instant Rollback</h3>
+        <p>Roll back to any previous revision with one click. The console triggers the rollback and monitors the revert process across all targeted clusters until the previous state is restored.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Real-Time</div>
+        <div class="stat-label">Rollout Tracking</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">One-Click</div>
+        <div class="stat-label">Rollback</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Canary</div>
+        <div class="stat-label">Release Support</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Fleet-Wide</div>
+        <div class="stat-label">Scaling</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Ship with confidence across every cluster.</h2>
+    <p>Monitor every deployment, catch stalled rollouts early, and roll back in seconds when things go wrong.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/events.html
+++ b/web/public/landing/events.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kubernetes Event Monitoring &amp; Alerting - KubeStellar Console</title>
+  <meta name="description" content="Monitor Kubernetes events across all clusters in real time. Filter, search, and correlate warning and error events. Detect patterns, identify root causes, and set up event-based alerts." />
+  <meta name="keywords" content="kubernetes events, event monitoring, kubernetes warning events, kubernetes alerting, event correlation, multi-cluster events, kubernetes troubleshooting" />
+  <link rel="canonical" href="https://console.kubestellar.io/events" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Kubernetes Event Monitoring &amp; Alerting - KubeStellar Console" />
+  <meta property="og:description" content="Monitor Kubernetes events across all clusters in real time. Filter, correlate, and alert on warning and error events fleet-wide." />
+  <meta property="og:url" content="https://console.kubestellar.io/events" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Kubernetes Event Monitoring &amp; Alerting - KubeStellar Console" />
+  <meta name="twitter:description" content="Monitor Kubernetes events across all clusters in real time. Filter, correlate, and alert on warning and error events." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Event Monitoring",
+    "description": "Monitor Kubernetes events across all clusters in real time. Filter, search, and correlate warning and error events. Detect patterns, identify root causes, and set up event-based alerts.",
+    "url": "https://console.kubestellar.io/events",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Real-time event stream, Warning event filtering, Event correlation, Pattern detection, Event-based alerting, Cross-cluster event search"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Kubernetes <span class="accent">Event</span> Monitoring</h1>
+    <p class="subtitle">Stream, filter, and analyze Kubernetes events from every cluster in your fleet. Catch warning events before they escalate, correlate patterns across namespaces, and set up smart alerts for critical event types.</p>
+    <div class="hero-actions">
+      <a href="/events" class="btn-primary">View Events</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Never Miss a Critical Event</h2>
+      <p>Kubernetes events tell the story of what is happening in your clusters. Make that story visible, searchable, and actionable.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4E1;</div>
+        <h3>Real-Time Event Stream</h3>
+        <p>Watch events flow in from all clusters as they happen. Color-coded by severity so you can instantly distinguish Normal events from Warning events that need attention.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F50D;</div>
+        <h3>Smart Filtering</h3>
+        <p>Filter events by type, reason, involved object, namespace, or cluster. Save filter presets for common investigations like &ldquo;all FailedScheduling events&rdquo; or &ldquo;OOMKilled in production.&rdquo;</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F517;</div>
+        <h3>Event Correlation</h3>
+        <p>Automatically group related events to reconstruct incident timelines. See how a node becoming NotReady cascades into pod evictions, rescheduling, and service endpoint changes.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4C8;</div>
+        <h3>Pattern Detection</h3>
+        <p>Identify recurring event patterns such as periodic OOMKills, repeated image pull failures, or scheduling flaps. Historical trend analysis reveals patterns invisible in real-time streams.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F514;</div>
+        <h3>Event-Based Alerts</h3>
+        <p>Configure alerts that fire when specific event types exceed a threshold. Get notified when BackOff events spike, FailedMount errors appear, or nodes report conditions across any cluster.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4CA;</div>
+        <h3>Event Analytics</h3>
+        <p>Aggregate event counts by reason, type, and cluster over time. Understand which clusters generate the most warnings, which namespaces are noisiest, and where to focus attention.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Real-Time</div>
+        <div class="stat-label">Event Stream</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">All Clusters</div>
+        <div class="stat-label">Aggregated</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Pattern</div>
+        <div class="stat-label">Detection</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Smart</div>
+        <div class="stat-label">Alerts</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Events are signals. Start listening across every cluster.</h2>
+    <p>Transform the noisy stream of Kubernetes events into actionable intelligence with filtering, correlation, and smart alerting.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/gitops.html
+++ b/web/public/landing/gitops.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>GitOps Dashboard &amp; Argo CD Integration - KubeStellar Console</title>
+  <meta name="description" content="Multi-cluster GitOps dashboard with Argo CD integration. Monitor sync status, detect configuration drift, and manage Git-driven deployments across Kubernetes clusters." />
+  <meta name="keywords" content="gitops dashboard, argo cd integration, kubernetes gitops, configuration drift detection, git driven deployment, multi-cluster gitops, flux cd" />
+  <link rel="canonical" href="https://console.kubestellar.io/gitops" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="GitOps Dashboard &amp; Argo CD Integration - KubeStellar Console" />
+  <meta property="og:description" content="Multi-cluster GitOps dashboard with Argo CD integration. Monitor sync status, detect configuration drift, and manage Git-driven deployments across Kubernetes clusters." />
+  <meta property="og:url" content="https://console.kubestellar.io/gitops" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="GitOps Dashboard &amp; Argo CD Integration - KubeStellar Console" />
+  <meta name="twitter:description" content="Multi-cluster GitOps dashboard with Argo CD integration. Monitor sync status, detect configuration drift, and manage Git-driven deployments across clusters." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - GitOps Dashboard",
+    "description": "Multi-cluster GitOps dashboard with Argo CD integration. Monitor sync status, detect configuration drift, and manage Git-driven deployments across Kubernetes clusters.",
+    "url": "https://console.kubestellar.io/gitops",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Argo CD integration, Sync status monitoring, Drift detection, Git repository tracking, Application health, Multi-cluster GitOps"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Multi-Cluster <span class="accent">GitOps</span> Dashboard</h1>
+    <p class="subtitle">Visualize and manage Git-driven deployments across your entire Kubernetes fleet. Integrated with Argo CD and Flux for real-time sync status, drift detection, and automated remediation.</p>
+    <div class="hero-actions">
+      <a href="/gitops" class="btn-primary">View GitOps Status</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Git as the Single Source of Truth</h2>
+      <p>Ensure every cluster matches its declared state with continuous reconciliation monitoring and drift alerting.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2B06;</div>
+        <h3>Sync Status Overview</h3>
+        <p>Track the sync status of every Argo CD application across all clusters. See which applications are synced, out-of-sync, or degraded at a glance with color-coded indicators.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F50D;</div>
+        <h3>Drift Detection</h3>
+        <p>Automatically detect when live cluster state diverges from the Git repository. View detailed diffs showing exactly what changed and when, with one-click remediation options.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F4C2;</div>
+        <h3>Repository Tracking</h3>
+        <p>Monitor all connected Git repositories, their branches, and latest commits. See which commits are deployed to which clusters and trace deployments back to specific pull requests.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2764;</div>
+        <h3>Application Health</h3>
+        <p>Beyond sync status, monitor the actual health of deployed applications. Detect CrashLoopBackOff pods, pending resources, and degraded services that may be synced but unhealthy.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F501;</div>
+        <h3>Rollback History</h3>
+        <p>View complete deployment history with Git commit references. Roll back to any previous state with a single click, and the change propagates across all targeted clusters automatically.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F512;</div>
+        <h3>Policy Enforcement</h3>
+        <p>Enforce GitOps policies that prevent manual cluster modifications. Ensure all changes flow through Git with audit trails, approval workflows, and compliance guardrails.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Argo CD</div>
+        <div class="stat-label">Native Integration</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Continuous</div>
+        <div class="stat-label">Drift Detection</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">One-Click</div>
+        <div class="stat-label">Rollbacks</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Full</div>
+        <div class="stat-label">Audit Trail</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Git-driven deployments, fleet-wide visibility.</h2>
+    <p>Bring GitOps best practices to your multi-cluster environment with a dashboard that keeps everything in sync.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/helm.html
+++ b/web/public/landing/helm.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Helm Chart Management &amp; Releases - KubeStellar Console</title>
+  <meta name="description" content="Manage Helm releases and chart repositories across Kubernetes clusters. Track installed charts, monitor release health, compare values, and upgrade Helm deployments fleet-wide." />
+  <meta name="keywords" content="helm chart management, helm releases, kubernetes helm, helm repository, helm upgrade, multi-cluster helm, helm dashboard, helm rollback" />
+  <link rel="canonical" href="https://console.kubestellar.io/helm" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Helm Chart Management &amp; Releases - KubeStellar Console" />
+  <meta property="og:description" content="Manage Helm releases and chart repositories across Kubernetes clusters. Track installed charts, monitor release health, and upgrade deployments fleet-wide." />
+  <meta property="og:url" content="https://console.kubestellar.io/helm" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Helm Chart Management &amp; Releases - KubeStellar Console" />
+  <meta name="twitter:description" content="Manage Helm releases and chart repositories across Kubernetes clusters. Track charts, monitor health, and upgrade fleet-wide." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Helm Chart Management",
+    "description": "Manage Helm releases and chart repositories across Kubernetes clusters. Track installed charts, monitor release health, compare values, and upgrade Helm deployments fleet-wide.",
+    "url": "https://console.kubestellar.io/helm",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Helm release tracking, Chart repository management, Values comparison, Fleet-wide upgrades, Release rollback, Multi-cluster Helm overview"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Helm <span class="accent">Chart</span> Management</h1>
+    <p class="subtitle">Track, upgrade, and manage Helm releases across your entire Kubernetes fleet. Compare chart values between clusters, detect version drift, and execute coordinated upgrades from one dashboard.</p>
+    <div class="hero-actions">
+      <a href="/helm" class="btn-primary">View Helm Releases</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Helm at Scale, Across Clusters</h2>
+      <p>Managing Helm releases in a single cluster is easy. Managing them across dozens of clusters requires a different approach.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4CB;</div>
+        <h3>Release Inventory</h3>
+        <p>See every Helm release installed across all clusters in one table. Filter by chart name, version, namespace, or status to quickly locate specific releases and their health.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4CA;</div>
+        <h3>Values Comparison</h3>
+        <p>Compare Helm values files across clusters to spot configuration differences. Detect when the same chart is deployed with different settings in production versus staging environments.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x2B06;</div>
+        <h3>Upgrade Orchestration</h3>
+        <p>Upgrade Helm releases across multiple clusters in a controlled sequence. Define upgrade order, pause between clusters for validation, and automatically roll back on failure detection.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4E6;</div>
+        <h3>Repository Management</h3>
+        <p>Manage Helm chart repositories across your fleet. Add, remove, and sync repositories. Browse available charts with version history and dependency information before installing.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x26A0;</div>
+        <h3>Failed Release Detection</h3>
+        <p>Identify Helm releases in failed, pending-install, or pending-upgrade states across clusters. View error messages, attempted values, and hooks that failed to guide remediation.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4C5;</div>
+        <h3>Release History</h3>
+        <p>View the complete history of every Helm release including install, upgrade, and rollback events. Compare any two revisions to see exactly what changed between deployments.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">All Releases</div>
+        <div class="stat-label">Tracked</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Cross-Cluster</div>
+        <div class="stat-label">Values Diff</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Orchestrated</div>
+        <div class="stat-label">Upgrades</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Full</div>
+        <div class="stat-label">History</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Helm management that scales with your fleet.</h2>
+    <p>Stop running helm list across every cluster. See all your releases, values, and upgrade paths in one place.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/llm-d-benchmarks.html
+++ b/web/public/landing/llm-d-benchmarks.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LLM Inference Benchmarks on Kubernetes - KubeStellar Console</title>
+  <meta name="description" content="Live LLM inference benchmarks on Kubernetes GPU clusters. Compare throughput, latency, and token generation rates across models, hardware configurations, and serving frameworks." />
+  <meta name="keywords" content="llm benchmarks, kubernetes gpu benchmarks, llm inference performance, vllm benchmarks, gpu kubernetes, large language model performance, ai inference kubernetes" />
+  <link rel="canonical" href="https://console.kubestellar.io/llm-d-benchmarks" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="LLM Inference Benchmarks on Kubernetes - KubeStellar Console" />
+  <meta property="og:description" content="Live LLM inference benchmarks on Kubernetes GPU clusters. Compare throughput, latency, and token generation rates across models, hardware, and serving frameworks." />
+  <meta property="og:url" content="https://console.kubestellar.io/llm-d-benchmarks" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="LLM Inference Benchmarks on Kubernetes - KubeStellar Console" />
+  <meta name="twitter:description" content="Live LLM inference benchmarks on Kubernetes GPU clusters. Compare throughput, latency, and token generation rates across models, hardware, and serving frameworks." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - LLM Inference Benchmarks",
+    "description": "Live LLM inference benchmarks on Kubernetes GPU clusters. Compare throughput, latency, and token generation rates across models, hardware configurations, and serving frameworks.",
+    "url": "https://console.kubestellar.io/llm-d-benchmarks",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "LLM inference benchmarks, GPU performance tracking, Hardware leaderboard, Throughput comparison, Latency breakdown, Performance timeline"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>LLM Inference <span class="accent">Benchmarks</span> on Kubernetes</h1>
+    <p class="subtitle">Compare large language model performance across GPU hardware, serving frameworks, and Kubernetes configurations. Real benchmark data from nightly E2E test runs with live streaming results.</p>
+    <div class="hero-actions">
+      <a href="/llm-d-benchmarks" class="btn-primary">View Benchmarks</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Data-Driven GPU Performance Insights</h2>
+      <p>Make informed decisions about hardware selection, model deployment, and inference optimization with comprehensive benchmark data.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x26A1;</div>
+        <h3>Throughput Comparison</h3>
+        <p>Compare tokens per second across GPU configurations including A100, H100, L40S, and more. See how different hardware handles various model sizes from 7B to 70B+ parameters.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x23F3;</div>
+        <h3>Latency Breakdown</h3>
+        <p>Analyze time-to-first-token (TTFT) and inter-token latency across configurations. Understand how batch sizes, tensor parallelism, and quantization affect response times.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F3C6;</div>
+        <h3>Hardware Leaderboard</h3>
+        <p>Ranked performance tables showing which GPU configurations deliver the best throughput, lowest latency, and highest efficiency for each model and workload type.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4C8;</div>
+        <h3>Performance Timeline</h3>
+        <p>Track benchmark performance over time with historical trend lines. Detect regressions from framework updates, driver changes, or configuration drift across nightly runs.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F4BB;</div>
+        <h3>Resource Utilization</h3>
+        <p>Monitor GPU memory usage, compute utilization, and power consumption during benchmark runs. Identify bottlenecks and optimize serving configurations for maximum efficiency.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4E1;</div>
+        <h3>Live Streaming Results</h3>
+        <p>Watch benchmark results stream in real time via WebSocket as nightly E2E tests execute. See throughput, latency, and status updates the moment they are generated.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Nightly</div>
+        <div class="stat-label">E2E Runs</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Multi-GPU</div>
+        <div class="stat-label">Hardware Tested</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Live</div>
+        <div class="stat-label">Streaming Data</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Open Source</div>
+        <div class="stat-label">Benchmarks</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Stop guessing. Start benchmarking.</h2>
+    <p>Make data-driven decisions about GPU hardware and model deployment with real-world Kubernetes benchmark data.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/logs.html
+++ b/web/public/landing/logs.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Centralized Log Aggregation - KubeStellar Console</title>
+  <meta name="description" content="Aggregate and search container logs across all Kubernetes clusters. Stream logs in real time, correlate across services, and debug distributed applications from a single interface." />
+  <meta name="keywords" content="kubernetes logs, centralized logging, container log aggregation, kubernetes log search, multi-cluster logs, log streaming, kubernetes debugging" />
+  <link rel="canonical" href="https://console.kubestellar.io/logs" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Centralized Log Aggregation - KubeStellar Console" />
+  <meta property="og:description" content="Aggregate and search container logs across all Kubernetes clusters. Stream logs in real time, correlate across services, and debug distributed applications." />
+  <meta property="og:url" content="https://console.kubestellar.io/logs" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Centralized Log Aggregation - KubeStellar Console" />
+  <meta name="twitter:description" content="Aggregate and search container logs across all Kubernetes clusters. Stream logs in real time and debug distributed applications." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Centralized Logging",
+    "description": "Aggregate and search container logs across all Kubernetes clusters. Stream logs in real time, correlate across services, and debug distributed applications from a single interface.",
+    "url": "https://console.kubestellar.io/logs",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Centralized log aggregation, Real-time log streaming, Cross-cluster log search, Service correlation, Log level filtering, Previous container logs"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Centralized <span class="accent">Log</span> Aggregation</h1>
+    <p class="subtitle">Search, stream, and analyze container logs from every cluster in your fleet. Correlate log entries across microservices, filter by severity, and trace request flows through distributed applications.</p>
+    <div class="hero-actions">
+      <a href="/logs" class="btn-primary">View Logs</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Logs from Every Container, One Search Bar</h2>
+      <p>Stop running kubectl logs across dozens of clusters. Bring all your container output together and find what you need in seconds.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4DC;</div>
+        <h3>Live Log Streaming</h3>
+        <p>Stream logs in real time from any container across any cluster. Support for following multiple containers simultaneously, with auto-scroll and pause controls for detailed analysis.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F50E;</div>
+        <h3>Full-Text Search</h3>
+        <p>Search across all container logs with regex support. Find error messages, stack traces, request IDs, and specific patterns across your entire fleet in milliseconds.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F517;</div>
+        <h3>Service Correlation</h3>
+        <p>Trace requests across microservices by correlating log entries using request IDs, trace IDs, or timestamps. See the full journey of a request as it passes through multiple services and clusters.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F3AF;</div>
+        <h3>Level Filtering</h3>
+        <p>Filter logs by severity level: DEBUG, INFO, WARN, ERROR, FATAL. Quickly surface error logs from noisy applications and focus on the messages that matter during incident response.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F4C1;</div>
+        <h3>Previous Container Logs</h3>
+        <p>Access logs from crashed and restarted containers. View previous container output to understand why a container exited, even after the pod has been rescheduled to a different node.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4E5;</div>
+        <h3>Log Export</h3>
+        <p>Export filtered log results for offline analysis or sharing with team members. Download as plain text or structured JSON, and integrate with external log management platforms.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">All Clusters</div>
+        <div class="stat-label">Aggregated</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Real-Time</div>
+        <div class="stat-label">Streaming</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Regex</div>
+        <div class="stat-label">Search</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Cross-Service</div>
+        <div class="stat-label">Correlation</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>One search bar for every log in your fleet.</h2>
+    <p>Debug faster with centralized logs that let you trace issues across services, clusters, and time from a single dashboard.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/marketplace.html
+++ b/web/public/landing/marketplace.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Extension Marketplace - KubeStellar Console</title>
+  <meta name="description" content="Browse and install dashboard extensions, custom cards, and AI-powered missions from the KubeStellar Console marketplace. Extend your Kubernetes management experience." />
+  <meta name="keywords" content="kubernetes dashboard extensions, kubestellar marketplace, dashboard plugins, kubernetes console extensions, custom dashboard cards, ai missions marketplace" />
+  <link rel="canonical" href="https://console.kubestellar.io/marketplace" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Extension Marketplace - KubeStellar Console" />
+  <meta property="og:description" content="Browse and install dashboard extensions, custom cards, and AI-powered missions from the KubeStellar Console marketplace." />
+  <meta property="og:url" content="https://console.kubestellar.io/marketplace" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Extension Marketplace - KubeStellar Console" />
+  <meta name="twitter:description" content="Browse and install dashboard extensions, custom cards, and AI-powered missions from the KubeStellar Console marketplace." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Extension Marketplace",
+    "description": "Browse and install dashboard extensions, custom cards, and AI-powered missions from the KubeStellar Console marketplace. Extend your Kubernetes management experience.",
+    "url": "https://console.kubestellar.io/marketplace",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Dashboard extensions, Custom card library, AI mission templates, One-click install, Community contributions, Plugin SDK"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Extension <span class="accent">Marketplace</span> for Kubernetes</h1>
+    <p class="subtitle">Discover, install, and manage dashboard extensions that add new capabilities to your KubeStellar Console. From custom monitoring cards to AI-powered automation missions, find what you need.</p>
+    <div class="hero-actions">
+      <a href="/marketplace" class="btn-primary">Browse Marketplace</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Extend Your Console Without Limits</h2>
+      <p>A growing ecosystem of extensions built by the community, for the community. Every team&rsquo;s Kubernetes setup is different, and your dashboard should reflect that.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4E6;</div>
+        <h3>Dashboard Card Library</h3>
+        <p>Browse dozens of pre-built dashboard cards covering monitoring, cost analysis, security scanning, and more. Install with one click and start getting insights immediately.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F916;</div>
+        <h3>AI Mission Templates</h3>
+        <p>Install ready-made AI missions that automate complex Kubernetes operations. From cluster optimization to incident response, leverage pre-built intelligence for your fleet.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F527;</div>
+        <h3>Plugin SDK</h3>
+        <p>Build your own extensions with a well-documented SDK. Create custom cards, integrate with internal tools, and share your work with the community through the marketplace.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2B50;</div>
+        <h3>Community Ratings</h3>
+        <p>Every extension includes community ratings, install counts, and update history. Make confident decisions about which extensions to add to your production dashboard.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F504;</div>
+        <h3>Auto-Updates</h3>
+        <p>Installed extensions update automatically when new versions are published. Stay current with the latest features and security patches without manual intervention.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F6E1;</div>
+        <h3>Verified Extensions</h3>
+        <p>Extensions from trusted publishers carry a verified badge. Every marketplace submission is reviewed for security, performance, and compatibility with the latest console version.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Growing</div>
+        <div class="stat-label">Extension Library</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">One-Click</div>
+        <div class="stat-label">Install</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Open</div>
+        <div class="stat-label">Plugin SDK</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Community</div>
+        <div class="stat-label">Driven</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Your dashboard, your extensions, your way.</h2>
+    <p>Customize your Kubernetes management experience with extensions built by practitioners who understand real-world operations.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/network.html
+++ b/web/public/landing/network.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Network Policy &amp; Service Mesh Visibility - KubeStellar Console</title>
+  <meta name="description" content="Manage Kubernetes network policies and service mesh configurations across clusters. Visualize traffic flow, audit network segmentation, and monitor Istio, Cilium, and Calico policies." />
+  <meta name="keywords" content="kubernetes network policy, service mesh dashboard, istio monitoring, cilium network policy, kubernetes networking, network segmentation, multi-cluster networking" />
+  <link rel="canonical" href="https://console.kubestellar.io/network" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Network Policy &amp; Service Mesh Visibility - KubeStellar Console" />
+  <meta property="og:description" content="Manage Kubernetes network policies and service mesh configurations across clusters. Visualize traffic flow, audit network segmentation, and monitor mesh health." />
+  <meta property="og:url" content="https://console.kubestellar.io/network" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Network Policy &amp; Service Mesh Visibility - KubeStellar Console" />
+  <meta name="twitter:description" content="Manage Kubernetes network policies and service mesh configurations. Visualize traffic flow and audit network segmentation." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Network Management",
+    "description": "Manage Kubernetes network policies and service mesh configurations across clusters. Visualize traffic flow, audit network segmentation, and monitor Istio, Cilium, and Calico policies.",
+    "url": "https://console.kubestellar.io/network",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Network policy management, Service mesh monitoring, Traffic flow visualization, Network segmentation audit, Cross-cluster connectivity, Ingress and egress tracking"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Network <span class="accent">Policy</span> &amp; Service Mesh</h1>
+    <p class="subtitle">Visualize and manage Kubernetes networking across your fleet. Audit network policies, monitor service mesh health, trace traffic flow, and ensure secure communication between services and clusters.</p>
+    <div class="hero-actions">
+      <a href="/network" class="btn-primary">View Network</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Kubernetes Networking Made Visible</h2>
+      <p>Network policies and service mesh configurations are notoriously hard to reason about. Make them visual, auditable, and manageable.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F6E1;</div>
+        <h3>Network Policy Viewer</h3>
+        <p>Visualize ingress and egress rules for every namespace. See which pods can communicate with which, identify overly permissive policies, and detect namespaces with no policies at all.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F578;</div>
+        <h3>Service Mesh Dashboard</h3>
+        <p>Monitor Istio, Linkerd, or Cilium service mesh health. Track sidecar injection status, mTLS coverage, and proxy resource consumption across all meshed clusters.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x27A1;</div>
+        <h3>Traffic Flow Map</h3>
+        <p>Interactive topology map showing real-time traffic between services. Visualize request rates, error percentages, and latency on each communication path to identify bottlenecks.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F50D;</div>
+        <h3>Segmentation Audit</h3>
+        <p>Audit network segmentation against compliance requirements. Verify that production namespaces are isolated from development, and that sensitive workloads have deny-all default policies.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F310;</div>
+        <h3>Cross-Cluster Connectivity</h3>
+        <p>Monitor connectivity between clusters in a multi-cluster mesh. Track VPN tunnels, gateway health, and cross-cluster latency to ensure reliable inter-cluster communication.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4CA;</div>
+        <h3>DNS &amp; Resolution Monitoring</h3>
+        <p>Track CoreDNS performance and resolution rates across clusters. Detect DNS lookup failures, high latency queries, and misconfigured service records before they cause application errors.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Policy</div>
+        <div class="stat-label">Visualization</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Service Mesh</div>
+        <div class="stat-label">Monitoring</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Traffic</div>
+        <div class="stat-label">Flow Maps</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">mTLS</div>
+        <div class="stat-label">Coverage</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>See how your services communicate, across every cluster.</h2>
+    <p>Replace guesswork with visibility. Audit network policies, trace traffic, and ensure secure communication across your Kubernetes fleet.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/nodes.html
+++ b/web/public/landing/nodes.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kubernetes Node Management &amp; Monitoring - KubeStellar Console</title>
+  <meta name="description" content="Monitor Kubernetes node health, capacity, and performance across clusters. Track node conditions, resource pressure, scheduling status, and plan capacity with real-time metrics." />
+  <meta name="keywords" content="kubernetes node management, node monitoring, kubernetes node health, node capacity planning, kubernetes node conditions, multi-cluster node management" />
+  <link rel="canonical" href="https://console.kubestellar.io/nodes" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Kubernetes Node Management &amp; Monitoring - KubeStellar Console" />
+  <meta property="og:description" content="Monitor Kubernetes node health, capacity, and performance across clusters. Track node conditions, resource pressure, scheduling status, and plan capacity." />
+  <meta property="og:url" content="https://console.kubestellar.io/nodes" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Kubernetes Node Management &amp; Monitoring - KubeStellar Console" />
+  <meta name="twitter:description" content="Monitor Kubernetes node health, capacity, and performance across clusters. Track conditions, resource pressure, and plan capacity." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Node Management",
+    "description": "Monitor Kubernetes node health, capacity, and performance across clusters. Track node conditions, resource pressure, scheduling status, and plan capacity with real-time metrics.",
+    "url": "https://console.kubestellar.io/nodes",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Node health monitoring, Capacity planning, Resource pressure tracking, Cordon and drain, Node pool management, Multi-cluster node view"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Kubernetes <span class="accent">Node</span> Management</h1>
+    <p class="subtitle">Complete visibility into every node across your Kubernetes fleet. Monitor health conditions, track resource utilization, detect pressure events, and plan capacity from a single dashboard.</p>
+    <div class="hero-actions">
+      <a href="/nodes" class="btn-primary">View Nodes</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Infrastructure Visibility at the Node Level</h2>
+      <p>Understand the health and capacity of your compute infrastructure across every cluster, provider, and region.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2764;</div>
+        <h3>Health Condition Tracking</h3>
+        <p>Monitor Ready, MemoryPressure, DiskPressure, PIDPressure, and NetworkUnavailable conditions for every node. Color-coded indicators make it easy to spot problems instantly.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4CA;</div>
+        <h3>Capacity Planning</h3>
+        <p>Visualize allocatable vs. requested resources per node. See CPU, memory, and pod capacity to determine when clusters need additional nodes or when existing nodes are underutilized.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F50B;</div>
+        <h3>Resource Pressure Alerts</h3>
+        <p>Detect nodes under memory, disk, or PID pressure before workloads are evicted. Historical pressure data helps identify recurring bottlenecks and inform scaling decisions.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F6AB;</div>
+        <h3>Cordon &amp; Drain</h3>
+        <p>Safely cordon nodes for maintenance and drain workloads to healthy nodes. Track cordoned nodes across clusters and ensure no workload is left running on nodes marked for decommission.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F3F7;</div>
+        <h3>Label &amp; Taint Management</h3>
+        <p>View and manage node labels and taints across your fleet. Filter nodes by labels, identify scheduling constraints, and ensure workload placement policies are correctly configured.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x2699;</div>
+        <h3>Node Pool Overview</h3>
+        <p>Group nodes by pool, instance type, or availability zone. Compare resource distribution across pools and identify which node pools are under the most pressure or best suited for specific workloads.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">All Nodes</div>
+        <div class="stat-label">Across Clusters</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">5 Conditions</div>
+        <div class="stat-label">Monitored</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Real-Time</div>
+        <div class="stat-label">Capacity Data</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Automated</div>
+        <div class="stat-label">Pressure Alerts</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Know every node in your fleet, from one place.</h2>
+    <p>Stop SSH-ing into nodes to check health. Get real-time node status, capacity metrics, and pressure alerts across all clusters.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/operators.html
+++ b/web/public/landing/operators.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Operator &amp; OLM Management - KubeStellar Console</title>
+  <meta name="description" content="Manage Kubernetes operators and OLM subscriptions across clusters. Monitor operator health, track custom resources, manage upgrades, and ensure consistent operator deployments fleet-wide." />
+  <meta name="keywords" content="kubernetes operators, operator lifecycle manager, olm kubernetes, custom resource management, operator upgrade, kubernetes operator monitoring, operator hub" />
+  <link rel="canonical" href="https://console.kubestellar.io/operators" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Operator &amp; OLM Management - KubeStellar Console" />
+  <meta property="og:description" content="Manage Kubernetes operators and OLM subscriptions across clusters. Monitor operator health, track custom resources, and manage upgrades fleet-wide." />
+  <meta property="og:url" content="https://console.kubestellar.io/operators" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Operator &amp; OLM Management - KubeStellar Console" />
+  <meta name="twitter:description" content="Manage Kubernetes operators and OLM subscriptions across clusters. Monitor health, track custom resources, and manage upgrades." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Operator Management",
+    "description": "Manage Kubernetes operators and OLM subscriptions across clusters. Monitor operator health, track custom resources, manage upgrades, and ensure consistent operator deployments fleet-wide.",
+    "url": "https://console.kubestellar.io/operators",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "OLM subscription management, Operator health monitoring, Custom resource tracking, Upgrade management, CRD version tracking, Multi-cluster operator consistency"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Kubernetes <span class="accent">Operator</span> Management</h1>
+    <p class="subtitle">Manage the operator ecosystem across your Kubernetes fleet. Monitor OLM subscriptions, track CRD versions, ensure consistent operator deployments, and control upgrade rollouts from a single console.</p>
+    <div class="hero-actions">
+      <a href="/operators" class="btn-primary">View Operators</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Operator Lifecycle Across Your Fleet</h2>
+      <p>From installation to upgrade, maintain visibility and control over every operator running in your multi-cluster environment.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4E6;</div>
+        <h3>Operator Catalog</h3>
+        <p>Browse available operators from OperatorHub, community catalogs, and private registries. Compare operator capabilities, maturity levels, and supported Kubernetes versions before installing.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x2764;</div>
+        <h3>Health Monitoring</h3>
+        <p>Track operator pod health, reconciliation loops, and error rates. Detect operators stuck in failed states, identify reconciliation bottlenecks, and monitor controller manager resource usage.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F4DD;</div>
+        <h3>Custom Resource Explorer</h3>
+        <p>Browse all custom resources managed by installed operators. View CR status, conditions, and spec details. Understand which CRDs are installed per cluster and their version compatibility.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2B06;</div>
+        <h3>Upgrade Management</h3>
+        <p>Track available operator upgrades across clusters. Review changelogs and breaking changes before approving upgrades. Execute coordinated rollouts or cluster-by-cluster upgrades with rollback support.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F50E;</div>
+        <h3>Version Consistency</h3>
+        <p>Detect operator version drift across clusters. See which clusters are running different versions of the same operator and enforce fleet-wide version consistency through automated policies.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F512;</div>
+        <h3>RBAC &amp; Permission Review</h3>
+        <p>Audit the permissions requested by each operator. Review ClusterRoles, ServiceAccounts, and RoleBindings created by operators to ensure they follow the principle of least privilege.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">OLM</div>
+        <div class="stat-label">Integration</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">CRD</div>
+        <div class="stat-label">Version Tracking</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Coordinated</div>
+        <div class="stat-label">Upgrades</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Fleet</div>
+        <div class="stat-label">Consistency</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Keep every operator healthy, updated, and consistent.</h2>
+    <p>Manage the growing complexity of Kubernetes operators across your fleet with a dashboard built for operator lifecycle management.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/pods.html
+++ b/web/public/landing/pods.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Pod Monitoring &amp; Debugging - KubeStellar Console</title>
+  <meta name="description" content="Monitor and debug Kubernetes pods across multiple clusters. View pod status, container logs, resource usage, restart counts, and troubleshoot issues from a single dashboard." />
+  <meta name="keywords" content="kubernetes pod monitoring, pod debugging, kubernetes logs, pod troubleshooting, container logs dashboard, multi-cluster pod management, crashloopbackoff" />
+  <link rel="canonical" href="https://console.kubestellar.io/pods" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Pod Monitoring &amp; Debugging - KubeStellar Console" />
+  <meta property="og:description" content="Monitor and debug Kubernetes pods across multiple clusters. View pod status, container logs, resource usage, and troubleshoot issues." />
+  <meta property="og:url" content="https://console.kubestellar.io/pods" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Pod Monitoring &amp; Debugging - KubeStellar Console" />
+  <meta name="twitter:description" content="Monitor and debug Kubernetes pods across multiple clusters. View pod status, container logs, and troubleshoot issues." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Pod Monitoring",
+    "description": "Monitor and debug Kubernetes pods across multiple clusters. View pod status, container logs, resource usage, restart counts, and troubleshoot issues from a single dashboard.",
+    "url": "https://console.kubestellar.io/pods",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Pod status monitoring, Container log streaming, Restart tracking, OOMKill detection, Multi-container pod support, Cross-cluster pod search"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Pod <span class="accent">Monitoring</span> &amp; Debugging</h1>
+    <p class="subtitle">Gain complete visibility into every pod across your Kubernetes fleet. Stream container logs, track restart patterns, detect OOMKills, and troubleshoot issues without touching kubectl.</p>
+    <div class="hero-actions">
+      <a href="/pods" class="btn-primary">View Pods</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Deep Pod-Level Troubleshooting</h2>
+      <p>Everything you need to understand what is happening inside your pods, across every cluster, in one place.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F7E2;</div>
+        <h3>Status Overview</h3>
+        <p>View Running, Pending, Succeeded, Failed, and Unknown pod states across all clusters. Filter by phase, namespace, or node to zero in on problem areas and track patterns over time.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4DC;</div>
+        <h3>Live Log Streaming</h3>
+        <p>Stream container logs in real time from any pod in any cluster. Support for multi-container pods, init containers, and previous container logs for debugging restart loops.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F504;</div>
+        <h3>Restart Analysis</h3>
+        <p>Track pod restart counts and reasons. Identify CrashLoopBackOff patterns, OOMKilled containers, and liveness probe failures with timelines showing when and why restarts occurred.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4CA;</div>
+        <h3>Resource Consumption</h3>
+        <p>Compare actual CPU and memory usage against requests and limits for each container. Identify containers hitting their memory ceiling or barely using their allocated CPU.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F50D;</div>
+        <h3>Event Correlation</h3>
+        <p>View Kubernetes events associated with each pod: scheduling decisions, image pulls, volume mounts, and probe outcomes. Understand the full lifecycle of a pod from creation to termination.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F310;</div>
+        <h3>Cross-Cluster Pod Search</h3>
+        <p>Find any pod across your entire fleet by name, label, image, or IP address. Instantly locate pods regardless of which cluster or namespace they are running in.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Live</div>
+        <div class="stat-label">Log Streaming</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">All Phases</div>
+        <div class="stat-label">Tracked</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">OOMKill</div>
+        <div class="stat-label">Detection</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Fleet-Wide</div>
+        <div class="stat-label">Pod Search</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Debug any pod, any cluster, any time.</h2>
+    <p>Replace scattered kubectl commands with a single dashboard that gives you logs, events, and metrics for every pod in your fleet.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/security-posture.html
+++ b/web/public/landing/security-posture.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Security Posture Assessment - KubeStellar Console</title>
+  <meta name="description" content="Assess the security posture of your Kubernetes clusters. Scan for misconfigurations, vulnerable container images, RBAC issues, and compliance violations across your entire fleet." />
+  <meta name="keywords" content="kubernetes security posture, security assessment kubernetes, kubernetes vulnerability scanning, rbac audit, kubernetes compliance, container security, cis benchmark" />
+  <link rel="canonical" href="https://console.kubestellar.io/security-posture" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Security Posture Assessment - KubeStellar Console" />
+  <meta property="og:description" content="Assess the security posture of your Kubernetes clusters. Scan for misconfigurations, vulnerable images, RBAC issues, and compliance violations fleet-wide." />
+  <meta property="og:url" content="https://console.kubestellar.io/security-posture" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Security Posture Assessment - KubeStellar Console" />
+  <meta name="twitter:description" content="Assess the security posture of your Kubernetes clusters. Scan for misconfigurations, vulnerable images, and RBAC issues." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Security Posture Assessment",
+    "description": "Assess the security posture of your Kubernetes clusters. Scan for misconfigurations, vulnerable container images, RBAC issues, and compliance violations across your entire fleet.",
+    "url": "https://console.kubestellar.io/security-posture",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Security posture scoring, Vulnerability scanning, RBAC audit, CIS benchmark compliance, Misconfiguration detection, Secret exposure scanning"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Security <span class="accent">Posture</span> Assessment</h1>
+    <p class="subtitle">Continuously assess the security posture of your Kubernetes fleet. Detect misconfigurations, scan for vulnerabilities, audit RBAC permissions, and measure compliance against CIS benchmarks and industry standards.</p>
+    <div class="hero-actions">
+      <a href="/security-posture" class="btn-primary">Assess Security</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Know Your Security Score Across Every Cluster</h2>
+      <p>Security is not a one-time check. Continuously evaluate and improve your Kubernetes security posture with automated assessments.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F3AF;</div>
+        <h3>Posture Score</h3>
+        <p>Get a numerical security score for each cluster based on configuration checks, vulnerability counts, and policy compliance. Track score improvements over time and compare clusters side by side.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F41B;</div>
+        <h3>Vulnerability Scanning</h3>
+        <p>Scan container images running in your clusters for known CVEs. Prioritize by severity (Critical, High, Medium, Low), filter by fixability, and track remediation progress across the fleet.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F512;</div>
+        <h3>RBAC Analysis</h3>
+        <p>Audit role bindings, cluster roles, and service accounts for excessive permissions. Identify subjects with cluster-admin access, detect unused service accounts, and enforce least-privilege policies.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2611;</div>
+        <h3>CIS Benchmark Compliance</h3>
+        <p>Evaluate clusters against CIS Kubernetes Benchmarks. See pass/fail/warn results for each check category, and get specific remediation steps for every failing control across your fleet.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x26A0;</div>
+        <h3>Misconfiguration Detection</h3>
+        <p>Detect pods running as root, containers with privilege escalation, missing security contexts, hostPath mounts, and other common misconfigurations that weaken your security posture.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F510;</div>
+        <h3>Secret Exposure Scanning</h3>
+        <p>Identify secrets mounted in environment variables, exposed in logs, or stored without encryption. Detect Kubernetes secrets that lack encryption at rest and audit secret access patterns.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">Continuous</div>
+        <div class="stat-label">Assessment</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">CVE</div>
+        <div class="stat-label">Scanning</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">CIS</div>
+        <div class="stat-label">Compliance</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">RBAC</div>
+        <div class="stat-label">Audit</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Security posture you can measure and improve.</h2>
+    <p>Replace ad-hoc security checks with continuous assessment. Know your score, fix what matters, and track improvement across every cluster.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/services.html
+++ b/web/public/landing/services.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Service Management &amp; Load Balancing - KubeStellar Console</title>
+  <meta name="description" content="Manage Kubernetes services, endpoints, and load balancers across clusters. Monitor service discovery, track ingress routes, and visualize traffic flow in a multi-cluster environment." />
+  <meta name="keywords" content="kubernetes service management, kubernetes load balancer, service discovery, kubernetes ingress, endpoint monitoring, multi-cluster services, kubernetes networking" />
+  <link rel="canonical" href="https://console.kubestellar.io/services" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Service Management &amp; Load Balancing - KubeStellar Console" />
+  <meta property="og:description" content="Manage Kubernetes services, endpoints, and load balancers across clusters. Monitor service discovery, track ingress routes, and visualize traffic flow." />
+  <meta property="og:url" content="https://console.kubestellar.io/services" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Service Management &amp; Load Balancing - KubeStellar Console" />
+  <meta name="twitter:description" content="Manage Kubernetes services, endpoints, and load balancers across clusters. Monitor service discovery and visualize traffic flow." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Service Management",
+    "description": "Manage Kubernetes services, endpoints, and load balancers across clusters. Monitor service discovery, track ingress routes, and visualize traffic flow in a multi-cluster environment.",
+    "url": "https://console.kubestellar.io/services",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Service monitoring, Endpoint tracking, Ingress management, Load balancer status, Cross-cluster service discovery, Traffic flow visualization"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Service <span class="accent">Discovery</span> &amp; Load Balancing</h1>
+    <p class="subtitle">Monitor and manage Kubernetes services, endpoints, and ingress routes across your multi-cluster fleet. Visualize traffic flow, track load balancer health, and ensure reliable service connectivity.</p>
+    <div class="hero-actions">
+      <a href="/services" class="btn-primary">View Services</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Network Connectivity at a Glance</h2>
+      <p>Understand how traffic reaches your workloads with complete visibility into services, endpoints, and routing across clusters.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F310;</div>
+        <h3>Service Catalog</h3>
+        <p>Browse all ClusterIP, NodePort, LoadBalancer, and ExternalName services across every cluster. Filter by type, namespace, or port to find specific services instantly.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F517;</div>
+        <h3>Endpoint Health</h3>
+        <p>Monitor endpoint readiness for every service. See which pods are backing each service, identify services with zero ready endpoints, and track endpoint churn over time.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x2197;</div>
+        <h3>Ingress &amp; Route Tracking</h3>
+        <p>View all ingress resources and OpenShift routes across clusters. Track TLS certificate expiry, hostname mappings, path rules, and backend service connectivity status.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2696;</div>
+        <h3>Load Balancer Status</h3>
+        <p>Monitor external load balancer provisioning, IP assignment, and health checks. Detect stuck LoadBalancer services waiting for IP allocation and track cloud provider load balancer costs.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F6E0;</div>
+        <h3>Port Mapping Visibility</h3>
+        <p>See the complete port chain from service port to target port to container port. Identify port conflicts, misconfigurations, and protocol mismatches before they cause connectivity issues.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F50C;</div>
+        <h3>Cross-Cluster Services</h3>
+        <p>Visualize services that span multiple clusters via multi-cluster service discovery. Track service export and import status, and monitor cross-cluster traffic routing health.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">All Types</div>
+        <div class="stat-label">Service Coverage</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Endpoint</div>
+        <div class="stat-label">Health Checks</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Ingress</div>
+        <div class="stat-label">Route Tracking</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Cross-Cluster</div>
+        <div class="stat-label">Discovery</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Every service, every endpoint, every cluster.</h2>
+    <p>Ensure reliable connectivity across your entire Kubernetes fleet with a dashboard that makes service networking visible and manageable.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/storage.html
+++ b/web/public/landing/storage.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Storage Management &amp; PV/PVC Monitoring - KubeStellar Console</title>
+  <meta name="description" content="Manage Kubernetes storage across clusters. Monitor persistent volumes, storage classes, PVC status, and capacity. Track storage utilization, detect orphaned volumes, and optimize storage costs." />
+  <meta name="keywords" content="kubernetes storage, persistent volume management, pvc monitoring, storage class kubernetes, kubernetes storage capacity, multi-cluster storage, kubernetes pv pvc" />
+  <link rel="canonical" href="https://console.kubestellar.io/storage" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Storage Management &amp; PV/PVC Monitoring - KubeStellar Console" />
+  <meta property="og:description" content="Manage Kubernetes storage across clusters. Monitor persistent volumes, storage classes, PVC status, and capacity. Track utilization and optimize storage costs." />
+  <meta property="og:url" content="https://console.kubestellar.io/storage" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Storage Management &amp; PV/PVC Monitoring - KubeStellar Console" />
+  <meta name="twitter:description" content="Manage Kubernetes storage across clusters. Monitor persistent volumes, storage classes, PVC status, and capacity." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Storage Management",
+    "description": "Manage Kubernetes storage across clusters. Monitor persistent volumes, storage classes, PVC status, and capacity. Track storage utilization, detect orphaned volumes, and optimize storage costs.",
+    "url": "https://console.kubestellar.io/storage",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "PV/PVC monitoring, Storage class management, Capacity tracking, Orphaned volume detection, Storage cost analysis, Multi-cluster storage overview"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Kubernetes <span class="accent">Storage</span> Management</h1>
+    <p class="subtitle">Monitor and manage persistent storage across your Kubernetes fleet. Track PV/PVC status, storage class usage, volume capacity, and cost. Detect orphaned volumes and prevent storage sprawl.</p>
+    <div class="hero-actions">
+      <a href="/storage" class="btn-primary">View Storage</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Persistent Storage Under Control</h2>
+      <p>Storage is the most stateful part of Kubernetes. Keep it visible, organized, and cost-efficient across every cluster.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x1F4BE;</div>
+        <h3>PV/PVC Dashboard</h3>
+        <p>View all persistent volumes and claims across clusters. Track binding status, access modes, storage capacity, and reclaim policies. Filter by storage class, namespace, or status.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4CA;</div>
+        <h3>Capacity Utilization</h3>
+        <p>Monitor actual storage usage versus provisioned capacity. Identify volumes nearing capacity before applications run out of disk space, and spot over-provisioned volumes wasting budget.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x1F5C2;</div>
+        <h3>Storage Class Management</h3>
+        <p>Compare storage classes across clusters. See which provisioners are available, their default settings, volume binding modes, and whether they support expansion or snapshot capabilities.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x26A0;</div>
+        <h3>Orphaned Volume Detection</h3>
+        <p>Find persistent volumes that are no longer bound to any claim. Identify Released and Failed volumes that may be consuming storage and incurring costs without serving any workload.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x1F4F8;</div>
+        <h3>Snapshot Management</h3>
+        <p>Track volume snapshots and snapshot classes across clusters. Monitor snapshot creation, size, and retention. Ensure backup policies are consistently applied across your fleet.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4B0;</div>
+        <h3>Storage Cost Tracking</h3>
+        <p>Map storage volumes to cloud provider costs. Compare pricing across storage tiers (SSD, HDD, NVMe) and identify opportunities to move cold data to cheaper storage classes.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">PV + PVC</div>
+        <div class="stat-label">Tracking</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Orphaned</div>
+        <div class="stat-label">Volume Detection</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Capacity</div>
+        <div class="stat-label">Monitoring</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Snapshot</div>
+        <div class="stat-label">Management</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Persistent storage that you can actually see and manage.</h2>
+    <p>Eliminate storage sprawl, detect orphaned volumes, and ensure your stateful workloads always have the capacity they need.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>

--- a/web/public/landing/workloads.html
+++ b/web/public/landing/workloads.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Kubernetes Workload Management - KubeStellar Console</title>
+  <meta name="description" content="Manage Kubernetes workloads across multiple clusters. Monitor deployments, pods, services, and jobs from a unified multi-cluster workload dashboard." />
+  <meta name="keywords" content="kubernetes workloads, workload management, kubernetes deployments, multi-cluster workloads, pod management, kubernetes services" />
+  <link rel="canonical" href="https://console.kubestellar.io/workloads" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Kubernetes Workload Management - KubeStellar Console" />
+  <meta property="og:description" content="Manage Kubernetes workloads across multiple clusters. Monitor deployments, pods, services, and jobs from a unified multi-cluster workload dashboard." />
+  <meta property="og:url" content="https://console.kubestellar.io/workloads" />
+  <meta property="og:image" content="https://console.kubestellar.io/kubestellar.png" />
+  <meta property="og:image:width" content="2048" />
+  <meta property="og:image:height" content="400" />
+  <meta property="og:site_name" content="KubeStellar Console" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Kubernetes Workload Management - KubeStellar Console" />
+  <meta name="twitter:description" content="Manage Kubernetes workloads across multiple clusters. Monitor deployments, pods, services, and jobs from a unified multi-cluster workload dashboard." />
+  <meta name="twitter:image" content="https://console.kubestellar.io/kubestellar.png" />
+
+  <link rel="stylesheet" href="/landing/style.css" />
+
+  <!-- JSON-LD Structured Data -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "KubeStellar Console - Workload Management",
+    "description": "Manage Kubernetes workloads across multiple clusters. Monitor deployments, pods, services, and jobs from a unified multi-cluster workload dashboard.",
+    "url": "https://console.kubestellar.io/workloads",
+    "applicationCategory": "DeveloperApplication",
+    "operatingSystem": "Web",
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD"
+    },
+    "screenshot": "https://console.kubestellar.io/kubestellar.png",
+    "softwareVersion": "1.0",
+    "author": {
+      "@type": "Organization",
+      "name": "KubeStellar Contributors",
+      "url": "https://kubestellar.io"
+    },
+    "license": "https://opensource.org/licenses/Apache-2.0",
+    "codeRepository": "https://github.com/kubestellar/console",
+    "featureList": "Multi-cluster workload monitoring, Deployment tracking, Pod health visibility, Service discovery, Job scheduling, Resource quota management"
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Navigation -->
+  <nav class="nav">
+    <a href="/" class="nav-brand">
+      <svg viewBox="0 0 24 24" fill="none" stroke="#7c3aed" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      KubeStellar Console
+    </a>
+    <div class="nav-links">
+      <a href="/clusters">Clusters</a>
+      <a href="/workloads">Workloads</a>
+      <a href="/missions">Missions</a>
+      <a href="/deploy">Deploy</a>
+    </div>
+    <a href="/" class="nav-cta">Open Console &rarr;</a>
+  </nav>
+
+  <!-- Hero -->
+  <section class="hero">
+    <h1>Unified <span class="accent">Workload</span> Management</h1>
+    <p class="subtitle">Monitor and manage all Kubernetes workloads across your entire fleet. Track deployments, pods, services, and jobs from a single pane of glass with real-time health and status indicators.</p>
+    <div class="hero-actions">
+      <a href="/workloads" class="btn-primary">View Workloads</a>
+      <a href="https://github.com/kubestellar/console" class="btn-secondary" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Features -->
+  <section class="section">
+    <div class="section-header">
+      <h2>Complete Workload Lifecycle Management</h2>
+      <p>From deployment to decommission, gain full visibility and control over every workload in your multi-cluster environment.</p>
+    </div>
+    <div class="features-grid">
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2B22;</div>
+        <h3>Multi-Cluster Overview</h3>
+        <p>See every workload running across all connected clusters in one consolidated view. Filter by namespace, cluster, status, or workload type to find exactly what you need.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x2714;</div>
+        <h3>Health Status Tracking</h3>
+        <p>Monitor workload health with color-coded status indicators. Quickly identify failing pods, pending deployments, and stuck jobs before they impact your users.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon blue">&#x21C4;</div>
+        <h3>Rolling Updates</h3>
+        <p>Track deployment rollout progress in real time. View revision history, rollback to previous versions, and monitor update strategies across multiple clusters simultaneously.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon purple">&#x2699;</div>
+        <h3>Resource Quotas</h3>
+        <p>Monitor CPU and memory requests versus limits for every workload. Identify over-provisioned and under-provisioned containers to optimize resource allocation and reduce costs.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon yellow">&#x23F1;</div>
+        <h3>Job &amp; CronJob Tracking</h3>
+        <p>Monitor batch job execution, completion rates, and scheduling. View CronJob history, detect failures early, and ensure scheduled tasks run reliably across your fleet.</p>
+      </div>
+      <div class="feature-card">
+        <div class="feature-icon green">&#x1F4CB;</div>
+        <h3>Namespace Organization</h3>
+        <p>Group and filter workloads by namespace across clusters. Apply consistent resource policies, labels, and annotations to keep workloads organized at scale.</p>
+      </div>
+    </div>
+  </section>
+
+  <hr class="section-divider" />
+
+  <!-- Stats -->
+  <section class="section">
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">All Types</div>
+        <div class="stat-label">Workload Resources</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Real-Time</div>
+        <div class="stat-label">Status Updates</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Multi-Cluster</div>
+        <div class="stat-label">Visibility</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">Instant</div>
+        <div class="stat-label">Rollbacks</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-section">
+    <h2>Every workload, every cluster, one dashboard.</h2>
+    <p>Stop switching between clusters to check workload status. Get a complete view of your entire Kubernetes fleet.</p>
+    <a href="/" class="btn-primary">Get Started</a>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-links">
+      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    </div>
+    <p>&copy; 2024 KubeStellar Contributors</p>
+  </footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- GSC shows **0 of 29 inner pages indexed** after 6 days — only the homepage is indexed
- Root cause: 23 of 29 sitemap routes served empty SPA shells to Googlebot
- Adds **23 new static landing pages** with full SEO markup (title, meta, OG, Twitter Cards, JSON-LD, rich HTML content)
- Updates `seo-meta.ts` edge function to serve all 29 routes to crawlers
- Adds `ROUTE_META` entries for 18 new routes (meta tag injection for human visitors)

### Before
- 6 routes had landing pages: `/`, `/clusters`, `/missions`, `/gpu-reservations`, `/deploy`, `/security`
- 23 routes served empty `<div id="root">` to crawlers

### After
- All 29 sitemap routes serve rich, crawlable HTML to search engine bots
- Each page has unique title, description, keywords, canonical URL, Open Graph, Twitter Cards, and JSON-LD structured data

## Test plan
- [x] `npm run build` passes
- [x] Verified Googlebot user-agent gets landing page HTML (tested with `curl -A "Googlebot"`)
- [ ] Monitor GSC indexing status over next 1-2 weeks (expect 0/29 → 29/29)