### PR TITLE
🐛 Fix settings page sidebar nav scroll regression

### DIFF
--- a/web/src/components/settings/Settings.tsx
+++ b/web/src/components/settings/Settings.tsx
@@ -239,10 +239,22 @@ export function Settings() {
     // Update URL hash without triggering the deep link effect (isNavScrollingRef guards it)
     navigate(`#${sectionId}`, { replace: true })
 
-    // Keep the clicked item visible in the sidebar's own scroll area
+    // Keep the clicked item visible in the sidebar's own scroll area.
+    // NOTE: scrollIntoView cascades to ALL ancestor scroll containers
+    // (including #main-content), which cancels the smooth scroll set by
+    // scrollToSection above. Instead, manually scroll only the sidebar's
+    // own overflow container so #main-content is unaffected.
     requestAnimationFrame(() => {
-      const btn = document.querySelector(`[data-settings-nav="${sectionId}"]`)
-      btn?.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+      const btn = document.querySelector<HTMLElement>(`[data-settings-nav="${sectionId}"]`)
+      if (!btn) return
+      const sidebar = btn.closest<HTMLElement>('.overflow-y-auto')
+      if (!sidebar || sidebar.id === 'main-content') return
+      const btnRect = btn.getBoundingClientRect()
+      const sidebarRect = sidebar.getBoundingClientRect()
+      if (btnRect.top < sidebarRect.top || btnRect.bottom > sidebarRect.bottom) {
+        const scrollDelta = btnRect.top - sidebarRect.top - sidebarRect.height / 2 + btnRect.height / 2
+        sidebar.scrollBy({ top: scrollDelta, behavior: 'smooth' })
+      }
     })
   }
 


### PR DESCRIPTION
## Summary
- **Fixes** settings page sidebar TOC click not auto-scrolling to the section (regression)
- **Root cause**: `scrollIntoView({ block: 'nearest', behavior: 'smooth' })` on the sidebar button cascades to ALL ancestor scroll containers, including `#main-content`, which cancels the in-progress smooth scroll set by `scrollToSection`
- **Fix**: Replace `scrollIntoView` with a manual scroll that only targets the sidebar's own `overflow-y-auto` container, leaving `#main-content` scroll unaffected

## Test plan
- [ ] Navigate to Settings page
- [ ] Click any sidebar TOC item (e.g. "Appearance", "Dashboard", "Data Management")
- [ ] Verify main content smoothly scrolls to the selected section
- [ ] Verify sidebar button stays visible if the sidebar itself is scrollable
- [ ] Verify IntersectionObserver still highlights the active section during manual scroll