### PR TITLE
✨ Add network alerts: DNS failure, certificate error, cluster unreachable

### DIFF
--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -988,6 +988,185 @@ Please provide:
     [createAlert]
   )
 
+  // Evaluate DNS failures — checks for CoreDNS pods crashing or not ready
+  const evaluateDNSFailure = useCallback(
+    (rule: AlertRule) => {
+      const currentPodIssues = podIssuesRef.current
+      const relevantClusters = rule.condition.clusters?.length
+        ? rule.condition.clusters
+        : undefined
+
+      // Find CoreDNS pods with issues (coredns, dns-default on OpenShift)
+      const dnsIssues = (currentPodIssues || []).filter(pod => {
+        const isDNSPod = pod.name.includes('coredns') || pod.name.includes('dns-default')
+        const matchesCluster = !relevantClusters || relevantClusters.includes(pod.cluster || '')
+        return isDNSPod && matchesCluster
+      })
+
+      // Group by cluster
+      const clusterDNSIssues = new Map<string, typeof dnsIssues>()
+      for (const pod of dnsIssues) {
+        const cluster = pod.cluster || 'unknown'
+        const existing = clusterDNSIssues.get(cluster) || []
+        existing.push(pod)
+        clusterDNSIssues.set(cluster, existing)
+      }
+
+      for (const [cluster, pods] of clusterDNSIssues) {
+        const podNames = pods.map(p => p.name).join(', ')
+        const issues = pods.flatMap(p => p.issues || []).join('; ')
+        createAlert(
+          rule,
+          `${cluster}: DNS failure — ${pods.length} CoreDNS pod(s) unhealthy`,
+          { clusterName: cluster, podNames, issues, podCount: pods.length },
+          cluster,
+          'kube-system',
+          podNames,
+          'Pod'
+        )
+
+        const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster)
+        if (
+          rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
+          !notifiedAlertKeysRef.current.has(notifKey)
+        ) {
+          notifiedAlertKeysRef.current.add(notifKey)
+          sendNotificationWithDeepLink(
+            `DNS Failure: ${cluster}`,
+            `${pods.length} CoreDNS pod(s) unhealthy — ${issues || 'check pod status'}`,
+            { drilldown: 'pod', cluster, namespace: pods[0].namespace, pod: pods[0].name }
+          )
+        }
+      }
+
+      // Auto-resolve clusters that no longer have DNS issues
+      const clustersWithIssues = new Set(clusterDNSIssues.keys())
+      setAlerts(prev => prev.map(a => {
+        if (a.ruleId === rule.id && a.status === 'firing' && a.cluster && !clustersWithIssues.has(a.cluster)) {
+          const notifKey = alertDedupKey(rule.id, rule.condition.type, a.cluster)
+          notifiedAlertKeysRef.current.delete(notifKey)
+          return { ...a, status: 'resolved' as const, resolvedAt: new Date().toISOString() }
+        }
+        return a
+      }))
+    },
+    [createAlert]
+  )
+
+  // Evaluate certificate errors — checks for clusters with certificate connection failures
+  const evaluateCertificateError = useCallback(
+    (rule: AlertRule) => {
+      const currentClusters = clustersRef.current
+      const relevantClusters = rule.condition.clusters?.length
+        ? currentClusters.filter(c => rule.condition.clusters!.includes(c.name))
+        : currentClusters
+
+      for (const cluster of relevantClusters) {
+        if (cluster.errorType === 'certificate') {
+          createAlert(
+            rule,
+            `${cluster.name}: Certificate error — ${cluster.errorMessage || 'TLS handshake failed'}`,
+            {
+              clusterName: cluster.name,
+              errorType: cluster.errorType,
+              errorMessage: cluster.errorMessage,
+              server: cluster.server,
+            },
+            cluster.name,
+            undefined,
+            cluster.name,
+            'Cluster'
+          )
+
+          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
+          if (
+            rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
+            !notifiedAlertKeysRef.current.has(notifKey)
+          ) {
+            notifiedAlertKeysRef.current.add(notifKey)
+            sendNotificationWithDeepLink(
+              `Certificate Error: ${cluster.name}`,
+              cluster.errorMessage || 'TLS certificate validation failed',
+              { drilldown: 'cluster', cluster: cluster.name, issue: 'certificate' }
+            )
+          }
+        } else {
+          // Auto-resolve if cert error clears
+          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
+          notifiedAlertKeysRef.current.delete(notifKey)
+          setAlerts(prev => {
+            const firingAlert = prev.find(a => a.ruleId === rule.id && a.status === 'firing' && a.cluster === cluster.name)
+            if (firingAlert) {
+              return prev.map(a => a.id === firingAlert.id ? { ...a, status: 'resolved' as const, resolvedAt: new Date().toISOString() } : a)
+            }
+            return prev
+          })
+        }
+      }
+    },
+    [createAlert]
+  )
+
+  // Evaluate cluster unreachable — checks for clusters with network/auth/timeout failures
+  const evaluateClusterUnreachable = useCallback(
+    (rule: AlertRule) => {
+      const currentClusters = clustersRef.current
+      const relevantClusters = rule.condition.clusters?.length
+        ? currentClusters.filter(c => rule.condition.clusters!.includes(c.name))
+        : currentClusters
+
+      for (const cluster of relevantClusters) {
+        if (cluster.reachable === false && cluster.errorType !== 'certificate') {
+          const errorLabel = cluster.errorType === 'timeout' ? 'connection timed out'
+            : cluster.errorType === 'auth' ? 'authentication failed'
+            : cluster.errorType === 'network' ? 'network unreachable'
+            : 'connection failed'
+
+          createAlert(
+            rule,
+            `${cluster.name}: Cluster unreachable — ${errorLabel}`,
+            {
+              clusterName: cluster.name,
+              errorType: cluster.errorType,
+              errorMessage: cluster.errorMessage,
+              server: cluster.server,
+              lastSeen: cluster.lastSeen,
+            },
+            cluster.name,
+            undefined,
+            cluster.name,
+            'Cluster'
+          )
+
+          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
+          if (
+            rule.channels?.some(ch => ch.type === 'browser' && ch.enabled) &&
+            !notifiedAlertKeysRef.current.has(notifKey)
+          ) {
+            notifiedAlertKeysRef.current.add(notifKey)
+            sendNotificationWithDeepLink(
+              `Cluster Unreachable: ${cluster.name}`,
+              `${errorLabel}${cluster.lastSeen ? ` — last seen ${cluster.lastSeen}` : ''}`,
+              { drilldown: 'cluster', cluster: cluster.name, issue: 'unreachable' }
+            )
+          }
+        } else if (cluster.reachable !== false) {
+          // Auto-resolve when cluster becomes reachable again
+          const notifKey = alertDedupKey(rule.id, rule.condition.type, cluster.name)
+          notifiedAlertKeysRef.current.delete(notifKey)
+          setAlerts(prev => {
+            const firingAlert = prev.find(a => a.ruleId === rule.id && a.status === 'firing' && a.cluster === cluster.name)
+            if (firingAlert) {
+              return prev.map(a => a.id === firingAlert.id ? { ...a, status: 'resolved' as const, resolvedAt: new Date().toISOString() } : a)
+            }
+            return prev
+          })
+        }
+      }
+    },
+    [createAlert]
+  )
+
   // Evaluate nightly E2E failures — reads cached run data from ref
   const evaluateNightlyE2EFailure = useCallback(
     (rule: AlertRule) => {
@@ -1098,6 +1277,15 @@ Please provide:
           case 'nightly_e2e_failure':
             evaluateNightlyE2EFailure(rule)
             break
+          case 'dns_failure':
+            evaluateDNSFailure(rule)
+            break
+          case 'certificate_error':
+            evaluateCertificateError(rule)
+            break
+          case 'cluster_unreachable':
+            evaluateClusterUnreachable(rule)
+            break
           default:
             break
         }
@@ -1106,7 +1294,7 @@ Please provide:
       isEvaluatingRef.current = false
       setIsEvaluating(false)
     }
-  }, [evaluateGPUUsage, evaluateGPUHealthCronJob, evaluateNodeReady, evaluatePodCrash, evaluateDiskPressure, evaluateMemoryPressure, evaluateWeatherAlerts, evaluateNightlyE2EFailure])
+  }, [evaluateGPUUsage, evaluateGPUHealthCronJob, evaluateNodeReady, evaluatePodCrash, evaluateDiskPressure, evaluateMemoryPressure, evaluateWeatherAlerts, evaluateNightlyE2EFailure, evaluateDNSFailure, evaluateCertificateError, evaluateClusterUnreachable])
 
   // Stable ref for evaluateConditions so the interval never resets
   const evaluateConditionsRef = useRef(evaluateConditions)

--- a/web/src/types/alerts.ts
+++ b/web/src/types/alerts.ts
@@ -7,6 +7,9 @@ export type AlertConditionType =
   | 'memory_pressure'
   | 'cpu_pressure'
   | 'disk_pressure'
+  | 'dns_failure'
+  | 'certificate_error'
+  | 'cluster_unreachable'
   | 'weather_alerts'
   | 'nightly_e2e_failure'
   | 'custom'
@@ -225,6 +228,42 @@ export const PRESET_ALERT_RULES: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt
     channels: [{ type: 'browser', enabled: true, config: {} }],
     aiDiagnose: true,
   },
+  {
+    name: 'DNS Failure',
+    description: 'Alert when CoreDNS pods are crashing or not ready in any cluster',
+    enabled: true,
+    condition: {
+      type: 'dns_failure',
+      duration: 0,
+    },
+    severity: 'critical',
+    channels: [{ type: 'browser', enabled: true, config: {} }],
+    aiDiagnose: true,
+  },
+  {
+    name: 'Certificate Error',
+    description: 'Alert when a cluster connection fails due to certificate issues (expired, untrusted, or mismatched)',
+    enabled: true,
+    condition: {
+      type: 'certificate_error',
+      duration: 0,
+    },
+    severity: 'warning',
+    channels: [{ type: 'browser', enabled: true, config: {} }],
+    aiDiagnose: true,
+  },
+  {
+    name: 'Cluster Unreachable',
+    description: 'Alert when a cluster cannot be reached (network timeout, auth failure, or DNS resolution failure)',
+    enabled: true,
+    condition: {
+      type: 'cluster_unreachable',
+      duration: 0,
+    },
+    severity: 'critical',
+    channels: [{ type: 'browser', enabled: true, config: {} }],
+    aiDiagnose: true,
+  },
 ]
 
 // Helper to get severity color
@@ -272,6 +311,12 @@ export function formatCondition(condition: AlertCondition): string {
       return `CPU usage > ${condition.threshold}%`
     case 'disk_pressure':
       return `Disk usage > ${condition.threshold}%`
+    case 'dns_failure':
+      return 'CoreDNS pods not ready or crashing'
+    case 'certificate_error':
+      return 'Cluster connection certificate error'
+    case 'cluster_unreachable':
+      return 'Cluster unreachable (network/auth/DNS)'
     case 'weather_alerts':
       if (condition.weatherCondition === 'extreme_heat') {
         return `Temperature > ${condition.temperatureThreshold || 100}°F`


### PR DESCRIPTION
## Summary

Adds three new network-related alert evaluators that detect DNS, certificate, and connectivity issues across all connected clusters.

### New Alert Types

| Alert | Severity | Default | Data Source | Deep Link |
|-------|----------|---------|-------------|-----------|
| **DNS Failure** | Critical | Enabled | Pod issues (CoreDNS crashes) | Pod drilldown |
| **Certificate Error** | Warning | Enabled | Cluster health `errorType: 'certificate'` | Cluster drilldown |
| **Cluster Unreachable** | Critical | Enabled | Cluster health `reachable: false` | Cluster drilldown |

### How they work

- **DNS Failure**: Scans pod issues for pods named `coredns` or `dns-default` (OpenShift). Groups by cluster. If CoreDNS pods are in CrashLoopBackOff or not ready, fires a critical alert.

- **Certificate Error**: Checks `cluster.errorType === 'certificate'` from the existing cluster health check. Fires when TLS handshake fails (expired cert, untrusted CA, hostname mismatch).

- **Cluster Unreachable**: Checks `cluster.reachable === false` for non-certificate errors (timeout, auth failure, DNS resolution failure). Shows error type, last-seen timestamp, and server URL.

All three:
- Use notification dedup (from PR #2772) — one notification per alert, not per evaluation cycle
- Auto-resolve when the condition clears
- Support cluster filtering (alert on specific clusters only)
- Deep link to the relevant drilldown when clicked

## Test plan

- [ ] Build passes
- [ ] DNS Failure: Stop CoreDNS in a test cluster → alert fires → restart CoreDNS → alert resolves
- [ ] Certificate Error: Connect cluster with expired cert → alert fires
- [ ] Cluster Unreachable: Disconnect a cluster → alert fires → reconnect → alert resolves
- [ ] Verify only one macOS notification per alert (no repeats)