### PR TITLE
✨ Storage monitoring alerts with desktop notifications

### DIFF
--- a/pkg/api/handlers/demo_data.go
+++ b/pkg/api/handlers/demo_data.go
@@ -492,6 +492,37 @@ func getDemoWorkloads() []v1alpha1.Workload {
 	}
 }
 
+func getDemoStorageAnalysis() []k8s.StorageAnalysis {
+	const (
+		bytesPerGiB             = 1024 * 1024 * 1024
+		orphanedPVCCapacity1    = 300 * bytesPerGiB
+		orphanedPVCCapacity2    = 2000 * bytesPerGiB
+		orphanedPVCCapacity3    = 50 * bytesPerGiB
+		pendingPVCDuration      = 1800 // 30 minutes
+		totalClaimedDemo        = 4500 * bytesPerGiB
+		demoPVCTotal            = 25
+		demoPVCBound            = 22
+		demoPVCPending          = 3
+	)
+	return []k8s.StorageAnalysis{
+		{
+			Cluster:           "demo-cluster",
+			TotalPVCs:         demoPVCTotal,
+			BoundPVCs:         demoPVCBound,
+			PendingPVCs:       demoPVCPending,
+			TotalClaimedBytes: totalClaimedDemo,
+			OrphanedPVCs: []k8s.OrphanedPVC{
+				{Name: "model-cache-old", Namespace: "ml-training", Capacity: "300Gi", CapacityBytes: orphanedPVCCapacity1, StorageClass: "ceph-rbd", Age: "45d"},
+				{Name: "backup-data-2024", Namespace: "data-pipeline", Capacity: "2000Gi", CapacityBytes: orphanedPVCCapacity2, StorageClass: "ceph-rbd", Age: "120d"},
+				{Name: "test-scratch", Namespace: "ci-cd", Capacity: "50Gi", CapacityBytes: orphanedPVCCapacity3, StorageClass: "gp3", Age: "30d"},
+			},
+			PendingPVCDetails: []k8s.PendingPVC{
+				{Name: "new-model-store", Namespace: "ml-inference", StorageClass: "ceph-rbd", PendingSince: "2026-03-13T10:00:00Z", PendingSeconds: pendingPVCDuration},
+			},
+		},
+	}
+}
+
 // Helper function to return demo data response
 func demoResponse(c *fiber.Ctx, key string, data interface{}) error {
 	return c.JSON(fiber.Map{key: data, "source": "demo"})

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -1312,6 +1312,65 @@ func (h *MCPHandlers) GetPVs(c *fiber.Ctx) error {
 	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
 }
 
+// GetStorageAnalysis returns cross-referenced storage analysis from clusters
+func (h *MCPHandlers) GetStorageAnalysis(c *fiber.Ctx) error {
+	// Demo mode: return demo data immediately
+	if isDemoMode(c) {
+		return demoResponse(c, "analysis", getDemoStorageAnalysis())
+	}
+
+	cluster := c.Query("cluster")
+
+	if h.k8sClient != nil {
+		if cluster == "" {
+			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
+			if err != nil {
+				log.Printf("internal error: %v", err)
+				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			}
+
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			allAnalyses := make([]k8s.StorageAnalysis, 0)
+			clusterTimeout := mcpDefaultTimeout
+
+			for _, cl := range clusters {
+				wg.Add(1)
+				go func(clusterName string) {
+					defer wg.Done()
+					ctx, cancel := context.WithTimeout(c.Context(), clusterTimeout)
+					defer cancel()
+
+					analysis, err := h.k8sClient.GetStorageAnalysis(ctx, clusterName)
+					if err == nil && analysis != nil {
+						mu.Lock()
+						allAnalyses = append(allAnalyses, *analysis)
+						mu.Unlock()
+					}
+				}(cl.Name)
+			}
+
+			waitWithDeadline(&wg, maxResponseDeadline)
+			return c.JSON(fiber.Map{"analysis": allAnalyses, "source": "k8s"})
+		}
+
+		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+		defer cancel()
+
+		analysis, err := h.k8sClient.GetStorageAnalysis(ctx, cluster)
+		if err != nil {
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		}
+		if analysis == nil {
+			return c.JSON(fiber.Map{"analysis": []k8s.StorageAnalysis{}, "source": "k8s"})
+		}
+		return c.JSON(fiber.Map{"analysis": []k8s.StorageAnalysis{*analysis}, "source": "k8s"})
+	}
+
+	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+}
+
 // GetResourceQuotas returns resource quotas from clusters
 func (h *MCPHandlers) GetResourceQuotas(c *fiber.Ctx) error {
 	// Demo mode: return demo data immediately

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -612,6 +612,7 @@ func (s *Server) setupRoutes() {
 	api.Get("/mcp/serviceaccounts", mcpHandlers.GetServiceAccounts)
 	api.Get("/mcp/pvcs", mcpHandlers.GetPVCs)
 	api.Get("/mcp/pvs", mcpHandlers.GetPVs)
+	api.Get("/mcp/storage/analysis", mcpHandlers.GetStorageAnalysis)
 	api.Get("/mcp/resourcequotas", mcpHandlers.GetResourceQuotas)
 	api.Post("/mcp/resourcequotas", mcpHandlers.CreateOrUpdateResourceQuota)
 	api.Delete("/mcp/resourcequotas", mcpHandlers.DeleteResourceQuota)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -513,6 +513,36 @@ type PV struct {
 	Labels        map[string]string `json:"labels,omitempty"`
 }
 
+// StorageAnalysis represents a cross-referenced analysis of PVC usage for a cluster
+type StorageAnalysis struct {
+	Cluster           string        `json:"cluster"`
+	TotalPVCs         int           `json:"totalPVCs"`
+	BoundPVCs         int           `json:"boundPVCs"`
+	PendingPVCs       int           `json:"pendingPVCs"`
+	TotalClaimedBytes int64         `json:"totalClaimedBytes"`
+	OrphanedPVCs      []OrphanedPVC `json:"orphanedPVCs"`
+	PendingPVCDetails []PendingPVC  `json:"pendingPVCDetails"`
+}
+
+// OrphanedPVC represents a PVC not mounted by any running pod
+type OrphanedPVC struct {
+	Name          string `json:"name"`
+	Namespace     string `json:"namespace"`
+	Capacity      string `json:"capacity,omitempty"`
+	CapacityBytes int64  `json:"capacityBytes"`
+	StorageClass  string `json:"storageClass,omitempty"`
+	Age           string `json:"age,omitempty"`
+}
+
+// PendingPVC represents a PVC stuck in Pending state
+type PendingPVC struct {
+	Name           string `json:"name"`
+	Namespace      string `json:"namespace"`
+	StorageClass   string `json:"storageClass,omitempty"`
+	PendingSince   string `json:"pendingSince"`
+	PendingSeconds int64  `json:"pendingSeconds"`
+}
+
 // ReplicaSet represents a Kubernetes ReplicaSet
 type ReplicaSet struct {
 	Name          string            `json:"name"`
@@ -3792,6 +3822,110 @@ func (m *MultiClusterClient) GetPVs(ctx context.Context, contextName string) ([]
 	}
 
 	return result, nil
+}
+
+// pvcPendingThresholdSeconds is the minimum time a PVC must be Pending before it is flagged (5 minutes).
+const pvcPendingThresholdSeconds = 300
+
+// GetStorageAnalysis cross-references PVCs with running pods to detect orphaned and stuck PVCs.
+func (m *MultiClusterClient) GetStorageAnalysis(ctx context.Context, contextName string) (*StorageAnalysis, error) {
+	client, err := m.GetClient(contextName)
+	if err != nil {
+		return nil, err
+	}
+
+	// List all PVCs
+	pvcs, err := client.CoreV1().PersistentVolumeClaims("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list PVCs: %w", err)
+	}
+
+	// List running pods and collect mounted PVC references (namespace/name)
+	pods, err := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		FieldSelector: "status.phase=Running",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list pods: %w", err)
+	}
+
+	// Build set of mounted PVCs: "namespace/name"
+	mountedPVCs := make(map[string]bool)
+	for _, pod := range pods.Items {
+		for _, vol := range pod.Spec.Volumes {
+			if vol.PersistentVolumeClaim != nil {
+				key := pod.Namespace + "/" + vol.PersistentVolumeClaim.ClaimName
+				mountedPVCs[key] = true
+			}
+		}
+	}
+
+	now := time.Now()
+	analysis := &StorageAnalysis{
+		Cluster:           contextName,
+		OrphanedPVCs:      make([]OrphanedPVC, 0),
+		PendingPVCDetails: make([]PendingPVC, 0),
+	}
+
+	for _, pvc := range pvcs.Items {
+		analysis.TotalPVCs++
+
+		// Parse capacity
+		var capBytes int64
+		var capStr string
+		if pvc.Status.Capacity != nil {
+			if storage, ok := pvc.Status.Capacity[corev1.ResourceStorage]; ok {
+				capBytes = storage.Value()
+				capStr = storage.String()
+			}
+		}
+		// For Pending PVCs, use requested size since status.capacity is empty
+		if capBytes == 0 && pvc.Spec.Resources.Requests != nil {
+			if storage, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+				capBytes = storage.Value()
+				capStr = storage.String()
+			}
+		}
+		analysis.TotalClaimedBytes += capBytes
+
+		switch pvc.Status.Phase {
+		case corev1.ClaimBound:
+			analysis.BoundPVCs++
+			// Check if orphaned (Bound but not mounted by any running pod)
+			key := pvc.Namespace + "/" + pvc.Name
+			if !mountedPVCs[key] {
+				analysis.OrphanedPVCs = append(analysis.OrphanedPVCs, OrphanedPVC{
+					Name:          pvc.Name,
+					Namespace:     pvc.Namespace,
+					Capacity:      capStr,
+					CapacityBytes: capBytes,
+					StorageClass:  derefString(pvc.Spec.StorageClassName),
+					Age:           formatAge(pvc.CreationTimestamp.Time),
+				})
+			}
+		case corev1.ClaimPending:
+			analysis.PendingPVCs++
+			pendingSeconds := int64(now.Sub(pvc.CreationTimestamp.Time).Seconds())
+			if pendingSeconds >= pvcPendingThresholdSeconds {
+				analysis.PendingPVCDetails = append(analysis.PendingPVCDetails, PendingPVC{
+					Name:           pvc.Name,
+					Namespace:      pvc.Namespace,
+					StorageClass:   derefString(pvc.Spec.StorageClassName),
+					PendingSince:   pvc.CreationTimestamp.Time.Format(time.RFC3339),
+					PendingSeconds: pendingSeconds,
+				})
+			}
+		}
+	}
+
+	return analysis, nil
+}
+
+// derefString safely dereferences a *string, returning "" if nil.
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // GetReplicaSets returns all ReplicaSets in a namespace or all namespaces if namespace is empty

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -146,6 +146,7 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
     gpuNodes: [],
     podIssues: [],
     clusters: [],
+    storageAnalyses: [],
     isLoading: true,
     error: null,
   })
@@ -162,6 +163,8 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
   podIssuesRef.current = mcpData.podIssues
   const clustersRef = useRef(mcpData.clusters)
   clustersRef.current = mcpData.clusters
+  const storageAnalysesRef = useRef(mcpData.storageAnalyses)
+  storageAnalysesRef.current = mcpData.storageAnalyses
   const rulesRef = useRef(rules)
   rulesRef.current = rules
 
@@ -1028,6 +1031,111 @@ Please provide:
     [createAlert]
   )
 
+  /** Bytes per GiB for orphaned PVC capacity reporting */
+  const BYTES_PER_GIB = 1024 * 1024 * 1024
+
+  // Evaluate PVC Pending condition — reads from storageAnalysesRef
+  const evaluatePVCPending = useCallback(
+    (rule: AlertRule) => {
+      const analyses = storageAnalysesRef.current
+      for (const analysis of (analyses || [])) {
+        const pendingPVCs = (analysis.pendingPVCDetails || [])
+        if (pendingPVCs.length > 0) {
+          const pvcNames = (pendingPVCs || []).map(p => `${p.namespace}/${p.name}`).join(', ')
+          createAlert(
+            rule,
+            `${analysis.cluster}: ${pendingPVCs.length} PVC(s) stuck Pending: ${pvcNames}`,
+            {
+              clusterName: analysis.cluster,
+              pendingCount: pendingPVCs.length,
+              pvcs: pendingPVCs,
+            },
+            analysis.cluster,
+            undefined,
+            pvcNames,
+            'PVC'
+          )
+
+          if (rule.channels?.some(ch => ch.type === 'browser' && ch.enabled)) {
+            sendNotificationWithDeepLink(
+              `PVC Pending: ${analysis.cluster}`,
+              `${pendingPVCs.length} PVC(s) stuck in Pending state`,
+              { card: 'pvc_status' }
+            )
+          }
+        } else {
+          // Auto-resolve
+          setAlerts(prev => {
+            const firingAlert = prev.find(
+              a => a.ruleId === rule.id && a.status === 'firing' && a.cluster === analysis.cluster
+            )
+            if (firingAlert) {
+              return prev.map(a =>
+                a.id === firingAlert.id
+                  ? { ...a, status: 'resolved' as const, resolvedAt: new Date().toISOString() }
+                  : a
+              )
+            }
+            return prev
+          })
+        }
+      }
+    },
+    [createAlert]
+  )
+
+  // Evaluate Orphaned PVC condition — reads from storageAnalysesRef
+  const evaluatePVCOrphaned = useCallback(
+    (rule: AlertRule) => {
+      const analyses = storageAnalysesRef.current
+      for (const analysis of (analyses || [])) {
+        const orphaned = (analysis.orphanedPVCs || [])
+        const threshold = rule.condition.threshold || 1
+        if (orphaned.length >= threshold) {
+          const totalClaimedGiB = (orphaned || []).reduce((sum, p) => sum + (p.capacityBytes || 0), 0) / BYTES_PER_GIB
+          createAlert(
+            rule,
+            `${analysis.cluster}: ${orphaned.length} orphaned PVC(s) claiming ${totalClaimedGiB.toFixed(0)} GiB`,
+            {
+              clusterName: analysis.cluster,
+              orphanedCount: orphaned.length,
+              totalClaimedGiB: Math.round(totalClaimedGiB),
+              pvcs: orphaned.slice(0, 10), // Limit details to first 10
+            },
+            analysis.cluster,
+            undefined,
+            `${orphaned.length} orphaned PVCs`,
+            'PVC'
+          )
+
+          if (rule.channels?.some(ch => ch.type === 'browser' && ch.enabled)) {
+            sendNotificationWithDeepLink(
+              `Orphaned PVCs: ${analysis.cluster}`,
+              `${orphaned.length} PVC(s) not mounted by any pod (${totalClaimedGiB.toFixed(0)} GiB wasted)`,
+              { card: 'storage_overview' }
+            )
+          }
+        } else {
+          // Auto-resolve
+          setAlerts(prev => {
+            const firingAlert = prev.find(
+              a => a.ruleId === rule.id && a.status === 'firing' && a.cluster === analysis.cluster
+            )
+            if (firingAlert) {
+              return prev.map(a =>
+                a.id === firingAlert.id
+                  ? { ...a, status: 'resolved' as const, resolvedAt: new Date().toISOString() }
+                  : a
+              )
+            }
+            return prev
+          })
+        }
+      }
+    },
+    [createAlert]
+  )
+
   // Evaluate alert conditions — uses refs so callback identity is stable
   const isEvaluatingRef = useRef(false)
   const evaluateConditions = useCallback(() => {
@@ -1064,6 +1172,12 @@ Please provide:
           case 'nightly_e2e_failure':
             evaluateNightlyE2EFailure(rule)
             break
+          case 'pvc_pending':
+            evaluatePVCPending(rule)
+            break
+          case 'pvc_orphaned':
+            evaluatePVCOrphaned(rule)
+            break
           default:
             break
         }
@@ -1072,7 +1186,7 @@ Please provide:
       isEvaluatingRef.current = false
       setIsEvaluating(false)
     }
-  }, [evaluateGPUUsage, evaluateGPUHealthCronJob, evaluateNodeReady, evaluatePodCrash, evaluateDiskPressure, evaluateMemoryPressure, evaluateWeatherAlerts, evaluateNightlyE2EFailure])
+  }, [evaluateGPUUsage, evaluateGPUHealthCronJob, evaluateNodeReady, evaluatePodCrash, evaluateDiskPressure, evaluateMemoryPressure, evaluateWeatherAlerts, evaluateNightlyE2EFailure, evaluatePVCPending, evaluatePVCOrphaned])
 
   // Stable ref for evaluateConditions so the interval never resets
   const evaluateConditionsRef = useRef(evaluateConditions)

--- a/web/src/contexts/AlertsDataFetcher.tsx
+++ b/web/src/contexts/AlertsDataFetcher.tsx
@@ -7,11 +7,14 @@
 
 import { useEffect } from 'react'
 import { useGPUNodes, usePodIssues, useClusters } from '../hooks/useMCP'
+import { useCachedStorageAnalysis } from '../hooks/useCachedData'
+import type { StorageAnalysis } from '../hooks/mcp/types'
 
 export interface AlertsMCPData {
   gpuNodes: ReturnType<typeof useGPUNodes>['nodes']
   podIssues: ReturnType<typeof usePodIssues>['issues']
   clusters: ReturnType<typeof useClusters>['deduplicatedClusters']
+  storageAnalyses: StorageAnalysis[]
   isLoading: boolean
   error: string | null
 }
@@ -24,17 +27,19 @@ export default function AlertsDataFetcher({ onData }: Props) {
   const { nodes: gpuNodes, isLoading: isGPULoading, error: gpuError } = useGPUNodes()
   const { issues: podIssues, isLoading: isPodIssuesLoading, error: podIssuesError } = usePodIssues()
   const { deduplicatedClusters: clusters, isLoading: isClustersLoading, error: clustersError } = useClusters()
+  const { analyses: storageAnalyses, isLoading: isStorageLoading, error: storageError } = useCachedStorageAnalysis()
 
   useEffect(() => {
-    const errors = [gpuError, podIssuesError, clustersError].filter(Boolean)
+    const errors = [gpuError, podIssuesError, clustersError, storageError].filter(Boolean)
     onData({
       gpuNodes: gpuNodes || [],
       podIssues: podIssues || [],
       clusters: clusters || [],
-      isLoading: isGPULoading || isPodIssuesLoading || isClustersLoading,
+      storageAnalyses: storageAnalyses || [],
+      isLoading: isGPULoading || isPodIssuesLoading || isClustersLoading || isStorageLoading,
       error: errors.length > 0 ? (errors || []).join('; ') : null,
     })
-  }, [gpuNodes, podIssues, clusters, isGPULoading, isPodIssuesLoading, isClustersLoading, gpuError, podIssuesError, clustersError, onData])
+  }, [gpuNodes, podIssues, clusters, storageAnalyses, isGPULoading, isPodIssuesLoading, isClustersLoading, isStorageLoading, gpuError, podIssuesError, clustersError, storageError, onData])
 
   return null
 }

--- a/web/src/hooks/mcp/types.ts
+++ b/web/src/hooks/mcp/types.ts
@@ -609,3 +609,35 @@ export interface HelmHistoryEntry {
   app_version: string
   description: string
 }
+
+/** PVC that is Bound but not mounted by any running pod */
+export interface OrphanedPVC {
+  name: string
+  namespace: string
+  cluster?: string
+  capacity?: string
+  capacityBytes: number
+  storageClass?: string
+  age?: string
+}
+
+/** PVC stuck in Pending state beyond threshold */
+export interface PendingPVCDetail {
+  name: string
+  namespace: string
+  cluster?: string
+  storageClass?: string
+  pendingSince: string
+  pendingSeconds: number
+}
+
+/** Cross-referenced storage analysis for a cluster */
+export interface StorageAnalysis {
+  cluster: string
+  totalPVCs: number
+  boundPVCs: number
+  pendingPVCs: number
+  totalClaimedBytes: number
+  orphanedPVCs: OrphanedPVC[]
+  pendingPVCDetails: PendingPVCDetail[]
+}

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -57,6 +57,7 @@ import type {
   K8sRoleBinding,
   K8sServiceAccountInfo,
   GPUHealthCronJobStatus,
+  StorageAnalysis,
 } from './useMCP'
 import type { ProwJob, ProwStatus } from './useProw'
 import type { LLMdServer, LLMdStatus, LLMdModel } from './useLLMd'
@@ -3571,6 +3572,42 @@ export function useCachedK8sServiceAccounts(
 
   return {
     serviceAccounts: result.data,
+    data: result.data,
+    isLoading: result.isLoading,
+    isRefreshing: result.isRefreshing,
+    isDemoFallback: result.isDemoFallback,
+    error: result.error,
+    isFailed: result.isFailed,
+    consecutiveFailures: result.consecutiveFailures,
+    lastRefresh: result.lastRefresh,
+    refetch: result.refetch,
+  }
+}
+
+/** Polling interval for storage analysis (2 minutes) */
+const STORAGE_ANALYSIS_POLL_MS = 120_000
+
+/**
+ * Hook to fetch and cache cross-referenced storage analysis.
+ * Detects orphaned PVCs and stuck-pending PVCs server-side.
+ */
+export function useCachedStorageAnalysis(): CachedHookResult<StorageAnalysis[]> & { analyses: StorageAnalysis[] } {
+  const key = 'storageAnalysis:all'
+
+  const result = useCache({
+    key,
+    category: 'default' as RefreshCategory,
+    initialData: [] as StorageAnalysis[],
+    demoData: [] as StorageAnalysis[],
+    refreshInterval: STORAGE_ANALYSIS_POLL_MS,
+    fetcher: async () => {
+      const resp = await fetchAPI<{ analysis: StorageAnalysis[]; source: string }>('storage/analysis')
+      return resp.analysis || []
+    },
+  })
+
+  return {
+    analyses: result.data,
     data: result.data,
     isLoading: result.isLoading,
     isRefreshing: result.isRefreshing,

--- a/web/src/lib/unified/registerHooks.ts
+++ b/web/src/lib/unified/registerHooks.ts
@@ -19,6 +19,7 @@ import {
   useCachedEvents,
   useCachedDeployments,
   useCachedDeploymentIssues,
+  useCachedStorageAnalysis,
 } from '../../hooks/useCachedData'
 import {
   useClusters,
@@ -932,8 +933,49 @@ function useActiveAlerts() {
   return useDemoDataHook(DEMO_ACTIVE_ALERTS)
 }
 
+/** Bytes per GiB for storage capacity display */
+const STORAGE_OVERVIEW_BYTES_PER_GIB = 1024 * 1024 * 1024
+
 function useStorageOverview() {
-  return useDemoDataHook([DEMO_STORAGE_OVERVIEW])
+  const { isDemoMode: demoMode } = useDemoMode()
+  const { analyses, isLoading, isDemoFallback } = useCachedStorageAnalysis()
+
+  const aggregated = useMemo(() => {
+    if (demoMode || isDemoFallback || !(analyses || []).length) {
+      return DEMO_STORAGE_OVERVIEW
+    }
+    let totalPVCs = 0
+    let boundPVCs = 0
+    let pendingPVCs = 0
+    let totalClaimedBytes = 0
+    let orphanedCount = 0
+
+    for (const a of (analyses || [])) {
+      totalPVCs += a.totalPVCs || 0
+      boundPVCs += a.boundPVCs || 0
+      pendingPVCs += a.pendingPVCs || 0
+      totalClaimedBytes += a.totalClaimedBytes || 0
+      orphanedCount += (a.orphanedPVCs || []).length
+    }
+
+    const totalClaimedGiB = Math.round(totalClaimedBytes / STORAGE_OVERVIEW_BYTES_PER_GIB)
+    return {
+      totalCapacity: totalClaimedGiB,
+      used: totalClaimedGiB,
+      pvcs: totalPVCs,
+      unbound: pendingPVCs + orphanedCount,
+      boundPVCs,
+      pendingPVCs,
+      orphanedCount,
+    }
+  }, [analyses, demoMode, isDemoFallback])
+
+  return {
+    data: [aggregated],
+    isLoading,
+    error: null,
+    refetch: () => {},
+  }
 }
 
 function useNetworkOverview() {

--- a/web/src/types/alerts.ts
+++ b/web/src/types/alerts.ts
@@ -9,6 +9,8 @@ export type AlertConditionType =
   | 'disk_pressure'
   | 'weather_alerts'
   | 'nightly_e2e_failure'
+  | 'pvc_pending'
+  | 'pvc_orphaned'
   | 'custom'
 
 // Alert severity levels
@@ -225,6 +227,30 @@ export const PRESET_ALERT_RULES: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt
     channels: [{ type: 'browser', enabled: true, config: {} }],
     aiDiagnose: true,
   },
+  {
+    name: 'PVC Stuck Pending',
+    description: 'Alert when a PVC is stuck in Pending state for more than 5 minutes',
+    enabled: true,
+    condition: {
+      type: 'pvc_pending' as AlertConditionType,
+      duration: 300, // 5 minutes
+    },
+    severity: 'warning' as AlertSeverity,
+    channels: [{ type: 'browser' as AlertChannelType, enabled: true, config: {} }],
+    aiDiagnose: true,
+  },
+  {
+    name: 'Orphaned PVCs',
+    description: 'Alert when PVCs are Bound but not mounted by any running pod',
+    enabled: true,
+    condition: {
+      type: 'pvc_orphaned' as AlertConditionType,
+      threshold: 1,
+    },
+    severity: 'warning' as AlertSeverity,
+    channels: [{ type: 'browser' as AlertChannelType, enabled: true, config: {} }],
+    aiDiagnose: true,
+  },
 ]
 
 // Helper to get severity color
@@ -282,6 +308,10 @@ export function formatCondition(condition: AlertCondition): string {
       return condition.weatherCondition?.replace(/_/g, ' ') || 'Weather alert'
     case 'nightly_e2e_failure':
       return 'Nightly E2E workflow run failed'
+    case 'pvc_pending':
+      return `PVC pending > ${((condition.duration || 300) / 60).toFixed(0)} min`
+    case 'pvc_orphaned':
+      return `Orphaned PVCs detected (not mounted by any pod)`
     case 'custom':
       return condition.customQuery || 'Custom condition'
     default:


### PR DESCRIPTION
## Summary
- Adds server-side PVC-to-pod cross-referencing to detect orphaned and stuck-pending PVCs
- Surfaces storage issues through the alert system with browser desktop notifications
- Makes the Storage Overview card show live data instead of demo-only
- Triggered by a CephFS full incident (HEALTH_ERR, 72 orphaned PVCs wasting 36 TiB) that the console had no way to detect

## What changed

### Backend (Go)
- **New endpoint** `GET /api/mcp/storage/analysis` — lists all PVCs and running pods per cluster, cross-references volume mounts to identify:
  - **Orphaned PVCs**: Bound but not mounted by any running pod (with claimed capacity)
  - **Stuck Pending PVCs**: Pending for more than 5 minutes (configurable threshold)
- Demo data included for demo mode

### Frontend (TypeScript/React)
- **`useCachedStorageAnalysis`** hook — fetches analysis every 2 minutes with localStorage caching
- **Two new alert condition types**: `pvc_pending` and `pvc_orphaned`
- **Alert evaluators** with:
  - Auto-resolve when condition clears
  - Desktop notifications via Service Worker (with deep links to PVC/Storage cards)
  - Per-cluster alerting (one alert per cluster, not per PVC)
- **Live Storage Overview** — `useStorageOverview` now returns real aggregated data (totalPVCs, bound, pending, orphaned count, total claimed GiB) instead of hardcoded demo data
- **Preset rules** auto-injected: "PVC Stuck Pending" (enabled, warning) and "Orphaned PVCs" (enabled, warning)

## Test plan
- [ ] Build passes (`go build ./...` + `npm run build`)
- [ ] Demo mode: Storage Overview card shows demo data with correct stats
- [ ] Live mode: Storage Overview card shows real PVC counts from clusters
- [ ] Alert fires for orphaned PVCs on clusters with unmounted Bound PVCs
- [ ] Alert fires for PVCs stuck Pending > 5 minutes
- [ ] Desktop notification appears when alert fires (requires browser notification permission)
- [ ] Alerts auto-resolve when condition clears
- [ ] Settings > Alerts shows the two new preset rules