### PR TITLE
🐛 fix: permanent vllm-d deploy RBAC + performance guard comments

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -126,8 +126,23 @@ jobs:
           kubectl config set-context deploy --cluster=in-cluster --user=sa-user
           kubectl config use-context deploy
           echo "KUBECONFIG=$KUBECONFIG" >> "$GITHUB_ENV"
-          echo "Verifying cluster access..."
-          kubectl get secrets -n kc --no-headers | head -3
+
+      - name: Verify RBAC permissions
+        run: |
+          echo "Checking deploy runner SA permissions..."
+          if ! kubectl auth can-i create namespaces 2>/dev/null; then
+            echo "::error::Runner SA lacks RBAC permissions to create namespaces."
+            echo "::error::Apply RBAC: kubectl apply -f deploy/arc/deploy-runner-rbac.yaml"
+            echo "::error::Then update RunnerDeployment: kubectl apply -f deploy/arc/kubestellar-console-runner.yaml"
+            exit 1
+          fi
+          if ! kubectl auth can-i create secrets -n kc 2>/dev/null; then
+            echo "::error::Runner SA lacks RBAC permissions to create secrets in kc namespace."
+            echo "::error::Apply RBAC: kubectl apply -f deploy/arc/deploy-runner-rbac.yaml"
+            exit 1
+          fi
+          echo "RBAC permissions verified."
+          kubectl get secrets -n kc --no-headers 2>/dev/null | head -3 || echo "Namespace kc does not exist yet (will be created)"
 
       - name: Create namespace if not exists
         run: |
@@ -167,6 +182,7 @@ jobs:
             --set route.host=kc.apps.fmaas-vllm-d.fmaas.res.ibm.com \
             --set clusterName=vllm-d \
             --set-string enabledDashboards="dashboard\,clusters\,gpu-reservations\,llm-d-benchmarks\,ai-ml\,arcade" \
+            --set persistence.storageClass=ocs-storagecluster-cephfs \
             --atomic \
             --wait \
             --timeout 5m

--- a/deploy/arc/deploy-runner-rbac.yaml
+++ b/deploy/arc/deploy-runner-rbac.yaml
@@ -1,0 +1,71 @@
+---
+# ServiceAccount for KubeStellar Console deploy runners.
+# This SA is used by ARC runner pods to deploy the console via Helm.
+# Must be applied to the cluster BEFORE the RunnerDeployment.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kc-deploy-runner
+  namespace: arc-systems
+  labels:
+    app.kubernetes.io/part-of: kubestellar-console
+    app.kubernetes.io/component: deploy-runner
+
+---
+# ClusterRole granting permissions needed to deploy the console via Helm.
+# Covers: namespace management, secrets, Helm releases, deployments,
+# services, routes, PVCs, RBAC for the deployed app.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kc-deploy-runner
+  labels:
+    app.kubernetes.io/part-of: kubestellar-console
+    app.kubernetes.io/component: deploy-runner
+rules:
+  # Namespace management
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "create", "update", "patch"]
+  # Core resources for Helm deployment
+  - apiGroups: [""]
+    resources: ["secrets", "configmaps", "services", "serviceaccounts", "persistentvolumeclaims"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  # Workload resources
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "replicasets"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  # OpenShift routes
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  # RBAC for the deployed app's SA
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
+  # Helm release tracking (stored as secrets in the release namespace)
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  # Rollout status
+  - apiGroups: ["apps"]
+    resources: ["deployments/status"]
+    verbs: ["get"]
+
+---
+# Bind the ClusterRole to the deploy runner SA
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kc-deploy-runner
+  labels:
+    app.kubernetes.io/part-of: kubestellar-console
+    app.kubernetes.io/component: deploy-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kc-deploy-runner
+subjects:
+  - kind: ServiceAccount
+    name: kc-deploy-runner
+    namespace: arc-systems

--- a/deploy/arc/kubestellar-console-runner.yaml
+++ b/deploy/arc/kubestellar-console-runner.yaml
@@ -23,6 +23,7 @@ spec:
   replicas: 2
   template:
     spec:
+      serviceAccountName: kc-deploy-runner
       repository: kubestellar/console
       githubAPICredentialsFrom:
         secretRef:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -423,6 +423,14 @@ function DataPrefetchInit() {
   return null
 }
 
+// ⚠️ PERFORMANCE CRITICAL — DO NOT MOVE MISSION ROUTES INTO FullDashboardApp ⚠️
+//
+// Mission landing pages (/missions/:missionId) MUST stay in LightweightShell,
+// NOT inside the FullDashboardApp provider stack. The full stack loads 12
+// providers + 156 JS chunks (1.8MB) which caused 10-20s cold-cache load times.
+// LightweightShell loads only ~200KB. If you move mission routes back into
+// FullDashboardApp, the CNCF outreach links will be unusably slow.
+//
 /** Lightweight shell for standalone pages that don't need the full dashboard provider stack */
 function LightweightShell({ children }: { children: React.ReactNode }) {
   return (

--- a/web/src/components/missions/MissionLandingPage.tsx
+++ b/web/src/components/missions/MissionLandingPage.tsx
@@ -87,6 +87,21 @@ const TABS: TabDef[] = [
 // Helpers
 // ============================================================================
 
+// ⚠️ PERFORMANCE CRITICAL — DO NOT CHANGE WITHOUT TESTING WITH CHROME CDP ⚠️
+//
+// This section uses smart prefix routing to resolve mission slugs to file
+// paths with 1-2 requests instead of the previous 13-directory brute-force.
+// The old approach fired 13 parallel requests (12 returning 404) and took
+// 10-20 seconds on cold cache. The current approach resolves in <2s.
+//
+// The MissionLandingPage route is also intentionally OUTSIDE the heavy
+// dashboard provider stack (see App.tsx LightweightShell) to avoid loading
+// 1.8MB of dashboard JS. Changing the route structure in App.tsx will
+// regress this. Always verify with:
+//   1. Clear browser cache via CDP: Network.clearBrowserCache
+//   2. Navigate to /missions/install-karmada
+//   3. Check: jsChunks < 20, totalJsKB < 300, apiCalls <= 3, pageLoadMs < 3000
+
 /**
  * Get the most likely file paths for a mission slug based on its prefix.
  * install-* → cncf-install/ or platform-install/


### PR DESCRIPTION
## Summary
### vllm-d Deploy (fixes the recurring SA RBAC failure)
- Create dedicated `kc-deploy-runner` ServiceAccount with deploy permissions (`deploy/arc/deploy-runner-rbac.yaml`)
- Set `serviceAccountName: kc-deploy-runner` in ARC RunnerDeployment (was using `default` SA which has no permissions)
- Add RBAC verification pre-check step that fails fast with actionable error message
- Add `persistence.storageClass=ocs-storagecluster-cephfs` to fix PVC mismatch

### Cluster-side action required
After merging, apply the RBAC manifests to the vllm-d cluster:
```bash
kubectl apply -f deploy/arc/deploy-runner-rbac.yaml
kubectl apply -f deploy/arc/kubestellar-console-runner.yaml
```

### Performance guard comments
- Added `PERFORMANCE CRITICAL` warnings in `MissionLandingPage.tsx` and `App.tsx`
- Documents that mission routes MUST stay in LightweightShell (not FullDashboardApp)
- Includes CDP verification steps in code comments