### PR TITLE
🐛 Remove Docker Hub publishing (GHCR only)

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -41,7 +41,6 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  DOCKERHUB_IMAGE: kubestellar/console
   IMAGE_NAME: ${{ github.repository }}
   # Helm release name used across both clusters
   HELM_RELEASE_NAME: kc
@@ -72,20 +71,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            docker.io/${{ env.DOCKERHUB_IMAGE }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
## Summary
- Remove Docker Hub login step and image target from build-deploy workflow
- Docker Hub requires a paid org ($540+/yr) to push to `kubestellar/console` namespace
- GHCR (`ghcr.io/kubestellar/console`) remains the sole container registry
- Fixes the failing `Build and Deploy KC` workflow

## Test plan
- [ ] Verify `Build and Deploy KC` workflow succeeds after merge (no more Docker Hub push failure)