### PR TITLE
🐛 Fix compliance cache: include errored clusters, increase timeouts

### DIFF
--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -23,7 +23,7 @@ const REFRESH_INTERVAL_MS = 120_000
 // Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000
 
 /** Timeout for CRD/API existence check (fast — missing resources fail instantly) */
-const CRD_CHECK_TIMEOUT_MS = 3_000
+const CRD_CHECK_TIMEOUT_MS = 8_000
 
 /** Timeout for data fetch — large clusters (vllm-d has 4155 items, 6MB JSON)
  *  need extra time when queued behind other kubectl requests */
@@ -85,7 +85,7 @@ function loadFromCache(): CacheData | null {
 function saveToCache(statuses: Record<string, KubescapeClusterStatus>): void {
   try {
     const completed = Object.fromEntries(
-      Object.entries(statuses).filter(([, s]) => !s.loading && !s.error)
+      Object.entries(statuses).filter(([, s]) => !s.loading)
     )
     if (Object.keys(completed).length > 0) {
       localStorage.setItem(STORAGE_KEY_KUBESCAPE_CACHE, JSON.stringify(completed))

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -24,10 +24,10 @@ const REFRESH_INTERVAL_MS = 120_000
 // Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000
 
 /** Timeout for CRD existence check (fast — missing resources fail instantly) */
-const CRD_CHECK_TIMEOUT_MS = 3_000
+const CRD_CHECK_TIMEOUT_MS = 8_000
 
 /** Timeout for data fetch */
-const DATA_FETCH_TIMEOUT_MS = 15_000
+const DATA_FETCH_TIMEOUT_MS = 30_000
 
 // ── Types ────────────────────────────────────────────────────────────────
 
@@ -90,7 +90,7 @@ function saveToCache(statuses: Record<string, KyvernoClusterStatus>): void {
   try {
     // Only cache completed (non-loading, non-error) statuses
     const completed = Object.fromEntries(
-      Object.entries(statuses).filter(([, s]) => !s.loading && !s.error)
+      Object.entries(statuses).filter(([, s]) => !s.loading)
     )
     if (Object.keys(completed).length > 0) {
       localStorage.setItem(STORAGE_KEY_KYVERNO_CACHE, JSON.stringify(completed))

--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -27,10 +27,10 @@ const REFRESH_INTERVAL_MS = 120_000
 // Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000
 
 /** Timeout for CRD/deployment existence check (fast — missing resources fail instantly) */
-const CRD_CHECK_TIMEOUT_MS = 3_000
+const CRD_CHECK_TIMEOUT_MS = 8_000
 
 /** Timeout for data fetch */
-const DATA_FETCH_TIMEOUT_MS = 15_000
+const DATA_FETCH_TIMEOUT_MS = 30_000
 
 /** Demo overall compliance percentage */
 const DEMO_OVERALL_SCORE = 82
@@ -100,7 +100,7 @@ function loadFromCache(): CacheData | null {
 function saveToCache(statuses: Record<string, TrestleClusterStatus>): void {
   try {
     const completed = Object.fromEntries(
-      Object.entries(statuses).filter(([, s]) => !s.loading && !s.error)
+      Object.entries(statuses).filter(([, s]) => !s.loading)
     )
     if (Object.keys(completed).length > 0) {
       localStorage.setItem(STORAGE_KEY_TRESTLE_CACHE, JSON.stringify(completed))

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -23,10 +23,10 @@ const REFRESH_INTERVAL_MS = 120_000
 // Unused after stale-while-revalidate change: const CACHE_TTL_MS = 120_000
 
 /** Timeout for CRD existence check (fast — missing resources fail instantly) */
-const CRD_CHECK_TIMEOUT_MS = 3_000
+const CRD_CHECK_TIMEOUT_MS = 8_000
 
 /** Timeout for data fetch */
-const DATA_FETCH_TIMEOUT_MS = 15_000
+const DATA_FETCH_TIMEOUT_MS = 30_000
 
 /** Maximum images to store per cluster to keep cache size reasonable */
 const MAX_IMAGES_PER_CLUSTER = 50
@@ -88,7 +88,7 @@ function loadFromCache(): CacheData | null {
 function saveToCache(statuses: Record<string, TrivyClusterStatus>): void {
   try {
     const completed = Object.fromEntries(
-      Object.entries(statuses).filter(([, s]) => !s.loading && !s.error)
+      Object.entries(statuses).filter(([, s]) => !s.loading)
     )
     if (Object.keys(completed).length > 0) {
       localStorage.setItem(STORAGE_KEY_TRIVY_CACHE, JSON.stringify(completed))


### PR DESCRIPTION
Timed-out clusters disappeared from cache. CRD check timeout was too short (3s). Data fetch timeout was too short (15s) for large clusters.