### PR TITLE
🐛 Fix brew relink: rm + unlink before link for proper recovery

### DIFF
--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -298,7 +298,9 @@ else
         BREW_BIN="$(command -v kc-agent 2>/dev/null || true)"
         if [ -n "$BREW_BIN" ] && [ ! -s "$BREW_BIN" ]; then
             echo -e "${YELLOW}Detected broken kc-agent binary (0 bytes), relinking...${NC}"
-            brew link --overwrite kc-agent 2>/dev/null || true
+            rm -f "$BREW_BIN"
+            brew unlink kc-agent 2>/dev/null || true
+            brew link kc-agent 2>/dev/null || true
             BREW_BIN="$(command -v kc-agent 2>/dev/null || true)"
         fi
 


### PR DESCRIPTION
## Summary
Follow-up to #2552. Testing revealed `brew link --overwrite` doesn't work when the broken file is a regular file (not a symlink) — brew's internal state still tracks the formula as linked.

**Fix**: Replace `brew link --overwrite` with the correct 3-step sequence:
1. `rm -f` the 0-byte file
2. `brew unlink` (clears brew's internal linked state)
3. `brew link` (creates proper symlink)

## Test results
Simulated the broken state and verified:
```
Before: size=0, type=empty
Detected broken kc-agent binary (0 bytes), relinking...
Unlinking .../kc-agent/0.3.16-nightly.20260313... 0 symlinks removed.
Linking .../kc-agent/0.3.16-nightly.20260313... 1 symlinks created.
After: /opt/homebrew/bin/kc-agent -> ../Cellar/kc-agent/.../bin/kc-agent
       Mach-O 64-bit executable arm64
```

## Test plan
- [x] Simulate broken state, verify script detects and fully recovers symlink
- [x] Verify kc-agent resolves to correct 44MB arm64 binary after recovery