### PR TITLE
🐛 Show stale compliance data instantly instead of re-scanning all clusters

### DIFF
--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -19,7 +19,7 @@ import { useDemoMode } from '../../hooks/useDemoMode'
 import { useModalState } from '../../lib/modals'
 
 /** Cache TTL: 5 minutes — short enough to pick up connectivity changes */
-const CACHE_TTL_MS = 5 * 60 * 1000
+// Unused: const CACHE_TTL_MS = 5 * 60 * 1000
 
 // Sort options for clusters
 type SortByOption = 'name' | 'violations' | 'policies'
@@ -222,8 +222,10 @@ function OPAPoliciesInternal({ config: _config }: OPAPoliciesProps) {
       if (cached) {
         const parsed = JSON.parse(cached)
         const cacheTime = localStorage.getItem(STORAGE_KEY_OPA_CACHE_TIME)
-        const cacheAge = cacheTime ? Date.now() - parseInt(cacheTime, 10) : Infinity
-        if (cacheAge < CACHE_TTL_MS) {
+        // Stale-while-revalidate: always return cached data.
+        // Auto-refresh handles freshness — showing stale data is better than
+        // showing loading spinners for 30+ seconds.
+        if (cacheTime) {
           return parsed
         }
       }

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -20,7 +20,7 @@ import { STORAGE_KEY_KUBESCAPE_CACHE, STORAGE_KEY_KUBESCAPE_CACHE_TIME } from '.
 const REFRESH_INTERVAL_MS = 120_000
 
 /** Cache TTL: 2 minutes — matches refresh interval */
-const CACHE_TTL_MS = 120_000
+// Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000
 
 /** Timeout for CRD/API existence check (fast — missing resources fail instantly) */
 const CRD_CHECK_TIMEOUT_MS = 3_000
@@ -74,8 +74,7 @@ function loadFromCache(): CacheData | null {
     const cached = localStorage.getItem(STORAGE_KEY_KUBESCAPE_CACHE)
     const cacheTime = localStorage.getItem(STORAGE_KEY_KUBESCAPE_CACHE_TIME)
     if (!cached || !cacheTime) return null
-    const age = Date.now() - parseInt(cacheTime, 10)
-    if (age > CACHE_TTL_MS) return null
+    // Stale-while-revalidate: always return cached data. Auto-refresh handles freshness.
     return { statuses: JSON.parse(cached), timestamp: parseInt(cacheTime, 10) }
   } catch {
     return null

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -21,7 +21,7 @@ import { STORAGE_KEY_KYVERNO_CACHE, STORAGE_KEY_KYVERNO_CACHE_TIME } from '../li
 const REFRESH_INTERVAL_MS = 120_000
 
 /** Cache TTL: 2 minutes — matches refresh interval */
-const CACHE_TTL_MS = 120_000
+// Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000
 
 /** Timeout for CRD existence check (fast — missing resources fail instantly) */
 const CRD_CHECK_TIMEOUT_MS = 3_000
@@ -79,8 +79,7 @@ function loadFromCache(): CacheData | null {
     const cached = localStorage.getItem(STORAGE_KEY_KYVERNO_CACHE)
     const cacheTime = localStorage.getItem(STORAGE_KEY_KYVERNO_CACHE_TIME)
     if (!cached || !cacheTime) return null
-    const age = Date.now() - parseInt(cacheTime, 10)
-    if (age > CACHE_TTL_MS) return null
+    // Stale-while-revalidate: always return cached data. Auto-refresh handles freshness.
     return { statuses: JSON.parse(cached), timestamp: parseInt(cacheTime, 10) }
   } catch {
     return null

--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -24,7 +24,7 @@ import { STORAGE_KEY_TRESTLE_CACHE, STORAGE_KEY_TRESTLE_CACHE_TIME } from '../li
 const REFRESH_INTERVAL_MS = 120_000
 
 /** Cache TTL: 2 minutes — matches refresh interval */
-const CACHE_TTL_MS = 120_000
+// Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000
 
 /** Timeout for CRD/deployment existence check (fast — missing resources fail instantly) */
 const CRD_CHECK_TIMEOUT_MS = 3_000
@@ -90,8 +90,7 @@ function loadFromCache(): CacheData | null {
     const cached = localStorage.getItem(STORAGE_KEY_TRESTLE_CACHE)
     const cacheTime = localStorage.getItem(STORAGE_KEY_TRESTLE_CACHE_TIME)
     if (!cached || !cacheTime) return null
-    const age = Date.now() - parseInt(cacheTime, 10)
-    if (age > CACHE_TTL_MS) return null
+    // Stale-while-revalidate: always return cached data. Auto-refresh handles freshness.
     return { statuses: JSON.parse(cached), timestamp: parseInt(cacheTime, 10) }
   } catch {
     return null

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -20,7 +20,7 @@ import { STORAGE_KEY_TRIVY_CACHE, STORAGE_KEY_TRIVY_CACHE_TIME } from '../lib/co
 const REFRESH_INTERVAL_MS = 120_000
 
 /** Cache TTL: 2 minutes — matches refresh interval */
-const CACHE_TTL_MS = 120_000
+// Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000
 
 /** Timeout for CRD existence check (fast — missing resources fail instantly) */
 const CRD_CHECK_TIMEOUT_MS = 3_000
@@ -76,8 +76,9 @@ function loadFromCache(): CacheData | null {
     const cached = localStorage.getItem(STORAGE_KEY_TRIVY_CACHE)
     const cacheTime = localStorage.getItem(STORAGE_KEY_TRIVY_CACHE_TIME)
     if (!cached || !cacheTime) return null
-    const age = Date.now() - parseInt(cacheTime, 10)
-    if (age > CACHE_TTL_MS) return null
+    // Always return cached data (stale-while-revalidate). The auto-refresh
+    // interval handles freshness — showing stale data is better than showing
+    // "Checking clusters... 0/8" for 30+ seconds on every page load.
     return { statuses: JSON.parse(cached), timestamp: parseInt(cacheTime, 10) }
   } catch {
     return null


### PR DESCRIPTION
Compliance cards showed 'Checking clusters... 0/8' for 30+ seconds because cached data was discarded after 2 min TTL. Now shows stale data instantly while refreshing in background.