### PR TITLE
🐛 Fix XSS in RSS parser (innerHTML → DOMParser)

### DIFF
--- a/web/src/components/cards/rss/RSSParser.ts
+++ b/web/src/components/cards/rss/RSSParser.ts
@@ -15,18 +15,16 @@ export function isValidThumbnail(url: string): boolean {
   return !invalidPatterns.some(pattern => lowerUrl.includes(pattern))
 }
 
-// Strip HTML tags from description
+// Strip HTML tags from description using DOMParser (safe — no script execution)
 export function stripHTML(html: string): string {
-  const tmp = document.createElement('div')
-  tmp.innerHTML = html
-  return tmp.textContent || tmp.innerText || ''
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  return doc.body.textContent || ''
 }
 
-// Decode HTML entities
+// Decode HTML entities using DOMParser (safe — no script execution)
 export function decodeHTMLEntities(text: string): string {
-  const tmp = document.createElement('textarea')
-  tmp.innerHTML = text
-  return tmp.value
+  const doc = new DOMParser().parseFromString(text, 'text/html')
+  return doc.body.textContent || ''
 }
 
 // Normalize Reddit URLs to use www.reddit.com instead of old.reddit.com


### PR DESCRIPTION
## Summary
- **[H4] Security fix**: `stripHTML()` and `decodeHTMLEntities()` used `innerHTML` on detached DOM elements, which could execute scripts via `<img onerror>` payloads in untrusted RSS feed content
- Replaced with `DOMParser.parseFromString('text/html')` which is safe because it does not execute scripts
- Functionally identical — both extract `textContent` from parsed HTML

## Security context
RSS feeds contain untrusted HTML from external sources. An attacker-controlled feed could include `<img src=x onerror="alert(document.cookie)">` in a description field, which would execute when parsed via `innerHTML`.

## Test plan
- [ ] RSS card still renders feed items correctly
- [ ] HTML entities in titles are decoded properly
- [ ] HTML tags in descriptions are stripped cleanly