### PR TITLE
✨ Add route constants and improve drill-down navigation

### DIFF
--- a/web/src/components/drilldown/views/EventsDrillDown.tsx
+++ b/web/src/components/drilldown/views/EventsDrillDown.tsx
@@ -1,7 +1,9 @@
 import { useMemo, useState, useEffect, useCallback, useRef } from 'react'
-import { AlertCircle, RefreshCw, Terminal, Copy, CheckCircle } from 'lucide-react'
+import { AlertCircle, RefreshCw, Terminal, Copy, CheckCircle, Server, Layers } from 'lucide-react'
 import { StatusIndicator } from '../../charts/StatusIndicator'
+import { ClusterBadge } from '../../ui/ClusterBadge'
 import { getDemoMode } from '../../../hooks/useDemoMode'
+import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useTranslation } from 'react-i18next'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { POLL_INTERVAL_MS, UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
@@ -54,6 +56,7 @@ export function EventsDrillDown({ data }: Props) {
   const namespace = data.namespace as string | undefined
   const objectName = data.objectName as string | undefined
   const clusterShort = cluster.split('/').pop() || cluster
+  const { drillToCluster, drillToNamespace } = useDrillDownActions()
 
   const [events, setEvents] = useState<ClusterEvent[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -196,6 +199,28 @@ export function EventsDrillDown({ data }: Props) {
 
   return (
     <div className="space-y-4">
+      {/* Contextual Navigation */}
+      <div className="flex items-center gap-6 text-sm">
+        {namespace && (
+          <button
+            onClick={() => drillToNamespace(cluster, namespace)}
+            className="flex items-center gap-2 hover:bg-purple-500/10 border border-transparent hover:border-purple-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+          >
+            <Layers className="w-4 h-4 text-purple-400" />
+            <span className="text-muted-foreground">{t('drilldown.fields.namespace')}</span>
+            <span className="font-mono text-purple-400 group-hover:text-purple-300 transition-colors">{namespace}</span>
+          </button>
+        )}
+        <button
+          onClick={() => drillToCluster(cluster)}
+          className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+        >
+          <Server className="w-4 h-4 text-blue-400" />
+          <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
+          <ClusterBadge cluster={clusterShort} size="sm" />
+        </button>
+      </div>
+
       {/* Stats */}
       <div className="grid grid-cols-3 gap-4">
         <div className="p-4 rounded-lg bg-card/50 border border-border">

--- a/web/src/components/drilldown/views/GPUNodeDrillDown.tsx
+++ b/web/src/components/drilldown/views/GPUNodeDrillDown.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
-import { Box, ChevronRight } from 'lucide-react'
+import { Box, ChevronRight, Server } from 'lucide-react'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { ClusterBadge } from '../../ui/ClusterBadge'
 import { useAllPods } from '../../../hooks/useMCP'
 import { Gauge } from '../../charts/Gauge'
 import { StatusIndicator, type Status } from '../../charts/StatusIndicator'
@@ -37,7 +38,8 @@ export function GPUNodeDrillDown({ data }: Props) {
   const gpuType = data.gpuType as string
   const gpuCount = (data.gpuCount as number) || 0
   const gpuAllocated = (data.gpuAllocated as number) || 0
-  const { drillToEvents, drillToPod } = useDrillDownActions()
+  const { drillToEvents, drillToPod, drillToCluster } = useDrillDownActions()
+  const clusterShort = cluster.split('/').pop() || cluster
 
   const utilizationPercent = gpuCount > 0 ? Math.round((gpuAllocated / gpuCount) * 100) : 0
 
@@ -55,6 +57,18 @@ export function GPUNodeDrillDown({ data }: Props) {
 
   return (
     <div className="space-y-6">
+      {/* Contextual Navigation */}
+      <div className="flex items-center gap-6 text-sm">
+        <button
+          onClick={() => drillToCluster(cluster)}
+          className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+        >
+          <Server className="w-4 h-4 text-blue-400" />
+          <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
+          <ClusterBadge cluster={clusterShort} size="sm" />
+        </button>
+      </div>
+
       {/* GPU Status */}
       <div className="p-6 rounded-lg bg-card/50 border border-border">
         <div className="flex items-center justify-between">

--- a/web/src/components/drilldown/views/LogsDrillDown.tsx
+++ b/web/src/components/drilldown/views/LogsDrillDown.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
-import { Loader2, AlertCircle } from 'lucide-react'
+import { Loader2, AlertCircle, Server, Layers, Box } from 'lucide-react'
+import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { ClusterBadge } from '../../ui/ClusterBadge'
 import { useTranslation } from 'react-i18next'
 
 interface Props {
@@ -7,9 +9,13 @@ interface Props {
 }
 
 export function LogsDrillDown({ data }: Props) {
-  const { t: _t } = useTranslation()
+  const { t } = useTranslation()
+  const cluster = data.cluster as string
+  const namespace = data.namespace as string
   const pod = data.pod as string
   const container = data.container as string | undefined
+  const { drillToCluster, drillToNamespace, drillToPod } = useDrillDownActions()
+  const clusterShort = cluster?.split('/').pop() || cluster
   const [tailLines, setTailLines] = useState(100)
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -56,6 +62,40 @@ Connect to kubestellar-ops MCP server to fetch real logs.`
 
   return (
     <div className="space-y-4">
+      {/* Contextual Navigation */}
+      {cluster && (
+        <div className="flex items-center gap-6 text-sm">
+          {pod && (
+            <button
+              onClick={() => drillToPod(cluster, namespace, pod)}
+              className="flex items-center gap-2 hover:bg-cyan-500/10 border border-transparent hover:border-cyan-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+            >
+              <Box className="w-4 h-4 text-cyan-400" />
+              <span className="text-muted-foreground">{t('drilldown.fields.pod')}</span>
+              <span className="font-mono text-cyan-400 group-hover:text-cyan-300 transition-colors">{pod}</span>
+            </button>
+          )}
+          {namespace && (
+            <button
+              onClick={() => drillToNamespace(cluster, namespace)}
+              className="flex items-center gap-2 hover:bg-purple-500/10 border border-transparent hover:border-purple-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+            >
+              <Layers className="w-4 h-4 text-purple-400" />
+              <span className="text-muted-foreground">{t('drilldown.fields.namespace')}</span>
+              <span className="font-mono text-purple-400 group-hover:text-purple-300 transition-colors">{namespace}</span>
+            </button>
+          )}
+          <button
+            onClick={() => drillToCluster(cluster)}
+            className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+          >
+            <Server className="w-4 h-4 text-blue-400" />
+            <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
+            <ClusterBadge cluster={clusterShort} size="sm" />
+          </button>
+        </div>
+      )}
+
       {/* Controls */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">

--- a/web/src/components/drilldown/views/NodeDrillDown.tsx
+++ b/web/src/components/drilldown/views/NodeDrillDown.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
-import { AlertTriangle, Terminal, Stethoscope, Wrench, CheckCircle, Copy, ExternalLink } from 'lucide-react'
+import { AlertTriangle, Terminal, Stethoscope, Wrench, CheckCircle, Copy, ExternalLink, Server } from 'lucide-react'
 import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
+import { ClusterBadge } from '../../ui/ClusterBadge'
 import { useMissions } from '../../../hooks/useMissions'
 import { useTranslation } from 'react-i18next'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
@@ -18,7 +19,7 @@ export function NodeDrillDown({ data }: Props) {
   const issue = data.issue as string | undefined
   const roles = data.roles as string[] | undefined
 
-  const { drillToEvents } = useDrillDownActions()
+  const { drillToEvents, drillToCluster } = useDrillDownActions()
   const { close: closeDialog } = useDrillDown()
   const { startMission } = useMissions()
   const [copied, setCopied] = useState<string | null>(null)
@@ -67,6 +68,18 @@ Start by checking node events and conditions.`,
 
   return (
     <div className="space-y-6">
+      {/* Contextual Navigation */}
+      <div className="flex items-center gap-6 text-sm">
+        <button
+          onClick={() => drillToCluster(cluster)}
+          className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+        >
+          <Server className="w-4 h-4 text-blue-400" />
+          <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
+          <ClusterBadge cluster={clusterShort} size="sm" />
+        </button>
+      </div>
+
       {/* Status Banner for Offline Nodes */}
       {isOffline && (
         <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/30">

--- a/web/src/components/drilldown/views/YAMLDrillDown.tsx
+++ b/web/src/components/drilldown/views/YAMLDrillDown.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useRef } from 'react'
-import { Copy, Check, Download, RefreshCw } from 'lucide-react'
+import { Copy, Check, Download, RefreshCw, Server, Layers } from 'lucide-react'
 import { api } from '../../../lib/api'
 import { useToast } from '../../ui/Toast'
+import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { ClusterBadge } from '../../ui/ClusterBadge'
 import { useTranslation } from 'react-i18next'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { emitDataExported } from '../../../lib/analytics'
@@ -17,6 +19,8 @@ export function YAMLDrillDown({ data }: Props) {
   const namespace = data.namespace as string
   const resourceType = data.resourceType as string
   const resourceName = data.resourceName as string
+  const { drillToCluster, drillToNamespace } = useDrillDownActions()
+  const clusterShort = cluster.split('/').pop() || cluster
 
   const [yaml, setYAML] = useState<string>('')
   const [isLoading, setIsLoading] = useState(true)
@@ -89,6 +93,28 @@ export function YAMLDrillDown({ data }: Props) {
 
   return (
     <div className="space-y-4">
+      {/* Contextual Navigation */}
+      <div className="flex items-center gap-6 text-sm">
+        {namespace && (
+          <button
+            onClick={() => drillToNamespace(cluster, namespace)}
+            className="flex items-center gap-2 hover:bg-purple-500/10 border border-transparent hover:border-purple-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+          >
+            <Layers className="w-4 h-4 text-purple-400" />
+            <span className="text-muted-foreground">{t('drilldown.fields.namespace')}</span>
+            <span className="font-mono text-purple-400 group-hover:text-purple-300 transition-colors">{namespace}</span>
+          </button>
+        )}
+        <button
+          onClick={() => drillToCluster(cluster)}
+          className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+        >
+          <Server className="w-4 h-4 text-blue-400" />
+          <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
+          <ClusterBadge cluster={clusterShort} size="sm" />
+        </button>
+      </div>
+
       {/* Resource Info */}
       <div className="flex items-center justify-between">
         <div>
@@ -96,7 +122,7 @@ export function YAMLDrillDown({ data }: Props) {
             {resourceType}/{resourceName}
           </h3>
           <p className="text-sm text-muted-foreground">
-            {namespace} - {cluster.split('/').pop()}
+            {namespace} - {clusterShort}
           </p>
         </div>
         <div className="flex items-center gap-2">

--- a/web/src/config/routes.ts
+++ b/web/src/config/routes.ts
@@ -55,8 +55,11 @@ export const ROUTES = {
   ARCADE: '/arcade',
   DEPLOY: '/deploy',
   AI_ML: '/ai-ml',
+  AI_AGENTS: '/ai-agents',
   CI_CD: '/ci-cd',
-  
+  LLM_D_BENCHMARKS: '/llm-d-benchmarks',
+  INSIGHTS: '/insights',
+
   // Persona dashboards
   CLUSTER_ADMIN: '/cluster-admin',
 
@@ -70,9 +73,23 @@ export const ROUTES = {
   // Widget
   WIDGET: '/widget',
 
+  // Feedback / issue shortcuts
+  ISSUE: '/issue',
+  ISSUES: '/issues',
+  FEEDBACK: '/feedback',
+  FEATURE: '/feature',
+  FEATURES: '/features',
+
   // Marketing / competitive landing pages
   FROM_LENS: '/from-lens',
   FROM_HEADLAMP: '/from-headlamp',
+
+  // Dev / test routes
+  TEST_UNIFIED_CARD: '/test/unified-card',
+  TEST_UNIFIED_STATS: '/test/unified-stats',
+  TEST_UNIFIED_DASHBOARD: '/test/unified-dashboard',
+  PERF_ALL_CARDS: '/__perf/all-cards',
+  PERF_COMPLIANCE: '/__compliance/all-cards',
 } as const
 
 /**

--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -1756,7 +1756,8 @@
       "suspend": "Suspend:",
       "revisionHistory": "Revision History Limit:",
       "minReadySeconds": "Min Ready Seconds:",
-      "progressDeadline": "Progress Deadline:"
+      "progressDeadline": "Progress Deadline:",
+      "pod": "Pod:"
     },
     "status": {
       "fetchingEvents": "Fetching events...",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1795,7 +1795,8 @@
       "suspend": "Suspend:",
       "revisionHistory": "Revision History Limit:",
       "minReadySeconds": "Min Ready Seconds:",
-      "progressDeadline": "Progress Deadline:"
+      "progressDeadline": "Progress Deadline:",
+      "pod": "Pod:"
     },
     "status": {
       "fetchingEvents": "Fetching events...",

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -1756,7 +1756,8 @@
       "suspend": "Suspend:",
       "revisionHistory": "Revision History Limit:",
       "minReadySeconds": "Min Ready Seconds:",
-      "progressDeadline": "Progress Deadline:"
+      "progressDeadline": "Progress Deadline:",
+      "pod": "Pod:"
     },
     "status": {
       "fetchingEvents": "Fetching events...",

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -1756,7 +1756,8 @@
       "suspend": "Suspend:",
       "revisionHistory": "Revision History Limit:",
       "minReadySeconds": "Min Ready Seconds:",
-      "progressDeadline": "Progress Deadline:"
+      "progressDeadline": "Progress Deadline:",
+      "pod": "Pod:"
     },
     "status": {
       "fetchingEvents": "Fetching events...",

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -1756,7 +1756,8 @@
       "suspend": "Suspend:",
       "revisionHistory": "Revision History Limit:",
       "minReadySeconds": "Min Ready Seconds:",
-      "progressDeadline": "Progress Deadline:"
+      "progressDeadline": "Progress Deadline:",
+      "pod": "Pod:"
     },
     "status": {
       "fetchingEvents": "Fetching events...",

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -1756,7 +1756,8 @@
       "suspend": "Suspend:",
       "revisionHistory": "Revision History Limit:",
       "minReadySeconds": "Min Ready Seconds:",
-      "progressDeadline": "Progress Deadline:"
+      "progressDeadline": "Progress Deadline:",
+      "pod": "Pod:"
     },
     "status": {
       "fetchingEvents": "Fetching events...",

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -1756,7 +1756,8 @@
       "suspend": "Suspend:",
       "revisionHistory": "Revision History Limit:",
       "minReadySeconds": "Min Ready Seconds:",
-      "progressDeadline": "Progress Deadline:"
+      "progressDeadline": "Progress Deadline:",
+      "pod": "Pod:"
     },
     "status": {
       "fetchingEvents": "Fetching events...",

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -1756,7 +1756,8 @@
       "suspend": "Suspend:",
       "revisionHistory": "Revision History Limit:",
       "minReadySeconds": "Min Ready Seconds:",
-      "progressDeadline": "Progress Deadline:"
+      "progressDeadline": "Progress Deadline:",
+      "pod": "Pod:"
     },
     "status": {
       "fetchingEvents": "Fetching events...",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -1756,7 +1756,8 @@
       "suspend": "Suspend:",
       "revisionHistory": "Revision History Limit:",
       "minReadySeconds": "Min Ready Seconds:",
-      "progressDeadline": "Progress Deadline:"
+      "progressDeadline": "Progress Deadline:",
+      "pod": "Pod:"
     },
     "status": {
       "fetchingEvents": "Fetching events...",


### PR DESCRIPTION
## Summary
- Added missing route constants (`AI_AGENTS`, `LLM_D_BENCHMARKS`, `INSIGHTS`, feedback/issue shortcuts, dev/test routes) to `routes.ts`
- Added contextual parent-resource navigation (cluster, namespace, pod links) to 5 drill-down views that were missing it: `EventsDrillDown`, `NodeDrillDown`, `GPUNodeDrillDown`, `YAMLDrillDown`, `LogsDrillDown`
- Added `pod` translation key to `drilldown.fields` in all 9 locale files
- Follows the exact same navigation pattern already used by `DeploymentDrillDown`, `PodDrillDown`, `SecretDrillDown`, etc.

Fixes #2393

## Test plan
- [ ] Verify drill-down views (Events, Node, GPU Node, YAML, Logs) show contextual navigation links to parent resources
- [ ] Verify clicking navigation links correctly pushes parent view onto the drill-down stack
- [ ] Verify route constants in `routes.ts` match actual router config in `App.tsx`
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)