### PR TITLE
🐛 Improve chunk load error recovery and cache headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -105,7 +105,9 @@
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"
 
-# HTML files must always revalidate to pick up new chunk references after deploys
+# HTML files and the SPA root must always revalidate to pick up new chunk
+# references after deploys. The root "/" is covered explicitly because Netlify
+# may serve index.html at "/" without the .html extension and miss the /*.html rule.
 [[headers]]
   for = "/*.html"
   [headers.values]
@@ -113,6 +115,11 @@
 
 [[headers]]
   for = "/index.html"
+  [headers.values]
+    Cache-Control = "no-cache"
+
+[[headers]]
+  for = "/"
   [headers.values]
     Cache-Control = "no-cache"
 

--- a/web/src/components/ChunkErrorBoundary.tsx
+++ b/web/src/components/ChunkErrorBoundary.tsx
@@ -23,6 +23,10 @@ interface State {
  * causing "Failed to fetch dynamically imported module" or
  * "MIME type text/html" errors. This boundary catches those and
  * auto-reloads once to pick up fresh chunk references.
+ *
+ * Recovery flow:
+ * 1. First chunk error → auto-reload (sessionStorage timestamp set, no error UI shown)
+ * 2. Chunk error within RELOAD_THROTTLE_MS of last reload → recovery failed, show error UI
  */
 export class ChunkErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
@@ -31,10 +35,17 @@ export class ChunkErrorBoundary extends Component<Props, State> {
   }
 
   static getDerivedStateFromError(error: Error): State | null {
-    if (isChunkLoadError(error)) {
-      return { hasChunkError: true }
+    if (!isChunkLoadError(error)) {
+      return null
     }
-    return null
+    // Only show the error UI if a reload has already been attempted within
+    // the throttle window (i.e., auto-reload failed to fix the problem).
+    // On the first occurrence we stay silent here and let componentDidCatch
+    // trigger the reload — no error UI flash before the reload.
+    const lastReload = sessionStorage.getItem(CHUNK_RELOAD_TS_KEY)
+    const now = Date.now()
+    const alreadyRetried = !!lastReload && now - parseInt(lastReload) <= RELOAD_THROTTLE_MS
+    return { hasChunkError: alreadyRetried }
   }
 
   componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
@@ -42,10 +53,10 @@ export class ChunkErrorBoundary extends Component<Props, State> {
       throw error
     }
 
-    console.warn('[ChunkErrorBoundary] Stale chunk detected, will reload:', error.message)
+    console.warn('[ChunkErrorBoundary] Stale chunk detected:', error.message)
     emitError('chunk_load', error.message)
 
-    // Auto-reload once. Use sessionStorage to prevent infinite loops.
+    // Auto-reload once. Use sessionStorage timestamp to prevent infinite loops.
     const lastReload = sessionStorage.getItem(CHUNK_RELOAD_TS_KEY)
     const now = Date.now()
     if (!lastReload || now - parseInt(lastReload) > RELOAD_THROTTLE_MS) {


### PR DESCRIPTION
## Summary
- Improve ChunkErrorBoundary retry logic: `getDerivedStateFromError` now checks sessionStorage before showing the error UI, so users no longer see a brief flash of the error screen before the auto-reload fires on first occurrence
- Add `Cache-Control: no-cache` header for the root `/` path in `netlify.toml` — Netlify may serve `index.html` at `/` without the `.html` extension, causing the `/*.html` rule to be missed and allowing browsers to cache a stale entry point
- Addresses chunk_load errors on `/clusters` and `/compliance` pages after deploys

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (no errors in changed files)
- [ ] Verify ChunkErrorBoundary shows error UI only after failed retry, not on first occurrence
- [ ] Verify cache headers are correct on Netlify preview deploy (`/` returns `Cache-Control: no-cache`)

Fixes #2586
Fixes #2587