### PR TITLE
🐛 fix: use source cluster name instead of namespace in deploy annotation

### DIFF
--- a/pkg/k8s/dependencies.go
+++ b/pkg/k8s/dependencies.go
@@ -377,7 +377,7 @@ func (m *MultiClusterClient) ResolveDependencies(
 		}
 
 		// Clean the manifest for cross-cluster deploy
-		dep.Object = cleanManifestForDeploy(obj, opts)
+		dep.Object = cleanManifestForDeploy(obj, sourceCluster, opts)
 
 		// For Secrets: strip service-account-token type secrets (auto-generated, cluster-specific)
 		if dep.Kind == DepSecret {

--- a/pkg/k8s/workload.go
+++ b/pkg/k8s/workload.go
@@ -482,7 +482,7 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 	}
 
 	// 3. Clean the workload manifest for cross-cluster apply
-	cleanedObj := cleanManifestForDeploy(sourceObj, opts)
+	cleanedObj := cleanManifestForDeploy(sourceObj, sourceCluster, opts)
 
 	// Override replicas if specified
 	if replicas > 0 {
@@ -698,7 +698,7 @@ func applyDependencies(
 }
 
 // cleanManifestForDeploy strips cluster-specific metadata and adds console labels
-func cleanManifestForDeploy(obj *unstructured.Unstructured, opts *DeployOptions) *unstructured.Unstructured {
+func cleanManifestForDeploy(obj *unstructured.Unstructured, sourceCluster string, opts *DeployOptions) *unstructured.Unstructured {
 	clean := obj.DeepCopy()
 
 	// Strip cluster-specific fields
@@ -735,7 +735,7 @@ func cleanManifestForDeploy(obj *unstructured.Unstructured, opts *DeployOptions)
 		annotations = make(map[string]string)
 	}
 	annotations["kubestellar.io/deploy-timestamp"] = time.Now().UTC().Format(time.RFC3339)
-	annotations["kubestellar.io/source-cluster"] = obj.GetNamespace()
+	annotations["kubestellar.io/source-cluster"] = sourceCluster
 	clean.SetAnnotations(annotations)
 
 	return clean


### PR DESCRIPTION
## Summary
- `cleanManifestForDeploy` was writing `obj.GetNamespace()` as the `kubestellar.io/source-cluster` annotation instead of the actual source cluster name
- This corrupts deployment provenance metadata for every deployed resource
- Now passes `sourceCluster` parameter through to the function

## Test plan
- [x] `go build ./pkg/k8s/...` passes
- [ ] Deploy a workload and verify `kubestellar.io/source-cluster` annotation has the cluster name, not namespace

Fixes #2874