### PR TITLE
🐛 fix: accept E2E responses with valid guides but empty runs

### DIFF
--- a/web/src/hooks/useNightlyE2EData.ts
+++ b/web/src/hooks/useNightlyE2EData.ts
@@ -86,7 +86,7 @@ export function useNightlyE2EData() {
           })
           if (res.ok) {
             const data = await res.json()
-            if (data.guides && data.guides.length > 0) {
+            if (data.guides && Array.isArray(data.guides)) {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               const guides: NightlyGuideStatus[] = data.guides.map((g: any) => ({
                 guide: g.guide,


### PR DESCRIPTION
## Summary
- The nightly E2E hook required `guides.length > 0`, but a valid API response with guides that have zero runs (new guide, no runs yet) was treated as a failure
- Changed to `Array.isArray(data.guides)` so empty-run responses are accepted and cached properly instead of triggering error/retry/fallback

## Test plan
- [x] TypeScript builds cleanly
- [ ] Verify nightly E2E card handles guides with empty runs array without falling back to demo data

Fixes #2873