### PR TITLE
🐛 Add writable emptyDir for settings directory in Helm chart

### DIFF
--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -146,11 +146,15 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           volumeMounts:
+            - name: kc-config
+              mountPath: /app/.kc
             {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: /app/data
             {{- end }}
       volumes:
+        - name: kc-config
+          emptyDir: {}
         {{- if .Values.persistence.enabled }}
         - name: data
           persistentVolumeClaim:


### PR DESCRIPTION
## Summary
- Adds an `emptyDir` volume mount at `/app/.kc/` in the Helm deployment template
- With `readOnlyRootFilesystem: true` (the default security context), the settings manager cannot write its encryption keyfile or settings.json to `/app/.kc/`
- This caused OAuth session management to fail silently on all Helm-deployed instances

## Test plan
- [ ] Deploy with Helm and verify `Settings manager initialized` appears in logs (not `initialization error: ... read-only file system`)
- [ ] Verify OAuth login works on deployed instance