### PR TITLE
✨ Add Helm chart validation CI

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -1,0 +1,142 @@
+name: Helm Chart Test
+
+on:
+  pull_request:
+    paths:
+      - 'deploy/helm/**'
+      - '.github/workflows/helm-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/helm/**'
+      - '.github/workflows/helm-test.yml'
+  workflow_call: {}
+
+jobs:
+  helm-lint-and-template:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - name: Install kubeconform
+        run: |
+          KUBECONFORM_VERSION="v0.6.7"
+          curl -sSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" | \
+            tar xz -C /usr/local/bin kubeconform
+
+      - name: Helm lint (default values)
+        run: helm lint deploy/helm/kubestellar-console
+
+      - name: Helm lint (OpenShift values)
+        run: |
+          helm lint deploy/helm/kubestellar-console \
+            -f deploy/helm/kubestellar-console/values.yaml \
+            -f deploy/helm/kubestellar-console/values-openshift.yaml
+
+      - name: Template — default values
+        run: |
+          helm template kc deploy/helm/kubestellar-console \
+            --namespace kc \
+            > /tmp/helm-default.yaml
+          echo "Rendered $(grep -c '^kind:' /tmp/helm-default.yaml) resources (default values)"
+
+      - name: Template — OpenShift values
+        run: |
+          helm template kc deploy/helm/kubestellar-console \
+            --namespace kc \
+            -f deploy/helm/kubestellar-console/values.yaml \
+            -f deploy/helm/kubestellar-console/values-openshift.yaml \
+            --set route.enabled=true \
+            --set route.host=console.apps.example.com \
+            > /tmp/helm-openshift.yaml
+          echo "Rendered $(grep -c '^kind:' /tmp/helm-openshift.yaml) resources (OpenShift values)"
+
+      - name: Template — all optional features enabled
+        run: |
+          helm template kc deploy/helm/kubestellar-console \
+            --namespace kc \
+            --set ingress.enabled=true \
+            --set ingress.className=nginx \
+            --set ingress.hosts[0].host=console.example.com \
+            --set ingress.hosts[0].paths[0].path=/ \
+            --set ingress.hosts[0].paths[0].pathType=Prefix \
+            --set networkPolicy.enabled=true \
+            --set podDisruptionBudget.enabled=true \
+            --set github.clientId=test-id \
+            --set github.clientSecret=test-secret \
+            --set claude.apiKey=test-key \
+            --set githubToken.token=test-token \
+            --set feedbackGithubToken.token=test-token \
+            --set googleDrive.apiKey=test-key \
+            --set watchdog.enabled=true \
+            > /tmp/helm-full.yaml
+          echo "Rendered $(grep -c '^kind:' /tmp/helm-full.yaml) resources (all features)"
+
+      - name: Template — minimal (no persistence, no RBAC)
+        run: |
+          helm template kc deploy/helm/kubestellar-console \
+            --namespace kc \
+            --set persistence.enabled=false \
+            --set rbac.create=false \
+            --set serviceAccount.create=false \
+            --set watchdog.enabled=false \
+            > /tmp/helm-minimal.yaml
+          echo "Rendered $(grep -c '^kind:' /tmp/helm-minimal.yaml) resources (minimal)"
+
+      - name: Kubeconform — validate default
+        run: |
+          kubeconform -strict -summary \
+            -kubernetes-version 1.30.0 \
+            -skip Route \
+            /tmp/helm-default.yaml
+
+      - name: Kubeconform — validate OpenShift
+        run: |
+          # Skip OpenShift Route CRD (no schema available in upstream)
+          kubeconform -strict -summary \
+            -kubernetes-version 1.30.0 \
+            -skip Route \
+            /tmp/helm-openshift.yaml
+
+      - name: Kubeconform — validate all features
+        run: |
+          kubeconform -strict -summary \
+            -kubernetes-version 1.30.0 \
+            -skip Route \
+            /tmp/helm-full.yaml
+
+      - name: Kubeconform — validate minimal
+        run: |
+          kubeconform -strict -summary \
+            -kubernetes-version 1.30.0 \
+            -skip Route \
+            /tmp/helm-minimal.yaml
+
+      - name: Verify no empty/broken templates
+        run: |
+          for f in /tmp/helm-default.yaml /tmp/helm-openshift.yaml /tmp/helm-full.yaml /tmp/helm-minimal.yaml; do
+            BASENAME=$(basename "$f")
+            RESOURCE_COUNT=$(grep -c '^kind:' "$f")
+            if [ "$RESOURCE_COUNT" -lt 2 ]; then
+              echo "ERROR: $BASENAME rendered only $RESOURCE_COUNT resources — chart may be broken"
+              exit 1
+            fi
+            echo "OK: $BASENAME has $RESOURCE_COUNT resources"
+          done
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Helm Chart Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Variant | Resources |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|-----------|" >> $GITHUB_STEP_SUMMARY
+          for f in /tmp/helm-default.yaml /tmp/helm-openshift.yaml /tmp/helm-full.yaml /tmp/helm-minimal.yaml; do
+            BASENAME=$(basename "$f" .yaml | sed 's/helm-//')
+            COUNT=$(grep -c '^kind:' "$f" 2>/dev/null || echo 0)
+            echo "| $BASENAME | $COUNT |" >> $GITHUB_STEP_SUMMARY
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  helm-test:
+    uses: ./.github/workflows/helm-test.yml
+
   determine-version:
     runs-on: ubuntu-latest
     outputs:
@@ -262,7 +265,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   helm-release:
-    needs: [determine-version, release]
+    needs: [determine-version, release, helm-test]
     runs-on: ubuntu-latest
     if: needs.release.result == 'success'
     permissions:


### PR DESCRIPTION
## Summary
- Adds `helm-test.yml` workflow that validates the Helm chart on every PR touching `deploy/helm/**`
- Tests 4 value combinations: default, OpenShift, all-features-enabled, minimal
- Runs `helm lint`, `helm template`, and `kubeconform` (K8s 1.30 schema validation)
- Wired into `release.yml` as a prerequisite — charts won't publish to gh-pages if validation fails

## What's tested

| Variant | Description | Resources |
|---------|-------------|-----------|
| default | `values.yaml` as-is | 7 |
| openshift | `values-openshift.yaml` overlay + Route | 7 |
| full | Ingress, NetworkPolicy, PDB, all secrets, watchdog | 9 |
| minimal | No persistence, no RBAC, no SA, no watchdog | 3 |

## Test plan
- [x] `helm lint` passes locally for both default and OpenShift values
- [x] `helm template` renders all 4 variants without errors
- [x] `kubeconform` validates all rendered YAML against K8s 1.30 schemas (16/16 valid)
- [ ] CI workflow runs on this PR (triggers on `deploy/helm/**` path match)