### PR TITLE
🐛 Require webhook secret and fix origin validation bypass

### DIFF
--- a/pkg/api/handlers/analytics_proxy.go
+++ b/pkg/api/handlers/analytics_proxy.go
@@ -215,9 +215,10 @@ func isAllowedOrigin(c *fiber.Ctx) bool {
 		}
 	}
 
-	// Browsers always send Origin or Referer for XHR/fetch requests.
-	// Allow requests with neither header (e.g., server-to-server, curl).
-	return origin == "" && referer == ""
+	// Reject requests with neither Origin nor Referer — browsers always send
+	// at least one for XHR/fetch. Requests without either are likely from
+	// non-browser clients bypassing origin checks.
+	return false
 }
 
 // stripPort removes the port from a hostname (e.g., "localhost:5174" → "localhost").

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -918,12 +918,15 @@ func (h *FeedbackHandler) MarkAllNotificationsRead(c *fiber.Ctx) error {
 
 // HandleGitHubWebhook handles incoming GitHub webhook events
 func (h *FeedbackHandler) HandleGitHubWebhook(c *fiber.Ctx) error {
-	// Verify webhook signature if secret is configured
-	if h.webhookSecret != "" {
-		signature := c.Get("X-Hub-Signature-256")
-		if !h.verifyWebhookSignature(c.Body(), signature) {
-			return fiber.NewError(fiber.StatusUnauthorized, "Invalid webhook signature")
-		}
+	// Reject webhooks if no secret is configured — signature verification is mandatory
+	if h.webhookSecret == "" {
+		log.Printf("[Webhook] Rejected: GITHUB_WEBHOOK_SECRET not configured")
+		return fiber.NewError(fiber.StatusServiceUnavailable, "Webhook signature verification not configured")
+	}
+
+	signature := c.Get("X-Hub-Signature-256")
+	if !h.verifyWebhookSignature(c.Body(), signature) {
+		return fiber.NewError(fiber.StatusUnauthorized, "Invalid webhook signature")
 	}
 
 	eventType := c.Get("X-GitHub-Event")


### PR DESCRIPTION
## Summary
- **feedback.go (M7)**: Reject GitHub webhooks when `GITHUB_WEBHOOK_SECRET` is not configured instead of silently accepting them without signature verification. Returns 503 with a clear log message.
- **analytics_proxy.go (M8-backend)**: Reject requests with neither Origin nor Referer header instead of allowing them to bypass the origin allowlist. Mirrors the same fix applied to the Netlify function.

**Security: M7, M8** — Previously webhooks were accepted without HMAC verification when the secret env var was not set, and non-browser clients could bypass origin checking on the Go analytics proxy.

## Test plan
- [ ] Verify webhooks work when `GITHUB_WEBHOOK_SECRET` is set
- [ ] Verify webhooks return 503 when `GITHUB_WEBHOOK_SECRET` is not set
- [ ] Verify GA4 analytics proxy accepts requests from allowed origins
- [ ] Verify GA4 analytics proxy rejects `curl` requests without Origin/Referer