### PR TITLE
🐛 Fix fetch timeout violation and array guard warnings

### DIFF
--- a/scripts/consistency-test.sh
+++ b/scripts/consistency-test.sh
@@ -452,6 +452,7 @@ phase6() {
     'src/components/cards/WorkloadDeployment.tsx'  # Date.now() for demo data timestamps, not cache TTL
     'src/components/cards/workload-monitor/GitHubCIMonitor.tsx'  # Date.now() for demo data, not cache TTL
     'src/components/cards/Missions.tsx'  # Date.now() for demo mission timestamps, not cache TTL
+    'src/App.tsx'  # Date.now() for page view analytics duration, not cache TTL
   )
 
   # Find files that implement caching with TTL: have localStorage AND Date.now() - (subtraction

--- a/web/src/hooks/useAdmissionWebhooks.ts
+++ b/web/src/hooks/useAdmissionWebhooks.ts
@@ -112,7 +112,7 @@ function getDemoWebhooks(clusterNames: string[]): WebhookData[] {
     { name: 'vault-agent-injector', type: 'mutating', failurePolicy: 'Ignore', matchPolicy: 'Exact', rules: 1 },
   ]
 
-  for (const cluster of names) {
+  for (const cluster of (names || [])) {
     const hash = cluster.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
     const count = 2 + (hash % 4) // 2-5 webhooks per cluster
     for (let i = 0; i < count && i < templates.length; i++) {

--- a/web/src/hooks/useHelmActions.ts
+++ b/web/src/hooks/useHelmActions.ts
@@ -6,6 +6,7 @@
  */
 
 import { useState, useCallback } from 'react'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 // ============================================================================
 // Types
@@ -72,6 +73,7 @@ export function useHelmActions(): UseHelmActionsResult {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
       const data = await response.json()

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -228,7 +228,7 @@ export function useKubescape() {
           const data = JSON.parse(scanResult.output)
           const items = (data.items || []) as ConfigScanSummaryResource[]
 
-          for (const item of items) {
+          for (const item of (items || [])) {
             const sevs = item.spec?.severities || {}
             const itemFails = (sevs.critical || 0) + (sevs.high || 0) + (sevs.medium || 0) + (sevs.low || 0)
             failedControls += itemFails
@@ -251,7 +251,7 @@ export function useKubescape() {
           const items = (data.items || []) as WorkloadConfigScanResource[]
 
           // Aggregate control results with names
-          for (const item of items) {
+          for (const item of (items || [])) {
             for (const [controlId, control] of Object.entries(item.spec?.controls || {})) {
               if (!controlResults.has(controlId)) {
                 controlResults.set(controlId, { name: control.name || controlId, passed: 0, failed: 0 })
@@ -360,7 +360,7 @@ export function useKubescape() {
         ? clusters
         : ['us-east-1', 'eu-central-1', 'us-west-2']
       const demoStatuses: Record<string, KubescapeClusterStatus> = {}
-      for (const name of demoNames) {
+      for (const name of (demoNames || [])) {
         demoStatuses[name] = getDemoStatus(name)
       }
       setStatuses(demoStatuses)

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -381,7 +381,7 @@ export function useKyverno() {
         ? clusters
         : ['us-east-1', 'eu-central-1', 'us-west-2']
       const demoStatuses: Record<string, KyvernoClusterStatus> = {}
-      for (const name of demoNames) {
+      for (const name of (demoNames || [])) {
         demoStatuses[name] = getDemoStatus(name)
       }
       setStatuses(demoStatuses)

--- a/web/src/hooks/useMultiClusterInsights.ts
+++ b/web/src/hooks/useMultiClusterInsights.ts
@@ -93,7 +93,7 @@ function detectEventCorrelations(events: ClusterEvent[]): MultiClusterInsight[] 
   // Group events into time windows
   const windows = new Map<number, Map<string, ClusterEvent[]>>()
 
-  for (const event of warnings) {
+  for (const event of (warnings || [])) {
     const ts = parseTimestamp(event.lastSeen)
     if (ts === 0) continue
     const bucket = Math.floor(ts / EVENT_CORRELATION_WINDOW_MS) * EVENT_CORRELATION_WINDOW_MS
@@ -344,7 +344,7 @@ function detectResourceImbalance(clusters: ClusterInfo[]): MultiClusterInsight[]
 
   if (overloaded.length > 0 || underloaded.length > 0) {
     const metrics: Record<string, number> = {}
-    for (const c of cpuPcts) metrics[c.name] = c.pct
+    for (const c of (cpuPcts || [])) metrics[c.name] = c.pct
 
     const parts: string[] = []
     if (overloaded.length > 0) {
@@ -382,7 +382,7 @@ function detectResourceImbalance(clusters: ClusterInfo[]): MultiClusterInsight[]
 
     if (memOverloaded.length > 0 || memUnderloaded.length > 0) {
       const metrics: Record<string, number> = {}
-      for (const c of memPcts) metrics[c.name] = c.pct
+      for (const c of (memPcts || [])) metrics[c.name] = c.pct
 
       insights.push({
         id: generateId('resource-imbalance', 'memory'),
@@ -411,7 +411,7 @@ function detectRestartCorrelation(podIssues: PodIssue[]): MultiClusterInsight[] 
 
   // Group by workload name (strip pod hash suffix) across clusters
   const workloadRestarts = new Map<string, Map<string, number>>()
-  for (const issue of issues) {
+  for (const issue of (issues || [])) {
     // Strip pod hash: "api-server-abc123-xyz" → "api-server"
     const parts = issue.name.split('-')
     const workload = parts.length > 2 ? parts.slice(0, -2).join('-') : issue.name
@@ -495,7 +495,7 @@ function trackRolloutProgress(deployments: Deployment[]): MultiClusterInsight[] 
 
     // Find the newest image (highest version or most common)
     const imageCounts = new Map<string, number>()
-    for (const dep of deps) {
+    for (const dep of (deps || [])) {
       if (dep.image) imageCounts.set(dep.image, (imageCounts.get(dep.image) || 0) + 1)
     }
     const [newestImage] = Array.from(imageCounts.entries()).sort((a, b) => b[1] - a[1])[0]
@@ -513,7 +513,7 @@ function trackRolloutProgress(deployments: Deployment[]): MultiClusterInsight[] 
       failed: failed.length,
       total: deps.length,
     }
-    for (const dep of deps) {
+    for (const dep of (deps || [])) {
       if (!dep.cluster) continue
       if (dep.status === 'failed') {
         metrics[`${dep.cluster}_progress`] = 0

--- a/web/src/hooks/useServiceExports.ts
+++ b/web/src/hooks/useServiceExports.ts
@@ -115,7 +115,7 @@ function getDemoServiceExports(clusterNames: string[]): ServiceExport[] {
     { name: 'legacy-backend', namespace: 'legacy', status: 'Failed' as const, message: 'Service not found in cluster' },
   ]
 
-  for (const cluster of names) {
+  for (const cluster of (names || [])) {
     const hash = cluster.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0)
     const count = 2 + (hash % 4) // 2-5 exports per cluster
     const others = names.filter(n => n !== cluster)

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -213,7 +213,7 @@ export function useTrivy() {
           const items = (data.items || []) as VulnerabilityReportResource[]
           totalReports = items.length
 
-          for (const item of items) {
+          for (const item of (items || [])) {
             const repo = item.report?.artifact?.repository || ''
             const tag = item.report?.artifact?.tag || 'latest'
             const ns = item.metadata?.namespace || 'default'
@@ -293,7 +293,7 @@ export function useTrivy() {
         ? clusters
         : ['us-east-1', 'eu-central-1', 'us-west-2']
       const demoStatuses: Record<string, TrivyClusterStatus> = {}
-      for (const name of demoNames) {
+      for (const name of (demoNames || [])) {
         demoStatuses[name] = getDemoStatus(name)
       }
       setStatuses(demoStatuses)


### PR DESCRIPTION
## Summary

Fixes the nightly consistency-test regression reported in #2229.

- **Phase 5 (Fetch Timeout):** Added `AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS)` to the `fetch()` call in `useHelmActions.ts` that was missing a timeout/signal
- **Phase 2 (Array Guards):** Added `(arr || [])` guards to 14 `for...of` loops across 6 hooks: `useAdmissionWebhooks`, `useMultiClusterInsights`, `useServiceExports`, `useKyverno`, `useTrivy`, `useKubescape`
- **Phase 6 (Cache Patterns):** Added `src/App.tsx` to the Phase 6 exclusion list since its `Date.now()` usage is for page view analytics duration tracking, not cache TTL

All 6 consistency phases now pass cleanly (0 errors, 0 warnings). TypeScript and ESLint also pass.

Fixes #2229

## Test plan

- [x] `bash scripts/consistency-test.sh` passes with 0 errors, 0 warnings
- [x] `npx tsc -b` compiles without errors
- [x] `npx eslint` passes on all changed files