### PR TITLE
✨ Add progress ring to remaining compliance cards

### DIFF
--- a/web/src/components/cards/ComplianceDrift.tsx
+++ b/web/src/components/cards/ComplianceDrift.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useMemo } from 'react'
 import { AlertTriangle, CheckCircle2, TrendingDown, TrendingUp, ChevronRight, Info, Loader2 } from 'lucide-react'
+import { ProgressRing } from '../ui/ProgressRing'
 import { Button } from '../ui/Button'
 import { StatusBadge } from '../ui/StatusBadge'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
@@ -49,15 +50,19 @@ function stats(values: number[]): { mean: number; stdDev: number } {
 }
 
 export function ComplianceDrift({ config: _config }: CardConfig) {
-  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, lastRefresh: kyvernoLastRefresh, isDemoData: kyvernoDemoData, refetch: kyvernoRefetch } = useKyverno()
-  const { statuses: trivyStatuses, isLoading: trivyLoading, isRefreshing: trivyRefreshing, isDemoData: trivyDemoData, refetch: trivyRefetch } = useTrivy()
-  const { statuses: kubescapeStatuses, isLoading: kubescapeLoading, isRefreshing: kubescapeRefreshing, isDemoData: kubescapeDemoData, refetch: kubescapeRefetch } = useKubescape()
+  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, lastRefresh: kyvernoLastRefresh, isDemoData: kyvernoDemoData, refetch: kyvernoRefetch, clustersChecked: kyvernoChecked, totalClusters: kyvernoTotal } = useKyverno()
+  const { statuses: trivyStatuses, isLoading: trivyLoading, isRefreshing: trivyRefreshing, isDemoData: trivyDemoData, refetch: trivyRefetch, clustersChecked: trivyChecked, totalClusters: trivyTotal } = useTrivy()
+  const { statuses: kubescapeStatuses, isLoading: kubescapeLoading, isRefreshing: kubescapeRefreshing, isDemoData: kubescapeDemoData, refetch: kubescapeRefetch, clustersChecked: kubescapeChecked, totalClusters: kubescapeTotal } = useKubescape()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const [modal, setModal] = useState<{ tool: string; cluster: string } | null>(null)
 
   const isLoading = kyvernoLoading || trivyLoading || kubescapeLoading
   const isRefreshing = kyvernoRefreshing || trivyRefreshing || kubescapeRefreshing
   const isDemoData = kyvernoDemoData || trivyDemoData || kubescapeDemoData
+
+  /** Combined progressive streaming progress across all three tools */
+  const totalChecking = Math.max(kyvernoTotal, kubescapeTotal, trivyTotal)
+  const minChecked = Math.min(kyvernoChecked, kubescapeChecked, trivyChecked)
 
   /** Whether all clusters encountered errors (none succeeded) */
   const hasError = !isLoading && !isRefreshing &&
@@ -163,8 +168,12 @@ export function ComplianceDrift({ config: _config }: CardConfig) {
   // Loading state: show spinner while initial data loads
   if (isLoading && drifts.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm gap-2 p-4">
-        <Loader2 className="w-6 h-6 animate-spin opacity-50" />
+      <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm gap-3 p-4">
+        {totalChecking > 0 ? (
+          <ProgressRing progress={minChecked / totalChecking} size={28} strokeWidth={2.5} />
+        ) : (
+          <Loader2 className="w-6 h-6 animate-spin opacity-50" />
+        )}
         <p>Scanning clusters for compliance drift...</p>
       </div>
     )
@@ -209,9 +218,17 @@ export function ComplianceDrift({ config: _config }: CardConfig) {
         <span>Flags clusters deviating from fleet average. Drift indicates inconsistent security posture that needs investigation.</span>
       </div>
 
-      {/* Refresh indicator */}
-      <div className="flex justify-end">
-        <RefreshIndicator isRefreshing={isRefreshing} lastUpdated={kyvernoLastRefresh} size="xs" />
+      {/* Refresh indicator + inline progress */}
+      <div className="flex items-center justify-between">
+        {(isLoading || isRefreshing) && totalChecking > 0 && (
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <ProgressRing progress={minChecked / totalChecking} size={14} strokeWidth={1.5} />
+            <span>Scanning...</span>
+          </div>
+        )}
+        <div className="ml-auto">
+          <RefreshIndicator isRefreshing={isRefreshing} lastUpdated={kyvernoLastRefresh} size="xs" />
+        </div>
       </div>
 
       {drifts.map((d, i) => {

--- a/web/src/components/cards/CrossClusterPolicyComparison.tsx
+++ b/web/src/components/cards/CrossClusterPolicyComparison.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useMemo } from 'react'
 import { AlertTriangle, CheckCircle2, XCircle, Minus, Info, Loader2 } from 'lucide-react'
+import { ProgressRing } from '../ui/ProgressRing'
 import { useTranslation } from 'react-i18next'
 import { Button } from '../ui/Button'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
@@ -39,7 +40,7 @@ interface PolicyRow {
 
 export function CrossClusterPolicyComparison({ config: _config }: CardConfig) {
   const { t } = useTranslation('cards')
-  const { statuses: kyvernoStatuses, isLoading, isRefreshing, lastRefresh, isDemoData, refetch } = useKyverno()
+  const { statuses: kyvernoStatuses, isLoading, isRefreshing, lastRefresh, isDemoData, refetch, clustersChecked, totalClusters } = useKyverno()
   const { deduplicatedClusters: rawClusters } = useClusters()
   const { selectedClusters: globalSelectedClusters, isAllClustersSelected, customFilter } = useGlobalFilters()
   const [localSelected, setLocalSelected] = useState<string[]>([])
@@ -166,8 +167,12 @@ export function CrossClusterPolicyComparison({ config: _config }: CardConfig) {
     // Still scanning — show loading state instead of definitive empty state
     if (isLoading || isRefreshing) {
       return (
-        <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm p-4 gap-2">
-          <Loader2 className="w-6 h-6 animate-spin opacity-50" />
+        <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm p-4 gap-3">
+          {totalClusters > 0 ? (
+            <ProgressRing progress={clustersChecked / totalClusters} size={28} strokeWidth={2.5} />
+          ) : (
+            <Loader2 className="w-6 h-6 animate-spin opacity-50" />
+          )}
           <p>{t('crossClusterPolicy.scanningKyverno')}</p>
         </div>
       )
@@ -197,9 +202,17 @@ export function CrossClusterPolicyComparison({ config: _config }: CardConfig) {
         <span>Compares Kyverno policy deployment across clusters. Missing policies (gray) mean inconsistent enforcement.</span>
       </div>
 
-      {/* Refresh indicator */}
-      <div className="flex justify-end">
-        <RefreshIndicator isRefreshing={isRefreshing} lastUpdated={lastRefresh} size="xs" />
+      {/* Refresh indicator + inline progress */}
+      <div className="flex items-center justify-between">
+        {(isLoading || isRefreshing) && totalClusters > 0 && (
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <ProgressRing progress={clustersChecked / totalClusters} size={14} strokeWidth={1.5} />
+            <span>Scanning...</span>
+          </div>
+        )}
+        <div className="ml-auto">
+          <RefreshIndicator isRefreshing={isRefreshing} lastUpdated={lastRefresh} size="xs" />
+        </div>
       </div>
 
       {/* Cluster selector */}

--- a/web/src/components/cards/FleetComplianceHeatmap.tsx
+++ b/web/src/components/cards/FleetComplianceHeatmap.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useMemo } from 'react'
 import { AlertTriangle, Info, Loader2 } from 'lucide-react'
+import { ProgressRing } from '../ui/ProgressRing'
 import { useTranslation } from 'react-i18next'
 import { Button } from '../ui/Button'
 import { useCardLoadingState } from './CardDataContext'
@@ -158,9 +159,9 @@ Please proceed step by step.`,
 
 export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
   const { t } = useTranslation('cards')
-  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, lastRefresh: kyvernoLastRefresh, isDemoData: kyvernoDemoData, installed: kyvernoInstalled, refetch: kyvernoRefetch } = useKyverno()
-  const { statuses: trivyStatuses, isLoading: trivyLoading, isRefreshing: trivyRefreshing, isDemoData: trivyDemoData, installed: trivyInstalled, refetch: trivyRefetch } = useTrivy()
-  const { statuses: kubescapeStatuses, isLoading: kubescapeLoading, isRefreshing: kubescapeRefreshing, isDemoData: kubescapeDemoData, installed: kubescapeInstalled, refetch: kubescapeRefetch } = useKubescape()
+  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, lastRefresh: kyvernoLastRefresh, isDemoData: kyvernoDemoData, installed: kyvernoInstalled, refetch: kyvernoRefetch, clustersChecked: kyvernoChecked, totalClusters: kyvernoTotal } = useKyverno()
+  const { statuses: trivyStatuses, isLoading: trivyLoading, isRefreshing: trivyRefreshing, isDemoData: trivyDemoData, installed: trivyInstalled, refetch: trivyRefetch, clustersChecked: trivyChecked, totalClusters: trivyTotal } = useTrivy()
+  const { statuses: kubescapeStatuses, isLoading: kubescapeLoading, isRefreshing: kubescapeRefreshing, isDemoData: kubescapeDemoData, installed: kubescapeInstalled, refetch: kubescapeRefetch, clustersChecked: kubescapeChecked, totalClusters: kubescapeTotal } = useKubescape()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { deduplicatedClusters } = useClusters()
   const { isDemoMode } = useDemoMode()
@@ -172,6 +173,10 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
   const isLoading = kyvernoLoading || trivyLoading || kubescapeLoading
   const isRefreshing = kyvernoRefreshing || trivyRefreshing || kubescapeRefreshing
   const isDemoData = isDemoMode || kyvernoDemoData || trivyDemoData || kubescapeDemoData
+
+  /** Combined progressive streaming progress across all three tools */
+  const totalChecking = Math.max(kyvernoTotal, kubescapeTotal, trivyTotal)
+  const minChecked = Math.min(kyvernoChecked, kubescapeChecked, trivyChecked)
 
   /** Whether all clusters encountered errors (none succeeded) */
   const hasError = !isLoading && !isRefreshing &&
@@ -312,8 +317,12 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
     // Still scanning — show loading state instead of definitive empty state
     if (isLoading || isRefreshing) {
       return (
-        <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm gap-2">
-          <Loader2 className="w-6 h-6 animate-spin opacity-50" />
+        <div className="flex flex-col items-center justify-center h-full text-muted-foreground text-sm gap-3">
+          {totalChecking > 0 ? (
+            <ProgressRing progress={minChecked / totalChecking} size={28} strokeWidth={2.5} />
+          ) : (
+            <Loader2 className="w-6 h-6 animate-spin opacity-50" />
+          )}
           <p>{t('fleetCompliance.scanningClusters')}</p>
         </div>
       )
@@ -341,9 +350,17 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
         <span>Each cell shows tool health per cluster. Click any cell for details. Gray cells mean the tool is not installed.</span>
       </div>
 
-      {/* Refresh indicator */}
-      <div className="flex justify-end">
-        <RefreshIndicator isRefreshing={isRefreshing} lastUpdated={kyvernoLastRefresh} size="xs" />
+      {/* Refresh indicator + inline progress */}
+      <div className="flex items-center justify-between">
+        {(isLoading || isRefreshing) && totalChecking > 0 && (
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <ProgressRing progress={minChecked / totalChecking} size={14} strokeWidth={1.5} />
+            <span>Scanning...</span>
+          </div>
+        )}
+        <div className="ml-auto">
+          <RefreshIndicator isRefreshing={isRefreshing} lastUpdated={kyvernoLastRefresh} size="xs" />
+        </div>
       </div>
 
       {/* Header row */}

--- a/web/src/components/cards/KyvernoPolicies.tsx
+++ b/web/src/components/cards/KyvernoPolicies.tsx
@@ -7,7 +7,8 @@
  */
 
 import { useState, useMemo } from 'react'
-import { AlertTriangle, CheckCircle, ExternalLink, AlertCircle, FileCheck, Sparkles } from 'lucide-react'
+import { AlertTriangle, CheckCircle, ExternalLink, AlertCircle, FileCheck, Sparkles, Loader2 } from 'lucide-react'
+import { ProgressRing } from '../ui/ProgressRing'
 import { CardSearchInput } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
@@ -26,7 +27,7 @@ interface KyvernoPoliciesProps {
 
 function KyvernoPoliciesInternal({ config: _config }: KyvernoPoliciesProps) {
   const { t } = useTranslation()
-  const { statuses, isLoading, isRefreshing, lastRefresh, installed, isDemoData, refetch } = useKyverno()
+  const { statuses, isLoading, isRefreshing, lastRefresh, installed, isDemoData, refetch, clustersChecked, totalClusters } = useKyverno()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
   const [localSearch, setLocalSearch] = useState('')
@@ -166,6 +167,18 @@ Please proceed step by step.`,
           <ExternalLink className="w-4 h-4" />
         </a>
       </div>
+
+      {/* Inline progress ring while scanning */}
+      {(isLoading || isRefreshing) && !installed && !isDemoData && (
+        <div className="flex items-center gap-2 mb-3 text-xs text-muted-foreground">
+          {totalClusters > 0 ? (
+            <ProgressRing progress={clustersChecked / totalClusters} size={14} strokeWidth={1.5} />
+          ) : (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          )}
+          <span>Scanning clusters...</span>
+        </div>
+      )}
 
       {/* Install prompt when not detected (only after scanning completes) */}
       {!installed && !isLoading && !isRefreshing && (

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { AlertTriangle, CheckCircle, ExternalLink, XCircle, Info, ChevronRight, RefreshCw, Plus, WifiOff, Loader2 } from 'lucide-react'
+import { ProgressRing } from '../ui/ProgressRing'
 import { useTranslation } from 'react-i18next'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
-import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardSkeleton } from '../../lib/cards/CardComponents'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 import { useClusters } from '../../hooks/useMCP'
 import { useMissions } from '../../hooks/useMissions'
 import { kubectlProxy } from '../../lib/kubectlProxy'
@@ -232,6 +233,8 @@ function OPAPoliciesInternal({ config: _config }: OPAPoliciesProps) {
   })
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [lastRefresh, setLastRefresh] = useState<number | null>(null)
+  const [opaClustersChecked, setOpaClustersChecked] = useState(0)
+  const [opaTotalClusters, setOpaTotalClusters] = useState(0)
 
   // Persist statuses to localStorage when they change (only successful results, not loading/error)
   useEffect(() => {
@@ -348,6 +351,8 @@ function OPAPoliciesInternal({ config: _config }: OPAPoliciesProps) {
     isCheckingRef.current = true
     globalCheckInProgress = true
     setIsRefreshing(true)
+    setOpaClustersChecked(0)
+    setOpaTotalClusters(clustersToCheck.length)
 
     // Mark clusters as being checked globally
     for (const cluster of clustersToCheck) {
@@ -403,6 +408,7 @@ function OPAPoliciesInternal({ config: _config }: OPAPoliciesProps) {
         })
       }
 
+      setOpaClustersChecked(prev => prev + 1)
       if (phase1Queue.length > 0) await processPhase1()
     }
 
@@ -617,9 +623,18 @@ Let's start by discussing what kind of policy I need.`,
     })
   }
 
-  // Show skeleton until OPA checks have populated (skip in demo mode — demo statuses are provided)
+  // Show progress ring until OPA checks have populated (skip in demo mode — demo statuses are provided)
   if (!shouldUseDemoData && ((isLoading && clusters.length === 0) || (isOPAChecking && !hasOPAData))) {
-    return <CardSkeleton rows={4} type="list" showHeader showSearch />
+    return (
+      <div className="h-full flex flex-col min-h-card items-center justify-center gap-3">
+        {opaTotalClusters > 0 ? (
+          <ProgressRing progress={opaClustersChecked / opaTotalClusters} size={28} strokeWidth={2.5} />
+        ) : (
+          <Loader2 className="w-6 h-6 animate-spin text-muted-foreground/50" />
+        )}
+        <p className="text-sm text-muted-foreground">Scanning clusters...</p>
+      </div>
+    )
   }
 
   return (

--- a/web/src/components/cards/RecommendedPolicies.tsx
+++ b/web/src/components/cards/RecommendedPolicies.tsx
@@ -9,6 +9,7 @@
 
 import { useMemo, useState } from 'react'
 import { Sparkles, Shield, ChevronRight, CheckCircle2, AlertTriangle, Zap, Loader2 } from 'lucide-react'
+import { ProgressRing } from '../ui/ProgressRing'
 import { useCardLoadingState } from './CardDataContext'
 import { useKyverno } from '../../hooks/useKyverno'
 import { useKubescape } from '../../hooks/useKubescape'
@@ -254,9 +255,9 @@ Deploy to ALL clusters with Kyverno installed. Proceed step by step.`,
 // ─── Component ──────────────────────────────────────────────────────
 
 function RecommendedPoliciesInternal({ config: _config }: CardConfig) {
-  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, installed: kyvernoInstalled, isDemoData: kyvernoDemoData } = useKyverno()
-  const { isLoading: kubescapeLoading, isRefreshing: kubescapeRefreshing, installed: kubescapeInstalled, isDemoData: kubescapeDemoData } = useKubescape()
-  const { isLoading: trivyLoading, isRefreshing: trivyRefreshing, installed: trivyInstalled, isDemoData: trivyDemoData } = useTrivy()
+  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, installed: kyvernoInstalled, isDemoData: kyvernoDemoData, clustersChecked: kyvernoChecked, totalClusters: kyvernoTotal } = useKyverno()
+  const { isLoading: kubescapeLoading, isRefreshing: kubescapeRefreshing, installed: kubescapeInstalled, isDemoData: kubescapeDemoData, clustersChecked: kubescapeChecked, totalClusters: kubescapeTotal } = useKubescape()
+  const { isLoading: trivyLoading, isRefreshing: trivyRefreshing, installed: trivyInstalled, isDemoData: trivyDemoData, clustersChecked: trivyChecked, totalClusters: trivyTotal } = useTrivy()
   const { deduplicatedClusters } = useClusters()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
@@ -266,6 +267,11 @@ function RecommendedPoliciesInternal({ config: _config }: CardConfig) {
   const isLoading = kyvernoLoading || kubescapeLoading || trivyLoading
   const isRefreshing = kyvernoRefreshing || kubescapeRefreshing || trivyRefreshing
   const isDemoData = isDemoMode || kyvernoDemoData || kubescapeDemoData || trivyDemoData
+
+  /** Combined progressive streaming progress across all three tools */
+  const totalChecking = Math.max(kyvernoTotal, kubescapeTotal, trivyTotal)
+  const minChecked = Math.min(kyvernoChecked, kubescapeChecked, trivyChecked)
+  const allChecked = minChecked >= totalChecking && totalChecking > 0
 
   // Build recommendations from real cluster data
   const { recommendations, fleetCoverage, totalGaps } = useMemo(() => {
@@ -393,10 +399,14 @@ Deploy each policy to every cluster where it's missing. Proceed cluster by clust
       return (
         <div className="space-y-3">
           <div className="flex flex-col items-center justify-center py-6 text-center">
-            <Loader2 className="w-8 h-8 text-muted-foreground/50 mb-3 animate-spin" />
+            {totalChecking > 0 ? (
+              <ProgressRing progress={minChecked / totalChecking} size={32} strokeWidth={2.5} className="mb-3" />
+            ) : (
+              <Loader2 className="w-8 h-8 text-muted-foreground/50 mb-3 animate-spin" />
+            )}
             <p className="text-sm font-medium text-foreground">Scanning clusters...</p>
             <p className="text-xs text-muted-foreground mt-1 max-w-[250px]">
-              Checking for compliance tools across your fleet
+              Detecting compliance tools across your fleet
             </p>
           </div>
         </div>
@@ -452,6 +462,14 @@ Deploy each policy to every cluster where it's missing. Proceed cluster by clust
           </button>
         )}
       </div>
+
+      {/* Inline progress ring while still scanning */}
+      {!allChecked && (isLoading || isRefreshing) && totalChecking > 0 && (
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <ProgressRing progress={minChecked / totalChecking} size={14} strokeWidth={1.5} />
+          <span>Scanning clusters...</span>
+        </div>
+      )}
 
       {/* Category sections */}
       <div className="space-y-1.5">

--- a/web/src/components/ui/ProgressRing.tsx
+++ b/web/src/components/ui/ProgressRing.tsx
@@ -1,0 +1,65 @@
+/**
+ * Subtle progress ring — shows scan progress as a circular indicator.
+ * Used across compliance cards to show cluster-checking progress.
+ */
+
+/** Full circle circumference for a unit circle (r=1), scaled at render time */
+const TWO_PI = 2 * Math.PI
+
+interface ProgressRingProps {
+  /** Progress value from 0 to 1 */
+  progress: number
+  /** Ring diameter in pixels */
+  size?: number
+  /** Ring stroke width in pixels */
+  strokeWidth?: number
+  className?: string
+}
+
+export function ProgressRing({
+  progress,
+  size = 16,
+  strokeWidth = 2,
+  className,
+}: ProgressRingProps) {
+  const radius = (size - strokeWidth) / 2
+  const circumference = TWO_PI * radius
+  const clamped = Math.max(0, Math.min(1, progress))
+  const strokeDashoffset = circumference * (1 - clamped)
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      className={className}
+      aria-label={`${Math.round(clamped * 100)}% complete`}
+      role="progressbar"
+      aria-valuenow={Math.round(clamped * 100)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        className="text-secondary"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={strokeWidth}
+        strokeDasharray={circumference}
+        strokeDashoffset={strokeDashoffset}
+        strokeLinecap="round"
+        className="text-blue-400/60 transition-all duration-300"
+        transform={`rotate(-90 ${size / 2} ${size / 2})`}
+      />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds a shared `ProgressRing` SVG component for subtle circular progress indicators
- Updates all 6 remaining compliance dashboard cards to show cluster scan progress visually:
  - **RecommendedPolicies** — progress ring in loading state + inline ring while scanning
  - **ComplianceDrift** — progress ring replaces spinner, inline ring in content view
  - **FleetComplianceHeatmap** — progress ring replaces spinner, inline ring in content view
  - **KyvernoPolicies** — inline progress ring while scanning clusters
  - **CrossClusterPolicyComparison** — progress ring replaces spinner, inline ring in content view
  - **OPAPolicies** — adds cluster count tracking to custom two-phase loader, shows progress ring

This completes the progressive streaming work started in #2578. All 11 compliance cards now show visual progress as cluster data streams in.

## Test plan
- [ ] Open compliance dashboard — all cards should show progress rings while scanning
- [ ] Progress rings should fill smoothly as clusters complete
- [ ] After all clusters are checked, progress rings should disappear
- [ ] Cards should display data progressively as each cluster responds
- [ ] Demo mode should work correctly (no progress ring shown)