### PR TITLE
✨ Add pod exec terminal for interactive shell sessions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,9 +49,11 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/moby/spdystream v0.4.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/onsi/gomega v1.33.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/moby/spdystream v0.4.0 h1:Vy79D6mHeJJjiPdFEL2yku1kl0chZpJfZcPpb16BRl8=
+github.com/moby/spdystream v0.4.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -93,6 +95,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA=

--- a/pkg/api/handlers/exec.go
+++ b/pkg/api/handlers/exec.go
@@ -1,0 +1,281 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"sync"
+
+	"github.com/gofiber/contrib/websocket"
+	"github.com/kubestellar/console/pkg/k8s"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// ExecHandlers handles pod exec API endpoints
+type ExecHandlers struct {
+	k8sClient *k8s.MultiClusterClient
+}
+
+// NewExecHandlers creates a new exec handlers instance
+func NewExecHandlers(k8sClient *k8s.MultiClusterClient) *ExecHandlers {
+	return &ExecHandlers{
+		k8sClient: k8sClient,
+	}
+}
+
+// execInitMessage is sent by the client to start an exec session
+type execInitMessage struct {
+	Type      string   `json:"type"`
+	Cluster   string   `json:"cluster"`
+	Namespace string   `json:"namespace"`
+	Pod       string   `json:"pod"`
+	Container string   `json:"container"`
+	Command   []string `json:"command"`
+	TTY       bool     `json:"tty"`
+	Cols      uint16   `json:"cols"`
+	Rows      uint16   `json:"rows"`
+}
+
+// execMessage is the framing for stdin/stdout/stderr/resize messages
+type execMessage struct {
+	Type      string `json:"type"`
+	Data      string `json:"data,omitempty"`
+	SessionID string `json:"sessionId,omitempty"`
+	Cols      uint16 `json:"cols,omitempty"`
+	Rows      uint16 `json:"rows,omitempty"`
+	ExitCode  int    `json:"exitCode,omitempty"`
+}
+
+// wsWriter adapts WebSocket writes to io.Writer for stdout/stderr
+type wsWriter struct {
+	conn    *websocket.Conn
+	msgType string // "stdout" or "stderr"
+	mu      *sync.Mutex
+}
+
+func (w *wsWriter) Write(p []byte) (int, error) {
+	msg := execMessage{
+		Type: w.msgType,
+		Data: string(p),
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return 0, err
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := w.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+// wsReader adapts WebSocket reads to io.Reader for stdin
+// It reads "stdin" type messages from a channel fed by the main read loop
+type wsReader struct {
+	ch  chan []byte
+	buf []byte
+}
+
+func (r *wsReader) Read(p []byte) (int, error) {
+	if len(r.buf) > 0 {
+		n := copy(p, r.buf)
+		r.buf = r.buf[n:]
+		return n, nil
+	}
+	data, ok := <-r.ch
+	if !ok {
+		return 0, io.EOF
+	}
+	n := copy(p, data)
+	if n < len(data) {
+		r.buf = data[n:]
+	}
+	return n, nil
+}
+
+// terminalSizeQueue implements remotecommand.TerminalSizeQueue
+type terminalSizeQueue struct {
+	ch chan remotecommand.TerminalSize
+}
+
+func (q *terminalSizeQueue) Next() *remotecommand.TerminalSize {
+	size, ok := <-q.ch
+	if !ok {
+		return nil
+	}
+	return &size
+}
+
+// HandleExec handles a WebSocket connection for pod exec
+func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
+	defer c.Close()
+
+	if h.k8sClient == nil {
+		writeError(c, "No Kubernetes client available")
+		return
+	}
+
+	// Read the init message
+	_, msg, err := c.ReadMessage()
+	if err != nil {
+		log.Printf("exec: failed to read init message: %v", err)
+		return
+	}
+
+	var init execInitMessage
+	if err := json.Unmarshal(msg, &init); err != nil {
+		writeError(c, "Invalid init message")
+		return
+	}
+
+	if init.Type != "exec_init" {
+		writeError(c, "Expected exec_init message")
+		return
+	}
+
+	if init.Cluster == "" || init.Namespace == "" || init.Pod == "" {
+		writeError(c, "Missing cluster, namespace, or pod")
+		return
+	}
+
+	// Default command
+	if len(init.Command) == 0 {
+		init.Command = []string{"/bin/sh"}
+	}
+
+	// Default terminal size
+	const defaultCols = 80
+	const defaultRows = 24
+	if init.Cols == 0 {
+		init.Cols = defaultCols
+	}
+	if init.Rows == 0 {
+		init.Rows = defaultRows
+	}
+
+	// Get k8s client and REST config for the target cluster
+	clientset, err := h.k8sClient.GetClient(init.Cluster)
+	if err != nil {
+		writeError(c, fmt.Sprintf("Failed to get client for cluster %s: %v", init.Cluster, err))
+		return
+	}
+
+	restConfig, err := h.k8sClient.GetRestConfig(init.Cluster)
+	if err != nil {
+		writeError(c, fmt.Sprintf("Failed to get REST config for cluster %s: %v", init.Cluster, err))
+		return
+	}
+
+	// Build the exec request
+	req := clientset.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(init.Pod).
+		Namespace(init.Namespace).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: init.Container,
+			Command:   init.Command,
+			Stdin:     true,
+			Stdout:    true,
+			Stderr:    !init.TTY, // when TTY is on, stderr is merged into stdout
+			TTY:       init.TTY,
+		}, scheme.ParameterCodec)
+
+	executor, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
+	if err != nil {
+		writeError(c, fmt.Sprintf("Failed to create executor: %v", err))
+		return
+	}
+
+	// Send exec_started acknowledgment
+	startMsg, _ := json.Marshal(execMessage{Type: "exec_started"})
+	writeMu := &sync.Mutex{}
+	writeMu.Lock()
+	_ = c.WriteMessage(websocket.TextMessage, startMsg)
+	writeMu.Unlock()
+
+	// Set up stdin reader, stdout/stderr writers, and resize queue
+	stdinCh := make(chan []byte, 32)
+	stdinReader := &wsReader{ch: stdinCh}
+
+	stdoutWriter := &wsWriter{conn: c, msgType: "stdout", mu: writeMu}
+	stderrWriter := &wsWriter{conn: c, msgType: "stderr", mu: writeMu}
+
+	sizeQueue := &terminalSizeQueue{
+		ch: make(chan remotecommand.TerminalSize, 4),
+	}
+
+	// Send initial terminal size
+	sizeQueue.ch <- remotecommand.TerminalSize{Width: init.Cols, Height: init.Rows}
+
+	// Start a goroutine to read WebSocket messages and route them
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer close(stdinCh)
+		for {
+			_, rawMsg, err := c.ReadMessage()
+			if err != nil {
+				return
+			}
+
+			var m execMessage
+			if err := json.Unmarshal(rawMsg, &m); err != nil {
+				continue
+			}
+
+			switch m.Type {
+			case "stdin":
+				select {
+				case stdinCh <- []byte(m.Data):
+				default:
+					// Drop if channel full
+				}
+			case "resize":
+				if m.Cols > 0 && m.Rows > 0 {
+					select {
+					case sizeQueue.ch <- remotecommand.TerminalSize{Width: m.Cols, Height: m.Rows}:
+					default:
+					}
+				}
+			}
+		}
+	}()
+
+	// Execute the command — this blocks until the exec session ends
+	streamOpts := remotecommand.StreamOptions{
+		Stdin:  stdinReader,
+		Stdout: stdoutWriter,
+		Tty:    init.TTY,
+	}
+	if !init.TTY {
+		streamOpts.Stderr = stderrWriter
+	}
+	if init.TTY {
+		streamOpts.TerminalSizeQueue = sizeQueue
+	}
+
+	execErr := executor.StreamWithContext(context.Background(), streamOpts)
+
+	// Send exit message
+	exitCode := 0
+	if execErr != nil {
+		exitCode = 1
+		log.Printf("exec: stream ended with error: %v", execErr)
+	}
+
+	exitMsg, _ := json.Marshal(execMessage{Type: "exit", ExitCode: exitCode})
+	writeMu.Lock()
+	_ = c.WriteMessage(websocket.TextMessage, exitMsg)
+	writeMu.Unlock()
+}
+
+func writeError(c *websocket.Conn, msg string) {
+	errMsg, _ := json.Marshal(execMessage{Type: "error", Data: msg})
+	_ = c.WriteMessage(websocket.TextMessage, errMsg)
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -761,6 +761,13 @@ func (s *Server) setupRoutes() {
 		s.hub.HandleConnection(c)
 	}))
 
+	// WebSocket for pod exec terminal
+	execHandlers := handlers.NewExecHandlers(s.k8sClient)
+	s.app.Use("/api/exec", middleware.WebSocketUpgrade())
+	s.app.Get("/api/exec", websocket.New(func(c *websocket.Conn) {
+		execHandlers.HandleExec(c)
+	}))
+
 	// Serve static files in production
 	if !s.config.DevMode {
 		// Serve pre-compressed assets (.gz/.br) with Content-Length to avoid chunked encoding

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,8 @@
         "@react-three/drei": "^9.120.4",
         "@react-three/fiber": "^8.17.10",
         "@sqlite.org/sqlite-wasm": "^3.51.2-build6",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "clsx": "^2.1.1",
         "echarts": "^6.0.0",
         "echarts-for-react": "^3.0.6",
@@ -3658,6 +3660,21 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/web/package.json
+++ b/web/package.json
@@ -50,6 +50,8 @@
     "@react-three/drei": "^9.120.4",
     "@react-three/fiber": "^8.17.10",
     "@sqlite.org/sqlite-wasm": "^3.51.2-build6",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "clsx": "^2.1.1",
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.6",

--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -5,7 +5,8 @@ import { LOCAL_AGENT_WS_URL } from '../../../lib/constants'
 import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useCanI } from '../../../hooks/usePermissions'
 import { ClusterBadge } from '../../ui/ClusterBadge'
-import { FileText, Terminal, Zap, Code, Info, Tag, ChevronDown, ChevronUp, Loader2, Copy, Check, Box, Layers, Server, AlertTriangle, Pencil, Trash2, Plus, Save, X, RefreshCw, Stethoscope, Wrench, Sparkles } from 'lucide-react'
+import { FileText, Terminal, Zap, Code, Info, Tag, ChevronDown, ChevronUp, Loader2, Copy, Check, Box, Layers, Server, AlertTriangle, Pencil, Trash2, Plus, Save, X, RefreshCw, Stethoscope, Wrench, Sparkles, TerminalSquare } from 'lucide-react'
+import { PodExecTerminal } from '../../terminal/PodExecTerminal'
 import { cn } from '../../../lib/cn'
 import { Button } from '../../ui/Button'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
@@ -1161,9 +1162,26 @@ Please proceed step by step and ask for confirmation before making any changes.`
     { id: 'related', label: t('drilldown.tabs.related'), icon: Layers },
     { id: 'describe', label: t('drilldown.tabs.describe'), icon: FileText },
     { id: 'logs', label: t('drilldown.tabs.logs'), icon: Terminal },
+    { id: 'exec', label: 'Exec', icon: TerminalSquare },
     { id: 'events', label: t('drilldown.tabs.events'), icon: Zap },
     { id: 'yaml', label: t('drilldown.tabs.yaml'), icon: Code },
   ]
+
+  // Extract container names from YAML output for exec tab
+  const containerNames = useMemo(() => {
+    if (!yamlOutput) return []
+    const names: string[] = []
+    // Match "- name: <container>" lines under "containers:" section
+    const containerNameRegex = /^\s+- name:\s+(.+)$/gm
+    let match
+    while ((match = containerNameRegex.exec(yamlOutput)) !== null) {
+      const name = match[1].trim()
+      if (name && !names.includes(name)) {
+        names.push(name)
+      }
+    }
+    return names
+  }, [yamlOutput])
 
   const labelEntries = Object.entries(labels || {})
   const annotationEntries = Object.entries(annotations || {})
@@ -2094,6 +2112,18 @@ Please proceed step by step and ask for confirmation before making any changes.`
               </button>
             </div>
           )}
+        </div>
+      )}
+
+      {activeTab === 'exec' && (
+        <div className="h-[500px] rounded-lg overflow-hidden border border-border">
+          <PodExecTerminal
+            cluster={cluster}
+            namespace={namespace}
+            pod={podName}
+            containers={containerNames}
+            defaultContainer={containerNames[0]}
+          />
         </div>
       )}
 

--- a/web/src/components/drilldown/views/pod-drilldown/types.ts
+++ b/web/src/components/drilldown/views/pod-drilldown/types.ts
@@ -2,7 +2,7 @@ export interface PodDrillDownProps {
   data: Record<string, unknown>
 }
 
-export type TabType = 'overview' | 'labels' | 'related' | 'describe' | 'logs' | 'events' | 'yaml'
+export type TabType = 'overview' | 'labels' | 'related' | 'describe' | 'logs' | 'exec' | 'events' | 'yaml'
 
 export interface RelatedResource {
   kind: string

--- a/web/src/components/terminal/PodExecTerminal.tsx
+++ b/web/src/components/terminal/PodExecTerminal.tsx
@@ -1,0 +1,358 @@
+/**
+ * PodExecTerminal - Interactive terminal for pod exec sessions
+ *
+ * Wraps xterm.js to provide an in-browser terminal connected via WebSocket
+ * to the backend /api/exec endpoint for SPDY-bridged pod exec.
+ */
+
+import { useEffect, useRef, useCallback, useState } from 'react'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { useExecSession, type ExecSessionConfig, type SessionStatus } from '../../hooks/useExecSession'
+import { Loader2, AlertCircle, RotateCcw, Power, ChevronDown } from 'lucide-react'
+import '@xterm/xterm/css/xterm.css'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Debounce delay for terminal resize events */
+const RESIZE_DEBOUNCE_MS = 100
+
+/** Default terminal font size in pixels */
+const TERMINAL_FONT_SIZE = 13
+
+/** Default terminal line height */
+const TERMINAL_LINE_HEIGHT = 1.2
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface PodExecTerminalProps {
+  cluster: string
+  namespace: string
+  pod: string
+  /** Available container names */
+  containers?: string[]
+  /** Pre-selected container (defaults to first in list) */
+  defaultContainer?: string
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function PodExecTerminal({
+  cluster,
+  namespace,
+  pod,
+  containers = [],
+  defaultContainer,
+}: PodExecTerminalProps) {
+  const terminalRef = useRef<HTMLDivElement>(null)
+  const xtermRef = useRef<Terminal | null>(null)
+  const fitAddonRef = useRef<FitAddon | null>(null)
+  const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [selectedContainer, setSelectedContainer] = useState(
+    defaultContainer || (containers.length > 0 ? containers[0] : '')
+  )
+  const [showContainerPicker, setShowContainerPicker] = useState(false)
+  const [exitCode, setExitCode] = useState<number | null>(null)
+
+  const {
+    status,
+    error,
+    connect,
+    disconnect,
+    sendInput,
+    resize,
+    onData,
+    onExit,
+  } = useExecSession()
+
+  // Initialize xterm.js terminal
+  useEffect(() => {
+    if (!terminalRef.current) return
+
+    const term = new Terminal({
+      cursorBlink: true,
+      fontSize: TERMINAL_FONT_SIZE,
+      lineHeight: TERMINAL_LINE_HEIGHT,
+      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      theme: {
+        background: '#0d1117',
+        foreground: '#c9d1d9',
+        cursor: '#58a6ff',
+        selectionBackground: '#264f78',
+        black: '#0d1117',
+        red: '#ff7b72',
+        green: '#7ee787',
+        yellow: '#d29922',
+        blue: '#58a6ff',
+        magenta: '#bc8cff',
+        cyan: '#39c5cf',
+        white: '#b1bac4',
+        brightBlack: '#484f58',
+        brightRed: '#ffa198',
+        brightGreen: '#56d364',
+        brightYellow: '#e3b341',
+        brightBlue: '#79c0ff',
+        brightMagenta: '#d2a8ff',
+        brightCyan: '#56d4dd',
+        brightWhite: '#f0f6fc',
+      },
+    })
+
+    const fitAddon = new FitAddon()
+    term.loadAddon(fitAddon)
+    term.open(terminalRef.current)
+
+    // Initial fit after a frame to ensure container is sized
+    requestAnimationFrame(() => {
+      fitAddon.fit()
+    })
+
+    xtermRef.current = term
+    fitAddonRef.current = fitAddon
+
+    return () => {
+      term.dispose()
+      xtermRef.current = null
+      fitAddonRef.current = null
+    }
+  }, [])
+
+  // Wire xterm input → WebSocket
+  useEffect(() => {
+    const term = xtermRef.current
+    if (!term) return
+
+    const disposable = term.onData((data) => {
+      sendInput(data)
+    })
+
+    return () => disposable.dispose()
+  }, [sendInput])
+
+  // Wire WebSocket output → xterm
+  useEffect(() => {
+    onData((data) => {
+      xtermRef.current?.write(data)
+    })
+  }, [onData])
+
+  // Wire exit callback
+  useEffect(() => {
+    onExit((code) => {
+      setExitCode(code)
+      xtermRef.current?.write(`\r\n\x1b[33m[Process exited with code ${code}]\x1b[0m\r\n`)
+    })
+  }, [onExit])
+
+  // Handle window resize → fit terminal → send resize to backend
+  useEffect(() => {
+    const handleResize = () => {
+      if (resizeTimerRef.current) {
+        clearTimeout(resizeTimerRef.current)
+      }
+      resizeTimerRef.current = setTimeout(() => {
+        const fitAddon = fitAddonRef.current
+        const term = xtermRef.current
+        if (fitAddon && term) {
+          fitAddon.fit()
+          resize(term.cols, term.rows)
+        }
+      }, RESIZE_DEBOUNCE_MS)
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    // Also observe the terminal container for size changes
+    const observer = new ResizeObserver(handleResize)
+    if (terminalRef.current) {
+      observer.observe(terminalRef.current)
+    }
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+      observer.disconnect()
+      if (resizeTimerRef.current) {
+        clearTimeout(resizeTimerRef.current)
+      }
+    }
+  }, [resize])
+
+  // Connect to exec session
+  const handleConnect = useCallback(() => {
+    setExitCode(null)
+    const term = xtermRef.current
+    const fitAddon = fitAddonRef.current
+
+    // Clear terminal
+    term?.reset()
+
+    // Fit to get accurate dimensions
+    if (fitAddon) {
+      fitAddon.fit()
+    }
+
+    const config: ExecSessionConfig = {
+      cluster,
+      namespace,
+      pod,
+      container: selectedContainer,
+      command: ['/bin/sh'],
+      tty: true,
+      cols: term?.cols || 80,
+      rows: term?.rows || 24,
+    }
+    connect(config)
+  }, [cluster, namespace, pod, selectedContainer, connect])
+
+  // Auto-connect on mount if container is known
+  useEffect(() => {
+    if (selectedContainer && status === 'disconnected' && exitCode === null) {
+      handleConnect()
+    }
+    // Only on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleDisconnect = useCallback(() => {
+    disconnect()
+  }, [disconnect])
+
+  const handleReconnect = useCallback(() => {
+    handleConnect()
+  }, [handleConnect])
+
+  // Focus terminal when connected
+  useEffect(() => {
+    if (status === 'connected') {
+      xtermRef.current?.focus()
+    }
+  }, [status])
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between px-4 py-2 bg-[#161b22] border-b border-[#30363d]">
+        <div className="flex items-center gap-3">
+          {/* Container picker */}
+          {containers.length > 1 && (
+            <div className="relative">
+              <button
+                onClick={() => setShowContainerPicker(!showContainerPicker)}
+                className="flex items-center gap-2 px-3 py-1 text-xs rounded bg-[#21262d] border border-[#30363d] text-[#c9d1d9] hover:border-[#58a6ff] transition-colors"
+              >
+                <span className="text-[#8b949e]">container:</span>
+                <span className="font-mono">{selectedContainer || 'none'}</span>
+                <ChevronDown className="w-3 h-3 text-[#8b949e]" />
+              </button>
+              {showContainerPicker && (
+                <div className="absolute top-full left-0 mt-1 z-50 bg-[#161b22] border border-[#30363d] rounded shadow-lg">
+                  {containers.map((c) => (
+                    <button
+                      key={c}
+                      onClick={() => {
+                        setSelectedContainer(c)
+                        setShowContainerPicker(false)
+                      }}
+                      className={`block w-full text-left px-3 py-1.5 text-xs font-mono hover:bg-[#21262d] transition-colors ${
+                        c === selectedContainer ? 'text-[#58a6ff]' : 'text-[#c9d1d9]'
+                      }`}
+                    >
+                      {c}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Status indicator */}
+          <StatusIndicatorDot status={status} />
+        </div>
+
+        <div className="flex items-center gap-2">
+          {(status === 'disconnected' || status === 'error') && (
+            <button
+              onClick={handleReconnect}
+              className="flex items-center gap-1.5 px-3 py-1 text-xs rounded bg-[#238636] hover:bg-[#2ea043] text-white transition-colors"
+            >
+              <RotateCcw className="w-3 h-3" />
+              {exitCode !== null ? 'Reconnect' : 'Connect'}
+            </button>
+          )}
+          {status === 'connected' && (
+            <button
+              onClick={handleDisconnect}
+              className="flex items-center gap-1.5 px-3 py-1 text-xs rounded bg-[#da3633] hover:bg-[#f85149] text-white transition-colors"
+            >
+              <Power className="w-3 h-3" />
+              Disconnect
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Terminal area */}
+      <div className="flex-1 relative bg-[#0d1117]">
+        {/* Overlay for connecting/error states */}
+        {status === 'connecting' && (
+          <div className="absolute inset-0 flex items-center justify-center bg-[#0d1117]/80 z-10">
+            <div className="flex items-center gap-3 text-[#8b949e]">
+              <Loader2 className="w-5 h-5 animate-spin" />
+              <span className="text-sm">Connecting to {pod}...</span>
+            </div>
+          </div>
+        )}
+        {status === 'error' && error && (
+          <div className="absolute inset-0 flex items-center justify-center bg-[#0d1117]/80 z-10">
+            <div className="flex flex-col items-center gap-3 text-center max-w-md">
+              <AlertCircle className="w-8 h-8 text-[#f85149]" />
+              <div className="text-sm text-[#f85149]">{error}</div>
+              <button
+                onClick={handleReconnect}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded bg-[#21262d] hover:bg-[#30363d] text-[#c9d1d9] border border-[#30363d] transition-colors"
+              >
+                <RotateCcw className="w-3 h-3" />
+                Try Again
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* xterm.js container */}
+        <div
+          ref={terminalRef}
+          className="absolute inset-0 p-2"
+          style={{ minHeight: 0 }}
+        />
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Sub-Components
+// ============================================================================
+
+function StatusIndicatorDot({ status }: { status: SessionStatus }) {
+  const config = {
+    disconnected: { color: 'bg-[#484f58]', label: 'Disconnected' },
+    connecting: { color: 'bg-[#d29922] animate-pulse', label: 'Connecting...' },
+    connected: { color: 'bg-[#56d364]', label: 'Connected' },
+    error: { color: 'bg-[#f85149]', label: 'Error' },
+  }
+
+  const { color, label } = config[status]
+
+  return (
+    <div className="flex items-center gap-2 text-xs text-[#8b949e]">
+      <div className={`w-2 h-2 rounded-full ${color}`} />
+      <span>{label}</span>
+    </div>
+  )
+}

--- a/web/src/hooks/useExecSession.ts
+++ b/web/src/hooks/useExecSession.ts
@@ -1,0 +1,200 @@
+/**
+ * Pod Exec Terminal Session Hook
+ *
+ * Manages a WebSocket connection to the backend /api/exec endpoint
+ * for interactive terminal sessions inside pods.
+ *
+ * Protocol:
+ * 1. Client opens WebSocket to /api/exec
+ * 2. Client sends exec_init message with cluster, namespace, pod, container, command
+ * 3. Server replies with exec_started
+ * 4. Client sends stdin/resize messages, server sends stdout/stderr/exit messages
+ */
+
+import { useRef, useCallback, useEffect, useState } from 'react'
+import { STORAGE_KEY_TOKEN } from '../lib/constants'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Reconnect delay after unexpected disconnect */
+const RECONNECT_DELAY_MS = 2_000
+
+/** Max reconnect attempts before giving up */
+const MAX_RECONNECT_ATTEMPTS = 3
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ExecSessionConfig {
+  cluster: string
+  namespace: string
+  pod: string
+  container: string
+  command?: string[]
+  tty?: boolean
+  cols?: number
+  rows?: number
+}
+
+export type SessionStatus = 'disconnected' | 'connecting' | 'connected' | 'error'
+
+interface ExecMessage {
+  type: string
+  data?: string
+  sessionId?: string
+  cols?: number
+  rows?: number
+  exitCode?: number
+}
+
+export interface UseExecSessionResult {
+  status: SessionStatus
+  error: string | null
+  connect: (config: ExecSessionConfig) => void
+  disconnect: () => void
+  sendInput: (data: string) => void
+  resize: (cols: number, rows: number) => void
+  onData: (callback: (data: string) => void) => void
+  onExit: (callback: (code: number) => void) => void
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export function useExecSession(): UseExecSessionResult {
+  const wsRef = useRef<WebSocket | null>(null)
+  const [status, setStatus] = useState<SessionStatus>('disconnected')
+  const [error, setError] = useState<string | null>(null)
+  const dataCallbackRef = useRef<((data: string) => void) | null>(null)
+  const exitCallbackRef = useRef<((code: number) => void) | null>(null)
+  const reconnectAttemptsRef = useRef(0)
+
+  const cleanup = useCallback(() => {
+    if (wsRef.current) {
+      wsRef.current.close()
+      wsRef.current = null
+    }
+  }, [])
+
+  const connect = useCallback((config: ExecSessionConfig) => {
+    cleanup()
+    setStatus('connecting')
+    setError(null)
+    reconnectAttemptsRef.current = 0
+
+    // Build WebSocket URL
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+    const wsUrl = `${protocol}//${window.location.host}/api/exec${token ? `?token=${encodeURIComponent(token)}` : ''}`
+
+    const ws = new WebSocket(wsUrl)
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      // Send the init message
+      const initMsg: ExecMessage & { cluster: string; namespace: string; pod: string; container: string; command: string[]; tty: boolean } = {
+        type: 'exec_init',
+        cluster: config.cluster,
+        namespace: config.namespace,
+        pod: config.pod,
+        container: config.container,
+        command: config.command || ['/bin/sh'],
+        tty: config.tty !== false,
+        cols: config.cols || 80,
+        rows: config.rows || 24,
+      }
+      ws.send(JSON.stringify(initMsg))
+    }
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data) as ExecMessage
+        switch (msg.type) {
+          case 'exec_started':
+            setStatus('connected')
+            break
+          case 'stdout':
+          case 'stderr':
+            if (msg.data && dataCallbackRef.current) {
+              dataCallbackRef.current(msg.data)
+            }
+            break
+          case 'exit':
+            if (exitCallbackRef.current) {
+              exitCallbackRef.current(msg.exitCode || 0)
+            }
+            setStatus('disconnected')
+            break
+          case 'error':
+            setError(msg.data || 'Unknown error')
+            setStatus('error')
+            break
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    }
+
+    ws.onerror = () => {
+      setError('WebSocket connection failed')
+      setStatus('error')
+    }
+
+    ws.onclose = () => {
+      if (status === 'connected' && reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
+        reconnectAttemptsRef.current++
+        setTimeout(() => connect(config), RECONNECT_DELAY_MS)
+      } else {
+        setStatus('disconnected')
+      }
+    }
+  }, [cleanup, status])
+
+  const disconnect = useCallback(() => {
+    reconnectAttemptsRef.current = MAX_RECONNECT_ATTEMPTS // Prevent reconnect
+    cleanup()
+    setStatus('disconnected')
+  }, [cleanup])
+
+  const sendInput = useCallback((data: string) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ type: 'stdin', data }))
+    }
+  }, [])
+
+  const resize = useCallback((cols: number, rows: number) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ type: 'resize', cols, rows }))
+    }
+  }, [])
+
+  const onData = useCallback((callback: (data: string) => void) => {
+    dataCallbackRef.current = callback
+  }, [])
+
+  const onExit = useCallback((callback: (code: number) => void) => {
+    exitCallbackRef.current = callback
+  }, [])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      cleanup()
+    }
+  }, [cleanup])
+
+  return {
+    status,
+    error,
+    connect,
+    disconnect,
+    sendInput,
+    resize,
+    onData,
+    onExit,
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a full interactive terminal (xterm.js) for pod exec, accessible as an "Exec" tab in the pod drill-down view
- Backend bridges WebSocket from browser to SPDY pod exec via `remotecommand.NewSPDYExecutor`
- Frontend hook manages WebSocket lifecycle with auto-reconnect, and PodExecTerminal wraps xterm.js with fit addon, container picker, and status controls
- Competitive parity with Lens: users can now exec into any pod container directly from the console UI

## Test plan
- [ ] Open pod drill-down for any pod → verify "Exec" tab appears alongside Logs, Describe, etc.
- [ ] Click Exec tab → terminal auto-connects to the pod's first container
- [ ] Type commands in terminal → verify stdin/stdout work bidirectionally
- [ ] Resize browser window → verify terminal resizes and content reflows
- [ ] For multi-container pods → verify container picker dropdown works
- [ ] Disconnect/reconnect → verify clean lifecycle management
- [ ] Verify Go build passes: `go build ./...`
- [ ] Verify frontend build: `cd web && npm run build`