### PR TITLE
✨ Check vCluster CRDs on clusters, show version and instance count in dropdown

### DIFF
--- a/pkg/agent/local_clusters.go
+++ b/pkg/agent/local_clusters.go
@@ -575,3 +575,103 @@ func runWithTimeout(cmd *exec.Cmd, timeout time.Duration) error {
 		return fmt.Errorf("command timed out after %s", timeout)
 	}
 }
+
+// VClusterClusterStatus represents vCluster status on a specific host cluster
+type VClusterClusterStatus struct {
+	Context    string `json:"context"`
+	Name       string `json:"name"`
+	HasCRD     bool   `json:"hasCRD"`
+	Version    string `json:"version,omitempty"`
+	Instances  int    `json:"instances"`
+	VClusters  []VClusterInstance `json:"vclusters,omitempty"`
+}
+
+/** Timeout for CRD check operations */
+const vclusterCRDCheckTimeout = 10 * time.Second
+
+// CheckVClusterOnCluster checks if vCluster CRDs are installed on a specific cluster
+// and lists any existing vCluster instances
+func (m *LocalClusterManager) CheckVClusterOnCluster(context string) (*VClusterClusterStatus, error) {
+	status := &VClusterClusterStatus{
+		Context: context,
+		Name:    context,
+	}
+
+	// Check for vCluster CRD
+	cmd := execCommand("kubectl", "--context", context, "get", "crd", "virtualclusters.storage.loft.sh", "-o", "jsonpath={.metadata.name}")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := runWithTimeout(cmd, vclusterCRDCheckTimeout); err == nil && strings.TrimSpace(stdout.String()) != "" {
+		status.HasCRD = true
+	}
+
+	// If CRD exists, get version from the CRD labels and list instances
+	if status.HasCRD {
+		// Get version from Helm release
+		cmd = execCommand("kubectl", "--context", context, "get", "pods", "-n", "vcluster", "-l", "app=vcluster", "-o", "jsonpath={.items[0].metadata.labels.chart}")
+		var verOut bytes.Buffer
+		cmd.Stdout = &verOut
+		if err := runWithTimeout(cmd, vclusterCRDCheckTimeout); err == nil {
+			ver := strings.TrimSpace(verOut.String())
+			re := regexp.MustCompile(`v?([\d.]+)`)
+			if matches := re.FindStringSubmatch(ver); len(matches) > 1 {
+				status.Version = matches[1]
+			}
+		}
+
+		// List vCluster instances via kubectl
+		cmd = execCommand("kubectl", "--context", context, "get", "virtualclusters.storage.loft.sh", "-A", "-o", "jsonpath={range .items[*]}{.metadata.name},{.metadata.namespace},{.status.phase}{\"\\n\"}{end}")
+		var listOut bytes.Buffer
+		cmd.Stdout = &listOut
+		if err := runWithTimeout(cmd, vclusterCRDCheckTimeout); err == nil {
+			lines := strings.Split(strings.TrimSpace(listOut.String()), "\n")
+			for _, line := range lines {
+				parts := strings.SplitN(line, ",", 3)
+				if len(parts) >= 2 && parts[0] != "" {
+					inst := VClusterInstance{
+						Name:      parts[0],
+						Namespace: parts[1],
+						Status:    "Running",
+					}
+					if len(parts) >= 3 && parts[2] != "" {
+						inst.Status = parts[2]
+					}
+					status.VClusters = append(status.VClusters, inst)
+				}
+			}
+			status.Instances = len(status.VClusters)
+		}
+	}
+
+	return status, nil
+}
+
+// CheckVClusterOnAllClusters checks vCluster status across all kubeconfig contexts
+func (m *LocalClusterManager) CheckVClusterOnAllClusters() ([]VClusterClusterStatus, error) {
+	cmd := execCommand("kubectl", "config", "get-contexts", "-o", "name")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("failed to list contexts: %w", err)
+	}
+
+	contexts := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	var results []VClusterClusterStatus
+
+	for _, ctx := range contexts {
+		if ctx == "" {
+			continue
+		}
+		status, err := m.CheckVClusterOnCluster(ctx)
+		if err != nil {
+			continue
+		}
+		if status.HasCRD {
+			results = append(results, *status)
+		}
+	}
+
+	return results, nil
+}

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -355,6 +355,7 @@ func (s *Server) Start() error {
 	mux.HandleFunc("/vcluster/connect", s.handleVClusterConnect)
 	mux.HandleFunc("/vcluster/disconnect", s.handleVClusterDisconnect)
 	mux.HandleFunc("/vcluster/delete", s.handleVClusterDelete)
+	mux.HandleFunc("/vcluster/check", s.handleVClusterCheck)
 
 	// Chat cancel endpoint — HTTP fallback when WebSocket is disconnected
 	mux.HandleFunc("/cancel-chat", s.handleCancelChatHTTP)
@@ -4588,4 +4589,43 @@ func (s *Server) handleInsightsAI(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(s.insightWorker.GetEnrichments())
+}
+
+// handleVClusterCheck checks vCluster CRD presence on clusters
+func (s *Server) handleVClusterCheck(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Optional: check a specific cluster context via query param
+	context := r.URL.Query().Get("context")
+	if context != "" {
+		status, err := s.localClusters.CheckVClusterOnCluster(context)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode(status)
+		return
+	}
+
+	// Check all clusters
+	results, err := s.localClusters.CheckVClusterOnAllClusters()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"clusters": results,
+	})
 }

--- a/web/src/components/settings/sections/LocalClustersSection.tsx
+++ b/web/src/components/settings/sections/LocalClustersSection.tsx
@@ -109,6 +109,7 @@ export function LocalClustersSection() {
     refresh,
     // vCluster state and actions
     vclusterInstances,
+    vclusterClusterStatus,
     isConnecting,
     isDisconnecting,
     createVCluster,
@@ -503,12 +504,13 @@ After installation, the user can create virtual clusters on this host cluster fr
                       onChange={(e) => setVclusterHostCluster(e.target.value)}
                       className="px-3 py-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/50"
                     >
-                      <option value="">Current context</option>
+                      <option value="" disabled>Select a host cluster...</option>
                       {(healthyClusters || []).map(c => {
-                        const hasVCluster = (c.namespaces || []).includes('vcluster')
+                        const vcStatus = (vclusterClusterStatus || []).find(s => s.context === (c.context || c.name))
+                        const hasVC = vcStatus?.hasCRD
                         return (
                           <option key={c.context || c.name} value={c.context || c.name}>
-                            {hasVCluster ? '✅ ' : ''}{c.name}{hasVCluster ? ' (vCluster ready)' : ''}{c.context && c.context !== c.name ? ` — ${c.context}` : ''}
+                            {hasVC ? '✅ ' : ''}{c.name}{hasVC ? ` (vCluster v${vcStatus?.version || '?'}, ${vcStatus?.instances || 0} instances)` : ''}{c.context && c.context !== c.name ? ` — ${c.context}` : ''}
                           </option>
                         )
                       })}
@@ -516,20 +518,23 @@ After installation, the user can create virtual clusters on this host cluster fr
                   </div>
                   <div className="flex flex-col gap-1 justify-end">
                     {(() => {
-                      const selectedCluster = (healthyClusters || []).find(c => (c.context || c.name) === vclusterHostCluster)
-                      const alreadyInstalled = selectedCluster && (selectedCluster.namespaces || []).includes('vcluster')
-                      const displayName = selectedCluster?.name || vclusterHostCluster || 'current cluster'
-                      return alreadyInstalled ? (
-                        <span className="flex items-center gap-2 px-3 py-2 text-xs text-green-400">
-                          ✅ vCluster ready on {displayName}
-                        </span>
-                      ) : (
+                      const vcStatus = (vclusterClusterStatus || []).find(s => s.context === vclusterHostCluster)
+                      const displayName = (healthyClusters || []).find(c => (c.context || c.name) === vclusterHostCluster)?.name || vclusterHostCluster
+                      if (vcStatus?.hasCRD) {
+                        return (
+                          <span className="flex items-center gap-2 px-3 py-2 text-xs text-green-400 font-medium">
+                            ✅ vCluster v{vcStatus.version || '?'} ready ({vcStatus.instances} instance{vcStatus.instances !== 1 ? 's' : ''})
+                          </span>
+                        )
+                      }
+                      return (
                         <button
-                          onClick={() => handleInstallVClusterOnCluster(vclusterHostCluster || 'current')}
-                          className="flex items-center gap-2 px-3 py-2 rounded-lg bg-orange-500/20 text-orange-400 text-xs font-medium hover:bg-orange-500/30 transition-colors"
+                          onClick={() => handleInstallVClusterOnCluster(vclusterHostCluster)}
+                          disabled={!vclusterHostCluster}
+                          className="flex items-center gap-2 px-3 py-2 rounded-lg bg-orange-500/20 text-orange-400 text-xs font-medium hover:bg-orange-500/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                           <Bot className="w-3.5 h-3.5" />
-                          Deploy vCluster to {displayName}
+                          {vclusterHostCluster ? `Deploy vCluster to ${displayName}` : 'Select a cluster first'}
                         </button>
                       )
                     })()}
@@ -557,7 +562,7 @@ After installation, the user can create virtual clusters on this host cluster fr
                   <div className="flex items-end">
                     <button
                       onClick={handleCreateVCluster}
-                      disabled={!vclusterName.trim() || isCreating}
+                      disabled={!vclusterName.trim() || !vclusterHostCluster || isCreating}
                       className="w-full flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-purple-500 text-white hover:bg-purple-600 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {isCreating ? (

--- a/web/src/hooks/useLocalClusterTools.ts
+++ b/web/src/hooks/useLocalClusterTools.ts
@@ -27,6 +27,16 @@ export interface VClusterInstance {
   context?: string
 }
 
+/** Status of vCluster on a specific host cluster */
+export interface VClusterClusterStatus {
+  context: string
+  name: string
+  hasCRD: boolean
+  version?: string
+  instances: number
+  vclusters?: VClusterInstance[]
+}
+
 export interface LocalCluster {
   name: string
   tool: string
@@ -71,6 +81,7 @@ export function useLocalClusterTools() {
 
   // vCluster state
   const [vclusterInstances, setVclusterInstances] = useState<VClusterInstance[]>([])
+  const [vclusterClusterStatus, setVclusterClusterStatus] = useState<VClusterClusterStatus[]>([])
   const [isConnecting, setIsConnecting] = useState<string | null>(null) // vcluster name being connected
   const [isDisconnecting, setIsDisconnecting] = useState<string | null>(null) // vcluster name being disconnected
 
@@ -261,6 +272,26 @@ export function useLocalClusterTools() {
       setError('Failed to fetch vCluster instances')
     }
   }, [isConnected, isDemoMode])
+
+  // Check which clusters have vCluster CRDs installed
+  const fetchVClusterClusterStatus = useCallback(async () => {
+    if (!isConnected) {
+      setVclusterClusterStatus([])
+      return
+    }
+
+    try {
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/check`, {
+        signal: AbortSignal.timeout(VCLUSTER_LIST_TIMEOUT_MS),
+      })
+      if (response.ok) {
+        const data = await response.json()
+        setVclusterClusterStatus(data.clusters || [])
+      }
+    } catch (err) {
+      console.error('Failed to check vCluster cluster status:', err)
+    }
+  }, [isConnected])
 
   // Create a new vCluster
   const createVCluster = useCallback(async (name: string, namespace: string): Promise<CreateClusterResult> => {
@@ -455,7 +486,8 @@ export function useLocalClusterTools() {
     fetchTools()
     fetchClusters()
     fetchVClusters()
-  }, [fetchTools, fetchClusters, fetchVClusters])
+    fetchVClusterClusterStatus()
+  }, [fetchTools, fetchClusters, fetchVClusters, fetchVClusterClusterStatus])
 
   // Initial fetch when connected or in demo mode
   useEffect(() => {
@@ -498,6 +530,7 @@ export function useLocalClusterTools() {
     refresh,
     // vCluster state and actions
     vclusterInstances,
+    vclusterClusterStatus,
     isConnecting,
     isDisconnecting,
     createVCluster,


### PR DESCRIPTION
## Summary
Proper vCluster detection per cluster via CRD checks:

### Backend
- `CheckVClusterOnCluster(context)` — checks for `virtualclusters.storage.loft.sh` CRD via kubectl
- Lists existing vCluster instances and extracts version from Helm release
- `CheckVClusterOnAllClusters()` — scans all kubeconfig contexts
- New `/vcluster/check` endpoint (GET, optional `?context=` param)

### Frontend
- Removed vcluster from Detected Tools grid and "Create New Cluster" dropdown
- Force user to select host cluster (removed "Current context" default)
- Host cluster dropdown: `✅ clusterName (vCluster v0.23.0, 2 instances)` for clusters with CRDs
- "Deploy vCluster" button replaced with "vCluster ready" confirmation when CRD detected
- Create button disabled until host cluster selected

## Test plan
- [x] Go builds cleanly
- [x] TypeScript builds cleanly
- [ ] Dropdown shows ✅ indicators for clusters with vCluster
- [ ] Deploy button shows "ready" when cluster has vCluster
- [ ] Deploy mission launches when cluster doesn't have vCluster