### PR TITLE
🐛 Split Go tools into continue-on-error step in nightly workflow

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -52,22 +52,26 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
 
+      - name: Install Go security tools
+        # Go tool compilation can fail with exit code 8 (OOM/signal during build).
+        # Individual test scripts handle missing binaries gracefully, so install
+        # failures should not block the remaining 32 test suites.
+        continue-on-error: true
+        env:
+          GOSEC_VERSION: 'v2.21.4'
+          GOVULNCHECK_VERSION: 'v1.1.4'
+          GO_LICENSES_VERSION: 'v1.6.0'
+        run: |
+          go install "github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}"
+          go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
+          go install "github.com/google/go-licenses@${GO_LICENSES_VERSION}"
+
       - name: Install test tools
         env:
-          # Pin tool versions for reproducibility and supply-chain safety
           GITLEAKS_VERSION: '8.21.2'
           TRIVY_VERSION: '0.58.1'
           SEMGREP_VERSION: '1.102.0'
-          GOSEC_VERSION: 'v2.21.4'
-          GOVULNCHECK_VERSION: 'v1.1.4'
         run: |
-          # Go security tools (pinned to avoid breakage from upstream changes)
-          go install "github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}"
-          go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
-          # NOTE: go-licenses is intentionally omitted — its gopkg.in/src-d/go-git.v4
-          # dependency tree fails to compile (exit code 8) and kills the entire step.
-          # The license-compliance-test script has a fallback using 'go list -m -json'.
-
           # Secret scanning (pinned version)
           wget -q "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -O /tmp/gitleaks.tar.gz
           tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks


### PR DESCRIPTION
## Summary

Go tool compilation (`gosec`, `govulncheck`, `go-licenses`) intermittently fails with **exit code 8** (signal-level kill during compilation that bypasses bash `|| echo` error handling). This has **blocked ALL 32 test suites from running** across 4+ consecutive nightly runs.

**Root cause**: The exit code 8 comes from Go compilation failures — sometimes `go-licenses` (its old `gopkg.in/src-d/go-git.v4` dependency tree), sometimes `govulncheck`. The failures are non-deterministic and appear to be resource-related on CI runners.

**Fix**: Split Go security tools into their own step with `continue-on-error: true`. The remaining tools (gitleaks, trivy, semgrep, ripgrep) move to a separate step so they're never blocked by Go compilation issues. Individual test scripts (gosec-test, license-compliance-test) already handle missing binaries gracefully with fallback paths.

## Test plan

- [ ] Nightly workflow proceeds past Go tool installation regardless of compilation result
- [ ] All 32 test suites execute
- [ ] gosec-test and license-compliance-test handle missing tools via fallback