### PR TITLE
🐛 Fix 26 runtime errors on dashboard: detect Safari chunk load failures

### DIFF
--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -14,7 +14,7 @@
  */
 
 import { STORAGE_KEY_ANALYTICS_OPT_OUT } from './constants'
-import { CHUNK_RELOAD_TS_KEY } from './chunkErrors'
+import { CHUNK_RELOAD_TS_KEY, isChunkLoadMessage } from './chunkErrors'
 import { isDemoMode } from './demoMode'
 
 // DECOY Measurement ID — the proxy rewrites this to the real ID server-side.
@@ -942,6 +942,34 @@ function checkChunkReloadRecovery() {
   }
 }
 
+// Reload throttle interval — must match ChunkErrorBoundary to prevent loops
+const GLOBAL_RELOAD_THROTTLE_MS = 30_000 // 30 seconds
+
+/**
+ * If the error message indicates a stale-chunk failure, auto-reload once
+ * (same throttle logic as ChunkErrorBoundary). Returns true if a reload
+ * was triggered so the caller can skip further processing.
+ */
+function tryChunkReloadRecovery(msg: string): boolean {
+  if (!isChunkLoadMessage(msg)) return false
+  emitError('chunk_load', msg)
+  try {
+    const lastReload = sessionStorage.getItem(CHUNK_RELOAD_TS_KEY)
+    const now = Date.now()
+    if (!lastReload || now - parseInt(lastReload) > GLOBAL_RELOAD_THROTTLE_MS) {
+      sessionStorage.setItem(CHUNK_RELOAD_TS_KEY, String(now))
+      window.location.reload()
+      return true
+    }
+    // Already reloaded recently — recovery failed
+    sessionStorage.removeItem(CHUNK_RELOAD_TS_KEY)
+    emitChunkReloadRecoveryFailed(msg)
+  } catch {
+    // sessionStorage unavailable — fall through to normal error reporting
+  }
+  return false
+}
+
 /** Track unhandled promise rejections and runtime errors globally */
 export function startGlobalErrorTracking() {
   // Check if we just recovered from a chunk-load auto-reload
@@ -956,6 +984,8 @@ export function startGlobalErrorTracking() {
     isEmitting = true
     try {
       const msg = event.reason?.message || String(event.reason || 'unknown')
+      // Stale chunks can surface as unhandled rejections from dynamic import()
+      if (tryChunkReloadRecovery(msg)) return
       emitError('unhandled_rejection', msg)
     } finally {
       isEmitting = false
@@ -968,6 +998,8 @@ export function startGlobalErrorTracking() {
     if (isEmitting) return
     isEmitting = true
     try {
+      // Stale chunks can surface as runtime errors (Safari: "Importing a module script failed")
+      if (tryChunkReloadRecovery(event.message)) return
       emitError('runtime', event.message)
     } finally {
       isEmitting = false

--- a/web/src/lib/chunkErrors.ts
+++ b/web/src/lib/chunkErrors.ts
@@ -11,7 +11,15 @@
 export const CHUNK_RELOAD_TS_KEY = 'chunk-reload-ts'
 
 export function isChunkLoadError(error: Error): boolean {
-  const msg = error.message || ''
+  return isChunkLoadMessage(error.message || '')
+}
+
+/**
+ * Check if an error message string indicates a chunk/module load failure.
+ * Used by both Error-object callers (isChunkLoadError) and the global
+ * window 'error' event handler which only has a message string.
+ */
+export function isChunkLoadMessage(msg: string): boolean {
   return (
     msg.includes('Failed to fetch dynamically imported module') ||
     msg.includes('Loading chunk') ||
@@ -21,6 +29,8 @@ export function isChunkLoadError(error: Error): boolean {
     // Vite-specific preload error
     msg.includes('Unable to preload CSS') ||
     // Server returned HTML instead of JS (404 → SPA fallback for missing chunk)
-    msg.includes('is not a valid JavaScript MIME type')
+    msg.includes('is not a valid JavaScript MIME type') ||
+    // Safari/WebKit uses this message for failed dynamic import()
+    msg.includes('Importing a module script failed')
   )
 }


### PR DESCRIPTION
## Summary
- **Root cause**: Safari/WebKit reports failed dynamic `import()` with the message `"Importing a module script failed"` — a wording not matched by the existing `isChunkLoadError()` detector. This meant:
  1. `ChunkErrorBoundary` did not recognize the error, so no auto-reload happened
  2. The global `window.addEventListener('error')` handler categorized it as `runtime` instead of `chunk_load`, bypassing auto-reload recovery entirely
  3. After the import resolved to `undefined`, accessing named exports (e.g., `.MultiClusterSummaryDrillDown`) crashed with secondary `TypeError` errors
- **GA4 data**: 23 of 26 errors were `"TypeError: Importing a module script failed."`, plus 2x `MultiClusterSummaryDrillDown` and 1x `.default` — all stale-chunk consequences
- **Fix (chunkErrors.ts)**: Added Safari's `"Importing a module script failed"` pattern to chunk error detection; extracted `isChunkLoadMessage()` for string-based matching
- **Fix (analytics.ts)**: Added `tryChunkReloadRecovery()` to both the global `error` and `unhandledrejection` handlers — when a chunk load error is detected, it now triggers auto-reload with the same 30-second throttle as `ChunkErrorBoundary`, instead of just logging it

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (no new errors)
- [ ] Monitor GA4 error dashboard — expect `runtime` errors on `/` to drop to near-zero
- [ ] Safari users should now get auto-reload recovery after deploys (same as Chrome/Firefox)

Fixes #2601