### PR TITLE
🌱 Enable Dependabot for Go, npm, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    reviewers:
+      - "clubanderson"
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+
+  # npm (frontend)
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    reviewers:
+      - "clubanderson"
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    reviewers:
+      - "clubanderson"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly checks for `gomod`, `npm` (web/), and `github-actions` ecosystems
- Auto-assigns @clubanderson as reviewer
- Limits to 10 open PRs per ecosystem (5 for actions) to avoid noise

## Security context
Part of the security hardening initiative — Dependabot monitors for known vulnerabilities in dependencies and opens PRs automatically.

## Test plan
- [ ] Verify Dependabot starts creating PRs within ~24 hours of merge
- [ ] Confirm PRs are labeled correctly (`dependencies`, `go`/`javascript`/`github-actions`)