### PR TITLE
🐛 Add null guards to prevent Cluster Admin crash on 404/500/empty

### DIFF
--- a/web/src/components/cluster-admin/ClusterAdmin.tsx
+++ b/web/src/components/cluster-admin/ClusterAdmin.tsx
@@ -10,11 +10,17 @@ const STORAGE_KEY = 'kubestellar-cluster-admin-cards'
 const DEFAULT_CARDS = getDefaultCards('cluster-admin')
 
 export function ClusterAdmin() {
-  const { clusters, isLoading, isRefreshing, lastUpdated, refetch, error } = useClusters()
-  const { issues: podIssues } = useCachedPodIssues()
-  const { events: warningEvents } = useCachedWarningEvents()
-  const { nodes } = useCachedNodes()
+  const { clusters: rawClusters, isLoading, isRefreshing, lastUpdated, refetch, error } = useClusters()
+  const { issues: rawPodIssues } = useCachedPodIssues()
+  const { events: rawWarningEvents } = useCachedWarningEvents()
+  const { nodes: rawNodes } = useCachedNodes()
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
+
+  // Guard all arrays against undefined to prevent crashes when APIs return 404/500/empty
+  const clusters = rawClusters || []
+  const podIssues = rawPodIssues || []
+  const warningEvents = rawWarningEvents || []
+  const nodes = rawNodes || []
 
   const reachable = clusters.filter(c => c.reachable !== false)
   const healthy = reachable.filter(c => c.healthy === true)

--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -172,7 +172,9 @@ function getStatusBadge(status: string) {
 export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSummaryDrillDownProps) {
   const { t } = useTranslation()
   const { clusters, deduplicatedClusters, pods, deployments, events, helmReleases, operatorSubscriptions, securityIssues } = useClusterData()
-  const { nodes: cachedNodes } = useCachedNodes()
+  const { nodes: rawCachedNodes } = useCachedNodes()
+  // Guard against undefined to prevent crashes when APIs return 404/500/empty
+  const cachedNodes = rawCachedNodes || []
   const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<string>('all')
   const [clusterFilter, setClusterFilter] = useState<string>('all')

--- a/web/src/hooks/useClusterData.ts
+++ b/web/src/hooks/useClusterData.ts
@@ -1,6 +1,11 @@
 /**
  * Aggregated cluster data hook for drill-down views
- * Combines data from multiple MCP hooks for convenience
+ * Combines data from multiple MCP hooks for convenience.
+ *
+ * All returned arrays are guaranteed non-undefined. If an upstream hook
+ * returns undefined (e.g., API 404/500, backend offline, hook error),
+ * the value is coalesced to an empty array to prevent render crashes
+ * in consumers that call .map(), .filter(), .flatMap(), .join(), etc.
  */
 
 import { useClusters, usePods, useDeployments, useNamespaces, useEvents, useHelmReleases, useOperatorSubscriptions, useSecurityIssues } from './useMCP'
@@ -16,14 +21,14 @@ export function useClusterData() {
   const { issues: securityIssues } = useSecurityIssues()
 
   return {
-    clusters,
-    deduplicatedClusters,
-    pods,
-    deployments,
-    namespaces,
-    events,
-    helmReleases,
-    operatorSubscriptions,
-    securityIssues,
+    clusters: clusters || [],
+    deduplicatedClusters: deduplicatedClusters || [],
+    pods: pods || [],
+    deployments: deployments || [],
+    namespaces: namespaces || [],
+    events: events || [],
+    helmReleases: helmReleases || [],
+    operatorSubscriptions: operatorSubscriptions || [],
+    securityIssues: securityIssues || [],
   }
 }

--- a/web/src/hooks/useUniversalStats.ts
+++ b/web/src/hooks/useUniversalStats.ts
@@ -45,7 +45,7 @@ export function useUniversalStats() {
     drillToAllSecurity, drillToAllGPU, drillToAllStorage,
   } = useDrillDownActions()
 
-  // Domain-specific data
+  // Domain-specific data — all guarded with || [] to prevent crashes on 404/500/empty
   const { issues: podIssues } = usePodIssues()
   const { deployments } = useDeployments()
   const { issues: deploymentIssues } = useDeploymentIssues()
@@ -62,18 +62,19 @@ export function useUniversalStats() {
   const { rules: alertRules } = useAlertRules()
 
   // ─── Cluster-derived values ───
-  const totalClusters = deduplicatedClusters.length
-  const healthyClusters = deduplicatedClusters.filter(c => c.healthy).length
-  const unhealthyClusters = deduplicatedClusters.filter(c => !c.healthy).length
-  const unreachableClusters = deduplicatedClusters.filter(c => c.reachable === false).length
-  const totalNodes = deduplicatedClusters.reduce((sum, c) => sum + (c.nodeCount || 0), 0)
-  const totalPods = deduplicatedClusters.reduce((sum, c) => sum + (c.podCount || 0), 0)
-  const totalCPUs = deduplicatedClusters.reduce((sum, c) => sum + (c.cpuCores || 0), 0)
-  const totalMemoryGB = deduplicatedClusters.reduce((sum, c) => sum + (c.memoryGB || 0), 0)
-  const totalStorageGB = deduplicatedClusters.reduce((sum, c) => sum + (c.storageGB || 0), 0)
+  const safeClusters = deduplicatedClusters || []
+  const totalClusters = safeClusters.length
+  const healthyClusters = safeClusters.filter(c => c.healthy).length
+  const unhealthyClusters = safeClusters.filter(c => !c.healthy).length
+  const unreachableClusters = safeClusters.filter(c => c.reachable === false).length
+  const totalNodes = safeClusters.reduce((sum, c) => sum + (c.nodeCount || 0), 0)
+  const totalPods = safeClusters.reduce((sum, c) => sum + (c.podCount || 0), 0)
+  const totalCPUs = safeClusters.reduce((sum, c) => sum + (c.cpuCores || 0), 0)
+  const totalMemoryGB = safeClusters.reduce((sum, c) => sum + (c.memoryGB || 0), 0)
+  const totalStorageGB = safeClusters.reduce((sum, c) => sum + (c.storageGB || 0), 0)
   const uniqueNamespaces = useMemo(
-    () => new Set(deduplicatedClusters.flatMap(c => c.namespaces || [])),
-    [deduplicatedClusters]
+    () => new Set(safeClusters.flatMap(c => c.namespaces || [])),
+    [safeClusters]
   )
 
   // ─── Pod-derived values ───
@@ -136,11 +137,11 @@ export function useUniversalStats() {
   // Only count GPUs from reachable clusters
   const unreachableClusterNames = useMemo(() => {
     return new Set(
-      deduplicatedClusters
+      safeClusters
         .filter(c => c.reachable === false)
         .map(c => c.name)
     )
-  }, [deduplicatedClusters])
+  }, [safeClusters])
 
   const realGPUCount = useMemo(() => {
     return (gpuNodes || [])
@@ -444,7 +445,7 @@ export function useUniversalStats() {
   return {
     getStatValue,
     isLoading,
-    clusters: deduplicatedClusters,
+    clusters: safeClusters,
   }
 }
 


### PR DESCRIPTION
## Summary
- Guards all array return values in `useClusterData` with `|| []` to prevent undefined propagation
- Guards `useUniversalStats` internal `deduplicatedClusters` reference with `safeClusters` alias
- Guards `ClusterAdmin` component's destructured hook values (`clusters`, `podIssues`, `warningEvents`, `nodes`)
- Guards `MultiClusterSummaryDrillDown` cached nodes against undefined

When backend APIs return 404, 500, or empty responses, hooks may transiently return undefined before settling. Without guards, calling `.filter()`, `.map()`, `.reduce()`, `.flatMap()`, `.length` on undefined triggers a TypeError that crashes the React render tree, surfacing as "React error boundary triggered" or permanent white spinner.

## Test plan
- [ ] Disable backend API, navigate to /cluster-admin -- verify cards show empty state or "No data" instead of crashing
- [ ] Simulate empty cluster (no namespaces, pods, etc.) -- verify drill-down views render without errors
- [ ] Normal operation with live clusters -- verify no regression

Fixes #2660