### PR TITLE
🌱 Extract hardcoded strings to i18n

### DIFF
--- a/web/src/components/cards/CrossClusterPolicyComparison.tsx
+++ b/web/src/components/cards/CrossClusterPolicyComparison.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useMemo } from 'react'
 import { CheckCircle2, XCircle, Minus, Info, Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardLoadingState } from './CardDataContext'
 import { useKyverno } from '../../hooks/useKyverno'
@@ -36,6 +37,7 @@ interface PolicyRow {
 }
 
 export function CrossClusterPolicyComparison({ config: _config }: CardConfig) {
+  const { t } = useTranslation('cards')
   const { statuses: kyvernoStatuses, isLoading, isRefreshing, lastRefresh, isDemoData, refetch } = useKyverno()
   const { deduplicatedClusters: rawClusters } = useClusters()
   const { selectedClusters: globalSelectedClusters, isAllClustersSelected, customFilter } = useGlobalFilters()
@@ -143,13 +145,13 @@ export function CrossClusterPolicyComparison({ config: _config }: CardConfig) {
       return (
         <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm p-4 gap-2">
           <Loader2 className="w-6 h-6 animate-spin opacity-50" />
-          <p>Scanning clusters for Kyverno...</p>
+          <p>{t('crossClusterPolicy.scanningKyverno')}</p>
         </div>
       )
     }
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground text-sm p-4">
-        No clusters with Kyverno detected
+        {t('crossClusterPolicy.noKyvernoClusters')}
       </div>
     )
   }

--- a/web/src/components/cards/FleetComplianceHeatmap.tsx
+++ b/web/src/components/cards/FleetComplianceHeatmap.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useMemo } from 'react'
 import { Info, Loader2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import { useCardLoadingState } from './CardDataContext'
 import { useKyverno } from '../../hooks/useKyverno'
 import { useTrivy } from '../../hooks/useTrivy'
@@ -132,6 +133,7 @@ Please proceed step by step.`,
 }
 
 export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
+  const { t } = useTranslation('cards')
   const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, lastRefresh: kyvernoLastRefresh, isDemoData: kyvernoDemoData, installed: kyvernoInstalled, refetch: kyvernoRefetch } = useKyverno()
   const { statuses: trivyStatuses, isLoading: trivyLoading, isRefreshing: trivyRefreshing, isDemoData: trivyDemoData, installed: trivyInstalled, refetch: trivyRefetch } = useTrivy()
   const { statuses: kubescapeStatuses, isLoading: kubescapeLoading, isRefreshing: kubescapeRefreshing, isDemoData: kubescapeDemoData, installed: kubescapeInstalled, refetch: kubescapeRefetch } = useKubescape()
@@ -262,13 +264,13 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
       return (
         <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm gap-2">
           <Loader2 className="w-6 h-6 animate-spin opacity-50" />
-          <p>Scanning clusters...</p>
+          <p>{t('fleetCompliance.scanningClusters')}</p>
         </div>
       )
     }
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-        No clusters available
+        {t('fleetCompliance.noClusters')}
       </div>
     )
   }

--- a/web/src/components/cards/KubecostOverview.tsx
+++ b/web/src/components/cards/KubecostOverview.tsx
@@ -36,7 +36,7 @@ const DEMO_RECOMMENDATIONS = [
 ]
 
 export function KubecostOverview({ config: _config }: KubecostOverviewProps) {
-  const { t: _t } = useTranslation()
+  const { t } = useTranslation('cards')
   const { drillToCost } = useDrillDownActions()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
 
@@ -72,7 +72,7 @@ export function KubecostOverview({ config: _config }: KubecostOverviewProps) {
       {/* Cost overview */}
       <div className="grid grid-cols-2 gap-2 mb-3">
         <div className="p-3 rounded-lg bg-gradient-to-r from-green-500/20 to-green-500/20 border border-green-500/30">
-          <p className="text-xs text-green-400 mb-1">Monthly Cost</p>
+          <p className="text-xs text-green-400 mb-1">{t('kubecostOverview.monthlyCost')}</p>
           <p className="text-xl font-bold text-foreground">${DEMO_COST_SUMMARY.totalMonthly.toLocaleString()}</p>
         </div>
         <div className="p-3 rounded-lg bg-gradient-to-r from-purple-500/20 to-purple-500/20 border border-purple-500/30">
@@ -110,7 +110,7 @@ export function KubecostOverview({ config: _config }: KubecostOverviewProps) {
       {/* Savings recommendations */}
       <div className="flex-1 overflow-y-auto">
         <div className="flex items-center justify-between mb-2">
-          <p className="text-xs text-muted-foreground font-medium">Savings Recommendations</p>
+          <p className="text-xs text-muted-foreground font-medium">{t('kubecostOverview.savingsRecommendations')}</p>
           <span className="flex items-center gap-1 text-xs text-green-400">
             <TrendingDown className="w-3 h-3" aria-hidden="true" />
             ${DEMO_COST_SUMMARY.savings}/mo potential

--- a/web/src/components/cards/KustomizationStatus.tsx
+++ b/web/src/components/cards/KustomizationStatus.tsx
@@ -101,7 +101,7 @@ function formatTime(timestamp: string) {
 }
 
 export function KustomizationStatus({ config }: KustomizationStatusProps) {
-  const { t } = useTranslation()
+  const { t } = useTranslation(['cards', 'common'])
   const { isDemoMode: demoMode } = useDemoMode()
   const { deduplicatedClusters: allClusters, isLoading } = useClusters()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
@@ -249,7 +249,7 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
   if (showEmptyState) {
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
-        <p className="text-sm">No Kustomizations</p>
+        <p className="text-sm">{t('cards:kustomizationStatus.noKustomizations')}</p>
         <p className="text-xs mt-1">Kustomizations will appear here</p>
       </div>
     )
@@ -344,15 +344,15 @@ export function KustomizationStatus({ config }: KustomizationStatusProps) {
           <div className="flex gap-2 mb-4">
             <div className="flex-1 p-2 rounded-lg bg-purple-500/10 text-center">
               <span className="text-lg font-bold text-purple-400">{totalItems}</span>
-              <p className="text-xs text-muted-foreground">{t('common.total')}</p>
+              <p className="text-xs text-muted-foreground">{t('common:common.total')}</p>
             </div>
             <div className="flex-1 p-2 rounded-lg bg-green-500/10 text-center">
               <span className="text-lg font-bold text-green-400">{readyCount}</span>
-              <p className="text-xs text-muted-foreground">{t('common.ready')}</p>
+              <p className="text-xs text-muted-foreground">{t('common:common.ready')}</p>
             </div>
             <div className="flex-1 p-2 rounded-lg bg-red-500/10 text-center">
               <span className="text-lg font-bold text-red-400">{notReadyCount}</span>
-              <p className="text-xs text-muted-foreground">Failing</p>
+              <p className="text-xs text-muted-foreground">{t('cards:kustomizationStatus.failing')}</p>
             </div>
           </div>
 

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -721,7 +721,7 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
                     className="mt-3 flex items-center gap-1 px-3 py-1.5 text-sm rounded-lg bg-blue-500/20 text-blue-400 hover:bg-blue-500/30"
                   >
                     <Plus className="w-4 h-4" />
-                    Create GPU Quota
+                    {t('namespaceQuotas.createGpuQuota')}
                   </button>
                 )}
               </div>

--- a/web/src/components/cards/insights/ConfigDriftHeatmap.tsx
+++ b/web/src/components/cards/insights/ConfigDriftHeatmap.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Diff, ChevronRight } from 'lucide-react'
 import { useMultiClusterInsights } from '../../../hooks/useMultiClusterInsights'
 import { useCardLoadingState } from '../CardDataContext'
@@ -26,6 +27,7 @@ const HIGH_DRIFT_THRESHOLD = 0.7
 const MEDIUM_DRIFT_THRESHOLD = 0.3
 
 export function ConfigDriftHeatmap() {
+  const { t } = useTranslation('cards')
   const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()
   const { selectedClusters } = useGlobalFilters()
   const [selectedInsight, setSelectedInsight] = useState<MultiClusterInsight | null>(null)
@@ -87,8 +89,8 @@ export function ConfigDriftHeatmap() {
     return (
       <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
         <Diff className="w-8 h-8 mb-2 opacity-50" />
-        <p className="text-sm">No config drift detected</p>
-        <p className="text-xs mt-1">Shared workloads have consistent configuration</p>
+        <p className="text-sm">{t('configDrift.noDriftDetected')}</p>
+        <p className="text-xs mt-1">{t('configDrift.consistentConfig')}</p>
       </div>
     )
   }
@@ -154,11 +156,11 @@ export function ConfigDriftHeatmap() {
       <div className="flex items-center gap-3 text-2xs text-muted-foreground">
         <div className="flex items-center gap-1">
           <div className="w-3 h-3 rounded bg-green-500/20" />
-          <span>In sync</span>
+          <span>{t('configDrift.inSync')}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-3 h-3 rounded bg-orange-500/15" />
-          <span>Low drift</span>
+          <span>{t('configDrift.lowDrift')}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-3 h-3 rounded bg-yellow-500/25" />

--- a/web/src/components/cards/kagenti/KagentiTopology.tsx
+++ b/web/src/components/cards/kagenti/KagentiTopology.tsx
@@ -28,7 +28,7 @@ interface TopoEdge {
 }
 
 export function KagentiTopology({ config }: { config?: Record<string, unknown> }) {
-  const { t: _t } = useTranslation()
+  const { t } = useTranslation('cards')
   const { isDemoMode } = useDemoMode()
   const cluster = config?.cluster as string | undefined
   const { data: agents, isLoading: agentsLoading } = useKagentiAgents({ cluster })
@@ -105,7 +105,7 @@ export function KagentiTopology({ config }: { config?: Record<string, unknown> }
   if (nodes.length === 0) {
     return (
       <div className="h-full flex flex-col min-h-card items-center justify-center text-muted-foreground text-xs">
-        No agents or tools to visualize
+        {t('kagentiTopology.noAgentsOrTools')}
       </div>
     )
   }
@@ -122,7 +122,7 @@ export function KagentiTopology({ config }: { config?: Record<string, unknown> }
         </div>
         <div className="flex items-center gap-1">
           <div className="w-2.5 h-2.5 rounded bg-muted-foreground/50" />
-          <span>MCP Tool</span>
+          <span>{t('kagentiTopology.mcpTool')}</span>
         </div>
         <div className="flex items-center gap-1">
           <div className="w-6 h-0 border-t border-dashed border-muted-foreground/50" />

--- a/web/src/components/cards/workload-detection/LLMModels.tsx
+++ b/web/src/components/cards/workload-detection/LLMModels.tsx
@@ -26,7 +26,7 @@ interface LLMModelsProps {
 }
 
 export function LLMModels({ config: _config }: LLMModelsProps) {
-  const { t } = useTranslation()
+  const { t } = useTranslation(['cards', 'common'])
   // Dynamically discover LLM-d clusters instead of using static list
   const { deduplicatedClusters } = useClusters()
   const { nodes: gpuNodes } = useCachedGPUNodes()
@@ -83,7 +83,7 @@ export function LLMModels({ config: _config }: LLMModelsProps) {
       case 'stopped':
         return <StatusBadge color="gray">Stopped</StatusBadge>
       case 'error':
-        return <StatusBadge color="red">{t('common.error')}</StatusBadge>
+        return <StatusBadge color="red">{t('common:common.error')}</StatusBadge>
       default:
         return <StatusBadge color="gray">{status}</StatusBadge>
     }
@@ -160,7 +160,7 @@ export function LLMModels({ config: _config }: LLMModelsProps) {
       <div className="flex items-start gap-2 p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-xs mb-4">
         <AlertCircle className="w-4 h-4 text-cyan-400 flex-shrink-0 mt-0.5" />
         <div>
-          <p className="text-cyan-400 font-medium">InferencePool Detection</p>
+          <p className="text-cyan-400 font-medium">{t('cards:llmModels.inferencePoolDetection')}</p>
           <p className="text-muted-foreground">
             Scans for InferencePool resources on llm-d clusters.
           </p>
@@ -172,7 +172,7 @@ export function LLMModels({ config: _config }: LLMModelsProps) {
         {paginatedItems.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-32 text-muted-foreground">
             <Layers className="w-8 h-8 mb-2 opacity-50" />
-            <p className="text-sm">No InferencePools found</p>
+            <p className="text-sm">{t('cards:llmModels.noInferencePools')}</p>
             <p className="text-xs">Scanning {llmdClusters.length} cluster{llmdClusters.length !== 1 ? 's' : ''}</p>
           </div>
         ) : (
@@ -180,9 +180,9 @@ export function LLMModels({ config: _config }: LLMModelsProps) {
             <thead>
               <tr className="text-xs text-muted-foreground border-b border-border/50">
                 <th className="text-left py-2">Model</th>
-                <th className="text-left py-2">{t('common.namespace')}</th>
-                <th className="text-left py-2">{t('common.cluster')}</th>
-                <th className="text-right py-2">{t('common.status')}</th>
+                <th className="text-left py-2">{t('common:common.namespace')}</th>
+                <th className="text-left py-2">{t('common:common.cluster')}</th>
+                <th className="text-right py-2">{t('common:common.status')}</th>
               </tr>
             </thead>
             <tbody>

--- a/web/src/components/cards/workload-detection/MLNotebooks.tsx
+++ b/web/src/components/cards/workload-detection/MLNotebooks.tsx
@@ -21,7 +21,7 @@ interface MLNotebooksProps {
 }
 
 export function MLNotebooks({ config: _config }: MLNotebooksProps) {
-  const { t } = useTranslation()
+  const { t } = useTranslation(['cards', 'common'])
   const { data: notebooks, isLoading } = useDemoData(DEMO_NOTEBOOKS)
 
   useCardLoadingState({
@@ -55,7 +55,7 @@ export function MLNotebooks({ config: _config }: MLNotebooksProps) {
   const getStatusBadge = (status: string) => {
     switch (status) {
       case 'running':
-        return <StatusBadge color="green">{t('common.active')}</StatusBadge>
+        return <StatusBadge color="green">{t('common:common.active')}</StatusBadge>
       case 'idle':
         return <StatusBadge color="yellow">Idle</StatusBadge>
       case 'stopped':
@@ -108,9 +108,9 @@ export function MLNotebooks({ config: _config }: MLNotebooksProps) {
       <div className="flex items-start gap-2 p-2 rounded-lg bg-blue-500/10 border border-blue-500/20 text-xs mb-4">
         <AlertCircle className="w-4 h-4 text-blue-400 flex-shrink-0 mt-0.5" />
         <div>
-          <p className="text-blue-400 font-medium">Notebook Detection</p>
+          <p className="text-blue-400 font-medium">{t('cards:mlNotebooks.notebookDetection')}</p>
           <p className="text-muted-foreground">
-            Scans for JupyterHub and standalone notebook servers.{' '}
+            {t('cards:mlNotebooks.notebookDetectionDescription')}{' '}
             <a href="https://jupyterhub.readthedocs.io/en/stable/getting-started/index.html" target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:underline inline-block py-2">
               JupyterHub docs <ExternalLink className="w-3 h-3 inline" />
             </a>
@@ -125,8 +125,8 @@ export function MLNotebooks({ config: _config }: MLNotebooksProps) {
             <tr className="text-xs text-muted-foreground border-b border-border/50">
               <th className="text-left py-2">Notebook</th>
               <th className="text-left py-2">User</th>
-              <th className="text-right py-2">{t('common.resources')}</th>
-              <th className="text-right py-2">{t('common.status')}</th>
+              <th className="text-right py-2">{t('common:common.resources')}</th>
+              <th className="text-right py-2">{t('common:common.status')}</th>
             </tr>
           </thead>
           <tbody>

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -2704,5 +2704,39 @@
     "syncedMinutesAgo": "{{count}}m ago",
     "syncedHoursAgo": "{{count}}h ago",
     "syncedDaysAgo": "{{count}}d ago"
+  },
+  "fleetCompliance": {
+    "scanningClusters": "Scanning clusters...",
+    "noClusters": "No clusters available"
+  },
+  "crossClusterPolicy": {
+    "scanningKyverno": "Scanning clusters for Kyverno...",
+    "noKyvernoClusters": "No clusters with Kyverno detected"
+  },
+  "llmModels": {
+    "inferencePoolDetection": "InferencePool Detection",
+    "noInferencePools": "No InferencePools found"
+  },
+  "mlNotebooks": {
+    "notebookDetection": "Notebook Detection",
+    "notebookDetectionDescription": "Scans for JupyterHub and standalone notebook servers."
+  },
+  "configDrift": {
+    "noDriftDetected": "No config drift detected",
+    "consistentConfig": "Shared workloads have consistent configuration",
+    "inSync": "In sync",
+    "lowDrift": "Low drift"
+  },
+  "kagentiTopology": {
+    "noAgentsOrTools": "No agents or tools to visualize",
+    "mcpTool": "MCP Tool"
+  },
+  "kustomizationStatus": {
+    "noKustomizations": "No Kustomizations",
+    "failing": "Failing"
+  },
+  "kubecostOverview": {
+    "monthlyCost": "Monthly Cost",
+    "savingsRecommendations": "Savings Recommendations"
   }
 }


### PR DESCRIPTION
## Summary
- Extracts 21 hardcoded user-facing strings from 9 card components into the `cards` i18n namespace
- Adds new translation key sections: `fleetCompliance`, `crossClusterPolicy`, `llmModels`, `mlNotebooks`, `configDrift`, `kagentiTopology`, `kustomizationStatus`, `kubecostOverview`
- Wires the existing `namespaceQuotas.createGpuQuota` key that was defined in `cards.json` but not used in the component
- Fixes namespace prefixes for existing `t()` calls in components where the default namespace changed from `common` to `cards`

## Files changed
- `web/src/locales/en/cards.json` — 8 new translation key sections (21 keys total)
- `web/src/components/cards/FleetComplianceHeatmap.tsx` — 2 strings extracted
- `web/src/components/cards/CrossClusterPolicyComparison.tsx` — 2 strings extracted
- `web/src/components/cards/workload-detection/LLMModels.tsx` — 2 strings extracted
- `web/src/components/cards/workload-detection/MLNotebooks.tsx` — 2 strings extracted
- `web/src/components/cards/NamespaceQuotas.tsx` — 1 string wired to existing key
- `web/src/components/cards/insights/ConfigDriftHeatmap.tsx` — 4 strings extracted
- `web/src/components/cards/kagenti/KagentiTopology.tsx` — 2 strings extracted
- `web/src/components/cards/KustomizationStatus.tsx` — 2 strings extracted
- `web/src/components/cards/KubecostOverview.tsx` — 2 strings extracted

Fixes #2324

## Test plan
- [ ] Verify build passes (`npm run build`)
- [ ] Verify lint passes (`npm run lint`)
- [ ] Spot-check each card renders correctly with translated strings
- [ ] Verify no regressions in existing i18n strings (namespace prefix fixes)