### PR TITLE
🐛 fix: remove double URL encoding in MissionLandingPage import

### DIFF
--- a/web/src/components/missions/MissionLandingPage.tsx
+++ b/web/src/components/missions/MissionLandingPage.tsx
@@ -282,7 +282,7 @@ export function MissionLandingPage() {
   const handleImport = () => {
     // Navigate to the full console with the import param — the sidebar
     // will detect it and directly import the mission (no browser popup)
-    navigate(`/?import=${encodeURIComponent(missionId || '')}`, { replace: true })
+    navigate(`/?import=${missionId || ''}`, { replace: true })
   }
 
   const handleBrowseAll = () => {


### PR DESCRIPTION
## Summary
- `MissionLandingPage.tsx:285` applied `encodeURIComponent()` to `missionId` which is already decoded by React Router
- This caused double-encoding for mission slugs with special characters when navigating to `/?import=`

## Test plan
- [x] TypeScript builds cleanly
- [ ] Navigate to `/missions/install-prometheus` → verify import works without encoding issues

Fixes #2868