### PR TITLE
🐛 Show fallback placeholder for unknown card types

### DIFF
--- a/web/src/components/arcade/Arcade.tsx
+++ b/web/src/components/arcade/Arcade.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, memo } from 'react'
 import { useSearchParams, useLocation } from 'react-router-dom'
-import { Gamepad2, Plus, LayoutGrid, ChevronDown, ChevronRight, GripVertical, Trophy, Zap } from 'lucide-react'
+import { Gamepad2, Plus, LayoutGrid, ChevronDown, ChevronRight, GripVertical, Trophy, Zap, AlertTriangle } from 'lucide-react'
 import {
   DndContext,
   closestCenter,
@@ -99,9 +99,6 @@ const SortableArcadeCard = memo(function SortableArcadeCard({
   }
 
   const CardComponent = CARD_COMPONENTS[card.card_type]
-  if (!CardComponent) {
-    return null
-  }
 
   return (
     <div ref={setNodeRef} style={style}>
@@ -125,7 +122,15 @@ const SortableArcadeCard = memo(function SortableArcadeCard({
           </button>
         }
       >
-        <CardComponent config={card.config} />
+        {CardComponent ? (
+          <CardComponent config={card.config} />
+        ) : (
+          <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
+            <AlertTriangle className="w-6 h-6 text-yellow-500" />
+            <p className="text-sm font-medium">Unknown card type: {card.card_type}</p>
+            <p className="text-xs">This card type is not registered. You can remove it.</p>
+          </div>
+        )}
       </CardWrapper>
     </div>
   )

--- a/web/src/components/clusters/components/SortableClusterCard.tsx
+++ b/web/src/components/clusters/components/SortableClusterCard.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { GripVertical } from 'lucide-react'
+import { GripVertical, AlertTriangle } from 'lucide-react'
 import { CardWrapper } from '../../cards/CardWrapper'
 import { CARD_COMPONENTS, DEMO_DATA_CARDS } from '../../cards/cardRegistry'
 import { DashboardCard } from '../../../lib/dashboards'
@@ -50,9 +50,6 @@ export const SortableClusterCard = memo(function SortableClusterCard({
   }
 
   const CardComponent = CARD_COMPONENTS[card.card_type]
-  if (!CardComponent) {
-    return null
-  }
 
   return (
     <div ref={setNodeRef} style={style}>
@@ -79,7 +76,15 @@ export const SortableClusterCard = memo(function SortableClusterCard({
           </button>
         }
       >
-        <CardComponent config={card.config} />
+        {CardComponent ? (
+          <CardComponent config={card.config} />
+        ) : (
+          <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
+            <AlertTriangle className="w-6 h-6 text-yellow-500" />
+            <p className="text-sm font-medium">Unknown card type: {card.card_type}</p>
+            <p className="text-xs">This card type is not registered. You can remove it.</p>
+          </div>
+        )}
       </CardWrapper>
     </div>
   )

--- a/web/src/components/dashboard/DashboardCards.tsx
+++ b/web/src/components/dashboard/DashboardCards.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Plus, LayoutGrid, ChevronDown, ChevronRight, Layout } from 'lucide-react'
+import { Plus, LayoutGrid, ChevronDown, ChevronRight, Layout, AlertTriangle } from 'lucide-react'
 import { useModalState } from '../../lib/modals'
 import { Button } from '../ui/Button'
 import { CardWrapper } from '../cards/CardWrapper'
@@ -164,9 +164,6 @@ export function DashboardCards({
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
               {cards.map(card => {
                 const CardComponent = CARD_COMPONENTS[card.card_type]
-                if (!CardComponent) {
-                  return null
-                }
                 return (
                   <CardWrapper
                     key={card.id}
@@ -178,7 +175,15 @@ export function DashboardCards({
                     isDemoData={DEMO_DATA_CARDS.has(card.card_type)}
                     isLive={LIVE_DATA_CARDS.has(card.card_type)}
                   >
-                    <CardComponent config={card.config} />
+                    {CardComponent ? (
+                      <CardComponent config={card.config} />
+                    ) : (
+                      <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
+                        <AlertTriangle className="w-6 h-6 text-yellow-500" />
+                        <p className="text-sm font-medium">Unknown card type: {card.card_type}</p>
+                        <p className="text-xs">This card type is not registered. You can remove it.</p>
+                      </div>
+                    )}
                   </CardWrapper>
                 )
               })}

--- a/web/src/components/deploy/Deploy.tsx
+++ b/web/src/components/deploy/Deploy.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, memo } from 'react'
 import { useSearchParams, useLocation } from 'react-router-dom'
-import { Rocket, Plus, LayoutGrid, ChevronDown, ChevronRight, GripVertical } from 'lucide-react'
+import { Rocket, Plus, LayoutGrid, ChevronDown, ChevronRight, GripVertical, AlertTriangle } from 'lucide-react'
 import { DashboardHeader } from '../shared/DashboardHeader'
 import { StatsOverview, StatBlockValue } from '../ui/StatsOverview'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
@@ -110,9 +110,6 @@ const SortableDeployCard = memo(function SortableDeployCard({
   }
 
   const CardComponent = CARD_COMPONENTS[card.card_type]
-  if (!CardComponent) {
-    return null
-  }
 
   return (
     <div ref={setNodeRef} style={style}>
@@ -139,7 +136,15 @@ const SortableDeployCard = memo(function SortableDeployCard({
           </button>
         }
       >
-        <CardComponent config={card.config} />
+        {CardComponent ? (
+          <CardComponent config={card.config} />
+        ) : (
+          <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
+            <AlertTriangle className="w-6 h-6 text-yellow-500" />
+            <p className="text-sm font-medium">Unknown card type: {card.card_type}</p>
+            <p className="text-xs">This card type is not registered. You can remove it.</p>
+          </div>
+        )}
       </CardWrapper>
     </div>
   )

--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -146,7 +146,6 @@ const SortableGpuCard = memo(function SortableGpuCard({
   } = useSortable({ id })
 
   const Component = CARD_COMPONENTS[card.type]
-  if (!Component) return null
 
   const colSpan = Math.min(12, Math.max(3, card.width))
   const style = {
@@ -181,7 +180,15 @@ const SortableGpuCard = memo(function SortableGpuCard({
             </button>
           }
         >
-          <Component />
+          {Component ? (
+            <Component />
+          ) : (
+            <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
+              <AlertTriangle className="w-6 h-6 text-yellow-500" />
+              <p className="text-sm font-medium">Unknown card type: {card.type}</p>
+              <p className="text-xs">This card type is not registered. You can remove it.</p>
+            </div>
+          )}
         </CardWrapper>
       </Suspense>
     </div>

--- a/web/src/lib/dashboards/DashboardComponents.tsx
+++ b/web/src/lib/dashboards/DashboardComponents.tsx
@@ -1,7 +1,7 @@
 import { memo, ReactNode } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { GripVertical, Plus, LayoutGrid, ChevronDown, ChevronRight, RefreshCw, Hourglass } from 'lucide-react'
+import { GripVertical, Plus, LayoutGrid, ChevronDown, ChevronRight, RefreshCw, Hourglass, AlertTriangle } from 'lucide-react'
 import { getIcon } from '../icons'
 import { DashboardCard } from './types'
 import { CardWrapper } from '../../components/cards/CardWrapper'
@@ -62,9 +62,6 @@ export const SortableDashboardCard = memo(function SortableDashboardCard({
   }
 
   const CardComponent = CARD_COMPONENTS[card.card_type]
-  if (!CardComponent) {
-    return null
-  }
 
   return (
     <div ref={setNodeRef} style={style}>
@@ -91,7 +88,15 @@ export const SortableDashboardCard = memo(function SortableDashboardCard({
           </button>
         }
       >
-        <CardComponent config={card.config} />
+        {CardComponent ? (
+          <CardComponent config={card.config} />
+        ) : (
+          <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
+            <AlertTriangle className="w-6 h-6 text-yellow-500" />
+            <p className="text-sm font-medium">Unknown card type: {card.card_type}</p>
+            <p className="text-xs">This card type is not registered. You can remove it.</p>
+          </div>
+        )}
       </CardWrapper>
     </div>
   )


### PR DESCRIPTION
## Summary
- Fixes #2648
- Six card rendering locations silently returned `null` when `CARD_COMPONENTS[card_type]` was undefined, causing dashboard cards to vanish without explanation
- Now all locations render the card inside `CardWrapper` with an AlertTriangle icon and "Unknown card type: {type}" message, matching the pattern already used in `SharedSortableCard.tsx` and `CustomDashboard.tsx`

## Files changed
- `web/src/components/dashboard/DashboardCards.tsx`
- `web/src/lib/dashboards/DashboardComponents.tsx`
- `web/src/components/gpu/GPUReservations.tsx`
- `web/src/components/clusters/components/SortableClusterCard.tsx`
- `web/src/components/arcade/Arcade.tsx`
- `web/src/components/deploy/Deploy.tsx`

## Test plan
- [ ] Add a card with an invalid/unknown `card_type` to a dashboard
- [ ] Verify the card renders with an AlertTriangle icon and "Unknown card type" message instead of silently disappearing
- [ ] Verify the card can still be removed via the remove button
- [ ] Verify normal cards continue to render correctly