### PR TITLE
🐛 Fix Trestle card showing 0% when not in demo mode

### DIFF
--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -383,7 +383,20 @@ export function useTrestle() {
     await Promise.allSettled(promises)
 
     if (mountedRef.current) {
-      saveToCache(allStatuses)
+      // If no cluster has Trestle installed, fall back to demo data so the
+      // card renders sample scores instead of showing 0% with empty profiles.
+      const anyInstalled = Object.values(allStatuses).some(s => s.installed)
+      if (!anyInstalled) {
+        const demoNames = clusterNames.length > 0 ? clusterNames : ['cluster-1', 'cluster-2', 'cluster-3']
+        const demoStatuses: Record<string, TrestleClusterStatus> = {}
+        for (const name of (demoNames || [])) {
+          demoStatuses[name] = getDemoStatus(name)
+        }
+        setStatuses(demoStatuses)
+        setClustersChecked(demoNames.length)
+      } else {
+        saveToCache(allStatuses)
+      }
       setIsLoading(false)
       setIsRefreshing(false)
       setLastRefresh(new Date())


### PR DESCRIPTION
## Summary
- When logged in as a real user (not demo-user), the Trestle card showed 0% scores and "No profiles assessed" despite having the Demo badge
- Root cause: demo data generation only ran when `isDemoMode` was true, but `isDemoData` was computed as `isDemoMode || (!installed && !isLoading)` — so the card knew it was in demo mode but had no demo data
- Now falls back to demo data after all real cluster checks complete with no Trestle installations found

## Test plan
- [ ] Log in as real user (not demo-user) with no Trestle installed on any cluster
- [ ] Verify Trestle card shows ~82% demo scores with NIST 800-53 and FedRAMP profiles
- [ ] Verify Demo badge appears on the card
- [ ] Log in as demo-user and verify same demo behavior