### PR TITLE
🐛 Fix PR Verifier GHCR permissions

### DIFF
--- a/.github/workflows/pr-verifier.yml
+++ b/.github/workflows/pr-verifier.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   checks: write
   pull-requests: read
+  packages: read
 
 jobs:
   verify:


### PR DESCRIPTION
## Summary
- Added `packages: read` permission to the PR Verifier workflow so it can pull the reusable workflow container from GHCR (GitHub Container Registry)

## Test plan
- [ ] Verify PR Verifier runs successfully on new PRs without GHCR permission errors