### PR TITLE
🐛 Enforce strict E2E coverage failures and remove flaky sleep waits

### DIFF
--- a/web/e2e/a11y.spec.ts
+++ b/web/e2e/a11y.spec.ts
@@ -25,6 +25,10 @@ async function setupDemoMode(page: Page) {
   })
 }
 
+async function waitForDashboardCards(page: Page) {
+  await expect(page.locator('[data-card-type]').first()).toBeVisible({ timeout: 10000 })
+}
+
 // Pages to audit for accessibility
 const pagesToAudit = [
   { name: 'Dashboard', path: '/' },
@@ -41,9 +45,7 @@ test.describe('Accessibility Audits', () => {
         await setupDemoMode(page)
         await page.goto(path)
         await page.waitForLoadState('networkidle', { timeout: 15000 })
-
-        // Wait for content to fully render
-        await page.waitForTimeout(1000)
+        await expect(page.locator('body')).toBeVisible()
 
         const results = await new AxeBuilder({ page })
           .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
@@ -270,7 +272,7 @@ test.describe('Accessibility Audits', () => {
       await setupDemoMode(page)
       await page.goto('/')
       await page.waitForLoadState('networkidle')
-      await page.waitForTimeout(2000) // Wait for cards to load
+      await waitForDashboardCards(page)
 
       // Check that cards have aria-label (cards are divs, not regions)
       const cards = page.locator('[data-card-type]')
@@ -290,7 +292,7 @@ test.describe('Accessibility Audits', () => {
       await setupDemoMode(page)
       await page.goto('/')
       await page.waitForLoadState('networkidle')
-      await page.waitForTimeout(2000)
+      await expect(page.locator('[data-testid="demo-badge"]').first()).toBeVisible({ timeout: 10000 })
 
       // Check for demo badges (visual indicators without aria-live to avoid announcement flood)
       const demoBadges = page.locator('[data-testid="demo-badge"]')
@@ -317,7 +319,7 @@ test.describe('Accessibility Audits', () => {
       await setupDemoMode(page)
       await page.goto('/')
       await page.waitForLoadState('networkidle')
-      await page.waitForTimeout(2000)
+      await waitForDashboardCards(page)
 
       // Run axe-core to check for WCAG 2.5.3 compliance (Label in Name)
       const results = await new AxeBuilder({ page })
@@ -334,7 +336,7 @@ test.describe('Accessibility Audits', () => {
       await setupDemoMode(page)
       await page.goto('/')
       await page.waitForLoadState('networkidle')
-      await page.waitForTimeout(2000)
+      await waitForDashboardCards(page)
 
       // Check for redundant roles (e.g., role="main" on <main>)
       const results = await new AxeBuilder({ page })
@@ -353,7 +355,7 @@ test.describe('Accessibility Audits', () => {
       await setupDemoMode(page)
       await page.goto('/')
       await page.waitForLoadState('networkidle')
-      await page.waitForTimeout(2000)
+      await waitForDashboardCards(page)
 
       // Find interactive elements (buttons) within cards
       const cardButtons = page.locator('[data-card-type] button')
@@ -367,7 +369,7 @@ test.describe('Accessibility Audits', () => {
       await setupDemoMode(page)
       await page.goto('/')
       await page.waitForLoadState('networkidle')
-      await page.waitForTimeout(2000)
+      await waitForDashboardCards(page)
 
       // Tab to first card
       await page.keyboard.press('Tab')

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -79,8 +79,7 @@ test.describe('Smoke Tests', () => {
         await page.goto(path)
         await page.waitForLoadState('networkidle', { timeout: 15000 })
 
-        // Allow time for any delayed errors
-        await page.waitForTimeout(1000)
+        await expect(page.locator('body')).toBeVisible()
 
         if (errors.length > 0) {
           console.log(`Console errors on ${path}:`, errors)
@@ -179,10 +178,10 @@ test.describe('Smoke Tests', () => {
       if (await themeToggle.first().isVisible({ timeout: 3000 })) {
         const htmlBefore = await page.locator('html').getAttribute('class')
         await themeToggle.first().click()
-        await page.waitForTimeout(500)
-        const htmlAfter = await page.locator('html').getAttribute('class')
-        // Theme class should change
-        expect(htmlBefore).not.toBe(htmlAfter)
+
+        await expect
+          .poll(async () => page.locator('html').getAttribute('class'))
+          .not.toBe(htmlBefore)
       }
     })
   })

--- a/web/scripts/run-e2e-coverage.sh
+++ b/web/scripts/run-e2e-coverage.sh
@@ -3,6 +3,14 @@
 
 set -e
 
+cleanup() {
+	if [ -n "${DEV_PID:-}" ]; then
+		kill "$DEV_PID" 2>/dev/null || true
+	fi
+}
+
+trap cleanup EXIT
+
 echo "🧹 Cleaning previous coverage data..."
 rm -rf .nyc_output coverage
 
@@ -17,10 +25,12 @@ npx wait-on http://localhost:5174 --timeout 60000
 export PLAYWRIGHT_BASE_URL=http://localhost:5174
 
 echo "🎭 Running Playwright tests (chromium only for coverage)..."
-VITE_COVERAGE=true npx playwright test --project=chromium || true
+PLAYWRIGHT_EXIT=0
+VITE_COVERAGE=true npx playwright test --project=chromium || PLAYWRIGHT_EXIT=$?
 
 echo "🛑 Stopping dev server..."
-kill $DEV_PID 2>/dev/null || true
+kill "$DEV_PID" 2>/dev/null || true
+DEV_PID=""
 
 echo "📊 Generating coverage report..."
 node scripts/coverage-report.mjs
@@ -28,3 +38,8 @@ node scripts/coverage-report.mjs
 echo ""
 echo "✅ Done! Coverage report available in ./coverage/index.html"
 echo ""
+
+if [ "$PLAYWRIGHT_EXIT" -ne 0 ]; then
+	echo "❌ Playwright tests failed during coverage run"
+	exit "$PLAYWRIGHT_EXIT"
+fi


### PR DESCRIPTION
### 📌 Fixes

Fixes #2828

---

### 📝 Summary of Changes

Make E2E coverage runs fail correctly when Playwright tests fail.
Reduce flaky E2E behavior by replacing fixed sleeps with deterministic waits in top flaky suites.

---

### Changes Made

<!-- Provide a detailed list of changes made in this PR. -->

- [x] Updated run-e2e-coverage.sh, smoke.spec.ts, a11y.spec.ts
- [ ] Refactored ...
- [ ] Fixed ...
- [ ] Added tests for ...

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I have reviewed the project's contribution guidelines.
- [x] I have written unit tests for the changes (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have tested the changes locally and ensured they work as expected.
- [x] My code follows the project's coding standards.

---

### Screenshots or Logs (if applicable)

<!-- Add any relevant screenshots or logs to help visualize/test the changes. -->

---

### 👀 Reviewer Notes

_Add any special notes for the reviewer here_
