### PR TITLE
🐛 Pin Go tool versions in nightly workflow

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -58,11 +58,14 @@ jobs:
           GITLEAKS_VERSION: '8.21.2'
           TRIVY_VERSION: '0.58.1'
           SEMGREP_VERSION: '1.102.0'
+          GOSEC_VERSION: 'v2.21.4'
+          GOVULNCHECK_VERSION: 'v1.1.4'
+          GO_LICENSES_VERSION: 'v1.6.0'
         run: |
-          # Go security tools
-          go install github.com/securego/gosec/v2/cmd/gosec@latest
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          go install github.com/google/go-licenses@latest
+          # Go security tools (pinned to avoid breakage from upstream changes)
+          go install "github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}"
+          go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
+          go install "github.com/google/go-licenses@${GO_LICENSES_VERSION}"
 
           # Secret scanning (pinned version)
           wget -q "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -O /tmp/gitleaks.tar.gz


### PR DESCRIPTION
## Summary

Fixes the nightly test suite failing at the "Install test tools" step (exit code 8) due to `go install github.com/google/go-licenses@latest` failing to compile.

**Root cause**: `gosec@latest` (v2.24.7) requires Go >= 1.25, causing the Go toolchain to auto-switch from 1.23 to 1.25.8. Under this switched version, `go-licenses@latest` fails to compile due to dependency conflicts in its old `gopkg.in/src-d/go-git.v4` dependency tree.

**Fix**: Pin all three Go security tools to known-good versions:
- `gosec` → v2.21.4 (last version compatible with Go 1.23)
- `govulncheck` → v1.1.4
- `go-licenses` → v1.6.0

This is consistent with the existing approach of pinning gitleaks, trivy, and semgrep versions.

## Test plan

- [ ] Nightly test suite passes the "Install test tools" step
- [ ] All 32 test suites execute successfully