### PR TITLE
⚡ perf: instant mission import via navigation state (skip re-fetch)

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -21,7 +21,7 @@ import {
   Eye,
   ShieldOff,
 } from 'lucide-react'
-import { useSearchParams } from 'react-router-dom'
+import { useSearchParams, useLocation } from 'react-router-dom'
 import { useMissions } from '../../../hooks/useMissions'
 import { useMobile } from '../../../hooks/useMobile'
 import { StatusBadge } from '../../ui/StatusBadge'
@@ -61,9 +61,12 @@ export function MissionSidebar() {
   // Deep-link: open MissionBrowser via ?mission= (specific) or ?browse=missions (explorer)
   // Direct import: ?import= fetches and imports mission directly (no browser popup)
   const [searchParams, setSearchParams] = useSearchParams()
+  const location = useLocation()
   const deepLinkMission = searchParams.get('mission')
   const directImportSlug = searchParams.get('import')
   const browseParam = searchParams.get('browse')
+  /** Mission pre-fetched by MissionLandingPage and passed via navigation state */
+  const prefetchedMission = (location.state as { prefetchedMission?: MissionExport } | null)?.prefetchedMission
 
   useEffect(() => {
     if (deepLinkMission || browseParam === 'missions') {
@@ -85,8 +88,16 @@ export function MissionSidebar() {
     newParams.delete('import')
     setSearchParams(newParams, { replace: true })
 
-    // Fetch and import the mission in the background.
-    // Try all known console-kb subdirectories in parallel for speed.
+    // Fast path: if MissionLandingPage passed the already-fetched mission
+    // via navigation state, use it directly (skips ~2s of re-fetching).
+    if (prefetchedMission) {
+      handleImportMission(prefetchedMission)
+      // Clear navigation state to prevent stale data on refresh
+      window.history.replaceState({}, '')
+      return
+    }
+
+    // Slow path: fetch the mission by racing all known directories.
     const KB_DIRS = [
       'cncf-install', 'cncf-generated', 'security', 'platform-install',
       'llm-d', 'multi-cluster', 'troubleshoot', 'troubleshooting',

--- a/web/src/components/missions/MissionLandingPage.tsx
+++ b/web/src/components/missions/MissionLandingPage.tsx
@@ -309,8 +309,13 @@ export function MissionLandingPage() {
 
   const handleImport = () => {
     // Navigate to the full console with the import param — the sidebar
-    // will detect it and directly import the mission (no browser popup)
-    navigate(`/?import=${missionId || ''}`, { replace: true })
+    // will detect it and directly import the mission (no browser popup).
+    // Pass the already-fetched mission via navigation state to skip
+    // the 13-directory race lookup on the receiving end (~2s saved).
+    navigate(`/?import=${missionId || ''}`, {
+      replace: true,
+      state: mission ? { prefetchedMission: mission } : undefined,
+    })
   }
 
   const handleBrowseAll = () => {


### PR DESCRIPTION
## Summary
- Pass already-fetched mission data via React Router navigation state when clicking Import
- Sidebar uses prefetched mission instantly instead of re-fetching via 13-directory race
- Combined with PR #2906 (Promise.any), mission import is now near-instant

## Before/After
- **Before**: Click Import → full page nav → 13-directory race lookup (~2s) → import
- **After**: Click Import → full page nav → use prefetched state (0ms) → import