### PR TITLE
✨ Add cluster_created and github_connected analytics events

### DIFF
--- a/web/src/components/auth/AuthCallback.tsx
+++ b/web/src/components/auth/AuthCallback.tsx
@@ -6,6 +6,7 @@ import { ROUTES, getLoginWithError } from '../../config/routes'
 import { useTranslation } from 'react-i18next'
 import { useToast } from '../ui/Toast'
 import { safeGetItem, safeRemoveItem } from '../../lib/utils/localStorage'
+import { emitGitHubConnected } from '../../lib/analytics'
 
 export function AuthCallback() {
   const { t } = useTranslation('common')
@@ -31,6 +32,7 @@ export function AuthCallback() {
 
     if (token) {
       setToken(token, true)
+      emitGitHubConnected()
       setStatus(t('authCallback.fetchingUserInfo'))
 
       // Check for a return-to URL saved by ProtectedRoute (deep-link through OAuth),

--- a/web/src/components/clusters/AddClusterDialog.tsx
+++ b/web/src/components/clusters/AddClusterDialog.tsx
@@ -5,6 +5,7 @@ import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/consta
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import { CloudProviderIcon } from '../ui/CloudProviderIcon'
 import { StatusBadge } from '../ui/StatusBadge'
+import { emitClusterCreated } from '../../lib/analytics'
 
 interface AddClusterDialogProps {
   open: boolean
@@ -288,6 +289,7 @@ export function AddClusterDialog({ open, onClose }: AddClusterDialogProps) {
         throw new Error(body.error || res.statusText)
       }
       setConnectState('done')
+      emitClusterCreated(clusterName, authType)
       clearTimeout(closeTimerRef.current)
       closeTimerRef.current = setTimeout(() => {
         resetConnectState()

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1305,6 +1305,20 @@ export function emitBenchmarkViewed(benchmarkType: string) {
   send('ksc_benchmark_viewed', { benchmark_type: benchmarkType })
 }
 
+// ── Cluster Lifecycle ───────────────────────────────────────────────
+
+/** Fired when a user successfully adds a cluster via the Add Cluster dialog */
+export function emitClusterCreated(clusterName: string, authType: string) {
+  send('ksc_cluster_created', { cluster_name: clusterName, auth_type: authType })
+}
+
+// ── GitHub OAuth ────────────────────────────────────────────────────
+
+/** Fired when a user completes GitHub OAuth login (token received) */
+export function emitGitHubConnected() {
+  send('ksc_github_connected')
+}
+
 // ── Cluster Admin ──────────────────────────────────────────────────
 
 export function emitClusterAction(action: string, clusterName: string) {


### PR DESCRIPTION
## Summary
- **`ksc_cluster_created`**: Fired when a user successfully adds a cluster via the Add Cluster dialog. Includes `cluster_name` and `auth_type`.
- **`ksc_github_connected`**: Fired when GitHub OAuth callback receives a token.

Fills the last two instrumentation gaps from the 30-day analytics review.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [ ] Add cluster → verify `ksc_cluster_created` in GA4
- [ ] OAuth login → verify `ksc_github_connected` in GA4