### PR TITLE
🐛 fix: use ring for visible demo outline on multi-tenancy modals

### DIFF
--- a/web/src/components/cards/multi-tenancy/k3s-status/K3sDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/K3sDetailModal.tsx
@@ -107,7 +107,7 @@ export function K3sDetailModal({ isOpen, onClose, data, isDemoData }: K3sDetailM
   }, [serverPods, search])
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'border border-yellow-500/30 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''}>
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'ring-2 ring-yellow-500/60 shadow-[0_0_20px_rgba(234,179,8,0.25)]' : ''}>
       <BaseModal.Header
         title={t('k3sStatus.detailTitle', 'K3s Details')}
         icon={Box}

--- a/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/kubeflex-status/KubeFlexDetailModal.tsx
@@ -83,7 +83,7 @@ export function KubeFlexDetailModal({ isOpen, onClose, data, isDemoData }: KubeF
   }, [controlPlanes, search])
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'border border-yellow-500/30 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''}>
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'ring-2 ring-yellow-500/60 shadow-[0_0_20px_rgba(234,179,8,0.25)]' : ''}>
       <BaseModal.Header
         title={t('kubeFlexStatus.detailTitle', 'KubeFlex Details')}
         icon={Layers}

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtDetailModal.tsx
@@ -149,7 +149,7 @@ export function KubevirtDetailModal({ isOpen, onClose, data, isDemoData }: Kubev
   }, [vms, search])
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'border border-yellow-500/30 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''}>
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'ring-2 ring-yellow-500/60 shadow-[0_0_20px_rgba(234,179,8,0.25)]' : ''}>
       <BaseModal.Header
         title={t('kubevirtStatus.detailTitle', 'KubeVirt Details')}
         icon={Monitor}

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyDetailModal.tsx
@@ -150,7 +150,7 @@ export function MultiTenancyDetailModal({ isOpen, onClose, data, isDemoData }: M
   const healthyCount = components.filter((c) => c.health === 'healthy').length
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'border border-yellow-500/30 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''}>
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'ring-2 ring-yellow-500/60 shadow-[0_0_20px_rgba(234,179,8,0.25)]' : ''}>
       <BaseModal.Header
         title={t('multiTenancy.detailTitle', 'Multi-Tenancy Overview Details')}
         icon={Shield}

--- a/web/src/components/cards/multi-tenancy/ovn-status/OvnDetailModal.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/OvnDetailModal.tsx
@@ -111,7 +111,7 @@ export function OvnDetailModal({ isOpen, onClose, data, isDemoData }: OvnDetailM
   }, [udns, search])
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'border border-yellow-500/30 shadow-[0_0_12px_rgba(234,179,8,0.15)]' : ''}>
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false} className={isDemoData ? 'ring-2 ring-yellow-500/60 shadow-[0_0_20px_rgba(234,179,8,0.25)]' : ''}>
       <BaseModal.Header
         title={t('ovnStatus.detailTitle', 'OVN-Kubernetes Details')}
         icon={Network}


### PR DESCRIPTION
## Summary
The previous `border border-yellow-500/30` was invisible because `.glass` CSS sets `border` via CSS, overriding Tailwind's border utility.

Switched to `ring-2 ring-yellow-500/60` which uses `box-shadow` (not affected by `.glass`) at 60% opacity with a stronger glow (`shadow-[0_0_20px_rgba(234,179,8,0.25)]`).

## Test plan
- [x] TypeScript builds
- [ ] Open modal from demo card → yellow ring outline clearly visible around modal