### PR TITLE
🐛 Fix Kyverno cards not responding to demo mode toggle

### DIFF
--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -14,6 +14,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { useDemoMode } from './useDemoMode'
+import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_KYVERNO_CACHE, STORAGE_KEY_KYVERNO_CACHE_TIME } from '../lib/constants/storage'
 
 /** Refresh interval for automatic polling (2 minutes) */
@@ -96,6 +97,16 @@ function saveToCache(statuses: Record<string, KyvernoClusterStatus>): void {
       localStorage.setItem(STORAGE_KEY_KYVERNO_CACHE, JSON.stringify(completed))
       localStorage.setItem(STORAGE_KEY_KYVERNO_CACHE_TIME, Date.now().toString())
     }
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/** Clear localStorage cache so stale data doesn't persist across mode transitions */
+function clearCache(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY_KYVERNO_CACHE)
+    localStorage.removeItem(STORAGE_KEY_KYVERNO_CACHE_TIME)
   } catch {
     // Ignore storage errors
   }
@@ -416,6 +427,28 @@ export function useKyverno() {
       setIsLoading(false)
     }
   }, [clusters.length, isDemoMode, clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Register with unified mode transition system so skeleton/refetch works
+  // in sync with all other cards when demo mode is toggled
+  useEffect(() => {
+    registerCacheReset('kyverno', () => {
+      clearCache()
+      setStatuses({})
+      setIsLoading(true)
+      setLastRefresh(null)
+      setClustersChecked(0)
+      initialLoadDone.current = false
+    })
+
+    const unregisterRefetch = registerRefetch('kyverno', () => {
+      refetch(false)
+    })
+
+    return () => {
+      unregisterCacheReset('kyverno')
+      unregisterRefetch()
+    }
+  }, [refetch])
 
   // Auto-refresh — always poll when clusters exist so we detect tools
   // that get installed later or clusters that become reachable


### PR DESCRIPTION
## Summary
- Registers `useKyverno` hook with the unified mode transition system (`registerCacheReset` / `registerRefetch`)
- Kyverno cards now show coordinated skeleton loading states when demo mode is toggled, matching behavior of all other cards
- Adds `clearCache()` helper to remove stale Kyverno localStorage entries during mode transitions, preventing live data from persisting in demo mode

## Analysis of Issue #2616

The auto-QA flagged 14 cards as "not responding to demo mode toggle." Investigation reveals:

- **12 of 14 are false positives**: Cards using `useCached*` hooks (EventStream, GPUStatus, HelmHistory, ChartVersions, TopPods, NamespaceMonitor, LLMInference, LLMModels, GPUNamespaceAllocations) and cards with custom hooks that use `useCache` internally (OpenFeatureStatus, StrimziStatus, Weather) already participate in the unified mode transition via `useCache`'s built-in `registerRefetch` and `useSyncExternalStore(subscribeDemoMode, ...)`.

- **2 cards genuinely affected**: KyvernoPolicies and CrossClusterPolicyComparison both use `useKyverno`, which managed its own localStorage cache and demo mode handling outside the unified system. Fixed in this PR.

## Remaining work from #2616
- Freshness indicators (8 components with caching but no "Updated X ago" display) -- not addressed in this PR
- localStorage TTL validation -- not addressed in this PR

Partially addresses #2616

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (no new warnings)
- [ ] Toggle demo mode with agent connected -- Kyverno cards show skeleton then switch to demo data
- [ ] Toggle back to live -- Kyverno cards show skeleton then re-fetch real data
- [ ] CrossClusterPolicyComparison also responds correctly (shares `useKyverno`)