### PR TITLE
✨ Virtualize MissionBrowser for large mission lists

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,7 @@
         "@react-three/drei": "^9.120.4",
         "@react-three/fiber": "^8.17.10",
         "@sqlite.org/sqlite-wasm": "^3.51.2-build6",
+        "@tanstack/react-virtual": "^3.13.22",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "clsx": "^2.1.1",
@@ -2789,6 +2790,33 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.22",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.22.tgz",
+      "integrity": "sha512-EaOrBBJLi3M0bTMQRjGkxLXRw7Gizwntoy5E2Q2UnSbML7Mo2a1P/Hfkw5tw9FLzK62bj34Jl6VNbQfRV6eJcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.22",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.22.tgz",
+      "integrity": "sha512-isuUGKsc5TAPDoHSbWTbl1SCil54zOS2MiWz/9GCWHPUQOvNTQx8qJEWC7UWR0lShhbK0Lmkcf0SZYxvch7G3g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",

--- a/web/package.json
+++ b/web/package.json
@@ -50,6 +50,7 @@
     "@react-three/drei": "^9.120.4",
     "@react-three/fiber": "^8.17.10",
     "@sqlite.org/sqlite-wasm": "^3.51.2-build6",
+    "@tanstack/react-virtual": "^3.13.22",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "clsx": "^2.1.1",

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -42,6 +42,7 @@ import {
   getMissionSlug, getMissionShareUrl, updateNodeInTree,
   missionCache, startMissionCacheFetch, resetMissionCache,
   fetchMissionContent, BROWSER_TABS,
+  VirtualizedMissionGrid,
 } from './browser'
 import type { TreeNode, ViewMode, BrowserTab } from './browser'
 
@@ -1565,30 +1566,38 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                     </div>
                     {/* Show cards progressively as they arrive */}
                     {filteredRecommendations.length > 0 && (
-                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                        {filteredRecommendations.map((match, i) => (
+                      <VirtualizedMissionGrid
+                        items={filteredRecommendations}
+                        viewMode="grid"
+                        maxColumns={3}
+                        className="flex-1"
+                        style={{ height: 'calc(90vh - 360px)' }}
+                        renderItem={(match) => (
                           <RecommendationCard
-                            key={i}
                             match={match}
                             onSelect={() => selectCardMission(match.mission)}
                             onImport={() => handleImport(match.mission)}
                             onCopyLink={(e) => handleCopyLink(match.mission, e)}
                           />
-                        ))}
-                      </div>
+                        )}
+                      />
                     )}
                   </div>
                 ) : (
-                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                    {filteredRecommendations.map((match, i) => (
+                  <VirtualizedMissionGrid
+                    items={filteredRecommendations}
+                    viewMode="grid"
+                    maxColumns={3}
+                    className="flex-1"
+                    style={{ height: 'calc(90vh - 360px)' }}
+                    renderItem={(match) => (
                       <RecommendationCard
-                        key={i}
                         match={match}
                         onSelect={() => selectCardMission(match.mission)}
                         onImport={() => handleImport(match.mission)}
                       />
-                    ))}
-                  </div>
+                    )}
+                  />
                 )}
               </CollapsibleSection>
             )}
@@ -1715,21 +1724,22 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                         Loading… {installerMissions.length} found so far
                       </div>
                     )}
-                    <div className={viewMode === 'grid'
-                      ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3"
-                      : "flex flex-col gap-2"
-                    }>
-                      {filteredInstallers.map((mission, i) => (
+                    <VirtualizedMissionGrid
+                      items={filteredInstallers}
+                      viewMode={viewMode}
+                      maxColumns={4}
+                      className="flex-1"
+                      style={{ height: 'calc(90vh - 280px)' }}
+                      renderItem={(mission) => (
                         <InstallerCard
-                          key={i}
                           mission={mission}
                           compact={viewMode === 'list'}
                           onSelect={() => selectCardMission(mission)}
                           onImport={() => handleImport(mission)}
                           onCopyLink={(e) => handleCopyLink(mission, e)}
                         />
-                      ))}
-                    </div>
+                      )}
+                    />
                   </>
                 )}
 
@@ -1791,21 +1801,22 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                         Loading… {solutionMissions.length} found so far
                       </div>
                     )}
-                    <div className={viewMode === 'grid'
-                      ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3"
-                      : "flex flex-col gap-2"
-                    }>
-                      {filteredSolutions.map((mission, i) => (
+                    <VirtualizedMissionGrid
+                      items={filteredSolutions}
+                      viewMode={viewMode}
+                      maxColumns={3}
+                      className="flex-1"
+                      style={{ height: 'calc(90vh - 280px)' }}
+                      renderItem={(mission) => (
                         <SolutionCard
-                          key={i}
                           mission={mission}
                           compact={viewMode === 'list'}
                           onSelect={() => selectCardMission(mission)}
                           onImport={() => handleImport(mission)}
                           onCopyLink={(e) => handleCopyLink(mission, e)}
                         />
-                      ))}
-                    </div>
+                      )}
+                    />
                   </>
                 )}
 

--- a/web/src/components/missions/browser/VirtualizedMissionGrid.tsx
+++ b/web/src/components/missions/browser/VirtualizedMissionGrid.tsx
@@ -1,0 +1,188 @@
+/**
+ * VirtualizedMissionGrid — Renders mission cards in a virtualized grid/list.
+ *
+ * Uses @tanstack/react-virtual to only render visible rows, dramatically
+ * reducing DOM nodes and improving performance for large mission lists
+ * (hundreds of installers/solutions).
+ *
+ * Grid mode: groups items into rows based on container width and column count,
+ * then virtualizes by row.
+ * List mode: each item is its own row.
+ */
+
+import { useRef, useMemo, useCallback, useState, useEffect } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import type { ViewMode } from './types'
+
+/** Estimated height (px) for a single card in grid mode */
+const GRID_CARD_HEIGHT_PX = 280
+/** Estimated height (px) for a single card in list/compact mode */
+const LIST_CARD_HEIGHT_PX = 48
+/** Gap between cards (px), matching Tailwind gap-3 */
+const CARD_GAP_PX = 12
+/** Extra space around the virtualizer to pre-render off-screen rows (px) */
+const OVERSCAN_PX = 300
+
+/** Breakpoints for column counts in grid mode (min container width -> columns) */
+const GRID_BREAKPOINTS: [number, number][] = [
+  [1200, 4], // xl: 4 columns
+  [900, 3],  // lg: 3 columns
+  [600, 2],  // md: 2 columns
+  [0, 1],    // sm: 1 column
+]
+
+function getColumnCount(containerWidth: number, maxColumns: number): number {
+  for (const [minWidth, cols] of GRID_BREAKPOINTS) {
+    if (containerWidth >= minWidth) {
+      return Math.min(cols, maxColumns)
+    }
+  }
+  return 1
+}
+
+// ============================================================================
+// Generic virtualized grid for mission cards
+// ============================================================================
+
+interface VirtualizedMissionGridProps<T> {
+  /** The filtered list of items to render */
+  items: T[]
+  /** Current view mode */
+  viewMode: ViewMode
+  /** Render a single card */
+  renderItem: (item: T, index: number) => React.ReactNode
+  /** Maximum columns in grid mode (e.g. 4 for installers, 3 for solutions) */
+  maxColumns?: number
+  /** Custom estimated row height for grid mode */
+  gridRowHeight?: number
+  /** Custom estimated row height for list mode */
+  listRowHeight?: number
+  /** Optional className for the scroll container */
+  className?: string
+  /** Optional inline style for the scroll container (e.g. fixed height) */
+  style?: React.CSSProperties
+}
+
+export function VirtualizedMissionGrid<T>({
+  items,
+  viewMode,
+  renderItem,
+  maxColumns = 4,
+  gridRowHeight = GRID_CARD_HEIGHT_PX,
+  listRowHeight = LIST_CARD_HEIGHT_PX,
+  className,
+  style,
+}: VirtualizedMissionGridProps<T>) {
+  const parentRef = useRef<HTMLDivElement>(null)
+  const [containerWidth, setContainerWidth] = useState(0)
+
+  // Track container width for responsive column count
+  useEffect(() => {
+    const el = parentRef.current
+    if (!el) return
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width)
+      }
+    })
+    observer.observe(el)
+    // Set initial width
+    setContainerWidth(el.clientWidth)
+
+    return () => observer.disconnect()
+  }, [])
+
+  const isGrid = viewMode === 'grid'
+  const columnCount = isGrid ? getColumnCount(containerWidth, maxColumns) : 1
+
+  // Group items into rows
+  const rows = useMemo(() => {
+    if (!isGrid) {
+      // List mode: each item is its own row
+      return items.map((item) => [item])
+    }
+    // Grid mode: chunk into rows of columnCount
+    const result: T[][] = []
+    for (let i = 0; i < items.length; i += columnCount) {
+      result.push(items.slice(i, i + columnCount))
+    }
+    return result
+  }, [items, columnCount, isGrid])
+
+  const estimatedRowHeight = isGrid ? gridRowHeight + CARD_GAP_PX : listRowHeight + CARD_GAP_PX
+
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: useCallback(() => estimatedRowHeight, [estimatedRowHeight]),
+    overscan: Math.ceil(OVERSCAN_PX / estimatedRowHeight),
+  })
+
+  const virtualItems = virtualizer.getVirtualItems()
+
+  // Calculate the base index for each row's items
+  const getItemIndex = useCallback(
+    (rowIndex: number, colIndex: number) => rowIndex * columnCount + colIndex,
+    [columnCount],
+  )
+
+  return (
+    <div
+      ref={parentRef}
+      className={className}
+      style={{
+        overflow: 'auto',
+        ...style,
+      }}
+    >
+      <div
+        style={{
+          height: virtualizer.getTotalSize(),
+          width: '100%',
+          position: 'relative',
+        }}
+      >
+        {virtualItems.map((virtualRow) => {
+          const rowItems = rows[virtualRow.index]
+          return (
+            <div
+              key={virtualRow.key}
+              data-index={virtualRow.index}
+              ref={virtualizer.measureElement}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+            >
+              {isGrid ? (
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))`,
+                    gap: `${CARD_GAP_PX}px`,
+                    paddingBottom: `${CARD_GAP_PX}px`,
+                  }}
+                >
+                  {rowItems.map((item, colIndex) => (
+                    <div key={getItemIndex(virtualRow.index, colIndex)}>
+                      {renderItem(item, getItemIndex(virtualRow.index, colIndex))}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div style={{ paddingBottom: `${CARD_GAP_PX / 2}px` }}>
+                  {renderItem(rowItems[0], virtualRow.index)}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+

--- a/web/src/components/missions/browser/index.ts
+++ b/web/src/components/missions/browser/index.ts
@@ -10,3 +10,4 @@ export {
   fetchMissionContent, MISSION_FILE_FETCH_TIMEOUT_MS,
 } from './missionCache'
 export type { MissionCache } from './missionCache'
+export { VirtualizedMissionGrid } from './VirtualizedMissionGrid'


### PR DESCRIPTION
## Summary
- Adds `@tanstack/react-virtual` to virtualize the installer, solution, and recommendation grids in `MissionBrowser`
- Creates a generic `VirtualizedMissionGrid` component that supports both grid and list view modes with responsive column counts
- Only visible rows are rendered to the DOM, reducing node count from hundreds of cards to ~10-15 visible rows at a time

## Problem
The MissionBrowser renders all missions at once (installers + solutions can be 300+ cards), creating excessive DOM nodes and causing jank during scrolling and filtering.

## Solution
A new `VirtualizedMissionGrid<T>` component wraps `@tanstack/react-virtual`:
- **Grid mode**: Groups items into rows based on container width (responsive breakpoints: 1-4 columns), virtualizes by row
- **List mode**: Each item is its own virtualized row  
- **ResizeObserver** tracks container width for responsive column count
- **Dynamic measurement** via `measureElement` for accurate row heights
- **Overscan** of 300px pre-renders off-screen rows for smooth scrolling
- All named constants (no magic numbers): `GRID_CARD_HEIGHT_PX`, `LIST_CARD_HEIGHT_PX`, `CARD_GAP_PX`, `OVERSCAN_PX`, etc.

Search/filter continues to work unchanged — the virtualized grid simply receives the already-filtered list.

## Test plan
- [ ] Open MissionBrowser, switch between Installers/Solutions/Recommended tabs
- [ ] Verify grid and list view modes render correctly
- [ ] Scroll through large lists — should be smooth with no jank
- [ ] Search/filter missions — virtualized list updates correctly
- [ ] Resize browser window — column count adjusts responsively
- [ ] Click a card to open detail view, then go back — grid state preserved
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds

Closes #2403