### PR TITLE
✨ Prompt new users to create/connect a cluster

### DIFF
--- a/web/src/components/dashboard/WelcomeCard.tsx
+++ b/web/src/components/dashboard/WelcomeCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { CheckCircle2, Monitor, Key, Rocket, X, Settings, ExternalLink } from 'lucide-react'
+import { CheckCircle2, Monitor, Key, Rocket, X, Settings, ExternalLink, Plus, Link2 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { cn } from '../../lib/cn'
 
@@ -37,14 +37,51 @@ export function WelcomeCard() {
         <X className="w-4 h-4" />
       </button>
 
-      <div className="flex items-center gap-3 mb-4">
-        <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-gradient-to-br from-purple-500 to-blue-500 shadow-lg shadow-purple-500/20">
-          <Rocket className="w-5 h-5 text-white" />
+      {/* Hero banner — big friendly greeting per #2207 */}
+      <div className="flex items-center gap-3 mb-3">
+        <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br from-purple-500 to-blue-500 shadow-lg shadow-purple-500/20">
+          <Rocket className="w-6 h-6 text-white" />
         </div>
         <div>
-          <h3 className="text-base font-semibold text-foreground">{t('dashboard.welcome.gettingStarted')}</h3>
+          <h3 className="text-lg font-bold text-foreground">{t('dashboard.welcome.gettingStarted')}</h3>
           <p className="text-sm text-muted-foreground">{t('dashboard.welcome.subtitle')}</p>
         </div>
+      </div>
+
+      {/* No-clusters hero message */}
+      <div className="mb-4 p-3 rounded-lg bg-purple-500/10 border border-purple-500/20">
+        <p className="text-sm font-medium text-foreground mb-1">{t('dashboard.welcome.noClustersHero')}</p>
+        <p className="text-xs text-muted-foreground">{t('dashboard.welcome.noClustersHint')}</p>
+      </div>
+
+      {/* Quick-action cards for cluster creation / connection */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4">
+        <a
+          href="https://console-docs.kubestellar.io/getting-started/create-cluster"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-3 p-3 rounded-lg bg-secondary/30 border border-border/50 hover:border-purple-500/30 hover:bg-secondary/50 transition-all text-left group"
+        >
+          <div className="p-2 rounded-lg bg-purple-500/10 group-hover:bg-purple-500/20 transition-colors flex-shrink-0">
+            <Plus className="w-4 h-4 text-purple-400" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground truncate">{t('dashboard.welcome.createCluster')}</p>
+            <p className="text-xs text-muted-foreground truncate">{t('dashboard.welcome.createClusterDesc')}</p>
+          </div>
+        </a>
+        <Link
+          to="/settings"
+          className="flex items-center gap-3 p-3 rounded-lg bg-secondary/30 border border-border/50 hover:border-blue-500/30 hover:bg-secondary/50 transition-all text-left group"
+        >
+          <div className="p-2 rounded-lg bg-blue-500/10 group-hover:bg-blue-500/20 transition-colors flex-shrink-0">
+            <Link2 className="w-4 h-4 text-blue-400" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground truncate">{t('dashboard.welcome.connectCluster')}</p>
+            <p className="text-xs text-muted-foreground truncate">{t('dashboard.welcome.connectClusterDesc')}</p>
+          </div>
+        </Link>
       </div>
 
       <div className="space-y-3">

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -681,8 +681,14 @@
       "redo": "Redo"
     },
     "welcome": {
-      "gettingStarted": "Getting Started",
-      "subtitle": "You're up and running — just a few optional steps left",
+      "gettingStarted": "Welcome to KubeStellar Console!",
+      "subtitle": "You're up and running — let's get your first cluster connected",
+      "noClustersHero": "No active clusters detected yet",
+      "noClustersHint": "Create a new test cluster or connect an existing one to start managing your multi-cluster workloads.",
+      "createCluster": "Create a Test Cluster",
+      "createClusterDesc": "Spin up a local kind/k3d cluster for testing",
+      "connectCluster": "Connect Existing Cluster",
+      "connectClusterDesc": "Configure kubeconfig path in Settings",
       "dismiss": "Dismiss",
       "step1Title": "Console is running",
       "step1Desc": "Your KubeStellar Console is up and ready.",


### PR DESCRIPTION
## Summary
- Fixes #2207
- Enhanced the `WelcomeCard` (shown when no clusters are detected) with a prominent hero banner and two quick-action cards:
  - **Create a Test Cluster** — links to getting-started docs for spinning up a local kind/k3d cluster
  - **Connect Existing Cluster** — links to Settings to configure kubeconfig path
- Updated i18n strings with friendlier "Welcome to KubeStellar Console!" heading and cluster-specific CTAs
- The existing getting-started steps (console running, connect cluster, enable AI) are preserved below the new hero section

## Test plan
- [ ] Launch console with no clusters in kubeconfig → verify the big welcome banner appears with both CTA cards
- [ ] Click "Create a Test Cluster" → opens docs in new tab
- [ ] Click "Connect Existing Cluster" → navigates to Settings page
- [ ] Dismiss banner → verify it stays dismissed on page refresh
- [ ] Connect a cluster → verify banner no longer shows
- [ ] Check Netlify Deploy Preview