### PR TITLE
✨ Add demo mode awareness to 6 high-visibility cards

### DIFF
--- a/web/src/components/cards/ArgoCDSyncStatus.tsx
+++ b/web/src/components/cards/ArgoCDSyncStatus.tsx
@@ -3,6 +3,7 @@ import { Skeleton } from '../ui/Skeleton'
 import { useChartFilters, CardClusterFilter } from '../../lib/cards'
 import { useArgoCDSyncStatus } from '../../hooks/useArgoCD'
 import { useCardLoadingState } from './CardDataContext'
+import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
 
 interface ArgoCDSyncStatusProps {
@@ -11,6 +12,7 @@ interface ArgoCDSyncStatusProps {
 
 export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
   const { t } = useTranslation('cards')
+  const { isDemoMode } = useDemoMode()
   // Local cluster filter
   const {
     localClusterFilter,
@@ -41,7 +43,7 @@ export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
     hasAnyData: total > 0,
     isFailed,
     consecutiveFailures,
-    isDemoData,
+    isDemoData: isDemoMode || isDemoData,
   })
 
   if (showSkeleton) {

--- a/web/src/components/cards/EventStream.tsx
+++ b/web/src/components/cards/EventStream.tsx
@@ -12,6 +12,7 @@ import {
   CardControlsRow, CardPaginationFooter,
 } from '../../lib/cards'
 import { useCardLoadingState } from './CardDataContext'
+import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
 
 type SortByOption = 'time' | 'count' | 'type'
@@ -24,6 +25,7 @@ const SORT_OPTIONS = [
 
 function EventStreamInternal() {
   const { t } = useTranslation()
+  const { isDemoMode } = useDemoMode()
   // Fetch more events from API to enable pagination (using cached data hook)
   const {
     events: rawEvents,
@@ -37,7 +39,7 @@ function EventStreamInternal() {
   // Report state to CardWrapper for refresh animation
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: hookLoading,
-    isDemoData: isDemoFallback,
+    isDemoData: isDemoMode || isDemoFallback,
     hasAnyData: rawEvents.length > 0,
     isFailed: !!error && rawEvents.length === 0,
     consecutiveFailures: error ? 1 : 0,

--- a/web/src/components/cards/GPUStatus.tsx
+++ b/web/src/components/cards/GPUStatus.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from '../ui/Skeleton'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 import { useCardLoadingState } from './CardDataContext'
+import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface GPUStatusProps {
   config?: Record<string, unknown>
@@ -32,6 +33,7 @@ interface ClusterGPUStats {
 
 export function GPUStatus({ config }: GPUStatusProps) {
   const { t } = useTranslation(['cards', 'common'])
+  const { isDemoMode } = useDemoMode()
   const cluster = config?.cluster as string | undefined
   const {
     nodes: rawNodes,
@@ -44,7 +46,7 @@ export function GPUStatus({ config }: GPUStatusProps) {
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: hookLoading,
     hasAnyData: rawNodes.length > 0,
-    isDemoData: isDemoFallback,
+    isDemoData: isDemoMode || isDemoFallback,
   })
 
   // Card-specific GPU type filter (not handled by useCardData)

--- a/web/src/components/cards/NamespaceMonitor.tsx
+++ b/web/src/components/cards/NamespaceMonitor.tsx
@@ -11,6 +11,7 @@ import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { CardComponentProps } from './cardRegistry'
 import { useCardLoadingState } from './CardDataContext'
+import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
 
 // Resource types to monitor
@@ -92,6 +93,7 @@ const ChangeAnimations: Record<Exclude<ChangeType, null>, string> = {
 
 export function NamespaceMonitor({ config: _config }: CardComponentProps) {
   const { t: _t } = useTranslation()
+  const { isDemoMode } = useDemoMode()
   const { deduplicatedClusters: clusters, isLoading } = useClusters()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { drillToNamespace, drillToPod, drillToDeployment, drillToService, drillToPVC } = useDrillDownActions()
@@ -149,7 +151,7 @@ export function NamespaceMonitor({ config: _config }: CardComponentProps) {
   useCardLoadingState({
     isLoading,
     hasAnyData: clusters.length > 0,
-    isDemoData,
+    isDemoData: isDemoMode || isDemoData,
   })
 
   // Build snapshots and detect changes

--- a/web/src/components/cards/TopPods.tsx
+++ b/web/src/components/cards/TopPods.tsx
@@ -7,6 +7,7 @@ import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useCardLoadingState } from './CardDataContext'
 import { useCardData, commonComparators, CardClusterFilter, CardSearchInput, CardAIActions } from '../../lib/cards'
+import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
 
 type SortByOption = 'restarts' | 'name' | 'cpu' | 'memory' | 'gpu'
@@ -65,6 +66,7 @@ export function TopPods({ config }: TopPodsProps) {
   const { t } = useTranslation()
   const clusterConfig = config?.cluster
   const namespaceConfig = config?.namespace
+  const { isDemoMode } = useDemoMode()
   const { drillToPod } = useDrillDownActions()
 
   // Fetch more pods to allow client-side filtering and pagination (using unified cache)
@@ -82,7 +84,7 @@ export function TopPods({ config }: TopPodsProps) {
   // Report data state to CardWrapper for failure badge rendering
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
-    isDemoData: isDemoFallback,
+    isDemoData: isDemoMode || isDemoFallback,
     hasAnyData: rawPods.length > 0,
     isFailed,
     consecutiveFailures,

--- a/web/src/components/cards/openfeature_status/OpenFeatureStatus.tsx
+++ b/web/src/components/cards/openfeature_status/OpenFeatureStatus.tsx
@@ -2,6 +2,7 @@ import { CheckCircle, AlertTriangle, RefreshCw, Flag, Server, Activity } from 'l
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../ui/Skeleton'
 import { useOpenFeatureStatus } from './useOpenFeatureStatus'
+import { useDemoMode } from '../../../hooks/useDemoMode'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 
 const ERROR_RATE_WARNING_PCT = 5 // Show warning when error rate exceeds this percentage
@@ -29,6 +30,10 @@ function useFormatRelativeTime() {
 
 export function OpenFeatureStatus() {
   const { t } = useTranslation('cards')
+  // useDemoMode provides explicit demo mode awareness; useOpenFeatureStatus also
+  // handles demo data internally via useCache, but we reference isDemoMode here
+  // to suppress the "not-installed" state when demo data is being shown.
+  const { isDemoMode } = useDemoMode()
   const formatRelativeTime = useFormatRelativeTime()
   const { data, error, showSkeleton, showEmptyState, isRefreshing } = useOpenFeatureStatus()
 
@@ -55,7 +60,7 @@ export function OpenFeatureStatus() {
     )
   }
 
-  if (data.health === 'not-installed') {
+  if (data.health === 'not-installed' && !isDemoMode) {
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
         <Flag className="w-6 h-6 text-muted-foreground/50" />


### PR DESCRIPTION
## Summary
- Import `useDemoMode` and wire `isDemoMode` to `useCardLoadingState` in 6 cards: **TopPods**, **GPUStatus**, **EventStream**, **ArgoCDSyncStatus**, **NamespaceMonitor**, and **OpenFeatureStatus**
- These cards already received demo data via `useCachedData`/`useCache` hooks internally, but lacked the explicit `useDemoMode` reference that the auto-QA workflow detects as demo-data-aware
- Also adds a safety net: `isDemoData: isDemoMode || isDemoFallback` ensures the Demo badge is visible when demo mode is toggled manually, matching the pattern used by ClusterHealth, RecentEvents, ResourceUsage, and other established cards

Partially addresses #2596 — remaining cards can be done in follow-up PRs.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes (0 new errors, only pre-existing warnings)
- [x] All 6 cards pass auto-QA `grep` pattern for demo data detection
- [ ] Toggle demo mode — cards show demo data with Demo badge
- [ ] Connect agent — cards show live data without Demo badge