### PR TITLE
🐛 Isolate TestManager_ImportDifferentKey from env tokens

### DIFF
--- a/pkg/settings/manager_test.go
+++ b/pkg/settings/manager_test.go
@@ -253,6 +253,11 @@ func TestManager_ExportImport(t *testing.T) {
 }
 
 func TestManager_ImportDifferentKey(t *testing.T) {
+	// Isolate from env vars so GetAll fallbacks don't leak into assertions.
+	// t.Setenv restores the original value (or unsets) after the test.
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("FEEDBACK_GITHUB_TOKEN", "")
+
 	sm := newTestManager(t)
 
 	all := DefaultAllSettings()


### PR DESCRIPTION
## Summary
- Fixes `TestManager_ImportDifferentKey` failing when `GITHUB_TOKEN` or `FEEDBACK_GITHUB_TOKEN` is set in the developer's environment
- `GetAll()` falls back to these env vars when no encrypted token is stored, causing the test assertion (`got.GitHubToken` should be empty) to fail
- Uses `t.Setenv("GITHUB_TOKEN", "")` and `t.Setenv("FEEDBACK_GITHUB_TOKEN", "")` to isolate the test; Go restores the original values automatically after the test

Closes #2388

## Test plan
- [x] `go test ./pkg/settings/... -run TestManager_ImportDifferentKey -v` passes
- [x] All settings package tests pass (`go test ./pkg/settings/... -v`)