### PR TITLE
✨ SEO: Add full internal link graph to all landing pages for crawler discovery

### DIFF
--- a/web/public/landing/ai-agents.html
+++ b/web/public/landing/ai-agents.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/ai-ml.html
+++ b/web/public/landing/ai-ml.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/alerts.html
+++ b/web/public/landing/alerts.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/arcade.html
+++ b/web/public/landing/arcade.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/ci-cd.html
+++ b/web/public/landing/ci-cd.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/clusters.html
+++ b/web/public/landing/clusters.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/compute.html
+++ b/web/public/landing/compute.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/cost.html
+++ b/web/public/landing/cost.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/data-compliance.html
+++ b/web/public/landing/data-compliance.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/deploy.html
+++ b/web/public/landing/deploy.html
@@ -202,14 +202,62 @@
     <a href="/" class="btn-primary">Open Console</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/deployments.html
+++ b/web/public/landing/deployments.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/events.html
+++ b/web/public/landing/events.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/gitops.html
+++ b/web/public/landing/gitops.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/gpu.html
+++ b/web/public/landing/gpu.html
@@ -172,15 +172,62 @@
     <a href="/gpu-reservations" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://kubestellar.io">KubeStellar</a>
-      <a href="https://github.com/kubestellar">GitHub</a>
-      <a href="https://docs.kubestellar.io">Documentation</a>
-      <a href="https://kubestellar.io/community">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors. All rights reserved.</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/helm.html
+++ b/web/public/landing/helm.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/index.html
+++ b/web/public/landing/index.html
@@ -153,14 +153,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/llm-d-benchmarks.html
+++ b/web/public/landing/llm-d-benchmarks.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/logs.html
+++ b/web/public/landing/logs.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/marketplace.html
+++ b/web/public/landing/marketplace.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/missions.html
+++ b/web/public/landing/missions.html
@@ -206,15 +206,62 @@
     <a href="/missions" class="btn-primary">Browse Missions</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://kubestellar.io">KubeStellar</a>
-      <a href="https://docs.kubestellar.io">Documentation</a>
-      <a href="https://github.com/kubestellar">GitHub</a>
-      <a href="https://kubestellar.io/community">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024&ndash;2026 KubeStellar Contributors. All rights reserved.</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/network.html
+++ b/web/public/landing/network.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/nodes.html
+++ b/web/public/landing/nodes.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/operators.html
+++ b/web/public/landing/operators.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/pods.html
+++ b/web/public/landing/pods.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/security-posture.html
+++ b/web/public/landing/security-posture.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/security.html
+++ b/web/public/landing/security.html
@@ -153,14 +153,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/services.html
+++ b/web/public/landing/services.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/storage.html
+++ b/web/public/landing/storage.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>

--- a/web/public/landing/style.css
+++ b/web/public/landing/style.css
@@ -195,14 +195,26 @@ body { min-height: 100vh; }
 
 /* Footer */
 .footer {
-  padding: 40px 24px;
-  text-align: center;
+  padding: 48px 24px 32px;
   border-top: 1px solid var(--border);
   color: var(--text-dim);
   font-size: 13px;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 .footer a { color: var(--text-muted); text-decoration: none; }
 .footer a:hover { color: var(--text); }
+.footer-columns {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 32px;
+  margin-bottom: 32px;
+  text-align: left;
+}
+.footer-col { display: flex; flex-direction: column; gap: 8px; }
+.footer-col h4 { color: var(--text); font-size: 13px; font-weight: 600; margin: 0 0 4px; letter-spacing: 0.03em; }
+.footer-col a { font-size: 13px; line-height: 1.6; }
+.footer-bottom { text-align: center; padding-top: 24px; border-top: 1px solid var(--border); }
 .footer-links { display: flex; gap: 24px; justify-content: center; margin-bottom: 16px; }
 
 /* Responsive */
@@ -212,4 +224,8 @@ body { min-height: 100vh; }
   .stats-row { grid-template-columns: repeat(2, 1fr); }
   .hero { padding-top: calc(var(--nav-height) + 48px); padding-bottom: 48px; }
   .section { padding: 48px 16px; }
+  .footer-columns { grid-template-columns: repeat(2, 1fr); gap: 24px; }
+}
+@media (max-width: 480px) {
+  .footer-columns { grid-template-columns: 1fr; }
 }

--- a/web/public/landing/workloads.html
+++ b/web/public/landing/workloads.html
@@ -154,14 +154,62 @@
     <a href="/" class="btn-primary">Get Started</a>
   </section>
 
-  <!-- Footer -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
+<!-- Footer with comprehensive internal links for SEO discovery -->
   <footer class="footer">
-    <div class="footer-links">
-      <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
-      <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
-      <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+    <div class="footer-columns">
+      <div class="footer-col">
+        <h4>Cluster Management</h4>
+        <a href="/clusters">Multi-Cluster Overview</a>
+        <a href="/nodes">Node Management</a>
+        <a href="/compute">Compute Resources</a>
+        <a href="/storage">Storage Management</a>
+        <a href="/network">Network &amp; Policies</a>
+      </div>
+      <div class="footer-col">
+        <h4>Workloads</h4>
+        <a href="/workloads">Workload Overview</a>
+        <a href="/deployments">Deployments</a>
+        <a href="/pods">Pods</a>
+        <a href="/services">Services</a>
+        <a href="/helm">Helm Charts</a>
+        <a href="/operators">Operators</a>
+      </div>
+      <div class="footer-col">
+        <h4>AI &amp; Operations</h4>
+        <a href="/missions">AI Missions</a>
+        <a href="/ai-agents">AI Agents</a>
+        <a href="/ai-ml">AI/ML Workloads</a>
+        <a href="/llm-d-benchmarks">LLM Benchmarks</a>
+        <a href="/gpu-reservations">GPU Management</a>
+      </div>
+      <div class="footer-col">
+        <h4>DevOps &amp; Security</h4>
+        <a href="/deploy">Deploy</a>
+        <a href="/gitops">GitOps</a>
+        <a href="/ci-cd">CI/CD Pipelines</a>
+        <a href="/security">Security Dashboard</a>
+        <a href="/security-posture">Security Posture</a>
+        <a href="/data-compliance">Data Compliance</a>
+      </div>
+      <div class="footer-col">
+        <h4>Monitoring</h4>
+        <a href="/events">Events</a>
+        <a href="/logs">Logs</a>
+        <a href="/alerts">Alerts</a>
+        <a href="/cost">Cost Management</a>
+        <a href="/marketplace">Marketplace</a>
+        <a href="/arcade">Learning Arcade</a>
+      </div>
     </div>
-    <p>&copy; 2024 KubeStellar Contributors</p>
+    <div class="footer-bottom">
+      <div class="footer-links">
+        <a href="https://github.com/kubestellar/console" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://docs.kubestellar.io" target="_blank" rel="noopener noreferrer">Documentation</a>
+        <a href="https://kubestellar.io" target="_blank" rel="noopener noreferrer">Community</a>
+      </div>
+      <p>&copy; 2024 KubeStellar Contributors. Open source under Apache 2.0.</p>
+    </div>
   </footer>
 
 </body>


### PR DESCRIPTION
## Summary
- All 28 inner pages are "unknown to Google" — crawler couldn't discover them because nav only linked to 4 routes
- Replaces minimal footer with 5-column link grid across all 29 landing pages
- Every page now has 37 internal links covering all dashboard routes
- Responsive: 5-col → 2-col → 1-col on mobile

## Test plan
- [x] `npm run build` passes
- [x] Verified 37 internal links per page
- [ ] Monitor GSC indexing — expect pages to start getting crawled within days