### PR TITLE
🐛 Fix swallowed errors in useInsightActions

### DIFF
--- a/web/src/components/cards/insights/useInsightActions.ts
+++ b/web/src/components/cards/insights/useInsightActions.ts
@@ -6,11 +6,15 @@
  */
 
 import { useState, useCallback, useMemo } from 'react'
+import { useToast } from '../../ui/Toast'
 
 /** localStorage key for acknowledged insight IDs */
 const INSIGHT_ACKNOWLEDGE_KEY = 'acknowledged-insights'
 /** sessionStorage key for dismissed insight IDs (session only) */
 const INSIGHT_DISMISS_KEY = 'dismissed-insights-session'
+
+/** User-facing message when insight preferences fail to save */
+const SAVE_ERROR_MESSAGE = 'Failed to save insight preference. Your browser storage may be full.'
 
 function loadSet(storage: Storage, key: string): Set<string> {
   try {
@@ -18,25 +22,34 @@ function loadSet(storage: Storage, key: string): Set<string> {
     if (!raw) return new Set()
     const parsed: unknown = JSON.parse(raw)
     if (!Array.isArray(parsed)) {
-      console.warn(`[useInsightActions] Invalid data in ${key}: expected array, got ${typeof parsed}`)
+      console.error(`[useInsightActions] Invalid data in ${key}: expected array, got ${typeof parsed}`)
       return new Set()
     }
     return new Set(parsed.filter((v): v is string => typeof v === 'string'))
   } catch (err) {
-    console.warn(`[useInsightActions] Failed to load ${key} from storage:`, err)
+    console.error(`[useInsightActions] Failed to load ${key} from storage:`, err)
     return new Set()
   }
 }
 
-function saveSet(storage: Storage, key: string, set: Set<string>): void {
+type ErrorCallback = (message: string) => void
+
+function saveSet(storage: Storage, key: string, set: Set<string>, onError?: ErrorCallback): void {
   try {
     storage.setItem(key, JSON.stringify(Array.from(set)))
   } catch (err) {
-    console.warn(`[useInsightActions] Failed to save ${key} to storage:`, err)
+    console.error(`[useInsightActions] Failed to save ${key} to storage:`, err)
+    onError?.(SAVE_ERROR_MESSAGE)
   }
 }
 
 export function useInsightActions() {
+  const { showToast } = useToast()
+
+  const onSaveError = useCallback((message: string) => {
+    showToast(message, 'error')
+  }, [showToast])
+
   const [acknowledgedIds, setAcknowledgedIds] = useState<Set<string>>(
     () => loadSet(localStorage, INSIGHT_ACKNOWLEDGE_KEY)
   )
@@ -48,19 +61,19 @@ export function useInsightActions() {
     setAcknowledgedIds(prev => {
       const next = new Set(prev)
       next.add(id)
-      saveSet(localStorage, INSIGHT_ACKNOWLEDGE_KEY, next)
+      saveSet(localStorage, INSIGHT_ACKNOWLEDGE_KEY, next, onSaveError)
       return next
     })
-  }, [])
+  }, [onSaveError])
 
   const dismissInsight = useCallback((id: string) => {
     setDismissedIds(prev => {
       const next = new Set(prev)
       next.add(id)
-      saveSet(sessionStorage, INSIGHT_DISMISS_KEY, next)
+      saveSet(sessionStorage, INSIGHT_DISMISS_KEY, next, onSaveError)
       return next
     })
-  }, [])
+  }, [onSaveError])
 
   const isAcknowledged = useCallback((id: string) => acknowledgedIds.has(id), [acknowledgedIds])
   const isDismissed = useCallback((id: string) => dismissedIds.has(id), [dismissedIds])


### PR DESCRIPTION
## Summary
- Upgraded `console.warn` to `console.error` in both `loadSet` and `saveSet` catch blocks so storage errors are logged at the correct severity level
- Added user-facing error toast via the existing `useToast` system when saving insight preferences fails (e.g., browser storage full or quota exceeded)
- Extracted error message to a named constant (`SAVE_ERROR_MESSAGE`) to avoid magic strings

## Details
The `loadSet` function (line 26) and `saveSet` function (line 35) previously only called `console.warn`, silently swallowing errors with no user feedback. Now:
- **`loadSet`**: Logs at `console.error` level. No toast here since the function gracefully returns an empty set and runs during initialization — the user simply sees a fresh state.
- **`saveSet`**: Logs at `console.error` level AND shows an error toast so the user knows their acknowledge/dismiss action was not persisted.

The `saveSet` function accepts an optional `onError` callback, keeping it decoupled from React while allowing `useInsightActions` to wire in the toast via `useToast()`.

Fixes #2322

## Test plan
- [ ] Verify build passes (`npm run build`)
- [ ] Verify lint passes (`npm run lint`)
- [ ] Simulate storage quota exceeded (DevTools > Application > Storage > check "Simulate custom storage quota" with a small value) and confirm error toast appears when acknowledging/dismissing an insight
- [ ] Confirm normal acknowledge/dismiss still works when storage is available