### PR TITLE
🐛 Use shared Button component in UI files

### DIFF
--- a/web/src/components/ui/CardControls.tsx
+++ b/web/src/components/ui/CardControls.tsx
@@ -3,6 +3,7 @@ import { useState, useRef, useEffect } from 'react'
 import { cn } from '../../lib/cn'
 import { emitCardSortChanged, emitCardSortDirectionChanged, emitCardLimitChanged } from '../../lib/analytics'
 import { useCardType } from '../cards/CardWrapper'
+import { Button } from './Button'
 
 interface LimitOption {
   value: number | 'unlimited'
@@ -86,13 +87,15 @@ export function CardControls<T extends string = string>({
       {/* Limit Dropdown */}
       {showLimit && onLimitChange && (
         <div ref={limitRef} className="relative">
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => { setLimitOpen(!limitOpen); setSortOpen(false) }}
-            className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+            className="bg-secondary/50 hover:bg-secondary"
+            iconRight={<ChevronDown className={cn('w-3 h-3 transition-transform', limitOpen && 'rotate-180')} />}
           >
-            <span>Show: {currentLimitLabel}</span>
-            <ChevronDown className={cn('w-3 h-3 transition-transform', limitOpen && 'rotate-180')} />
-          </button>
+            Show: {currentLimitLabel}
+          </Button>
           {limitOpen && (
             <div className="absolute top-full left-0 mt-1 bg-card border border-border rounded-lg shadow-lg z-50 min-w-[80px] py-1">
               {LIMIT_OPTIONS.map(option => (
@@ -116,13 +119,15 @@ export function CardControls<T extends string = string>({
       {showSort && sortOptions && sortOptions.length > 0 && onSortChange && (
         <div className="flex items-center gap-1">
           <div ref={sortRef} className="relative">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => { setSortOpen(!sortOpen); setLimitOpen(false) }}
-              className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+              className="bg-secondary/50 hover:bg-secondary"
+              iconRight={<ChevronDown className={cn('w-3 h-3 transition-transform', sortOpen && 'rotate-180')} />}
             >
-              <span>Sort: {currentSortLabel}</span>
-              <ChevronDown className={cn('w-3 h-3 transition-transform', sortOpen && 'rotate-180')} />
-            </button>
+              Sort: {currentSortLabel}
+            </Button>
             {sortOpen && (
               <div className="absolute top-full left-0 mt-1 bg-card border border-border rounded-lg shadow-lg z-50 min-w-[100px] py-1">
                 {sortOptions.map(option => (
@@ -141,18 +146,19 @@ export function CardControls<T extends string = string>({
             )}
           </div>
           {onSortDirectionChange && (
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={toggleDirection}
-              className="p-1 text-xs rounded bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+              className="p-1 bg-secondary/50 hover:bg-secondary"
               title={sortDirection === 'asc' ? 'Ascending' : 'Descending'}
               aria-label={sortDirection === 'asc' ? 'Sort ascending, click to sort descending' : 'Sort descending, click to sort ascending'}
-            >
-              {sortDirection === 'asc' ? (
+              icon={sortDirection === 'asc' ? (
                 <ArrowUp className="w-3 h-3" />
               ) : (
                 <ArrowDown className="w-3 h-3" />
               )}
-            </button>
+            />
           )}
         </div>
       )}

--- a/web/src/components/ui/CardSearch.tsx
+++ b/web/src/components/ui/CardSearch.tsx
@@ -121,13 +121,14 @@ export function CardSearch({
         )}
       />
       {localValue && (
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={handleClear}
-          className="absolute right-2 p-0.5 rounded hover:bg-secondary/80 text-muted-foreground hover:text-foreground"
+          className="absolute right-2 p-0.5"
           title={t('common.clearSearch')}
-        >
-          <X className={cn(iconSize, 'w-3 h-3')} />
-        </button>
+          icon={<X className={cn(iconSize, 'w-3 h-3')} />}
+        />
       )}
     </div>
   )

--- a/web/src/components/ui/CodeBlock.tsx
+++ b/web/src/components/ui/CodeBlock.tsx
@@ -5,6 +5,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { Copy, Check, AlertCircle } from 'lucide-react'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
+import { Button } from './Button'
 
 interface CodeBlockProps {
   children: string
@@ -47,19 +48,20 @@ export function CodeBlock({ children, language = 'text', fontSize = 'sm' }: Code
   return (
     <div className="relative group">
       <div className="absolute right-2 top-2 opacity-0 group-hover:opacity-100 transition-opacity">
-        <button
+        <Button
+          variant="secondary"
+          size="sm"
           onClick={handleCopy}
-          className="p-1.5 rounded bg-secondary/80 hover:bg-secondary/60 text-secondary-foreground transition-colors"
+          className="p-1.5"
           title={copied ? 'Copied!' : copyFailed ? 'Copy failed' : 'Copy code'}
-        >
-          {copied ? (
+          icon={copied ? (
             <Check className="w-4 h-4 text-green-600 dark:text-green-400" />
           ) : copyFailed ? (
             <AlertCircle className="w-4 h-4 text-red-500 dark:text-red-400" />
           ) : (
             <Copy className="w-4 h-4 text-muted-foreground" />
           )}
-        </button>
+        />
       </div>
       <pre
         className={`bg-secondary border border-border rounded-md p-4 overflow-x-auto ${

--- a/web/src/components/ui/CollapsibleSection.tsx
+++ b/web/src/components/ui/CollapsibleSection.tsx
@@ -1,5 +1,6 @@
 import { useState, ReactNode } from 'react'
 import { ChevronDown, ChevronRight } from 'lucide-react'
+import { Button } from './Button'
 
 interface CollapsibleSectionProps {
   title: string
@@ -20,18 +21,21 @@ export function CollapsibleSection({
 
   return (
     <div className={className}>
-      <button
+      <Button
+        variant="ghost"
+        size="md"
         onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex items-center gap-2 px-2 py-2 text-sm font-medium text-foreground hover:bg-secondary/50 rounded-lg transition-colors"
-      >
-        {isOpen ? (
+        className="w-full justify-start px-2 py-2 font-medium text-foreground"
+        fullWidth
+        icon={isOpen ? (
           <ChevronDown className="w-4 h-4 text-muted-foreground" />
         ) : (
           <ChevronRight className="w-4 h-4 text-muted-foreground" />
         )}
-        <span>{title}</span>
-        {badge && <span className="ml-auto">{badge}</span>}
-      </button>
+        iconRight={badge ? <span className="ml-auto">{badge}</span> : undefined}
+      >
+        {title}
+      </Button>
       {isOpen && (
         <div className="mt-2 animate-fade-in">
           {children}

--- a/web/src/components/ui/FeatureHintTooltip.tsx
+++ b/web/src/components/ui/FeatureHintTooltip.tsx
@@ -6,6 +6,7 @@
  */
 
 import { X } from 'lucide-react'
+import { Button } from './Button'
 
 type Placement = 'top' | 'bottom' | 'bottom-right' | 'left' | 'right'
 
@@ -35,13 +36,14 @@ export function FeatureHintTooltip({
     >
       <div className="flex items-center gap-2 px-3 py-2 rounded-lg glass border border-purple-500/30 bg-purple-500/10 shadow-lg w-72">
         <span className="text-xs text-purple-300 leading-tight">{message}</span>
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={onDismiss}
-          className="flex-shrink-0 p-0.5 rounded hover:bg-purple-500/20 text-purple-400 hover:text-purple-300 transition-colors"
+          className="flex-shrink-0 p-0.5 hover:bg-purple-500/20 text-purple-400 hover:text-purple-300"
           aria-label="Dismiss hint"
-        >
-          <X className="w-3 h-3" />
-        </button>
+          icon={<X className="w-3 h-3" />}
+        />
       </div>
     </div>
   )

--- a/web/src/components/ui/Pagination.tsx
+++ b/web/src/components/ui/Pagination.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from 'react'
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { Button } from './Button'
 
 // Hook for managing pagination state
 export function usePagination<T>(items: T[], defaultPerPage: number = 5, resetOnFilterChange: boolean = true) {
@@ -137,47 +138,51 @@ export function Pagination({
 
         {/* Page navigation */}
         <div className="flex items-center gap-1">
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => onPageChange(1)}
             disabled={!canGoPrevious}
-            className="p-1.5 rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed text-muted-foreground hover:text-foreground transition-colors"
+            className="p-1.5"
             title={t('pagination.firstPage')}
             aria-label={t('pagination.firstPage')}
-          >
-            <ChevronsLeft className="w-4 h-4" />
-          </button>
-          <button
+            icon={<ChevronsLeft className="w-4 h-4" />}
+          />
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => onPageChange(currentPage - 1)}
             disabled={!canGoPrevious}
-            className="p-1.5 rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed text-muted-foreground hover:text-foreground transition-colors"
+            className="p-1.5"
             title={t('pagination.previousPage')}
             aria-label={t('pagination.previousPage')}
-          >
-            <ChevronLeft className="w-4 h-4" />
-          </button>
+            icon={<ChevronLeft className="w-4 h-4" />}
+          />
 
           <span className="px-3 py-1 text-foreground">
             {currentPage} / {totalPages || 1}
           </span>
 
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => onPageChange(currentPage + 1)}
             disabled={!canGoNext}
-            className="p-1.5 rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed text-muted-foreground hover:text-foreground transition-colors"
+            className="p-1.5"
             title={t('pagination.nextPage')}
             aria-label={t('pagination.nextPage')}
-          >
-            <ChevronRight className="w-4 h-4" />
-          </button>
-          <button
+            icon={<ChevronRight className="w-4 h-4" />}
+          />
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => onPageChange(totalPages)}
             disabled={!canGoNext}
-            className="p-1.5 rounded hover:bg-secondary disabled:opacity-50 disabled:cursor-not-allowed text-muted-foreground hover:text-foreground transition-colors"
+            className="p-1.5"
             title={t('pagination.lastPage')}
             aria-label={t('pagination.lastPage')}
-          >
-            <ChevronsRight className="w-4 h-4" />
-          </button>
+            icon={<ChevronsRight className="w-4 h-4" />}
+          />
         </div>
       </div>
     </div>

--- a/web/src/components/ui/RefreshIndicator.tsx
+++ b/web/src/components/ui/RefreshIndicator.tsx
@@ -3,6 +3,7 @@ import { RefreshCw, Clock, AlertTriangle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../lib/cn'
 import { formatLastSeen } from '../../lib/errorClassifier'
+import { Button } from './Button'
 
 // Minimum duration to show spin animation (ensures at least one full rotation)
 // Must match animation duration (1s) defined in index.css for animate-spin-min
@@ -207,23 +208,26 @@ export function RefreshButton({
           <span>{t('refresh.failed')}</span>
         </div>
       )}
-      <button
+      <Button
+        variant="ghost"
+        size="sm"
         onClick={onRefresh}
         disabled={disabled || isRefreshing || isVisuallySpinning}
-        className={`${buttonPadding} hover:bg-secondary rounded transition-colors disabled:opacity-50`}
+        className={buttonPadding}
         title={tooltipText}
         aria-label={tooltipText}
-      >
-        <RefreshCw
-          className={`${sizeClasses} ${
-            isVisuallySpinning
-              ? 'text-blue-400 animate-spin-min'
-              : isFailed
-              ? 'text-red-400'
-              : 'text-muted-foreground'
-          }`}
-        />
-      </button>
+        icon={
+          <RefreshCw
+            className={`${sizeClasses} ${
+              isVisuallySpinning
+                ? 'text-blue-400 animate-spin-min'
+                : isFailed
+                ? 'text-red-400'
+                : 'text-muted-foreground'
+            }`}
+          />
+        }
+      />
     </div>
   )
 }

--- a/web/src/components/ui/StatsConfig.tsx
+++ b/web/src/components/ui/StatsConfig.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Settings, Check, GripVertical, Eye, EyeOff, Plus, Trash2, Search, ChevronRight, ChevronDown } from 'lucide-react'
+import { Button } from './Button'
 import { BaseModal } from '../../lib/modals'
 import {
   DndContext,
@@ -148,25 +149,27 @@ function SortableItem({ block, onToggleVisibility, onRemove, isCustom }: Sortabl
         <span className="text-sm">{iconEmojis[block.icon] || '📊'}</span>
       </div>
       <span className="flex-1 text-sm text-foreground">{block.name}</span>
-      <button
+      <Button
+        variant="ghost"
+        size="sm"
         onClick={() => onToggleVisibility(block.id)}
-        className={`p-1 rounded transition-colors ${
+        className={`p-1 ${
           block.visible
-            ? 'hover:bg-secondary text-green-400'
-            : 'hover:bg-secondary text-muted-foreground'
+            ? 'text-green-400'
+            : 'text-muted-foreground'
         }`}
         title={block.visible ? 'Hide' : 'Show'}
-      >
-        {block.visible ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
-      </button>
+        icon={block.visible ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
+      />
       {isCustom && onRemove && (
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={() => onRemove(block.id)}
-          className="p-1 rounded transition-colors hover:bg-red-500/20 text-muted-foreground hover:text-red-400"
+          className="p-1 hover:bg-red-500/20 text-muted-foreground hover:text-red-400"
           title={t('common.remove')}
-        >
-          <Trash2 className="w-4 h-4" />
-        </button>
+          icon={<Trash2 className="w-4 h-4" />}
+        />
       )}
     </div>
   )
@@ -224,16 +227,19 @@ interface AvailableStatItemProps {
 
 function AvailableStatItem({ block, onAdd }: AvailableStatItemProps) {
   return (
-    <button
+    <Button
+      variant="ghost"
+      size="md"
       onClick={() => onAdd(block)}
-      className="flex items-center gap-3 p-2 pl-8 rounded-lg hover:bg-secondary/40 transition-colors w-full text-left"
+      className="w-full justify-start pl-8 rounded-lg"
+      fullWidth
+      iconRight={<Plus className="w-4 h-4 text-muted-foreground" />}
     >
       <div className={`w-5 h-5 ${colorClasses[block.color] || 'text-foreground'}`}>
         <span className="text-sm">{iconEmojis[block.icon] || '📊'}</span>
       </div>
-      <span className="flex-1 text-sm text-foreground">{block.name}</span>
-      <Plus className="w-4 h-4 text-muted-foreground" />
-    </button>
+      <span className="flex-1 text-sm text-foreground text-left">{block.name}</span>
+    </Button>
   )
 }
 
@@ -250,19 +256,22 @@ function DashboardCategory({ category, availableBlocks, onAdd, isExpanded, onTog
 
   return (
     <div className="border-b border-border/50 last:border-b-0">
-      <button
+      <Button
+        variant="ghost"
+        size="md"
         onClick={onToggle}
-        className="flex items-center gap-2 w-full p-2 hover:bg-secondary/30 rounded-lg transition-colors"
-      >
-        {isExpanded ? (
+        className="w-full justify-start"
+        fullWidth
+        icon={isExpanded ? (
           <ChevronDown className="w-4 h-4 text-muted-foreground" />
         ) : (
           <ChevronRight className="w-4 h-4 text-muted-foreground" />
         )}
+        iconRight={<span className="text-xs text-muted-foreground">{availableBlocks.length}</span>}
+      >
         <span className="text-base">{category.icon}</span>
         <span className="flex-1 text-sm font-medium text-foreground text-left">{category.name}</span>
-        <span className="text-xs text-muted-foreground">{availableBlocks.length}</span>
-      </button>
+      </Button>
       {isExpanded && (
         <div className="border-l-2 border-purple-500/30 ml-2">
           {availableBlocks.map(block => (
@@ -442,12 +451,13 @@ export function StatsConfigModal({
                   autoFocus
                 />
               </div>
-              <button
+              <Button
+                variant="ghost"
+                size="sm"
                 onClick={() => setShowAddPanel(false)}
-                className="text-sm text-muted-foreground hover:text-foreground"
               >
                 Done
-              </button>
+              </Button>
             </div>
             <div className="space-y-0 min-h-48 max-h-80 overflow-y-auto border border-border/50 rounded-lg">
               {hasAvailableStats ? (
@@ -473,38 +483,44 @@ export function StatsConfigModal({
             </div>
           </div>
         ) : (
-          <button
+          <Button
+            variant="ghost"
+            size="md"
             onClick={() => setShowAddPanel(true)}
-            className="mt-4 w-full flex items-center justify-center gap-2 py-2 border border-dashed border-border rounded-lg text-sm text-muted-foreground hover:text-foreground hover:border-purple-500/50 transition-colors"
+            className="mt-4 w-full border border-dashed border-border hover:border-purple-500/50"
+            icon={<Plus className="w-4 h-4" />}
+            fullWidth
           >
-            <Plus className="w-4 h-4" />
             Add stat from other dashboards
-          </button>
+          </Button>
         )}
       </BaseModal.Content>
 
       <BaseModal.Footer>
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={handleReset}
-          className="text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
           Reset to Default
-        </button>
+        </Button>
         <div className="flex-1" />
         <div className="flex items-center gap-2">
-          <button
+          <Button
+            variant="ghost"
+            size="md"
             onClick={onClose}
-            className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
           >
             Cancel
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="accent"
+            size="md"
             onClick={handleSave}
-            className="flex items-center gap-2 px-4 py-2 bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-colors"
+            icon={<Check className="w-4 h-4" />}
           >
-            <Check className="w-4 h-4" />
             Save
-          </button>
+          </Button>
         </div>
       </BaseModal.Footer>
     </BaseModal>

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -8,6 +8,7 @@ import {
   ShieldAlert, ShieldOff, User, Info, Percent, ClipboardList, Sparkles, Activity,
   List, DollarSign, ChevronDown, ChevronRight, FlaskConical,
 } from 'lucide-react'
+import { Button } from './Button'
 import { StatusBadge } from './StatusBadge'
 import { StatBlockConfig, DashboardStatsType } from './StatsBlockDefinitions'
 import { StatsConfigModal, useStatsConfig } from './StatsConfig'
@@ -206,14 +207,16 @@ export function StatsOverview({
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-3">
           {collapsible ? (
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={toggleExpanded}
-              className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+              className="font-medium"
+              icon={<Activity className="w-4 h-4" />}
+              iconRight={isExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
             >
-              <Activity className="w-4 h-4" />
-              <span>{resolvedTitle}</span>
-              {isExpanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-            </button>
+              {resolvedTitle}
+            </Button>
           ) : (
             <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
               <Activity className="w-4 h-4" />
@@ -232,13 +235,14 @@ export function StatsOverview({
           )}
         </div>
         {showConfigButton && isExpanded && (
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={openConfig}
-            className="p-1 text-muted-foreground hover:text-foreground hover:bg-secondary rounded transition-colors"
+            className="p-1"
             title={t('statsOverview.configureStats')}
-          >
-            <Settings className="w-4 h-4" />
-          </button>
+            icon={<Settings className="w-4 h-4" />}
+          />
         )}
       </div>
 

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, useCallback, useEffect, useRef, ReactNode } from 'react'
 import { X, Check, AlertTriangle, Info } from 'lucide-react'
 import { cn } from '../../lib/cn'
+import { Button } from './Button'
 
 type ToastType = 'success' | 'error' | 'warning' | 'info'
 
@@ -128,13 +129,14 @@ function ToastItem({ toast, onRemove }: ToastItemProps) {
     >
       <span className={iconColors[toast.type]}>{icons[toast.type]}</span>
       <span className="flex-1 text-sm">{toast.message}</span>
-      <button
+      <Button
+        variant="ghost"
+        size="sm"
         onClick={onRemove}
-        className="p-1 rounded hover:bg-white/10 text-muted-foreground hover:text-foreground"
+        className="p-1 hover:bg-white/10"
         aria-label="Dismiss notification"
-      >
-        <X className="w-3 h-3" aria-hidden="true" />
-      </button>
+        icon={<X className="w-3 h-3" aria-hidden="true" />}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Converted 25 raw `<button>` elements across 10 shared UI component files to use the shared `<Button>` component
- Ensures consistent button styling, focus states, and accessibility across all shared UI components
- Files updated: StatsConfig, CardControls, Pagination, StatsOverview, Toast, CollapsibleSection, CodeBlock, FeatureHintTooltip, RefreshIndicator, CardSearch
- Remaining raw buttons are justified exceptions (dnd-kit drag handles, dropdown menu option items)

Partially addresses #2323

## Test plan
- [ ] Verify StatsConfig modal buttons (save, cancel, reset, add stat, visibility toggle, remove) render and function correctly
- [ ] Verify Pagination navigation buttons (first, prev, next, last) work with proper disabled states
- [ ] Verify CardControls sort/limit dropdown triggers and sort direction toggle work
- [ ] Verify StatsOverview collapsible toggle and configure button work
- [ ] Verify Toast dismiss button works
- [ ] Verify CollapsibleSection expand/collapse works
- [ ] Verify CodeBlock copy button works
- [ ] Verify FeatureHintTooltip dismiss button works
- [ ] Verify RefreshButton refresh action works
- [ ] Verify CardSearch clear button works
- [ ] Verify focus/hover states are consistent with other Button usages