### PR TITLE
✨ Add configurable visualization modes for stat blocks

### DIFF
--- a/web/src/components/ui/StatBlockModePicker.tsx
+++ b/web/src/components/ui/StatBlockModePicker.tsx
@@ -1,0 +1,132 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { createPortal } from 'react-dom'
+import { Settings, Hash, TrendingUp, CircleDot, BarChart3 } from 'lucide-react'
+import type { StatDisplayMode } from './StatsBlockDefinitions'
+
+/** Gap between trigger button and popover in pixels */
+const POPOVER_GAP_PX = 4
+
+/** Gauge icon — custom SVG since Lucide doesn't have a half-arc gauge */
+function GaugeIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M12 16.5a4.5 4.5 0 1 1 0-9 4.5 4.5 0 0 1 0 9z" opacity="0" />
+      <path d="M5.63 7.63A7 7 0 0 1 19 12" />
+      <path d="M12 12l-2.5-4" />
+      <circle cx="12" cy="12" r="1" fill="currentColor" stroke="none" />
+    </svg>
+  )
+}
+
+const MODE_OPTIONS: { mode: StatDisplayMode; icon: React.ComponentType<{ className?: string }>; label: string }[] = [
+  { mode: 'numeric', icon: Hash, label: 'Number' },
+  { mode: 'sparkline', icon: TrendingUp, label: 'Sparkline' },
+  { mode: 'gauge', icon: GaugeIcon, label: 'Gauge' },
+  { mode: 'ring', icon: CircleDot, label: 'Ring' },
+  { mode: 'mini-bar', icon: BarChart3, label: 'Bar' },
+]
+
+interface StatBlockModePickerProps {
+  currentMode: StatDisplayMode
+  availableModes: StatDisplayMode[]
+  onModeChange: (mode: StatDisplayMode) => void
+}
+
+export function StatBlockModePicker({ currentMode, availableModes, onModeChange }: StatBlockModePickerProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const [position, setPosition] = useState({ top: 0, left: 0 })
+
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current) return
+    const rect = triggerRef.current.getBoundingClientRect()
+    setPosition({
+      top: rect.bottom + POPOVER_GAP_PX,
+      left: Math.max(rect.right - 160, 8), // Right-align, keep on screen
+    })
+  }, [])
+
+  const handleToggle = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (!isOpen) updatePosition()
+    setIsOpen(!isOpen)
+  }
+
+  const handleSelect = (mode: StatDisplayMode) => {
+    onModeChange(mode)
+    setIsOpen(false)
+  }
+
+  // Close on click outside
+  useEffect(() => {
+    if (!isOpen) return
+    const handleClick = (e: MouseEvent) => {
+      if (
+        popoverRef.current && !popoverRef.current.contains(e.target as Node) &&
+        triggerRef.current && !triggerRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false)
+      }
+    }
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleEsc)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleEsc)
+    }
+  }, [isOpen])
+
+  const availableSet = new Set(availableModes)
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        onClick={handleToggle}
+        className="absolute top-1.5 right-1.5 p-1 rounded opacity-0 group-hover:opacity-100 hover:bg-secondary/80 text-muted-foreground hover:text-foreground transition-all z-10"
+        title="Change display mode"
+        aria-label="Change display mode"
+      >
+        <Settings className="w-3 h-3" />
+      </button>
+      {isOpen && createPortal(
+        <div
+          ref={popoverRef}
+          className="fixed z-[100] bg-card border border-border rounded-lg shadow-xl p-1.5 animate-in fade-in zoom-in-95 duration-150"
+          style={{ top: position.top, left: position.left, width: 160 }}
+        >
+          <div className="text-2xs text-muted-foreground px-2 py-1 font-medium uppercase tracking-wider">
+            Display Mode
+          </div>
+          {MODE_OPTIONS.map(({ mode, icon: Icon, label }) => {
+            const isAvailable = availableSet.has(mode)
+            const isActive = mode === currentMode
+            return (
+              <button
+                key={mode}
+                onClick={() => isAvailable && handleSelect(mode)}
+                disabled={!isAvailable}
+                className={`w-full flex items-center gap-2.5 px-2 py-1.5 rounded text-xs transition-colors ${
+                  isActive
+                    ? 'bg-purple-500/20 text-purple-400'
+                    : isAvailable
+                      ? 'text-foreground hover:bg-secondary'
+                      : 'text-muted-foreground/40 cursor-not-allowed'
+                }`}
+              >
+                <Icon className="w-3.5 h-3.5 flex-shrink-0" />
+                <span>{label}</span>
+                {isActive && <span className="ml-auto text-purple-400">&#x2713;</span>}
+              </button>
+            )
+          })}
+        </div>,
+        document.body,
+      )}
+    </>
+  )
+}

--- a/web/src/components/ui/StatsBlockDefinitions.ts
+++ b/web/src/components/ui/StatsBlockDefinitions.ts
@@ -4,6 +4,11 @@
  */
 
 /**
+ * Display mode for a stat block visualization
+ */
+export type StatDisplayMode = 'numeric' | 'sparkline' | 'gauge' | 'ring' | 'mini-bar'
+
+/**
  * Configuration for a single stat block
  */
 export interface StatBlockConfig {
@@ -12,6 +17,8 @@ export interface StatBlockConfig {
   icon: string
   visible: boolean
   color: string
+  /** Visualization mode — defaults to 'numeric' if absent (backward-compatible) */
+  displayMode?: StatDisplayMode
 }
 
 /**
@@ -409,4 +416,40 @@ export function getDefaultStatBlocks(dashboardType: DashboardStatsType): StatBlo
  */
 export function getStatsStorageKey(dashboardType: DashboardStatsType): string {
   return `${dashboardType}-stats-config`
+}
+
+/**
+ * Default display modes for specific stat blocks to showcase visualization options.
+ * Key format: "dashboardType:blockId"
+ */
+export const STAT_DISPLAY_MODE_DEFAULTS: Record<string, StatDisplayMode> = {
+  // Compliance — scores are percentages, perfect for gauges
+  'compliance:score': 'gauge',
+  'compliance:cis_score': 'gauge',
+  'compliance:nsa_score': 'gauge',
+
+  // Compute — utilization percentages fit rings
+  'compute:cpu_util': 'ring',
+  'compute:memory_util': 'ring',
+
+  // Data compliance — encryption score
+  'data-compliance:encryption_score': 'ring',
+
+  // Clusters — trend over time
+  'clusters:healthy': 'sparkline',
+  'clusters:pods': 'sparkline',
+
+  // Pods — trend over time
+  'pods:total_pods': 'sparkline',
+}
+
+/**
+ * Get the default display mode for a specific stat block on a specific dashboard.
+ * Returns undefined if no non-numeric default is defined (falls back to 'numeric').
+ */
+export function getDefaultDisplayMode(
+  dashboardType: DashboardStatsType,
+  blockId: string,
+): StatDisplayMode | undefined {
+  return STAT_DISPLAY_MODE_DEFAULTS[`${dashboardType}:${blockId}`]
 }

--- a/web/src/components/ui/StatsConfig.tsx
+++ b/web/src/components/ui/StatsConfig.tsx
@@ -25,6 +25,7 @@ import {
   DashboardStatsType,
   ALL_STAT_BLOCKS,
   getDefaultStatBlocks,
+  getDefaultDisplayMode,
   getStatsStorageKey,
   CLUSTERS_STAT_BLOCKS,
   WORKLOADS_STAT_BLOCKS,
@@ -537,6 +538,14 @@ export function useStatsConfig(
   const defaultBlocks = getDefaultStatBlocks(dashboardType)
   const key = storageKey || getStatsStorageKey(dashboardType)
 
+  // Apply default display modes from STAT_DISPLAY_MODE_DEFAULTS to blocks
+  // that don't have an explicit displayMode set
+  const applyDefaultModes = (blockList: StatBlockConfig[]): StatBlockConfig[] =>
+    blockList.map(b => ({
+      ...b,
+      displayMode: b.displayMode ?? getDefaultDisplayMode(dashboardType, b.id),
+    }))
+
   const [blocks, setBlocks] = useState<StatBlockConfig[]>(() => {
     const saved = safeGetJSON<StatBlockConfig[]>(key)
     if (saved) {
@@ -551,9 +560,9 @@ export function useStatsConfig(
           merged.push(defaultBlock)
         }
       })
-      return merged
+      return applyDefaultModes(merged)
     }
-    return defaultBlocks
+    return applyDefaultModes(defaultBlocks)
   })
 
   const saveBlocks = (newBlocks: StatBlockConfig[]) => {

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import { useModalState } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'
 import {
@@ -10,12 +10,17 @@ import {
 } from 'lucide-react'
 import { Button } from './Button'
 import { StatusBadge } from './StatusBadge'
-import { StatBlockConfig, DashboardStatsType } from './StatsBlockDefinitions'
+import { StatBlockConfig, DashboardStatsType, StatDisplayMode } from './StatsBlockDefinitions'
 import { StatsConfigModal, useStatsConfig } from './StatsConfig'
+import { StatBlockModePicker } from './StatBlockModePicker'
+import { Sparkline } from '../charts/Sparkline'
+import { Gauge } from '../charts/Gauge'
+import { CircularProgress } from '../charts/ProgressBar'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useIsModeSwitching } from '../../lib/unified/demo'
+import { useStatHistory, MIN_SPARKLINE_POINTS } from '../../hooks/useStatHistory'
 
 // Icon mapping for dynamic rendering
 const ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
@@ -61,6 +66,52 @@ const VALUE_COLORS: Record<string, string> = {
   root: 'text-orange-400',
 }
 
+/** Hex color values for chart components, keyed by stat block color name */
+const COLOR_HEX: Record<string, string> = {
+  purple: '#9333ea',
+  green: '#22c55e',
+  orange: '#f97316',
+  yellow: '#eab308',
+  cyan: '#06b6d4',
+  blue: '#3b82f6',
+  red: '#ef4444',
+  gray: '#6b7280',
+}
+
+/** Stat block IDs that represent percentage-type values (0-100) */
+const PERCENTAGE_STAT_IDS = new Set([
+  'score', 'cis_score', 'nsa_score', 'pci_score', 'kubescape_score',
+  'encryption_score', 'cpu_util', 'memory_util',
+  'gdpr_score', 'hipaa_score', 'soc2_score',
+])
+
+/** Determine which display modes are appropriate for a given stat block */
+function getAvailableModes(blockId: string, data: StatBlockValue): StatDisplayMode[] {
+  if (data.modeHints && data.modeHints.length > 0) return data.modeHints
+
+  const modes: StatDisplayMode[] = ['numeric']
+  const numericValue = typeof data.value === 'number'
+    ? data.value
+    : parseFloat(String(data.value))
+
+  if (!isNaN(numericValue)) {
+    modes.push('sparkline', 'mini-bar')
+    if (data.max !== undefined || PERCENTAGE_STAT_IDS.has(blockId) || String(data.value).includes('%')) {
+      modes.push('gauge', 'ring')
+    }
+  }
+  return modes
+}
+
+/** Height of the mini-bar progress bar in pixels */
+const MINI_BAR_HEIGHT_PX = 6
+
+/** Size of the circular ring indicator in pixels */
+const RING_SIZE_PX = 44
+
+/** Stroke width of the circular ring indicator in pixels */
+const RING_STROKE_PX = 5
+
 /**
  * Value and metadata for a single stat block
  */
@@ -71,6 +122,12 @@ export interface StatBlockValue {
   isClickable?: boolean
   /** Whether this stat uses demo/mock data (shows yellow border + badge) */
   isDemo?: boolean
+  /** For gauge/ring modes: the max value (default 100) */
+  max?: number
+  /** For gauge mode: threshold config */
+  thresholds?: { warning: number; critical: number }
+  /** Hint to the display mode picker about what modes are appropriate */
+  modeHints?: StatDisplayMode[]
 }
 
 interface StatBlockProps {
@@ -78,34 +135,124 @@ interface StatBlockProps {
   data: StatBlockValue
   hasData: boolean
   isLoading?: boolean
+  history?: number[]
+  onDisplayModeChange?: (mode: StatDisplayMode) => void
 }
 
-function StatBlock({ block, data, hasData, isLoading }: StatBlockProps) {
+function StatBlock({ block, data, hasData, isLoading, history, onDisplayModeChange }: StatBlockProps) {
   const IconComponent = ICONS[block.icon] || Server
   const colorClass = COLOR_CLASSES[block.color] || 'text-foreground'
   const valueColor = VALUE_COLORS[block.id] || 'text-foreground'
+  const hexColor = COLOR_HEX[block.color] || '#9333ea'
   const isClickable = !isLoading && data.isClickable !== false && !!data.onClick
   const isDemo = data.isDemo === true
+  const mode: StatDisplayMode = block.displayMode || 'numeric'
+  const availableModes = getAvailableModes(block.id, data)
 
   const displayValue = hasData ? data.value : '-'
+  const numericValue = typeof data.value === 'number'
+    ? data.value
+    : parseFloat(String(data.value))
+  const maxValue = data.max ?? 100
+
+  // Sparkline: fall back to numeric if not enough data yet
+  const hasEnoughHistory = (history?.length ?? 0) >= MIN_SPARKLINE_POINTS
+  const effectiveMode = mode === 'sparkline' && !hasEnoughHistory ? 'numeric' : mode
 
   return (
     <div
-      className={`relative glass p-4 rounded-lg ${isLoading ? 'animate-pulse' : ''} ${isClickable ? 'cursor-pointer hover:bg-secondary/50' : ''} ${isDemo ? 'border border-yellow-500/30 bg-yellow-500/5 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''} transition-colors`}
+      className={`group relative glass p-4 rounded-lg min-h-[100px] ${isLoading ? 'animate-pulse' : ''} ${isClickable ? 'cursor-pointer hover:bg-secondary/50' : ''} ${isDemo ? 'border border-yellow-500/30 bg-yellow-500/5 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''} transition-colors`}
       onClick={() => isClickable && data.onClick?.()}
     >
+      {/* Demo badge */}
       {isDemo && (
         <span className="absolute -top-1 -right-1" title="Demo data">
           <FlaskConical className="w-3.5 h-3.5 text-yellow-400/70" />
         </span>
       )}
+
+      {/* Mode picker gear — appears on hover */}
+      {!isLoading && onDisplayModeChange && (
+        <StatBlockModePicker
+          currentMode={mode}
+          availableModes={availableModes}
+          onModeChange={onDisplayModeChange}
+        />
+      )}
+
+      {/* Header: icon + name */}
       <div className="flex items-center gap-2 mb-2">
         <IconComponent className={`w-5 h-5 shrink-0 ${isLoading ? 'text-muted-foreground/30' : colorClass}`} />
         <span className="text-sm text-muted-foreground truncate">{block.name}</span>
       </div>
-      <div className={`text-3xl font-bold ${isLoading ? 'text-muted-foreground/30' : valueColor}`}>{displayValue}</div>
-      {data.sublabel && (
-        <div className="text-xs text-muted-foreground">{data.sublabel}</div>
+
+      {/* Mode-specific content */}
+      {effectiveMode === 'sparkline' && hasEnoughHistory && !isNaN(numericValue) ? (
+        <>
+          <div className="flex items-end justify-between gap-2">
+            <div className={`text-2xl font-bold ${isLoading ? 'text-muted-foreground/30' : valueColor}`}>
+              {displayValue}
+            </div>
+            <Sparkline data={history!} color={hexColor} height={28} width={64} fill />
+          </div>
+          {data.sublabel && <div className="text-xs text-muted-foreground mt-1">{data.sublabel}</div>}
+        </>
+      ) : effectiveMode === 'gauge' && !isNaN(numericValue) ? (
+        <>
+          <div className="flex justify-center">
+            <Gauge
+              value={numericValue}
+              max={maxValue}
+              size="xs"
+              thresholds={data.thresholds}
+              invertColors={PERCENTAGE_STAT_IDS.has(block.id)}
+            />
+          </div>
+          {data.sublabel && <div className="text-xs text-muted-foreground text-center mt-1">{data.sublabel}</div>}
+        </>
+      ) : effectiveMode === 'ring' && !isNaN(numericValue) ? (
+        <>
+          <div className="flex items-center gap-3">
+            <CircularProgress
+              value={numericValue}
+              max={maxValue}
+              size={RING_SIZE_PX}
+              strokeWidth={RING_STROKE_PX}
+              color={hexColor}
+            />
+            <div>
+              <div className={`text-2xl font-bold ${isLoading ? 'text-muted-foreground/30' : valueColor}`}>
+                {displayValue}
+              </div>
+              {data.sublabel && <div className="text-xs text-muted-foreground">{data.sublabel}</div>}
+            </div>
+          </div>
+        </>
+      ) : effectiveMode === 'mini-bar' && !isNaN(numericValue) ? (
+        <>
+          <div className={`text-2xl font-bold ${isLoading ? 'text-muted-foreground/30' : valueColor}`}>
+            {displayValue}
+          </div>
+          <div className="mt-1.5 w-full bg-secondary rounded-full overflow-hidden" style={{ height: MINI_BAR_HEIGHT_PX }}>
+            <div
+              className="h-full rounded-full transition-all duration-500"
+              style={{
+                width: `${Math.min((numericValue / maxValue) * 100, 100)}%`,
+                backgroundColor: hexColor,
+              }}
+            />
+          </div>
+          {data.sublabel && <div className="text-xs text-muted-foreground mt-1">{data.sublabel}</div>}
+        </>
+      ) : (
+        /* Default numeric mode */
+        <>
+          <div className={`text-3xl font-bold ${isLoading ? 'text-muted-foreground/30' : valueColor}`}>{displayValue}</div>
+          {mode === 'sparkline' && !hasEnoughHistory && !isLoading && hasData && (
+            <div className="text-2xs text-muted-foreground/50 mt-0.5">Building trend…</div>
+          )}
+          {data.sublabel && <div className="text-xs text-muted-foreground">{data.sublabel}</div>}
+        </>
       )}
     </div>
   )
@@ -171,6 +318,21 @@ export function StatsOverview({
   const effectiveIsLoading = isLoading || forceLoadingForOffline || isModeSwitching
   const effectiveHasData = forceLoadingForOffline ? false : hasData
   const { isOpen, open: openConfig, close: closeConfig } = useModalState()
+
+  // Sparkline history buffer — accumulates values over the session
+  const { getHistory } = useStatHistory(
+    dashboardType,
+    getStatValue,
+    visibleBlocks.map(b => b.id),
+    effectiveIsLoading,
+  )
+
+  // Handle per-block display mode changes — persists to localStorage (synced to agent)
+  const handleDisplayModeChange = useCallback((blockId: string, mode: StatDisplayMode) => {
+    const updated = blocks.map(b => b.id === blockId ? { ...b, displayMode: mode } : b)
+    saveBlocks(updated)
+    window.dispatchEvent(new CustomEvent('kubestellar-settings-changed'))
+  }, [blocks, saveBlocks])
 
   // Manage collapsed state with localStorage persistence
   const storageKey = collapsedStorageKey || `kubestellar-${dashboardType}-stats-collapsed`
@@ -260,6 +422,8 @@ export function StatsOverview({
                 data={data}
                 hasData={effectiveHasData && !effectiveIsLoading && data?.value !== undefined}
                 isLoading={effectiveIsLoading}
+                history={getHistory(block.id)}
+                onDisplayModeChange={(mode) => handleDisplayModeChange(block.id, mode)}
               />
             )
           })}

--- a/web/src/hooks/useStatHistory.ts
+++ b/web/src/hooks/useStatHistory.ts
@@ -1,0 +1,88 @@
+import { useRef, useEffect, useCallback } from 'react'
+import type { DashboardStatsType } from '../components/ui/StatsBlockDefinitions'
+
+/**
+ * Ring buffer hook that accumulates stat values over time for sparkline rendering.
+ *
+ * Samples current numeric values from getStatValue at a fixed interval and stores
+ * them in a ref-backed Map. History is ephemeral (session only) — sparklines fill
+ * up progressively as the user keeps the dashboard open.
+ */
+
+/** Maximum number of data points retained per stat block */
+const HISTORY_BUFFER_SIZE = 20
+
+/** Minimum interval (ms) between recording data points */
+const HISTORY_SAMPLE_INTERVAL_MS = 15_000
+
+/** Minimum data points needed before sparkline rendering kicks in */
+export const MIN_SPARKLINE_POINTS = 3
+
+interface StatHistoryEntry {
+  values: number[]
+  lastRecordedAt: number
+}
+
+interface StatBlockValueLike {
+  value: string | number
+}
+
+export function useStatHistory(
+  dashboardType: DashboardStatsType,
+  getStatValue: (blockId: string) => StatBlockValueLike,
+  visibleBlockIds: string[],
+  isLoading: boolean,
+): {
+  getHistory: (blockId: string) => number[]
+} {
+  const historyRef = useRef<Map<string, StatHistoryEntry>>(new Map())
+  const dashboardRef = useRef(dashboardType)
+
+  // Reset history when dashboard type changes
+  if (dashboardRef.current !== dashboardType) {
+    dashboardRef.current = dashboardType
+    historyRef.current = new Map()
+  }
+
+  // Sample current values at the configured interval
+  useEffect(() => {
+    if (isLoading) return
+
+    const sample = () => {
+      const now = Date.now()
+      for (const blockId of visibleBlockIds) {
+        const data = getStatValue(blockId)
+        const numericValue = typeof data.value === 'number'
+          ? data.value
+          : parseFloat(String(data.value))
+
+        if (isNaN(numericValue)) continue
+
+        const entry = historyRef.current.get(blockId)
+        if (entry && now - entry.lastRecordedAt < HISTORY_SAMPLE_INTERVAL_MS) {
+          continue
+        }
+
+        const values = entry ? [...entry.values] : []
+        values.push(numericValue)
+        // Keep only the last HISTORY_BUFFER_SIZE points
+        if (values.length > HISTORY_BUFFER_SIZE) {
+          values.splice(0, values.length - HISTORY_BUFFER_SIZE)
+        }
+
+        historyRef.current.set(blockId, { values, lastRecordedAt: now })
+      }
+    }
+
+    // Sample immediately, then on interval
+    sample()
+    const timer = setInterval(sample, HISTORY_SAMPLE_INTERVAL_MS)
+    return () => clearInterval(timer)
+  }, [dashboardType, visibleBlockIds, isLoading, getStatValue])
+
+  const getHistory = useCallback((blockId: string): number[] => {
+    return historyRef.current.get(blockId)?.values ?? []
+  }, [])
+
+  return { getHistory }
+}

--- a/web/src/lib/settingsSync.ts
+++ b/web/src/lib/settingsSync.ts
@@ -116,6 +116,21 @@ export function collectFromLocalStorage(): Partial<AllSettings> {
   const tourCompleted = localStorage.getItem(STORAGE_KEY_TOUR_COMPLETED)
   if (tourCompleted !== null) result.tourCompleted = tourCompleted === 'true'
 
+  // Stat block configs — collect all *-stats-config keys from localStorage
+  const statBlockConfigs: Record<string, unknown[]> = {}
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key && key.endsWith('-stats-config')) {
+      try {
+        const parsed = JSON.parse(localStorage.getItem(key) || '')
+        if (Array.isArray(parsed)) statBlockConfigs[key] = parsed
+      } catch { /* skip corrupted */ }
+    }
+  }
+  if (Object.keys(statBlockConfigs).length > 0) {
+    result.statBlockConfigs = statBlockConfigs
+  }
+
   return result
 }
 
@@ -181,6 +196,15 @@ export function restoreToLocalStorage(settings: AllSettings): void {
 
   if (settings.tourCompleted !== undefined) {
     localStorage.setItem(STORAGE_KEY_TOUR_COMPLETED, String(settings.tourCompleted))
+  }
+
+  // Restore stat block configs
+  if (settings.statBlockConfigs) {
+    for (const [key, value] of Object.entries(settings.statBlockConfigs)) {
+      if (Array.isArray(value)) {
+        try { localStorage.setItem(key, JSON.stringify(value)) } catch { /* skip */ }
+      }
+    }
   }
 
   // Notify hooks to re-read from localStorage

--- a/web/src/lib/settingsTypes.ts
+++ b/web/src/lib/settingsTypes.ts
@@ -82,4 +82,7 @@ export interface AllSettings {
   githubTokenSource?: 'settings' | 'env'
   /** Where the feedback GitHub token came from: "settings" (user UI), "env" (.env file), or undefined */
   feedbackGithubTokenSource?: 'settings' | 'env'
+
+  /** Per-dashboard stat block configurations (order, visibility, display mode) */
+  statBlockConfigs?: Record<string, unknown[]>
 }


### PR DESCRIPTION
## Summary
Stat blocks now support **5 display modes** instead of just numbers:

| Mode | Visual | Best for |
|------|--------|----------|
| **numeric** | Big number (current default) | Everything |
| **sparkline** | Mini area chart + number | Trends over time |
| **gauge** | Semicircular arc | Percentages, scores |
| **ring** | Circular progress | Utilization, completion |
| **mini-bar** | Horizontal progress bar | Any bounded value |

### How it works
- **Gear icon** appears on hover over any stat block → opens mode picker
- **Smart defaults**: Compliance scores default to gauge, utilization to ring, cluster healthy/pods to sparkline
- **Mode compatibility**: Gauge/ring only available for percentage-type stats
- **Sparkline history**: `useStatHistory` hook accumulates values over the session (20 points, 15s intervals). Sparklines fill up progressively — shows "Building trend..." until 3+ data points collected.
- **Persistence**: Display mode saved in existing stat config localStorage key, synced to kc-agent via settings sync

### Files changed
- **New**: `StatBlockModePicker.tsx` — portal-based popover for mode selection
- **New**: `useStatHistory.ts` — ring buffer hook for sparkline data
- **Modified**: `StatsBlockDefinitions.ts` — `StatDisplayMode` type + default mode map
- **Modified**: `StatsOverview.tsx` — Multi-mode rendering in StatBlock component
- **Modified**: `StatsConfig.tsx` — Apply default display modes from map
- **Modified**: `settingsSync.ts` + `settingsTypes.ts` — Sync stat configs to agent

## Test plan
- [ ] Clusters dashboard: healthy/pods blocks show "Building trend..." then sparklines after ~45s
- [ ] Compliance dashboard: score/CIS/NSA blocks show gauge by default
- [ ] Compute dashboard: CPU/Memory Util show ring by default
- [ ] Hover any stat block → gear icon appears → click → mode picker → change mode
- [ ] Reload page → mode choice persists
- [ ] All 5 modes render correctly at different grid sizes