### PR TITLE
⏪ revert: remove modulePreload config (restores Vite defaults)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -70,17 +70,6 @@ export default defineConfig(({ mode }) => ({
     exclude: ['@sqlite.org/sqlite-wasm'],
   },
   build: {
-    // Filter modulepreload hints for chunks NEVER used on the dashboard.
-    // Keep charts-vendor (dashboard cards need it) and markdown-vendor.
-    // Only drop chunks used exclusively on non-dashboard pages.
-    modulePreload: {
-      resolveDependencies: (_filename, deps) => {
-        return deps.filter(dep =>
-          !dep.includes('three-vendor') &&   // arcade only (195KB)
-          !dep.includes('sucrase-vendor')    // dynamic card editor only
-        )
-      },
-    },
     // Enable minification optimizations
     minify: 'terser',
     terserOptions: {


### PR DESCRIPTION
Reverts #2901 and #2904. The modulePreload filtering didn't improve cold load times. Restores Vite's default preload-all behavior.