### PR TITLE
🐛 Fix watchdog marking backend down on client disconnects

### DIFF
--- a/cmd/console/watchdog.go
+++ b/cmd/console/watchdog.go
@@ -76,10 +76,23 @@ func runWatchdog(cfg WatchdogConfig) error {
 	}
 
 	// Custom error handler: serve fallback page on connection failures.
-	// Only mark backend unhealthy on hard connection errors (refused, reset, EOF),
-	// NOT on request timeouts — slow requests don't mean the backend is down.
+	// Only mark backend unhealthy on hard connection errors (refused, reset, EOF).
+	// Client-side disconnects (context canceled) and timeouts do NOT mean the
+	// backend is down — the client navigated away or the request was slow.
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
 		errMsg := err.Error()
+
+		// Client disconnected (e.g. browser navigated away, closed SSE stream).
+		// This is normal — do NOT mark backend unhealthy.
+		isClientGone := strings.Contains(errMsg, "context canceled") ||
+			strings.Contains(errMsg, "client disconnected") ||
+			strings.Contains(errMsg, "write: broken pipe")
+		if isClientGone {
+			log.Printf("[Watchdog] Client disconnected (backend still healthy): %v", err)
+			return
+		}
+
+		// Backend slow but still running — don't mark unhealthy.
 		isTimeout := strings.Contains(errMsg, "timeout awaiting response headers") ||
 			strings.Contains(errMsg, "context deadline exceeded")
 		if isTimeout {
@@ -87,6 +100,8 @@ func runWatchdog(cfg WatchdogConfig) error {
 			http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
 			return
 		}
+
+		// Hard connection failure — backend is genuinely down.
 		log.Printf("[Watchdog] Proxy error (backend down): %v", err)
 		atomic.StoreInt32(&backendHealthy, 0)
 		serveFallback(w, r)


### PR DESCRIPTION
## Summary
- The watchdog reverse proxy treated `context canceled` errors as backend failures, marking the backend unhealthy and returning 503s to subsequent requests
- This happened when the browser navigated away (e.g. during dev-mode auth redirect) and closed SSE connections — the client-side disconnect was misinterpreted as a backend crash
- Caused a **login loop in Helm deployments**: auth redirect closed SSE streams → watchdog marked backend down → auth callback page JS bundles got 503'd → token never stored → redirect to login again

## Fix
- `context canceled`, `client disconnected`, and `broken pipe` errors are now logged but do **not** mark the backend unhealthy
- Only hard connection failures (refused, reset, EOF) mark the backend as down

## Test plan
- [ ] Deploy via Helm with no GitHub OAuth configured (dev-mode login)
- [ ] Verify the auth redirect flow completes without 503 errors
- [ ] Verify the dashboard loads after dev-mode login
- [ ] Verify SSE streams reconnect cleanly after page navigation
- [ ] Verify the watchdog still detects actual backend crashes (kill the backend process)