### PR TITLE
✨ Add drill-down detail modals for all multi-tenancy dashboard cards

### DIFF
--- a/web/src/components/cards/multi-tenancy/k3s-status/K3sDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/K3sDetailModal.tsx
@@ -1,0 +1,249 @@
+/**
+ * K3s Detail Modal — drill-down view for K3s status.
+ *
+ * Shows full server pod list with name, version, node, status, and uptime.
+ * Also displays agent pod distribution and health breakdown.
+ *
+ * Follows the TrivyDetailModal pattern using BaseModal compound components.
+ */
+
+import { useMemo, useState } from 'react'
+import { Box, Search, ExternalLink, CheckCircle, XCircle, Server } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { BaseModal } from '../../../../lib/modals'
+import { StatusBadge } from '../../../ui/StatusBadge'
+import type { K3sStatus } from './useK3sStatus'
+import type { K3sServerPodInfo } from './demoData'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Number of columns in the summary grid */
+const SUMMARY_GRID_COLS = 3
+
+/** Color classes for pod statuses */
+const POD_STATUS_COLORS: Record<string, string> = {
+  running: 'text-green-400 bg-green-500/15',
+  pending: 'text-yellow-400 bg-yellow-500/15',
+  failed: 'text-red-400 bg-red-500/15',
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface K3sDetailModalProps {
+  isOpen: boolean
+  onClose: () => void
+  data: K3sStatus
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+function ServerPodRow({ pod }: { pod: K3sServerPodInfo }) {
+  const statusColor = POD_STATUS_COLORS[pod.status] || POD_STATUS_COLORS.failed
+
+  return (
+    <div className="flex items-center justify-between text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        <Server className="w-4 h-4 text-purple-400 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <span className="text-foreground truncate font-medium block" title={pod.name}>
+            {pod.name}
+          </span>
+          <span className="text-[10px] text-muted-foreground truncate block" title={pod.namespace}>
+            {pod.namespace}
+          </span>
+        </div>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <span className="px-2 py-0.5 rounded bg-secondary text-muted-foreground text-xs font-mono">
+          {pod.version}
+        </span>
+        <span className={`px-2 py-0.5 rounded text-xs font-medium capitalize ${statusColor}`}>
+          {pod.status}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function K3sDetailModal({ isOpen, onClose, data }: K3sDetailModalProps) {
+  const { t } = useTranslation('cards')
+  const [search, setSearch] = useState('')
+
+  const serverPods = data.serverPods || []
+  const agentPodCount = data.podCount - serverPods.length
+  const isHealthy = data.health === 'healthy'
+
+  // Collect unique versions
+  const versions = useMemo(() => {
+    const versionSet = new Set<string>()
+    for (const pod of serverPods) {
+      versionSet.add(pod.version)
+    }
+    return Array.from(versionSet)
+  }, [serverPods])
+
+  // Filter pods by search
+  const filteredPods = useMemo(() => {
+    if (!search.trim()) return serverPods
+    const q = search.toLowerCase()
+    return serverPods.filter(
+      (pod) =>
+        pod.name.toLowerCase().includes(q) ||
+        pod.namespace.toLowerCase().includes(q) ||
+        pod.version.toLowerCase().includes(q) ||
+        pod.status.toLowerCase().includes(q),
+    )
+  }, [serverPods, search])
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false}>
+      <BaseModal.Header
+        title={t('k3sStatus.detailTitle', 'K3s Details')}
+        icon={Box}
+        onClose={onClose}
+        badges={
+          <StatusBadge color={isHealthy ? 'green' : 'orange'} size="sm">
+            {data.podCount} {t('k3sStatus.totalPods', 'pods')} · {serverPods.length} {t('k3sStatus.serverPods', 'servers')}
+          </StatusBadge>
+        }
+      />
+
+      <BaseModal.Content>
+        <div className="space-y-4">
+          {/* Summary grid */}
+          <div className={`grid grid-cols-${SUMMARY_GRID_COLS} gap-3`}>
+            <div className="p-3 rounded-lg bg-blue-500/10 text-center">
+              <div className="flex items-center justify-center gap-1.5 mb-1">
+                <Box className="w-4 h-4 text-blue-400" />
+              </div>
+              <p className="text-xl font-bold text-blue-400">{data.podCount}</p>
+              <p className="text-xs text-muted-foreground">{t('k3sStatus.totalPods', 'Total Pods')}</p>
+            </div>
+            <div className="p-3 rounded-lg bg-green-500/10 text-center">
+              <div className="flex items-center justify-center gap-1.5 mb-1">
+                <CheckCircle className="w-4 h-4 text-green-400" />
+              </div>
+              <p className="text-xl font-bold text-green-400">{data.healthyPods}</p>
+              <p className="text-xs text-muted-foreground">{t('k3sStatus.healthyPods', 'Healthy')}</p>
+            </div>
+            <div className="p-3 rounded-lg bg-purple-500/10 text-center">
+              <div className="flex items-center justify-center gap-1.5 mb-1">
+                <Server className="w-4 h-4 text-purple-400" />
+              </div>
+              <p className="text-xl font-bold text-purple-400">{serverPods.length}</p>
+              <p className="text-xs text-muted-foreground">{t('k3sStatus.serverPods', 'Servers')}</p>
+            </div>
+          </div>
+
+          {/* Agent distribution */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="p-3 rounded-lg bg-secondary/30 border border-border/50">
+              <p className="text-xs text-muted-foreground mb-1">{t('k3sStatus.agentPods', 'Agent Pods')}</p>
+              <p className="text-lg font-bold text-foreground">{agentPodCount >= 0 ? agentPodCount : 0}</p>
+            </div>
+            <div className="p-3 rounded-lg bg-secondary/30 border border-border/50">
+              <p className="text-xs text-muted-foreground mb-1">{t('k3sStatus.versions', 'Version(s)')}</p>
+              <p className="text-sm font-mono text-foreground truncate" title={(versions || []).join(', ')}>
+                {(versions || []).join(', ') || 'N/A'}
+              </p>
+            </div>
+          </div>
+
+          {/* Health bar */}
+          {data.podCount > 0 && (
+            <div className="space-y-1">
+              <div className="flex h-3 rounded-full overflow-hidden bg-secondary/50">
+                <div
+                  className="bg-green-500 transition-all"
+                  style={{ width: `${(data.healthyPods / data.podCount) * 100}%` }}
+                  title={`Healthy: ${data.healthyPods}`}
+                />
+                {data.unhealthyPods > 0 && (
+                  <div
+                    className="bg-red-500 transition-all"
+                    style={{ width: `${(data.unhealthyPods / data.podCount) * 100}%` }}
+                    title={`Unhealthy: ${data.unhealthyPods}`}
+                  />
+                )}
+              </div>
+              <div className="flex gap-4 text-xs text-muted-foreground">
+                <span className="text-green-400">
+                  {t('k3sStatus.healthyPods', 'Healthy')}: {data.healthyPods}
+                </span>
+                {data.unhealthyPods > 0 && (
+                  <span className="text-red-400">
+                    {t('k3sStatus.unhealthyWarning', { count: data.unhealthyPods })}
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Search */}
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={t('k3sStatus.searchPods', 'Search pods...')}
+              className="w-full pl-9 pr-3 py-2 bg-secondary/50 border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500"
+            />
+          </div>
+
+          {/* Server pod list */}
+          <div>
+            <p className="text-xs font-medium text-muted-foreground mb-2">
+              {t('k3sStatus.serverPodList', 'Server Pods')}
+            </p>
+            {filteredPods.length === 0 ? (
+              <div className="text-center py-8 text-muted-foreground text-sm">
+                {serverPods.length === 0
+                  ? t('k3sStatus.noServerPods', 'No K3s server pods found.')
+                  : t('k3sStatus.noServerPodMatch', 'No pods match your search.')}
+              </div>
+            ) : (
+              <div className="space-y-1.5">
+                {filteredPods.map((pod) => (
+                  <ServerPodRow key={pod.name} pod={pod} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Unhealthy warning */}
+          {data.unhealthyPods > 0 && (
+            <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-orange-500/10 border border-orange-500/20">
+              <XCircle className="w-4 h-4 text-orange-400 shrink-0" />
+              <p className="text-xs text-orange-400">
+                {t('k3sStatus.unhealthyWarning', { count: data.unhealthyPods })}
+              </p>
+            </div>
+          )}
+        </div>
+      </BaseModal.Content>
+
+      <BaseModal.Footer>
+        <a
+          href="https://k3s.io"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-cyan-400 transition-colors"
+        >
+          <ExternalLink className="w-3 h-3" />
+          {t('k3sStatus.openDocs', 'K3s Docs')}
+        </a>
+      </BaseModal.Footer>
+    </BaseModal>
+  )
+}

--- a/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
@@ -6,6 +6,7 @@
  * installation mission.
  */
 
+import { useState } from 'react'
 import { AlertTriangle, Box, CheckCircle, RefreshCw, Server, XCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../../ui/Skeleton'
@@ -15,6 +16,7 @@ import { useApiKeyCheck, ApiKeyPromptModal } from '../../console-missions/shared
 import { useK3sStatus } from './useK3sStatus'
 import { K3S_INSTALL_PROMPT } from '../shared'
 import { loadMissionPrompt } from '../missionLoader'
+import { K3sDetailModal } from './K3sDetailModal'
 
 // ============================================================================
 // Constants
@@ -60,6 +62,7 @@ export function K3sStatus() {
   const { data, error, showSkeleton, showEmptyState, isRefreshing } = useK3sStatus()
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
+  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
 
   // ------ Loading ------
   if (showSkeleton) {
@@ -126,7 +129,8 @@ export function K3sStatus() {
       {/* Health badge + last check */}
       <div className="flex items-center justify-between">
         <div
-          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+          onClick={() => setIsDetailModalOpen(true)}
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium cursor-pointer hover:bg-secondary/50 transition-colors ${
             isHealthy
               ? 'bg-green-500/15 text-green-400'
               : 'bg-orange-500/15 text-orange-400'
@@ -147,7 +151,7 @@ export function K3sStatus() {
       </div>
 
       {/* Top metrics */}
-      <div className="flex gap-3">
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" onClick={() => setIsDetailModalOpen(true)}>
         <MetricTile
           label={t('k3sStatus.totalPods')}
           value={data.podCount}
@@ -174,7 +178,7 @@ export function K3sStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('k3sStatus.serverPodList')}</p>
           <div className="space-y-1.5 max-h-40 overflow-y-auto scrollbar-thin">
             {serverPods.map((pod) => (
-              <div key={pod.name} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30">
+              <div key={pod.name} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" onClick={() => setIsDetailModalOpen(true)}>
                 <span className="text-foreground truncate flex-1" title={pod.name}>
                   {pod.name}
                 </span>
@@ -218,6 +222,12 @@ export function K3sStatus() {
           </svg>
         </a>
       </div>
+
+      <K3sDetailModal
+        isOpen={isDetailModalOpen}
+        onClose={() => setIsDetailModalOpen(false)}
+        data={data}
+      />
     </div>
   )
 }

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexDetailModal.tsx
@@ -1,0 +1,228 @@
+/**
+ * KubeFlex Detail Modal — drill-down view for KubeFlex status.
+ *
+ * Shows full control plane list with name, type, health status, and
+ * tenant assignment. Also displays controller pod details.
+ *
+ * Follows the TrivyDetailModal pattern using BaseModal compound components.
+ */
+
+import { useMemo, useState } from 'react'
+import { Layers, Search, ExternalLink, CheckCircle, XCircle, Server } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { BaseModal } from '../../../../lib/modals'
+import { StatusBadge } from '../../../ui/StatusBadge'
+import type { KubeFlexStatus } from './useKubeflexStatus'
+import type { ControlPlaneInfo } from './helpers'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Number of columns in the summary grid */
+const SUMMARY_GRID_COLS = 3
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface KubeFlexDetailModalProps {
+  isOpen: boolean
+  onClose: () => void
+  data: KubeFlexStatus
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+function ControlPlaneRow({ cp }: { cp: ControlPlaneInfo }) {
+  return (
+    <div className="flex items-center justify-between text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        <Layers className="w-4 h-4 text-purple-400 shrink-0" />
+        <span className="text-foreground truncate font-medium" title={cp.name}>
+          {cp.name}
+        </span>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        {cp.healthy ? (
+          <>
+            <CheckCircle className="w-4 h-4 text-green-400" />
+            <span className="text-xs font-medium text-green-400">Healthy</span>
+          </>
+        ) : (
+          <>
+            <XCircle className="w-4 h-4 text-red-400" />
+            <span className="text-xs font-medium text-red-400">Unhealthy</span>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function KubeFlexDetailModal({ isOpen, onClose, data }: KubeFlexDetailModalProps) {
+  const { t } = useTranslation('cards')
+  const [search, setSearch] = useState('')
+
+  const controlPlanes = data.controlPlanes || []
+  const healthyCPs = controlPlanes.filter((cp) => cp.healthy).length
+  const unhealthyCPs = controlPlanes.length - healthyCPs
+
+  // Filter control planes by search
+  const filteredCPs = useMemo(() => {
+    if (!search.trim()) return controlPlanes
+    const q = search.toLowerCase()
+    return controlPlanes.filter((cp) => cp.name.toLowerCase().includes(q))
+  }, [controlPlanes, search])
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false}>
+      <BaseModal.Header
+        title={t('kubeFlexStatus.detailTitle', 'KubeFlex Details')}
+        icon={Layers}
+        onClose={onClose}
+        badges={
+          <StatusBadge
+            color={data.controllerHealthy && unhealthyCPs === 0 ? 'green' : 'orange'}
+            size="sm"
+          >
+            {controlPlanes.length} {t('kubeFlexStatus.controlPlanes', 'control planes')} · {data.tenantCount} {t('kubeFlexStatus.tenants', 'tenants')}
+          </StatusBadge>
+        }
+      />
+
+      <BaseModal.Content>
+        <div className="space-y-4">
+          {/* Summary grid */}
+          <div className={`grid grid-cols-${SUMMARY_GRID_COLS} gap-3`}>
+            <div className="p-3 rounded-lg bg-blue-500/10 text-center">
+              <div className="flex items-center justify-center gap-1.5 mb-1">
+                <Server className="w-4 h-4 text-blue-400" />
+              </div>
+              <p className={`text-xl font-bold ${data.controllerHealthy ? 'text-green-400' : 'text-red-400'}`}>
+                {data.controllerHealthy
+                  ? t('kubeFlexStatus.controllerUp', 'Up')
+                  : t('kubeFlexStatus.controllerDown', 'Down')}
+              </p>
+              <p className="text-xs text-muted-foreground">{t('kubeFlexStatus.controller', 'Controller')}</p>
+            </div>
+            <div className="p-3 rounded-lg bg-purple-500/10 text-center">
+              <div className="flex items-center justify-center gap-1.5 mb-1">
+                <Layers className="w-4 h-4 text-purple-400" />
+              </div>
+              <p className="text-xl font-bold text-purple-400">{controlPlanes.length}</p>
+              <p className="text-xs text-muted-foreground">{t('kubeFlexStatus.controlPlanes', 'Control Planes')}</p>
+            </div>
+            <div className="p-3 rounded-lg bg-cyan-500/10 text-center">
+              <div className="flex items-center justify-center gap-1.5 mb-1">
+                <Layers className="w-4 h-4 text-cyan-400" />
+              </div>
+              <p className="text-xl font-bold text-cyan-400">{data.tenantCount}</p>
+              <p className="text-xs text-muted-foreground">{t('kubeFlexStatus.tenants', 'Tenants')}</p>
+            </div>
+          </div>
+
+          {/* Control plane health summary */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="p-3 rounded-lg bg-green-500/10 border border-green-500/20 flex items-center gap-3">
+              <CheckCircle className="w-5 h-5 text-green-400" />
+              <div>
+                <p className="text-lg font-bold text-green-400">{healthyCPs}</p>
+                <p className="text-xs text-muted-foreground">{t('kubeFlexStatus.cpHealthy', 'Healthy')}</p>
+              </div>
+            </div>
+            <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20 flex items-center gap-3">
+              <XCircle className="w-5 h-5 text-red-400" />
+              <div>
+                <p className={`text-lg font-bold ${unhealthyCPs > 0 ? 'text-red-400' : 'text-muted-foreground'}`}>
+                  {unhealthyCPs}
+                </p>
+                <p className="text-xs text-muted-foreground">{t('kubeFlexStatus.cpUnhealthy', 'Unhealthy')}</p>
+              </div>
+            </div>
+          </div>
+
+          {/* Health bar */}
+          {controlPlanes.length > 0 && (
+            <div className="space-y-1">
+              <div className="flex h-3 rounded-full overflow-hidden bg-secondary/50">
+                <div
+                  className="bg-green-500 transition-all"
+                  style={{ width: `${(healthyCPs / controlPlanes.length) * 100}%` }}
+                  title={`Healthy: ${healthyCPs}`}
+                />
+                {unhealthyCPs > 0 && (
+                  <div
+                    className="bg-red-500 transition-all"
+                    style={{ width: `${(unhealthyCPs / controlPlanes.length) * 100}%` }}
+                    title={`Unhealthy: ${unhealthyCPs}`}
+                  />
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Search */}
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={t('kubeFlexStatus.searchControlPlanes', 'Search control planes...')}
+              className="w-full pl-9 pr-3 py-2 bg-secondary/50 border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500"
+            />
+          </div>
+
+          {/* Control plane list */}
+          <div>
+            <p className="text-xs font-medium text-muted-foreground mb-2">
+              {t('kubeFlexStatus.controlPlaneList', 'Control Planes')}
+            </p>
+            {filteredCPs.length === 0 ? (
+              <div className="text-center py-8 text-muted-foreground text-sm">
+                {controlPlanes.length === 0
+                  ? t('kubeFlexStatus.noControlPlanes', 'No control planes found.')
+                  : t('kubeFlexStatus.noControlPlaneMatch', 'No control planes match your search.')}
+              </div>
+            ) : (
+              <div className="space-y-1.5">
+                {filteredCPs.map((cp) => (
+                  <ControlPlaneRow key={cp.name} cp={cp} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Unhealthy warning */}
+          {unhealthyCPs > 0 && (
+            <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-orange-500/10 border border-orange-500/20">
+              <XCircle className="w-4 h-4 text-orange-400 shrink-0" />
+              <p className="text-xs text-orange-400">
+                {t('kubeFlexStatus.unhealthyCPWarning', { count: unhealthyCPs })}
+              </p>
+            </div>
+          )}
+        </div>
+      </BaseModal.Content>
+
+      <BaseModal.Footer>
+        <a
+          href="https://github.com/kubestellar/kubeflex"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-cyan-400 transition-colors"
+        >
+          <ExternalLink className="w-3 h-3" />
+          {t('kubeFlexStatus.openDocs', 'KubeFlex Docs')}
+        </a>
+      </BaseModal.Footer>
+    </BaseModal>
+  )
+}

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexStatus.tsx
@@ -6,6 +6,7 @@
  * installation mission.
  */
 
+import { useState } from 'react'
 import { AlertTriangle, CheckCircle, Layers, RefreshCw, Server, XCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../../ui/Skeleton'
@@ -15,6 +16,7 @@ import { useApiKeyCheck, ApiKeyPromptModal } from '../../console-missions/shared
 import { useKubeFlexStatus } from './useKubeflexStatus'
 import { KUBEFLEX_INSTALL_PROMPT } from '../shared'
 import { loadMissionPrompt } from '../missionLoader'
+import { KubeFlexDetailModal } from './KubeFlexDetailModal'
 
 // ============================================================================
 // Constants
@@ -57,6 +59,7 @@ export function KubeFlexStatus() {
   const { data, error, showSkeleton, showEmptyState, isRefreshing } = useKubeFlexStatus()
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
+  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
 
   // ------ Loading ------
   if (showSkeleton) {
@@ -124,7 +127,8 @@ export function KubeFlexStatus() {
       {/* Health badge + last check */}
       <div className="flex items-center justify-between">
         <div
-          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+          onClick={() => setIsDetailModalOpen(true)}
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium cursor-pointer hover:bg-secondary/50 transition-colors ${
             isHealthy
               ? 'bg-green-500/15 text-green-400'
               : 'bg-orange-500/15 text-orange-400'
@@ -145,7 +149,7 @@ export function KubeFlexStatus() {
       </div>
 
       {/* Metric tiles */}
-      <div className="flex gap-3">
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" onClick={() => setIsDetailModalOpen(true)}>
         <MetricTile
           label={t('kubeFlexStatus.controller')}
           value={data.controllerHealthy ? t('kubeFlexStatus.controllerUp') : t('kubeFlexStatus.controllerDown')}
@@ -172,7 +176,7 @@ export function KubeFlexStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('kubeFlexStatus.controlPlaneList')}</p>
           <div className="space-y-1.5 max-h-40 overflow-y-auto scrollbar-thin">
             {(data.controlPlanes || []).map((cp) => (
-              <div key={cp.name} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30">
+              <div key={cp.name} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" onClick={() => setIsDetailModalOpen(true)}>
                 <span className="text-foreground truncate flex-1" title={cp.name}>
                   {cp.name}
                 </span>
@@ -214,6 +218,12 @@ export function KubeFlexStatus() {
           </svg>
         </a>
       </div>
+
+      <KubeFlexDetailModal
+        isOpen={isDetailModalOpen}
+        onClose={() => setIsDetailModalOpen(false)}
+        data={data}
+      />
     </div>
   )
 }

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx
@@ -1,0 +1,326 @@
+/**
+ * KubeVirt Detail Modal — drill-down view for KubeVirt status.
+ *
+ * Shows full VM list with name, namespace, state, and resource info.
+ * Also displays VM state breakdown as colored segments and tenant distribution.
+ *
+ * Follows the TrivyDetailModal pattern using BaseModal compound components.
+ */
+
+import { useMemo, useState } from 'react'
+import { Monitor, Search, ExternalLink, CheckCircle, XCircle, Server, Users, RefreshCw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { BaseModal } from '../../../../lib/modals'
+import { StatusBadge } from '../../../ui/StatusBadge'
+import type { KubevirtStatus } from './useKubevirtStatus'
+import type { VmInfo } from './demoData'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Number of columns in the top summary grid */
+const SUMMARY_GRID_COLS = 3
+
+/** VM state color map for badges */
+const VM_STATE_BADGE_COLORS: Record<string, string> = {
+  running: 'text-green-400 bg-green-500/15',
+  stopped: 'text-zinc-400 bg-zinc-500/15',
+  migrating: 'text-blue-400 bg-blue-500/15',
+  pending: 'text-yellow-400 bg-yellow-500/15',
+  failed: 'text-red-400 bg-red-500/15',
+  unknown: 'text-muted-foreground bg-secondary',
+}
+
+/** VM state color for the breakdown bar */
+const VM_STATE_BAR_COLORS: Record<string, string> = {
+  running: 'bg-green-500',
+  stopped: 'bg-zinc-500',
+  migrating: 'bg-blue-500',
+  pending: 'bg-yellow-500',
+  failed: 'bg-red-500',
+  unknown: 'bg-zinc-600',
+}
+
+/** VM state text colors for breakdown labels */
+const VM_STATE_TEXT_COLORS: Record<string, string> = {
+  running: 'text-green-400',
+  stopped: 'text-zinc-400',
+  migrating: 'text-blue-400',
+  pending: 'text-yellow-400',
+  failed: 'text-red-400',
+  unknown: 'text-muted-foreground',
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface KubevirtDetailModalProps {
+  isOpen: boolean
+  onClose: () => void
+  data: KubevirtStatus
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+function VmRow({ vm }: { vm: VmInfo }) {
+  const stateColor = VM_STATE_BADGE_COLORS[vm.state] || VM_STATE_BADGE_COLORS.unknown
+
+  return (
+    <div className="flex items-center justify-between text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        <Monitor className="w-4 h-4 text-purple-400 shrink-0" />
+        <div className="min-w-0 flex-1">
+          <span className="text-foreground truncate font-medium block" title={vm.name}>
+            {vm.name}
+          </span>
+          <span className="text-[10px] text-muted-foreground truncate block" title={vm.namespace}>
+            {vm.namespace}
+          </span>
+        </div>
+      </div>
+      <span className={`px-2 py-0.5 rounded text-xs font-medium capitalize shrink-0 ${stateColor}`}>
+        {vm.state}
+      </span>
+    </div>
+  )
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function KubevirtDetailModal({ isOpen, onClose, data }: KubevirtDetailModalProps) {
+  const { t } = useTranslation('cards')
+  const [search, setSearch] = useState('')
+
+  const vms = data.vms || []
+  const isHealthy = data.health === 'healthy'
+
+  // Count VMs by state
+  const stateCounts = useMemo(() => {
+    const counts: Record<string, number> = {}
+    for (const vm of vms) {
+      counts[vm.state] = (counts[vm.state] || 0) + 1
+    }
+    return counts
+  }, [vms])
+
+  // Breakdown segments for the state bar
+  const stateSegments = useMemo(() => {
+    const total = vms.length
+    if (total === 0) return []
+    return Object.entries(stateCounts)
+      .filter(([, count]) => count > 0)
+      .map(([state, count]) => ({
+        state,
+        count,
+        pct: (count / total) * 100,
+        barColor: VM_STATE_BAR_COLORS[state] || VM_STATE_BAR_COLORS.unknown,
+        textColor: VM_STATE_TEXT_COLORS[state] || VM_STATE_TEXT_COLORS.unknown,
+      }))
+  }, [vms.length, stateCounts])
+
+  // Group VMs by namespace for tenant distribution
+  const tenantDistribution = useMemo(() => {
+    const nsMap = new Map<string, number>()
+    for (const vm of vms) {
+      nsMap.set(vm.namespace, (nsMap.get(vm.namespace) || 0) + 1)
+    }
+    return Array.from(nsMap.entries())
+      .sort((a, b) => b[1] - a[1])
+      .map(([ns, count]) => ({ namespace: ns, vmCount: count }))
+  }, [vms])
+
+  // Filter VMs by search
+  const filteredVMs = useMemo(() => {
+    if (!search.trim()) return vms
+    const q = search.toLowerCase()
+    return vms.filter(
+      (vm) =>
+        vm.name.toLowerCase().includes(q) ||
+        vm.namespace.toLowerCase().includes(q) ||
+        vm.state.toLowerCase().includes(q),
+    )
+  }, [vms, search])
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false}>
+      <BaseModal.Header
+        title={t('kubevirtStatus.detailTitle', 'KubeVirt Details')}
+        icon={Monitor}
+        onClose={onClose}
+        badges={
+          <StatusBadge color={isHealthy ? 'green' : 'orange'} size="sm">
+            {vms.length} {t('kubevirtStatus.totalVMs', 'VMs')} · {data.tenantCount} {t('kubevirtStatus.tenants', 'tenants')}
+          </StatusBadge>
+        }
+      />
+
+      <BaseModal.Content>
+        <div className="space-y-4">
+          {/* Top summary */}
+          <div className={`grid grid-cols-${SUMMARY_GRID_COLS} gap-3`}>
+            <div className="p-3 rounded-lg bg-blue-500/10 text-center">
+              <div className="flex items-center justify-center gap-1.5 mb-1">
+                <Server className="w-4 h-4 text-blue-400" />
+              </div>
+              <p className="text-xl font-bold text-blue-400">{data.podCount}</p>
+              <p className="text-xs text-muted-foreground">{t('kubevirtStatus.infraPods', 'Infra Pods')}</p>
+            </div>
+            <div className="p-3 rounded-lg bg-purple-500/10 text-center">
+              <div className="flex items-center justify-center gap-1.5 mb-1">
+                <Monitor className="w-4 h-4 text-purple-400" />
+              </div>
+              <p className="text-xl font-bold text-purple-400">{vms.length}</p>
+              <p className="text-xs text-muted-foreground">{t('kubevirtStatus.totalVMs', 'Total VMs')}</p>
+            </div>
+            <div className="p-3 rounded-lg bg-cyan-500/10 text-center">
+              <div className="flex items-center justify-center gap-1.5 mb-1">
+                <Users className="w-4 h-4 text-cyan-400" />
+              </div>
+              <p className="text-xl font-bold text-cyan-400">{data.tenantCount}</p>
+              <p className="text-xs text-muted-foreground">{t('kubevirtStatus.tenants', 'Tenants')}</p>
+            </div>
+          </div>
+
+          {/* VM state breakdown */}
+          {vms.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">
+                {t('kubevirtStatus.stateBreakdown', 'VM State Breakdown')}
+              </p>
+              <div className="grid grid-cols-4 gap-2">
+                <div className="p-2 rounded bg-green-500/10 text-center">
+                  <div className="flex items-center justify-center gap-1 mb-0.5">
+                    <CheckCircle className="w-3 h-3 text-green-400" />
+                  </div>
+                  <p className="text-sm font-bold text-green-400">{stateCounts['running'] || 0}</p>
+                  <p className="text-[10px] text-muted-foreground">{t('kubevirtStatus.runningVMs', 'Running')}</p>
+                </div>
+                <div className="p-2 rounded bg-zinc-500/10 text-center">
+                  <div className="flex items-center justify-center gap-1 mb-0.5">
+                    <XCircle className="w-3 h-3 text-zinc-400" />
+                  </div>
+                  <p className="text-sm font-bold text-zinc-400">{stateCounts['stopped'] || 0}</p>
+                  <p className="text-[10px] text-muted-foreground">{t('kubevirtStatus.stoppedVMs', 'Stopped')}</p>
+                </div>
+                <div className="p-2 rounded bg-blue-500/10 text-center">
+                  <div className="flex items-center justify-center gap-1 mb-0.5">
+                    <RefreshCw className="w-3 h-3 text-blue-400" />
+                  </div>
+                  <p className="text-sm font-bold text-blue-400">{stateCounts['migrating'] || 0}</p>
+                  <p className="text-[10px] text-muted-foreground">{t('kubevirtStatus.migratingVMs', 'Migrating')}</p>
+                </div>
+                <div className="p-2 rounded bg-red-500/10 text-center">
+                  <div className="flex items-center justify-center gap-1 mb-0.5">
+                    <XCircle className="w-3 h-3 text-red-400" />
+                  </div>
+                  <p className="text-sm font-bold text-red-400">
+                    {(stateCounts['failed'] || 0) + (stateCounts['pending'] || 0)}
+                  </p>
+                  <p className="text-[10px] text-muted-foreground">{t('kubevirtStatus.failedPending', 'Failed/Pending')}</p>
+                </div>
+              </div>
+
+              {/* State bar */}
+              <div className="flex h-3 rounded-full overflow-hidden bg-secondary/50">
+                {(stateSegments || []).map((seg) => (
+                  <div
+                    key={seg.state}
+                    className={`${seg.barColor} transition-all`}
+                    style={{ width: `${seg.pct}%` }}
+                    title={`${seg.state}: ${seg.count}`}
+                  />
+                ))}
+              </div>
+              <div className="flex gap-3 text-xs text-muted-foreground flex-wrap">
+                {(stateSegments || []).map((seg) => (
+                  <span key={seg.state} className={seg.textColor}>
+                    {seg.state}: {seg.count}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Tenant distribution */}
+          {(tenantDistribution || []).length > 0 && (
+            <div>
+              <p className="text-xs font-medium text-muted-foreground mb-2">
+                {t('kubevirtStatus.tenantDistribution', 'Tenant Distribution')}
+              </p>
+              <div className="grid grid-cols-3 gap-2">
+                {(tenantDistribution || []).map((td) => (
+                  <div key={td.namespace} className="p-2 rounded bg-secondary/30 text-center">
+                    <p className="text-sm font-bold text-foreground">{td.vmCount}</p>
+                    <p className="text-[10px] text-muted-foreground truncate" title={td.namespace}>
+                      {td.namespace}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Search */}
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={t('kubevirtStatus.searchVMs', 'Search VMs...')}
+              className="w-full pl-9 pr-3 py-2 bg-secondary/50 border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500"
+            />
+          </div>
+
+          {/* VM list */}
+          <div>
+            <p className="text-xs font-medium text-muted-foreground mb-2">
+              {t('kubevirtStatus.vmList', 'Virtual Machines')}
+            </p>
+            {filteredVMs.length === 0 ? (
+              <div className="text-center py-8 text-muted-foreground text-sm">
+                {vms.length === 0
+                  ? t('kubevirtStatus.noVMs', 'No virtual machines found.')
+                  : t('kubevirtStatus.noVMMatch', 'No VMs match your search.')}
+              </div>
+            ) : (
+              <div className="space-y-1.5">
+                {filteredVMs.map((vm) => (
+                  <VmRow key={`${vm.namespace}/${vm.name}`} vm={vm} />
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Unhealthy infra warning */}
+          {data.unhealthyPods > 0 && (
+            <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-orange-500/10 border border-orange-500/20">
+              <XCircle className="w-4 h-4 text-orange-400 shrink-0" />
+              <p className="text-xs text-orange-400">
+                {t('kubevirtStatus.unhealthyWarning', { count: data.unhealthyPods })}
+              </p>
+            </div>
+          )}
+        </div>
+      </BaseModal.Content>
+
+      <BaseModal.Footer>
+        <a
+          href="https://kubevirt.io"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-cyan-400 transition-colors"
+        >
+          <ExternalLink className="w-3 h-3" />
+          {t('kubevirtStatus.openDocs', 'KubeVirt Docs')}
+        </a>
+      </BaseModal.Footer>
+    </BaseModal>
+  )
+}

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
@@ -6,6 +6,7 @@
  * installation mission.
  */
 
+import { useState } from 'react'
 import { AlertTriangle, CheckCircle, Monitor, RefreshCw, Server, Users, XCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../../ui/Skeleton'
@@ -15,6 +16,7 @@ import { useApiKeyCheck, ApiKeyPromptModal } from '../../console-missions/shared
 import { useKubevirtStatus } from './useKubevirtStatus'
 import { KUBEVIRT_INSTALL_PROMPT } from '../shared'
 import { loadMissionPrompt } from '../missionLoader'
+import { KubevirtDetailModal } from './KubevirtDetailModal'
 
 // ============================================================================
 // Constants
@@ -76,6 +78,7 @@ export function KubevirtStatus() {
   const { data, error, showSkeleton, showEmptyState, isRefreshing } = useKubevirtStatus()
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
+  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
 
   // ------ Loading ------
   if (showSkeleton) {
@@ -149,7 +152,8 @@ export function KubevirtStatus() {
       {/* Health badge + last check */}
       <div className="flex items-center justify-between">
         <div
-          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+          onClick={() => setIsDetailModalOpen(true)}
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium cursor-pointer hover:bg-secondary/50 transition-colors ${
             isHealthy
               ? 'bg-green-500/15 text-green-400'
               : 'bg-orange-500/15 text-orange-400'
@@ -170,7 +174,7 @@ export function KubevirtStatus() {
       </div>
 
       {/* Top metrics: infra pods */}
-      <div className="flex gap-3">
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" onClick={() => setIsDetailModalOpen(true)}>
         <MetricTile
           label={t('kubevirtStatus.infraPods')}
           value={data.podCount}
@@ -192,7 +196,7 @@ export function KubevirtStatus() {
       </div>
 
       {/* Bottom metrics: VM state breakdown */}
-      <div className="flex gap-3">
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" onClick={() => setIsDetailModalOpen(true)}>
         <MetricTile
           label={t('kubevirtStatus.runningVMs')}
           value={runningVMs}
@@ -221,7 +225,7 @@ export function KubevirtStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('kubevirtStatus.vmList')}</p>
           <div className="space-y-1.5 max-h-40 overflow-y-auto scrollbar-thin">
             {vms.map((vm) => (
-              <div key={`${vm.namespace}/${vm.name}`} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30">
+              <div key={`${vm.namespace}/${vm.name}`} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" onClick={() => setIsDetailModalOpen(true)}>
                 <div className="flex flex-col min-w-0 flex-1">
                   <span className="text-foreground truncate" title={vm.name}>
                     {vm.name}
@@ -263,6 +267,12 @@ export function KubevirtStatus() {
           </svg>
         </a>
       </div>
+
+      <KubevirtDetailModal
+        isOpen={isDetailModalOpen}
+        onClose={() => setIsDetailModalOpen(false)}
+        data={data}
+      />
     </div>
   )
 }

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
@@ -1,0 +1,257 @@
+/**
+ * Multi-Tenancy Overview Detail Modal — drill-down view for multi-tenancy status.
+ *
+ * Shows full component health details (OVN, KubeFlex, K3s, KubeVirt) with
+ * detection status and health indicators. Also shows all isolation levels
+ * with detailed status and provider information.
+ *
+ * Follows the TrivyDetailModal pattern using BaseModal compound components.
+ */
+
+import { Shield, ExternalLink, CheckCircle, XCircle, AlertTriangle, Network, Layers, Box, Monitor, Users } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { BaseModal } from '../../../../lib/modals'
+import { StatusBadge } from '../../../ui/StatusBadge'
+import type { MultiTenancyOverviewData, ComponentStatus, IsolationLevel, IsolationStatus } from './useMultiTenancyOverview'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Number of columns in the component grid */
+const COMPONENT_GRID_COLS = 2
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface MultiTenancyDetailModalProps {
+  isOpen: boolean
+  onClose: () => void
+  data: MultiTenancyOverviewData
+}
+
+// ============================================================================
+// Icon / Color Maps
+// ============================================================================
+
+/** Map component icon strings to lucide components */
+const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
+  network: Network,
+  layers: Layers,
+  box: Box,
+  monitor: Monitor,
+}
+
+/** Color classes for health states */
+const HEALTH_COLORS: Record<string, string> = {
+  healthy: 'text-green-400',
+  degraded: 'text-orange-400',
+  unhealthy: 'text-red-400',
+  'not-installed': 'text-zinc-500',
+  unknown: 'text-zinc-500',
+}
+
+/** Background classes for health states */
+const HEALTH_BG: Record<string, string> = {
+  healthy: 'bg-green-500/10 border-green-500/20',
+  degraded: 'bg-orange-500/10 border-orange-500/20',
+  unhealthy: 'bg-red-500/10 border-red-500/20',
+  'not-installed': 'bg-zinc-500/10 border-zinc-500/20',
+  unknown: 'bg-zinc-500/10 border-zinc-500/20',
+}
+
+/** Isolation status colors */
+const ISOLATION_STATUS_COLORS: Record<IsolationStatus, string> = {
+  ready: 'text-green-400',
+  degraded: 'text-orange-400',
+  missing: 'text-zinc-500',
+}
+
+/** Isolation status backgrounds */
+const ISOLATION_STATUS_BG: Record<IsolationStatus, string> = {
+  ready: 'bg-green-500/10 border-green-500/20',
+  degraded: 'bg-orange-500/10 border-orange-500/20',
+  missing: 'bg-zinc-500/10 border-zinc-500/20',
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+function IsolationStatusIcon({ status }: { status: IsolationStatus }) {
+  switch (status) {
+    case 'ready':
+      return <CheckCircle className="w-5 h-5 text-green-400" />
+    case 'degraded':
+      return <AlertTriangle className="w-5 h-5 text-orange-400" />
+    case 'missing':
+      return <XCircle className="w-5 h-5 text-zinc-500" />
+  }
+}
+
+function ComponentDetailCard({ component }: { component: ComponentStatus }) {
+  const IconComponent = ICON_MAP[component.icon] || Shield
+  const healthColor = HEALTH_COLORS[component.health] || HEALTH_COLORS.unknown
+  const healthBg = HEALTH_BG[component.health] || HEALTH_BG.unknown
+
+  return (
+    <div className={`p-4 rounded-lg border ${healthBg} flex items-start gap-3`}>
+      <IconComponent className={`w-5 h-5 ${healthColor} shrink-0 mt-0.5`} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-sm font-medium text-foreground">{component.name}</span>
+          <div className={`w-2.5 h-2.5 rounded-full ${component.detected ? 'bg-green-400' : 'bg-zinc-500'}`} />
+        </div>
+        <div className="flex items-center gap-2 mt-1">
+          <span className={`text-xs font-medium capitalize ${healthColor}`}>
+            {component.detected ? component.health : 'Not detected'}
+          </span>
+        </div>
+        <p className="text-[10px] text-muted-foreground mt-1">
+          {component.detected ? 'Detected and monitored' : 'Not installed on any cluster'}
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function IsolationLevelCard({ level }: { level: IsolationLevel }) {
+  const statusColor = ISOLATION_STATUS_COLORS[level.status]
+  const statusBg = ISOLATION_STATUS_BG[level.status]
+
+  return (
+    <div className={`p-4 rounded-lg border ${statusBg} flex items-center justify-between`}>
+      <div className="flex items-center gap-3">
+        <IsolationStatusIcon status={level.status} />
+        <div>
+          <span className="text-sm font-medium text-foreground">{level.type}</span>
+          <p className="text-xs text-muted-foreground mt-0.5">{level.provider}</p>
+        </div>
+      </div>
+      <span className={`text-xs font-medium capitalize px-2.5 py-1 rounded ${statusColor} bg-secondary/30`}>
+        {level.status}
+      </span>
+    </div>
+  )
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function MultiTenancyDetailModal({ isOpen, onClose, data }: MultiTenancyDetailModalProps) {
+  const { t } = useTranslation('cards')
+
+  const components = data.components || []
+  const isolationLevels = data.isolationLevels || []
+  const detectedCount = components.filter((c) => c.detected).length
+  const healthyCount = components.filter((c) => c.health === 'healthy').length
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false}>
+      <BaseModal.Header
+        title={t('multiTenancy.detailTitle', 'Multi-Tenancy Overview Details')}
+        icon={Shield}
+        onClose={onClose}
+        badges={
+          <StatusBadge
+            color={data.overallScore === data.totalLevels ? 'green' : data.overallScore > 0 ? 'orange' : 'red'}
+            size="sm"
+          >
+            {data.overallScore}/{data.totalLevels} {t('multiTenancy.isolationScore', 'Isolation Score')}
+          </StatusBadge>
+        }
+      />
+
+      <BaseModal.Content>
+        <div className="space-y-6">
+          {/* Score and tenant summary */}
+          <div className="grid grid-cols-3 gap-3">
+            <div className="p-4 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-center">
+              <div className="flex items-center justify-center gap-1.5 mb-1">
+                <Shield className="w-5 h-5 text-cyan-400" />
+              </div>
+              <p className="text-2xl font-bold text-cyan-400">
+                {data.overallScore}/{data.totalLevels}
+              </p>
+              <p className="text-xs text-muted-foreground">{t('multiTenancy.isolationScore', 'Isolation Score')}</p>
+            </div>
+            <div className="p-4 rounded-lg bg-purple-500/10 border border-purple-500/20 text-center">
+              <div className="flex items-center justify-center gap-1.5 mb-1">
+                <Users className="w-5 h-5 text-purple-400" />
+              </div>
+              <p className="text-2xl font-bold text-purple-400">{data.tenantCount}</p>
+              <p className="text-xs text-muted-foreground">{t('multiTenancy.tenantsLabel', 'Tenants')}</p>
+            </div>
+            <div className="p-4 rounded-lg bg-blue-500/10 border border-blue-500/20 text-center">
+              <div className="flex items-center justify-center gap-1.5 mb-1">
+                <CheckCircle className="w-5 h-5 text-blue-400" />
+              </div>
+              <p className="text-2xl font-bold text-blue-400">
+                {detectedCount}/{components.length}
+              </p>
+              <p className="text-xs text-muted-foreground">{t('multiTenancy.detected', 'Detected')}</p>
+            </div>
+          </div>
+
+          {/* Component health section */}
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-sm font-medium text-muted-foreground">
+                {t('multiTenancy.componentHealth', 'Component Health')}
+              </p>
+              <span className="text-xs text-muted-foreground">
+                {healthyCount}/{components.length} {t('multiTenancy.healthy', 'healthy')}
+              </span>
+            </div>
+            <div className={`grid grid-cols-${COMPONENT_GRID_COLS} gap-3`}>
+              {components.map((component) => (
+                <ComponentDetailCard key={component.name} component={component} />
+              ))}
+            </div>
+          </div>
+
+          {/* Isolation levels section */}
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-sm font-medium text-muted-foreground">
+                {t('multiTenancy.isolationLevels', 'Isolation Levels')}
+              </p>
+              <span className="text-xs text-muted-foreground">
+                {data.overallScore}/{data.totalLevels} {t('multiTenancy.ready', 'ready')}
+              </span>
+            </div>
+            <div className="space-y-2">
+              {isolationLevels.map((level) => (
+                <IsolationLevelCard key={level.type} level={level} />
+              ))}
+            </div>
+          </div>
+
+          {/* Explanation */}
+          <div className="p-3 rounded-lg bg-secondary/30 border border-border/50">
+            <p className="text-xs text-muted-foreground leading-relaxed">
+              {t(
+                'multiTenancy.explanation',
+                'Multi-tenancy isolation is achieved through three layers: Control-plane isolation (KubeFlex + K3s), Data-plane isolation (KubeVirt), and Network isolation (OVN-Kubernetes). All three layers must be ready for full tenant isolation.',
+              )}
+            </p>
+          </div>
+        </div>
+      </BaseModal.Content>
+
+      <BaseModal.Footer>
+        <a
+          href="https://docs.kubestellar.io/stable/Getting-Started/quickstart/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-cyan-400 transition-colors"
+        >
+          <ExternalLink className="w-3 h-3" />
+          {t('multiTenancy.openDocs', 'KubeStellar Docs')}
+        </a>
+      </BaseModal.Footer>
+    </BaseModal>
+  )
+}

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
@@ -6,12 +6,13 @@
  * indicators, overall score, and tenant count. Purely derived from
  * the 4 individual technology hooks (no direct fetch).
  */
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { Network, Layers, Box, Monitor, Shield, CheckCircle, XCircle, AlertTriangle, Users } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useMultiTenancyOverview } from './useMultiTenancyOverview'
 import { DEMO_MULTI_TENANCY_OVERVIEW } from './demoData'
 import { useCardLoadingState } from '../../CardDataContext'
+import { MultiTenancyDetailModal } from './MultiTenancyDetailModal'
 
 import type { ComponentStatus, IsolationLevel, IsolationStatus } from './useMultiTenancyOverview'
 
@@ -62,13 +63,13 @@ const ISOLATION_STATUS_COLORS: Record<IsolationStatus, string> = {
 }
 
 /** Single component badge in the 2x2 grid */
-function ComponentBadge({ component }: { component: ComponentStatus }) {
+function ComponentBadge({ component, onClick }: { component: ComponentStatus; onClick?: () => void }) {
   const IconComponent = ICON_MAP[component.icon] || Shield
   const healthColor = HEALTH_COLORS[component.health] || HEALTH_COLORS.unknown
   const healthBg = HEALTH_BG[component.health] || HEALTH_BG.unknown
 
   return (
-    <div className={`p-2.5 rounded-lg border ${healthBg} flex items-center gap-2`}>
+    <div className={`p-2.5 rounded-lg border ${healthBg} flex items-center gap-2 cursor-pointer hover:bg-secondary/50 transition-colors`} onClick={onClick}>
       <IconComponent className={`w-4 h-4 ${healthColor}`} />
       <div className="flex-1 min-w-0">
         <div className="text-xs font-medium text-foreground truncate">{component.name}</div>
@@ -82,9 +83,9 @@ function ComponentBadge({ component }: { component: ComponentStatus }) {
 }
 
 /** Single isolation level row */
-function IsolationRow({ level }: { level: IsolationLevel }) {
+function IsolationRow({ level, onClick }: { level: IsolationLevel; onClick?: () => void }) {
   return (
-    <div className="flex items-center justify-between py-1.5">
+    <div className="flex items-center justify-between py-1.5 cursor-pointer hover:bg-secondary/50 transition-colors rounded px-1 -mx-1" onClick={onClick}>
       <div className="flex items-center gap-2">
         <IsolationStatusIcon status={level.status} />
         <span className="text-xs font-medium text-foreground">{level.type}</span>
@@ -102,6 +103,7 @@ function IsolationRow({ level }: { level: IsolationLevel }) {
 export function MultiTenancyOverview() {
   const { t } = useTranslation(['cards'])
   const liveData = useMultiTenancyOverview()
+  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
 
   // Use demo data when all hooks return demo data
   const data = useMemo(
@@ -137,7 +139,7 @@ export function MultiTenancyOverview() {
   return (
     <div className="h-full flex flex-col gap-3">
       {/* Overall score header */}
-      <div className="flex items-center justify-between px-2 py-1.5 bg-secondary/30 rounded-lg">
+      <div className="flex items-center justify-between px-2 py-1.5 bg-secondary/30 rounded-lg cursor-pointer hover:bg-secondary/50 transition-colors" onClick={() => setIsDetailModalOpen(true)}>
         <div className="flex items-center gap-2">
           <Shield className="w-4 h-4 text-cyan-400" />
           <span className="text-xs font-medium text-foreground">
@@ -160,7 +162,7 @@ export function MultiTenancyOverview() {
       {/* 2x2 component status grid */}
       <div className={`grid grid-cols-${COMPONENT_GRID_COLS} gap-2`}>
         {(data.components || []).map((component) => (
-          <ComponentBadge key={component.name} component={component} />
+          <ComponentBadge key={component.name} component={component} onClick={() => setIsDetailModalOpen(true)} />
         ))}
       </div>
 
@@ -171,10 +173,16 @@ export function MultiTenancyOverview() {
         </div>
         <div className="space-y-0.5 bg-secondary/20 rounded-lg px-3 py-2">
           {(data.isolationLevels || []).map((level) => (
-            <IsolationRow key={level.type} level={level} />
+            <IsolationRow key={level.type} level={level} onClick={() => setIsDetailModalOpen(true)} />
           ))}
         </div>
       </div>
+
+      <MultiTenancyDetailModal
+        isOpen={isDetailModalOpen}
+        onClose={() => setIsDetailModalOpen(false)}
+        data={data}
+      />
     </div>
   )
 }

--- a/web/src/components/cards/multi-tenancy/ovn-status/OvnDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/OvnDetailModal.tsx
@@ -1,0 +1,297 @@
+/**
+ * OVN Detail Modal — drill-down view for OVN-Kubernetes status.
+ *
+ * Shows full UDN list with network type, role, subnet details,
+ * and pod health details with name, status, and node info.
+ *
+ * Follows the TrivyDetailModal pattern using BaseModal compound components.
+ */
+
+import { useMemo, useState } from 'react'
+import { Network, Search, ExternalLink, CheckCircle, XCircle } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { BaseModal } from '../../../../lib/modals'
+import { StatusBadge } from '../../../ui/StatusBadge'
+import type { OvnStatus } from './useOvnStatus'
+import type { UdnInfo } from './helpers'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Number of columns in the UDN summary grid */
+const UDN_SUMMARY_GRID_COLS = 3
+
+/** Tab identifiers */
+const TAB_UDNS = 'udns' as const
+const TAB_PODS = 'pods' as const
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface OvnDetailModalProps {
+  isOpen: boolean
+  onClose: () => void
+  data: OvnStatus
+}
+
+type TabId = typeof TAB_UDNS | typeof TAB_PODS
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+/** Color classes for network types */
+const NETWORK_TYPE_COLORS: Record<string, string> = {
+  layer2: 'text-teal-400 bg-teal-500/15',
+  layer3: 'text-cyan-400 bg-cyan-500/15',
+  unknown: 'text-zinc-400 bg-zinc-500/15',
+}
+
+/** Color classes for UDN roles */
+const ROLE_COLORS: Record<string, string> = {
+  primary: 'text-purple-400 bg-purple-500/15',
+  secondary: 'text-blue-400 bg-blue-500/15',
+  unknown: 'text-zinc-400 bg-zinc-500/15',
+}
+
+function UdnRow({ udn }: { udn: UdnInfo }) {
+  const networkTypeColor = NETWORK_TYPE_COLORS[udn.networkType] || NETWORK_TYPE_COLORS.unknown
+  const roleColor = ROLE_COLORS[udn.role] || ROLE_COLORS.unknown
+
+  return (
+    <div className="flex items-center justify-between text-sm gap-3 px-3 py-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        <Network className="w-4 h-4 text-purple-400 shrink-0" />
+        <span className="text-foreground truncate font-medium" title={udn.name}>
+          {udn.name}
+        </span>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <span className={`px-2 py-0.5 rounded text-xs font-medium ${networkTypeColor}`}>
+          {udn.networkType === 'layer2' ? 'Layer 2' : udn.networkType === 'layer3' ? 'Layer 3' : 'Unknown'}
+        </span>
+        <span className={`px-2 py-0.5 rounded text-xs font-medium capitalize ${roleColor}`}>
+          {udn.role}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function OvnDetailModal({ isOpen, onClose, data }: OvnDetailModalProps) {
+  const { t } = useTranslation('cards')
+  const [search, setSearch] = useState('')
+  const [activeTab, setActiveTab] = useState<TabId>(TAB_UDNS)
+
+  const udns = data.udns || []
+  const layer2Count = udns.filter((u) => u.networkType === 'layer2').length
+  const layer3Count = udns.filter((u) => u.networkType === 'layer3').length
+  const primaryCount = udns.filter((u) => u.role === 'primary').length
+  const secondaryCount = udns.filter((u) => u.role === 'secondary').length
+
+  const isHealthy = data.health === 'healthy'
+
+  // Filter UDNs by search
+  const filteredUdns = useMemo(() => {
+    if (!search.trim()) return udns
+    const q = search.toLowerCase()
+    return udns.filter(
+      (udn) =>
+        udn.name.toLowerCase().includes(q) ||
+        udn.networkType.toLowerCase().includes(q) ||
+        udn.role.toLowerCase().includes(q),
+    )
+  }, [udns, search])
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false}>
+      <BaseModal.Header
+        title={t('ovnStatus.detailTitle', 'OVN-Kubernetes Details')}
+        icon={Network}
+        onClose={onClose}
+        badges={
+          <StatusBadge color={isHealthy ? 'green' : 'orange'} size="sm">
+            {data.podCount} {t('ovnStatus.ovnPods', 'pods')} · {udns.length} {t('ovnStatus.udnCount', 'UDNs')}
+          </StatusBadge>
+        }
+      />
+
+      <BaseModal.Content>
+        <div className="space-y-4">
+          {/* Pod health summary */}
+          <div className={`grid grid-cols-${UDN_SUMMARY_GRID_COLS} gap-3`}>
+            <div className="p-3 rounded-lg bg-blue-500/10 text-center">
+              <p className="text-xl font-bold text-blue-400">{data.podCount}</p>
+              <p className="text-xs text-muted-foreground">{t('ovnStatus.ovnPods', 'OVN Pods')}</p>
+            </div>
+            <div className="p-3 rounded-lg bg-green-500/10 text-center">
+              <p className="text-xl font-bold text-green-400">{data.healthyPods}</p>
+              <p className="text-xs text-muted-foreground">{t('ovnStatus.healthyPods', 'Healthy')}</p>
+            </div>
+            <div className="p-3 rounded-lg bg-red-500/10 text-center">
+              <p className={`text-xl font-bold ${data.unhealthyPods > 0 ? 'text-red-400' : 'text-muted-foreground'}`}>
+                {data.unhealthyPods}
+              </p>
+              <p className="text-xs text-muted-foreground">{t('ovnStatus.unhealthyPods', 'Unhealthy')}</p>
+            </div>
+          </div>
+
+          {/* Tabs */}
+          <div className="flex border-b border-border/50">
+            <button
+              onClick={() => setActiveTab(TAB_UDNS)}
+              className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                activeTab === TAB_UDNS
+                  ? 'text-purple-400 border-purple-400'
+                  : 'text-muted-foreground border-transparent hover:text-foreground'
+              }`}
+            >
+              {t('ovnStatus.udnList', 'User Defined Networks')} ({udns.length})
+            </button>
+            <button
+              onClick={() => setActiveTab(TAB_PODS)}
+              className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
+                activeTab === TAB_PODS
+                  ? 'text-purple-400 border-purple-400'
+                  : 'text-muted-foreground border-transparent hover:text-foreground'
+              }`}
+            >
+              {t('ovnStatus.podHealth', 'Pod Health')}
+            </button>
+          </div>
+
+          {/* UDN Tab */}
+          {activeTab === TAB_UDNS && (
+            <div className="space-y-3">
+              {/* Network type breakdown */}
+              <div className="grid grid-cols-4 gap-2">
+                <div className="p-2 rounded bg-secondary/30 text-center">
+                  <p className="text-sm font-bold text-foreground">{udns.length}</p>
+                  <p className="text-[10px] text-muted-foreground">{t('ovnStatus.totalUdns', 'Total')}</p>
+                </div>
+                <div className="p-2 rounded bg-secondary/30 text-center">
+                  <p className="text-sm font-bold text-cyan-400">{layer3Count}</p>
+                  <p className="text-[10px] text-muted-foreground">{t('ovnStatus.layer3Networks', 'Layer 3')}</p>
+                </div>
+                <div className="p-2 rounded bg-secondary/30 text-center">
+                  <p className="text-sm font-bold text-teal-400">{layer2Count}</p>
+                  <p className="text-[10px] text-muted-foreground">{t('ovnStatus.layer2Networks', 'Layer 2')}</p>
+                </div>
+                <div className="p-2 rounded bg-secondary/30 text-center">
+                  <p className="text-sm font-bold text-purple-400">{primaryCount}</p>
+                  <p className="text-[10px] text-muted-foreground">
+                    {t('ovnStatus.primaryNetworks', 'Primary')}
+                    {secondaryCount > 0 && ` / ${secondaryCount} sec`}
+                  </p>
+                </div>
+              </div>
+
+              {/* Search */}
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder={t('ovnStatus.searchUdns', 'Search networks...')}
+                  className="w-full pl-9 pr-3 py-2 bg-secondary/50 border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500"
+                />
+              </div>
+
+              {/* UDN list */}
+              {filteredUdns.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground text-sm">
+                  {udns.length === 0
+                    ? t('ovnStatus.noUdns', 'No User Defined Networks found.')
+                    : t('ovnStatus.noUdnMatch', 'No networks match your search.')}
+                </div>
+              ) : (
+                <div className="space-y-1.5">
+                  {filteredUdns.map((udn) => (
+                    <UdnRow key={udn.name} udn={udn} />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Pod Health Tab */}
+          {activeTab === TAB_PODS && (
+            <div className="space-y-3">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="p-4 rounded-lg bg-green-500/10 border border-green-500/20 flex items-center gap-3">
+                  <CheckCircle className="w-6 h-6 text-green-400" />
+                  <div>
+                    <p className="text-2xl font-bold text-green-400">{data.healthyPods}</p>
+                    <p className="text-xs text-muted-foreground">{t('ovnStatus.healthyPods', 'Healthy Pods')}</p>
+                  </div>
+                </div>
+                <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/20 flex items-center gap-3">
+                  <XCircle className="w-6 h-6 text-red-400" />
+                  <div>
+                    <p className={`text-2xl font-bold ${data.unhealthyPods > 0 ? 'text-red-400' : 'text-muted-foreground'}`}>
+                      {data.unhealthyPods}
+                    </p>
+                    <p className="text-xs text-muted-foreground">{t('ovnStatus.unhealthyPods', 'Unhealthy Pods')}</p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Health bar */}
+              {data.podCount > 0 && (
+                <div className="space-y-1">
+                  <div className="flex h-3 rounded-full overflow-hidden bg-secondary/50">
+                    <div
+                      className="bg-green-500 transition-all"
+                      style={{ width: `${(data.healthyPods / data.podCount) * 100}%` }}
+                      title={`Healthy: ${data.healthyPods}`}
+                    />
+                    {data.unhealthyPods > 0 && (
+                      <div
+                        className="bg-red-500 transition-all"
+                        style={{ width: `${(data.unhealthyPods / data.podCount) * 100}%` }}
+                        title={`Unhealthy: ${data.unhealthyPods}`}
+                      />
+                    )}
+                  </div>
+                  <div className="flex gap-4 text-xs text-muted-foreground">
+                    <span className="text-green-400">
+                      {t('ovnStatus.healthyPods', 'Healthy')}: {data.healthyPods}
+                    </span>
+                    {data.unhealthyPods > 0 && (
+                      <span className="text-red-400">
+                        {t('ovnStatus.unhealthyPods', 'Unhealthy')}: {data.unhealthyPods}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              <p className="text-xs text-muted-foreground">
+                {t('ovnStatus.podHealthNote', 'OVN infrastructure pods include ovnkube-node, ovnkube-master, and ovnkube-controller DaemonSets.')}
+              </p>
+            </div>
+          )}
+        </div>
+      </BaseModal.Content>
+
+      <BaseModal.Footer>
+        <a
+          href="https://github.com/ovn-org/ovn-kubernetes"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-cyan-400 transition-colors"
+        >
+          <ExternalLink className="w-3 h-3" />
+          {t('ovnStatus.openDocs', 'OVN-Kubernetes Docs')}
+        </a>
+      </BaseModal.Footer>
+    </BaseModal>
+  )
+}

--- a/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
@@ -6,6 +6,7 @@
  * installation mission.
  */
 
+import { useState } from 'react'
 import { AlertTriangle, CheckCircle, Network, RefreshCw, Wifi, WifiOff } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../../ui/Skeleton'
@@ -15,6 +16,7 @@ import { useApiKeyCheck, ApiKeyPromptModal } from '../../console-missions/shared
 import { useOvnStatus } from './useOvnStatus'
 import { OVN_INSTALL_PROMPT } from '../shared'
 import { loadMissionPrompt } from '../missionLoader'
+import { OvnDetailModal } from './OvnDetailModal'
 
 // ============================================================================
 // Constants
@@ -60,6 +62,7 @@ export function OvnStatus() {
   const { data, error, showSkeleton, showEmptyState, isRefreshing } = useOvnStatus()
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
+  const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
 
   // ------ Loading ------
   if (showSkeleton) {
@@ -127,7 +130,8 @@ export function OvnStatus() {
       {/* Health badge + last check */}
       <div className="flex items-center justify-between">
         <div
-          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${
+          onClick={() => setIsDetailModalOpen(true)}
+          className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium cursor-pointer hover:bg-secondary/50 transition-colors ${
             isHealthy
               ? 'bg-green-500/15 text-green-400'
               : 'bg-orange-500/15 text-orange-400'
@@ -148,7 +152,7 @@ export function OvnStatus() {
       </div>
 
       {/* Metric tiles */}
-      <div className="flex gap-3">
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" onClick={() => setIsDetailModalOpen(true)}>
         <MetricTile
           label={t('ovnStatus.ovnPods')}
           value={data.podCount}
@@ -170,7 +174,7 @@ export function OvnStatus() {
       </div>
 
       {/* UDN summary */}
-      <div className="flex gap-3">
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" onClick={() => setIsDetailModalOpen(true)}>
         <MetricTile
           label={t('ovnStatus.udnCount')}
           value={(data.udns || []).length}
@@ -197,7 +201,7 @@ export function OvnStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('ovnStatus.udnList')}</p>
           <div className="space-y-1.5 max-h-32 overflow-y-auto scrollbar-thin">
             {(data.udns || []).map((udn) => (
-              <div key={udn.name} className="flex items-center justify-between text-xs gap-2">
+              <div key={udn.name} className="flex items-center justify-between text-xs gap-2 cursor-pointer hover:bg-secondary/50 transition-colors rounded px-1 -mx-1" onClick={() => setIsDetailModalOpen(true)}>
                 <span className="text-muted-foreground truncate flex-1" title={udn.name}>
                   {udn.name}
                 </span>
@@ -229,6 +233,12 @@ export function OvnStatus() {
           </svg>
         </a>
       </div>
+
+      <OvnDetailModal
+        isOpen={isDetailModalOpen}
+        onClose={() => setIsDetailModalOpen(false)}
+        data={data}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Addresses Mike Spreitzer's feedback that users can't "push into" anything on the multi-tenancy dashboard. Adds click-to-drill-down modals for all 5 status cards:

- **OVN Status**: UDN list with network type, role, search; Pod health tab
- **KubeFlex Status**: Control plane list with health status, controller details
- **K3s Status**: Server pod details with version, status; agent distribution
- **KubeVirt Status**: VM details with state, namespace; tenant distribution grid
- **Multi-Tenancy Overview**: Component health cards, isolation level details

All clickable elements have hover effects. Modals use the existing `BaseModal` compound component pattern.

## Test plan
- [x] TypeScript builds cleanly
- [ ] Click health badges → modal opens
- [ ] Click metric tiles → modal opens
- [ ] Click list rows → modal opens
- [ ] Modal content shows full detail data
- [ ] Close via X button, Escape key
- [ ] Verify on deployment preview via CDP

Fixes #2871