### PR TITLE
🐛 Fix alert click-through showing 'No cluster selected'

### DIFF
--- a/web/src/components/cards/ActiveAlerts.tsx
+++ b/web/src/components/cards/ActiveAlerts.tsx
@@ -171,7 +171,7 @@ export function ActiveAlerts() {
       open({
         type: 'cluster',
         title: alert.cluster,
-        data: { name: alert.cluster, alert },
+        data: { cluster: alert.cluster, alert },
       })
     }
   }

--- a/web/src/components/ui/AlertBadge.tsx
+++ b/web/src/components/ui/AlertBadge.tsx
@@ -167,7 +167,7 @@ export function AlertBadge() {
       openDrillDown({
         type: 'cluster',
         title: alert.cluster,
-        data: { name: alert.cluster, alert },
+        data: { cluster: alert.cluster, alert },
       })
     }
   }


### PR DESCRIPTION
## Summary
- Fixed alert click handlers in `ActiveAlerts.tsx` and `AlertBadge.tsx` passing cluster name as `data.name` instead of `data.cluster`
- `ClusterDrillDown` reads `data.cluster`, so the mismatch caused the drilldown to open with "No cluster selected"

## Test plan
- [ ] Click on any alert in the Active Alerts card — cluster drilldown should show cluster details instead of "No cluster selected"
- [ ] Click on alert notification badge popup alerts — same fix applied