### PR TITLE
🐛 Fix exec WebSocket blocked by /api group JWTAuth middleware

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -766,9 +766,10 @@ func (s *Server) setupRoutes() {
 	}))
 
 	// WebSocket for pod exec terminal
+	// Registered at /ws/exec (not /api/exec) to avoid the /api group's JWTAuth middleware
 	execHandlers := handlers.NewExecHandlers(s.k8sClient)
-	s.app.Use("/api/exec", middleware.WebSocketUpgrade())
-	s.app.Get("/api/exec", websocket.New(func(c *websocket.Conn) {
+	s.app.Use("/ws/exec", middleware.WebSocketUpgrade())
+	s.app.Get("/ws/exec", websocket.New(func(c *websocket.Conn) {
 		execHandlers.HandleExec(c)
 	}))
 

--- a/web/src/hooks/useExecSession.ts
+++ b/web/src/hooks/useExecSession.ts
@@ -89,7 +89,7 @@ export function useExecSession(): UseExecSessionResult {
     // Build WebSocket URL
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
     const token = localStorage.getItem(STORAGE_KEY_TOKEN)
-    const wsUrl = `${protocol}//${window.location.host}/api/exec${token ? `?token=${encodeURIComponent(token)}` : ''}`
+    const wsUrl = `${protocol}//${window.location.host}/ws/exec${token ? `?token=${encodeURIComponent(token)}` : ''}`
 
     const ws = new WebSocket(wsUrl)
     wsRef.current = ws


### PR DESCRIPTION
## Summary
- Exec WebSocket at `/api/exec` was getting 401 because the `/api` group's JWTAuth middleware intercepted it before the WebSocket upgrade handler
- Moved to `/ws/exec` (alongside existing `/ws` SSE endpoint) which bypasses the API auth middleware
- Updated frontend hook to connect to new path

## Test plan
- [ ] Open pod drill-down, click Exec tab
- [ ] Click Connect — should establish WebSocket connection
- [ ] Verify terminal shows shell prompt for running pods