### PR TITLE
🐛 Fix compliance card detection: OPA false positives, Kubescape timeout, invalid flag

### DIFF
--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -518,6 +518,19 @@ function OPAPoliciesInternal({ config: _config }: OPAPoliciesProps) {
     setStatuses(demoStatuses)
   }, [shouldUseDemoData, effectiveClusters])
 
+  // Clear demo statuses when transitioning from demo → live mode.
+  // Without this, fake violations from demo mode persist for clusters
+  // where Gatekeeper is not installed (e.g., konflux-ci, ks-docs-oci).
+  const prevDemoRef = useRef(shouldUseDemoData)
+  useEffect(() => {
+    if (prevDemoRef.current && !shouldUseDemoData) {
+      // Was demo, now live — clear all statuses so only real detection shows
+      setStatuses({})
+      setHasTriggeredInitialCheck(false)
+    }
+    prevDemoRef.current = shouldUseDemoData
+  }, [shouldUseDemoData])
+
   // Initial check - only check reachable clusters without cached data
   // Skip if we've already triggered a check this session
   useEffect(() => {

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -25,8 +25,9 @@ const REFRESH_INTERVAL_MS = 120_000
 /** Timeout for CRD/API existence check (fast — missing resources fail instantly) */
 const CRD_CHECK_TIMEOUT_MS = 3_000
 
-/** Timeout for data fetch */
-const DATA_FETCH_TIMEOUT_MS = 15_000
+/** Timeout for data fetch — large clusters (vllm-d has 4155 items, 6MB JSON)
+ *  need extra time when queued behind other kubectl requests */
+const DATA_FETCH_TIMEOUT_MS = 30_000
 
 /** Default overall score for demo clusters */
 const DEMO_OVERALL_SCORE = 78
@@ -211,7 +212,7 @@ async function fetchSingleCluster(cluster: string): Promise<KubescapeClusterStat
     const frameworks: KubescapeFrameworkScore[] = []
     const controlResults = new Map<string, { name: string; passed: number; failed: number }>()
     const detailResult = await kubectlProxy.exec(
-      ['get', 'workloadconfigurationscans', '-A', '-o', 'json', '--limit=50'],
+      ['get', 'workloadconfigurationscans', '-A', '-o', 'json', '--chunk-size=50'],
       { context: cluster, timeout: DATA_FETCH_TIMEOUT_MS }
     )
 


### PR DESCRIPTION
OPA showed fake violations for clusters without Gatekeeper (demo data persisted). Kubescape timed out on vllm-d (6MB, 4155 items). kubectl --limit=50 was invalid (changed to --chunk-size=50).