### PR TITLE
🐛 Fix Event Stream empty on load + remove Latest Benchmark from main dashboard

### DIFF
--- a/web/src/config/dashboards/main.ts
+++ b/web/src/config/dashboards/main.ts
@@ -122,12 +122,7 @@ export const mainDashboardConfig: UnifiedDashboardConfig = {
     {
       id: 'default-8',
       cardType: 'compliance_score',
-      position: { w: 6, h: 3, x: 0, y: 13 },
-    },
-    {
-      id: 'default-9',
-      cardType: 'benchmark_hero',
-      position: { w: 6, h: 3, x: 6, y: 13 },
+      position: { w: 12, h: 3, x: 0, y: 13 },
     },
   ],
 
@@ -143,7 +138,6 @@ export const mainDashboardConfig: UnifiedDashboardConfig = {
     'cluster_metrics',
     'events_timeline',
     'compliance_score',
-    'benchmark_hero',
     'nightly_e2e_status',
   ],
 

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -528,6 +528,37 @@ export function useCachedEvents(
     initialData: [] as ClusterEvent[],
     demoData: getDemoEvents(),
     fetcher: async () => {
+      // Try agent first (direct kubectl proxy — works before backend auth)
+      if (clusterCacheRef.clusters.length > 0 && !isAgentUnavailable()) {
+        if (cluster) {
+          const ci = clusterCacheRef.clusters.find(c => c.name === cluster)
+          const ctx = ci?.context || cluster
+          const events = await kubectlProxy.getEvents(ctx, namespace, limit)
+          return events.map(e => ({ ...e, cluster }))
+        }
+        // Fetch from all clusters via agent
+        const clusters = getAgentClusters()
+        const allEvents: ClusterEvent[] = []
+        const results = await Promise.allSettled(
+          clusters.map(async (ci) => {
+            const ctx = ci.context || ci.name
+            const events = await kubectlProxy.getEvents(ctx, namespace, limit)
+            return events.map(e => ({ ...e, cluster: ci.name }))
+          })
+        )
+        for (const r of results) {
+          if (r.status === 'fulfilled') allEvents.push(...r.value)
+        }
+        return allEvents
+          .sort((a, b) => {
+            const timeA = a.lastSeen ? new Date(a.lastSeen).getTime() : 0
+            const timeB = b.lastSeen ? new Date(b.lastSeen).getTime() : 0
+            return timeB - timeA
+          })
+          .slice(0, limit)
+      }
+
+      // Fall back to REST API (requires backend auth)
       if (cluster) {
         const data = await fetchAPI<{ events: ClusterEvent[] }>('events', { cluster, namespace, limit })
         return data.events || []
@@ -535,6 +566,28 @@ export function useCachedEvents(
       return await fetchFromAllClusters<ClusterEvent>('events', 'events', { namespace, limit })
     },
     progressiveFetcher: cluster ? undefined : async (onProgress) => {
+      // Try agent-based progressive fetch first
+      if (clusterCacheRef.clusters.length > 0 && !isAgentUnavailable()) {
+        const clusters = getAgentClusters()
+        const accumulated: ClusterEvent[] = []
+        for (const ci of clusters) {
+          try {
+            const ctx = ci.context || ci.name
+            const events = await kubectlProxy.getEvents(ctx, namespace, limit)
+            accumulated.push(...events.map(e => ({ ...e, cluster: ci.name })))
+            accumulated.sort((a, b) => {
+              const timeA = a.lastSeen ? new Date(a.lastSeen).getTime() : 0
+              const timeB = b.lastSeen ? new Date(b.lastSeen).getTime() : 0
+              return timeB - timeA
+            })
+            onProgress([...accumulated].slice(0, limit))
+          } catch {
+            // Skip failed clusters, continue with others
+          }
+        }
+        return accumulated.slice(0, limit)
+      }
+      // Fall back to SSE via backend
       return await fetchViaSSE<ClusterEvent>('events', 'events', { namespace, limit }, onProgress)
     },
   })


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Event Stream shows "No events" on load

**Root cause:** `useCachedEvents` only fetched via the Go backend REST API (`/api/events`), which requires OAuth. On initial load before auth, or in local-only setups without OAuth, the fetcher returned `[]` immediately.

**Fix:** Added agent-first path (same pattern as pod issues, deployments). Tries `kubectlProxy.getEvents()` across all clusters before falling back to REST API. Progressive fetcher also streams events cluster-by-cluster via agent.

### 2. Latest Benchmark card removed from main dashboard

The `benchmark_hero` card belongs on the llm-d Benchmarks dashboard, not the main dashboard. Removed from default cards and available card types. Compliance Score expanded to full width.

## Test plan
- [ ] Build passes
- [ ] Event Stream populates immediately on dashboard load
- [ ] Events stream progressively (cluster by cluster)
- [ ] Latest Benchmark no longer appears on main dashboard by default
- [ ] Latest Benchmark still appears on llm-d Benchmarks dashboard