### PR TITLE
🐛 fix: throttle auto-qa Copilot assignments to avoid rate limiting

### DIFF
--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -38,6 +38,7 @@ on:
 env:
   BUNDLE_SIZE_LIMIT_KB: 5120
   MAX_ISSUES_PER_RUN: 3
+  COPILOT_ASSIGNMENT_DELAY_S: 120  # Seconds between Copilot assignments to avoid rate limiting
   ISSUE_PREFIX: "[Auto-QA]"
   NODE_VERSION: "20"
   GO_VERSION: "1.23"
@@ -4452,6 +4453,15 @@ jobs:
                 core.warning(`Could not assign Copilot to #${issue.number}: ${e.message}${hint}`);
               }
               created++;
+
+              // Throttle Copilot assignments to avoid rate limiting.
+              // Copilot's coding agent has concurrency limits — rapid-fire
+              // assignments cause silent failures or queuing issues.
+              const delaySeconds = parseInt(process.env.COPILOT_ASSIGNMENT_DELAY_S || '120');
+              if (created < maxIssues && delaySeconds > 0) {
+                core.info(`Waiting ${delaySeconds}s before next Copilot assignment to avoid rate limits...`);
+                await new Promise(resolve => setTimeout(resolve, delaySeconds * 1000));
+              }
 
               // Auto-triage is handled by including triage/accepted in the issue labels at creation
             }


### PR DESCRIPTION
## Summary
The auto-qa workflow assigns 3-5 issues to Copilot's coding agent in a tight `for` loop with no delay. This hits Copilot's concurrency limits, causing some assignments to silently fail or queue poorly.

Added a configurable `COPILOT_ASSIGNMENT_DELAY_S` (default: 120 seconds) between assignments. The delay:
- Only applies between assignments, not after the last one
- Is logged in workflow output for visibility
- Makes a 3-issue run take ~4 minutes instead of <1 second
- Is well within the 6-hour window between scheduled runs (4x/day)

## Test plan
- [x] YAML syntax valid
- [ ] Trigger auto-qa manually via `workflow_dispatch`
- [ ] Verify delay messages appear in workflow logs between assignments
- [ ] Verify all issues get assigned successfully (no 429 errors)