### PR TITLE
🐛 Fix nightly unit-test regression (#2370)

### DIFF
--- a/web/src/hooks/useVersionCheck.test.tsx
+++ b/web/src/hooks/useVersionCheck.test.tsx
@@ -216,8 +216,8 @@ describe('getLatestForChannel', () => {
 // Cache behaviour
 // ---------------------------------------------------------------------------
 
-/** Subset of the GitHub API URL used to identify calls to the releases endpoint */
-const RELEASES_API_PATH = 'api.github.com/repos/kubestellar/console/releases'
+/** Subset of the proxy URL used to identify calls to the releases endpoint */
+const RELEASES_API_PATH = '/api/github/repos/kubestellar/console/releases'
 
 /** Returns true when a fetch mock call is targeting the GitHub releases endpoint */
 function isReleasesApiCall(call: unknown[]): boolean {


### PR DESCRIPTION
## Summary
- The `GITHUB_API_URL` constant in `useVersionCheck.tsx` was previously changed from the direct GitHub API URL (`api.github.com/repos/kubestellar/console/releases`) to a server-side proxy path (`/api/github/repos/kubestellar/console/releases`)
- The test file's `RELEASES_API_PATH` filter was not updated to match the new URL, causing `isReleasesApiCall()` to never match any mock fetch calls
- Two tests failed: `forceCheck() calls the GitHub API even when cache is fresh` and `checkForUpdates calls the GitHub API when cache is stale`

## Changes
- Updated `RELEASES_API_PATH` in `useVersionCheck.test.tsx` to match the new proxy URL path

## Test plan
- [x] All 28 tests in `useVersionCheck.test.tsx` pass
- [x] Full test suite passes (107 files, 739 tests)
- [x] `tsc --noEmit` clean

Closes #2370