### PR TITLE
⚡ Stream Trestle card data progressively with parallel cluster checks

### DIFF
--- a/web/src/components/cards/TrestleScan.tsx
+++ b/web/src/components/cards/TrestleScan.tsx
@@ -4,6 +4,7 @@
  * Displays OSCAL compliance assessment status from Compliance Trestle / c2p.
  * When installed, shows per-profile pass/fail counts and an overall score.
  * When not installed, falls back to demo data and offers an AI mission install link.
+ * Uses progressive streaming — shows results as each cluster check completes.
  *
  * Compliance Trestle is a CNCF Sandbox project for compliance-as-code using NIST OSCAL.
  */
@@ -44,10 +45,13 @@ Please diagnose step by step and fix any issues found.`,
 }
 
 export function TrestleScan({ config: _config }: CardConfig) {
-  const { statuses, aggregated, isLoading, isRefreshing, installed, isDemoData, lastRefresh } = useTrestle()
+  const { statuses, aggregated, isLoading, isRefreshing, installed, isDemoData, lastRefresh, clustersChecked, totalClusters } = useTrestle()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
   const [expandedProfile, setExpandedProfile] = useState<string | null>(null)
+
+  /** Whether all clusters have been checked */
+  const allChecked = clustersChecked >= totalClusters && totalClusters > 0
 
   // Filter by selected clusters
   const filtered = useMemo(() => {
@@ -136,11 +140,16 @@ Please proceed step by step. Start with verifying prerequisites (Python 3.9+, ku
     return Array.from(profileMap.values())
   }, [statuses, selectedClusters])
 
-  // Loading state
-  if (isLoading) {
+  // Only show full-screen spinner on very first load with zero data
+  if (isLoading && Object.keys(statuses).length === 0) {
     return (
-      <div className="flex items-center justify-center h-full">
+      <div className="flex flex-col items-center justify-center h-full gap-2">
         <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+        {totalClusters > 0 && (
+          <span className="text-xs text-muted-foreground">
+            Checking clusters... {clustersChecked}/{totalClusters}
+          </span>
+        )}
       </div>
     )
   }
@@ -217,9 +226,15 @@ Please proceed step by step. Start with verifying prerequisites (Python 3.9+, ku
 
   return (
     <div className="space-y-3 h-full flex flex-col">
-      {/* Refresh indicator */}
+      {/* Refresh / streaming progress indicator */}
       {isRefreshing && lastRefresh && (
         <RefreshIndicator isRefreshing={isRefreshing} lastUpdated={lastRefresh} />
+      )}
+      {!allChecked && totalClusters > 0 && !isRefreshing && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="w-3 h-3 animate-spin" />
+          <span>Checking clusters... {clustersChecked}/{totalClusters}</span>
+        </div>
       )}
 
       {/* Overall Score */}

--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -1,9 +1,11 @@
 /**
  * Hook to fetch Compliance Trestle / OSCAL assessment data from connected clusters.
  *
- * Follows the useKubescape.ts pattern:
+ * Uses parallel cluster checks with progressive streaming:
  * - Phase 1: CRD existence check per cluster (5s timeout)
  * - Phase 2: Fetch assessment data from installed clusters (15s timeout)
+ * - All clusters checked in parallel via Promise.allSettled
+ * - Results stream to the card as each cluster completes
  * - localStorage cache with auto-refresh
  * - Demo fallback when no clusters are connected
  *
@@ -184,6 +186,142 @@ function emptyStatus(cluster: string, installed: boolean, error?: string): Trest
   }
 }
 
+// ── Single-cluster fetch (used in parallel) ──────────────────────────────
+
+async function fetchSingleCluster(cluster: string): Promise<TrestleClusterStatus> {
+  try {
+    // Phase 1: CRD detection — check for OSCAL CRDs
+    let found = false
+
+    for (const crdName of (TRESTLE_CRD_NAMES || [])) {
+      const crdCheck = await kubectlProxy.exec(
+        ['get', 'crd', crdName, '-o', 'name'],
+        { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
+      )
+      if (crdCheck.exitCode === 0) {
+        found = true
+        break
+      }
+    }
+
+    // Fallback: check for known deployments
+    if (!found) {
+      for (const dep of (TRESTLE_DEPLOYMENT_CHECKS || [])) {
+        const depCheck = await kubectlProxy.exec(
+          ['get', 'deployment', dep.name, '-n', dep.ns, '-o', 'name'],
+          { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
+        )
+        if (depCheck.exitCode === 0) {
+          found = true
+          break
+        }
+      }
+    }
+
+    if (!found) {
+      return emptyStatus(cluster, false)
+    }
+
+    // Phase 2: Fetch assessment data
+    const apiGroups = [
+      { group: 'oscal.io', version: 'v1alpha1', resource: 'assessmentresults' },
+      { group: 'compliance.oscal.io', version: 'v1', resource: 'complianceassessments' },
+      { group: 'oscal.io', version: 'v1', resource: 'assessmentresults' },
+    ]
+
+    for (const api of (apiGroups || [])) {
+      const result = await kubectlProxy.exec(
+        ['get', `${api.resource}.${api.group}`, '-A', '-o', 'json'],
+        { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+      )
+
+      if (result.exitCode === 0 && result.output) {
+        try {
+          const data = JSON.parse(result.output)
+          const items = (data.items || []) as Array<Record<string, unknown>>
+
+          if (items.length > 0) {
+            const profiles: OscalProfile[] = []
+            const controlResults: OscalControlResult[] = []
+
+            for (const item of (items || [])) {
+              const spec = (item.spec || {}) as Record<string, unknown>
+              const status = (item.status || {}) as Record<string, unknown>
+              const meta = (item.metadata || {}) as Record<string, unknown>
+              const profileName = String(spec.profile || spec.profileName || meta.name || 'Unknown Profile')
+
+              const results = (status.results || status.controlResults || []) as Array<Record<string, unknown>>
+              let passed = 0
+              let failed = 0
+              let other = 0
+
+              for (const r of (results || [])) {
+                const controlStatus = String(r.status || r.state || 'other').toLowerCase()
+                const controlId = String(r.controlId || r.control || r.id || '')
+                const title = String(r.title || r.description || controlId)
+
+                if (controlStatus === 'pass' || controlStatus === 'satisfied') {
+                  passed++
+                  controlResults.push({ controlId, title, status: 'pass' })
+                } else if (controlStatus === 'fail' || controlStatus === 'not-satisfied') {
+                  failed++
+                  controlResults.push({ controlId, title, status: 'fail' })
+                } else {
+                  other++
+                  controlResults.push({
+                    controlId, title,
+                    status: controlStatus === 'not-applicable' ? 'not-applicable' : 'other',
+                  })
+                }
+              }
+
+              profiles.push({
+                name: profileName,
+                totalControls: passed + failed + other,
+                controlsPassed: passed,
+                controlsFailed: failed,
+                controlsOther: other,
+              })
+            }
+
+            const totalControls = controlResults.length
+            const passedControls = controlResults.filter(c => c.status === 'pass').length
+            const failedControls = controlResults.filter(c => c.status === 'fail').length
+            const otherControls = totalControls - passedControls - failedControls
+            const overallScore = totalControls > 0
+              ? Math.round((passedControls / totalControls) * 100)
+              : 0
+
+            return {
+              cluster,
+              installed: true,
+              loading: false,
+              overallScore,
+              profiles,
+              totalControls,
+              passedControls,
+              failedControls,
+              otherControls,
+              controlResults,
+              lastAssessment: new Date().toISOString(),
+            }
+          }
+        } catch {
+          // JSON parse error, try next API group
+        }
+      }
+    }
+
+    // Installed but no assessment data yet
+    return emptyStatus(cluster, true)
+  } catch (err) {
+    return emptyStatus(
+      cluster, false,
+      err instanceof Error ? err.message : 'Unknown error'
+    )
+  }
+}
+
 // ── Hook ──────────────────────────────────────────────────────────────────
 
 export function useTrestle() {
@@ -193,6 +331,8 @@ export function useTrestle() {
   const [isLoading, setIsLoading] = useState(true)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
+  /** Number of clusters that have completed checking (for progressive UI) */
+  const [clustersChecked, setClustersChecked] = useState(0)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const mountedRef = useRef(true)
 
@@ -210,6 +350,7 @@ export function useTrestle() {
 
     if (isRefresh) setIsRefreshing(true)
     else setIsLoading(true)
+    setClustersChecked(0)
 
     // Demo mode
     if (isDemoMode) {
@@ -220,6 +361,7 @@ export function useTrestle() {
       }
       if (mountedRef.current) {
         setStatuses(demoStatuses)
+        setClustersChecked(demoNames.length)
         setIsLoading(false)
         setIsRefreshing(false)
         setLastRefresh(new Date())
@@ -227,160 +369,26 @@ export function useTrestle() {
       return
     }
 
-    // Real mode: check each cluster
-    const newStatuses: Record<string, TrestleClusterStatus> = {}
+    // Real mode: check all clusters in parallel, stream results progressively
+    const allStatuses: Record<string, TrestleClusterStatus> = {}
 
-    for (const cluster of (clusterNames || [])) {
-      try {
-        // Phase 1: CRD detection — check for OSCAL CRDs
-        let found = false
-
-        for (const crdName of (TRESTLE_CRD_NAMES || [])) {
-          const crdCheck = await kubectlProxy.exec(
-            ['get', 'crd', crdName, '-o', 'name'],
-            { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
-          )
-          if (crdCheck.exitCode === 0) {
-            found = true
-            break
-          }
-        }
-
-        // Fallback: check for known deployments
-        if (!found) {
-          for (const dep of (TRESTLE_DEPLOYMENT_CHECKS || [])) {
-            const depCheck = await kubectlProxy.exec(
-              ['get', 'deployment', dep.name, '-n', dep.ns, '-o', 'name'],
-              { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
-            )
-            if (depCheck.exitCode === 0) {
-              found = true
-              break
-            }
-          }
-        }
-
-        if (!found) {
-          newStatuses[cluster] = emptyStatus(cluster, false)
-          setStatuses(prev => ({ ...prev, [cluster]: newStatuses[cluster] }))
-          continue
-        }
-
-        // Phase 2: Fetch assessment data
-        // Try each known API group for OSCAL assessment results
-        const apiGroups = [
-          { group: 'oscal.io', version: 'v1alpha1', resource: 'assessmentresults' },
-          { group: 'compliance.oscal.io', version: 'v1', resource: 'complianceassessments' },
-          { group: 'oscal.io', version: 'v1', resource: 'assessmentresults' },
-        ]
-
-        let fetchedData = false
-        for (const api of (apiGroups || [])) {
-          const result = await kubectlProxy.exec(
-            ['get', `${api.resource}.${api.group}`, '-A', '-o', 'json'],
-            { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
-          )
-
-          if (result.exitCode === 0 && result.output) {
-            try {
-              const data = JSON.parse(result.output)
-              const items = (data.items || []) as Array<Record<string, unknown>>
-
-              if (items.length > 0) {
-                const profiles: OscalProfile[] = []
-                const controlResults: OscalControlResult[] = []
-
-                for (const item of (items || [])) {
-                  const spec = (item.spec || {}) as Record<string, unknown>
-                  const status = (item.status || {}) as Record<string, unknown>
-                  const meta = (item.metadata || {}) as Record<string, unknown>
-                  const profileName = String(spec.profile || spec.profileName || meta.name || 'Unknown Profile')
-
-                  const results = (status.results || status.controlResults || []) as Array<Record<string, unknown>>
-                  let passed = 0
-                  let failed = 0
-                  let other = 0
-
-                  for (const r of (results || [])) {
-                    const controlStatus = String(r.status || r.state || 'other').toLowerCase()
-                    const controlId = String(r.controlId || r.control || r.id || '')
-                    const title = String(r.title || r.description || controlId)
-
-                    if (controlStatus === 'pass' || controlStatus === 'satisfied') {
-                      passed++
-                      controlResults.push({ controlId, title, status: 'pass' })
-                    } else if (controlStatus === 'fail' || controlStatus === 'not-satisfied') {
-                      failed++
-                      controlResults.push({ controlId, title, status: 'fail' })
-                    } else {
-                      other++
-                      controlResults.push({
-                        controlId, title,
-                        status: controlStatus === 'not-applicable' ? 'not-applicable' : 'other',
-                      })
-                    }
-                  }
-
-                  profiles.push({
-                    name: profileName,
-                    totalControls: passed + failed + other,
-                    controlsPassed: passed,
-                    controlsFailed: failed,
-                    controlsOther: other,
-                  })
-                }
-
-                const totalControls = controlResults.length
-                const passedControls = controlResults.filter(c => c.status === 'pass').length
-                const failedControls = controlResults.filter(c => c.status === 'fail').length
-                const otherControls = totalControls - passedControls - failedControls
-                const overallScore = totalControls > 0
-                  ? Math.round((passedControls / totalControls) * 100)
-                  : 0
-
-                newStatuses[cluster] = {
-                  cluster,
-                  installed: true,
-                  loading: false,
-                  overallScore,
-                  profiles,
-                  totalControls,
-                  passedControls,
-                  failedControls,
-                  otherControls,
-                  controlResults,
-                  lastAssessment: new Date().toISOString(),
-                }
-                fetchedData = true
-                break
-              }
-            } catch {
-              // JSON parse error, try next API group
-            }
-          }
-        }
-
-        if (!fetchedData) {
-          // Installed but no assessment data yet
-          newStatuses[cluster] = emptyStatus(cluster, true)
-        }
-
+    const promises = (clusterNames || []).map(cluster =>
+      fetchSingleCluster(cluster).then(status => {
+        allStatuses[cluster] = status
         if (mountedRef.current) {
-          setStatuses(prev => ({ ...prev, [cluster]: newStatuses[cluster] }))
+          // Stream each result immediately — card re-renders progressively
+          setStatuses(prev => ({ ...prev, [cluster]: status }))
+          setClustersChecked(prev => prev + 1)
+          // Clear initial loading after first result arrives
+          setIsLoading(false)
         }
-      } catch (err) {
-        newStatuses[cluster] = emptyStatus(
-          cluster, false,
-          err instanceof Error ? err.message : 'Unknown error'
-        )
-        if (mountedRef.current) {
-          setStatuses(prev => ({ ...prev, [cluster]: newStatuses[cluster] }))
-        }
-      }
-    }
+      })
+    )
+
+    await Promise.allSettled(promises)
 
     if (mountedRef.current) {
-      saveToCache(newStatuses)
+      saveToCache(allStatuses)
       setIsLoading(false)
       setIsRefreshing(false)
       setLastRefresh(new Date())
@@ -442,6 +450,10 @@ export function useTrestle() {
     lastRefresh,
     installed,
     isDemoData,
+    /** Number of clusters checked so far (for progressive UI) */
+    clustersChecked,
+    /** Total number of clusters being checked */
+    totalClusters: clusterNames.length,
     refetch: () => fetchData(true),
   }
 }


### PR DESCRIPTION
## Summary
- Parallelizes cluster checks using `Promise.allSettled` instead of sequential `for...of` loop — all clusters checked simultaneously
- Card shows results progressively as each cluster completes instead of blocking behind a spinner until all finish
- Adds cluster progress counter ("Checking clusters... X/Y") visible during initial load
- Full-screen spinner only shown when zero data exists; partial results shown immediately

## Changes
- `useTrestle.ts`: Extracted `fetchSingleCluster()` function, parallel dispatch via `.map()` + `Promise.allSettled`, `setIsLoading(false)` after first result, new `clustersChecked`/`totalClusters` return values
- `TrestleScan.tsx`: Progressive loading indicator, only full-block spinner when no data at all

## Test plan
- [x] Build passes
- [x] Lint clean on changed files
- [ ] Card shows progress counter during initial load
- [ ] Results stream in as clusters complete (visible on compliance dashboard)
- [ ] Cached data displays immediately on page load