### PR TITLE
fix: propagate request context in MCP handler to prevent resource leaks

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -138,7 +138,7 @@ func (h *MCPHandlers) ListClusters(c *fiber.Ctx) error {
 
 		// Kick off a background health refresh so subsequent calls get fresh data
 		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), mcpHealthTimeout)
+			ctx, cancel := context.WithTimeout(c.Context(), mcpHealthTimeout)
 			defer cancel()
 			h.k8sClient.GetAllClusterHealth(ctx)
 		}()


### PR DESCRIPTION
Replace context.Background() with c.Context() in ListClusters handler to ensure background health checks respect request cancellation and prevent orphaned goroutines.


> **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.

### 📌 Fixes

Fixes #2664

---

### 📝 Summary of Changes

- Short description of what was changed
- Include links to related issues/discussions if any

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
