### PR TITLE
🐛 fix: show Demo badge in multi-tenancy detail modals

### DIFF
--- a/web/src/components/cards/multi-tenancy/k3s-status/K3sDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/K3sDetailModal.tsx
@@ -37,6 +37,7 @@ interface K3sDetailModalProps {
   isOpen: boolean
   onClose: () => void
   data: K3sStatus
+  isDemoData?: boolean
 }
 
 // ============================================================================
@@ -75,7 +76,7 @@ function ServerPodRow({ pod }: { pod: K3sServerPodInfo }) {
 // Component
 // ============================================================================
 
-export function K3sDetailModal({ isOpen, onClose, data }: K3sDetailModalProps) {
+export function K3sDetailModal({ isOpen, onClose, data, isDemoData }: K3sDetailModalProps) {
   const { t } = useTranslation('cards')
   const [search, setSearch] = useState('')
 
@@ -112,9 +113,12 @@ export function K3sDetailModal({ isOpen, onClose, data }: K3sDetailModalProps) {
         icon={Box}
         onClose={onClose}
         badges={
-          <StatusBadge color={isHealthy ? 'green' : 'orange'} size="sm">
-            {data.podCount} {t('k3sStatus.totalPods', 'pods')} · {serverPods.length} {t('k3sStatus.serverPods', 'servers')}
-          </StatusBadge>
+          <>
+            {isDemoData && <StatusBadge color="yellow" size="sm">{t('cards:cardWrapper.demo', 'Demo')}</StatusBadge>}
+            <StatusBadge color={isHealthy ? 'green' : 'orange'} size="sm">
+              {data.podCount} {t('k3sStatus.totalPods', 'pods')} · {serverPods.length} {t('k3sStatus.serverPods', 'servers')}
+            </StatusBadge>
+          </>
         }
       />
 

--- a/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
@@ -59,7 +59,7 @@ function useFormatRelativeTime() {
 export function K3sStatus() {
   const { t } = useTranslation('cards')
   const formatRelativeTime = useFormatRelativeTime()
-  const { data, error, showSkeleton, showEmptyState, isRefreshing } = useK3sStatus()
+  const { data, error, showSkeleton, showEmptyState, isRefreshing, isDemoData } = useK3sStatus()
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
@@ -227,6 +227,7 @@ export function K3sStatus() {
         isOpen={isDetailModalOpen}
         onClose={() => setIsDetailModalOpen(false)}
         data={data}
+        isDemoData={isDemoData}
       />
     </div>
   )

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexDetailModal.tsx
@@ -30,6 +30,7 @@ interface KubeFlexDetailModalProps {
   isOpen: boolean
   onClose: () => void
   data: KubeFlexStatus
+  isDemoData?: boolean
 }
 
 // ============================================================================
@@ -66,7 +67,7 @@ function ControlPlaneRow({ cp }: { cp: ControlPlaneInfo }) {
 // Component
 // ============================================================================
 
-export function KubeFlexDetailModal({ isOpen, onClose, data }: KubeFlexDetailModalProps) {
+export function KubeFlexDetailModal({ isOpen, onClose, data, isDemoData }: KubeFlexDetailModalProps) {
   const { t } = useTranslation('cards')
   const [search, setSearch] = useState('')
 
@@ -88,12 +89,15 @@ export function KubeFlexDetailModal({ isOpen, onClose, data }: KubeFlexDetailMod
         icon={Layers}
         onClose={onClose}
         badges={
-          <StatusBadge
-            color={data.controllerHealthy && unhealthyCPs === 0 ? 'green' : 'orange'}
-            size="sm"
-          >
-            {controlPlanes.length} {t('kubeFlexStatus.controlPlanes', 'control planes')} · {data.tenantCount} {t('kubeFlexStatus.tenants', 'tenants')}
-          </StatusBadge>
+          <>
+            {isDemoData && <StatusBadge color="yellow" size="sm">{t('cards:cardWrapper.demo', 'Demo')}</StatusBadge>}
+            <StatusBadge
+              color={data.controllerHealthy && unhealthyCPs === 0 ? 'green' : 'orange'}
+              size="sm"
+            >
+              {controlPlanes.length} {t('kubeFlexStatus.controlPlanes', 'control planes')} · {data.tenantCount} {t('kubeFlexStatus.tenants', 'tenants')}
+            </StatusBadge>
+          </>
         }
       />
 

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexStatus.tsx
@@ -56,7 +56,7 @@ function useFormatRelativeTime() {
 export function KubeFlexStatus() {
   const { t } = useTranslation('cards')
   const formatRelativeTime = useFormatRelativeTime()
-  const { data, error, showSkeleton, showEmptyState, isRefreshing } = useKubeFlexStatus()
+  const { data, error, showSkeleton, showEmptyState, isRefreshing, isDemoData } = useKubeFlexStatus()
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
@@ -223,6 +223,7 @@ export function KubeFlexStatus() {
         isOpen={isDetailModalOpen}
         onClose={() => setIsDetailModalOpen(false)}
         data={data}
+        isDemoData={isDemoData}
       />
     </div>
   )

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx
@@ -60,6 +60,7 @@ interface KubevirtDetailModalProps {
   isOpen: boolean
   onClose: () => void
   data: KubevirtStatus
+  isDemoData?: boolean
 }
 
 // ============================================================================
@@ -93,7 +94,7 @@ function VmRow({ vm }: { vm: VmInfo }) {
 // Component
 // ============================================================================
 
-export function KubevirtDetailModal({ isOpen, onClose, data }: KubevirtDetailModalProps) {
+export function KubevirtDetailModal({ isOpen, onClose, data, isDemoData }: KubevirtDetailModalProps) {
   const { t } = useTranslation('cards')
   const [search, setSearch] = useState('')
 
@@ -154,9 +155,12 @@ export function KubevirtDetailModal({ isOpen, onClose, data }: KubevirtDetailMod
         icon={Monitor}
         onClose={onClose}
         badges={
-          <StatusBadge color={isHealthy ? 'green' : 'orange'} size="sm">
-            {vms.length} {t('kubevirtStatus.totalVMs', 'VMs')} · {data.tenantCount} {t('kubevirtStatus.tenants', 'tenants')}
-          </StatusBadge>
+          <>
+            {isDemoData && <StatusBadge color="yellow" size="sm">{t('cards:cardWrapper.demo', 'Demo')}</StatusBadge>}
+            <StatusBadge color={isHealthy ? 'green' : 'orange'} size="sm">
+              {vms.length} {t('kubevirtStatus.totalVMs', 'VMs')} · {data.tenantCount} {t('kubevirtStatus.tenants', 'tenants')}
+            </StatusBadge>
+          </>
         }
       />
 

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
@@ -75,7 +75,7 @@ function vmStateColorClass(state: string): string {
 export function KubevirtStatus() {
   const { t } = useTranslation('cards')
   const formatRelativeTime = useFormatRelativeTime()
-  const { data, error, showSkeleton, showEmptyState, isRefreshing } = useKubevirtStatus()
+  const { data, error, showSkeleton, showEmptyState, isRefreshing, isDemoData } = useKubevirtStatus()
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
@@ -272,6 +272,7 @@ export function KubevirtStatus() {
         isOpen={isDetailModalOpen}
         onClose={() => setIsDetailModalOpen(false)}
         data={data}
+        isDemoData={isDemoData}
       />
     </div>
   )

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
@@ -29,6 +29,7 @@ interface MultiTenancyDetailModalProps {
   isOpen: boolean
   onClose: () => void
   data: MultiTenancyOverviewData
+  isDemoData?: boolean
 }
 
 // ============================================================================
@@ -140,7 +141,7 @@ function IsolationLevelCard({ level }: { level: IsolationLevel }) {
 // Component
 // ============================================================================
 
-export function MultiTenancyDetailModal({ isOpen, onClose, data }: MultiTenancyDetailModalProps) {
+export function MultiTenancyDetailModal({ isOpen, onClose, data, isDemoData }: MultiTenancyDetailModalProps) {
   const { t } = useTranslation('cards')
 
   const components = data.components || []
@@ -155,12 +156,15 @@ export function MultiTenancyDetailModal({ isOpen, onClose, data }: MultiTenancyD
         icon={Shield}
         onClose={onClose}
         badges={
-          <StatusBadge
-            color={data.overallScore === data.totalLevels ? 'green' : data.overallScore > 0 ? 'orange' : 'red'}
-            size="sm"
-          >
-            {data.overallScore}/{data.totalLevels} {t('multiTenancy.isolationScore', 'Isolation Score')}
-          </StatusBadge>
+          <>
+            {isDemoData && <StatusBadge color="yellow" size="sm">{t('cards:cardWrapper.demo', 'Demo')}</StatusBadge>}
+            <StatusBadge
+              color={data.overallScore === data.totalLevels ? 'green' : data.overallScore > 0 ? 'orange' : 'red'}
+              size="sm"
+            >
+              {data.overallScore}/{data.totalLevels} {t('multiTenancy.isolationScore', 'Isolation Score')}
+            </StatusBadge>
+          </>
         }
       />
 

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
@@ -182,6 +182,7 @@ export function MultiTenancyOverview() {
         isOpen={isDetailModalOpen}
         onClose={() => setIsDetailModalOpen(false)}
         data={data}
+        isDemoData={liveData.isDemoData}
       />
     </div>
   )

--- a/web/src/components/cards/multi-tenancy/ovn-status/OvnDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/OvnDetailModal.tsx
@@ -34,6 +34,7 @@ interface OvnDetailModalProps {
   isOpen: boolean
   onClose: () => void
   data: OvnStatus
+  isDemoData?: boolean
 }
 
 type TabId = typeof TAB_UDNS | typeof TAB_PODS
@@ -84,7 +85,7 @@ function UdnRow({ udn }: { udn: UdnInfo }) {
 // Component
 // ============================================================================
 
-export function OvnDetailModal({ isOpen, onClose, data }: OvnDetailModalProps) {
+export function OvnDetailModal({ isOpen, onClose, data, isDemoData }: OvnDetailModalProps) {
   const { t } = useTranslation('cards')
   const [search, setSearch] = useState('')
   const [activeTab, setActiveTab] = useState<TabId>(TAB_UDNS)
@@ -116,9 +117,12 @@ export function OvnDetailModal({ isOpen, onClose, data }: OvnDetailModalProps) {
         icon={Network}
         onClose={onClose}
         badges={
-          <StatusBadge color={isHealthy ? 'green' : 'orange'} size="sm">
-            {data.podCount} {t('ovnStatus.ovnPods', 'pods')} · {udns.length} {t('ovnStatus.udnCount', 'UDNs')}
-          </StatusBadge>
+          <>
+            {isDemoData && <StatusBadge color="yellow" size="sm">{t('cards:cardWrapper.demo', 'Demo')}</StatusBadge>}
+            <StatusBadge color={isHealthy ? 'green' : 'orange'} size="sm">
+              {data.podCount} {t('ovnStatus.ovnPods', 'pods')} · {udns.length} {t('ovnStatus.udnCount', 'UDNs')}
+            </StatusBadge>
+          </>
         }
       />
 

--- a/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
@@ -59,7 +59,7 @@ function useFormatRelativeTime() {
 export function OvnStatus() {
   const { t } = useTranslation('cards')
   const formatRelativeTime = useFormatRelativeTime()
-  const { data, error, showSkeleton, showEmptyState, isRefreshing } = useOvnStatus()
+  const { data, error, showSkeleton, showEmptyState, isRefreshing, isDemoData } = useOvnStatus()
   const { startMission } = useMissions()
   const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
@@ -238,6 +238,7 @@ export function OvnStatus() {
         isOpen={isDetailModalOpen}
         onClose={() => setIsDetailModalOpen(false)}
         data={data}
+        isDemoData={isDemoData}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
Each multi-tenancy detail modal now shows a yellow "Demo" badge in its header when the parent card is displaying demo/fallback data.

- Pass `isDemoData` from each parent card's hook to its detail modal
- Render `<StatusBadge color="yellow">Demo</StatusBadge>` in the modal header when true
- All 5 modals updated: OVN, KubeFlex, K3s, KubeVirt, Multi-Tenancy Overview

## Test plan
- [x] TypeScript builds cleanly
- [ ] Open modal from demo-mode card → yellow "Demo" badge visible in modal header
- [ ] Open modal from live-data card → no Demo badge shown