### PR TITLE
🐛 Fix dashboard data disappearing on refresh

### DIFF
--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -568,6 +568,23 @@ class CacheStore<T> {
         return
       }
 
+      // Guard: if the fetcher returned empty data (same as initialData) but we
+      // already have cached data, keep the cache. This prevents refresh from
+      // wiping card data when the agent/backend hasn't connected yet.
+      // Fetchers return [] when both agent and backend are unavailable, which
+      // would overwrite perfectly good cached data with nothing.
+      const isEmptyResult = Array.isArray(newData) && (newData as unknown[]).length === 0
+        && Array.isArray(this.initialData) && (this.initialData as unknown[]).length === 0
+      if (isEmptyResult && hasCachedData) {
+        // Don't overwrite cache — treat as "no data available yet"
+        this.fetchingRef = false
+        this.setState({
+          isLoading: false,
+          isRefreshing: false,
+        })
+        return
+      }
+
       const finalData = merge && hasCachedData ? merge(this.state.data, newData) : newData
 
       await this.saveToStorage(finalData)


### PR DESCRIPTION
## Summary

Fixes cards (PredictiveHealth, Inventory, PodIssues, DeploymentStatus) showing empty data after page refresh.

### Root cause

1. Page refreshes → SQLite preload correctly loads cached data into CacheStore
2. Cards mount with cached data (good)
3. Each card's `useCache` calls `refetch()` immediately
4. Agent/backend haven't reconnected yet (takes 1-3 seconds)
5. Fetcher returns `[]` because both `isAgentUnavailable()` and `isBackendUnavailable()` are true
6. Empty `[]` overwrites the cached data in state AND gets saved to SQLite
7. Card shows empty state — cached data is gone

### Fix

In `CacheStore.fetch()`, if the fetcher returns empty data (same shape as `initialData`, typically `[]`) but the cache already has real data, keep the cached data instead of overwriting. The next auto-refresh cycle will fetch fresh data once the agent reconnects.

This is a cache-layer fix — no changes needed to any of the 30+ fetcher functions.

### What stays the same

- First-ever load (no cache) still shows loading → fetches → shows data
- Successful fetches still update the cache normally
- Error handling (exceptions) still preserves cached data
- Demo mode still works as before

## Test plan

- [ ] Build passes
- [ ] Load dashboard → data appears → refresh page → data persists (not blank)
- [ ] Wait for agent to connect → data updates to latest
- [ ] First load with empty cache → shows skeleton → fetches → shows data