### PR TITLE
🌱 Split high-complexity settings and alert components

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -1,48 +1,25 @@
 import { useState, useMemo, useCallback } from 'react'
 import {
   AlertTriangle,
-  Bell,
   CheckCircle,
-  Clock,
-  ChevronRight,
-  Bot,
-  Server,
   Eye,
   EyeOff,
-  ExternalLink,
+  Server,
 } from 'lucide-react'
 import { useAlerts } from '../../hooks/useAlerts'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useGlobalFilters, type SeverityLevel } from '../../hooks/useGlobalFilters'
 import { useDrillDown } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
-import { getSeverityIcon } from '../../types/alerts'
 import type { Alert, AlertSeverity } from '../../types/alerts'
-import { Button } from '../ui/Button'
 import { CardControls } from '../ui/CardControls'
 import { Pagination } from '../ui/Pagination'
-import { useCardData, CardClusterFilter, CardSearchInput, CardAIActions } from '../../lib/cards'
+import { useCardData, CardClusterFilter, CardSearchInput } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
-import type { TFunction } from 'i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
-import { isBrowserNotifVerified, setBrowserNotifVerified } from '../../lib/notificationStatus'
-
-// Severity color map — defined at module level to avoid re-creation on each render
-const SEVERITY_COLORS: Record<AlertSeverity, string> = {
-  critical: 'bg-red-500/20 text-red-400 border-red-500/30',
-  warning: 'bg-orange-500/20 text-orange-400 border-orange-500/30',
-  info: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
-}
-
-// Severity indicator badge — extracted to module level to prevent re-creation on every render
-function SeverityBadge({ severity }: { severity: AlertSeverity }) {
-  return (
-    <span className={`px-1.5 py-0.5 text-xs rounded border ${SEVERITY_COLORS[severity]}`}>
-      {severity}
-    </span>
-  )
-}
+import { NotificationVerifyIndicator } from './NotificationVerifyIndicator'
+import { AlertListItem } from './AlertListItem'
 
 // Stats summary row shown at the top of the alerts card
 function AlertStatsRow({ critical, warning, acknowledged }: { critical: number; warning: number; acknowledged: number }) {
@@ -74,23 +51,8 @@ function AlertStatsRow({ critical, warning, acknowledged }: { critical: number; 
   )
 }
 
-// Format relative time
-function formatRelativeTime(dateString: string, t: TFunction<'cards'>): string {
-  const date = new Date(dateString)
-  const now = new Date()
-  const diffMs = now.getTime() - date.getTime()
-  const diffMins = Math.floor(diffMs / 60000)
-  const diffHours = Math.floor(diffMins / 60)
-  const diffDays = Math.floor(diffHours / 24)
-
-  if (diffMins < 1) return t('activeAlerts.justNow')
-  if (diffMins < 60) return t('activeAlerts.minutesAgo', { count: diffMins })
-  if (diffHours < 24) return t('activeAlerts.hoursAgo', { count: diffHours })
-  return t('activeAlerts.daysAgo', { count: diffDays })
-}
-
-/** Notification verification flow state */
-type NotifVerifyState = 'idle' | 'asked' | 'verified' | 'failed'
+/** Default pagination size for the alerts list */
+const DEFAULT_PAGE_SIZE = 5
 
 type SortField = 'severity' | 'time'
 
@@ -110,42 +72,6 @@ export function ActiveAlerts() {
   const { missions, setActiveMission, openSidebar } = useMissions()
 
   const [showAcknowledged, setShowAcknowledged] = useState(false)
-
-  // Browser notification verification state
-  const [notifVerifyState, setNotifVerifyState] = useState<NotifVerifyState>('idle')
-  const [notifVerified, setNotifVerified] = useState(() => isBrowserNotifVerified())
-
-  /** Whether the notification indicator should be visible */
-  const showNotifIndicator =
-    typeof Notification !== 'undefined' &&
-    Notification.permission === 'granted' &&
-    !notifVerified &&
-    notifVerifyState !== 'verified'
-
-  /** Send a test notification and ask user to confirm receipt */
-  const handleSendTestNotif = () => {
-    try {
-      new Notification('KubeStellar Console', {
-        body: t('activeAlerts.testNotificationBody'),
-        icon: '/favicon.ico',
-      })
-    } catch {
-      // Notification constructor may throw in some environments
-    }
-    setNotifVerifyState('asked')
-  }
-
-  /** User confirmed they saw the test notification */
-  const handleNotifYes = () => {
-    setBrowserNotifVerified(true)
-    setNotifVerified(true)
-    setNotifVerifyState('verified')
-  }
-
-  /** User did NOT see the test notification */
-  const handleNotifNo = () => {
-    setNotifVerifyState('failed')
-  }
 
   // Combine active and acknowledged alerts when toggle is on
   const allAlertsToShow = useMemo(() => {
@@ -237,7 +163,7 @@ export function ActiveAlerts() {
         time: (a, b) => new Date(b.firedAt).getTime() - new Date(a.firedAt).getTime(),
       },
     },
-    defaultLimit: 5,
+    defaultLimit: DEFAULT_PAGE_SIZE,
   })
 
   const handleAlertClick = (alert: Alert) => {
@@ -292,40 +218,8 @@ export function ActiveAlerts() {
               {localClusterFilter.length}/{availableClustersForFilter.length}
             </span>
           )}
-          {/* Subtle browser notification verification indicator */}
-          {showNotifIndicator && notifVerifyState === 'idle' && (
-            <button
-              onClick={handleSendTestNotif}
-              title={t('activeAlerts.notifNotVerified')}
-              className="relative flex items-center p-1 rounded hover:bg-secondary/60 transition-colors"
-            >
-              <Bell className="w-3.5 h-3.5 text-muted-foreground" />
-              <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-amber-400" />
-            </button>
-          )}
-          {notifVerifyState === 'asked' && (
-            <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-              <span>{t('activeAlerts.didYouSeeIt')}</span>
-              <button
-                onClick={handleNotifYes}
-                className="px-1.5 py-0.5 rounded bg-green-500/20 text-green-400 hover:bg-green-500/30 transition-colors text-xs"
-              >
-                {t('activeAlerts.yes')}
-              </button>
-              <button
-                onClick={handleNotifNo}
-                className="px-1.5 py-0.5 rounded bg-secondary text-muted-foreground hover:text-foreground transition-colors text-xs"
-              >
-                {t('activeAlerts.no')}
-              </button>
-            </span>
-          )}
-          {notifVerifyState === 'failed' && (
-            <span className="flex items-center gap-1 text-xs text-amber-400">
-              <Bell className="w-3 h-3" />
-              <span>{t('activeAlerts.checkSystemSettings')}</span>
-            </span>
-          )}
+          {/* Browser notification verification indicator */}
+          <NotificationVerifyIndicator />
         </div>
 
         <div className="flex items-center gap-2">
@@ -393,87 +287,15 @@ export function ActiveAlerts() {
           </div>
         ) : (
           displayedAlerts.map((alert: Alert) => (
-            <div
+            <AlertListItem
               key={alert.id}
-              onClick={() => handleAlertClick(alert)}
-              className="p-2 rounded-lg bg-secondary/30 border border-border/50 hover:bg-secondary/50 cursor-pointer transition-colors group"
-            >
-              <div className="flex items-start gap-2">
-                <span className="text-lg">{getSeverityIcon(alert.severity)}</span>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="text-sm font-medium text-foreground truncate">
-                      {alert.ruleName}
-                    </span>
-                    <SeverityBadge severity={alert.severity} />
-                  </div>
-                  <p className="text-xs text-muted-foreground line-clamp-2">
-                    {alert.message}
-                  </p>
-                  <div className="flex items-center gap-3 mt-1.5">
-                    {alert.cluster && (
-                      <span className="text-xs text-muted-foreground flex items-center gap-1">
-                        <Server className="w-3 h-3" />
-                        {alert.cluster}
-                      </span>
-                    )}
-                    <span className="text-xs text-muted-foreground flex items-center gap-1">
-                      <Clock className="w-3 h-3" />
-                      {formatRelativeTime(alert.firedAt, t)}
-                    </span>
-                    {getMissionForAlert(alert) && (
-                      <span className="text-xs text-purple-400 flex items-center gap-1">
-                        <Bot className="w-3 h-3" />
-                        AI
-                      </span>
-                    )}
-                    {alert.acknowledgedAt && (
-                      <span className="text-xs text-green-400">{t('activeAlerts.acknowledged')}</span>
-                    )}
-                  </div>
-                </div>
-                <ChevronRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
-              </div>
-
-              {/* Quick Actions */}
-              <div className="flex items-center gap-2 mt-2 pt-2 border-t border-border/30">
-                {!alert.acknowledgedAt && (
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={e => handleAcknowledge(e, alert.id)}
-                    className="rounded"
-                  >
-                    {t('activeAlerts.acknowledge')}
-                  </Button>
-                )}
-                {(() => {
-                  const mission = getMissionForAlert(alert)
-                  if (mission) {
-                    return (
-                      <Button
-                        variant="accent"
-                        size="sm"
-                        onClick={e => handleOpenMission(e, alert)}
-                        icon={<ExternalLink className="w-3 h-3" />}
-                        className="rounded"
-                      >
-                        {t('activeAlerts.viewDiagnosis')}
-                      </Button>
-                    )
-                  } else {
-                    return (
-                      <CardAIActions
-                        resource={{ kind: 'Alert', name: alert.ruleName, cluster: alert.cluster, status: alert.severity }}
-                        issues={[{ name: alert.ruleName, message: alert.message }]}
-                        showRepair={false}
-                        onDiagnose={e => handleAIDiagnose(e, alert.id)}
-                      />
-                    )
-                  }
-                })()}
-              </div>
-            </div>
+              alert={alert}
+              mission={getMissionForAlert(alert)}
+              onAlertClick={handleAlertClick}
+              onAcknowledge={handleAcknowledge}
+              onAIDiagnose={handleAIDiagnose}
+              onOpenMission={handleOpenMission}
+            />
           ))
         )}
       </div>
@@ -485,7 +307,7 @@ export function ActiveAlerts() {
             currentPage={currentPage}
             totalPages={totalPages}
             totalItems={totalItems}
-            itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : 5}
+            itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : DEFAULT_PAGE_SIZE}
             onPageChange={goToPage}
             showItemsPerPage={false}
           />

--- a/web/src/components/cards/AlertListItem.tsx
+++ b/web/src/components/cards/AlertListItem.tsx
@@ -1,0 +1,159 @@
+import {
+  Clock,
+  ChevronRight,
+  Bot,
+  Server,
+  ExternalLink,
+} from 'lucide-react'
+import { getSeverityIcon } from '../../types/alerts'
+import type { Alert, AlertSeverity } from '../../types/alerts'
+import { Button } from '../ui/Button'
+import { CardAIActions } from '../../lib/cards'
+import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
+import type { Mission } from '../../hooks/useMissions'
+
+// Severity color map — defined at module level to avoid re-creation on each render
+const SEVERITY_COLORS: Record<AlertSeverity, string> = {
+  critical: 'bg-red-500/20 text-red-400 border-red-500/30',
+  warning: 'bg-orange-500/20 text-orange-400 border-orange-500/30',
+  info: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
+}
+
+/** Milliseconds in one minute — used for relative time formatting */
+const MS_PER_MINUTE = 60000
+/** Minutes in one hour */
+const MINUTES_PER_HOUR = 60
+/** Hours in one day */
+const HOURS_PER_DAY = 24
+
+// Severity indicator badge
+function SeverityBadge({ severity }: { severity: AlertSeverity }) {
+  return (
+    <span className={`px-1.5 py-0.5 text-xs rounded border ${SEVERITY_COLORS[severity]}`}>
+      {severity}
+    </span>
+  )
+}
+
+// Format relative time
+function formatRelativeTime(dateString: string, t: TFunction<'cards'>): string {
+  const date = new Date(dateString)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffMins = Math.floor(diffMs / MS_PER_MINUTE)
+  const diffHours = Math.floor(diffMins / MINUTES_PER_HOUR)
+  const diffDays = Math.floor(diffHours / HOURS_PER_DAY)
+
+  if (diffMins < 1) return t('activeAlerts.justNow')
+  if (diffMins < MINUTES_PER_HOUR) return t('activeAlerts.minutesAgo', { count: diffMins })
+  if (diffHours < HOURS_PER_DAY) return t('activeAlerts.hoursAgo', { count: diffHours })
+  return t('activeAlerts.daysAgo', { count: diffDays })
+}
+
+interface AlertListItemProps {
+  alert: Alert
+  mission: Mission | null
+  onAlertClick: (alert: Alert) => void
+  onAcknowledge: (e: React.MouseEvent, alertId: string) => void
+  onAIDiagnose: (e: React.MouseEvent, alertId: string) => void
+  onOpenMission: (e: React.MouseEvent, alert: Alert) => void
+}
+
+/**
+ * Renders a single alert row in the ActiveAlerts card.
+ * Includes severity badge, metadata, and quick action buttons.
+ */
+export function AlertListItem({
+  alert,
+  mission,
+  onAlertClick,
+  onAcknowledge,
+  onAIDiagnose,
+  onOpenMission,
+}: AlertListItemProps) {
+  const { t } = useTranslation('cards')
+
+  return (
+    <div
+      key={alert.id}
+      onClick={() => onAlertClick(alert)}
+      className="p-2 rounded-lg bg-secondary/30 border border-border/50 hover:bg-secondary/50 cursor-pointer transition-colors group"
+    >
+      <div className="flex items-start gap-2">
+        <span className="text-lg">{getSeverityIcon(alert.severity)}</span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-sm font-medium text-foreground truncate">
+              {alert.ruleName}
+            </span>
+            <SeverityBadge severity={alert.severity} />
+          </div>
+          <p className="text-xs text-muted-foreground line-clamp-2">
+            {alert.message}
+          </p>
+          <div className="flex items-center gap-3 mt-1.5">
+            {alert.cluster && (
+              <span className="text-xs text-muted-foreground flex items-center gap-1">
+                <Server className="w-3 h-3" />
+                {alert.cluster}
+              </span>
+            )}
+            <span className="text-xs text-muted-foreground flex items-center gap-1">
+              <Clock className="w-3 h-3" />
+              {formatRelativeTime(alert.firedAt, t)}
+            </span>
+            {mission && (
+              <span className="text-xs text-purple-400 flex items-center gap-1">
+                <Bot className="w-3 h-3" />
+                AI
+              </span>
+            )}
+            {alert.acknowledgedAt && (
+              <span className="text-xs text-green-400">{t('activeAlerts.acknowledged')}</span>
+            )}
+          </div>
+        </div>
+        <ChevronRight className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+      </div>
+
+      {/* Quick Actions */}
+      <div className="flex items-center gap-2 mt-2 pt-2 border-t border-border/30">
+        {!alert.acknowledgedAt && (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={e => onAcknowledge(e, alert.id)}
+            className="rounded"
+          >
+            {t('activeAlerts.acknowledge')}
+          </Button>
+        )}
+        {(() => {
+          if (mission) {
+            return (
+              <Button
+                variant="accent"
+                size="sm"
+                onClick={e => onOpenMission(e, alert)}
+                icon={<ExternalLink className="w-3 h-3" />}
+                className="rounded"
+              >
+                {t('activeAlerts.viewDiagnosis')}
+              </Button>
+            )
+          } else {
+            return (
+              <CardAIActions
+                resource={{ kind: 'Alert', name: alert.ruleName, cluster: alert.cluster, status: alert.severity }}
+                issues={[{ name: alert.ruleName, message: alert.message }]}
+                showRepair={false}
+                onDiagnose={e => onAIDiagnose(e, alert.id)}
+              />
+            )
+          }
+        })()}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/cards/NotificationVerifyIndicator.tsx
+++ b/web/src/components/cards/NotificationVerifyIndicator.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import { Bell } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { isBrowserNotifVerified, setBrowserNotifVerified } from '../../lib/notificationStatus'
+
+/** Notification verification flow state */
+type NotifVerifyState = 'idle' | 'asked' | 'verified' | 'failed'
+
+/**
+ * Inline browser notification verification indicator for the ActiveAlerts card header.
+ * Shows a bell icon with a dot when notifications aren't verified, and guides
+ * the user through a send-test / confirm flow.
+ */
+export function NotificationVerifyIndicator() {
+  const { t } = useTranslation('cards')
+  const [notifVerifyState, setNotifVerifyState] = useState<NotifVerifyState>('idle')
+  const [notifVerified, setNotifVerified] = useState(() => isBrowserNotifVerified())
+
+  /** Whether the notification indicator should be visible */
+  const showNotifIndicator =
+    typeof Notification !== 'undefined' &&
+    Notification.permission === 'granted' &&
+    !notifVerified &&
+    notifVerifyState !== 'verified'
+
+  /** Send a test notification and ask user to confirm receipt */
+  const handleSendTestNotif = () => {
+    try {
+      new Notification('KubeStellar Console', {
+        body: t('activeAlerts.testNotificationBody'),
+        icon: '/favicon.ico',
+      })
+    } catch {
+      // Notification constructor may throw in some environments
+    }
+    setNotifVerifyState('asked')
+  }
+
+  /** User confirmed they saw the test notification */
+  const handleNotifYes = () => {
+    setBrowserNotifVerified(true)
+    setNotifVerified(true)
+    setNotifVerifyState('verified')
+  }
+
+  /** User did NOT see the test notification */
+  const handleNotifNo = () => {
+    setNotifVerifyState('failed')
+  }
+
+  // Don't render anything once verified or if not applicable
+  if (!showNotifIndicator && notifVerifyState !== 'asked' && notifVerifyState !== 'failed') {
+    return null
+  }
+
+  return (
+    <>
+      {showNotifIndicator && notifVerifyState === 'idle' && (
+        <button
+          onClick={handleSendTestNotif}
+          title={t('activeAlerts.notifNotVerified')}
+          className="relative flex items-center p-1 rounded hover:bg-secondary/60 transition-colors"
+        >
+          <Bell className="w-3.5 h-3.5 text-muted-foreground" />
+          <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-amber-400" />
+        </button>
+      )}
+      {notifVerifyState === 'asked' && (
+        <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span>{t('activeAlerts.didYouSeeIt')}</span>
+          <button
+            onClick={handleNotifYes}
+            className="px-1.5 py-0.5 rounded bg-green-500/20 text-green-400 hover:bg-green-500/30 transition-colors text-xs"
+          >
+            {t('activeAlerts.yes')}
+          </button>
+          <button
+            onClick={handleNotifNo}
+            className="px-1.5 py-0.5 rounded bg-secondary text-muted-foreground hover:text-foreground transition-colors text-xs"
+          >
+            {t('activeAlerts.no')}
+          </button>
+        </span>
+      )}
+      {notifVerifyState === 'failed' && (
+        <span className="flex items-center gap-1 text-xs text-amber-400">
+          <Bell className="w-3 h-3" />
+          <span>{t('activeAlerts.checkSystemSettings')}</span>
+        </span>
+      )}
+    </>
+  )
+}

--- a/web/src/components/settings/sections/BrowserNotificationSettings.tsx
+++ b/web/src/components/settings/sections/BrowserNotificationSettings.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Globe, Check, X } from 'lucide-react'
+import { isBrowserNotifVerified, setBrowserNotifVerified } from '../../../lib/notificationStatus'
+
+/** Browser notification verification flow state */
+type BrowserNotifState = 'idle' | 'asked' | 'verified' | 'failed'
+
+/**
+ * Browser notification settings sub-section.
+ * Handles permission requests, test notifications, and verification flow.
+ */
+export function BrowserNotificationSettings() {
+  const { t } = useTranslation()
+  const [browserNotifState, setBrowserNotifState] = useState<BrowserNotifState>(
+    () => (isBrowserNotifVerified() ? 'verified' : 'idle'),
+  )
+
+  const browserPermission =
+    typeof Notification !== 'undefined' ? Notification.permission : 'default'
+
+  const handleRequestPermission = async () => {
+    if (typeof Notification === 'undefined') return
+    try {
+      const result = await Notification.requestPermission()
+      if (result === 'granted') {
+        setBrowserNotifState('idle')
+      }
+    } catch {
+      // Permission request may fail in some environments
+    }
+  }
+
+  const handleSendBrowserTest = () => {
+    try {
+      new Notification('KubeStellar Console Test', {
+        body: t('settings.notifications.browser.testBody'),
+        requireInteraction: true,
+        icon: '/favicon.ico',
+      })
+    } catch {
+      // Notification constructor may throw in some environments
+    }
+    setBrowserNotifState('asked')
+  }
+
+  const handleBrowserNotifYes = () => {
+    setBrowserNotifVerified(true)
+    setBrowserNotifState('verified')
+  }
+
+  const handleBrowserNotifNo = () => {
+    setBrowserNotifVerified(false)
+    setBrowserNotifState('failed')
+  }
+
+  return (
+    <div className="space-y-4 mb-6">
+      <div className="flex items-center gap-2 pb-2 border-b border-border">
+        <Globe className="w-4 h-4 text-foreground" />
+        <h3 className="text-sm font-medium text-foreground">{t('settings.notifications.browser.title')}</h3>
+      </div>
+
+      {/* Permission status */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-muted-foreground">{t('settings.notifications.browser.permissionStatus')}</span>
+        <span
+          className={`px-2 py-0.5 text-xs rounded-full border ${
+            browserPermission === 'granted'
+              ? 'bg-green-500/10 border-green-500/20 text-green-400'
+              : browserPermission === 'denied'
+                ? 'bg-red-500/10 border-red-500/20 text-red-400'
+                : 'bg-yellow-500/10 border-yellow-500/20 text-yellow-400'
+          }`}
+        >
+          {browserPermission}
+        </span>
+      </div>
+
+      {browserPermission === 'granted' ? (
+        <>
+          {browserNotifState === 'idle' && (
+            <button
+              onClick={handleSendBrowserTest}
+              className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors"
+            >
+              {t('settings.notifications.browser.sendTest')}
+            </button>
+          )}
+
+          {browserNotifState === 'asked' && (
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">{t('settings.notifications.browser.didYouSeeIt')}</p>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={handleBrowserNotifYes}
+                  className="px-3 py-1.5 text-sm rounded-lg bg-green-500/20 text-green-400 border border-green-500/30 hover:bg-green-500/30 transition-colors"
+                >
+                  {t('settings.notifications.browser.yes')}
+                </button>
+                <button
+                  onClick={handleBrowserNotifNo}
+                  className="px-3 py-1.5 text-sm rounded-lg bg-secondary text-muted-foreground border border-border hover:text-foreground transition-colors"
+                >
+                  {t('settings.notifications.browser.no')}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {browserNotifState === 'verified' && (
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
+              <Check className="w-4 h-4 text-green-400 flex-shrink-0 mt-0.5" />
+              <p className="text-sm text-green-400">
+                {t('settings.notifications.browser.verified')}
+              </p>
+            </div>
+          )}
+
+          {browserNotifState === 'failed' && (
+            <div className="space-y-2">
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
+                <X className="w-4 h-4 text-amber-400 flex-shrink-0 mt-0.5" />
+                <p className="text-sm text-amber-400">
+                  {t('settings.notifications.browser.enableInstructions')}
+                </p>
+              </div>
+              <button
+                onClick={handleSendBrowserTest}
+                className="px-4 py-2 text-sm rounded-lg bg-secondary text-muted-foreground border border-border hover:text-foreground transition-colors"
+              >
+                {t('settings.notifications.browser.tryAgain')}
+              </button>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="space-y-2">
+          {browserPermission === 'denied' ? (
+            <div className="flex items-start gap-2 p-3 rounded-lg bg-red-500/10 border border-red-500/20">
+              <X className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+              <p className="text-sm text-red-400">
+                {t('settings.notifications.browser.blocked')}
+              </p>
+            </div>
+          ) : (
+            <button
+              onClick={handleRequestPermission}
+              className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors"
+            >
+              {t('settings.notifications.browser.requestPermission')}
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/settings/sections/EmailNotificationSettings.tsx
+++ b/web/src/components/settings/sections/EmailNotificationSettings.tsx
@@ -1,0 +1,176 @@
+import { useTranslation } from 'react-i18next'
+import { Mail, Check, X } from 'lucide-react'
+import { NotificationConfig } from '../../../types/alerts'
+import type { TestResultState } from './NotificationSettingsSection'
+
+/** Default SMTP port for email configuration */
+const DEFAULT_SMTP_PORT = 587
+
+interface EmailNotificationSettingsProps {
+  config: NotificationConfig
+  updateConfig: (updates: Partial<NotificationConfig>) => void
+  testResult: TestResultState | null
+  setTestResult: (result: TestResultState | null) => void
+  testNotification: (type: 'slack' | 'email' | 'webhook', config: Record<string, unknown>) => Promise<unknown>
+  isLoading: boolean
+}
+
+/**
+ * Email notification channel configuration.
+ * Manages SMTP settings, addresses, and test notification flow.
+ */
+export function EmailNotificationSettings({
+  config,
+  updateConfig,
+  testResult,
+  setTestResult,
+  testNotification,
+  isLoading,
+}: EmailNotificationSettingsProps) {
+  const { t } = useTranslation()
+
+  const handleTestEmail = async () => {
+    if (!config.emailSMTPHost || !config.emailFrom || !config.emailTo) {
+      setTestResult({ type: 'email', success: false, message: t('settings.notifications.email.configureFirst') })
+      return
+    }
+
+    setTestResult(null)
+    try {
+      await testNotification('email', {
+        emailSMTPHost: config.emailSMTPHost,
+        emailSMTPPort: config.emailSMTPPort || DEFAULT_SMTP_PORT,
+        emailFrom: config.emailFrom,
+        emailTo: config.emailTo,
+        emailUsername: config.emailUsername,
+        emailPassword: config.emailPassword,
+      })
+      setTestResult({ type: 'email', success: true, message: t('settings.notifications.email.testSuccess') })
+    } catch (error) {
+      setTestResult({
+        type: 'email',
+        success: false,
+        message: error instanceof Error ? error.message : t('settings.notifications.email.testFailed'),
+      })
+    }
+  }
+
+  return (
+    <div className="space-y-4 mb-6">
+      <div className="flex items-center gap-2 pb-2 border-b border-border">
+        <Mail className="w-4 h-4 text-foreground" />
+        <h3 className="text-sm font-medium text-foreground">{t('settings.notifications.email.title')}</h3>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-1">
+            {t('settings.notifications.email.smtpHost')}
+          </label>
+          <input
+            type="text"
+            value={config.emailSMTPHost || ''}
+            onChange={e => updateConfig({ emailSMTPHost: e.target.value })}
+            placeholder="smtp.gmail.com"
+            className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-1">
+            {t('settings.notifications.email.smtpPort')}
+          </label>
+          <input
+            type="number"
+            value={config.emailSMTPPort || DEFAULT_SMTP_PORT}
+            onChange={e => updateConfig({ emailSMTPPort: parseInt(e.target.value) })}
+            placeholder={String(DEFAULT_SMTP_PORT)}
+            className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-foreground mb-1">
+          {t('settings.notifications.email.fromAddress')}
+        </label>
+        <input
+          type="email"
+          value={config.emailFrom || ''}
+          onChange={e => updateConfig({ emailFrom: e.target.value })}
+          placeholder="alerts@example.com"
+          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-foreground mb-1">
+          {t('settings.notifications.email.toAddresses')}
+        </label>
+        <input
+          type="text"
+          value={config.emailTo || ''}
+          onChange={e => updateConfig({ emailTo: e.target.value })}
+          placeholder="team@example.com, oncall@example.com"
+          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          {t('settings.notifications.email.toHint')}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-1">
+            {t('settings.notifications.email.username')}
+          </label>
+          <input
+            type="text"
+            value={config.emailUsername || ''}
+            onChange={e => updateConfig({ emailUsername: e.target.value })}
+            placeholder="username"
+            className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-1">
+            {t('settings.notifications.email.password')}
+          </label>
+          <input
+            type="password"
+            value={config.emailPassword || ''}
+            onChange={e => updateConfig({ emailPassword: e.target.value })}
+            placeholder="password"
+            className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
+          />
+        </div>
+      </div>
+
+      <button
+        onClick={handleTestEmail}
+        disabled={isLoading}
+        className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors disabled:opacity-50"
+      >
+        {isLoading ? t('settings.notifications.email.testing') : t('settings.notifications.email.testNotification')}
+      </button>
+
+      {testResult && testResult.type === 'email' && (
+        <div
+          className={`flex items-start gap-2 p-3 rounded-lg ${
+            testResult.success ? 'bg-green-500/10 border border-green-500/20' : 'bg-red-500/10 border border-red-500/20'
+          }`}
+        >
+          {testResult.success ? (
+            <Check className="w-4 h-4 text-green-400 flex-shrink-0 mt-0.5" />
+          ) : (
+            <X className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+          )}
+          <p className={`text-sm ${testResult.success ? 'text-green-400' : 'text-red-400'}`}>
+            {testResult.message}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/settings/sections/NotificationSettingsSection.tsx
+++ b/web/src/components/settings/sections/NotificationSettingsSection.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Bell, Globe, Mail, Slack, Check, X } from 'lucide-react'
+import { Bell } from 'lucide-react'
 import { useNotificationAPI } from '../../../hooks/useNotificationAPI'
 import { NotificationConfig } from '../../../types/alerts'
-import { isBrowserNotifVerified, setBrowserNotifVerified } from '../../../lib/notificationStatus'
+import { BrowserNotificationSettings } from './BrowserNotificationSettings'
+import { SlackNotificationSettings } from './SlackNotificationSettings'
+import { EmailNotificationSettings } from './EmailNotificationSettings'
 
 const STORAGE_KEY = 'kc_notification_config'
 
@@ -30,110 +32,23 @@ function saveConfig(config: NotificationConfig): void {
   }
 }
 
-/** Browser notification verification flow state */
-type BrowserNotifState = 'idle' | 'asked' | 'verified' | 'failed'
+/** Result of a test notification attempt */
+export interface TestResultState {
+  type: string
+  success: boolean
+  message: string
+}
 
 export function NotificationSettingsSection() {
   const { t } = useTranslation()
   const [config, setConfig] = useState<NotificationConfig>(loadConfig())
-  const [testResult, setTestResult] = useState<{ type: string; success: boolean; message: string } | null>(null)
+  const [testResult, setTestResult] = useState<TestResultState | null>(null)
   const { testNotification, isLoading } = useNotificationAPI()
-
-  // Browser notification verification state
-  const [browserNotifState, setBrowserNotifState] = useState<BrowserNotifState>(
-    () => (isBrowserNotifVerified() ? 'verified' : 'idle'),
-  )
-
-  const browserPermission =
-    typeof Notification !== 'undefined' ? Notification.permission : 'default'
-
-  const handleRequestPermission = async () => {
-    if (typeof Notification === 'undefined') return
-    try {
-      const result = await Notification.requestPermission()
-      if (result === 'granted') {
-        setBrowserNotifState('idle')
-      }
-    } catch {
-      // Permission request may fail in some environments
-    }
-  }
-
-  const handleSendBrowserTest = () => {
-    try {
-      new Notification('KubeStellar Console Test', {
-        body: t('settings.notifications.browser.testBody'),
-        requireInteraction: true,
-        icon: '/favicon.ico',
-      })
-    } catch {
-      // Notification constructor may throw in some environments
-    }
-    setBrowserNotifState('asked')
-  }
-
-  const handleBrowserNotifYes = () => {
-    setBrowserNotifVerified(true)
-    setBrowserNotifState('verified')
-  }
-
-  const handleBrowserNotifNo = () => {
-    setBrowserNotifVerified(false)
-    setBrowserNotifState('failed')
-  }
 
   const updateConfig = (updates: Partial<NotificationConfig>) => {
     const newConfig = { ...config, ...updates }
     setConfig(newConfig)
     saveConfig(newConfig)
-  }
-
-  const handleTestSlack = async () => {
-    if (!config.slackWebhookUrl) {
-      setTestResult({ type: 'slack', success: false, message: t('settings.notifications.slack.configureFirst') })
-      return
-    }
-
-    setTestResult(null)
-    try {
-      await testNotification('slack', {
-        slackWebhookUrl: config.slackWebhookUrl,
-        slackChannel: config.slackChannel,
-      })
-      setTestResult({ type: 'slack', success: true, message: t('settings.notifications.slack.testSuccess') })
-    } catch (error) {
-      setTestResult({
-        type: 'slack',
-        success: false,
-        message: error instanceof Error ? error.message : t('settings.notifications.slack.testFailed'),
-      })
-    }
-  }
-
-  const handleTestEmail = async () => {
-    if (!config.emailSMTPHost || !config.emailFrom || !config.emailTo) {
-      setTestResult({ type: 'email', success: false, message: t('settings.notifications.email.configureFirst') })
-      return
-    }
-
-    setTestResult(null)
-    try {
-      await testNotification('email', {
-        emailSMTPHost: config.emailSMTPHost,
-        emailSMTPPort: config.emailSMTPPort || 587,
-        emailFrom: config.emailFrom,
-        emailTo: config.emailTo,
-        emailUsername: config.emailUsername,
-        emailPassword: config.emailPassword,
-      })
-      setTestResult({ type: 'email', success: true, message: t('settings.notifications.email.testSuccess') })
-    } catch (error) {
-      setTestResult({
-        type: 'email',
-        success: false,
-        message: error instanceof Error ? error.message : t('settings.notifications.email.testFailed'),
-      })
-    }
   }
 
   return (
@@ -153,288 +68,27 @@ export function NotificationSettingsSection() {
       </p>
 
       {/* Browser Notifications */}
-      <div className="space-y-4 mb-6">
-        <div className="flex items-center gap-2 pb-2 border-b border-border">
-          <Globe className="w-4 h-4 text-foreground" />
-          <h3 className="text-sm font-medium text-foreground">{t('settings.notifications.browser.title')}</h3>
-        </div>
-
-        {/* Permission status */}
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-muted-foreground">{t('settings.notifications.browser.permissionStatus')}</span>
-          <span
-            className={`px-2 py-0.5 text-xs rounded-full border ${
-              browserPermission === 'granted'
-                ? 'bg-green-500/10 border-green-500/20 text-green-400'
-                : browserPermission === 'denied'
-                  ? 'bg-red-500/10 border-red-500/20 text-red-400'
-                  : 'bg-yellow-500/10 border-yellow-500/20 text-yellow-400'
-            }`}
-          >
-            {browserPermission}
-          </span>
-        </div>
-
-        {browserPermission === 'granted' ? (
-          <>
-            {browserNotifState === 'idle' && (
-              <button
-                onClick={handleSendBrowserTest}
-                className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors"
-              >
-                {t('settings.notifications.browser.sendTest')}
-              </button>
-            )}
-
-            {browserNotifState === 'asked' && (
-              <div className="space-y-2">
-                <p className="text-sm text-muted-foreground">{t('settings.notifications.browser.didYouSeeIt')}</p>
-                <div className="flex items-center gap-2">
-                  <button
-                    onClick={handleBrowserNotifYes}
-                    className="px-3 py-1.5 text-sm rounded-lg bg-green-500/20 text-green-400 border border-green-500/30 hover:bg-green-500/30 transition-colors"
-                  >
-                    {t('settings.notifications.browser.yes')}
-                  </button>
-                  <button
-                    onClick={handleBrowserNotifNo}
-                    className="px-3 py-1.5 text-sm rounded-lg bg-secondary text-muted-foreground border border-border hover:text-foreground transition-colors"
-                  >
-                    {t('settings.notifications.browser.no')}
-                  </button>
-                </div>
-              </div>
-            )}
-
-            {browserNotifState === 'verified' && (
-              <div className="flex items-start gap-2 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
-                <Check className="w-4 h-4 text-green-400 flex-shrink-0 mt-0.5" />
-                <p className="text-sm text-green-400">
-                  {t('settings.notifications.browser.verified')}
-                </p>
-              </div>
-            )}
-
-            {browserNotifState === 'failed' && (
-              <div className="space-y-2">
-                <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
-                  <X className="w-4 h-4 text-amber-400 flex-shrink-0 mt-0.5" />
-                  <p className="text-sm text-amber-400">
-                    {t('settings.notifications.browser.enableInstructions')}
-                  </p>
-                </div>
-                <button
-                  onClick={handleSendBrowserTest}
-                  className="px-4 py-2 text-sm rounded-lg bg-secondary text-muted-foreground border border-border hover:text-foreground transition-colors"
-                >
-                  {t('settings.notifications.browser.tryAgain')}
-                </button>
-              </div>
-            )}
-          </>
-        ) : (
-          <div className="space-y-2">
-            {browserPermission === 'denied' ? (
-              <div className="flex items-start gap-2 p-3 rounded-lg bg-red-500/10 border border-red-500/20">
-                <X className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
-                <p className="text-sm text-red-400">
-                  {t('settings.notifications.browser.blocked')}
-                </p>
-              </div>
-            ) : (
-              <button
-                onClick={handleRequestPermission}
-                className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors"
-              >
-                {t('settings.notifications.browser.requestPermission')}
-              </button>
-            )}
-          </div>
-        )}
-      </div>
+      <BrowserNotificationSettings />
 
       {/* Slack Configuration */}
-      <div className="space-y-4 mb-6">
-        <div className="flex items-center gap-2 pb-2 border-b border-border">
-          <Slack className="w-4 h-4 text-foreground" />
-          <h3 className="text-sm font-medium text-foreground">{t('settings.notifications.slack.title')}</h3>
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-foreground mb-1">
-            {t('settings.notifications.slack.webhookUrl')}
-          </label>
-          <input
-            type="text"
-            value={config.slackWebhookUrl || ''}
-            onChange={e => updateConfig({ slackWebhookUrl: e.target.value })}
-            placeholder="https://hooks.slack.com/services/..."
-            className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            {t('settings.notifications.slack.webhookHint')}
-          </p>
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-foreground mb-1">
-            {t('settings.notifications.slack.channel')}
-          </label>
-          <input
-            type="text"
-            value={config.slackChannel || ''}
-            onChange={e => updateConfig({ slackChannel: e.target.value })}
-            placeholder="#alerts"
-            className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            {t('settings.notifications.slack.channelHint')}
-          </p>
-        </div>
-
-        <button
-          onClick={handleTestSlack}
-          disabled={isLoading}
-          className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors disabled:opacity-50"
-        >
-          {isLoading ? t('settings.notifications.slack.testing') : t('settings.notifications.slack.testNotification')}
-        </button>
-
-        {testResult && testResult.type === 'slack' && (
-          <div
-            className={`flex items-start gap-2 p-3 rounded-lg ${
-              testResult.success ? 'bg-green-500/10 border border-green-500/20' : 'bg-red-500/10 border border-red-500/20'
-            }`}
-          >
-            {testResult.success ? (
-              <Check className="w-4 h-4 text-green-400 flex-shrink-0 mt-0.5" />
-            ) : (
-              <X className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
-            )}
-            <p className={`text-sm ${testResult.success ? 'text-green-400' : 'text-red-400'}`}>
-              {testResult.message}
-            </p>
-          </div>
-        )}
-      </div>
+      <SlackNotificationSettings
+        config={config}
+        updateConfig={updateConfig}
+        testResult={testResult}
+        setTestResult={setTestResult}
+        testNotification={testNotification}
+        isLoading={isLoading}
+      />
 
       {/* Email Configuration */}
-      <div className="space-y-4 mb-6">
-        <div className="flex items-center gap-2 pb-2 border-b border-border">
-          <Mail className="w-4 h-4 text-foreground" />
-          <h3 className="text-sm font-medium text-foreground">{t('settings.notifications.email.title')}</h3>
-        </div>
-
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-foreground mb-1">
-              {t('settings.notifications.email.smtpHost')}
-            </label>
-            <input
-              type="text"
-              value={config.emailSMTPHost || ''}
-              onChange={e => updateConfig({ emailSMTPHost: e.target.value })}
-              placeholder="smtp.gmail.com"
-              className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-foreground mb-1">
-              {t('settings.notifications.email.smtpPort')}
-            </label>
-            <input
-              type="number"
-              value={config.emailSMTPPort || 587}
-              onChange={e => updateConfig({ emailSMTPPort: parseInt(e.target.value) })}
-              placeholder="587"
-              className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
-            />
-          </div>
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-foreground mb-1">
-            {t('settings.notifications.email.fromAddress')}
-          </label>
-          <input
-            type="email"
-            value={config.emailFrom || ''}
-            onChange={e => updateConfig({ emailFrom: e.target.value })}
-            placeholder="alerts@example.com"
-            className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
-          />
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-foreground mb-1">
-            {t('settings.notifications.email.toAddresses')}
-          </label>
-          <input
-            type="text"
-            value={config.emailTo || ''}
-            onChange={e => updateConfig({ emailTo: e.target.value })}
-            placeholder="team@example.com, oncall@example.com"
-            className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            {t('settings.notifications.email.toHint')}
-          </p>
-        </div>
-
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm font-medium text-foreground mb-1">
-              {t('settings.notifications.email.username')}
-            </label>
-            <input
-              type="text"
-              value={config.emailUsername || ''}
-              onChange={e => updateConfig({ emailUsername: e.target.value })}
-              placeholder="username"
-              className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-foreground mb-1">
-              {t('settings.notifications.email.password')}
-            </label>
-            <input
-              type="password"
-              value={config.emailPassword || ''}
-              onChange={e => updateConfig({ emailPassword: e.target.value })}
-              placeholder="password"
-              className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
-            />
-          </div>
-        </div>
-
-        <button
-          onClick={handleTestEmail}
-          disabled={isLoading}
-          className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors disabled:opacity-50"
-        >
-          {isLoading ? t('settings.notifications.email.testing') : t('settings.notifications.email.testNotification')}
-        </button>
-
-        {testResult && testResult.type === 'email' && (
-          <div
-            className={`flex items-start gap-2 p-3 rounded-lg ${
-              testResult.success ? 'bg-green-500/10 border border-green-500/20' : 'bg-red-500/10 border border-red-500/20'
-            }`}
-          >
-            {testResult.success ? (
-              <Check className="w-4 h-4 text-green-400 flex-shrink-0 mt-0.5" />
-            ) : (
-              <X className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
-            )}
-            <p className={`text-sm ${testResult.success ? 'text-green-400' : 'text-red-400'}`}>
-              {testResult.message}
-            </p>
-          </div>
-        )}
-      </div>
+      <EmailNotificationSettings
+        config={config}
+        updateConfig={updateConfig}
+        testResult={testResult}
+        setTestResult={setTestResult}
+        testNotification={testNotification}
+        isLoading={isLoading}
+      />
 
       {/* Info Box */}
       <div className="mt-6 p-4 rounded-lg bg-blue-500/10 border border-blue-500/20">

--- a/web/src/components/settings/sections/SlackNotificationSettings.tsx
+++ b/web/src/components/settings/sections/SlackNotificationSettings.tsx
@@ -1,0 +1,116 @@
+import { useTranslation } from 'react-i18next'
+import { Slack, Check, X } from 'lucide-react'
+import { NotificationConfig } from '../../../types/alerts'
+import type { TestResultState } from './NotificationSettingsSection'
+
+interface SlackNotificationSettingsProps {
+  config: NotificationConfig
+  updateConfig: (updates: Partial<NotificationConfig>) => void
+  testResult: TestResultState | null
+  setTestResult: (result: TestResultState | null) => void
+  testNotification: (type: 'slack' | 'email' | 'webhook', config: Record<string, unknown>) => Promise<unknown>
+  isLoading: boolean
+}
+
+/**
+ * Slack notification channel configuration.
+ * Manages webhook URL, channel, and test notification flow.
+ */
+export function SlackNotificationSettings({
+  config,
+  updateConfig,
+  testResult,
+  setTestResult,
+  testNotification,
+  isLoading,
+}: SlackNotificationSettingsProps) {
+  const { t } = useTranslation()
+
+  const handleTestSlack = async () => {
+    if (!config.slackWebhookUrl) {
+      setTestResult({ type: 'slack', success: false, message: t('settings.notifications.slack.configureFirst') })
+      return
+    }
+
+    setTestResult(null)
+    try {
+      await testNotification('slack', {
+        slackWebhookUrl: config.slackWebhookUrl,
+        slackChannel: config.slackChannel,
+      })
+      setTestResult({ type: 'slack', success: true, message: t('settings.notifications.slack.testSuccess') })
+    } catch (error) {
+      setTestResult({
+        type: 'slack',
+        success: false,
+        message: error instanceof Error ? error.message : t('settings.notifications.slack.testFailed'),
+      })
+    }
+  }
+
+  return (
+    <div className="space-y-4 mb-6">
+      <div className="flex items-center gap-2 pb-2 border-b border-border">
+        <Slack className="w-4 h-4 text-foreground" />
+        <h3 className="text-sm font-medium text-foreground">{t('settings.notifications.slack.title')}</h3>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-foreground mb-1">
+          {t('settings.notifications.slack.webhookUrl')}
+        </label>
+        <input
+          type="text"
+          value={config.slackWebhookUrl || ''}
+          onChange={e => updateConfig({ slackWebhookUrl: e.target.value })}
+          placeholder="https://hooks.slack.com/services/..."
+          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          {t('settings.notifications.slack.webhookHint')}
+        </p>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-foreground mb-1">
+          {t('settings.notifications.slack.channel')}
+        </label>
+        <input
+          type="text"
+          value={config.slackChannel || ''}
+          onChange={e => updateConfig({ slackChannel: e.target.value })}
+          placeholder="#alerts"
+          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          {t('settings.notifications.slack.channelHint')}
+        </p>
+      </div>
+
+      <button
+        onClick={handleTestSlack}
+        disabled={isLoading}
+        className="px-4 py-2 text-sm rounded-lg bg-purple-500 text-white hover:bg-purple-600 transition-colors disabled:opacity-50"
+      >
+        {isLoading ? t('settings.notifications.slack.testing') : t('settings.notifications.slack.testNotification')}
+      </button>
+
+      {testResult && testResult.type === 'slack' && (
+        <div
+          className={`flex items-start gap-2 p-3 rounded-lg ${
+            testResult.success ? 'bg-green-500/10 border border-green-500/20' : 'bg-red-500/10 border border-red-500/20'
+          }`}
+        >
+          {testResult.success ? (
+            <Check className="w-4 h-4 text-green-400 flex-shrink-0 mt-0.5" />
+          ) : (
+            <X className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+          )}
+          <p className={`text-sm ${testResult.success ? 'text-green-400' : 'text-red-400'}`}>
+            {testResult.message}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Split `NotificationSettingsSection.tsx` (456 lines) into 3 focused sub-components: `BrowserNotificationSettings`, `SlackNotificationSettings`, `EmailNotificationSettings` — reducing the main component to ~95 lines
- Split `ActiveAlerts.tsx` (498 lines) by extracting `AlertListItem` and `NotificationVerifyIndicator` — reducing the main component to ~260 lines
- Each sub-component is self-contained with its own state and event handlers
- Public API (exports) unchanged — no impact on consumers

Partially addresses #2500

## Test plan
- [ ] Verify Notification Settings section renders correctly in Settings page
- [ ] Verify browser notification permission request and verification flow works
- [ ] Verify Slack webhook URL/channel inputs persist and test notification sends
- [ ] Verify Email SMTP configuration inputs persist and test notification sends
- [ ] Verify Active Alerts card renders alert list with correct severity badges
- [ ] Verify alert acknowledge and AI diagnose buttons work
- [ ] Verify notification verification indicator appears in alerts card header
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds