### PR TITLE
🐛 fix: prevent duplicate mission completion events in GA4

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -688,7 +688,9 @@ Install the console locally with the KubeStellar Console agent to use AI mission
 
           // Clear active token tracking
           setActiveTokenCategory(null)
-          emitMissionCompleted(m.type, Math.round((Date.now() - m.createdAt.getTime()) / 1000))
+          if (m.status === 'running') {
+            emitMissionCompleted(m.type, Math.round((Date.now() - m.createdAt.getTime()) / 1000))
+          }
           return {
             ...m,
             status: 'waiting_input' as MissionStatus,
@@ -721,7 +723,9 @@ Install the console locally with the KubeStellar Console agent to use AI mission
 
         // Clear active token tracking and emit completion event
         setActiveTokenCategory(null)
-        emitMissionCompleted(m.type, Math.round((Date.now() - m.createdAt.getTime()) / 1000))
+        if (m.status === 'running') {
+          emitMissionCompleted(m.type, Math.round((Date.now() - m.createdAt.getTime()) / 1000))
+        }
 
         return {
           ...m,


### PR DESCRIPTION
## Summary
- Both `stream_complete` (line 691) and `result` (line 726) handlers called `emitMissionCompleted()` unconditionally
- If both fire for the same mission, GA4 double-counts completions
- Added `m.status === 'running'` guard so the event only fires on the first transition out of running state

## Test plan
- [x] TypeScript builds cleanly
- [ ] Complete a mission → verify only one `mission_completed` event in GA4

Fixes #2861