### PR TITLE
🐛 Add triage/needed label to console-created issues

### DIFF
--- a/.github/workflows/console-issue-labels.yml
+++ b/.github/workflows/console-issue-labels.yml
@@ -27,8 +27,9 @@ jobs:
             const typeLabel = isBug ? 'kind/bug' : 'enhancement';
 
             // Labels that should be present on all console-created issues
-            // Note: triage/accepted is intentionally omitted — only humans should add it
-            const requiredLabels = [typeLabel, 'ai-fix-requested', 'help wanted'];
+            // triage/needed signals the issue awaits human triage; once a maintainer
+            // reviews and adds triage/accepted, the Copilot assignment workflow kicks in
+            const requiredLabels = [typeLabel, 'ai-fix-requested', 'help wanted', 'triage/needed'];
 
             const labelsToAdd = requiredLabels.filter(l => !existingLabels.includes(l));
 


### PR DESCRIPTION
## Summary
- Console-created issues were missing `triage/needed`, breaking the triage pipeline
- Without `triage/needed`, issues never appeared in triage queues
- Without triage, nobody adds `triage/accepted`, so Copilot assignment never triggers
- Issues sat indefinitely with no visibility

## Change
Added `triage/needed` to the `requiredLabels` array in `console-issue-labels.yml`

## Test plan
- [x] Backfilled `triage/needed` on all 19 existing open `ai-fix-requested` issues
- [ ] Verify next console-created issue gets `triage/needed` automatically