### PR TITLE
🐛 Fix multi-tenancy cards showing Refresh Failed without auth

### DIFF
--- a/web/src/components/cards/multi-tenancy/k3s-status/useK3sStatus.ts
+++ b/web/src/components/cards/multi-tenancy/k3s-status/useK3sStatus.ts
@@ -103,6 +103,9 @@ async function fetchK3sStatus(): Promise<K3sStatus> {
   })
 
   if (!podsResp.ok) {
+    if (podsResp.status === 401 || podsResp.status === 403) {
+      return { ...INITIAL_DATA, lastCheckTime: new Date().toISOString() }
+    }
     throw new Error(`HTTP ${podsResp.status}`)
   }
 

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/useKubeflexStatus.ts
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/useKubeflexStatus.ts
@@ -76,6 +76,9 @@ async function fetchKubeFlexStatus(): Promise<KubeFlexStatus> {
   })
 
   if (!podsResp.ok) {
+    if (podsResp.status === 401 || podsResp.status === 403) {
+      return { ...INITIAL_DATA, lastCheckTime: new Date().toISOString() }
+    }
     throw new Error(`HTTP ${podsResp.status}`)
   }
 

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/useKubevirtStatus.ts
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/useKubevirtStatus.ts
@@ -75,6 +75,9 @@ async function fetchKubevirtStatus(): Promise<KubevirtStatus> {
   })
 
   if (!podsResp.ok) {
+    if (podsResp.status === 401 || podsResp.status === 403) {
+      return { ...INITIAL_DATA, lastCheckTime: new Date().toISOString() }
+    }
     throw new Error(`HTTP ${podsResp.status}`)
   }
 

--- a/web/src/components/cards/multi-tenancy/ovn-status/useOvnStatus.ts
+++ b/web/src/components/cards/multi-tenancy/ovn-status/useOvnStatus.ts
@@ -77,6 +77,10 @@ async function fetchOvnStatus(): Promise<OvnStatus> {
   })
 
   if (!podsResp.ok) {
+    // 401/403 = not authenticated — return empty so useCache falls back to demo data
+    if (podsResp.status === 401 || podsResp.status === 403) {
+      return { ...INITIAL_DATA, lastCheckTime: new Date().toISOString() }
+    }
     throw new Error(`HTTP ${podsResp.status}`)
   }
 


### PR DESCRIPTION
## Summary
- Multi-tenancy card fetchers now handle 401/403 gracefully
- Returns empty initial data instead of throwing, allowing useCache to fall back to demo data
- Fixes "Refresh failed" error on all 4 technology cards + aggregate cards when viewing without login

## Test plan
- [ ] Navigate to /multi-tenancy without login — no "Refresh failed" errors
- [ ] Cards show demo data with demo badge cleanly