### PR TITLE
🐛 Fix GPU NaN% in Resource Allocation card

### DIFF
--- a/web/src/components/cards/ResourceUsage.tsx
+++ b/web/src/components/cards/ResourceUsage.tsx
@@ -52,8 +52,8 @@ export function ResourceUsage() {
     const xpuOnly = gpuNodes.filter(n => n.acceleratorType === 'XPU')
 
     const sumAccel = (nodes: typeof gpuNodes) => ({
-      total: nodes.reduce((s, n) => s + n.gpuCount, 0),
-      used: nodes.reduce((s, n) => s + n.gpuAllocated, 0),
+      total: nodes.reduce((s, n) => s + (n.gpuCount || 0), 0),
+      used: nodes.reduce((s, n) => s + (n.gpuAllocated || 0), 0),
     })
 
     return {


### PR DESCRIPTION
Guard gpuCount and gpuAllocated with || 0 in accelerator sum reducer. Nodes without GPU metrics returned undefined, propagating NaN through the percentage display.