### PR TITLE
🐛 Fix chunk error double-emission causing inflated runtime error counts

### DIFF
--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -947,8 +947,8 @@ const GLOBAL_RELOAD_THROTTLE_MS = 30_000 // 30 seconds
 
 /**
  * If the error message indicates a stale-chunk failure, auto-reload once
- * (same throttle logic as ChunkErrorBoundary). Returns true if a reload
- * was triggered so the caller can skip further processing.
+ * (same throttle logic as ChunkErrorBoundary). Returns true when the error
+ * IS a chunk error so the caller skips emitting a duplicate 'runtime' event.
  */
 function tryChunkReloadRecovery(msg: string): boolean {
   if (!isChunkLoadMessage(msg)) return false
@@ -965,9 +965,11 @@ function tryChunkReloadRecovery(msg: string): boolean {
     sessionStorage.removeItem(CHUNK_RELOAD_TS_KEY)
     emitChunkReloadRecoveryFailed(msg)
   } catch {
-    // sessionStorage unavailable — fall through to normal error reporting
+    // sessionStorage unavailable — chunk_load was already emitted above
   }
-  return false
+  // Always return true when the error IS a chunk error — prevents the caller
+  // from also emitting a 'runtime' error for the same event (double reporting).
+  return true
 }
 
 /** Track unhandled promise rejections and runtime errors globally */


### PR DESCRIPTION
## Summary

- **Fixes `tryChunkReloadRecovery()` returning `false` when a chunk error was detected but reload was throttled**, causing the global `window.error` handler to also emit a duplicate `runtime` error for the same event.
- This caused a **+400% spike in runtime errors** in GA4 — today alone, 23 "runtime" errors were actually Safari chunk load failures (`TypeError: Importing a module script failed.`) being double-reported as both `chunk_load` AND `runtime`.
- Now always returns `true` when `isChunkLoadMessage()` matches, preventing the caller from double-reporting.

## Root Cause

The flow that triggers the bug:
1. User visits with stale cached HTML after a deploy
2. Vite's `preloadError` handler sets `chunk-reload-ts` in sessionStorage and reloads
3. After reload, chunks are still stale (CDN edge cache)
4. Safari fires `window.error` with `"TypeError: Importing a module script failed."`
5. `tryChunkReloadRecovery()` identifies it as a chunk error, emits `chunk_load` ✅
6. Reload throttle prevents another reload, function returns `false` ← **BUG**
7. Global handler sees `false` and also emits `runtime` ← **double report**

## GA4 Error Impact (28-day dashboard)

| Error Category | Trend | Expected After Fix |
|---|---|---|
| runtime | +400% (18 events) | Should drop significantly |
| uncaught_render | +1000% (12 events) | Unaffected |
| chunk_load | +38% (19 events) | No change |
| card_render | +167% (14 events) | Unaffected |
| unhandled_rejection | +11 (11 events) | May drop slightly |

## Test plan

- [ ] Verify build passes
- [ ] Verify lint passes
- [ ] Simulate: with sessionStorage `chunk-reload-ts` set < 30s ago, trigger a chunk error — confirm only `chunk_load` is emitted (no `runtime`)
- [ ] Monitor GA4 `ksc_error` events after deploy — runtime error count should decrease