### PR TITLE
🐛 Add dark mode variants to components missing dark: classes

### DIFF
--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -208,7 +208,7 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
                 )}
               >
                 <span className={cn(
-                  'inline-block h-4 w-4 transform rounded-full bg-white transition-transform',
+                  'inline-block h-4 w-4 transform rounded-full bg-white dark:bg-gray-200 transition-transform',
                   !isNoneSelected ? 'translate-x-6' : 'translate-x-1'
                 )} />
               </button>

--- a/web/src/components/auth/Login.tsx
+++ b/web/src/components/auth/Login.tsx
@@ -308,7 +308,7 @@ export function Login() {
           <button
             data-testid="github-login-button"
             onClick={() => { emitLogin('github'); login() }}
-            className="w-full flex items-center justify-center gap-3 bg-white text-gray-900 font-medium py-3 px-4 rounded-lg hover:bg-gray-100 transition-all duration-200 hover:shadow-lg"
+            className="w-full flex items-center justify-center gap-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 font-medium py-3 px-4 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200 hover:shadow-lg"
           >
             <Github className="w-5 h-5" />
             {t('login.continueWithGitHub')}

--- a/web/src/components/cards/ServiceExports.tsx
+++ b/web/src/components/cards/ServiceExports.tsx
@@ -36,7 +36,7 @@ const getStatusColors = (status: ServiceExportStatus) => {
     case 'Failed':
       return { bg: 'bg-red-500/20', text: 'text-red-400', border: 'border-red-500/20', iconBg: 'bg-red-500/20' }
     default:
-      return { bg: 'bg-gray-500/20', text: 'text-muted-foreground', border: 'border-gray-500/20', iconBg: 'bg-gray-500/20' }
+      return { bg: 'bg-gray-500/20 dark:bg-gray-400/20', text: 'text-muted-foreground', border: 'border-gray-500/20', iconBg: 'bg-gray-500/20 dark:bg-gray-400/20' }
   }
 }
 

--- a/web/src/components/cards/llmd/NightlyE2EStatus.tsx
+++ b/web/src/components/cards/llmd/NightlyE2EStatus.tsx
@@ -93,7 +93,7 @@ function RunDot({ run, guide, isHighlighted, onMouseEnter, onMouseLeave }: {
         : isFailed
           ? 'bg-red-400'
           : run.conclusion === 'cancelled'
-            ? 'bg-gray-500'
+            ? 'bg-gray-500 dark:bg-gray-400'
             : 'bg-yellow-400'
 
   const reasonLabel = isGPUFailure ? 'GPU unavailable' : ''
@@ -1037,7 +1037,7 @@ export function NightlyE2EStatus() {
           <span>{t('common:common.running').toLowerCase()}</span>
         </div>
         <div className="flex items-center gap-1">
-          <div className="w-2 h-2 rounded-full bg-gray-500" />
+          <div className="w-2 h-2 rounded-full bg-gray-500 dark:bg-gray-400" />
           <span>{t('cards:llmd.cancelled')}</span>
         </div>
         <span className="text-muted-foreground">|</span>

--- a/web/src/components/cards/llmd/StackSelector.tsx
+++ b/web/src/components/cards/llmd/StackSelector.tsx
@@ -16,7 +16,7 @@ const STATUS_COLORS = {
   healthy: 'bg-green-500',
   degraded: 'bg-yellow-500',
   unhealthy: 'bg-red-500',
-  unknown: 'bg-gray-500',
+  unknown: 'bg-gray-500 dark:bg-gray-400',
 }
 
 type SortField = 'name' | 'accelerators' | 'status' | 'replicas'

--- a/web/src/components/cards/workload-detection/LLMInference.tsx
+++ b/web/src/components/cards/workload-detection/LLMInference.tsx
@@ -131,9 +131,9 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
       'tgi': 'bg-blue-500/20 text-blue-400',
       'llm-d': 'bg-cyan-500/20 text-cyan-400',
       'triton': 'bg-green-500/20 text-green-400',
-      'unknown': 'bg-gray-500/20 text-muted-foreground',
+      'unknown': 'bg-gray-500/20 dark:bg-gray-400/20 text-muted-foreground',
     }
-    return colors[type] || 'bg-gray-500/20 text-muted-foreground'
+    return colors[type] || 'bg-gray-500/20 dark:bg-gray-400/20 text-muted-foreground'
   }
 
   const getTypeLabel = (type: LLMdServer['type']) => {
@@ -154,7 +154,7 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
       'gateway': { bg: 'bg-blue-500/20', text: 'text-blue-400', label: 'Gateway' },
       'prometheus': { bg: 'bg-orange-500/20', text: 'text-orange-400', label: 'Prometheus' },
       'autoscaler': { bg: 'bg-yellow-500/20', text: 'text-yellow-400', label: 'Autoscaler' },
-      'other': { bg: 'bg-gray-500/20', text: 'text-muted-foreground', label: 'Other' },
+      'other': { bg: 'bg-gray-500/20 dark:bg-gray-400/20', text: 'text-muted-foreground', label: 'Other' },
     }
     return config[componentType] || config['other']
   }
@@ -330,7 +330,7 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
                     className={`flex items-center gap-1 px-1.5 py-0.5 rounded ${
                       server.gatewayStatus === 'running'
                         ? 'bg-blue-500/20 text-blue-400'
-                        : 'bg-gray-500/20 text-muted-foreground'
+                        : 'bg-gray-500/20 dark:bg-gray-400/20 text-muted-foreground'
                     }`}
                     title={`Gateway (${server.gatewayType || 'envoy'}): ${server.gatewayStatus}`}
                   >
@@ -344,7 +344,7 @@ export function LLMInference({ config: _config }: LLMInferenceProps) {
                     className={`flex items-center gap-1 px-1.5 py-0.5 rounded ${
                       server.prometheusStatus === 'running'
                         ? 'bg-orange-500/20 text-orange-400'
-                        : 'bg-gray-500/20 text-muted-foreground'
+                        : 'bg-gray-500/20 dark:bg-gray-400/20 text-muted-foreground'
                     }`}
                     title={`Prometheus: ${server.prometheusStatus}`}
                   >

--- a/web/src/components/cards/workload-detection/ProwJobs.tsx
+++ b/web/src/components/cards/workload-detection/ProwJobs.tsx
@@ -110,7 +110,7 @@ export function ProwJobs({ config: _config }: ProwJobsProps) {
       periodic: 'bg-purple-500/20 text-purple-400',
       batch: 'bg-cyan-500/20 text-cyan-400',
     }
-    return colors[type] || 'bg-gray-500/20 text-muted-foreground'
+    return colors[type] || 'bg-gray-500/20 dark:bg-gray-400/20 text-muted-foreground'
   }
 
   if (isLoading) {

--- a/web/src/components/charts/StatusIndicator.tsx
+++ b/web/src/components/charts/StatusIndicator.tsx
@@ -22,7 +22,7 @@ const statusConfig: Record<Status, {
   critical: { icon: XCircle, color: 'text-red-500', bg: 'bg-red-600', label: 'Critical' },
   pending: { icon: Clock, color: 'text-blue-400', bg: 'bg-blue-500', label: 'Pending' },
   loading: { icon: Loader2, color: 'text-purple-400', bg: 'bg-purple-500', label: 'Loading' },
-  unknown: { icon: AlertTriangle, color: 'text-muted-foreground', bg: 'bg-gray-500', label: 'Unknown' },
+  unknown: { icon: AlertTriangle, color: 'text-muted-foreground', bg: 'bg-gray-500 dark:bg-gray-400', label: 'Unknown' },
   unreachable: { icon: WifiOff, color: 'text-yellow-400', bg: 'bg-yellow-500', label: 'Offline' },
 }
 
@@ -119,7 +119,7 @@ export function BooleanSwitch({
         }`}
       >
         <div
-          className={`${dotSizes[size]} bg-white rounded-full absolute top-0.5 transition-transform ${
+          className={`${dotSizes[size]} bg-white dark:bg-gray-200 rounded-full absolute top-0.5 transition-transform ${
             value ? 'translate-x-full -ml-0.5' : 'translate-x-0.5'
           }`}
         />

--- a/web/src/components/ui/AlertBadge.tsx
+++ b/web/src/components/ui/AlertBadge.tsx
@@ -236,7 +236,7 @@ export function AlertBadge() {
     if (stats.critical > 0) return 'bg-red-500'
     if (stats.warning > 0) return 'bg-orange-500'
     if (stats.info > 0) return 'bg-blue-500'
-    return 'bg-gray-500'
+    return 'bg-gray-500 dark:bg-gray-400'
   }
 
   return (


### PR DESCRIPTION
## Summary
- Added `dark:` Tailwind variants to 9 components with light-only color classes
- Key changes: Login button, AlertBadge, StatusIndicator, AgentSelector toggle, LLMInference cards, ProwJobs, ServiceExports, StackSelector, NightlyE2EStatus
- Skipped inline styles and transparent bg values that already work in dark mode (e.g. `bg-white/10` in KubeBert)

Fixes #2391

## Test plan
- [ ] Toggle dark mode and verify all updated components render correctly
- [ ] Check Login page button in dark mode
- [ ] Check AlertBadge badge color in dark mode (when no alerts)
- [ ] Check StatusIndicator `unknown` state and BooleanSwitch dot in dark mode
- [ ] Check AgentSelector toggle switch in dark mode
- [ ] Check LLMInference card type/component badges and gateway/prometheus indicators in dark mode
- [ ] Check ProwJobs type badges in dark mode
- [ ] Check ServiceExports unknown status colors in dark mode
- [ ] Check StackSelector unknown status dot in dark mode
- [ ] Check NightlyE2EStatus cancelled run dots in dark mode