### PR TITLE
🐛 Fix GPUReservations test OOM crash

### DIFF
--- a/web/src/components/gpu/GPUReservations.test.tsx
+++ b/web/src/components/gpu/GPUReservations.test.tsx
@@ -1,6 +1,9 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+
+// Use fake timers to prevent real intervals/timeouts from hanging the worker
+vi.useFakeTimers()
 
 vi.mock('../../lib/demoMode', () => ({
   isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
@@ -10,10 +13,22 @@ vi.mock('../../lib/demoMode', () => ({
   isFeatureEnabled: () => true,
 }))
 vi.mock('../../hooks/useDemoMode', () => ({
-  getDemoMode: () => true, default: () => true, useDemoMode: () => true, isDemoModeForced: false,
+  getDemoMode: () => true,
+  default: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false,
+  isDemoModeForced: false,
+  isNetlifyDeployment: false,
+  canToggleDemoMode: () => true,
+  isDemoToken: () => true,
+  setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
 }))
 vi.mock('../../lib/analytics', () => ({
   emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitAddCardModalAbandoned: vi.fn(),
+  emitCardCategoryBrowsed: vi.fn(), emitRecommendedCardShown: vi.fn(),
+  emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
 }))
 vi.mock('../../hooks/useTokenUsage', () => ({
   useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
@@ -78,7 +93,7 @@ vi.mock('../../hooks/useAIMode', () => ({
 }))
 
 vi.mock('../../lib/auth', () => ({
-  useAuth: () => ({ user: { login: 'test-user', name: 'Test User' } }),
+  useAuth: () => ({ user: { login: 'test-user', name: 'Test User' }, isAuthenticated: false }),
 }))
 
 vi.mock('../ui/Toast', () => ({
@@ -89,9 +104,111 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
 }))
 
+// Mock useBackendHealth to prevent the singleton from polling /health
+vi.mock('../../hooks/useBackendHealth', () => ({
+  useBackendHealth: () => ({
+    status: 'disconnected',
+    isConnected: false,
+    lastCheck: null,
+    versionChanged: false,
+    inCluster: false,
+    isInClusterMode: false,
+  }),
+  isBackendConnected: () => false,
+  isInClusterMode: () => false,
+}))
+
+// Mock useGPUUtilizations to prevent API calls and interval polling
+vi.mock('../../hooks/useGPUUtilizations', () => ({
+  useGPUUtilizations: () => ({ utilizations: {}, isLoading: false }),
+}))
+
+// Mock useRefreshIndicator to prevent timers
+vi.mock('../../hooks/useRefreshIndicator', () => ({
+  useRefreshIndicator: () => ({ showIndicator: false, triggerRefresh: vi.fn() }),
+}))
+
+// Mock the card registry to avoid loading 50+ lazy card components
+vi.mock('../cards/cardRegistry', () => ({
+  CARD_COMPONENTS: {} as Record<string, unknown>,
+  getDefaultCardWidth: () => 6,
+  DEMO_DATA_CARDS: [],
+  LIVE_DATA_CARDS: [],
+  MODULE_MAP: {},
+  CARD_SIZES: {},
+  registerDynamicCardType: vi.fn(),
+}))
+
+// Mock CardWrapper to avoid loading its heavy dependency tree (timers, effects, portals)
+vi.mock('../cards/CardWrapper', () => ({
+  CardWrapper: ({ children }: { children?: React.ReactNode }) => <div data-testid="card-wrapper">{children}</div>,
+  CARD_TITLES: {} as Record<string, string>,
+  CARD_DESCRIPTIONS: {} as Record<string, string>,
+}))
+
+// Mock AddCardModal to avoid loading CardFactory + dynamic card infrastructure
+vi.mock('../dashboard/AddCardModal', () => ({
+  AddCardModal: () => null,
+}))
+
+// Mock ReservationFormModal to reduce component tree size
+vi.mock('./ReservationFormModal', () => ({
+  ReservationFormModal: () => null,
+}))
+
+// Mock chart components to avoid heavy rendering libraries
+vi.mock('../charts/PieChart', () => ({
+  DonutChart: () => <div data-testid="donut-chart" />,
+}))
+vi.mock('../charts/BarChart', () => ({
+  BarChart: () => <div data-testid="bar-chart" />,
+}))
+vi.mock('../charts/Sparkline', () => ({
+  Sparkline: () => <div data-testid="sparkline" />,
+}))
+
+// Mock @dnd-kit to avoid drag-and-drop overhead in unit tests
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  closestCenter: vi.fn(),
+  KeyboardSensor: vi.fn(),
+  PointerSensor: vi.fn(),
+  useSensor: () => ({}),
+  useSensors: () => [],
+}))
+vi.mock('@dnd-kit/sortable', () => ({
+  arrayMove: (arr: unknown[]) => arr,
+  SortableContext: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  sortableKeyboardCoordinates: vi.fn(),
+  rectSortingStrategy: vi.fn(),
+  useSortable: () => ({
+    attributes: {}, listeners: {}, setNodeRef: vi.fn(),
+    transform: null, transition: null, isDragging: false,
+  }),
+}))
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: { Transform: { toString: () => '' } },
+}))
+
+// Mock localStorage utilities
+vi.mock('../../lib/utils/localStorage', () => ({
+  safeGetJSON: () => null,
+  safeSetJSON: vi.fn(),
+}))
+
+// Mock useSnoozedCards (used by CardWrapper, but CardWrapper is mocked above — belt-and-suspenders)
+vi.mock('../../hooks/useSnoozedCards', () => ({
+  useSnoozedCards: () => ({ snoozedCards: [], snoozeSwap: vi.fn(), unsnooze: vi.fn() }),
+}))
+
 import { GPUReservations } from './GPUReservations'
 
 describe('GPUReservations Component', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllTimers()
+  })
+
   const renderGPU = () =>
     render(
       <MemoryRouter>


### PR DESCRIPTION
## Summary

Fixes #2188 (also fixes recurring issue from #2057).

The `GPUReservations.test.tsx` was crashing the Vitest worker with OOM/timeout ("Worker exited unexpectedly") because it rendered the full `GPUReservations` component without mocking its heavy dependencies. The component imports:

- **`cardRegistry`** — lazily loads 50+ card components at module parse time
- **`CardWrapper`** — 1100-line component with 14 `useEffect` hooks creating timers, intervals, and DOM event listeners
- **`AddCardModal`** — 1575 lines with `CardFactoryModal` and dynamic card infrastructure
- **`useBackendHealth`** — module-level singleton that starts `setInterval` polling `/health`
- **`useGPUUtilizations`** — makes API calls and sets up polling intervals
- **`@dnd-kit`** — drag-and-drop library with sensor overhead
- Chart components (`DonutChart`, `BarChart`, `Sparkline`)

Additionally, the existing `useDemoMode` mock returned `true` instead of `{ isDemoMode, toggleDemoMode, setDemoMode }` and was missing `hasRealToken`, causing render errors.

### Changes
- Added mocks for `useBackendHealth`, `useGPUUtilizations`, `useRefreshIndicator`
- Added mocks for `cardRegistry`, `CardWrapper`, `AddCardModal`, `ReservationFormModal`
- Added mocks for chart components and `@dnd-kit`
- Fixed `useDemoMode` mock to return correct shape with `hasRealToken` export
- Fixed `useAuth` mock to include `isAuthenticated`
- Added `vi.useFakeTimers()` to prevent real timers from hanging the worker
- Added `afterEach` cleanup with `vi.clearAllTimers()`

### Results
- Test execution: **43ms** (was timing out at 672s+ in CI)
- Full test suite: **105 files pass, 648 tests pass**

## Test plan
- [x] `npx vitest run src/components/gpu/GPUReservations.test.tsx` passes (2/2 tests)
- [x] Full test suite passes (`npx vitest run` — 105 files, 648 tests)
- [x] TypeScript build passes (`npx tsc -b`)
- [ ] CI nightly run passes without worker timeout