### PR TITLE
✨ Add progressive streaming to all compliance dashboard cards

### DIFF
--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -140,10 +140,13 @@ export function FalcoAlerts({ config: _config }: CardConfig) {
 
 export function TrivyScan({ config: _config }: CardConfig) {
   const { t } = useTranslation()
-  const { statuses, aggregated, isLoading, isRefreshing, installed, isDemoData, refetch } = useTrivy()
+  const { statuses, aggregated, isLoading, isRefreshing, installed, isDemoData, clustersChecked, totalClusters, refetch } = useTrivy()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
   const [modalCluster, setModalCluster] = useState<string | null>(null)
+
+  /** Whether all clusters have been checked */
+  const allChecked = clustersChecked >= totalClusters && totalClusters > 0
 
   // Filter by selected clusters
   const filtered = useMemo(() => {
@@ -199,8 +202,30 @@ Please proceed step by step.`,
     })
   }
 
+  // Only show full-screen spinner on very first load with zero data
+  if (isLoading && Object.keys(statuses).length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-2">
+        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+        {totalClusters > 0 && (
+          <span className="text-xs text-muted-foreground">
+            Checking clusters... {clustersChecked}/{totalClusters}
+          </span>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-3">
+      {/* Progressive streaming indicator */}
+      {!allChecked && totalClusters > 0 && !isRefreshing && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="w-3 h-3 animate-spin" />
+          <span>Checking clusters... {clustersChecked}/{totalClusters}</span>
+        </div>
+      )}
+
       {/* Install prompt when not detected (only after scanning completes) */}
       {!installed && !isLoading && !isRefreshing && (
         <div className="flex items-start gap-2 p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-xs">
@@ -315,10 +340,13 @@ Please proceed step by step.`,
 // ── Kubescape Security Posture ──────────────────────────────────────────
 
 export function KubescapeScan({ config: _config }: CardConfig) {
-  const { statuses, aggregated, isLoading, isRefreshing, installed, isDemoData, refetch } = useKubescape()
+  const { statuses, aggregated, isLoading, isRefreshing, installed, isDemoData, clustersChecked, totalClusters, refetch } = useKubescape()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
   const [modalCluster, setModalCluster] = useState<string | null>(null)
+
+  /** Whether all clusters have been checked */
+  const allChecked = clustersChecked >= totalClusters && totalClusters > 0
 
   // Filter by selected clusters
   const filtered = useMemo(() => {
@@ -378,8 +406,30 @@ Please proceed step by step.`,
 
   const score = filtered.overallScore
 
+  // Only show full-screen spinner on very first load with zero data
+  if (isLoading && Object.keys(statuses).length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-2">
+        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+        {totalClusters > 0 && (
+          <span className="text-xs text-muted-foreground">
+            Checking clusters... {clustersChecked}/{totalClusters}
+          </span>
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-3">
+      {/* Progressive streaming indicator */}
+      {!allChecked && totalClusters > 0 && !isRefreshing && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="w-3 h-3 animate-spin" />
+          <span>Checking clusters... {clustersChecked}/{totalClusters}</span>
+        </div>
+      )}
+
       {/* Install prompt when not detected (only after scanning completes) */}
       {!installed && !isLoading && !isRefreshing && (
         <div className="flex items-start gap-2 p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-xs">
@@ -544,11 +594,14 @@ Please proceed step by step.`,
 // ── Policy Violations Aggregated ────────────────────────────────────────
 
 export function PolicyViolations({ config: _config }: CardConfig) {
-  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, isDemoData: kyvernoDemoData, installed: kyvernoInstalled, refetch: kyvernoRefetch } = useKyverno()
+  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, isDemoData: kyvernoDemoData, installed: kyvernoInstalled, clustersChecked: kyvernoChecked, totalClusters: kyvernoTotal, refetch: kyvernoRefetch } = useKyverno()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
   const [modalCluster, setModalCluster] = useState<string | null>(null)
   const [selectedViolation, setSelectedViolation] = useState<{ policy: string; count: number; tool: string; clusters: string[] } | null>(null)
+
+  /** Whether all clusters have been checked */
+  const kyvernoAllChecked = kyvernoChecked >= kyvernoTotal && kyvernoTotal > 0
 
   // Aggregate violations from Kyverno reports. Per-policy violation counts are
   // back-populated from PolicyReport results in the hook, but we also use
@@ -614,6 +667,12 @@ export function PolicyViolations({ config: _config }: CardConfig) {
     })
   }
 
+  // Clusters contributing Kyverno data (must be before early returns to satisfy hooks rules)
+  const participatingClusters = useMemo(() =>
+    Object.values(kyvernoStatuses).filter(s => s.installed).map(s => s.cluster),
+    [kyvernoStatuses],
+  )
+
   const hasData = violations.length > 0 || kyvernoDemoData
   useCardLoadingState({ isLoading: kyvernoLoading, hasAnyData: hasData, isDemoData: kyvernoDemoData })
 
@@ -625,7 +684,11 @@ export function PolicyViolations({ config: _config }: CardConfig) {
           <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
             <Loader2 className="w-8 h-8 mb-2 opacity-50 animate-spin" />
             <p className="text-sm">Scanning for policy violations...</p>
-            <p className="text-xs mt-1">Checking Kyverno reports across clusters</p>
+            {kyvernoTotal > 0 ? (
+              <p className="text-xs mt-1">Checking clusters... {kyvernoChecked}/{kyvernoTotal}</p>
+            ) : (
+              <p className="text-xs mt-1">Checking Kyverno reports across clusters</p>
+            )}
           </div>
         </div>
       )
@@ -656,14 +719,16 @@ export function PolicyViolations({ config: _config }: CardConfig) {
     )
   }
 
-  // Clusters contributing Kyverno data
-  const participatingClusters = useMemo(() =>
-    Object.values(kyvernoStatuses).filter(s => s.installed).map(s => s.cluster),
-    [kyvernoStatuses],
-  )
-
   return (
     <div className="space-y-3">
+      {/* Progressive streaming indicator */}
+      {!kyvernoAllChecked && kyvernoTotal > 0 && !kyvernoRefreshing && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="w-3 h-3 animate-spin" />
+          <span>Checking clusters... {kyvernoChecked}/{kyvernoTotal}</span>
+        </div>
+      )}
+
       {/* Participating clusters */}
       {participatingClusters.length > 0 && (
         <div className="flex flex-wrap gap-1">
@@ -738,12 +803,17 @@ export function PolicyViolations({ config: _config }: CardConfig) {
 // ── Compliance Score Gauge ──────────────────────────────────────────────
 
 export function ComplianceScore({ config: _config }: CardConfig) {
-  const { statuses: kubescapeStatuses, aggregated: kubescapeAgg, isLoading: ksLoading, isDemoData: ksDemoData } = useKubescape()
-  const { statuses: kyvernoStatuses, isLoading: kyLoading, isDemoData: kyDemoData } = useKyverno()
+  const { statuses: kubescapeStatuses, aggregated: kubescapeAgg, isLoading: ksLoading, isDemoData: ksDemoData, clustersChecked: ksChecked, totalClusters: ksTotal } = useKubescape()
+  const { statuses: kyvernoStatuses, isLoading: kyLoading, isDemoData: kyDemoData, clustersChecked: kyChecked, totalClusters: kyTotal } = useKyverno()
   const { selectedClusters } = useGlobalFilters()
   const [showBreakdown, setShowBreakdown] = useState(false)
 
   const isLoading = ksLoading || kyLoading
+
+  /** Combined progress: use the slower of the two tools' cluster checks */
+  const totalChecking = Math.max(ksTotal, kyTotal)
+  const minChecked = Math.min(ksChecked, kyChecked)
+  const allChecked = minChecked >= totalChecking && totalChecking > 0
 
   // Compute composite score from available tools
   const { score, breakdown, usingFallback } = useMemo(() => {
@@ -834,6 +904,14 @@ export function ComplianceScore({ config: _config }: CardConfig) {
 
   return (
     <div className="space-y-3">
+      {/* Progressive streaming indicator */}
+      {!allChecked && totalChecking > 0 && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="w-3 h-3 animate-spin" />
+          <span>Checking clusters... {minChecked}/{totalChecking}</span>
+        </div>
+      )}
+
       {/* Participating clusters */}
       {scoreClusters.length > 0 && !isDemoData && (
         <div className="flex flex-wrap gap-1">

--- a/web/src/components/cards/TrestleScan.tsx
+++ b/web/src/components/cards/TrestleScan.tsx
@@ -26,6 +26,8 @@ interface CardConfig {
 const SCORE_GOOD_THRESHOLD = 80
 /** Score threshold for "warning" compliance posture */
 const SCORE_WARNING_THRESHOLD = 60
+/** Minimum content height to prevent layout shift during progressive loading (pixels) */
+const MIN_CONTENT_HEIGHT_PX = 240
 
 /** Troubleshoot mission for Trestle installed but no data */
 const TROUBLESHOOT_MISSION = {
@@ -143,7 +145,7 @@ Please proceed step by step. Start with verifying prerequisites (Python 3.9+, ku
   // Only show full-screen spinner on very first load with zero data
   if (isLoading && Object.keys(statuses).length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full gap-2">
+      <div className="flex flex-col items-center justify-center h-full gap-2" style={{ minHeight: MIN_CONTENT_HEIGHT_PX }}>
         <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
         {totalClusters > 0 && (
           <span className="text-xs text-muted-foreground">
@@ -225,7 +227,7 @@ Please proceed step by step. Start with verifying prerequisites (Python 3.9+, ku
       : 'Critical'
 
   return (
-    <div className="space-y-3 h-full flex flex-col">
+    <div className="space-y-3 h-full flex flex-col" style={{ minHeight: MIN_CONTENT_HEIGHT_PX }}>
       {/* Refresh / streaming progress indicator */}
       {isRefreshing && lastRefresh && (
         <RefreshIndicator isRefreshing={isRefreshing} lastUpdated={lastRefresh} />

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -1,9 +1,11 @@
 /**
  * Hook to fetch Kubescape security posture data from connected clusters.
  *
- * Follows the useCertManager.ts pattern:
- * - Phase 1: CRD existence check per cluster (5s timeout)
+ * Uses parallel cluster checks with progressive streaming:
+ * - Phase 1: CRD/API existence check per cluster (3s timeout)
  * - Phase 2: Fetch ConfigurationScanSummaries from installed clusters (15s timeout)
+ * - All clusters checked in parallel via Promise.allSettled
+ * - Results stream to the card as each cluster completes
  * - localStorage cache with auto-refresh
  * - Demo fallback when no clusters are connected
  */
@@ -20,8 +22,8 @@ const REFRESH_INTERVAL_MS = 120_000
 /** Cache TTL: 2 minutes — matches refresh interval */
 const CACHE_TTL_MS = 120_000
 
-/** Timeout for CRD existence check */
-const CRD_CHECK_TIMEOUT_MS = 5_000
+/** Timeout for CRD/API existence check (fast — missing resources fail instantly) */
+const CRD_CHECK_TIMEOUT_MS = 3_000
 
 /** Timeout for data fetch */
 const DATA_FETCH_TIMEOUT_MS = 15_000
@@ -140,6 +142,158 @@ interface WorkloadConfigScanResource {
   }
 }
 
+// ── Single-cluster fetch (used in parallel) ──────────────────────────────
+
+function emptyStatus(cluster: string, installed: boolean, error?: string): KubescapeClusterStatus {
+  return {
+    cluster, installed, loading: false, error,
+    overallScore: 0, frameworks: [], controls: [],
+    totalControls: 0, passedControls: 0, failedControls: 0,
+  }
+}
+
+async function fetchSingleCluster(cluster: string): Promise<KubescapeClusterStatus> {
+  try {
+    // Phase 1: API resource check — Kubescape uses workloadconfigurationscansummaries
+    // Note: Kubescape Operator serves these via API aggregation (storage pod),
+    // not as standard CRDs, so we check API availability instead of CRD existence.
+    const apiCheck = await kubectlProxy.exec(
+      ['api-resources', '--api-group=spdx.softwarecomposition.kubescape.io', '-o', 'name'],
+      { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
+    )
+
+    const hasKubescapeApi = apiCheck.exitCode === 0 &&
+      (apiCheck.output || '').includes('workloadconfigurationscansummaries')
+
+    if (!hasKubescapeApi) {
+      // Fallback: try traditional CRD check (some installations use standard CRDs)
+      const crdCheck = await kubectlProxy.exec(
+        ['get', 'crd', 'workloadconfigurationscansummaries.spdx.softwarecomposition.kubescape.io', '-o', 'name'],
+        { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
+      )
+
+      if (crdCheck.exitCode !== 0) {
+        return emptyStatus(cluster, false)
+      }
+    }
+
+    // Phase 2: Fetch workload configuration scan summaries
+    let totalControls = 0
+    let passedControls = 0
+    let failedControls = 0
+
+    const scanResult = await kubectlProxy.exec(
+      ['get', 'workloadconfigurationscansummaries', '-A', '-o', 'json'],
+      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+    )
+
+    if (scanResult.exitCode === 0 && scanResult.output) {
+      const data = JSON.parse(scanResult.output)
+      const items = (data.items || []) as ConfigScanSummaryResource[]
+
+      for (const item of (items || [])) {
+        const sevs = item.spec?.severities || {}
+        const itemFails = (sevs.critical || 0) + (sevs.high || 0) + (sevs.medium || 0) + (sevs.low || 0)
+        failedControls += itemFails
+        // Each workload summary represents scanned controls
+        totalControls += itemFails + 1 // at least 1 passed per workload
+        passedControls += 1
+      }
+    }
+
+    // Try to fetch detailed control scan data for framework breakdown
+    const frameworks: KubescapeFrameworkScore[] = []
+    const controlResults = new Map<string, { name: string; passed: number; failed: number }>()
+    const detailResult = await kubectlProxy.exec(
+      ['get', 'workloadconfigurationscans', '-A', '-o', 'json', '--limit=50'],
+      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+    )
+
+    if (detailResult.exitCode === 0 && detailResult.output) {
+      const data = JSON.parse(detailResult.output)
+      const items = (data.items || []) as WorkloadConfigScanResource[]
+
+      // Aggregate control results with names
+      for (const item of (items || [])) {
+        for (const [controlId, control] of Object.entries(item.spec?.controls || {})) {
+          if (!controlResults.has(controlId)) {
+            controlResults.set(controlId, { name: control.name || controlId, passed: 0, failed: 0 })
+          }
+          const entry = controlResults.get(controlId)!
+          // Update name if we find a non-empty one
+          if (control.name && entry.name === controlId) {
+            entry.name = control.name
+          }
+          if (control.status?.status === 'passed') {
+            entry.passed++
+          } else {
+            entry.failed++
+          }
+        }
+      }
+
+      // Use total controls for overall score
+      if (controlResults.size > 0) {
+        totalControls = controlResults.size
+        passedControls = 0
+        failedControls = 0
+        for (const result of controlResults.values()) {
+          if (result.passed > result.failed) {
+            passedControls++
+          } else {
+            failedControls++
+          }
+        }
+      }
+    }
+
+    const overallScore = totalControls > 0
+      ? Math.round((passedControls / totalControls) * 100)
+      : 0
+
+    // Build framework scores if we don't have detailed data
+    if (frameworks.length === 0 && totalControls > 0) {
+      // Derive approximate framework scores from overall
+      frameworks.push(
+        { name: 'NSA-CISA', score: Math.min(100, overallScore + 4), passCount: passedControls, failCount: failedControls },
+        { name: 'MITRE ATT&CK', score: Math.max(0, overallScore - 3), passCount: passedControls, failCount: failedControls },
+        { name: 'CIS Benchmark', score: Math.min(100, overallScore + 1), passCount: passedControls, failCount: failedControls },
+      )
+    }
+
+    // Build per-control detail array from aggregated results
+    const controls: KubescapeControl[] = []
+    if (detailResult.exitCode === 0 && controlResults.size > 0) {
+      for (const [id, result] of controlResults.entries()) {
+        controls.push({ id, name: result.name, passed: result.passed, failed: result.failed })
+      }
+      // Sort failed-first for drill-down priority
+      controls.sort((a, b) => b.failed - a.failed)
+    }
+
+    return {
+      cluster,
+      installed: true,
+      loading: false,
+      overallScore,
+      frameworks,
+      totalControls,
+      passedControls,
+      failedControls,
+      controls,
+    }
+  } catch (err) {
+    const isDemoError = err instanceof Error && err.message.includes('demo mode')
+    if (!isDemoError) {
+      console.error(`[useKubescape] Error fetching from ${cluster}:`, err)
+    }
+    return emptyStatus(
+      cluster, false,
+      err instanceof Error ? err.message : 'Connection failed'
+    )
+  }
+}
+
 // ── Hook ─────────────────────────────────────────────────────────────────
 
 export function useKubescape() {
@@ -155,6 +309,8 @@ export function useKubescape() {
   const [lastRefresh, setLastRefresh] = useState<Date | null>(
     cachedData.current?.timestamp ? new Date(cachedData.current.timestamp) : null
   )
+  /** Number of clusters that have completed checking (for progressive UI) */
+  const [clustersChecked, setClustersChecked] = useState(0)
   const initialLoadDone = useRef(!!cachedData.current)
   /** Guard to prevent concurrent refetch calls from flooding the request queue */
   const fetchInProgress = useRef(false)
@@ -179,171 +335,29 @@ export function useKubescape() {
       setIsRefreshing(true)
       if (!initialLoadDone.current) setIsLoading(true)
     }
+    setClustersChecked(0)
 
-    const newStatuses: Record<string, KubescapeClusterStatus> = {}
+    // Check all clusters in parallel, stream results progressively
+    const allStatuses: Record<string, KubescapeClusterStatus> = {}
 
-    for (const cluster of (clusters || [])) {
-      try {
-        // Phase 1: API resource check — Kubescape uses workloadconfigurationscansummaries
-        // Note: Kubescape Operator serves these via API aggregation (storage pod),
-        // not as standard CRDs, so we check API availability instead of CRD existence.
-        const apiCheck = await kubectlProxy.exec(
-          ['api-resources', '--api-group=spdx.softwarecomposition.kubescape.io', '-o', 'name'],
-          { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
-        )
-
-        const hasKubescapeApi = apiCheck.exitCode === 0 &&
-          (apiCheck.output || '').includes('workloadconfigurationscansummaries')
-
-        if (!hasKubescapeApi) {
-          // Fallback: try traditional CRD check (some installations use standard CRDs)
-          const crdCheck = await kubectlProxy.exec(
-            ['get', 'crd', 'workloadconfigurationscansummaries.spdx.softwarecomposition.kubescape.io', '-o', 'name'],
-            { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
-          )
-
-          if (crdCheck.exitCode !== 0) {
-            newStatuses[cluster] = {
-              cluster, installed: false, loading: false,
-              overallScore: 0, frameworks: [], controls: [],
-              totalControls: 0, passedControls: 0, failedControls: 0,
-            }
-            // Progressive update — show not-installed immediately
-            setStatuses(prev => ({ ...prev, [cluster]: newStatuses[cluster] }))
-            continue
-          }
+    const promises = (clusters || []).map(cluster =>
+      fetchSingleCluster(cluster).then(status => {
+        allStatuses[cluster] = status
+        // Stream each result immediately — card re-renders progressively
+        setStatuses(prev => ({ ...prev, [cluster]: status }))
+        setClustersChecked(prev => prev + 1)
+        // Clear loading state once first cluster with data arrives
+        if (!initialLoadDone.current && status.installed) {
+          initialLoadDone.current = true
+          setIsLoading(false)
         }
+      })
+    )
 
-        // Phase 2: Fetch workload configuration scan summaries
-        let totalControls = 0
-        let passedControls = 0
-        let failedControls = 0
-
-        const scanResult = await kubectlProxy.exec(
-          ['get', 'workloadconfigurationscansummaries', '-A', '-o', 'json'],
-          { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
-        )
-
-        if (scanResult.exitCode === 0 && scanResult.output) {
-          const data = JSON.parse(scanResult.output)
-          const items = (data.items || []) as ConfigScanSummaryResource[]
-
-          for (const item of (items || [])) {
-            const sevs = item.spec?.severities || {}
-            const itemFails = (sevs.critical || 0) + (sevs.high || 0) + (sevs.medium || 0) + (sevs.low || 0)
-            failedControls += itemFails
-            // Each workload summary represents scanned controls
-            totalControls += itemFails + 1 // at least 1 passed per workload
-            passedControls += 1
-          }
-        }
-
-        // Try to fetch detailed control scan data for framework breakdown
-        const frameworks: KubescapeFrameworkScore[] = []
-        const controlResults = new Map<string, { name: string; passed: number; failed: number }>()
-        const detailResult = await kubectlProxy.exec(
-          ['get', 'workloadconfigurationscans', '-A', '-o', 'json', '--limit=50'],
-          { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
-        )
-
-        if (detailResult.exitCode === 0 && detailResult.output) {
-          const data = JSON.parse(detailResult.output)
-          const items = (data.items || []) as WorkloadConfigScanResource[]
-
-          // Aggregate control results with names
-          for (const item of (items || [])) {
-            for (const [controlId, control] of Object.entries(item.spec?.controls || {})) {
-              if (!controlResults.has(controlId)) {
-                controlResults.set(controlId, { name: control.name || controlId, passed: 0, failed: 0 })
-              }
-              const entry = controlResults.get(controlId)!
-              // Update name if we find a non-empty one
-              if (control.name && entry.name === controlId) {
-                entry.name = control.name
-              }
-              if (control.status?.status === 'passed') {
-                entry.passed++
-              } else {
-                entry.failed++
-              }
-            }
-          }
-
-          // Use total controls for overall score
-          if (controlResults.size > 0) {
-            totalControls = controlResults.size
-            passedControls = 0
-            failedControls = 0
-            for (const result of controlResults.values()) {
-              if (result.passed > result.failed) {
-                passedControls++
-              } else {
-                failedControls++
-              }
-            }
-          }
-        }
-
-        const overallScore = totalControls > 0
-          ? Math.round((passedControls / totalControls) * 100)
-          : 0
-
-        // Build framework scores if we don't have detailed data
-        if (frameworks.length === 0 && totalControls > 0) {
-          // Derive approximate framework scores from overall
-          frameworks.push(
-            { name: 'NSA-CISA', score: Math.min(100, overallScore + 4), passCount: passedControls, failCount: failedControls },
-            { name: 'MITRE ATT&CK', score: Math.max(0, overallScore - 3), passCount: passedControls, failCount: failedControls },
-            { name: 'CIS Benchmark', score: Math.min(100, overallScore + 1), passCount: passedControls, failCount: failedControls },
-          )
-        }
-
-        // Build per-control detail array from aggregated results
-        const controls: KubescapeControl[] = []
-        if (detailResult.exitCode === 0 && controlResults.size > 0) {
-          for (const [id, result] of controlResults.entries()) {
-            controls.push({ id, name: result.name, passed: result.passed, failed: result.failed })
-          }
-          // Sort failed-first for drill-down priority
-          controls.sort((a, b) => b.failed - a.failed)
-        }
-
-        newStatuses[cluster] = {
-          cluster,
-          installed: true,
-          loading: false,
-          overallScore,
-          frameworks,
-          totalControls,
-          passedControls,
-          failedControls,
-          controls,
-        }
-      } catch (err) {
-        const isDemoError = err instanceof Error && err.message.includes('demo mode')
-        if (!isDemoError) {
-          console.error(`[useKubescape] Error fetching from ${cluster}:`, err)
-        }
-        newStatuses[cluster] = {
-          cluster, installed: false, loading: false,
-          error: err instanceof Error ? err.message : 'Connection failed',
-          overallScore: 0, frameworks: [], controls: [],
-          totalControls: 0, passedControls: 0, failedControls: 0,
-        }
-      }
-
-      // Progressive update: stream each cluster's data to the UI as it arrives
-      setStatuses(prev => ({ ...prev, [cluster]: newStatuses[cluster] }))
-
-      // Clear loading state once first cluster with data arrives
-      if (!initialLoadDone.current && newStatuses[cluster].installed) {
-        initialLoadDone.current = true
-        setIsLoading(false)
-      }
-    }
+    await Promise.allSettled(promises)
 
     // Final: save complete cache and clear refresh state
-    saveToCache(newStatuses)
+    saveToCache(allStatuses)
     setLastRefresh(new Date())
     initialLoadDone.current = true
     setIsLoading(false)
@@ -364,6 +378,7 @@ export function useKubescape() {
         demoStatuses[name] = getDemoStatus(name)
       }
       setStatuses(demoStatuses)
+      setClustersChecked(demoNames.length)
       setIsLoading(false)
       setLastRefresh(new Date())
       initialLoadDone.current = true
@@ -415,6 +430,10 @@ export function useKubescape() {
     lastRefresh,
     installed,
     isDemoData,
+    /** Number of clusters checked so far (for progressive UI) */
+    clustersChecked,
+    /** Total number of clusters being checked */
+    totalClusters: clusters.length,
     refetch,
   }
 }

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -1,9 +1,11 @@
 /**
  * Hook to fetch Kyverno policy data from connected clusters.
  *
- * Follows the useCertManager.ts pattern:
- * - Phase 1: CRD existence check per cluster (5s timeout)
+ * Uses parallel cluster checks with progressive streaming:
+ * - Phase 1: CRD existence check per cluster (3s timeout)
  * - Phase 2: Fetch policies/reports from installed clusters (15s timeout)
+ * - All clusters checked in parallel via Promise.allSettled
+ * - Results stream to the card as each cluster completes
  * - localStorage cache with auto-refresh
  * - Demo fallback when no clusters are connected
  */
@@ -20,8 +22,8 @@ const REFRESH_INTERVAL_MS = 120_000
 /** Cache TTL: 2 minutes — matches refresh interval */
 const CACHE_TTL_MS = 120_000
 
-/** Timeout for CRD existence check */
-const CRD_CHECK_TIMEOUT_MS = 5_000
+/** Timeout for CRD existence check (fast — missing resources fail instantly) */
+const CRD_CHECK_TIMEOUT_MS = 3_000
 
 /** Timeout for data fetch */
 const DATA_FETCH_TIMEOUT_MS = 15_000
@@ -156,6 +158,165 @@ interface PolicyReportResource {
   results?: PolicyReportResult[]
 }
 
+// ── Empty status helper ──────────────────────────────────────────────────
+
+function emptyStatus(cluster: string, installed: boolean, error?: string): KyvernoClusterStatus {
+  return {
+    cluster, installed, loading: false, error, policies: [], reports: [],
+    totalPolicies: 0, totalViolations: 0, enforcingCount: 0, auditCount: 0,
+  }
+}
+
+// ── Single-cluster fetch (used in parallel) ──────────────────────────────
+
+async function fetchSingleCluster(cluster: string): Promise<KyvernoClusterStatus> {
+  try {
+    // Phase 1: CRD check
+    const crdCheck = await kubectlProxy.exec(
+      ['get', 'crd', 'clusterpolicies.kyverno.io', '-o', 'name'],
+      { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
+    )
+
+    if (crdCheck.exitCode !== 0) {
+      return emptyStatus(cluster, false)
+    }
+
+    // Phase 2: Fetch ClusterPolicies
+    const policies: KyvernoPolicy[] = []
+
+    const cpResult = await kubectlProxy.exec(
+      ['get', 'clusterpolicies', '-o', 'json'],
+      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+    )
+
+    if (cpResult.exitCode === 0 && cpResult.output) {
+      const data = JSON.parse(cpResult.output)
+      for (const item of (data.items || []) as KyvernoPolicyResource[]) {
+        const action = (item.spec.validationFailureAction || 'Audit').toLowerCase()
+        policies.push({
+          name: item.metadata.name,
+          kind: 'ClusterPolicy',
+          cluster,
+          category: item.metadata.annotations?.['policies.kyverno.io/category'] || 'Other',
+          status: action === 'enforce' ? 'enforcing' : 'audit',
+          violations: 0, // Will be populated from reports
+          description: item.metadata.annotations?.['policies.kyverno.io/description'] || '',
+          background: item.spec.background !== false,
+        })
+      }
+    }
+
+    // Fetch namespaced Policies
+    const pResult = await kubectlProxy.exec(
+      ['get', 'policies', '-A', '-o', 'json'],
+      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+    )
+
+    if (pResult.exitCode === 0 && pResult.output) {
+      const data = JSON.parse(pResult.output)
+      for (const item of (data.items || []) as KyvernoPolicyResource[]) {
+        const action = (item.spec.validationFailureAction || 'Audit').toLowerCase()
+        policies.push({
+          name: item.metadata.name,
+          kind: 'Policy',
+          namespace: item.metadata.namespace,
+          cluster,
+          category: item.metadata.annotations?.['policies.kyverno.io/category'] || 'Other',
+          status: action === 'enforce' ? 'enforcing' : 'audit',
+          violations: 0,
+          description: item.metadata.annotations?.['policies.kyverno.io/description'] || '',
+          background: item.spec.background !== false,
+        })
+      }
+    }
+
+    // Fetch PolicyReports for violation counts
+    const reports: KyvernoPolicyReport[] = []
+    const reportResult = await kubectlProxy.exec(
+      ['get', 'policyreports', '-A', '-o', 'json'],
+      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+    )
+
+    let totalViolations = 0
+    if (reportResult.exitCode === 0 && reportResult.output) {
+      const data = JSON.parse(reportResult.output)
+      for (const item of (data.items || []) as PolicyReportResource[]) {
+        const summary = item.summary || { pass: 0, fail: 0, warn: 0, error: 0, skip: 0 }
+        reports.push({
+          name: item.metadata.name,
+          namespace: item.metadata.namespace,
+          cluster,
+          pass: summary.pass,
+          fail: summary.fail,
+          warn: summary.warn,
+          error: summary.error,
+          skip: summary.skip,
+        })
+        totalViolations += summary.fail
+
+        // Back-populate per-policy violation counts from report results
+        if (item.results) {
+          for (const result of (item.results || [])) {
+            if (result.result === 'fail' && result.policy) {
+              const matchingPolicy = policies.find(p => p.name === result.policy)
+              if (matchingPolicy) {
+                matchingPolicy.violations += 1
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Also check ClusterPolicyReports
+    const clusterReportResult = await kubectlProxy.exec(
+      ['get', 'clusterpolicyreports', '-o', 'json'],
+      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+    )
+
+    if (clusterReportResult.exitCode === 0 && clusterReportResult.output) {
+      const data = JSON.parse(clusterReportResult.output)
+      for (const item of (data.items || []) as PolicyReportResource[]) {
+        const summary = item.summary || { pass: 0, fail: 0, warn: 0, error: 0, skip: 0 }
+        totalViolations += summary.fail
+
+        // Back-populate per-policy violation counts from cluster report results
+        if (item.results) {
+          for (const result of (item.results || [])) {
+            if (result.result === 'fail' && result.policy) {
+              const matchingPolicy = policies.find(p => p.name === result.policy)
+              if (matchingPolicy) {
+                matchingPolicy.violations += 1
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return {
+      cluster,
+      installed: true,
+      loading: false,
+      policies,
+      reports,
+      totalPolicies: policies.length,
+      totalViolations,
+      enforcingCount: policies.filter(p => p.status === 'enforcing').length,
+      auditCount: policies.filter(p => p.status === 'audit').length,
+    }
+  } catch (err) {
+    const isDemoError = err instanceof Error && err.message.includes('demo mode')
+    if (!isDemoError) {
+      console.error(`[useKyverno] Error fetching from ${cluster}:`, err)
+    }
+    return emptyStatus(
+      cluster, false,
+      err instanceof Error ? err.message : 'Connection failed'
+    )
+  }
+}
+
 // ── Hook ─────────────────────────────────────────────────────────────────
 
 export function useKyverno() {
@@ -171,6 +332,8 @@ export function useKyverno() {
   const [lastRefresh, setLastRefresh] = useState<Date | null>(
     cachedData.current?.timestamp ? new Date(cachedData.current.timestamp) : null
   )
+  /** Number of clusters that have completed checking (for progressive UI) */
+  const [clustersChecked, setClustersChecked] = useState(0)
   const initialLoadDone = useRef(!!cachedData.current)
   /** Guard to prevent concurrent refetch calls from flooding the request queue */
   const fetchInProgress = useRef(false)
@@ -195,176 +358,29 @@ export function useKyverno() {
       setIsRefreshing(true)
       if (!initialLoadDone.current) setIsLoading(true)
     }
+    setClustersChecked(0)
 
-    const newStatuses: Record<string, KyvernoClusterStatus> = {}
+    // Check all clusters in parallel, stream results progressively
+    const allStatuses: Record<string, KyvernoClusterStatus> = {}
 
-    for (const cluster of (clusters || [])) {
-      try {
-        // Phase 1: CRD check
-        const crdCheck = await kubectlProxy.exec(
-          ['get', 'crd', 'clusterpolicies.kyverno.io', '-o', 'name'],
-          { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
-        )
-
-        if (crdCheck.exitCode !== 0) {
-          newStatuses[cluster] = {
-            cluster, installed: false, loading: false, policies: [], reports: [],
-            totalPolicies: 0, totalViolations: 0, enforcingCount: 0, auditCount: 0,
-          }
-          // Progressive update — show not-installed immediately
-          setStatuses(prev => ({ ...prev, [cluster]: newStatuses[cluster] }))
-          continue
+    const promises = (clusters || []).map(cluster =>
+      fetchSingleCluster(cluster).then(status => {
+        allStatuses[cluster] = status
+        // Stream each result immediately — card re-renders progressively
+        setStatuses(prev => ({ ...prev, [cluster]: status }))
+        setClustersChecked(prev => prev + 1)
+        // Clear loading state once first cluster with data arrives
+        if (!initialLoadDone.current && status.installed) {
+          initialLoadDone.current = true
+          setIsLoading(false)
         }
+      })
+    )
 
-        // Phase 2: Fetch ClusterPolicies
-        const policies: KyvernoPolicy[] = []
-
-        const cpResult = await kubectlProxy.exec(
-          ['get', 'clusterpolicies', '-o', 'json'],
-          { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
-        )
-
-        if (cpResult.exitCode === 0 && cpResult.output) {
-          const data = JSON.parse(cpResult.output)
-          for (const item of (data.items || []) as KyvernoPolicyResource[]) {
-            const action = (item.spec.validationFailureAction || 'Audit').toLowerCase()
-            policies.push({
-              name: item.metadata.name,
-              kind: 'ClusterPolicy',
-              cluster,
-              category: item.metadata.annotations?.['policies.kyverno.io/category'] || 'Other',
-              status: action === 'enforce' ? 'enforcing' : 'audit',
-              violations: 0, // Will be populated from reports
-              description: item.metadata.annotations?.['policies.kyverno.io/description'] || '',
-              background: item.spec.background !== false,
-            })
-          }
-        }
-
-        // Fetch namespaced Policies
-        const pResult = await kubectlProxy.exec(
-          ['get', 'policies', '-A', '-o', 'json'],
-          { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
-        )
-
-        if (pResult.exitCode === 0 && pResult.output) {
-          const data = JSON.parse(pResult.output)
-          for (const item of (data.items || []) as KyvernoPolicyResource[]) {
-            const action = (item.spec.validationFailureAction || 'Audit').toLowerCase()
-            policies.push({
-              name: item.metadata.name,
-              kind: 'Policy',
-              namespace: item.metadata.namespace,
-              cluster,
-              category: item.metadata.annotations?.['policies.kyverno.io/category'] || 'Other',
-              status: action === 'enforce' ? 'enforcing' : 'audit',
-              violations: 0,
-              description: item.metadata.annotations?.['policies.kyverno.io/description'] || '',
-              background: item.spec.background !== false,
-            })
-          }
-        }
-
-        // Fetch PolicyReports for violation counts
-        const reports: KyvernoPolicyReport[] = []
-        const reportResult = await kubectlProxy.exec(
-          ['get', 'policyreports', '-A', '-o', 'json'],
-          { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
-        )
-
-        let totalViolations = 0
-        if (reportResult.exitCode === 0 && reportResult.output) {
-          const data = JSON.parse(reportResult.output)
-          for (const item of (data.items || []) as PolicyReportResource[]) {
-            const summary = item.summary || { pass: 0, fail: 0, warn: 0, error: 0, skip: 0 }
-            reports.push({
-              name: item.metadata.name,
-              namespace: item.metadata.namespace,
-              cluster,
-              pass: summary.pass,
-              fail: summary.fail,
-              warn: summary.warn,
-              error: summary.error,
-              skip: summary.skip,
-            })
-            totalViolations += summary.fail
-
-            // Back-populate per-policy violation counts from report results
-            if (item.results) {
-              for (const result of (item.results || [])) {
-                if (result.result === 'fail' && result.policy) {
-                  const matchingPolicy = policies.find(p => p.name === result.policy)
-                  if (matchingPolicy) {
-                    matchingPolicy.violations += 1
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        // Also check ClusterPolicyReports
-        const clusterReportResult = await kubectlProxy.exec(
-          ['get', 'clusterpolicyreports', '-o', 'json'],
-          { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
-        )
-
-        if (clusterReportResult.exitCode === 0 && clusterReportResult.output) {
-          const data = JSON.parse(clusterReportResult.output)
-          for (const item of (data.items || []) as PolicyReportResource[]) {
-            const summary = item.summary || { pass: 0, fail: 0, warn: 0, error: 0, skip: 0 }
-            totalViolations += summary.fail
-
-            // Back-populate per-policy violation counts from cluster report results
-            if (item.results) {
-              for (const result of (item.results || [])) {
-                if (result.result === 'fail' && result.policy) {
-                  const matchingPolicy = policies.find(p => p.name === result.policy)
-                  if (matchingPolicy) {
-                    matchingPolicy.violations += 1
-                  }
-                }
-              }
-            }
-          }
-        }
-
-        newStatuses[cluster] = {
-          cluster,
-          installed: true,
-          loading: false,
-          policies,
-          reports,
-          totalPolicies: policies.length,
-          totalViolations,
-          enforcingCount: policies.filter(p => p.status === 'enforcing').length,
-          auditCount: policies.filter(p => p.status === 'audit').length,
-        }
-      } catch (err) {
-        const isDemoError = err instanceof Error && err.message.includes('demo mode')
-        if (!isDemoError) {
-          console.error(`[useKyverno] Error fetching from ${cluster}:`, err)
-        }
-        newStatuses[cluster] = {
-          cluster, installed: false, loading: false,
-          error: err instanceof Error ? err.message : 'Connection failed',
-          policies: [], reports: [],
-          totalPolicies: 0, totalViolations: 0, enforcingCount: 0, auditCount: 0,
-        }
-      }
-
-      // Progressive update: stream each cluster's data to the UI as it arrives
-      setStatuses(prev => ({ ...prev, [cluster]: newStatuses[cluster] }))
-
-      // Clear loading state once first cluster with data arrives
-      if (!initialLoadDone.current && newStatuses[cluster].installed) {
-        initialLoadDone.current = true
-        setIsLoading(false)
-      }
-    }
+    await Promise.allSettled(promises)
 
     // Final: save complete cache and clear refresh state
-    saveToCache(newStatuses)
+    saveToCache(allStatuses)
     setLastRefresh(new Date())
     initialLoadDone.current = true
     setIsLoading(false)
@@ -385,6 +401,7 @@ export function useKyverno() {
         demoStatuses[name] = getDemoStatus(name)
       }
       setStatuses(demoStatuses)
+      setClustersChecked(demoNames.length)
       setIsLoading(false)
       setLastRefresh(new Date())
       initialLoadDone.current = true
@@ -419,6 +436,10 @@ export function useKyverno() {
     lastRefresh,
     installed,
     isDemoData,
+    /** Number of clusters checked so far (for progressive UI) */
+    clustersChecked,
+    /** Total number of clusters being checked */
+    totalClusters: clusters.length,
     refetch,
   }
 }

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -1,9 +1,11 @@
 /**
  * Hook to fetch Trivy Operator vulnerability data from connected clusters.
  *
- * Follows the useCertManager.ts pattern:
- * - Phase 1: CRD existence check per cluster (5s timeout)
+ * Uses parallel cluster checks with progressive streaming:
+ * - Phase 1: CRD existence check per cluster (3s timeout)
  * - Phase 2: Fetch VulnerabilityReports from installed clusters (15s timeout)
+ * - All clusters checked in parallel via Promise.allSettled
+ * - Results stream to the card as each cluster completes
  * - localStorage cache with auto-refresh
  * - Demo fallback when no clusters are connected
  */
@@ -20,8 +22,8 @@ const REFRESH_INTERVAL_MS = 120_000
 /** Cache TTL: 2 minutes — matches refresh interval */
 const CACHE_TTL_MS = 120_000
 
-/** Timeout for CRD existence check */
-const CRD_CHECK_TIMEOUT_MS = 5_000
+/** Timeout for CRD existence check (fast — missing resources fail instantly) */
+const CRD_CHECK_TIMEOUT_MS = 3_000
 
 /** Timeout for data fetch */
 const DATA_FETCH_TIMEOUT_MS = 15_000
@@ -136,6 +138,93 @@ interface VulnerabilityReportResource {
   }
 }
 
+// ── Single-cluster fetch (used in parallel) ──────────────────────────────
+
+async function fetchSingleCluster(cluster: string): Promise<TrivyClusterStatus> {
+  try {
+    // Phase 1: CRD check
+    const crdCheck = await kubectlProxy.exec(
+      ['get', 'crd', 'vulnerabilityreports.aquasecurity.github.io', '-o', 'name'],
+      { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
+    )
+
+    if (crdCheck.exitCode !== 0) {
+      return {
+        cluster, installed: false, loading: false,
+        vulnerabilities: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
+        totalReports: 0, scannedImages: 0, images: [],
+      }
+    }
+
+    // Phase 2: Fetch VulnerabilityReports
+    const result = await kubectlProxy.exec(
+      ['get', 'vulnerabilityreports', '-A', '-o', 'json'],
+      { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
+    )
+
+    const summary: TrivyVulnSummary = { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 }
+    let totalReports = 0
+    const imageSet = new Set<string>()
+    const imageReports: TrivyImageReport[] = []
+
+    if (result.exitCode === 0 && result.output) {
+      const data = JSON.parse(result.output)
+      const items = (data.items || []) as VulnerabilityReportResource[]
+      totalReports = items.length
+
+      for (const item of (items || [])) {
+        const repo = item.report?.artifact?.repository || ''
+        const tag = item.report?.artifact?.tag || 'latest'
+        const ns = item.metadata?.namespace || 'default'
+        if (repo) imageSet.add(repo)
+
+        const crit = item.report?.summary?.criticalCount || 0
+        const high = item.report?.summary?.highCount || 0
+        const med = item.report?.summary?.mediumCount || 0
+        const low = item.report?.summary?.lowCount || 0
+
+        if (item.report?.summary) {
+          summary.critical += crit
+          summary.high += high
+          summary.medium += med
+          summary.low += low
+          summary.unknown += item.report.summary.unknownCount || 0
+        }
+
+        // Collect per-image data for drill-down
+        if (repo) {
+          imageReports.push({ image: repo, tag, namespace: ns, critical: crit, high, medium: med, low })
+        }
+      }
+    }
+
+    // Sort by severity (critical+high desc) and limit to top N
+    imageReports.sort((a, b) => (b.critical + b.high) - (a.critical + a.high))
+    const topImages = imageReports.slice(0, MAX_IMAGES_PER_CLUSTER)
+
+    return {
+      cluster,
+      installed: true,
+      loading: false,
+      vulnerabilities: summary,
+      totalReports,
+      scannedImages: imageSet.size,
+      images: topImages,
+    }
+  } catch (err) {
+    const isDemoError = err instanceof Error && err.message.includes('demo mode')
+    if (!isDemoError) {
+      console.error(`[useTrivy] Error fetching from ${cluster}:`, err)
+    }
+    return {
+      cluster, installed: false, loading: false,
+      error: err instanceof Error ? err.message : 'Connection failed',
+      vulnerabilities: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
+      totalReports: 0, scannedImages: 0, images: [],
+    }
+  }
+}
+
 // ── Hook ─────────────────────────────────────────────────────────────────
 
 export function useTrivy() {
@@ -151,6 +240,8 @@ export function useTrivy() {
   const [lastRefresh, setLastRefresh] = useState<Date | null>(
     cachedData.current?.timestamp ? new Date(cachedData.current.timestamp) : null
   )
+  /** Number of clusters that have completed checking (for progressive UI) */
+  const [clustersChecked, setClustersChecked] = useState(0)
   const initialLoadDone = useRef(!!cachedData.current)
   /** Guard to prevent concurrent refetch calls from flooding the request queue */
   const fetchInProgress = useRef(false)
@@ -175,108 +266,29 @@ export function useTrivy() {
       setIsRefreshing(true)
       if (!initialLoadDone.current) setIsLoading(true)
     }
+    setClustersChecked(0)
 
-    const newStatuses: Record<string, TrivyClusterStatus> = {}
+    // Check all clusters in parallel, stream results progressively
+    const allStatuses: Record<string, TrivyClusterStatus> = {}
 
-    for (const cluster of (clusters || [])) {
-      try {
-        // Phase 1: CRD check
-        const crdCheck = await kubectlProxy.exec(
-          ['get', 'crd', 'vulnerabilityreports.aquasecurity.github.io', '-o', 'name'],
-          { context: cluster, timeout: CRD_CHECK_TIMEOUT_MS }
-        )
-
-        if (crdCheck.exitCode !== 0) {
-          newStatuses[cluster] = {
-            cluster, installed: false, loading: false,
-            vulnerabilities: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
-            totalReports: 0, scannedImages: 0, images: [],
-          }
-          // Progressive update — show not-installed immediately
-          setStatuses(prev => ({ ...prev, [cluster]: newStatuses[cluster] }))
-          continue
+    const promises = (clusters || []).map(cluster =>
+      fetchSingleCluster(cluster).then(status => {
+        allStatuses[cluster] = status
+        // Stream each result immediately — card re-renders progressively
+        setStatuses(prev => ({ ...prev, [cluster]: status }))
+        setClustersChecked(prev => prev + 1)
+        // Clear loading state once first cluster with data arrives
+        if (!initialLoadDone.current && status.installed) {
+          initialLoadDone.current = true
+          setIsLoading(false)
         }
+      })
+    )
 
-        // Phase 2: Fetch VulnerabilityReports
-        const result = await kubectlProxy.exec(
-          ['get', 'vulnerabilityreports', '-A', '-o', 'json'],
-          { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
-        )
-
-        const summary: TrivyVulnSummary = { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 }
-        let totalReports = 0
-        const imageSet = new Set<string>()
-        const imageReports: TrivyImageReport[] = []
-
-        if (result.exitCode === 0 && result.output) {
-          const data = JSON.parse(result.output)
-          const items = (data.items || []) as VulnerabilityReportResource[]
-          totalReports = items.length
-
-          for (const item of (items || [])) {
-            const repo = item.report?.artifact?.repository || ''
-            const tag = item.report?.artifact?.tag || 'latest'
-            const ns = item.metadata?.namespace || 'default'
-            if (repo) imageSet.add(repo)
-
-            const crit = item.report?.summary?.criticalCount || 0
-            const high = item.report?.summary?.highCount || 0
-            const med = item.report?.summary?.mediumCount || 0
-            const low = item.report?.summary?.lowCount || 0
-
-            if (item.report?.summary) {
-              summary.critical += crit
-              summary.high += high
-              summary.medium += med
-              summary.low += low
-              summary.unknown += item.report.summary.unknownCount || 0
-            }
-
-            // Collect per-image data for drill-down
-            if (repo) {
-              imageReports.push({ image: repo, tag, namespace: ns, critical: crit, high, medium: med, low })
-            }
-          }
-        }
-
-        // Sort by severity (critical+high desc) and limit to top N
-        imageReports.sort((a, b) => (b.critical + b.high) - (a.critical + a.high))
-        const topImages = imageReports.slice(0, MAX_IMAGES_PER_CLUSTER)
-
-        newStatuses[cluster] = {
-          cluster,
-          installed: true,
-          loading: false,
-          vulnerabilities: summary,
-          totalReports,
-          scannedImages: imageSet.size,
-          images: topImages,
-        }
-      } catch (err) {
-        const isDemoError = err instanceof Error && err.message.includes('demo mode')
-        if (!isDemoError) {
-          console.error(`[useTrivy] Error fetching from ${cluster}:`, err)
-        }
-        newStatuses[cluster] = {
-          cluster, installed: false, loading: false,
-          error: err instanceof Error ? err.message : 'Connection failed',
-          vulnerabilities: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
-          totalReports: 0, scannedImages: 0, images: [],
-        }
-      }
-
-      // Progressive update: stream each cluster's data to the UI as it arrives
-      setStatuses(prev => ({ ...prev, [cluster]: newStatuses[cluster] }))
-
-      // Clear loading state once first cluster with data arrives
-      if (!initialLoadDone.current && newStatuses[cluster].installed) {
-        initialLoadDone.current = true
-        setIsLoading(false)
-      }
-    }
+    await Promise.allSettled(promises)
 
     // Final: save complete cache and clear refresh state
-    saveToCache(newStatuses)
+    saveToCache(allStatuses)
     setLastRefresh(new Date())
     initialLoadDone.current = true
     setIsLoading(false)
@@ -297,6 +309,7 @@ export function useTrivy() {
         demoStatuses[name] = getDemoStatus(name)
       }
       setStatuses(demoStatuses)
+      setClustersChecked(demoNames.length)
       setIsLoading(false)
       setLastRefresh(new Date())
       initialLoadDone.current = true
@@ -346,6 +359,10 @@ export function useTrivy() {
     lastRefresh,
     installed,
     isDemoData,
+    /** Number of clusters checked so far (for progressive UI) */
+    clustersChecked,
+    /** Total number of clusters being checked */
+    totalClusters: clusters.length,
     refetch,
   }
 }


### PR DESCRIPTION
## Summary
- Convert Trivy, Kubescape, and Kyverno hooks from sequential `for...of` cluster iteration to parallel `Promise.allSettled` with progressive result streaming
- Each card now shows "Checking clusters... X/Y" progress as results arrive from each cluster
- Reduce CRD check timeout from 5s to 3s for faster fail-and-move-on
- Add `fetchSingleCluster` extraction for clean parallel dispatch in all three hooks
- Add `clustersChecked` / `totalClusters` counters to all compliance hooks
- Fix Trestle card height shifting with `minHeight` constant
- Fix pre-existing React hooks rule violation in PolicyViolations (useMemo after early return)

## Test plan
- [ ] Verify all compliance cards show "Checking clusters... X/Y" during initial load
- [ ] Verify cards stream results progressively (partial data appears before all clusters finish)
- [ ] Verify Trestle card no longer shifts height during loading
- [ ] Verify demo mode still works correctly for all cards
- [ ] Verify build and lint pass