### PR TITLE
🐛 Add HttpOnly cookie for JWT auth (backend plumbing)

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -157,6 +157,8 @@ const (
 	oauthStateCookieName = "oauth_state"
 	// OAuth state cookie max age (10 minutes)
 	oauthStateCookieMaxAge = 600
+	// jwtCookieName is the HttpOnly cookie that carries the JWT.
+	jwtCookieName = "kc_auth"
 )
 
 // GitHubLogin initiates GitHub OAuth flow
@@ -255,6 +257,9 @@ func (h *AuthHandler) devModeLogin(c *fiber.Ctx) error {
 		return c.Redirect(h.frontendURL+"/login?error=jwt_failed", fiber.StatusTemporaryRedirect)
 	}
 
+	// Set HttpOnly cookie (primary auth) and pass token in URL (migration fallback)
+	h.setJWTCookie(c, jwtToken)
+
 	// Redirect to frontend with token
 	redirectURL := fmt.Sprintf("%s/auth/callback?token=%s&onboarded=%t", h.frontendURL, jwtToken, user.Onboarded)
 	return c.Redirect(redirectURL, fiber.StatusTemporaryRedirect)
@@ -325,6 +330,9 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 		return c.Redirect(h.frontendURL+"/login?error=jwt_failed", fiber.StatusTemporaryRedirect)
 	}
 
+	// Set HttpOnly cookie (primary auth) and pass token in URL (migration fallback)
+	h.setJWTCookie(c, jwtToken)
+
 	// Redirect to frontend with token
 	redirectURL := fmt.Sprintf("%s/auth/callback?token=%s&onboarded=%t", h.frontendURL, jwtToken, user.Onboarded)
 	return c.Redirect(redirectURL, fiber.StatusTemporaryRedirect)
@@ -334,12 +342,18 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 // The token's jti is added to an in-memory revocation list that is
 // checked by the JWTAuth middleware on every request.
 func (h *AuthHandler) Logout(c *fiber.Ctx) error {
+	// Accept token from Authorization header or HttpOnly cookie
+	var tokenString string
 	authHeader := c.Get("Authorization")
-	if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+	if authHeader != "" && strings.HasPrefix(authHeader, "Bearer ") {
+		tokenString = authHeader[len("Bearer "):]
+	}
+	if tokenString == "" {
+		tokenString = c.Cookies(jwtCookieName)
+	}
+	if tokenString == "" {
 		return fiber.NewError(fiber.StatusUnauthorized, "Missing authorization")
 	}
-
-	tokenString := authHeader[len("Bearer "):]
 	token, err := jwt.ParseWithClaims(tokenString, &middleware.UserClaims{}, func(token *jwt.Token) (interface{}, error) {
 		return []byte(h.jwtSecret), nil
 	})
@@ -358,6 +372,9 @@ func (h *AuthHandler) Logout(c *fiber.Ctx) error {
 		expiresAt = claims.ExpiresAt.Time
 	}
 	middleware.RevokeToken(claims.ID, expiresAt)
+
+	// Clear the HttpOnly cookie so the browser stops sending it
+	h.clearJWTCookie(c)
 
 	log.Printf("[Auth] Token revoked for user %s (jti: %s)", claims.GitHubLogin, claims.ID)
 	return c.JSON(fiber.Map{"success": true, "message": "Token revoked"})
@@ -410,6 +427,9 @@ func (h *AuthHandler) RefreshToken(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusInternalServerError, "Failed to generate token")
 	}
 
+	// Update HttpOnly cookie with the fresh token
+	h.setJWTCookie(c, newToken)
+
 	return c.JSON(fiber.Map{
 		"token":     newToken,
 		"onboarded": user.Onboarded,
@@ -450,6 +470,37 @@ func (h *AuthHandler) getGitHubUser(accessToken string) (*GitHubUser, error) {
 	}
 
 	return &user, nil
+}
+
+// setJWTCookie sets an HttpOnly cookie carrying the JWT token.
+// The cookie is Secure when the frontend URL uses HTTPS, SameSite=Lax
+// to allow top-level navigations (OAuth redirects) while blocking
+// cross-site POST requests.
+func (h *AuthHandler) setJWTCookie(c *fiber.Ctx, token string) {
+	secure := strings.HasPrefix(h.frontendURL, "https://")
+	c.Cookie(&fiber.Cookie{
+		Name:     jwtCookieName,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   int(jwtExpiration.Seconds()),
+		HTTPOnly: true,
+		Secure:   secure,
+		SameSite: "Lax",
+	})
+}
+
+// clearJWTCookie removes the JWT HttpOnly cookie.
+func (h *AuthHandler) clearJWTCookie(c *fiber.Ctx) {
+	secure := strings.HasPrefix(h.frontendURL, "https://")
+	c.Cookie(&fiber.Cookie{
+		Name:     jwtCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HTTPOnly: true,
+		Secure:   secure,
+		SameSite: "Lax",
+	})
 }
 
 func (h *AuthHandler) generateJWT(user *models.User) (string, error) {

--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -15,8 +15,8 @@ import (
 const (
 	// githubProxyTimeout is the timeout for proxied GitHub API requests.
 	githubProxyTimeout = 15 * time.Second
-	// githubAPIBase is the base URL for the GitHub API.
-	githubAPIBase = "https://api.github.com"
+	// githubProxyAPIBase is the base URL for proxied GitHub API requests.
+	githubProxyAPIBase = "https://api.github.com"
 	// maxGitHubProxyPathLen is the maximum allowed path length to prevent abuse.
 	maxGitHubProxyPathLen = 512
 )
@@ -107,7 +107,7 @@ func (h *GitHubProxyHandler) Proxy(c *fiber.Ctx) error {
 	}
 
 	// Build target URL with query params
-	targetURL := githubAPIBase + apiPath
+	targetURL := githubProxyAPIBase + apiPath
 	if qs := c.Context().QueryArgs().QueryString(); len(qs) > 0 {
 		targetURL += "?" + string(qs)
 	}

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -86,7 +86,12 @@ func IsTokenRevoked(jti string) bool {
 	return revokedTokens.IsRevoked(jti)
 }
 
-// JWTAuth creates JWT authentication middleware
+// jwtCookieName is the HttpOnly cookie that carries the JWT.
+// Must match the name used in handlers/auth.go.
+const jwtCookieName = "kc_auth"
+
+// JWTAuth creates JWT authentication middleware.
+// Token resolution order: Authorization header → HttpOnly cookie → _token query param (SSE only).
 func JWTAuth(secret string) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		authHeader := c.Get("Authorization")
@@ -100,7 +105,12 @@ func JWTAuth(secret string) fiber.Handler {
 			}
 		}
 
-		// Fallback: accept _token query param for SSE /stream endpoints
+		// Fallback 1: read from HttpOnly cookie (set during login/refresh)
+		if tokenString == "" {
+			tokenString = c.Cookies(jwtCookieName)
+		}
+
+		// Fallback 2: accept _token query param for SSE /stream endpoints
 		// (EventSource API does not support custom headers)
 		if tokenString == "" && c.Query("_token") != "" && strings.HasSuffix(c.Path(), "/stream") {
 			tokenString = c.Query("_token")


### PR DESCRIPTION
## Summary
- Set `kc_auth` HttpOnly cookie (SameSite=Lax, Secure when HTTPS) on login, OAuth callback, and token refresh
- Clear cookie on logout alongside existing token revocation
- Auth middleware now accepts JWT from: `Authorization` header → `kc_auth` cookie → `_token` query param (SSE only)
- Logout handler accepts token from either header or cookie
- Fix `githubAPIBase` constant name collision with `nightly_e2e.go` (renamed to `githubProxyAPIBase`)

## Security Context
Finding **H2** from penetration test: JWT stored in `localStorage` is accessible to XSS. This PR adds the backend plumbing to support HttpOnly cookies as the primary auth mechanism. The frontend continues to work with `Authorization` headers during the migration period — both paths are supported simultaneously.

Full frontend migration (removing localStorage token reads from ~39 files) is tracked separately.

## Test plan
- [ ] Login sets both `kc_auth` cookie and URL token param
- [ ] Authenticated API requests work with either Authorization header or cookie
- [ ] Logout clears the cookie and revokes the token
- [ ] Token refresh updates the cookie
- [ ] Go backend compiles cleanly