### PR TITLE
🐛 fix: emit deploy:result on failure and pass groupName to API

### DIFF
--- a/web/src/components/deploy/Deploy.tsx
+++ b/web/src/components/deploy/Deploy.tsx
@@ -364,6 +364,7 @@ export function Deploy() {
         namespace,
         sourceCluster,
         targetClusters,
+        groupName,
       }, {
         onSuccess: (result) => {
           const resp = result as unknown as {
@@ -392,6 +393,16 @@ export function Deploy() {
       })
     } catch (err) {
       console.error('Deploy failed:', err)
+      publishCardEvent({
+        type: 'deploy:result',
+        payload: {
+          id: deployId,
+          success: false,
+          message: err instanceof Error ? err.message : 'Deploy failed',
+          deployedTo: [],
+          failedClusters: targetClusters,
+        },
+      })
     }
   }, [pendingDeploy, publishCardEvent, deployWorkload, shouldPersist, createManagedWorkload, createWorkloadDeployment, showToast])
 

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -42,6 +42,7 @@ export interface DeployRequest {
   namespace: string
   sourceCluster: string
   targetClusters: string[]
+  groupName?: string
   replicas?: number
 }
 


### PR DESCRIPTION
## Summary
- Deploy catch block now publishes `deploy:result` with `success: false` so cards/UI receive a terminal failure event instead of hanging in pending state
- Added `groupName` to `DeployRequest` interface and pass it through to the backend so cluster group selection is preserved during deploy

## Test plan
- [x] TypeScript builds cleanly
- [ ] Trigger a deploy failure — verify UI receives the failure event and shows error state
- [ ] Deploy to a cluster group — verify groupName is sent to the backend

Fixes #2876, fixes #2875