### PR TITLE
✨ Add vCluster support for creating and managing virtual clusters

### DIFF
--- a/pkg/agent/local_clusters.go
+++ b/pkg/agent/local_clusters.go
@@ -2,10 +2,13 @@ package agent
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // Progress percentage constants for cluster creation/deletion phases
@@ -13,8 +16,17 @@ const (
 	progressValidating = 10  // Pre-flight checks (Docker daemon, tool availability)
 	progressCreating   = 30  // Cluster creation command dispatched
 	progressDeleting   = 30  // Cluster deletion command dispatched
+	progressConnecting = 50  // Connection/disconnect operation in progress
 	progressDone       = 100 // Operation completed successfully
 	progressFailed     = 0   // Operation failed
+)
+
+// vCluster CLI operation timeouts
+const (
+	vclusterListTimeout    = 15 * time.Second  // Timeout for listing vClusters
+	vclusterCreateTimeout  = 120 * time.Second // Timeout for creating a vCluster
+	vclusterConnectTimeout = 30 * time.Second  // Timeout for connecting/disconnecting a vCluster
+	vclusterDeleteTimeout  = 60 * time.Second  // Timeout for deleting a vCluster
 )
 
 var (
@@ -35,6 +47,24 @@ type LocalCluster struct {
 	Name   string `json:"name"`
 	Tool   string `json:"tool"`
 	Status string `json:"status"` // "running", "stopped", "unknown"
+}
+
+// VClusterInstance represents a vCluster instance
+type VClusterInstance struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Status    string `json:"status"`    // "Running", "Paused", etc.
+	Connected bool   `json:"connected"` // whether kubeconfig context exists
+	Context   string `json:"context"`   // kubeconfig context name if connected
+}
+
+// vclusterListEntry mirrors the JSON output from `vcluster list --output json`
+type vclusterListEntry struct {
+	Name      string `json:"Name"`
+	Namespace string `json:"Namespace"`
+	Status    string `json:"Status"`
+	Connected bool   `json:"Connected"`
+	Context   string `json:"Context"`
 }
 
 // LocalClusterManager handles local cluster operations
@@ -88,6 +118,11 @@ func (m *LocalClusterManager) DetectTools() []LocalClusterTool {
 
 	// Check minikube
 	if tool := m.detectMinikube(); tool != nil {
+		tools = append(tools, *tool)
+	}
+
+	// Check vcluster
+	if tool := m.detectVCluster(); tool != nil {
 		tools = append(tools, *tool)
 	}
 
@@ -377,4 +412,166 @@ func (m *LocalClusterManager) deleteMinikubeCluster(name string) error {
 		return fmt.Errorf("minikube delete failed: %s", stderr.String())
 	}
 	return nil
+}
+
+// detectVCluster checks if the vcluster CLI is installed and returns tool info
+func (m *LocalClusterManager) detectVCluster() *LocalClusterTool {
+	path, err := lookPath("vcluster")
+	if err != nil {
+		return nil
+	}
+
+	tool := &LocalClusterTool{
+		Name:      "vcluster",
+		Installed: true,
+		Path:      path,
+	}
+
+	// Get version
+	cmd := execCommand("vcluster", "version")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err == nil {
+		// Parse version output — typically "vcluster version 0.19.0" or just "0.19.0"
+		version := strings.TrimSpace(out.String())
+		re := regexp.MustCompile(`v?([\d.]+)`)
+		if matches := re.FindStringSubmatch(version); len(matches) > 1 {
+			tool.Version = matches[1]
+		}
+	}
+
+	return tool
+}
+
+// ListVClusters runs `vcluster list --output json` and returns parsed results
+func (m *LocalClusterManager) ListVClusters() ([]VClusterInstance, error) {
+	cmd := execCommand("vcluster", "list", "--output", "json")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := runWithTimeout(cmd, vclusterListTimeout); err != nil {
+		return nil, fmt.Errorf("vcluster list failed: %s", strings.TrimSpace(stderr.String()))
+	}
+
+	var entries []vclusterListEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		return nil, fmt.Errorf("failed to parse vcluster list output: %w", err)
+	}
+
+	instances := make([]VClusterInstance, 0, len(entries))
+	for _, e := range entries {
+		instances = append(instances, VClusterInstance{
+			Name:      e.Name,
+			Namespace: e.Namespace,
+			Status:    e.Status,
+			Connected: e.Connected,
+			Context:   e.Context,
+		})
+	}
+
+	return instances, nil
+}
+
+// CreateVCluster creates a new vCluster with progress broadcasting
+func (m *LocalClusterManager) CreateVCluster(name, namespace string) error {
+	// Phase 1: Validating
+	m.broadcastProgress("vcluster", name, "validating", "Checking vcluster CLI...", progressValidating)
+
+	if _, err := lookPath("vcluster"); err != nil {
+		return fmt.Errorf("vcluster CLI is not installed")
+	}
+
+	// Phase 2: Creating
+	m.broadcastProgress("vcluster", name, "creating",
+		fmt.Sprintf("Creating vCluster '%s' in namespace '%s'...", name, namespace), progressCreating)
+
+	cmd := execCommand("vcluster", "create", name, "-n", namespace)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := runWithTimeout(cmd, vclusterCreateTimeout); err != nil {
+		return fmt.Errorf("vcluster create failed: %s", strings.TrimSpace(stderr.String()))
+	}
+
+	return nil
+}
+
+// ConnectVCluster connects to an existing vCluster by updating kubeconfig
+func (m *LocalClusterManager) ConnectVCluster(name, namespace string) error {
+	m.broadcastProgress("vcluster", name, "connecting",
+		fmt.Sprintf("Connecting to vCluster '%s' in namespace '%s'...", name, namespace), progressConnecting)
+
+	cmd := execCommand("vcluster", "connect", name, "-n", namespace, "--update-current=false")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := runWithTimeout(cmd, vclusterConnectTimeout); err != nil {
+		return fmt.Errorf("vcluster connect failed: %s", strings.TrimSpace(stderr.String()))
+	}
+
+	return nil
+}
+
+// DisconnectVCluster disconnects from a vCluster
+func (m *LocalClusterManager) DisconnectVCluster(name, namespace string) error {
+	m.broadcastProgress("vcluster", name, "disconnecting",
+		fmt.Sprintf("Disconnecting from vCluster '%s'...", name), progressConnecting)
+
+	cmd := execCommand("vcluster", "disconnect")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := runWithTimeout(cmd, vclusterConnectTimeout); err != nil {
+		return fmt.Errorf("vcluster disconnect failed: %s", strings.TrimSpace(stderr.String()))
+	}
+
+	return nil
+}
+
+// DeleteVCluster deletes a vCluster with progress broadcasting
+func (m *LocalClusterManager) DeleteVCluster(name, namespace string) error {
+	// Phase 1: Validating
+	m.broadcastProgress("vcluster", name, "validating",
+		fmt.Sprintf("Preparing to delete vCluster '%s'...", name), progressValidating)
+
+	// Phase 2: Deleting
+	m.broadcastProgress("vcluster", name, "deleting",
+		fmt.Sprintf("Deleting vCluster '%s' from namespace '%s'...", name, namespace), progressDeleting)
+
+	cmd := execCommand("vcluster", "delete", name, "-n", namespace)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := runWithTimeout(cmd, vclusterDeleteTimeout); err != nil {
+		return fmt.Errorf("vcluster delete failed: %s", strings.TrimSpace(stderr.String()))
+	}
+
+	return nil
+}
+
+// runWithTimeout runs a pre-built *exec.Cmd with a timeout context.
+// It kills the process if the timeout expires before the command finishes.
+func runWithTimeout(cmd *exec.Cmd, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		if cmd.Process != nil {
+			cmd.Process.Kill()
+		}
+		return fmt.Errorf("command timed out after %s", timeout)
+	}
 }

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -349,6 +349,13 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/local-cluster-tools", s.handleLocalClusterTools)
 	mux.HandleFunc("/local-clusters", s.handleLocalClusters)
 
+	// vCluster management endpoints
+	mux.HandleFunc("/vcluster/list", s.handleVClusterList)
+	mux.HandleFunc("/vcluster/create", s.handleVClusterCreate)
+	mux.HandleFunc("/vcluster/connect", s.handleVClusterConnect)
+	mux.HandleFunc("/vcluster/disconnect", s.handleVClusterDisconnect)
+	mux.HandleFunc("/vcluster/delete", s.handleVClusterDelete)
+
 	// Chat cancel endpoint — HTTP fallback when WebSocket is disconnected
 	mux.HandleFunc("/cancel-chat", s.handleCancelChatHTTP)
 
@@ -4239,6 +4246,267 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+// handleVClusterList returns all vCluster instances
+func (s *Server) handleVClusterList(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	instances, err := s.localClusters.ListVClusters()
+	if err != nil {
+		log.Printf("[vCluster] Failed to list vclusters: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"vclusters": instances,
+	})
+}
+
+// handleVClusterCreate creates a new vCluster
+func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" || req.Namespace == "" {
+		http.Error(w, "name and namespace are required", http.StatusBadRequest)
+		return
+	}
+
+	// Create vCluster in background and return immediately
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("[vCluster] recovered from panic creating vcluster %s: %v", req.Name, r)
+			}
+		}()
+		if err := s.localClusters.CreateVCluster(req.Name, req.Namespace); err != nil {
+			log.Printf("[vCluster] Failed to create vcluster %s: %v", req.Name, err)
+			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
+				"tool":     "vcluster",
+				"name":     req.Name,
+				"status":   "failed",
+				"message":  "operation failed",
+				"progress": progressFailed,
+			})
+		} else {
+			log.Printf("[vCluster] Created vcluster %s in namespace %s", req.Name, req.Namespace)
+			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
+				"tool":     "vcluster",
+				"name":     req.Name,
+				"status":   "done",
+				"message":  fmt.Sprintf("vCluster '%s' created successfully", req.Name),
+				"progress": progressDone,
+			})
+		}
+	}()
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":    "creating",
+		"name":      req.Name,
+		"namespace": req.Namespace,
+		"message":   "vCluster creation started. You will be notified when it completes.",
+	})
+}
+
+// handleVClusterConnect connects to an existing vCluster
+func (s *Server) handleVClusterConnect(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" || req.Namespace == "" {
+		http.Error(w, "name and namespace are required", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.localClusters.ConnectVCluster(req.Name, req.Namespace); err != nil {
+		log.Printf("[vCluster] Failed to connect to vcluster %s: %v", req.Name, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("[vCluster] Connected to vcluster %s in namespace %s", req.Name, req.Namespace)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":    "connected",
+		"name":      req.Name,
+		"namespace": req.Namespace,
+		"message":   fmt.Sprintf("Connected to vCluster '%s'", req.Name),
+	})
+}
+
+// handleVClusterDisconnect disconnects from a vCluster
+func (s *Server) handleVClusterDisconnect(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" || req.Namespace == "" {
+		http.Error(w, "name and namespace are required", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.localClusters.DisconnectVCluster(req.Name, req.Namespace); err != nil {
+		log.Printf("[vCluster] Failed to disconnect from vcluster %s: %v", req.Name, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("[vCluster] Disconnected from vcluster %s", req.Name)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":    "disconnected",
+		"name":      req.Name,
+		"namespace": req.Namespace,
+		"message":   fmt.Sprintf("Disconnected from vCluster '%s'", req.Name),
+	})
+}
+
+// handleVClusterDelete deletes a vCluster
+func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" || req.Namespace == "" {
+		http.Error(w, "name and namespace are required", http.StatusBadRequest)
+		return
+	}
+
+	// Delete vCluster in background and return immediately
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("[vCluster] recovered from panic deleting vcluster %s: %v", req.Name, r)
+			}
+		}()
+		if err := s.localClusters.DeleteVCluster(req.Name, req.Namespace); err != nil {
+			log.Printf("[vCluster] Failed to delete vcluster %s: %v", req.Name, err)
+			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
+				"tool":     "vcluster",
+				"name":     req.Name,
+				"status":   "failed",
+				"message":  "operation failed",
+				"progress": progressFailed,
+			})
+		} else {
+			log.Printf("[vCluster] Deleted vcluster %s from namespace %s", req.Name, req.Namespace)
+			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
+				"tool":     "vcluster",
+				"name":     req.Name,
+				"status":   "done",
+				"message":  fmt.Sprintf("vCluster '%s' deleted successfully", req.Name),
+				"progress": progressDone,
+			})
+		}
+	}()
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":    "deleting",
+		"name":      req.Name,
+		"namespace": req.Namespace,
+		"message":   "vCluster deletion started. You will be notified when it completes.",
+	})
 }
 
 // handleInsightsEnrich accepts heuristic insight summaries and returns AI enrichments

--- a/web/src/components/cards/ClusterLocations.tsx
+++ b/web/src/components/cards/ClusterLocations.tsx
@@ -198,7 +198,7 @@ function extractRegion(cluster: ClusterInfo): string | null {
   }
 
   // Local clusters
-  if (name.includes('kind') || name.includes('minikube') || name.includes('k3d') || name.includes('docker-desktop') || name.includes('rancher-desktop') || name.includes('colima')) {
+  if (name.includes('kind') || name.includes('minikube') || name.includes('k3d') || name.includes('docker-desktop') || name.includes('rancher-desktop') || name.includes('colima') || name.includes('vcluster')) {
     return 'local'
   }
 

--- a/web/src/components/settings/sections/LocalClustersSection.tsx
+++ b/web/src/components/settings/sections/LocalClustersSection.tsx
@@ -1,11 +1,16 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Container, RefreshCw, Plus, Trash2, Check, AlertCircle, AlertTriangle, Loader2, X } from 'lucide-react'
+import { Container, RefreshCw, Plus, Trash2, Check, AlertCircle, AlertTriangle, Loader2, X, Plug, Unplug, Bot } from 'lucide-react'
 import { Button } from '../../ui/Button'
 import { useLocalClusterTools } from '../../../hooks/useLocalClusterTools'
 import { CLUSTER_PROGRESS_AUTO_DISMISS_MS } from '../../../hooks/useClusterProgress'
 import { emitLocalClusterCreated } from '../../../lib/analytics'
+import { useMissions } from '../../../hooks/useMissions'
+import { useApiKeyCheck, ApiKeyPromptModal } from '../../cards/console-missions/shared'
 import type { ClusterProgress } from '../../../hooks/useClusterProgress'
+
+/** Default namespace for new vCluster instances */
+const VCLUSTER_DEFAULT_NAMESPACE = 'vcluster'
 
 // ------------------------------------------------------------------
 // ClusterProgressBanner — inline progress feedback for create/delete
@@ -101,10 +106,27 @@ export function LocalClustersSection() {
     createCluster,
     deleteCluster,
     refresh,
+    // vCluster state and actions
+    vclusterInstances,
+    isConnecting,
+    isDisconnecting,
+    createVCluster,
+    connectVCluster,
+    disconnectVCluster,
+    deleteVCluster,
   } = useLocalClusterTools()
+
+  const { startMission } = useMissions()
+  const { showKeyPrompt, checkKeyAndRun, goToSettings, dismissPrompt } = useApiKeyCheck()
 
   const [selectedTool, setSelectedTool] = useState<string>('')
   const [clusterName, setClusterName] = useState('')
+
+  // vCluster form state
+  const [vclusterName, setVclusterName] = useState('')
+  const [vclusterNamespace, setVclusterNamespace] = useState(VCLUSTER_DEFAULT_NAMESPACE)
+
+  const hasVClusterTool = installedTools.some(t => t.name === 'vcluster')
 
   const handleCreate = async () => {
     if (!selectedTool || !clusterName.trim()) return
@@ -123,6 +145,34 @@ export function LocalClustersSection() {
     await deleteCluster(tool, name)
   }
 
+  const handleCreateVCluster = async () => {
+    if (!vclusterName.trim()) return
+
+    const result = await createVCluster(vclusterName.trim(), vclusterNamespace.trim() || VCLUSTER_DEFAULT_NAMESPACE)
+    emitLocalClusterCreated('vcluster')
+
+    if (result.status === 'creating') {
+      setVclusterName('')
+      setVclusterNamespace(VCLUSTER_DEFAULT_NAMESPACE)
+    }
+  }
+
+  const handleDeleteVCluster = async (name: string, namespace: string) => {
+    if (!confirm(t('settings.localClusters.vclusterDeleteConfirm', { name, namespace }))) return
+    await deleteVCluster(name, namespace)
+  }
+
+  const handleInstallVCluster = () => {
+    checkKeyAndRun(() => {
+      startMission({
+        title: 'Install vCluster CLI',
+        description: 'Install the vCluster CLI for creating virtual Kubernetes clusters',
+        type: 'deploy',
+        initialPrompt: 'Install the vCluster CLI tool. Try using homebrew first (brew install loft-sh/tap/vcluster), and if that is not available, use the official install script: curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-$(uname -s)-$(uname -m)" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster. Verify the installation by running vcluster --version.',
+      })
+    })
+  }
+
   // Get icon for tool
   const getToolIcon = (tool: string) => {
     switch (tool) {
@@ -132,6 +182,8 @@ export function LocalClustersSection() {
         return '🚀'
       case 'minikube':
         return '📦'
+      case 'vcluster':
+        return '🔮'
       default:
         return '☸️'
     }
@@ -146,6 +198,8 @@ export function LocalClustersSection() {
         return 'k3s in Docker - lightweight Kubernetes'
       case 'minikube':
         return 'Local Kubernetes with multiple drivers'
+      case 'vcluster':
+        return 'Virtual clusters inside existing Kubernetes clusters'
       default:
         return 'Local Kubernetes cluster'
     }
@@ -360,6 +414,202 @@ export function LocalClustersSection() {
             )}
           </div>
 
+          {/* ------------------------------------------------------------------ */}
+          {/* vCluster Section                                                    */}
+          {/* ------------------------------------------------------------------ */}
+
+          {/* vCluster Install CTA — shown when vcluster CLI is not detected */}
+          {!hasVClusterTool && (
+            <div className="mt-6 p-4 rounded-lg bg-purple-500/10 border border-purple-500/20">
+              <div className="flex items-center gap-2 text-purple-400 mb-2">
+                <span className="text-xl">🔮</span>
+                <span className="font-medium">{t('settings.localClusters.vclusterInstallTitle')}</span>
+              </div>
+              <p className="text-sm text-muted-foreground mb-3">
+                {t('settings.localClusters.vclusterInstallDesc')}
+              </p>
+              <ul className="mb-3 space-y-1 text-sm text-muted-foreground">
+                <li><code className="px-1 bg-secondary rounded">brew install loft-sh/tap/vcluster</code></li>
+                <li><code className="px-1 bg-secondary rounded">curl -L -o vcluster https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-...</code></li>
+              </ul>
+              <button
+                onClick={handleInstallVCluster}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-500 text-white hover:bg-purple-600"
+              >
+                <Bot className="w-4 h-4" />
+                {t('settings.localClusters.vclusterInstallWithAgent')}
+              </button>
+            </div>
+          )}
+
+          {/* vCluster instances and create form — shown when vcluster CLI is detected */}
+          {hasVClusterTool && (
+            <div className="mt-6">
+              {/* Section header */}
+              <div className="flex items-center gap-2 mb-4">
+                <span className="text-xl">🔮</span>
+                <h3 className="text-sm font-medium text-muted-foreground">
+                  {t('settings.localClusters.vclusterSection')}
+                </h3>
+                <span className="text-xs text-muted-foreground">
+                  — {t('settings.localClusters.vclusterDesc')}
+                </span>
+              </div>
+
+              {/* Create vCluster Form */}
+              <div className="mb-4 p-4 rounded-lg bg-purple-500/10 border border-purple-500/20">
+                <h3 className="text-sm font-medium text-purple-400 mb-3 flex items-center gap-2">
+                  <Plus className="w-4 h-4" />
+                  {t('settings.localClusters.vclusterCreateNew')}
+                </h3>
+                <div className="flex flex-col sm:flex-row gap-3">
+                  <input
+                    type="text"
+                    value={vclusterName}
+                    onChange={(e) => setVclusterName(e.target.value)}
+                    placeholder="vCluster name"
+                    className="flex-1 px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/50"
+                  />
+                  <input
+                    type="text"
+                    value={vclusterNamespace}
+                    onChange={(e) => setVclusterNamespace(e.target.value)}
+                    placeholder={t('settings.localClusters.vclusterDefaultNamespace')}
+                    className="sm:w-48 px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/50"
+                  />
+                  <button
+                    onClick={handleCreateVCluster}
+                    disabled={!vclusterName.trim() || isCreating}
+                    className="flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-purple-500 text-white hover:bg-purple-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isCreating ? (
+                      <>
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        {t('settings.localClusters.creating')}
+                      </>
+                    ) : (
+                      <>
+                        <Plus className="w-4 h-4" />
+                        {t('settings.localClusters.create')}
+                      </>
+                    )}
+                  </button>
+                </div>
+              </div>
+
+              {/* vCluster Instances List */}
+              <div>
+                <h3 className="text-sm font-medium text-muted-foreground mb-3">
+                  {t('settings.localClusters.vclusterCount', { count: (vclusterInstances || []).length })}
+                </h3>
+                {(vclusterInstances || []).length === 0 ? (
+                  <p className="text-sm text-muted-foreground p-4 bg-secondary/30 rounded-lg">
+                    {t('settings.localClusters.noClusters')}
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {(vclusterInstances || []).map((instance) => {
+                      const isRunning = instance.status === 'Running'
+                      const isPaused = instance.status === 'Paused'
+
+                      return (
+                        <div
+                          key={`vcluster-${instance.namespace}-${instance.name}`}
+                          className="flex items-center justify-between p-3 rounded-lg bg-secondary/30 border border-border"
+                        >
+                          <div className="flex items-center gap-3">
+                            <span className="text-lg">🔮</span>
+                            <div>
+                              <p className="font-medium text-foreground">{instance.name}</p>
+                              <div className="flex items-center gap-2 text-xs">
+                                <span className="text-muted-foreground">
+                                  {t('settings.localClusters.vclusterNamespace')}: {instance.namespace}
+                                </span>
+                                <span className="text-muted-foreground">•</span>
+                                <div className="flex items-center gap-1.5">
+                                  <div className={`w-1.5 h-1.5 rounded-full ${
+                                    isRunning ? 'bg-green-500' :
+                                    isPaused ? 'bg-yellow-500' :
+                                    'bg-orange-500'
+                                  }`} />
+                                  <span className={
+                                    isRunning ? 'text-green-400' :
+                                    isPaused ? 'text-yellow-400' :
+                                    'text-orange-400'
+                                  }>
+                                    {isPaused ? t('settings.localClusters.vclusterPaused') : instance.status}
+                                  </span>
+                                </div>
+                                {instance.connected && (
+                                  <>
+                                    <span className="text-muted-foreground">•</span>
+                                    <span className="text-green-400 flex items-center gap-1">
+                                      <Plug className="w-3 h-3" />
+                                      {t('settings.localClusters.vclusterConnected')}
+                                    </span>
+                                  </>
+                                )}
+                                {instance.connected && instance.context && (
+                                  <>
+                                    <span className="text-muted-foreground">•</span>
+                                    <code className="px-1 bg-secondary rounded text-muted-foreground">{instance.context}</code>
+                                  </>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-1">
+                            {/* Connect / Disconnect button */}
+                            {instance.connected ? (
+                              <button
+                                onClick={() => disconnectVCluster(instance.name, instance.namespace)}
+                                disabled={isDisconnecting === instance.name}
+                                className="p-2 rounded-lg text-muted-foreground hover:text-orange-400 hover:bg-orange-500/10 disabled:opacity-50"
+                                title={t('settings.localClusters.vclusterDisconnect')}
+                              >
+                                {isDisconnecting === instance.name ? (
+                                  <Loader2 className="w-4 h-4 animate-spin" />
+                                ) : (
+                                  <Unplug className="w-4 h-4" />
+                                )}
+                              </button>
+                            ) : (
+                              <button
+                                onClick={() => connectVCluster(instance.name, instance.namespace)}
+                                disabled={isConnecting === instance.name}
+                                className="p-2 rounded-lg text-muted-foreground hover:text-green-400 hover:bg-green-500/10 disabled:opacity-50"
+                                title={t('settings.localClusters.vclusterConnect')}
+                              >
+                                {isConnecting === instance.name ? (
+                                  <Loader2 className="w-4 h-4 animate-spin" />
+                                ) : (
+                                  <Plug className="w-4 h-4" />
+                                )}
+                              </button>
+                            )}
+                            {/* Delete button */}
+                            <button
+                              onClick={() => handleDeleteVCluster(instance.name, instance.namespace)}
+                              disabled={isDeleting === instance.name}
+                              className="p-2 rounded-lg text-muted-foreground hover:text-red-400 hover:bg-red-500/10 disabled:opacity-50"
+                              title="Delete vCluster"
+                            >
+                              {isDeleting === instance.name ? (
+                                <Loader2 className="w-4 h-4 animate-spin" />
+                              ) : (
+                                <Trash2 className="w-4 h-4" />
+                              )}
+                            </button>
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
           {/* Error Display */}
           {error && (
             <div className="mt-4 p-3 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 text-sm">
@@ -369,6 +619,13 @@ export function LocalClustersSection() {
           )}
         </>
       )}
+
+      {/* API Key Prompt Modal for vCluster install mission */}
+      <ApiKeyPromptModal
+        isOpen={showKeyPrompt}
+        onDismiss={dismissPrompt}
+        onGoToSettings={goToSettings}
+      />
     </div>
   )
 }

--- a/web/src/hooks/useLocalClusterTools.ts
+++ b/web/src/hooks/useLocalClusterTools.ts
@@ -5,11 +5,26 @@ import { FETCH_DEFAULT_TIMEOUT_MS, RETRY_DELAY_MS, UI_FEEDBACK_TIMEOUT_MS } from
 import { useDemoMode } from './useDemoMode'
 import { useClusterProgress } from './useClusterProgress'
 
+/** Timeout for vCluster list operations */
+const VCLUSTER_LIST_TIMEOUT_MS = 15_000
+/** Timeout for vCluster connect operations */
+const VCLUSTER_CONNECT_TIMEOUT_MS = 30_000
+/** Timeout for vCluster create operations */
+const VCLUSTER_CREATE_TIMEOUT_MS = 120_000
+
 export interface LocalClusterTool {
-  name: 'kind' | 'k3d' | 'minikube'
+  name: 'kind' | 'k3d' | 'minikube' | 'vcluster'
   installed: boolean
   version?: string
   path?: string
+}
+
+export interface VClusterInstance {
+  name: string
+  namespace: string
+  status: string  // 'Running' | 'Paused' | 'Unknown'
+  connected: boolean
+  context?: string
 }
 
 export interface LocalCluster {
@@ -28,6 +43,7 @@ const DEMO_TOOLS: LocalClusterTool[] = [
   { name: 'kind', installed: true, version: '0.20.0', path: '/usr/local/bin/kind' },
   { name: 'k3d', installed: true, version: '5.6.0', path: '/usr/local/bin/k3d' },
   { name: 'minikube', installed: true, version: '1.32.0', path: '/usr/local/bin/minikube' },
+  { name: 'vcluster', installed: true, version: '0.21.0', path: '/usr/local/bin/vcluster' },
 ]
 
 const DEMO_CLUSTERS: LocalCluster[] = [
@@ -35,6 +51,12 @@ const DEMO_CLUSTERS: LocalCluster[] = [
   { name: 'kind-test', tool: 'kind', status: 'stopped' },
   { name: 'k3d-dev', tool: 'k3d', status: 'running' },
   { name: 'minikube', tool: 'minikube', status: 'running' },
+]
+
+const DEMO_VCLUSTER_INSTANCES: VClusterInstance[] = [
+  { name: 'dev-tenant', namespace: 'vcluster', status: 'Running', connected: true, context: 'vcluster_dev-tenant_vcluster' },
+  { name: 'staging', namespace: 'vcluster', status: 'Running', connected: false },
+  { name: 'test-isolated', namespace: 'testing', status: 'Paused', connected: false },
 ]
 
 export function useLocalClusterTools() {
@@ -46,6 +68,11 @@ export function useLocalClusterTools() {
   const [error, setError] = useState<string | null>(null)
   const [isCreating, setIsCreating] = useState(false)
   const [isDeleting, setIsDeleting] = useState<string | null>(null) // cluster name being deleted
+
+  // vCluster state
+  const [vclusterInstances, setVclusterInstances] = useState<VClusterInstance[]>([])
+  const [isConnecting, setIsConnecting] = useState<string | null>(null) // vcluster name being connected
+  const [isDisconnecting, setIsDisconnecting] = useState<string | null>(null) // vcluster name being disconnected
 
   // Real-time progress from kc-agent WebSocket
   const { progress: clusterProgress, dismiss: dismissProgress } = useClusterProgress()
@@ -206,29 +233,250 @@ export function useLocalClusterTools() {
     }
   }, [isConnected, isDemoMode, fetchClusters])
 
+  // Fetch vCluster instances
+  const fetchVClusters = useCallback(async () => {
+    // In demo mode (without agent connected), show demo vcluster instances
+    if (isDemoMode && !isConnected) {
+      setVclusterInstances(DEMO_VCLUSTER_INSTANCES)
+      setError(null)
+      return
+    }
+
+    if (!isConnected) {
+      setVclusterInstances([])
+      return
+    }
+
+    try {
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/list`, {
+        signal: AbortSignal.timeout(VCLUSTER_LIST_TIMEOUT_MS),
+      })
+      if (response.ok) {
+        const data = await response.json()
+        setVclusterInstances(data.instances || [])
+        setError(null)
+      }
+    } catch (err) {
+      console.error('Failed to fetch vCluster instances:', err)
+      setError('Failed to fetch vCluster instances')
+    }
+  }, [isConnected, isDemoMode])
+
+  // Create a new vCluster
+  const createVCluster = useCallback(async (name: string, namespace: string): Promise<CreateClusterResult> => {
+    // In demo mode (without agent connected), simulate vcluster creation
+    if (isDemoMode && !isConnected) {
+      setIsCreating(true)
+      setError(null)
+
+      // Simulate delay
+      await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS))
+
+      setIsCreating(false)
+      return {
+        status: 'creating',
+        message: `Simulation: vCluster "${name}" in namespace "${namespace}" would be created here. Connect kc-agent to create real virtual clusters.`,
+      }
+    }
+
+    if (!isConnected) {
+      return { status: 'error', message: 'Agent not connected' }
+    }
+
+    setIsCreating(true)
+    setError(null)
+
+    try {
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/create`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, namespace }),
+        signal: AbortSignal.timeout(VCLUSTER_CREATE_TIMEOUT_MS),
+      })
+
+      if (response.ok) {
+        const data = await response.json()
+        // Refresh vcluster list after creation starts
+        setTimeout(() => fetchVClusters(), UI_FEEDBACK_TIMEOUT_MS)
+        return { status: 'creating', message: data.message }
+      } else {
+        const text = await response.text()
+        return { status: 'error', message: text }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create vCluster'
+      setError(message)
+      return { status: 'error', message }
+    } finally {
+      setIsCreating(false)
+    }
+  }, [isConnected, isDemoMode, fetchVClusters])
+
+  // Connect to a vCluster
+  const connectVCluster = useCallback(async (name: string, namespace: string): Promise<boolean> => {
+    // In demo mode (without agent connected), simulate connect
+    if (isDemoMode && !isConnected) {
+      setIsConnecting(name)
+      setError(null)
+
+      await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS))
+
+      setIsConnecting(null)
+      return true
+    }
+
+    if (!isConnected) {
+      return false
+    }
+
+    setIsConnecting(name)
+    setError(null)
+
+    try {
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/connect`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, namespace }),
+        signal: AbortSignal.timeout(VCLUSTER_CONNECT_TIMEOUT_MS),
+      })
+
+      if (response.ok) {
+        // Refresh vcluster list to update connected status
+        setTimeout(() => fetchVClusters(), UI_FEEDBACK_TIMEOUT_MS)
+        return true
+      } else {
+        const text = await response.text()
+        setError(text)
+        return false
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to connect to vCluster'
+      setError(message)
+      return false
+    } finally {
+      setIsConnecting(null)
+    }
+  }, [isConnected, isDemoMode, fetchVClusters])
+
+  // Disconnect from a vCluster
+  const disconnectVCluster = useCallback(async (name: string, namespace: string): Promise<boolean> => {
+    // In demo mode (without agent connected), simulate disconnect
+    if (isDemoMode && !isConnected) {
+      setIsDisconnecting(name)
+      setError(null)
+
+      await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS))
+
+      setIsDisconnecting(null)
+      return true
+    }
+
+    if (!isConnected) {
+      return false
+    }
+
+    setIsDisconnecting(name)
+    setError(null)
+
+    try {
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/disconnect`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, namespace }),
+        signal: AbortSignal.timeout(VCLUSTER_CONNECT_TIMEOUT_MS),
+      })
+
+      if (response.ok) {
+        // Refresh vcluster list to update connected status
+        setTimeout(() => fetchVClusters(), UI_FEEDBACK_TIMEOUT_MS)
+        return true
+      } else {
+        const text = await response.text()
+        setError(text)
+        return false
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to disconnect from vCluster'
+      setError(message)
+      return false
+    } finally {
+      setIsDisconnecting(null)
+    }
+  }, [isConnected, isDemoMode, fetchVClusters])
+
+  // Delete a vCluster
+  const deleteVCluster = useCallback(async (name: string, namespace: string): Promise<boolean> => {
+    // In demo mode (without agent connected), simulate deletion
+    if (isDemoMode && !isConnected) {
+      setIsDeleting(name)
+      setError(null)
+
+      await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS))
+
+      setIsDeleting(null)
+      return true
+    }
+
+    if (!isConnected) {
+      return false
+    }
+
+    setIsDeleting(name)
+    setError(null)
+
+    try {
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/delete`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, namespace }),
+        signal: AbortSignal.timeout(VCLUSTER_CONNECT_TIMEOUT_MS),
+      })
+
+      if (response.ok) {
+        // Refresh vcluster list after deletion
+        setTimeout(() => fetchVClusters(), UI_FEEDBACK_TIMEOUT_MS)
+        return true
+      } else {
+        const text = await response.text()
+        setError(text)
+        return false
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete vCluster'
+      setError(message)
+      return false
+    } finally {
+      setIsDeleting(null)
+    }
+  }, [isConnected, isDemoMode, fetchVClusters])
+
   // Refresh all data
   const refresh = useCallback(() => {
     fetchTools()
     fetchClusters()
-  }, [fetchTools, fetchClusters])
+    fetchVClusters()
+  }, [fetchTools, fetchClusters, fetchVClusters])
 
   // Initial fetch when connected or in demo mode
   useEffect(() => {
     if (isConnected || isDemoMode) {
       fetchTools()
       fetchClusters()
+      fetchVClusters()
     } else {
       setTools([])
       setClusters([])
+      setVclusterInstances([])
     }
-  }, [isConnected, isDemoMode, fetchTools, fetchClusters])
+  }, [isConnected, isDemoMode, fetchTools, fetchClusters, fetchVClusters])
 
   // Auto-refresh cluster list when a create/delete operation completes
   useEffect(() => {
     if (clusterProgress?.status === 'done') {
       fetchClusters()
+      fetchVClusters()
     }
-  }, [clusterProgress?.status, fetchClusters])
+  }, [clusterProgress?.status, fetchClusters, fetchVClusters])
 
   // Get only installed tools
   const installedTools = tools.filter(t => t.installed)
@@ -248,5 +496,14 @@ export function useLocalClusterTools() {
     createCluster,
     deleteCluster,
     refresh,
+    // vCluster state and actions
+    vclusterInstances,
+    isConnecting,
+    isDisconnecting,
+    createVCluster,
+    connectVCluster,
+    disconnectVCluster,
+    deleteVCluster,
+    fetchVClusters,
   }
 }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -430,7 +430,21 @@
       "localClustersCount_one": "Local Clusters ({{count}})",
       "localClustersCount_other": "Local Clusters ({{count}})",
       "noClusters": "No local clusters found. Create one above to get started.",
-      "deleteConfirm": "Delete cluster \"{{name}}\"? This cannot be undone."
+      "deleteConfirm": "Delete cluster \"{{name}}\"? This cannot be undone.",
+      "vclusterSection": "Virtual Clusters",
+      "vclusterDesc": "Virtual clusters running inside host Kubernetes clusters",
+      "vclusterCount": "{{count}} virtual cluster(s)",
+      "vclusterNamespace": "Namespace",
+      "vclusterConnect": "Connect",
+      "vclusterDisconnect": "Disconnect",
+      "vclusterConnected": "Connected",
+      "vclusterPaused": "Paused",
+      "vclusterInstallTitle": "vCluster Not Detected",
+      "vclusterInstallDesc": "Install the vCluster CLI to create and manage virtual Kubernetes clusters",
+      "vclusterInstallWithAgent": "Install with AI Agent",
+      "vclusterCreateNew": "Create Virtual Cluster",
+      "vclusterDefaultNamespace": "vcluster",
+      "vclusterDeleteConfirm": "Delete virtual cluster \"{{name}}\" in namespace \"{{namespace}}\"? This cannot be undone."
     },
     "backup": {
       "title": "Backup & Sync",


### PR DESCRIPTION
## Summary
Full vCluster lifecycle support in the console — create, connect, disconnect, delete virtual Kubernetes clusters alongside existing kind/k3d/minikube support.

### Backend (kc-agent)
- `detectVCluster()` added to `DetectTools()` — checks for `vcluster` CLI
- `ListVClusters()` — runs `vcluster list --output json`, parses results
- `CreateVCluster(name, namespace)` — creates with WebSocket progress broadcast
- `ConnectVCluster(name, namespace)` — adds kubeconfig context via `vcluster connect --update-current=false`
- `DisconnectVCluster()` — removes context via `vcluster disconnect`
- `DeleteVCluster(name, namespace)` — deletes with progress broadcast
- 5 new HTTP endpoints: `/vcluster/{list,create,connect,disconnect,delete}`

### Frontend
- Extended `LocalClusterTool` type with `'vcluster'`
- `VClusterInstance` interface with name, namespace, status, connected flag
- Settings page: vCluster section with create form (name + namespace), connect/disconnect toggles, delete
- AI install mission CTA when `vcluster` CLI not detected
- Demo data for 3 vCluster instances
- vCluster contexts recognized as "local" in cluster map
- i18n strings for all UI elements

### Seamless Integration
vCluster contexts, once connected via `vcluster connect`, are standard kubeconfig contexts. All existing hooks (`useMCP`, `useClusterFilter`, cluster listings, dashboards) pick them up automatically — no changes needed.

## Test plan
- [x] `go build ./pkg/agent/...` passes
- [x] `npx tsc -b` passes
- [ ] Settings page shows vCluster section with detected tools
- [ ] Create vCluster → progress feedback → appears in list
- [ ] Connect → context added → appears in My Clusters
- [ ] Disconnect → context removed
- [ ] Delete → cluster removed
- [ ] Install mission CTA works when vcluster CLI not detected