### PR TITLE
🐛 Bake VITE_APP_VERSION into Docker images via build arg

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -92,6 +92,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
+            APP_VERSION=main-${{ github.sha }}
             COMMIT_HASH=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-version.outputs.version }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-version.outputs.release_type }}
           build-args: |
+            APP_VERSION=${{ needs.determine-version.outputs.version }}
             COMMIT_HASH=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ FROM node:20-alpine AS frontend-builder
 
 WORKDIR /app
 
-# Build arg for commit hash
+# Build args for version and commit hash
+ARG APP_VERSION=0.0.0
 ARG COMMIT_HASH=unknown
 
 # Copy package files
@@ -28,7 +29,8 @@ RUN npm ci
 # Copy source
 COPY web/ ./
 
-# Build with commit hash
+# Build with version and commit hash baked into the JS bundle
+ENV VITE_APP_VERSION=${APP_VERSION}
 ENV VITE_COMMIT_HASH=${COMMIT_HASH}
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- Docker images never received `APP_VERSION` as a build arg, so `VITE_APP_VERSION` was always unset
- Inside the container there's no `.git` directory, so `getGitVersion()` in vite.config.ts returns `0.0.0`
- This meant every Helm install showed "Current Version: 0.0.0" regardless of the actual release
- Adds `ARG APP_VERSION` to the Dockerfile and passes it from both CI workflows:
  - `build-deploy.yml` (dev): `main-<full-sha>`
  - `release.yml`: the release tag (e.g. `v0.3.15`)

## Test plan
- [ ] Verify build-deploy CI passes with the new build-arg
- [ ] After next release, verify the Docker image reports the correct version tag in Settings > Updates