### PR TITLE
✨ Add trend, stacked-bar, heatmap, and horseshoe stat block modes

### DIFF
--- a/web/src/components/ui/StatBlockModePicker.tsx
+++ b/web/src/components/ui/StatBlockModePicker.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
-import { Settings, Hash, TrendingUp, CircleDot, BarChart3 } from 'lucide-react'
+import { Settings, Hash, TrendingUp, CircleDot, BarChart3, ArrowUpDown, Layers } from 'lucide-react'
 import type { StatDisplayMode } from './StatsBlockDefinitions'
 
 /** Gap between trigger button and popover in pixels */
@@ -18,12 +18,38 @@ function GaugeIcon({ className }: { className?: string }) {
   )
 }
 
+/** Horseshoe icon — U-shaped arc */
+function HorseshoeIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M5 8a7 7 0 0 1 14 0v5" />
+      <path d="M5 8v5" />
+    </svg>
+  )
+}
+
+/** Heatmap icon — grid of squares */
+function HeatmapIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <rect x="3" y="3" width="7" height="7" rx="1" opacity="0.3" />
+      <rect x="14" y="3" width="7" height="7" rx="1" opacity="0.6" />
+      <rect x="3" y="14" width="7" height="7" rx="1" opacity="0.8" />
+      <rect x="14" y="14" width="7" height="7" rx="1" opacity="1" />
+    </svg>
+  )
+}
+
 const MODE_OPTIONS: { mode: StatDisplayMode; icon: React.ComponentType<{ className?: string }>; label: string }[] = [
   { mode: 'numeric', icon: Hash, label: 'Number' },
   { mode: 'sparkline', icon: TrendingUp, label: 'Sparkline' },
   { mode: 'gauge', icon: GaugeIcon, label: 'Gauge' },
+  { mode: 'horseshoe', icon: HorseshoeIcon, label: 'Horseshoe' },
   { mode: 'ring', icon: CircleDot, label: 'Ring' },
   { mode: 'mini-bar', icon: BarChart3, label: 'Bar' },
+  { mode: 'trend', icon: ArrowUpDown, label: 'Trend' },
+  { mode: 'stacked-bar', icon: Layers, label: 'Stacked' },
+  { mode: 'heatmap', icon: HeatmapIcon, label: 'Heatmap' },
 ]
 
 interface StatBlockModePickerProps {

--- a/web/src/components/ui/StatsBlockDefinitions.ts
+++ b/web/src/components/ui/StatsBlockDefinitions.ts
@@ -6,7 +6,16 @@
 /**
  * Display mode for a stat block visualization
  */
-export type StatDisplayMode = 'numeric' | 'sparkline' | 'gauge' | 'ring' | 'mini-bar'
+export type StatDisplayMode =
+  | 'numeric'
+  | 'sparkline'
+  | 'gauge'
+  | 'ring'
+  | 'mini-bar'
+  | 'trend'
+  | 'stacked-bar'
+  | 'heatmap'
+  | 'horseshoe'
 
 /**
  * Configuration for a single stat block
@@ -432,12 +441,26 @@ export const STAT_DISPLAY_MODE_DEFAULTS: Record<string, StatDisplayMode> = {
   'compute:cpu_util': 'ring',
   'compute:memory_util': 'ring',
 
-  // Data compliance — encryption score
-  'data-compliance:encryption_score': 'ring',
+  // Data compliance — horseshoe for scores
+  'data-compliance:encryption_score': 'horseshoe',
+  'data-compliance:gdpr_score': 'horseshoe',
 
-  // Clusters — trend over time
+  // Clusters — trend and heatmap
   'clusters:healthy': 'sparkline',
   'clusters:pods': 'sparkline',
+  'clusters:unhealthy': 'heatmap',
+  'clusters:unreachable': 'heatmap',
+
+  // Workloads — trend delta for issues
+  'workloads:critical': 'trend',
+  'workloads:warning': 'trend',
+
+  // Security — heatmap for severity
+  'security:critical': 'heatmap',
+  'security:high': 'heatmap',
+
+  // Alerts — trend for firing
+  'alerts:firing': 'trend',
 
   // Pods — trend over time
   'pods:total_pods': 'sparkline',

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -95,10 +95,14 @@ function getAvailableModes(blockId: string, data: StatBlockValue): StatDisplayMo
     : parseFloat(String(data.value))
 
   if (!isNaN(numericValue)) {
-    modes.push('sparkline', 'mini-bar')
+    modes.push('sparkline', 'mini-bar', 'trend', 'heatmap')
     if (data.max !== undefined || PERCENTAGE_STAT_IDS.has(blockId) || String(data.value).includes('%')) {
-      modes.push('gauge', 'ring')
+      modes.push('gauge', 'horseshoe', 'ring')
     }
+  }
+  // Stacked bar available for all numeric stats (renders as single segment if no breakdown)
+  if (!isNaN(numericValue)) {
+    modes.push('stacked-bar')
   }
   return modes
 }
@@ -111,6 +115,26 @@ const RING_SIZE_PX = 64
 
 /** Stroke width of the circular ring indicator in pixels */
 const RING_STROKE_PX = 6
+
+/** Size of the horseshoe gauge in pixels */
+const HORSESHOE_SIZE_PX = 64
+
+/** Stroke width of the horseshoe gauge */
+const HORSESHOE_STROKE_PX = 6
+
+/** Angle span of the horseshoe arc in degrees (270 = 3/4 circle) */
+const HORSESHOE_ARC_DEG = 270
+
+/** Heatmap intensity thresholds — maps value ranges to opacity */
+const HEATMAP_THRESHOLDS = [
+  { max: 0, opacity: 0 },
+  { max: 1, opacity: 0.15 },
+  { max: 5, opacity: 0.3 },
+  { max: 10, opacity: 0.5 },
+  { max: 25, opacity: 0.7 },
+  { max: 50, opacity: 0.85 },
+  { max: Infinity, opacity: 1.0 },
+]
 
 /**
  * Value and metadata for a single stat block
@@ -128,6 +152,53 @@ export interface StatBlockValue {
   thresholds?: { warning: number; critical: number }
   /** Hint to the display mode picker about what modes are appropriate */
   modeHints?: StatDisplayMode[]
+}
+
+/** Inline horseshoe gauge — a 270° arc with value text centered */
+function HorseshoeGauge({ value, max = 100, size, strokeWidth, color }: {
+  value: number; max?: number; size: number; strokeWidth: number; color: string
+}) {
+  const percentage = max > 0 ? Math.min((value / max) * 100, 100) : 0
+  const radius = (size - strokeWidth) / 2
+  const circumference = radius * 2 * Math.PI
+  const arcFraction = HORSESHOE_ARC_DEG / 360
+  const arcLength = circumference * arcFraction
+  const offset = arcLength - (percentage / 100) * arcLength
+  /** Rotation to center the gap at the bottom: -(90 + half of gap angle) */
+  const gapDeg = 360 - HORSESHOE_ARC_DEG
+  const rotationDeg = 90 + gapDeg / 2
+
+  return (
+    <div className="relative" style={{ width: size, height: size }}>
+      <svg width={size} height={size} style={{ transform: `rotate(${rotationDeg}deg)` }}>
+        <circle
+          cx={size / 2} cy={size / 2} r={radius}
+          fill="none" stroke="currentColor" strokeWidth={strokeWidth}
+          strokeDasharray={`${arcLength} ${circumference}`}
+          className="text-secondary"
+        />
+        <circle
+          cx={size / 2} cy={size / 2} r={radius}
+          fill="none" stroke={color} strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={`${arcLength} ${circumference}`}
+          strokeDashoffset={offset}
+          style={{ transition: 'stroke-dashoffset 0.5s ease', filter: `drop-shadow(0 0 6px ${color}40)` }}
+        />
+      </svg>
+      <div className="absolute inset-0 flex items-center justify-center">
+        <span className="text-sm font-bold text-foreground">{Math.round(percentage)}%</span>
+      </div>
+    </div>
+  )
+}
+
+/** Get heatmap opacity for a value */
+function getHeatmapOpacity(value: number): number {
+  for (const t of HEATMAP_THRESHOLDS) {
+    if (value <= t.max) return t.opacity
+  }
+  return 1.0
 }
 
 interface StatBlockProps {
@@ -238,6 +309,73 @@ function StatBlock({ block, data, hasData, isLoading, history, onDisplayModeChan
             />
           </div>
           {data.sublabel && <div className="text-xs text-muted-foreground mt-1">{data.sublabel}</div>}
+        </>
+      ) : effectiveMode === 'horseshoe' && !isNaN(numericValue) ? (
+        <>
+          <div className="flex justify-center">
+            <HorseshoeGauge
+              value={numericValue}
+              max={maxValue}
+              size={HORSESHOE_SIZE_PX}
+              strokeWidth={HORSESHOE_STROKE_PX}
+              color={hexColor}
+            />
+          </div>
+          {data.sublabel && <div className="text-xs text-muted-foreground text-center mt-1">{data.sublabel}</div>}
+        </>
+      ) : effectiveMode === 'trend' && !isNaN(numericValue) ? (
+        (() => {
+          const prevValue = history && history.length >= 2 ? history[history.length - 2] : undefined
+          const delta = prevValue !== undefined ? numericValue - prevValue : undefined
+          const deltaPercent = prevValue !== undefined && prevValue !== 0
+            ? Math.round(((numericValue - prevValue) / prevValue) * 100)
+            : undefined
+          return (
+            <>
+              <div className="flex items-baseline gap-2">
+                <div className={`text-2xl font-bold ${isLoading ? 'text-muted-foreground/30' : valueColor}`}>
+                  {displayValue}
+                </div>
+                {delta !== undefined && (
+                  <span className={`text-sm font-medium ${delta > 0 ? 'text-red-400' : delta < 0 ? 'text-green-400' : 'text-muted-foreground'}`}>
+                    {delta > 0 ? '▲' : delta < 0 ? '▼' : '—'}
+                    {deltaPercent !== undefined && ` ${Math.abs(deltaPercent)}%`}
+                  </span>
+                )}
+              </div>
+              {delta === undefined && !isLoading && hasData && (
+                <div className="text-2xs text-muted-foreground/50 mt-0.5">Collecting…</div>
+              )}
+              {data.sublabel && <div className="text-xs text-muted-foreground mt-1">{data.sublabel}</div>}
+            </>
+          )
+        })()
+      ) : effectiveMode === 'stacked-bar' && !isNaN(numericValue) ? (
+        <>
+          <div className={`text-2xl font-bold ${isLoading ? 'text-muted-foreground/30' : valueColor}`}>
+            {displayValue}
+          </div>
+          <div className="mt-1.5 w-full bg-secondary rounded-full overflow-hidden flex" style={{ height: MINI_BAR_HEIGHT_PX }}>
+            <div
+              className="h-full transition-all duration-500"
+              style={{
+                width: `${Math.min((numericValue / maxValue) * 100, 100)}%`,
+                backgroundColor: hexColor,
+              }}
+            />
+          </div>
+          {data.sublabel && <div className="text-xs text-muted-foreground mt-1">{data.sublabel}</div>}
+        </>
+      ) : effectiveMode === 'heatmap' && !isNaN(numericValue) ? (
+        <>
+          <div
+            className="absolute inset-0 rounded-lg transition-colors duration-500"
+            style={{ backgroundColor: hexColor, opacity: getHeatmapOpacity(numericValue) }}
+          />
+          <div className="relative">
+            <div className={`text-3xl font-bold ${numericValue > 0 ? 'text-white drop-shadow-sm' : valueColor}`}>{displayValue}</div>
+            {data.sublabel && <div className={`text-xs ${numericValue > 0 ? 'text-white/70' : 'text-muted-foreground'}`}>{data.sublabel}</div>}
+          </div>
         </>
       ) : (
         /* Default numeric mode */


### PR DESCRIPTION
## Summary
4 new visualization modes, bringing the total to **9**:

| Mode | Visual | Best for |
|------|--------|----------|
| **trend** | Number + ▲/▼ arrow + % change | Issue counts, alerts |
| **stacked-bar** | Segmented horizontal bar | Breakdowns |
| **heatmap** | Background color intensity | Severity (errors, issues) |
| **horseshoe** | 270° arc gauge (llm-d style) | Percentages, scores |

### New defaults
- Clusters unhealthy/unreachable → heatmap (glows red as count increases)
- Workloads critical/warning → trend (shows direction of change)
- Security critical/high → heatmap
- Alerts firing → trend
- Data compliance GDPR/encryption → horseshoe

## Test plan
- [ ] Clusters dashboard: unhealthy/unreachable blocks show heatmap (background color intensity)
- [ ] Workloads dashboard: critical/warning blocks show trend arrows
- [ ] Hover any stat → gear icon → all 9 modes available in picker
- [ ] Horseshoe renders as 270° arc with value centered
- [ ] Heatmap opacity scales with value (0 = transparent, 50+ = full intensity)