### PR TITLE
🐛 Fix kc-agent failing to start after brew upgrade

### DIFF
--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -287,13 +287,34 @@ else
     if command -v brew &>/dev/null; then
         if brew list kc-agent &>/dev/null; then
             echo -e "${GREEN}Upgrading kc-agent...${NC}"
-            brew update --quiet && brew upgrade kc-agent 2>/dev/null || true
+            brew update --quiet && brew upgrade kc-agent || true
         else
             echo -e "${GREEN}Installing kc-agent...${NC}"
             brew update --quiet && brew install kubestellar/tap/kc-agent
         fi
+
+        # Validate the brew-installed binary — brew upgrade can leave a broken
+        # symlink (0-byte regular file) if the link step fails silently.
+        BREW_BIN="$(command -v kc-agent 2>/dev/null || true)"
+        if [ -n "$BREW_BIN" ] && [ ! -s "$BREW_BIN" ]; then
+            echo -e "${YELLOW}Detected broken kc-agent binary (0 bytes), relinking...${NC}"
+            brew link --overwrite kc-agent 2>/dev/null || true
+            BREW_BIN="$(command -v kc-agent 2>/dev/null || true)"
+        fi
+
+        # Final fallback: if the symlink is still broken, find the binary
+        # directly in the Cellar and use it without the symlink.
+        if [ -n "$BREW_BIN" ] && [ ! -s "$BREW_BIN" ]; then
+            echo -e "${YELLOW}Brew symlink still broken, using Cellar binary directly...${NC}"
+            CELLAR_BIN="$(find "$(brew --cellar kc-agent 2>/dev/null)" -name kc-agent -type f -perm +111 2>/dev/null | head -1)"
+            if [ -n "$CELLAR_BIN" ] && [ -s "$CELLAR_BIN" ]; then
+                BREW_BIN="$CELLAR_BIN"
+            fi
+        fi
     fi
-    if command -v kc-agent &>/dev/null; then
+    if [ -n "$BREW_BIN" ] && [ -s "$BREW_BIN" ] && [ -x "$BREW_BIN" ]; then
+        KC_AGENT_BIN="$BREW_BIN"
+    elif command -v kc-agent &>/dev/null && [ -s "$(command -v kc-agent)" ]; then
         KC_AGENT_BIN="$(command -v kc-agent)"
     fi
 fi


### PR DESCRIPTION
## Summary
- **Root cause**: `brew upgrade kc-agent` can leave a 0-byte regular file at `/opt/homebrew/bin/kc-agent` instead of a proper symlink to the Cellar binary. The old code suppressed all stderr (`2>/dev/null`) so the broken link was invisible.
- **Validation**: After `brew upgrade`, check the binary is non-empty (`-s` test). If it's 0 bytes, auto-heal with `brew link --overwrite`.
- **Fallback**: If relinking still fails, find and use the Cellar binary directly (`find $(brew --cellar kc-agent) ...`).
- **Stderr**: Stop suppressing `brew upgrade` stderr so link errors are visible.

## What happened
1. `startup-oauth.sh` runs `brew upgrade kc-agent 2>/dev/null || true`
2. Brew unlinks the old version and installs the new one to Cellar (correctly)
3. The relink step fails (race condition or stale file), leaving a 0-byte regular file instead of a symlink
4. The script resolves `command -v kc-agent` → the 0-byte file
5. kc-agent starts, immediately exits with code 0 (empty binary), auto-restart loop spins

## Test plan
- [ ] `startup-oauth.sh` starts kc-agent successfully after clean brew install
- [ ] Simulate broken symlink (`echo -n > /opt/homebrew/bin/kc-agent`), verify script detects and auto-heals
- [ ] Verify kc-agent runs on port 8585 after startup