### PR TITLE
🐛 Fix mission tests using outdated /api/missions/kb/* routes

### DIFF
--- a/pkg/api/handlers/missions_test.go
+++ b/pkg/api/handlers/missions_test.go
@@ -18,7 +18,7 @@ func setupMissionsTest() (*fiber.App, *MissionsHandler) {
 	app := fiber.New()
 	handler := NewMissionsHandler()
 	handler.RegisterRoutes(app.Group("/api/missions"))
-	handler.RegisterPublicRoutes(app.Group("/api/missions/kb"))
+	handler.RegisterPublicRoutes(app.Group("/api/missions"))
 	return app, handler
 }
 
@@ -37,7 +37,7 @@ func TestMissions_BrowseConsoleKB_Success(t *testing.T) {
 	app, handler := setupMissionsTest()
 	handler.githubAPIURL = mock.URL
 
-	req, err := http.NewRequest("GET", "/api/missions/kb/browse?path=missions", nil)
+	req, err := http.NewRequest("GET", "/api/missions/browse?path=missions", nil)
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestMissions_BrowseConsoleKB_NoPath(t *testing.T) {
 	app, handler := setupMissionsTest()
 	handler.githubAPIURL = mock.URL
 
-	req, err := http.NewRequest("GET", "/api/missions/kb/browse", nil)
+	req, err := http.NewRequest("GET", "/api/missions/browse", nil)
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -291,7 +291,7 @@ func TestMissions_GetMissionFile_Success(t *testing.T) {
 	app, handler := setupMissionsTest()
 	handler.githubRawURL = mock.URL
 
-	req, err := http.NewRequest("GET", "/api/missions/kb/file?path=missions/example.yaml", nil)
+	req, err := http.NewRequest("GET", "/api/missions/file?path=missions/example.yaml", nil)
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)
@@ -312,7 +312,7 @@ func TestMissions_GetMissionFile_NotFound(t *testing.T) {
 	app, handler := setupMissionsTest()
 	handler.githubRawURL = mock.URL
 
-	req, err := http.NewRequest("GET", "/api/missions/kb/file?path=missions/nonexistent.yaml", nil)
+	req, err := http.NewRequest("GET", "/api/missions/file?path=missions/nonexistent.yaml", nil)
 	require.NoError(t, err)
 	resp, err := app.Test(req, 5000)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Fixed `setupMissionsTest()` to register public routes under `/api/missions` instead of the outdated `/api/missions/kb` group, matching the actual server registration in `server.go`
- Updated 4 test request URLs from `/api/missions/kb/browse` and `/api/missions/kb/file` to `/api/missions/browse` and `/api/missions/file`
- All 12 mission handler tests now pass against the correct route paths

## Test plan
- [x] Ran `go test ./pkg/api/handlers/ -run TestMissions -v` — all 12 tests pass
- [x] Verified route registration in `server.go:478` confirms `/api/missions` is the correct group prefix

Closes #2389