### PR TITLE
🐛 Add JWT auth header to MCP API calls in status card hooks

### DIFF
--- a/web/src/components/cards/cloudevents_status/useCloudEventsStatus.ts
+++ b/web/src/components/cards/cloudevents_status/useCloudEventsStatus.ts
@@ -1,6 +1,7 @@
 import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { authFetch } from '../../../lib/api'
 import { CLOUDEVENTS_DEMO_DATA, type CloudEventResource, type CloudEventsDemoData } from './demoData'
 
 export type CloudEventsStatus = CloudEventsDemoData
@@ -115,7 +116,7 @@ export const __testables = {
 async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
   try {
     const params = new URLSearchParams({ group, version, resource })
-    const response = await fetch(`/api/mcp/custom-resources?${params.toString()}`, {
+    const response = await authFetch(`/api/mcp/custom-resources?${params.toString()}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })

--- a/web/src/components/cards/contour-status/useContourStatus.ts
+++ b/web/src/components/cards/contour-status/useContourStatus.ts
@@ -2,6 +2,7 @@ import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { CONTOUR_DEMO_DATA } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
+import { authFetch } from '../../../lib/api'
 import type { ContourDemoData } from './demoData'
 
 export type ContourStatus = ContourDemoData
@@ -71,7 +72,7 @@ function isPodReady(pod: BackendPodInfo): boolean {
 }
 
 async function fetchContourStatus(): Promise<ContourStatus> {
-  const resp = await fetch('/api/mcp/pods', {
+  const resp = await authFetch('/api/mcp/pods', {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/crio_status/useCrioStatus.ts
+++ b/web/src/components/cards/crio_status/useCrioStatus.ts
@@ -2,6 +2,7 @@ import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { CRIO_DEMO_DATA, type CrioStatusDemoData } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { authFetch } from '../../../lib/api'
 
 export interface CrioStatus {
   totalNodes: number
@@ -75,7 +76,7 @@ interface BackendNodeInfo {
  * CRI-O nodes are identified by containerRuntime containing "cri-o".
  */
 async function fetchCrioStatus(): Promise<CrioStatus> {
-  const resp = await fetch('/api/mcp/nodes', {
+  const resp = await authFetch('/api/mcp/nodes', {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/flatcar_status/useFlatcarStatus.ts
+++ b/web/src/components/cards/flatcar_status/useFlatcarStatus.ts
@@ -3,6 +3,7 @@ import { useCardLoadingState } from '../CardDataContext'
 import { FLATCAR_DEMO_DATA, type FlatcarDemoData } from './demoData'
 import { compareFlatcarVersions } from './versionUtils'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { authFetch } from '../../../lib/api'
 
 export interface FlatcarStatus {
   totalNodes: number
@@ -41,7 +42,7 @@ interface FlatcarNodeInfo {
  * so no client-side filtering is needed.
  */
 async function fetchFlatcarStatus(): Promise<FlatcarStatus> {
-  const resp = await fetch('/api/mcp/flatcar/nodes', {
+  const resp = await authFetch('/api/mcp/flatcar/nodes', {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/fluentd_status/useFluentdStatus.ts
+++ b/web/src/components/cards/fluentd_status/useFluentdStatus.ts
@@ -2,6 +2,7 @@ import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { FLUENTD_DEMO_DATA, type FluentdDemoData } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
+import { authFetch } from '../../../lib/api'
 
 export type FluentdStatus = FluentdDemoData
 
@@ -158,7 +159,7 @@ export function estimateEventsPerSecond(events: BackendEventInfo[]): number {
 }
 
 async function fetchPods(url: string): Promise<BackendPodInfo[]> {
-  const resp = await fetch(url, {
+  const resp = await authFetch(url, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
@@ -173,7 +174,7 @@ async function fetchPods(url: string): Promise<BackendPodInfo[]> {
 
 async function fetchDaemonSets(namespace?: string): Promise<BackendDaemonSetInfo[]> {
   const query = namespace ? `?namespace=${encodeURIComponent(namespace)}` : ''
-  const resp = await fetch(`/api/mcp/daemonsets${query}`, {
+  const resp = await authFetch(`/api/mcp/daemonsets${query}`, {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
@@ -193,7 +194,7 @@ async function fetchEvents(namespace: string): Promise<BackendEventInfo[]> {
       limit: String(EVENT_SAMPLE_LIMIT),
     })
 
-    const resp = await fetch(`/api/mcp/events?${params}`, {
+    const resp = await authFetch(`/api/mcp/events?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })

--- a/web/src/components/cards/keda_status/useKedaStatus.ts
+++ b/web/src/components/cards/keda_status/useKedaStatus.ts
@@ -2,6 +2,7 @@ import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { KEDA_DEMO_DATA, type KedaDemoData, type KedaScaledObject, type KedaTriggerType } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
+import { authFetch } from '../../../lib/api'
 
 export type KedaStatus = KedaDemoData
 
@@ -73,7 +74,7 @@ function isPodReady(pod: BackendPodInfo): boolean {
 async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
   try {
     const params = new URLSearchParams({ group, version, resource })
-    const resp = await fetch(`/api/mcp/custom-resources?${params}`, {
+    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })

--- a/web/src/components/cards/kubevela_status/useKubeVelaStatus.ts
+++ b/web/src/components/cards/kubevela_status/useKubeVelaStatus.ts
@@ -2,6 +2,7 @@ import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { KUBEVELA_DEMO_DATA, type KubeVelaDemoData, type KubeVelaApplication } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
+import { authFetch } from '../../../lib/api'
 
 export type KubeVelaStatus = KubeVelaDemoData
 
@@ -76,7 +77,7 @@ function isPodReady(pod: BackendPodInfo): boolean {
 async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
   try {
     const params = new URLSearchParams({ group, version, resource })
-    const resp = await fetch(`/api/mcp/custom-resources?${params}`, {
+    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
@@ -153,7 +154,7 @@ function parseApplication(item: CRItem): KubeVelaApplication {
 
 async function fetchKubeVelaStatus(): Promise<KubeVelaStatus> {
   // Step 1: Detect controller pods
-  const resp = await fetch('/api/mcp/pods', {
+  const resp = await authFetch('/api/mcp/pods', {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/lima_status/useLimaStatus.ts
+++ b/web/src/components/cards/lima_status/useLimaStatus.ts
@@ -2,6 +2,7 @@ import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { LIMA_DEMO_DATA, type LimaDemoData, type LimaInstance } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { authFetch } from '../../../lib/api'
 
 export interface LimaStatus {
   instances: LimaInstance[]
@@ -55,7 +56,7 @@ interface BackendNodeInfo {
  * clusters. The backend returns { nodes: NodeInfo[], source: string }.
  */
 async function fetchLimaStatus(): Promise<LimaStatus> {
-  const resp = await fetch('/api/mcp/nodes', {
+  const resp = await authFetch('/api/mcp/nodes', {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/openfeature_status/useOpenFeatureStatus.ts
+++ b/web/src/components/cards/openfeature_status/useOpenFeatureStatus.ts
@@ -2,6 +2,7 @@ import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { OPENFEATURE_DEMO_DATA } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { authFetch } from '../../../lib/api'
 import type { OpenFeatureDemoData } from './demoData'
 
 export type OpenFeatureStatus = OpenFeatureDemoData
@@ -100,7 +101,7 @@ function extractProviderName(pod: BackendPodInfo): string {
 async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
   try {
     const params = new URLSearchParams({ group, version, resource })
-    const resp = await fetch(`/api/mcp/custom-resources?${params}`, {
+    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
@@ -146,7 +147,7 @@ function countFlags(items: CRItem[]): { total: number; enabled: number; disabled
 
 async function fetchOpenFeatureStatus(): Promise<OpenFeatureStatus> {
   // Step 1: Detect OpenFeature pods
-  const resp = await fetch('/api/mcp/pods', {
+  const resp = await authFetch('/api/mcp/pods', {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/components/cards/strimzi_status/useStrimziStatus.ts
+++ b/web/src/components/cards/strimzi_status/useStrimziStatus.ts
@@ -2,6 +2,7 @@ import { useCache } from '../../../lib/cache'
 import { useCardLoadingState } from '../CardDataContext'
 import { STRIMZI_DEMO_DATA, type StrimziDemoData, type StrimziTopic } from './demoData'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { authFetch } from '../../../lib/api'
 
 export type StrimziStatus = StrimziDemoData
 
@@ -80,7 +81,7 @@ function isBrokerPod(pod: BackendPodInfo): boolean {
 async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
   try {
     const params = new URLSearchParams({ group, version, resource })
-    const resp = await fetch(`/api/mcp/custom-resources?${params}`, {
+    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
       headers: { Accept: 'application/json' },
       signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
     })
@@ -125,7 +126,7 @@ function parseTopic(item: CRItem): StrimziTopic {
 
 async function fetchStrimziStatus(): Promise<StrimziStatus> {
   // Step 1: Detect Strimzi pods
-  const resp = await fetch('/api/mcp/pods', {
+  const resp = await authFetch('/api/mcp/pods', {
     headers: { Accept: 'application/json' },
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -17,7 +17,7 @@
 
 import { useState, useCallback } from 'react'
 import { useCache, type RefreshCategory } from '../lib/cache'
-import { isBackendUnavailable } from '../lib/api'
+import { isBackendUnavailable, authFetch } from '../lib/api'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { fetchSSE } from '../lib/sseClient'
 import { clusterCacheRef } from './mcp/shared'
@@ -1681,7 +1681,7 @@ export function useCachedSecurityIssues(
           const params = new URLSearchParams()
           if (cluster) params.append('cluster', cluster)
           if (namespace) params.append('namespace', namespace)
-          const response = await fetch(`/api/mcp/security-issues?${params}`, {
+          const response = await authFetch(`/api/mcp/security-issues?${params}`, {
             method: 'GET',
             headers: {
               'Content-Type': 'application/json',
@@ -1906,7 +1906,7 @@ export function useGPUHealthCronJob(cluster?: string) {
     try {
       const token = getToken()
       if (!token) throw new Error('No authentication token')
-      const response = await fetch('/api/mcp/gpu-nodes/health/cronjob', {
+      const response = await authFetch('/api/mcp/gpu-nodes/health/cronjob', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -1939,7 +1939,7 @@ export function useGPUHealthCronJob(cluster?: string) {
     try {
       const token = getToken()
       if (!token) throw new Error('No authentication token')
-      const response = await fetch('/api/mcp/gpu-nodes/health/cronjob', {
+      const response = await authFetch('/api/mcp/gpu-nodes/health/cronjob', {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
@@ -2101,7 +2101,7 @@ export const coreFetchers = {
     }
     const token = getToken()
     if (token && token !== 'demo-token' && !isBackendUnavailable()) {
-      const response = await fetch('/api/mcp/security-issues', {
+      const response = await authFetch('/api/mcp/security-issues', {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -510,3 +510,21 @@ class ApiClient {
 }
 
 export const api = new ApiClient()
+
+/**
+ * Drop-in replacement for `fetch()` that auto-injects the JWT Authorization
+ * header from localStorage.  Use this for MCP endpoint calls that need auth
+ * but return a raw Response (unlike `api.get()` which returns `{data}`).
+ *
+ * Existing callers only need to change `fetch(url, init)` -> `authFetch(url, init)`.
+ */
+export function authFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const headers = new Headers(init?.headers)
+
+  if (token && token !== DEMO_TOKEN_VALUE && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${token}`)
+  }
+
+  return fetch(input, { ...init, headers })
+}


### PR DESCRIPTION
## Summary
- Fixes #2643
- Status card hooks used raw `fetch()` without the `Authorization` header when calling `/api/mcp/*` endpoints, which require JWT auth (via `middleware.JWTAuth` on the `/api` route group), causing 401 errors in production
- Added `authFetch()` helper in `lib/api.ts` -- a drop-in `fetch()` replacement that auto-injects the JWT Bearer token from localStorage
- Replaced all 18 raw `fetch()` calls to MCP endpoints across 11 files with `authFetch()`

## Affected hooks
- `useContourStatus` / `useStrimziStatus` / `useKubeVelaStatus` / `useKedaStatus`
- `useOpenFeatureStatus` / `useCloudEventsStatus` / `useFluentdStatus`
- `useFlatcarStatus` / `useLimaStatus` / `useCrioStatus`
- `useCachedData` (security-issues, GPU health cronjob)

## Test plan
- [ ] Verify status cards load data successfully when JWT auth is enabled
- [ ] Verify `authFetch` injects the Authorization header (check Network tab)
- [ ] Verify demo mode (no token) still works -- `authFetch` skips header for demo tokens
- [ ] Verify cards that already had manual Authorization headers still work (no duplicate header)