### PR TITLE
🐛 Fix demo mode switch not resetting workload caches

### DIFF
--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -489,7 +489,16 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
     refetch(!!hasCachedData) // silent=true if we have cached data
     // Poll for pod updates
     const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
-    return () => clearInterval(interval)
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`allPods:${cacheKey}`, () => {
+      refetch(false)
+    })
+
+    return () => {
+      clearInterval(interval)
+      unregisterRefetch()
+    }
   }, [refetch, cacheKey])
 
   // Subscribe to cache reset notifications - triggers skeleton when cache is cleared
@@ -661,7 +670,16 @@ export function usePodIssues(cluster?: string, namespace?: string) {
     refetch(!!hasCachedData) // silent=true if we have cached data
     // Poll every 30 seconds for pod issue updates
     const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
-    return () => clearInterval(interval)
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`podIssues:${cacheKey}`, () => {
+      refetch(false)
+    })
+
+    return () => {
+      clearInterval(interval)
+      unregisterRefetch()
+    }
   }, [refetch, cacheKey])
 
   // Subscribe to cache reset notifications - triggers skeleton when cache is cleared
@@ -799,7 +817,16 @@ export function useDeploymentIssues(cluster?: string, namespace?: string) {
     refetch(!!hasCachedData) // silent=true if we have cached data
     // Poll every 30 seconds for deployment issues
     const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
-    return () => clearInterval(interval)
+
+    // Register for unified mode transition refetch
+    const unregisterRefetch = registerRefetch(`deploymentIssues:${cacheKey}`, () => {
+      refetch(false)
+    })
+
+    return () => {
+      clearInterval(interval)
+      unregisterRefetch()
+    }
   }, [refetch, cacheKey])
 
   // Subscribe to cache reset notifications - triggers skeleton when cache is cleared


### PR DESCRIPTION
## Summary
- Add `registerRefetch` calls to `useAllPods`, `usePodIssues`, and `useDeploymentIssues` hooks
- These hooks were missing the mode transition refetch registration that `usePods` and `useDeployments` already had
- Without this, toggling demo mode would clear the caches (showing skeletons) but never trigger a re-fetch with the correct data source

## Test plan
- [ ] Connect to a real cluster and let workload data load
- [ ] Toggle Demo Mode on — verify all workload cards show demo data (not stale live data)
- [ ] Toggle Demo Mode off — verify cards re-fetch live data

Fixes #2693