### PR TITLE
✨ Wire ServiceExports and AdmissionWebhooks to real backend APIs

### DIFF
--- a/pkg/api/handlers/admission_webhooks.go
+++ b/pkg/api/handlers/admission_webhooks.go
@@ -1,0 +1,148 @@
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/k8s"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// GVRs for webhook configurations
+var (
+	validatingWebhookGVR = schema.GroupVersionResource{
+		Group:    "admissionregistration.k8s.io",
+		Version:  "v1",
+		Resource: "validatingwebhookconfigurations",
+	}
+	mutatingWebhookGVR = schema.GroupVersionResource{
+		Group:    "admissionregistration.k8s.io",
+		Version:  "v1",
+		Resource: "mutatingwebhookconfigurations",
+	}
+)
+
+// WebhookHandlers handles admission webhook API endpoints
+type WebhookHandlers struct {
+	k8sClient *k8s.MultiClusterClient
+}
+
+// NewWebhookHandlers creates a new webhook handlers instance
+func NewWebhookHandlers(k8sClient *k8s.MultiClusterClient) *WebhookHandlers {
+	return &WebhookHandlers{
+		k8sClient: k8sClient,
+	}
+}
+
+// WebhookSummary represents a webhook configuration as returned by the API
+type WebhookSummary struct {
+	Name          string `json:"name"`
+	Type          string `json:"type"` // "mutating" or "validating"
+	FailurePolicy string `json:"failurePolicy"`
+	MatchPolicy   string `json:"matchPolicy"`
+	Rules         int    `json:"rules"`
+	Cluster       string `json:"cluster"`
+}
+
+// WebhookListResponse is the response for GET /api/admission-webhooks
+type WebhookListResponse struct {
+	Webhooks   []WebhookSummary `json:"webhooks"`
+	IsDemoData bool             `json:"isDemoData"`
+}
+
+// HTTP status code for service unavailable
+const statusServiceUnavailableWebhook = 503
+
+// ListWebhooks returns all admission webhook configurations across clusters
+// GET /api/admission-webhooks
+func (h *WebhookHandlers) ListWebhooks(c *fiber.Ctx) error {
+	if h.k8sClient == nil {
+		return c.Status(statusServiceUnavailableWebhook).JSON(WebhookListResponse{
+			Webhooks:   []WebhookSummary{},
+			IsDemoData: true,
+		})
+	}
+
+	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+	if err != nil {
+		clusters, _ = h.k8sClient.ListClusters(c.Context())
+	}
+
+	var allWebhooks []WebhookSummary
+
+	for _, cluster := range clusters {
+		client, err := h.k8sClient.GetDynamicClient(cluster.Name)
+		if err != nil {
+			continue
+		}
+
+		// Fetch validating webhooks
+		valList, err := client.Resource(validatingWebhookGVR).List(c.Context(), metav1.ListOptions{})
+		if err == nil {
+			for _, item := range valList.Items {
+				wh := parseWebhookFromUnstructured(&item, cluster.Name, "validating")
+				if wh != nil {
+					allWebhooks = append(allWebhooks, *wh)
+				}
+			}
+		}
+
+		// Fetch mutating webhooks
+		mutList, err := client.Resource(mutatingWebhookGVR).List(c.Context(), metav1.ListOptions{})
+		if err == nil {
+			for _, item := range mutList.Items {
+				wh := parseWebhookFromUnstructured(&item, cluster.Name, "mutating")
+				if wh != nil {
+					allWebhooks = append(allWebhooks, *wh)
+				}
+			}
+		}
+	}
+
+	return c.JSON(WebhookListResponse{
+		Webhooks:   allWebhooks,
+		IsDemoData: false,
+	})
+}
+
+// parseWebhookFromUnstructured extracts webhook info from an unstructured object
+func parseWebhookFromUnstructured(item *unstructured.Unstructured, cluster, whType string) *WebhookSummary {
+	name := item.GetName()
+
+	// Count rules and extract policies from the webhooks array
+	failurePolicy := "Fail"
+	matchPolicy := "Exact"
+	ruleCount := 0
+
+	// The webhook list is under "webhooks" for both mutating and validating
+	if webhooks, ok := item.Object["webhooks"].([]interface{}); ok {
+		for _, wh := range webhooks {
+			whMap, ok := wh.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			// Count rules across all webhooks in this configuration
+			if rules, ok := whMap["rules"].([]interface{}); ok {
+				ruleCount += len(rules)
+			}
+
+			// Use failure policy from first webhook entry
+			if fp, ok := whMap["failurePolicy"].(string); ok && ruleCount <= len(webhooks) {
+				failurePolicy = fp
+			}
+			if mp, ok := whMap["matchPolicy"].(string); ok && ruleCount <= len(webhooks) {
+				matchPolicy = mp
+			}
+		}
+	}
+
+	return &WebhookSummary{
+		Name:          name,
+		Type:          whType,
+		FailurePolicy: failurePolicy,
+		MatchPolicy:   matchPolicy,
+		Rules:         ruleCount,
+		Cluster:       cluster,
+	}
+}

--- a/pkg/api/handlers/service_exports.go
+++ b/pkg/api/handlers/service_exports.go
@@ -1,0 +1,152 @@
+package handlers
+
+import (
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/kubestellar/console/pkg/k8s"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// serviceExportGVR is the GroupVersionResource for MCS ServiceExports
+var serviceExportGVR = schema.GroupVersionResource{
+	Group:    "multicluster.x-k8s.io",
+	Version:  "v1alpha1",
+	Resource: "serviceexports",
+}
+
+// ServiceExportHandlers handles MCS ServiceExport API endpoints
+type ServiceExportHandlers struct {
+	k8sClient *k8s.MultiClusterClient
+}
+
+// NewServiceExportHandlers creates a new ServiceExport handlers instance
+func NewServiceExportHandlers(k8sClient *k8s.MultiClusterClient) *ServiceExportHandlers {
+	return &ServiceExportHandlers{
+		k8sClient: k8sClient,
+	}
+}
+
+// ServiceExportSummary represents a ServiceExport as returned by the API
+type ServiceExportSummary struct {
+	Name      string   `json:"name"`
+	Namespace string   `json:"namespace"`
+	Cluster   string   `json:"cluster"`
+	Status    string   `json:"status"`
+	Message   string   `json:"message,omitempty"`
+	CreatedAt string   `json:"createdAt"`
+	Targets   []string `json:"targetClusters,omitempty"`
+}
+
+// ServiceExportListResponse is the response for GET /api/service-exports
+type ServiceExportListResponse struct {
+	Exports    []ServiceExportSummary `json:"exports"`
+	IsDemoData bool                   `json:"isDemoData"`
+}
+
+// HTTP status code for service unavailable
+const statusServiceUnavailableSvcExport = 503
+
+// ListServiceExports returns all ServiceExports across clusters
+// GET /api/service-exports
+func (h *ServiceExportHandlers) ListServiceExports(c *fiber.Ctx) error {
+	if h.k8sClient == nil {
+		return c.Status(statusServiceUnavailableSvcExport).JSON(ServiceExportListResponse{
+			Exports:    []ServiceExportSummary{},
+			IsDemoData: true,
+		})
+	}
+
+	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+	if err != nil {
+		clusters, _ = h.k8sClient.ListClusters(c.Context())
+	}
+
+	var allExports []ServiceExportSummary
+
+	for _, cluster := range clusters {
+		client, err := h.k8sClient.GetDynamicClient(cluster.Name)
+		if err != nil {
+			continue
+		}
+
+		exportList, err := client.Resource(serviceExportGVR).Namespace("").List(c.Context(), metav1.ListOptions{})
+		if err != nil {
+			// MCS API may not be installed on this cluster — skip silently
+			continue
+		}
+
+		for _, item := range exportList.Items {
+			exp := parseServiceExportFromUnstructured(&item, cluster.Name)
+			if exp != nil {
+				allExports = append(allExports, *exp)
+			}
+		}
+	}
+
+	return c.JSON(ServiceExportListResponse{
+		Exports:    allExports,
+		IsDemoData: false,
+	})
+}
+
+// parseServiceExportFromUnstructured extracts ServiceExport info from an unstructured object
+func parseServiceExportFromUnstructured(item *unstructured.Unstructured, cluster string) *ServiceExportSummary {
+	name := item.GetName()
+	namespace := item.GetNamespace()
+	createdAt := item.GetCreationTimestamp().Format(time.RFC3339)
+
+	// Derive status from conditions
+	status := "Unknown"
+	message := ""
+	if statusObj, ok := item.Object["status"].(map[string]interface{}); ok {
+		if conditions, ok := statusObj["conditions"].([]interface{}); ok {
+			for _, cond := range conditions {
+				condMap, ok := cond.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				condType, _ := condMap["type"].(string)
+				condStatus, _ := condMap["status"].(string)
+				condMsg, _ := condMap["message"].(string)
+
+				if condType == "Ready" || condType == "Valid" {
+					if condStatus == "True" {
+						status = "Ready"
+					} else {
+						status = "Pending"
+						message = condMsg
+					}
+				}
+				// A conflict condition overrides to Failed
+				if condType == "Conflict" && condStatus == "True" {
+					status = "Failed"
+					message = condMsg
+				}
+			}
+		}
+	}
+
+	// If no conditions found, check if recently created (within 5 min) → Pending, else Ready
+	if status == "Unknown" {
+		const recentThresholdMin = 5
+		created := item.GetCreationTimestamp().Time
+		if time.Since(created) < time.Duration(recentThresholdMin)*time.Minute {
+			status = "Pending"
+			message = "Waiting for controller to reconcile"
+		} else {
+			status = "Ready"
+		}
+	}
+
+	return &ServiceExportSummary{
+		Name:      name,
+		Namespace: namespace,
+		Cluster:   cluster,
+		Status:    status,
+		Message:   message,
+		CreatedAt: createdAt,
+	}
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -637,6 +637,14 @@ func (s *Server) setupRoutes() {
 	crdHandlers := handlers.NewCRDHandlers(s.k8sClient)
 	api.Get("/crds", crdHandlers.ListCRDs)
 
+	// MCS ServiceExport routes
+	svcExportHandlers := handlers.NewServiceExportHandlers(s.k8sClient)
+	api.Get("/service-exports", svcExportHandlers.ListServiceExports)
+
+	// Admission webhook routes
+	webhookHandlers := handlers.NewWebhookHandlers(s.k8sClient)
+	api.Get("/admission-webhooks", webhookHandlers.ListWebhooks)
+
 	// Service Topology routes
 	topologyHandlers := handlers.NewTopologyHandlers(s.k8sClient, s.hub)
 	api.Get("/topology", topologyHandlers.GetTopology)

--- a/web/src/components/cards/AdmissionWebhooks.tsx
+++ b/web/src/components/cards/AdmissionWebhooks.tsx
@@ -1,33 +1,13 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCardLoadingState } from './CardDataContext'
-
-interface Webhook {
-  name: string
-  type: 'mutating' | 'validating'
-  failurePolicy: 'Fail' | 'Ignore'
-  matchPolicy: string
-  rules: number
-  cluster: string
-}
-
-const DEMO_WEBHOOKS: Webhook[] = [
-  { name: 'gatekeeper-validating', type: 'validating', failurePolicy: 'Ignore', matchPolicy: 'Exact', rules: 3, cluster: 'prod-us-east' },
-  { name: 'kyverno-resource-validating', type: 'validating', failurePolicy: 'Fail', matchPolicy: 'Equivalent', rules: 12, cluster: 'prod-us-east' },
-  { name: 'cert-manager-webhook', type: 'mutating', failurePolicy: 'Fail', matchPolicy: 'Exact', rules: 2, cluster: 'prod-us-east' },
-  { name: 'istio-sidecar-injector', type: 'mutating', failurePolicy: 'Ignore', matchPolicy: 'Exact', rules: 1, cluster: 'prod-us-east' },
-  { name: 'vault-agent-injector', type: 'mutating', failurePolicy: 'Ignore', matchPolicy: 'Exact', rules: 1, cluster: 'prod-eu-west' },
-  { name: 'gatekeeper-validating', type: 'validating', failurePolicy: 'Ignore', matchPolicy: 'Exact', rules: 5, cluster: 'prod-eu-west' },
-  { name: 'kyverno-resource-validating', type: 'validating', failurePolicy: 'Fail', matchPolicy: 'Equivalent', rules: 8, cluster: 'staging' },
-  { name: 'webhook-admission-controller', type: 'validating', failurePolicy: 'Fail', matchPolicy: 'Exact', rules: 4, cluster: 'staging' },
-]
+import { useAdmissionWebhooks } from '../../hooks/useAdmissionWebhooks'
 
 export function AdmissionWebhooks() {
   const { t } = useTranslation('cards')
   const [tab, setTab] = useState<'all' | 'mutating' | 'validating'>('all')
-  useCardLoadingState({ isLoading: false, hasAnyData: true, isDemoData: true })
-
-  const webhooks = DEMO_WEBHOOKS
+  const { webhooks, isLoading, isDemoData } = useAdmissionWebhooks()
+  useCardLoadingState({ isLoading, hasAnyData: webhooks.length > 0, isDemoData })
   const filtered = tab === 'all' ? webhooks : webhooks.filter(w => w.type === tab)
   const mutatingCount = webhooks.filter(w => w.type === 'mutating').length
   const validatingCount = webhooks.filter(w => w.type === 'validating').length

--- a/web/src/components/cards/ServiceExports.tsx
+++ b/web/src/components/cards/ServiceExports.tsx
@@ -11,66 +11,8 @@ import { Skeleton } from '../ui/Skeleton'
 import { K8S_DOCS } from '../../config/externalApis'
 import type { ServiceExport, ServiceExportStatus } from '../../types/mcs'
 import { useCardLoadingState } from './CardDataContext'
-import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
-
-// Demo data for MCS ServiceExports
-const DEMO_EXPORTS: ServiceExport[] = [
-  {
-    name: 'api-gateway',
-    namespace: 'production',
-    cluster: 'us-east-1',
-    serviceName: 'api-gateway',
-    status: 'Ready',
-    targetClusters: ['us-west-2', 'eu-central-1'],
-    createdAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
-  },
-  {
-    name: 'auth-service',
-    namespace: 'production',
-    cluster: 'us-east-1',
-    serviceName: 'auth-service',
-    status: 'Ready',
-    targetClusters: ['us-west-2', 'eu-central-1', 'ap-southeast-1'],
-    createdAt: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString(),
-  },
-  {
-    name: 'cache-redis',
-    namespace: 'infrastructure',
-    cluster: 'us-west-2',
-    serviceName: 'redis-master',
-    status: 'Ready',
-    targetClusters: ['us-east-1'],
-    createdAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
-  },
-  {
-    name: 'payment-processor',
-    namespace: 'payments',
-    cluster: 'eu-central-1',
-    serviceName: 'payment-processor',
-    status: 'Pending',
-    message: 'Waiting for endpoints to become ready',
-    createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(),
-  },
-  {
-    name: 'legacy-backend',
-    namespace: 'legacy',
-    cluster: 'on-prem-dc1',
-    serviceName: 'backend-v1',
-    status: 'Failed',
-    message: 'Service not found in cluster',
-    createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
-  },
-]
-
-const DEMO_STATS = {
-  totalExports: 12,
-  readyCount: 9,
-  pendingCount: 2,
-  failedCount: 1,
-  clustersWithMCS: 4,
-  totalClusters: 5,
-}
+import { useServiceExports } from '../../hooks/useServiceExports'
 
 const getStatusIcon = (status: ServiceExportStatus) => {
   switch (status) {
@@ -120,20 +62,17 @@ interface ServiceExportsProps {
 
 export function ServiceExports({ config: _config }: ServiceExportsProps) {
   const { t } = useTranslation(['cards', 'common'])
-  const { isDemoMode } = useDemoMode()
+  const { exports: allExports, isLoading, isDemoData } = useServiceExports()
   const SORT_OPTIONS = useMemo(() =>
     SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) })),
     [t]
   )
-  // Demo data - always available, never loading/erroring
-  const isLoading = false
-  const hasError = false
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
-  useCardLoadingState({
+  const { showSkeleton } = useCardLoadingState({
     isLoading,
-    hasAnyData: DEMO_EXPORTS.length > 0,
-    isDemoData: isDemoMode,
+    hasAnyData: allExports.length > 0,
+    isDemoData,
   })
 
   const {
@@ -164,7 +103,7 @@ export function ServiceExports({ config: _config }: ServiceExportsProps) {
     },
     containerRef,
     containerStyle,
-  } = useCardData<ServiceExport, SortByOption>(DEMO_EXPORTS, {
+  } = useCardData<ServiceExport, SortByOption>(allExports, {
     filter: {
       searchFields: ['name', 'namespace', 'cluster', 'serviceName', 'status'],
       clusterField: 'cluster',
@@ -178,8 +117,12 @@ export function ServiceExports({ config: _config }: ServiceExportsProps) {
     defaultLimit: 5,
   })
 
+  // Compute stats from the data
+  const readyCount = allExports.filter(e => e.status === 'Ready').length
+  const pendingCount = allExports.filter(e => e.status === 'Pending').length
+
   // Show skeleton while loading
-  if (isLoading) {
+  if (showSkeleton) {
     return (
       <div className="h-full flex flex-col min-h-card">
         <div className="flex items-center justify-between mb-3">
@@ -191,22 +134,6 @@ export function ServiceExports({ config: _config }: ServiceExportsProps) {
           <Skeleton variant="rounded" height={50} />
           <Skeleton variant="rounded" height={50} />
         </div>
-      </div>
-    )
-  }
-
-  // Show error state if data fetch failed
-  if (hasError) {
-    return (
-      <div className="h-full flex flex-col items-center justify-center min-h-card p-6">
-        <AlertCircle className="w-12 h-12 text-red-400 mb-4" />
-        <p className="text-sm text-muted-foreground mb-4">{t('serviceExports.loadFailed')}</p>
-        <button
-          onClick={() => window.location.reload()}
-          className="px-4 py-2 rounded-lg bg-purple-500 hover:bg-purple-600 text-white text-sm"
-        >
-          {t('common:common.retry')}
-        </button>
       </div>
     )
   }
@@ -226,7 +153,7 @@ export function ServiceExports({ config: _config }: ServiceExportsProps) {
             <ExternalLink className="w-4 h-4" />
           </a>
           <span className="text-sm font-medium text-muted-foreground">
-            {t('serviceExports.nExports', { count: DEMO_STATS.totalExports })}
+            {t('serviceExports.nExports', { count: totalItems })}
           </span>
           {localClusterFilter.length > 0 && (
             <span className="flex items-center gap-1 text-xs text-muted-foreground bg-secondary/50 px-1.5 py-0.5 rounded">
@@ -281,15 +208,15 @@ export function ServiceExports({ config: _config }: ServiceExportsProps) {
       <div className="grid grid-cols-3 gap-2 mb-3">
         <div className="p-2 rounded-lg bg-blue-500/10 border border-blue-500/20 text-center">
           <p className="text-2xs text-blue-400">{t('serviceExports.exports')}</p>
-          <p className="text-lg font-bold text-foreground">{DEMO_STATS.totalExports}</p>
+          <p className="text-lg font-bold text-foreground">{totalItems}</p>
         </div>
         <div className="p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-center">
           <p className="text-2xs text-green-400">{t('common:common.ready')}</p>
-          <p className="text-lg font-bold text-foreground">{DEMO_STATS.readyCount}</p>
+          <p className="text-lg font-bold text-foreground">{readyCount}</p>
         </div>
         <div className="p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
           <p className="text-2xs text-yellow-400">{t('common:common.pending')}</p>
-          <p className="text-lg font-bold text-foreground">{DEMO_STATS.pendingCount}</p>
+          <p className="text-lg font-bold text-foreground">{pendingCount}</p>
         </div>
       </div>
 

--- a/web/src/hooks/useAdmissionWebhooks.ts
+++ b/web/src/hooks/useAdmissionWebhooks.ts
@@ -1,0 +1,225 @@
+/**
+ * Admission Webhooks Hook with real backend API and demo data fallback
+ *
+ * Fetches live webhook data from GET /api/admission-webhooks.
+ * Falls back to demo data when the API returns 503 (no k8s client)
+ * or on network error.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useClusters } from './useMCP'
+import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Cache expiry time — 5 minutes */
+const CACHE_EXPIRY_MS = 300_000
+
+/** Auto-refresh interval — 2 minutes */
+const REFRESH_INTERVAL_MS = 120_000
+
+/** Number of consecutive failures before marking as failed */
+const FAILURE_THRESHOLD = 3
+
+/** localStorage key for webhooks cache */
+const CACHE_KEY = 'kc-admission-webhooks-cache'
+
+/** HTTP status code returned when the backend has no k8s client */
+const STATUS_SERVICE_UNAVAILABLE = 503
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface WebhookData {
+  name: string
+  type: 'mutating' | 'validating'
+  failurePolicy: 'Fail' | 'Ignore'
+  matchPolicy: string
+  rules: number
+  cluster: string
+}
+
+interface WebhookListResponse {
+  webhooks: WebhookData[]
+  isDemoData: boolean
+}
+
+interface CachedData {
+  data: WebhookData[]
+  timestamp: number
+  isDemoData: boolean
+}
+
+// ============================================================================
+// Auth Helper
+// ============================================================================
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = { 'Accept': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
+}
+
+// ============================================================================
+// Cache Helpers
+// ============================================================================
+
+function loadFromCache(): CachedData | null {
+  try {
+    const stored = localStorage.getItem(CACHE_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored) as CachedData
+      if (Date.now() - parsed.timestamp < CACHE_EXPIRY_MS) {
+        return parsed
+      }
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return null
+}
+
+function saveToCache(data: WebhookData[], isDemoData: boolean): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({
+      data,
+      timestamp: Date.now(),
+      isDemoData,
+    }))
+  } catch {
+    // Ignore storage errors (quota, etc.)
+  }
+}
+
+// ============================================================================
+// Demo Data Generator
+// ============================================================================
+
+function getDemoWebhooks(clusterNames: string[]): WebhookData[] {
+  const webhooks: WebhookData[] = []
+  const names = clusterNames.length > 0 ? clusterNames : ['prod-us-east', 'prod-eu-west', 'staging']
+
+  const templates: Omit<WebhookData, 'cluster'>[] = [
+    { name: 'gatekeeper-validating', type: 'validating', failurePolicy: 'Ignore', matchPolicy: 'Exact', rules: 3 },
+    { name: 'kyverno-resource-validating', type: 'validating', failurePolicy: 'Fail', matchPolicy: 'Equivalent', rules: 12 },
+    { name: 'cert-manager-webhook', type: 'mutating', failurePolicy: 'Fail', matchPolicy: 'Exact', rules: 2 },
+    { name: 'istio-sidecar-injector', type: 'mutating', failurePolicy: 'Ignore', matchPolicy: 'Exact', rules: 1 },
+    { name: 'vault-agent-injector', type: 'mutating', failurePolicy: 'Ignore', matchPolicy: 'Exact', rules: 1 },
+  ]
+
+  for (const cluster of names) {
+    const hash = cluster.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+    const count = 2 + (hash % 4) // 2-5 webhooks per cluster
+    for (let i = 0; i < count && i < templates.length; i++) {
+      webhooks.push({ ...templates[i], cluster })
+    }
+  }
+
+  return webhooks
+}
+
+// ============================================================================
+// Hook: useAdmissionWebhooks
+// ============================================================================
+
+export interface UseAdmissionWebhooksResult {
+  webhooks: WebhookData[]
+  isDemoData: boolean
+  isLoading: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  refetch: () => Promise<void>
+}
+
+export function useAdmissionWebhooks(): UseAdmissionWebhooksResult {
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading } = useClusters()
+
+  const cachedData = useRef(loadFromCache())
+  const [webhooks, setWebhooks] = useState<WebhookData[]>(cachedData.current?.data || [])
+  const [isDemoData, setIsDemoData] = useState(cachedData.current?.isDemoData ?? true)
+  const [isLoading, setIsLoading] = useState(!cachedData.current)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
+  const [lastRefresh, setLastRefresh] = useState<number | null>(
+    cachedData.current?.timestamp || null
+  )
+  const initialLoadDone = useRef(!!cachedData.current)
+
+  const refetch = useCallback(async (silent = false) => {
+    if (!silent && !initialLoadDone.current) {
+      setIsLoading(true)
+    }
+
+    try {
+      const res = await fetch('/api/admission-webhooks', {
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+
+      if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+        throw new Error('Service unavailable')
+      }
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+      }
+
+      const data = (await res.json()) as WebhookListResponse
+
+      if (data.isDemoData || (data.webhooks || []).length === 0) {
+        throw new Error('No webhook data available')
+      }
+
+      setWebhooks(data.webhooks || [])
+      setIsDemoData(false)
+      setConsecutiveFailures(0)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+      saveToCache(data.webhooks || [], false)
+    } catch {
+      const clusterNames = (clusters || []).filter(c => c.reachable !== false).map(c => c.name)
+      const demoWebhooks = getDemoWebhooks(clusterNames)
+      setWebhooks(demoWebhooks)
+      setIsDemoData(true)
+      setConsecutiveFailures(prev => prev + 1)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+      saveToCache(demoWebhooks, true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [clusters])
+
+  // Initial load
+  useEffect(() => {
+    if (!clustersLoading) {
+      refetch()
+    }
+  }, [clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-refresh
+  useEffect(() => {
+    if (!initialLoadDone.current) return
+
+    const interval = setInterval(() => {
+      refetch(true)
+    }, REFRESH_INTERVAL_MS)
+
+    return () => clearInterval(interval)
+  }, [refetch])
+
+  return {
+    webhooks,
+    isDemoData,
+    isLoading: isLoading || clustersLoading,
+    isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
+    consecutiveFailures,
+    lastRefresh,
+    refetch: () => refetch(false),
+  }
+}

--- a/web/src/hooks/useServiceExports.ts
+++ b/web/src/hooks/useServiceExports.ts
@@ -1,0 +1,243 @@
+/**
+ * ServiceExport Data Hook with real backend API and demo data fallback
+ *
+ * Fetches live MCS ServiceExport data from GET /api/service-exports.
+ * Falls back to demo data when the API returns 503 (no k8s client)
+ * or on network error.
+ *
+ * Provides:
+ * - localStorage cache load/save with 5 minute expiry
+ * - isDemoData flag for CardWrapper demo badge
+ * - Auto-refresh every 2 minutes
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useClusters } from './useMCP'
+import { STORAGE_KEY_TOKEN } from '../lib/constants'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import type { ServiceExport } from '../types/mcs'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Cache expiry time — 5 minutes */
+const CACHE_EXPIRY_MS = 300_000
+
+/** Auto-refresh interval — 2 minutes */
+const REFRESH_INTERVAL_MS = 120_000
+
+/** Number of consecutive failures before marking as failed */
+const FAILURE_THRESHOLD = 3
+
+/** localStorage key for ServiceExport cache */
+const CACHE_KEY = 'kc-service-exports-cache'
+
+/** HTTP status code returned when the backend has no k8s client */
+const STATUS_SERVICE_UNAVAILABLE = 503
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ServiceExportListResponse {
+  exports: ServiceExport[]
+  isDemoData: boolean
+}
+
+interface CachedData {
+  data: ServiceExport[]
+  timestamp: number
+  isDemoData: boolean
+}
+
+// ============================================================================
+// Auth Helper
+// ============================================================================
+
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers: Record<string, string> = { 'Accept': 'application/json' }
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  return headers
+}
+
+// ============================================================================
+// Cache Helpers
+// ============================================================================
+
+function loadFromCache(): CachedData | null {
+  try {
+    const stored = localStorage.getItem(CACHE_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored) as CachedData
+      if (Date.now() - parsed.timestamp < CACHE_EXPIRY_MS) {
+        return parsed
+      }
+    }
+  } catch {
+    // Ignore parse errors
+  }
+  return null
+}
+
+function saveToCache(data: ServiceExport[], isDemoData: boolean): void {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({
+      data,
+      timestamp: Date.now(),
+      isDemoData,
+    }))
+  } catch {
+    // Ignore storage errors (quota, etc.)
+  }
+}
+
+// ============================================================================
+// Demo Data Generator
+// ============================================================================
+
+/** Days in milliseconds */
+const MS_PER_DAY = 86_400_000
+/** Hours in milliseconds */
+const MS_PER_HOUR = 3_600_000
+
+function getDemoServiceExports(clusterNames: string[]): ServiceExport[] {
+  const exports: ServiceExport[] = []
+  const names = clusterNames.length > 0 ? clusterNames : ['us-east-1', 'us-west-2', 'eu-central-1']
+
+  // Generate realistic ServiceExports
+  const templates = [
+    { name: 'api-gateway', namespace: 'production', status: 'Ready' as const },
+    { name: 'auth-service', namespace: 'production', status: 'Ready' as const },
+    { name: 'cache-redis', namespace: 'infrastructure', status: 'Ready' as const },
+    { name: 'payment-processor', namespace: 'payments', status: 'Pending' as const, message: 'Waiting for endpoints to become ready' },
+    { name: 'legacy-backend', namespace: 'legacy', status: 'Failed' as const, message: 'Service not found in cluster' },
+  ]
+
+  for (const cluster of names) {
+    const hash = cluster.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
+    const count = 2 + (hash % 4) // 2-5 exports per cluster
+    const others = names.filter(n => n !== cluster)
+
+    for (let i = 0; i < count && i < templates.length; i++) {
+      const tmpl = templates[i]
+      exports.push({
+        name: tmpl.name,
+        namespace: tmpl.namespace,
+        cluster,
+        serviceName: tmpl.name,
+        status: tmpl.status,
+        message: tmpl.message,
+        targetClusters: others.slice(0, 1 + (hash % others.length)),
+        createdAt: new Date(Date.now() - (i + 1) * MS_PER_DAY - hash * MS_PER_HOUR).toISOString(),
+      })
+    }
+  }
+
+  return exports
+}
+
+// ============================================================================
+// Hook: useServiceExports
+// ============================================================================
+
+export interface UseServiceExportsResult {
+  exports: ServiceExport[]
+  isDemoData: boolean
+  isLoading: boolean
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  refetch: () => Promise<void>
+}
+
+export function useServiceExports(): UseServiceExportsResult {
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading } = useClusters()
+
+  // Initialize from cache
+  const cachedData = useRef(loadFromCache())
+  const [exports, setExports] = useState<ServiceExport[]>(cachedData.current?.data || [])
+  const [isDemoData, setIsDemoData] = useState(cachedData.current?.isDemoData ?? true)
+  const [isLoading, setIsLoading] = useState(!cachedData.current)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
+  const [lastRefresh, setLastRefresh] = useState<number | null>(
+    cachedData.current?.timestamp || null
+  )
+  const initialLoadDone = useRef(!!cachedData.current)
+
+  const refetch = useCallback(async (silent = false) => {
+    if (!silent && !initialLoadDone.current) {
+      setIsLoading(true)
+    }
+
+    try {
+      const res = await fetch('/api/service-exports', {
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+
+      if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+        throw new Error('Service unavailable')
+      }
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}: ${res.statusText}`)
+      }
+
+      const data = (await res.json()) as ServiceExportListResponse
+
+      if (data.isDemoData || (data.exports || []).length === 0) {
+        // API returned but no real data — fall through to demo
+        throw new Error('No ServiceExport data available')
+      }
+
+      setExports(data.exports || [])
+      setIsDemoData(false)
+      setConsecutiveFailures(0)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+      saveToCache(data.exports || [], false)
+    } catch {
+      // API failed or returned demo indicator — fall back to demo data
+      const clusterNames = (clusters || []).filter(c => c.reachable !== false).map(c => c.name)
+      const demoExports = getDemoServiceExports(clusterNames)
+      setExports(demoExports)
+      setIsDemoData(true)
+      setConsecutiveFailures(prev => prev + 1)
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+      saveToCache(demoExports, true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [clusters])
+
+  // Initial load
+  useEffect(() => {
+    if (!clustersLoading) {
+      refetch()
+    }
+  }, [clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-refresh
+  useEffect(() => {
+    if (!initialLoadDone.current) return
+
+    const interval = setInterval(() => {
+      refetch(true)
+    }, REFRESH_INTERVAL_MS)
+
+    return () => clearInterval(interval)
+  }, [refetch])
+
+  return {
+    exports,
+    isDemoData,
+    isLoading: isLoading || clustersLoading,
+    isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
+    consecutiveFailures,
+    lastRefresh,
+    refetch: () => refetch(false),
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Go backend handlers for **ServiceExports** (`GET /api/service-exports`) and **Admission Webhooks** (`GET /api/admission-webhooks`)
- Both query real cluster resources via `DeduplicatedClusters()` with demo fallback
- Creates `useServiceExports` and `useAdmissionWebhooks` hooks following the same API-first + demo pattern as CRD Health (#2210)
- Replaces hardcoded `DEMO_EXPORTS` and `DEMO_WEBHOOKS` arrays in the card components

## Details

### ServiceExports
- Queries `multicluster.x-k8s.io/v1alpha1/serviceexports` across all clusters
- Derives status from conditions (Ready/Valid → Ready, Conflict → Failed, else Pending/Unknown)
- Stats (total, ready, pending) now computed from real data instead of hardcoded constants

### Admission Webhooks
- Queries both `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` (admissionregistration.k8s.io/v1)
- Extracts failure policy, match policy, and rule count from webhook entries
- Card now shows real webhooks from clusters with demo badge when no clusters available

## Test plan
- [ ] `go build ./...` passes
- [ ] `npm run build` passes
- [ ] `npm run lint` passes (no new errors)
- [ ] ServiceExports card shows real data when MCS API is installed
- [ ] ServiceExports card falls back to demo data with Demo badge when no MCS
- [ ] AdmissionWebhooks card shows real webhook configs from clusters
- [ ] AdmissionWebhooks card falls back to demo data with Demo badge when no clusters