### PR TITLE
🐛 Add SQLite connection pool configuration to prevent resource exhaustion

### DIFF
--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -11,6 +13,28 @@ import (
 
 	"github.com/kubestellar/console/pkg/models"
 )
+
+// SQLite connection pool defaults
+const (
+	// sqliteDefaultMaxOpenConns limits concurrent database connections
+	sqliteDefaultMaxOpenConns = 25
+	// sqliteDefaultMaxIdleConns controls idle connection pool size
+	sqliteDefaultMaxIdleConns = 5
+	// sqliteDefaultConnMaxLifetime recycles connections periodically
+	sqliteDefaultConnMaxLifetime = 5 * time.Minute
+	// sqliteDefaultConnMaxIdleTime closes long-idle connections
+	sqliteDefaultConnMaxIdleTime = 2 * time.Minute
+)
+
+// getEnvInt reads an integer from the environment, falling back to defaultVal.
+func getEnvInt(key string, defaultVal int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return defaultVal
+}
 
 // SQLiteStore implements Store using SQLite
 type SQLiteStore struct {
@@ -23,6 +47,12 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
+
+	// Configure connection pool for resource management under high load
+	db.SetMaxOpenConns(getEnvInt("KC_SQLITE_MAX_OPEN_CONNS", sqliteDefaultMaxOpenConns))
+	db.SetMaxIdleConns(getEnvInt("KC_SQLITE_MAX_IDLE_CONNS", sqliteDefaultMaxIdleConns))
+	db.SetConnMaxLifetime(sqliteDefaultConnMaxLifetime)
+	db.SetConnMaxIdleTime(sqliteDefaultConnMaxIdleTime)
 
 	store := &SQLiteStore{db: db}
 	if err := store.migrate(); err != nil {


### PR DESCRIPTION
## Summary
- Configure connection pool settings in `NewSQLiteStore()` to optimize performance and prevent file handle exhaustion under high load
- Extract all pool values to named constants (no magic numbers) per project guidelines
- Add env-var overrides (`KC_SQLITE_MAX_OPEN_CONNS`, `KC_SQLITE_MAX_IDLE_CONNS`) for deployment-specific tuning
- Defaults: 25 max open, 5 max idle, 5min connection lifetime, 2min idle timeout

Supersedes #2686 — addresses review feedback (named constants + env-var configurability).

Fixes #2659

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Confirm connection pool settings are applied at startup
- [ ] Test env-var overrides: `KC_SQLITE_MAX_OPEN_CONNS=10` should override the default
- [ ] Verify invalid env-var values fall back to defaults gracefully