### PR TITLE
🐛 Fix update indicator showing for demo/Helm users

### DIFF
--- a/web/src/components/layout/navbar/UpdateIndicator.tsx
+++ b/web/src/components/layout/navbar/UpdateIndicator.tsx
@@ -6,6 +6,7 @@ import { useVersionCheck } from '../../../hooks/useVersionCheck'
 import { useFeatureHints } from '../../../hooks/useFeatureHints'
 import { FeatureHintTooltip } from '../../ui/FeatureHintTooltip'
 import { getSettingsWithHash } from '../../../config/routes'
+import { isDemoMode } from '../../../lib/demoMode'
 
 export function UpdateIndicator() {
   const navigate = useNavigate()
@@ -26,7 +27,8 @@ export function UpdateIndicator() {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  if (!hasUpdate) {
+  // Don't show update indicator in demo mode — demo users can't update
+  if (!hasUpdate || isDemoMode()) {
     return null
   }
 

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -739,6 +739,16 @@ function useVersionCheckCore() {
     }
   }, [agentHealth?.install_method])
 
+  // Auto-reset channel when it's no longer valid for the detected install method.
+  // Example: localhost defaults to 'developer', but backend reports 'helm' install —
+  // developer channel is only valid for 'dev' installs, so fall back to 'stable'.
+  useEffect(() => {
+    if (channel === 'developer' && installMethod !== 'dev' && installMethod !== 'unknown') {
+      console.debug('[version-check] Resetting channel from developer to stable — installMethod is', installMethod)
+      setChannel('stable')
+    }
+  }, [installMethod, channel, setChannel])
+
   // Fetch install_method from backend /health as fallback (one-time on mount)
   useEffect(() => {
     async function fetchBackendInstallMethod() {


### PR DESCRIPTION
## Summary
- **Auto-reset update channel**: When `installMethod` changes (e.g., localhost initially assumes `dev` but backend reports `helm`), the developer channel gets filtered out of the dropdown but the state stays on `developer`. This left the dropdown empty and triggered false SHA-comparison updates. Now auto-resets to `stable` when the current channel is invalid for the install method.
- **Hide update indicator in demo mode**: Demo users (Helm installs without OAuth, console.kubestellar.io) can't perform updates, so the navbar update button is now hidden via `isDemoMode()` check.

## What was broken
On a Helm install accessed via localhost (e.g., port-forwarded from konflux-ci cluster) running in demo mode:
1. Update Channel dropdown showed empty (just the chevron icon, no label)
2. Navbar showed the green update indicator button even though demo users can't update
3. Version status showed "Update available" based on stale developer channel SHA comparison

## Test plan
- [ ] Deploy on a Helm-installed cluster in demo mode — verify no update indicator in navbar
- [ ] Verify Update Channel dropdown shows "Stable" (not empty) for Helm installs
- [ ] Verify dev installs still default to developer channel correctly
- [ ] Build passes, lint clean (no new errors)