### PR TITLE
🐛 Revert demoWhenEmpty default + throw when no data source available

### DIFF
--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -654,7 +654,8 @@ export function useCachedPodIssues(
         return sortIssues(issues)
       }
 
-      return []
+      // No data source available yet — throw so cache preserves existing data and retries
+      throw new Error('No data source available (agent connecting or backend not authenticated)')
     },
     progressiveFetcher: cluster ? undefined : async (onProgress) => {
       // Try agent first
@@ -747,7 +748,7 @@ export function useCachedDeploymentIssues(
         return data.issues || []
       }
 
-      return []
+      throw new Error("No data source available")
     },
     progressiveFetcher: cluster ? undefined : async (onProgress) => {
       if (clusterCacheRef.clusters.length > 0 && !isAgentUnavailable()) {
@@ -833,7 +834,7 @@ export function useCachedDeployments(
         return await fetchFromAllClusters<Deployment>('deployments', 'deployments', { namespace })
       }
 
-      return []
+      throw new Error("No data source available")
     },
     progressiveFetcher: cluster ? undefined : async (onProgress) => {
       if (clusterCacheRef.clusters.length > 0 && !isAgentUnavailable()) {
@@ -1751,7 +1752,7 @@ export function useCachedSecurityIssues(
         }
       }
 
-      return []
+      throw new Error("No data source available")
     },
     // Progressive loading: show results as each cluster completes
     progressiveFetcher: !cluster ? async (onProgress) => {

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -791,7 +791,7 @@ export function useCache<T>({
   persist = true,
   autoRefresh = true,
   enabled = true,
-  demoWhenEmpty = demoData !== undefined,
+  demoWhenEmpty = false,
   liveInDemoMode = false,
   merge,
   shared = true,


### PR DESCRIPTION
Reverts #2783 which showed demo data in live mode. Fetchers now throw instead of returning [] when no data source is available, preserving cached data.