### PR TITLE
🐛 Fix hasUpdate for Helm installs with unset app version

### DIFF
--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -728,8 +728,14 @@ function useVersionCheckCore() {
 
     if (!latestRelease || currentVersion === 'unknown') return false
     if (skippedVersions.includes(latestRelease.tag)) return false
+
+    // Helm installs with unset VITE_APP_VERSION report '0.0.0' which isDevVersion
+    // treats as a dev build. For Helm self-upgrade we still want to show the update
+    // button whenever a newer release exists on the selected channel.
+    if (installMethod === 'helm' && isDevVersion(currentVersion)) return true
+
     return isNewerVersion(currentVersion, latestRelease.tag, channel)
-  }, [latestRelease, currentVersion, skippedVersions, channel, autoUpdateStatus, latestMainSHA, commitHash])
+  }, [latestRelease, currentVersion, skippedVersions, channel, autoUpdateStatus, latestMainSHA, commitHash, installMethod])
 
   // Load cached data on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Helm installs with unset `VITE_APP_VERSION` report version `0.0.0`, which `isDevVersion()` treats as a dev build
- This caused `isNewerVersion()` to always return `false`, so the upgrade button never appeared even when self-upgrade was available and working
- Adds a Helm-specific fallback in the `hasUpdate` memo: when `installMethod === 'helm'` and the current version is a dev version, any release on the selected channel is treated as an available update

## Test plan
- [ ] Deploy to a Helm cluster with `selfUpgrade.enabled=true` and no `VITE_APP_VERSION` set (version shows `0.0.0`)
- [ ] Verify the upgrade button appears in Settings > System Updates when a release exists
- [ ] Verify non-Helm installs with dev versions still behave as before (no false update prompts)