### PR TITLE
🐛 Fix trivy version in nightly workflow

### DIFF
--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           GOSEC_VERSION: '2.21.4'
           GITLEAKS_VERSION: '8.21.2'
-          TRIVY_VERSION: '0.58.1'
+          TRIVY_VERSION: '0.69.3'
           SEMGREP_VERSION: '1.102.0'
         shell: bash {0}
         run: |


### PR DESCRIPTION
## Summary
- Update trivy from v0.58.1 to v0.69.3 — the old release was removed from GitHub (404 on download)
- This was causing container-scan-test to fail in nightly runs

## Test plan
- [ ] Trivy downloads successfully in Install test tools step
- [ ] container-scan-test runs with trivy available