### PR TITLE
⚡ perf: drop modulepreload for lazy-loaded heavy chunks (-550KB)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -70,6 +70,21 @@ export default defineConfig(({ mode }) => ({
     exclude: ['@sqlite.org/sqlite-wasm'],
   },
   build: {
+    // Filter modulepreload hints — Vite preloads ALL chunks by default, even
+    // lazy-loaded ones. This adds ~550KB of unnecessary downloads on first
+    // visit (three-vendor 195KB, charts-vendor 354KB, markdown-vendor, etc.)
+    // that are never used on the dashboard. Only preload the core chunks.
+    modulePreload: {
+      resolveDependencies: (_filename, deps) => {
+        return deps.filter(dep =>
+          !dep.includes('three-vendor') &&
+          !dep.includes('charts-vendor') &&
+          !dep.includes('markdown-vendor') &&
+          !dep.includes('sucrase-vendor') &&
+          !dep.includes('motion-vendor')
+        )
+      },
+    },
     // Enable minification optimizations
     minify: 'terser',
     terserOptions: {


### PR DESCRIPTION
## Summary

Vite adds `<link rel="modulepreload">` for ALL chunks by default, including lazy-loaded ones. This causes the browser to eagerly download ~550KB of JS on every first page load that is never used on the dashboard:

| Chunk | Size | Used on |
|-------|------|---------|
| `three-vendor` | 195 KB | Arcade (globe animation), never on dashboard |
| `charts-vendor` | 354 KB | Chart cards (loaded on-demand when rendered) |
| `markdown-vendor` | ~30 KB | Mission sidebar (loaded when opened) |
| `sucrase-vendor` | ~50 KB | Dynamic card editor only |
| `motion-vendor` | ~30 KB | Animated page transitions only |

**Fix**: Filter these from the `modulePreload.resolveDependencies` callback so they're only fetched when actually imported.

## Results

- **Before**: 6 modulepreload chunks in `index.html`
- **After**: 4 modulepreload chunks (react-vendor, vendor, i18n-vendor, ui-vendor)
- **Savings**: ~550KB less transferred on cold first visit

## Test plan

- [ ] Cold load of `/` — should load faster, no three-vendor/charts-vendor in Network waterfall until needed
- [ ] Navigate to `/arcade` — three-vendor should load on-demand
- [ ] Open a chart card — charts-vendor should load on-demand
- [ ] Open mission sidebar — markdown-vendor should load on-demand