### PR TITLE
✨ Unified card descriptor for simplified card registration

### DIFF
--- a/web/src/components/cards/cardDescriptor.ts
+++ b/web/src/components/cards/cardDescriptor.ts
@@ -1,0 +1,222 @@
+/**
+ * Unified Card Descriptor System
+ *
+ * Replaces the need to register a card in 6+ separate places:
+ *   1. RAW_CARD_COMPONENTS in cardRegistry.ts
+ *   2. CARD_CHUNK_PRELOADERS in cardRegistry.ts
+ *   3. CARD_DEFAULT_WIDTHS in cardRegistry.ts
+ *   4. CARD_TITLES in cardMetadata.ts
+ *   5. CARD_DESCRIPTIONS in cardMetadata.ts
+ *   6. CARD_CATALOG in AddCardModal.tsx
+ *   7. (optionally) DEMO_DATA_CARDS, LIVE_DATA_CARDS, DEMO_EXEMPT_CARDS
+ *
+ * With the descriptor system, a new card only needs ONE registration call:
+ *
+ *   registerCard({
+ *     id: 'my_card',
+ *     title: 'My Card',
+ *     description: 'What this card does.',
+ *     category: 'Cluster Health',
+ *     defaultWidth: 6,
+ *     visualization: 'status',
+ *     component: () => import('./MyCard').then(m => ({ default: m.MyCard })),
+ *   })
+ *
+ * The function auto-populates all existing maps so everything stays
+ * backwards-compatible.
+ *
+ * @see https://github.com/kubestellar/console/issues/2377
+ */
+
+import { lazy, ComponentType } from 'react'
+import type { CardVisualization } from '../../lib/cards/types'
+import type { CardComponentProps } from './cardRegistry'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Visualization type used in the AddCardModal catalog */
+export type CatalogVisualization = CardVisualization
+
+/** Categories matching the CARD_CATALOG keys in AddCardModal.tsx */
+export type CardCatalogCategory =
+  | 'Cluster Admin'
+  | 'Cluster Health'
+  | 'Workloads'
+  | 'Compute'
+  | 'Storage'
+  | 'Network'
+  | 'GitOps'
+  | 'ArgoCD'
+  | 'Operators'
+  | 'Namespaces'
+  | 'Crossplane'
+  | 'Security & Events'
+  | 'Live Trends'
+  | 'AI Agents'
+  | 'AI Assistant'
+  | 'Alerting'
+  | 'Cost Management'
+  | 'Security Posture'
+  | 'Data Compliance'
+  | 'Workload Detection'
+  | 'Arcade'
+  | 'Utilities'
+  | 'Misc'
+  | 'Orchestration'
+  | 'Streaming & Messaging'
+
+/**
+ * Single source of truth for everything needed to register a card.
+ *
+ * Every field that was previously spread across 6+ separate maps
+ * is consolidated here.
+ */
+export interface CardDescriptor {
+  /** Unique card type id (e.g. 'cluster_health') — used as the key everywhere */
+  id: string
+
+  /** Display title (English default — i18n key `cards.titles.<id>` takes priority if available) */
+  title: string
+
+  /** Short description shown in AddCardModal catalog and card info tooltip */
+  description: string
+
+  /** Category in AddCardModal catalog */
+  category: CardCatalogCategory
+
+  /** Default grid width in columns (out of 12) */
+  defaultWidth: number
+
+  /** Visualization type hint for the AddCardModal icon */
+  visualization: CatalogVisualization
+
+  /**
+   * Dynamic import function that returns the card component module.
+   * Used to create both the lazy React component and the chunk preloader.
+   *
+   * Example: `() => import('./MyCard').then(m => ({ default: m.MyCard }))`
+   */
+  component: () => Promise<{ default: ComponentType<CardComponentProps> }>
+
+  /**
+   * Chunk preloader — if the card is part of a shared barrel bundle,
+   * provide the barrel import here so preloading warms the shared chunk.
+   * Defaults to using `component` if not provided.
+   *
+   * Example: `() => import('./deploy-bundle')`
+   */
+  preloader?: () => Promise<unknown>
+
+  /** Whether the card always uses demo/mock data (no live data source exists) */
+  isDemoOnly?: boolean
+
+  /** Whether the card shows a "Live" badge when rendering real data */
+  isLiveData?: boolean
+
+  /** Whether the card should never show demo indicators (badge/yellow border) — e.g., arcade games */
+  isDemoExempt?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Central map of all card descriptors registered via `registerCard()`.
+ * Keyed by card type id.
+ */
+export const CARD_DESCRIPTORS = new Map<string, CardDescriptor>()
+
+/**
+ * Register a card using a single unified descriptor.
+ *
+ * This function populates all existing legacy maps so that every part of the
+ * codebase continues to work without changes:
+ *   - RAW_CARD_COMPONENTS / CARD_COMPONENTS  (via cardRegistry.ts)
+ *   - CARD_CHUNK_PRELOADERS                   (via cardRegistry.ts)
+ *   - CARD_DEFAULT_WIDTHS                     (via cardRegistry.ts)
+ *   - CARD_TITLES                             (via cardMetadata.ts)
+ *   - CARD_DESCRIPTIONS                       (via cardMetadata.ts)
+ *   - DEMO_DATA_CARDS                         (via cardRegistry.ts)
+ *   - LIVE_DATA_CARDS                         (via cardRegistry.ts)
+ *   - DEMO_EXEMPT_CARDS                       (via cardMetadata.ts)
+ *
+ * The CARD_CATALOG in AddCardModal can read from CARD_DESCRIPTORS directly
+ * (or fall back to its existing hard-coded catalog for cards not yet migrated).
+ */
+export function registerCard(
+  descriptor: CardDescriptor,
+  targets: {
+    components: Record<string, ComponentType<CardComponentProps>>
+    preloaders: Record<string, () => Promise<unknown>>
+    defaultWidths: Record<string, number>
+    titles: Record<string, string>
+    descriptions: Record<string, string>
+    demoDataCards: Set<string>
+    liveDataCards: Set<string>
+    demoExemptCards: Set<string>
+  },
+): void {
+  const { id } = descriptor
+
+  // Store the full descriptor
+  CARD_DESCRIPTORS.set(id, descriptor)
+
+  // 1. Register lazy component
+  const LazyComponent = lazy(descriptor.component)
+  targets.components[id] = LazyComponent
+
+  // 2. Register chunk preloader (use explicit preloader or fall back to component import)
+  targets.preloaders[id] = descriptor.preloader ?? descriptor.component
+
+  // 3. Register default width
+  targets.defaultWidths[id] = descriptor.defaultWidth
+
+  // 4. Register title
+  targets.titles[id] = descriptor.title
+
+  // 5. Register description
+  targets.descriptions[id] = descriptor.description
+
+  // 6. Register demo/live/exempt flags
+  if (descriptor.isDemoOnly) {
+    targets.demoDataCards.add(id)
+  }
+  if (descriptor.isLiveData) {
+    targets.liveDataCards.add(id)
+  }
+  if (descriptor.isDemoExempt) {
+    targets.demoExemptCards.add(id)
+  }
+}
+
+/**
+ * Get all registered descriptors as an array.
+ * Useful for building the AddCardModal catalog dynamically.
+ */
+export function getAllDescriptors(): CardDescriptor[] {
+  return Array.from(CARD_DESCRIPTORS.values())
+}
+
+/**
+ * Get all registered descriptors grouped by category.
+ * Returns a Map where keys are category names and values are descriptor arrays.
+ */
+export function getDescriptorsByCategory(): Map<CardCatalogCategory, CardDescriptor[]> {
+  const byCategory = new Map<CardCatalogCategory, CardDescriptor[]>()
+  for (const descriptor of CARD_DESCRIPTORS.values()) {
+    const existing = byCategory.get(descriptor.category) || []
+    existing.push(descriptor)
+    byCategory.set(descriptor.category, existing)
+  }
+  return byCategory
+}
+
+/**
+ * Get a single descriptor by card type id.
+ */
+export function getDescriptor(id: string): CardDescriptor | undefined {
+  return CARD_DESCRIPTORS.get(id)
+}

--- a/web/src/components/cards/cardDescriptors.registry.ts
+++ b/web/src/components/cards/cardDescriptors.registry.ts
@@ -1,0 +1,86 @@
+/**
+ * Card Descriptor Registrations
+ *
+ * This file contains cards that have been migrated to the unified
+ * CardDescriptor system. Each card is registered with a single call
+ * to `registerCard()` instead of being spread across 6+ maps.
+ *
+ * To migrate a card:
+ *   1. Add its descriptor to the DESCRIPTORS array below
+ *   2. Remove its entries from:
+ *      - RAW_CARD_COMPONENTS in cardRegistry.ts
+ *      - CARD_CHUNK_PRELOADERS in cardRegistry.ts
+ *      - CARD_DEFAULT_WIDTHS in cardRegistry.ts
+ *      - CARD_TITLES in cardMetadata.ts
+ *      - CARD_DESCRIPTIONS in cardMetadata.ts
+ *      - DEMO_DATA_CARDS / LIVE_DATA_CARDS / DEMO_EXEMPT_CARDS as applicable
+ *      - CARD_CATALOG in AddCardModal.tsx
+ *   3. Remove the lazy() import at the top of cardRegistry.ts
+ *   4. Run `npx tsc --noEmit` to verify no type errors
+ *
+ * @see https://github.com/kubestellar/console/issues/2377
+ */
+
+import type { ComponentType } from 'react'
+import type { CardDescriptor } from './cardDescriptor'
+import { registerCard } from './cardDescriptor'
+import type { CardComponentProps } from './cardRegistry'
+
+/**
+ * All card descriptors using the unified registration system.
+ *
+ * Proof of concept: 3 cards migrated from the legacy multi-map system.
+ */
+const DESCRIPTORS: CardDescriptor[] = [
+  // ── Weather card ──────────────────────────────────────────────────────
+  {
+    id: 'weather',
+    title: 'Weather',
+    description: 'Weather conditions with multi-day forecasts and animated backgrounds',
+    category: 'Misc',
+    defaultWidth: 6,
+    visualization: 'status',
+    component: () => import('./weather/Weather').then(m => ({ default: m.Weather as ComponentType<CardComponentProps> })),
+  },
+
+  // ── Stock Market Ticker card ──────────────────────────────────────────
+  {
+    id: 'stock_market_ticker',
+    title: 'Stock Market Ticker',
+    description: 'Track multiple stocks with real-time sparkline charts and iPhone-style design',
+    category: 'Misc',
+    defaultWidth: 6,
+    visualization: 'timeseries',
+    component: () => import('./StockMarketTicker').then(m => ({ default: m.StockMarketTicker as ComponentType<CardComponentProps> })),
+  },
+
+  // ── Active Alerts card ────────────────────────────────────────────────
+  {
+    id: 'active_alerts',
+    title: 'Active Alerts',
+    description: 'Currently firing alerts from Prometheus or other sources.',
+    category: 'Alerting',
+    defaultWidth: 4,
+    visualization: 'status',
+    component: () => import('./ActiveAlerts').then(m => ({ default: m.ActiveAlerts as ComponentType<CardComponentProps> })),
+  },
+]
+
+/**
+ * Register all descriptor-based cards into the legacy maps.
+ * Called from cardRegistry.ts during module initialization.
+ */
+export function registerAllDescriptorCards(targets: {
+  components: Record<string, ComponentType<CardComponentProps>>
+  preloaders: Record<string, () => Promise<unknown>>
+  defaultWidths: Record<string, number>
+  titles: Record<string, string>
+  descriptions: Record<string, string>
+  demoDataCards: Set<string>
+  liveDataCards: Set<string>
+  demoExemptCards: Set<string>
+}): void {
+  for (const descriptor of DESCRIPTORS) {
+    registerCard(descriptor, targets)
+  }
+}

--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -117,8 +117,7 @@ export const CARD_TITLES: Record<string, string> = {
   external_secrets: 'External Secrets',
   cert_manager: 'Cert Manager',
 
-  // Alerting cards
-  active_alerts: 'Active Alerts',
+  // Alerting cards — active_alerts registered via unified descriptor system
   alert_rules: 'Alert Rules',
 
   // Cost management
@@ -136,7 +135,7 @@ export const CARD_TITLES: Record<string, string> = {
   user_management: 'User Management',
   github_activity: 'GitHub Activity',
   kubectl: 'Kubectl Terminal',
-  weather: 'Weather',
+  // weather — registered via unified descriptor system
   rss_feed: 'RSS Feed',
   iframe_embed: 'Iframe Embed',
   network_utils: 'Network Utils',
@@ -148,8 +147,7 @@ export const CARD_TITLES: Record<string, string> = {
   console_ai_health_check: 'AI Health Check',
   console_ai_offline_detection: 'Predictive Health Monitor',
 
-  // Stock Market Ticker
-  stock_market_ticker: 'Stock Market Ticker',
+  // stock_market_ticker — registered via unified descriptor system
 
   // PROW CI/CD cards
   prow_jobs: 'PROW Jobs',
@@ -316,7 +314,7 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   vault_secrets: 'HashiCorp Vault secrets management status.',
   external_secrets: 'External Secrets Operator sync status.',
   cert_manager: 'TLS certificate status and renewal from cert-manager.',
-  active_alerts: 'Currently firing alerts from Prometheus or other sources.',
+  // active_alerts — registered via unified descriptor system
   alert_rules: 'Configured alert rules and their evaluation status.',
   opencost_overview: 'Cost allocation data from OpenCost.',
   kubecost_overview: 'Cost breakdown and optimization from Kubecost.',
@@ -328,7 +326,7 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   user_management: 'Manage console users and their roles.',
   github_activity: 'Recent GitHub activity: commits, PRs, and issues.',
   kubectl: 'Interactive kubectl terminal for running commands.',
-  weather: 'Current weather conditions for cluster locations.',
+  // weather — registered via unified descriptor system
   rss_feed: 'RSS feed reader for Kubernetes news and blogs.',
   iframe_embed: 'Embed an external web page inside a card.',
   network_utils: 'Network diagnostic utilities: ping, DNS, traceroute.',
@@ -337,7 +335,7 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   console_ai_kubeconfig_audit: 'AI audit of kubeconfig files for security and cleanup.',
   console_ai_health_check: 'AI-powered cluster health analysis.',
   console_ai_offline_detection: 'Monitors cluster health and predicts failures before they happen. Detects offline nodes, GPU exhaustion, resource pressure, and groups issues by root cause for efficient remediation.',
-  stock_market_ticker: 'Live stock market ticker with tech company prices.',
+  // stock_market_ticker — registered via unified descriptor system
   prow_jobs: 'PROW CI/CD job status and results.',
   prow_status: 'Overall PROW system health and queue depth.',
   prow_history: 'Historical PROW job runs and success rates.',

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -1,6 +1,8 @@
 import { lazy, createElement, ComponentType } from 'react'
 import { isDynamicCardRegistered } from '../../lib/dynamic-cards/dynamicCardRegistry'
 import { getCardConfig } from '../../config/cards'
+import { registerAllDescriptorCards } from './cardDescriptors.registry'
+import { CARD_TITLES, CARD_DESCRIPTIONS, DEMO_EXEMPT_CARDS } from './cardMetadata'
 
 // Lazy load all card components for better code splitting
 const ClusterHealth = lazy(() => import('./ClusterHealth').then(m => ({ default: m.ClusterHealth })))
@@ -68,7 +70,7 @@ const ConsoleHealthCheckCard = lazy(() => import('./console-missions/ConsoleHeal
 const ConsoleOfflineDetectionCard = lazy(() => import('./console-missions/ConsoleOfflineDetectionCard').then(m => ({ default: m.ConsoleOfflineDetectionCard })))
 const HardwareHealthCard = lazy(() => import('./HardwareHealthCard').then(m => ({ default: m.HardwareHealthCard })))
 const ProactiveGPUNodeHealthMonitor = lazy(() => import('./ProactiveGPUNodeHealthMonitor').then(m => ({ default: m.ProactiveGPUNodeHealthMonitor })))
-const ActiveAlerts = lazy(() => import('./ActiveAlerts').then(m => ({ default: m.ActiveAlerts })))
+// ActiveAlerts — migrated to cardDescriptors.registry.ts (unified descriptor system)
 const AlertRulesCard = lazy(() => import('./AlertRules').then(m => ({ default: m.AlertRulesCard })))
 const OpenCostOverview = lazy(() => import('./OpenCostOverview').then(m => ({ default: m.OpenCostOverview })))
 const KubecostOverview = lazy(() => import('./KubecostOverview').then(m => ({ default: m.KubecostOverview })))
@@ -94,7 +96,7 @@ const LLMInference = lazy(() => _workloadDetectionBundle.then(m => ({ default: m
 const LLMModels = lazy(() => _workloadDetectionBundle.then(m => ({ default: m.LLMModels })))
 const MLJobs = lazy(() => _workloadDetectionBundle.then(m => ({ default: m.MLJobs })))
 const MLNotebooks = lazy(() => _workloadDetectionBundle.then(m => ({ default: m.MLNotebooks })))
-const Weather = lazy(() => import('./weather/Weather').then(m => ({ default: m.Weather })))
+// Weather — migrated to cardDescriptors.registry.ts (unified descriptor system)
 const GitHubActivity = lazy(() => import('./GitHubActivity').then(m => ({ default: m.GitHubActivity })))
 const RSSFeed = lazy(() => import('./rss').then(m => ({ default: m.RSSFeed })))
 const Kubectl = lazy(() => import('./Kubectl').then(m => ({ default: m.Kubectl })))
@@ -103,7 +105,7 @@ const MatchGame = lazy(() => import('./MatchGame').then(m => ({ default: m.Match
 const Solitaire = lazy(() => import('./Solitaire').then(m => ({ default: m.Solitaire })))
 const Checkers = lazy(() => import('./Checkers').then(m => ({ default: m.Checkers })))
 const Game2048 = lazy(() => import('./Game2048').then(m => ({ default: m.Game2048 })))
-const StockMarketTicker = lazy(() => import('./StockMarketTicker').then(m => ({ default: m.StockMarketTicker })))
+// StockMarketTicker — migrated to cardDescriptors.registry.ts (unified descriptor system)
 const Kubedle = lazy(() => import('./Kubedle').then(m => ({ default: m.Kubedle })))
 const PodSweeper = lazy(() => import('./PodSweeper').then(m => ({ default: m.PodSweeper })))
 const ContainerTetris = lazy(() => import('./ContainerTetris').then(m => ({ default: m.ContainerTetris })))
@@ -308,8 +310,7 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   console_ai_offline_detection: ConsoleOfflineDetectionCard,
   hardware_health: HardwareHealthCard,
   gpu_node_health: ProactiveGPUNodeHealthMonitor,
-  // Alerting cards
-  active_alerts: ActiveAlerts,
+  // Alerting cards — active_alerts registered via unified descriptor system
   alert_rules: AlertRulesCard,
   // Cost management integrations
   opencost_overview: OpenCostOverview,
@@ -340,8 +341,7 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   llm_models: LLMModels,
   ml_jobs: MLJobs,
   ml_notebooks: MLNotebooks,
-  // Weather card
-  weather: Weather,
+  // Weather card — registered via unified descriptor system
   // GitHub Activity Monitoring card
   github_activity: GitHubActivity,
   // RSS Feed card
@@ -358,8 +358,7 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   checkers: Checkers,
   // Kube 2048 card
   game_2048: Game2048,
-  // Stock Market Ticker card
-  stock_market_ticker: StockMarketTicker,
+  // Stock Market Ticker card — registered via unified descriptor system
   // Kubedle card
   kubedle: Kubedle,
   // Pod Sweeper card
@@ -628,8 +627,10 @@ export const DEMO_DATA_CARDS = new Set([
  * Cards that should never show demo indicators (badge/yellow border).
  * Arcade/game cards don't have "demo data" — they're always just games.
  */
-// Re-export from cardMetadata for backward compatibility
-export { DEMO_EXEMPT_CARDS } from './cardMetadata'
+// Re-export the imported DEMO_EXEMPT_CARDS for backward compatibility.
+// (Imported at the top of this file from cardMetadata.ts so the descriptor
+// registration can mutate the same Set instance.)
+export { DEMO_EXEMPT_CARDS }
 
 /**
  * Map of card type → chunk preload function.
@@ -696,7 +697,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   argocd_applications: () => import('./deploy-bundle'),
   argocd_sync_status: () => import('./deploy-bundle'),
   argocd_health: () => import('./deploy-bundle'),
-  active_alerts: () => import('./ActiveAlerts'),
+  // active_alerts — preloader registered via unified descriptor system
   alert_rules: () => import('./AlertRules'),
   opencost_overview: () => import('./OpenCostOverview'),
   kubecost_overview: () => import('./KubecostOverview'),
@@ -929,7 +930,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   storage_overview: 4,
   network_overview: 4,
   gpu_overview: 4,
-  active_alerts: 4,
+  // active_alerts — width registered via unified descriptor system
   security_issues: 4,
   upgrade_status: 4,
   crossplane_managed_resources: 4,
@@ -1073,8 +1074,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   gpu_node_health: 6,
   node_status: 6,
   user_management: 6,
-  // Weather card
-  weather: 6,
+  // weather — width registered via unified descriptor system
   // GitHub Activity Monitoring card
   github_activity: 8,
   // RSS Feed card
@@ -1085,8 +1085,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   sudoku_game: 6,
   // Kube Match card
   match_game: 6,
-  // Stock Market Ticker
-  stock_market_ticker: 6,
+  // stock_market_ticker — width registered via unified descriptor system
   // Kubedle
   kubedle: 6,
   // Pod Sweeper
@@ -1140,6 +1139,24 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   cluster_comparison: 12,
   cluster_resource_tree: 12,
 }
+
+// ---------------------------------------------------------------------------
+// Unified Card Descriptor Registration
+// ---------------------------------------------------------------------------
+// Cards migrated to the descriptor system are registered here.
+// This populates RAW_CARD_COMPONENTS, CARD_CHUNK_PRELOADERS,
+// CARD_DEFAULT_WIDTHS, CARD_TITLES, CARD_DESCRIPTIONS, and
+// DEMO_DATA_CARDS / LIVE_DATA_CARDS / DEMO_EXEMPT_CARDS in one call.
+registerAllDescriptorCards({
+  components: RAW_CARD_COMPONENTS,
+  preloaders: CARD_CHUNK_PRELOADERS,
+  defaultWidths: CARD_DEFAULT_WIDTHS,
+  titles: CARD_TITLES,
+  descriptions: CARD_DESCRIPTIONS,
+  demoDataCards: DEMO_DATA_CARDS,
+  liveDataCards: LIVE_DATA_CARDS,
+  demoExemptCards: DEMO_EXEMPT_CARDS,
+})
 
 // Default width for cards not in the map
 const DEFAULT_CARD_WIDTH = 4

--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -11,6 +11,7 @@ import { useToast } from '../ui/Toast'
 import { FOCUS_DELAY_MS, RETRY_DELAY_MS } from '../../lib/constants/network'
 import { emitAddCardModalOpened, emitAddCardModalAbandoned, emitCardCategoryBrowsed, emitRecommendedCardShown } from '../../lib/analytics'
 import { isCardVisibleForProject } from '../../config/cards'
+import { getDescriptorsByCategory } from '../cards/cardDescriptor'
 
 // Helper function to wrap technical abbreviations in text with tooltips
 function wrapAbbreviations(text: string): ReactNode {
@@ -201,7 +202,7 @@ const CARD_CATALOG = {
     { type: 'hardware_health', title: 'Hardware Health', description: 'Track GPU, NIC, NVMe, InfiniBand disappearances on SuperMicro/HGX nodes', visualization: 'status' },
   ],
   'Alerting': [
-    { type: 'active_alerts', title: 'Active Alerts', description: 'Firing alerts with severity and quick actions', visualization: 'status' },
+    // active_alerts — registered via unified descriptor system (auto-merged below)
     { type: 'alert_rules', title: 'Alert Rules', description: 'Manage alert rules and notification channels', visualization: 'table' },
   ],
   'Cost Management': [
@@ -276,10 +277,10 @@ const CARD_CATALOG = {
   'Misc': [
     { type: 'buildpacks_status', title: 'Buildpacks Status', description: 'Cloud Native Buildpacks detection, builders, and image build status', visualization: 'status' },
     { type: 'flatcar_status', title: 'Flatcar Container Linux', description: 'Flatcar node OS versions, update status, and version distribution', visualization: 'status' },
-    { type: 'weather', title: 'Weather', description: 'Weather conditions with multi-day forecasts and animated backgrounds', visualization: 'status' },
+    // weather — registered via unified descriptor system (auto-merged below)
     { type: 'github_activity', title: 'GitHub Activity', description: 'Monitor GitHub repository activity - PRs, issues, releases, and contributors', visualization: 'table' },
     { type: 'kubectl', title: 'Kubectl', description: 'Interactive kubectl terminal with AI assistance, YAML editor, and command history', visualization: 'table' },
-    { type: 'stock_market_ticker', title: 'Stock Market Ticker', description: 'Track multiple stocks with real-time sparkline charts and iPhone-style design', visualization: 'timeseries' },
+    // stock_market_ticker — registered via unified descriptor system (auto-merged below)
   ],
   'Orchestration': [
     { type: 'keda_status', title: 'KEDA', description: 'KEDA autoscaler status, scaled object metrics, and trigger queue depths', visualization: 'status' },
@@ -1000,7 +1001,15 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
   // Compute recommended cards — popular cards not already on the dashboard
   const recommendedCards = useMemo(() => {
     const existing = new Set(existingCardTypes || [])
-    const allCards = Object.values(CARD_CATALOG).flat()
+    // Include both static catalog cards and descriptor-registered cards
+    const catalogCards = Object.values(CARD_CATALOG).flat() as Array<{ type: string; title: string; description: string; visualization: string }>
+    const descriptorCards = Array.from(getDescriptorsByCategory().values()).flat().map(d => ({
+      type: d.id,
+      title: d.title,
+      description: d.description,
+      visualization: d.visualization,
+    }))
+    const allCards = [...catalogCards, ...descriptorCards]
     return (RECOMMENDED_CARD_TYPES as readonly string[])
       .filter(type => !existing.has(type))
       .map(type => allCards.find(c => c.type === type))
@@ -1109,6 +1118,27 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
       .filter(([, v]) => (v as unknown[]).length > 0),
   ) as Record<string, Array<{ type: string; title: string; description: string; visualization: string }>>
 
+  // Merge cards registered via the unified descriptor system into the catalog.
+  // Descriptors are grouped by their category and appended to the matching
+  // static catalog category (or create a new category if none exists).
+  const descriptorsByCategory = getDescriptorsByCategory()
+  for (const [category, descriptors] of descriptorsByCategory) {
+    const existing = staticCatalog[category] || []
+    const existingTypes = new Set(existing.map(c => c.type))
+    for (const d of descriptors) {
+      // Skip if already present in the static catalog (avoid duplicates during migration)
+      if (!existingTypes.has(d.id)) {
+        existing.push({
+          type: d.id,
+          title: d.title,
+          description: d.description,
+          visualization: d.visualization,
+        })
+      }
+    }
+    staticCatalog[category] = existing
+  }
+
   const mergedCatalog: Record<string, Array<{ type: string; title: string; description: string; visualization: string }>> = {
     ...(dynamicCatalogEntries.length > 0 ? { 'Custom Cards': dynamicCatalogEntries } : {}),
     ...staticCatalog,
@@ -1172,6 +1202,22 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
             title: card.title,
             description: card.description,
             visualization: card.visualization as CardSuggestion['visualization'],
+            config: {},
+          })
+        }
+      }
+    }
+
+    // Handle cards registered via the unified descriptor system
+    for (const descriptors of descriptorsByCategory.values()) {
+      for (const d of descriptors) {
+        if (selectedBrowseCards.has(d.id) && !addedTypes.has(d.id)) {
+          addedTypes.add(d.id)
+          cardsToAdd.push({
+            type: d.id,
+            title: d.title,
+            description: d.description,
+            visualization: d.visualization as CardSuggestion['visualization'],
             config: {},
           })
         }


### PR DESCRIPTION
## Summary
- Introduced `CardDescriptor` type as single source of truth for card metadata
- Added `registerCard()` function that auto-populates all existing maps (components, preloaders, widths, titles, descriptions, demo/live flags)
- Backwards compatible — existing card registrations continue to work unchanged
- Converted 3 cards (`weather`, `stock_market_ticker`, `active_alerts`) to the new system as proof of concept
- AddCardModal automatically merges descriptor-based cards into its browse catalog
- New cards only need **one registration** instead of 6+ separate map entries
- Clear migration instructions in `cardDescriptors.registry.ts` for converting remaining cards

### New files
- `cardDescriptor.ts` — `CardDescriptor` interface, `registerCard()` function, and descriptor query helpers
- `cardDescriptors.registry.ts` — All migrated card descriptors with `registerAllDescriptorCards()` entry point

### Modified files
- `cardRegistry.ts` — Calls `registerAllDescriptorCards()` at module init, removed migrated cards from legacy maps
- `cardMetadata.ts` — Removed migrated cards from `CARD_TITLES` and `CARD_DESCRIPTIONS`
- `AddCardModal.tsx` — Merges descriptor-based cards into catalog and recommended cards

Fixes #2377

## Test plan
- [ ] Verify converted cards (Weather, Stock Market Ticker, Active Alerts) still render correctly on dashboard
- [ ] Verify AddCardModal still shows all cards in correct categories
- [ ] Verify card widths and preloading still work for converted cards
- [ ] Verify recommended cards section still includes Active Alerts
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npm run build` passes (verified)
- [ ] Add a new card using only the descriptor and verify it works end-to-end