### PR TITLE
🐛 Fix Artifact Hub repository ID and preserve metadata on release

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -76,8 +76,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Copy chart package and build index
+          # Copy chart package, Artifact Hub metadata, and build index
           cp ../.helm-releases/*.tgz .
+          cp ../deploy/helm/kubestellar-console/artifacthub-repo.yml .
           helm repo index . --url https://kubestellar.github.io/console
           git add .
           git commit -m "Release Helm chart ${{ steps.version.outputs.version }}" || echo "No changes"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,8 +319,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Copy chart package and build index
+          # Copy chart package, Artifact Hub metadata, and build index
           cp ../.helm-releases/*.tgz .
+          cp ../deploy/helm/kubestellar-console/artifacthub-repo.yml .
           helm repo index . --url https://kubestellar.github.io/console
           git add .
           git commit -m "Release Helm chart ${{ needs.determine-version.outputs.version }}" || echo "No changes"

--- a/deploy/helm/kubestellar-console/artifacthub-repo.yml
+++ b/deploy/helm/kubestellar-console/artifacthub-repo.yml
@@ -1,6 +1,6 @@
 # Artifact Hub repository metadata
 # See https://artifacthub.io/docs/topics/repositories/helm-charts/
-repositoryID: kubestellar-console
+repositoryID: 9911473d-94b2-4b62-bbfa-a8b5acae052b
 owners:
   - name: Andy Anderson
     email: andy@clubanderson.com


### PR DESCRIPTION
## Summary
- Updates `artifacthub-repo.yml` with the actual repository ID (`9911473d-94b2-4b62-bbfa-a8b5acae052b`) from Artifact Hub registration
- Ensures `artifacthub-repo.yml` is copied to `gh-pages` during both `release.yml` and `helm-release.yml` chart publishes, so the Verified Publisher badge persists across nightly/weekly releases

## Test plan
- [x] Pushed `artifacthub-repo.yml` directly to `gh-pages` for immediate verification
- [ ] Artifact Hub processes the repo (~22 min) and shows Verified Publisher badge