### PR TITLE
🐛 Remove read:user OAuth scope — only request user:email

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -140,7 +140,7 @@ func NewAuthHandler(s store.Store, cfg AuthConfig) *AuthHandler {
 			ClientID:     cfg.GitHubClientID,
 			ClientSecret: cfg.GitHubSecret,
 			RedirectURL:  redirectURL,
-			Scopes:       []string{"user:email", "read:user"},
+			Scopes:       []string{"user:email"},
 			Endpoint:     oauthEndpoint,
 		},
 		githubAPIBase: apiBase,
@@ -529,7 +529,68 @@ func (h *AuthHandler) getGitHubUser(accessToken string) (*GitHubUser, error) {
 		return nil, err
 	}
 
+	// GET /user only returns the user's public email (empty if not set).
+	// Fall back to GET /user/emails (requires user:email scope) to find
+	// the primary verified email address.
+	if user.Email == "" {
+		if email, err := h.getGitHubPrimaryEmail(accessToken); err == nil {
+			user.Email = email
+		}
+	}
+
 	return &user, nil
+}
+
+// gitHubEmail represents one entry from GitHub's GET /user/emails response.
+type gitHubEmail struct {
+	Email    string `json:"email"`
+	Primary  bool   `json:"primary"`
+	Verified bool   `json:"verified"`
+}
+
+// getGitHubPrimaryEmail fetches the user's primary verified email via
+// GET /user/emails (requires the user:email OAuth scope).
+func (h *AuthHandler) getGitHubPrimaryEmail(accessToken string) (string, error) {
+	req, err := http.NewRequest("GET", h.githubAPIBase+"/user/emails", nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	client := &http.Client{Timeout: githubHTTPTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub emails API returned %d", resp.StatusCode)
+	}
+
+	var emails []gitHubEmail
+	if err := json.NewDecoder(resp.Body).Decode(&emails); err != nil {
+		return "", err
+	}
+
+	// Return the primary verified email; fall back to first verified email.
+	var firstVerified string
+	for _, e := range emails {
+		if e.Primary && e.Verified {
+			return e.Email, nil
+		}
+		if e.Verified && firstVerified == "" {
+			firstVerified = e.Email
+		}
+	}
+
+	if firstVerified != "" {
+		return firstVerified, nil
+	}
+
+	return "", fmt.Errorf("no verified email found")
 }
 
 // setJWTCookie sets an HttpOnly cookie carrying the JWT token.

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -101,7 +101,7 @@ const OAUTH_ERROR_INFO: Record<string, OAuthErrorEntry> = {
     message: 'Login succeeded but the console was unable to fetch your GitHub profile.',
     steps: [
       'Try logging in again — this may be a temporary GitHub API issue',
-      'Check that your GitHub OAuth app has the "read:user" scope',
+      'Check that your GitHub OAuth app has the "user:email" scope',
       'Verify your internet connection to api.github.com',
     ],
   },


### PR DESCRIPTION
## Summary
- Removes the `read:user` OAuth scope, keeping only `user:email` — follows the principle of least privilege
- The console only uses public profile fields (`id`, `login`, `avatar_url`) from GitHub's `GET /user` endpoint, which are available **without** any user scope. The `read:user` scope was granting unnecessary access to private profile data.
- Adds a `GET /user/emails` fallback (requires `user:email` scope) when the user has no public email set on their GitHub profile — finds the primary verified email address
- Updates the error message in Login.tsx to reference the correct scope

## What users will see
After this change, the GitHub OAuth consent screen will no longer ask for "Read all user profile data" — it will only request access to email addresses.

**Note:** Existing users who already authorized the app won't see any change until they re-authorize. New users will see the reduced permission request.

## Test plan
- [ ] Login via GitHub OAuth — verify profile (login, avatar) still populated
- [ ] User with public email on GitHub profile → email should be populated from `GET /user`
- [ ] User without public email → email should be populated from `GET /user/emails` (primary verified)
- [ ] Dev mode login with `GITHUB_TOKEN` → still works
- [ ] Dev mode login without token → still creates `dev-user`

Closes #2369