### PR TITLE
✨ Wire CRD browser to real backend API

### DIFF
--- a/pkg/api/handlers/crds.go
+++ b/pkg/api/handlers/crds.go
@@ -1,0 +1,183 @@
+package handlers
+
+import (
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/k8s"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// crdGVR is the GroupVersionResource for CustomResourceDefinitions
+var crdGVR = schema.GroupVersionResource{
+	Group:    "apiextensions.k8s.io",
+	Version:  "v1",
+	Resource: "customresourcedefinitions",
+}
+
+// CRDHandlers handles Custom Resource Definition API endpoints
+type CRDHandlers struct {
+	k8sClient *k8s.MultiClusterClient
+}
+
+// NewCRDHandlers creates a new CRD handlers instance
+func NewCRDHandlers(k8sClient *k8s.MultiClusterClient) *CRDHandlers {
+	return &CRDHandlers{
+		k8sClient: k8sClient,
+	}
+}
+
+// CRDSummary represents a CRD as returned by the API
+type CRDSummary struct {
+	Name      string       `json:"name"`
+	Group     string       `json:"group"`
+	Version   string       `json:"version"`
+	Scope     string       `json:"scope"`
+	Status    string       `json:"status"`
+	Instances int          `json:"instances"`
+	Cluster   string       `json:"cluster"`
+	Versions  []CRDVersion `json:"versions,omitempty"`
+}
+
+// CRDVersion represents a single version of a CRD
+type CRDVersion struct {
+	Name    string `json:"name"`
+	Served  bool   `json:"served"`
+	Storage bool   `json:"storage"`
+}
+
+// CRDListResponse is the response for GET /api/crds
+type CRDListResponse struct {
+	CRDs       []CRDSummary `json:"crds"`
+	IsDemoData bool         `json:"isDemoData"`
+}
+
+// HTTP status code for service unavailable
+const statusServiceUnavailableCRD = 503
+
+// ListCRDs returns all CRDs across clusters
+// GET /api/crds
+func (h *CRDHandlers) ListCRDs(c *fiber.Ctx) error {
+	if h.k8sClient == nil {
+		return c.Status(statusServiceUnavailableCRD).JSON(CRDListResponse{
+			CRDs:       []CRDSummary{},
+			IsDemoData: true,
+		})
+	}
+
+	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+	if err != nil {
+		clusters, _ = h.k8sClient.ListClusters(c.Context())
+	}
+	var allCRDs []CRDSummary
+
+	for _, cluster := range clusters {
+		client, err := h.k8sClient.GetDynamicClient(cluster.Name)
+		if err != nil {
+			continue
+		}
+
+		crdList, err := client.Resource(crdGVR).List(c.Context(), metav1.ListOptions{})
+		if err != nil {
+			continue
+		}
+
+		for _, item := range crdList.Items {
+			crd := parseCRDFromUnstructured(&item, cluster.Name)
+			if crd != nil {
+				allCRDs = append(allCRDs, *crd)
+			}
+		}
+	}
+
+	return c.JSON(CRDListResponse{
+		CRDs:       allCRDs,
+		IsDemoData: false,
+	})
+}
+
+// parseCRDFromUnstructured extracts CRD info from an unstructured object
+func parseCRDFromUnstructured(item *unstructured.Unstructured, cluster string) *CRDSummary {
+	spec, ok := item.Object["spec"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	name := item.GetName()
+
+	// Extract group
+	group, _ := spec["group"].(string)
+
+	// Extract scope
+	scope, _ := spec["scope"].(string)
+
+	// Extract versions
+	var versions []CRDVersion
+	var primaryVersion string
+	if versionsRaw, ok := spec["versions"].([]interface{}); ok {
+		for _, v := range versionsRaw {
+			vMap, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			vName, _ := vMap["name"].(string)
+			served, _ := vMap["served"].(bool)
+			storage, _ := vMap["storage"].(bool)
+			versions = append(versions, CRDVersion{
+				Name:    vName,
+				Served:  served,
+				Storage: storage,
+			})
+			if storage {
+				primaryVersion = vName
+			}
+		}
+	}
+
+	if primaryVersion == "" && len(versions) > 0 {
+		primaryVersion = versions[0].Name
+	}
+
+	// Extract status
+	status := "Established"
+	if statusObj, ok := item.Object["status"].(map[string]interface{}); ok {
+		if conditions, ok := statusObj["conditions"].([]interface{}); ok {
+			for _, cond := range conditions {
+				condMap, ok := cond.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				condType, _ := condMap["type"].(string)
+				condStatus, _ := condMap["status"].(string)
+				if condType == "Established" {
+					if condStatus == "True" {
+						status = "Established"
+					} else {
+						status = "NotEstablished"
+					}
+				}
+				if condType == "Terminating" && condStatus == "True" {
+					status = "Terminating"
+				}
+			}
+		}
+	}
+
+	// Extract the short name (e.g., "certificates" from "certificates.cert-manager.io")
+	shortName := name
+	if idx := strings.Index(name, "."); idx > 0 {
+		shortName = name[:idx]
+	}
+
+	return &CRDSummary{
+		Name:     shortName,
+		Group:    group,
+		Version:  primaryVersion,
+		Scope:    scope,
+		Status:   status,
+		Cluster:  cluster,
+		Versions: versions,
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -633,6 +633,10 @@ func (s *Server) setupRoutes() {
 	api.Get("/gateway/httproutes", gatewayHandlers.ListHTTPRoutes)
 	api.Get("/gateway/httproutes/:cluster/:namespace/:name", gatewayHandlers.GetHTTPRoute)
 
+	// CRD routes (Custom Resource Definition browser)
+	crdHandlers := handlers.NewCRDHandlers(s.k8sClient)
+	api.Get("/crds", crdHandlers.ListCRDs)
+
 	// Service Topology routes
 	topologyHandlers := handlers.NewTopologyHandlers(s.k8sClient, s.hub)
 	api.Get("/topology", topologyHandlers.GetTopology)

--- a/web/src/components/cards/CRDHealth.tsx
+++ b/web/src/components/cards/CRDHealth.tsx
@@ -1,28 +1,18 @@
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo } from 'react'
 import { CheckCircle, AlertTriangle, XCircle, Database } from 'lucide-react'
-import { useClusters } from '../../hooks/useMCP'
 import { Skeleton } from '../ui/Skeleton'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
 import { useTranslation } from 'react-i18next'
-import { useDemoMode } from '../../hooks/useDemoMode'
+import { useCRDs } from '../../hooks/useCRDs'
+import type { CRDData } from '../../hooks/useCRDs'
 
 interface CRDHealthProps {
   config?: {
     cluster?: string
   }
-}
-
-interface CRD {
-  name: string
-  group: string
-  version: string
-  scope: 'Namespaced' | 'Cluster'
-  status: 'Established' | 'NotEstablished' | 'Terminating'
-  instances: number
-  cluster: string
 }
 
 type SortByOption = 'status' | 'name' | 'group' | 'instances'
@@ -43,48 +33,15 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
     SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) })),
     [t]
   )
-  const { isLoading, deduplicatedClusters } = useClusters()
-  const { isDemoMode } = useDemoMode()
+  const { crds: allCRDs, isLoading, isDemoData } = useCRDs()
 
   const [filterGroup, setFilterGroup] = useState<string>('')
-
-  // Generate cluster-specific CRD data
-  const getClusterCRDs = useCallback((clusterName: string): CRD[] => {
-    // Generate cluster-specific data using hash of cluster name
-    const hash = clusterName.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
-    const crdCount = 5 + (hash % 6) // 5-10 CRDs per cluster
-
-    const baseCRDs: CRD[] = [
-      { name: 'certificates', group: 'cert-manager.io', version: 'v1', scope: 'Namespaced', status: 'Established', instances: 20 + (hash % 30), cluster: clusterName },
-      { name: 'clusterissuers', group: 'cert-manager.io', version: 'v1', scope: 'Cluster', status: 'Established', instances: 1 + (hash % 3), cluster: clusterName },
-      { name: 'issuers', group: 'cert-manager.io', version: 'v1', scope: 'Namespaced', status: hash % 7 === 0 ? 'NotEstablished' : 'Established', instances: hash % 7 === 0 ? 0 : 5 + (hash % 10), cluster: clusterName },
-      { name: 'prometheuses', group: 'monitoring.coreos.com', version: 'v1', scope: 'Namespaced', status: 'Established', instances: 1 + (hash % 5), cluster: clusterName },
-      { name: 'servicemonitors', group: 'monitoring.coreos.com', version: 'v1', scope: 'Namespaced', status: 'Established', instances: 50 + (hash % 100), cluster: clusterName },
-      { name: 'alertmanagers', group: 'monitoring.coreos.com', version: 'v1', scope: 'Namespaced', status: hash % 5 === 0 ? 'Terminating' : 'Established', instances: 1 + (hash % 3), cluster: clusterName },
-      { name: 'kafkas', group: 'kafka.strimzi.io', version: 'v1beta2', scope: 'Namespaced', status: 'Established', instances: 2 + (hash % 5), cluster: clusterName },
-      { name: 'kafkatopics', group: 'kafka.strimzi.io', version: 'v1beta2', scope: 'Namespaced', status: hash % 4 === 0 ? 'NotEstablished' : 'Established', instances: hash % 4 === 0 ? 0 : 10 + (hash % 20), cluster: clusterName },
-      { name: 'applications', group: 'argoproj.io', version: 'v1alpha1', scope: 'Namespaced', status: 'Established', instances: 20 + (hash % 50), cluster: clusterName },
-      { name: 'appprojects', group: 'argoproj.io', version: 'v1alpha1', scope: 'Namespaced', status: 'Established', instances: 2 + (hash % 5), cluster: clusterName },
-    ]
-
-    return baseCRDs.slice(0, crdCount)
-  }, [])
-
-  // Generate CRDs for all reachable clusters (useCardData handles cluster filtering)
-  const allCRDs: CRD[] = useMemo(() => {
-    const reachable = deduplicatedClusters.filter(c => c.reachable !== false)
-    const crdsWithClusters: CRD[] = []
-    reachable.forEach(c => {
-      crdsWithClusters.push(...getClusterCRDs(c.name))
-    })
-    return crdsWithClusters
-  }, [deduplicatedClusters, getClusterCRDs])
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     hasAnyData: allCRDs.length > 0,
-    isDemoData: isDemoMode,
+    isDemoData,
   })
 
   // Apply group filter before passing to useCardData
@@ -122,10 +79,10 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
     },
     containerRef,
     containerStyle,
-  } = useCardData<CRD, SortByOption>(groupFilteredCRDs, {
+  } = useCardData<CRDData, SortByOption>(groupFilteredCRDs, {
     filter: {
-      searchFields: ['name', 'group', 'cluster'] as (keyof CRD)[],
-      clusterField: 'cluster' as keyof CRD,
+      searchFields: ['name', 'group', 'cluster'] as (keyof CRDData)[],
+      clusterField: 'cluster' as keyof CRDData,
       storageKey: 'crd-health',
     },
     sort: {
@@ -147,7 +104,7 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
     return Array.from(groupSet).sort()
   }, [allCRDs])
 
-  const getStatusIcon = (status: CRD['status']) => {
+  const getStatusIcon = (status: CRDData['status']) => {
     switch (status) {
       case 'Established': return CheckCircle
       case 'NotEstablished': return XCircle
@@ -155,7 +112,7 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
     }
   }
 
-  const getStatusColor = (status: CRD['status']) => {
+  const getStatusColor = (status: CRDData['status']) => {
     switch (status) {
       case 'Established': return 'green'
       case 'NotEstablished': return 'red'

--- a/web/src/hooks/useCRDs.ts
+++ b/web/src/hooks/useCRDs.ts
@@ -1,0 +1,246 @@
+/**
+ * CRD Data Hook with real backend API and demo data fallback
+ *
+ * Fetches live CRD data from GET /api/crds.
+ * Falls back to demo data when the API returns 503 (no k8s client)
+ * or on network error.
+ *
+ * Provides:
+ * - localStorage cache load/save with 5 minute expiry
+ * - isDemoData flag for CardWrapper demo badge
+ * - Auto-refresh every 2 minutes
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useClusters } from './useMCP'
+import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Cache expiry time — 5 minutes */
+const CACHE_EXPIRY_MS = 300_000
+
+/** Auto-refresh interval — 2 minutes */
+const REFRESH_INTERVAL_MS = 120_000
+
+/** Number of consecutive failures before marking as failed */
+const FAILURE_THRESHOLD = 3
+
+/** localStorage key for CRD cache */
+const CRD_CACHE_KEY = 'kc-crd-cache'
+
+/** HTTP status code returned when the backend has no k8s client */
+const STATUS_SERVICE_UNAVAILABLE = 503
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface CRDData {
+  name: string
+  group: string
+  version: string
+  scope: 'Namespaced' | 'Cluster'
+  status: 'Established' | 'NotEstablished' | 'Terminating'
+  instances: number
+  cluster: string
+  versions?: Array<{
+    name: string
+    served: boolean
+    storage: boolean
+  }>
+}
+
+interface CRDListResponse {
+  crds: CRDData[]
+  isDemoData: boolean
+}
+
+interface CachedData {
+  data: CRDData[]
+  timestamp: number
+  isDemoData: boolean
+}
+
+// ============================================================================
+// Auth Helper
+// ============================================================================
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = { 'Accept': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
+}
+
+// ============================================================================
+// Cache Helpers
+// ============================================================================
+
+function loadFromCache(): CachedData | null {
+  try {
+    const stored = localStorage.getItem(CRD_CACHE_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored) as CachedData
+      if (Date.now() - parsed.timestamp < CACHE_EXPIRY_MS) {
+        return parsed
+      }
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return null
+}
+
+function saveToCache(data: CRDData[], isDemoData: boolean): void {
+  try {
+    localStorage.setItem(CRD_CACHE_KEY, JSON.stringify({
+      data,
+      timestamp: Date.now(),
+      isDemoData,
+    }))
+  } catch {
+    // Ignore storage errors (quota, etc.)
+  }
+}
+
+// ============================================================================
+// Demo Data Generator
+// ============================================================================
+
+function getDemoCRDs(clusterNames: string[]): CRDData[] {
+  const crds: CRDData[] = []
+
+  ;(clusterNames || []).forEach((clusterName) => {
+    const hash = clusterName.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+    const CRD_MIN_COUNT = 5
+    const CRD_RANGE = 6
+
+    const baseCRDs: CRDData[] = [
+      { name: 'certificates', group: 'cert-manager.io', version: 'v1', scope: 'Namespaced', status: 'Established', instances: 20 + (hash % 30), cluster: clusterName },
+      { name: 'clusterissuers', group: 'cert-manager.io', version: 'v1', scope: 'Cluster', status: 'Established', instances: 1 + (hash % 3), cluster: clusterName },
+      { name: 'issuers', group: 'cert-manager.io', version: 'v1', scope: 'Namespaced', status: hash % 7 === 0 ? 'NotEstablished' : 'Established', instances: hash % 7 === 0 ? 0 : 5 + (hash % 10), cluster: clusterName },
+      { name: 'prometheuses', group: 'monitoring.coreos.com', version: 'v1', scope: 'Namespaced', status: 'Established', instances: 1 + (hash % 5), cluster: clusterName },
+      { name: 'servicemonitors', group: 'monitoring.coreos.com', version: 'v1', scope: 'Namespaced', status: 'Established', instances: 50 + (hash % 100), cluster: clusterName },
+      { name: 'alertmanagers', group: 'monitoring.coreos.com', version: 'v1', scope: 'Namespaced', status: hash % 5 === 0 ? 'Terminating' : 'Established', instances: 1 + (hash % 3), cluster: clusterName },
+      { name: 'kafkas', group: 'kafka.strimzi.io', version: 'v1beta2', scope: 'Namespaced', status: 'Established', instances: 2 + (hash % 5), cluster: clusterName },
+      { name: 'kafkatopics', group: 'kafka.strimzi.io', version: 'v1beta2', scope: 'Namespaced', status: hash % 4 === 0 ? 'NotEstablished' : 'Established', instances: hash % 4 === 0 ? 0 : 10 + (hash % 20), cluster: clusterName },
+      { name: 'applications', group: 'argoproj.io', version: 'v1alpha1', scope: 'Namespaced', status: 'Established', instances: 20 + (hash % 50), cluster: clusterName },
+      { name: 'appprojects', group: 'argoproj.io', version: 'v1alpha1', scope: 'Namespaced', status: 'Established', instances: 2 + (hash % 5), cluster: clusterName },
+    ]
+
+    const crdCount = CRD_MIN_COUNT + (hash % CRD_RANGE)
+    crds.push(...baseCRDs.slice(0, crdCount))
+  })
+
+  return crds
+}
+
+// ============================================================================
+// Hook: useCRDs
+// ============================================================================
+
+export interface UseCRDsResult {
+  crds: CRDData[]
+  isDemoData: boolean
+  isLoading: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  refetch: () => Promise<void>
+}
+
+export function useCRDs(): UseCRDsResult {
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading } = useClusters()
+
+  // Initialize from cache
+  const cachedData = useRef(loadFromCache())
+  const [crds, setCRDs] = useState<CRDData[]>(cachedData.current?.data || [])
+  const [isDemoData, setIsDemoData] = useState(cachedData.current?.isDemoData ?? true)
+  const [isLoading, setIsLoading] = useState(!cachedData.current)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
+  const [lastRefresh, setLastRefresh] = useState<number | null>(
+    cachedData.current?.timestamp || null
+  )
+  const initialLoadDone = useRef(!!cachedData.current)
+
+  const refetch = useCallback(async (silent = false) => {
+    if (!silent && !initialLoadDone.current) {
+      setIsLoading(true)
+    }
+
+    try {
+      const res = await fetch('/api/crds', {
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+
+      if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+        // Backend has no k8s client — response includes isDemoData: true
+        // Fall through to demo data
+        throw new Error('Service unavailable')
+      }
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+      }
+
+      const data = (await res.json()) as CRDListResponse
+
+      if (data.isDemoData || (data.crds || []).length === 0) {
+        // API returned but no real data — fall through to demo
+        throw new Error('No CRD data available')
+      }
+
+      setCRDs(data.crds || [])
+      setIsDemoData(false)
+      setConsecutiveFailures(0)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+      saveToCache(data.crds || [], false)
+    } catch {
+      // API failed or returned demo indicator — fall back to demo data
+      const clusterNames = (clusters || []).filter(c => c.reachable !== false).map(c => c.name)
+      const demoCRDs = getDemoCRDs(clusterNames.length > 0 ? clusterNames : ['us-east-1', 'us-west-2', 'eu-central-1'])
+      setCRDs(demoCRDs)
+      setIsDemoData(true)
+      setConsecutiveFailures(prev => prev + 1)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+      saveToCache(demoCRDs, true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [clusters])
+
+  // Initial load
+  useEffect(() => {
+    if (!clustersLoading) {
+      refetch()
+    }
+  }, [clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-refresh
+  useEffect(() => {
+    if (!initialLoadDone.current) return
+
+    const interval = setInterval(() => {
+      refetch(true)
+    }, REFRESH_INTERVAL_MS)
+
+    return () => clearInterval(interval)
+  }, [refetch])
+
+  return {
+    crds,
+    isDemoData,
+    isLoading: isLoading || clustersLoading,
+    isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
+    consecutiveFailures,
+    lastRefresh,
+    refetch: () => refetch(false),
+  }
+}


### PR DESCRIPTION
## Summary
- Add `GET /api/crds` backend handler that lists all CRDs across deduplicated clusters using the k8s dynamic client
- Parse unstructured CRD objects: extract group, scope, versions, status conditions (Established/NotEstablished/Terminating)
- Create `useCRDs()` hook with localStorage cache (5min expiry), auto-refresh (2min), consecutive failure tracking, and demo data fallback
- Wire `CRDHealth` card to use `useCRDs()` hook instead of hardcoded demo data
- Report `isDemoData` to `useCardLoadingState()` for proper Demo badge display

Part of the Lens feature parity initiative — CRD browser is one of the key features Lens users expect.

## Test plan
- [ ] Verify CRD card shows demo data when no clusters connected
- [ ] Verify CRD card shows real CRDs when clusters are connected
- [ ] Verify Demo badge appears when using demo data
- [ ] Verify search, sort, group filter, and pagination still work
- [ ] Verify cluster deduplication (no duplicate CRDs from same cluster via multiple contexts)