### PR TITLE
🐛 Fix parseTimestamp returning NaN for malformed dates

### DIFF
--- a/web/src/hooks/useMultiClusterInsights.test.ts
+++ b/web/src/hooks/useMultiClusterInsights.test.ts
@@ -120,10 +120,9 @@ describe('parseTimestamp', () => {
     expect(parseTimestamp(ts)).toBe(new Date(ts).getTime())
   })
 
-  it('returns NaN for malformed date string (known bug — NaN guard not yet added)', () => {
-    // TODO: parseTimestamp should return 0 for invalid dates — add isNaN guard after Date.parse
-    expect(parseTimestamp('not-a-date')).toBeNaN()
-    expect(parseTimestamp('abc123')).toBeNaN()
+  it('returns 0 for malformed date strings', () => {
+    expect(parseTimestamp('not-a-date')).toBe(0)
+    expect(parseTimestamp('abc123')).toBe(0)
   })
 })
 
@@ -213,14 +212,13 @@ describe('detectEventCorrelations', () => {
     expect(detectEventCorrelations(events)).toEqual([])
   })
 
-  it('throws on malformed timestamps (known bug — NaN guard not yet added)', () => {
+  it('skips events with malformed timestamps instead of crashing', () => {
     const events = [
       makeEvent({ cluster: 'cluster-1', lastSeen: 'not-a-date' }),
       makeEvent({ cluster: 'cluster-2', lastSeen: 'also-bad' }),
     ]
-    // TODO: parseTimestamp returns NaN for malformed strings — add isNaN guard so these are skipped
-    // Without NaN guard, `new Date(NaN).toISOString()` throws RangeError when building the insight.
-    expect(() => detectEventCorrelations(events)).toThrow(RangeError)
+    // parseTimestamp returns 0 for invalid dates, and the ts === 0 guard skips them
+    expect(detectEventCorrelations(events)).toEqual([])
   })
 
   it('truncates results to MAX_INSIGHTS_PER_CATEGORY', () => {

--- a/web/src/hooks/useMultiClusterInsights.ts
+++ b/web/src/hooks/useMultiClusterInsights.ts
@@ -86,7 +86,8 @@ function now(): string {
 /** @internal Exported for testing */
 export function parseTimestamp(ts?: string): number {
   if (!ts) return 0
-  return new Date(ts).getTime()
+  const time = new Date(ts).getTime()
+  return isNaN(time) ? 0 : time
 }
 
 /** @internal Exported for testing */


### PR DESCRIPTION
Fixes #2398 — `parseTimestamp()` now returns `0` for unparseable date strings instead of `NaN`, which previously caused `detectEventCorrelations()` and `detectCascadeImpact()` to crash with `RangeError: Invalid time value` when calling `new Date(NaN).toISOString()`.

## Changes
- Added `isNaN` guard in `parseTimestamp()` so malformed dates return `0` (treated as "no timestamp")
- Updated tests from expecting NaN/RangeError to asserting the corrected behavior (return `0`, skip gracefully)

## Test plan
- [x] All 62 existing tests pass
- [x] Malformed date strings return `0` instead of `NaN`
- [x] `detectEventCorrelations` skips malformed timestamps instead of throwing `RangeError`