### PR TITLE
🐛 fix: warn when using default feedback/rewards repo targets

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -1748,6 +1748,22 @@ func LoadFeedbackConfig() FeedbackConfig {
 			githubToken = all.FeedbackGitHubToken
 		}
 	}
+
+	// Warn when feedback repo env vars are not set — forks and enterprise
+	// deployments should configure these to avoid routing feedback to the
+	// upstream kubestellar repositories.  See #2826.
+	feedbackEnvVars := map[string]string{
+		"FEEDBACK_REPO_OWNER": "kubestellar",
+		"FEEDBACK_REPO_NAME":  "console",
+	}
+	for envVar, defaultVal := range feedbackEnvVars {
+		if os.Getenv(envVar) == "" {
+			log.Printf("WARNING: %s is not set, using default %q — "+
+				"set this env var for fork/enterprise deployments to avoid "+
+				"routing feedback to the upstream repository", envVar, defaultVal)
+		}
+	}
+
 	return FeedbackConfig{
 		GitHubToken:   githubToken,
 		WebhookSecret: os.Getenv("GITHUB_WEBHOOK_SECRET"),

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1080,6 +1080,15 @@ func LoadConfigFromEnv() Config {
 	// (This allows --dev flag to override env var for JWT secret default)
 	jwtSecret := os.Getenv("JWT_SECRET")
 
+	// Warn when feedback/rewards env vars are not set — forks and enterprise
+	// deployments should set these to avoid routing user actions to the
+	// upstream kubestellar repositories.  See #2826.
+	warnDefaultEnvVars(map[string]string{
+		"FEEDBACK_REPO_OWNER":  "kubestellar",
+		"FEEDBACK_REPO_NAME":   "console",
+		"REWARDS_GITHUB_ORGS":  "repo:kubestellar/console repo:kubestellar/console-marketplace repo:kubestellar/console-kb",
+	})
+
 	return Config{
 		Port:             port,
 		DevMode:          devMode,
@@ -1138,6 +1147,19 @@ func getEnvOrDefault(key, defaultVal string) string {
 		return v
 	}
 	return defaultVal
+}
+
+// warnDefaultEnvVars logs a warning for each env var that is not explicitly
+// set.  This helps fork and enterprise deployers notice that the defaults
+// point to the upstream kubestellar repositories so they can override them.
+func warnDefaultEnvVars(vars map[string]string) {
+	for envVar, defaultVal := range vars {
+		if os.Getenv(envVar) == "" {
+			log.Printf("WARNING: %s is not set, using default %q — "+
+				"set this env var for fork/enterprise deployments to avoid "+
+				"routing actions to the upstream repository", envVar, defaultVal)
+		}
+	}
 }
 
 func generateDevSecret() string {


### PR DESCRIPTION
## Summary
- Add startup log warnings when `FEEDBACK_REPO_OWNER`, `FEEDBACK_REPO_NAME`, or `REWARDS_GITHUB_ORGS` env vars are not set
- Warns in both `LoadConfigFromEnv()` (server.go) and `LoadFeedbackConfig()` (feedback.go)
- Makes it obvious to fork/enterprise deployers that these need configuring to avoid routing user feedback and rewards to the upstream kubestellar repositories

## Test plan
- [ ] Start server without setting `FEEDBACK_REPO_OWNER`, `FEEDBACK_REPO_NAME`, `REWARDS_GITHUB_ORGS` — verify WARNING logs appear
- [ ] Set all three env vars — verify no warnings appear
- [ ] `go build ./...` passes

Fixes #2826