### PR TITLE
🐛 Fix login page globe animation oversized on large viewports

### DIFF
--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -223,7 +223,7 @@ export function Login() {
       </div>
 
       {/* Right side - Globe animation */}
-      <div className="hidden lg:flex flex-1 items-center justify-center relative">
+      <div className="hidden lg:flex flex-1 items-center justify-center relative overflow-hidden">
         {/* Subtle gradient background for the globe side */}
         <div className="absolute inset-0 bg-gradient-to-l from-[#0a0f1c] to-transparent" />
         <Suspense fallback={
@@ -237,6 +237,7 @@ export function Login() {
             showLoader={true}
             enableControls={true}
             className="absolute inset-0"
+            style={{ transform: 'scale(0.65)', transformOrigin: 'center center' }}
           />
         </Suspense>
       </div>


### PR DESCRIPTION
## Summary
- Scale the globe animation to 65% with CSS `transform: scale(0.65)` to prevent the Three.js scene from visually dominating the login page
- Add `overflow-hidden` to the right-side container to clip any scene overflow
- The login card was already centered (verified via CDP element measurement), but the oversized globe created a visual illusion of misalignment

## Before
![before](/tmp/login-current.jpg)
Login card appears off-center due to massive globe bleeding across the page.

## After
![after](/tmp/login-fix-v3.jpg)
Globe properly contained and scaled; login card visually centered.

## Test plan
- [x] CDP screenshot verification — card midpoint at 1000px = exactly 50% of 2000px viewport
- [x] Lint passes on Login.tsx
- [x] Build succeeds
- [ ] Check on different viewport sizes (sm, md, lg, xl)