### PR TITLE
✨ Add generic custom resources API endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/onsi/gomega v1.33.1 // indirect
+	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
@@ -66,6 +67,7 @@ require (
 	github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
+	github.com/tinylib/msgp v1.2.5 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.55.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -103,6 +105,8 @@ github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA
 github.com/onsi/ginkgo/v2 v2.19.0/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
 github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
 github.com/onsi/gomega v1.33.1/go.mod h1:U4R44UsT+9eLIaYRB2a5qajjtQYn0hauxvRm16AVYg0=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c h1:dAMKvw0MlJT1GshSTtih8C2gDs04w8dReiOGXrGLNoY=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -138,6 +142,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tinylib/msgp v1.2.5 h1:WeQg1whrXRFiZusidTQqzETkRpGjFjcIhW6uqWH09po=
+github.com/tinylib/msgp v1.2.5/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.55.0 h1:Zkefzgt6a7+bVKHnu/YaYSOPfNYNisSVBo/unVCf8k8=

--- a/pkg/api/handlers/custom_resources.go
+++ b/pkg/api/handlers/custom_resources.go
@@ -1,0 +1,180 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/gofiber/fiber/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// CustomResourceItem represents a single custom resource instance returned by the API.
+type CustomResourceItem struct {
+	Name      string                 `json:"name"`
+	Namespace string                 `json:"namespace,omitempty"`
+	Cluster   string                 `json:"cluster"`
+	Status    map[string]interface{} `json:"status,omitempty"`
+	Spec      map[string]interface{} `json:"spec,omitempty"`
+	Labels    map[string]string      `json:"labels,omitempty"`
+}
+
+// CustomResourceResponse is the response for GET /api/mcp/custom-resources.
+type CustomResourceResponse struct {
+	Items      []CustomResourceItem `json:"items"`
+	IsDemoData bool                 `json:"isDemoData"`
+}
+
+// GetCustomResources queries custom resource instances across clusters.
+//
+// Query parameters:
+//
+//	group     — API group (e.g. "keda.sh", "kafka.strimzi.io")
+//	version   — API version (e.g. "v1alpha1", "v1beta2")
+//	resource  — plural resource name (e.g. "scaledobjects", "kafkas")
+//	cluster   — (optional) restrict to a single cluster
+//	namespace — (optional) restrict to a single namespace
+//
+// Kubernetes RBAC controls access — if the user's kubeconfig cannot list the
+// resource, the per-cluster query silently returns zero items.
+func (h *MCPHandlers) GetCustomResources(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(CustomResourceResponse{Items: []CustomResourceItem{}, IsDemoData: true})
+	}
+
+	group := c.Query("group")
+	version := c.Query("version")
+	resource := c.Query("resource")
+	cluster := c.Query("cluster")
+	namespace := c.Query("namespace")
+
+	if group == "" || version == "" || resource == "" {
+		return c.Status(400).JSON(fiber.Map{
+			"error": "group, version, and resource query parameters are required",
+		})
+	}
+
+	if h.k8sClient == nil {
+		return c.Status(503).JSON(CustomResourceResponse{Items: []CustomResourceItem{}, IsDemoData: true})
+	}
+
+	gvr := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
+
+	// Single-cluster path
+	if cluster != "" {
+		items, err := h.listCR(c.Context(), cluster, namespace, gvr)
+		if err != nil {
+			log.Printf("custom-resources: cluster %s: %v", cluster, err)
+			return c.Status(500).JSON(fiber.Map{"error": fmt.Sprintf("failed to list %s: %v", resource, err)})
+		}
+		return c.JSON(CustomResourceResponse{Items: items, IsDemoData: false})
+	}
+
+	// Fan-out across all healthy clusters
+	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
+	if err != nil {
+		log.Printf("custom-resources: HealthyClusters: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	allItems := make([]CustomResourceItem, 0)
+
+	for _, cl := range clusters {
+		wg.Add(1)
+		go func(clusterName string) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+			defer cancel()
+
+			items, err := h.listCR(ctx, clusterName, namespace, gvr)
+			if err != nil {
+				// RBAC denied or CRD not installed on this cluster — skip silently
+				return
+			}
+			if len(items) > 0 {
+				mu.Lock()
+				allItems = append(allItems, items...)
+				mu.Unlock()
+			}
+		}(cl.Name)
+	}
+
+	waitWithDeadline(&wg, maxResponseDeadline)
+	return c.JSON(CustomResourceResponse{Items: allItems, IsDemoData: false})
+}
+
+// listCR queries a single cluster for custom resource instances using the dynamic client.
+func (h *MCPHandlers) listCR(
+	ctx context.Context,
+	clusterName, namespace string,
+	gvr schema.GroupVersionResource,
+) ([]CustomResourceItem, error) {
+	dynClient, err := h.k8sClient.GetDynamicClient(clusterName)
+	if err != nil {
+		return nil, fmt.Errorf("dynamic client: %w", err)
+	}
+
+	var uList interface{}
+	if namespace != "" {
+		uList, err = dynClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	} else {
+		uList, err = dynClient.Resource(gvr).List(ctx, metav1.ListOptions{})
+	}
+	if err != nil {
+		return nil, fmt.Errorf("list %s: %w", gvr.Resource, err)
+	}
+
+	// Dynamic client returns *unstructured.UnstructuredList
+	type unstructuredList interface {
+		UnstructuredContent() map[string]interface{}
+	}
+	ul, ok := uList.(unstructuredList)
+	if !ok {
+		return nil, fmt.Errorf("unexpected return type %T", uList)
+	}
+
+	content := ul.UnstructuredContent()
+	rawItems, _ := content["items"].([]interface{})
+	items := make([]CustomResourceItem, 0, len(rawItems))
+
+	for _, raw := range rawItems {
+		obj, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		items = append(items, parseCRItem(obj, clusterName))
+	}
+
+	return items, nil
+}
+
+// parseCRItem extracts the key fields from an unstructured custom resource.
+func parseCRItem(obj map[string]interface{}, clusterName string) CustomResourceItem {
+	item := CustomResourceItem{Cluster: clusterName}
+
+	if metadata, ok := obj["metadata"].(map[string]interface{}); ok {
+		item.Name, _ = metadata["name"].(string)
+		item.Namespace, _ = metadata["namespace"].(string)
+		if labels, ok := metadata["labels"].(map[string]interface{}); ok {
+			item.Labels = make(map[string]string, len(labels))
+			for k, v := range labels {
+				if s, ok := v.(string); ok {
+					item.Labels[k] = s
+				}
+			}
+		}
+	}
+
+	if status, ok := obj["status"].(map[string]interface{}); ok {
+		item.Status = status
+	}
+	if spec, ok := obj["spec"].(map[string]interface{}); ok {
+		item.Spec = spec
+	}
+
+	return item
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -613,6 +613,7 @@ func (s *Server) setupRoutes() {
 	api.Post("/mcp/tools/deploy/call", mcpHandlers.CallDeployTool)
 	api.Get("/mcp/wasmcloud/hosts", mcpHandlers.GetWasmCloudHosts)
 	api.Get("/mcp/wasmcloud/actors", mcpHandlers.GetWasmCloudActors)
+	api.Get("/mcp/custom-resources", mcpHandlers.GetCustomResources)
 
 	// SSE streaming variants — stream per-cluster results as they arrive
 	api.Get("/mcp/pods/stream", mcpHandlers.GetPodsStream)


### PR DESCRIPTION
## Summary
- Add `GET /api/mcp/custom-resources` endpoint that queries arbitrary CRD instances across clusters using the Kubernetes dynamic client
- Parameters: `group`, `version`, `resource` (required), `cluster`, `namespace` (optional)
- Kubernetes RBAC controls access — no server-side allowlist needed
- Fan-out across all healthy clusters with per-cluster timeout
- Used by CNCF card hooks (KEDA, Strimzi, OpenFeature, KubeVela) to fetch ScaledObjects, Kafka CRs, FeatureFlags, and OAM Applications

## Test plan
- [ ] Verify endpoint returns 400 for missing required params
- [ ] Verify endpoint returns empty items in demo mode
- [ ] Verify single-cluster query with `cluster` param
- [ ] Verify multi-cluster fan-out returns aggregated results
- [ ] Verify RBAC denial on a cluster silently returns 0 items (no error)
- [ ] Verify CRD not installed on a cluster silently returns 0 items