### PR TITLE
🐛 Add FEEDBACK_GITHUB_TOKEN status display to Settings

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -92,6 +92,67 @@ func (h *FeedbackHandler) HasToken(c *fiber.Ctx) error {
 	})
 }
 
+// SaveToken handles POST /api/feedback/token — saves a user-provided
+// feedback GitHub PAT to the encrypted server-side settings file.
+func (h *FeedbackHandler) SaveToken(c *fiber.Ctx) error {
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := c.BodyParser(&body); err != nil || body.Token == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Token is required",
+		})
+	}
+
+	sm := settings.GetSettingsManager()
+	if sm == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "Settings manager not available",
+		})
+	}
+
+	all, err := sm.GetAll()
+	if err != nil {
+		all = &settings.AllSettings{}
+	}
+	all.FeedbackGitHubToken = body.Token
+	all.FeedbackGitHubTokenSource = settings.GitHubTokenSourceSettings
+	if err := sm.SaveAll(all); err != nil {
+		log.Printf("[Feedback] Failed to save feedback token: %v", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to save token",
+		})
+	}
+
+	log.Printf("[Feedback] Feedback GitHub token saved to encrypted settings")
+	return c.JSON(fiber.Map{"success": true})
+}
+
+// DeleteToken handles DELETE /api/feedback/token — removes the user-provided
+// feedback GitHub PAT from server-side settings.
+func (h *FeedbackHandler) DeleteToken(c *fiber.Ctx) error {
+	sm := settings.GetSettingsManager()
+	if sm == nil {
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+			"error": "Settings manager not available",
+		})
+	}
+
+	all, err := sm.GetAll()
+	if err != nil {
+		return c.JSON(fiber.Map{"success": true}) // Nothing to delete
+	}
+	all.FeedbackGitHubToken = ""
+	all.FeedbackGitHubTokenSource = ""
+	if err := sm.SaveAll(all); err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to clear token",
+		})
+	}
+
+	return c.JSON(fiber.Map{"success": true})
+}
+
 // CreateFeatureRequest creates a new feature request and GitHub issue
 func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 	userID := middleware.GetUserID(c)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -740,6 +740,8 @@ func (s *Server) setupRoutes() {
 	feedbackCfg := handlers.LoadFeedbackConfig()
 	feedback := handlers.NewFeedbackHandler(s.store, feedbackCfg)
 	api.Get("/feedback/token/status", feedback.HasToken)
+	api.Post("/feedback/token", feedback.SaveToken)
+	api.Delete("/feedback/token", feedback.DeleteToken)
 	api.Post("/feedback/requests", feedback.CreateFeatureRequest)
 	api.Get("/feedback/requests", feedback.ListFeatureRequests)
 	api.Get("/feedback/queue", feedback.ListAllFeatureRequests)

--- a/web/src/components/settings/sections/GitHubTokenSection.tsx
+++ b/web/src/components/settings/sections/GitHubTokenSection.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Save, RefreshCw, Check, X, Github, ExternalLink, Loader2, Server } from 'lucide-react'
+import { Save, RefreshCw, Check, X, Github, ExternalLink, Loader2, Server, MessageSquare } from 'lucide-react'
 import { STORAGE_KEY_TOKEN, STORAGE_KEY_GITHUB_TOKEN_SOURCE, STORAGE_KEY_GITHUB_TOKEN_DISMISSED, STORAGE_KEY_FEEDBACK_GITHUB_TOKEN, STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE, STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED, FETCH_EXTERNAL_TIMEOUT_MS } from '../../../lib/constants'
 import { emitGitHubTokenConfigured, emitGitHubTokenRemoved, emitConversionStep } from '../../../lib/analytics'
 import { UI_FEEDBACK_TIMEOUT_MS, SCROLL_COMPLETE_MS } from '../../../lib/constants/network'
@@ -9,23 +9,18 @@ interface GitHubTokenSectionProps {
   forceVersionCheck: () => void
 }
 
-// Helper functions for base64 encoding (obfuscation, not encryption)
-// Used only for the feedback token which remains in localStorage
-const encodeToken = (token: string) => btoa(token)
-const decodeToken = (encoded: string) => {
-  try {
-    return atob(encoded)
-  } catch {
-    return encoded // Return as-is if not encoded (migration from old format)
-  }
-}
-
 /** Token source values matching backend GitHubTokenSource constants */
 const TOKEN_SOURCE_SETTINGS = 'settings'
 const TOKEN_SOURCE_ENV = 'env'
 
 /** Timeout for fetching settings from the backend */
 const AGENT_FETCH_TIMEOUT_MS = 5000
+
+/** Delay before applying deep link highlight effect */
+const HIGHLIGHT_DELAY_MS = 400
+
+/** Delay before trying to render deep-link scroll */
+const DEEP_LINK_RENDER_DELAY_MS = 300
 
 /** Build JWT auth headers for backend proxy requests */
 function authHeaders(): Record<string, string> {
@@ -51,19 +46,40 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
   const [feedbackGithubRateLimit, setFeedbackGithubRateLimit] = useState<{ limit: number; remaining: number; reset: Date } | null>(null)
   const [isInitializing, setIsInitializing] = useState(true)
 
-  // Load GitHub token status on mount — check backend proxy for main token, localStorage for feedback token
+  // Load GitHub token status on mount — check backend for both main and feedback tokens
   useEffect(() => {
     const loadToken = async () => {
-      // Load feedback token from localStorage
-      const encodedFeedbackToken = localStorage.getItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN)
-      const storedFeedbackSource = localStorage.getItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE)
-      const feedbackDismissed = localStorage.getItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED) === 'true'
+      // Check backend for feedback token status (env var or settings-saved)
+      let feedbackTokenFound = false
+      try {
+        const fbResponse = await fetch('/api/feedback/token/status', {
+          headers: authHeaders(),
+          signal: AbortSignal.timeout(AGENT_FETCH_TIMEOUT_MS),
+        })
+        if (fbResponse.ok) {
+          const fbData = await fbResponse.json() as { hasToken: boolean; source: string }
+          if (fbData.hasToken) {
+            const source = fbData.source || TOKEN_SOURCE_SETTINGS
+            localStorage.setItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE, source)
+            setHasFeedbackGithubToken(true)
+            setFeedbackTokenSource(source)
+            feedbackTokenFound = true
+          }
+        }
+      } catch {
+        // Backend unavailable — fall back to localStorage check below
+      }
 
-      if (encodedFeedbackToken && !feedbackDismissed) {
-        setHasFeedbackGithubToken(true)
-        setFeedbackTokenSource(storedFeedbackSource)
-        const token = decodeToken(encodedFeedbackToken)
-        await testFeedbackGithubToken(token)
+      // Fallback: also check localStorage for legacy feedback tokens
+      if (!feedbackTokenFound) {
+        const encodedFeedbackToken = localStorage.getItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN)
+        const storedFeedbackSource = localStorage.getItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE)
+        const feedbackDismissed = localStorage.getItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED) === 'true'
+
+        if (encodedFeedbackToken && !feedbackDismissed) {
+          setHasFeedbackGithubToken(true)
+          setFeedbackTokenSource(storedFeedbackSource)
+        }
       }
 
       // Check backend proxy for main token status
@@ -124,7 +140,7 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
           setTimeout(() => {
             section.classList.add('ring-2', 'ring-purple-500/50')
             setTimeout(() => section.classList.remove('ring-2', 'ring-purple-500/50'), UI_FEEDBACK_TIMEOUT_MS)
-          }, 400)
+          }, HIGHLIGHT_DELAY_MS)
         }
 
         if (input) {
@@ -135,7 +151,7 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
         if (hash || params.get('focus')) {
           window.history.replaceState({}, '', window.location.pathname)
         }
-      }, 300)
+      }, DEEP_LINK_RENDER_DELAY_MS)
 
       return () => clearTimeout(timer)
     }
@@ -296,23 +312,60 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
     if (!feedbackGithubToken.trim()) return
 
     setFeedbackGithubTokenTesting(true)
-    const isValid = await testFeedbackGithubToken(feedbackGithubToken.trim())
-    if (isValid) {
-      localStorage.setItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN, encodeToken(feedbackGithubToken.trim()))
-      localStorage.setItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE, TOKEN_SOURCE_SETTINGS)
-      // Clear any previous env-token dismissal
-      localStorage.removeItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED)
-      window.dispatchEvent(new CustomEvent('kubestellar-settings-changed'))
-      setHasFeedbackGithubToken(true)
-      setFeedbackTokenSource(TOKEN_SOURCE_SETTINGS)
-      setFeedbackGithubToken('')
-      setFeedbackGithubTokenSaved(true)
-      setTimeout(() => setFeedbackGithubTokenSaved(false), UI_FEEDBACK_TIMEOUT_MS)
+    setFeedbackGithubTokenError(null)
+
+    try {
+      // Save token to backend (encrypted storage)
+      const saveResponse = await fetch('/api/feedback/token', {
+        method: 'POST',
+        headers: {
+          ...authHeaders(),
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ token: feedbackGithubToken.trim() }),
+        signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS),
+      })
+
+      if (!saveResponse.ok) {
+        throw new Error(`Failed to save token: ${saveResponse.status}`)
+      }
+
+      // Validate the token directly against GitHub API
+      const isValid = await testFeedbackGithubToken(feedbackGithubToken.trim())
+
+      if (isValid) {
+        // Clear legacy localStorage token (now stored server-side)
+        localStorage.removeItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN)
+        localStorage.setItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE, TOKEN_SOURCE_SETTINGS)
+        // Clear any previous env-token dismissal
+        localStorage.removeItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED)
+        window.dispatchEvent(new CustomEvent('kubestellar-settings-changed'))
+        setHasFeedbackGithubToken(true)
+        setFeedbackTokenSource(TOKEN_SOURCE_SETTINGS)
+        setFeedbackGithubToken('')
+        setFeedbackGithubTokenSaved(true)
+        setTimeout(() => setFeedbackGithubTokenSaved(false), UI_FEEDBACK_TIMEOUT_MS)
+      }
+    } catch (err) {
+      setFeedbackGithubTokenError(err instanceof Error ? err.message : 'Failed to save token')
+    } finally {
+      setFeedbackGithubTokenTesting(false)
     }
-    setFeedbackGithubTokenTesting(false)
   }
 
-  const handleClearFeedbackGithubToken = () => {
+  const handleClearFeedbackGithubToken = async () => {
+    try {
+      // Remove token from backend
+      await fetch('/api/feedback/token', {
+        method: 'DELETE',
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS),
+      })
+    } catch {
+      // Best-effort — clear local state regardless
+    }
+
+    // Clear legacy localStorage entries
     localStorage.removeItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN)
     localStorage.removeItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE)
     if (isFeedbackEnvToken) {
@@ -347,7 +400,7 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
         </div>
       ) : (
         <>
-          {/* Status */}
+          {/* Main Token Status */}
           <div className={`p-4 rounded-lg mb-4 ${
         githubTokenError ? 'bg-red-500/10 border border-red-500/20' :
         hasGithubToken ? 'bg-green-500/10 border border-green-500/20' :
@@ -395,6 +448,61 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
           </p>
         )}
       </div>
+
+          {/* Feedback Token Status */}
+          <div className={`p-4 rounded-lg mb-4 ${
+            feedbackGithubTokenError ? 'bg-red-500/10 border border-red-500/20' :
+            hasFeedbackGithubToken ? 'bg-green-500/10 border border-green-500/20' :
+            'bg-yellow-500/10 border border-yellow-500/20'
+          }`}>
+            <div className="flex items-center gap-2 flex-wrap">
+              <MessageSquare className="w-4 h-4 text-muted-foreground" />
+              <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">{t('settings.github.feedbackTokenLabel')}</span>
+              <span className="text-muted-foreground">|</span>
+              {feedbackGithubTokenTesting ? (
+                <>
+                  <RefreshCw className="w-4 h-4 text-blue-400 animate-spin" />
+                  <span className="text-sm font-medium text-blue-400">{t('settings.github.testingToken')}</span>
+                </>
+              ) : feedbackGithubTokenError ? (
+                <>
+                  <X className="w-4 h-4 text-red-400" />
+                  <span className="text-sm font-medium text-red-400">{t('settings.github.tokenError')}</span>
+                  <span className="text-sm text-muted-foreground">- {feedbackGithubTokenError}</span>
+                </>
+              ) : hasFeedbackGithubToken && feedbackGithubRateLimit ? (
+                <>
+                  <Check className="w-4 h-4 text-green-400" />
+                  <span className="text-sm font-medium text-green-400">{t('settings.github.tokenValid')}</span>
+                  <span className="text-sm text-muted-foreground">
+                    - {feedbackGithubRateLimit.remaining.toLocaleString()}/{feedbackGithubRateLimit.limit.toLocaleString()} {t('settings.github.requestsRemaining')}
+                  </span>
+                  {isFeedbackEnvToken && <EnvBadge />}
+                </>
+              ) : hasFeedbackGithubToken ? (
+                <>
+                  <Check className="w-4 h-4 text-green-400" />
+                  <span className="text-sm font-medium text-green-400">{t('settings.github.tokenConfigured')}</span>
+                  {isFeedbackEnvToken && <EnvBadge />}
+                </>
+              ) : (
+                <>
+                  <X className="w-4 h-4 text-yellow-400" />
+                  <span className="text-sm font-medium text-yellow-400">{t('settings.github.feedbackTokenNotConfigured')}</span>
+                  <span className="text-sm text-muted-foreground">- {t('settings.github.feedbackTokenNotConfiguredHint')}</span>
+                </>
+              )}
+            </div>
+            {feedbackGithubRateLimit && hasFeedbackGithubToken && !feedbackGithubTokenError && (
+              <p className="text-xs text-muted-foreground mt-2">
+                {t('settings.github.feedbackRateLimit', {
+                  remaining: feedbackGithubRateLimit.remaining.toLocaleString(),
+                  limit: feedbackGithubRateLimit.limit.toLocaleString(),
+                  time: feedbackGithubRateLimit.reset.toLocaleTimeString(),
+                })}
+              </p>
+            )}
+          </div>
 
           {/* Token Input */}
           <div className="space-y-4">
@@ -472,16 +580,9 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
                 {t('settings.github.feedbackTokenDescription')}
                 {isFeedbackEnvToken ? ` ${t('settings.github.feedbackTokenEnvSource')}` : ''}
               </p>
-              {feedbackGithubTokenError && (
-                <p className="text-xs text-red-400 mt-2">{feedbackGithubTokenError}</p>
-              )}
-              {hasFeedbackGithubToken && feedbackGithubRateLimit && !feedbackGithubTokenError && (
-                <p className="text-xs text-muted-foreground mt-2">
-                  {t('settings.github.feedbackRateLimit', {
-                    remaining: feedbackGithubRateLimit.remaining.toLocaleString(),
-                    limit: feedbackGithubRateLimit.limit.toLocaleString(),
-                    time: feedbackGithubRateLimit.reset.toLocaleTimeString(),
-                  })}
+              {!hasFeedbackGithubToken && (
+                <p className="text-xs text-yellow-400/70 mt-2">
+                  {t('settings.github.feedbackTokenSetupHint')}
                 </p>
               )}
             </div>
@@ -541,7 +642,7 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
   )
 }
 
-/** Badge shown when the token was auto-detected from FEEDBACK_GITHUB_TOKEN in .env */
+/** Badge shown when the token was auto-detected from environment variable in .env */
 function EnvBadge() {
   const { t } = useTranslation()
   return (

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -281,11 +281,15 @@
       "createClassic": "Create Classic Token",
       "fineGrainedInstructions": "Set expiration, select 'Public repositories (read-only)'. No additional permissions needed for public repos.",
       "classicInstructions": "No scopes needed for public repos. For private repos, check the 'repo' scope.",
-      "securityWarning": "Token is stored in browser localStorage (not encrypted). Use a token with minimal permissions and set an expiration date.",
+      "securityWarning": "Token is stored in encrypted server-side settings. Use a token with minimal permissions and set an expiration date.",
       "envBadge": "from .env",
       "feedbackToken": "Feedback GitHub Token (FEEDBACK_GITHUB_TOKEN)",
-      "feedbackTokenDescription": "Used by the feedback / bug submission integration. This should stay separate from the main GitHub Activity token.",
+      "feedbackTokenLabel": "Feedback Token",
+      "feedbackTokenDescription": "Used by the feedback / bug submission integration. Requires a PAT with repo scope. This should stay separate from the main GitHub Activity token.",
       "feedbackTokenEnvSource": "Currently sourced from .env.",
+      "feedbackTokenNotConfigured": "Not Configured",
+      "feedbackTokenNotConfiguredHint": "Bug/feature submission is disabled",
+      "feedbackTokenSetupHint": "To enable bug/feature submission, add a GitHub PAT with repo scope here or set FEEDBACK_GITHUB_TOKEN in your .env file.",
       "feedbackRateLimit": "{{remaining}}/{{limit}} requests remaining · resets at {{time}}"
     },
     "predictions": {


### PR DESCRIPTION
## Summary
- Adds a dedicated status card for the feedback GitHub token (FEEDBACK_GITHUB_TOKEN) in the Settings > GitHub Integration section, matching the existing main token status card pattern
- Checks the backend `GET /api/feedback/token/status` endpoint on mount to detect tokens configured via environment variable (.env) or saved through the UI
- Adds `POST /api/feedback/token` and `DELETE /api/feedback/token` backend endpoints so the feedback token is saved/deleted server-side with encryption (instead of localStorage)
- Shows clear "Not Configured" status with setup instructions when the token is missing, so users know bug/feature submission is disabled and how to fix it

## Test plan
- [ ] Open Settings page -- verify both token status cards render (main token and feedback token)
- [ ] With no FEEDBACK_GITHUB_TOKEN set: verify yellow "Not Configured" status with hint about disabling bug/feature submission
- [ ] Set FEEDBACK_GITHUB_TOKEN in .env and restart: verify green "Token Configured" status with "from .env" badge
- [ ] Enter a feedback token via the UI input: verify it saves to the backend, validates against GitHub API, and shows green status
- [ ] Clear the feedback token: verify it calls DELETE endpoint and shows "Not Configured" again
- [ ] Verify `npx tsc --noEmit` passes
- [ ] Verify `go build ./...` passes
- [ ] Verify `go test ./pkg/api/handlers/... ./pkg/settings/...` passes

Closes #2208