### PR TITLE
🐛 Remove misleading brew note from localhost tab

### DIFF
--- a/web/src/pages/FromLens.tsx
+++ b/web/src/pages/FromLens.tsx
@@ -121,7 +121,6 @@ const LOCALHOST_STEPS: InstallStep[] = [
       '  https://raw.githubusercontent.com/kubestellar/console/main/start.sh \\',
       '  | bash',
     ],
-    note: 'Or via Homebrew: brew tap kubestellar/tap && brew install --head kc-agent && kc-agent',
     description: 'Downloads pre-built binaries, starts the console and kc-agent, and opens your browser at http://localhost:8080. No Go, Node.js, or build tools required.',
   },
 ]


### PR DESCRIPTION
## Summary
- Removes the "Or via Homebrew" note from the localhost tab on `/from-lens`
- The brew command only installs kc-agent (agent only), not the full console+backend
- The curl | bash script installs everything — they're not equivalent alternatives
- Brew is already correctly shown in the cluster ingress tab for agent-only installs

## Test plan
- [ ] Localhost tab shows only the curl | bash command with no brew note