### PR TITLE
🐛 Fix remaining cards going blank on refresh (events, pods, nodes)

### DIFF
--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -146,6 +146,9 @@ async function fetchFromAllClusters<T>(
   onProgress?: (partial: T[]) => void
 ): Promise<T[]> {
   const clusters = await fetchClusters()
+  if (clusters.length === 0) {
+    throw new Error('No clusters available (agent connecting or backend not authenticated)')
+  }
   const accumulated: T[] = []
   let failedCount = 0
 
@@ -219,7 +222,7 @@ async function fetchViaGitOpsSSE<T>(
 ): Promise<T[]> {
   const token = getToken()
   if (!token || token === 'demo-token' || isBackendUnavailable()) {
-    return []
+    throw new Error('No data source available (backend not authenticated)')
   }
 
   const accumulated: T[] = []


### PR DESCRIPTION
fetchFromAllClusters and fetchViaGitOpsSSE now throw instead of returning [] when no data sources are available. This prevents cache wipe for ALL multi-cluster cards, not just the four fixed in PR #2784.