### PR TITLE
🐛 Cache mission recommendations to avoid redundant recomputation

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -43,6 +43,7 @@ import {
   missionCache, startMissionCacheFetch, resetMissionCache,
   fetchMissionContent, BROWSER_TABS,
   VirtualizedMissionGrid,
+  getCachedRecommendations, setCachedRecommendations,
 } from './browser'
 import type { TreeNode, ViewMode, BrowserTab } from './browser'
 
@@ -258,7 +259,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   }, [isOpen, isAuthenticated, user, watchedRepos, watchedPaths])
 
   // ============================================================================
-  // Fetch recommendations
+  // Fetch recommendations (with module-level caching to avoid recomputation)
   // ============================================================================
 
   useEffect(() => {
@@ -271,13 +272,32 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       if (allMissions.length === 0) {
         if (!missionCache.solutionsDone) {
           setLoadingRecommendations(true)
-          setSearchProgress({ step: 'Scanning', detail: 'Loading solutions…', found: 0, scanned: 0 })
+          setSearchProgress({ step: 'Scanning', detail: 'Loading solutions...', found: 0, scanned: 0 })
         }
         return
       }
+
+      // Use cached recommendations if available and still valid
+      const cached = getCachedRecommendations()
+      if (cached) {
+        setRecommendations(cached)
+        setHasCluster(!!clusterContextRef.current)
+        setLoadingRecommendations(false)
+        const done = missionCache.solutionsDone
+        setSearchProgress({
+          step: done ? 'Done' : 'Scanning',
+          detail: `${allMissions.length} solutions`,
+          found: allMissions.length,
+          scanned: allMissions.length,
+        })
+        return
+      }
+
+      // Cache miss — compute recommendations and store them
       const cluster = clusterContextRef.current
       setHasCluster(!!cluster)
       const matched = matchMissionsToCluster(allMissions, cluster)
+      setCachedRecommendations(matched)
       setRecommendations(matched)
       setLoadingRecommendations(false)
       const done = missionCache.solutionsDone
@@ -293,7 +313,6 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
     updateRecommendations()
     missionCache.listeners.add(updateRecommendations)
     return () => { missionCache.listeners.delete(updateRecommendations) }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen])
 
   // ============================================================================

--- a/web/src/components/missions/browser/index.ts
+++ b/web/src/components/missions/browser/index.ts
@@ -8,6 +8,7 @@ export { getMissionSlug, getMissionShareUrl, updateNodeInTree, formatBytes, norm
 export {
   missionCache, notifyCacheListeners, startMissionCacheFetch, resetMissionCache,
   fetchMissionContent, MISSION_FILE_FETCH_TIMEOUT_MS,
+  getCachedRecommendations, setCachedRecommendations, resetRecommendationCache,
 } from './missionCache'
 export type { MissionCache } from './missionCache'
 export { VirtualizedMissionGrid } from './VirtualizedMissionGrid'

--- a/web/src/components/missions/browser/missionCache.ts
+++ b/web/src/components/missions/browser/missionCache.ts
@@ -3,10 +3,12 @@
  * Also persisted to localStorage so data is instant on page reload.
  * Cache refreshes only when user clicks refresh or after CACHE_TTL_MS elapses.
  */
-import type { MissionExport } from '../../../lib/missions/types'
+import type { MissionExport, MissionMatch } from '../../../lib/missions/types'
 
 /** Cache time-to-live: 6 hours */
 const MISSION_CACHE_TTL_MS = 6 * 60 * 60 * 1000
+/** Recommendation cache TTL: 10 minutes (shorter since it depends on cluster context) */
+const RECOMMENDATION_CACHE_TTL_MS = 10 * 60 * 1000
 /** localStorage key for persisted mission cache */
 const MISSION_CACHE_STORAGE_KEY = 'kc-mission-cache'
 
@@ -259,7 +261,54 @@ export function resetMissionCache() {
   missionCache.solutionsFetching = false
   missionCache.fetchedAt = 0
   missionCache.fetchError = null
+  // Also invalidate recommendation cache when mission data is refreshed
+  resetRecommendationCache()
   try { localStorage.removeItem(MISSION_CACHE_STORAGE_KEY) } catch { /* ok */ }
   notifyCacheListeners()
   startMissionCacheFetch()
+}
+
+// ============================================================================
+// Recommendation cache — avoids re-running matchMissionsToCluster on every dialog open
+// ============================================================================
+
+interface RecommendationCacheEntry {
+  /** Cached recommendation results */
+  recommendations: MissionMatch[]
+  /** Number of solutions when recommendations were computed (invalidation key) */
+  solutionCount: number
+  /** Timestamp of last computation */
+  computedAt: number
+}
+
+let recommendationCacheEntry: RecommendationCacheEntry | null = null
+
+/**
+ * Get cached recommendations if the cache is still valid.
+ * Returns null if the cache is stale, empty, or the solution count has changed
+ * (indicating new data was fetched).
+ */
+export function getCachedRecommendations(): MissionMatch[] | null {
+  if (!recommendationCacheEntry) return null
+  // Invalidate if solutions changed (new data arrived)
+  if (recommendationCacheEntry.solutionCount !== missionCache.solutions.length) return null
+  // Invalidate if TTL expired
+  if (Date.now() - recommendationCacheEntry.computedAt > RECOMMENDATION_CACHE_TTL_MS) return null
+  return recommendationCacheEntry.recommendations
+}
+
+/**
+ * Store computed recommendations in the module-level cache.
+ */
+export function setCachedRecommendations(recommendations: MissionMatch[]) {
+  recommendationCacheEntry = {
+    recommendations,
+    solutionCount: missionCache.solutions.length,
+    computedAt: Date.now(),
+  }
+}
+
+/** Clear the recommendation cache (used on explicit refresh) */
+export function resetRecommendationCache() {
+  recommendationCacheEntry = null
 }


### PR DESCRIPTION
## Summary
- Adds module-level caching for recommendation results (output of `matchMissionsToCluster`) with a 10-minute TTL
- Prevents redundant recomputation every time the Mission Browser dialog is opened/closed
- Cache auto-invalidates when the solution count changes (new data fetched) or after TTL expires
- Manual refresh via the refresh button continues to bypass cache (clears both mission and recommendation caches)

## Implementation
- `getCachedRecommendations()` / `setCachedRecommendations()` / `resetRecommendationCache()` added to `missionCache.ts`
- `MissionBrowser.tsx` checks the cache before calling `matchMissionsToCluster` and stores results after computation
- `resetMissionCache()` also resets recommendation cache to ensure consistency

## Test plan
- [ ] Open Mission Browser, see recommendations load normally
- [ ] Close and reopen Mission Browser — recommendations should appear instantly (no loading spinner)
- [ ] Click the refresh button — recommendations should reload from scratch
- [ ] Wait >10 minutes, reopen — recommendations should recompute (TTL expired)
- [ ] Verify no regressions in installer/solution tabs

Fixes #2603