### PR TITLE
🐛 Fix TestLocalClusterManager to expect vcluster as 4th detected tool

### DIFF
--- a/pkg/agent/local_clusters_test.go
+++ b/pkg/agent/local_clusters_test.go
@@ -37,15 +37,21 @@ func TestLocalClusterManager(t *testing.T) {
 		if name == "minikube" && arg[1] == "profile" && arg[2] == "list" {
 			return exec.Command("echo", `{"valid": [{"Name": "minikube"}]}`)
 		}
+		if name == "vcluster" && arg[0] == "version" {
+			return exec.Command("echo", "vcluster version 0.19.0")
+		}
 		return exec.Command("echo", "ok")
 	}
+
+	// expectedToolCount covers kind, k3d, minikube, and vcluster
+	const expectedToolCount = 4
 
 	m := NewLocalClusterManager(nil)
 
 	// 2. Test DetectTools
 	tools := m.DetectTools()
-	if len(tools) != 3 {
-		t.Errorf("Expected 3 tools, got %d", len(tools))
+	if len(tools) != expectedToolCount {
+		t.Errorf("Expected %d tools, got %d", expectedToolCount, len(tools))
 	}
 
 	// 3. Test ListClusters


### PR DESCRIPTION
## Summary
- The nightly Release workflow failed on 2026-03-19 because `TestLocalClusterManager` expected 3 tools from `DetectTools()` but got 4. PR #2915 added vcluster detection to `DetectTools()`, but the test was never updated.
- Added a `vcluster version` mock to `execCommand` and updated the expected tool count from 3 to 4 using a named constant.

## Test plan
- [x] `go test ./pkg/agent/ -run TestLocalClusterManager -v` passes locally
- [ ] CI build/lint passes
- [ ] Re-run nightly Release workflow after merge to produce v0.3.17-nightly.20260319