### PR TITLE
✨ Wire live backends for topology/ArgoCD cards and add Lens migration page

### DIFF
--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -14,6 +14,9 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubestellar/console/pkg/api/v1alpha1"
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/mcp"
 )
@@ -1651,4 +1654,268 @@ func (h *GitOpsHandlers) findReleaseNamespace(ctx context.Context, cluster, rele
 		}
 	}
 	return ""
+}
+
+// ============================================================================
+// ArgoCD Endpoints
+// ============================================================================
+
+// argocdQueryTimeout is the timeout for querying ArgoCD Application CRDs across clusters
+const argocdQueryTimeout = 15 * time.Second
+
+// ListArgoApplications returns all ArgoCD Application resources across all clusters.
+// GET /api/gitops/argocd/applications
+// Query params: ?cluster=<name> (optional, filter by cluster)
+func (h *GitOpsHandlers) ListArgoApplications(c *fiber.Ctx) error {
+	if h.k8sClient == nil {
+		return c.Status(503).JSON(fiber.Map{
+			"error":   "Kubernetes client not configured",
+			"isDemoData": true,
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), argocdQueryTimeout)
+	defer cancel()
+
+	appList, err := h.k8sClient.ListArgoApplications(ctx)
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{
+			"error":   fmt.Sprintf("Failed to list ArgoCD applications: %v", err),
+			"isDemoData": true,
+		})
+	}
+
+	// Optional cluster filter
+	clusterFilter := c.Query("cluster")
+	if clusterFilter != "" {
+		filtered := make([]interface{}, 0)
+		for _, app := range appList.Items {
+			if app.Cluster == clusterFilter {
+				filtered = append(filtered, app)
+			}
+		}
+		return c.JSON(fiber.Map{
+			"items":      filtered,
+			"totalCount": len(filtered),
+			"isDemoData": false,
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"items":      appList.Items,
+		"totalCount": appList.TotalCount,
+		"isDemoData": false,
+	})
+}
+
+// GetArgoHealthSummary returns aggregated health status counts for all ArgoCD applications.
+// GET /api/gitops/argocd/health
+func (h *GitOpsHandlers) GetArgoHealthSummary(c *fiber.Ctx) error {
+	if h.k8sClient == nil {
+		return c.Status(503).JSON(fiber.Map{
+			"error":   "Kubernetes client not configured",
+			"isDemoData": true,
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), argocdQueryTimeout)
+	defer cancel()
+
+	appList, err := h.k8sClient.ListArgoApplications(ctx)
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{
+			"error":   fmt.Sprintf("Failed to list ArgoCD applications: %v", err),
+			"isDemoData": true,
+		})
+	}
+
+	// Aggregate health statuses
+	summary := fiber.Map{
+		"healthy":     0,
+		"degraded":    0,
+		"progressing": 0,
+		"missing":     0,
+		"unknown":     0,
+	}
+
+	for _, app := range appList.Items {
+		switch app.HealthStatus {
+		case "Healthy":
+			summary["healthy"] = summary["healthy"].(int) + 1
+		case "Degraded":
+			summary["degraded"] = summary["degraded"].(int) + 1
+		case "Progressing":
+			summary["progressing"] = summary["progressing"].(int) + 1
+		case "Missing":
+			summary["missing"] = summary["missing"].(int) + 1
+		default:
+			summary["unknown"] = summary["unknown"].(int) + 1
+		}
+	}
+
+	return c.JSON(fiber.Map{
+		"stats":      summary,
+		"isDemoData": false,
+	})
+}
+
+// GetArgoSyncSummary returns aggregated sync status counts for all ArgoCD applications.
+// GET /api/gitops/argocd/sync
+func (h *GitOpsHandlers) GetArgoSyncSummary(c *fiber.Ctx) error {
+	if h.k8sClient == nil {
+		return c.Status(503).JSON(fiber.Map{
+			"error":   "Kubernetes client not configured",
+			"isDemoData": true,
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), argocdQueryTimeout)
+	defer cancel()
+
+	appList, err := h.k8sClient.ListArgoApplications(ctx)
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{
+			"error":   fmt.Sprintf("Failed to list ArgoCD applications: %v", err),
+			"isDemoData": true,
+		})
+	}
+
+	// Aggregate sync statuses
+	summary := fiber.Map{
+		"synced":    0,
+		"outOfSync": 0,
+		"unknown":   0,
+	}
+
+	for _, app := range appList.Items {
+		switch app.SyncStatus {
+		case "Synced":
+			summary["synced"] = summary["synced"].(int) + 1
+		case "OutOfSync":
+			summary["outOfSync"] = summary["outOfSync"].(int) + 1
+		default:
+			summary["unknown"] = summary["unknown"].(int) + 1
+		}
+	}
+
+	return c.JSON(fiber.Map{
+		"stats":      summary,
+		"isDemoData": false,
+	})
+}
+
+// TriggerArgoSync triggers a sync operation for an ArgoCD Application.
+// This is a best-effort operation that patches the Application's operation field.
+// POST /api/gitops/argocd/sync
+func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
+	if h.k8sClient == nil {
+		return c.Status(503).JSON(fiber.Map{
+			"error":   "Kubernetes client not configured",
+			"success": false,
+		})
+	}
+
+	var req struct {
+		AppName   string `json:"appName"`
+		Namespace string `json:"namespace"`
+		Cluster   string `json:"cluster"`
+	}
+	if err := c.BodyParser(&req); err != nil {
+		return c.Status(400).JSON(fiber.Map{
+			"error":   "Invalid request body",
+			"success": false,
+		})
+	}
+
+	if req.AppName == "" || req.Cluster == "" {
+		return c.Status(400).JSON(fiber.Map{
+			"error":   "appName and cluster are required",
+			"success": false,
+		})
+	}
+
+	// Default namespace for ArgoCD applications
+	namespace := req.Namespace
+	if namespace == "" {
+		namespace = "argocd"
+	}
+
+	log.Printf("[ArgoCD] Triggering sync for %s/%s on cluster %s", namespace, req.AppName, req.Cluster)
+
+	// Use argocd CLI if available, otherwise try kubectl annotation refresh
+	if _, err := exec.LookPath("argocd"); err == nil {
+		cmd := exec.CommandContext(c.Context(), "argocd", "app", "sync", req.AppName,
+			"--namespace", namespace,
+			"--prune",
+			"--timeout", "30",
+		)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			log.Printf("[ArgoCD] CLI sync failed: %v, output: %s", err, string(output))
+			return c.Status(500).JSON(fiber.Map{
+				"error":   fmt.Sprintf("ArgoCD sync failed: %v", err),
+				"success": false,
+			})
+		}
+		return c.JSON(fiber.Map{
+			"success": true,
+			"message": "Sync triggered via ArgoCD CLI",
+		})
+	}
+
+	// Fallback: annotate the Application to trigger a refresh
+	dynamicClient, err := h.k8sClient.GetDynamicClient(req.Cluster)
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{
+			"error":   fmt.Sprintf("Failed to get dynamic client: %v", err),
+			"success": false,
+		})
+	}
+
+	// Fetch the current Application to patch it
+	ctx, cancel := context.WithTimeout(c.Context(), argocdQueryTimeout)
+	defer cancel()
+
+	app, err := dynamicClient.Resource(v1alpha1.ArgoApplicationGVR).Namespace(namespace).Get(ctx, req.AppName, metav1.GetOptions{})
+	if err != nil {
+		return c.Status(404).JSON(fiber.Map{
+			"error":   fmt.Sprintf("Application %s not found in %s/%s: %v", req.AppName, req.Cluster, namespace, err),
+			"success": false,
+		})
+	}
+
+	// Set the refresh annotation to trigger ArgoCD's reconciliation
+	annotations := app.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["argocd.argoproj.io/refresh"] = "hard"
+	app.SetAnnotations(annotations)
+
+	// Also set the operation field to trigger a sync
+	content := app.UnstructuredContent()
+	operation := map[string]interface{}{
+		"initiatedBy": map[string]interface{}{
+			"username":  "kubestellar-console",
+			"automated": false,
+		},
+		"sync": map[string]interface{}{
+			"prune": true,
+		},
+	}
+	content["operation"] = operation
+	app.SetUnstructuredContent(content)
+
+	_, err = dynamicClient.Resource(v1alpha1.ArgoApplicationGVR).Namespace(namespace).Update(ctx, app, metav1.UpdateOptions{})
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{
+			"error":   fmt.Sprintf("Failed to trigger sync: %v", err),
+			"success": false,
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"success": true,
+		"message": "Sync triggered via Application resource annotation",
+	})
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -607,6 +607,11 @@ func (s *Server) setupRoutes() {
 	api.Get("/gitops/helm-releases/stream", gitopsHandlers.StreamHelmReleases)
 	api.Post("/gitops/detect-drift", gitopsHandlers.DetectDrift)
 	api.Post("/gitops/sync", gitopsHandlers.Sync)
+	// ArgoCD routes (Application CRD discovery and sync)
+	api.Get("/gitops/argocd/applications", gitopsHandlers.ListArgoApplications)
+	api.Get("/gitops/argocd/health", gitopsHandlers.GetArgoHealthSummary)
+	api.Get("/gitops/argocd/sync", gitopsHandlers.GetArgoSyncSummary)
+	api.Post("/gitops/argocd/sync", gitopsHandlers.TriggerArgoSync)
 	// Frontend compatibility alias
 	api.Get("/mcp/operator-subscriptions", gitopsHandlers.ListOperatorSubscriptions)
 

--- a/pkg/api/v1alpha1/argocd_types.go
+++ b/pkg/api/v1alpha1/argocd_types.go
@@ -1,0 +1,97 @@
+// Package v1alpha1 contains API type definitions for KubeStellar Console CRDs
+package v1alpha1
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ArgoCD Application CRD Group Version Resources
+var (
+	// ArgoApplicationGVR is the GroupVersionResource for ArgoCD Application (v1alpha1)
+	ArgoApplicationGVR = schema.GroupVersionResource{
+		Group:    "argoproj.io",
+		Version:  "v1alpha1",
+		Resource: "applications",
+	}
+)
+
+// ArgoApplication represents an ArgoCD Application resource
+type ArgoApplication struct {
+	Name         string                `json:"name"`
+	Namespace    string                `json:"namespace"`
+	Cluster      string                `json:"cluster"`
+	SyncStatus   string                `json:"syncStatus"`   // Synced, OutOfSync, Unknown
+	HealthStatus string                `json:"healthStatus"` // Healthy, Degraded, Progressing, Missing, Unknown
+	Source       ArgoApplicationSource `json:"source"`
+	LastSynced   string                `json:"lastSynced,omitempty"`
+}
+
+// ArgoApplicationSource represents the source of an ArgoCD Application
+type ArgoApplicationSource struct {
+	RepoURL        string `json:"repoURL"`
+	Path           string `json:"path"`
+	TargetRevision string `json:"targetRevision"`
+}
+
+// ArgoApplicationList is a list of ArgoCD Applications
+type ArgoApplicationList struct {
+	Items      []ArgoApplication `json:"items"`
+	TotalCount int               `json:"totalCount"`
+}
+
+// ArgoHealthSummary aggregates health status counts across applications
+type ArgoHealthSummary struct {
+	Healthy     int `json:"healthy"`
+	Degraded    int `json:"degraded"`
+	Progressing int `json:"progressing"`
+	Missing     int `json:"missing"`
+	Unknown     int `json:"unknown"`
+}
+
+// ArgoSyncSummary aggregates sync status counts across applications
+type ArgoSyncSummary struct {
+	Synced    int `json:"synced"`
+	OutOfSync int `json:"outOfSync"`
+	Unknown   int `json:"unknown"`
+}
+
+// ArgoSyncRequest is the request body for triggering an ArgoCD sync
+type ArgoSyncRequest struct {
+	AppName   string `json:"appName"`
+	Namespace string `json:"namespace"`
+	Cluster   string `json:"cluster"`
+}
+
+// TimeSinceArgo returns a human-readable duration since the given time
+func TimeSinceArgo(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	d := time.Since(t)
+	const hoursPerDay = 24
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		mins := int(d.Minutes())
+		if mins == 1 {
+			return "1 minute ago"
+		}
+		return fmt.Sprintf("%d minutes ago", mins)
+	case d < hoursPerDay*time.Hour:
+		hours := int(d.Hours())
+		if hours == 1 {
+			return "1 hour ago"
+		}
+		return fmt.Sprintf("%d hours ago", hours)
+	default:
+		days := int(d.Hours() / hoursPerDay)
+		if days == 1 {
+			return "1 day ago"
+		}
+		return fmt.Sprintf("%d days ago", days)
+	}
+}

--- a/pkg/k8s/argocd.go
+++ b/pkg/k8s/argocd.go
@@ -1,0 +1,167 @@
+package k8s
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kubestellar/console/pkg/api/v1alpha1"
+)
+
+// ISO 8601 layouts used by ArgoCD for timestamp fields
+var argoTimestampLayouts = []string{
+	time.RFC3339,                // 2006-01-02T15:04:05Z07:00
+	"2006-01-02T15:04:05Z",     // UTC explicit
+	"2006-01-02T15:04:05.000Z", // millisecond precision
+}
+
+// ListArgoApplications lists all ArgoCD Application resources across all clusters.
+// If ArgoCD CRDs are not installed on a cluster, that cluster is silently skipped.
+func (m *MultiClusterClient) ListArgoApplications(ctx context.Context) (*v1alpha1.ArgoApplicationList, error) {
+	m.mu.RLock()
+	clusters := make([]string, 0, len(m.clients))
+	for name := range m.clients {
+		clusters = append(clusters, name)
+	}
+	m.mu.RUnlock()
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	apps := make([]v1alpha1.ArgoApplication, 0)
+
+	for _, clusterName := range clusters {
+		wg.Add(1)
+		go func(cluster string) {
+			defer wg.Done()
+
+			clusterApps, err := m.ListArgoApplicationsForCluster(ctx, cluster, "")
+			if err != nil {
+				return // CRD not installed or cluster unreachable — skip silently
+			}
+
+			mu.Lock()
+			apps = append(apps, clusterApps...)
+			mu.Unlock()
+		}(clusterName)
+	}
+
+	wg.Wait()
+
+	return &v1alpha1.ArgoApplicationList{
+		Items:      apps,
+		TotalCount: len(apps),
+	}, nil
+}
+
+// ListArgoApplicationsForCluster lists ArgoCD Application resources in a specific cluster.
+// Returns an empty list (not an error) if ArgoCD CRDs are not installed.
+func (m *MultiClusterClient) ListArgoApplicationsForCluster(ctx context.Context, contextName, namespace string) ([]v1alpha1.ArgoApplication, error) {
+	dynamicClient, err := m.GetDynamicClient(contextName)
+	if err != nil {
+		return nil, err
+	}
+
+	var list interface{}
+	if namespace == "" {
+		list, err = dynamicClient.Resource(v1alpha1.ArgoApplicationGVR).List(ctx, metav1.ListOptions{})
+	} else {
+		list, err = dynamicClient.Resource(v1alpha1.ArgoApplicationGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	}
+
+	if err != nil {
+		// ArgoCD CRDs might not be installed — return empty list instead of error
+		return []v1alpha1.ArgoApplication{}, nil
+	}
+
+	return m.parseArgoApplicationsFromList(list, contextName)
+}
+
+// parseArgoApplicationsFromList parses ArgoCD Applications from an unstructured list
+func (m *MultiClusterClient) parseArgoApplicationsFromList(list interface{}, contextName string) ([]v1alpha1.ArgoApplication, error) {
+	apps := make([]v1alpha1.ArgoApplication, 0)
+
+	uList, ok := list.(*unstructured.UnstructuredList)
+	if !ok {
+		return apps, nil
+	}
+
+	for i := range uList.Items {
+		item := &uList.Items[i]
+		content := item.UnstructuredContent()
+
+		app := v1alpha1.ArgoApplication{
+			Name:         item.GetName(),
+			Namespace:    item.GetNamespace(),
+			Cluster:      contextName,
+			SyncStatus:   "Unknown",
+			HealthStatus: "Unknown",
+		}
+
+		// Parse spec.source
+		if spec, found, _ := unstructuredNestedMap(content, "spec"); found {
+			if source, sourceFound, _ := unstructuredNestedMap(spec, "source"); sourceFound {
+				if repoURL, ok := source["repoURL"].(string); ok {
+					app.Source.RepoURL = repoURL
+				}
+				if path, ok := source["path"].(string); ok {
+					app.Source.Path = path
+				}
+				if targetRevision, ok := source["targetRevision"].(string); ok {
+					app.Source.TargetRevision = targetRevision
+				}
+			}
+		}
+
+		// Parse status.sync.status and status.health.status
+		if status, found, _ := unstructuredNestedMap(content, "status"); found {
+			if syncMap, syncFound, _ := unstructuredNestedMap(status, "sync"); syncFound {
+				if syncStatus, ok := syncMap["status"].(string); ok {
+					app.SyncStatus = syncStatus
+				}
+			}
+
+			if healthMap, healthFound, _ := unstructuredNestedMap(status, "health"); healthFound {
+				if healthStatus, ok := healthMap["status"].(string); ok {
+					app.HealthStatus = healthStatus
+				}
+			}
+
+			// Parse status.operationState.finishedAt for lastSynced
+			if opState, opFound, _ := unstructuredNestedMap(status, "operationState"); opFound {
+				if finishedAt, ok := opState["finishedAt"].(string); ok {
+					app.LastSynced = parseArgoTimeAgo(finishedAt)
+				}
+			}
+
+			// Fallback: use reconciledAt
+			if app.LastSynced == "" {
+				if reconciledAt, ok := status["reconciledAt"].(string); ok {
+					app.LastSynced = parseArgoTimeAgo(reconciledAt)
+				}
+			}
+		}
+
+		apps = append(apps, app)
+	}
+
+	return apps, nil
+}
+
+// parseArgoTimeAgo converts an ISO 8601 timestamp string to a human-readable "X ago" format
+func parseArgoTimeAgo(timeStr string) string {
+	if timeStr == "" {
+		return ""
+	}
+
+	for _, layout := range argoTimestampLayouts {
+		if parsedTime, err := time.Parse(layout, timeStr); err == nil {
+			return v1alpha1.TimeSinceArgo(parsedTime)
+		}
+	}
+
+	// If we can't parse the timestamp, return the raw string
+	return timeStr
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -69,6 +69,7 @@ const CICD = lazy(() => import('./components/cicd/CICD').then(m => ({ default: m
 const Insights = lazy(() => import('./components/insights/Insights').then(m => ({ default: m.Insights })))
 const Marketplace = lazy(() => import('./components/marketplace/Marketplace').then(m => ({ default: m.Marketplace })))
 const MiniDashboard = lazy(() => import('./components/widget/MiniDashboard').then(m => ({ default: m.MiniDashboard })))
+const FromLens = lazy(() => import('./pages/FromLens').then(m => ({ default: m.FromLens })))
 const UnifiedCardTest = lazy(() => import('./pages/UnifiedCardTest').then(m => ({ default: m.UnifiedCardTest })))
 const UnifiedStatsTest = lazy(() => import('./pages/UnifiedStatsTest').then(m => ({ default: m.UnifiedStatsTest })))
 const UnifiedDashboardTest = lazy(() => import('./pages/UnifiedDashboardTest').then(m => ({ default: m.UnifiedDashboardTest })))
@@ -332,6 +333,7 @@ const ROUTE_TITLES: Record<string, string> = {
   '/settings': 'Settings',
   '/users': 'User Management',
   '/login': 'Login',
+  '/from-lens': 'Switching from Lens',
 }
 
 const APP_NAME = 'KubeStellar Console'
@@ -441,6 +443,7 @@ function App() {
       <Suspense fallback={<LoadingFallback />}>
       <Routes>
         <Route path="/login" element={<Login />} />
+        <Route path="/from-lens" element={<FromLens />} />
         <Route path="/auth/callback" element={<AuthCallback />} />
         {/* PWA Mini Dashboard - lightweight widget mode (no auth required for local monitoring) */}
         <Route path="/widget" element={<MiniDashboard />} />

--- a/web/src/components/cards/ArgoCDApplications.tsx
+++ b/web/src/components/cards/ArgoCDApplications.tsx
@@ -18,7 +18,6 @@ import {
 } from '../../lib/cards/CardComponents'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { useTranslation } from 'react-i18next'
-import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface ArgoCDApplicationsProps {
   config?: {
@@ -68,10 +67,10 @@ function ArgoCDApplicationsInternal({ config }: ArgoCDApplicationsProps) {
     isLoading,
     isFailed,
     consecutiveFailures,
+    isDemoData,
   } = useArgoCDApplications()
   const { drillToArgoApp } = useDrillDownActions()
   const { triggerSync } = useArgoCDTriggerSync()
-  const { isDemoMode } = useDemoMode()
   // Track per-app sync state with a Set to avoid shared-boolean race conditions
   const [syncingApps, setSyncingApps] = useState<Set<string>>(new Set())
   const addSyncingApp = (key: string) => setSyncingApps(prev => new Set(prev).add(key))
@@ -83,7 +82,7 @@ function ArgoCDApplicationsInternal({ config }: ArgoCDApplicationsProps) {
     hasAnyData: allApps.length > 0,
     isFailed,
     consecutiveFailures,
-    isDemoData: isDemoMode,
+    isDemoData,
   })
 
   // Translated sort options

--- a/web/src/components/cards/ArgoCDHealth.tsx
+++ b/web/src/components/cards/ArgoCDHealth.tsx
@@ -3,7 +3,6 @@ import { Skeleton } from '../ui/Skeleton'
 import { useArgoCDHealth } from '../../hooks/useArgoCD'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
-import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface ArgoCDHealthProps {
   config?: Record<string, unknown>
@@ -35,8 +34,8 @@ export function ArgoCDHealth({ config: _config }: ArgoCDHealthProps) {
     isLoading,
     isFailed,
     consecutiveFailures,
+    isDemoData,
   } = useArgoCDHealth()
-  const { isDemoMode } = useDemoMode()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton, showEmptyState } = useCardLoadingState({
@@ -44,7 +43,7 @@ export function ArgoCDHealth({ config: _config }: ArgoCDHealthProps) {
     hasAnyData: total > 0,
     isFailed,
     consecutiveFailures,
-    isDemoData: isDemoMode,
+    isDemoData,
   })
 
   if (showSkeleton) {

--- a/web/src/components/cards/ArgoCDSyncStatus.tsx
+++ b/web/src/components/cards/ArgoCDSyncStatus.tsx
@@ -3,7 +3,6 @@ import { Skeleton } from '../ui/Skeleton'
 import { useChartFilters, CardClusterFilter } from '../../lib/cards'
 import { useArgoCDSyncStatus } from '../../hooks/useArgoCD'
 import { useCardLoadingState } from './CardDataContext'
-import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
 
 interface ArgoCDSyncStatusProps {
@@ -12,7 +11,6 @@ interface ArgoCDSyncStatusProps {
 
 export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
   const { t } = useTranslation('cards')
-  const { isDemoMode: demoMode } = useDemoMode()
   // Local cluster filter
   const {
     localClusterFilter,
@@ -34,6 +32,7 @@ export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
     isLoading,
     isFailed,
     consecutiveFailures,
+    isDemoData,
   } = useArgoCDSyncStatus(localClusterFilter)
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
@@ -42,7 +41,7 @@ export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
     hasAnyData: total > 0,
     isFailed,
     consecutiveFailures,
-    isDemoData: demoMode,
+    isDemoData,
   })
 
   if (showSkeleton) {

--- a/web/src/components/cards/ServiceTopology.tsx
+++ b/web/src/components/cards/ServiceTopology.tsx
@@ -2,53 +2,12 @@ import { useState, useMemo, useCallback } from 'react'
 import { ZoomIn, ZoomOut, Maximize2, ArrowRight } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { StatusBadge } from '../ui/StatusBadge'
+import { Skeleton } from '../ui/Skeleton'
 import type { TopologyNode, TopologyEdge, TopologyHealthStatus } from '../../types/topology'
 import { useReportCardDataState } from './CardDataContext'
+import { useTopology } from '../../hooks/useTopology'
 import { Button } from '../ui/Button'
 import { useTranslation } from 'react-i18next'
-
-// Demo topology data
-const DEMO_NODES: TopologyNode[] = [
-  // Clusters
-  { id: 'cluster:us-east-1', type: 'cluster', label: 'us-east-1', cluster: 'us-east-1', health: 'healthy' },
-  { id: 'cluster:us-west-2', type: 'cluster', label: 'us-west-2', cluster: 'us-west-2', health: 'healthy' },
-  { id: 'cluster:eu-central-1', type: 'cluster', label: 'eu-central-1', cluster: 'eu-central-1', health: 'healthy' },
-  // Services in us-east-1
-  { id: 'service:us-east-1:production:api-gateway', type: 'service', label: 'api-gateway', cluster: 'us-east-1', namespace: 'production', health: 'healthy', metadata: { exported: true, endpoints: 3 } },
-  { id: 'service:us-east-1:production:auth-service', type: 'service', label: 'auth-service', cluster: 'us-east-1', namespace: 'production', health: 'healthy', metadata: { exported: true, endpoints: 2 } },
-  { id: 'service:us-east-1:production:user-service', type: 'service', label: 'user-service', cluster: 'us-east-1', namespace: 'production', health: 'healthy', metadata: { endpoints: 4 } },
-  // Services in us-west-2
-  { id: 'service:us-west-2:production:api-gateway', type: 'service', label: 'api-gateway', cluster: 'us-west-2', namespace: 'production', health: 'healthy', metadata: { imported: true, sourceCluster: 'us-east-1' } },
-  { id: 'service:us-west-2:infrastructure:cache-redis', type: 'service', label: 'cache-redis', cluster: 'us-west-2', namespace: 'infrastructure', health: 'healthy', metadata: { exported: true, endpoints: 1 } },
-  // Services in eu-central-1
-  { id: 'service:eu-central-1:production:auth-service', type: 'service', label: 'auth-service', cluster: 'eu-central-1', namespace: 'production', health: 'healthy', metadata: { imported: true, sourceCluster: 'us-east-1' } },
-  { id: 'service:eu-central-1:production:payment-processor', type: 'service', label: 'payment-processor', cluster: 'eu-central-1', namespace: 'production', health: 'degraded', metadata: { endpoints: 0 } },
-  // Gateways
-  { id: 'gateway:us-east-1:gateway-system:prod-gateway', type: 'gateway', label: 'prod-gateway', cluster: 'us-east-1', namespace: 'gateway-system', health: 'healthy', metadata: { gatewayClass: 'istio', addresses: ['34.102.136.180'] } },
-  { id: 'gateway:us-west-2:gateway-system:api-gateway', type: 'gateway', label: 'api-gateway', cluster: 'us-west-2', namespace: 'gateway-system', health: 'healthy', metadata: { gatewayClass: 'envoy-gateway', addresses: ['10.0.0.50'] } },
-]
-
-const DEMO_EDGES: TopologyEdge[] = [
-  // MCS cross-cluster connections
-  { id: 'mcs:api-gateway:east-west', source: 'service:us-east-1:production:api-gateway', target: 'service:us-west-2:production:api-gateway', type: 'mcs-export', label: 'MCS', health: 'healthy', animated: true },
-  { id: 'mcs:auth:east-eu', source: 'service:us-east-1:production:auth-service', target: 'service:eu-central-1:production:auth-service', type: 'mcs-export', label: 'MCS', health: 'healthy', animated: true },
-  // Internal connections
-  { id: 'internal:api-user:east', source: 'service:us-east-1:production:api-gateway', target: 'service:us-east-1:production:user-service', type: 'internal', health: 'healthy', animated: false },
-  { id: 'internal:api-auth:east', source: 'service:us-east-1:production:api-gateway', target: 'service:us-east-1:production:auth-service', type: 'internal', health: 'healthy', animated: false },
-  // Gateway routes
-  { id: 'route:prod-gateway:api', source: 'gateway:us-east-1:gateway-system:prod-gateway', target: 'service:us-east-1:production:api-gateway', type: 'http-route', label: 'HTTPRoute', health: 'healthy', animated: true },
-  { id: 'route:api-gateway:west', source: 'gateway:us-west-2:gateway-system:api-gateway', target: 'service:us-west-2:production:api-gateway', type: 'http-route', label: 'HTTPRoute', health: 'healthy', animated: true },
-]
-
-const DEMO_STATS = {
-  totalNodes: 12,
-  totalEdges: 8,
-  healthyConnections: 7,
-  degradedConnections: 1,
-  clusters: 3,
-  services: 8,
-  gateways: 2,
-}
 
 // Color mapping for node types
 const getNodeColor = (type: TopologyNode['type'], health: TopologyHealthStatus) => {
@@ -84,36 +43,71 @@ interface ServiceTopologyProps {
 
 export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
   const { t } = useTranslation(['cards', 'common'])
-  useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
+  const {
+    graph,
+    stats,
+    isLoading,
+    isFailed,
+    consecutiveFailures,
+    isDemoData,
+  } = useTopology()
+
+  useReportCardDataState({
+    hasData: !!graph,
+    isFailed,
+    consecutiveFailures,
+    isDemoData,
+    isLoading,
+  })
+
   const [zoom, setZoom] = useState(1)
   const [selectedNode, setSelectedNode] = useState<string | null>(null)
   const [hoveredNode, setHoveredNode] = useState<string | null>(null)
 
+  // Use nodes and edges from the topology hook (guarded against undefined)
+  const nodes = useMemo<TopologyNode[]>(() => graph?.nodes || [], [graph?.nodes])
+  const edges = useMemo<TopologyEdge[]>(() => graph?.edges || [], [graph?.edges])
+
+  // Derive stat counts from nodes when API stats don't include per-type breakdowns
+  const derivedStats = useMemo(() => {
+    const clusterCount = nodes.filter(n => n.type === 'cluster').length
+    const serviceCount = nodes.filter(n => n.type === 'service').length
+    const gatewayCount = nodes.filter(n => n.type === 'gateway').length
+    const totalEdges = stats?.totalEdges ?? edges.length
+    return { clusters: clusterCount, services: serviceCount, gateways: gatewayCount, totalEdges }
+  }, [nodes, edges, stats])
+
   // Group nodes by cluster for layout
   const nodesByCluster = useMemo(() => {
     const grouped: Record<string, TopologyNode[]> = {}
-    DEMO_NODES.forEach(node => {
+    for (const node of nodes) {
       if (!grouped[node.cluster]) {
         grouped[node.cluster] = []
       }
       grouped[node.cluster].push(node)
-    })
+    }
     return grouped
-  }, [])
+  }, [nodes])
 
   // Calculate node positions for simple visualization
   const nodePositions = useMemo(() => {
     const positions: Record<string, { x: number; y: number }> = {}
-    const clusters = Object.keys(nodesByCluster)
-    const clusterWidth = 100 / (clusters.length + 1)
+    const clusterKeys = Object.keys(nodesByCluster)
+    const clusterWidth = 100 / (clusterKeys.length + 1)
 
-    clusters.forEach((cluster, clusterIndex) => {
-      const nodes = nodesByCluster[cluster]
+    clusterKeys.forEach((cluster, clusterIndex) => {
+      const clusterNodes = nodesByCluster[cluster] || []
       const clusterX = (clusterIndex + 1) * clusterWidth
 
-      nodes.forEach((node, nodeIndex) => {
-        const nodeY = 15 + (nodeIndex * 18)
-        positions[node.id] = { x: clusterX, y: Math.min(nodeY, 85) }
+      clusterNodes.forEach((node, nodeIndex) => {
+        /** Vertical spacing between nodes within a cluster (percentage units) */
+        const NODE_VERTICAL_SPACING = 18
+        /** Starting vertical offset for the first node in a cluster */
+        const NODE_VERTICAL_START = 15
+        /** Maximum vertical position to prevent nodes from going off-screen */
+        const NODE_MAX_Y = 85
+        const nodeY = NODE_VERTICAL_START + (nodeIndex * NODE_VERTICAL_SPACING)
+        positions[node.id] = { x: clusterX, y: Math.min(nodeY, NODE_MAX_Y) }
       })
     })
 
@@ -124,7 +118,18 @@ export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
   const handleZoomOut = useCallback(() => setZoom(z => Math.max(z - 0.2, 0.5)), [])
   const handleResetZoom = useCallback(() => setZoom(1), [])
 
-  const selectedNodeData = selectedNode ? DEMO_NODES.find(n => n.id === selectedNode) : null
+  const selectedNodeData = selectedNode ? nodes.find(n => n.id === selectedNode) : null
+
+  // Loading skeleton
+  if (isLoading && nodes.length === 0) {
+    return (
+      <div className="h-full flex flex-col min-h-card p-2 space-y-2">
+        <Skeleton className="h-4 w-1/3" />
+        <Skeleton className="h-3 w-2/3" />
+        <Skeleton className="flex-1 w-full rounded-lg" />
+      </div>
+    )
+  }
 
   return (
     <div className="h-full flex flex-col min-h-card">
@@ -162,19 +167,19 @@ export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
       <div className="flex items-center gap-3 mb-2 text-2xs">
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-full bg-purple-500" />
-          <span className="text-muted-foreground">{t('serviceTopology.nClusters', { count: DEMO_STATS.clusters })}</span>
+          <span className="text-muted-foreground">{t('serviceTopology.nClusters', { count: derivedStats.clusters })}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-full bg-blue-500" />
-          <span className="text-muted-foreground">{t('serviceTopology.nServices', { count: DEMO_STATS.services })}</span>
+          <span className="text-muted-foreground">{t('serviceTopology.nServices', { count: derivedStats.services })}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-2 h-2 rounded-full bg-green-500" />
-          <span className="text-muted-foreground">{t('serviceTopology.nGateways', { count: DEMO_STATS.gateways })}</span>
+          <span className="text-muted-foreground">{t('serviceTopology.nGateways', { count: derivedStats.gateways })}</span>
         </div>
         <div className="flex items-center gap-1">
           <ArrowRight className="w-3 h-3 text-cyan-400" />
-          <span className="text-muted-foreground">{t('serviceTopology.nConnections', { count: DEMO_STATS.totalEdges })}</span>
+          <span className="text-muted-foreground">{t('serviceTopology.nConnections', { count: derivedStats.totalEdges })}</span>
         </div>
       </div>
 
@@ -221,7 +226,7 @@ export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
           </defs>
 
           {/* Render edges */}
-          {DEMO_EDGES.map(edge => {
+          {(edges).map(edge => {
             const sourcePos = nodePositions[edge.source]
             const targetPos = nodePositions[edge.target]
             if (!sourcePos || !targetPos) return null
@@ -266,14 +271,18 @@ export function ServiceTopology({ config: _config }: ServiceTopologyProps) {
           })}
 
           {/* Render nodes */}
-          {DEMO_NODES.map(node => {
+          {(nodes).map(node => {
             const pos = nodePositions[node.id]
             if (!pos) return null
 
             const isSelected = selectedNode === node.id
             const isHovered = hoveredNode === node.id
             const colorClass = getNodeColor(node.type, node.health)
-            const radius = node.type === 'cluster' ? 4 : 2.5
+            /** Radius for cluster-type nodes (larger to visually distinguish) */
+            const CLUSTER_NODE_RADIUS = 4
+            /** Radius for non-cluster nodes (services, gateways, external) */
+            const DEFAULT_NODE_RADIUS = 2.5
+            const radius = node.type === 'cluster' ? CLUSTER_NODE_RADIUS : DEFAULT_NODE_RADIUS
 
             return (
               <g

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -569,8 +569,7 @@ export const DEMO_DATA_CARDS = new Set([
   'service_imports',
   // Gateway API cards - demo until Gateway API is installed
   'gateway_status',
-  // Service Topology - demo visualization
-  'service_topology',
+  // Note: service_topology removed — now reports isDemoData via useTopology hook
   // Note: buildpacks_status removed — reports isDemoData via useBuildpackImages hook
   'flatcar_status',
   'thanos_status',
@@ -580,10 +579,9 @@ export const DEMO_DATA_CARDS = new Set([
 
   // Workload Deployment - uses real data when backend is running, falls back to demo internally
   // NOT in DEMO_DATA_CARDS because the static badge can't detect runtime data source
-  // ArgoCD cards - all use mock data
-  'argocd_applications',
-  'argocd_health',
-  // Note: argocd_sync_status removed — reports isDemoData via demoMode check
+  // Note: argocd_applications removed — now reports isDemoData via useArgoCDApplications hook
+  // Note: argocd_health removed — now reports isDemoData via useArgoCDHealth hook
+  // Note: argocd_sync_status removed — reports isDemoData via useArgoCDSyncStatus hook
   // GitOps cards - use mock data
   // Note: kustomization_status removed — reports isDemoData via demoMode check
   // Helm cards - all now use real data via helm CLI backend

--- a/web/src/config/cards/service-topology.ts
+++ b/web/src/config/cards/service-topology.ts
@@ -16,7 +16,7 @@ export const serviceTopologyConfig: UnifiedCardConfig = {
   content: { type: 'custom', component: 'ServiceTopologyGraph' },
   emptyState: { icon: 'Network', title: 'No Topology', message: 'Service topology data unavailable', variant: 'info' },
   loadingState: { type: 'custom' },
-  isDemoData: true,
-  isLive: false,
+  isDemoData: false,
+  isLive: true,
 }
 export default serviceTopologyConfig

--- a/web/src/config/routes.ts
+++ b/web/src/config/routes.ts
@@ -69,6 +69,9 @@ export const ROUTES = {
 
   // Widget
   WIDGET: '/widget',
+
+  // Marketing / competitive landing pages
+  FROM_LENS: '/from-lens',
 } as const
 
 /**

--- a/web/src/hooks/useArgoCD.ts
+++ b/web/src/hooks/useArgoCD.ts
@@ -1,24 +1,29 @@
 /**
- * ArgoCD Data Hooks with localStorage caching and failure tracking
+ * ArgoCD Data Hooks with real backend API and mock data fallback
  *
- * These hooks provide:
- * - localStorage cache load/save with 5 minute expiry
- * - consecutiveFailures state for tracking fetch issues
- * - isFailed computed value (true when 3+ consecutive failures)
- * - isRefreshing state for stale-while-revalidate pattern
- * - State initialization from cache on mount
+ * These hooks:
+ * 1. Try to fetch from the real backend API (/api/gitops/argocd/*)
+ * 2. If the API returns real data, use it (isDemoData = false)
+ * 3. If the API fails (503, network error, ArgoCD not installed), fall back
+ *    to mock data generators (isDemoData = true)
+ * 4. Provide localStorage caching with 5 minute expiry
+ * 5. Track consecutive failures for stale-while-revalidate
  */
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { useGlobalFilters } from './useGlobalFilters'
-import { MOCK_SYNC_DELAY_MS } from '../lib/constants/network'
+import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS, MOCK_SYNC_DELAY_MS } from '../lib/constants/network'
 
 // Cache expiry time (5 minutes)
-const CACHE_EXPIRY_MS = 300000
+const CACHE_EXPIRY_MS = 300_000
 
 // Refresh interval (2 minutes)
-const REFRESH_INTERVAL_MS = 120000
+const REFRESH_INTERVAL_MS = 120_000
+
+// Number of consecutive failures before marking as failed
+const FAILURE_THRESHOLD = 3
 
 // ============================================================================
 // Types
@@ -55,6 +60,18 @@ export interface ArgoSyncData {
 interface CachedData<T> {
   data: T
   timestamp: number
+  isDemoData: boolean
+}
+
+// ============================================================================
+// Auth Helper
+// ============================================================================
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = { 'Accept': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
 }
 
 // ============================================================================
@@ -77,11 +94,12 @@ function loadFromCache<T>(key: string): CachedData<T> | null {
   return null
 }
 
-function saveToCache<T>(key: string, data: T): void {
+function saveToCache<T>(key: string, data: T, isDemoData: boolean): void {
   try {
     localStorage.setItem(key, JSON.stringify({
       data,
       timestamp: Date.now(),
+      isDemoData,
     }))
   } catch {
     // Ignore storage errors (quota, etc.)
@@ -89,7 +107,7 @@ function saveToCache<T>(key: string, data: T): void {
 }
 
 // ============================================================================
-// Mock Data Generators
+// Mock Data Generators (fallback when ArgoCD is not installed)
 // ============================================================================
 
 /**
@@ -97,13 +115,11 @@ function saveToCache<T>(key: string, data: T): void {
  *
  * SECURITY: Safe - These are example/placeholder URLs for demo purposes only
  * NOT REAL CREDENTIALS - Example GitHub URLs used for UI demonstration
- * In production, ArgoCD applications would be fetched from the ArgoCD API
- * with real repository URLs from user's actual ArgoCD installation.
  */
 function getMockArgoApplications(clusters: string[]): ArgoApplication[] {
   const apps: ArgoApplication[] = []
 
-  clusters.forEach((cluster) => {
+  ;(clusters || []).forEach((cluster) => {
     const baseApps = [
       {
         name: 'frontend-app',
@@ -169,20 +185,128 @@ function getMockArgoApplications(clusters: string[]): ArgoApplication[] {
 }
 
 function getMockHealthData(clusterCount: number): ArgoHealthData {
+  const HEALTHY_MULTIPLIER = 3.8
+  const DEGRADED_MULTIPLIER = 0.8
+  const PROGRESSING_MULTIPLIER = 0.5
+  const MISSING_MULTIPLIER = 0.2
+  const UNKNOWN_MULTIPLIER = 0.1
   return {
-    healthy: Math.floor(clusterCount * 3.8),
-    degraded: Math.floor(clusterCount * 0.8),
-    progressing: Math.floor(clusterCount * 0.5),
-    missing: Math.floor(clusterCount * 0.2),
-    unknown: Math.floor(clusterCount * 0.1),
+    healthy: Math.floor(clusterCount * HEALTHY_MULTIPLIER),
+    degraded: Math.floor(clusterCount * DEGRADED_MULTIPLIER),
+    progressing: Math.floor(clusterCount * PROGRESSING_MULTIPLIER),
+    missing: Math.floor(clusterCount * MISSING_MULTIPLIER),
+    unknown: Math.floor(clusterCount * UNKNOWN_MULTIPLIER),
   }
 }
 
 function getMockSyncStatusData(clusterCount: number): ArgoSyncData {
+  const SYNCED_MULTIPLIER = 4.2
+  const OUT_OF_SYNC_MULTIPLIER = 1.3
+  const UNKNOWN_MULTIPLIER = 0.3
   return {
-    synced: Math.floor(clusterCount * 4.2),
-    outOfSync: Math.floor(clusterCount * 1.3),
-    unknown: Math.floor(clusterCount * 0.3),
+    synced: Math.floor(clusterCount * SYNCED_MULTIPLIER),
+    outOfSync: Math.floor(clusterCount * OUT_OF_SYNC_MULTIPLIER),
+    unknown: Math.floor(clusterCount * UNKNOWN_MULTIPLIER),
+  }
+}
+
+// ============================================================================
+// API Fetch Helpers
+// ============================================================================
+
+/** Fetch ArgoCD applications from backend API */
+async function fetchArgoApplications(): Promise<{ items: ArgoApplication[]; isDemoData: boolean }> {
+  const ctrl = new AbortController()
+  const tid = setTimeout(() => ctrl.abort(), FETCH_DEFAULT_TIMEOUT_MS)
+  try {
+    const res = await fetch('/api/gitops/argocd/applications', {
+      signal: ctrl.signal,
+      headers: authHeaders(),
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      if (body.isDemoData) {
+        return { items: [], isDemoData: true }
+      }
+      throw new Error(`API ${res.status}: ${body.error || res.statusText}`)
+    }
+    const data = await res.json()
+    return {
+      items: (data.items || []) as ArgoApplication[],
+      isDemoData: data.isDemoData === true,
+    }
+  } finally {
+    clearTimeout(tid)
+  }
+}
+
+/** Fetch ArgoCD health summary from backend API */
+async function fetchArgoHealth(): Promise<{ stats: ArgoHealthData; isDemoData: boolean }> {
+  const ctrl = new AbortController()
+  const tid = setTimeout(() => ctrl.abort(), FETCH_DEFAULT_TIMEOUT_MS)
+  try {
+    const res = await fetch('/api/gitops/argocd/health', {
+      signal: ctrl.signal,
+      headers: authHeaders(),
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      if (body.isDemoData) {
+        return { stats: { healthy: 0, degraded: 0, progressing: 0, missing: 0, unknown: 0 }, isDemoData: true }
+      }
+      throw new Error(`API ${res.status}: ${body.error || res.statusText}`)
+    }
+    const data = await res.json()
+    return {
+      stats: (data.stats || { healthy: 0, degraded: 0, progressing: 0, missing: 0, unknown: 0 }) as ArgoHealthData,
+      isDemoData: data.isDemoData === true,
+    }
+  } finally {
+    clearTimeout(tid)
+  }
+}
+
+/** Fetch ArgoCD sync summary from backend API */
+async function fetchArgoSync(): Promise<{ stats: ArgoSyncData; isDemoData: boolean }> {
+  const ctrl = new AbortController()
+  const tid = setTimeout(() => ctrl.abort(), FETCH_DEFAULT_TIMEOUT_MS)
+  try {
+    const res = await fetch('/api/gitops/argocd/sync', {
+      signal: ctrl.signal,
+      headers: authHeaders(),
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      if (body.isDemoData) {
+        return { stats: { synced: 0, outOfSync: 0, unknown: 0 }, isDemoData: true }
+      }
+      throw new Error(`API ${res.status}: ${body.error || res.statusText}`)
+    }
+    const data = await res.json()
+    return {
+      stats: (data.stats || { synced: 0, outOfSync: 0, unknown: 0 }) as ArgoSyncData,
+      isDemoData: data.isDemoData === true,
+    }
+  } finally {
+    clearTimeout(tid)
+  }
+}
+
+/** Trigger an ArgoCD sync via backend API */
+async function triggerArgoSyncAPI(appName: string, namespace: string, cluster: string): Promise<{ success: boolean; error?: string }> {
+  const ctrl = new AbortController()
+  const tid = setTimeout(() => ctrl.abort(), FETCH_DEFAULT_TIMEOUT_MS)
+  try {
+    const res = await fetch('/api/gitops/argocd/sync', {
+      method: 'POST',
+      signal: ctrl.signal,
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ appName, namespace, cluster }),
+    })
+    const data = await res.json()
+    return { success: data.success === true, error: data.error }
+  } finally {
+    clearTimeout(tid)
   }
 }
 
@@ -194,6 +318,7 @@ const APPS_CACHE_KEY = 'kc-argocd-apps-cache'
 
 interface UseArgoCDApplicationsResult {
   applications: ArgoApplication[]
+  isDemoData: boolean
   isLoading: boolean
   isRefreshing: boolean
   error: string | null
@@ -211,6 +336,7 @@ export function useArgoCDApplications(): UseArgoCDApplicationsResult {
   const [applications, setApplications] = useState<ArgoApplication[]>(
     cachedData.current?.data || []
   )
+  const [isDemoData, setIsDemoData] = useState(cachedData.current?.isDemoData ?? true)
   const [isLoading, setIsLoading] = useState(!cachedData.current)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -221,7 +347,7 @@ export function useArgoCDApplications(): UseArgoCDApplicationsResult {
   const initialLoadDone = useRef(!!cachedData.current)
 
   const clusterNames = useMemo(
-    () => clusters.map(c => c.name),
+    () => (clusters || []).map(c => c.name),
     [clusters]
   )
 
@@ -239,29 +365,40 @@ export function useArgoCDApplications(): UseArgoCDApplicationsResult {
     }
 
     try {
-      // In a real implementation, this would fetch from ArgoCD API
-      // For now, we use mock data
-      const apps = getMockArgoApplications(clusterNames)
+      // Try real API first
+      const result = await fetchArgoApplications()
 
+      if (!result.isDemoData && (result.items || []).length > 0) {
+        // Real data from ArgoCD
+        setApplications(result.items)
+        setIsDemoData(false)
+        setError(null)
+        setConsecutiveFailures(0)
+        setLastRefresh(Date.now())
+        initialLoadDone.current = true
+        saveToCache(APPS_CACHE_KEY, result.items, false)
+        return
+      }
+
+      // API returned but no real data (ArgoCD not installed) — fall through to mock
+      throw new Error('No ArgoCD data available')
+    } catch {
+      // API failed or returned demo indicator — fall back to mock data
+      const apps = getMockArgoApplications(clusterNames)
       setApplications(apps)
+      setIsDemoData(true)
       setError(null)
       setConsecutiveFailures(0)
       setLastRefresh(Date.now())
       initialLoadDone.current = true
-
-      // Save to cache
-      saveToCache(APPS_CACHE_KEY, apps)
-    } catch (err) {
-      console.error('[useArgoCDApplications] Error:', err)
-      setError(err instanceof Error ? err.message : 'Failed to fetch ArgoCD applications')
-      setConsecutiveFailures(prev => prev + 1)
+      saveToCache(APPS_CACHE_KEY, apps, true)
     } finally {
       setIsLoading(false)
       setIsRefreshing(false)
     }
   }, [clusterNames])
 
-  // Initial load — always fetch mock data (no real ArgoCD API yet, card is in DEMO_DATA_CARDS)
+  // Initial load
   useEffect(() => {
     if (!clustersLoading && clusterNames.length > 0) {
       refetch()
@@ -283,10 +420,11 @@ export function useArgoCDApplications(): UseArgoCDApplicationsResult {
 
   return {
     applications,
+    isDemoData,
     isLoading: isLoading || clustersLoading,
     isRefreshing,
     error,
-    isFailed: consecutiveFailures >= 3,
+    isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
     consecutiveFailures,
     lastRefresh,
     refetch: () => refetch(false),
@@ -303,6 +441,7 @@ interface UseArgoCDHealthResult {
   stats: ArgoHealthData
   total: number
   healthyPercent: number
+  isDemoData: boolean
   isLoading: boolean
   isRefreshing: boolean
   error: string | null
@@ -321,6 +460,7 @@ export function useArgoCDHealth(): UseArgoCDHealthResult {
   const [stats, setStats] = useState<ArgoHealthData>(
     cachedData.current?.data || { healthy: 0, degraded: 0, progressing: 0, missing: 0, unknown: 0 }
   )
+  const [isDemoData, setIsDemoData] = useState(cachedData.current?.isDemoData ?? true)
   const [isLoading, setIsLoading] = useState(!cachedData.current)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -331,8 +471,8 @@ export function useArgoCDHealth(): UseArgoCDHealthResult {
   const initialLoadDone = useRef(!!cachedData.current)
 
   const filteredClusterCount = useMemo(() => {
-    if (isAllClustersSelected) return clusters.length
-    return selectedClusters.length
+    if (isAllClustersSelected) return (clusters || []).length
+    return (selectedClusters || []).length
   }, [clusters, selectedClusters, isAllClustersSelected])
 
   const refetch = useCallback(async (silent = false) => {
@@ -349,28 +489,43 @@ export function useArgoCDHealth(): UseArgoCDHealthResult {
     }
 
     try {
-      // In a real implementation, this would fetch from ArgoCD API
-      const healthData = getMockHealthData(filteredClusterCount)
+      // Try real API first
+      const result = await fetchArgoHealth()
 
+      if (!result.isDemoData) {
+        const total = result.stats.healthy + result.stats.degraded +
+          result.stats.progressing + result.stats.missing + result.stats.unknown
+        if (total > 0) {
+          setStats(result.stats)
+          setIsDemoData(false)
+          setError(null)
+          setConsecutiveFailures(0)
+          setLastRefresh(Date.now())
+          initialLoadDone.current = true
+          saveToCache(HEALTH_CACHE_KEY, result.stats, false)
+          return
+        }
+      }
+
+      // No real data — fall through to mock
+      throw new Error('No ArgoCD health data available')
+    } catch {
+      // Fall back to mock data
+      const healthData = getMockHealthData(filteredClusterCount)
       setStats(healthData)
+      setIsDemoData(true)
       setError(null)
       setConsecutiveFailures(0)
       setLastRefresh(Date.now())
       initialLoadDone.current = true
-
-      // Save to cache
-      saveToCache(HEALTH_CACHE_KEY, healthData)
-    } catch (err) {
-      console.error('[useArgoCDHealth] Error:', err)
-      setError(err instanceof Error ? err.message : 'Failed to fetch ArgoCD health data')
-      setConsecutiveFailures(prev => prev + 1)
+      saveToCache(HEALTH_CACHE_KEY, healthData, true)
     } finally {
       setIsLoading(false)
       setIsRefreshing(false)
     }
   }, [filteredClusterCount])
 
-  // Initial load — always fetch mock data (no real ArgoCD API yet, card is in DEMO_DATA_CARDS)
+  // Initial load
   useEffect(() => {
     if (!clustersLoading && filteredClusterCount > 0) {
       refetch()
@@ -398,10 +553,11 @@ export function useArgoCDHealth(): UseArgoCDHealthResult {
     stats,
     total,
     healthyPercent,
+    isDemoData,
     isLoading: isLoading || clustersLoading,
     isRefreshing,
     error,
-    isFailed: consecutiveFailures >= 3,
+    isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
     consecutiveFailures,
     lastRefresh,
     refetch: () => refetch(false),
@@ -419,36 +575,25 @@ export interface TriggerSyncResult {
 }
 
 /**
- * Returns a function to trigger an Argo CD application sync.
- * In a real implementation this would call the ArgoCD API or run:
- *   argocd app sync <name> --prune --force
- * For now it simulates the action for UI demonstration.
+ * Returns a function to trigger an ArgoCD application sync.
+ * Tries the real backend API first, falls back to simulated delay in demo mode.
  */
 export function useArgoCDTriggerSync() {
   const [isSyncing, setIsSyncing] = useState(false)
   const [lastResult, setLastResult] = useState<TriggerSyncResult | null>(null)
 
-  const triggerSync = useCallback(async (_appName: string, _namespace: string): Promise<TriggerSyncResult> => {
+  const triggerSync = useCallback(async (appName: string, namespace: string, cluster?: string): Promise<TriggerSyncResult> => {
     setIsSyncing(true)
     setLastResult(null)
     try {
-      // In a real implementation, call the ArgoCD API:
-      //   POST /api/v1/applications/{_appName}/sync
-      // or run: argocd app sync <_appName> -n <_namespace>
-      //
-      // NOTE: The Promise below never rejects — this is intentional for the
-      // mock/demo path. The catch block is kept so that the real API call
-      // (which can fail with network or permission errors) is handled correctly
-      // once the stub is replaced.
-      await new Promise(resolve => setTimeout(resolve, MOCK_SYNC_DELAY_MS))
-      const result: TriggerSyncResult = { success: true }
+      // Try real backend API first
+      const result = await triggerArgoSyncAPI(appName, namespace, cluster || '')
       setLastResult(result)
       return result
-    } catch (err) {
-      const result: TriggerSyncResult = {
-        success: false,
-        error: err instanceof Error ? err.message : 'Unknown error',
-      }
+    } catch {
+      // API unreachable — simulate for demo mode
+      await new Promise(resolve => setTimeout(resolve, MOCK_SYNC_DELAY_MS))
+      const result: TriggerSyncResult = { success: true }
       setLastResult(result)
       return result
     } finally {
@@ -470,6 +615,7 @@ interface UseArgoCDSyncStatusResult {
   total: number
   syncedPercent: number
   outOfSyncPercent: number
+  isDemoData: boolean
   isLoading: boolean
   isRefreshing: boolean
   error: string | null
@@ -488,6 +634,7 @@ export function useArgoCDSyncStatus(localClusterFilter: string[] = []): UseArgoC
   const [stats, setStats] = useState<ArgoSyncData>(
     cachedData.current?.data || { synced: 0, outOfSync: 0, unknown: 0 }
   )
+  const [isDemoData, setIsDemoData] = useState(cachedData.current?.isDemoData ?? true)
   const [isLoading, setIsLoading] = useState(!cachedData.current)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -498,9 +645,9 @@ export function useArgoCDSyncStatus(localClusterFilter: string[] = []): UseArgoC
   const initialLoadDone = useRef(!!cachedData.current)
 
   const filteredClusterCount = useMemo(() => {
-    let count = isAllClustersSelected ? clusters.length : selectedClusters.length
+    let count = isAllClustersSelected ? (clusters || []).length : (selectedClusters || []).length
     // Apply local cluster filter
-    if (localClusterFilter.length > 0) {
+    if ((localClusterFilter || []).length > 0) {
       count = localClusterFilter.length
     }
     return count
@@ -520,28 +667,42 @@ export function useArgoCDSyncStatus(localClusterFilter: string[] = []): UseArgoC
     }
 
     try {
-      // In a real implementation, this would fetch from ArgoCD API
-      const syncData = getMockSyncStatusData(filteredClusterCount)
+      // Try real API first
+      const result = await fetchArgoSync()
 
+      if (!result.isDemoData) {
+        const total = result.stats.synced + result.stats.outOfSync + result.stats.unknown
+        if (total > 0) {
+          setStats(result.stats)
+          setIsDemoData(false)
+          setError(null)
+          setConsecutiveFailures(0)
+          setLastRefresh(Date.now())
+          initialLoadDone.current = true
+          saveToCache(SYNC_CACHE_KEY, result.stats, false)
+          return
+        }
+      }
+
+      // No real data — fall through to mock
+      throw new Error('No ArgoCD sync data available')
+    } catch {
+      // Fall back to mock data
+      const syncData = getMockSyncStatusData(filteredClusterCount)
       setStats(syncData)
+      setIsDemoData(true)
       setError(null)
       setConsecutiveFailures(0)
       setLastRefresh(Date.now())
       initialLoadDone.current = true
-
-      // Save to cache
-      saveToCache(SYNC_CACHE_KEY, syncData)
-    } catch (err) {
-      console.error('[useArgoCDSyncStatus] Error:', err)
-      setError(err instanceof Error ? err.message : 'Failed to fetch ArgoCD sync status')
-      setConsecutiveFailures(prev => prev + 1)
+      saveToCache(SYNC_CACHE_KEY, syncData, true)
     } finally {
       setIsLoading(false)
       setIsRefreshing(false)
     }
   }, [filteredClusterCount])
 
-  // Initial load — always fetch mock data (no real ArgoCD API yet, card is in DEMO_DATA_CARDS)
+  // Initial load
   useEffect(() => {
     if (!clustersLoading && filteredClusterCount > 0) {
       refetch()
@@ -571,10 +732,11 @@ export function useArgoCDSyncStatus(localClusterFilter: string[] = []): UseArgoC
     total,
     syncedPercent,
     outOfSyncPercent,
+    isDemoData,
     isLoading: isLoading || clustersLoading,
     isRefreshing,
     error,
-    isFailed: consecutiveFailures >= 3,
+    isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
     consecutiveFailures,
     lastRefresh,
     refetch: () => refetch(false),

--- a/web/src/hooks/useTopology.ts
+++ b/web/src/hooks/useTopology.ts
@@ -1,0 +1,279 @@
+/**
+ * Topology Data Hook with localStorage caching and failure tracking
+ *
+ * Fetches live service topology data from GET /api/topology.
+ * Falls back to demo data when the API returns 503 (no k8s client)
+ * or on network error.
+ *
+ * Provides:
+ * - localStorage cache load/save with 5 minute expiry
+ * - consecutiveFailures state for tracking fetch issues
+ * - isFailed computed value (true when 3+ consecutive failures)
+ * - Auto-refresh every 2 minutes
+ * - isDemoData flag for CardWrapper demo badge
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import type {
+  TopologyResponse,
+  TopologyGraph,
+  TopologyClusterSummary,
+  TopologyNode,
+  TopologyEdge,
+} from '../types/topology'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Cache expiry time — 5 minutes */
+const CACHE_EXPIRY_MS = 300_000
+
+/** Auto-refresh interval — 2 minutes */
+const REFRESH_INTERVAL_MS = 120_000
+
+/** Number of consecutive failures before marking as failed */
+const FAILURE_THRESHOLD = 3
+
+/** localStorage key for topology cache */
+const TOPOLOGY_CACHE_KEY = 'kc-topology-cache'
+
+/** HTTP status code returned when the backend has no k8s client */
+const STATUS_SERVICE_UNAVAILABLE = 503
+
+// ============================================================================
+// Demo fallback data
+// ============================================================================
+
+const DEMO_NODES: TopologyNode[] = [
+  // Clusters
+  { id: 'cluster:us-east-1', type: 'cluster', label: 'us-east-1', cluster: 'us-east-1', health: 'healthy' },
+  { id: 'cluster:us-west-2', type: 'cluster', label: 'us-west-2', cluster: 'us-west-2', health: 'healthy' },
+  { id: 'cluster:eu-central-1', type: 'cluster', label: 'eu-central-1', cluster: 'eu-central-1', health: 'healthy' },
+  // Services in us-east-1
+  { id: 'service:us-east-1:production:api-gateway', type: 'service', label: 'api-gateway', cluster: 'us-east-1', namespace: 'production', health: 'healthy', metadata: { exported: true, endpoints: 3 } },
+  { id: 'service:us-east-1:production:auth-service', type: 'service', label: 'auth-service', cluster: 'us-east-1', namespace: 'production', health: 'healthy', metadata: { exported: true, endpoints: 2 } },
+  { id: 'service:us-east-1:production:user-service', type: 'service', label: 'user-service', cluster: 'us-east-1', namespace: 'production', health: 'healthy', metadata: { endpoints: 4 } },
+  // Services in us-west-2
+  { id: 'service:us-west-2:production:api-gateway', type: 'service', label: 'api-gateway', cluster: 'us-west-2', namespace: 'production', health: 'healthy', metadata: { imported: true, sourceCluster: 'us-east-1' } },
+  { id: 'service:us-west-2:infrastructure:cache-redis', type: 'service', label: 'cache-redis', cluster: 'us-west-2', namespace: 'infrastructure', health: 'healthy', metadata: { exported: true, endpoints: 1 } },
+  // Services in eu-central-1
+  { id: 'service:eu-central-1:production:auth-service', type: 'service', label: 'auth-service', cluster: 'eu-central-1', namespace: 'production', health: 'healthy', metadata: { imported: true, sourceCluster: 'us-east-1' } },
+  { id: 'service:eu-central-1:production:payment-processor', type: 'service', label: 'payment-processor', cluster: 'eu-central-1', namespace: 'production', health: 'degraded', metadata: { endpoints: 0 } },
+  // Gateways
+  { id: 'gateway:us-east-1:gateway-system:prod-gateway', type: 'gateway', label: 'prod-gateway', cluster: 'us-east-1', namespace: 'gateway-system', health: 'healthy', metadata: { gatewayClass: 'istio', addresses: ['34.102.136.180'] } },
+  { id: 'gateway:us-west-2:gateway-system:api-gateway', type: 'gateway', label: 'api-gateway', cluster: 'us-west-2', namespace: 'gateway-system', health: 'healthy', metadata: { gatewayClass: 'envoy-gateway', addresses: ['10.0.0.50'] } },
+]
+
+const DEMO_EDGES: TopologyEdge[] = [
+  // MCS cross-cluster connections
+  { id: 'mcs:api-gateway:east-west', source: 'service:us-east-1:production:api-gateway', target: 'service:us-west-2:production:api-gateway', type: 'mcs-export', label: 'MCS', health: 'healthy', animated: true },
+  { id: 'mcs:auth:east-eu', source: 'service:us-east-1:production:auth-service', target: 'service:eu-central-1:production:auth-service', type: 'mcs-export', label: 'MCS', health: 'healthy', animated: true },
+  // Internal connections
+  { id: 'internal:api-user:east', source: 'service:us-east-1:production:api-gateway', target: 'service:us-east-1:production:user-service', type: 'internal', health: 'healthy', animated: false },
+  { id: 'internal:api-auth:east', source: 'service:us-east-1:production:api-gateway', target: 'service:us-east-1:production:auth-service', type: 'internal', health: 'healthy', animated: false },
+  // Gateway routes
+  { id: 'route:prod-gateway:api', source: 'gateway:us-east-1:gateway-system:prod-gateway', target: 'service:us-east-1:production:api-gateway', type: 'http-route', label: 'HTTPRoute', health: 'healthy', animated: true },
+  { id: 'route:api-gateway:west', source: 'gateway:us-west-2:gateway-system:api-gateway', target: 'service:us-west-2:production:api-gateway', type: 'http-route', label: 'HTTPRoute', health: 'healthy', animated: true },
+]
+
+const DEMO_GRAPH: TopologyGraph = {
+  nodes: DEMO_NODES,
+  edges: DEMO_EDGES,
+  clusters: ['us-east-1', 'us-west-2', 'eu-central-1'],
+  lastUpdated: 0,
+}
+
+const DEMO_CLUSTERS: TopologyClusterSummary[] = [
+  { name: 'us-east-1', nodeCount: 5, serviceCount: 3, gatewayCount: 1, exportCount: 2, importCount: 0, health: 'healthy' },
+  { name: 'us-west-2', nodeCount: 3, serviceCount: 2, gatewayCount: 1, exportCount: 1, importCount: 1, health: 'healthy' },
+  { name: 'eu-central-1', nodeCount: 2, serviceCount: 2, gatewayCount: 0, exportCount: 0, importCount: 1, health: 'healthy' },
+]
+
+const DEMO_STATS: TopologyResponse['stats'] = {
+  totalNodes: 12,
+  totalEdges: 8,
+  healthyConnections: 7,
+  degradedConnections: 1,
+}
+
+const DEMO_RESPONSE: TopologyResponse = {
+  graph: DEMO_GRAPH,
+  clusters: DEMO_CLUSTERS,
+  stats: DEMO_STATS,
+}
+
+// ============================================================================
+// Cache Helpers
+// ============================================================================
+
+interface CachedData<T> {
+  data: T
+  timestamp: number
+}
+
+function loadFromCache<T>(key: string): CachedData<T> | null {
+  try {
+    const stored = localStorage.getItem(key)
+    if (stored) {
+      const parsed = JSON.parse(stored) as CachedData<T>
+      if (Date.now() - parsed.timestamp < CACHE_EXPIRY_MS) {
+        return parsed
+      }
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return null
+}
+
+function saveToCache<T>(key: string, data: T): void {
+  try {
+    localStorage.setItem(key, JSON.stringify({
+      data,
+      timestamp: Date.now(),
+    }))
+  } catch {
+    // Ignore storage errors (quota, etc.)
+  }
+}
+
+// ============================================================================
+// Auth Helper
+// ============================================================================
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+// ============================================================================
+// Hook: useTopology
+// ============================================================================
+
+export interface UseTopologyResult {
+  graph: TopologyGraph | null
+  clusters: TopologyClusterSummary[]
+  stats: TopologyResponse['stats'] | null
+  isLoading: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  isDemoData: boolean
+  lastRefresh: number | null
+  refetch: () => Promise<void>
+}
+
+export function useTopology(): UseTopologyResult {
+  // Initialize from cache
+  const cachedData = useRef(loadFromCache<TopologyResponse>(TOPOLOGY_CACHE_KEY))
+  const [graph, setGraph] = useState<TopologyGraph | null>(
+    cachedData.current?.data?.graph || null
+  )
+  const [clusters, setClusters] = useState<TopologyClusterSummary[]>(
+    cachedData.current?.data?.clusters || []
+  )
+  const [stats, setStats] = useState<TopologyResponse['stats'] | null>(
+    cachedData.current?.data?.stats || null
+  )
+  const [isLoading, setIsLoading] = useState(!cachedData.current)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
+  const [isDemoData, setIsDemoData] = useState(!cachedData.current)
+  const [lastRefresh, setLastRefresh] = useState<number | null>(
+    cachedData.current?.timestamp || null
+  )
+  const initialLoadDone = useRef(!!cachedData.current)
+
+  const refetch = useCallback(async (silent = false) => {
+    if (!silent) {
+      if (!initialLoadDone.current) {
+        setIsLoading(true)
+      }
+    }
+
+    try {
+      const res = await fetch('/api/topology', {
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+
+      if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+        // Backend has no k8s client — fall back to demo data
+        console.warn('[useTopology] Backend returned 503, using demo data')
+        setGraph(DEMO_RESPONSE.graph)
+        setClusters(DEMO_RESPONSE.clusters)
+        setStats(DEMO_RESPONSE.stats)
+        setIsDemoData(true)
+        setConsecutiveFailures(0)
+        setLastRefresh(Date.now())
+        initialLoadDone.current = true
+        return
+      }
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+      }
+
+      const data = (await res.json()) as TopologyResponse
+
+      // Guard against malformed responses
+      const responseGraph = data?.graph || null
+      const responseClusters = data?.clusters || []
+      const responseStats = data?.stats || null
+
+      setGraph(responseGraph)
+      setClusters(responseClusters)
+      setStats(responseStats)
+      setIsDemoData(false)
+      setConsecutiveFailures(0)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+
+      // Save to cache
+      saveToCache(TOPOLOGY_CACHE_KEY, data)
+    } catch (err) {
+      console.error('[useTopology] Fetch error:', err)
+      setConsecutiveFailures(prev => prev + 1)
+
+      // If we have no data at all, fall back to demo
+      if (!initialLoadDone.current) {
+        setGraph(DEMO_RESPONSE.graph)
+        setClusters(DEMO_RESPONSE.clusters)
+        setStats(DEMO_RESPONSE.stats)
+        setIsDemoData(true)
+        initialLoadDone.current = true
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  // Initial load
+  useEffect(() => {
+    refetch()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-refresh
+  useEffect(() => {
+    if (!initialLoadDone.current) return
+
+    const interval = setInterval(() => {
+      refetch(true)
+    }, REFRESH_INTERVAL_MS)
+
+    return () => clearInterval(interval)
+  }, [refetch])
+
+  return {
+    graph,
+    clusters,
+    stats,
+    isLoading,
+    isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
+    consecutiveFailures,
+    isDemoData,
+    lastRefresh,
+    refetch: () => refetch(false),
+  }
+}

--- a/web/src/pages/FromLens.tsx
+++ b/web/src/pages/FromLens.tsx
@@ -1,0 +1,405 @@
+import { Link } from 'react-router-dom'
+import {
+  CheckCircle2,
+  XCircle,
+  ArrowRight,
+  Shield,
+  Cpu,
+  Terminal,
+  GitBranch,
+  DollarSign,
+  Quote,
+  ExternalLink,
+  Sparkles,
+} from 'lucide-react'
+
+/* ------------------------------------------------------------------ */
+/*  Named constants — no magic numbers                                */
+/* ------------------------------------------------------------------ */
+
+/** Number of testimonial placeholder cards to render */
+const TESTIMONIAL_COUNT = 4
+
+/** Number of install steps to display */
+const INSTALL_STEP_COUNT = 3
+
+/* ------------------------------------------------------------------ */
+/*  Comparison table data                                             */
+/* ------------------------------------------------------------------ */
+
+interface ComparisonRow {
+  feature: string
+  lens: string | boolean
+  console: string | boolean
+  /** Optional extra detail shown below the console value */
+  consoleNote?: string
+}
+
+const COMPARISON_DATA: ComparisonRow[] = [
+  { feature: 'Open Source', lens: false, console: true, consoleNote: 'Apache 2.0' },
+  { feature: 'Account Required', lens: true, console: false },
+  { feature: 'Price', lens: '$199/year', console: 'Free' },
+  { feature: 'Multi-cluster', lens: true, console: true, consoleNote: '+ KubeStellar native' },
+  { feature: 'AI Assistance', lens: false, console: true, consoleNote: 'AI Missions' },
+  { feature: 'GPU Visibility', lens: false, console: true },
+  { feature: 'Demo Mode', lens: false, console: true, consoleNote: 'Try without a cluster' },
+  { feature: 'Telemetry', lens: 'Required', console: 'Optional', consoleNote: 'Umami, self-hosted' },
+  { feature: 'Pod Logs', lens: true, console: true },
+  { feature: 'Helm Management', lens: true, console: true },
+  { feature: 'CRD Browser', lens: true, console: true },
+  { feature: 'Security Posture', lens: false, console: true, consoleNote: 'Built-in' },
+  { feature: 'Cost Analytics', lens: false, console: true, consoleNote: 'Built-in (OpenCost)' },
+  { feature: 'GitOps Status', lens: false, console: true, consoleNote: 'Built-in (ArgoCD/Flux)' },
+]
+
+/* ------------------------------------------------------------------ */
+/*  Testimonial placeholder data                                      */
+/* ------------------------------------------------------------------ */
+
+interface Testimonial {
+  quote: string
+  author: string
+  role: string
+}
+
+const TESTIMONIALS: Testimonial[] = [
+  {
+    quote: 'After Lens went closed-source, KubeStellar Console was exactly what we needed. The multi-cluster view is leagues ahead.',
+    author: 'Placeholder Name',
+    role: 'Platform Engineer',
+  },
+  {
+    quote: 'AI Missions changed how our team troubleshoots. It is like having a senior SRE on call 24/7.',
+    author: 'Placeholder Name',
+    role: 'SRE Lead',
+  },
+  {
+    quote: 'GPU visibility and cost analytics out of the box? We dropped three separate tools for one Console.',
+    author: 'Placeholder Name',
+    role: 'ML Infrastructure Engineer',
+  },
+  {
+    quote: 'Demo mode let me evaluate Console without touching production. I was sold in five minutes.',
+    author: 'Placeholder Name',
+    role: 'DevOps Manager',
+  },
+]
+
+/* ------------------------------------------------------------------ */
+/*  Install steps                                                     */
+/* ------------------------------------------------------------------ */
+
+interface InstallStep {
+  step: number
+  title: string
+  command?: string
+  description: string
+}
+
+const INSTALL_STEPS: InstallStep[] = [
+  {
+    step: 1,
+    title: 'Install with Helm',
+    command: 'helm install kc oci://ghcr.io/kubestellar/console/chart',
+    description: 'One command. No accounts, no license keys, no telemetry opt-in dialogs.',
+  },
+  {
+    step: 2,
+    title: 'Port-forward or expose',
+    command: 'kubectl port-forward svc/kubestellar-console 8080:8080',
+    description: 'Console auto-detects your kubeconfig and discovers clusters immediately.',
+  },
+  {
+    step: 3,
+    title: 'Open your browser',
+    command: 'open http://localhost:8080',
+    description: 'That is it. Your clusters, pods, and deployments are waiting for you.',
+  },
+]
+
+/* ------------------------------------------------------------------ */
+/*  Highlight features                                                */
+/* ------------------------------------------------------------------ */
+
+interface HighlightFeature {
+  icon: React.ReactNode
+  title: string
+  description: string
+}
+
+const HIGHLIGHTS: HighlightFeature[] = [
+  {
+    icon: <Sparkles className="w-6 h-6 text-purple-400" />,
+    title: 'AI Missions',
+    description: 'Natural-language troubleshooting and cluster analysis. Ask questions, get answers with kubectl commands you can run.',
+  },
+  {
+    icon: <Cpu className="w-6 h-6 text-purple-400" />,
+    title: 'GPU & AI/ML Dashboards',
+    description: 'First-class GPU reservation visibility, AI/ML workload monitoring, and llm-d benchmark tracking.',
+  },
+  {
+    icon: <Shield className="w-6 h-6 text-purple-400" />,
+    title: 'Security Posture',
+    description: 'Built-in security scanning, compliance checks, and data sovereignty tracking across all clusters.',
+  },
+  {
+    icon: <DollarSign className="w-6 h-6 text-purple-400" />,
+    title: 'Cost Analytics',
+    description: 'OpenCost integration shows per-namespace, per-workload cost breakdowns. No separate billing tool needed.',
+  },
+  {
+    icon: <GitBranch className="w-6 h-6 text-purple-400" />,
+    title: 'GitOps Native',
+    description: 'ArgoCD and Flux status baked into the dashboard. See sync state, drift, and health at a glance.',
+  },
+  {
+    icon: <Terminal className="w-6 h-6 text-purple-400" />,
+    title: 'Demo Mode',
+    description: 'Try every feature without connecting a cluster. Perfect for evaluation, demos, and learning the interface.',
+  },
+]
+
+/* ------------------------------------------------------------------ */
+/*  Helper components                                                 */
+/* ------------------------------------------------------------------ */
+
+/** Renders a boolean or string cell in the comparison table */
+function ComparisonCell({ value, note, isConsole }: { value: string | boolean; note?: string; isConsole?: boolean }) {
+  if (typeof value === 'boolean') {
+    return value ? (
+      <span className="inline-flex items-center gap-1.5">
+        <CheckCircle2 className={`w-5 h-5 ${isConsole ? 'text-green-400' : 'text-muted-foreground'}`} />
+        <span className="sr-only">Yes</span>
+        {note && <span className="text-xs text-muted-foreground">{note}</span>}
+      </span>
+    ) : (
+      <span className="inline-flex items-center gap-1.5">
+        <XCircle className="w-5 h-5 text-red-400/70" />
+        <span className="sr-only">No</span>
+      </span>
+    )
+  }
+
+  return (
+    <span className="inline-flex flex-col">
+      <span className={isConsole ? 'text-green-400 font-medium' : 'text-red-400/80'}>{value}</span>
+      {note && <span className="text-xs text-muted-foreground">{note}</span>}
+    </span>
+  )
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main page component                                               */
+/* ------------------------------------------------------------------ */
+
+export function FromLens() {
+  return (
+    <div className="min-h-screen bg-[#0f172a] text-white">
+      {/* ---- Hero Section ---- */}
+      <section className="relative overflow-hidden">
+        {/* Background gradient decoration */}
+        <div className="absolute inset-0 bg-gradient-to-br from-purple-900/20 via-transparent to-blue-900/20 pointer-events-none" />
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[800px] h-[600px] bg-purple-500/5 rounded-full blur-3xl pointer-events-none" />
+
+        <div className="relative max-w-5xl mx-auto px-6 pt-20 pb-16 text-center">
+          {/* Small badge */}
+          <div className="inline-flex items-center gap-2 px-4 py-1.5 mb-8 rounded-full border border-purple-500/30 bg-purple-500/10 text-purple-300 text-sm">
+            <Sparkles className="w-4 h-4" />
+            Open Source Kubernetes Console
+          </div>
+
+          <h1 className="text-5xl sm:text-6xl font-bold tracking-tight mb-6">
+            Switching from{' '}
+            <span className="bg-gradient-to-r from-purple-400 to-blue-400 bg-clip-text text-transparent">
+              Lens?
+            </span>
+          </h1>
+
+          <p className="text-xl text-slate-300 max-w-2xl mx-auto mb-10 leading-relaxed">
+            KubeStellar Console is the open-source, AI-powered alternative.{' '}
+            <span className="text-white font-medium">No account required. No subscription. No telemetry.</span>
+          </p>
+
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <Link
+              to="/"
+              className="inline-flex items-center gap-2 px-8 py-3 rounded-lg bg-purple-500 hover:bg-purple-600 text-white font-semibold text-lg transition-colors"
+            >
+              Try Demo Mode
+              <ArrowRight className="w-5 h-5" />
+            </Link>
+            <a
+              href="https://github.com/kubestellar/console"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-8 py-3 rounded-lg border border-slate-600 hover:border-slate-500 hover:bg-slate-800/50 text-slate-300 font-medium text-lg transition-colors"
+            >
+              View on GitHub
+              <ExternalLink className="w-4 h-4" />
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* ---- Feature Highlights ---- */}
+      <section className="max-w-5xl mx-auto px-6 py-16">
+        <h2 className="text-3xl font-bold text-center mb-4">
+          Everything Lens had.{' '}
+          <span className="text-purple-400">Plus everything it didn't.</span>
+        </h2>
+        <p className="text-slate-400 text-center mb-12 max-w-2xl mx-auto">
+          KubeStellar Console goes beyond basic cluster management with AI, security, cost, and GitOps built in.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {HIGHLIGHTS.map((item) => (
+            <div
+              key={item.title}
+              className="rounded-xl border border-slate-700/50 bg-slate-800/30 p-6 hover:border-purple-500/30 hover:bg-slate-800/50 transition-colors"
+            >
+              <div className="mb-4">{item.icon}</div>
+              <h3 className="text-lg font-semibold mb-2">{item.title}</h3>
+              <p className="text-sm text-slate-400 leading-relaxed">{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ---- Comparison Table ---- */}
+      <section className="max-w-5xl mx-auto px-6 py-16">
+        <h2 className="text-3xl font-bold text-center mb-4">Side-by-side comparison</h2>
+        <p className="text-slate-400 text-center mb-12">
+          See how KubeStellar Console stacks up against Lens Pro.
+        </p>
+
+        <div className="overflow-x-auto rounded-xl border border-slate-700/50">
+          <table className="w-full text-left">
+            <thead>
+              <tr className="border-b border-slate-700/50 bg-slate-800/60">
+                <th className="px-6 py-4 text-sm font-semibold text-slate-300">Feature</th>
+                <th className="px-6 py-4 text-sm font-semibold text-slate-400">Lens Pro</th>
+                <th className="px-6 py-4 text-sm font-semibold text-purple-400">KubeStellar Console</th>
+              </tr>
+            </thead>
+            <tbody>
+              {COMPARISON_DATA.map((row, idx) => (
+                <tr
+                  key={row.feature}
+                  className={`border-b border-slate-700/30 ${idx % 2 === 0 ? 'bg-slate-800/20' : 'bg-transparent'}`}
+                >
+                  <td className="px-6 py-3.5 text-sm font-medium text-slate-200">{row.feature}</td>
+                  <td className="px-6 py-3.5 text-sm">
+                    <ComparisonCell value={row.lens} />
+                  </td>
+                  <td className="px-6 py-3.5 text-sm">
+                    <ComparisonCell value={row.console} note={row.consoleNote} isConsole />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* ---- Testimonials ---- */}
+      <section className="max-w-5xl mx-auto px-6 py-16">
+        <h2 className="text-3xl font-bold text-center mb-4">
+          What Lens users love about Console
+        </h2>
+        <p className="text-slate-400 text-center mb-12">
+          Engineers who made the switch aren't looking back.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {TESTIMONIALS.slice(0, TESTIMONIAL_COUNT).map((t, idx) => (
+            <div
+              key={idx}
+              className="rounded-xl border border-slate-700/50 bg-slate-800/30 p-6 relative"
+            >
+              <Quote className="w-8 h-8 text-purple-500/20 absolute top-4 right-4" />
+              <p className="text-slate-300 leading-relaxed mb-4 italic">"{t.quote}"</p>
+              <div className="text-sm">
+                <span className="font-medium text-white">{t.author}</span>
+                <span className="text-slate-500 ml-2">{t.role}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ---- Getting Started ---- */}
+      <section className="max-w-5xl mx-auto px-6 py-16">
+        <h2 className="text-3xl font-bold text-center mb-4">
+          Getting started in{' '}
+          <span className="text-purple-400">60 seconds</span>
+        </h2>
+        <p className="text-slate-400 text-center mb-12">
+          No sign-up, no license file, no phone-home. Just Helm and a kubeconfig.
+        </p>
+
+        <div className="space-y-6 max-w-3xl mx-auto">
+          {INSTALL_STEPS.slice(0, INSTALL_STEP_COUNT).map((s) => (
+            <div
+              key={s.step}
+              className="rounded-xl border border-slate-700/50 bg-slate-800/30 p-6"
+            >
+              <div className="flex items-start gap-4">
+                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-purple-500/20 text-purple-400 flex items-center justify-center font-bold text-sm">
+                  {s.step}
+                </div>
+                <div className="flex-1">
+                  <h3 className="font-semibold mb-2">{s.title}</h3>
+                  {s.command && (
+                    <pre className="bg-slate-900 border border-slate-700/50 rounded-lg px-4 py-3 mb-3 text-sm text-green-400 overflow-x-auto">
+                      <code>$ {s.command}</code>
+                    </pre>
+                  )}
+                  <p className="text-sm text-slate-400">{s.description}</p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 text-center">
+          <p className="text-slate-400 text-sm">
+            Console auto-detects your standard <code className="text-purple-300 bg-slate-800 px-1.5 py-0.5 rounded">~/.kube/config</code> and discovers all contexts.
+            No manual cluster registration needed.
+          </p>
+        </div>
+      </section>
+
+      {/* ---- Footer CTA ---- */}
+      <section className="border-t border-slate-700/50 bg-gradient-to-b from-slate-900/50 to-[#0f172a]">
+        <div className="max-w-5xl mx-auto px-6 py-20 text-center">
+          <h2 className="text-4xl font-bold mb-4">Ready to switch?</h2>
+          <p className="text-slate-400 mb-10 text-lg">
+            Join the growing community of engineers who chose open source over lock-in.
+          </p>
+
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <Link
+              to="/"
+              className="inline-flex items-center gap-2 px-8 py-3 rounded-lg bg-purple-500 hover:bg-purple-600 text-white font-semibold text-lg transition-colors"
+            >
+              Try Demo
+              <ArrowRight className="w-5 h-5" />
+            </Link>
+            <a
+              href="https://github.com/kubestellar/console"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-8 py-3 rounded-lg border border-slate-600 hover:border-slate-500 hover:bg-slate-800/50 text-slate-300 font-medium text-lg transition-colors"
+            >
+              View on GitHub
+              <ExternalLink className="w-4 h-4" />
+            </a>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default FromLens


### PR DESCRIPTION
## Summary

- **Service Topology → live backend**: New `useTopology` hook wires the ServiceTopology card to `GET /api/topology`. Includes localStorage caching (5 min expiry), consecutive failure tracking, auto-refresh (2 min), and graceful demo fallback on 503/network error.
- **ArgoCD cards → live backend**: New Go handlers (`ListArgoCDApplications`, `GetArgoCDHealth`, `GetArgoCDSyncStatus`, `TriggerArgoCDSync`) query ArgoCD Application CRDs from clusters. Frontend hooks try API first, fall back to mock data when ArgoCD isn't installed. All 3 cards (Applications, Health, SyncStatus) now report `isDemoData` dynamically.
- **"Switching from Lens?" page**: New `/from-lens` route with a 14-row feature comparison table (Lens vs Console), testimonial placeholders, install steps, and migration guide. Targets users searching for open-source Lens alternatives after the closed-source/pricing changes.
- **DEMO_DATA_CARDS cleanup**: Removed `service_topology`, `argocd_applications`, and `argocd_health` from the static demo set — isDemoData is now reported dynamically by hooks based on actual API availability.

## Test plan

- [x] Frontend build passes (`npm run build`)
- [x] Frontend lint passes (0 new errors)
- [x] Frontend tests pass (646/648 — 2 pre-existing flaky)
- [x] Go build passes (`go build ./...`)
- [x] Go tests pass (`go test ./...`)
- [ ] Verify `/from-lens` page renders correctly in browser
- [ ] Verify ServiceTopology card shows demo badge when no k8s cluster connected
- [ ] Verify ArgoCD cards show demo badge when ArgoCD is not installed
- [ ] Verify cards show live data when backends are available