### PR TITLE
🐛 Fix AI Mission 429 quota errors and add message size validation

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -17,6 +17,7 @@ import {
 import { useMissions, type Mission } from '../../../hooks/useMissions'
 import { useResolutions, detectIssueSignature, type Resolution } from '../../../hooks/useResolutions'
 import { cn } from '../../../lib/cn'
+import { MAX_MESSAGE_SIZE_CHARS } from '../../../lib/constants'
 import { AgentBadge, AgentIcon } from '../../agent/AgentIcon'
 import { ResolutionKnowledgePanel } from '../../missions/ResolutionKnowledgePanel'
 import { ResolutionHistoryPanel } from '../../missions/ResolutionHistoryPanel'
@@ -46,6 +47,8 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
   const [appliedResolutionId, setAppliedResolutionId] = useState<string | null>(null)
   const [resolutionPanelView, setResolutionPanelView] = useState<'related' | 'history'>('related')
   const [showSetupDialog, setShowSetupDialog] = useState(false)
+  // Message validation error (e.g. too long)
+  const [inputError, setInputError] = useState<string | null>(null)
 
   // Find related resolutions based on mission content
   const relatedResolutions = useMemo(() => {
@@ -205,6 +208,17 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
 
   const handleSend = () => {
     if (!input.trim()) return
+    // Validate message size before sending
+    if (input.length > MAX_MESSAGE_SIZE_CHARS) {
+      setInputError(
+        t('missionChat.messageTooLong', {
+          current: input.length.toLocaleString(),
+          max: MAX_MESSAGE_SIZE_CHARS.toLocaleString(),
+          defaultValue: `Message is too long ({{current}} characters). Maximum is {{max}} characters.`,
+        })
+      )
+      return
+    }
     // Add to command history
     setCommandHistory(prev => [...prev, input.trim()])
     setHistoryIndex(-1)
@@ -466,7 +480,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 ref={inputRef}
                 type="text"
                 value={input}
-                onChange={(e) => setInput(e.target.value)}
+                onChange={(e) => { setInput(e.target.value); setInputError(null) }}
                 onKeyDown={handleKeyDown}
                 placeholder={t('missionChat.typeNextMessage')}
                 className="flex-1 min-w-0 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
@@ -583,7 +597,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 ref={inputRef}
                 type="text"
                 value={input}
-                onChange={(e) => setInput(e.target.value)}
+                onChange={(e) => { setInput(e.target.value); setInputError(null) }}
                 onKeyDown={handleKeyDown}
                 placeholder={t('missionChat.retryWithMessage')}
                 className="flex-1 min-w-0 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
@@ -611,7 +625,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                 ref={inputRef}
                 type="text"
                 value={input}
-                onChange={(e) => setInput(e.target.value)}
+                onChange={(e) => { setInput(e.target.value); setInputError(null) }}
                 onKeyDown={handleKeyDown}
                 placeholder={t('missionChat.typeMessage')}
                 className="flex-1 min-w-0 px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
@@ -631,6 +645,13 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               <ChevronLeft className="w-3 h-3" />
               {t('missionChat.backToMissions')}
             </button>
+          </div>
+        )}
+
+        {/* Message size validation error */}
+        {inputError && (
+          <div className="mt-2 px-1 text-xs text-red-400 flex items-center gap-1.5">
+            <span>{inputError}</span>
           </div>
         )}
       </div>

--- a/web/src/components/missions/SaveResolutionDialog.tsx
+++ b/web/src/components/missions/SaveResolutionDialog.tsx
@@ -43,6 +43,31 @@ interface SaveResolutionDialogProps {
   onSaved?: () => void
 }
 
+/** Timeout for AI summary generation WebSocket request */
+const AI_SUMMARY_TIMEOUT_MS = 30_000
+
+/**
+ * Detect whether an error message indicates an AI provider rate limit / quota error.
+ * Matches HTTP 429 status codes, "rate limit", "quota", and "too many requests" patterns.
+ */
+function isRateLimitError(message: string): boolean {
+  const lower = message.toLowerCase()
+  return (
+    lower.includes('429') ||
+    lower.includes('rate limit') ||
+    lower.includes('rate_limit') ||
+    lower.includes('quota') ||
+    lower.includes('too many requests') ||
+    lower.includes('resource_exhausted') ||
+    lower.includes('tokens per min') ||
+    lower.includes('requests per min')
+  )
+}
+
+/** User-friendly rate limit error message */
+const RATE_LIMIT_MESSAGE =
+  'AI provider rate limit exceeded. Please wait a minute and try again, or switch to a different AI provider in Settings.'
+
 /**
  * Request AI to generate a resolution summary from the mission conversation
  */
@@ -52,7 +77,7 @@ async function generateAISummary(mission: Mission): Promise<AISummary> {
     const timeout = setTimeout(() => {
       ws.close()
       reject(new Error('Timeout waiting for AI summary'))
-    }, 30000)
+    }, AI_SUMMARY_TIMEOUT_MS)
 
     let responseContent = ''
 
@@ -104,6 +129,12 @@ Return ONLY valid JSON, no markdown code blocks or explanation.`
 
           const content = message.payload?.content || message.payload?.output || responseContent
 
+          // Check if the result content itself indicates a rate limit error
+          if (isRateLimitError(content)) {
+            reject(new Error(RATE_LIMIT_MESSAGE))
+            return
+          }
+
           // Try to parse JSON from response
           try {
             // Extract JSON if wrapped in code blocks
@@ -128,7 +159,13 @@ Return ONLY valid JSON, no markdown code blocks or explanation.`
         } else if (message.type === 'error') {
           clearTimeout(timeout)
           ws.close()
-          reject(new Error(message.payload?.message || 'AI request failed'))
+          const errorMsg = message.payload?.message || 'AI request failed'
+          // Surface a clear rate-limit message instead of the generic backend error
+          if (isRateLimitError(errorMsg) || isRateLimitError(message.payload?.code || '')) {
+            reject(new Error(RATE_LIMIT_MESSAGE))
+          } else {
+            reject(new Error(errorMsg))
+          }
         }
       } catch {
         // Ignore parse errors for non-JSON messages

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -687,6 +687,22 @@ Install the console locally with the KubeStellar Console agent to use AI mission
           errorContent = `${payload.message}\n\n[Configure API Keys →](/settings)\n\nAdd your API key for Claude, OpenAI, or Gemini to use AI missions.`
         }
 
+        // Detect rate limit / quota errors from the AI provider (HTTP 429)
+        const combinedErrorText = `${payload.code || ''} ${payload.message || ''}`.toLowerCase()
+        const isRateLimit =
+          combinedErrorText.includes('429') ||
+          combinedErrorText.includes('rate limit') ||
+          combinedErrorText.includes('rate_limit') ||
+          combinedErrorText.includes('quota') ||
+          combinedErrorText.includes('too many requests') ||
+          combinedErrorText.includes('resource_exhausted') ||
+          combinedErrorText.includes('tokens per min') ||
+          combinedErrorText.includes('requests per min')
+
+        if (isRateLimit) {
+          errorContent = '**AI Provider Rate Limit Exceeded**\n\nThe AI provider returned a quota/rate limit error (HTTP 429). Please wait a minute before retrying, or switch to a different AI provider.\n\n[Configure API Keys →](/settings)'
+        }
+
         return {
           ...m,
           status: 'failed' as MissionStatus,

--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -223,3 +223,10 @@ export const POPUP_HIDE_DELAY_MS = 150
 
 /** Hover tooltip hide delay (50ms) */
 export const TOOLTIP_HIDE_DELAY_MS = 50
+
+// ============================================================================
+// AI Mission Chat Limits
+// ============================================================================
+
+/** Maximum number of characters allowed in a single mission chat message */
+export const MAX_MESSAGE_SIZE_CHARS = 10_000


### PR DESCRIPTION
## Summary
- **Fix 429 rate limit errors showing as JSON parse errors** (#2378): When an AI provider returns a quota/rate limit error (HTTP 429), the frontend now detects the error pattern and shows a clear "rate limit exceeded" message instead of a confusing "Could not parse AI response as JSON" error. Detection covers both the Save Resolution dialog (WebSocket `error` and `result` message types) and the main mission chat error handler.
- **Add message size validation before sending** (#2374): Adds a `MAX_MESSAGE_SIZE_CHARS` constant (10,000 chars) and validates message length before sending in the mission chat. Overly large messages are rejected with a user-friendly error shown below the input field.

## Changes
- `SaveResolutionDialog.tsx`: Added `isRateLimitError()` helper to detect 429/quota/rate-limit patterns in error messages and result content. Both `error` and `result` WebSocket message types now surface a clear rate-limit message.
- `useMissions.tsx`: Extended the `error` message handler to detect rate-limit patterns and show a formatted "AI Provider Rate Limit Exceeded" message with a link to Settings.
- `MissionChat.tsx`: Added message size validation in `handleSend()` with an `inputError` state that displays below the input field and clears on edit.
- `network.ts`: Added `MAX_MESSAGE_SIZE_CHARS = 10_000` constant.

## Test plan
- [ ] Trigger a 429 error from an AI provider (e.g., send many rapid requests to exhaust quota) and verify the mission chat shows "AI Provider Rate Limit Exceeded" instead of a JSON parse error
- [ ] Open the Save Resolution dialog when the AI provider is rate-limited and verify a clear "rate limit exceeded" message appears instead of "Could not parse AI response"
- [ ] Type a message longer than 10,000 characters in the mission chat and verify a validation error appears preventing the send
- [ ] Verify editing the message clears the validation error
- [ ] Verify normal mission chat and Save Resolution flows still work correctly

Closes #2378, closes #2374