### PR TITLE
🐛 Fix timer cleanup to prevent memory leaks

### DIFF
--- a/web/src/components/dashboard/DemoToLocalCTA.tsx
+++ b/web/src/components/dashboard/DemoToLocalCTA.tsx
@@ -32,6 +32,7 @@ export function DemoToLocalCTA() {
   const [copied, setCopied] = useState(false)
   const [showSetupDialog, setShowSetupDialog] = useState(false)
   const emittedRef = useRef(false)
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Localhost without OAuth = user ran start.sh but hasn't configured GitHub OAuth yet
   const isLocalNoOAuth = !isNetlifyDeployment && getDemoMode() && !hasRealToken()
@@ -62,7 +63,8 @@ export function DemoToLocalCTA() {
       setCopied(true)
       emitDemoToLocalActioned('copy_command')
       emitInstallCommandCopied('demo_to_local', NETLIFY_INSTALL_COMMAND)
-      setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+      copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
     } catch {
       // Clipboard API not available — select the text instead
       const el = document.querySelector('[data-install-command]') as HTMLElement

--- a/web/src/components/dashboard/WelcomeCard.tsx
+++ b/web/src/components/dashboard/WelcomeCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Terminal, Globe, Rocket, X, ExternalLink, Copy, Check } from 'lucide-react'
 import { cn } from '../../lib/cn'
@@ -21,6 +21,7 @@ export function WelcomeCard() {
     }
   })
   const [copied, setCopied] = useState(false)
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   if (dismissed) return null
 
@@ -37,7 +38,8 @@ export function WelcomeCard() {
     try {
       await navigator.clipboard.writeText(INSTALL_COMMAND)
       setCopied(true)
-      setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+      copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
     } catch {
       // Clipboard API not available
     }

--- a/web/src/components/missions/browser/RecommendationCard.tsx
+++ b/web/src/components/missions/browser/RecommendationCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { CheckCircle, Check, Link } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import { StatusBadge } from '../../ui/StatusBadge'
@@ -19,6 +19,7 @@ export function RecommendationCard({
   const { mission, score, matchPercent, matchReasons } = match
   const isClusterMatch = score > 1
   const [linkCopied, setLinkCopied] = useState(false)
+  const linkCopyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   return (
     <div
@@ -36,7 +37,8 @@ export function RecommendationCard({
                 e.stopPropagation()
                 onCopyLink(e)
                 setLinkCopied(true)
-                setTimeout(() => setLinkCopied(false), UI_FEEDBACK_TIMEOUT_MS)
+                if (linkCopyTimerRef.current) clearTimeout(linkCopyTimerRef.current)
+                linkCopyTimerRef.current = setTimeout(() => setLinkCopied(false), UI_FEEDBACK_TIMEOUT_MS)
               }}
               className="p-0.5 rounded text-muted-foreground/50 hover:text-purple-400 transition-colors"
               title="Copy shareable link"


### PR DESCRIPTION
## Summary
- Add ref-based timer tracking (`useRef`) to `WelcomeCard`, `DemoToLocalCTA`, and `RecommendationCard` to clear previous `setTimeout` before starting a new one
- Prevents stale state updates when the copy button is clicked multiple times in quick succession

Fixes #2650