### PR TITLE
✨ Wire undo/redo into main dashboard + collapse update prereqs

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -46,6 +46,7 @@ import { DashboardTemplate } from './templates'
 import { SortableCard, DragPreviewCard } from './SharedSortableCard'
 import type { Card, DashboardData } from './dashboardUtils'
 import { useDashboardReset } from '../../hooks/useDashboardReset'
+import { useDashboardUndoRedo } from '../../hooks/useUndoRedo'
 import { WelcomeCard } from './WelcomeCard'
 
 import { PostConnectBanner } from './PostConnectBanner'
@@ -147,6 +148,14 @@ export function Dashboard() {
     setCards: setLocalCards,
     cards: localCards,
   })
+
+  // Undo/redo for card mutations
+  const localCardsRef = useRef(localCards)
+  localCardsRef.current = localCards
+  const { snapshot, undo, redo, canUndo, canRedo } = useDashboardUndoRedo<Card>(
+    setLocalCards,
+    () => localCardsRef.current,
+  )
 
   // Contextual nudges (replaces traditional tour with in-context hints)
   const { activeNudge, showDragHint, dismissNudge, actionNudge, recordVisit } = useContextualNudges(isCustomized)
@@ -314,6 +323,7 @@ export function Dashboard() {
         try {
           await moveCardToDashboard(active.id as string, targetDashboardId)
           // Remove card from local state
+          snapshot(localCards)
           setLocalCards((items) => items.filter((item) => item.id !== active.id))
           // Show success toast
           showToast(`Card moved to "${targetDashboardName}"`, 'success')
@@ -329,6 +339,7 @@ export function Dashboard() {
     if (active.id !== over.id) {
       const draggedCard = localCards.find(c => c.id === active.id)
       if (draggedCard) emitCardDragged(draggedCard.card_type)
+      snapshot(localCards)
       setLocalCards((items) => {
         const oldIndex = items.findIndex((item) => item.id === active.id)
         const newIndex = items.findIndex((item) => item.id === over.id)
@@ -487,6 +498,7 @@ export function Dashboard() {
         dashboard?.name
       )
       // Add the card at the TOP
+      snapshot(localCards)
       setLocalCards((prev) => [newCard, ...prev])
       // Clear the pending card
       clearPendingRestoreCard()
@@ -616,6 +628,7 @@ export function Dashboard() {
       emitCardAdded(card.card_type, 'add_modal')
     })
     // Add new cards at the TOP of the dashboard (prepend)
+    snapshot(localCards)
     setLocalCards((prev) => [...newCards, ...prev])
 
     // Persist to backend if dashboard exists
@@ -645,6 +658,7 @@ export function Dashboard() {
         dashboard?.name
       )
     }
+    snapshot(localCards)
     setLocalCards((prev) => prev.filter((c) => c.id !== cardId))
 
     // Persist deletion to backend
@@ -656,7 +670,7 @@ export function Dashboard() {
         showToast('Failed to delete card from backend', 'error')
       }
     }
-  }, [localCards, dashboard, recordCardRemoved])
+  }, [localCards, dashboard, recordCardRemoved, snapshot])
 
   const handleConfigureCard = useCallback((card: Card) => {
     setSelectedCard(card)
@@ -664,6 +678,7 @@ export function Dashboard() {
   }, [openConfigureCard])
 
   const handleWidthChange = useCallback(async (cardId: string, newWidth: number) => {
+    snapshot(localCards)
     setLocalCards((prev) =>
       prev.map((c) =>
         c.id === cardId
@@ -686,7 +701,7 @@ export function Dashboard() {
         showToast('Failed to update card width', 'error')
       }
     }
-  }, [dashboard, localCards])
+  }, [dashboard, localCards, snapshot])
 
   const handleCardConfigured = useCallback(async (cardId: string, newConfig: Record<string, unknown>, newTitle?: string) => {
     const card = localCards.find((c) => c.id === cardId)
@@ -701,6 +716,7 @@ export function Dashboard() {
         dashboard?.name
       )
     }
+    snapshot(localCards)
     setLocalCards((prev) =>
       prev.map((c) =>
         c.id === cardId
@@ -720,9 +736,10 @@ export function Dashboard() {
         showToast('Failed to update card configuration', 'error')
       }
     }
-  }, [localCards, dashboard, recordCardConfigured, closeConfigureCard])
+  }, [localCards, dashboard, recordCardConfigured, closeConfigureCard, snapshot])
 
   const handleAddRecommendedCard = useCallback((cardType: string, config?: Record<string, unknown>, title?: string) => {
+    snapshot(localCards)
     setLocalCards((prev) => {
       // Check if a card with the same type already exists
       const existingIndex = prev.findIndex((c) => c.card_type === cardType)
@@ -745,7 +762,7 @@ export function Dashboard() {
       recordCardAdded(newCard.id, cardType, title, config, dashboard?.id, dashboard?.name)
       return [newCard, ...prev]
     })
-  }, [dashboard, recordCardAdded])
+  }, [dashboard, recordCardAdded, snapshot, localCards])
 
   // Create a new card from AI configuration
   const handleCreateCardFromAI = useCallback((cardType: string, config: Record<string, unknown>, title?: string) => {
@@ -760,10 +777,11 @@ export function Dashboard() {
     // Record in history
     recordCardAdded(newCard.id, cardType, title, config, dashboard?.id, dashboard?.name)
     // Add at TOP and close the configure modal
+    snapshot(localCards)
     setLocalCards((prev) => [newCard, ...prev])
     closeConfigureCard()
     setSelectedCard(null)
-  }, [dashboard, recordCardAdded, closeConfigureCard])
+  }, [dashboard, recordCardAdded, closeConfigureCard, snapshot, localCards])
 
   // Apply template - add all template cards to dashboard
   const handleApplyTemplate = useCallback((template: DashboardTemplate) => {
@@ -779,9 +797,10 @@ export function Dashboard() {
       recordCardAdded(card.id, card.card_type, card.title, card.config, dashboard?.id, dashboard?.name)
     })
     // Add template cards at the top
+    snapshot(localCards)
     setLocalCards((prev) => [...newCards, ...prev])
     showToast(`Applied "${template.name}" template with ${newCards.length} cards`, 'success')
-  }, [dashboard, recordCardAdded, showToast])
+  }, [dashboard, recordCardAdded, showToast, snapshot, localCards])
 
   // Handle single card addition from smart suggestions or discover placeholder
   const handleAddSingleCard = useCallback((cardType: string) => {
@@ -794,8 +813,9 @@ export function Dashboard() {
     }
     recordCardAdded(newCard.id, cardType, undefined, {}, dashboard?.id, dashboard?.name)
     emitCardAdded(cardType, 'smart_suggestion')
+    snapshot(localCards)
     setLocalCards((prev) => [newCard, ...prev])
-  }, [dashboard, recordCardAdded])
+  }, [dashboard, recordCardAdded, snapshot, localCards])
 
   // Handle nudge CTA actions
   const handleNudgeAction = useCallback(() => {
@@ -1002,6 +1022,10 @@ export function Dashboard() {
         onOpenTemplates={openTemplatesModal}
         onReset={reset}
         isCustomized={isCustomized}
+        onUndo={undo}
+        onRedo={redo}
+        canUndo={canUndo}
+        canRedo={canRedo}
         onExport={dashboard?.id ? async () => {
           try {
             const data = await exportDashboard(dashboard.id)

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -21,13 +21,11 @@ import {
   Shield,
   HardDrive,
   GitCommitHorizontal,
-  Github,
 } from 'lucide-react'
 import { useVersionCheck } from '../../hooks/useVersionCheck'
 import { useUpdateProgress } from '../../hooks/useUpdateProgress'
 import { Button } from '../ui/Button'
 import { useAuth } from '../../lib/auth'
-import { STORAGE_KEY_GITHUB_TOKEN } from '../../lib/constants'
 import type { UpdateChannel } from '../../types/updates'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import {
@@ -123,12 +121,12 @@ export function UpdateSettings() {
   )
 
   const [showReleaseNotes, setShowReleaseNotes] = useState(false)
+  const [showPrereqs, setShowPrereqs] = useState(false)
   const [copiedCommand, setCopiedCommand] = useState<string | null>(null)
   const [channelDropdownOpen, setChannelDropdownOpen] = useState(false)
   const [triggerState, setTriggerState] = useState<'idle' | 'triggered' | 'error'>('idle')
   const [triggerError, setTriggerError] = useState<string | null>(null)
   const [countdown, setCountdown] = useState(ESTIMATED_UPDATE_SECS)
-  const [hasGithubToken, setHasGithubToken] = useState(() => Boolean(localStorage.getItem(STORAGE_KEY_GITHUB_TOKEN)))
   const triggerGuardRef = useRef(false) // prevents rapid double-clicks from firing multiple triggers
   const triggerTimestampRef = useRef(0) // when "Update Now" was clicked (for duration tracking)
 
@@ -196,13 +194,6 @@ export function UpdateSettings() {
     return () => clearTimeout(timer)
   }, [triggerState])
 
-
-  // Re-check GitHub token when settings change (e.g. env token auto-detected by GitHubTokenSection)
-  useEffect(() => {
-    const handler = () => setHasGithubToken(Boolean(localStorage.getItem(STORAGE_KEY_GITHUB_TOKEN)))
-    window.addEventListener('kubestellar-settings-changed', handler)
-    return () => window.removeEventListener('kubestellar-settings-changed', handler)
-  }, [])
 
   useEffect(() => {
     return () => {
@@ -347,75 +338,72 @@ export function UpdateSettings() {
         </div>
       </div>
 
-      {/* Environment Prerequisites — always visible on developer channel */}
-      {isDeveloperChannel && (
-        <div className="mb-4 p-4 rounded-lg bg-secondary/30 border border-border">
-          <h3 className="text-sm font-medium text-foreground mb-3">
-            {t('settings.updates.environment')}
-          </h3>
-          <div className="space-y-2">
-            <PrereqRow
-              ok={agentConnected}
-              label={t('settings.updates.prereqKCAgent')}
-              okText={t('settings.updates.prereqKCAgentOk')}
-              failText={t('settings.updates.prereqKCAgentFail')}
-              fixText={t('settings.updates.prereqKCAgentFix')}
-              onFix={() => scrollToSettingsSection('agent-settings')}
-              icon={<Terminal className="w-3.5 h-3.5" />}
-            />
-            <PrereqRow
-              ok={hasCodingAgent}
-              label={t('settings.updates.prereqCodingAgent')}
-              okText={t('settings.updates.prereqCodingAgentOk')}
-              failText={t('settings.updates.prereqCodingAgentFail')}
-              fixText={t('settings.updates.prereqCodingAgentFix')}
-              onFix={() => scrollToSettingsSection('agent-settings')}
-              icon={<Bot className="w-3.5 h-3.5" />}
-            />
-            <PrereqRow
-              ok={oauthConfigured}
-              label={t('settings.updates.prereqOAuth')}
-              okText={t('settings.updates.prereqOAuthOk')}
-              failText={t('settings.updates.prereqOAuthFail')}
-              icon={<Shield className="w-3.5 h-3.5" />}
-            />
-            <PrereqRow
-              ok={hasGithubToken}
-              label={t('settings.updates.prereqGithubToken')}
-              okText={t('settings.updates.prereqGithubTokenOk')}
-              failText={t('settings.updates.prereqGithubTokenFail')}
-              fixText={t('settings.updates.prereqGithubTokenFix')}
-              onFix={() => scrollToSettingsSection('github-token-settings')}
-              icon={<Github className="w-3.5 h-3.5" />}
-            />
-            <PrereqRow
-              ok={installMethod === 'dev'}
-              label={t('settings.updates.prereqInstall')}
-              okText={t('settings.updates.prereqInstallOk')}
-              failText={t('settings.updates.prereqInstallFail')}
-              icon={<HardDrive className="w-3.5 h-3.5" />}
-            />
-          </div>
-          {/* Summary line */}
-          {(() => {
-            const checks = [
-              agentConnected,
-              hasCodingAgent,
-              oauthConfigured,
-              hasGithubToken,
-              installMethod === 'dev',
-            ]
-            const failCount = checks.filter((c) => !c).length
-            return (
-              <div className={`mt-3 pt-3 border-t border-border text-xs ${failCount === 0 ? 'text-green-400' : 'text-yellow-400'}`}>
-                {failCount === 0
-                  ? t('settings.updates.allPrereqsMet')
-                  : t('settings.updates.prereqsMissing', { count: failCount })}
+      {/* Environment Prerequisites — collapsible, developer channel only */}
+      {isDeveloperChannel && (() => {
+        const prereqChecks = [
+          agentConnected,
+          hasCodingAgent,
+          oauthConfigured,
+          installMethod === 'dev',
+        ]
+        const failCount = prereqChecks.filter((c) => !c).length
+        return (
+          <div className="mb-4 rounded-lg bg-secondary/30 border border-border overflow-hidden">
+            <button
+              onClick={() => setShowPrereqs(!showPrereqs)}
+              className="w-full flex items-center justify-between px-4 py-3 text-sm hover:bg-secondary/50 transition-colors"
+            >
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-foreground">
+                  {t('settings.updates.environment')}
+                </span>
+                <span className={`text-xs ${failCount === 0 ? 'text-green-400' : 'text-yellow-400'}`}>
+                  {failCount === 0
+                    ? t('settings.updates.allPrereqsMet')
+                    : t('settings.updates.prereqsMissing', { count: failCount })}
+                </span>
               </div>
-            )
-          })()}
-        </div>
-      )}
+              {showPrereqs ? <ChevronUp className="w-4 h-4 text-muted-foreground" /> : <ChevronDown className="w-4 h-4 text-muted-foreground" />}
+            </button>
+            {showPrereqs && (
+              <div className="px-4 pb-4 space-y-2 border-t border-border pt-3">
+                <PrereqRow
+                  ok={agentConnected}
+                  label={t('settings.updates.prereqKCAgent')}
+                  okText={t('settings.updates.prereqKCAgentOk')}
+                  failText={t('settings.updates.prereqKCAgentFail')}
+                  fixText={t('settings.updates.prereqKCAgentFix')}
+                  onFix={() => scrollToSettingsSection('agent-settings')}
+                  icon={<Terminal className="w-3.5 h-3.5" />}
+                />
+                <PrereqRow
+                  ok={hasCodingAgent}
+                  label={t('settings.updates.prereqCodingAgent')}
+                  okText={t('settings.updates.prereqCodingAgentOk')}
+                  failText={t('settings.updates.prereqCodingAgentFail')}
+                  fixText={t('settings.updates.prereqCodingAgentFix')}
+                  onFix={() => scrollToSettingsSection('agent-settings')}
+                  icon={<Bot className="w-3.5 h-3.5" />}
+                />
+                <PrereqRow
+                  ok={oauthConfigured}
+                  label={t('settings.updates.prereqOAuth')}
+                  okText={t('settings.updates.prereqOAuthOk')}
+                  failText={t('settings.updates.prereqOAuthFail')}
+                  icon={<Shield className="w-3.5 h-3.5" />}
+                />
+                <PrereqRow
+                  ok={installMethod === 'dev'}
+                  label={t('settings.updates.prereqInstall')}
+                  okText={t('settings.updates.prereqInstallOk')}
+                  failText={t('settings.updates.prereqInstallFail')}
+                  icon={<HardDrive className="w-3.5 h-3.5" />}
+                />
+              </div>
+            )}
+          </div>
+        )
+      })()}
 
       {/* Auto-Update Toggle — requires kc-agent + coding agent (Claude Code, etc.) */}
       {!isHelmInstall && agentConnected && hasCodingAgent && (


### PR DESCRIPTION
## Summary
- **Dashboard undo/redo**: PR #2252 added undo/redo but only wired it into `DashboardRuntime` and `CustomDashboard`. The main `Dashboard.tsx` (homepage) was missing it. Now all card mutations capture snapshots and Undo/Redo buttons appear in the FAB menu with keyboard shortcuts (Cmd+Z / Cmd+Shift+Z).
- **System Updates prereqs**: Environment prerequisites section is now collapsible (collapsed by default) showing a compact summary like "All prerequisites met" or "2 prerequisite(s) not met". Click to expand and see details. Saves ~120px of vertical space.
- **Removed GitHub token from prereqs**: The token has no effect on the update process — it only affects GitHub API rate limits for fetching release notes/commit history (display data). Removing it avoids confusing users into thinking updates won't work without it.

## Test plan
- [ ] Open main dashboard (homepage), add a card, press Cmd+Z — card should undo
- [ ] Press Cmd+Shift+Z — card should redo
- [ ] Open FAB menu — Undo/Redo buttons should appear when history exists
- [ ] Remove a card, undo — card comes back
- [ ] Drag-reorder cards, undo — order reverts
- [ ] Open Settings > System Updates on developer channel — Environment section should be collapsed by default
- [ ] Click to expand — should show 4 prereqs (kc-agent, coding agent, OAuth, install mode)
- [ ] GitHub token should NOT appear in the prereqs list