### PR TITLE
🐛 Fix Merge Test Reports CI check failing on all PRs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -127,16 +127,31 @@ jobs:
         run: npm ci
 
       - name: Download all blob reports
+        id: download-reports
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           pattern: blob-report-*
           path: web/all-blob-reports
           merge-multiple: true
 
+      - name: Check for blob reports
+        id: check-reports
+        run: |
+          if [ -d "./all-blob-reports" ] && [ "$(ls -A ./all-blob-reports 2>/dev/null)" ]; then
+            echo "has_reports=true" >> "$GITHUB_OUTPUT"
+            echo "Found blob reports to merge"
+          else
+            echo "has_reports=false" >> "$GITHUB_OUTPUT"
+            echo "No blob reports found — test job likely failed, was cancelled, or produced no artifacts"
+          fi
+
       - name: Merge reports
+        if: steps.check-reports.outputs.has_reports == 'true'
         run: npx playwright merge-reports --reporter=html,json ./all-blob-reports
 
       - name: Upload HTML report
+        if: steps.check-reports.outputs.has_reports == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
@@ -148,7 +163,9 @@ jobs:
         run: |
           echo "## Playwright Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ -f "test-results.json" ]; then
+          if [ "${{ steps.check-reports.outputs.has_reports }}" != "true" ]; then
+            echo "No test reports were produced. The test job may have failed, been cancelled, or been skipped." >> $GITHUB_STEP_SUMMARY
+          elif [ -f "test-results.json" ]; then
             total=$(jq '.stats.expected + .stats.unexpected + .stats.flaky + .stats.skipped' test-results.json 2>/dev/null || echo "N/A")
             passed=$(jq '.stats.expected' test-results.json 2>/dev/null || echo "N/A")
             failed=$(jq '.stats.unexpected' test-results.json 2>/dev/null || echo "N/A")


### PR DESCRIPTION
## Summary

The **Merge Test Reports** CI check is failing on 18 of 30 open PRs. This is a systemic CI infrastructure issue — the `merge-reports` job in `playwright.yml` crashes when no Playwright blob report artifacts exist.

**Root cause:** The `merge-reports` job has `if: always()`, so it runs even when the upstream `test` job fails, is cancelled, or is skipped. When no `blob-report-*` artifacts are uploaded, `actions/download-artifact` downloads nothing, so the `web/all-blob-reports` directory never gets created. Then `npx playwright merge-reports ./all-blob-reports` fails with:

```
Error: Directory does not exist: /home/runner/work/console/console/web/all-blob-reports
```

**Fix:**
- Add `continue-on-error: true` to the download-artifact step so it gracefully handles missing artifacts
- Add a check step that detects whether blob reports were actually downloaded
- Gate the merge-reports and upload steps on the check result (skip if no reports)
- Update the summary step to report when no test results are available instead of crashing

## Test plan

- [ ] Verify this PR's own Merge Test Reports check passes (the workflow will trigger since `playwright.yml` is in the paths filter)
- [ ] Check that the summary step correctly shows "No test reports were produced" when tests are skipped/cancelled
- [ ] Confirm existing PRs pass the Merge Test Reports check on re-run