### PR TITLE
🐛 Fix architecture diagram label truncation

### DIFF
--- a/web/src/components/cards/llmd/EPPRouting.tsx
+++ b/web/src/components/cards/llmd/EPPRouting.tsx
@@ -903,9 +903,9 @@ export function EPPRouting() {
           {/* Stack info */}
           {selectedStack && (
             <div className="flex items-center gap-1 text-xs">
-              <span className={`px-1.5 py-0.5 rounded font-medium truncate max-w-[80px] ${
+              <span className={`px-1.5 py-0.5 rounded font-medium truncate max-w-[180px] ${
                 isDemoMode ? 'bg-yellow-500/20 text-yellow-400' : 'bg-green-500/20 text-green-400'
-              }`}>
+              }`} title={selectedStack.name}>
                 {selectedStack.name}
               </span>
               {isDemoMode && (
@@ -957,7 +957,7 @@ export function EPPRouting() {
       {/* Main visualization area */}
       <div className={`flex-1 relative ${isExpanded ? 'min-h-0' : 'min-h-[200px]'}`}>
         <svg
-          viewBox="-5 -5 120 120"
+          viewBox="-5 -10 120 130"
           className="w-full h-full overflow-visible"
           preserveAspectRatio="xMidYMid meet"
           style={{ overflow: 'visible' }}

--- a/web/src/components/cards/llmd/KVCacheMonitor.tsx
+++ b/web/src/components/cards/llmd/KVCacheMonitor.tsx
@@ -571,9 +571,9 @@ export function KVCacheMonitor() {
           {/* Stack info */}
           {selectedStack && (
             <div className="flex items-center gap-1 text-xs">
-              <span className={`px-1.5 py-0.5 rounded font-medium truncate max-w-[80px] ${
+              <span className={`px-1.5 py-0.5 rounded font-medium truncate max-w-[180px] ${
                 isDemoMode ? 'bg-yellow-500/20 text-yellow-400' : 'bg-green-500/20 text-green-400'
-              }`}>
+              }`} title={selectedStack.name}>
                 {selectedStack.name}
               </span>
               {isDemoMode && (

--- a/web/src/components/cards/llmd/LLMdFlow.tsx
+++ b/web/src/components/cards/llmd/LLMdFlow.tsx
@@ -962,7 +962,7 @@ export function LLMdFlow() {
   const showEmptyState = !selectedStack && !isDemoMode
 
   return (
-    <div className={`relative w-full h-full flex-1 bg-gradient-to-br from-background/50 to-secondary/30 rounded-lg overflow-hidden ${isExpanded ? 'min-h-0' : 'min-h-[300px]'}`}>
+    <div className={`relative w-full h-full flex-1 bg-gradient-to-br from-background/50 to-secondary/30 rounded-lg ${isExpanded ? 'min-h-0' : 'min-h-[300px]'}`}>
       {/* Empty state overlay */}
       {showEmptyState && (
         <div className="absolute inset-0 flex flex-col items-center justify-center z-20 bg-background/60 backdrop-blur-sm">
@@ -977,9 +977,9 @@ export function LLMdFlow() {
           {/* Stack info */}
           {selectedStack && (
             <div className="flex items-center gap-1.5 text-xs">
-              <span className={`px-1.5 py-0.5 rounded font-medium truncate max-w-[100px] ${
+              <span className={`px-1.5 py-0.5 rounded font-medium truncate max-w-[180px] ${
                 isDemoMode ? 'bg-yellow-500/20 text-yellow-400' : 'bg-green-500/20 text-green-400'
-              }`}>
+              }`} title={selectedStack.name}>
                 {selectedStack.name}
               </span>
               <span className="text-muted-foreground">{selectedStack.cluster}</span>
@@ -1059,7 +1059,7 @@ export function LLMdFlow() {
 
       {/* SVG Flow Diagram - overflow visible allows labels to extend beyond viewBox */}
       <svg
-        viewBox="-5 -5 120 130"
+        viewBox="-5 -10 120 140"
         className="w-full h-[calc(100%-2rem)] mt-8 overflow-visible"
         preserveAspectRatio="xMidYMid meet"
         style={{ overflow: 'visible' }}

--- a/web/src/components/cards/llmd/PDDisaggregation.tsx
+++ b/web/src/components/cards/llmd/PDDisaggregation.tsx
@@ -345,9 +345,9 @@ export function PDDisaggregation() {
         </div>
         <div className="flex items-center gap-2">
           {selectedStack && (
-            <span className={`px-1.5 py-0.5 rounded text-xs font-medium truncate max-w-[80px] ${
+            <span className={`px-1.5 py-0.5 rounded text-xs font-medium truncate max-w-[180px] ${
               isDemoMode ? 'bg-yellow-500/20 text-yellow-400' : 'bg-green-500/20 text-green-400'
-            }`}>
+            }`} title={selectedStack.name}>
               {selectedStack.name}
             </span>
           )}


### PR DESCRIPTION
## Summary
- Removed `overflow-hidden` from the LLMdFlow parent container that was clipping SVG node labels extending beyond the container bounds
- Expanded SVG viewBox vertical padding in LLMdFlow (`-5 -5 120 130` to `-5 -10 120 140`) and EPPRouting (`-5 -5 120 120` to `-5 -10 120 130`) to prevent labels at the top/bottom edges from being cut off
- Increased stack name badge `max-w` from 80-100px to 180px across all four architecture diagram cards (LLMdFlow, EPPRouting, PDDisaggregation, KVCacheMonitor) so stack names are no longer aggressively truncated
- Added `title` attribute to all stack name badges for full-name tooltip on hover when truncation still occurs at very narrow widths

Closes #2397

## Test plan
- [ ] Verify LLMdFlow diagram node labels (Clients, Gateway, EPP, Prefill-N, Decode-N) are fully visible in both default and horseshoe views
- [ ] Verify EPPRouting diagram node labels are fully visible in both views
- [ ] Verify stack name badges show full names (or wider truncation) in all four cards
- [ ] Hover over a truncated stack name and confirm the full name appears in a tooltip
- [ ] Check with many replicas (5+) to confirm top/bottom node labels are not clipped