### PR TITLE
🐛 fix: resolve 3 GA4 runtime errors

### DIFF
--- a/web/src/components/cards/DeploymentProgress.tsx
+++ b/web/src/components/cards/DeploymentProgress.tsx
@@ -168,7 +168,8 @@ export function DeploymentProgress({ config }: DeploymentProgressProps) {
     drillToDeployment(clusterName, deployment.namespace, deployment.name, {
       status: deployment.status,
       version: extractVersion(deployment.image),
-      replicas: { ready: deployment.readyReplicas, desired: deployment.replicas },
+      replicas: deployment.replicas,
+      readyReplicas: deployment.readyReplicas,
       progress: deployment.progress,
     })
   }

--- a/web/src/components/cards/DeploymentStatus.tsx
+++ b/web/src/components/cards/DeploymentStatus.tsx
@@ -183,7 +183,8 @@ export function DeploymentStatus() {
     drillToDeployment(clusterName, deployment.namespace, deployment.name, {
       status: deployment.status,
       version: extractVersion(deployment.image),
-      replicas: { ready: deployment.readyReplicas, desired: deployment.replicas },
+      replicas: deployment.replicas,
+      readyReplicas: deployment.readyReplicas,
       progress: deployment.progress,
     })
   }

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1049,6 +1049,8 @@ export function startGlobalErrorTracking() {
     try {
       // Skip errors already reported by React error boundaries (prevents double-counting)
       if (wasAlreadyReported(event.message)) return
+      // Skip clipboard API errors — expected on non-HTTPS and in restricted contexts
+      if (event.message.includes('writeText') || event.message.includes('clipboard') || event.message.includes('copy')) return
       // Stale chunks can surface as runtime errors (Safari: "Importing a module script failed")
       if (tryChunkReloadRecovery(event.message)) return
       emitError('runtime', event.message)

--- a/web/src/lib/clipboard.ts
+++ b/web/src/lib/clipboard.ts
@@ -8,25 +8,27 @@
  * Returns true if the copy succeeded, false otherwise.
  */
 export async function copyToClipboard(text: string): Promise<boolean> {
-  // Clipboard API is only available in secure contexts (HTTPS or localhost)
-  if (navigator.clipboard?.writeText) {
-    try {
+  // Clipboard API is only available in secure contexts (HTTPS or localhost).
+  // Guard with typeof to handle browsers where writeText exists but is not callable.
+  try {
+    if (typeof navigator?.clipboard?.writeText === 'function') {
       await navigator.clipboard.writeText(text)
       return true
-    } catch {
-      // Clipboard API can throw even when available (e.g., iframe restrictions)
-      // Fall through to execCommand fallback
     }
+  } catch {
+    // Clipboard API can throw even when available (e.g., iframe restrictions,
+    // Firefox focus requirements). Fall through to execCommand fallback.
   }
 
-  // Fallback: textarea + execCommand for non-secure contexts
+  // Fallback: textarea + execCommand for non-secure contexts / Firefox
   try {
     const textarea = document.createElement('textarea')
     textarea.value = text
-    // Position off-screen to avoid visual flash
+    // Position off-screen and invisible to avoid visual flash
     textarea.style.position = 'fixed'
     textarea.style.left = '-9999px'
     textarea.style.top = '-9999px'
+    textarea.style.opacity = '0'
     document.body.appendChild(textarea)
     textarea.select()
     const ok = document.execCommand('copy')

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -112,7 +112,7 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
   // Check result cache — if fresh, replay cached data via callbacks and resolve
   const cached = resultCache.get(cacheKey)
   if (cached && Date.now() - cached.at < RESULT_CACHE_TTL_MS) {
-    const items = cached.data as T[]
+    const items = (cached.data as T[]) || []
     // Replay per-cluster grouping for onClusterData callbacks
     const byCluster = new Map<string, T[]>()
     for (const item of items) {


### PR DESCRIPTION
## Summary

Fixes 3 runtime errors appearing in GA4 error tracking (22 total hits across pages):

- **Bug 1 - "Objects are not valid as React child {ready, desired}" on /deploy (5 hits):** `DeploymentStatus` and `DeploymentProgress` passed `replicas` as an object `{ready, desired}` to drill-down context. Now passes `replicas` and `readyReplicas` as separate numeric fields, consistent with all other cards.

- **Bug 2 - "items is not iterable" on / (8 hits):** `sseClient.ts` iterated `cached.data` in a `for...of` loop without a null guard. When `cached.data` was `undefined`, this threw a TypeError. Now defaults to `[]`.

- **Bug 3 - "navigator.clipboard.writeText is undefined" on /nodes and / (9 hits):** Hardened `clipboard.ts` with a `typeof` guard to handle browsers where `navigator.clipboard` exists but `writeText` is not callable. Also added clipboard error filtering to the `window.error` handler in `analytics.ts` (was only filtered in `unhandledrejection`).

## Files changed

| File | Change |
|------|--------|
| `web/src/components/cards/DeploymentStatus.tsx` | Pass replicas/readyReplicas as numbers, not object |
| `web/src/components/cards/DeploymentProgress.tsx` | Same fix |
| `web/src/lib/sseClient.ts` | Guard `for...of` with `|| []` fallback |
| `web/src/lib/clipboard.ts` | `typeof` guard + opacity on fallback textarea |
| `web/src/lib/analytics.ts` | Filter clipboard errors in `window.error` handler |

## Test plan

- [ ] Verify TypeScript build passes (`npx tsc -b`)
- [ ] Click a deployment on /deploy to open drill-down -- confirm replicas display correctly
- [ ] Load home page with empty SSE cache -- confirm no "items is not iterable" error
- [ ] Test copy-to-clipboard in HTTP context -- confirm fallback works
- [ ] Check GA4 error dashboard after deploy -- these 3 error types should stop appearing