### PR TITLE
🐛 fix: align CI/CD statsType across config, page, and type union

### DIFF
--- a/web/src/components/cicd/CICD.tsx
+++ b/web/src/components/cicd/CICD.tsx
@@ -91,7 +91,7 @@ export function CICD() {
       icon="GitPullRequest"
       storageKey={CICD_CARDS_KEY}
       defaultCards={DEFAULT_CICD_CARDS}
-      statsType="gitops"
+      statsType="ci-cd"
       getStatValue={getStatValue}
       onRefresh={refetch}
       isLoading={isLoading || prowLoading || deploymentsLoading}

--- a/web/src/components/ui/StatsBlockDefinitions.ts
+++ b/web/src/components/ui/StatsBlockDefinitions.ts
@@ -54,6 +54,7 @@ export type DashboardStatsType =
   | 'cluster-admin'
   | 'insights'
   | 'multi-tenancy'
+  | 'ci-cd'
 
 /**
  * Default stat blocks for the Clusters dashboard
@@ -431,6 +432,8 @@ export function getDefaultStatBlocks(dashboardType: DashboardStatsType): StatBlo
       return INSIGHTS_STAT_BLOCKS
     case 'multi-tenancy':
       return MULTI_TENANCY_STAT_BLOCKS
+    case 'ci-cd':
+      return GITOPS_STAT_BLOCKS
     default:
       return []
   }

--- a/web/src/components/ui/StatsConfig.tsx
+++ b/web/src/components/ui/StatsConfig.tsx
@@ -196,6 +196,7 @@ const DASHBOARD_CATEGORIES: { type: DashboardStatsType; name: string; icon: stri
   { type: 'alerts', name: 'Alerts', icon: '🔴' },
   { type: 'operators', name: 'Operators', icon: '⚙️' },
   { type: 'dashboard', name: 'Main Dashboard', icon: '📊' },
+  { type: 'ci-cd', name: 'CI/CD', icon: '🔄' },
 ]
 
 /**
@@ -218,6 +219,7 @@ function getStatBlocksForDashboard(dashboardType: DashboardStatsType): StatBlock
     case 'alerts': return ALERTS_STAT_BLOCKS
     case 'dashboard': return DASHBOARD_STAT_BLOCKS
     case 'operators': return OPERATORS_STAT_BLOCKS
+    case 'ci-cd': return GITOPS_STAT_BLOCKS
     default: return []
   }
 }

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -79,6 +79,7 @@ const DASHBOARD_NAMES: Record<DashboardStatsType, string> = {
   'cluster-admin': 'Cluster Admin',
   insights: 'Insights',
   'multi-tenancy': 'Multi-Tenancy',
+  'ci-cd': 'CI/CD',
 }
 
 const DASHBOARD_ROUTES: Record<DashboardStatsType, string> = {
@@ -102,13 +103,14 @@ const DASHBOARD_ROUTES: Record<DashboardStatsType, string> = {
   'cluster-admin': '/cluster-admin',
   insights: '/insights',
   'multi-tenancy': '/multi-tenancy',
+  'ci-cd': '/ci-cd',
 }
 
 const ALL_STATS_DASHBOARD_TYPES: DashboardStatsType[] = [
   'dashboard', 'clusters', 'workloads', 'pods', 'gitops', 'storage',
   'network', 'security', 'compliance', 'data-compliance', 'compute',
   'events', 'cost', 'alerts', 'operators', 'deploy', 'ai-agents',
-  'cluster-admin', 'insights',
+  'cluster-admin', 'insights', 'ci-cd',
 ]
 
 // --- Dashboard storage keys → routes (for scanning placed cards) ---


### PR DESCRIPTION
## Summary
- Add `ci-cd` to the `DashboardStatsType` union in `StatsBlockDefinitions.ts`
- Add `ci-cd` case to `getDefaultStatBlocks()` and `getStatBlocksForDashboard()` (reuses GitOps stat blocks)
- Add `ci-cd` entries to `DASHBOARD_NAMES`, `DASHBOARD_ROUTES`, `ALL_STATS_DASHBOARD_TYPES` in `useSearchIndex.ts`
- Add `ci-cd` entry to `DASHBOARD_CATEGORIES` in `StatsConfig.tsx`
- Update `CICD.tsx` to use `ci-cd` statsType (matching the dashboard config in `ci-cd.ts`)

Fixes #2841