### PR TITLE
🐛 Fix dashboard scroll not reaching bottom

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -438,7 +438,7 @@ export function Layout({ children }: LayoutProps) {
           id="main-content"
           style={{ marginLeft: sidebarWidthPx }}
           className={cn(
-            'relative flex-1 p-4 md:p-6 transition-[margin] duration-300 overflow-y-auto scroll-enhanced min-w-0',
+            'relative flex-1 p-4 pb-24 md:p-6 md:pb-28 transition-[margin] duration-300 overflow-y-auto scroll-enhanced min-w-0',
             // Don't apply right margin when fullscreen is active or on mobile
             !isMobile && isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen && 'mr-[580px]',
             !isMobile && isMissionSidebarOpen && isMissionSidebarMinimized && !isMissionFullScreen && 'mr-12'


### PR DESCRIPTION
## Summary
- Adds bottom padding (`pb-24`/`pb-28`) to the main content `<main>` element in `Layout.tsx` to clear the fixed floating action button (`bottom-20`/80px)
- Without this, the last cards on every dashboard were hidden behind the FAB and users couldn't scroll to see them
- Fix is at the layout level so it applies to all dashboards and pages

## Test plan
- [ ] Open any dashboard with enough cards to require scrolling
- [ ] Verify you can scroll all the way to the bottom and see the last card fully
- [ ] Verify the floating action button doesn't overlap content
- [ ] Check on mobile viewport sizes as well