### PR TITLE
🐛 fix: expose safe timer APIs in dynamic card sandbox

### DIFF
--- a/web/src/lib/dynamic-cards/compiler.ts
+++ b/web/src/lib/dynamic-cards/compiler.ts
@@ -13,7 +13,9 @@ const BLOCKED_GLOBALS = [
   'eval', 'Function', 'importScripts',
   'localStorage', 'sessionStorage', 'indexedDB', 'caches',
   'navigator', 'location', 'history',
-  'setTimeout', 'setInterval', 'requestAnimationFrame',
+  // setTimeout/setInterval/clearTimeout/clearInterval are provided as safe
+  // wrappers via getDynamicScope() — NOT blocked here.
+  'requestAnimationFrame',
   'postMessage', 'crypto',
 ] as const
 

--- a/web/src/lib/dynamic-cards/scope.ts
+++ b/web/src/lib/dynamic-cards/scope.ts
@@ -10,6 +10,30 @@ import { useCardData, commonComparators } from '../cards/cardHooks'
 import { Skeleton } from '../../components/ui/Skeleton'
 import { Pagination } from '../../components/ui/Pagination'
 
+/** Minimum allowed interval for setInterval in dynamic cards (ms) */
+const MIN_INTERVAL_MS = 1_000
+
+/** Safe setTimeout wrapper — delegates to the real window.setTimeout */
+function safeSetTimeout(callback: TimerHandler, delay?: number, ...args: unknown[]): number {
+  return window.setTimeout(callback, delay, ...args)
+}
+
+/** Safe clearTimeout wrapper */
+function safeClearTimeout(id: number | undefined): void {
+  window.clearTimeout(id)
+}
+
+/** Safe setInterval wrapper — enforces MIN_INTERVAL_MS minimum to prevent tight loops */
+function safeSetInterval(callback: TimerHandler, delay?: number, ...args: unknown[]): number {
+  const clamped = Math.max(delay ?? 0, MIN_INTERVAL_MS)
+  return window.setInterval(callback, clamped, ...args)
+}
+
+/** Safe clearInterval wrapper */
+function safeClearInterval(id: number | undefined): void {
+  window.clearInterval(id)
+}
+
 /**
  * The sandboxed scope of libraries available to Tier 2 dynamic cards.
  *
@@ -41,5 +65,11 @@ export function getDynamicScope(): Record<string, unknown> {
     // UI components
     Skeleton,
     Pagination,
+
+    // Safe timer APIs (setInterval clamped to MIN_INTERVAL_MS minimum)
+    setTimeout: safeSetTimeout,
+    clearTimeout: safeClearTimeout,
+    setInterval: safeSetInterval,
+    clearInterval: safeClearInterval,
   }
 }


### PR DESCRIPTION
## Summary
- Dynamic cards calling `setTimeout`/`setInterval` got "not a function" errors (58 GA4 `ksc_error` events today from 1 user) because the sandbox blocked all timer APIs
- Now provides safe wrappers: `setTimeout`/`clearTimeout` delegate to `window.*`, `setInterval`/`clearInterval` clamped to 1s minimum
- `requestAnimationFrame` remains blocked (no card use case)

## Test plan
- [ ] Create a dynamic card that uses `setInterval` — should work without errors
- [ ] Verify `setInterval` with delay < 1s is clamped to 1s
- [ ] Verify `clearInterval`/`clearTimeout` clean up properly
- [ ] Verify `fetch`, `localStorage`, etc. remain blocked