### PR TITLE
⚠️ Revert HTTP/2 disable — Go 1.24 has hpack fix, HTTP/1.1 causes OOM

### DIFF
--- a/pkg/agent/kubectl.go
+++ b/pkg/agent/kubectl.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/kubestellar/console/pkg/agent/protocol"
-	"github.com/kubestellar/console/pkg/k8s"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -573,7 +572,6 @@ func (k *KubectlProxy) TestClusterConnection(req TestConnectionRequest) (*TestCo
 		cfg.TLSClientConfig.CAData = caBytes
 	}
 	cfg.TLSClientConfig.Insecure = req.SkipTLSVerify
-	k8s.DisableHTTP2(cfg)
 
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {

--- a/pkg/agent/prometheus.go
+++ b/pkg/agent/prometheus.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/kubestellar/console/pkg/k8s"
 	"k8s.io/client-go/rest"
 )
 
@@ -84,7 +83,6 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 	fullURL := fmt.Sprintf("%s%s?%s", config.Host, proxyPath, params.Encode())
 
 	// Create an HTTP client with the cluster's TLS/auth config
-	k8s.DisableHTTP2(config)
 	transport, err := rest.TransportFor(config)
 	if err != nil {
 		json.NewEncoder(w).Encode(map[string]interface{}{

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -40,13 +40,6 @@ const (
 	slowClusterTTL            = 2 * time.Minute
 )
 
-// DisableHTTP2 forces HTTP/1.1 on a rest.Config to avoid a known Go runtime
-// panic in the HTTP/2 hpack encoder (id <= evictCount) that occurs under
-// concurrent connections to Kubernetes API servers.
-func DisableHTTP2(config *rest.Config) {
-	config.NextProtos = []string{"http/1.1"}
-}
-
 // MultiClusterClient manages connections to multiple Kubernetes clusters
 type MultiClusterClient struct {
 	mu              sync.RWMutex
@@ -653,7 +646,6 @@ func NewMultiClusterClient(kubeconfig string) (*MultiClusterClient, error) {
 		// No kubeconfig file, try in-cluster config
 		if inClusterConfig, err := rest.InClusterConfig(); err == nil {
 			log.Println("Using in-cluster config (no kubeconfig file found)")
-			DisableHTTP2(inClusterConfig)
 			client.inClusterConfig = inClusterConfig
 			client.inClusterName = detectInClusterName(inClusterConfig)
 			log.Printf("Detected in-cluster name: %s", client.inClusterName)
@@ -1203,7 +1195,6 @@ func (m *MultiClusterClient) GetClient(contextName string) (kubernetes.Interface
 	// Set reasonable timeouts — large OpenShift clusters (18+ nodes) can return
 	// 800KB+ node payloads that take >10s over higher-latency links
 	config.Timeout = k8sClientTimeout
-	DisableHTTP2(config)
 
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -1264,7 +1255,6 @@ func (m *MultiClusterClient) GetDynamicClient(contextName string) (dynamic.Inter
 			}
 		}
 		config.Timeout = k8sClientTimeout
-		DisableHTTP2(config)
 		m.configs[contextName] = config
 	}
 


### PR DESCRIPTION
## Summary
- Reverts PR #2256 which disabled HTTP/2 on all k8s API client connections
- HTTP/1.1 fallback opens too many TCP connections/buffers, causing memory to spike from 133Mi to 2.5Gi+ and OOMKill on vllm-d
- Go 1.24 (our Dockerfile base) includes the hpack table fix — the panics we saw were from an older image
- Re-enables HTTP/2 multiplexing which keeps memory stable

## Evidence
- vllm-d with HTTP/1.1: 133Mi → 2480Mi in ~60s, OOMKilled at 2Gi then 4Gi
- pok-prod with same code: stable at 40Mi (less traffic, but pattern is clear)
- Memory spike correlates with initial k8s API calls + asset serving burst

## Test plan
- [ ] Deploy to vllm-d and verify no OOM kills
- [ ] Verify no hpack panics on Go 1.24
- [ ] Monitor memory stays under 500Mi under normal traffic