### PR TITLE
🐛 Batch consecutive setState calls to prevent UI flicker

### DIFF
--- a/web/src/components/ui/AlertBadge.tsx
+++ b/web/src/components/ui/AlertBadge.tsx
@@ -21,24 +21,27 @@ const MINS_PER_HOUR = 60
 /** Number of hours in a day, used for relative-time formatting */
 const HOURS_PER_DAY = 24
 
+interface AnimationState {
+  isAnimating: boolean
+  direction: 'up' | 'down'
+}
+
 // Animated counter component for the badge - exported for future use
 export function AnimatedCounter({ value, className }: { value: number; className?: string }) {
   const { t: _t } = useTranslation()
   const [displayValue, setDisplayValue] = useState(value)
-  const [isAnimating, setIsAnimating] = useState(false)
-  const [direction, setDirection] = useState<'up' | 'down'>('up')
+  const [animation, setAnimation] = useState<AnimationState>({ isAnimating: false, direction: 'up' })
   const prevValueRef = useRef(value)
 
   useEffect(() => {
     if (value !== prevValueRef.current) {
-      setDirection(value > prevValueRef.current ? 'up' : 'down')
-      setIsAnimating(true)
+      setAnimation({ isAnimating: true, direction: value > prevValueRef.current ? 'up' : 'down' })
       // Wait for exit animation, then update value
       const timer = setTimeout(() => {
         setDisplayValue(value)
         prevValueRef.current = value
         // Reset animation after enter completes
-        setTimeout(() => setIsAnimating(false), TRANSITION_DELAY_MS)
+        setTimeout(() => setAnimation(prev => ({ ...prev, isAnimating: false })), TRANSITION_DELAY_MS)
       }, 150)
       return () => clearTimeout(timer)
     }
@@ -49,8 +52,8 @@ export function AnimatedCounter({ value, className }: { value: number; className
   return (
     <span
       className={`inline-block transition-all duration-200 ${className} ${
-        isAnimating
-          ? direction === 'up'
+        animation.isAnimating
+          ? animation.direction === 'up'
             ? 'animate-roll-up'
             : 'animate-roll-down'
           : ''

--- a/web/src/components/ui/CodeBlock.tsx
+++ b/web/src/components/ui/CodeBlock.tsx
@@ -13,9 +13,10 @@ interface CodeBlockProps {
   fontSize?: 'sm' | 'base' | 'lg'
 }
 
+type CopyStatus = 'idle' | 'copied' | 'failed'
+
 export function CodeBlock({ children, language = 'text', fontSize = 'sm' }: CodeBlockProps) {
-  const [copied, setCopied] = useState(false)
-  const [copyFailed, setCopyFailed] = useState(false)
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle')
   const timeoutRef = useRef<number>()
 
   const handleCopy = async () => {
@@ -23,16 +24,15 @@ export function CodeBlock({ children, language = 'text', fontSize = 'sm' }: Code
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current)
     }
-    
+
     try {
       await navigator.clipboard.writeText(children)
-      setCopied(true)
-      setCopyFailed(false)
-      timeoutRef.current = setTimeout(() => setCopied(false), UI_FEEDBACK_TIMEOUT_MS)
+      setCopyStatus('copied')
+      timeoutRef.current = setTimeout(() => setCopyStatus('idle'), UI_FEEDBACK_TIMEOUT_MS)
     } catch (err) {
       console.error('Failed to copy:', err)
-      setCopyFailed(true)
-      timeoutRef.current = setTimeout(() => setCopyFailed(false), UI_FEEDBACK_TIMEOUT_MS)
+      setCopyStatus('failed')
+      timeoutRef.current = setTimeout(() => setCopyStatus('idle'), UI_FEEDBACK_TIMEOUT_MS)
     }
   }
 
@@ -53,10 +53,10 @@ export function CodeBlock({ children, language = 'text', fontSize = 'sm' }: Code
           size="sm"
           onClick={handleCopy}
           className="p-1.5"
-          title={copied ? 'Copied!' : copyFailed ? 'Copy failed' : 'Copy code'}
-          icon={copied ? (
+          title={copyStatus === 'copied' ? 'Copied!' : copyStatus === 'failed' ? 'Copy failed' : 'Copy code'}
+          icon={copyStatus === 'copied' ? (
             <Check className="w-4 h-4 text-green-600 dark:text-green-400" />
-          ) : copyFailed ? (
+          ) : copyStatus === 'failed' ? (
             <AlertCircle className="w-4 h-4 text-red-500 dark:text-red-400" />
           ) : (
             <Copy className="w-4 h-4 text-muted-foreground" />

--- a/web/src/components/ui/Pagination.tsx
+++ b/web/src/components/ui/Pagination.tsx
@@ -3,10 +3,15 @@ import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-r
 import { useTranslation } from 'react-i18next'
 import { Button } from './Button'
 
+interface PaginationState {
+  currentPage: number
+  itemsPerPage: number
+}
+
 // Hook for managing pagination state
 export function usePagination<T>(items: T[], defaultPerPage: number = 5, resetOnFilterChange: boolean = true) {
-  const [currentPage, setCurrentPage] = useState(1)
-  const [itemsPerPage, setItemsPerPage] = useState(defaultPerPage)
+  const [pagination, setPagination] = useState<PaginationState>({ currentPage: 1, itemsPerPage: defaultPerPage })
+  const { currentPage, itemsPerPage } = pagination
   const prevDefaultPerPage = useRef(defaultPerPage)
   const prevItemsLength = useRef(items.length)
 
@@ -14,8 +19,7 @@ export function usePagination<T>(items: T[], defaultPerPage: number = 5, resetOn
   useEffect(() => {
     if (prevDefaultPerPage.current !== defaultPerPage) {
       prevDefaultPerPage.current = defaultPerPage
-      setItemsPerPage(defaultPerPage)
-      setCurrentPage(1)
+      setPagination({ currentPage: 1, itemsPerPage: defaultPerPage })
     }
   }, [defaultPerPage])
 
@@ -23,7 +27,7 @@ export function usePagination<T>(items: T[], defaultPerPage: number = 5, resetOn
   useEffect(() => {
     if (resetOnFilterChange && prevItemsLength.current !== items.length) {
       if (currentPage > 1) {
-        setCurrentPage(1)
+        setPagination(prev => ({ ...prev, currentPage: 1 }))
       }
       prevItemsLength.current = items.length
     }
@@ -38,7 +42,7 @@ export function usePagination<T>(items: T[], defaultPerPage: number = 5, resetOn
   // Sync currentPage back when out of bounds, but via effect not during render
   useEffect(() => {
     if (currentPage > totalPages && totalPages > 0) {
-      setCurrentPage(totalPages)
+      setPagination(prev => ({ ...prev, currentPage: totalPages }))
     }
   }, [currentPage, totalPages])
 
@@ -52,12 +56,11 @@ export function usePagination<T>(items: T[], defaultPerPage: number = 5, resetOn
   totalPagesRef.current = totalPages
 
   const goToPage = useCallback((page: number) => {
-    setCurrentPage(Math.max(1, Math.min(page, totalPagesRef.current)))
+    setPagination(prev => ({ ...prev, currentPage: Math.max(1, Math.min(page, totalPagesRef.current)) }))
   }, [])
 
   const setPerPage = useCallback((perPage: number) => {
-    setItemsPerPage(perPage)
-    setCurrentPage(1)
+    setPagination({ currentPage: 1, itemsPerPage: perPage })
   }, [])
 
   return {

--- a/web/src/components/ui/StatsConfig.tsx
+++ b/web/src/components/ui/StatsConfig.tsx
@@ -293,6 +293,18 @@ interface StatsConfigModalProps {
   title?: string
 }
 
+interface AddPanelState {
+  showAddPanel: boolean
+  searchQuery: string
+  expandedCategories: Set<string>
+}
+
+const INITIAL_ADD_PANEL_STATE: AddPanelState = {
+  showAddPanel: false,
+  searchQuery: '',
+  expandedCategories: new Set(),
+}
+
 export function StatsConfigModal({
   isOpen,
   onClose,
@@ -303,28 +315,25 @@ export function StatsConfigModal({
 }: StatsConfigModalProps) {
   const { t: _t } = useTranslation()
   const [localBlocks, setLocalBlocks] = useState<StatBlockConfig[]>(blocks)
-  const [showAddPanel, setShowAddPanel] = useState(false)
-  const [searchQuery, setSearchQuery] = useState('')
-  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set())
+  const [addPanelState, setAddPanelState] = useState<AddPanelState>(INITIAL_ADD_PANEL_STATE)
+  const { showAddPanel, searchQuery, expandedCategories } = addPanelState
 
   useEffect(() => {
     if (isOpen) {
       setLocalBlocks(blocks)
-      setShowAddPanel(false)
-      setSearchQuery('')
-      setExpandedCategories(new Set())
+      setAddPanelState(INITIAL_ADD_PANEL_STATE)
     }
   }, [isOpen, blocks])
 
   const toggleCategory = (type: string) => {
-    setExpandedCategories(prev => {
-      const next = new Set(prev)
+    setAddPanelState(prev => {
+      const next = new Set(prev.expandedCategories)
       if (next.has(type)) {
         next.delete(type)
       } else {
         next.add(type)
       }
-      return next
+      return { ...prev, expandedCategories: next }
     })
   }
 
@@ -367,7 +376,7 @@ export function StatsConfigModal({
   useEffect(() => {
     if (searchQuery.trim()) {
       // Expand all categories that have matching results
-      setExpandedCategories(new Set(availableStatsByCategory.keys()))
+      setAddPanelState(prev => ({ ...prev, expandedCategories: new Set(availableStatsByCategory.keys()) }))
     }
   }, [searchQuery, availableStatsByCategory])
 
@@ -446,7 +455,7 @@ export function StatsConfigModal({
                 <input
                   type="text"
                   value={searchQuery}
-                  onChange={e => setSearchQuery(e.target.value)}
+                  onChange={e => setAddPanelState(prev => ({ ...prev, searchQuery: e.target.value }))}
                   placeholder="Search all available stats..."
                   className="w-full pl-9 pr-3 py-2 bg-secondary/30 border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/50"
                   autoFocus
@@ -455,7 +464,7 @@ export function StatsConfigModal({
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => setShowAddPanel(false)}
+                onClick={() => setAddPanelState(prev => ({ ...prev, showAddPanel: false }))}
               >
                 Done
               </Button>
@@ -487,7 +496,7 @@ export function StatsConfigModal({
           <Button
             variant="ghost"
             size="md"
-            onClick={() => setShowAddPanel(true)}
+            onClick={() => setAddPanelState(prev => ({ ...prev, showAddPanel: true }))}
             className="mt-4 w-full border border-dashed border-border hover:border-purple-500/50"
             icon={<Plus className="w-4 h-4" />}
             fullWidth


### PR DESCRIPTION
## Summary
- Batch consecutive setState calls in UI components to prevent unnecessary re-renders
- Affected components: AlertBadge, CodeBlock, Pagination, StatsConfig
- Uses combined state objects where multiple state values always change together: `AnimationState` (AlertBadge), `CopyStatus` enum (CodeBlock), `PaginationState` (Pagination), `AddPanelState` (StatsConfig)

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors, only pre-existing warnings)
- [ ] Visual regression: verify no flicker in AlertBadge, CodeBlock, Pagination, StatsConfig components

Fixes #2572