### PR TITLE
🐛 fix: use RegExp for GA4 subdomain passthrough in MSW

### DIFF
--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -198,7 +198,7 @@ export const handlers = [
   http.all('https://www.google-analytics.com/*', () => passthrough()),
   http.all('https://analytics.google.com/*', () => passthrough()),
   http.all('https://www.googletagmanager.com/*', () => passthrough()),
-  http.all('https://*.google-analytics.com/*', () => passthrough()),
+  http.all(/^https:\/\/[^/]*google-analytics\.com\//, () => passthrough()),
 
   // Auth endpoints
   http.get('/api/auth/me', async () => {


### PR DESCRIPTION
## Summary
- Replace invalid `https://*.google-analytics.com/*` URL pattern with RegExp `/^https:\/\/[^/]*google-analytics\.com\//`
- URL wildcards don't support host-level globs — MSW needs RegExp for subdomain matching

Addresses Copilot review on #2895.