### PR TITLE
🐛 Distinguish scanner fetch failures from clean scan results

### DIFF
--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -140,7 +140,7 @@ export function FalcoAlerts({ config: _config }: CardConfig) {
 
 export function TrivyScan({ config: _config }: CardConfig) {
   const { t } = useTranslation()
-  const { statuses, aggregated, isLoading, isRefreshing, installed, isDemoData, clustersChecked, totalClusters, refetch } = useTrivy()
+  const { statuses, aggregated, isLoading, isRefreshing, installed, hasErrors, isDemoData, clustersChecked, totalClusters, refetch } = useTrivy()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
   const [modalCluster, setModalCluster] = useState<string | null>(null)
@@ -226,8 +226,24 @@ Please proceed step by step.`,
         </div>
       )}
 
-      {/* Install prompt when not detected (only after scanning completes) */}
-      {!installed && !isLoading && !isRefreshing && (
+      {/* Error banner when fetch failed — distinct from "not installed" */}
+      {hasErrors && !installed && !isLoading && !isRefreshing && (
+        <div className="flex items-start gap-2 p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-xs">
+          <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-red-400 font-medium">Scanner Data Unavailable</p>
+            <p className="text-muted-foreground">
+              Could not fetch Trivy data — results below may be incomplete.{' '}
+              <button onClick={() => refetch()} className="text-red-400 hover:underline">
+                Retry →
+              </button>
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Install prompt when not detected (only after scanning completes, and no errors) */}
+      {!installed && !hasErrors && !isLoading && !isRefreshing && (
         <div className="flex items-start gap-2 p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-xs">
           <AlertCircle className="w-4 h-4 text-cyan-400 flex-shrink-0 mt-0.5" />
           <div>
@@ -340,7 +356,7 @@ Please proceed step by step.`,
 // ── Kubescape Security Posture ──────────────────────────────────────────
 
 export function KubescapeScan({ config: _config }: CardConfig) {
-  const { statuses, aggregated, isLoading, isRefreshing, installed, isDemoData, clustersChecked, totalClusters, refetch } = useKubescape()
+  const { statuses, aggregated, isLoading, isRefreshing, installed, hasErrors, isDemoData, clustersChecked, totalClusters, refetch } = useKubescape()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
   const [modalCluster, setModalCluster] = useState<string | null>(null)
@@ -430,8 +446,24 @@ Please proceed step by step.`,
         </div>
       )}
 
-      {/* Install prompt when not detected (only after scanning completes) */}
-      {!installed && !isLoading && !isRefreshing && (
+      {/* Error banner when fetch failed — distinct from "not installed" */}
+      {hasErrors && !installed && !isLoading && !isRefreshing && (
+        <div className="flex items-start gap-2 p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-xs">
+          <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-red-400 font-medium">Scanner Data Unavailable</p>
+            <p className="text-muted-foreground">
+              Could not fetch Kubescape data — results below may be incomplete.{' '}
+              <button onClick={() => refetch()} className="text-red-400 hover:underline">
+                Retry →
+              </button>
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Install prompt when not detected (only after scanning completes, and no errors) */}
+      {!installed && !hasErrors && !isLoading && !isRefreshing && (
         <div className="flex items-start gap-2 p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-xs">
           <AlertCircle className="w-4 h-4 text-green-400 flex-shrink-0 mt-0.5" />
           <div>
@@ -594,7 +626,7 @@ Please proceed step by step.`,
 // ── Policy Violations Aggregated ────────────────────────────────────────
 
 export function PolicyViolations({ config: _config }: CardConfig) {
-  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, isDemoData: kyvernoDemoData, installed: kyvernoInstalled, clustersChecked: kyvernoChecked, totalClusters: kyvernoTotal, refetch: kyvernoRefetch } = useKyverno()
+  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, isDemoData: kyvernoDemoData, installed: kyvernoInstalled, hasErrors: kyvernoHasErrors, clustersChecked: kyvernoChecked, totalClusters: kyvernoTotal, refetch: kyvernoRefetch } = useKyverno()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
   const [modalCluster, setModalCluster] = useState<string | null>(null)
@@ -695,6 +727,21 @@ export function PolicyViolations({ config: _config }: CardConfig) {
     }
     return (
       <div className="space-y-3">
+        {/* Error banner when fetch failed — distinct from "no violations" */}
+        {kyvernoHasErrors && !kyvernoInstalled && (
+          <div className="flex items-start gap-2 p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-xs">
+            <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+            <div>
+              <p className="text-red-400 font-medium">Scanner Data Unavailable</p>
+              <p className="text-muted-foreground">
+                Could not fetch Kyverno data — violation counts may be incomplete.{' '}
+                <button onClick={() => kyvernoRefetch()} className="text-red-400 hover:underline">
+                  Retry →
+                </button>
+              </p>
+            </div>
+          </div>
+        )}
         {/* Degraded state: installed but no policies */}
         {isDegraded && (
           <div className="flex items-start gap-2 p-2 rounded-lg bg-amber-500/10 border border-amber-500/20 text-xs">
@@ -710,11 +757,14 @@ export function PolicyViolations({ config: _config }: CardConfig) {
             </div>
           </div>
         )}
-        <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
-          <Shield className="w-8 h-8 mb-2 opacity-50" />
-          <p className="text-sm">No policy violations detected</p>
-          <p className="text-xs mt-1">All resources comply with active policies</p>
-        </div>
+        {/* Only show clean-scan message when there are no errors */}
+        {!kyvernoHasErrors && (
+          <div className="flex flex-col items-center justify-center h-full text-muted-foreground py-8">
+            <Shield className="w-8 h-8 mb-2 opacity-50" />
+            <p className="text-sm">No policy violations detected</p>
+            <p className="text-xs mt-1">All resources comply with active policies</p>
+          </div>
+        )}
       </div>
     )
   }
@@ -803,8 +853,8 @@ export function PolicyViolations({ config: _config }: CardConfig) {
 // ── Compliance Score Gauge ──────────────────────────────────────────────
 
 export function ComplianceScore({ config: _config }: CardConfig) {
-  const { statuses: kubescapeStatuses, aggregated: kubescapeAgg, isLoading: ksLoading, isDemoData: ksDemoData, clustersChecked: ksChecked, totalClusters: ksTotal } = useKubescape()
-  const { statuses: kyvernoStatuses, isLoading: kyLoading, isDemoData: kyDemoData, clustersChecked: kyChecked, totalClusters: kyTotal } = useKyverno()
+  const { statuses: kubescapeStatuses, aggregated: kubescapeAgg, isLoading: ksLoading, isDemoData: ksDemoData, hasErrors: ksHasErrors, clustersChecked: ksChecked, totalClusters: ksTotal, refetch: ksRefetch } = useKubescape()
+  const { statuses: kyvernoStatuses, isLoading: kyLoading, isDemoData: kyDemoData, hasErrors: kyHasErrors, clustersChecked: kyChecked, totalClusters: kyTotal, refetch: kyRefetch } = useKyverno()
   const { selectedClusters } = useGlobalFilters()
   const [showBreakdown, setShowBreakdown] = useState(false)
 
@@ -909,6 +959,22 @@ export function ComplianceScore({ config: _config }: CardConfig) {
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <Loader2 className="w-3 h-3 animate-spin" />
           <span>Checking clusters... {minChecked}/{totalChecking}</span>
+        </div>
+      )}
+
+      {/* Error banner when scanner data fetch failed */}
+      {(ksHasErrors || kyHasErrors) && !isLoading && (
+        <div className="flex items-start gap-2 p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-xs">
+          <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-red-400 font-medium">Scanner Data Unavailable</p>
+            <p className="text-muted-foreground">
+              Could not fetch data from {[ksHasErrors && 'Kubescape', kyHasErrors && 'Kyverno'].filter(Boolean).join(' and ')} — score may be incomplete.{' '}
+              <button onClick={() => { if (ksHasErrors) ksRefetch(); if (kyHasErrors) kyRefetch(); }} className="text-red-400 hover:underline">
+                Retry →
+              </button>
+            </p>
+          </div>
         </div>
       )}
 

--- a/web/src/components/cards/KyvernoPolicies.tsx
+++ b/web/src/components/cards/KyvernoPolicies.tsx
@@ -27,7 +27,7 @@ interface KyvernoPoliciesProps {
 
 function KyvernoPoliciesInternal({ config: _config }: KyvernoPoliciesProps) {
   const { t } = useTranslation()
-  const { statuses, isLoading, isRefreshing, lastRefresh, installed, isDemoData, refetch, clustersChecked, totalClusters } = useKyverno()
+  const { statuses, isLoading, isRefreshing, lastRefresh, installed, hasErrors, isDemoData, refetch, clustersChecked, totalClusters } = useKyverno()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
   const [localSearch, setLocalSearch] = useState('')
@@ -180,8 +180,24 @@ Please proceed step by step.`,
         </div>
       )}
 
-      {/* Install prompt when not detected (only after scanning completes) */}
-      {!installed && !isLoading && !isRefreshing && (
+      {/* Error banner when fetch failed — distinct from "not installed" */}
+      {hasErrors && !installed && !isLoading && !isRefreshing && (
+        <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-red-500/10 border border-red-500/20 text-xs">
+          <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-red-400 font-medium">Scanner Data Unavailable</p>
+            <p className="text-muted-foreground">
+              Could not fetch Kyverno data — policy list may be incomplete.{' '}
+              <button onClick={() => refetch()} className="text-red-400 hover:underline">
+                Retry →
+              </button>
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Install prompt when not detected (only after scanning completes, and no errors) */}
+      {!installed && !hasErrors && !isLoading && !isRefreshing && (
         <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-xs">
           <AlertCircle className="w-4 h-4 text-cyan-400 flex-shrink-0 mt-0.5" />
           <div>

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -406,6 +406,12 @@ export function useKubescape() {
   const isDemoData = isDemoMode
   const installed = Object.values(statuses).some(s => s.installed)
 
+  /** True when at least one cluster had a fetch error (distinct from "not installed") */
+  const hasErrors = useMemo(() =>
+    Object.values(statuses).some(s => !!s.error),
+    [statuses]
+  )
+
   // Aggregate across all clusters
   const aggregated = useMemo(() => {
     const clusterStatuses = Object.values(statuses).filter(s => s.installed)
@@ -429,6 +435,8 @@ export function useKubescape() {
     isRefreshing,
     lastRefresh,
     installed,
+    /** True when at least one cluster had a fetch error */
+    hasErrors,
     isDemoData,
     /** Number of clusters checked so far (for progressive UI) */
     clustersChecked,

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -429,12 +429,20 @@ export function useKyverno() {
   const isDemoData = isDemoMode
   const installed = Object.values(statuses).some(s => s.installed)
 
+  /** True when at least one cluster had a fetch error (distinct from "not installed") */
+  const hasErrors = useMemo(() =>
+    Object.values(statuses).some(s => !!s.error),
+    [statuses]
+  )
+
   return {
     statuses,
     isLoading,
     isRefreshing,
     lastRefresh,
     installed,
+    /** True when at least one cluster had a fetch error */
+    hasErrors,
     isDemoData,
     /** Number of clusters checked so far (for progressive UI) */
     clustersChecked,

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -337,6 +337,12 @@ export function useTrivy() {
   const isDemoData = isDemoMode
   const installed = Object.values(statuses).some(s => s.installed)
 
+  /** True when at least one cluster had a fetch error (distinct from "not installed") */
+  const hasErrors = useMemo(() =>
+    Object.values(statuses).some(s => !!s.error),
+    [statuses]
+  )
+
   // Aggregate across all clusters
   const aggregated = useMemo((): TrivyVulnSummary => {
     const agg: TrivyVulnSummary = { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 }
@@ -358,6 +364,8 @@ export function useTrivy() {
     isRefreshing,
     lastRefresh,
     installed,
+    /** True when at least one cluster had a fetch error */
+    hasErrors,
     isDemoData,
     /** Number of clusters checked so far (for progressive UI) */
     clustersChecked,


### PR DESCRIPTION
## Summary
- Scanner hooks (`useTrivy`, `useKyverno`, `useKubescape`) now return a `hasErrors` boolean computed from per-cluster error states
- Compliance cards (TrivyScan, KubescapeScan, PolicyViolations, ComplianceScore, KyvernoPolicies) show a red "Scanner Data Unavailable" banner with a Retry button when fetch errors occur
- The "Install with AI Mission" prompt now only appears when there are no errors (i.e., the scanner genuinely wasn't found)
- PolicyViolations no longer shows "No policy violations detected" / green shield when the actual reason is a fetch failure

## What was happening
When `fetchSingleCluster` threw an error (timeout, network failure, etc.), the catch block returned a status with `installed: false` and `error` set. But the hooks only exposed `installed` (which was false when all clusters errored). The cards checked `!installed` and showed "Install X" or "0 findings" — hiding the real problem.

## Test plan
- [ ] With connected clusters: scanner cards show real data as before
- [ ] Simulate fetch failure (e.g., disconnect a cluster): card shows red "Scanner Data Unavailable" banner with Retry
- [ ] When scanner is genuinely not installed: card shows the cyan/green "Install" prompt (not the error banner)
- [ ] ComplianceScore card shows error banner naming which specific tool(s) failed
- [ ] Demo mode: unaffected — still shows demo data normally

Fixes #2717