### PR TITLE
🐛 Promote discoverable dashboards to sidebar when in ENABLED_DASHBOARDS

### DIFF
--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -126,7 +126,15 @@ export function getEnabledDashboardIds(): string[] | null {
 function applyDashboardFilter(config: SidebarConfig): SidebarConfig {
   if (!enabledDashboardIds) return config
   const enabledSet = new Set(enabledDashboardIds)
-  const filtered = config.primaryNav.filter(
+  const existingIds = new Set(config.primaryNav.map(item => item.id))
+
+  // Promote discoverable dashboards into primaryNav when ENABLED_DASHBOARDS includes them
+  const promoted = DISCOVERABLE_DASHBOARDS.filter(
+    item => enabledSet.has(item.id) && !existingIds.has(item.id)
+  )
+
+  const combined = [...config.primaryNav, ...promoted]
+  const filtered = combined.filter(
     item => item.isCustom || enabledSet.has(item.id)
   )
   // Sort filtered items to match the order specified in ENABLED_DASHBOARDS


### PR DESCRIPTION
## Summary
- When `ENABLED_DASHBOARDS` includes IDs from `DISCOVERABLE_DASHBOARDS` (e.g. `gpu-reservations`, `llm-d-benchmarks`), those dashboards are now automatically promoted into the sidebar
- Previously, `applyDashboardFilter` only **filtered** existing `primaryNav` items — discoverable dashboards were never added, so they remained invisible even when explicitly enabled server-side
- This fixes the vllm-d deployment where `ENABLED_DASHBOARDS=dashboard,clusters,gpu-reservations,llm-d-benchmarks,ai-ml,arcade` but GPU Reservations and llm-d Benchmarks were missing from the sidebar

## Test plan
- [ ] Set `ENABLED_DASHBOARDS=dashboard,clusters,gpu-reservations,llm-d-benchmarks,ai-ml,arcade` and verify gpu-reservations and llm-d-benchmarks appear in sidebar
- [ ] Verify sidebar order matches the order specified in `ENABLED_DASHBOARDS`
- [ ] Without `ENABLED_DASHBOARDS` set, verify all default dashboards still appear normally
- [ ] Verify custom (user-added) sidebar items are preserved and appear after enabled items