### PR TITLE
🐛 Fix GitHub OAuth setup instructions ordering and URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,28 @@ go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent  # Linux (Go 1.24+)
 
 ## GitHub OAuth
 
-Create a [GitHub OAuth App](https://github.com/settings/developers) with callback URL `http://localhost:8080/auth/github/callback`, then add credentials to `.env`:
+1. **Create a [GitHub OAuth App](https://github.com/settings/developers)**
+   - Homepage URL: `http://localhost:8080`
+   - Callback URL: `http://localhost:8080/auth/github/callback`
 
-```
-GITHUB_CLIENT_ID=your-client-id
-GITHUB_CLIENT_SECRET=your-client-secret
-```
+2. **Clone the repo** (if you haven't already):
+   ```bash
+   git clone https://github.com/kubestellar/console.git
+   cd console
+   ```
 
-Restart with `./startup-oauth.sh` (local dev) or pass `--github-oauth` to `deploy.sh`.
+3. **Create a `.env` file in the repo root** (`console/.env`):
+   ```
+   GITHUB_CLIENT_ID=your-client-id
+   GITHUB_CLIENT_SECRET=your-client-secret
+   ```
+
+4. **Start the console**:
+   ```bash
+   ./startup-oauth.sh
+   ```
+
+Open http://localhost:8080 and sign in with GitHub. For Kubernetes deployments, pass `--github-oauth` to `deploy.sh` instead.
 
 To enable feedback and GitHub-powered features (nightly E2E status, community activity), go to **Settings** in the console sidebar and add a GitHub personal access token under **GitHub Token**.
 

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -182,8 +182,8 @@ if [ -z "$GITHUB_CLIENT_ID" ]; then
     echo ""
     echo "Or create a GitHub OAuth App at:"
     echo "  https://github.com/settings/developers"
-    echo "  Homepage URL: http://localhost:5174"
-    echo "  Callback URL: http://localhost:5174/auth/github/callback"
+    echo "  Homepage URL: http://localhost:8080"
+    echo "  Callback URL: http://localhost:8080/auth/github/callback"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Reorders the README OAuth setup steps so the repo is cloned (step 2) **before** creating the `.env` file (step 3). Previously step 2 told users to create `.env` "in the project root" before step 3 cloned the repo, which is impossible since the directory doesn't exist yet.
- Fixes the error message in `startup-oauth.sh` that incorrectly referenced `http://localhost:5174` instead of the default `http://localhost:8080`.
- A companion PR on `kubestellar/docs` fixes the same issue on the [installation page](https://kubestellar.io/docs/console/overview/installation#run-from-source-with-oauth).

Closes #2463

## Test plan
- [ ] Verify the README OAuth steps read in logical order (create OAuth app -> clone repo -> create .env -> run script)
- [ ] Verify `startup-oauth.sh` error message shows port 8080 URLs when `GITHUB_CLIENT_ID` is missing