### PR TITLE
🐛 Fix React hook order violations

### DIFF
--- a/web/src/components/cards/llmd/StackSelector.tsx
+++ b/web/src/components/cards/llmd/StackSelector.tsx
@@ -229,17 +229,14 @@ export function StackSelector() {
     }
   }, [isOpen])
 
-  // If no context, show placeholder
-  if (!stackContext) {
-    return (
-      <div className="flex items-center gap-2 px-3 py-1.5 rounded bg-secondary/50 text-muted-foreground text-sm">
-        <Layers className="w-4 h-4" />
-        <span>{t('common.noStackData')}</span>
-      </div>
-    )
-  }
-
-  const { stacks, isLoading, selectedStack, selectedStackId, setSelectedStackId, refetch, isDemoMode } = stackContext
+  // Extract values from context (use defaults when context is missing so hooks below run unconditionally)
+  const stacks = stackContext?.stacks || []
+  const isLoading = stackContext?.isLoading ?? false
+  const selectedStack = stackContext?.selectedStack
+  const selectedStackId = stackContext?.selectedStackId
+  const setSelectedStackId = stackContext?.setSelectedStackId
+  const refetch = stackContext?.refetch
+  const isDemoMode = stackContext?.isDemoMode ?? false
 
   // Filter and sort stacks
   const filteredAndSortedStacks = useMemo(() => {
@@ -296,7 +293,7 @@ export function StackSelector() {
   const handleRefetch = async () => {
     setFetchError(null)
     try {
-      await refetch()
+      await refetch?.()
     } catch (err) {
       setFetchError(err instanceof Error ? err.message : 'Failed to refresh stacks')
     }
@@ -325,9 +322,19 @@ export function StackSelector() {
 
   // Memoize stack selection handler to prevent re-renders
   const handleSelectStack = useCallback((stackId: string) => {
-    setSelectedStackId(stackId)
+    setSelectedStackId?.(stackId)
     setIsOpen(false)
   }, [setSelectedStackId])
+
+  // If no context, show placeholder (after all hooks have been called)
+  if (!stackContext) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-1.5 rounded bg-secondary/50 text-muted-foreground text-sm">
+        <Layers className="w-4 h-4" />
+        <span>{t('common.noStackData')}</span>
+      </div>
+    )
+  }
 
   const totalAccelerators = stacks.reduce((sum, s) => sum + estimateAccelerators(s).count, 0)
 

--- a/web/src/components/shared/ConditionBadges.tsx
+++ b/web/src/components/shared/ConditionBadges.tsx
@@ -1,5 +1,4 @@
 import { cn } from '../../lib/cn'
-import { useTranslation } from 'react-i18next'
 
 export interface Condition {
   type: string
@@ -41,7 +40,6 @@ export function ConditionBadges({ conditions, className }: ConditionBadgesProps)
  * Get the appropriate style class for a condition badge
  */
 export function getConditionStyle(condition: Condition): string {
-  const { t: _t } = useTranslation()
   const { type, status } = condition
 
   if (type === 'Ready') {

--- a/web/src/lib/cards/CardRuntime.tsx
+++ b/web/src/lib/cards/CardRuntime.tsx
@@ -143,6 +143,17 @@ export interface CardRuntimeProps {
 // CardRuntime Component
 // ============================================================================
 
+// Noop data hook used when the requested hook is not registered.
+// This ensures hooks are called unconditionally to satisfy the Rules of Hooks.
+const NOOP_HOOK_RESULT: DataHookResult<unknown> = {
+  data: [],
+  isLoading: false,
+  isRefreshing: false,
+  error: undefined,
+  refetch: () => {},
+}
+const noopDataHook = () => NOOP_HOOK_RESULT
+
 export function CardRuntime({ definition, config: _config, title }: CardRuntimeProps) {
   const {
     type,
@@ -156,15 +167,9 @@ export function CardRuntime({ definition, config: _config, title }: CardRuntimeP
     loadingState,
   } = definition
 
-  // Get the data hook
-  const useDataHook = dataHookRegistry.get(dataSource.hook)
-  if (!useDataHook) {
-    return (
-      <CardErrorState
-        error={`Data hook "${dataSource.hook}" not registered for card "${type}"`}
-      />
-    )
-  }
+  // Get the data hook (fall back to noop so hooks are always called unconditionally)
+  const useDataHook = dataHookRegistry.get(dataSource.hook) || noopDataHook
+  const hookMissing = !dataHookRegistry.has(dataSource.hook)
 
   // Call the data hook
   const {
@@ -241,6 +246,15 @@ export function CardRuntime({ definition, config: _config, title }: CardRuntimeP
     filters,
     sorting,
   } = cardData
+
+  // If the data hook was not registered, render an error after all hooks have been called
+  if (hookMissing) {
+    return (
+      <CardErrorState
+        error={`Data hook "${dataSource.hook}" not registered for card "${type}"`}
+      />
+    )
+  }
 
   // Only show skeleton when no cached data exists
   const isLoading = hookLoading && rawData.length === 0


### PR DESCRIPTION
## Summary
- **CardRuntime**: Hooks were conditionally skipped when a data hook was not registered (early return before `useMemo`/`useCardData`). Now uses a noop fallback hook so all hooks execute unconditionally, with the error rendered after hooks complete.
- **StackSelector**: Hooks (`useMemo`, `useCallback`) were conditionally skipped when `stackContext` was null (early return before them). Now extracts context values with defaults before hooks, and moves the early return after all hooks.
- **ConditionBadges**: `useTranslation()` was called inside the `getConditionStyle()` helper function (not a component or custom hook). Removed the unused hook call from the helper.

Closes #2387, closes #2386, closes #2385

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Cards using `CardRuntime` with valid data hooks render correctly
- [ ] Cards with missing data hooks show the error state
- [ ] `StackSelector` renders placeholder when no stack context is available
- [ ] `StackSelector` renders normally when stack context exists
- [ ] `ConditionBadges` renders condition badges with correct styling