### PR TITLE
🐛 fix: assign unique user_id to demo users to prevent GA4 data loss

### DIFF
--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -13,7 +13,7 @@
  * block it, in which case the custom proxy fallback kicks in.
  */
 
-import { STORAGE_KEY_ANALYTICS_OPT_OUT } from './constants'
+import { STORAGE_KEY_ANALYTICS_OPT_OUT, STORAGE_KEY_ANONYMOUS_USER_ID } from './constants'
 import { CHUNK_RELOAD_TS_KEY, isChunkLoadMessage } from './chunkErrors'
 import { isDemoMode } from './demoMode'
 
@@ -689,9 +689,29 @@ async function hashUserId(uid: string): Promise<string> {
     .join('')
 }
 
+/**
+ * Get or create a persistent anonymous user ID for demo/unauthenticated users.
+ * Stored in localStorage so the same browser always gets the same ID.
+ * This ensures GA4 receives a unique user_id for every user — mixing
+ * identified and anonymous sessions causes GA4 to delete data.
+ */
+function getOrCreateAnonymousId(): string {
+  let anonId = localStorage.getItem(STORAGE_KEY_ANONYMOUS_USER_ID)
+  if (!anonId) {
+    anonId = crypto.randomUUID()
+    localStorage.setItem(STORAGE_KEY_ANONYMOUS_USER_ID, anonId)
+  }
+  return anonId
+}
+
 export async function setAnalyticsUserId(uid: string) {
-  if (!uid || uid === 'demo-user') return
-  userId = await hashUserId(uid)
+  // For demo/anonymous users, assign a persistent random ID so GA4 sees
+  // consistent user_id on every session. Without this, GA4's mixed
+  // identified/anonymous user model triggers data deletion.
+  const effectiveUid = (!uid || uid === 'demo-user')
+    ? getOrCreateAnonymousId()
+    : uid
+  userId = await hashUserId(effectiveUid)
   // Propagate to gtag if available
   if (gtagAvailable && window.gtag && realMeasurementId) {
     window.gtag('config', realMeasurementId, { user_id: userId })

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -169,6 +169,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
     setUser(demoUser)
     cacheUser(demoUser)
+    setAnalyticsUserId(demoUser.id)
     setAnalyticsUserProperties({ auth_mode: 'demo' })
     // Sync the global demoMode singleton so Layout banners and useDemoMode() hook
     // reflect demo state immediately — without this, the in-cluster banner won't

--- a/web/src/lib/constants/storage.ts
+++ b/web/src/lib/constants/storage.ts
@@ -36,6 +36,7 @@ export const STORAGE_KEY_ACCESSIBILITY = 'accessibility-settings'
 export const STORAGE_KEY_NOTIFICATION_CONFIG = 'kc_notification_config'
 export const STORAGE_KEY_TOUR_COMPLETED = 'kubestellar-console-tour-completed'
 export const STORAGE_KEY_ANALYTICS_OPT_OUT = 'kc-analytics-opt-out'
+export const STORAGE_KEY_ANONYMOUS_USER_ID = 'kc-anonymous-user-id'
 
 // ── UI state persistence ───────────────────────────────────────────────
 export const STORAGE_KEY_CLUSTER_LAYOUT = 'kubestellar-cluster-layout-mode'


### PR DESCRIPTION
## Summary

- GA4 was showing **"property lost data due to user ID implementation issue"** — deleting ~36K user records over the last 28 days
- Root cause: OAuth users received a hashed `user_id` via gtag, but demo/anonymous users received **no `user_id` at all**. This mixed identification model violates GA4's requirements
- Fix: demo users now get a persistent random UUID (stored in localStorage via `STORAGE_KEY_ANONYMOUS_USER_ID`), hashed identically to OAuth user IDs. Every session sends a unique `user_id`

## Changes

- `web/src/lib/constants/storage.ts` — add `STORAGE_KEY_ANONYMOUS_USER_ID`
- `web/src/lib/analytics.ts` — add `getOrCreateAnonymousId()` helper; update `setAnalyticsUserId()` to assign anonymous IDs instead of returning early for demo users
- `web/src/lib/auth.tsx` — call `setAnalyticsUserId(demoUser.id)` in `setDemoMode()` (was missing entirely)

## Test plan

- [ ] Visit console.kubestellar.io in demo mode — verify `kc-anonymous-user-id` appears in localStorage
- [ ] Verify GA4 Realtime shows events with a `user_id` property for demo sessions
- [ ] Verify OAuth login still sends hashed GitHub user ID as before
- [ ] Monitor GA4 for 48h — the "property lost data" warning should clear