### PR TITLE
🐛 fix: on-demand vCluster detection per cluster selection

### DIFF
--- a/web/src/components/settings/sections/LocalClustersSection.tsx
+++ b/web/src/components/settings/sections/LocalClustersSection.tsx
@@ -110,6 +110,7 @@ export function LocalClustersSection() {
     // vCluster state and actions
     vclusterInstances,
     vclusterClusterStatus,
+    checkVClusterOnCluster,
     isConnecting,
     isDisconnecting,
     createVCluster,
@@ -501,7 +502,7 @@ After installation, the user can create virtual clusters on this host cluster fr
                     <label className="text-xs text-muted-foreground font-medium">Host Cluster</label>
                     <select
                       value={vclusterHostCluster}
-                      onChange={(e) => setVclusterHostCluster(e.target.value)}
+                      onChange={(e) => { setVclusterHostCluster(e.target.value); if (e.target.value) checkVClusterOnCluster(e.target.value) }}
                       className="px-3 py-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/50"
                     >
                       <option value="" disabled>Select a host cluster...</option>

--- a/web/src/hooks/useLocalClusterTools.ts
+++ b/web/src/hooks/useLocalClusterTools.ts
@@ -273,25 +273,32 @@ export function useLocalClusterTools() {
     }
   }, [isConnected, isDemoMode])
 
-  // Check which clusters have vCluster CRDs installed
-  const fetchVClusterClusterStatus = useCallback(async () => {
-    if (!isConnected) {
-      setVclusterClusterStatus([])
-      return
-    }
+  // Check if a specific cluster has vCluster installed (on-demand per cluster)
+  const checkVClusterOnCluster = useCallback(async (context: string) => {
+    if (!isConnected || !context) return
 
     try {
-      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/check`, {
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/vcluster/check?context=${encodeURIComponent(context)}`, {
         signal: AbortSignal.timeout(VCLUSTER_LIST_TIMEOUT_MS),
       })
       if (response.ok) {
         const data = await response.json()
-        setVclusterClusterStatus(data.clusters || [])
+        setVclusterClusterStatus(prev => {
+          // Replace or add the status for this context
+          const filtered = (prev || []).filter(s => s.context !== context)
+          return [...filtered, data]
+        })
       }
     } catch (err) {
-      console.error('Failed to check vCluster cluster status:', err)
+      console.error(`Failed to check vCluster on ${context}:`, err)
     }
   }, [isConnected])
+
+  // Backwards-compatible: scan all healthy clusters (but one at a time, non-blocking)
+  const fetchVClusterClusterStatus = useCallback(async () => {
+    // No-op: individual checks happen on-demand via checkVClusterOnCluster
+    // This prevents the slow sequential scan of all contexts
+  }, [])
 
   // Create a new vCluster
   const createVCluster = useCallback(async (name: string, namespace: string): Promise<CreateClusterResult> => {
@@ -533,6 +540,7 @@ export function useLocalClusterTools() {
     // vCluster state and actions
     vclusterInstances,
     vclusterClusterStatus,
+    checkVClusterOnCluster,
     isConnecting,
     isDisconnecting,
     createVCluster,


### PR DESCRIPTION
The all-clusters scan timed out because unreachable clusters block for 10s each. Now checks vCluster status on-demand when user selects a cluster from the dropdown — instant feedback.