### PR TITLE
✨ Proxy Umami analytics through first-party domain

### DIFF
--- a/pkg/api/handlers/analytics_proxy.go
+++ b/pkg/api/handlers/analytics_proxy.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-var ga4Client = &http.Client{Timeout: 10 * time.Second}
+var analyticsClient = &http.Client{Timeout: 10 * time.Second}
 
 // allowedOrigins lists hostnames that may send analytics through the proxy.
 var allowedOrigins = map[string]bool{
@@ -31,6 +31,12 @@ const (
 	// a fresh 376KB buffer, which under rapid polling (e.g. login redirect loop)
 	// causes memory to grow faster than GC can reclaim.
 	gtagCacheTTL = 1 * time.Hour
+
+	// umamiScriptCacheTTL is how long the Umami tracking script is cached.
+	umamiScriptCacheTTL = 1 * time.Hour
+
+	// umamiUpstreamBase is the external Umami instance that the proxy relays to.
+	umamiUpstreamBase = "https://analytics.kubestellar.io"
 )
 
 // gtagCache holds a server-side cache of the gtag.js script to avoid
@@ -63,7 +69,7 @@ func GA4ScriptProxy(c *fiber.Ctx) error {
 
 	// Cache miss — fetch from Google
 	target := "https://www.googletagmanager.com/gtag/js?" + qs
-	resp, err := ga4Client.Get(target)
+	resp, err := analyticsClient.Get(target)
 	if err != nil {
 		log.Printf("[GA4] Failed to fetch gtag.js: %v", err)
 		return c.SendStatus(fiber.StatusBadGateway)
@@ -161,7 +167,7 @@ func GA4CollectProxy(c *fiber.Ctx) error {
 		req.Header.Set("X-Forwarded-For", clientIP)
 	}
 
-	resp, err := ga4Client.Do(req)
+	resp, err := analyticsClient.Do(req)
 	if err != nil {
 		return c.SendStatus(fiber.StatusBadGateway)
 	}
@@ -233,4 +239,109 @@ func isPrivateIP(ip string) bool {
 		return false
 	}
 	return parsed.IsLoopback() || parsed.IsPrivate() || parsed.IsLinkLocalUnicast()
+}
+
+// ── Umami First-Party Proxy ─────────────────────────────────────────
+// Mirrors the GA4 first-party proxy pattern: serve the tracking script
+// and relay events through the console's own domain so that ad blockers
+// and corporate firewalls don't block analytics.kubestellar.io.
+
+// umamiScriptCache holds a server-side cache of the Umami tracking script.
+var umamiScriptCache struct {
+	sync.RWMutex
+	body        []byte
+	contentType string
+	fetchedAt   time.Time
+}
+
+// UmamiScriptProxy serves the Umami tracking script (/api/ksc) from the
+// console's own domain. The script is cached server-side to avoid
+// re-fetching on every page load.
+func UmamiScriptProxy(c *fiber.Ctx) error {
+	// Check cache
+	umamiScriptCache.RLock()
+	if umamiScriptCache.body != nil && time.Since(umamiScriptCache.fetchedAt) < umamiScriptCacheTTL {
+		body := umamiScriptCache.body
+		ct := umamiScriptCache.contentType
+		umamiScriptCache.RUnlock()
+		c.Set("Content-Type", ct)
+		c.Set("Cache-Control", "public, max-age=3600")
+		return c.Send(body)
+	}
+	umamiScriptCache.RUnlock()
+
+	// Cache miss — fetch from upstream Umami instance
+	target := umamiUpstreamBase + "/ksc"
+	resp, err := analyticsClient.Get(target)
+	if err != nil {
+		log.Printf("[Umami] Failed to fetch tracking script: %v", err)
+		return c.SendStatus(fiber.StatusBadGateway)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return c.SendStatus(fiber.StatusBadGateway)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+
+	// Update cache on success
+	if resp.StatusCode == http.StatusOK {
+		umamiScriptCache.Lock()
+		umamiScriptCache.body = body
+		umamiScriptCache.contentType = ct
+		umamiScriptCache.fetchedAt = time.Now()
+		umamiScriptCache.Unlock()
+	}
+
+	c.Set("Content-Type", ct)
+	c.Set("Cache-Control", "public, max-age=3600")
+	return c.Status(resp.StatusCode).Send(body)
+}
+
+// UmamiCollectProxy relays Umami event payloads to the upstream instance.
+// The browser POSTs JSON to /api/send; this handler forwards it to
+// analytics.kubestellar.io/api/send with the client's real IP so
+// geolocation works correctly.
+func UmamiCollectProxy(c *fiber.Ctx) error {
+	if !isAllowedOrigin(c) {
+		return c.SendStatus(fiber.StatusForbidden)
+	}
+
+	// Extract client IP for geolocation (same logic as GA4 proxy)
+	clientIP := c.Get("X-Forwarded-For")
+	if clientIP != "" {
+		if i := strings.Index(clientIP, ","); i != -1 {
+			clientIP = strings.TrimSpace(clientIP[:i])
+		}
+	}
+	if clientIP == "" {
+		clientIP = c.Get("X-Real-Ip")
+	}
+	if clientIP == "" {
+		clientIP = c.IP()
+	}
+
+	target := umamiUpstreamBase + "/api/send"
+	req, err := http.NewRequest(http.MethodPost, target, bytes.NewReader(c.Body()))
+	if err != nil {
+		return c.SendStatus(fiber.StatusBadGateway)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", c.Get("User-Agent"))
+	if clientIP != "" && !isPrivateIP(clientIP) {
+		req.Header.Set("X-Forwarded-For", clientIP)
+	}
+
+	resp, err := analyticsClient.Do(req)
+	if err != nil {
+		return c.SendStatus(fiber.StatusBadGateway)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return c.SendStatus(fiber.StatusBadGateway)
+	}
+	return c.Status(resp.StatusCode).Send(body)
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -435,10 +435,12 @@ func (s *Server) setupRoutes() {
 	s.app.Get("/api/public/nightly-e2e/runs", nightlyE2EPublic.GetRuns)
 	s.app.Get("/api/public/nightly-e2e/run-logs", nightlyE2EPublic.GetRunLogs)
 
-	// GA4 analytics proxy (public — no auth required, has its own origin validation)
-	// MUST be registered before the /api group so JWTAuth middleware doesn't intercept it
+	// Analytics proxies (public — no auth required, have their own origin validation)
+	// MUST be registered before the /api group so JWTAuth middleware doesn't intercept them
 	s.app.All("/api/m", handlers.GA4CollectProxy)
 	s.app.Get("/api/gtag", handlers.GA4ScriptProxy)
+	s.app.Get("/api/ksc", handlers.UmamiScriptProxy)
+	s.app.Post("/api/send", handlers.UmamiCollectProxy)
 
 	// MCP handlers (used in protected routes below)
 	mcpHandlers := handlers.NewMCPHandlers(s.bridge, s.k8sClient)

--- a/web/netlify/functions/umami-collect.mts
+++ b/web/netlify/functions/umami-collect.mts
@@ -1,0 +1,94 @@
+/**
+ * Netlify Function: Umami Event Collection Proxy
+ *
+ * Relays Umami event payloads from the browser to analytics.kubestellar.io.
+ * The browser POSTs JSON to /api/send; this function forwards it to the
+ * upstream Umami instance with the client's real IP for geolocation.
+ *
+ * This is the Netlify equivalent of the Go backend's UmamiCollectProxy handler.
+ */
+
+import type { Config } from "@netlify/functions"
+
+const UMAMI_COLLECT_URL = "https://analytics.kubestellar.io/api/send"
+
+const ALLOWED_HOSTS = new Set([
+  "console.kubestellar.io",
+  "localhost",
+  "127.0.0.1",
+])
+
+function isAllowedOrigin(req: Request): boolean {
+  const origin = req.headers.get("origin") || ""
+  const referer = req.headers.get("referer") || ""
+
+  for (const header of [origin, referer]) {
+    if (!header) continue
+    try {
+      const hostname = new URL(header).hostname
+      if (ALLOWED_HOSTS.has(hostname) || hostname.endsWith(".netlify.app")) {
+        return true
+      }
+    } catch {
+      /* ignore parse errors */
+    }
+  }
+  // Allow if neither header present (browsers always send one for fetch)
+  return !origin && !referer
+}
+
+export default async (req: Request) => {
+  const corsHeaders: Record<string, string> = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  }
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+
+  if (!isAllowedOrigin(req)) {
+    return new Response("Forbidden", { status: 403, headers: corsHeaders })
+  }
+
+  // Forward client IP for geolocation
+  const clientIp =
+    req.headers.get("x-nf-client-connection-ip") ||
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    ""
+
+  try {
+    const body = await req.text()
+
+    const resp = await fetch(UMAMI_COLLECT_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": req.headers.get("user-agent") || "",
+        ...(clientIp && { "X-Forwarded-For": clientIp }),
+      },
+      body,
+    })
+
+    const isNullBody = resp.status === 204 || resp.status === 304
+    const responseBody = isNullBody ? null : await resp.text()
+    return new Response(responseBody, {
+      status: resp.status,
+      headers: {
+        ...corsHeaders,
+        ...(!isNullBody && { "Content-Type": resp.headers.get("content-type") || "application/json" }),
+      },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return new Response(JSON.stringify({ error: "proxy_error", message }), {
+      status: 502,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    })
+  }
+}
+
+export const config: Config = {
+  path: "/api/send",
+}

--- a/web/netlify/functions/umami-script.mts
+++ b/web/netlify/functions/umami-script.mts
@@ -1,0 +1,47 @@
+/**
+ * Netlify Function: Umami Tracking Script Proxy
+ *
+ * Serves the Umami tracking script from the console's own domain (/api/ksc)
+ * so that ad blockers and corporate firewalls don't block it. This is the
+ * Netlify equivalent of the Go backend's UmamiScriptProxy handler.
+ *
+ * Without this, the script loads from analytics.kubestellar.io which is
+ * blocked by virtually every ad blocker and most corporate networks.
+ */
+
+import type { Config } from "@netlify/functions"
+
+/** Upstream Umami instance — the custom script name is "ksc" */
+const UMAMI_SCRIPT_URL = "https://analytics.kubestellar.io/ksc"
+const CACHE_MAX_AGE_SECS = 3600 // 1 hour — matches Go backend
+
+export default async (req: Request) => {
+  try {
+    const resp = await fetch(UMAMI_SCRIPT_URL, {
+      headers: {
+        "User-Agent": req.headers.get("user-agent") || "",
+      },
+    })
+
+    if (!resp.ok) {
+      return new Response(null, { status: resp.status })
+    }
+
+    const body = await resp.text()
+
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/javascript; charset=utf-8",
+        "Cache-Control": `public, max-age=${CACHE_MAX_AGE_SECS}`,
+        "X-Content-Type-Options": "nosniff",
+      },
+    })
+  } catch {
+    return new Response(null, { status: 502 })
+  }
+}
+
+export const config: Config = {
+  path: "/api/ksc",
+}

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -28,16 +28,22 @@ const GTAG_SCRIPT_PATH = '/api/gtag'
 // Events flow to both platforms via the send() function.
 // Umami auto-tracks pageviews; custom events use umami.track().
 
-const UMAMI_SCRIPT_URL = 'https://analytics.kubestellar.io/ksc'
+/** First-party proxy path for the Umami tracking script — bypasses ad blockers */
+const UMAMI_SCRIPT_PATH = '/api/ksc'
 /** Single Umami website ID — all environments report here, filterable by hostname */
 const UMAMI_WEBSITE_ID = '07111027-162f-4e37-a0bb-067b9d08b88a'
 
-/** Load Umami tracking script (async, non-blocking) */
+/** Load Umami tracking script via first-party proxy (async, non-blocking).
+ *  data-host-url tells Umami to POST events to our own origin (which proxies
+ *  to analytics.kubestellar.io/api/send) instead of the script's source domain. */
 function loadUmamiScript() {
   const script = document.createElement('script')
-  script.src = UMAMI_SCRIPT_URL
+  script.src = UMAMI_SCRIPT_PATH
   script.defer = true
   script.dataset.websiteId = UMAMI_WEBSITE_ID
+  // Umami appends /api/send internally — set host to our origin so events
+  // go through the first-party proxy at /api/send → analytics.kubestellar.io
+  script.dataset.hostUrl = window.location.origin
   document.head.appendChild(script)
 }
 


### PR DESCRIPTION
## Summary
- Replicate the GA4 first-party proxy pattern for Umami so ad blockers and corporate firewalls no longer block `analytics.kubestellar.io`
- Go backend: `UmamiScriptProxy` (GET `/api/ksc`) with server-side caching + `UmamiCollectProxy` (POST `/api/send`) with IP forwarding for geolocation
- Netlify Functions: `umami-script.mts` and `umami-collect.mts` for production (console.kubestellar.io)
- Frontend: Umami script loads from same-origin `/api/ksc` with `data-host-url` pointing events to `/api/send`

## Why
GA4 captures ~14,500 users via its first-party proxy while Umami only sees ~42 visitors because `analytics.kubestellar.io` is blocked by ad blockers and corporate firewalls. This closes the 400:1 tracking gap.

## Test plan
- [ ] Verify `/api/ksc` returns the Umami tracking script (not blocked)
- [ ] Verify `/api/send` relays events to upstream Umami and returns 200
- [ ] Check Umami dashboard shows pageviews from console.kubestellar.io after deploy
- [ ] Confirm GA4 analytics still works unchanged (no regression)