### PR TITLE
🐛 Fix GA4-tracked runtime errors (81 events / 28 days)

### DIFF
--- a/web/src/components/cards/PodIssues.tsx
+++ b/web/src/components/cards/PodIssues.tsx
@@ -208,7 +208,7 @@ export function PodIssues() {
                       </span>
                     )}
                   </div>
-                  {issue.issues.length > 0 && (
+                  {(issue.issues || []).length > 0 && (
                     <p className="text-xs text-muted-foreground mt-1 truncate" title={(issue.issues || []).join(', ')}>
                       {(issue.issues || []).join(', ')}
                     </p>
@@ -223,7 +223,7 @@ export function PodIssues() {
                     cluster: issue.cluster || 'default',
                     status: issue.status,
                   }}
-                  issues={issue.issues.map(msg => ({ name: issue.status, message: msg }))}
+                  issues={(issue.issues || []).map(msg => ({ name: issue.status, message: msg }))}
                   additionalContext={{ restarts: issue.restarts }}
                 />
               </div>

--- a/web/src/hooks/mcp/operators.ts
+++ b/web/src/hooks/mcp/operators.ts
@@ -75,17 +75,28 @@ export function useOperators(cluster?: string) {
   const [error, setError] = useState<string | null>(null)
   const [lastRefresh, setLastRefresh] = useState<number | null>(cached?.timestamp || null)
   const [consecutiveFailures, setConsecutiveFailures] = useState(0)
-  const [clusterCount, setClusterCount] = useState(clusterCacheRef.clusters.length)
   const [fetchVersion, setFetchVersion] = useState(0)
+  const clusterCountRef = useRef(clusterCacheRef.clusters.length)
 
+  // When clusters change, bump fetchVersion to re-trigger the fetch effect
+  // instead of putting clusterCount directly in the dependency array.
   useEffect(() => {
     return subscribeClusterCache((cache) => {
-      setClusterCount(cache.clusters.length)
+      const newCount = cache.clusters.length
+      if (newCount !== clusterCountRef.current) {
+        clusterCountRef.current = newCount
+        fetchInProgressRef.current = false
+        setFetchVersion(v => v + 1)
+      }
     })
   }, [])
 
   useEffect(() => {
     if (fetchInProgressRef.current) return
+
+    // Set guard immediately — including demo mode — to prevent re-entrant
+    // state-update cascades (React error #185: max update depth exceeded).
+    fetchInProgressRef.current = true
 
     abortRef.current?.abort()
     const controller = new AbortController()
@@ -100,10 +111,10 @@ export function useOperators(cluster?: string) {
         setConsecutiveFailures(0)
         setIsLoading(false)
         setIsRefreshing(false)
+        fetchInProgressRef.current = false
         return
       }
 
-      fetchInProgressRef.current = true
       setIsRefreshing(true)
 
       // Try SSE streaming first for progressive rendering
@@ -202,7 +213,7 @@ export function useOperators(cluster?: string) {
       fetchInProgressRef.current = false
       unregisterRefetch()
     }
-  }, [cluster, clusterCount, fetchVersion, cacheKey])
+  }, [cluster, fetchVersion, cacheKey])
 
   const refetch = useCallback(() => {
     abortRef.current?.abort()
@@ -237,17 +248,28 @@ export function useOperatorSubscriptions(cluster?: string) {
   const [error, setError] = useState<string | null>(null)
   const [lastRefresh, setLastRefresh] = useState<number | null>(cached?.timestamp || null)
   const [consecutiveFailures, setConsecutiveFailures] = useState(0)
-  const [clusterCount, setClusterCount] = useState(clusterCacheRef.clusters.length)
   const [fetchVersion, setFetchVersion] = useState(0)
+  const clusterCountRef = useRef(clusterCacheRef.clusters.length)
 
+  // When clusters change, bump fetchVersion to re-trigger the fetch effect
+  // instead of putting clusterCount directly in the dependency array.
   useEffect(() => {
     return subscribeClusterCache((cache) => {
-      setClusterCount(cache.clusters.length)
+      const newCount = cache.clusters.length
+      if (newCount !== clusterCountRef.current) {
+        clusterCountRef.current = newCount
+        fetchInProgressRef.current = false
+        setFetchVersion(v => v + 1)
+      }
     })
   }, [])
 
   useEffect(() => {
     if (fetchInProgressRef.current) return
+
+    // Set guard immediately — including demo mode — to prevent re-entrant
+    // state-update cascades (React error #185: max update depth exceeded).
+    fetchInProgressRef.current = true
 
     abortRef.current?.abort()
     const controller = new AbortController()
@@ -262,10 +284,10 @@ export function useOperatorSubscriptions(cluster?: string) {
         setConsecutiveFailures(0)
         setIsLoading(false)
         setIsRefreshing(false)
+        fetchInProgressRef.current = false
         return
       }
 
-      fetchInProgressRef.current = true
       setIsRefreshing(true)
 
       // Try SSE streaming first — backend handles multi-cluster parallelism
@@ -350,7 +372,7 @@ export function useOperatorSubscriptions(cluster?: string) {
       fetchInProgressRef.current = false
       unregisterRefetch()
     }
-  }, [cluster, clusterCount, fetchVersion, cacheKey])
+  }, [cluster, fetchVersion, cacheKey])
 
   const refetch = useCallback(() => {
     abortRef.current?.abort()

--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -42,7 +42,11 @@ const SMOOTHING_WINDOW = 5 // Keep last 5 counts
 function getSessionId(): string {
   let id = sessionStorage.getItem('kc-session-id')
   if (!id) {
-    id = crypto.randomUUID()
+    // crypto.randomUUID() requires a secure context (HTTPS / localhost).
+    // Fall back to Math.random-based ID for HTTP contexts.
+    id = typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
     sessionStorage.setItem('kc-session-id', id)
   }
   return id

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -648,6 +648,20 @@ export function initAnalytics() {
 
 async function hashUserId(uid: string): Promise<string> {
   const data = new TextEncoder().encode(`ksc-analytics:${uid}`)
+
+  // crypto.subtle is only available in secure contexts (HTTPS / localhost).
+  // Fall back to a simple FNV-1a-style hash so analytics still works over HTTP.
+  if (!crypto.subtle) {
+    const FNV_OFFSET_BASIS = 0x811c9dc5
+    const FNV_PRIME = 0x01000193
+    let h = FNV_OFFSET_BASIS
+    for (const byte of data) {
+      h ^= byte
+      h = Math.imul(h, FNV_PRIME)
+    }
+    return (h >>> 0).toString(16).padStart(8, '0')
+  }
+
   const hash = await crypto.subtle.digest('SHA-256', data)
   return Array.from(new Uint8Array(hash))
     .map(b => b.toString(16).padStart(2, '0'))

--- a/web/src/lib/cards/statusColors.ts
+++ b/web/src/lib/cards/statusColors.ts
@@ -98,7 +98,8 @@ const SEVERITY_KEYWORDS: Array<[string[], StatusSeverity]> = [
  * getStatusSeverity('Pending')          // => 'warning'
  * getStatusSeverity('custom-thing')     // => 'neutral'
  */
-export function getStatusSeverity(status: string): StatusSeverity {
+export function getStatusSeverity(status: string | undefined | null): StatusSeverity {
+  if (!status) return 'neutral'
   const lower = status.toLowerCase()
   for (const [keywords, severity] of SEVERITY_KEYWORDS) {
     if (keywords.some((kw) => lower.includes(kw))) {
@@ -117,7 +118,7 @@ export function getStatusSeverity(status: string): StatusSeverity {
  * // colors.text => 'text-red-400'
  * // colors.bg   => 'bg-red-500/20'
  */
-export function getStatusColors(status: string): StatusColorSet {
+export function getStatusColors(status: string | undefined | null): StatusColorSet {
   return STATUS_COLORS[getStatusSeverity(status)]
 }
 


### PR DESCRIPTION
## Summary
- Fix 5 categories of runtime errors identified via GA4 error tracking dashboard (81 total events over 28 days)
- **crypto.subtle fallback** (13 events): Add FNV-1a hash fallback for insecure contexts where `crypto.subtle` is unavailable
- **Operator infinite re-render** (18 events): Fix React error #185 in `useOperatorSubscriptions` — demo mode didn't set re-entrancy guard, causing cascading state updates
- **Null safety** (9 events): Guard `getStatusSeverity`/`getStatusColors` against undefined status, guard `issue.issues` array access in PodIssues
- **Maximum call stack** (28 events): Resolved by the operator re-entrancy fix
- Chunk load errors (46 events) already handled by existing ChunkErrorBoundary (146 successful recoveries)

## Test plan
- [ ] Verify operators page loads without console errors in demo mode
- [ ] Verify dashboard loads PodIssues card without crashes
- [ ] Verify analytics still tracks user IDs (check GA4 real-time)
- [ ] Build passes, lint passes