### PR TITLE
🐛 fix: make GitHub API base URL configurable for GHE support

### DIFF
--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -15,11 +15,15 @@ import (
 const (
 	// githubProxyTimeout is the timeout for proxied GitHub API requests.
 	githubProxyTimeout = 15 * time.Second
-	// githubProxyAPIBase is the base URL for proxied GitHub API requests.
-	githubProxyAPIBase = "https://api.github.com"
+	// githubProxyAPIBaseDefault is the default base URL for GitHub API requests.
+	githubProxyAPIBaseDefault = "https://api.github.com"
 	// maxGitHubProxyPathLen is the maximum allowed path length to prevent abuse.
 	maxGitHubProxyPathLen = 512
 )
+
+// githubProxyAPIBase is the base URL for proxied GitHub API requests.
+// Configurable via GITHUB_API_BASE_URL env var to support GitHub Enterprise Server.
+var githubProxyAPIBase = getEnvOrDefault("GITHUB_API_BASE_URL", githubProxyAPIBaseDefault)
 
 var githubProxyClient = &http.Client{Timeout: githubProxyTimeout}
 


### PR DESCRIPTION
## Summary
- Make `githubProxyAPIBase` configurable via `GITHUB_API_BASE_URL` env var
- Defaults to `https://api.github.com` (no change for existing deployments)
- Enables GitHub Enterprise Server compatibility

Fixes #2821