### PR TITLE
✨ Add Copilot assignment health monitoring to auto-qa

### DIFF
--- a/.github/workflows/auto-qa-tuner.yml
+++ b/.github/workflows/auto-qa-tuner.yml
@@ -1,20 +1,22 @@
 name: Auto-QA Tuner
 
 # Learns from accepted/rejected Copilot PRs and CNCF landscape to tune auto-qa issue creation.
-# Three feedback loops:
-#   daily-feedback:    Tracks per-category acceptance rates from last 24h
-#   weekly-analysis:   Broader pattern analysis, creates summary report issue
-#   cncf-intelligence: Scans CNCF repos for improvement patterns
+# Four feedback loops:
+#   daily-feedback:      Tracks per-category acceptance rates from last 24h
+#   weekly-analysis:     Broader pattern analysis, creates summary report issue
+#   cncf-intelligence:   Scans CNCF repos for improvement patterns
+#   copilot-stall-check: Detects assigned issues where Copilot hasn't started work
 
 on:
   schedule:
     - cron: '0 3 * * *'    # Daily at 3am UTC
     - cron: '0 4 * * 0'    # Sunday at 4am UTC
     - cron: '0 5 * * 3'    # Wednesday at 5am UTC
+    - cron: '*/30 * * * *' # Every 30 min — copilot stall detection
   workflow_dispatch:
     inputs:
       job_override:
-        description: 'Which job to run (daily|weekly|cncf|all)'
+        description: 'Which job to run (daily|weekly|cncf|stall|all)'
         required: false
         default: 'all'
         type: string
@@ -778,3 +780,156 @@ jobs:
           git commit -m "chore: update auto-qa tuning config (CNCF intelligence)"
           git pull --rebase origin main || true
           git push
+
+  # ============================================================
+  # Job D: Copilot Stall Detection — find assigned issues with no activity
+  # ============================================================
+  copilot-stall-check:
+    if: >
+      github.event.schedule == '*/30 * * * *' ||
+      (github.event_name == 'workflow_dispatch' &&
+       (inputs.job_override == 'stall' || inputs.job_override == 'all'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      COPILOT_STALL_THRESHOLD_MINUTES: 20
+      COPILOT_STALL_ESCALATION_MINUTES: 60
+    steps:
+      - name: Detect stalled Copilot assignments
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CONSOLE_AUTO || secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const stallThresholdMs = parseInt(process.env.COPILOT_STALL_THRESHOLD_MINUTES) * 60 * 1000;
+            const escalationThresholdMs = parseInt(process.env.COPILOT_STALL_ESCALATION_MINUTES) * 60 * 1000;
+            const now = Date.now();
+
+            // Find issues assigned to Copilot with AI labels
+            const aiLabels = ['ai-awaiting-fix', 'ai-processing', 'ai-fix-requested'];
+            let stalledIssues = [];
+            let escalationNeeded = [];
+
+            for (const label of aiLabels) {
+              const { data: issues } = await github.rest.issues.listForRepo({
+                owner, repo,
+                state: 'open',
+                labels: label,
+                per_page: 20,
+              });
+
+              for (const issue of issues) {
+                // Skip issues that already have ai-stalled label
+                if ((issue.labels || []).some(l => l.name === 'ai-stalled')) continue;
+
+                // Check if Copilot is assigned
+                const copilotAssigned = (issue.assignees || []).some(a =>
+                  a.login === 'copilot-swe-agent[bot]' || a.login === 'Copilot'
+                );
+                if (!copilotAssigned) continue;
+
+                // Calculate time since last update
+                const updatedAt = new Date(issue.updated_at).getTime();
+                const stalledFor = now - updatedAt;
+
+                if (stalledFor < stallThresholdMs) continue;
+
+                // Check if Copilot has created a PR for this issue
+                const { data: prs } = await github.rest.pulls.list({
+                  owner, repo,
+                  state: 'open',
+                  per_page: 50,
+                });
+                const hasCopilotPR = prs.some(pr =>
+                  (pr.user?.login === 'copilot-swe-agent[bot]' || pr.user?.login === 'Copilot') &&
+                  (pr.body || '').includes(`#${issue.number}`)
+                );
+
+                if (hasCopilotPR) continue; // Copilot is working — PR exists
+
+                const stalledMinutes = Math.round(stalledFor / 60000);
+                stalledIssues.push({ number: issue.number, title: issue.title, stalledMinutes });
+
+                if (stalledFor >= escalationThresholdMs) {
+                  escalationNeeded.push({ number: issue.number, title: issue.title, stalledMinutes });
+                }
+
+                // Add ai-stalled label
+                try {
+                  await github.rest.issues.addLabels({
+                    owner, repo,
+                    issue_number: issue.number,
+                    labels: ['ai-stalled'],
+                  });
+                } catch (e) {
+                  core.warning(`Failed to add ai-stalled label to #${issue.number}: ${e.message}`);
+                }
+
+                // Comment on the issue (avoid duplicates)
+                const { data: comments } = await github.rest.issues.listComments({
+                  owner, repo,
+                  issue_number: issue.number,
+                  per_page: 10,
+                });
+                const hasStallComment = comments.some(c => c.body.includes('Copilot Stall Detected'));
+                if (!hasStallComment) {
+                  await github.rest.issues.createComment({
+                    owner, repo,
+                    issue_number: issue.number,
+                    body: [
+                      '## Copilot Stall Detected',
+                      '',
+                      `Copilot was assigned ${stalledMinutes} minutes ago but hasn't created a PR.`,
+                      'This may indicate the assignment was silently dropped or rate-limited.',
+                      '',
+                      '**Next steps:**',
+                      '- If Copilot doesn\'t respond within 1 hour, the assignment will be escalated',
+                      '- You can manually re-assign by commenting `/assign-copilot`',
+                      '',
+                      '*Auto-detected by the Copilot stall monitor.*',
+                    ].join('\n'),
+                  });
+                }
+              }
+            }
+
+            // Escalation: create diagnostic issue if stalled > 1 hour
+            if (escalationNeeded.length > 0) {
+              const { data: existingDiag } = await github.rest.issues.listForRepo({
+                owner, repo, state: 'open',
+                labels: 'auto-qa,auto-qa:rate-limit',
+                per_page: 10,
+              });
+              const hasDiag = existingDiag.some(i => i.title.includes('stalled'));
+              if (!hasDiag) {
+                const issueList = escalationNeeded.map(i =>
+                  `- #${i.number}: ${i.title} (stalled ${i.stalledMinutes}m)`
+                ).join('\n');
+                await github.rest.issues.create({
+                  owner, repo,
+                  title: '[Auto-QA] Copilot assignments stalled — review config',
+                  body: [
+                    '## Stalled Copilot Assignments',
+                    '',
+                    `${escalationNeeded.length} issue(s) assigned to Copilot for 60+ minutes with no PR:`,
+                    '',
+                    issueList,
+                    '',
+                    '## Recommendation',
+                    'Copilot may be hitting rate limits or the assignment was silently dropped.',
+                    'Consider:',
+                    '- Increasing `COPILOT_ASSIGNMENT_DELAY_S` in auto-qa.yml',
+                    '- Decreasing `MAX_ISSUES_PER_RUN`',
+                    '- Manually re-assigning stalled issues',
+                    '',
+                    '---',
+                    '*Auto-created by the Copilot stall monitor.*',
+                  ].join('\n'),
+                  labels: ['auto-qa', 'auto-qa:rate-limit', 'triage/needed'],
+                });
+                core.warning(`Created escalation issue: ${escalationNeeded.length} stalled assignment(s)`);
+              }
+            }
+
+            core.info(`Stall check: ${stalledIssues.length} stalled, ${escalationNeeded.length} escalated`);

--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -4400,6 +4400,7 @@ jobs:
             };
 
             let created = 0;
+            const rejections = [];
 
             for (const check of checks) {
               if (created >= maxIssues) {
@@ -4451,6 +4452,7 @@ jobs:
                   ? ' — token may lack repo scope or Copilot agent is not enabled'
                   : '';
                 core.warning(`Could not assign Copilot to #${issue.number}: ${e.message}${hint}`);
+                rejections.push({ issueNumber: issue.number, status: e.status || 'unknown', message: e.message });
               }
               created++;
 
@@ -4464,6 +4466,58 @@ jobs:
               }
 
               // Auto-triage is handled by including triage/accepted in the issue labels at creation
+            }
+
+            // If any Copilot assignments were rejected, create a diagnostic issue
+            // recommending rate limit config changes (deduplicated).
+            if (rejections.length > 0) {
+              const diagTitle = '[Auto-QA] Copilot assignment rejected — review rate limit config';
+              try {
+                const existingDiag = await github.rest.issues.listForRepo({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  labels: 'auto-qa,auto-qa:rate-limit',
+                  per_page: 10,
+                });
+                const hasDiag = existingDiag.data.some(i => i.title.includes('Copilot assignment rejected'));
+                if (!hasDiag) {
+                  const currentDelay = process.env.COPILOT_ASSIGNMENT_DELAY_S || '120';
+                  const rejectionList = rejections.map(r =>
+                    `- Issue #${r.issueNumber}: HTTP ${r.status} — ${r.message}`
+                  ).join('\n');
+                  await github.rest.issues.create({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    title: diagTitle,
+                    body: [
+                      '## Copilot Assignment Failures',
+                      '',
+                      `${rejections.length} assignment(s) were rejected during the auto-qa run:`,
+                      '',
+                      rejectionList,
+                      '',
+                      '## Current Config',
+                      `- \`COPILOT_ASSIGNMENT_DELAY_S\`: ${currentDelay}s`,
+                      `- \`MAX_ISSUES_PER_RUN\`: ${maxIssues}`,
+                      '',
+                      '## Recommendation',
+                      `Increase \`COPILOT_ASSIGNMENT_DELAY_S\` (currently ${currentDelay}s) or decrease \`MAX_ISSUES_PER_RUN\` to reduce Copilot rate limit pressure.`,
+                      '',
+                      'If the error is 401/403, check that the `CONSOLE_AUTO` PAT is valid and Copilot agent is enabled.',
+                      '',
+                      '---',
+                      '*Auto-created by the auto-qa workflow when Copilot assignments fail.*',
+                    ].join('\n'),
+                    labels: ['auto-qa', 'auto-qa:rate-limit', 'triage/needed'],
+                  });
+                  core.warning(`Created diagnostic issue: ${rejections.length} Copilot assignment(s) rejected`);
+                } else {
+                  core.info('Diagnostic issue for Copilot rejections already exists — skipping');
+                }
+              } catch (diagErr) {
+                core.warning(`Failed to create diagnostic issue: ${diagErr.message}`);
+              }
             }
 
             core.info(`Auto-QA complete (focus: ${focusArea}): ${created} issue(s) created, ${checks.length} finding(s) total.`);


### PR DESCRIPTION
## Summary
Two complementary mechanisms to detect and surface Copilot assignment problems:

### Part 1: Immediate Rejection Detection (auto-qa.yml)
- Tracks assignment API failures (401/403/429) during issue creation
- After the loop, creates a diagnostic issue titled `[Auto-QA] Copilot assignment rejected — review rate limit config`
- Includes: failed issue numbers, HTTP status codes, current config values, and recommendations
- Deduplicated via `auto-qa:rate-limit` label

### Part 2: Stall Detection (auto-qa-tuner.yml)
- New `copilot-stall-check` job runs **every 30 minutes**
- Finds issues assigned to Copilot with AI labels (`ai-awaiting-fix`, `ai-processing`, `ai-fix-requested`)
- If assigned 20+ minutes with no Copilot PR → adds `ai-stalled` label + comments on issue
- If stalled 60+ minutes → creates diagnostic issue recommending config changes
- Avoids duplicate comments and issues

## Test plan
- [x] YAML syntax valid
- [ ] Trigger auto-qa with `workflow_dispatch` → verify rejection tracking works
- [ ] Trigger tuner with `job_override=stall` → verify stall check runs
- [ ] Verify deduplication: multiple runs don't create duplicate diagnostic issues