### PR TITLE
🌱 Disable 7 demo-only cards until wired to real backends

### DIFF
--- a/web/src/components/cards/cardIcons.ts
+++ b/web/src/components/cards/cardIcons.ts
@@ -178,9 +178,6 @@ export const CARD_ICONS: Record<string, { icon: ComponentType<{ className?: stri
   github_ci_monitor: { icon: GitBranch, color: 'text-purple-400' },
   cluster_health_monitor: { icon: Server, color: 'text-green-400' },
 
-  // Runtime cards
-  wasmcloud_status: { icon: Box, color: 'text-purple-400' },
-
   // Provider health
   provider_health: { icon: Activity, color: 'text-green-400' },
   // CoreDNS

--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -168,9 +168,6 @@ export const CARD_TITLES: Record<string, string> = {
   ml_jobs: 'ML Jobs',
   ml_notebooks: 'ML Notebooks',
 
-  // Runtime cards
-  wasmcloud_status: 'WasmCloud Status',
-
   // Benchmark cards
   nightly_e2e_status: 'Nightly E2E Status',
   benchmark_hero: 'Latest Benchmark',
@@ -347,9 +344,6 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   ml_jobs: 'Machine learning training and batch job status.',
   ml_notebooks: 'Jupyter notebook server status and resource usage.',
   provider_health: 'Health and status of AI and cloud infrastructure providers.',
-
-  // Runtime cards
-  wasmcloud_status: 'wasmCloud host status, actor inventory, and health monitoring.',
 
   // Games
   sudoku_game: 'Classic Sudoku puzzle game with multiple difficulty levels.',

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -179,20 +179,8 @@ const KagentiTopology = lazy(() => _kagentiBundle.then(m => ({ default: m.Kagent
 const CrossplaneManagedResources = lazy(() => import('./crossplane-status/CrossplaneManagedResources').then(m => ({ default: m.CrossplaneManagedResources })))
 // Cloud Native Buildpacks card
 const BuildpacksStatus = lazy(() => import('./buildpacks-status').then(m => ({ default: m.BuildpacksStatus })))
-// Flatcar Container Linux card
-const FlatcarStatus = lazy(() => import('./flatcar_status').then(m => ({ default: m.FlatcarStatus })))
-// Thanos global view metrics card
-const ThanosStatus = lazy(() => import('./thanos_status').then(m => ({ default: m.ThanosStatus })))
-// Contour ingress controller card
-const ContourStatus = lazy(() => import('./contour-status').then(m => ({ default: m.ContourStatus })))
-// CRI-O container runtime card
-const CrioStatus = lazy(() => import('./crio_status').then(m => ({ default: m.CrioStatus })))
 // CoreDNS card
 const CoreDNSStatus = lazy(() => import('./coredns_status').then(m => ({ default: m.CoreDNSStatus })))
-// Fluentd log collector card
-const FluentdStatus = lazy(() => import('./fluentd_status').then(m => ({ default: m.FluentdStatus })))
-// Lima VM card
-const LimaStatus = lazy(() => import('./lima_status').then(m => ({ default: m.LimaStatus })))
 
 // Multi-cluster insights cards — share one chunk via barrel import
 const _insightsBundle = import('./insights')
@@ -217,7 +205,6 @@ const RBACExplorer = lazy(() => _clusterAdminBundle.then(m => ({ default: m.RBAC
 const MaintenanceWindows = lazy(() => _clusterAdminBundle.then(m => ({ default: m.MaintenanceWindows })))
 const ClusterChangelog = lazy(() => _clusterAdminBundle.then(m => ({ default: m.ClusterChangelog })))
 const QuotaHeatmap = lazy(() => _clusterAdminBundle.then(m => ({ default: m.QuotaHeatmap })))
-const WasmCloudStatus = lazy(() => import('./wasmcloud_status').then(m => ({ default: m.WasmCloudStatus })))
 
 // Type for card component props
 export type CardComponentProps = { config?: Record<string, unknown> }
@@ -448,20 +435,8 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   quota_heatmap: QuotaHeatmap,
   // Cloud Native Buildpacks
   buildpacks_status: BuildpacksStatus,
-  // Flatcar Container Linux
-  flatcar_status: FlatcarStatus,
-  // Thanos global view metrics
-  thanos_status: ThanosStatus,
-  // Contour ingress controller
-  contour_status: ContourStatus,
-  // CRI-O container runtime
-  crio_status: CrioStatus,
   // CoreDNS
   coredns_status: CoreDNSStatus,
-  // Fluentd log collector
-  fluentd_status: FluentdStatus,
-  // Lima VM
-  lima_status: LimaStatus,
 
   // LLM-d stunning visualization cards
   llmd_flow: LLMdFlow,
@@ -506,7 +481,6 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   error_count: PodIssues,
   security_overview: SecurityIssues,
   rbac_summary: NamespaceRBAC,
-  wasmcloud_status: WasmCloudStatus,
 }
 
 // Lazy-load UnifiedCard — keeps it out of the main bundle for fast page load
@@ -571,11 +545,6 @@ export const DEMO_DATA_CARDS = new Set([
   'gateway_status',
   // Note: service_topology removed — now reports isDemoData via useTopology hook
   // Note: buildpacks_status removed — reports isDemoData via useBuildpackImages hook
-  'flatcar_status',
-  'thanos_status',
-  'contour_status',
-  'fluentd_status',
-  'lima_status',
 
   // Workload Deployment - uses real data when backend is running, falls back to demo internally
   // NOT in DEMO_DATA_CARDS because the static badge can't detect runtime data source
@@ -794,18 +763,6 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   crossplane_managed_resources: () => import('./crossplane-status'),
   // Cloud Native Buildpacks
   buildpacks_status: () => import('./buildpacks-status'),
-  //wasmcloud
-  wasmcloud_status: () => import('./wasmcloud_status'),
-  // Flatcar Container Linux
-  flatcar_status: () => import('./flatcar_status'),
-  // Thanos global view metrics
-  thanos_status: () => import('./thanos_status'),
-  // Contour ingress controller
-  contour_status: () => import('./contour-status'),
-  // CRI-O container runtime
-  crio_status: () => import('./crio_status'),
-  // Lima VM
-  lima_status: () => import('./lima_status'),
 }
 
 /**
@@ -942,12 +899,6 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   upgrade_status: 4,
   crossplane_managed_resources: 4,
   buildpacks_status: 6,
-  flatcar_status: 6,
-  thanos_status: 6,
-  contour_status: 6,
-  crio_status: 6,
-  fluentd_status: 6,
-  lima_status: 6,
 
   // MCS cards
   service_exports: 6,
@@ -1149,7 +1100,6 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   // Full width cards (12 columns) - complex visualizations
   cluster_comparison: 12,
   cluster_resource_tree: 12,
-  wasmcloud_status: 6,
 }
 
 // Default width for cards not in the map

--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -124,7 +124,6 @@ const CARD_CATALOG = {
     { type: 'service_imports', title: 'Service Imports (MCS)', description: 'Multi-cluster service imports receiving cross-cluster traffic', visualization: 'table' },
     { type: 'gateway_status', title: 'Gateway API', description: 'Kubernetes Gateway API resources and HTTPRoutes', visualization: 'status' },
     { type: 'service_topology', title: 'Service Topology', description: 'Animated service mesh visualization with cross-cluster traffic', visualization: 'status' },
-    { type: 'contour_status', title: 'Contour', description: 'Contour ingress proxy status, HTTPProxy resources', visualization: 'status' },
     { type: 'ingress_status', title: 'Ingress Status', description: 'Ingress resources with hosts, paths, and backend services', visualization: 'table' },
     { type: 'network_policy_status', title: 'Network Policy Status', description: 'NetworkPolicy resources with pod selectors and rules', visualization: 'table' },
   ],
@@ -274,19 +273,11 @@ const CARD_CATALOG = {
   ],
   'Misc': [
     { type: 'buildpacks_status', title: 'Buildpacks Status', description: 'Cloud Native Buildpacks detection, builders, and image build status', visualization: 'status' },
-    { type: 'flatcar_status', title: 'Flatcar Container Linux', description: 'Flatcar node OS versions, update status, and version distribution', visualization: 'status' },
-    { type: 'thanos_status', title: 'Thanos', description: 'Thanos global view metrics, store gateway status, and target health', visualization: 'status' },
-    { type: 'fluentd_status', title: 'Fluentd', description: 'Log pipeline status, buffer utilization, and output plugin health', visualization: 'status' },
     { type: 'weather', title: 'Weather', description: 'Weather conditions with multi-day forecasts and animated backgrounds', visualization: 'status' },
     { type: 'github_activity', title: 'GitHub Activity', description: 'Monitor GitHub repository activity - PRs, issues, releases, and contributors', visualization: 'table' },
     { type: 'kubectl', title: 'Kubectl', description: 'Interactive kubectl terminal with AI assistance, YAML editor, and command history', visualization: 'table' },
     { type: 'stock_market_ticker', title: 'Stock Market Ticker', description: 'Track multiple stocks with real-time sparkline charts and iPhone-style design', visualization: 'timeseries' },
   ],
-  'Runtime': [
-    { type: 'wasmcloud_status', title: 'WasmCloud Status', description: 'wasmCloud host status, actor inventory.', visualization: 'status' },
-    { type: 'crio_status', title: 'CRI-O', description: 'CRI-O container runtime metrics, image pulls, and pod sandbox status', visualization: 'status' },
-    { type: 'lima_status', title: 'Lima', description: 'Lima virtual machine instances and resource usage', visualization: 'status' },
-  ]
 } as const
 
 /**


### PR DESCRIPTION
## Summary
- Removes 7 cards from the registry that only display hardcoded demo data with no real backend API wiring
- Cards disabled: **Contour**, **CRI-O**, **Fluentd**, **Flatcar**, **Lima**, **Thanos**, **WasmCloud**
- Source files preserved — cards can be re-enabled once connected to live cluster data

## Why
These cards were merged with demo data only, meaning they never show real information from actual clusters. This creates a misleading user experience — the cards look functional but display fabricated data without any indication that the data isn't real.

Going forward, all cards must include:
1. **Real backend wiring** — Go handler that queries actual cluster resources
2. **Demo fallback** — Graceful degradation with `isDemoData` flag when no clusters are available
3. **Demo badge** — Proper `useCardLoadingState()` integration so users see when data is synthetic

See PR #2210 (CRD Health) for the pattern to follow.

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Lint passes (`npm run lint`)
- [ ] Disabled cards no longer appear in the Add Card modal
- [ ] Disabled cards no longer appear on dashboards
- [ ] No console errors from missing card references