### PR TITLE
🐛 Fix static asset 404s on read-only container filesystems

### DIFF
--- a/cmd/console/watchdog.go
+++ b/cmd/console/watchdog.go
@@ -64,11 +64,16 @@ func runWatchdog(cfg WatchdogConfig) error {
 	// Create reverse proxy
 	proxy := httputil.NewSingleHostReverseProxy(backendURL)
 
-	// Custom transport with managed connection pool and timeouts
+	// Custom transport with managed connection pool and timeouts.
+	// DisableCompression prevents the Transport from adding Accept-Encoding: gzip
+	// to proxied requests. Without this, fasthttp's SendFile tries to create
+	// compressed file caches (.fiber.gz) which fails on read-only filesystems,
+	// causing 404s for static assets like manifest.json and favicon.ico.
 	proxy.Transport = &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout: watchdogHealthTimeout,
 		}).DialContext,
+		DisableCompression:    true,
 		ResponseHeaderTimeout: watchdogProxyHeaderTimeout,
 		MaxIdleConns:          watchdogMaxIdleConns,
 		MaxIdleConnsPerHost:   watchdogMaxIdleConnsPerHost,

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -840,7 +840,7 @@ func preCompressedStatic(root string) fiber.Handler {
 				c.Set("Cache-Control", fmt.Sprintf("public, max-age=%d, immutable", oneYear))
 				c.Set("Content-Length", fmt.Sprintf("%d", brInfo.Size()))
 				c.Set("Vary", "Accept-Encoding")
-				return c.SendFile(brPath, true)
+				return c.SendFile(brPath)
 			}
 		}
 		if strings.Contains(accept, "gzip") {
@@ -851,7 +851,7 @@ func preCompressedStatic(root string) fiber.Handler {
 				c.Set("Cache-Control", fmt.Sprintf("public, max-age=%d, immutable", oneYear))
 				c.Set("Content-Length", fmt.Sprintf("%d", gzInfo.Size()))
 				c.Set("Vary", "Accept-Encoding")
-				return c.SendFile(gzPath, true)
+				return c.SendFile(gzPath)
 			}
 		}
 
@@ -860,7 +860,7 @@ func preCompressedStatic(root string) fiber.Handler {
 			c.Set("Content-Type", contentType)
 		}
 		c.Set("Cache-Control", fmt.Sprintf("public, max-age=%d, immutable", oneYear))
-		return c.SendFile(filePath, true)
+		return c.SendFile(filePath)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Root cause**: When the watchdog reverse proxy forwards requests, Go's `http.Transport` injects `Accept-Encoding: gzip` by default. This causes Fiber's `c.SendFile(path, true)` to invoke fasthttp's built-in file compression, which tries to write cached compressed files (`.fiber.gz`) to disk. On containers with `readOnlyRootFilesystem: true` (our Helm default), these writes fail and fasthttp returns **404** for assets without pre-compressed (`.br`/`.gz`) variants — including `manifest.json`, `favicon.ico`, and several PNG/SVG files.
- **Impact**: Both vllm-d and pok-prod consoles fail to load — the browser gets 404 for critical assets, JS module imports fail with `TypeError: 'text/html' is not a valid JavaScript MIME type`, and the app stays stuck on the loading spinner.
- **Fix 1**: Remove `compress=true` from all `c.SendFile()` calls in `preCompressedStatic` — the middleware already handles serving pre-compressed `.br`/`.gz` variants, so fasthttp's built-in compression is redundant.
- **Fix 2**: Set `DisableCompression: true` on the watchdog proxy's `http.Transport` to prevent it from injecting `Accept-Encoding: gzip` into requests forwarded to the backend.

## Evidence
Tested inside the vllm-d pod — adding `Accept-Encoding: gzip` to direct backend requests reproduces the exact same 404 pattern:
```
With Accept-Encoding: gzip (direct to backend 8081):
  manifest.json:      404 ← FAIL
  favicon.ico:        404 ← FAIL
  kubestellar.png:    404 ← FAIL
  pwa-icon-512.png:   404 ← FAIL
  pwa-icon.svg:       404 ← FAIL
  robots.txt:         200 ✓
  kubestellar-logo.svg: 200 ✓ (has .br/.gz pre-compressed)
  pwa-icon-192.png:   200 ✓
  bob-icon.png:       200 ✓

Without Accept-Encoding (direct to backend 8081):
  ALL files:          200 ✓
```

## Test plan
- [ ] CI build passes
- [ ] Deploy to vllm-d cluster — verify `manifest.json`, `favicon.ico`, `kubestellar.png` return 200 through the watchdog proxy
- [ ] Verify console loads (no more app-shell spinner)
- [ ] Verify pre-compressed assets (.br/.gz) still served correctly with proper Content-Encoding