### PR TITLE
🐛 fix: GA4 passthrough in MSW to fix UTM tracking on deploy previews

### DIFF
--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -1,4 +1,4 @@
-import { http, HttpResponse, delay } from 'msw'
+import { http, HttpResponse, delay, passthrough } from 'msw'
 
 /**
  * MSW (Mock Service Worker) handlers for KubeStellar Console
@@ -191,6 +191,15 @@ const savedCards: Record<string, unknown> = {}
 const sharedDashboards: Record<string, unknown> = {}
 
 export const handlers = [
+  // ── Analytics passthrough ─────────────────────────────────────────
+  // Explicitly pass through GA4/analytics requests so the service worker
+  // does not intercept them. Without this, cross-origin passthrough fails
+  // in some browsers, breaking UTM campaign tracking (intern affiliate links).
+  http.all('https://www.google-analytics.com/*', () => passthrough()),
+  http.all('https://analytics.google.com/*', () => passthrough()),
+  http.all('https://www.googletagmanager.com/*', () => passthrough()),
+  http.all('https://*.google-analytics.com/*', () => passthrough()),
+
   // Auth endpoints
   http.get('/api/auth/me', async () => {
     await delay(100)


### PR DESCRIPTION
## Summary
- Add explicit `passthrough()` handlers for Google Analytics domains in MSW handlers
- Fixes UTM campaign tracking (intern affiliate links) on Netlify deploy previews
- MSW service worker was intercepting cross-origin GA4 collection requests, causing `net::ERR_FAILED`

## Root Cause
The `onUnhandledRequest: 'bypass'` setting tells MSW client-side to bypass, but the service worker still intercepts all fetch events and its cross-origin `passthrough` fails for `google-analytics.com`. Adding explicit `passthrough()` handlers resolves this.

## Test
Visit a deploy preview with UTM params:
`https://deploy-preview-XXXX.console-deploy-preview.kubestellar.io?utm_source=social&utm_medium=blog&utm_campaign=intern_outreach&utm_term=intern-01`
Verify no `mockServiceWorker.js` errors for GA4 requests in DevTools console.

Fixes intern_outreach UTM tracking.