### PR TITLE
🐛 Fix recommendation cache serving stale data after cluster switch

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -278,7 +278,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       }
 
       // Use cached recommendations if available and still valid
-      const cached = getCachedRecommendations()
+      const cached = getCachedRecommendations(clusterContextRef.current)
       if (cached) {
         setRecommendations(cached)
         setHasCluster(!!clusterContextRef.current)
@@ -297,7 +297,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       const cluster = clusterContextRef.current
       setHasCluster(!!cluster)
       const matched = matchMissionsToCluster(allMissions, cluster)
-      setCachedRecommendations(matched)
+      setCachedRecommendations(matched, cluster)
       setRecommendations(matched)
       setLoadingRecommendations(false)
       const done = missionCache.solutionsDone

--- a/web/src/components/missions/browser/missionCache.ts
+++ b/web/src/components/missions/browser/missionCache.ts
@@ -4,6 +4,7 @@
  * Cache refreshes only when user clicks refresh or after CACHE_TTL_MS elapses.
  */
 import type { MissionExport, MissionMatch } from '../../../lib/missions/types'
+import type { ClusterContext } from '../../../hooks/useClusterContext'
 
 /** Cache time-to-live: 6 hours */
 const MISSION_CACHE_TTL_MS = 6 * 60 * 60 * 1000
@@ -279,32 +280,56 @@ interface RecommendationCacheEntry {
   solutionCount: number
   /** Timestamp of last computation */
   computedAt: number
+  /** Fingerprint of the cluster context used to compute recommendations */
+  clusterFingerprint: string
+}
+
+/**
+ * Generate a stable fingerprint string from a ClusterContext.
+ * Used to invalidate the recommendation cache when the user switches clusters
+ * or when cluster state changes (new operators, different issues, etc.).
+ * Returns a fixed string for null context (no cluster connected).
+ */
+const NO_CLUSTER_FINGERPRINT = '__no_cluster__'
+
+export function computeClusterFingerprint(ctx: ClusterContext | null): string {
+  if (!ctx) return NO_CLUSTER_FINGERPRINT
+  // Sort arrays for stability — the order of resources/issues/labels
+  // can vary between renders without meaning the cluster actually changed.
+  const resources = [...ctx.resources].sort().join(',')
+  const issues = [...ctx.issues].sort().join(',')
+  const labelEntries = Object.entries(ctx.labels).sort(([a], [b]) => a.localeCompare(b))
+  const labels = labelEntries.map(([k, v]) => `${k}=${v}`).join(',')
+  return `${ctx.name}|${ctx.provider ?? ''}|${ctx.version ?? ''}|${resources}|${issues}|${labels}`
 }
 
 let recommendationCacheEntry: RecommendationCacheEntry | null = null
 
 /**
  * Get cached recommendations if the cache is still valid.
- * Returns null if the cache is stale, empty, or the solution count has changed
- * (indicating new data was fetched).
+ * Returns null if the cache is stale, empty, the solution count has changed
+ * (indicating new data was fetched), or the cluster context has changed.
  */
-export function getCachedRecommendations(): MissionMatch[] | null {
+export function getCachedRecommendations(clusterCtx: ClusterContext | null): MissionMatch[] | null {
   if (!recommendationCacheEntry) return null
   // Invalidate if solutions changed (new data arrived)
   if (recommendationCacheEntry.solutionCount !== missionCache.solutions.length) return null
   // Invalidate if TTL expired
   if (Date.now() - recommendationCacheEntry.computedAt > RECOMMENDATION_CACHE_TTL_MS) return null
+  // Invalidate if cluster context changed (different cluster, new operators, etc.)
+  if (recommendationCacheEntry.clusterFingerprint !== computeClusterFingerprint(clusterCtx)) return null
   return recommendationCacheEntry.recommendations
 }
 
 /**
  * Store computed recommendations in the module-level cache.
  */
-export function setCachedRecommendations(recommendations: MissionMatch[]) {
+export function setCachedRecommendations(recommendations: MissionMatch[], clusterCtx: ClusterContext | null) {
   recommendationCacheEntry = {
     recommendations,
     solutionCount: missionCache.solutions.length,
     computedAt: Date.now(),
+    clusterFingerprint: computeClusterFingerprint(clusterCtx),
   }
 }
 


### PR DESCRIPTION
## Summary
- Add cluster fingerprint to recommendation cache key so it invalidates when cluster context changes
- Generates a stable fingerprint from cluster name, provider, version, resources, issues, and labels
- Cache now invalidates on cluster switch, new operators, changed issues, etc.
- Follow-up to #2627 which added recommendation caching

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (no new errors)
- [ ] Switch clusters while mission browser is open — recommendations update immediately
- [ ] Disconnect all clusters — recommendations recompute for generic mode