### PR TITLE
🐛 Fix Hub.Broadcast() blocking indefinitely

### DIFF
--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -129,14 +129,27 @@ func (h *Hub) Close() {
 	close(h.done)
 }
 
-// Broadcast sends a message to all clients of a user
+// Broadcast sends a message to all clients of a user.
+// Uses non-blocking send to prevent callers from blocking indefinitely
+// when the broadcast buffer is full or the hub has been shut down.
+// Messages that cannot be delivered are dropped rather than stalling the sender.
 func (h *Hub) Broadcast(userID uuid.UUID, msg Message) {
 	data, err := json.Marshal(msg)
 	if err != nil {
 		log.Printf("Failed to marshal message: %v", err)
 		return
 	}
-	h.broadcast <- broadcastMessage{userID: userID, data: data}
+
+	select {
+	case h.broadcast <- broadcastMessage{userID: userID, data: data}:
+		// Message queued successfully
+	case <-h.done:
+		// Hub is shut down; discard the message
+		log.Printf("Hub closed, dropping broadcast for user %s", userID)
+	default:
+		// Broadcast buffer is full; drop the message to avoid blocking the sender
+		log.Printf("Broadcast buffer full, dropping message for user %s (type: %s)", userID, msg.Type)
+	}
 }
 
 // GetActiveUsersCount returns the number of unique users with active connections
@@ -177,8 +190,18 @@ func (h *Hub) GetDemoSessionCount() int {
 	return count
 }
 
-// BroadcastAll sends a message to all connected clients
+// BroadcastAll sends a message to all connected clients.
+// Checks if the hub is shut down before iterating clients, and uses
+// non-blocking sends to avoid stalling on any individual client.
 func (h *Hub) BroadcastAll(msg Message) {
+	// Check if the hub has been shut down before doing any work
+	select {
+	case <-h.done:
+		log.Printf("Hub closed, dropping broadcast-all (type: %s)", msg.Type)
+		return
+	default:
+	}
+
 	data, err := json.Marshal(msg)
 	if err != nil {
 		log.Printf("Failed to marshal message: %v", err)


### PR DESCRIPTION
## Summary

- Fix `Hub.Broadcast()` blocking indefinitely when the broadcast channel buffer is full or the hub has been shut down (#2383)
- Use `select` with `case <-h.done` and `default` to make the send non-blocking — messages that can't be delivered are dropped with a log message instead of stalling the caller
- Add a shutdown guard to `BroadcastAll()` so it returns immediately if the hub is closed

## Details

`Broadcast()` previously did an unconditional channel send (`h.broadcast <- msg`). This could block forever in two scenarios:

1. **Buffer full**: The broadcast channel has a 256-entry buffer. Under high message volume, the buffer fills and senders block until `Run()` drains it.
2. **Hub shut down**: After `Close()` is called, `Run()` exits its select loop. No goroutine is draining the broadcast channel, so any subsequent send blocks permanently.

The fix uses a three-way `select`:
- Try to send on the broadcast channel (normal path)
- Check `h.done` to detect shutdown
- Fall through to `default` if the buffer is full

`BroadcastAll()` also gets a `h.done` check at the top to bail out early after shutdown.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] Existing WebSocket functionality continues to work (messages delivered to connected clients)
- [ ] Under high broadcast volume, senders are not blocked — messages are dropped with a log entry
- [ ] After `Hub.Close()`, calls to `Broadcast()` and `BroadcastAll()` return immediately

Closes #2383