### PR TITLE
🐛 fix: restore modulepreload for charts/markdown — only drop three-vendor

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -70,18 +70,14 @@ export default defineConfig(({ mode }) => ({
     exclude: ['@sqlite.org/sqlite-wasm'],
   },
   build: {
-    // Filter modulepreload hints — Vite preloads ALL chunks by default, even
-    // lazy-loaded ones. This adds ~550KB of unnecessary downloads on first
-    // visit (three-vendor 195KB, charts-vendor 354KB, markdown-vendor, etc.)
-    // that are never used on the dashboard. Only preload the core chunks.
+    // Filter modulepreload hints for chunks NEVER used on the dashboard.
+    // Keep charts-vendor (dashboard cards need it) and markdown-vendor.
+    // Only drop chunks used exclusively on non-dashboard pages.
     modulePreload: {
       resolveDependencies: (_filename, deps) => {
         return deps.filter(dep =>
-          !dep.includes('three-vendor') &&
-          !dep.includes('charts-vendor') &&
-          !dep.includes('markdown-vendor') &&
-          !dep.includes('sucrase-vendor') &&
-          !dep.includes('motion-vendor')
+          !dep.includes('three-vendor') &&   // arcade only (195KB)
+          !dep.includes('sucrase-vendor')    // dynamic card editor only
         )
       },
     },


### PR DESCRIPTION
## Summary

Follow-up to #2901 which removed too many modulepreloads. `charts-vendor` and `markdown-vendor` are needed on the dashboard — removing their preload hints created a runtime waterfall that made cold loads **slower**, not faster.

This restores preloads for `charts-vendor`, `markdown-vendor`, and `motion-vendor`. Only keeps `three-vendor` (195KB, arcade only) and `sucrase-vendor` (dynamic card editor only) filtered.

## Test plan
- [ ] Cold load of `/` — should be same speed or faster than before #2901
- [ ] Chart cards should render without delay on dashboard