### PR TITLE
🐛 Move GitHub PAT to backend-only storage via API proxy

### DIFF
--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -1,0 +1,252 @@
+package handlers
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/kubestellar/console/pkg/settings"
+)
+
+const (
+	// githubProxyTimeout is the timeout for proxied GitHub API requests.
+	githubProxyTimeout = 15 * time.Second
+	// githubAPIBase is the base URL for the GitHub API.
+	githubAPIBase = "https://api.github.com"
+	// maxGitHubProxyPathLen is the maximum allowed path length to prevent abuse.
+	maxGitHubProxyPathLen = 512
+)
+
+var githubProxyClient = &http.Client{Timeout: githubProxyTimeout}
+
+// allowedGitHubPrefixes restricts which GitHub API paths can be proxied.
+// Only read-only endpoints needed by the frontend are permitted.
+var allowedGitHubPrefixes = []string{
+	"/repos/",     // repo info, PRs, issues, releases, contributors, actions, git refs, compare
+	"/rate_limit", // token validation
+}
+
+// GitHubProxyHandler proxies read-only GitHub API requests through the backend,
+// keeping the GitHub PAT server-side. The frontend sends requests to
+// /api/github/* and this handler forwards them to api.github.com/* with
+// the server-side token in the Authorization header.
+type GitHubProxyHandler struct {
+	// serverToken is the configured GITHUB_TOKEN from env
+	serverToken string
+}
+
+// NewGitHubProxyHandler creates a new GitHub API proxy handler.
+func NewGitHubProxyHandler(serverToken string) *GitHubProxyHandler {
+	return &GitHubProxyHandler{
+		serverToken: serverToken,
+	}
+}
+
+// resolveToken returns the best available GitHub token:
+// 1. User-saved token from encrypted settings file
+// 2. Server-configured GITHUB_TOKEN from env
+func (h *GitHubProxyHandler) resolveToken() string {
+	// Check user-saved settings first (may have a user-specific PAT)
+	if sm := settings.GetSettingsManager(); sm != nil {
+		if all, err := sm.GetAll(); err == nil && all.GitHubToken != "" {
+			return all.GitHubToken
+		}
+	}
+	return h.serverToken
+}
+
+// Proxy handles GET /api/github/* by forwarding to api.github.com/*.
+// Only GET requests are allowed (read-only proxy).
+func (h *GitHubProxyHandler) Proxy(c *fiber.Ctx) error {
+	// Only allow GET — this is a read-only proxy
+	if c.Method() != fiber.MethodGet {
+		return c.Status(fiber.StatusMethodNotAllowed).JSON(fiber.Map{
+			"error": "Only GET requests are proxied",
+		})
+	}
+
+	// Extract the path after /api/github/
+	path := c.Params("*")
+	if path == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Missing API path",
+		})
+	}
+
+	// Security: validate path length
+	if len(path) > maxGitHubProxyPathLen {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Path too long",
+		})
+	}
+
+	// Security: block path traversal
+	if strings.Contains(path, "..") {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid path",
+		})
+	}
+
+	// Security: only allow specific GitHub API prefixes
+	apiPath := "/" + path
+	allowed := false
+	for _, prefix := range allowedGitHubPrefixes {
+		if strings.HasPrefix(apiPath, prefix) {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+			"error": "GitHub API path not allowed",
+		})
+	}
+
+	// Build target URL with query params
+	targetURL := githubAPIBase + apiPath
+	if qs := c.Context().QueryArgs().QueryString(); len(qs) > 0 {
+		targetURL += "?" + string(qs)
+	}
+
+	// Create proxied request
+	req, err := http.NewRequest(http.MethodGet, targetURL, nil)
+	if err != nil {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
+			"error": "Failed to create proxy request",
+		})
+	}
+
+	// Add GitHub token from server-side storage
+	token := h.resolveToken()
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("User-Agent", "KubeStellar-Console-Proxy")
+
+	// Forward conditional request headers for caching
+	if etag := c.Get("If-None-Match"); etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	// Execute request
+	resp, err := githubProxyClient.Do(req)
+	if err != nil {
+		log.Printf("[GitHubProxy] Request failed for %s: %v", apiPath, err)
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
+			"error": "GitHub API request failed",
+		})
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
+			"error": "Failed to read GitHub API response",
+		})
+	}
+
+	// Forward rate limit headers so the frontend can display them
+	for _, header := range []string{
+		"X-RateLimit-Limit",
+		"X-RateLimit-Remaining",
+		"X-RateLimit-Reset",
+		"X-RateLimit-Used",
+		"ETag",
+		"Link",
+	} {
+		if v := resp.Header.Get(header); v != "" {
+			c.Set(header, v)
+		}
+	}
+
+	// Forward Content-Type
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		c.Set("Content-Type", ct)
+	}
+
+	return c.Status(resp.StatusCode).Send(body)
+}
+
+// SaveToken handles POST /api/github/token — saves a user-provided GitHub PAT
+// to the encrypted server-side settings file. The token is NOT stored in
+// localStorage after this migration.
+func (h *GitHubProxyHandler) SaveToken(c *fiber.Ctx) error {
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := c.BodyParser(&body); err != nil || body.Token == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Token is required",
+		})
+	}
+
+	sm := settings.GetSettingsManager()
+	if sm == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "Settings manager not available",
+		})
+	}
+
+	all, err := sm.GetAll()
+	if err != nil {
+		all = &settings.AllSettings{}
+	}
+	all.GitHubToken = body.Token
+	if err := sm.SaveAll(all); err != nil {
+		log.Printf("[GitHubProxy] Failed to save token: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to save token",
+		})
+	}
+
+	log.Printf("[GitHubProxy] GitHub token saved to encrypted settings")
+	return c.JSON(fiber.Map{"success": true})
+}
+
+// DeleteToken handles DELETE /api/github/token — removes the user-provided
+// GitHub PAT from server-side settings.
+func (h *GitHubProxyHandler) DeleteToken(c *fiber.Ctx) error {
+	sm := settings.GetSettingsManager()
+	if sm == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "Settings manager not available",
+		})
+	}
+
+	all, err := sm.GetAll()
+	if err != nil {
+		return c.JSON(fiber.Map{"success": true}) // Nothing to delete
+	}
+	all.GitHubToken = ""
+	if err := sm.SaveAll(all); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to clear token",
+		})
+	}
+
+	return c.JSON(fiber.Map{"success": true})
+}
+
+// HasToken handles GET /api/github/token/status — returns whether a GitHub
+// token is configured (without exposing the token itself).
+func (h *GitHubProxyHandler) HasToken(c *fiber.Ctx) error {
+	token := h.resolveToken()
+	source := "none"
+	if h.serverToken != "" {
+		source = "env"
+	}
+	if sm := settings.GetSettingsManager(); sm != nil {
+		if all, err := sm.GetAll(); err == nil && all.GitHubToken != "" {
+			source = "settings"
+		}
+	}
+	return c.JSON(fiber.Map{
+		"hasToken": token != "",
+		"source":   source,
+	})
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -497,6 +497,13 @@ func (s *Server) setupRoutes() {
 	api.Get("/me", user.GetCurrentUser)
 	api.Put("/me", user.UpdateCurrentUser)
 
+	// GitHub API proxy — keeps PAT server-side, frontend calls /api/github/*
+	githubProxy := handlers.NewGitHubProxyHandler(s.config.GitHubToken)
+	api.Get("/github/token/status", githubProxy.HasToken)
+	api.Post("/github/token", githubProxy.SaveToken)
+	api.Delete("/github/token", githubProxy.DeleteToken)
+	api.Get("/github/*", githubProxy.Proxy)
+
 	// Persistent settings routes
 	settingsHandler := handlers.NewSettingsHandler(settings.GetSettingsManager())
 	api.Get("/settings", settingsHandler.GetSettings)

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -328,12 +328,8 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
         'Accept': 'application/vnd.github.v3+json',
       }
 
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`
-      }
-
       // Fetch repository info
-      const repoResponse = await fetch(`https://api.github.com/repos/${targetRepo}`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
+      const repoResponse = await fetch(`/api/github/repos/${targetRepo}`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
       if (!repoResponse.ok) throw new Error(`Failed to fetch repo: ${repoResponse.statusText}`)
       const repoData = await repoResponse.json()
       setRepoInfo(repoData)
@@ -341,8 +337,8 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
       // Fetch open PRs and closed/merged PRs separately to ensure we get merged PRs
       // For active repos, all "recently updated" PRs might be open ones
       const [openPRsResponse, closedPRsResponse] = await Promise.all([
-        fetch(`https://api.github.com/repos/${targetRepo}/pulls?state=open&per_page=50&sort=updated`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }),
-        fetch(`https://api.github.com/repos/${targetRepo}/pulls?state=closed&per_page=50&sort=updated`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
+        fetch(`/api/github/repos/${targetRepo}/pulls?state=open&per_page=50&sort=updated`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }),
+        fetch(`/api/github/repos/${targetRepo}/pulls?state=closed&per_page=50&sort=updated`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
       ])
 
       if (!openPRsResponse.ok) throw new Error(`Failed to fetch open PRs: ${openPRsResponse.statusText}`)
@@ -361,8 +357,8 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
 
       // Fetch open Issues count and recent issues
       const [openIssuesResponse, recentIssuesResponse] = await Promise.all([
-        fetch(`https://api.github.com/repos/${targetRepo}/issues?state=open&per_page=1`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }),
-        fetch(`https://api.github.com/repos/${targetRepo}/issues?state=all&per_page=50&sort=updated`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
+        fetch(`/api/github/repos/${targetRepo}/issues?state=open&per_page=1`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }),
+        fetch(`/api/github/repos/${targetRepo}/issues?state=all&per_page=50&sort=updated`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
       ])
 
       // Get open issue count from Link header or response body
@@ -386,13 +382,13 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
       setIssues(filteredIssues)
 
       // Fetch Releases
-      const releasesResponse = await fetch(`https://api.github.com/repos/${targetRepo}/releases?per_page=10`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
+      const releasesResponse = await fetch(`/api/github/repos/${targetRepo}/releases?per_page=10`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
       if (!releasesResponse.ok) throw new Error(`Failed to fetch releases: ${releasesResponse.statusText}`)
       const releasesData = await releasesResponse.json()
       setReleases(releasesData)
 
       // Fetch Contributors
-      const contributorsResponse = await fetch(`https://api.github.com/repos/${targetRepo}/contributors?per_page=20`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
+      const contributorsResponse = await fetch(`/api/github/repos/${targetRepo}/contributors?per_page=20`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
       if (!contributorsResponse.ok) throw new Error(`Failed to fetch contributors: ${contributorsResponse.statusText}`)
       const contributorsData = await contributorsResponse.json()
       setContributors(contributorsData)

--- a/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
+++ b/web/src/components/cards/workload-monitor/GitHubCIMonitor.tsx
@@ -1,9 +1,9 @@
-import { useState, useMemo, useCallback, useEffect, useImperativeHandle, forwardRef } from 'react'
+import { useState, useMemo, useCallback, useImperativeHandle, forwardRef } from 'react'
 import {
   GitBranch, AlertTriangle, CheckCircle, XCircle,
   Clock, Loader2, ExternalLink, Key, Settings, Plus, X, Check,
 } from 'lucide-react'
-import { STORAGE_KEY_GITHUB_TOKEN, FETCH_EXTERNAL_TIMEOUT_MS } from '../../../lib/constants'
+import { FETCH_EXTERNAL_TIMEOUT_MS } from '../../../lib/constants'
 import { Button } from '../../ui/Button'
 import { Skeleton } from '../../ui/Skeleton'
 import { Pagination } from '../../ui/Pagination'
@@ -26,18 +26,8 @@ export interface GitHubCIMonitorRef {
   refresh: () => void
 }
 
-// Decode base64 encoded token from localStorage
-const decodeToken = (encoded: string): string => {
-  try {
-    return atob(encoded)
-  } catch {
-    return encoded // Return as-is if not encoded (backwards compatibility)
-  }
-}
-
 interface GitHubCIConfig {
   repos?: string[]
-  token?: string
 }
 
 interface WorkflowRun {
@@ -152,21 +142,15 @@ export const GitHubCIMonitor = forwardRef<GitHubCIMonitorRef, GitHubCIMonitorPro
     demoData: { workflows: DEMO_WORKFLOWS, isDemo: true },
     persist: true,
     fetcher: async () => {
-      const storedToken = localStorage.getItem(STORAGE_KEY_GITHUB_TOKEN)
-      const token = ghConfig?.token || (storedToken ? decodeToken(storedToken) : null)
-      if (!token) {
-        return { workflows: DEMO_WORKFLOWS, isDemo: true }
-      }
-
       const allRuns: WorkflowRun[] = []
       for (const repo of repos) {
         try {
-          const response = await fetch(`https://api.github.com/repos/${repo}/actions/runs?per_page=10`, {
-            headers: { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github.v3+json' },
+          const response = await fetch(`/api/github/repos/${repo}/actions/runs?per_page=10`, {
+            headers: { Accept: 'application/vnd.github.v3+json' },
             signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS),
           })
           if (response.status === 401 || response.status === 403) {
-            // Token lacks actions scope or is invalid — fall back to demo data
+            // Token invalid or missing — fall back to demo data
             return { workflows: DEMO_WORKFLOWS, isDemo: true }
           }
           if (!response.ok) continue // Skip this repo on other errors
@@ -232,17 +216,6 @@ export const GitHubCIMonitor = forwardRef<GitHubCIMonitorRef, GitHubCIMonitorPro
     setRepos(updatedRepos)
     saveRepos(updatedRepos)
   }, [repos])
-
-  // Listen for token changes in localStorage (e.g., when user adds token in Settings)
-  useEffect(() => {
-    const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === 'github_token') {
-        refetch()
-      }
-    }
-    window.addEventListener('storage', handleStorageChange)
-    return () => window.removeEventListener('storage', handleStorageChange)
-  }, [refetch])
 
   // Stats
   const stats = useMemo(() => {

--- a/web/src/components/settings/sections/GitHubTokenSection.tsx
+++ b/web/src/components/settings/sections/GitHubTokenSection.tsx
@@ -1,16 +1,16 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Save, RefreshCw, Check, X, Github, ExternalLink, Loader2, Server } from 'lucide-react'
-import { STORAGE_KEY_GITHUB_TOKEN, STORAGE_KEY_GITHUB_TOKEN_SOURCE, STORAGE_KEY_GITHUB_TOKEN_DISMISSED, STORAGE_KEY_FEEDBACK_GITHUB_TOKEN, STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE, STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED, FETCH_EXTERNAL_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../../lib/constants'
+import { STORAGE_KEY_TOKEN, STORAGE_KEY_GITHUB_TOKEN_SOURCE, STORAGE_KEY_GITHUB_TOKEN_DISMISSED, STORAGE_KEY_FEEDBACK_GITHUB_TOKEN, STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE, STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED, FETCH_EXTERNAL_TIMEOUT_MS } from '../../../lib/constants'
 import { emitGitHubTokenConfigured, emitGitHubTokenRemoved, emitConversionStep } from '../../../lib/analytics'
 import { UI_FEEDBACK_TIMEOUT_MS, SCROLL_COMPLETE_MS } from '../../../lib/constants/network'
-import type { AllSettings } from '../../../lib/settingsTypes'
 
 interface GitHubTokenSectionProps {
   forceVersionCheck: () => void
 }
 
 // Helper functions for base64 encoding (obfuscation, not encryption)
+// Used only for the feedback token which remains in localStorage
 const encodeToken = (token: string) => btoa(token)
 const decodeToken = (encoded: string) => {
   try {
@@ -24,8 +24,14 @@ const decodeToken = (encoded: string) => {
 const TOKEN_SOURCE_SETTINGS = 'settings'
 const TOKEN_SOURCE_ENV = 'env'
 
-/** Timeout for fetching settings from the local kc-agent */
+/** Timeout for fetching settings from the backend */
 const AGENT_FETCH_TIMEOUT_MS = 5000
+
+/** Build JWT auth headers for backend proxy requests */
+function authHeaders(): Record<string, string> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
 
 export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProps) {
   const { t } = useTranslation()
@@ -45,75 +51,46 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
   const [feedbackGithubRateLimit, setFeedbackGithubRateLimit] = useState<{ limit: number; remaining: number; reset: Date } | null>(null)
   const [isInitializing, setIsInitializing] = useState(true)
 
-  // Load GitHub token status on mount — check localStorage first, then backend
+  // Load GitHub token status on mount — check backend proxy for main token, localStorage for feedback token
   useEffect(() => {
     const loadToken = async () => {
-      const encodedToken = localStorage.getItem(STORAGE_KEY_GITHUB_TOKEN)
-      const storedSource = localStorage.getItem(STORAGE_KEY_GITHUB_TOKEN_SOURCE)
+      // Load feedback token from localStorage
       const encodedFeedbackToken = localStorage.getItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN)
       const storedFeedbackSource = localStorage.getItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE)
-
-      if (encodedToken) {
-        setHasGithubToken(true)
-        setTokenSource(storedSource)
-        const token = decodeToken(encodedToken)
-        await testGithubToken(token)
-      }
       const feedbackDismissed = localStorage.getItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED) === 'true'
+
       if (encodedFeedbackToken && !feedbackDismissed) {
         setHasFeedbackGithubToken(true)
         setFeedbackTokenSource(storedFeedbackSource)
         const token = decodeToken(encodedFeedbackToken)
         await testFeedbackGithubToken(token)
       }
-      // If both tokens exist locally, no need to check backend
-      const mainDismissed = localStorage.getItem(STORAGE_KEY_GITHUB_TOKEN_DISMISSED) === 'true'
-      if (encodedToken && (encodedFeedbackToken || feedbackDismissed)) {
+
+      // Check backend proxy for main token status
+      // Skip if user explicitly dismissed the env token
+      if (localStorage.getItem(STORAGE_KEY_GITHUB_TOKEN_DISMISSED) === 'true') {
         setIsInitializing(false)
         return
       }
 
-      // Check backend for any tokens not already in localStorage
-      // Skip entirely if both tokens are dismissed or already present
-      if (mainDismissed && (encodedFeedbackToken || feedbackDismissed)) {
-        setIsInitializing(false)
-        return
-      }
       try {
-        const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/settings`, {
-          headers: { 'Content-Type': 'application/json' },
+        const response = await fetch('/api/github/token/status', {
+          headers: authHeaders(),
           signal: AbortSignal.timeout(AGENT_FETCH_TIMEOUT_MS),
         })
         if (response.ok) {
-          const data: AllSettings = await response.json()
-          // Only restore main token if not dismissed (or if it's settings-sourced, not env)
-          if (!encodedToken && data?.githubToken) {
-            const source = data.githubTokenSource || TOKEN_SOURCE_SETTINGS
-            const isEnvSourced = source === TOKEN_SOURCE_ENV
-            if (!mainDismissed || !isEnvSourced) {
-              localStorage.setItem(STORAGE_KEY_GITHUB_TOKEN, encodeToken(data.githubToken))
-              localStorage.setItem(STORAGE_KEY_GITHUB_TOKEN_SOURCE, source)
-              setHasGithubToken(true)
-              setTokenSource(source)
-              await testGithubToken(data.githubToken)
-            }
+          const data = await response.json() as { hasToken: boolean; source: string }
+          if (data.hasToken) {
+            const source = data.source || TOKEN_SOURCE_SETTINGS
+            localStorage.setItem(STORAGE_KEY_GITHUB_TOKEN_SOURCE, source)
+            window.dispatchEvent(new CustomEvent('kubestellar-settings-changed'))
+            setHasGithubToken(true)
+            setTokenSource(source)
+            await validateViaProxy()
           }
-          // Only restore feedback token if not dismissed (or if it's settings-sourced, not env)
-          if (!encodedFeedbackToken && data?.feedbackGithubToken) {
-            const source = data.feedbackGithubTokenSource || TOKEN_SOURCE_SETTINGS
-            const isEnvSourced = source === TOKEN_SOURCE_ENV
-            if (!feedbackDismissed || !isEnvSourced) {
-              localStorage.setItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN, encodeToken(data.feedbackGithubToken))
-              localStorage.setItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE, source)
-              setHasFeedbackGithubToken(true)
-              setFeedbackTokenSource(source)
-              await testFeedbackGithubToken(data.feedbackGithubToken)
-            }
-          }
-          window.dispatchEvent(new CustomEvent('kubestellar-settings-changed'))
         }
       } catch {
-        // Agent unavailable — no token available
+        // Backend unavailable — no token available
       }
 
       setIsInitializing(false)
@@ -164,6 +141,7 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
     }
   }, [isInitializing])
 
+  /** Validate a token directly against GitHub API (used for feedback token only) */
   const validateToken = async (token: string) => {
     const response = await fetch('https://api.github.com/rate_limit', {
       headers: {
@@ -188,12 +166,32 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
     }
   }
 
-  const testGithubToken = async (token: string) => {
+  /** Validate the main token already stored on the backend via the proxy */
+  const validateViaProxy = async () => {
     setGithubTokenTesting(true)
     setGithubTokenError(null)
     try {
-      const rate = await validateToken(token)
-      setGithubRateLimit(rate)
+      const response = await fetch('/api/github/rate_limit', {
+        headers: {
+          ...authHeaders(),
+          'Accept': 'application/vnd.github.v3+json',
+        },
+        signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS),
+      })
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          throw new Error('Invalid token - authentication failed')
+        }
+        throw new Error(`GitHub API error: ${response.status}`)
+      }
+
+      const data = await response.json()
+      setGithubRateLimit({
+        limit: data.rate.limit,
+        remaining: data.rate.remaining,
+        reset: new Date(data.rate.reset * 1000),
+      })
       return true
     } catch (err) {
       setGithubTokenError(err instanceof Error ? err.message : 'Failed to validate token')
@@ -224,33 +222,64 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
     if (!githubToken.trim()) return
 
     setGithubTokenTesting(true)
-    const isValid = await testGithubToken(githubToken.trim())
+    setGithubTokenError(null)
 
-    if (isValid) {
-      // Store base64 encoded (obfuscation)
-      localStorage.setItem(STORAGE_KEY_GITHUB_TOKEN, encodeToken(githubToken.trim()))
-      // User-entered tokens always have "settings" source
-      localStorage.setItem(STORAGE_KEY_GITHUB_TOKEN_SOURCE, TOKEN_SOURCE_SETTINGS)
-      // Clear any previous env-token dismissal
-      localStorage.removeItem(STORAGE_KEY_GITHUB_TOKEN_DISMISSED)
-      window.dispatchEvent(new CustomEvent('kubestellar-settings-changed'))
-      setHasGithubToken(true)
-      setTokenSource(TOKEN_SOURCE_SETTINGS)
-      setGithubToken('')
-      setGithubTokenSaved(true)
-      setTimeout(() => setGithubTokenSaved(false), UI_FEEDBACK_TIMEOUT_MS)
+    try {
+      // Save token to backend (encrypted storage)
+      const saveResponse = await fetch('/api/github/token', {
+        method: 'POST',
+        headers: {
+          ...authHeaders(),
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ token: githubToken.trim() }),
+        signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS),
+      })
 
-      emitGitHubTokenConfigured()
-      emitConversionStep(6, 'github_token')
+      if (!saveResponse.ok) {
+        throw new Error(`Failed to save token: ${saveResponse.status}`)
+      }
 
-      // Trigger system updates check with the new token
-      forceVersionCheck()
+      // Validate via proxy (backend injects the saved token)
+      const isValid = await validateViaProxy()
+
+      if (isValid) {
+        // Store flags only (NOT the token itself)
+        localStorage.setItem(STORAGE_KEY_GITHUB_TOKEN_SOURCE, TOKEN_SOURCE_SETTINGS)
+        // Clear any previous env-token dismissal
+        localStorage.removeItem(STORAGE_KEY_GITHUB_TOKEN_DISMISSED)
+        window.dispatchEvent(new CustomEvent('kubestellar-settings-changed'))
+        setHasGithubToken(true)
+        setTokenSource(TOKEN_SOURCE_SETTINGS)
+        setGithubToken('') // Clear from input field
+        setGithubTokenSaved(true)
+        setTimeout(() => setGithubTokenSaved(false), UI_FEEDBACK_TIMEOUT_MS)
+
+        emitGitHubTokenConfigured()
+        emitConversionStep(6, 'github_token')
+
+        // Trigger system updates check with the new token
+        forceVersionCheck()
+      }
+    } catch (err) {
+      setGithubTokenError(err instanceof Error ? err.message : 'Failed to save token')
+    } finally {
+      setGithubTokenTesting(false)
     }
-    setGithubTokenTesting(false)
   }
 
-  const handleClearGithubToken = () => {
-    localStorage.removeItem(STORAGE_KEY_GITHUB_TOKEN)
+  const handleClearGithubToken = async () => {
+    try {
+      // Remove token from backend
+      await fetch('/api/github/token', {
+        method: 'DELETE',
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS),
+      })
+    } catch {
+      // Best-effort — clear local state regardless
+    }
+
     localStorage.removeItem(STORAGE_KEY_GITHUB_TOKEN_SOURCE)
     if (isEnvToken) {
       localStorage.setItem(STORAGE_KEY_GITHUB_TOKEN_DISMISSED, 'true')

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -10,7 +10,6 @@ import type {
   UpdateProgress,
 } from '../types/updates'
 import { UPDATE_STORAGE_KEYS } from '../types/updates'
-import { STORAGE_KEY_GITHUB_TOKEN } from '../lib/constants'
 import { LOCAL_AGENT_HTTP_URL, FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
 import { useLocalAgent } from './useLocalAgent'
 
@@ -18,9 +17,9 @@ declare const __APP_VERSION__: string
 declare const __COMMIT_HASH__: string
 
 const GITHUB_API_URL =
-  'https://api.github.com/repos/kubestellar/console/releases'
+  '/api/github/repos/kubestellar/console/releases'
 const GITHUB_MAIN_SHA_URL =
-  'https://api.github.com/repos/kubestellar/console/git/ref/heads/main'
+  '/api/github/repos/kubestellar/console/git/ref/heads/main'
 const CACHE_TTL_MS = 30 * 60 * 1000 // 30 minutes cache
 const MIN_CHECK_INTERVAL_MS = 30 * 60 * 1000 // 30 minutes minimum between checks
 const AUTO_UPDATE_POLL_MS = 60 * 1000 // Poll kc-agent for update status every 60s
@@ -367,14 +366,6 @@ function useVersionCheckCore() {
       const headers: HeadersInit = {
         Accept: 'application/vnd.github.v3+json',
       }
-      const storedToken = localStorage.getItem(STORAGE_KEY_GITHUB_TOKEN)
-      if (storedToken) {
-        try {
-          headers['Authorization'] = `Bearer ${atob(storedToken)}`
-        } catch {
-          headers['Authorization'] = `Bearer ${storedToken}`
-        }
-      }
       console.debug('[version-check] Fetching latest main SHA from GitHub...')
       const resp = await fetch(GITHUB_MAIN_SHA_URL, {
         headers,
@@ -435,14 +426,9 @@ function useVersionCheckCore() {
     }
     try {
       const headers: HeadersInit = { Accept: 'application/vnd.github.v3+json' }
-      const storedToken = localStorage.getItem(STORAGE_KEY_GITHUB_TOKEN)
-      if (storedToken) {
-        try { headers['Authorization'] = `Bearer ${atob(storedToken)}` }
-        catch { headers['Authorization'] = `Bearer ${storedToken}` }
-      }
       console.debug('[version-check] Fetching commits:', currentSHA.slice(0, 7), '→', latestSHA.slice(0, 7))
       const resp = await fetch(
-        `https://api.github.com/repos/kubestellar/console/compare/${currentSHA}...${latestSHA}`,
+        `/api/github/repos/kubestellar/console/compare/${currentSHA}...${latestSHA}`,
         { headers, signal: AbortSignal.timeout(10000) }
       )
       if (resp.ok) {
@@ -558,18 +544,6 @@ function useVersionCheckCore() {
       }
       if (cache?.etag) {
         headers['If-None-Match'] = cache.etag
-      }
-
-      // Use GitHub token if available (base64 encoded in localStorage)
-      const storedToken = localStorage.getItem(STORAGE_KEY_GITHUB_TOKEN)
-      if (storedToken) {
-        try {
-          const token = atob(storedToken)
-          headers['Authorization'] = `Bearer ${token}`
-        } catch {
-          // Token not base64 encoded (old format), use as-is
-          headers['Authorization'] = `Bearer ${storedToken}`
-        }
       }
 
       const response = await fetch(GITHUB_API_URL, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })


### PR DESCRIPTION
## Summary
- **New backend proxy** (`/api/github/*`): Forwards read-only GitHub API requests through the backend, injecting the PAT from server-side encrypted storage (AES-256-GCM). Path validation restricts to `/repos/` and `/rate_limit` prefixes only.
- **Token management API**: `POST /api/github/token` (save), `DELETE /api/github/token` (clear), `GET /api/github/token/status` (check availability)
- **4 frontend files updated** to route through proxy instead of calling api.github.com directly:
  - `GitHubActivity.tsx` — 7 fetch calls migrated
  - `GitHubCIMonitor.tsx` — 1 fetch call migrated, removed localStorage token gate
  - `useVersionCheck.tsx` — 3 fetch calls migrated (SHA, compare, releases)
  - `GitHubTokenSection.tsx` — saves token to backend, validates via proxy

**Security: H3** — Previously the GitHub PAT was stored base64-encoded in localStorage, making it accessible to any XSS. The PAT now lives only in AES-256-GCM encrypted settings on the backend server.

## Test plan
- [ ] Enter a GitHub PAT in Settings → verify it saves to backend (check `/api/github/token/status`)
- [ ] Verify GitHubActivity card loads PRs, issues, releases via proxy
- [ ] Verify GitHub CI Monitor card loads workflow runs via proxy
- [ ] Verify version check fetches releases and SHA comparison via proxy
- [ ] Clear the token → verify it's removed from backend
- [ ] Verify no GitHub PAT appears in localStorage after save
- [ ] Verify rate limit headers are forwarded to frontend