### PR TITLE
🐛 Fix solution import: support nested KB format with lenient validation

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -19,6 +19,7 @@ import {
   emitSolutionBrowsed,
   emitSolutionViewed,
   emitSolutionImported,
+  emitSolutionImportError,
   emitSolutionGitHubLink,
   emitSolutionLinkCopied,
 } from '../../lib/analytics'
@@ -690,6 +691,14 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
     }
     const validation = validateMissionExport(toValidate)
     if (!validation.valid) {
+      const missionTitle = (toValidate as Record<string, unknown>)?.title as string
+        ?? (toValidate as Record<string, unknown>)?.name as string
+        ?? 'unknown'
+      emitSolutionImportError(
+        missionTitle,
+        validation.errors.length,
+        validation.errors[0]?.message ?? 'unknown',
+      )
       setScanResult({
         valid: false,
         findings: validation.errors.map((e) => ({

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -878,6 +878,14 @@ export function emitSolutionImported(title: string, cncfProject?: string) {
   send('ksc_solution_imported', { title, cncf_project: cncfProject ?? '' })
 }
 
+export function emitSolutionImportError(title: string, errorCount: number, firstError: string) {
+  send('ksc_solution_import_error', {
+    title,
+    error_count: String(errorCount),
+    first_error: firstError.slice(0, 100),
+  })
+}
+
 export function emitSolutionLinkCopied(title: string, cncfProject?: string) {
   send('ksc_solution_link_copied', { title, cncf_project: cncfProject ?? '' })
 }

--- a/web/src/lib/missions/types.ts
+++ b/web/src/lib/missions/types.ts
@@ -120,43 +120,92 @@ export interface ValidationResult {
 const MISSION_TYPES: string[] = ['upgrade', 'troubleshoot', 'analyze', 'deploy', 'repair', 'custom']
 
 /**
+ * Normalize a raw mission object into a flat MissionExport shape.
+ *
+ * Console-kb missions use a nested format where the actual content is inside
+ * a `mission` wrapper object:
+ *   { version, name, missionClass, mission: { title, type, steps, ... } }
+ *
+ * This function unwraps the nested format and merges top-level metadata
+ * (author, authorGithub, version, missionClass, name) with the inner
+ * mission content so the validator always sees a flat structure.
+ *
+ * Also applies lenient defaults for optional fields (tags, description, type)
+ * so that KB content with minor omissions still imports successfully.
+ */
+function normalizeMissionData(raw: Record<string, unknown>): Record<string, unknown> {
+  // If there's a nested `mission` object, unwrap it and merge with top-level metadata
+  if (raw.mission && typeof raw.mission === 'object' && !Array.isArray(raw.mission)) {
+    const inner = raw.mission as Record<string, unknown>
+    return {
+      // Top-level metadata
+      version: raw.version ?? inner.version ?? 'kc-mission-v1',
+      name: raw.name ?? inner.name,
+      missionClass: raw.missionClass ?? inner.missionClass,
+      author: raw.author ?? inner.author,
+      authorGithub: raw.authorGithub ?? inner.authorGithub,
+      // Inner mission content takes priority
+      ...inner,
+      // Ensure top-level version/missionClass aren't overwritten by undefined inner values
+      ...(raw.version ? { version: raw.version } : {}),
+      ...(raw.missionClass ? { missionClass: raw.missionClass } : {}),
+    }
+  }
+  return raw
+}
+
+/**
  * Validate that a parsed object conforms to the MissionExport schema.
+ *
+ * Lenient by design — applies defaults for missing optional fields so that
+ * console-kb content and community-contributed missions import successfully
+ * even if they don't include every field. Only truly fatal issues (no title
+ * AND no name, no steps at all) produce errors.
  */
 export function validateMissionExport(obj: unknown): ValidationResult {
   const errors: Array<{ message: string; path?: string }> = []
-  const data = obj as Record<string, unknown>
 
-  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) {
     return {
       valid: false,
       errors: [{ message: 'Mission must be a JSON object', path: '' }],
-      data: data as unknown as MissionExport,
+      data: obj as unknown as MissionExport,
     }
   }
 
+  // Normalize nested console-kb format into flat structure
+  const data = normalizeMissionData(obj as Record<string, unknown>)
+
+  // Version — default if missing
   if (typeof data.version !== 'string') {
-    errors.push({ message: 'Missing or invalid "version" field', path: '.version' })
+    data.version = 'kc-mission-v1'
   }
 
+  // Title — fall back to name field if title is missing
   if (typeof data.title !== 'string' || !data.title) {
-    errors.push({ message: 'Missing or empty "title" field', path: '.title' })
+    if (typeof data.name === 'string' && data.name) {
+      data.title = data.name.replace(/[-_]/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase())
+    } else {
+      errors.push({ message: 'Missing or empty "title" field', path: '.title' })
+    }
   }
 
+  // Description — default to empty string if missing
   if (typeof data.description !== 'string') {
-    errors.push({ message: 'Missing "description" field', path: '.description' })
+    data.description = ''
   }
 
+  // Type — default to 'custom' if missing or unrecognized
   if (typeof data.type !== 'string' || !MISSION_TYPES.includes(data.type)) {
-    errors.push({
-      message: `Invalid "type" — expected one of: ${MISSION_TYPES.join(', ')}`,
-      path: '.type',
-    })
+    data.type = 'custom'
   }
 
+  // Tags — default to empty array if missing
   if (!Array.isArray(data.tags)) {
-    errors.push({ message: '"tags" must be an array', path: '.tags' })
+    data.tags = []
   }
 
+  // Steps — this is the only hard requirement (but we're lenient about step content)
   if (!Array.isArray(data.steps) || data.steps.length === 0) {
     errors.push({ message: '"steps" must be a non-empty array', path: '.steps' })
   } else {
@@ -166,11 +215,13 @@ export function validateMissionExport(obj: unknown): ValidationResult {
         errors.push({ message: `Step ${i} is not an object`, path: `.steps[${i}]` })
         continue
       }
+      // Default step title from description or index if missing
       if (typeof step.title !== 'string' || !step.title) {
-        errors.push({ message: `Step ${i} missing "title"`, path: `.steps[${i}].title` })
+        step.title = `Step ${i + 1}`
       }
+      // Default step description to empty string if missing
       if (typeof step.description !== 'string') {
-        errors.push({ message: `Step ${i} missing "description"`, path: `.steps[${i}].description` })
+        step.description = ''
       }
     }
   }


### PR DESCRIPTION
## Summary
- Console-kb missions use a nested format `{ mission: { title, steps, ... } }` but the validator expected flat top-level fields — **every KB mission failed to import**
- Added `normalizeMissionData()` to unwrap the nested format and merge with top-level metadata
- Made validation lenient: defaults for tags (→ []), description (→ ""), type (→ custom), version, step titles
- Only hard-fail on truly fatal issues (no title AND no name, no steps)
- Added `ksc_solution_import_error` GA4 event to track import failures going forward

## Test plan
- [ ] Import a console-kb mission (e.g., CVE-2026-3864 NFS CSI path traversal) — should succeed
- [ ] Import a flat-format mission — should still work
- [ ] Verify GA4 fires `ksc_solution_import_error` when a mission with no steps is imported
- [ ] Check that previously-failing KB missions now import cleanly