### PR TITLE
🐛 fix: send button hidden for missions with long descriptions

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -456,7 +456,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
           </div>
         </div>
         <div className="flex items-center gap-2 flex-wrap">
-          <p className="text-xs text-muted-foreground flex-1">{mission.description}</p>
+          <p className="text-xs text-muted-foreground flex-1 line-clamp-2">{mission.description}</p>
           {mission.agent && (
             <AgentBadge
               provider={
@@ -559,7 +559,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
       </div>
 
       {/* Input / Actions */}
-      <div className="p-4 border-t border-border flex-shrink-0 bg-card min-w-0 overflow-hidden">
+      <div className="p-4 border-t border-border flex-shrink-0 bg-card min-w-0">
         {mission.status === 'running' ? (
           <div className="flex flex-col gap-2">
             <div className="flex gap-2 min-w-0">


### PR DESCRIPTION
## Summary
- Removed `overflow-hidden` from the input/actions container in `MissionChat.tsx` that was clipping the send button when the chat header had a long description
- Added `line-clamp-2` to the mission description text to prevent excessively tall headers from consuming sidebar space

The "Configure Multi-Tenancy Framework (Three Shades of Isolation)" mission has a ~400-character description that wraps to 5-6 lines, making the header tall. The `overflow-hidden` on the input container could clip the send button in certain viewport configurations. Removing it and clamping the description resolves the issue.

## Test plan
- [ ] Import "Configure Multi-Tenancy Framework (Three Shades of Isolation)" mission from Browse Missions → Installed tab
- [ ] Verify send button is visible in the sidebar chat view
- [ ] Verify other imported missions still show send button correctly
- [ ] Verify description shows max 2 lines with ellipsis for long descriptions

Closes #2884