### PR TITLE
✨ Auto-enable demo mode for Helm installs (no OAuth/agent)

### DIFF
--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -259,7 +259,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       window.location.hostname.includes('netlify.app')
 
     // Single check: backend availability + OAuth config (the /health endpoint returns both)
-    const { backendUp, oauthConfigured } = await checkOAuthConfigured()
+    let backendUp = false
+    let oauthConfigured = false
+    try {
+      ({ backendUp, oauthConfigured } = await checkOAuthConfigured())
+    } catch {
+      // Backend unreachable — fall through to demo mode
+    }
 
     // When backend is up but no OAuth is configured (e.g. Helm install with no agent),
     // go straight to demo mode — same auto-login behavior as console.kubestellar.io.


### PR DESCRIPTION
## Summary
- When deployed via Helm with no OAuth and no kc-agent, the console now auto-enables demo mode on first visit — same instant-dashboard experience as `console.kubestellar.io`
- Eliminates the login page friction for the **from-lens** installation flow (`helm install` → `port-forward` → open browser → dashboard)
- When OAuth IS configured, the login page still appears as before

## What changed in `auth.tsx`
- **Mount effect**: Always calls `refreshUser()` on mount, even without a token (previously skipped when no token, causing redirect to login page)
- **`refreshUser()` no-token path**: Checks OAuth config — if no OAuth configured, auto-enables demo mode; if OAuth configured, shows login page
- **`refreshUser()` demo-token path**: When backend is up with no OAuth, stays in demo mode instead of redirecting to `/auth/github` for an unnecessary dev-user JWT
- **`login()` function**: Single `/health` check for both backend availability and OAuth config; no OAuth → demo mode directly
- **`isLoading` initial state**: Starts `true` to prevent login page flash while checking OAuth

## How it works
| Scenario | Before | After |
|----------|--------|-------|
| Helm install, no OAuth, no agent | Login page → "Continue with GitHub" (stuck) | Dashboard in demo mode instantly |
| Helm install, no OAuth, agent connected | Login page → auto-redirect → dev-user JWT | Demo mode → Layout auto-disables when agent detected |
| OAuth configured, no token | Login page | Login page (unchanged) |
| console.kubestellar.io (Netlify) | Demo mode | Demo mode (unchanged) |

## Test plan
- [x] Fresh visit with cleared localStorage on Helm-deployed console (no OAuth) → dashboard loads in demo mode immediately
- [x] Demo mode banner and card badges visible
- [x] `npm run build` passes
- [x] `npm run lint` passes (same pre-existing warnings as main)
- [ ] Verify OAuth flow still works when `GITHUB_CLIENT_ID` is set
- [ ] Verify console.kubestellar.io still works as before