### PR TITLE
🐛 Fix inconsistent component patterns

### DIFF
--- a/web/src/components/ui/CardControls.tsx
+++ b/web/src/components/ui/CardControls.tsx
@@ -99,16 +99,19 @@ export function CardControls<T extends string = string>({
           {limitOpen && (
             <div className="absolute top-full left-0 mt-1 bg-card border border-border rounded-lg shadow-lg z-50 min-w-[80px] py-1">
               {LIMIT_OPTIONS.map(option => (
-                <button
+                <Button
                   key={String(option.value)}
+                  variant="ghost"
+                  size="sm"
                   onClick={() => { onLimitChange(option.value); setLimitOpen(false); emitCardLimitChanged(String(option.value), cardType) }}
                   className={cn(
-                    'w-full px-3 py-1.5 text-left text-xs hover:bg-secondary/50 transition-colors',
+                    'w-full justify-start px-3 py-1.5 text-xs',
                     limit === option.value ? 'text-primary bg-primary/10' : 'text-foreground'
                   )}
+                  fullWidth
                 >
                   {option.label}
-                </button>
+                </Button>
               ))}
             </div>
           )}
@@ -131,16 +134,19 @@ export function CardControls<T extends string = string>({
             {sortOpen && (
               <div className="absolute top-full left-0 mt-1 bg-card border border-border rounded-lg shadow-lg z-50 min-w-[100px] py-1">
                 {sortOptions.map(option => (
-                  <button
+                  <Button
                     key={option.value}
+                    variant="ghost"
+                    size="sm"
                     onClick={() => { onSortChange(option.value); setSortOpen(false); emitCardSortChanged(option.value, cardType) }}
                     className={cn(
-                      'w-full px-3 py-1.5 text-left text-xs hover:bg-secondary/50 transition-colors',
+                      'w-full justify-start px-3 py-1.5 text-xs',
                       sortBy === option.value ? 'text-primary bg-primary/10' : 'text-foreground'
                     )}
+                    fullWidth
                   >
                     {option.label}
-                  </button>
+                  </Button>
                 ))}
               </div>
             )}

--- a/web/src/components/ui/ClusterFilterDropdown.tsx
+++ b/web/src/components/ui/ClusterFilterDropdown.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Filter, ChevronDown, Server } from 'lucide-react'
 import { ClusterStatusDot, getClusterState, type ClusterState } from './ClusterStatusBadge'
 import type { ClusterErrorType } from '../../lib/errorClassifier'
+import { Button } from './Button'
 
 interface ClusterFilterDropdownProps {
   localClusterFilter: string[]
@@ -86,21 +87,22 @@ export function ClusterFilterDropdown({
 
       {/* Cluster filter dropdown */}
       <div ref={clusterFilterRef} className="relative">
-        <button
+        <Button
           ref={buttonRef}
+          variant="ghost"
+          size="sm"
           onClick={() => setShowClusterFilter(!showClusterFilter)}
           aria-haspopup="listbox"
           aria-expanded={showClusterFilter}
-          className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${
+          className={`px-2 py-1 text-xs border ${
             localClusterFilter.length > 0
               ? 'bg-purple-900 border-purple-800 text-purple-400'
               : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
           }`}
           title={t('clusterFilter.filterByCluster')}
-        >
-          <Filter className="w-3 h-3" />
-          <ChevronDown className="w-3 h-3" />
-        </button>
+          icon={<Filter className="w-3 h-3" />}
+          iconRight={<ChevronDown className="w-3 h-3" />}
+        />
 
         {/* Portal dropdown to escape overflow-hidden containers */}
         {showClusterFilter && dropdownStyle && createPortal(
@@ -123,16 +125,19 @@ export function ClusterFilterDropdown({
             }}
           >
             <div className="p-1">
-              <button
+              <Button
+                variant="ghost"
+                size="sm"
                 role="option"
                 aria-selected={localClusterFilter.length === 0}
                 onClick={clearClusterFilter}
-                className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors ${
-                  localClusterFilter.length === 0 ? 'bg-purple-900 text-purple-400' : 'hover:bg-secondary text-foreground'
+                className={`w-full justify-start px-2 py-1.5 text-xs ${
+                  localClusterFilter.length === 0 ? 'bg-purple-900 text-purple-400' : 'text-foreground'
                 }`}
+                fullWidth
               >
                 {t('clusterFilter.allClusters')}
-              </button>
+              </Button>
               {availableClusters.map(cluster => {
                 const clusterState: ClusterState = cluster.healthy !== undefined || cluster.reachable !== undefined
                   ? getClusterState(
@@ -152,27 +157,30 @@ export function ClusterFilterDropdown({
                   clusterState.startsWith('unreachable') ? t('clusterFilter.offline') : ''
 
                 return (
-                  <button
+                  <Button
                     key={cluster.name}
+                    variant="ghost"
+                    size="sm"
                     role="option"
                     aria-selected={localClusterFilter.includes(cluster.name)}
                     onClick={() => !isUnreachable && toggleClusterFilter(cluster.name)}
                     disabled={isUnreachable}
-                    className={`w-full px-2 py-1.5 text-xs text-left rounded transition-colors flex items-center gap-2 ${
+                    className={`w-full justify-start px-2 py-1.5 text-xs ${
                       isUnreachable
                         ? 'opacity-40 cursor-not-allowed'
                         : localClusterFilter.includes(cluster.name)
                         ? 'bg-purple-900 text-purple-400'
-                          : 'hover:bg-secondary text-foreground'
+                          : 'text-foreground'
                     }`}
+                    fullWidth
                     title={stateLabel ? `${cluster.name} (${stateLabel})` : cluster.name}
+                    icon={<ClusterStatusDot state={clusterState} size="sm" />}
                   >
-                    <ClusterStatusDot state={clusterState} size="sm" />
                     <span className="flex-1 truncate">{cluster.name}</span>
                     {stateLabel && (
                       <span className="text-2xs text-muted-foreground shrink-0">{stateLabel}</span>
                     )}
-                  </button>
+                  </Button>
                 )
               })}
             </div>

--- a/web/src/components/ui/ClusterSelect.tsx
+++ b/web/src/components/ui/ClusterSelect.tsx
@@ -4,6 +4,7 @@ import { ChevronDown } from 'lucide-react'
 import { ClusterStatusDot, getClusterState, type ClusterState } from './ClusterStatusBadge'
 import type { ClusterErrorType } from '../../lib/errorClassifier'
 import { cn } from '../../lib/cn'
+import { Button } from './Button'
 
 interface ClusterInfo {
   name: string
@@ -91,23 +92,24 @@ export function ClusterSelect({
 
   return (
     <>
-      <button
+      <Button
         ref={buttonRef}
         type="button"
+        variant="secondary"
+        size="md"
         aria-haspopup="listbox"
         aria-expanded={isOpen}
         onClick={() => !disabled && setIsOpen(!isOpen)}
         disabled={disabled}
         className={cn(
-          'flex items-center gap-2 text-sm rounded-md bg-secondary border border-border px-2 py-1.5 text-foreground focus:outline-none focus:ring-1 focus:ring-blue-500/50 text-left',
-          disabled && 'opacity-50 cursor-not-allowed',
+          'rounded-md border border-border px-2 py-1.5 text-foreground focus:outline-none focus:ring-1 focus:ring-blue-500/50 text-left',
           className,
         )}
+        icon={selectedState ? <ClusterStatusDot state={selectedState} size="sm" /> : undefined}
+        iconRight={<ChevronDown className="w-3 h-3 text-muted-foreground shrink-0" />}
       >
-        {selectedState && <ClusterStatusDot state={selectedState} size="sm" />}
         <span className="flex-1 truncate">{value || placeholder}</span>
-        <ChevronDown className="w-3 h-3 text-muted-foreground shrink-0" />
-      </button>
+      </Button>
 
       {isOpen && dropdownPos && createPortal(
         <div
@@ -120,17 +122,20 @@ export function ClusterSelect({
         >
           <div className="p-1">
             {/* Empty option */}
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               role="option"
               aria-selected={!value}
               onClick={() => { onChange(''); setIsOpen(false) }}
               className={cn(
-                'w-full px-2 py-1.5 text-xs text-left rounded transition-colors',
-                !value ? 'bg-purple-900 text-purple-400' : 'hover:bg-secondary text-muted-foreground',
+                'w-full justify-start px-2 py-1.5 text-xs',
+                !value ? 'bg-purple-900 text-purple-400' : 'text-muted-foreground',
               )}
+              fullWidth
             >
               {placeholder}
-            </button>
+            </Button>
             {clusters.map(cluster => {
               const clusterState: ClusterState = cluster.healthy !== undefined || cluster.reachable !== undefined
                 ? getClusterState(cluster.healthy ?? true, cluster.reachable, cluster.nodeCount, undefined, cluster.errorType)
@@ -144,8 +149,10 @@ export function ClusterSelect({
                 clusterState.startsWith('unreachable') ? 'offline' : ''
 
               return (
-                <button
+                <Button
                   key={cluster.name}
+                  variant="ghost"
+                  size="sm"
                   role="option"
                   aria-selected={value === cluster.name}
                   onClick={() => {
@@ -156,21 +163,22 @@ export function ClusterSelect({
                   }}
                   disabled={isUnreachable}
                   className={cn(
-                    'w-full px-2 py-1.5 text-xs text-left rounded transition-colors flex items-center gap-2',
+                    'w-full justify-start px-2 py-1.5 text-xs',
                     isUnreachable
                       ? 'opacity-40 cursor-not-allowed'
                       : value === cluster.name
                         ? 'bg-purple-900 text-purple-400'
-                        : 'hover:bg-secondary text-foreground',
+                        : 'text-foreground',
                   )}
+                  fullWidth
                   title={stateLabel ? `${cluster.name} (${stateLabel})` : cluster.name}
+                  icon={<ClusterStatusDot state={clusterState} size="sm" />}
                 >
-                  <ClusterStatusDot state={clusterState} size="sm" />
                   <span className="flex-1 truncate">{cluster.name}</span>
                   {stateLabel && (
                     <span className="text-2xs text-muted-foreground shrink-0">{stateLabel}</span>
                   )}
-                </button>
+                </Button>
               )
             })}
           </div>

--- a/web/src/components/ui/StatsConfig.tsx
+++ b/web/src/components/ui/StatsConfig.tsx
@@ -138,13 +138,14 @@ function SortableItem({ block, onToggleVisibility, onRemove, isCustom }: Sortabl
         block.visible ? '' : 'opacity-50'
       }`}
     >
-      <button
+      <Button
+        variant="ghost"
+        size="sm"
+        className="cursor-grab active:cursor-grabbing p-1"
+        icon={<GripVertical className="w-4 h-4 text-muted-foreground" />}
         {...attributes}
         {...listeners}
-        className="cursor-grab active:cursor-grabbing p-1 hover:bg-secondary rounded"
-      >
-        <GripVertical className="w-4 h-4 text-muted-foreground" />
-      </button>
+      />
       <div className={`w-5 h-5 ${colorClasses[block.color] || 'text-foreground'}`}>
         <span className="text-sm">{iconEmojis[block.icon] || '📊'}</span>
       </div>


### PR DESCRIPTION
## Summary
- Replace raw `<button>` elements with the shared `Button` component in `StatsConfig.tsx`, `CardControls.tsx`, `ClusterSelect.tsx`, and `ClusterFilterDropdown.tsx`
- Standardizes component patterns flagged by Auto-QA consistency check (issue #2323)
- AlertBadge.tsx was already fixed by PR #2342; modal visibility patterns were already consistent using `isOpen`

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (no new errors)
- [ ] Visual regression: dropdown menus in CardControls, ClusterSelect, ClusterFilterDropdown render and function correctly
- [ ] Drag-and-drop reordering in StatsConfig modal still works

Fixes #2323