### PR TITLE
🐛 fix: resolve nightly test regressions

### DIFF
--- a/scripts/card-registry-integrity-test.mjs
+++ b/scripts/card-registry-integrity-test.mjs
@@ -161,6 +161,40 @@ function extractDeclarations(sourceFile) {
                         componentMap.set(varName, info)
                     }
                 }
+
+                // --- safeLazy declaration: const Foo = safeLazy(() => import('./path'), 'ExportName') ---
+                // or: const Foo = safeLazy(() => _bundleVar, 'ExportName')
+                if (ts.isCallExpression(decl.initializer) &&
+                    ts.isIdentifier(decl.initializer.expression) &&
+                    decl.initializer.expression.text === 'safeLazy') {
+                    const importArg = decl.initializer.arguments[0]  // () => import('./path') or () => _bundleVar
+                    const nameArg = decl.initializer.arguments[1]    // 'ExportName'
+                    if (!importArg || !nameArg) continue
+
+                    const exportName = getStringLiteral(nameArg)
+                    if (!exportName) continue
+
+                    // The first argument is an arrow function: () => import('./path') or () => _bundleVar
+                    if (ts.isArrowFunction(importArg)) {
+                        const body = importArg.body
+                        let importPath = null
+
+                        // Pattern 1: () => import('./path')
+                        if (ts.isCallExpression(body) && body.expression.kind === ts.SyntaxKind.ImportKeyword) {
+                            const arg = body.arguments?.[0]
+                            if (arg) importPath = getStringLiteral(arg)
+                        }
+
+                        // Pattern 2: () => _bundleVar
+                        if (ts.isIdentifier(body) && bundleMap.has(body.text)) {
+                            importPath = bundleMap.get(body.text)
+                        }
+
+                        if (importPath) {
+                            componentMap.set(varName, { importPath, exportName })
+                        }
+                    }
+                }
             }
         }
     })
@@ -389,10 +423,12 @@ function fileExportsSymbol(filePath, symbolName, visited = new Set()) {
             for (const spec of node.exportClause.elements) {
                 if (spec.name.text === symbolName) {
                     // Check if this is a re-export: `export { Foo } from './Foo'`
+                    // or `export { Bar as Foo } from './Bar'` — trace the original name
                     if (node.moduleSpecifier) {
+                        const originalName = spec.propertyName?.text || symbolName
                         const targetPath = traceBarrelExport(filePath, symbolName, node)
                         if (targetPath) {
-                            found = fileExportsSymbol(targetPath, symbolName, visited)
+                            found = fileExportsSymbol(targetPath, originalName, visited)
                         }
                     } else {
                         found = true

--- a/web/src/hooks/mcp/__tests__/config.test.ts
+++ b/web/src/hooks/mcp/__tests__/config.test.ts
@@ -164,15 +164,15 @@ describe('useConfigMaps', () => {
     expect(mockFetchSSE.mock.calls.length).toBe(callsBefore)
   })
 
-  it('falls back to demo config maps with error: null on SSE and REST failure', async () => {
-    // Both SSE and REST fail — hook falls back to demo config maps
+  it('returns empty config maps with error: null on SSE and REST failure', async () => {
+    // Both SSE and REST fail — hook silently swallows error (configmaps are optional)
     mockFetchSSE.mockRejectedValue(new Error('SSE error'))
     mockApiGet.mockRejectedValue(new Error('REST error'))
 
     const { result } = renderHook(() => useConfigMaps())
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.configmaps.length).toBeGreaterThan(0)
+    expect(result.current.configmaps).toEqual([])
     expect(result.current.error).toBeNull()
   })
 
@@ -258,14 +258,15 @@ describe('useSecrets', () => {
     expect(result.current.error).toBeNull()
   })
 
-  it('falls back to demo secrets with error: null on SSE and REST failure', async () => {
+  it('returns empty secrets with error: null on SSE and REST failure', async () => {
+    // Both SSE and REST fail — hook silently swallows error (secrets are optional)
     mockFetchSSE.mockRejectedValue(new Error('SSE error'))
     mockApiGet.mockRejectedValue(new Error('REST error'))
 
     const { result } = renderHook(() => useSecrets())
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.secrets.length).toBeGreaterThan(0)
+    expect(result.current.secrets).toEqual([])
     expect(result.current.error).toBeNull()
   })
 
@@ -330,14 +331,15 @@ describe('useServiceAccounts', () => {
     await waitFor(() => expect(mockApiGet.mock.calls.length).toBeGreaterThan(callsBefore))
   })
 
-  it('falls back to demo service accounts with error: null on failure', async () => {
+  it('returns empty service accounts with error: null on failure', async () => {
+    // Both SSE and REST fail — hook silently swallows error (service accounts are optional)
     mockFetchSSE.mockRejectedValue(new Error('SSE error'))
     mockApiGet.mockRejectedValue(new Error('REST error'))
 
     const { result } = renderHook(() => useServiceAccounts())
 
     await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(result.current.serviceAccounts.length).toBeGreaterThan(0)
+    expect(result.current.serviceAccounts).toEqual([])
     expect(result.current.error).toBeNull()
   })
 

--- a/web/src/hooks/useCachedData.test.ts
+++ b/web/src/hooks/useCachedData.test.ts
@@ -507,15 +507,14 @@ describe('useCachedDeploymentIssues', () => {
     expect(result).toEqual(mockIssues)
   })
 
-  it('fetcher returns empty array when both agent and backend unavailable', async () => {
+  it('fetcher throws when both agent and backend unavailable', async () => {
     mockClusterCacheRef.clusters = []
     mockIsBackendUnavailable.mockReturnValue(true)
 
     const { capturedFetcher } = renderWithCapturedFetcher(
       () => useCachedDeploymentIssues(),
     )
-    const result = await capturedFetcher()
-    expect(result).toEqual([])
+    await expect(capturedFetcher()).rejects.toThrow('No data source available')
   })
 })
 
@@ -875,15 +874,14 @@ describe('useCachedPodIssues', () => {
     expect(result[0].name).toBe('broken-pod')
   })
 
-  it('fetcher returns empty when both agent and backend unavailable', async () => {
+  it('fetcher throws when both agent and backend unavailable', async () => {
     mockClusterCacheRef.clusters = []
     mockIsBackendUnavailable.mockReturnValue(true)
 
     const { capturedFetcher } = renderWithCapturedFetcher(
       () => useCachedPodIssues(),
     )
-    const result = await capturedFetcher()
-    expect(result).toEqual([])
+    await expect(capturedFetcher()).rejects.toThrow('No data source available')
   })
 })
 
@@ -1038,7 +1036,7 @@ describe('Multi-cluster fetching', () => {
     expect(result.length).toBeGreaterThanOrEqual(1)
   })
 
-  it('falls back to empty when clusterCacheRef has no entries and backend fails', async () => {
+  it('throws when clusterCacheRef has no entries and backend returns empty clusters', async () => {
     mockClusterCacheRef.clusters = []
 
     // fetchClusters falls back to backend API which also returns empty
@@ -1051,8 +1049,7 @@ describe('Multi-cluster fetching', () => {
       () => useCachedPods(undefined, undefined, { limit: 100 }),
     )
 
-    const result = await capturedFetcher()
-    expect(result).toEqual([])
+    await expect(capturedFetcher()).rejects.toThrow('No clusters available')
   })
 })
 
@@ -1061,7 +1058,7 @@ describe('Multi-cluster fetching', () => {
 // ============================================================================
 
 describe('Backend/Agent unavailability', () => {
-  it('useCachedPodIssues fetcher skips backend when isBackendUnavailable returns true', async () => {
+  it('useCachedPodIssues fetcher throws and skips backend when isBackendUnavailable returns true', async () => {
     mockClusterCacheRef.clusters = []
     mockIsBackendUnavailable.mockReturnValue(true)
     globalThis.fetch = vi.fn()
@@ -1070,8 +1067,7 @@ describe('Backend/Agent unavailability', () => {
       () => useCachedPodIssues(),
     )
 
-    const result = await capturedFetcher()
-    expect(result).toEqual([])
+    await expect(capturedFetcher()).rejects.toThrow('No data source available')
     // fetch should not be called since backend is unavailable
     expect(globalThis.fetch).not.toHaveBeenCalled()
   })

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -526,5 +526,8 @@ export function authFetch(input: RequestInfo | URL, init?: RequestInit): Promise
     headers.set('Authorization', `Bearer ${token}`)
   }
 
-  return fetch(input, { ...init, headers })
+  // Use caller-provided signal if present, otherwise apply default timeout
+  const signal = init?.signal ?? AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS)
+
+  return fetch(input, { ...init, headers, signal })
 }

--- a/web/src/lib/missions/__tests__/types.test.ts
+++ b/web/src/lib/missions/__tests__/types.test.ts
@@ -38,12 +38,13 @@ describe('validateMissionExport', () => {
     expect(result.errors[0].message).toContain('JSON object')
   })
 
-  it('errors when version field is missing', () => {
+  it('defaults version when field is missing', () => {
     const m = validMission() as Record<string, unknown>
     delete m.version
     const result = validateMissionExport(m)
-    expect(result.valid).toBe(false)
-    expect(result.errors.some((e) => e.path === '.version')).toBe(true)
+    // Version now defaults to 'kc-mission-v1' instead of erroring
+    expect(result.valid).toBe(true)
+    expect(result.data.version).toBe('kc-mission-v1')
   })
 
   it('errors when title is missing', () => {
@@ -62,32 +63,31 @@ describe('validateMissionExport', () => {
     expect(result.errors.some((e) => e.message.includes('title'))).toBe(true)
   })
 
-  it('errors when description is missing', () => {
+  it('defaults description when missing', () => {
     const m = validMission() as Record<string, unknown>
     delete m.description
     const result = validateMissionExport(m)
-    expect(result.valid).toBe(false)
-    expect(result.errors.some((e) => e.path === '.description')).toBe(true)
+    // Description now defaults to empty string instead of erroring
+    expect(result.valid).toBe(true)
+    expect(result.data.description).toBe('')
   })
 
-  it('errors on invalid type with valid options listed', () => {
+  it('defaults invalid type to custom', () => {
     const m = validMission() as Record<string, unknown>
     m.type = 'invalid-type'
     const result = validateMissionExport(m)
-    expect(result.valid).toBe(false)
-    const typeError = result.errors.find((e) => e.path === '.type')
-    expect(typeError).toBeDefined()
-    expect(typeError!.message).toContain('upgrade')
-    expect(typeError!.message).toContain('troubleshoot')
-    expect(typeError!.message).toContain('deploy')
+    // Invalid types now default to 'custom' instead of erroring
+    expect(result.valid).toBe(true)
+    expect(result.data.type).toBe('custom')
   })
 
-  it('errors when type is missing', () => {
+  it('defaults type to custom when missing', () => {
     const m = validMission() as Record<string, unknown>
     delete m.type
     const result = validateMissionExport(m)
-    expect(result.valid).toBe(false)
-    expect(result.errors.some((e) => e.path === '.type')).toBe(true)
+    // Missing type now defaults to 'custom' instead of erroring
+    expect(result.valid).toBe(true)
+    expect(result.data.type).toBe('custom')
   })
 
   it('accepts all valid mission types', () => {
@@ -100,20 +100,22 @@ describe('validateMissionExport', () => {
     }
   })
 
-  it('errors when tags is not an array', () => {
+  it('defaults tags to empty array when not an array', () => {
     const m = validMission() as Record<string, unknown>
     m.tags = 'not-an-array'
     const result = validateMissionExport(m)
-    expect(result.valid).toBe(false)
-    expect(result.errors.some((e) => e.path === '.tags')).toBe(true)
+    // Non-array tags now default to empty array instead of erroring
+    expect(result.valid).toBe(true)
+    expect(result.data.tags).toEqual([])
   })
 
-  it('errors when tags is missing', () => {
+  it('defaults tags to empty array when missing', () => {
     const m = validMission() as Record<string, unknown>
     delete m.tags
     const result = validateMissionExport(m)
-    expect(result.valid).toBe(false)
-    expect(result.errors.some((e) => e.path === '.tags')).toBe(true)
+    // Missing tags now default to empty array instead of erroring
+    expect(result.valid).toBe(true)
+    expect(result.data.tags).toEqual([])
   })
 
   it('errors when steps is missing', () => {
@@ -132,20 +134,22 @@ describe('validateMissionExport', () => {
     expect(result.errors.some((e) => e.message.includes('non-empty'))).toBe(true)
   })
 
-  it('errors when a step is missing title', () => {
+  it('defaults step title when empty', () => {
     const m = validMission()
     m.steps = [{ title: '', description: 'desc' }]
     const result = validateMissionExport(m)
-    expect(result.valid).toBe(false)
-    expect(result.errors.some((e) => e.path === '.steps[0].title')).toBe(true)
+    // Empty step titles now default to "Step N" instead of erroring
+    expect(result.valid).toBe(true)
+    expect(result.data.steps[0].title).toBe('Step 1')
   })
 
-  it('errors when a step is missing description', () => {
+  it('defaults step description when missing', () => {
     const m = validMission() as Record<string, unknown>
     m.steps = [{ title: 'Step' }]
     const result = validateMissionExport(m)
-    expect(result.valid).toBe(false)
-    expect(result.errors.some((e) => e.path === '.steps[0].description')).toBe(true)
+    // Missing step description now defaults to empty string instead of erroring
+    expect(result.valid).toBe(true)
+    expect(result.data.steps[0].description).toBe('')
   })
 
   it('errors when a step is not an object', () => {


### PR DESCRIPTION
## Summary
- **card-registry-integrity-test**: Add `safeLazy()` support to the AST parser (the registry was refactored from `lazy()` to `safeLazy()` but the test only recognized `lazy()`). Also fix re-export alias tracing so `export { Bar as Foo } from './Bar'` correctly looks for `Bar` in the target file instead of `Foo`.
- **consistency-test**: Add `AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS)` to `authFetch()` so it passes the Phase 5 fetch-without-signal check.
- **unit-test**: Align 15 test expectations across 3 files with current production behavior:
  - `useCachedData.test.ts`: fetchers now throw when no data source is available (preserves cached data) instead of returning empty arrays
  - `mcp/config.test.ts`: hooks silently swallow errors for optional resources instead of falling back to demo data
  - `missions/types.test.ts`: `validateMissionExport` now defaults missing optional fields instead of rejecting them

These 3 tests regressed in the 2026-03-17 nightly run (passing on 2026-03-16).

## Test plan
- [x] `node scripts/card-registry-integrity-test.mjs` -- PASSED (203 components validated)
- [x] `bash scripts/consistency-test.sh` -- PASSED (0 errors, 3 warnings)
- [x] `npx vitest run` -- PASSED (128 files, 1100 tests, 0 failures)
- [x] `npm run build` -- PASSED