### PR TITLE
🐛 Remove go-licenses from nightly workflow (unblocks all tests)

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -60,14 +60,13 @@ jobs:
           SEMGREP_VERSION: '1.102.0'
           GOSEC_VERSION: 'v2.21.4'
           GOVULNCHECK_VERSION: 'v1.1.4'
-          GO_LICENSES_VERSION: 'v1.6.0'
         run: |
           # Go security tools (pinned to avoid breakage from upstream changes)
           go install "github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}"
           go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
-          # go-licenses install is best-effort — the license-compliance-test script
-          # has a fallback path using 'go list -m -json' when the binary is absent.
-          go install "github.com/google/go-licenses@${GO_LICENSES_VERSION}" || echo "Warning: go-licenses install failed — license test will use fallback"
+          # NOTE: go-licenses is intentionally omitted — its gopkg.in/src-d/go-git.v4
+          # dependency tree fails to compile (exit code 8) and kills the entire step.
+          # The license-compliance-test script has a fallback using 'go list -m -json'.
 
           # Secret scanning (pinned version)
           wget -q "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -O /tmp/gitleaks.tar.gz


### PR DESCRIPTION
## Summary

The nightly test suite has been **completely blocked** for 3+ runs because `go install github.com/google/go-licenses` fails with exit code 8 (signal-level kill during compilation of its `gopkg.in/src-d/go-git.v4` dependency tree). This exit code bypasses bash `|| echo` error handling, crashing the entire "Install test tools" step before any of the 32 test suites can run.

**Fix**: Remove `go-licenses` from the install step entirely. The `license-compliance-test.sh` script already has a built-in fallback that uses `go list -m -json all` when the `go-licenses` binary is absent (lines 144-166 of the script).

**Previous attempts**:
- PR #2457: Pinned to v1.6.0 — same exit code 8
- Added `|| echo "Warning..."` — exit code 8 bypasses bash error handling

## Test plan

- [ ] Nightly workflow passes "Install test tools" step
- [ ] All 32 test suites execute
- [ ] `license-compliance-test` passes using fallback path