### PR TITLE
🐛 Fix demo badge showing on cards with live data

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -507,7 +507,7 @@ export function CardWrapper({
   // Merge isDemoData from child-reported state with prop.
   // When forceLive is true, ignore child-reported isDemoData — the child checks global
   // demo mode independently but we know the data is real (in-cluster with OAuth).
-  const effectiveIsDemoData = forceLive ? false : (isDemoData || childDataState?.isDemoData || false)
+  const effectiveIsDemoData = forceLive ? false : (childDataState?.isDemoData ?? isDemoData ?? false)
 
   // Child can explicitly opt-out of demo indicator by reporting isDemoData: false
   // This is used by stack-dependent cards that use stack data even in global demo mode


### PR DESCRIPTION
Fixes #2399

## Summary
- Child data state (`childDataState?.isDemoData`) now takes precedence over the parent `DEMO_DATA_CARDS` set
- Changed `isDemoData || childDataState?.isDemoData` to `childDataState?.isDemoData ?? isDemoData` using nullish coalescing
- When a card explicitly reports `isDemoData: false` via `useCardLoadingState`, it overrides the parent — so cards with live data no longer show the demo badge

## Test plan
- [ ] Verify cards listed in `DEMO_DATA_CARDS` that fetch live data no longer show the yellow demo badge
- [ ] Verify cards that are truly demo-only still show the demo badge
- [ ] Verify `forceLive` still overrides everything to non-demo