### PR TITLE
🐛 Fix watchdog reconnect overlay: remove clutter, fix stuck behavior

### DIFF
--- a/cmd/console/watchdog_html.go
+++ b/cmd/console/watchdog_html.go
@@ -16,7 +16,6 @@ body{background:#0a0a1a;color:#e2e8f0;font-family:system-ui,-apple-system,sans-s
 .ring-wrap{position:relative;width:80px;height:80px;margin:0 auto 1.5rem}
 .ring{width:80px;height:80px;border:3px solid rgba(99,102,241,.15);border-top-color:#6366f1;border-radius:50%;animation:spin 1s linear infinite}
 @keyframes spin{to{transform:rotate(360deg)}}
-.countdown{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:1.5rem;font-weight:600;color:#6366f1}
 h1{font-size:1.25rem;font-weight:500;margin-bottom:.5rem}
 p{color:#94a3b8;font-size:.875rem;line-height:1.5}
 .status{margin-top:1rem;font-size:.8rem;color:#64748b}
@@ -32,7 +31,6 @@ p{color:#94a3b8;font-size:.875rem;line-height:1.5}
 <div class="wrap">
 <div class="ring-wrap">
 <div class="ring"></div>
-<div class="countdown" id="cd">—</div>
 </div>
 <h1>Reconnecting to KubeStellar Console</h1>
 <p>The console is restarting or updating. This page will reload automatically when it's ready.</p>
@@ -44,57 +42,72 @@ p{color:#94a3b8;font-size:.875rem;line-height:1.5}
 (function(){var s=document.getElementById('stars');for(var i=0;i<30;i++){var d=document.createElement('div');d.className='star';d.style.left=Math.random()*100+'%';d.style.top=Math.random()*100+'%';d.style.animationDelay=Math.random()*3+'s';s.appendChild(d)}})();
 
 var POLL_INTERVAL_MS=2000;
+var FORCE_RELOAD_MS=60000; // Force-reload after 60s to recover from stale connections
 var attempts=0;
 var startTime=Date.now();
-var cdEl=document.getElementById('cd');
 var statusEl=document.getElementById('status');
-var countdownSec=Math.floor(POLL_INTERVAL_MS/1000);
+var reloading=false;
 
-// Countdown display between polls
-var cdTimer=setInterval(function(){
-  countdownSec--;
-  if(countdownSec<0)countdownSec=0;
-  cdEl.textContent=countdownSec;
-},1000);
-
-function elapsedStr(){
-  var s=Math.floor((Date.now()-startTime)/1000);
-  if(s<60)return s+'s';
-  return Math.floor(s/60)+'m '+s%60+'s';
+function doReload(){
+  if(reloading)return;
+  reloading=true;
+  statusEl.textContent='Reloading…';
+  clearInterval(pollTimer);
+  location.reload();
 }
 
 async function checkNow(){
+  if(reloading)return;
   attempts++;
-  cdEl.textContent='…';
-  statusEl.textContent='Checking connection… (attempt '+attempts+')';
+  statusEl.textContent='Checking connection…';
+
+  // Force-reload after max wait — handles stale connections, pod restarts, proxy changes
+  if(Date.now()-startTime>FORCE_RELOAD_MS){
+    doReload();
+    return;
+  }
+
+  // Primary check: watchdog health endpoint
   try{
     var r=await fetch('/watchdog/health',{cache:'no-store'});
     if(r.ok){
       var d=await r.json();
       if(d.backend==='ok'){
         statusEl.textContent='Backend is ready! Reloading…';
-        clearInterval(cdTimer);
         clearInterval(pollTimer);
-        // Send GA4 event so we can track watchdog usage
         var waitSec=Math.floor((Date.now()-startTime)/1000);
         if(typeof gtag==='function'){
           gtag('event','watchdog_reconnect',{attempts:attempts,wait_seconds:waitSec});
         }else{
-          // Beacon fallback if gtag not loaded yet
           try{navigator.sendBeacon('/api/telemetry/watchdog',JSON.stringify({event:'watchdog_reconnect',attempts:attempts,wait_seconds:waitSec}))}catch(e){}
         }
-        // Small delay to let the backend fully settle, then reload the original page
-        setTimeout(function(){location.reload();},500);
+        setTimeout(function(){doReload();},500);
         return;
       }
     }
   }catch(e){}
-  if(attempts>15){
-    statusEl.textContent='Still reconnecting… ('+attempts+' attempts, '+elapsedStr()+')';
-  }else{
-    statusEl.textContent='Waiting for backend… (attempt '+attempts+')';
-  }
-  countdownSec=Math.floor(POLL_INTERVAL_MS/1000);
+
+  // Fallback check: if watchdog health fails, try HEAD on root — catches pod restarts
+  // where the old watchdog is gone but the new one (with backend) is already up
+  try{
+    var h=await fetch('/',{method:'HEAD',cache:'no-store'});
+    if(h.ok && h.headers.get('content-type') && !h.headers.get('content-type').includes('text/html')){
+      // Got a non-HTML 200 from root — backend is serving the SPA (JS/asset)
+      doReload();
+      return;
+    }
+    // Even an HTML 200 might be the app — check if it's NOT the fallback page
+    if(h.ok && h.status===200){
+      var len=h.headers.get('content-length');
+      // Fallback page is small (~2KB); the real SPA index.html is larger
+      if(len && parseInt(len,10)>5000){
+        doReload();
+        return;
+      }
+    }
+  }catch(e){}
+
+  statusEl.textContent='Waiting for backend…';
 }
 
 // Poll on interval
@@ -103,4 +116,4 @@ var pollTimer=setInterval(checkNow,POLL_INTERVAL_MS);
 checkNow();
 </script>
 </body>
-</html>`
+</html>` + "\n"


### PR DESCRIPTION
## Summary
- Removes countdown number from inside the spinner circle (keeps the spinning ring animation)
- Removes attempt count and elapsed time from status text — status now shows simple "Checking connection…" / "Waiting for backend…"
- Fixes the page getting stuck by adding a **force-reload after 60 seconds** — handles stale connections, pod restarts, and proxy changes
- Adds a **fallback HEAD check** on the root URL to detect backend recovery when the watchdog health endpoint itself is unreachable (e.g., after a full pod restart where the old watchdog is gone)

## Test plan
- [ ] Verify spinner shows only the spinning ring with no number inside
- [ ] Verify status text shows only "Checking connection…" and "Waiting for backend…" (no attempt counts)
- [ ] Verify page auto-reloads when backend recovers
- [ ] Verify page force-reloads after ~60s even if health checks are failing
- [ ] Verify "Retry now" button still works