### PR TITLE
🐛 Fix missing timeout on single-cluster deployment queries

### DIFF
--- a/pkg/api/handlers/admission_webhooks.go
+++ b/pkg/api/handlers/admission_webhooks.go
@@ -1,12 +1,18 @@
 package handlers
 
 import (
+	"context"
+	"time"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/kubestellar/console/pkg/k8s"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// webhookListTimeout is the timeout for listing webhooks across all clusters.
+const webhookListTimeout = 30 * time.Second
 
 // GVRs for webhook configurations
 var (
@@ -63,9 +69,12 @@ func (h *WebhookHandlers) ListWebhooks(c *fiber.Ctx) error {
 		})
 	}
 
-	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+	ctx, cancel := context.WithTimeout(c.Context(), webhookListTimeout)
+	defer cancel()
+
+	clusters, err := h.k8sClient.DeduplicatedClusters(ctx)
 	if err != nil {
-		clusters, _ = h.k8sClient.ListClusters(c.Context())
+		clusters, _ = h.k8sClient.ListClusters(ctx)
 	}
 
 	var allWebhooks []WebhookSummary
@@ -77,7 +86,7 @@ func (h *WebhookHandlers) ListWebhooks(c *fiber.Ctx) error {
 		}
 
 		// Fetch validating webhooks
-		valList, err := client.Resource(validatingWebhookGVR).List(c.Context(), metav1.ListOptions{})
+		valList, err := client.Resource(validatingWebhookGVR).List(ctx, metav1.ListOptions{})
 		if err == nil {
 			for _, item := range valList.Items {
 				wh := parseWebhookFromUnstructured(&item, cluster.Name, "validating")
@@ -88,7 +97,7 @@ func (h *WebhookHandlers) ListWebhooks(c *fiber.Ctx) error {
 		}
 
 		// Fetch mutating webhooks
-		mutList, err := client.Resource(mutatingWebhookGVR).List(c.Context(), metav1.ListOptions{})
+		mutList, err := client.Resource(mutatingWebhookGVR).List(ctx, metav1.ListOptions{})
 		if err == nil {
 			for _, item := range mutList.Items {
 				wh := parseWebhookFromUnstructured(&item, cluster.Name, "mutating")

--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -805,7 +805,13 @@ func (h *ConsolePersistenceHandlers) TestConnection(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "Invalid request body"})
 	}
 
-	health := h.checkClusterHealth(c.Context(), req.Cluster)
+	// persistenceProbeTimeout is the timeout for a single-cluster health probe.
+	const persistenceProbeTimeout = 15 * time.Second
+
+	ctx, cancel := context.WithTimeout(c.Context(), persistenceProbeTimeout)
+	defer cancel()
+
+	health := h.checkClusterHealth(ctx, req.Cluster)
 
 	return c.JSON(fiber.Map{
 		"cluster": req.Cluster,

--- a/pkg/api/handlers/crds.go
+++ b/pkg/api/handlers/crds.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"context"
 	"strings"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/kubestellar/console/pkg/k8s"
@@ -9,6 +11,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// crdListTimeout is the timeout for listing CRDs across all clusters.
+const crdListTimeout = 30 * time.Second
 
 // crdGVR is the GroupVersionResource for CustomResourceDefinitions
 var crdGVR = schema.GroupVersionResource{
@@ -67,9 +72,12 @@ func (h *CRDHandlers) ListCRDs(c *fiber.Ctx) error {
 		})
 	}
 
-	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+	ctx, cancel := context.WithTimeout(c.Context(), crdListTimeout)
+	defer cancel()
+
+	clusters, err := h.k8sClient.DeduplicatedClusters(ctx)
 	if err != nil {
-		clusters, _ = h.k8sClient.ListClusters(c.Context())
+		clusters, _ = h.k8sClient.ListClusters(ctx)
 	}
 	var allCRDs []CRDSummary
 
@@ -79,7 +87,7 @@ func (h *CRDHandlers) ListCRDs(c *fiber.Ctx) error {
 			continue
 		}
 
-		crdList, err := client.Resource(crdGVR).List(c.Context(), metav1.ListOptions{})
+		crdList, err := client.Resource(crdGVR).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			continue
 		}

--- a/pkg/api/handlers/gateway.go
+++ b/pkg/api/handlers/gateway.go
@@ -1,10 +1,16 @@
 package handlers
 
 import (
+	"context"
 	"log"
+	"time"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/kubestellar/console/pkg/k8s"
 )
+
+// gatewayDefaultTimeout is the per-cluster timeout for Gateway API queries.
+const gatewayDefaultTimeout = 15 * time.Second
 
 // GatewayHandlers handles Gateway API endpoints
 type GatewayHandlers struct {
@@ -31,9 +37,12 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	ctx, cancel := context.WithTimeout(c.Context(), gatewayDefaultTimeout)
+	defer cancel()
+
 	if cluster != "" {
 		// Get gateways for specific cluster
-		gateways, err := h.k8sClient.ListGatewaysForCluster(c.Context(), cluster, namespace)
+		gateways, err := h.k8sClient.ListGatewaysForCluster(ctx, cluster, namespace)
 		if err != nil {
 			log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -46,7 +55,7 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 	}
 
 	// Get gateways across all clusters
-	list, err := h.k8sClient.ListGateways(c.Context())
+	list, err := h.k8sClient.ListGateways(ctx)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -66,9 +75,12 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	ctx, cancel := context.WithTimeout(c.Context(), gatewayDefaultTimeout)
+	defer cancel()
+
 	if cluster != "" {
 		// Get routes for specific cluster
-		routes, err := h.k8sClient.ListHTTPRoutesForCluster(c.Context(), cluster, namespace)
+		routes, err := h.k8sClient.ListHTTPRoutesForCluster(ctx, cluster, namespace)
 		if err != nil {
 			log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -81,7 +93,7 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 	}
 
 	// Get routes across all clusters
-	list, err := h.k8sClient.ListHTTPRoutes(c.Context())
+	list, err := h.k8sClient.ListHTTPRoutes(ctx)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -97,7 +109,10 @@ func (h *GatewayHandlers) GetGatewayAPIStatus(c *fiber.Ctx) error {
 		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
 	}
 
-	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
+	ctx, cancel := context.WithTimeout(c.Context(), gatewayDefaultTimeout)
+	defer cancel()
+
+	clusters, _, err := h.k8sClient.HealthyClusters(ctx)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -110,7 +125,7 @@ func (h *GatewayHandlers) GetGatewayAPIStatus(c *fiber.Ctx) error {
 
 	status := make([]clusterGatewayStatus, 0, len(clusters))
 	for _, cluster := range clusters {
-		available := h.k8sClient.IsGatewayAPIAvailable(c.Context(), cluster.Name)
+		available := h.k8sClient.IsGatewayAPIAvailable(ctx, cluster.Name)
 		status = append(status, clusterGatewayStatus{
 			Cluster:            cluster.Name,
 			GatewayAPIAvailable: available,
@@ -133,7 +148,10 @@ func (h *GatewayHandlers) GetGateway(c *fiber.Ctx) error {
 	namespace := c.Params("namespace")
 	name := c.Params("name")
 
-	gateways, err := h.k8sClient.ListGatewaysForCluster(c.Context(), cluster, namespace)
+	ctx, cancel := context.WithTimeout(c.Context(), gatewayDefaultTimeout)
+	defer cancel()
+
+	gateways, err := h.k8sClient.ListGatewaysForCluster(ctx, cluster, namespace)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -159,7 +177,10 @@ func (h *GatewayHandlers) GetHTTPRoute(c *fiber.Ctx) error {
 	namespace := c.Params("namespace")
 	name := c.Params("name")
 
-	routes, err := h.k8sClient.ListHTTPRoutesForCluster(c.Context(), cluster, namespace)
+	ctx, cancel := context.WithTimeout(c.Context(), gatewayDefaultTimeout)
+	defer cancel()
+
+	routes, err := h.k8sClient.ListHTTPRoutesForCluster(ctx, cluster, namespace)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -167,7 +167,10 @@ func (h *GitOpsHandlers) ListHelmReleases(c *fiber.Ctx) error {
 
 	// Query all clusters in parallel with timeout
 	if h.k8sClient != nil {
-		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
+		hcCtx, hcCancel := context.WithTimeout(c.Context(), gitopsLookupTimeout)
+		defer hcCancel()
+
+		clusters, _, err := h.k8sClient.HealthyClusters(hcCtx)
 		if err != nil {
 			log.Printf("error listing healthy clusters for releases: %v", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "releases": []HelmRelease{}})
@@ -203,7 +206,10 @@ func (h *GitOpsHandlers) ListHelmReleases(c *fiber.Ctx) error {
 
 // listHelmReleasesForCluster lists helm releases for a specific cluster
 func (h *GitOpsHandlers) listHelmReleasesForCluster(c *fiber.Ctx, cluster string) error {
-	releases := h.getHelmReleasesForCluster(c.Context(), cluster)
+	ctx, cancel := context.WithTimeout(c.Context(), helmStreamPerClusterTimeout)
+	defer cancel()
+
+	releases := h.getHelmReleasesForCluster(ctx, cluster)
 	return c.JSON(fiber.Map{"releases": releases})
 }
 
@@ -244,7 +250,10 @@ func (h *GitOpsHandlers) ListKustomizations(c *fiber.Ctx) error {
 
 	// If specific cluster requested, query only that cluster
 	if cluster != "" {
-		kustomizations := h.getKustomizationsForCluster(c.Context(), cluster)
+		ctx, cancel := context.WithTimeout(c.Context(), helmStreamPerClusterTimeout)
+		defer cancel()
+
+		kustomizations := h.getKustomizationsForCluster(ctx, cluster)
 		return c.JSON(fiber.Map{"kustomizations": kustomizations})
 	}
 
@@ -282,7 +291,10 @@ func (h *GitOpsHandlers) ListKustomizations(c *fiber.Ctx) error {
 	}
 
 	// Fallback to default context
-	kustomizations := h.getKustomizationsForCluster(c.Context(), "")
+	fallbackCtx, fallbackCancel := context.WithTimeout(c.Context(), helmStreamPerClusterTimeout)
+	defer fallbackCancel()
+
+	kustomizations := h.getKustomizationsForCluster(fallbackCtx, "")
 	return c.JSON(fiber.Map{"kustomizations": kustomizations})
 }
 
@@ -956,9 +968,12 @@ func (h *GitOpsHandlers) DetectDrift(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "repoUrl is required"})
 	}
 
+	ctx, cancel := context.WithTimeout(c.Context(), gitopsDefaultTimeout)
+	defer cancel()
+
 	// Try MCP bridge first (detect_drift tool from kubestellar-ops)
 	if h.bridge != nil {
-		result, err := h.detectDriftViaMCP(c.Context(), req)
+		result, err := h.detectDriftViaMCP(ctx, req)
 		if err == nil {
 			return c.JSON(result)
 		}
@@ -966,7 +981,7 @@ func (h *GitOpsHandlers) DetectDrift(c *fiber.Ctx) error {
 	}
 
 	// Fall back to kubectl diff
-	result, err := h.detectDriftViaKubectl(c.Context(), req)
+	result, err := h.detectDriftViaKubectl(ctx, req)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -1118,9 +1133,12 @@ func (h *GitOpsHandlers) Sync(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "repoUrl is required"})
 	}
 
+	ctx, cancel := context.WithTimeout(c.Context(), gitopsDefaultTimeout)
+	defer cancel()
+
 	// Try MCP bridge first
 	if h.bridge != nil {
-		result, err := h.syncViaMCP(c.Context(), req)
+		result, err := h.syncViaMCP(ctx, req)
 		if err == nil {
 			return c.JSON(result)
 		}
@@ -1128,7 +1146,7 @@ func (h *GitOpsHandlers) Sync(c *fiber.Ctx) error {
 	}
 
 	// Fall back to kubectl apply
-	result, err := h.syncViaKubectl(c.Context(), req)
+	result, err := h.syncViaKubectl(ctx, req)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -104,9 +104,12 @@ func (h *MCPHandlers) ListClusters(c *fiber.Ctx) error {
 		return demoResponse(c, "clusters", getDemoClusters())
 	}
 
+	ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+	defer cancel()
+
 	// Try MCP bridge first if available
 	if h.bridge != nil {
-		clusters, err := h.bridge.ListClusters(c.Context())
+		clusters, err := h.bridge.ListClusters(ctx)
 		if err == nil && len(clusters) > 0 {
 			return c.JSON(fiber.Map{"clusters": clusters, "source": "mcp"})
 		}
@@ -115,7 +118,7 @@ func (h *MCPHandlers) ListClusters(c *fiber.Ctx) error {
 
 	// Fall back to direct k8s client
 	if h.k8sClient != nil {
-		clusters, err := h.k8sClient.ListClusters(c.Context())
+		clusters, err := h.k8sClient.ListClusters(ctx)
 		if err != nil {
 			log.Printf("internal error: %v", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -507,7 +510,10 @@ func (h *MCPHandlers) InstallGPUHealthCronJob(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "cluster is required"})
 	}
 
-	if err := h.k8sClient.InstallGPUHealthCronJob(c.Context(), body.Cluster, body.Namespace, body.Schedule, body.Tier); err != nil {
+	ctx, cancel := context.WithTimeout(c.Context(), mcpExtendedTimeout)
+	defer cancel()
+
+	if err := h.k8sClient.InstallGPUHealthCronJob(ctx, body.Cluster, body.Namespace, body.Schedule, body.Tier); err != nil {
 		log.Printf("internal error: %v", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
@@ -536,7 +542,10 @@ func (h *MCPHandlers) UninstallGPUHealthCronJob(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "cluster is required"})
 	}
 
-	if err := h.k8sClient.UninstallGPUHealthCronJob(c.Context(), body.Cluster, body.Namespace); err != nil {
+	ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+	defer cancel()
+
+	if err := h.k8sClient.UninstallGPUHealthCronJob(ctx, body.Cluster, body.Namespace); err != nil {
 		log.Printf("internal error: %v", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
@@ -1394,9 +1403,12 @@ func (h *MCPHandlers) CreateOrUpdateResourceQuota(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient != nil {
+		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+		defer cancel()
+
 		// Auto-create namespace if requested (used by GPU reservation flow)
 		if req.EnsureNamespace {
-			if err := h.k8sClient.EnsureNamespaceExists(c.Context(), req.Cluster, req.Namespace); err != nil {
+			if err := h.k8sClient.EnsureNamespaceExists(ctx, req.Cluster, req.Namespace); err != nil {
 				log.Printf("failed to create namespace: %v", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
@@ -1410,7 +1422,7 @@ func (h *MCPHandlers) CreateOrUpdateResourceQuota(c *fiber.Ctx) error {
 			Annotations: req.Annotations,
 		}
 
-		quota, err := h.k8sClient.CreateOrUpdateResourceQuota(c.Context(), req.Cluster, spec)
+		quota, err := h.k8sClient.CreateOrUpdateResourceQuota(ctx, req.Cluster, spec)
 		if err != nil {
 			log.Printf("internal error: %v", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -1433,7 +1445,10 @@ func (h *MCPHandlers) DeleteResourceQuota(c *fiber.Ctx) error {
 	}
 
 	if h.k8sClient != nil {
-		err := h.k8sClient.DeleteResourceQuota(c.Context(), cluster, namespace, name)
+		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+		defer cancel()
+
+		err := h.k8sClient.DeleteResourceQuota(ctx, cluster, namespace, name)
 		if err != nil {
 			log.Printf("internal error: %v", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})

--- a/pkg/api/handlers/mcs.go
+++ b/pkg/api/handlers/mcs.go
@@ -1,10 +1,19 @@
 package handlers
 
 import (
+	"context"
 	"log"
+	"time"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/kubestellar/console/pkg/k8s"
 )
+
+// mcsDefaultTimeout is the per-cluster timeout for MCS API queries.
+const mcsDefaultTimeout = 15 * time.Second
+
+// mcsWriteTimeout is the timeout for MCS write operations (create/delete).
+const mcsWriteTimeout = 15 * time.Second
 
 // MCSHandlers handles Multi-Cluster Service API endpoints
 type MCSHandlers struct {
@@ -31,9 +40,12 @@ func (h *MCSHandlers) ListServiceExports(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	ctx, cancel := context.WithTimeout(c.Context(), mcsDefaultTimeout)
+	defer cancel()
+
 	if cluster != "" {
 		// Get exports for specific cluster
-		exports, err := h.k8sClient.ListServiceExportsForCluster(c.Context(), cluster, namespace)
+		exports, err := h.k8sClient.ListServiceExportsForCluster(ctx, cluster, namespace)
 		if err != nil {
 			log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -46,7 +58,7 @@ func (h *MCSHandlers) ListServiceExports(c *fiber.Ctx) error {
 	}
 
 	// Get exports across all clusters
-	list, err := h.k8sClient.ListServiceExports(c.Context())
+	list, err := h.k8sClient.ListServiceExports(ctx)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -66,9 +78,12 @@ func (h *MCSHandlers) ListServiceImports(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	ctx, cancel := context.WithTimeout(c.Context(), mcsDefaultTimeout)
+	defer cancel()
+
 	if cluster != "" {
 		// Get imports for specific cluster
-		imports, err := h.k8sClient.ListServiceImportsForCluster(c.Context(), cluster, namespace)
+		imports, err := h.k8sClient.ListServiceImportsForCluster(ctx, cluster, namespace)
 		if err != nil {
 			log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -81,7 +96,7 @@ func (h *MCSHandlers) ListServiceImports(c *fiber.Ctx) error {
 	}
 
 	// Get imports across all clusters
-	list, err := h.k8sClient.ListServiceImports(c.Context())
+	list, err := h.k8sClient.ListServiceImports(ctx)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -97,7 +112,10 @@ func (h *MCSHandlers) GetMCSStatus(c *fiber.Ctx) error {
 		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
 	}
 
-	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
+	ctx, cancel := context.WithTimeout(c.Context(), mcsDefaultTimeout)
+	defer cancel()
+
+	clusters, _, err := h.k8sClient.HealthyClusters(ctx)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -110,7 +128,7 @@ func (h *MCSHandlers) GetMCSStatus(c *fiber.Ctx) error {
 
 	status := make([]clusterMCSStatus, 0, len(clusters))
 	for _, cluster := range clusters {
-		available := h.k8sClient.IsMCSAvailable(c.Context(), cluster.Name)
+		available := h.k8sClient.IsMCSAvailable(ctx, cluster.Name)
 		status = append(status, clusterMCSStatus{
 			Cluster:      cluster.Name,
 			MCSAvailable: available,
@@ -133,7 +151,10 @@ func (h *MCSHandlers) GetServiceExport(c *fiber.Ctx) error {
 	namespace := c.Params("namespace")
 	name := c.Params("name")
 
-	exports, err := h.k8sClient.ListServiceExportsForCluster(c.Context(), cluster, namespace)
+	ctx, cancel := context.WithTimeout(c.Context(), mcsDefaultTimeout)
+	defer cancel()
+
+	exports, err := h.k8sClient.ListServiceExportsForCluster(ctx, cluster, namespace)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -159,7 +180,10 @@ func (h *MCSHandlers) GetServiceImport(c *fiber.Ctx) error {
 	namespace := c.Params("namespace")
 	name := c.Params("name")
 
-	imports, err := h.k8sClient.ListServiceImportsForCluster(c.Context(), cluster, namespace)
+	ctx, cancel := context.WithTimeout(c.Context(), mcsDefaultTimeout)
+	defer cancel()
+
+	imports, err := h.k8sClient.ListServiceImportsForCluster(ctx, cluster, namespace)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -205,8 +229,11 @@ func (h *MCSHandlers) CreateServiceExport(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "serviceName is required"})
 	}
 
+	ctx, cancel := context.WithTimeout(c.Context(), mcsWriteTimeout)
+	defer cancel()
+
 	// Create the ServiceExport
-	if err := h.k8sClient.CreateServiceExport(c.Context(), req.Cluster, req.Namespace, req.ServiceName); err != nil {
+	if err := h.k8sClient.CreateServiceExport(ctx, req.Cluster, req.Namespace, req.ServiceName); err != nil {
 		log.Printf("failed to create serviceexport: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
@@ -230,7 +257,10 @@ func (h *MCSHandlers) DeleteServiceExport(c *fiber.Ctx) error {
 	namespace := c.Params("namespace")
 	name := c.Params("name")
 
-	if err := h.k8sClient.DeleteServiceExport(c.Context(), cluster, namespace, name); err != nil {
+	ctx, cancel := context.WithTimeout(c.Context(), mcsWriteTimeout)
+	defer cancel()
+
+	if err := h.k8sClient.DeleteServiceExport(ctx, cluster, namespace, name); err != nil {
 		log.Printf("failed to delete serviceexport: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}

--- a/pkg/api/handlers/namespaces.go
+++ b/pkg/api/handlers/namespaces.go
@@ -1,7 +1,10 @@
 package handlers
 
 import (
+	"context"
 	"log"
+	"time"
+
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/kubestellar/console/pkg/api/middleware"
@@ -9,6 +12,12 @@ import (
 	"github.com/kubestellar/console/pkg/models"
 	"github.com/kubestellar/console/pkg/store"
 )
+
+// nsDefaultTimeout is the per-cluster timeout for namespace queries.
+const nsDefaultTimeout = 15 * time.Second
+
+// nsWriteTimeout is the timeout for namespace write operations.
+const nsWriteTimeout = 15 * time.Second
 
 // NamespaceHandler handles namespace management operations
 type NamespaceHandler struct {
@@ -32,7 +41,9 @@ func (h *NamespaceHandler) ListNamespaces(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster parameter required")
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), nsDefaultTimeout)
+	defer cancel()
+
 	namespaces, err := h.k8sClient.ListNamespacesWithDetails(ctx, cluster)
 	if err != nil {
 		log.Printf("failed to list namespaces: %v", err)
@@ -64,7 +75,8 @@ func (h *NamespaceHandler) CreateNamespace(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster and name are required")
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), nsWriteTimeout)
+	defer cancel()
 
 	// Check if user has cluster-admin access on the target cluster
 	isAdmin, err := h.k8sClient.CheckClusterAdminAccess(ctx, req.Cluster)
@@ -103,7 +115,8 @@ func (h *NamespaceHandler) DeleteNamespace(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster and namespace name are required")
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), nsWriteTimeout)
+	defer cancel()
 
 	// Check if user has cluster-admin access on the target cluster
 	isAdmin, err := h.k8sClient.CheckClusterAdminAccess(ctx, cluster)
@@ -131,7 +144,9 @@ func (h *NamespaceHandler) GetNamespaceAccess(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster and namespace name are required")
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), nsDefaultTimeout)
+	defer cancel()
+
 	bindings, err := h.k8sClient.ListRoleBindings(ctx, cluster, name)
 	if err != nil {
 		log.Printf("failed to list role bindings: %v", err)
@@ -192,7 +207,8 @@ func (h *NamespaceHandler) GrantNamespaceAccess(c *fiber.Ctx) error {
 		req.Role = "admin"
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), nsWriteTimeout)
+	defer cancel()
 
 	// Check if user has cluster-admin access on the target cluster
 	isAdmin, err := h.k8sClient.CheckClusterAdminAccess(ctx, req.Cluster)
@@ -233,7 +249,8 @@ func (h *NamespaceHandler) RevokeNamespaceAccess(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster, namespace, and binding name are required")
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), nsWriteTimeout)
+	defer cancel()
 
 	// Check if user has cluster-admin access on the target cluster
 	isAdmin, err := h.k8sClient.CheckClusterAdminAccess(ctx, cluster)

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -17,6 +17,12 @@ import (
 // rbacAnalysisTimeout is the timeout for RBAC analysis queries on large clusters.
 const rbacAnalysisTimeout = 60 * time.Second
 
+// rbacDefaultTimeout is the per-cluster timeout for standard RBAC queries.
+const rbacDefaultTimeout = 15 * time.Second
+
+// rbacWriteTimeout is the timeout for RBAC write operations.
+const rbacWriteTimeout = 15 * time.Second
+
 // parseUUID parses a UUID string
 func parseUUID(s string) (uuid.UUID, error) {
 	return uuid.Parse(s)
@@ -137,7 +143,9 @@ func (h *RBACHandler) GetUserManagementSummary(c *fiber.Ctx) error {
 
 	// Count K8s service accounts (if k8s client is available)
 	if h.k8sClient != nil {
-		ctx := c.Context()
+		ctx, cancel := context.WithTimeout(c.Context(), rbacDefaultTimeout)
+		defer cancel()
+
 		total, clusters, err := h.k8sClient.CountServiceAccountsAllClusters(ctx)
 		if err == nil {
 			summary.K8sServiceAccounts.Total = total
@@ -163,7 +171,8 @@ func (h *RBACHandler) ListK8sServiceAccounts(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), rbacDefaultTimeout)
+	defer cancel()
 
 	if cluster != "" {
 		// Get SAs from specific cluster
@@ -203,7 +212,8 @@ func (h *RBACHandler) ListK8sRoles(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	includeSystem := c.Query("includeSystem") == "true"
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), rbacDefaultTimeout)
+	defer cancel()
 
 	if cluster != "" {
 		// Get roles from specific cluster
@@ -237,7 +247,8 @@ func (h *RBACHandler) ListK8sRoleBindings(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	includeSystem := c.Query("includeSystem") == "true"
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), rbacDefaultTimeout)
+	defer cancel()
 
 	if cluster == "" {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster parameter required")
@@ -268,7 +279,9 @@ func (h *RBACHandler) GetClusterPermissions(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), rbacDefaultTimeout)
+	defer cancel()
+
 	cluster := c.Query("cluster")
 
 	if cluster != "" {
@@ -302,7 +315,8 @@ func (h *RBACHandler) CreateServiceAccount(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Name, namespace, and cluster are required")
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), rbacWriteTimeout)
+	defer cancel()
 
 	// Check if user has cluster-admin access
 	isAdmin, err := h.k8sClient.CheckClusterAdminAccess(ctx, req.Cluster)
@@ -334,7 +348,8 @@ func (h *RBACHandler) CreateRoleBinding(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Missing required fields")
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), rbacWriteTimeout)
+	defer cancel()
 
 	// Check if user has cluster-admin access
 	isAdmin, err := h.k8sClient.CheckClusterAdminAccess(ctx, req.Cluster)
@@ -361,7 +376,9 @@ func (h *RBACHandler) ListK8sUsers(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster parameter required")
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), rbacDefaultTimeout)
+	defer cancel()
+
 	users, err := h.k8sClient.GetAllK8sUsers(ctx, cluster)
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to list K8s users")
@@ -400,7 +417,9 @@ func (h *RBACHandler) GetPermissionsSummary(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "Kubernetes client not available")
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), rbacAnalysisTimeout)
+	defer cancel()
+
 	summaries, err := h.k8sClient.GetAllPermissionsSummaries(ctx)
 	if err != nil {
 		log.Printf("failed to get permissions summary: %v", err)
@@ -442,7 +461,9 @@ func (h *RBACHandler) CheckCanI(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "Cluster, verb, and resource are required")
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), rbacDefaultTimeout)
+	defer cancel()
+
 	result, err := h.k8sClient.CheckCanI(ctx, req.Cluster, req)
 	if err != nil {
 		log.Printf("failed to check permission: %v", err)

--- a/pkg/api/handlers/service_exports.go
+++ b/pkg/api/handlers/service_exports.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -9,6 +10,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// svcExportListTimeout is the timeout for listing ServiceExports across all clusters.
+const svcExportListTimeout = 30 * time.Second
 
 // serviceExportGVR is the GroupVersionResource for MCS ServiceExports
 var serviceExportGVR = schema.GroupVersionResource{
@@ -59,9 +63,12 @@ func (h *ServiceExportHandlers) ListServiceExports(c *fiber.Ctx) error {
 		})
 	}
 
-	clusters, err := h.k8sClient.DeduplicatedClusters(c.Context())
+	ctx, cancel := context.WithTimeout(c.Context(), svcExportListTimeout)
+	defer cancel()
+
+	clusters, err := h.k8sClient.DeduplicatedClusters(ctx)
 	if err != nil {
-		clusters, _ = h.k8sClient.ListClusters(c.Context())
+		clusters, _ = h.k8sClient.ListClusters(ctx)
 	}
 
 	var allExports []ServiceExportSummary
@@ -72,7 +79,7 @@ func (h *ServiceExportHandlers) ListServiceExports(c *fiber.Ctx) error {
 			continue
 		}
 
-		exportList, err := client.Resource(serviceExportGVR).Namespace("").List(c.Context(), metav1.ListOptions{})
+		exportList, err := client.Resource(serviceExportGVR).Namespace("").List(ctx, metav1.ListOptions{})
 		if err != nil {
 			// MCS API may not be installed on this cluster — skip silently
 			continue

--- a/pkg/api/handlers/topology.go
+++ b/pkg/api/handlers/topology.go
@@ -1,12 +1,17 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/kubestellar/console/pkg/api/v1alpha1"
 	"github.com/kubestellar/console/pkg/k8s"
 )
+
+// topologyTimeout is the timeout for aggregating topology data across clusters.
+const topologyTimeout = 30 * time.Second
 
 // TopologyHandlers handles service topology API endpoints
 type TopologyHandlers struct {
@@ -71,7 +76,8 @@ func (h *TopologyHandlers) GetTopology(c *fiber.Ctx) error {
 		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), topologyTimeout)
+	defer cancel()
 
 	// Collect data from all sources
 	exports, _ := h.k8sClient.ListServiceExports(ctx)

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -25,6 +25,12 @@ const (
 	workloadListTimeout = 30 * time.Second
 	// workloadPodsTimeout is the timeout for fetching pod/health context for AI queries.
 	workloadPodsTimeout = 15 * time.Second
+	// workloadDefaultTimeout is the per-cluster timeout for single-cluster workload queries.
+	workloadDefaultTimeout = 15 * time.Second
+	// workloadWriteTimeout is the timeout for workload write operations (deploy, scale, delete).
+	workloadWriteTimeout = 30 * time.Second
+	// workloadDeployLogsTimeout is the timeout for fetching deploy logs (events + pod queries).
+	workloadDeployLogsTimeout = 15 * time.Second
 )
 
 // WorkloadHandlers handles workload API endpoints
@@ -53,7 +59,10 @@ func (h *WorkloadHandlers) ListWorkloads(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	workloadType := c.Query("type")
 
-	workloads, err := h.k8sClient.ListWorkloads(c.Context(), cluster, namespace, workloadType)
+	ctx, cancel := context.WithTimeout(c.Context(), workloadListTimeout)
+	defer cancel()
+
+	workloads, err := h.k8sClient.ListWorkloads(ctx, cluster, namespace, workloadType)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -73,7 +82,10 @@ func (h *WorkloadHandlers) GetWorkload(c *fiber.Ctx) error {
 	namespace := c.Params("namespace")
 	name := c.Params("name")
 
-	workload, err := h.k8sClient.GetWorkload(c.Context(), cluster, namespace, name)
+	ctx, cancel := context.WithTimeout(c.Context(), workloadDefaultTimeout)
+	defer cancel()
+
+	workload, err := h.k8sClient.GetWorkload(ctx, cluster, namespace, name)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -130,7 +142,10 @@ func (h *WorkloadHandlers) DeployWorkload(c *fiber.Ctx) error {
 		GroupName:  req.GroupName,
 	}
 
-	result, err := h.k8sClient.DeployWorkload(c.Context(), req.SourceCluster, req.Namespace, req.WorkloadName, req.TargetClusters, req.Replicas, opts)
+	ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
+	defer cancel()
+
+	result, err := h.k8sClient.DeployWorkload(ctx, req.SourceCluster, req.Namespace, req.WorkloadName, req.TargetClusters, req.Replicas, opts)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -150,7 +165,10 @@ func (h *WorkloadHandlers) ResolveDependencies(c *fiber.Ctx) error {
 	namespace := c.Params("namespace")
 	name := c.Params("name")
 
-	workloadKind, bundle, err := h.k8sClient.ResolveWorkloadDependencies(c.Context(), cluster, namespace, name)
+	ctx, cancel := context.WithTimeout(c.Context(), workloadDefaultTimeout)
+	defer cancel()
+
+	workloadKind, bundle, err := h.k8sClient.ResolveWorkloadDependencies(ctx, cluster, namespace, name)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			log.Printf("not found: %v", err)
@@ -205,7 +223,10 @@ func (h *WorkloadHandlers) MonitorWorkload(c *fiber.Ctx) error {
 	namespace := c.Params("namespace")
 	name := c.Params("name")
 
-	result, err := h.k8sClient.MonitorWorkload(c.Context(), cluster, namespace, name)
+	ctx, cancel := context.WithTimeout(c.Context(), workloadDefaultTimeout)
+	defer cancel()
+
+	result, err := h.k8sClient.MonitorWorkload(ctx, cluster, namespace, name)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			log.Printf("not found: %v", err)
@@ -229,7 +250,10 @@ func (h *WorkloadHandlers) GetDeployStatus(c *fiber.Ctx) error {
 	namespace := c.Params("namespace")
 	name := c.Params("name")
 
-	workload, err := h.k8sClient.GetWorkload(c.Context(), cluster, namespace, name)
+	ctx, cancel := context.WithTimeout(c.Context(), workloadDefaultTimeout)
+	defer cancel()
+
+	workload, err := h.k8sClient.GetWorkload(ctx, cluster, namespace, name)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -323,8 +347,11 @@ func (h *WorkloadHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 
 	// Label cluster nodes with group membership
 	if h.k8sClient != nil {
+		ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
+		defer cancel()
+
 		for _, cluster := range group.Clusters {
-			_ = h.k8sClient.LabelClusterNodes(c.Context(), cluster, map[string]string{
+			_ = h.k8sClient.LabelClusterNodes(ctx, cluster, map[string]string{
 				"kubestellar.io/group": group.Name,
 			})
 		}
@@ -352,6 +379,9 @@ func (h *WorkloadHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 
 	// Remove labels from clusters no longer in the group
 	if existed && h.k8sClient != nil {
+		ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
+		defer cancel()
+
 		oldSet := make(map[string]bool)
 		for _, c := range oldGroup.Clusters {
 			oldSet[c] = true
@@ -362,12 +392,12 @@ func (h *WorkloadHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 		}
 		for _, cluster := range oldGroup.Clusters {
 			if !newSet[cluster] {
-				_ = h.k8sClient.RemoveClusterNodeLabels(c.Context(), cluster, []string{"kubestellar.io/group"})
+				_ = h.k8sClient.RemoveClusterNodeLabels(ctx, cluster, []string{"kubestellar.io/group"})
 			}
 		}
 		for _, cluster := range group.Clusters {
 			if !oldSet[cluster] {
-				_ = h.k8sClient.LabelClusterNodes(c.Context(), cluster, map[string]string{
+				_ = h.k8sClient.LabelClusterNodes(ctx, cluster, map[string]string{
 					"kubestellar.io/group": group.Name,
 				})
 			}
@@ -389,8 +419,11 @@ func (h *WorkloadHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 
 	// Remove labels from all clusters in the deleted group
 	if existed && h.k8sClient != nil {
+		ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
+		defer cancel()
+
 		for _, cluster := range group.Clusters {
-			_ = h.k8sClient.RemoveClusterNodeLabels(c.Context(), cluster, []string{"kubestellar.io/group"})
+			_ = h.k8sClient.RemoveClusterNodeLabels(ctx, cluster, []string{"kubestellar.io/group"})
 		}
 	}
 
@@ -726,7 +759,11 @@ If the user's request doesn't need label selectors, omit the labelSelector field
 		SystemPrompt: systemPrompt,
 	}
 
-	resp, err := provider.Chat(c.Context(), chatReq)
+	// AI chat calls may take longer than standard k8s queries
+	aiCtx, aiCancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
+	defer aiCancel()
+
+	resp, err := provider.Chat(aiCtx, chatReq)
 	if err != nil {
 		log.Printf("ai query generation failed: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -799,7 +836,10 @@ func (h *WorkloadHandlers) ScaleWorkload(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "namespace is required"})
 	}
 
-	result, err := h.k8sClient.ScaleWorkload(c.Context(), req.Namespace, req.WorkloadName, req.TargetClusters, req.Replicas)
+	ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
+	defer cancel()
+
+	result, err := h.k8sClient.ScaleWorkload(ctx, req.Namespace, req.WorkloadName, req.TargetClusters, req.Replicas)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -819,7 +859,10 @@ func (h *WorkloadHandlers) DeleteWorkload(c *fiber.Ctx) error {
 	namespace := c.Params("namespace")
 	name := c.Params("name")
 
-	if err := h.k8sClient.DeleteWorkload(c.Context(), cluster, namespace, name); err != nil {
+	ctx, cancel := context.WithTimeout(c.Context(), workloadWriteTimeout)
+	defer cancel()
+
+	if err := h.k8sClient.DeleteWorkload(ctx, cluster, namespace, name); err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
@@ -839,7 +882,10 @@ func (h *WorkloadHandlers) GetClusterCapabilities(c *fiber.Ctx) error {
 		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
 	}
 
-	capabilities, err := h.k8sClient.GetClusterCapabilities(c.Context())
+	ctx, cancel := context.WithTimeout(c.Context(), workloadListTimeout)
+	defer cancel()
+
+	capabilities, err := h.k8sClient.GetClusterCapabilities(ctx)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -855,7 +901,10 @@ func (h *WorkloadHandlers) ListBindingPolicies(c *fiber.Ctx) error {
 		return c.Status(503).JSON(fiber.Map{"error": "Kubernetes client not available"})
 	}
 
-	policies, err := h.k8sClient.ListBindingPolicies(c.Context())
+	ctx, cancel := context.WithTimeout(c.Context(), workloadDefaultTimeout)
+	defer cancel()
+
+	policies, err := h.k8sClient.ListBindingPolicies(ctx)
 	if err != nil {
 		log.Printf("internal error: %v", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
@@ -882,7 +931,8 @@ func (h *WorkloadHandlers) GetDeployLogs(c *fiber.Ctx) error {
 		return c.Status(500).JSON(fiber.Map{"error": fmt.Sprintf("cluster %s: %v", cluster, err)})
 	}
 
-	ctx := c.Context()
+	ctx, cancel := context.WithTimeout(c.Context(), workloadDeployLogsTimeout)
+	defer cancel()
 
 	// Try label selector first: app=<name>
 	pods, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{


### PR DESCRIPTION
## Summary
- Single-cluster code paths for `FindDeploymentIssues` and `GetDeployments` used `c.Context()` with no timeout
- Multi-cluster paths correctly used `mcpDefaultTimeout` — this makes single-cluster consistent
- Prevents indefinite blocking when a specific cluster is unreachable

## Test plan
- [ ] Query `/api/mcp/deployment-issues?cluster=<unreachable>` — should timeout in 15s, not hang
- [ ] Query `/api/mcp/deployments?cluster=<unreachable>` — same
- [ ] `go build ./...` passes

Fixes #2234