### PR TITLE
🐛 fix: use same-origin relative URLs instead of localhost fallback

### DIFF
--- a/web/src/lib/constants/network.ts
+++ b/web/src/lib/constants/network.ts
@@ -33,8 +33,10 @@ export const LOCAL_AGENT_WS_URL = _isNetlify ? '' : 'ws://127.0.0.1:8585/ws'
  */
 export const LOCAL_AGENT_HTTP_URL = _isNetlify ? '' : 'http://127.0.0.1:8585'
 
-/** Default backend URL (used as fallback when not configured) */
-export const BACKEND_DEFAULT_URL = 'http://localhost:8080'
+/** Default backend URL — empty string means same-origin relative URL.
+ * This ensures API requests work in deployed environments (custom domain,
+ * ingress, reverse proxy) without requiring VITE_API_BASE_URL to be set. */
+export const BACKEND_DEFAULT_URL = ''
 
 // ============================================================================
 // WebSocket Timeouts


### PR DESCRIPTION
## Summary
- Change `BACKEND_DEFAULT_URL` from `'http://localhost:8080'` to `''` (empty string) so API requests use same-origin relative URLs
- This fixes frontend API calls in deployed environments (custom domain, ingress, reverse proxy) that don't set `VITE_API_BASE_URL`
- Since all consumers import from this single constant, only one line needed to change

## Files affected (all use `BACKEND_DEFAULT_URL`)
- `web/src/lib/constants/network.ts` — the source of truth (changed)
- `web/src/hooks/useNotificationAPI.ts` — inherits fix
- `web/src/hooks/useGitHubRewards.ts` — inherits fix
- `web/src/components/feedback/FeatureRequestModal.tsx` — inherits fix
- `web/src/components/cards/llmd/NightlyE2EStatus.tsx` — inherits fix
- `web/src/components/widgets/WidgetExportModal.tsx` — inherits fix

## Test plan
- [ ] Verify API requests work in local dev (Go backend on same port 8080)
- [ ] Verify API requests work on console.kubestellar.io (same-origin)
- [ ] Verify API requests work behind reverse proxy / custom domain
- [ ] Verify widget export modal still defaults correctly

Fixes #2825