### PR TITLE
🐛 Add server-side token revocation with jti-based blocklist

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/onsi/gomega v1.33.1 // indirect
+	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
@@ -64,6 +65,7 @@ require (
 	github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
+	github.com/tinylib/msgp v1.2.5 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.55.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA
 github.com/onsi/ginkgo/v2 v2.19.0/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
 github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
 github.com/onsi/gomega v1.33.1/go.mod h1:U4R44UsT+9eLIaYRB2a5qajjtQYn0hauxvRm16AVYg0=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c h1:dAMKvw0MlJT1GshSTtih8C2gDs04w8dReiOGXrGLNoY=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -140,6 +142,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tinylib/msgp v1.2.5 h1:WeQg1whrXRFiZusidTQqzETkRpGjFjcIhW6uqWH09po=
+github.com/tinylib/msgp v1.2.5/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.55.0 h1:Zkefzgt6a7+bVKHnu/YaYSOPfNYNisSVBo/unVCf8k8=

--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -330,6 +330,39 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 	return c.Redirect(redirectURL, fiber.StatusTemporaryRedirect)
 }
 
+// Logout revokes the current JWT so it can no longer be used.
+// The token's jti is added to an in-memory revocation list that is
+// checked by the JWTAuth middleware on every request.
+func (h *AuthHandler) Logout(c *fiber.Ctx) error {
+	authHeader := c.Get("Authorization")
+	if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+		return fiber.NewError(fiber.StatusUnauthorized, "Missing authorization")
+	}
+
+	tokenString := authHeader[len("Bearer "):]
+	token, err := jwt.ParseWithClaims(tokenString, &middleware.UserClaims{}, func(token *jwt.Token) (interface{}, error) {
+		return []byte(h.jwtSecret), nil
+	})
+	if err != nil {
+		return fiber.NewError(fiber.StatusUnauthorized, "Invalid token")
+	}
+
+	claims, ok := token.Claims.(*middleware.UserClaims)
+	if !ok || claims.ID == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "Token has no revocable identifier")
+	}
+
+	// Add to revocation list — expires when the JWT itself would expire
+	expiresAt := time.Now().Add(jwtExpiration) // fallback
+	if claims.ExpiresAt != nil {
+		expiresAt = claims.ExpiresAt.Time
+	}
+	middleware.RevokeToken(claims.ID, expiresAt)
+
+	log.Printf("[Auth] Token revoked for user %s (jti: %s)", claims.GitHubLogin, claims.ID)
+	return c.JSON(fiber.Map{"success": true, "message": "Token revoked"})
+}
+
 // RefreshToken refreshes the JWT token
 func (h *AuthHandler) RefreshToken(c *fiber.Ctx) error {
 	// Get current user from context
@@ -354,6 +387,15 @@ func (h *AuthHandler) RefreshToken(c *fiber.Ctx) error {
 	claims, ok := token.Claims.(*middleware.UserClaims)
 	if !ok {
 		return fiber.NewError(fiber.StatusUnauthorized, "Invalid claims")
+	}
+
+	// Revoke the old token to prevent reuse
+	if claims.ID != "" {
+		expiresAt := time.Now().Add(jwtExpiration)
+		if claims.ExpiresAt != nil {
+			expiresAt = claims.ExpiresAt.Time
+		}
+		middleware.RevokeToken(claims.ID, expiresAt)
 	}
 
 	// Get fresh user data
@@ -415,6 +457,7 @@ func (h *AuthHandler) generateJWT(user *models.User) (string, error) {
 		UserID:      user.ID,
 		GitHubLogin: user.GitHubLogin,
 		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        uuid.New().String(), // jti — unique token identifier for revocation
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(jwtExpiration)),
 			IssuedAt:  jwt.NewNumericDate(time.Now()),
 			Subject:   user.ID.String(),

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -14,6 +15,9 @@ const (
 	// tokenRefreshThresholdFraction is the fraction of JWT lifetime after which
 	// the server signals the client to silently refresh its token.
 	tokenRefreshThresholdFraction = 0.5
+
+	// revokedTokenCleanupInterval is how often expired entries are pruned from the in-memory revocation store.
+	revokedTokenCleanupInterval = 1 * time.Hour
 )
 
 // UserClaims represents JWT claims for a user
@@ -21,6 +25,65 @@ type UserClaims struct {
 	UserID      uuid.UUID `json:"user_id"`
 	GitHubLogin string    `json:"github_login"`
 	jwt.RegisteredClaims
+}
+
+// revokedTokenStore is an in-memory store of revoked JWT token IDs (jti).
+// Entries auto-expire when the underlying JWT would have expired.
+// NOTE: This store does not survive server restarts — revoked tokens become
+// valid again after restart. For production use, consider a persistent store.
+type revokedTokenStore struct {
+	sync.RWMutex
+	tokens map[string]time.Time // jti -> expiresAt
+}
+
+var revokedTokens = &revokedTokenStore{
+	tokens: make(map[string]time.Time),
+}
+
+func init() {
+	go revokedTokens.cleanupLoop()
+}
+
+func (s *revokedTokenStore) Revoke(jti string, expiresAt time.Time) {
+	s.Lock()
+	defer s.Unlock()
+	s.tokens[jti] = expiresAt
+}
+
+func (s *revokedTokenStore) IsRevoked(jti string) bool {
+	s.RLock()
+	defer s.RUnlock()
+	_, ok := s.tokens[jti]
+	return ok
+}
+
+func (s *revokedTokenStore) cleanupLoop() {
+	ticker := time.NewTicker(revokedTokenCleanupInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.cleanup()
+	}
+}
+
+func (s *revokedTokenStore) cleanup() {
+	s.Lock()
+	defer s.Unlock()
+	now := time.Now()
+	for jti, exp := range s.tokens {
+		if now.After(exp) {
+			delete(s.tokens, jti)
+		}
+	}
+}
+
+// RevokeToken adds a token to the revocation store. Exported for use by handlers.
+func RevokeToken(jti string, expiresAt time.Time) {
+	revokedTokens.Revoke(jti, expiresAt)
+}
+
+// IsTokenRevoked checks if a token has been revoked.
+func IsTokenRevoked(jti string) bool {
+	return revokedTokens.IsRevoked(jti)
 }
 
 // JWTAuth creates JWT authentication middleware
@@ -66,6 +129,12 @@ func JWTAuth(secret string) fiber.Handler {
 		if !ok {
 			log.Printf("[Auth] Invalid token claims for %s", c.Path())
 			return fiber.NewError(fiber.StatusUnauthorized, "Invalid token claims")
+		}
+
+		// Check if token has been revoked (server-side logout)
+		if claims.ID != "" && IsTokenRevoked(claims.ID) {
+			log.Printf("[Auth] Revoked token used for %s", c.Path())
+			return fiber.NewError(fiber.StatusUnauthorized, "Token has been revoked")
 		}
 
 		// Store user info in context

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -414,6 +414,7 @@ func (s *Server) setupRoutes() {
 	s.app.Get("/auth/github", authLimiter, auth.GitHubLogin)
 	s.app.Get("/auth/github/callback", authLimiter, auth.GitHubCallback)
 	s.app.Post("/auth/refresh", authLimiter, auth.RefreshToken)
+	s.app.Post("/auth/logout", authLimiter, auth.Logout)
 
 	// Active users endpoint (public — returns only aggregate counts, no sensitive data)
 	s.app.Get("/api/active-users", func(c *fiber.Ctx) error {


### PR DESCRIPTION
## Summary
- Adds `POST /auth/logout` endpoint that revokes the current JWT by adding its jti to an in-memory blocklist
- JWTAuth middleware now checks the revocation blocklist on every request, rejecting revoked tokens with 401
- All newly issued JWTs include a `jti` (unique token ID) claim via `uuid.New()`
- Token refresh now revokes the old token before issuing a new one, preventing reuse of rotated credentials
- Background goroutine prunes expired revocation entries hourly

**Security: M6** — Previously logout was client-side only (removed token from localStorage), meaning stolen JWTs remained valid for the full 7-day lifetime.

## Test plan
- [ ] Login, verify JWT contains `jti` claim (decode at jwt.io)
- [ ] Call `POST /auth/logout` with Bearer token, verify 200 response
- [ ] Try using the same token after logout, verify 401 "Token has been revoked"
- [ ] Call `POST /auth/refresh`, verify old token is rejected and new token works
- [ ] Verify server restart clears revocation list (expected — in-memory store)