### PR TITLE
✨ Track install method, update channel, and make update usage in GA4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,15 @@
 #   make restart   Restart all processes via startup-oauth.sh
 #   make help      Show available targets
 
-.PHONY: help dev build restart update pull lint
+.PHONY: help dev build restart update pull lint analytics-ping
 
 SHELL := /bin/bash
+
+# GA4 Measurement Protocol — anonymous "make update" tracking
+# The API secret and Measurement ID are non-sensitive (client-side analytics).
+# No PII is collected; only a random client ID and the event name.
+GA4_MP_API_SECRET := LpGb3fZkSk2q2d_1hJ8Haw
+GA4_MP_MEASUREMENT_ID := G-PXWNVQ8D1T
 
 ## help: Show this help message
 help:
@@ -34,8 +40,17 @@ build:
 restart:
 	bash startup-oauth.sh
 
-## update: Pull, build, and restart (full update cycle)
-update: pull build restart
+## analytics-ping: Send anonymous "make update" event to GA4 (fire-and-forget)
+analytics-ping:
+	@# Anonymous ping — no PII, random client ID per machine, fire-and-forget
+	@CID=$$(cat ~/.ksc-analytics-cid 2>/dev/null || (uuidgen | tr '[:upper:]' '[:lower:]' | tee ~/.ksc-analytics-cid)); \
+	curl -s -o /dev/null --max-time 3 \
+	  'https://www.google-analytics.com/mp/collect?measurement_id=$(GA4_MP_MEASUREMENT_ID)&api_secret=$(GA4_MP_API_SECRET)' \
+	  -d "{\"client_id\":\"$$CID\",\"events\":[{\"name\":\"ksc_make_update\",\"params\":{\"install_method\":\"dev\",\"commit_sha\":\"$$(git rev-parse --short HEAD 2>/dev/null || echo unknown)\"}}]}" \
+	  2>/dev/null || true
+
+## update: Pull, build, restart, and send anonymous analytics ping
+update: pull build restart analytics-ping
 
 ## dev: Start frontend, backend, and kc-agent for local development (no OAuth required)
 dev:

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -9,6 +9,7 @@ import type {
   AutoUpdateStatus,
   UpdateProgress,
 } from '../types/updates'
+import { emitSessionContext } from '../lib/analytics'
 import { UPDATE_STORAGE_KEYS } from '../types/updates'
 import { LOCAL_AGENT_HTTP_URL, FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
 import { useLocalAgent } from './useLocalAgent'
@@ -725,6 +726,13 @@ function useVersionCheckCore() {
       setInstallMethod(agentHealth.install_method as InstallMethod)
     }
   }, [agentHealth?.install_method])
+
+  // Send install method + update channel to GA4 as user properties once known
+  useEffect(() => {
+    if (installMethod !== 'unknown') {
+      emitSessionContext(installMethod, channel)
+    }
+  }, [installMethod, channel])
 
   // Auto-reset channel when it's no longer valid for the detected install method.
   // Example: localhost defaults to 'developer', but backend reports 'helm' install —

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1443,6 +1443,35 @@ export function emitLinkedInShare(source: string) {
   send('ksc_linkedin_share', { source })
 }
 
+// ── Session Context ──────────────────────────────────────────────
+
+/**
+ * Set install method and update channel as GA4 user properties.
+ * Call this once the version-check hook has detected the install method.
+ * Also fires a ksc_session_start event so we can segment sessions by
+ * install method and channel in GA4 reports.
+ *
+ * Deduplicated per browser session — only fires once per tab lifecycle.
+ */
+const SESSION_START_KEY = '_ksc_session_start_sent'
+
+export function emitSessionContext(installMethod: string, updateChannel: string) {
+  // Set as persistent user properties — available on ALL future events
+  setAnalyticsUserProperties({
+    install_method: installMethod,
+    update_channel: updateChannel,
+  })
+
+  // Fire session start event once per page load
+  if (sessionStorage.getItem(SESSION_START_KEY)) return
+  sessionStorage.setItem(SESSION_START_KEY, '1')
+
+  send('ksc_session_start', {
+    install_method: installMethod,
+    update_channel: updateChannel,
+  })
+}
+
 // ── Settings: Update ──────────────────────────────────────────────
 
 /** Fired when user clicks "Check for Updates" in settings */


### PR DESCRIPTION
## Summary
- **install_method** and **update_channel** are now GA4 user properties, set once the version-check hook detects the install method — enables segmenting all metrics by install type (dev, helm, make, binary)
- **ksc_session_start** event fires once per browser session with install_method + update_channel dimensions — answers "how many users are on developer mode?"
- **make update** now pings GA4 via Measurement Protocol (anonymous, fire-and-forget) — answers "how many developers use `make update` to stay current?"

Fixes no issue — new analytics instrumentation.

## Test plan
- [ ] Run `make update` locally, verify no errors from the curl ping
- [ ] Open console in browser, check GA4 Realtime → Events for `ksc_session_start` with `install_method=dev`
- [ ] Check GA4 User Properties for `install_method` and `update_channel`
- [ ] Verify `ksc_make_update` appears in GA4 Realtime after running `make update`
- [ ] Confirm `sessionStorage._ksc_session_start_sent` prevents duplicate fires on same tab