### PR TITLE
✨ Add yellow demo outline to multi-tenancy detail modals

### DIFF
--- a/web/src/components/cards/multi-tenancy/k3s-status/K3sDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/K3sDetailModal.tsx
@@ -107,7 +107,7 @@ export function K3sDetailModal({ isOpen, onClose, data, isDemoData }: K3sDetailM
   }, [serverPods, search])
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false}>
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'border border-yellow-500/30 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''}>
       <BaseModal.Header
         title={t('k3sStatus.detailTitle', 'K3s Details')}
         icon={Box}

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexDetailModal.tsx
@@ -83,7 +83,7 @@ export function KubeFlexDetailModal({ isOpen, onClose, data, isDemoData }: KubeF
   }, [controlPlanes, search])
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false}>
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'border border-yellow-500/30 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''}>
       <BaseModal.Header
         title={t('kubeFlexStatus.detailTitle', 'KubeFlex Details')}
         icon={Layers}

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx
@@ -149,7 +149,7 @@ export function KubevirtDetailModal({ isOpen, onClose, data, isDemoData }: Kubev
   }, [vms, search])
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false}>
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'border border-yellow-500/30 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''}>
       <BaseModal.Header
         title={t('kubevirtStatus.detailTitle', 'KubeVirt Details')}
         icon={Monitor}

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
@@ -150,7 +150,7 @@ export function MultiTenancyDetailModal({ isOpen, onClose, data, isDemoData }: M
   const healthyCount = components.filter((c) => c.health === 'healthy').length
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false}>
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'border border-yellow-500/30 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''}>
       <BaseModal.Header
         title={t('multiTenancy.detailTitle', 'Multi-Tenancy Overview Details')}
         icon={Shield}

--- a/web/src/components/cards/multi-tenancy/ovn-status/OvnDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/OvnDetailModal.tsx
@@ -111,7 +111,7 @@ export function OvnDetailModal({ isOpen, onClose, data, isDemoData }: OvnDetailM
   }, [udns, search])
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false}>
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'border border-yellow-500/30 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''}>
       <BaseModal.Header
         title={t('ovnStatus.detailTitle', 'OVN-Kubernetes Details')}
         icon={Network}


### PR DESCRIPTION
## Summary
When multi-tenancy detail modals display demo data, they now show a subtle yellow border + glow outline matching the card-level demo indicator pattern (`border-yellow-500/30` + `shadow-[0_0_12px_rgba(234,179,8,0.15)]`).

All 5 modals updated: OVN, KubeFlex, K3s, KubeVirt, Multi-Tenancy Overview.

## Test plan
- [x] TypeScript builds cleanly
- [ ] Open modal from demo card → yellow outline visible around modal
- [ ] Open modal from live card → no yellow outline