### PR TITLE
🐛 Pin CI tool versions and remove curl-pipe-bash

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -49,28 +49,31 @@ jobs:
       - name: Install Playwright browsers
         run: cd web && npx playwright install --with-deps chromium
 
+      - name: Set up Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+
       - name: Install test tools
+        env:
+          # Pin tool versions for reproducibility and supply-chain safety
+          GITLEAKS_VERSION: '8.21.2'
+          TRIVY_VERSION: '0.58.1'
+          SEMGREP_VERSION: '1.102.0'
         run: |
           # Go security tools
           go install github.com/securego/gosec/v2/cmd/gosec@latest
           go install golang.org/x/vuln/cmd/govulncheck@latest
           go install github.com/google/go-licenses@latest
 
-          # Secret scanning — fetch latest release dynamically
-          GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          # Secret scanning (pinned version)
           wget -q "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -O /tmp/gitleaks.tar.gz
           tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks
 
-          # Helm
-          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-
-          # Container scanning — fetch latest release dynamically
-          TRIVY_VERSION=$(curl -s https://api.github.com/repos/aquasecurity/trivy/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          # Container scanning (pinned version)
           wget -q "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -O /tmp/trivy.tar.gz
           tar -xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
 
-          # SAST (semgrep)
-          pip3 install --break-system-packages semgrep
+          # SAST (pinned version)
+          pip3 install --break-system-packages "semgrep==${SEMGREP_VERSION}"
 
           # ripgrep (some scripts use rg)
           sudo apt-get install -y ripgrep


### PR DESCRIPTION
## Summary
- **[H7] Security fix**: Replaced `curl -fsSL ... | bash` Helm installation with SHA-pinned `azure/setup-helm@v4.2.0` action
- Pinned gitleaks (8.21.2), trivy (0.58.1), and semgrep (1.102.0) to specific versions instead of fetching latest dynamically
- Eliminates supply-chain risk from mutable latest-version downloads

## Security context
The nightly workflow previously used `curl | bash` to install Helm and fetched the latest version of gitleaks/trivy at runtime. A compromised upstream release could inject malicious code into CI. Pinning versions ensures reproducibility and requires explicit updates.

## Test plan
- [ ] Nightly workflow still installs all tools correctly
- [ ] Helm, gitleaks, trivy, semgrep are available at expected versions
- [ ] Full test suite runs successfully