### PR TITLE
✨ Add kc-agent brew install as step 2 on localhost tab

### DIFF
--- a/web/src/pages/FromLens.tsx
+++ b/web/src/pages/FromLens.tsx
@@ -123,6 +123,15 @@ const LOCALHOST_STEPS: InstallStep[] = [
     ],
     description: 'Downloads pre-built binaries, starts the console and kc-agent, and opens your browser at http://localhost:8080. No Go, Node.js, or build tools required.',
   },
+  {
+    step: 2,
+    title: 'Or install the agent separately',
+    commands: [
+      'brew tap kubestellar/tap && brew install --head kc-agent',
+      'kc-agent',
+    ],
+    description: 'The kc-agent connects to your clusters via kubeconfig. Without it, the console runs in demo mode only.',
+  },
 ]
 
 /* -- Cluster: shared Helm repo step ---------------------------------- */


### PR DESCRIPTION
## Summary
- Adds step 2 to the localhost tab: install kc-agent via Homebrew
- Without the agent, console runs in demo mode only — this makes that clear
- Step 1 (curl | bash) installs everything; step 2 is for users who prefer brew

## Test plan
- [ ] Localhost tab shows two steps: curl | bash, then brew kc-agent