### PR TITLE
🐛 Revert localhost tab to single curl|bash step

### DIFF
--- a/web/src/pages/FromLens.tsx
+++ b/web/src/pages/FromLens.tsx
@@ -123,15 +123,6 @@ const LOCALHOST_STEPS: InstallStep[] = [
     ],
     description: 'Downloads pre-built binaries, starts the console and kc-agent, and opens your browser at http://localhost:8080. No Go, Node.js, or build tools required.',
   },
-  {
-    step: 2,
-    title: 'Or install the agent separately',
-    commands: [
-      'brew tap kubestellar/tap && brew install --head kc-agent',
-      'kc-agent',
-    ],
-    description: 'The kc-agent connects to your clusters via kubeconfig. Without it, the console runs in demo mode only.',
-  },
 ]
 
 /* -- Cluster: shared Helm repo step ---------------------------------- */


### PR DESCRIPTION
## Summary
- Removes the redundant brew install step 2 from the localhost tab on `/from-lens`
- The `start.sh` script already downloads and starts both `console` and `kc-agent` — no separate agent install needed

## Test plan
- [ ] Visit `/from-lens` and confirm localhost tab shows only the single curl|bash command
- [ ] Verify copy button still works correctly