### PR TITLE
✨ Improve GitHub OAuth error handling and user feedback

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -3,16 +3,19 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
-	"strings"
 
 	"golang.org/x/oauth2"
 
@@ -265,11 +268,62 @@ func (h *AuthHandler) devModeLogin(c *fiber.Ctx) error {
 	return c.Redirect(redirectURL, fiber.StatusTemporaryRedirect)
 }
 
+// oauthErrorRedirect builds a redirect URL to the login page with a structured error.
+// The error code is always present; detail is optional human-readable context.
+func (h *AuthHandler) oauthErrorRedirect(c *fiber.Ctx, errorCode, detail string) error {
+	q := url.Values{"error": {errorCode}}
+	if detail != "" {
+		q.Set("error_detail", detail)
+	}
+	return c.Redirect(h.frontendURL+"/login?"+q.Encode(), fiber.StatusTemporaryRedirect)
+}
+
+// classifyExchangeError inspects a token-exchange error and returns a specific
+// error code plus a short description suitable for logging and the frontend.
+func classifyExchangeError(err error) (code, detail string) {
+	msg := err.Error()
+
+	// Network-level failures (DNS, TCP, TLS)
+	var netErr net.Error
+	if ok := errors.As(err, &netErr); ok {
+		if netErr.Timeout() {
+			return "network_error", "Request to GitHub timed out — check your internet connection"
+		}
+		return "network_error", "Could not reach GitHub — check your internet connection or firewall"
+	}
+
+	// oauth2 wraps the HTTP response body when GitHub returns a non-200.
+	// Common patterns from GitHub's OAuth error responses:
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.Contains(lower, "incorrect_client_credentials") ||
+		strings.Contains(lower, "client_id"):
+		return "invalid_client", "GitHub rejected the client credentials — verify GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET"
+	case strings.Contains(lower, "redirect_uri_mismatch"):
+		return "redirect_mismatch", "The callback URL does not match the one registered in GitHub OAuth app settings"
+	case strings.Contains(lower, "bad_verification_code"):
+		return "exchange_failed", "Authorization code expired or was already used — please try logging in again"
+	default:
+		return "exchange_failed", msg
+	}
+}
+
 // GitHubCallback handles the OAuth callback
 func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
+	// GitHub may redirect with an error parameter when the user denies access
+	// or the OAuth app is misconfigured (e.g., suspended, wrong callback URL).
+	if ghError := c.Query("error"); ghError != "" {
+		ghDescription := c.Query("error_description", ghError)
+		log.Printf("[Auth] GitHub returned error: %s — %s", ghError, ghDescription)
+		if ghError == "access_denied" {
+			return h.oauthErrorRedirect(c, "access_denied", ghDescription)
+		}
+		return h.oauthErrorRedirect(c, "github_error", ghDescription)
+	}
+
 	code := c.Query("code")
 	if code == "" {
-		return c.Redirect(h.frontendURL+"/login?error=missing_code", fiber.StatusTemporaryRedirect)
+		return h.oauthErrorRedirect(c, "missing_code", "")
 	}
 
 	// CSRF validation: verify state parameter matches server-side store
@@ -277,28 +331,32 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 	state := c.Query("state")
 	if state == "" || !validateAndConsumeOAuthState(state) {
 		log.Printf("[Auth] CSRF validation failed: invalid or expired state token")
-		return c.Redirect(h.frontendURL+"/login?error=csrf_validation_failed", fiber.StatusTemporaryRedirect)
+		return h.oauthErrorRedirect(c, "csrf_validation_failed", "")
 	}
 
-	// Exchange code for token
-	token, err := h.oauthConfig.Exchange(context.Background(), code)
+	// Exchange code for token — use a context with timeout for resilience
+	ctx, cancel := context.WithTimeout(context.Background(), githubHTTPTimeout)
+	defer cancel()
+	token, err := h.oauthConfig.Exchange(ctx, code)
 	if err != nil {
-		log.Printf("[Auth] Token exchange failed: %v", err)
-		return c.Redirect(h.frontendURL+"/login?error=exchange_failed", fiber.StatusTemporaryRedirect)
+		errCode, detail := classifyExchangeError(err)
+		log.Printf("[Auth] Token exchange failed (%s): %v", errCode, err)
+		return h.oauthErrorRedirect(c, errCode, detail)
 	}
 
 	// Get user info from GitHub
 	ghUser, err := h.getGitHubUser(token.AccessToken)
 	if err != nil {
 		log.Printf("[Auth] Failed to get GitHub user: %v", err)
-		return c.Redirect(h.frontendURL+"/login?error=user_fetch_failed", fiber.StatusTemporaryRedirect)
+		detail := err.Error()
+		return h.oauthErrorRedirect(c, "user_fetch_failed", detail)
 	}
 
 	// Find or create user
 	user, err := h.store.GetUserByGitHubID(fmt.Sprintf("%d", ghUser.ID))
 	if err != nil {
 		log.Printf("[Auth] Database error getting user: %v", err)
-		return c.Redirect(h.frontendURL+"/login?error=db_error", fiber.StatusTemporaryRedirect)
+		return h.oauthErrorRedirect(c, "db_error", "")
 	}
 
 	if user == nil {
@@ -311,7 +369,8 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 			Onboarded:   h.skipOnboarding, // Skip questionnaire if SKIP_ONBOARDING=true
 		}
 		if err := h.store.CreateUser(user); err != nil {
-			return c.Redirect(h.frontendURL+"/login?error=create_user_failed", fiber.StatusTemporaryRedirect)
+			log.Printf("[Auth] Failed to create user: %v", err)
+			return h.oauthErrorRedirect(c, "create_user_failed", "")
 		}
 	} else {
 		// Update user info
@@ -327,7 +386,8 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 	// Generate JWT
 	jwtToken, err := h.generateJWT(user)
 	if err != nil {
-		return c.Redirect(h.frontendURL+"/login?error=jwt_failed", fiber.StatusTemporaryRedirect)
+		log.Printf("[Auth] JWT generation failed: %v", err)
+		return h.oauthErrorRedirect(c, "jwt_failed", "")
 	}
 
 	// Set HttpOnly cookie (primary auth) and pass token in URL (migration fallback)

--- a/pkg/api/handlers/auth_test.go
+++ b/pkg/api/handlers/auth_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -222,5 +223,62 @@ func TestGitHubCallback_InvalidState(t *testing.T) {
 	assert.Contains(t, loc.String(), "error=csrf_validation_failed")
 }
 
+func TestGitHubCallback_GitHubError(t *testing.T) {
+	app, _, handler := setupAuthTest()
+	app.Get("/auth/callback", handler.GitHubCallback)
+
+	t.Run("Access denied by user", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/auth/callback?error=access_denied&error_description=The+user+denied+access", nil)
+		resp, err := app.Test(req, 5000)
+		if err != nil || resp == nil {
+			t.Fatalf("app.Test failed: %v", err)
+		}
+
+		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+		loc, _ := resp.Location()
+		assert.Contains(t, loc.String(), "error=access_denied")
+		assert.Contains(t, loc.String(), "error_detail=")
+	})
+
+	t.Run("Generic GitHub error", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/auth/callback?error=application_suspended&error_description=App+is+suspended", nil)
+		resp, err := app.Test(req, 5000)
+		if err != nil || resp == nil {
+			t.Fatalf("app.Test failed: %v", err)
+		}
+
+		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+		loc, _ := resp.Location()
+		assert.Contains(t, loc.String(), "error=github_error")
+		assert.Contains(t, loc.String(), "error_detail=")
+	})
+}
+
+func TestClassifyExchangeError(t *testing.T) {
+	t.Run("Incorrect client credentials", func(t *testing.T) {
+		err := fmt.Errorf("oauth2: cannot fetch token: 401 Unauthorized\nResponse: incorrect_client_credentials")
+		code, _ := classifyExchangeError(err)
+		assert.Equal(t, "invalid_client", code)
+	})
+
+	t.Run("Redirect URI mismatch", func(t *testing.T) {
+		err := fmt.Errorf("oauth2: cannot fetch token: 400 Bad Request\nResponse: redirect_uri_mismatch")
+		code, _ := classifyExchangeError(err)
+		assert.Equal(t, "redirect_mismatch", code)
+	})
+
+	t.Run("Bad verification code", func(t *testing.T) {
+		err := fmt.Errorf("oauth2: cannot fetch token: 400 Bad Request\nResponse: bad_verification_code")
+		code, _ := classifyExchangeError(err)
+		assert.Equal(t, "exchange_failed", code)
+	})
+
+	t.Run("Generic exchange error", func(t *testing.T) {
+		err := fmt.Errorf("some unknown error from oauth2 library")
+		code, _ := classifyExchangeError(err)
+		assert.Equal(t, "exchange_failed", code)
+	})
+}
+
 // We cannot easily test successful GitHubCallback flow without mocking oauth lib
-// or doing extensive interface extraction, but we covered the error headers above.
+// or doing extensive interface extraction, but we covered the error paths above.

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -11,8 +11,15 @@ import { LogoWithStar } from '../ui/LogoWithStar'
 // Lazy load the heavy Three.js globe animation
 const GlobeAnimation = lazy(() => import('../animations/globe').then(m => ({ default: m.GlobeAnimation })))
 
+/** Structured info displayed for each OAuth error code returned by the backend. */
+interface OAuthErrorEntry {
+  title: string
+  message: string
+  steps: string[]
+}
+
 // Map backend error codes to user-friendly messages with troubleshooting steps
-const OAUTH_ERROR_INFO: Record<string, { title: string; message: string; steps: string[] }> = {
+const OAUTH_ERROR_INFO: Record<string, OAuthErrorEntry> = {
   exchange_failed: {
     title: 'GitHub OAuth Token Exchange Failed',
     message: 'The console was unable to complete the login with GitHub. This usually means your OAuth app is misconfigured.',
@@ -21,6 +28,36 @@ const OAUTH_ERROR_INFO: Record<string, { title: string; message: string; steps: 
       'Verify the Client Secret in your GitHub OAuth app matches what\'s in .env (regenerate if unsure)',
       'Confirm the "Authorization callback URL" in your GitHub OAuth app is set to: http://localhost:8080/auth/github/callback',
       'Restart the console after updating .env',
+    ],
+  },
+  invalid_client: {
+    title: 'Invalid OAuth Client Credentials',
+    message: 'GitHub rejected the client ID or client secret. Your OAuth app may be misconfigured or the credentials may have been rotated.',
+    steps: [
+      'Open your GitHub OAuth app settings and copy a fresh Client ID and Client Secret',
+      'Update GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET in your .env file',
+      'If using GitHub Enterprise, verify GITHUB_URL points to the correct instance',
+      'Restart the console after updating .env',
+    ],
+  },
+  redirect_mismatch: {
+    title: 'OAuth Callback URL Mismatch',
+    message: 'The callback URL configured in the console does not match the one registered in your GitHub OAuth app.',
+    steps: [
+      'Open your GitHub OAuth app settings',
+      'Set "Authorization callback URL" to: http://localhost:8080/auth/github/callback',
+      'If using a custom BACKEND_URL, make sure the callback URL matches: <BACKEND_URL>/auth/github/callback',
+      'Restart the console after updating the GitHub OAuth app',
+    ],
+  },
+  network_error: {
+    title: 'Network Error',
+    message: 'The console backend could not reach GitHub to complete authentication. This is usually a connectivity issue.',
+    steps: [
+      'Check your internet connection',
+      'If behind a corporate proxy or firewall, ensure github.com and api.github.com are reachable',
+      'Try again in a few moments — GitHub may be experiencing an outage',
+      'Check https://www.githubstatus.com for service status',
     ],
   },
   csrf_validation_failed: {
@@ -41,6 +78,24 @@ const OAUTH_ERROR_INFO: Record<string, { title: string; message: string; steps: 
       'Verify the "Homepage URL" in your GitHub OAuth app settings',
     ],
   },
+  access_denied: {
+    title: 'Access Denied',
+    message: 'You denied the GitHub authorization request, or the OAuth app does not have permission to access your account.',
+    steps: [
+      'Click "Continue with GitHub" below and approve the authorization prompt',
+      'If you did not deny access, check that the GitHub OAuth app is not restricted by your organization\'s policies',
+      'Contact your GitHub organization admin if SSO enforcement is blocking access',
+    ],
+  },
+  github_error: {
+    title: 'GitHub Authorization Error',
+    message: 'GitHub returned an error during the authorization process.',
+    steps: [
+      'Try logging in again — this may be a temporary issue',
+      'Verify your GitHub OAuth app is not suspended or deleted',
+      'Check https://www.githubstatus.com for service status',
+    ],
+  },
   user_fetch_failed: {
     title: 'Could Not Retrieve GitHub Profile',
     message: 'Login succeeded but the console was unable to fetch your GitHub profile.',
@@ -58,6 +113,35 @@ const OAUTH_ERROR_INFO: Record<string, { title: string; message: string; steps: 
       'Check the backend logs for more details',
     ],
   },
+  create_user_failed: {
+    title: 'Account Creation Failed',
+    message: 'The console was unable to create your user account in its local database.',
+    steps: [
+      'Restart the console and try again',
+      'Check the backend logs for database errors',
+      'If the problem persists, try deleting the local database file and restarting',
+    ],
+  },
+  jwt_failed: {
+    title: 'Session Token Generation Failed',
+    message: 'The console backend was unable to generate a session token after successful GitHub login.',
+    steps: [
+      'Restart the console and try again',
+      'Ensure JWT_SECRET is set in your .env file (any random string)',
+      'Check the backend logs for more details',
+    ],
+  },
+}
+
+/** Fallback error info for unrecognized error codes. */
+const UNKNOWN_ERROR_FALLBACK: OAuthErrorEntry = {
+  title: 'Authentication Error',
+  message: 'An unexpected error occurred during login.',
+  steps: [
+    'Try logging in again — click "Continue with GitHub" below',
+    'Restart the console and try again',
+    'Check the backend logs for more details',
+  ],
 }
 
 export function Login() {
@@ -66,7 +150,14 @@ export function Login() {
   const [searchParams] = useSearchParams()
   const sessionExpired = useMemo(() => searchParams.get('reason') === 'session_expired', [searchParams])
   const oauthError = useMemo(() => searchParams.get('error'), [searchParams])
-  const errorInfo = oauthError ? OAUTH_ERROR_INFO[oauthError] : null
+  const errorDetail = useMemo(() => searchParams.get('error_detail'), [searchParams])
+  const errorInfo = useMemo(() => {
+    if (!oauthError) return null
+    const known = OAUTH_ERROR_INFO[oauthError]
+    if (known) return known
+    // Fallback for unrecognized error codes so the user always sees actionable UI
+    return { ...UNKNOWN_ERROR_FALLBACK, message: `An unexpected error occurred during login (code: ${oauthError}).` }
+  }, [oauthError])
 
   // Auto-login for Netlify deploy previews or when backend has no OAuth configured
   // Skip auto-login when there's an OAuth error so the user can see the troubleshooting info
@@ -156,7 +247,7 @@ export function Login() {
 
           {/* OAuth error banner */}
           {errorInfo && (
-            <div className="mb-6 rounded-lg border border-red-500/50 bg-red-500/10 overflow-hidden">
+            <div data-testid="oauth-error-banner" className="mb-6 rounded-lg border border-red-500/50 bg-red-500/10 overflow-hidden">
               <div className="flex items-center gap-3 px-4 py-3 text-red-300 text-sm">
                 <AlertTriangle className="w-5 h-5 shrink-0 text-red-400" />
                 <div>
@@ -164,6 +255,14 @@ export function Login() {
                   <div className="text-xs text-red-400/80 mt-0.5">{errorInfo.message}</div>
                 </div>
               </div>
+              {/* Server-provided detail (e.g., specific GitHub error description) */}
+              {errorDetail && (
+                <div className="px-4 pb-2">
+                  <div className="text-xs text-red-400/60 bg-red-500/5 rounded px-3 py-2 font-mono break-words">
+                    {errorDetail}
+                  </div>
+                </div>
+              )}
               <div className="px-4 pb-3">
                 <div className="text-xs font-medium text-red-300/80 mb-1.5">Troubleshooting:</div>
                 <ol className="text-xs text-red-400/70 space-y-1 list-decimal list-inside">


### PR DESCRIPTION
## Summary
- **Backend**: Handle GitHub's own error parameters (`access_denied`, app suspended) in the OAuth callback instead of falling through to `missing_code`
- **Backend**: Classify token exchange errors into specific codes (`invalid_client`, `redirect_mismatch`, `network_error`) instead of a generic `exchange_failed`, with a timeout context for network resilience
- **Backend**: Pass `error_detail` query parameter with server-side context to the frontend
- **Frontend**: Add error mappings for all 12 error codes with titles, descriptions, and troubleshooting steps — including a fallback for unrecognized codes
- **Frontend**: Display server-provided `error_detail` in a monospace block when available
- **Tests**: Add Go tests for GitHub error parameter handling and `classifyExchangeError`

Closes #2404

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Verify `go test ./pkg/api/handlers/` passes (including new tests)
- [ ] Verify frontend Login component test passes
- [ ] Manual: Start console with invalid `GITHUB_CLIENT_SECRET` and attempt login — should see "Invalid OAuth Client Credentials" with troubleshooting steps
- [ ] Manual: Start console and deny the GitHub OAuth prompt — should see "Access Denied" error
- [ ] Manual: Start console with no internet — should see "Network Error" with retry suggestions
- [ ] Manual: Navigate to `/login?error=some_unknown_code` — should see fallback "Authentication Error" with the code displayed