### PR TITLE
🐛 Fix mock handler field names for deployments endpoint

### DIFF
--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -338,9 +338,9 @@ export const handlers = [
     await delay(100)
     return HttpResponse.json({
       deployments: [
-        { name: 'nginx', namespace: 'default', replicas: 3, ready: 3, cluster: 'kind-local' },
-        { name: 'redis', namespace: 'cache', replicas: 2, ready: 2, cluster: 'kind-local' },
-        { name: 'api-server', namespace: 'backend', replicas: 5, ready: 5, cluster: 'kind-local' },
+        { name: 'nginx', namespace: 'default', cluster: 'kind-local', status: 'running', replicas: 3, readyReplicas: 3, updatedReplicas: 3, availableReplicas: 3, progress: 100 },
+        { name: 'redis', namespace: 'cache', cluster: 'kind-local', status: 'running', replicas: 2, readyReplicas: 2, updatedReplicas: 2, availableReplicas: 2, progress: 100 },
+        { name: 'api-server', namespace: 'backend', cluster: 'kind-local', status: 'deploying', replicas: 5, readyReplicas: 3, updatedReplicas: 5, availableReplicas: 3, progress: 60 },
       ],
     })
   }),


### PR DESCRIPTION
## Summary
- Fix mock data to use correct field names matching Go struct JSON tags: `readyReplicas`, `updatedReplicas`, `availableReplicas`, `progress`, `status`
- Old mock used `ready` instead of `readyReplicas` and was missing several fields

## Test plan
- [ ] Run MSW-backed tests — deployment data should render correctly
- [ ] Verify mock response shape matches `Deployment` TypeScript type

Fixes #2237