### PR TITLE
🐛 Stop injecting demo data when API fails in live mode

### DIFF
--- a/web/src/hooks/mcp/config.ts
+++ b/web/src/hooks/mcp/config.ts
@@ -89,9 +89,6 @@ export function useConfigMaps(cluster?: string, namespace?: string) {
     } catch {
       // Don't show error - ConfigMaps are optional
       setError(null)
-      setConfigMaps(getDemoConfigMaps().filter(cm =>
-        (!cluster || cm.cluster === cluster) && (!namespace || cm.namespace === namespace)
-      ))
     } finally {
       setIsLoading(false)
     }
@@ -196,9 +193,6 @@ export function useSecrets(cluster?: string, namespace?: string) {
     } catch {
       // Don't show error - Secrets are optional
       setError(null)
-      setSecrets(getDemoSecrets().filter(s =>
-        (!cluster || s.cluster === cluster) && (!namespace || s.namespace === namespace)
-      ))
     } finally {
       setIsLoading(false)
     }
@@ -277,9 +271,6 @@ export function useServiceAccounts(cluster?: string, namespace?: string) {
     } catch {
       // Don't show error - ServiceAccounts are optional
       setError(null)
-      setServiceAccounts(getDemoServiceAccounts().filter(sa =>
-        (!cluster || sa.cluster === cluster) && (!namespace || sa.namespace === namespace)
-      ))
     } finally {
       setIsLoading(false)
     }

--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -178,7 +178,6 @@ export function useEvents(cluster?: string, namespace?: string, limit = 20) {
       setLastRefresh(new Date())
       if (!silent && !eventsCache) {
         setError('Failed to fetch events')
-        setEvents(getDemoEvents())
       }
     } finally {
       if (!isMountedRef.current) return
@@ -335,7 +334,6 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
     } catch {
       if (!silent && !warningEventsCache) {
         setError('Failed to fetch warning events')
-        setEvents(getDemoEvents().filter(e => e.type === 'Warning'))
       }
     } finally {
       setIsLoading(false)

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -270,12 +270,6 @@ export function useServices(cluster?: string, namespace?: string) {
       if (!silent) {
         // Don't show error at dashboard level - services are optional
         setError(null)
-        // Fall back to demo data on error if no cached data
-        if (services.length === 0) {
-          setServices(getDemoServices().filter(s =>
-            (!cluster || s.cluster === cluster) && (!namespace || s.namespace === namespace)
-          ))
-        }
       }
       // Don't clear services on error - keep stale data
     } finally {

--- a/web/src/hooks/mcp/security.ts
+++ b/web/src/hooks/mcp/security.ts
@@ -107,8 +107,6 @@ export function useSecurityIssues(cluster?: string, namespace?: string) {
       setLastRefresh(new Date())
       if (!silent && hadNoData) {
         setError('Failed to fetch security issues')
-        setIssues(getDemoSecurityIssues())
-        setIsUsingDemoData(true)
       }
     } finally {
       setIsLoading(false)

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -342,12 +342,11 @@ export function usePods(cluster?: string, namespace?: string, sortBy: 'restarts'
       setConsecutiveFailures(0)
       setLastRefresh(now)
     } catch (err) {
-      // Keep stale data on error - don't fall back to demo
+      // Keep stale data on error — only fall back to demo data when demo mode is active
       setConsecutiveFailures(prev => prev + 1)
       setLastRefresh(new Date())
       if (!silent && !podsCache) {
         setError('Failed to fetch pods')
-        setPods(getDemoPods())
       }
     } finally {
       setIsLoading(false)
@@ -472,9 +471,6 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
     } catch (err) {
       if (!silent && !podsCache) {
         setError('Failed to fetch pods')
-        setPods(getDemoAllPods().filter(p =>
-          (!cluster || p.cluster === cluster) && (!namespace || p.namespace === namespace)
-        ))
       }
     } finally {
       if (!silent) {
@@ -800,7 +796,6 @@ export function useDeploymentIssues(cluster?: string, namespace?: string) {
       setLastRefresh(new Date())
       if (!silent && !deploymentIssuesCache) {
         setError('Failed to fetch deployment issues')
-        setIssues(getDemoDeploymentIssues())
       }
     } finally {
       setIsLoading(false)


### PR DESCRIPTION
## Summary
- Remove demo data fallbacks from error handlers in 10 hooks across 5 files
- Previously, when an MCP API request failed in live mode, catch blocks injected demo data (e.g., `setPods(getDemoPods())`) without checking `isDemoMode()`, causing realistic-looking fake data to appear in the dashboard
- Now API failures show error states or empty results; demo data is only used when demo mode is explicitly active

### Files changed
- `workloads.ts` — usePods, useAllPods, useDeploymentIssues
- `networking.ts` — useServices
- `security.ts` — useSecurityIssues
- `events.ts` — useEvents, useWarningEvents
- `config.ts` — useConfigMaps, useSecrets, useServiceAccounts

## Test plan
- [ ] Stop the backend/MCP server and verify cards show error state (not demo data)
- [ ] Enable demo mode and verify demo data still displays correctly
- [ ] With backend running, verify live data loads normally

Fixes #2647