### PR TITLE
🐛 Fix stale closure in useTrendHistory addPoint callback

### DIFF
--- a/web/src/lib/cache/hooks.ts
+++ b/web/src/lib/cache/hooks.ts
@@ -403,9 +403,10 @@ export function useTrendHistory<T extends TrendPoint>({
     maxAge,
   })
 
-  // Keep a ref to the latest history to avoid stale closures in addPoint.
-  // Without this, rapid calls to addPoint capture the same stale `history`
-  // array, causing earlier points to be overwritten.
+  // historyRef is the source of truth for rapid addPoint calls.
+  // We update it immediately inside addPoint so that successive calls
+  // (before React re-renders) each see the previous call's result.
+  // The render-time sync below picks up external changes (e.g. initial load).
   const historyRef = useRef(history)
   historyRef.current = history
 
@@ -424,6 +425,11 @@ export function useTrendHistory<T extends TrendPoint>({
 
     // Add new point and trim to maxPoints
     const newHistory = [...currentHistory, point].slice(-maxPoints)
+
+    // Update ref immediately so the next addPoint call (even before
+    // React re-renders) sees this result instead of the stale array.
+    historyRef.current = newHistory
+
     await save(newHistory)
   }, [maxPoints, save])
 


### PR DESCRIPTION
## Summary
- Fixes #2231
- `addPoint` in `useTrendHistory` captured a stale `history` array via closure, causing rapid calls to overwrite earlier points
- Added a `useRef` to always read the latest `history` value inside the callback, matching the standard React stale-closure fix pattern

## Test plan
- [ ] Verify trend cards (Resource Trends, Health Trends) accumulate points correctly on rapid data updates
- [ ] Confirm no duplicate or missing data points in trend charts
- [ ] Check Netlify Deploy Preview for visual regression