### PR TITLE
🐛 Fix consistency test violations

### DIFF
--- a/scripts/consistency-test.sh
+++ b/scripts/consistency-test.sh
@@ -453,6 +453,7 @@ phase6() {
     'src/components/cards/workload-monitor/GitHubCIMonitor.tsx'  # Date.now() for demo data, not cache TTL
     'src/components/cards/Missions.tsx'  # Date.now() for demo mission timestamps, not cache TTL
     'src/App.tsx'  # Date.now() for page view analytics duration, not cache TTL
+    'src/hooks/useSelfUpgrade.ts'  # Date.now() for restart polling elapsed, not cache TTL
   )
 
   # Find files that implement caching with TTL: have localStorage AND Date.now() - (subtraction

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -161,7 +161,7 @@ function buildDashboardStorage(): { key: string; route: string; name: string }[]
     { key: 'kubestellar-aiml-cards', route: '/ai-ml', name: 'AI/ML' },
   ]
 
-  for (const legacy of LEGACY_COMPONENT_KEYS) {
+  for (const legacy of (LEGACY_COMPONENT_KEYS || [])) {
     if (!seenKeys.has(legacy.key)) {
       seenKeys.add(legacy.key)
       entries.push(legacy)

--- a/web/src/hooks/useSelfUpgrade.ts
+++ b/web/src/hooks/useSelfUpgrade.ts
@@ -14,6 +14,9 @@ const RESTART_POLL_MAX_MS = 120_000
 /** Short timeout for health probes during restart polling (ms) */
 const RESTART_HEALTH_TIMEOUT_MS = 3_000
 
+/** Delay before auto-reload so the user sees the success state (ms) */
+const RELOAD_DELAY_MS = 1_500
+
 /** Read the JWT token from localStorage for authenticated API calls */
 const getToken = () => localStorage.getItem(STORAGE_KEY_TOKEN)
 
@@ -105,7 +108,7 @@ export function useSelfUpgrade() {
           setIsRestarting(false)
           setRestartComplete(true)
           // Auto-reload after a brief pause so the user sees the success state
-          setTimeout(() => window.location.reload(), 1500)
+          setTimeout(() => window.location.reload(), RELOAD_DELAY_MS)
         }
       } catch {
         // Expected — pod is still restarting

--- a/web/src/lib/notificationStatus.ts
+++ b/web/src/lib/notificationStatus.ts
@@ -1,7 +1,7 @@
 const STORAGE_KEY = 'kc_browser_notif_verified'
 
 /** Verification expiry — 30 days in milliseconds */
-const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000
+const VERIFICATION_TTL_MS = 30 * 24 * 60 * 60 * 1000
 
 /** Returns true if user has confirmed browser notifications work */
 export function isBrowserNotifVerified(): boolean {
@@ -9,7 +9,7 @@ export function isBrowserNotifVerified(): boolean {
     const val = localStorage.getItem(STORAGE_KEY)
     if (!val) return false
     const { verified, at } = JSON.parse(val)
-    if (Date.now() - at > THIRTY_DAYS_MS) return false
+    if (Date.now() - at > VERIFICATION_TTL_MS) return false
     return verified === true
   } catch {
     return false


### PR DESCRIPTION
## Summary
Fixes the last 4 consistency-test violations (1 error + 3 warnings):

- **Phase 1**: `useSelfUpgrade.ts:108` — magic number `1500` → named `RELOAD_DELAY_MS` constant
- **Phase 2**: `useSearchIndex.ts:164` — add `|| []` guard on `for...of LEGACY_COMPONENT_KEYS`
- **Phase 6**: `notificationStatus.ts` — rename `THIRTY_DAYS_MS` → `VERIFICATION_TTL_MS` to match TTL pattern check
- **Phase 6**: `useSelfUpgrade.ts` — add to exclude list (uses `Date.now()` for restart polling, not data caching)

## Context
This is the last remaining nightly test failure (other than the Playwright test we ignore by policy).

## Test plan
- [ ] consistency-test passes with 0 errors, 0 warnings
- [ ] Build + lint pass
- [ ] Nightly runs 32/32 clean