### PR TITLE
🐛 Redirect Netlify subdomain to console.kubestellar.io

### DIFF
--- a/web/netlify/edge-functions/seo-meta.ts
+++ b/web/netlify/edge-functions/seo-meta.ts
@@ -578,6 +578,17 @@ export default async (request: Request, context: Context) => {
   const url = new URL(request.url);
   const pathname = url.pathname;
 
+  // Redirect the default Netlify subdomain to the canonical custom domain.
+  // localStorage (tour state, settings) is per-domain, so having two origins
+  // causes confusing state divergence. Deploy previews are unaffected because
+  // their hostnames include a prefix (e.g. deploy-preview-123--...).
+  if (url.hostname === "kubestellarconsole.netlify.app") {
+    return Response.redirect(
+      `https://console.kubestellar.io${pathname}${url.search}`,
+      301,
+    );
+  }
+
   // Only process HTML page requests (not assets, API calls, etc.)
   if (
     pathname.startsWith("/api/") ||


### PR DESCRIPTION
## Summary
- Adds a 301 redirect from `kubestellarconsole.netlify.app` to `console.kubestellar.io` in the seo-meta edge function
- Both URLs serve the same Netlify deployment, but `localStorage` (tour state, settings) is scoped per domain — causing confusing state divergence (e.g., tour appears completed on one but not the other)
- Deploy preview URLs (e.g., `deploy-preview-123--kubestellarconsole.netlify.app`) are **not** affected — the redirect only matches the exact production subdomain

## How it works
The seo-meta edge function already runs on `/*`. A hostname check at the top of the handler returns a 301 redirect before any other processing occurs.

## Test plan
- [ ] Visit `https://kubestellarconsole.netlify.app` → should 301 redirect to `https://console.kubestellar.io`
- [ ] Visit `https://kubestellarconsole.netlify.app/clusters` → should redirect to `https://console.kubestellar.io/clusters` (preserves path)
- [ ] Visit `https://console.kubestellar.io` → should work normally (no redirect)
- [ ] Verify deploy previews still work (no redirect on preview URLs)

Closes #2456