### PR TITLE
🐛 Make go-licenses install non-fatal in nightly workflow

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -65,7 +65,9 @@ jobs:
           # Go security tools (pinned to avoid breakage from upstream changes)
           go install "github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}"
           go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
-          go install "github.com/google/go-licenses@${GO_LICENSES_VERSION}"
+          # go-licenses install is best-effort — the license-compliance-test script
+          # has a fallback path using 'go list -m -json' when the binary is absent.
+          go install "github.com/google/go-licenses@${GO_LICENSES_VERSION}" || echo "Warning: go-licenses install failed — license test will use fallback"
 
           # Secret scanning (pinned version)
           wget -q "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -O /tmp/gitleaks.tar.gz


### PR DESCRIPTION
## Summary

The nightly test suite has been completely blocked because `go install github.com/google/go-licenses@v1.6.0` (and `@latest`) fails to compile — `gopkg.in/src-d/go-git.v4` has dependency conflicts with the current Go toolchain (exit code 8). This prevents ALL 32 test suites from running.

The `license-compliance-test.sh` script already handles this gracefully — when `go-licenses` binary is absent, it falls back to `go list -m -json all` for license detection. Making the install non-fatal with `|| echo "Warning: ..."` allows the remaining tool installs (gitleaks, trivy, semgrep, ripgrep) to proceed and all 32 test suites to execute.

## Test plan

- [ ] Nightly workflow passes the "Install test tools" step
- [ ] All 32 test suites run (license-compliance-test uses fallback path)
- [ ] Previously fixed issues (unit-test, security-e2e-test) also pass