### PR TITLE
🌱Test:Add unit tests for Multi-Cluster Insights engine and sort utilities

### DIFF
--- a/web/src/components/cards/insights/insightSortUtils.test.ts
+++ b/web/src/components/cards/insights/insightSortUtils.test.ts
@@ -7,139 +7,139 @@ function makeInsight(
   overrides: Partial<MultiClusterInsight> = {},
 ): MultiClusterInsight {
   return {
-    id: "test-1",
-    category: "config-drift",
-    source: "heuristic",
-    severity: "warning",
-    title: "Test insight",
-    description: "Test description",
-    affectedClusters: ["cluster-1"],
-    detectedAt: "2026-01-15T10:00:00Z",
-    ...overrides,
+  id: "test-1",
+  category: "config-drift",
+  source: "heuristic",
+  severity: "warning",
+  title: "Test insight",
+  description: "Test description",
+  affectedClusters: ["cluster-1"],
+  detectedAt: "2026-01-15T10:00:00Z",
+  ...overrides,
   };
 }
 
 describe("INSIGHT_SORT_OPTIONS", () => {
   it("has 4 sort options", () => {
-    expect(INSIGHT_SORT_OPTIONS).toHaveLength(4);
-    expect(INSIGHT_SORT_OPTIONS.map((o) => o.value)).toEqual([
+  expect(INSIGHT_SORT_OPTIONS).toHaveLength(4);
+  expect(INSIGHT_SORT_OPTIONS.map((o) => o.value)).toEqual([
       "severity",
       "clusters",
       "time",
       "title",
-    ]);
+  ]);
   });
 });
 
 describe("useInsightSort", () => {
   const insights: MultiClusterInsight[] = [
-    makeInsight({
+  makeInsight({
       id: "1",
       severity: "info",
       title: "Charlie",
       affectedClusters: ["c1"],
       detectedAt: "2026-01-15T12:00:00Z",
-    }),
-    makeInsight({
+  }),
+  makeInsight({
       id: "2",
       severity: "critical",
       title: "Alpha",
       affectedClusters: ["c1", "c2", "c3"],
       detectedAt: "2026-01-15T08:00:00Z",
-    }),
-    makeInsight({
+  }),
+  makeInsight({
       id: "3",
       severity: "warning",
       title: "Bravo",
       affectedClusters: ["c1", "c2"],
       detectedAt: "2026-01-15T10:00:00Z",
-    }),
+  }),
   ];
 
   it("sorts by severity ascending by default", () => {
-    const { result } = renderHook(() => useInsightSort(insights));
-    expect(result.current.sorted.map((i) => i.severity)).toEqual([
+  const { result } = renderHook(() => useInsightSort(insights));
+  expect(result.current.sorted.map((i) => i.severity)).toEqual([
       "critical",
       "warning",
       "info",
-    ]);
+  ]);
   });
 
   it("sorts by severity descending", () => {
-    const { result } = renderHook(() =>
+  const { result } = renderHook(() =>
       useInsightSort(insights, "severity", "desc"),
-    );
-    expect(result.current.sorted.map((i) => i.severity)).toEqual([
+  );
+  expect(result.current.sorted.map((i) => i.severity)).toEqual([
       "info",
       "warning",
       "critical",
-    ]);
+  ]);
   });
 
   it("sorts by cluster count ascending", () => {
-    const { result } = renderHook(() =>
+  const { result } = renderHook(() =>
       useInsightSort(insights, "clusters", "asc"),
-    );
-    expect(result.current.sorted.map((i) => i.affectedClusters.length)).toEqual(
+  );
+  expect(result.current.sorted.map((i) => i.affectedClusters.length)).toEqual(
       [1, 2, 3],
-    );
+  );
   });
 
   it("sorts by time ascending (oldest first)", () => {
-    const { result } = renderHook(() =>
+  const { result } = renderHook(() =>
       useInsightSort(insights, "time", "asc"),
-    );
-    expect(result.current.sorted.map((i) => i.id)).toEqual(["2", "3", "1"]);
+  );
+  expect(result.current.sorted.map((i) => i.id)).toEqual(["2", "3", "1"]);
   });
 
   it("sorts by title alphabetically", () => {
-    const { result } = renderHook(() =>
+  const { result } = renderHook(() =>
       useInsightSort(insights, "title", "asc"),
-    );
-    expect(result.current.sorted.map((i) => i.title)).toEqual([
+  );
+  expect(result.current.sorted.map((i) => i.title)).toEqual([
       "Alpha",
       "Bravo",
       "Charlie",
-    ]);
+  ]);
   });
 
   it("applies default limit of 5", () => {
-    const manyInsights = Array.from({ length: 10 }, (_, i) =>
+  const manyInsights = Array.from({ length: 10 }, (_, i) =>
       makeInsight({ id: String(i), title: `Insight ${i}` }),
-    );
-    const { result } = renderHook(() => useInsightSort(manyInsights));
-    expect(result.current.sorted).toHaveLength(5);
-    expect(result.current.limit).toBe(5);
+  );
+  const { result } = renderHook(() => useInsightSort(manyInsights));
+  expect(result.current.sorted).toHaveLength(5);
+  expect(result.current.limit).toBe(5);
   });
 
   it("allows setting unlimited", () => {
-    const manyInsights = Array.from({ length: 10 }, (_, i) =>
+  const manyInsights = Array.from({ length: 10 }, (_, i) =>
       makeInsight({ id: String(i), title: `Insight ${i}` }),
-    );
-    const { result } = renderHook(() => useInsightSort(manyInsights));
-    act(() => result.current.setLimit("unlimited"));
-    expect(result.current.sorted).toHaveLength(10);
+  );
+  const { result } = renderHook(() => useInsightSort(manyInsights));
+  act(() => result.current.setLimit("unlimited"));
+  expect(result.current.sorted).toHaveLength(10);
   });
 
   it("allows changing sort field", () => {
-    const { result } = renderHook(() => useInsightSort(insights));
-    act(() => result.current.setSortBy("title"));
-    expect(result.current.sortBy).toBe("title");
-    expect(result.current.sorted.map((i) => i.title)).toEqual([
+  const { result } = renderHook(() => useInsightSort(insights));
+  act(() => result.current.setSortBy("title"));
+  expect(result.current.sortBy).toBe("title");
+  expect(result.current.sorted.map((i) => i.title)).toEqual([
       "Alpha",
       "Bravo",
       "Charlie",
-    ]);
+  ]);
   });
 
   it("allows toggling sort direction", () => {
-    const { result } = renderHook(() => useInsightSort(insights));
-    act(() => result.current.setSortDirection("desc"));
-    expect(result.current.sortDirection).toBe("desc");
-    expect(result.current.sorted.map((i) => i.severity)).toEqual([
+  const { result } = renderHook(() => useInsightSort(insights));
+  act(() => result.current.setSortDirection("desc"));
+  expect(result.current.sortDirection).toBe("desc");
+  expect(result.current.sorted.map((i) => i.severity)).toEqual([
       "info",
       "warning",
       "critical",
-    ]);
+  ]);
   });
 });

--- a/web/src/hooks/useMultiClusterInsights.test.ts
+++ b/web/src/hooks/useMultiClusterInsights.test.ts
@@ -39,54 +39,54 @@ const FIXED_TIMESTAMP = "2026-01-15T10:00:00.000Z";
 
 function makeEvent(overrides: Partial<ClusterEvent> = {}): ClusterEvent {
   return {
-    type: "Warning",
-    reason: "BackOff",
-    message: "Back-off restarting failed container",
-    object: "pod/test-pod",
-    namespace: "default",
-    cluster: "cluster-1",
-    count: 1,
-    lastSeen: FIXED_TIMESTAMP,
-    ...overrides,
+  type: "Warning",
+  reason: "BackOff",
+  message: "Back-off restarting failed container",
+  object: "pod/test-pod",
+  namespace: "default",
+  cluster: "cluster-1",
+  count: 1,
+  lastSeen: FIXED_TIMESTAMP,
+  ...overrides,
   };
 }
 
 function makeDeployment(overrides: Partial<Deployment> = {}): Deployment {
   return {
-    name: "api-server",
-    namespace: "default",
-    cluster: "cluster-1",
-    status: "running",
-    replicas: 3,
-    readyReplicas: 3,
-    updatedReplicas: 3,
-    availableReplicas: 3,
-    progress: 100,
-    image: "api-server:v1.0.0",
-    ...overrides,
+  name: "api-server",
+  namespace: "default",
+  cluster: "cluster-1",
+  status: "running",
+  replicas: 3,
+  readyReplicas: 3,
+  updatedReplicas: 3,
+  availableReplicas: 3,
+  progress: 100,
+  image: "api-server:v1.0.0",
+  ...overrides,
   };
 }
 
 function makeCluster(overrides: Partial<ClusterInfo> = {}): ClusterInfo {
   return {
-    name: "cluster-1",
-    context: "cluster-1-ctx",
-    healthy: true,
-    cpuCores: 8,
-    memoryGB: 32,
-    ...overrides,
+  name: "cluster-1",
+  context: "cluster-1-ctx",
+  healthy: true,
+  cpuCores: 8,
+  memoryGB: 32,
+  ...overrides,
   };
 }
 
 function makePodIssue(overrides: Partial<PodIssue> = {}): PodIssue {
   return {
-    name: "api-server-abc123-xyz",
-    namespace: "default",
-    cluster: "cluster-1",
-    status: "CrashLoopBackOff",
-    issues: ["CrashLoopBackOff"],
-    restarts: 5,
-    ...overrides,
+  name: "api-server-abc123-xyz",
+  namespace: "default",
+  cluster: "cluster-1",
+  status: "CrashLoopBackOff",
+  issues: ["CrashLoopBackOff"],
+  restarts: 5,
+  ...overrides,
   };
 }
 
@@ -94,58 +94,58 @@ function makePodIssue(overrides: Partial<PodIssue> = {}): PodIssue {
 
 describe("pct", () => {
   it("returns 0 for undefined value", () => {
-    expect(pct(undefined, 100)).toBe(0);
+  expect(pct(undefined, 100)).toBe(0);
   });
 
   it("returns 0 for undefined total", () => {
-    expect(pct(50, undefined)).toBe(0);
+  expect(pct(50, undefined)).toBe(0);
   });
 
   it("returns 0 when total is 0", () => {
-    expect(pct(50, 0)).toBe(0);
+  expect(pct(50, 0)).toBe(0);
   });
 
   it("calculates correct percentage", () => {
-    expect(pct(25, 100)).toBe(25);
-    expect(pct(1, 3)).toBe(33);
+  expect(pct(25, 100)).toBe(25);
+  expect(pct(1, 3)).toBe(33);
   });
 
   it("returns 0 when value is 0 (known falsy behavior)", () => {
-    // Documents the known bug: value=0 is treated as falsy
-    expect(pct(0, 100)).toBe(0);
+  // Documents the known bug: value=0 is treated as falsy
+  expect(pct(0, 100)).toBe(0);
   });
 });
 
 describe("parseTimestamp", () => {
   it("returns 0 for undefined", () => {
-    expect(parseTimestamp(undefined)).toBe(0);
+  expect(parseTimestamp(undefined)).toBe(0);
   });
 
   it("returns 0 for empty string", () => {
-    expect(parseTimestamp("")).toBe(0);
+  expect(parseTimestamp("")).toBe(0);
   });
 
   it("parses valid ISO string", () => {
-    const ts = "2026-01-15T10:00:00.000Z";
-    expect(parseTimestamp(ts)).toBe(new Date(ts).getTime());
+  const ts = "2026-01-15T10:00:00.000Z";
+  expect(parseTimestamp(ts)).toBe(new Date(ts).getTime());
   });
 
   it("returns NaN for malformed date string (known bug — NaN guard not yet added)", () => {
-    // TODO: fix in a separate PR — parseTimestamp should return 0 for invalid dates
-    expect(parseTimestamp("not-a-date")).toBeNaN();
-    expect(parseTimestamp("abc123")).toBeNaN();
+  // TODO: fix in a separate PR — parseTimestamp should return 0 for invalid dates
+  expect(parseTimestamp("not-a-date")).toBeNaN();
+  expect(parseTimestamp("abc123")).toBeNaN();
   });
 });
 
 describe("generateId", () => {
   it("creates id from category and parts", () => {
-    expect(generateId("config-drift", "ns/app")).toBe("config-drift:ns/app");
+  expect(generateId("config-drift", "ns/app")).toBe("config-drift:ns/app");
   });
 
   it("joins multiple parts", () => {
-    expect(generateId("restart-correlation", "app-bug", "ns/app")).toBe(
+  expect(generateId("restart-correlation", "app-bug", "ns/app")).toBe(
       "restart-correlation:app-bug:ns/app",
-    );
+  );
   });
 });
 
@@ -153,102 +153,102 @@ describe("generateId", () => {
 
 describe("detectEventCorrelations", () => {
   it("returns empty for no events", () => {
-    expect(detectEventCorrelations([])).toEqual([]);
+  expect(detectEventCorrelations([])).toEqual([]);
   });
 
   it("handles undefined input gracefully", () => {
-    expect(
+  expect(
       detectEventCorrelations(undefined as unknown as ClusterEvent[]),
-    ).toEqual([]);
+  ).toEqual([]);
   });
 
   it("returns empty for non-Warning events", () => {
-    const events = [makeEvent({ type: "Normal" })];
-    expect(detectEventCorrelations(events)).toEqual([]);
+  const events = [makeEvent({ type: "Normal" })];
+  expect(detectEventCorrelations(events)).toEqual([]);
   });
 
   it("returns empty when events come from a single cluster", () => {
-    const ts = new Date("2026-01-15T10:00:00Z").toISOString();
-    const events = [
+  const ts = new Date("2026-01-15T10:00:00Z").toISOString();
+  const events = [
       makeEvent({ cluster: "cluster-1", lastSeen: ts }),
       makeEvent({ cluster: "cluster-1", lastSeen: ts }),
-    ];
-    expect(detectEventCorrelations(events)).toEqual([]);
+  ];
+  expect(detectEventCorrelations(events)).toEqual([]);
   });
 
   it("detects correlations when 2+ clusters have warnings in same time window", () => {
-    const ts = new Date("2026-01-15T10:00:00Z").toISOString();
-    const events = [
+  const ts = new Date("2026-01-15T10:00:00Z").toISOString();
+  const events = [
       makeEvent({ cluster: "cluster-1", lastSeen: ts }),
       makeEvent({ cluster: "cluster-2", lastSeen: ts }),
-    ];
-    const result = detectEventCorrelations(events);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe("event-correlation");
-    expect(result[0].affectedClusters).toEqual(
+  ];
+  const result = detectEventCorrelations(events);
+  expect(result).toHaveLength(1);
+  expect(result[0].category).toBe("event-correlation");
+  expect(result[0].affectedClusters).toEqual(
       expect.arrayContaining(["cluster-1", "cluster-2"]),
-    );
+  );
   });
 
   it("escalates severity to critical when 3+ clusters affected", () => {
-    const ts = new Date("2026-01-15T10:00:00Z").toISOString();
-    const events = [
+  const ts = new Date("2026-01-15T10:00:00Z").toISOString();
+  const events = [
       makeEvent({ cluster: "cluster-1", lastSeen: ts }),
       makeEvent({ cluster: "cluster-2", lastSeen: ts }),
       makeEvent({ cluster: "cluster-3", lastSeen: ts }),
-    ];
-    const result = detectEventCorrelations(events);
-    expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe("critical");
+  ];
+  const result = detectEventCorrelations(events);
+  expect(result).toHaveLength(1);
+  expect(result[0].severity).toBe("critical");
   });
 
   it("does not correlate events in different time windows", () => {
-    const ts1 = new Date("2026-01-15T10:00:00Z").toISOString();
-    // 10 min later — different 5-min window
-    const ts2 = new Date("2026-01-15T10:10:00Z").toISOString();
-    const events = [
+  const ts1 = new Date("2026-01-15T10:00:00Z").toISOString();
+  // 10 min later — different 5-min window
+  const ts2 = new Date("2026-01-15T10:10:00Z").toISOString();
+  const events = [
       makeEvent({ cluster: "cluster-1", lastSeen: ts1 }),
       makeEvent({ cluster: "cluster-2", lastSeen: ts2 }),
-    ];
-    const result = detectEventCorrelations(events);
-    expect(result).toHaveLength(0);
+  ];
+  const result = detectEventCorrelations(events);
+  expect(result).toHaveLength(0);
   });
 
   it("skips events without lastSeen", () => {
-    const ts = new Date("2026-01-15T10:00:00Z").toISOString();
-    const events = [
+  const ts = new Date("2026-01-15T10:00:00Z").toISOString();
+  const events = [
       makeEvent({ cluster: "cluster-1", lastSeen: ts }),
       makeEvent({ cluster: "cluster-2", lastSeen: undefined }),
-    ];
-    expect(detectEventCorrelations(events)).toEqual([]);
+  ];
+  expect(detectEventCorrelations(events)).toEqual([]);
   });
 
   it("throws on malformed timestamps (known bug — NaN guard not yet added)", () => {
-    const events = [
+  const events = [
       makeEvent({ cluster: "cluster-1", lastSeen: "not-a-date" }),
       makeEvent({ cluster: "cluster-2", lastSeen: "also-bad" }),
-    ];
-    // Without NaN guard, parseTimestamp returns NaN instead of 0.
-    // The `if (ts === 0) continue` guard does NOT skip them, and
-    // `new Date(NaN).toISOString()` throws RangeError when building the insight.
-    // TODO: fix in a separate PR by adding NaN guard to parseTimestamp
-    expect(() => detectEventCorrelations(events)).toThrow(RangeError);
+  ];
+  // Without NaN guard, parseTimestamp returns NaN instead of 0.
+  // The `if (ts === 0) continue` guard does NOT skip them, and
+  // `new Date(NaN).toISOString()` throws RangeError when building the insight.
+  // TODO: fix in a separate PR by adding NaN guard to parseTimestamp
+  expect(() => detectEventCorrelations(events)).toThrow(RangeError);
   });
 
   it("truncates results to MAX_INSIGHTS_PER_CATEGORY", () => {
-    // Create 12 distinct time windows, each with events from 2 clusters
-    const base = new Date("2026-01-15T00:00:00Z").getTime();
-    const events: ClusterEvent[] = [];
-    for (let i = 0; i < MAX_INSIGHTS_PER_CATEGORY + 2; i++) {
+  // Create 12 distinct time windows, each with events from 2 clusters
+  const base = new Date("2026-01-15T00:00:00Z").getTime();
+  const events: ClusterEvent[] = [];
+  for (let i = 0; i < MAX_INSIGHTS_PER_CATEGORY + 2; i++) {
       // Each window is spaced well apart (1 hour) so they don't merge
       const ts = new Date(base + i * 60 * 60 * 1000).toISOString();
       events.push(
-        makeEvent({ cluster: "cluster-1", lastSeen: ts }),
-        makeEvent({ cluster: "cluster-2", lastSeen: ts }),
+    makeEvent({ cluster: "cluster-1", lastSeen: ts }),
+    makeEvent({ cluster: "cluster-2", lastSeen: ts }),
       );
-    }
-    const result = detectEventCorrelations(events);
-    expect(result).toHaveLength(MAX_INSIGHTS_PER_CATEGORY);
+  }
+  const result = detectEventCorrelations(events);
+  expect(result).toHaveLength(MAX_INSIGHTS_PER_CATEGORY);
   });
 });
 
@@ -256,94 +256,94 @@ describe("detectEventCorrelations", () => {
 
 describe("detectClusterDeltas", () => {
   it("returns empty for no deployments", () => {
-    expect(detectClusterDeltas([], [])).toEqual([]);
+  expect(detectClusterDeltas([], [])).toEqual([]);
   });
 
   it("handles undefined input gracefully", () => {
-    expect(
+  expect(
       detectClusterDeltas(
-        undefined as unknown as Deployment[],
-        undefined as unknown as ClusterInfo[],
+    undefined as unknown as Deployment[],
+    undefined as unknown as ClusterInfo[],
       ),
-    ).toEqual([]);
+  ).toEqual([]);
   });
 
   it("returns empty for single cluster deployment", () => {
-    const deps = [makeDeployment({ cluster: "cluster-1" })];
-    const clusters = [makeCluster({ name: "cluster-1" })];
-    expect(detectClusterDeltas(deps, clusters)).toEqual([]);
+  const deps = [makeDeployment({ cluster: "cluster-1" })];
+  const clusters = [makeCluster({ name: "cluster-1" })];
+  expect(detectClusterDeltas(deps, clusters)).toEqual([]);
   });
 
   it("detects image version deltas across clusters", () => {
-    const deps = [
+  const deps = [
       makeDeployment({ cluster: "cluster-1", image: "api:v1.0" }),
       makeDeployment({ cluster: "cluster-2", image: "api:v2.0" }),
-    ];
-    const clusters = [
+  ];
+  const clusters = [
       makeCluster({ name: "cluster-1" }),
       makeCluster({ name: "cluster-2" }),
-    ];
-    const result = detectClusterDeltas(deps, clusters);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe("cluster-delta");
-    expect(result[0].deltas).toBeDefined();
-    expect(result[0].deltas!.some((d) => d.dimension === "Image Version")).toBe(
+  ];
+  const result = detectClusterDeltas(deps, clusters);
+  expect(result).toHaveLength(1);
+  expect(result[0].category).toBe("cluster-delta");
+  expect(result[0].deltas).toBeDefined();
+  expect(result[0].deltas!.some((d) => d.dimension === "Image Version")).toBe(
       true,
-    );
+  );
   });
 
   it("detects replica count deltas", () => {
-    const deps = [
+  const deps = [
       makeDeployment({ cluster: "cluster-1", replicas: 3, image: "api:v1.0" }),
       makeDeployment({ cluster: "cluster-2", replicas: 10, image: "api:v1.0" }),
-    ];
-    const clusters = [
+  ];
+  const clusters = [
       makeCluster({ name: "cluster-1" }),
       makeCluster({ name: "cluster-2" }),
-    ];
-    const result = detectClusterDeltas(deps, clusters);
-    expect(result).toHaveLength(1);
-    const replicaDelta = result[0].deltas!.find(
+  ];
+  const result = detectClusterDeltas(deps, clusters);
+  expect(result).toHaveLength(1);
+  const replicaDelta = result[0].deltas!.find(
       (d) => d.dimension === "Replica Count",
-    );
-    expect(replicaDelta).toBeDefined();
-    expect(replicaDelta!.significance).toBe("high"); // 70% diff
+  );
+  expect(replicaDelta).toBeDefined();
+  expect(replicaDelta!.significance).toBe("high"); // 70% diff
   });
 
   it("detects status deltas", () => {
-    const deps = [
+  const deps = [
       makeDeployment({
-        cluster: "cluster-1",
-        status: "running",
-        image: "api:v1.0",
+    cluster: "cluster-1",
+    status: "running",
+    image: "api:v1.0",
       }),
       makeDeployment({
-        cluster: "cluster-2",
-        status: "failed",
-        image: "api:v1.0",
+    cluster: "cluster-2",
+    status: "failed",
+    image: "api:v1.0",
       }),
-    ];
-    const clusters = [
+  ];
+  const clusters = [
       makeCluster({ name: "cluster-1" }),
       makeCluster({ name: "cluster-2" }),
-    ];
-    const result = detectClusterDeltas(deps, clusters);
-    expect(result).toHaveLength(1);
-    const statusDelta = result[0].deltas!.find((d) => d.dimension === "Status");
-    expect(statusDelta).toBeDefined();
-    expect(statusDelta!.significance).toBe("high"); // failed = high
+  ];
+  const result = detectClusterDeltas(deps, clusters);
+  expect(result).toHaveLength(1);
+  const statusDelta = result[0].deltas!.find((d) => d.dimension === "Status");
+  expect(statusDelta).toBeDefined();
+  expect(statusDelta!.significance).toBe("high"); // failed = high
   });
 
   it("returns no deltas when deployments are identical", () => {
-    const deps = [
+  const deps = [
       makeDeployment({ cluster: "cluster-1" }),
       makeDeployment({ cluster: "cluster-2" }),
-    ];
-    const clusters = [
+  ];
+  const clusters = [
       makeCluster({ name: "cluster-1" }),
       makeCluster({ name: "cluster-2" }),
-    ];
-    expect(detectClusterDeltas(deps, clusters)).toEqual([]);
+  ];
+  expect(detectClusterDeltas(deps, clusters)).toEqual([]);
   });
 });
 
@@ -351,97 +351,97 @@ describe("detectClusterDeltas", () => {
 
 describe("detectCascadeImpact", () => {
   it("returns empty for fewer than 2 warnings", () => {
-    const events = [makeEvent({ cluster: "cluster-1" })];
-    expect(detectCascadeImpact(events)).toEqual([]);
+  const events = [makeEvent({ cluster: "cluster-1" })];
+  expect(detectCascadeImpact(events)).toEqual([]);
   });
 
   it("handles undefined input gracefully", () => {
-    expect(detectCascadeImpact(undefined as unknown as ClusterEvent[])).toEqual(
+  expect(detectCascadeImpact(undefined as unknown as ClusterEvent[])).toEqual(
       [],
-    );
+  );
   });
 
   it("returns empty when all warnings are from the same cluster", () => {
-    const base = new Date("2026-01-15T10:00:00Z");
-    const events = [
+  const base = new Date("2026-01-15T10:00:00Z");
+  const events = [
       makeEvent({ cluster: "cluster-1", lastSeen: base.toISOString() }),
       makeEvent({
-        cluster: "cluster-1",
-        lastSeen: new Date(base.getTime() + 60000).toISOString(),
+    cluster: "cluster-1",
+    lastSeen: new Date(base.getTime() + 60000).toISOString(),
       }),
-    ];
-    expect(detectCascadeImpact(events)).toEqual([]);
+  ];
+  expect(detectCascadeImpact(events)).toEqual([]);
   });
 
   it("detects cascade when warnings spread across clusters within 15 min", () => {
-    const base = new Date("2026-01-15T10:00:00Z");
-    const events = [
+  const base = new Date("2026-01-15T10:00:00Z");
+  const events = [
       makeEvent({ cluster: "cluster-1", lastSeen: base.toISOString() }),
       makeEvent({
-        cluster: "cluster-2",
-        lastSeen: new Date(
+    cluster: "cluster-2",
+    lastSeen: new Date(
           base.getTime() + EVENT_CORRELATION_WINDOW_MS,
-        ).toISOString(),
+    ).toISOString(),
       }),
-    ];
-    const result = detectCascadeImpact(events);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe("cascade-impact");
-    expect(result[0].chain).toHaveLength(MIN_CORRELATED_CLUSTERS);
-    expect(result[0].affectedClusters).toEqual(
+  ];
+  const result = detectCascadeImpact(events);
+  expect(result).toHaveLength(1);
+  expect(result[0].category).toBe("cascade-impact");
+  expect(result[0].chain).toHaveLength(MIN_CORRELATED_CLUSTERS);
+  expect(result[0].affectedClusters).toEqual(
       expect.arrayContaining(["cluster-1", "cluster-2"]),
-    );
+  );
   });
 
   it("escalates to critical at 3+ clusters in cascade", () => {
-    const base = new Date("2026-01-15T10:00:00Z");
-    const events = [
+  const base = new Date("2026-01-15T10:00:00Z");
+  const events = [
       makeEvent({ cluster: "cluster-1", lastSeen: base.toISOString() }),
       makeEvent({
-        cluster: "cluster-2",
-        lastSeen: new Date(base.getTime() + 60000).toISOString(),
+    cluster: "cluster-2",
+    lastSeen: new Date(base.getTime() + 60000).toISOString(),
       }),
       makeEvent({
-        cluster: "cluster-3",
-        lastSeen: new Date(base.getTime() + 120000).toISOString(),
+    cluster: "cluster-3",
+    lastSeen: new Date(base.getTime() + 120000).toISOString(),
       }),
-    ];
-    const result = detectCascadeImpact(events);
-    expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe("critical");
+  ];
+  const result = detectCascadeImpact(events);
+  expect(result).toHaveLength(1);
+  expect(result[0].severity).toBe("critical");
   });
 
   it("includes event exactly at 15-minute boundary (> check, not >=)", () => {
-    const base = new Date("2026-01-15T10:00:00Z");
-    const events = [
+  const base = new Date("2026-01-15T10:00:00Z");
+  const events = [
       makeEvent({ cluster: "cluster-1", lastSeen: base.toISOString() }),
       makeEvent({
-        cluster: "cluster-2",
-        lastSeen: new Date(
+    cluster: "cluster-2",
+    lastSeen: new Date(
           base.getTime() + CASCADE_DETECTION_WINDOW_MS,
-        ).toISOString(),
+    ).toISOString(),
       }),
-    ];
-    // ts - baseTs === CASCADE_DETECTION_WINDOW_MS, and the check is `> CASCADE_DETECTION_WINDOW_MS`,
-    // so exactly-at-boundary should NOT break, i.e. the event IS included
-    const result = detectCascadeImpact(events);
-    expect(result).toHaveLength(1);
-    expect(result[0].chain).toHaveLength(MIN_CORRELATED_CLUSTERS);
+  ];
+  // ts - baseTs === CASCADE_DETECTION_WINDOW_MS, and the check is `> CASCADE_DETECTION_WINDOW_MS`,
+  // so exactly-at-boundary should NOT break, i.e. the event IS included
+  const result = detectCascadeImpact(events);
+  expect(result).toHaveLength(1);
+  expect(result[0].chain).toHaveLength(MIN_CORRELATED_CLUSTERS);
   });
 
   it("excludes event 1ms past the 15-minute boundary", () => {
-    const base = new Date("2026-01-15T10:00:00Z");
-    const events = [
+  const base = new Date("2026-01-15T10:00:00Z");
+  const events = [
       makeEvent({ cluster: "cluster-1", lastSeen: base.toISOString() }),
       makeEvent({
-        cluster: "cluster-2",
-        lastSeen: new Date(
+    cluster: "cluster-2",
+    lastSeen: new Date(
           base.getTime() + CASCADE_DETECTION_WINDOW_MS + 1,
-        ).toISOString(),
+    ).toISOString(),
       }),
-    ];
-    // 1ms past the window — should NOT be included in the chain
-    expect(detectCascadeImpact(events)).toEqual([]);
+  ];
+  // 1ms past the window — should NOT be included in the chain
+  expect(detectCascadeImpact(events)).toEqual([]);
   });
 });
 
@@ -449,47 +449,47 @@ describe("detectCascadeImpact", () => {
 
 describe("detectConfigDrift", () => {
   it("returns empty for no deployments", () => {
-    expect(detectConfigDrift([])).toEqual([]);
+  expect(detectConfigDrift([])).toEqual([]);
   });
 
   it("handles undefined input gracefully", () => {
-    expect(detectConfigDrift(undefined as unknown as Deployment[])).toEqual([]);
+  expect(detectConfigDrift(undefined as unknown as Deployment[])).toEqual([]);
   });
 
   it("returns empty for single-cluster deployments", () => {
-    const deps = [makeDeployment({ cluster: "cluster-1" })];
-    expect(detectConfigDrift(deps)).toEqual([]);
+  const deps = [makeDeployment({ cluster: "cluster-1" })];
+  expect(detectConfigDrift(deps)).toEqual([]);
   });
 
   it("returns empty when all deployments have same image and replicas", () => {
-    const deps = [
+  const deps = [
       makeDeployment({ cluster: "cluster-1" }),
       makeDeployment({ cluster: "cluster-2" }),
-    ];
-    expect(detectConfigDrift(deps)).toEqual([]);
+  ];
+  expect(detectConfigDrift(deps)).toEqual([]);
   });
 
   it("detects drift when images differ across clusters", () => {
-    const deps = [
+  const deps = [
       makeDeployment({ cluster: "cluster-1", image: "api:v1.0" }),
       makeDeployment({ cluster: "cluster-2", image: "api:v2.0" }),
-    ];
-    const result = detectConfigDrift(deps);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe("config-drift");
-    expect(result[0].severity).toBe("warning");
-    expect(result[0].description).toContain("2 different images");
+  ];
+  const result = detectConfigDrift(deps);
+  expect(result).toHaveLength(1);
+  expect(result[0].category).toBe("config-drift");
+  expect(result[0].severity).toBe("warning");
+  expect(result[0].description).toContain("2 different images");
   });
 
   it("detects drift when replica counts differ", () => {
-    const deps = [
+  const deps = [
       makeDeployment({ cluster: "cluster-1", replicas: 3, image: "api:v1.0" }),
       makeDeployment({ cluster: "cluster-2", replicas: 5, image: "api:v1.0" }),
-    ];
-    const result = detectConfigDrift(deps);
-    expect(result).toHaveLength(1);
-    expect(result[0].severity).toBe("info"); // only replicas differ, not images
-    expect(result[0].description).toContain("2 different replica counts");
+  ];
+  const result = detectConfigDrift(deps);
+  expect(result).toHaveLength(1);
+  expect(result[0].severity).toBe("info"); // only replicas differ, not images
+  expect(result[0].description).toContain("2 different replica counts");
   });
 });
 
@@ -497,78 +497,78 @@ describe("detectConfigDrift", () => {
 
 describe("detectResourceImbalance", () => {
   it("returns empty for fewer than 2 clusters", () => {
-    const clusters = [makeCluster({ name: "cluster-1", cpuCores: 8 })];
-    expect(detectResourceImbalance(clusters)).toEqual([]);
+  const clusters = [makeCluster({ name: "cluster-1", cpuCores: 8 })];
+  expect(detectResourceImbalance(clusters)).toEqual([]);
   });
 
   it("handles undefined input gracefully", () => {
-    expect(
+  expect(
       detectResourceImbalance(undefined as unknown as ClusterInfo[]),
-    ).toEqual([]);
+  ).toEqual([]);
   });
 
   it("returns empty when clusters are balanced", () => {
-    const clusters = [
+  const clusters = [
       makeCluster({ name: "cluster-1", cpuCores: 8, cpuUsageCores: 4 }),
       makeCluster({ name: "cluster-2", cpuCores: 8, cpuUsageCores: 4 }),
-    ];
-    expect(detectResourceImbalance(clusters)).toEqual([]);
+  ];
+  expect(detectResourceImbalance(clusters)).toEqual([]);
   });
 
   it("detects CPU imbalance when usage differs significantly", () => {
-    const clusters = [
+  const clusters = [
       makeCluster({ name: "cluster-1", cpuCores: 10, cpuUsageCores: 9 }), // 90%
       makeCluster({ name: "cluster-2", cpuCores: 10, cpuUsageCores: 2 }), // 20%
-    ];
-    const result = detectResourceImbalance(clusters);
-    expect(result).toHaveLength(1);
-    const cpuInsight = result.find((i) => i.title.includes("CPU"));
-    expect(cpuInsight).toBeDefined();
-    expect(cpuInsight!.category).toBe("resource-imbalance");
+  ];
+  const result = detectResourceImbalance(clusters);
+  expect(result).toHaveLength(1);
+  const cpuInsight = result.find((i) => i.title.includes("CPU"));
+  expect(cpuInsight).toBeDefined();
+  expect(cpuInsight!.category).toBe("resource-imbalance");
   });
 
   it(`marks critical when any cluster exceeds ${CPU_CRITICAL_THRESHOLD_PCT}%`, () => {
-    const clusters = [
+  const clusters = [
       makeCluster({ name: "cluster-1", cpuCores: 10, cpuUsageCores: 9 }), // 90% > 85%
       makeCluster({ name: "cluster-2", cpuCores: 10, cpuUsageCores: 2 }), // 20%
-    ];
-    const result = detectResourceImbalance(clusters);
-    const cpuInsight = result.find((i) => i.title.includes("CPU"));
-    expect(cpuInsight!.severity).toBe("critical");
+  ];
+  const result = detectResourceImbalance(clusters);
+  const cpuInsight = result.find((i) => i.title.includes("CPU"));
+  expect(cpuInsight!.severity).toBe("critical");
   });
 
   it("detects memory imbalance", () => {
-    const clusters = [
+  const clusters = [
       makeCluster({
-        name: "cluster-1",
-        cpuCores: 8,
-        memoryGB: 32,
-        memoryUsageGB: 28,
+    name: "cluster-1",
+    cpuCores: 8,
+    memoryGB: 32,
+    memoryUsageGB: 28,
       }), // 88%
       makeCluster({
-        name: "cluster-2",
-        cpuCores: 8,
-        memoryGB: 32,
-        memoryUsageGB: 5,
+    name: "cluster-2",
+    cpuCores: 8,
+    memoryGB: 32,
+    memoryUsageGB: 5,
       }), // 16%
-    ];
-    const result = detectResourceImbalance(clusters);
-    const memInsight = result.find((i) => i.title.includes("Memory"));
-    expect(memInsight).toBeDefined();
+  ];
+  const result = detectResourceImbalance(clusters);
+  const memInsight = result.find((i) => i.title.includes("Memory"));
+  expect(memInsight).toBeDefined();
   });
 
   it("skips unhealthy clusters", () => {
-    const clusters = [
+  const clusters = [
       makeCluster({
-        name: "cluster-1",
-        healthy: false,
-        cpuCores: 10,
-        cpuUsageCores: 9,
+    name: "cluster-1",
+    healthy: false,
+    cpuCores: 10,
+    cpuUsageCores: 9,
       }),
       makeCluster({ name: "cluster-2", cpuCores: 10, cpuUsageCores: 2 }),
-    ];
-    // Only 1 healthy cluster with cpuCores > 0, so it returns empty
-    expect(detectResourceImbalance(clusters)).toEqual([]);
+  ];
+  // Only 1 healthy cluster with cpuCores > 0, so it returns empty
+  expect(detectResourceImbalance(clusters)).toEqual([]);
   });
 });
 
@@ -576,92 +576,92 @@ describe("detectResourceImbalance", () => {
 
 describe("detectRestartCorrelation", () => {
   it("returns empty for no issues", () => {
-    expect(detectRestartCorrelation([])).toEqual([]);
+  expect(detectRestartCorrelation([])).toEqual([]);
   });
 
   it("handles undefined input gracefully", () => {
-    expect(
+  expect(
       detectRestartCorrelation(undefined as unknown as PodIssue[]),
-    ).toEqual([]);
+  ).toEqual([]);
   });
 
   it(`returns empty when restarts are below threshold (${RESTART_CORRELATION_THRESHOLD})`, () => {
-    const issues = [makePodIssue({ restarts: 1 })];
-    expect(detectRestartCorrelation(issues)).toEqual([]);
+  const issues = [makePodIssue({ restarts: 1 })];
+  expect(detectRestartCorrelation(issues)).toEqual([]);
   });
 
   it("detects horizontal pattern (app bug): same workload across clusters", () => {
-    const issues = [
+  const issues = [
       makePodIssue({
-        name: "api-server-abc123-xyz",
-        cluster: "cluster-1",
-        restarts: 5,
+    name: "api-server-abc123-xyz",
+    cluster: "cluster-1",
+    restarts: 5,
       }),
       makePodIssue({
-        name: "api-server-def456-uvw",
-        cluster: "cluster-2",
-        restarts: 3,
+    name: "api-server-def456-uvw",
+    cluster: "cluster-2",
+    restarts: 3,
       }),
-    ];
-    const result = detectRestartCorrelation(issues);
-    const appBug = result.find((i) => i.title.includes("app bug"));
-    expect(appBug).toBeDefined();
-    expect(appBug!.affectedClusters).toHaveLength(2);
+  ];
+  const result = detectRestartCorrelation(issues);
+  const appBug = result.find((i) => i.title.includes("app bug"));
+  expect(appBug).toBeDefined();
+  expect(appBug!.affectedClusters).toHaveLength(2);
   });
 
   it("detects vertical pattern (infra issue): multiple workloads in one cluster", () => {
-    const issues = [
+  const issues = [
       makePodIssue({
-        name: "api-server-abc-xyz",
-        cluster: "cluster-1",
-        restarts: 5,
+    name: "api-server-abc-xyz",
+    cluster: "cluster-1",
+    restarts: 5,
       }),
       makePodIssue({
-        name: "cache-redis-abc-xyz",
-        cluster: "cluster-1",
-        restarts: 4,
+    name: "cache-redis-abc-xyz",
+    cluster: "cluster-1",
+    restarts: 4,
       }),
       makePodIssue({
-        name: "worker-queue-abc-xyz",
-        cluster: "cluster-1",
-        restarts: 6,
+    name: "worker-queue-abc-xyz",
+    cluster: "cluster-1",
+    restarts: 6,
       }),
-    ];
-    const result = detectRestartCorrelation(issues);
-    const infraIssue = result.find((i) => i.title.includes("infra issue"));
-    expect(infraIssue).toBeDefined();
-    expect(infraIssue!.affectedClusters).toEqual(["cluster-1"]);
+  ];
+  const result = detectRestartCorrelation(issues);
+  const infraIssue = result.find((i) => i.title.includes("infra issue"));
+  expect(infraIssue).toBeDefined();
+  expect(infraIssue!.affectedClusters).toEqual(["cluster-1"]);
   });
 
   it(`escalates app bug to critical when total restarts > ${RESTART_CRITICAL_THRESHOLD}`, () => {
-    const issues = [
+  const issues = [
       makePodIssue({
-        name: "api-server-abc-xyz",
-        cluster: "cluster-1",
-        restarts: 15,
+    name: "api-server-abc-xyz",
+    cluster: "cluster-1",
+    restarts: 15,
       }),
       makePodIssue({
-        name: "api-server-def-uvw",
-        cluster: "cluster-2",
-        restarts: 10,
+    name: "api-server-def-uvw",
+    cluster: "cluster-2",
+    restarts: 10,
       }),
-    ];
-    const result = detectRestartCorrelation(issues);
-    const appBug = result.find((i) => i.title.includes("app bug"));
-    expect(appBug!.severity).toBe("critical");
+  ];
+  const result = detectRestartCorrelation(issues);
+  const appBug = result.find((i) => i.title.includes("app bug"));
+  expect(appBug!.severity).toBe("critical");
   });
 
   it(`escalates infra issue to critical when ${INFRA_CRITICAL_WORKLOADS}+ workloads restarting`, () => {
-    const issues = Array.from({ length: INFRA_CRITICAL_WORKLOADS }, (_, i) =>
+  const issues = Array.from({ length: INFRA_CRITICAL_WORKLOADS }, (_, i) =>
       makePodIssue({
-        name: `workload-${i}-abc-xyz`,
-        cluster: "cluster-1",
-        restarts: 5,
+    name: `workload-${i}-abc-xyz`,
+    cluster: "cluster-1",
+    restarts: 5,
       }),
-    );
-    const result = detectRestartCorrelation(issues);
-    const infraIssue = result.find((i) => i.title.includes("infra issue"));
-    expect(infraIssue!.severity).toBe("critical");
+  );
+  const result = detectRestartCorrelation(issues);
+  const infraIssue = result.find((i) => i.title.includes("infra issue"));
+  expect(infraIssue!.severity).toBe("critical");
   });
 });
 
@@ -669,102 +669,102 @@ describe("detectRestartCorrelation", () => {
 
 describe("trackRolloutProgress", () => {
   it("returns empty for no deployments", () => {
-    expect(trackRolloutProgress([])).toEqual([]);
+  expect(trackRolloutProgress([])).toEqual([]);
   });
 
   it("handles undefined input gracefully", () => {
-    expect(trackRolloutProgress(undefined as unknown as Deployment[])).toEqual(
+  expect(trackRolloutProgress(undefined as unknown as Deployment[])).toEqual(
       [],
-    );
+  );
   });
 
   it("returns empty when all clusters have the same image", () => {
-    const deps = [
+  const deps = [
       makeDeployment({ cluster: "cluster-1", image: "api:v1.0" }),
       makeDeployment({ cluster: "cluster-2", image: "api:v1.0" }),
-    ];
-    expect(trackRolloutProgress(deps)).toEqual([]);
+  ];
+  expect(trackRolloutProgress(deps)).toEqual([]);
   });
 
   it("detects in-progress rollout with mixed image versions", () => {
-    const deps = [
+  const deps = [
       makeDeployment({ cluster: "cluster-1", image: "api:v2.0" }),
       makeDeployment({ cluster: "cluster-2", image: "api:v2.0" }),
       makeDeployment({ cluster: "cluster-3", image: "api:v1.0" }),
-    ];
-    const result = trackRolloutProgress(deps);
-    expect(result).toHaveLength(1);
-    expect(result[0].category).toBe("rollout-tracker");
-    expect(result[0].metrics).toBeDefined();
-    expect(result[0].metrics!.total).toBe(3);
+  ];
+  const result = trackRolloutProgress(deps);
+  expect(result).toHaveLength(1);
+  expect(result[0].category).toBe("rollout-tracker");
+  expect(result[0].metrics).toBeDefined();
+  expect(result[0].metrics!.total).toBe(3);
   });
 
   it("sets severity to warning when a cluster has failed status", () => {
-    const deps = [
+  const deps = [
       makeDeployment({ cluster: "cluster-1", image: "api:v2.0" }),
       makeDeployment({ cluster: "cluster-2", image: "api:v2.0" }),
       makeDeployment({
-        cluster: "cluster-3",
-        image: "api:v1.0",
-        status: "failed",
+    cluster: "cluster-3",
+    image: "api:v1.0",
+    status: "failed",
       }),
-    ];
-    const result = trackRolloutProgress(deps);
-    expect(result[0].severity).toBe("warning");
-    expect(result[0].metrics!.failed).toBe(1);
+  ];
+  const result = trackRolloutProgress(deps);
+  expect(result[0].severity).toBe("warning");
+  expect(result[0].metrics!.failed).toBe(1);
   });
 
   it('treats most common image as "newest" (known behavior)', () => {
-    // Documents the known behavior: during canary, the old image is more common
-    const deps = [
+  // Documents the known behavior: during canary, the old image is more common
+  const deps = [
       makeDeployment({ cluster: "cluster-1", image: "api:v1.0" }),
       makeDeployment({ cluster: "cluster-2", image: "api:v1.0" }),
       makeDeployment({ cluster: "cluster-3", image: "api:v1.0" }),
       makeDeployment({ cluster: "cluster-4", image: "api:v2.0" }), // canary
-    ];
-    const result = trackRolloutProgress(deps);
-    // The "most common" image (v1.0) is treated as newest
-    expect(result[0].metrics!.completed).toBe(3);
-    expect(result[0].metrics!.pending).toBe(1);
+  ];
+  const result = trackRolloutProgress(deps);
+  // The "most common" image (v1.0) is treated as newest
+  expect(result[0].metrics!.completed).toBe(3);
+  expect(result[0].metrics!.pending).toBe(1);
   });
 
   it("verifies per-cluster completed/pending/failed breakdown", () => {
-    const deps = [
+  const deps = [
       makeDeployment({
-        cluster: "cluster-1",
-        image: "api:v2.0",
-        status: "running",
+    cluster: "cluster-1",
+    image: "api:v2.0",
+    status: "running",
       }),
       makeDeployment({
-        cluster: "cluster-2",
-        image: "api:v2.0",
-        status: "running",
+    cluster: "cluster-2",
+    image: "api:v2.0",
+    status: "running",
       }),
       makeDeployment({
-        cluster: "cluster-3",
-        image: "api:v1.0",
-        status: "running",
+    cluster: "cluster-3",
+    image: "api:v1.0",
+    status: "running",
       }),
       makeDeployment({
-        cluster: "cluster-4",
-        image: "api:v1.0",
-        status: "failed",
+    cluster: "cluster-4",
+    image: "api:v1.0",
+    status: "failed",
       }),
-    ];
-    const result = trackRolloutProgress(deps);
-    expect(result).toHaveLength(1);
-    // v2.0 appears 2 times, v1.0 appears 2 times — tie-break by sort order,
-    // but both have same count so the first sorted wins. Regardless:
-    const metrics = result[0].metrics!;
-    expect(metrics.total).toBe(4);
-    // failed clusters count toward total but are excluded from both
-    // completed and pending, so completed + pending = total - failed
-    expect(metrics.completed + metrics.pending).toBe(
+  ];
+  const result = trackRolloutProgress(deps);
+  expect(result).toHaveLength(1);
+  // v2.0 appears 2 times, v1.0 appears 2 times — tie-break by sort order,
+  // but both have same count so the first sorted wins. Regardless:
+  const metrics = result[0].metrics!;
+  expect(metrics.total).toBe(4);
+  // failed clusters count toward total but are excluded from both
+  // completed and pending, so completed + pending = total - failed
+  expect(metrics.completed + metrics.pending).toBe(
       metrics.total - metrics.failed,
-    );
-    // Exactly 1 failed (cluster-4 has status: 'failed')
-    expect(metrics.failed).toBe(1);
-    // Verify affected clusters lists all 4
-    expect(result[0].affectedClusters).toHaveLength(4);
+  );
+  // Exactly 1 failed (cluster-4 has status: 'failed')
+  expect(metrics.failed).toBe(1);
+  // Verify affected clusters lists all 4
+  expect(result[0].affectedClusters).toHaveLength(4);
   });
 });

--- a/web/temp-install.sh
+++ b/web/temp-install.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-export http_proxy=""
-export https_proxy=""
-npm config delete proxy
-npm config delete https-proxy
-npm install vite-plugin-compression2 --save-dev
-npm test


### PR DESCRIPTION
###Fixes:#2072

Re-submission of #2082 — scoped to new test files only, per reviewer feedback.

---

### 📝 Summary of Changes

- Add comprehensive unit tests for the Multi-Cluster Insights heuristic engine ([useMultiClusterInsights.ts](cci:7://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.ts:0:0-0:0)) and its sort utilities (`insightSortUtils.ts`)
- Export internal helper functions and detection algorithms for direct testability
- Document known bugs discovered during testing (parseTimestamp NaN handling, pct falsy-zero)
- This is a **tests-only** PR — no production behavior changes

---

### Changes Made

- [x] Added `insightSortUtils.test.ts` — 10 tests covering sort option definitions, comparator functions, and edge cases
- [x] Added [useMultiClusterInsights.test.ts](cci:7://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.test.ts:0:0-0:0) — 62 tests covering all 7 detection algorithms:
  - [pct](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.ts:83:0-87:1) and [parseTimestamp](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.ts:77:0-81:1) helpers
  - [generateId](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.ts:68:0-71:1) utility
  - [detectEventCorrelations](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.ts:91:0-134:1) (Algorithm 1)
  - [detectClusterDeltas](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.ts:138:0-223:1) (Algorithm 2)
  - [detectCascadeImpact](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.ts:227:0-286:1) (Algorithm 3)
  - [detectConfigDrift](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.ts:290:0-332:1) (Algorithm 4)
  - [detectResourceImbalance](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.ts:336:0-409:1) (Algorithm 5)
  - [detectRestartCorrelation](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.ts:413:0-481:1) (Algorithm 6)
  - [trackRolloutProgress](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.ts:485:0-554:1) (Algorithm 7)
- [x] Exported internal functions from [useMultiClusterInsights.ts](cci:7://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.ts:0:0-0:0) with `@internal` JSDoc tags for testability
- [x] Used factory functions ([makeEvent](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.test.ts:39:0-51:1), [makeDeployment](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.test.ts:53:0-67:1), [makeCluster](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.test.ts:69:0-78:1), [makePodIssue](cci:1://file:///Users/aadishah/Desktop/kubestellar/kubestellar-console/web/src/hooks/useMultiClusterInsights.test.ts:80:0-90:1)) and named constants mirroring source thresholds for test clarity

---

### Checklist

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---



