### PR TITLE
🐛 fix: memory leak in waitWithDeadline function

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -39,10 +39,12 @@ func waitWithDeadline(wg *sync.WaitGroup, deadline time.Duration) bool {
 		wg.Wait()
 		close(done)
 	}()
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
 	select {
 	case <-done:
 		return false
-	case <-time.After(deadline):
+	case <-timer.C:
 		return true
 	}
 }


### PR DESCRIPTION
Replace time.After(deadline) with time.NewTimer(deadline) and defer timer.Stop() to prevent timer resource leaks when WaitGroup completes before deadline.

This affects all multi-cluster API endpoints (30+ call sites) and fixes gradual memory increase in long-running deployments.

Fixes: memory leak in pkg/api/handlers/mcp.go lines 36-48

> **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.

### 📌 Fixes

Fixes #2657 

---

### 📝 Summary of Changes

- Short description of what was changed
- Include links to related issues/discussions if any

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [ ] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
