### PR TITLE
🐛 Harden Netlify functions: origin bypass, sessionId, CORS

### DIFF
--- a/web/netlify/functions/analytics-collect.mts
+++ b/web/netlify/functions/analytics-collect.mts
@@ -19,6 +19,19 @@ const ALLOWED_HOSTS = new Set([
   "127.0.0.1",
 ]);
 
+function getAllowedCorsOrigin(origin: string): string {
+  if (!origin) return "https://console.kubestellar.io";
+  try {
+    const hostname = new URL(origin).hostname;
+    if (ALLOWED_HOSTS.has(hostname) || hostname.endsWith(".netlify.app")) {
+      return origin;
+    }
+  } catch {
+    /* ignore */
+  }
+  return "https://console.kubestellar.io";
+}
+
 function isAllowedOrigin(req: Request): boolean {
   const origin = req.headers.get("origin") || "";
   const referer = req.headers.get("referer") || "";
@@ -34,13 +47,15 @@ function isAllowedOrigin(req: Request): boolean {
       /* ignore parse errors */
     }
   }
-  // Allow if neither header present (browsers always send one for fetch)
-  return !origin && !referer;
+  // Reject if neither header present — non-browser clients (curl, scripts) omit both
+  return false;
 }
 
 export default async (req: Request) => {
+  const origin = req.headers.get("origin") || "";
+  const corsOrigin = getAllowedCorsOrigin(origin);
   const corsHeaders: Record<string, string> = {
-    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Origin": corsOrigin,
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
   };

--- a/web/netlify/functions/presence.mts
+++ b/web/netlify/functions/presence.mts
@@ -1,15 +1,38 @@
 import { getStore } from "@netlify/blobs";
 
+const ALLOWED_HOSTS = new Set([
+  "console.kubestellar.io",
+  "localhost",
+  "127.0.0.1",
+]);
+
+function getAllowedCorsOrigin(origin: string): string {
+  if (!origin) return "https://console.kubestellar.io";
+  try {
+    const hostname = new URL(origin).hostname;
+    if (ALLOWED_HOSTS.has(hostname) || hostname.endsWith(".netlify.app")) {
+      return origin;
+    }
+  } catch {
+    /* ignore */
+  }
+  return "https://console.kubestellar.io";
+}
+
 const STORE_NAME = "presence";
 const SESSION_PREFIX = "session-";
 const SESSION_TTL_MS = 90_000; // 90 seconds — sessions expire if no heartbeat
+const MAX_SESSION_ID_LEN = 64;
+const SESSION_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 export default async (req: Request) => {
   const store = getStore(STORE_NAME);
 
-  // CORS headers for cross-origin requests (preview deploys)
+  // CORS headers — restrict to allowed origins (production + preview deploys)
+  const origin = req.headers.get("origin") || "";
+  const corsOrigin = getAllowedCorsOrigin(origin);
   const headers = {
-    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Origin": corsOrigin,
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
     "Cache-Control": "no-cache, no-store",
@@ -27,7 +50,12 @@ export default async (req: Request) => {
     try {
       const body = await req.json();
       const sessionId = body.sessionId;
-      if (typeof sessionId === "string" && sessionId.length > 0) {
+      if (
+        typeof sessionId === "string" &&
+        sessionId.length > 0 &&
+        sessionId.length <= MAX_SESSION_ID_LEN &&
+        SESSION_ID_PATTERN.test(sessionId)
+      ) {
         await store.set(`${SESSION_PREFIX}${sessionId}`, String(now));
       }
     } catch {


### PR DESCRIPTION
## Summary
- **analytics-collect.mts (M8)**: Reject requests with no Origin/Referer instead of allowing them to bypass the origin allowlist. Replace wildcard `Access-Control-Allow-Origin: *` with dynamic origin checking against the allowlist.
- **presence.mts (M9)**: Add sessionId format validation — alphanumeric only, max 64 characters — to prevent storage abuse via arbitrary keys.
- **presence.mts (M11)**: Replace wildcard CORS with dynamic origin-based CORS matching the same allowlist pattern.

**Security: M8, M9, M11** — Previously non-browser clients could bypass origin checks, sessionId had no format validation, and write endpoints used `Access-Control-Allow-Origin: *`.

## Test plan
- [ ] Verify analytics collection works from console.kubestellar.io
- [ ] Verify analytics collection works from Netlify preview deploys (*.netlify.app)
- [ ] Verify presence heartbeat accepts valid session IDs
- [ ] Verify presence rejects oversized or special-character session IDs
- [ ] Verify `curl` requests without Origin/Referer are rejected (403)