### PR TITLE
🐛 Handle localStorage QuotaExceededError in mission storage

### DIFF
--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -840,6 +840,138 @@ describe('persistence', () => {
   })
 })
 
+// ── Quota / pruning ─────────────────────────────────────────────────────────
+
+describe('localStorage quota handling', () => {
+  /**
+   * Helper: build a minimal serialised mission object.
+   */
+  function makeMission(overrides: Partial<{
+    id: string; status: string; updatedAt: string
+  }> = {}) {
+    return {
+      id: overrides.id ?? `m-${Math.random()}`,
+      title: 'M',
+      description: 'D',
+      type: 'troubleshoot',
+      status: overrides.status ?? 'completed',
+      messages: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: overrides.updatedAt ?? new Date().toISOString(),
+    }
+  }
+
+  it('prunes completed/failed missions but preserves saved (library) missions on QuotaExceededError', () => {
+    // Seed a mix of saved (library), completed, and active missions
+    const saved1 = makeMission({ id: 'saved-1', status: 'saved' })
+    const saved2 = makeMission({ id: 'saved-2', status: 'saved' })
+    const completed1 = makeMission({ id: 'completed-1', status: 'completed', updatedAt: '2020-01-01T00:00:00Z' })
+    const completed2 = makeMission({ id: 'completed-2', status: 'completed', updatedAt: '2025-01-01T00:00:00Z' })
+    const failed1 = makeMission({ id: 'failed-1', status: 'failed', updatedAt: '2019-01-01T00:00:00Z' })
+    const pending1 = makeMission({ id: 'pending-1', status: 'pending' })
+
+    localStorage.setItem('kc_missions', JSON.stringify([
+      saved1, saved2, completed1, completed2, failed1, pending1,
+    ]))
+
+    // Intercept setItem: throw QuotaExceededError on the FIRST kc_missions
+    // write (the save triggered by useEffect), then allow the retry.
+    let missionWriteCount = 0
+    const realSetItem = Storage.prototype.setItem
+    Storage.prototype.setItem = function (key: string, value: string) {
+      if (key === 'kc_missions') {
+        missionWriteCount++
+        if (missionWriteCount === 1) {
+          throw new DOMException('quota exceeded', 'QuotaExceededError')
+        }
+      }
+      return realSetItem.call(this, key, value)
+    }
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Mount — loadMissions() then saveMissions() via useEffect
+    const { result } = renderHook(() => useMissions(), { wrapper })
+
+    // The pruning path must have retried
+    expect(missionWriteCount).toBeGreaterThanOrEqual(2)
+    expect(warnSpy).toHaveBeenCalledWith('[Missions] localStorage quota exceeded, pruning old missions')
+
+    // All saved (library) missions must still be present
+    expect(result.current.missions.some(m => m.id === 'saved-1')).toBe(true)
+    expect(result.current.missions.some(m => m.id === 'saved-2')).toBe(true)
+
+    // Active missions must still be present
+    expect(result.current.missions.some(m => m.id === 'pending-1')).toBe(true)
+
+    Storage.prototype.setItem = realSetItem
+    warnSpy.mockRestore()
+  })
+
+  it('detects QuotaExceededError via legacy numeric code 22', () => {
+    const completed1 = makeMission({ id: 'c1', status: 'completed' })
+    localStorage.setItem('kc_missions', JSON.stringify([completed1]))
+
+    let missionWriteCount = 0
+    const realSetItem = Storage.prototype.setItem
+    Storage.prototype.setItem = function (key: string, value: string) {
+      if (key === 'kc_missions') {
+        missionWriteCount++
+        if (missionWriteCount === 1) {
+          // Simulate legacy code-22 DOMException (no named exception)
+          const err = new DOMException('quota exceeded')
+          Object.defineProperty(err, 'code', { value: 22 })
+          Object.defineProperty(err, 'name', { value: '' })
+          throw err
+        }
+      }
+      return realSetItem.call(this, key, value)
+    }
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    renderHook(() => useMissions(), { wrapper })
+
+    // The pruning branch should have fired (retry = missionWriteCount >= 2)
+    expect(missionWriteCount).toBeGreaterThanOrEqual(2)
+    expect(warnSpy).toHaveBeenCalledWith('[Missions] localStorage quota exceeded, pruning old missions')
+
+    Storage.prototype.setItem = realSetItem
+    warnSpy.mockRestore()
+  })
+
+  it('logs the error and clears storage when pruning still exceeds quota', () => {
+    const completed1 = makeMission({ id: 'c1', status: 'completed' })
+    localStorage.setItem('kc_missions', JSON.stringify([completed1]))
+
+    const realSetItem = Storage.prototype.setItem
+    Storage.prototype.setItem = function (key: string, value: string) {
+      if (key === 'kc_missions') {
+        throw new DOMException('quota exceeded', 'QuotaExceededError')
+      }
+      return realSetItem.call(this, key, value)
+    }
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    renderHook(() => useMissions(), { wrapper })
+
+    // Should log the inner retry error (not silently swallow it)
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[Missions] localStorage still full after pruning, clearing missions',
+      expect.any(DOMException),
+    )
+
+    // Storage should have been cleared as a last resort
+    expect(localStorage.getItem('kc_missions')).toBeNull()
+
+    Storage.prototype.setItem = realSetItem
+    errorSpy.mockRestore()
+    warnSpy.mockRestore()
+  })
+})
+
 // ── saveMission ───────────────────────────────────────────────────────────────
 
 describe('saveMission', () => {

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -164,33 +164,40 @@ function loadMissions(): Mission[] {
   return []
 }
 
-// Maximum number of missions to keep in localStorage to avoid QuotaExceededError
-const MAX_STORED_MISSIONS = 50
+// Maximum number of completed/failed missions to retain when pruning for quota.
+// Active (pending/running/waiting_input) and saved (library) missions are always kept.
+const MAX_COMPLETED_MISSIONS = 50
 
-// Save missions to localStorage, pruning old completed missions if quota is exceeded
+// Save missions to localStorage, pruning old completed/failed missions if quota is exceeded
 function saveMissions(missions: Mission[]) {
   try {
     localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(missions))
   } catch (e) {
     // QuotaExceededError: DOMException with name 'QuotaExceededError', or legacy
     // browsers that use numeric code 22 instead of the named exception.
-    const isQuotaError = (e instanceof DOMException && e.name === 'QuotaExceededError')
-      || (e instanceof DOMException && (e as DOMException & { code?: number }).code === 22)
+    // Pattern matches useMetricsHistory for consistency across the codebase.
+    const isQuotaError = e instanceof DOMException
+      && (e.name === 'QuotaExceededError' || e.code === 22)
     if (isQuotaError) {
       console.warn('[Missions] localStorage quota exceeded, pruning old missions')
-      // Keep active missions and most recent completed/saved ones
-      const active = missions.filter(m => m.status === 'running' || m.status === 'pending' || m.status === 'waiting_input')
-      const completed = missions
-        .filter(m => m.status === 'completed' || m.status === 'failed' || m.status === 'saved')
+      // Keep active missions (pending/running/waiting_input) unconditionally
+      const active = missions.filter(m =>
+        m.status === 'running' || m.status === 'pending' || m.status === 'waiting_input'
+      )
+      // Keep saved/library missions unconditionally — they are small (no chat history)
+      const saved = missions.filter(m => m.status === 'saved')
+      // Only prune completed/failed missions by age
+      const completedOrFailed = missions
+        .filter(m => m.status === 'completed' || m.status === 'failed')
         .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
-        .slice(0, MAX_STORED_MISSIONS)
-      const pruned = [...active, ...completed]
+        .slice(0, MAX_COMPLETED_MISSIONS)
+      const pruned = [...active, ...saved, ...completedOrFailed]
       try {
         localStorage.setItem(MISSIONS_STORAGE_KEY, JSON.stringify(pruned))
         return
-      } catch {
+      } catch (retryError) {
         // Still too large — clear missions storage as last resort
-        console.error('[Missions] localStorage still full after pruning, clearing missions')
+        console.error('[Missions] localStorage still full after pruning, clearing missions', retryError)
         localStorage.removeItem(MISSIONS_STORAGE_KEY)
       }
     } else {


### PR DESCRIPTION
## Summary
- Catch QuotaExceededError specifically and prune old completed missions (keep 50 most recent)
- Retry save after pruning; clear storage as last resort
- Prevents silent data loss when localStorage fills up

## Test plan
- [ ] Fill localStorage near quota → create a mission → verify it saves after pruning
- [ ] Check console for warning about quota exceeded

Fixes #2251