### PR TITLE
🐛 Fix memory leak in console watcher timer backoff

### DIFF
--- a/pkg/k8s/console_watcher.go
+++ b/pkg/k8s/console_watcher.go
@@ -120,12 +120,15 @@ func (w *ConsoleWatcher) watchResource(ctx context.Context, gvr schema.GroupVers
 		if err != nil {
 			log.Printf("[ConsoleWatcher] Watch error for %s: %v, retrying in %v", resourceType, err, backoff)
 
+			timer := time.NewTimer(backoff)
 			select {
 			case <-w.stopCh:
+				timer.Stop()
 				return
 			case <-ctx.Done():
+				timer.Stop()
 				return
-			case <-time.After(backoff):
+			case <-timer.C:
 			}
 
 			// Exponential backoff


### PR DESCRIPTION
Replace time.After with time.NewTimer and properly stop timer in all select cases to prevent memory accumulation when watcher is stopped during retry periods.

> **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.

### 📌 Fixes

Fixes #2663

---

### 📝 Summary of Changes

- Short description of what was changed
- Include links to related issues/discussions if any

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [ ] Updated ...
- [ ] Refactored ...
- [x] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [ ] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
