### PR TITLE
🐛 fix: set isDone on SSE error to prevent benchmark retry loop

### DIFF
--- a/web/src/hooks/useBenchmarkData.ts
+++ b/web/src/hooks/useBenchmarkData.ts
@@ -111,7 +111,7 @@ function startGlobalStream(since: string) {
   })
     .then(async (res) => {
       if (!res.ok || !res.body) {
-        streamState = { ...streamState, isStreaming: false, error: `Stream error: ${res.status}` }
+        streamState = { ...streamState, isStreaming: false, isDone: true, error: `Stream error: ${res.status}` }
         notifySubscribers()
         return
       }
@@ -165,7 +165,7 @@ function startGlobalStream(since: string) {
                 streamState = { ...streamState, isDone: true, isStreaming: false, status: 'done' }
                 notifySubscribers()
               } else if (eventType === 'error') {
-                streamState = { ...streamState, error: rawData, isStreaming: false, status: 'error' }
+                streamState = { ...streamState, error: rawData, isStreaming: false, isDone: true, status: 'error' }
                 notifySubscribers()
               }
             }
@@ -180,7 +180,7 @@ function startGlobalStream(since: string) {
     })
     .catch((err) => {
       if (err.name !== 'AbortError') {
-        streamState = { ...streamState, error: err.message, isStreaming: false }
+        streamState = { ...streamState, error: err.message, isStreaming: false, isDone: true }
         notifySubscribers()
       }
     })


### PR DESCRIPTION
## Summary
- Set `isDone: true` when SSE stream returns error (503/non-ok), not just `isStreaming: false`
- Also set `isDone: true` on SSE `error` event and network-level fetch errors
- Prevents repeated 503 retry loop against benchmark REST endpoint
- The `useCache` fetcher now correctly sees the stream is done and won't loop

Fixes #2816