### PR TITLE
🌱 Add CI pattern lint for recurring code issues

### DIFF
--- a/.github/workflows/ci-pattern-lint.yml
+++ b/.github/workflows/ci-pattern-lint.yml
@@ -1,0 +1,110 @@
+name: CI Pattern Lint
+
+# Lightweight static checks that catch recurring code patterns known to cause
+# bugs.  Each check corresponds to a class of issue that has regressed before:
+#
+#   1. Nil Go slices → JSON `null` instead of `[]`         (#2235)
+#   2. Missing context.WithTimeout on single-cluster MCP   (#2234)
+#   3. Missing fork guards on nightly workflows             (#2194)
+#   4. Eager bundle imports without .catch()                (#2190)
+#
+# Runs in < 30 s with zero dependencies (pure grep/bash).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pkg/api/handlers/**'
+      - 'web/src/components/cards/cardRegistry.ts'
+      - '.github/workflows/nightly-*.yml'
+      - '.github/workflows/ci-pattern-lint.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  pattern-lint:
+    if: github.repository == 'kubestellar/console'
+    name: Pattern Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Check 1: Nil slice declarations in MCP handlers ──────────────
+      # Go's encoding/json serializes nil slices as `null`. Every
+      # multi-cluster aggregation slice must use make([]T, 0) so the API
+      # returns `[]` when empty.
+      - name: "Check: no nil slice aggregation in MCP handlers"
+        run: |
+          echo "Scanning for 'var all... []' nil-slice declarations in handler files..."
+          FOUND=$(grep -rnE '^\s*var\s+all\w+\s+\[' pkg/api/handlers/*.go || true)
+          if [ -n "$FOUND" ]; then
+            echo "::error::Found nil-slice declarations that will serialize as JSON null."
+            echo "Use 'allXxx := make([]Type, 0)' instead of 'var allXxx []Type'."
+            echo ""
+            echo "$FOUND"
+            exit 1
+          fi
+          echo "✓ No nil-slice aggregation declarations found."
+
+      # ── Check 2: Missing timeouts on single-cluster MCP calls ────────
+      # Every single-cluster k8sClient read call must use a context with
+      # a timeout, not bare c.Context().  Excluded:
+      #   - ListClusters / HealthyClusters / GetAllCluster* (multi-cluster)
+      #   - EnsureNamespace / CreateOrUpdate / Delete* / Install / Uninstall (mutating)
+      - name: "Check: no bare c.Context() in single-cluster k8sClient reads"
+        run: |
+          echo "Scanning for h.k8sClient calls using bare c.Context()..."
+          EXCLUDED='(ListClusters|HealthyClusters|GetAllCluster|EnsureNamespace|CreateOrUpdate|DeleteResource|Install|Uninstall)'
+          FOUND=$(grep -rnE 'h\.k8sClient\.\w+\(c\.Context\(\)' pkg/api/handlers/mcp.go \
+            | grep -vE "$EXCLUDED" || true)
+          if [ -n "$FOUND" ]; then
+            echo "::error::Found k8sClient calls using bare c.Context() without timeout."
+            echo "Wrap with: ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)"
+            echo ""
+            echo "$FOUND"
+            exit 1
+          fi
+          echo "✓ All single-cluster k8sClient reads use a timeout-wrapped context."
+
+      # ── Check 3: Fork guards on nightly workflows ────────────────────
+      # Every nightly-*.yml must have a fork guard on its first job to
+      # prevent wasted CI on forks.
+      - name: "Check: nightly workflows have fork guards"
+        run: |
+          EXIT_CODE=0
+          for f in .github/workflows/nightly-*.yml; do
+            [ -f "$f" ] || continue
+            # Check that the file contains the repository guard somewhere
+            if ! grep -q "github.repository == 'kubestellar/console'" "$f"; then
+              echo "::error file=$f::Missing fork guard: if: github.repository == 'kubestellar/console'"
+              EXIT_CODE=1
+            fi
+          done
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "✓ All nightly workflows have fork guards."
+          fi
+          exit $EXIT_CODE
+
+      # ── Check 4: Eager bundle imports need .catch() ──────────────────
+      # Top-level import() calls in cardRegistry.ts must have a .catch()
+      # to prevent unhandled promise rejections at module scope.
+      - name: "Check: eager imports have .catch() handlers"
+        run: |
+          FILE="web/src/components/cards/cardRegistry.ts"
+          if [ ! -f "$FILE" ]; then
+            echo "✓ cardRegistry.ts not found (skipped)."
+            exit 0
+          fi
+          echo "Scanning for top-level import() without .catch()..."
+          # Match lines like: const _xxxBundle = import('./xxx')
+          # that do NOT end with .catch(...)
+          FOUND=$(grep -nE '^const _\w+Bundle\s*=\s*import\(' "$FILE" | grep -v '\.catch(' || true)
+          if [ -n "$FOUND" ]; then
+            echo "::error file=$FILE::Found eager bundle import() without .catch() handler."
+            echo "Add .catch((err) => { throw err }) to prevent unhandled promise rejections."
+            echo ""
+            echo "$FOUND"
+            exit 1
+          fi
+          echo "✓ All eager bundle imports have .catch() handlers."


### PR DESCRIPTION
## Summary
Adds a lightweight CI workflow (`ci-pattern-lint.yml`) that catches four classes of bugs known to regress when new code is added. Runs in < 30 seconds with zero dependencies (pure grep/bash).

### Checks
| # | Pattern | Issue | What it catches |
|---|---------|-------|-----------------|
| 1 | Nil slice declarations | #2235 | `var allX []T` → JSON `null` instead of `[]` |
| 2 | Missing context timeouts | #2234 | `h.k8sClient.Foo(c.Context())` without `WithTimeout` |
| 3 | Missing fork guards | #2194 | `nightly-*.yml` without `github.repository` check |
| 4 | Eager imports without .catch() | #2190 | `import()` at module scope without error handler |

### When it runs
Only on PRs that touch `pkg/api/handlers/**`, `web/src/components/cards/cardRegistry.ts`, or `.github/workflows/nightly-*.yml`. Skipped entirely for docs-only or frontend-only changes.

### Note
This check will fail on current `main` because the underlying issues exist — it will pass once PRs #2296, #2297, #2305, and #2313 are merged.

## Test plan
- [ ] Verify workflow runs on PR and all 4 checks pass (after the fix PRs merge)
- [ ] Verify workflow is skipped when no relevant files are changed
- [ ] Try adding a `var allFoo []string` to a handler — verify check 1 catches it