### PR TITLE
🐛 Disable HTTP/2 on k8s API clients to fix recurring hpack panic

### DIFF
--- a/pkg/agent/kubectl.go
+++ b/pkg/agent/kubectl.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/console/pkg/agent/protocol"
+	"github.com/kubestellar/console/pkg/k8s"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -572,6 +573,7 @@ func (k *KubectlProxy) TestClusterConnection(req TestConnectionRequest) (*TestCo
 		cfg.TLSClientConfig.CAData = caBytes
 	}
 	cfg.TLSClientConfig.Insecure = req.SkipTLSVerify
+	k8s.DisableHTTP2(cfg)
 
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {

--- a/pkg/agent/prometheus.go
+++ b/pkg/agent/prometheus.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/kubestellar/console/pkg/k8s"
 	"k8s.io/client-go/rest"
 )
 
@@ -83,6 +84,7 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 	fullURL := fmt.Sprintf("%s%s?%s", config.Host, proxyPath, params.Encode())
 
 	// Create an HTTP client with the cluster's TLS/auth config
+	k8s.DisableHTTP2(config)
 	transport, err := rest.TransportFor(config)
 	if err != nil {
 		json.NewEncoder(w).Encode(map[string]interface{}{

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -40,6 +40,13 @@ const (
 	slowClusterTTL            = 2 * time.Minute
 )
 
+// DisableHTTP2 forces HTTP/1.1 on a rest.Config to avoid a known Go runtime
+// panic in the HTTP/2 hpack encoder (id <= evictCount) that occurs under
+// concurrent connections to Kubernetes API servers.
+func DisableHTTP2(config *rest.Config) {
+	config.NextProtos = []string{"http/1.1"}
+}
+
 // MultiClusterClient manages connections to multiple Kubernetes clusters
 type MultiClusterClient struct {
 	mu              sync.RWMutex
@@ -646,6 +653,7 @@ func NewMultiClusterClient(kubeconfig string) (*MultiClusterClient, error) {
 		// No kubeconfig file, try in-cluster config
 		if inClusterConfig, err := rest.InClusterConfig(); err == nil {
 			log.Println("Using in-cluster config (no kubeconfig file found)")
+			DisableHTTP2(inClusterConfig)
 			client.inClusterConfig = inClusterConfig
 			client.inClusterName = detectInClusterName(inClusterConfig)
 			log.Printf("Detected in-cluster name: %s", client.inClusterName)
@@ -1195,6 +1203,7 @@ func (m *MultiClusterClient) GetClient(contextName string) (kubernetes.Interface
 	// Set reasonable timeouts — large OpenShift clusters (18+ nodes) can return
 	// 800KB+ node payloads that take >10s over higher-latency links
 	config.Timeout = k8sClientTimeout
+	DisableHTTP2(config)
 
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -1255,6 +1264,7 @@ func (m *MultiClusterClient) GetDynamicClient(contextName string) (dynamic.Inter
 			}
 		}
 		config.Timeout = k8sClientTimeout
+		DisableHTTP2(config)
 		m.configs[contextName] = config
 	}
 


### PR DESCRIPTION
## Summary
- The Go HTTP/2 hpack encoder has a [known bug](https://github.com/golang/go/issues/47882) where concurrent connections trigger `panic: id (N) <= evictCount (M)` in `tables.go`
- This has been crashing the console backend repeatedly on the vllm-d cluster (multiple restarts within minutes)
- Forces HTTP/1.1 on **all** outbound Kubernetes API connections by setting `NextProtos=["http/1.1"]` on every `rest.Config` before client creation
- Applied at all 5 client creation points: kubernetes clientset, dynamic client, in-cluster config, Prometheus proxy, kubectl test connection
- Adds an exported `DisableHTTP2()` helper in `pkg/k8s/client.go` for use across packages

## Test plan
- [ ] Verify Go build passes (`go build ./...`)
- [ ] Verify `go vet` passes
- [ ] Deploy to vllm-d cluster and confirm no more hpack panics
- [ ] Verify all dashboard pages load correctly (k8s API calls still work over HTTP/1.1)
- [ ] Verify Prometheus metrics cards still work