### PR TITLE
🐛 Fix watchdog proxy flashing: don't mark backend unhealthy on timeouts

### DIFF
--- a/cmd/console/watchdog.go
+++ b/cmd/console/watchdog.go
@@ -75,9 +75,19 @@ func runWatchdog(cfg WatchdogConfig) error {
 		IdleConnTimeout:       watchdogIdleConnTimeout,
 	}
 
-	// Custom error handler: serve fallback page instead of 502 when backend dies mid-request
+	// Custom error handler: serve fallback page on connection failures.
+	// Only mark backend unhealthy on hard connection errors (refused, reset, EOF),
+	// NOT on request timeouts — slow requests don't mean the backend is down.
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-		log.Printf("[Watchdog] Proxy error: %v", err)
+		errMsg := err.Error()
+		isTimeout := strings.Contains(errMsg, "timeout awaiting response headers") ||
+			strings.Contains(errMsg, "context deadline exceeded")
+		if isTimeout {
+			log.Printf("[Watchdog] Proxy timeout (backend still healthy): %v", err)
+			http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
+			return
+		}
+		log.Printf("[Watchdog] Proxy error (backend down): %v", err)
 		atomic.StoreInt32(&backendHealthy, 0)
 		serveFallback(w, r)
 	}


### PR DESCRIPTION
## Summary
- The watchdog proxy error handler was unconditionally setting `backendHealthy=0` on ANY proxy error, including request timeouts
- This caused a visible **flash cycle** on the vllm-d cluster: backend healthy → slow request times out → watchdog serves fallback "Reconnecting" page → health poller marks healthy → app loads → repeat
- Now only hard connection errors (connection refused, reset, EOF) mark the backend as unhealthy and show the fallback page
- Request timeouts return a standard `504 Gateway Timeout` instead

## Root cause
The backend's initial k8s API calls after startup can be slow (>30s `ResponseHeaderTimeout`). The proxy error handler was treating these timeouts the same as connection failures, causing the watchdog to flip-flop between serving the app and the reconnecting page.

## Test plan
- [ ] Verify Go build passes
- [ ] Deploy to vllm-d cluster and confirm no more flashing between app and reconnecting page
- [ ] Verify actual backend crashes still show the reconnecting page correctly
- [ ] Verify slow requests return 504 instead of the reconnecting page