### PR TITLE
🐛 Fix demo mode getting-started instructions

### DIFF
--- a/web/src/components/dashboard/WelcomeCard.tsx
+++ b/web/src/components/dashboard/WelcomeCard.tsx
@@ -1,10 +1,15 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { CheckCircle2, Monitor, Key, Rocket, X, Settings, ExternalLink, Plus, Link2 } from 'lucide-react'
-import { Link } from 'react-router-dom'
+import { Terminal, Globe, Rocket, X, ExternalLink, Copy, Check } from 'lucide-react'
 import { cn } from '../../lib/cn'
 
 const DISMISSED_KEY = 'kc-welcome-dismissed'
+
+/** The canonical quick-start install command */
+const INSTALL_COMMAND = 'curl -sL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash'
+
+/** How long the "Copied!" confirmation shows (ms) */
+const COPY_FEEDBACK_MS = 2000
 
 export function WelcomeCard() {
   const { t } = useTranslation()
@@ -15,6 +20,7 @@ export function WelcomeCard() {
       return false
     }
   })
+  const [copied, setCopied] = useState(false)
 
   if (dismissed) return null
 
@@ -24,6 +30,16 @@ export function WelcomeCard() {
       localStorage.setItem(DISMISSED_KEY, 'true')
     } catch {
       // Ignore storage errors (e.g. private browsing)
+    }
+  }
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(INSTALL_COMMAND)
+      setCopied(true)
+      setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
+    } catch {
+      // Clipboard API not available
     }
   }
 
@@ -37,7 +53,7 @@ export function WelcomeCard() {
         <X className="w-4 h-4" />
       </button>
 
-      {/* Hero banner — big friendly greeting per #2207 */}
+      {/* Hero banner */}
       <div className="flex items-center gap-3 mb-3">
         <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br from-purple-500 to-blue-500 shadow-lg shadow-purple-500/20">
           <Rocket className="w-6 h-6 text-white" />
@@ -48,79 +64,36 @@ export function WelcomeCard() {
         </div>
       </div>
 
-      {/* No-clusters hero message */}
-      <div className="mb-4 p-3 rounded-lg bg-purple-500/10 border border-purple-500/20">
-        <p className="text-sm font-medium text-foreground mb-1">{t('dashboard.welcome.noClustersHero')}</p>
-        <p className="text-xs text-muted-foreground">{t('dashboard.welcome.noClustersHint')}</p>
-      </div>
-
-      {/* Quick-action cards for cluster creation / connection */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mb-4">
-        <a
-          href="https://console-docs.kubestellar.io/getting-started/create-cluster"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-3 p-3 rounded-lg bg-secondary/30 border border-border/50 hover:border-purple-500/30 hover:bg-secondary/50 transition-all text-left group"
-        >
-          <div className="p-2 rounded-lg bg-purple-500/10 group-hover:bg-purple-500/20 transition-colors flex-shrink-0">
-            <Plus className="w-4 h-4 text-purple-400" />
-          </div>
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground truncate">{t('dashboard.welcome.createCluster')}</p>
-            <p className="text-xs text-muted-foreground truncate">{t('dashboard.welcome.createClusterDesc')}</p>
-          </div>
-        </a>
-        <Link
-          to="/settings"
-          className="flex items-center gap-3 p-3 rounded-lg bg-secondary/30 border border-border/50 hover:border-blue-500/30 hover:bg-secondary/50 transition-all text-left group"
-        >
-          <div className="p-2 rounded-lg bg-blue-500/10 group-hover:bg-blue-500/20 transition-colors flex-shrink-0">
-            <Link2 className="w-4 h-4 text-blue-400" />
-          </div>
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground truncate">{t('dashboard.welcome.connectCluster')}</p>
-            <p className="text-xs text-muted-foreground truncate">{t('dashboard.welcome.connectClusterDesc')}</p>
-          </div>
-        </Link>
-      </div>
-
       <div className="space-y-3">
         <Step
           number={1}
-          icon={CheckCircle2}
+          icon={Terminal}
           title={t('dashboard.welcome.step1Title')}
           description={t('dashboard.welcome.step1Desc')}
-          done
+          action={
+            <div className="flex items-center gap-2 mt-1">
+              <code className="flex-1 px-3 py-2 text-xs font-mono bg-secondary/50 rounded-lg border border-border/50 text-foreground overflow-x-auto whitespace-nowrap">
+                {INSTALL_COMMAND}
+              </code>
+              <button
+                onClick={handleCopy}
+                className={`p-2 rounded-lg border transition-all flex-shrink-0 ${
+                  copied
+                    ? 'bg-green-500/20 border-green-500/30 text-green-400'
+                    : 'bg-secondary/50 border-border/50 hover:border-purple-500/30 text-muted-foreground hover:text-foreground'
+                }`}
+                title={copied ? 'Copied!' : 'Copy install command'}
+              >
+                {copied ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+              </button>
+            </div>
+          }
         />
         <Step
           number={2}
-          icon={Monitor}
+          icon={Globe}
           title={t('dashboard.welcome.step2Title')}
           description={t('dashboard.welcome.step2Desc')}
-          action={
-            <Link
-              to="/settings"
-              className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-purple-500/15 border border-purple-500/30 hover:bg-purple-500/25 text-purple-300 font-medium transition-colors"
-            >
-              <Settings className="w-3.5 h-3.5" />
-              {t('dashboard.welcome.openSettings')}
-            </Link>
-          }
-        />
-        <Step
-          number={3}
-          icon={Key}
-          title={t('dashboard.welcome.step3Title')}
-          description={t('dashboard.welcome.step3Desc')}
-          action={
-            <Link
-              to="/settings"
-              className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-secondary/50 border border-border/50 hover:bg-secondary/80 text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <Settings className="w-3.5 h-3.5" />
-              {t('settings.title')}
-            </Link>
-          }
         />
       </div>
 
@@ -144,14 +117,12 @@ function Step({
   icon: Icon,
   title,
   description,
-  done,
   action,
 }: {
   number: number
   icon: React.ComponentType<{ className?: string }>
   title: string
   description: string
-  done?: boolean
   action?: React.ReactNode
 }) {
   return (
@@ -159,17 +130,15 @@ function Step({
       <div
         className={cn(
           'flex items-center justify-center w-7 h-7 rounded-full shrink-0 text-sm font-bold',
-          done
-            ? 'bg-green-500/20 text-green-400'
-            : 'bg-secondary/50 border border-border/50 text-muted-foreground'
+          'bg-secondary/50 border border-border/50 text-muted-foreground'
         )}
       >
-        {done ? <CheckCircle2 className="w-4 h-4" /> : number}
+        {number}
       </div>
       <div className="flex-1 min-w-0 pt-0.5">
         <div className="flex items-center gap-2 mb-0.5">
-          <Icon className={cn('w-4 h-4', done ? 'text-green-400' : 'text-muted-foreground')} />
-          <span className={cn('text-sm font-medium', done ? 'text-green-400' : 'text-foreground')}>
+          <Icon className={cn('w-4 h-4', 'text-muted-foreground')} />
+          <span className={cn('text-sm font-medium', 'text-foreground')}>
             {title}
           </span>
         </div>

--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -677,15 +677,12 @@
     },
     "welcome": {
       "gettingStarted": "Getting Started",
-      "subtitle": "You're up and running — just a few optional steps left",
+      "subtitle": "Up and running in two steps",
       "dismiss": "Dismiss",
-      "step1Title": "Console is running",
-      "step1Desc": "Your KubeStellar Console is up and ready.",
-      "step2Title": "Connect a cluster",
-      "step2Desc": "Clusters are auto-detected from your kubeconfig. Place a kubeconfig at ~/.kube/config or configure via Settings.",
-      "openSettings": "Open Settings",
-      "step3Title": "Optional: Enable AI features",
-      "step3Desc": "Add API keys for Anthropic, OpenAI, or Google to enable AI-powered predictions and card suggestions.",
+      "step1Title": "Download and run the install script",
+      "step1Desc": "One command — downloads binaries, starts the console and kc-agent, and opens your browser. No Go, Node.js, or build tools required.",
+      "step2Title": "Open the console",
+      "step2Desc": "Once the script finishes, open http://localhost:8080 in your browser. Your clusters are auto-detected from ~/.kube/config.",
       "documentation": "Documentation"
     },
     "missions": {

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -700,22 +700,13 @@
       "redo": "Redo"
     },
     "welcome": {
-      "gettingStarted": "Welcome to KubeStellar Console!",
-      "subtitle": "You're up and running — let's get your first cluster connected",
-      "noClustersHero": "No active clusters detected yet",
-      "noClustersHint": "Create a new test cluster or connect an existing one to start managing your multi-cluster workloads.",
-      "createCluster": "Create a Test Cluster",
-      "createClusterDesc": "Spin up a local kind/k3d cluster for testing",
-      "connectCluster": "Connect Existing Cluster",
-      "connectClusterDesc": "Configure kubeconfig path in Settings",
+      "gettingStarted": "Getting Started",
+      "subtitle": "Up and running in two steps",
       "dismiss": "Dismiss",
-      "step1Title": "Console is running",
-      "step1Desc": "Your KubeStellar Console is up and ready.",
-      "step2Title": "Connect a cluster",
-      "step2Desc": "Clusters are auto-detected from your kubeconfig. Place a kubeconfig at ~/.kube/config or configure via Settings.",
-      "openSettings": "Open Settings",
-      "step3Title": "Optional: Enable AI features",
-      "step3Desc": "Add API keys for Anthropic, OpenAI, or Google to enable AI-powered predictions and card suggestions.",
+      "step1Title": "Download and run the install script",
+      "step1Desc": "One command — downloads binaries, starts the console and kc-agent, and opens your browser. No Go, Node.js, or build tools required.",
+      "step2Title": "Open the console",
+      "step2Desc": "Once the script finishes, open http://localhost:8080 in your browser. Your clusters are auto-detected from ~/.kube/config.",
       "documentation": "Documentation"
     },
     "missions": {

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -677,15 +677,12 @@
     },
     "welcome": {
       "gettingStarted": "Getting Started",
-      "subtitle": "You're up and running — just a few optional steps left",
+      "subtitle": "Up and running in two steps",
       "dismiss": "Dismiss",
-      "step1Title": "Console is running",
-      "step1Desc": "Your KubeStellar Console is up and ready.",
-      "step2Title": "Connect a cluster",
-      "step2Desc": "Clusters are auto-detected from your kubeconfig. Place a kubeconfig at ~/.kube/config or configure via Settings.",
-      "openSettings": "Open Settings",
-      "step3Title": "Optional: Enable AI features",
-      "step3Desc": "Add API keys for Anthropic, OpenAI, or Google to enable AI-powered predictions and card suggestions.",
+      "step1Title": "Download and run the install script",
+      "step1Desc": "One command — downloads binaries, starts the console and kc-agent, and opens your browser. No Go, Node.js, or build tools required.",
+      "step2Title": "Open the console",
+      "step2Desc": "Once the script finishes, open http://localhost:8080 in your browser. Your clusters are auto-detected from ~/.kube/config.",
       "documentation": "Documentation"
     },
     "missions": {

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -677,15 +677,12 @@
     },
     "welcome": {
       "gettingStarted": "Getting Started",
-      "subtitle": "You're up and running — just a few optional steps left",
+      "subtitle": "Up and running in two steps",
       "dismiss": "Dismiss",
-      "step1Title": "Console is running",
-      "step1Desc": "Your KubeStellar Console is up and ready.",
-      "step2Title": "Connect a cluster",
-      "step2Desc": "Clusters are auto-detected from your kubeconfig. Place a kubeconfig at ~/.kube/config or configure via Settings.",
-      "openSettings": "Open Settings",
-      "step3Title": "Optional: Enable AI features",
-      "step3Desc": "Add API keys for Anthropic, OpenAI, or Google to enable AI-powered predictions and card suggestions.",
+      "step1Title": "Download and run the install script",
+      "step1Desc": "One command — downloads binaries, starts the console and kc-agent, and opens your browser. No Go, Node.js, or build tools required.",
+      "step2Title": "Open the console",
+      "step2Desc": "Once the script finishes, open http://localhost:8080 in your browser. Your clusters are auto-detected from ~/.kube/config.",
       "documentation": "Documentation"
     },
     "missions": {

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -677,15 +677,12 @@
     },
     "welcome": {
       "gettingStarted": "Getting Started",
-      "subtitle": "You're up and running — just a few optional steps left",
+      "subtitle": "Up and running in two steps",
       "dismiss": "Dismiss",
-      "step1Title": "Console is running",
-      "step1Desc": "Your KubeStellar Console is up and ready.",
-      "step2Title": "Connect a cluster",
-      "step2Desc": "Clusters are auto-detected from your kubeconfig. Place a kubeconfig at ~/.kube/config or configure via Settings.",
-      "openSettings": "Open Settings",
-      "step3Title": "Optional: Enable AI features",
-      "step3Desc": "Add API keys for Anthropic, OpenAI, or Google to enable AI-powered predictions and card suggestions.",
+      "step1Title": "Download and run the install script",
+      "step1Desc": "One command — downloads binaries, starts the console and kc-agent, and opens your browser. No Go, Node.js, or build tools required.",
+      "step2Title": "Open the console",
+      "step2Desc": "Once the script finishes, open http://localhost:8080 in your browser. Your clusters are auto-detected from ~/.kube/config.",
       "documentation": "Documentation"
     },
     "missions": {

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -677,15 +677,12 @@
     },
     "welcome": {
       "gettingStarted": "Getting Started",
-      "subtitle": "You're up and running — just a few optional steps left",
+      "subtitle": "Up and running in two steps",
       "dismiss": "Dismiss",
-      "step1Title": "Console is running",
-      "step1Desc": "Your KubeStellar Console is up and ready.",
-      "step2Title": "Connect a cluster",
-      "step2Desc": "Clusters are auto-detected from your kubeconfig. Place a kubeconfig at ~/.kube/config or configure via Settings.",
-      "openSettings": "Open Settings",
-      "step3Title": "Optional: Enable AI features",
-      "step3Desc": "Add API keys for Anthropic, OpenAI, or Google to enable AI-powered predictions and card suggestions.",
+      "step1Title": "Download and run the install script",
+      "step1Desc": "One command — downloads binaries, starts the console and kc-agent, and opens your browser. No Go, Node.js, or build tools required.",
+      "step2Title": "Open the console",
+      "step2Desc": "Once the script finishes, open http://localhost:8080 in your browser. Your clusters are auto-detected from ~/.kube/config.",
       "documentation": "Documentation"
     },
     "missions": {

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -677,15 +677,12 @@
     },
     "welcome": {
       "gettingStarted": "Getting Started",
-      "subtitle": "You're up and running — just a few optional steps left",
+      "subtitle": "Up and running in two steps",
       "dismiss": "Dismiss",
-      "step1Title": "Console is running",
-      "step1Desc": "Your KubeStellar Console is up and ready.",
-      "step2Title": "Connect a cluster",
-      "step2Desc": "Clusters are auto-detected from your kubeconfig. Place a kubeconfig at ~/.kube/config or configure via Settings.",
-      "openSettings": "Open Settings",
-      "step3Title": "Optional: Enable AI features",
-      "step3Desc": "Add API keys for Anthropic, OpenAI, or Google to enable AI-powered predictions and card suggestions.",
+      "step1Title": "Download and run the install script",
+      "step1Desc": "One command — downloads binaries, starts the console and kc-agent, and opens your browser. No Go, Node.js, or build tools required.",
+      "step2Title": "Open the console",
+      "step2Desc": "Once the script finishes, open http://localhost:8080 in your browser. Your clusters are auto-detected from ~/.kube/config.",
       "documentation": "Documentation"
     },
     "missions": {

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -677,15 +677,12 @@
     },
     "welcome": {
       "gettingStarted": "Getting Started",
-      "subtitle": "You're up and running — just a few optional steps left",
+      "subtitle": "Up and running in two steps",
       "dismiss": "Dismiss",
-      "step1Title": "Console is running",
-      "step1Desc": "Your KubeStellar Console is up and ready.",
-      "step2Title": "Connect a cluster",
-      "step2Desc": "Clusters are auto-detected from your kubeconfig. Place a kubeconfig at ~/.kube/config or configure via Settings.",
-      "openSettings": "Open Settings",
-      "step3Title": "Optional: Enable AI features",
-      "step3Desc": "Add API keys for Anthropic, OpenAI, or Google to enable AI-powered predictions and card suggestions.",
+      "step1Title": "Download and run the install script",
+      "step1Desc": "One command — downloads binaries, starts the console and kc-agent, and opens your browser. No Go, Node.js, or build tools required.",
+      "step2Title": "Open the console",
+      "step2Desc": "Once the script finishes, open http://localhost:8080 in your browser. Your clusters are auto-detected from ~/.kube/config.",
       "documentation": "Documentation"
     },
     "missions": {

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -677,15 +677,12 @@
     },
     "welcome": {
       "gettingStarted": "Getting Started",
-      "subtitle": "You're up and running — just a few optional steps left",
+      "subtitle": "Up and running in two steps",
       "dismiss": "Dismiss",
-      "step1Title": "Console is running",
-      "step1Desc": "Your KubeStellar Console is up and ready.",
-      "step2Title": "Connect a cluster",
-      "step2Desc": "Clusters are auto-detected from your kubeconfig. Place a kubeconfig at ~/.kube/config or configure via Settings.",
-      "openSettings": "Open Settings",
-      "step3Title": "Optional: Enable AI features",
-      "step3Desc": "Add API keys for Anthropic, OpenAI, or Google to enable AI-powered predictions and card suggestions.",
+      "step1Title": "Download and run the install script",
+      "step1Desc": "One command — downloads binaries, starts the console and kc-agent, and opens your browser. No Go, Node.js, or build tools required.",
+      "step2Title": "Open the console",
+      "step2Desc": "Once the script finishes, open http://localhost:8080 in your browser. Your clusters are auto-detected from ~/.kube/config.",
       "documentation": "Documentation"
     },
     "missions": {


### PR DESCRIPTION
## Summary
- Updated getting-started instructions shown in the WelcomeCard to match the official quick-start docs
- Replaced the old 3-step flow (Console running / Connect cluster / Enable AI) with the canonical 2-step quick-start: (1) curl the install script, (2) open http://localhost:8080
- Added a copy-to-clipboard button for the install command
- Updated all 9 locale files (en, de, es, fr, hi, it, ja, pt, zh)

Fixes #2533

## Test plan
- [ ] Visit demo mode and verify instructions match quick-start docs
- [ ] Verify the curl command is correct and copyable
- [ ] Check that the WelcomeCard renders correctly with 2 steps
- [ ] Verify locale strings are consistent across all languages