### PR TITLE
✨ Add install conversion funnel — track command copies through agent connection

### DIFF
--- a/web/netlify/functions/analytics-dashboard.mts
+++ b/web/netlify/functions/analytics-dashboard.mts
@@ -70,6 +70,7 @@ interface DashboardData {
   funnel: {
     landing: number;
     login: number;
+    commandCopied: number;
     agentConnected: number;
     solutionViewed: number;
     missionStarted: number;
@@ -400,6 +401,7 @@ async function fetchDashboardData(
           expressions: [
             "ksc_utm_landing",
             "login",
+            "ksc_install_command_copied",
             "ksc_agent_connected",
             "ksc_solution_viewed",
             "ksc_mission_started",
@@ -781,6 +783,7 @@ async function fetchDashboardData(
     funnel: {
       landing: funnelMap["page_view"] || funnelMap["first_visit"] || 0,
       login: funnelMap["login"] || 0,
+      commandCopied: funnelMap["ksc_install_command_copied"] || 0,
       agentConnected: funnelMap["ksc_agent_connected"] || 0,
       solutionViewed: funnelMap["ksc_solution_viewed"] || 0,
       missionStarted: funnelMap["ksc_mission_started"] || 0,

--- a/web/public/analytics.html
+++ b/web/public/analytics.html
@@ -387,7 +387,7 @@
   <script>
     const API_URL = '/api/analytics-dashboard';
     const CHART_COLORS = ['#6366f1', '#06b6d4', '#22c55e', '#f97316', '#a855f7', '#ef4444', '#eab308', '#3b82f6'];
-    const FUNNEL_COLORS = ['#6366f1', '#818cf8', '#3b82f6', '#06b6d4', '#22c55e'];
+    const FUNNEL_COLORS = ['#6366f1', '#818cf8', '#a855f7', '#3b82f6', '#06b6d4', '#22c55e'];
 
     if (typeof Chart === 'undefined') {
       document.getElementById('content').innerHTML = '<div class="error-box"><strong>Chart.js failed to load</strong><br>The charting library could not be loaded. This may be due to a Content Security Policy restriction or network issue. Try refreshing the page.</div>';
@@ -552,12 +552,9 @@
         { label: 'Sessions', value: fmt(ov.sessions), change: pctChange(ov.sessions, ovp.sessions) },
         { label: 'Page Views', value: fmt(ov.pageViews), change: pctChange(ov.pageViews, ovp.pageViews) },
         { label: 'Avg Engagement', value: fmtTime(ov.avgEngagementTime), change: pctChange(ov.avgEngagementTime, ovp.avgEngagementTime) },
-        { label: 'Bounce Rate', value: fmtPct(ov.bounceRate), change: pctChange(ov.bounceRate, ovp.bounceRate) },
+        { label: 'Install Conv. Rate', value: fmtPct(ov.activeUsers > 0 ? (data.funnel.agentConnected / ov.activeUsers) : 0), change: { dir: 'flat', value: '—' } },
         { label: 'Events / Session', value: ov.eventsPerSession.toFixed(1), change: pctChange(ov.eventsPerSession, ovp.eventsPerSession) },
       ];
-
-      // Invert bounce rate direction (lower is better)
-      kpis[4].change.dir = kpis[4].change.dir === 'up' ? 'down' : kpis[4].change.dir === 'down' ? 'up' : 'flat';
 
       html += '<div class="kpi-grid">';
       for (const kpi of kpis) {
@@ -591,9 +588,10 @@
       const funnelSteps = [
         { label: 'Page View', value: funnel.landing, color: FUNNEL_COLORS[0] },
         { label: 'Login', value: funnel.login, color: FUNNEL_COLORS[1] },
-        { label: 'Agent Connected', value: funnel.agentConnected, color: FUNNEL_COLORS[2] },
-        { label: 'Solution Viewed', value: funnel.solutionViewed, color: FUNNEL_COLORS[3] },
-        { label: 'Mission Started', value: funnel.missionStarted, color: FUNNEL_COLORS[4] },
+        { label: 'Command Copied', value: funnel.commandCopied || 0, color: FUNNEL_COLORS[2] },
+        { label: 'Agent Connected', value: funnel.agentConnected, color: FUNNEL_COLORS[3] },
+        { label: 'Solution Viewed', value: funnel.solutionViewed, color: FUNNEL_COLORS[4] },
+        { label: 'Mission Started', value: funnel.missionStarted, color: FUNNEL_COLORS[5] },
       ];
       const maxFunnel = Math.max(...funnelSteps.map(s => s.value), 1);
 

--- a/web/src/components/agent/AgentStatus.tsx
+++ b/web/src/components/agent/AgentStatus.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useLocalAgent } from '@/hooks/useLocalAgent'
 import { useTranslation } from 'react-i18next'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
+import { emitInstallCommandCopied } from '@/lib/analytics'
 
 export function AgentStatus() {
   const { t } = useTranslation('common')
@@ -78,7 +79,7 @@ export function AgentInstallBanner() {
             {installCommand}
           </code>
           <button
-            onClick={() => copyToClipboard(installCommand)}
+            onClick={() => { copyToClipboard(installCommand); emitInstallCommandCopied('agent_install_banner', installCommand) }}
             className="rounded bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
             {t('agentSetup.copy')}

--- a/web/src/components/dashboard/DemoToLocalCTA.tsx
+++ b/web/src/components/dashboard/DemoToLocalCTA.tsx
@@ -15,7 +15,7 @@ import {
   STORAGE_KEY_DEMO_CTA_DISMISSED,
   STORAGE_KEY_HINTS_SUPPRESSED,
 } from '../../lib/constants/storage'
-import { emitDemoToLocalShown, emitDemoToLocalActioned } from '../../lib/analytics'
+import { emitDemoToLocalShown, emitDemoToLocalActioned, emitInstallCommandCopied } from '../../lib/analytics'
 
 const NETLIFY_INSTALL_COMMAND = 'curl -sSL https://raw.githubusercontent.com/kubestellar/console/main/start.sh | bash'
 
@@ -61,6 +61,7 @@ export function DemoToLocalCTA() {
       await navigator.clipboard.writeText(NETLIFY_INSTALL_COMMAND)
       setCopied(true)
       emitDemoToLocalActioned('copy_command')
+      emitInstallCommandCopied('demo_to_local', NETLIFY_INSTALL_COMMAND)
       setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
     } catch {
       // Clipboard API not available — select the text instead

--- a/web/src/components/setup/SetupInstructionsDialog.tsx
+++ b/web/src/components/setup/SetupInstructionsDialog.tsx
@@ -5,6 +5,7 @@ import { Rocket, Copy, Check, Terminal, ExternalLink, ChevronDown, ChevronRight,
 import { BaseModal } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
+import { emitInstallCommandCopied } from '../../lib/analytics'
 
 interface SetupInstructionsDialogProps {
   isOpen: boolean
@@ -18,6 +19,8 @@ const CURL_BASE = 'https://raw.githubusercontent.com/kubestellar/console/main'
 const QUICKSTART_CMD = `curl -sSL ${CURL_BASE}/start.sh | bash`
 const K8S_DEPLOY_CMD = `curl -sSL ${CURL_BASE}/deploy.sh | bash`
 
+/** Index of the "Restart the console" step — the last OAuth step */
+const OAUTH_RESTART_STEP_IDX = 7
 const OAUTH_STEPS = [
   { label: 'Go to', link: 'https://github.com/settings/developers', linkText: 'GitHub Developer Settings' },
   { label: 'Click "New OAuth App" and fill in:' },
@@ -107,7 +110,7 @@ export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDi
                     {QUICKSTART_CMD}
                   </code>
                   <button
-                    onClick={() => copyToClipboard(QUICKSTART_CMD, 1)}
+                    onClick={() => { copyToClipboard(QUICKSTART_CMD, 1); emitInstallCommandCopied('setup_quickstart', QUICKSTART_CMD) }}
                     className="shrink-0 p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                     title={t('drilldown.tooltips.copyCommand')}
                   >
@@ -140,7 +143,7 @@ export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDi
                           git clone https://github.com/kubestellar/console.git && cd console && ./start-dev.sh
                         </code>
                         <button
-                          onClick={() => copyToClipboard('git clone https://github.com/kubestellar/console.git && cd console && ./start-dev.sh', 300)}
+                          onClick={() => { const cmd = 'git clone https://github.com/kubestellar/console.git && cd console && ./start-dev.sh'; copyToClipboard(cmd, 300); emitInstallCommandCopied('setup_dev_mode', cmd) }}
                           className="shrink-0 p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                           title={t('drilldown.tooltips.copyCommand')}
                         >
@@ -182,7 +185,7 @@ export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDi
                           {K8S_DEPLOY_CMD}
                         </code>
                         <button
-                          onClick={() => copyToClipboard(K8S_DEPLOY_CMD, 400)}
+                          onClick={() => { copyToClipboard(K8S_DEPLOY_CMD, 400); emitInstallCommandCopied('setup_k8s_deploy', K8S_DEPLOY_CMD) }}
                           className="shrink-0 p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                           title={t('drilldown.tooltips.copyCommand')}
                         >
@@ -245,7 +248,7 @@ export function SetupInstructionsDialog({ isOpen, onClose }: SetupInstructionsDi
                                   {oStep.command}
                                 </pre>
                                 <button
-                                  onClick={() => copyToClipboard(oStep.command, 200 + idx)}
+                                  onClick={() => { copyToClipboard(oStep.command, 200 + idx); emitInstallCommandCopied(idx === OAUTH_RESTART_STEP_IDX ? 'setup_oauth_restart' : 'setup_oauth_env', oStep.command) }}
                                   className="shrink-0 p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors self-start"
                                   title={t('common.copy')}
                                 >

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1161,6 +1161,27 @@ export function emitApiKeyRemoved(provider: string) {
   send('ksc_api_key_removed', { provider })
 }
 
+// ── Install Command Copied ──────────────────────────────────────
+// Unified event for any "copy install command" action across the site.
+// Feeds into the adoption funnel: Page View → Login → Command Copied → Agent Connected → …
+
+/** Source labels for install command copy events */
+type InstallCopySource =
+  | 'setup_quickstart'
+  | 'setup_dev_mode'
+  | 'setup_k8s_deploy'
+  | 'setup_oauth_env'
+  | 'setup_oauth_restart'
+  | 'agent_install_banner'
+  | 'demo_to_local'
+  | 'from_lens'
+  | 'from_headlamp'
+  | 'white_label'
+
+export function emitInstallCommandCopied(source: InstallCopySource, command: string) {
+  send('ksc_install_command_copied', { source, command })
+}
+
 // ── Conversion Funnel ───────────────────────────────────────────
 // Unified step-based funnel event for user journey:
 //   1 = discovery     (visited site)

--- a/web/src/pages/FromHeadlamp.tsx
+++ b/web/src/pages/FromHeadlamp.tsx
@@ -20,7 +20,7 @@ import {
   Puzzle,
   Heart,
 } from 'lucide-react'
-import { emitFromHeadlampViewed, emitFromHeadlampActioned, emitFromHeadlampTabSwitch, emitFromHeadlampCommandCopy } from '../lib/analytics'
+import { emitFromHeadlampViewed, emitFromHeadlampActioned, emitFromHeadlampTabSwitch, emitFromHeadlampCommandCopy, emitInstallCommandCopied } from '../lib/analytics'
 
 /* ------------------------------------------------------------------ */
 /*  Named constants — no magic numbers                                */
@@ -238,6 +238,7 @@ function DeploymentSection() {
     clearTimeout(copiedTimerRef.current)
     copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_MS)
     emitFromHeadlampCommandCopy(activeTab, step, commands[0])
+    emitInstallCommandCopied('from_headlamp', commands[0])
   }, [activeTab])
 
   const steps = activeTab === 'localhost'

--- a/web/src/pages/FromLens.tsx
+++ b/web/src/pages/FromLens.tsx
@@ -19,7 +19,7 @@ import {
   Copy,
   Check,
 } from 'lucide-react'
-import { emitFromLensViewed, emitFromLensActioned, emitFromLensTabSwitch, emitFromLensCommandCopy } from '../lib/analytics'
+import { emitFromLensViewed, emitFromLensActioned, emitFromLensTabSwitch, emitFromLensCommandCopy, emitInstallCommandCopied } from '../lib/analytics'
 
 /* ------------------------------------------------------------------ */
 /*  Named constants — no magic numbers                                */
@@ -250,6 +250,7 @@ function DeploymentSection() {
     clearTimeout(copiedTimerRef.current)
     copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_MS)
     emitFromLensCommandCopy(activeTab, step, commands[0])
+    emitInstallCommandCopied('from_lens', commands[0])
   }, [activeTab])
 
   const steps = activeTab === 'localhost'

--- a/web/src/pages/WhiteLabel.tsx
+++ b/web/src/pages/WhiteLabel.tsx
@@ -18,7 +18,7 @@ import {
   Package,
   Puzzle,
 } from 'lucide-react'
-import { emitWhiteLabelViewed, emitWhiteLabelActioned, emitWhiteLabelTabSwitch, emitWhiteLabelCommandCopy } from '../lib/analytics'
+import { emitWhiteLabelViewed, emitWhiteLabelActioned, emitWhiteLabelTabSwitch, emitWhiteLabelCommandCopy, emitInstallCommandCopied } from '../lib/analytics'
 
 /* ------------------------------------------------------------------ */
 /*  Named constants — no magic numbers                                */
@@ -257,6 +257,7 @@ function DeploymentSection() {
     clearTimeout(copiedTimerRef.current)
     copiedTimerRef.current = setTimeout(() => setCopiedStep(null), COPY_FEEDBACK_MS)
     emitWhiteLabelCommandCopy(activeTab, step, commands[0])
+    emitInstallCommandCopied('white_label', commands[0])
   }, [activeTab])
 
   const steps = activeTab === 'binary'


### PR DESCRIPTION
## Summary
- Adds unified `ksc_install_command_copied` analytics event fired from **all** copy buttons across the site (SetupInstructionsDialog, AgentInstallBanner, DemoToLocalCTA, FromLens, FromHeadlamp, WhiteLabel)
- Adds **"Command Copied"** as a new step in the adoption funnel between Login and Agent Connected
- Replaces the **Bounce Rate** KPI with **Install Conversion Rate** (`agentConnected / activeUsers`) — the true success metric for a demo/showcase site
- New 6-step funnel: Page View → Login → Command Copied → Agent Connected → Solution Viewed → Mission Started

## Files Changed
| File | Change |
|------|--------|
| `web/src/lib/analytics.ts` | New `emitInstallCommandCopied(source, command)` with typed `InstallCopySource` union |
| `web/src/components/setup/SetupInstructionsDialog.tsx` | Fire event on all 4 copy buttons |
| `web/src/components/agent/AgentStatus.tsx` | Fire event on AgentInstallBanner copy |
| `web/src/components/dashboard/DemoToLocalCTA.tsx` | Fire unified event alongside existing specific event |
| `web/src/pages/FromLens.tsx` | Fire unified event alongside existing specific event |
| `web/src/pages/FromHeadlamp.tsx` | Fire unified event alongside existing specific event |
| `web/src/pages/WhiteLabel.tsx` | Fire unified event alongside existing specific event |
| `web/netlify/functions/analytics-dashboard.mts` | Add `commandCopied` to funnel query + response |
| `web/public/analytics.html` | Add funnel step + replace Bounce Rate KPI |

## Test plan
- [ ] Click each copy button in SetupInstructionsDialog — verify `ksc_install_command_copied` fires in GA4 DebugView
- [ ] Click AgentInstallBanner copy button — verify event fires
- [ ] Click copy on FromLens, FromHeadlamp, WhiteLabel pages — verify both specific + unified events fire
- [ ] Visit `/analytics` on deploy preview — verify 6-step funnel renders with "Command Copied" step
- [ ] Verify Install Conversion Rate KPI shows instead of Bounce Rate