### PR TITLE
🐛 Add security response headers to Go backend

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -302,6 +302,16 @@ func (s *Server) setupMiddleware() {
 		ExposeHeaders:    "X-Token-Refresh",
 		AllowCredentials: true,
 	}))
+
+	// Security headers
+	s.app.Use(func(c *fiber.Ctx) error {
+		c.Set("X-Content-Type-Options", "nosniff")
+		c.Set("X-Frame-Options", "DENY")
+		c.Set("X-XSS-Protection", "0") // Disabled per OWASP — modern browsers don't need it and it can introduce vulnerabilities
+		c.Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		c.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+		return c.Next()
+	})
 }
 
 // startupLoadingHTML is a self-contained loading page served while the server initializes.


### PR DESCRIPTION
## Summary
- **[M4] Security fix**: Adds security response headers via Fiber middleware
- Headers added: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy: camera=(), microphone=(), geolocation=()`
- `X-XSS-Protection` set to `0` per OWASP recommendation (modern browsers don't need it)

## Test plan
- [ ] Verify headers are present in API responses via browser DevTools
- [ ] Confirm frontend still loads correctly (X-Frame-Options: DENY only blocks iframe embedding)
- [ ] CORS still works as expected