### PR TITLE
🐛 Default demoWhenEmpty to true when demoData is provided

### DIFF
--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -791,7 +791,7 @@ export function useCache<T>({
   persist = true,
   autoRefresh = true,
   enabled = true,
-  demoWhenEmpty = false,
+  demoWhenEmpty = demoData !== undefined,
   liveInDemoMode = false,
   merge,
   shared = true,


### PR DESCRIPTION
One-line fix: cards show demo data while agent connects instead of going blank on startup. Affects all 39 cached data hooks.