### PR TITLE
🐛 fix: resolve nightly consistency-test failures

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -38,6 +38,7 @@ import { MissionChat } from './MissionChat'
 import { ClusterSelectionDialog } from '../../missions/ClusterSelectionDialog'
 import { useTranslation } from 'react-i18next'
 import { SAVED_TOAST_MS, FOCUS_DELAY_MS } from '../../../lib/constants/network'
+import { MISSION_FILE_FETCH_TIMEOUT_MS } from '../../missions/browser/missionCache'
 
 export function MissionSidebar() {
   const { t } = useTranslation(['common'])
@@ -96,7 +97,9 @@ export function MissionSidebar() {
     const tryImport = async () => {
       for (const path of paths) {
         try {
-          const res = await fetch(`/api/missions/file?path=${encodeURIComponent(path)}`)
+          const res = await fetch(`/api/missions/file?path=${encodeURIComponent(path)}`, {
+            signal: AbortSignal.timeout(MISSION_FILE_FETCH_TIMEOUT_MS),
+          })
           if (!res.ok) continue
           const raw = await res.text()
           const parsed = JSON.parse(raw)

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -549,7 +549,7 @@ export function useCachedEvents(
             return events.map(e => ({ ...e, cluster: ci.name }))
           })
         )
-        for (const r of results) {
+        for (const r of (results || [])) {
           if (r.status === 'fulfilled') allEvents.push(...r.value)
         }
         return allEvents
@@ -573,7 +573,7 @@ export function useCachedEvents(
       if (clusterCacheRef.clusters.length > 0 && !isAgentUnavailable()) {
         const clusters = getAgentClusters()
         const accumulated: ClusterEvent[] = []
-        for (const ci of clusters) {
+        for (const ci of (clusters || [])) {
           try {
             const ctx = ci.context || ci.name
             const events = await kubectlProxy.getEvents(ctx, namespace, limit)

--- a/web/src/hooks/useStatHistory.ts
+++ b/web/src/hooks/useStatHistory.ts
@@ -50,7 +50,7 @@ export function useStatHistory(
 
     const sample = () => {
       const now = Date.now()
-      for (const blockId of visibleBlockIds) {
+      for (const blockId of (visibleBlockIds || [])) {
         const data = getStatValue(blockId)
         const numericValue = typeof data.value === 'number'
           ? data.value


### PR DESCRIPTION
## Summary
- Add `AbortSignal.timeout()` to unguarded `fetch()` in MissionSidebar (Phase 5 violation)
- Guard `for...of` loops against undefined in useStatHistory and useCachedData (Phase 2 warnings)

## Test plan
- [x] `bash scripts/consistency-test.sh` passes with 0 errors, 0 warnings
- [x] TypeScript builds cleanly
- [x] ESLint passes (pre-existing warnings only)

Fixes #2872