### PR TITLE
🐛 Add missing MCP API endpoint handlers for frontend hooks

### DIFF
--- a/pkg/api/handlers/demo_data.go
+++ b/pkg/api/handlers/demo_data.go
@@ -245,6 +245,60 @@ func getDemoLimitRanges() []k8s.LimitRange {
 	}
 }
 
+// Demo ReplicaSets
+func getDemoReplicaSets() []k8s.ReplicaSet {
+	return []k8s.ReplicaSet{
+		{Name: "frontend-7d8f9c6b5", Namespace: "production", Cluster: "eks-prod-us-east-1", Replicas: 3, ReadyReplicas: 3, OwnerName: "frontend", OwnerKind: "Deployment", Age: "2d"},
+		{Name: "api-server-5c4d8e7f2", Namespace: "production", Cluster: "eks-prod-us-east-1", Replicas: 5, ReadyReplicas: 5, OwnerName: "api-server", OwnerKind: "Deployment", Age: "1d"},
+		{Name: "worker-9a8b7c6d5", Namespace: "batch", Cluster: "gke-staging", Replicas: 2, ReadyReplicas: 2, OwnerName: "worker", OwnerKind: "Deployment", Age: "6h"},
+	}
+}
+
+// Demo StatefulSets
+func getDemoStatefulSets() []k8s.StatefulSet {
+	return []k8s.StatefulSet{
+		{Name: "postgres", Namespace: "database", Cluster: "aks-dev-westeu", Replicas: 3, ReadyReplicas: 3, Status: "Running", Image: "postgres:15", Age: "30d"},
+		{Name: "redis-cluster", Namespace: "cache", Cluster: "eks-prod-us-east-1", Replicas: 6, ReadyReplicas: 6, Status: "Running", Image: "redis:7", Age: "14d"},
+		{Name: "elasticsearch", Namespace: "logging", Cluster: "openshift-prod", Replicas: 3, ReadyReplicas: 2, Status: "Updating", Image: "elasticsearch:8.10", Age: "7d"},
+	}
+}
+
+// Demo DaemonSets
+func getDemoDaemonSets() []k8s.DaemonSet {
+	return []k8s.DaemonSet{
+		{Name: "fluentd", Namespace: "logging", Cluster: "eks-prod-us-east-1", DesiredScheduled: 5, CurrentScheduled: 5, Ready: 5, Status: "Running", Age: "60d"},
+		{Name: "node-exporter", Namespace: "monitoring", Cluster: "openshift-prod", DesiredScheduled: 3, CurrentScheduled: 3, Ready: 3, Status: "Running", Age: "45d"},
+		{Name: "calico-node", Namespace: "kube-system", Cluster: "gke-staging", DesiredScheduled: 4, CurrentScheduled: 4, Ready: 4, Status: "Running", Age: "90d"},
+	}
+}
+
+// Demo CronJobs
+func getDemoCronJobs() []k8s.CronJob {
+	return []k8s.CronJob{
+		{Name: "db-backup", Namespace: "database", Cluster: "aks-dev-westeu", Schedule: "0 2 * * *", Suspend: false, Active: 0, LastSchedule: "6h ago", Age: "30d"},
+		{Name: "log-cleanup", Namespace: "logging", Cluster: "eks-prod-us-east-1", Schedule: "0 0 * * 0", Suspend: false, Active: 0, LastSchedule: "2d ago", Age: "60d"},
+		{Name: "report-gen", Namespace: "analytics", Cluster: "gke-staging", Schedule: "30 8 * * 1-5", Suspend: false, Active: 1, LastSchedule: "4h ago", Age: "14d"},
+	}
+}
+
+// Demo Ingresses
+func getDemoIngresses() []k8s.Ingress {
+	return []k8s.Ingress{
+		{Name: "frontend-ingress", Namespace: "production", Cluster: "eks-prod-us-east-1", Class: "nginx", Hosts: []string{"app.example.com"}, Address: "10.0.1.100", Age: "30d"},
+		{Name: "api-ingress", Namespace: "production", Cluster: "eks-prod-us-east-1", Class: "nginx", Hosts: []string{"api.example.com"}, Address: "10.0.1.101", Age: "30d"},
+		{Name: "monitoring-ingress", Namespace: "monitoring", Cluster: "openshift-prod", Class: "haproxy", Hosts: []string{"grafana.internal.example.com"}, Address: "10.0.2.50", Age: "14d"},
+	}
+}
+
+// Demo NetworkPolicies
+func getDemoNetworkPolicies() []k8s.NetworkPolicy {
+	return []k8s.NetworkPolicy{
+		{Name: "deny-all", Namespace: "production", Cluster: "eks-prod-us-east-1", PolicyTypes: []string{"Ingress", "Egress"}, PodSelector: "", Age: "60d"},
+		{Name: "allow-frontend", Namespace: "production", Cluster: "eks-prod-us-east-1", PolicyTypes: []string{"Ingress"}, PodSelector: "app=frontend", Age: "60d"},
+		{Name: "allow-monitoring", Namespace: "monitoring", Cluster: "openshift-prod", PolicyTypes: []string{"Ingress"}, PodSelector: "app=prometheus", Age: "30d"},
+	}
+}
+
 // Demo GPU nodes
 func getDemoGPUNodeHealth() []k8s.GPUNodeHealthStatus {
 	return []k8s.GPUNodeHealthStatus{

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -2007,3 +2007,375 @@ func (h *MCPHandlers) GetFlatcarNodes(c *fiber.Ctx) error {
 
 	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
 }
+
+// GetReplicaSets returns ReplicaSets from clusters
+func (h *MCPHandlers) GetReplicaSets(c *fiber.Ctx) error {
+	// Demo mode: return demo data immediately
+	if isDemoMode(c) {
+		return demoResponse(c, "replicasets", getDemoReplicaSets())
+	}
+
+	cluster := c.Query("cluster")
+	namespace := c.Query("namespace")
+
+	if h.k8sClient != nil {
+		if cluster == "" {
+			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
+			if err != nil {
+				log.Printf("internal error: %v", err)
+				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			}
+
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			allItems := make([]k8s.ReplicaSet, 0)
+			clusterTimeout := mcpDefaultTimeout
+
+			for _, cl := range clusters {
+				wg.Add(1)
+				go func(clusterName string) {
+					defer wg.Done()
+					ctx, cancel := context.WithTimeout(c.Context(), clusterTimeout)
+					defer cancel()
+
+					items, err := h.k8sClient.GetReplicaSets(ctx, clusterName, namespace)
+					if err == nil && len(items) > 0 {
+						mu.Lock()
+						allItems = append(allItems, items...)
+						mu.Unlock()
+					}
+				}(cl.Name)
+			}
+
+			waitWithDeadline(&wg, maxResponseDeadline)
+			return c.JSON(fiber.Map{"replicasets": allItems, "source": "k8s"})
+		}
+
+		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+		defer cancel()
+
+		items, err := h.k8sClient.GetReplicaSets(ctx, cluster, namespace)
+		if err != nil {
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		}
+		if items == nil {
+			items = make([]k8s.ReplicaSet, 0)
+		}
+		return c.JSON(fiber.Map{"replicasets": items, "source": "k8s"})
+	}
+
+	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+}
+
+// GetStatefulSets returns StatefulSets from clusters
+func (h *MCPHandlers) GetStatefulSets(c *fiber.Ctx) error {
+	// Demo mode: return demo data immediately
+	if isDemoMode(c) {
+		return demoResponse(c, "statefulsets", getDemoStatefulSets())
+	}
+
+	cluster := c.Query("cluster")
+	namespace := c.Query("namespace")
+
+	if h.k8sClient != nil {
+		if cluster == "" {
+			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
+			if err != nil {
+				log.Printf("internal error: %v", err)
+				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			}
+
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			allItems := make([]k8s.StatefulSet, 0)
+			clusterTimeout := mcpDefaultTimeout
+
+			for _, cl := range clusters {
+				wg.Add(1)
+				go func(clusterName string) {
+					defer wg.Done()
+					ctx, cancel := context.WithTimeout(c.Context(), clusterTimeout)
+					defer cancel()
+
+					items, err := h.k8sClient.GetStatefulSets(ctx, clusterName, namespace)
+					if err == nil && len(items) > 0 {
+						mu.Lock()
+						allItems = append(allItems, items...)
+						mu.Unlock()
+					}
+				}(cl.Name)
+			}
+
+			waitWithDeadline(&wg, maxResponseDeadline)
+			return c.JSON(fiber.Map{"statefulsets": allItems, "source": "k8s"})
+		}
+
+		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+		defer cancel()
+
+		items, err := h.k8sClient.GetStatefulSets(ctx, cluster, namespace)
+		if err != nil {
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		}
+		if items == nil {
+			items = make([]k8s.StatefulSet, 0)
+		}
+		return c.JSON(fiber.Map{"statefulsets": items, "source": "k8s"})
+	}
+
+	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+}
+
+// GetDaemonSets returns DaemonSets from clusters
+func (h *MCPHandlers) GetDaemonSets(c *fiber.Ctx) error {
+	// Demo mode: return demo data immediately
+	if isDemoMode(c) {
+		return demoResponse(c, "daemonsets", getDemoDaemonSets())
+	}
+
+	cluster := c.Query("cluster")
+	namespace := c.Query("namespace")
+
+	if h.k8sClient != nil {
+		if cluster == "" {
+			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
+			if err != nil {
+				log.Printf("internal error: %v", err)
+				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			}
+
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			allItems := make([]k8s.DaemonSet, 0)
+			clusterTimeout := mcpDefaultTimeout
+
+			for _, cl := range clusters {
+				wg.Add(1)
+				go func(clusterName string) {
+					defer wg.Done()
+					ctx, cancel := context.WithTimeout(c.Context(), clusterTimeout)
+					defer cancel()
+
+					items, err := h.k8sClient.GetDaemonSets(ctx, clusterName, namespace)
+					if err == nil && len(items) > 0 {
+						mu.Lock()
+						allItems = append(allItems, items...)
+						mu.Unlock()
+					}
+				}(cl.Name)
+			}
+
+			waitWithDeadline(&wg, maxResponseDeadline)
+			return c.JSON(fiber.Map{"daemonsets": allItems, "source": "k8s"})
+		}
+
+		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+		defer cancel()
+
+		items, err := h.k8sClient.GetDaemonSets(ctx, cluster, namespace)
+		if err != nil {
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		}
+		if items == nil {
+			items = make([]k8s.DaemonSet, 0)
+		}
+		return c.JSON(fiber.Map{"daemonsets": items, "source": "k8s"})
+	}
+
+	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+}
+
+// GetCronJobs returns CronJobs from clusters
+func (h *MCPHandlers) GetCronJobs(c *fiber.Ctx) error {
+	// Demo mode: return demo data immediately
+	if isDemoMode(c) {
+		return demoResponse(c, "cronjobs", getDemoCronJobs())
+	}
+
+	cluster := c.Query("cluster")
+	namespace := c.Query("namespace")
+
+	if h.k8sClient != nil {
+		if cluster == "" {
+			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
+			if err != nil {
+				log.Printf("internal error: %v", err)
+				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			}
+
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			allItems := make([]k8s.CronJob, 0)
+			clusterTimeout := mcpDefaultTimeout
+
+			for _, cl := range clusters {
+				wg.Add(1)
+				go func(clusterName string) {
+					defer wg.Done()
+					ctx, cancel := context.WithTimeout(c.Context(), clusterTimeout)
+					defer cancel()
+
+					items, err := h.k8sClient.GetCronJobs(ctx, clusterName, namespace)
+					if err == nil && len(items) > 0 {
+						mu.Lock()
+						allItems = append(allItems, items...)
+						mu.Unlock()
+					}
+				}(cl.Name)
+			}
+
+			waitWithDeadline(&wg, maxResponseDeadline)
+			return c.JSON(fiber.Map{"cronjobs": allItems, "source": "k8s"})
+		}
+
+		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+		defer cancel()
+
+		items, err := h.k8sClient.GetCronJobs(ctx, cluster, namespace)
+		if err != nil {
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		}
+		if items == nil {
+			items = make([]k8s.CronJob, 0)
+		}
+		return c.JSON(fiber.Map{"cronjobs": items, "source": "k8s"})
+	}
+
+	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+}
+
+// GetIngresses returns Ingresses from clusters
+func (h *MCPHandlers) GetIngresses(c *fiber.Ctx) error {
+	// Demo mode: return demo data immediately
+	if isDemoMode(c) {
+		return demoResponse(c, "ingresses", getDemoIngresses())
+	}
+
+	cluster := c.Query("cluster")
+	namespace := c.Query("namespace")
+
+	if h.k8sClient != nil {
+		if cluster == "" {
+			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
+			if err != nil {
+				log.Printf("internal error: %v", err)
+				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			}
+
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			allItems := make([]k8s.Ingress, 0)
+			clusterTimeout := mcpDefaultTimeout
+
+			for _, cl := range clusters {
+				wg.Add(1)
+				go func(clusterName string) {
+					defer wg.Done()
+					ctx, cancel := context.WithTimeout(c.Context(), clusterTimeout)
+					defer cancel()
+
+					items, err := h.k8sClient.GetIngresses(ctx, clusterName, namespace)
+					if err == nil && len(items) > 0 {
+						mu.Lock()
+						allItems = append(allItems, items...)
+						mu.Unlock()
+					}
+				}(cl.Name)
+			}
+
+			waitWithDeadline(&wg, maxResponseDeadline)
+			return c.JSON(fiber.Map{"ingresses": allItems, "source": "k8s"})
+		}
+
+		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+		defer cancel()
+
+		items, err := h.k8sClient.GetIngresses(ctx, cluster, namespace)
+		if err != nil {
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		}
+		if items == nil {
+			items = make([]k8s.Ingress, 0)
+		}
+		return c.JSON(fiber.Map{"ingresses": items, "source": "k8s"})
+	}
+
+	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+}
+
+// GetNetworkPolicies returns NetworkPolicies from clusters
+func (h *MCPHandlers) GetNetworkPolicies(c *fiber.Ctx) error {
+	// Demo mode: return demo data immediately
+	if isDemoMode(c) {
+		return demoResponse(c, "networkpolicies", getDemoNetworkPolicies())
+	}
+
+	cluster := c.Query("cluster")
+	namespace := c.Query("namespace")
+
+	if h.k8sClient != nil {
+		if cluster == "" {
+			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
+			if err != nil {
+				log.Printf("internal error: %v", err)
+				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			}
+
+			var wg sync.WaitGroup
+			var mu sync.Mutex
+			allItems := make([]k8s.NetworkPolicy, 0)
+			clusterTimeout := mcpDefaultTimeout
+
+			for _, cl := range clusters {
+				wg.Add(1)
+				go func(clusterName string) {
+					defer wg.Done()
+					ctx, cancel := context.WithTimeout(c.Context(), clusterTimeout)
+					defer cancel()
+
+					items, err := h.k8sClient.GetNetworkPolicies(ctx, clusterName, namespace)
+					if err == nil && len(items) > 0 {
+						mu.Lock()
+						allItems = append(allItems, items...)
+						mu.Unlock()
+					}
+				}(cl.Name)
+			}
+
+			waitWithDeadline(&wg, maxResponseDeadline)
+			return c.JSON(fiber.Map{"networkpolicies": allItems, "source": "k8s"})
+		}
+
+		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
+		defer cancel()
+
+		items, err := h.k8sClient.GetNetworkPolicies(ctx, cluster, namespace)
+		if err != nil {
+			log.Printf("internal error: %v", err)
+			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		}
+		if items == nil {
+			items = make([]k8s.NetworkPolicy, 0)
+		}
+		return c.JSON(fiber.Map{"networkpolicies": items, "source": "k8s"})
+	}
+
+	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+}
+
+// GetResourceYAML returns the YAML representation of a Kubernetes resource.
+// This is a stub handler — full resource YAML retrieval requires dynamic client
+// support which will be added in a future iteration. For now, it returns an
+// empty yaml field so the frontend can gracefully fall back to demo YAML.
+func (h *MCPHandlers) GetResourceYAML(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return c.JSON(fiber.Map{"yaml": "", "source": "demo"})
+	}
+
+	return c.JSON(fiber.Map{"yaml": "", "source": "stub"})
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -622,6 +622,13 @@ func (s *Server) setupRoutes() {
 	api.Get("/mcp/wasmcloud/hosts", mcpHandlers.GetWasmCloudHosts)
 	api.Get("/mcp/wasmcloud/actors", mcpHandlers.GetWasmCloudActors)
 	api.Get("/mcp/custom-resources", mcpHandlers.GetCustomResources)
+	api.Get("/mcp/replicasets", mcpHandlers.GetReplicaSets)
+	api.Get("/mcp/statefulsets", mcpHandlers.GetStatefulSets)
+	api.Get("/mcp/daemonsets", mcpHandlers.GetDaemonSets)
+	api.Get("/mcp/cronjobs", mcpHandlers.GetCronJobs)
+	api.Get("/mcp/ingresses", mcpHandlers.GetIngresses)
+	api.Get("/mcp/networkpolicies", mcpHandlers.GetNetworkPolicies)
+	api.Get("/mcp/resource-yaml", mcpHandlers.GetResourceYAML)
 
 	// SSE streaming variants — stream per-cluster results as they arrive
 	api.Get("/mcp/pods/stream", mcpHandlers.GetPodsStream)


### PR DESCRIPTION
## Summary
- The frontend hooks call 7 MCP API endpoints (`/api/mcp/replicasets`, `/api/mcp/statefulsets`, `/api/mcp/daemonsets`, `/api/mcp/cronjobs`, `/api/mcp/ingresses`, `/api/mcp/networkpolicies`, `/api/mcp/resource-yaml`) that had no backend handlers, causing 404 errors
- Added full multi-cluster REST handlers for 6 resource types (ReplicaSets, StatefulSets, DaemonSets, CronJobs, Ingresses, NetworkPolicies) following the same pattern as existing handlers (demo mode, multi-cluster fan-out, single-cluster query)
- Added a stub handler for `/api/mcp/resource-yaml` that returns an empty yaml field so the frontend gracefully falls back to demo YAML
- Added demo data functions for all 6 new resource types

## Test plan
- [ ] Verify `go build ./...` passes (confirmed locally)
- [ ] Verify demo mode returns proper demo data for all new endpoints
- [ ] Verify frontend hooks no longer get 404s when calling these endpoints
- [ ] Check that YAML drilldown gracefully falls back to demo YAML

Closes #2373