### PR TITLE
✨ Add dev mode accent line and remove redundant developer CTA

### DIFF
--- a/web/src/components/dashboard/DemoToLocalCTA.tsx
+++ b/web/src/components/dashboard/DemoToLocalCTA.tsx
@@ -7,11 +7,9 @@
  */
 
 import { useState, useEffect, useRef } from 'react'
-import { Terminal, Copy, Check, X, Rocket, KeyRound, Code2 } from 'lucide-react'
+import { Terminal, Copy, Check, X, Rocket, KeyRound } from 'lucide-react'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
-import { DeveloperSetupDialog } from '../setup/DeveloperSetupDialog'
 import { isNetlifyDeployment, getDemoMode, hasRealToken } from '../../lib/demoMode'
-import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
 import {
   STORAGE_KEY_DEMO_CTA_DISMISSED,
@@ -33,16 +31,14 @@ export function DemoToLocalCTA() {
   )
   const [copied, setCopied] = useState(false)
   const [showSetupDialog, setShowSetupDialog] = useState(false)
-  const [showDevDialog, setShowDevDialog] = useState(false)
   const emittedRef = useRef(false)
-  const { isConnected } = useLocalAgent()
 
   // Localhost without OAuth = user ran start.sh but hasn't configured GitHub OAuth yet
   const isLocalNoOAuth = !isNetlifyDeployment && getDemoMode() && !hasRealToken()
-  // Localhost with OAuth + agent = fully set up, offer developer setup
-  const isLocalDeveloper = !isNetlifyDeployment && hasRealToken() && isConnected
+  // Fully set up local developers don't need onboarding CTAs — the same info
+  // is available in the profile dropdown's Developer panel.
   const shouldShow =
-    (isNetlifyDeployment || isLocalNoOAuth || isLocalDeveloper) &&
+    (isNetlifyDeployment || isLocalNoOAuth) &&
     !dismissed &&
     !hintsSuppressed
 
@@ -83,40 +79,7 @@ export function DemoToLocalCTA() {
     setShowSetupDialog(true)
   }
 
-  const handleDevSetup = () => {
-    emitDemoToLocalActioned('developer_setup')
-    setShowDevDialog(true)
-  }
-
-  // ── State 3: Localhost with OAuth + agent — small developer link ──
-  if (isLocalDeveloper) {
-    return (
-      <>
-        <div className="mb-4 flex items-center gap-2 text-xs animate-in fade-in duration-300">
-          <Code2 className="w-3.5 h-3.5 text-green-400 flex-shrink-0" />
-          <button
-            onClick={handleDevSetup}
-            className="text-green-400 hover:text-green-300 transition-colors"
-          >
-            Developer setup &amp; advanced options
-          </button>
-          <button
-            onClick={handleDismiss}
-            className="p-0.5 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors flex-shrink-0 ml-auto"
-            aria-label="Dismiss"
-          >
-            <X className="w-3 h-3" />
-          </button>
-        </div>
-        <DeveloperSetupDialog
-          isOpen={showDevDialog}
-          onClose={() => setShowDevDialog(false)}
-        />
-      </>
-    )
-  }
-
-  // ── State 2: Localhost without OAuth — prompt to set up GitHub OAuth ──
+  // ── Localhost without OAuth — prompt to set up GitHub OAuth ──
   if (isLocalNoOAuth) {
     return (
       <div className="mb-4 rounded-xl border border-purple-500/20 bg-gradient-to-br from-purple-500/5 via-blue-500/5 to-transparent p-4 animate-in slide-in-from-top-2 duration-300">

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -279,6 +279,11 @@ export function Layout({ children }: LayoutProps) {
     <VersionCheckProvider>
     <TourProvider>
     <div className="h-screen bg-background overflow-hidden flex flex-col">
+      {/* Dev mode accent line — 2px green bar at top of viewport (like VS Code debug mode) */}
+      {__DEV_MODE__ && (
+        <div className="h-0.5 bg-green-500 flex-shrink-0 z-[60]" title="Development build" />
+      )}
+
       {/* Skip to content link for keyboard users and screen readers */}
       <a
         href="#main-content"
@@ -286,7 +291,7 @@ export function Layout({ children }: LayoutProps) {
       >
         {t('actions.skipToContent')}
       </a>
-      
+
       {/* Tour overlay and prompt */}
       <TourOverlay />
       <TourPrompt />


### PR DESCRIPTION
## Summary
- **Dev mode indicator**: 2px green accent line at the very top of the viewport when running a development build (`__DEV_MODE__`). Same pattern VS Code uses for debug mode — always visible, takes zero horizontal space, doesn't crowd the navbar.
- **Remove redundant CTA**: The "Developer setup & advanced options" link on the dashboard was showing for fully-set-up developers (OAuth + agent connected). That's onboarding content for someone who's already done onboarding. The same developer info is available in the profile dropdown's Developer panel.

## What changed
- `Layout.tsx`: Added conditional `h-0.5 bg-green-500` div before the Navbar
- `DemoToLocalCTA.tsx`: Removed the `isLocalDeveloper` state/render path, cleaned up unused imports

## Test plan
- [ ] Dev build shows thin green line at top of viewport
- [ ] Prod build shows no green line
- [ ] Fully set up localhost (OAuth + agent) no longer shows "Developer setup" CTA on dashboard
- [ ] Netlify demo and localhost-no-OAuth CTAs still work as before