### PR TITLE
📖 docs: add Claude Code recommendation and marketplace redirect to contributing docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 > **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.
 
+> **New CNCF project card?** New cards go in [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo. PRs adding new cards here will be redirected.
+
+> **Use a coding agent.** This repo is primarily developed with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Opus 4.5/4.6). It knows all codebase patterns (isDemoData, useCardLoadingState, locale strings, DCO). Manual PRs that miss required patterns will be sent back.
+
 ### 📌 Fixes
 
 Fixes #<issue-number> (Use "Fixes", "Closes", or "Resolves" for automatic closing)
@@ -28,11 +32,13 @@ Fixes #<issue-number> (Use "Fixes", "Closes", or "Resolves" for automatic closin
 
 Please ensure the following before submitting your PR:
 
-- [ ] I have reviewed the project's contribution guidelines.
-- [ ] I have written unit tests for the changes (if applicable).
-- [ ] I have updated the documentation (if applicable).
-- [ ] I have tested the changes locally and ensured they work as expected.
-- [ ] My code follows the project's coding standards.
+- [ ] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
+- [ ] I have reviewed the project's contribution guidelines
+- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
+- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
+- [ ] I have written unit tests for the changes (if applicable)
+- [ ] I have tested the changes locally and ensured they work as expected
+- [ ] All commits are signed with DCO (`git commit -s`)
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,12 +10,20 @@ The fastest way to file an issue or feature request is by navigating to [`/issue
 
 Most code in this repo is written by coding agents — Claude Opus 4.5/4.6, Gemini, and Codex. PRs are generated, reviewed, and iterated on by these agents with human oversight.
 
-**Manual coding PRs are discouraged.** They take significantly longer to complete and review compared to agent-generated code. If you want to contribute code, use one of the supported agents:
+**Manual coding PRs are discouraged.** They take significantly longer to complete and review compared to agent-generated code. PRs that miss required patterns (isDemoData wiring, useCardLoadingState, locale strings, marketplace vs console) will be sent back — these are things coding agents catch automatically.
 
-- **Claude Code** (Claude Opus 4.5 or 4.6) — primary development tool
+If you want to contribute code, use one of the supported agents:
+
+- **Claude Code** (Claude Opus 4.5 or 4.6) — **strongly recommended**. Knows the full codebase, all CLAUDE.md rules, isDemoData wiring, card loading state patterns, and locale requirements. Install: `npm install -g @anthropic-ai/claude-code`
 - **GitHub Copilot** — used for automated PR fixes
 - **Google Gemini** — supported for code generation
 - **OpenAI Codex** — supported for code generation
+
+## New CNCF Project Cards
+
+New monitoring cards for CNCF projects (Karmada, Falco, KEDA, etc.) belong in [**kubestellar/console-marketplace**](https://github.com/kubestellar/console-marketplace), **not** in this repo. The marketplace loads cards on-demand so they don't bloat the core bundle for users who don't need them.
+
+PRs that add new card components to `web/src/components/cards/` will be redirected to console-marketplace.
 
 ## Test PRs Are Favored
 


### PR DESCRIPTION
## Summary

Two external PRs (#2882, #2834) both missed required patterns that Claude Code catches automatically. This updates the contributing docs to prevent repeat occurrences.

**CONTRIBUTING.md:**
- Clarify that manual PRs missing required patterns will be sent back
- Strongly recommend Claude Code with install command
- New section: CNCF project cards go to console-marketplace, not this repo

**PR template:**
- Banner: new cards go to console-marketplace
- Banner: use a coding agent (Claude Code recommended)
- New checklist items: coding agent used, isDemoData wired, marketplace targeting, DCO signed

## Test plan
- [ ] Open "New PR" on console repo — template should show the new banners and checklist