### PR TITLE
🐛 Fix exec tab extracting wrong container names from YAML

### DIFF
--- a/web/src/components/drilldown/views/PodDrillDown.tsx
+++ b/web/src/components/drilldown/views/PodDrillDown.tsx
@@ -1171,13 +1171,28 @@ Please proceed step by step and ask for confirmation before making any changes.`
   const containerNames = useMemo(() => {
     if (!yamlOutput) return []
     const names: string[] = []
-    // Match "- name: <container>" lines under "containers:" section
-    const containerNameRegex = /^\s+- name:\s+(.+)$/gm
-    let match
-    while ((match = containerNameRegex.exec(yamlOutput)) !== null) {
-      const name = match[1].trim()
-      if (name && !names.includes(name)) {
-        names.push(name)
+    // In kubectl YAML, container objects live under "  containers:" or "  initContainers:"
+    // and have "    name: <value>" (4-space indent, no dash prefix).
+    // Env vars/volumes use "    - name:" (with dash) — we must NOT match those.
+    const lines = yamlOutput.split('\n')
+    let inContainerSection = false
+    for (const line of lines) {
+      if (/^ {2}(?:init)?containers:\s*$/.test(line)) {
+        inContainerSection = true
+        continue
+      }
+      // Exit section at next spec-level key (2-space indent, not a list item)
+      if (inContainerSection && /^ {2}[a-z]/.test(line)) {
+        inContainerSection = false
+      }
+      if (inContainerSection) {
+        const match = line.match(/^ {4}name:\s+(.+)$/)
+        if (match) {
+          const name = match[1].trim()
+          if (name && !names.includes(name)) {
+            names.push(name)
+          }
+        }
       }
     }
     return names


### PR DESCRIPTION
## Summary
- The container name extraction regex in PodDrillDown was matching ALL `- name:` entries in pod YAML, including env vars (`NAMESPACE`, `GITHUB_TOKEN`), volume mounts, and other list items
- Fixed to properly scope to `containers:` and `initContainers:` sections only, matching the correct 4-space indent pattern (`name: X`) that kubectl YAML uses for container name fields
- This caused the Exec tab to show wrong container names (e.g., "NAMESPACE" instead of the actual container name)

## Test plan
- [ ] Open a pod drill-down and click the Exec tab
- [ ] Verify container dropdown shows actual container names (e.g., `manager`, `kube-rbac-proxy`) not env var names
- [ ] Verify exec Connect works with the correct container name