### PR TITLE
🐛 fix: improve connection routing in Tenant Architecture card

### DIFF
--- a/web/src/components/cards/multi-tenancy/tenant-topology/TenantTopology.tsx
+++ b/web/src/components/cards/multi-tenancy/tenant-topology/TenantTopology.tsx
@@ -439,10 +439,10 @@ function buildConnections(
       throughputBytesPerSec: rates.k3sEth1Rate,
       rxBytesPerSec: rates.k3sEth1Rx,
       txBytesPerSec: rates.k3sEth1Tx,
-      rxLabelX: K3S_ETH1_ROUTE_X + 2,
-      rxLabelY: l2BottomY + 1,
-      txLabelX: K3S_ETH1_ROUTE_X + 2,
-      txLabelY: l2BottomY + 6,
+      rxLabelX: k3sLeftX - THROUGHPUT_PILL_FULL_W - 1,
+      rxLabelY: k3sLeftY - 5,
+      txLabelX: k3sLeftX - THROUGHPUT_PILL_FULL_W - 1,
+      txLabelY: k3sLeftY + 1,
     },
     {
       // K3s Server eth0 -> Default k8s Network -> KubeFlex (dark blue, bidirectional)


### PR DESCRIPTION
## Summary
- Route the K3s Server Pod eth1-to-Cluster UDN connection through the gap between namespace-1 and namespace-2 instead of through the pod body
- The previous SVG path went rightward from eth1 at (127, 78) to (160, 78), cutting directly through the K3s Server Pod (which spans x: 127-173), then up to the L2 UDN
- The new path goes leftward to x=115 (the gap between ns-1 ending at x=110 and ns-2 starting at x=120), then up to the L2 UDN bottom edge
- Throughput labels repositioned to sit beside the vertical segment of the corrected path

Fixes #2839