### PR TITLE
🐛 fix: show newest missions first in sidebar chat list

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -679,7 +679,7 @@ export function MissionSidebar() {
                   <span className="text-2xs bg-secondary px-1.5 py-0.5 rounded-full">{activeMissions.length}</span>
                 </div>
               )}
-              {[...activeMissions].reverse().map((mission) => (
+              {[...activeMissions].map((mission) => (
                 <MissionListItem
                   key={mission.id}
                   mission={mission}


### PR DESCRIPTION
## Summary
- Missions are prepended to the array (newest first) via `[mission, ...prev]`
- `.reverse()` was flipping the order to oldest-first
- Removed the `.reverse()` so the most recent missions appear at the top

## Test plan
- [x] TypeScript builds cleanly
- [ ] Start multiple missions — verify newest appears at top of sidebar list

Fixes #2877