### PR TITLE
🐛 Add JWT authentication to /ws/exec endpoint

### DIFF
--- a/pkg/api/handlers/exec.go
+++ b/pkg/api/handlers/exec.go
@@ -7,23 +7,32 @@ import (
 	"io"
 	"log"
 	"sync"
+	"time"
 
 	"github.com/gofiber/contrib/websocket"
+	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 )
 
+// execAuthDeadline is how long the client has to send an auth message after connecting.
+const execAuthDeadline = 5 * time.Second
+
 // ExecHandlers handles pod exec API endpoints
 type ExecHandlers struct {
 	k8sClient *k8s.MultiClusterClient
+	jwtSecret string
+	devMode   bool
 }
 
 // NewExecHandlers creates a new exec handlers instance
-func NewExecHandlers(k8sClient *k8s.MultiClusterClient) *ExecHandlers {
+func NewExecHandlers(k8sClient *k8s.MultiClusterClient, jwtSecret string, devMode bool) *ExecHandlers {
 	return &ExecHandlers{
 		k8sClient: k8sClient,
+		jwtSecret: jwtSecret,
+		devMode:   devMode,
 	}
 }
 
@@ -111,9 +120,57 @@ func (q *terminalSizeQueue) Next() *remotecommand.TerminalSize {
 	return &size
 }
 
+// execAuthMessage is the first message the client must send to authenticate
+type execAuthMessage struct {
+	Type  string `json:"type"`
+	Token string `json:"token"`
+}
+
 // HandleExec handles a WebSocket connection for pod exec
 func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 	defer c.Close()
+
+	// SECURITY: Require JWT authentication before allowing exec.
+	// The client must send an {"type":"auth","token":"<jwt>"} message first.
+	c.SetReadDeadline(time.Now().Add(execAuthDeadline))
+
+	var authMsg execAuthMessage
+	if err := c.ReadJSON(&authMsg); err != nil {
+		log.Printf("SECURITY: exec: failed to read auth message: %v", err)
+		writeError(c, "authentication required")
+		return
+	}
+
+	if authMsg.Type != "auth" || authMsg.Token == "" {
+		log.Printf("SECURITY: exec: invalid or missing auth message")
+		writeError(c, "authentication required")
+		return
+	}
+
+	// Validate JWT token
+	if authMsg.Token == "demo-token" {
+		log.Printf("SECURITY: exec: rejected demo-token (exec requires real authentication)")
+		writeError(c, "exec requires real authentication, demo-token not allowed")
+		return
+	}
+
+	if h.jwtSecret == "" {
+		log.Printf("SECURITY: exec: rejected connection (JWT secret not configured)")
+		writeError(c, "server misconfiguration: authentication unavailable")
+		return
+	}
+
+	claims, err := middleware.ValidateJWT(authMsg.Token, h.jwtSecret)
+	if err != nil {
+		log.Printf("SECURITY: exec: rejected invalid token: %v", err)
+		writeError(c, "invalid token")
+		return
+	}
+
+	log.Printf("exec: authenticated user %s for pod exec", claims.GitHubLogin)
+
+	// Clear read deadline after successful auth
+	c.SetReadDeadline(time.Time{})
 
 	if h.k8sClient == nil {
 		writeError(c, "No Kubernetes client available")

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -773,9 +773,8 @@ func (s *Server) setupRoutes() {
 		s.hub.HandleConnection(c)
 	}))
 
-	// WebSocket for pod exec terminal
-	// Registered at /ws/exec (not /api/exec) to avoid the /api group's JWTAuth middleware
-	execHandlers := handlers.NewExecHandlers(s.k8sClient)
+	// WebSocket for pod exec terminal — uses first-message JWT auth (same pattern as /ws hub)
+	execHandlers := handlers.NewExecHandlers(s.k8sClient, s.config.JWTSecret, s.config.DevMode)
 	s.app.Use("/ws/exec", middleware.WebSocketUpgrade())
 	s.app.Get("/ws/exec", websocket.New(func(c *websocket.Conn) {
 		execHandlers.HandleExec(c)

--- a/web/src/hooks/useExecSession.ts
+++ b/web/src/hooks/useExecSession.ts
@@ -1,14 +1,15 @@
 /**
  * Pod Exec Terminal Session Hook
  *
- * Manages a WebSocket connection to the backend /api/exec endpoint
+ * Manages a WebSocket connection to the backend /ws/exec endpoint
  * for interactive terminal sessions inside pods.
  *
  * Protocol:
- * 1. Client opens WebSocket to /api/exec
- * 2. Client sends exec_init message with cluster, namespace, pod, container, command
- * 3. Server replies with exec_started
- * 4. Client sends stdin/resize messages, server sends stdout/stderr/exit messages
+ * 1. Client opens WebSocket to /ws/exec
+ * 2. Client sends auth message with JWT token (first message)
+ * 3. Client sends exec_init message with cluster, namespace, pod, container, command
+ * 4. Server replies with exec_started
+ * 5. Client sends stdin/resize messages, server sends stdout/stderr/exit messages
  */
 
 import { useRef, useCallback, useEffect, useState } from 'react'
@@ -86,16 +87,26 @@ export function useExecSession(): UseExecSessionResult {
     setError(null)
     reconnectAttemptsRef.current = 0
 
-    // Build WebSocket URL
+    // Build WebSocket URL — token is sent as first message, NOT in the URL
+    // (keeps JWT out of server logs, browser history, and proxy logs)
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const token = localStorage.getItem(STORAGE_KEY_TOKEN)
-    const wsUrl = `${protocol}//${window.location.host}/ws/exec${token ? `?token=${encodeURIComponent(token)}` : ''}`
+    const wsUrl = `${protocol}//${window.location.host}/ws/exec`
 
     const ws = new WebSocket(wsUrl)
     wsRef.current = ws
 
     ws.onopen = () => {
-      // Send the init message
+      // Step 1: Send auth message with JWT token
+      const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+      if (!token) {
+        setError('Not authenticated')
+        setStatus('error')
+        ws.close()
+        return
+      }
+      ws.send(JSON.stringify({ type: 'auth', token }))
+
+      // Step 2: Send the exec_init message
       const initMsg: ExecMessage & { cluster: string; namespace: string; pod: string; container: string; command: string[]; tty: boolean } = {
         type: 'exec_init',
         cluster: config.cluster,


### PR DESCRIPTION
## Summary
- **HIGH security fix**: The `/ws/exec` WebSocket endpoint had **zero authentication** — it was explicitly registered outside the JWT middleware group. Anyone who could reach port 8080 could exec into any pod the kubeconfig permits.
- Now requires a JWT auth message as the first WebSocket message (same proven pattern as the `/ws` hub handler)
- Rejects demo-token for exec (exec requires real authentication)
- Fails closed if JWT secret is not configured
- Frontend updated to send auth as first message instead of URL query param (keeps JWT out of logs)

## Attack scenario (before fix)
```
wscat -c ws://target:8080/ws/exec
> {"type":"exec_init","cluster":"prod","namespace":"default","pod":"app-xyz","command":["/bin/sh"]}
# Now has a shell inside the pod — no credentials needed
```

## Test plan
- [ ] Verify pod exec terminal works for authenticated users
- [ ] Verify unauthenticated WebSocket connections are rejected
- [ ] Verify demo-token is rejected for exec
- [ ] Build passes (`go build ./...`)