### PR TITLE
🐛 Fix alert notifications: dedup, deep link, and repeated firing

### DIFF
--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -165,6 +165,11 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
   const rulesRef = useRef(rules)
   rulesRef.current = rules
 
+  // Track which alert dedup keys have already triggered a browser notification.
+  // Prevents the same alert from sending repeated macOS notifications on every
+  // evaluation cycle. Keys are cleared when the alert resolves.
+  const notifiedAlertKeysRef = useRef<Set<string>>(new Set())
+
   // CronJob health results cache — fetched async, read synchronously by evaluator
   const cronJobResultsRef = useRef<Record<string, GPUHealthCheckResult[]>>({})
 
@@ -812,8 +817,13 @@ Please provide:
             'Node'
           )
 
-          // Send browser notification with deep link to GPU node
-          if (rule.channels?.some(ch => ch.type === 'browser' && ch.enabled)) {
+          // Send browser notification only once per alert (not on every evaluation cycle)
+          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
+          if (
+            rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
+            !notifiedAlertKeysRef.current.has(notifKey)
+          ) {
+            notifiedAlertKeysRef.current.add(notifKey)
             const firstNode = failedNodes[0]
             sendNotificationWithDeepLink(
               `GPU Health Alert: ${cluster.name}`,
@@ -826,6 +836,9 @@ Please provide:
             )
           }
         } else {
+          // Auto-resolve — clear the notification dedup key
+          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
+          notifiedAlertKeysRef.current.delete(notifKey)
           // Auto-resolve if all nodes are healthy
           setAlerts(prev => {
             const firingAlert = prev.find(
@@ -863,6 +876,10 @@ Please provide:
         )
 
         if (diskPressureIssue) {
+          // Extract node name from issue string (format: "DiskPressure on node-name")
+          const nodeMatch = diskPressureIssue.match(/on\s+(\S+)/)
+          const affectedNode = nodeMatch?.[1]
+
           createAlert(
             rule,
             `${cluster.name}: ${diskPressureIssue}`,
@@ -870,6 +887,7 @@ Please provide:
               clusterName: cluster.name,
               issue: diskPressureIssue,
               nodeCount: cluster.nodeCount,
+              affectedNode,
             },
             cluster.name,
             undefined,
@@ -877,16 +895,27 @@ Please provide:
             'Cluster'
           )
 
-          // Send browser notification with deep link
-          if (rule.channels?.some(ch => ch.type === 'browser' && ch.enabled)) {
+          // Send browser notification only once per alert (not on every evaluation cycle).
+          // notifiedAlertKeysRef tracks which (ruleId, cluster) combos already sent a notification.
+          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
+          if (
+            rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
+            !notifiedAlertKeysRef.current.has(notifKey)
+          ) {
+            notifiedAlertKeysRef.current.add(notifKey)
             sendNotificationWithDeepLink(
               `Disk Pressure: ${cluster.name}`,
               diskPressureIssue,
-              { card: 'cluster_health' }
+              // Deep link to the affected node drilldown (not cluster_health card)
+              affectedNode
+                ? { drilldown: 'node', cluster: cluster.name, node: affectedNode, issue: 'DiskPressure' }
+                : { drilldown: 'cluster', cluster: cluster.name, issue: 'DiskPressure' }
             )
           }
         } else {
-          // Auto-resolve if DiskPressure clears
+          // Auto-resolve if DiskPressure clears — also clear the notification dedup key
+          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
+          notifiedAlertKeysRef.current.delete(notifKey)
           setAlerts(prev => {
             const firingAlert = prev.find(
               a =>
@@ -1007,8 +1036,13 @@ Please provide:
             'WorkflowRun'
           )
 
-          // Send browser notification with deep link to nightly card
-          if (rule.channels?.some(ch => ch.type === 'browser' && ch.enabled)) {
+          // Send browser notification only once per failed run (not on every evaluation cycle)
+          const notifKey = `${rule.id}::${guide.acronym}::${run.runNumber}`
+          if (
+            rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
+            !notifiedAlertKeysRef.current.has(notifKey)
+          ) {
+            notifiedAlertKeysRef.current.add(notifKey)
             sendNotificationWithDeepLink(
               `Nightly E2E Failed: ${guide.acronym} (${guide.platform})`,
               `Run #${run.runNumber} failed — ${guide.guide}`,


### PR DESCRIPTION
## Summary

Fixes three alert notification bugs reported by user:

### 1. Repeated macOS notifications (no dedup)

**Before:** Every 60-second evaluation cycle sent a new browser notification as long as the condition was true. Disk pressure → notification every minute.

**After:** `notifiedAlertKeysRef` tracks which alerts already triggered a notification. A notification fires once when the condition first appears. The key is cleared when the alert resolves, so if the condition recurs after resolution, a fresh notification fires.

### 2. Disk pressure notification opens wrong page

**Before:** Clicking the notification opened `?card=cluster_health` — the cluster health card, where disk pressure isn't visible.

**After:** Opens a node drilldown (`?drilldown=node&cluster=X&node=Y&issue=DiskPressure`) showing the affected node's conditions, events, and kubectl access. Falls back to cluster drilldown if the node name can't be parsed.

### 3. Missing affected node in alert details

**Before:** Alert details only had `clusterName` and `issue` — no way to know which node had disk pressure.

**After:** Parses node name from the issue string and includes `affectedNode` in the alert details.

### Evaluators fixed

| Evaluator | Notification dedup | Deep link fix |
|-----------|-------------------|---------------|
| disk_pressure | Added | Fixed (node drilldown) |
| gpu_health_cronjob | Added | Already correct |
| nightly_e2e_failure | Added | Already correct |
| memory_pressure | N/A (no notification) | N/A |

## Test plan

- [ ] Build passes
- [ ] Trigger disk pressure alert → notification fires once
- [ ] Wait 60s → no repeat notification
- [ ] Click notification → opens node drilldown (not cluster health)
- [ ] Resolve disk pressure → notification key cleared
- [ ] Disk pressure recurs → new notification fires