### PR TITLE
🐛 fix: add SQLite connection pool configuration to prevent resource exh…

### DIFF
--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -24,6 +24,12 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 
+	// Configure connection pool for optimal performance and resource management
+	db.SetMaxOpenConns(25)                // Limit concurrent connections
+	db.SetMaxIdleConns(5)                 // Maintain idle connection pool
+	db.SetConnMaxLifetime(5 * time.Minute) // Recycle connections periodically
+	db.SetConnMaxIdleTime(2 * time.Minute) // Close long-idle connections
+
 	store := &SQLiteStore{db: db}
 	if err := store.migrate(); err != nil {
 		db.Close()


### PR DESCRIPTION
Configure connection pool settings in NewSQLiteStore() to optimize performance and prevent file handle exhaustion under high load conditions:

- SetMaxOpenConns(25): Limit concurrent connections
- SetMaxIdleConns(5): Maintain idle connection pool
- SetConnMaxLifetime(5min): Recycle connections periodically
- SetConnMaxIdleTime(2min): Close long-idle connections

This provides defense-in-depth protection alongside existing rate limiting.

> **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.

### 📌 Fixes

Fixes #2659


---

### 📝 Summary of Changes

- Short description of what was changed
- Include links to related issues/discussions if any

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
