### PR TITLE
⚠️ fix: harden dynamic card timer sandbox (Copilot review)

### DIFF
--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { AlertTriangle, Loader2, Database } from 'lucide-react'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { getDynamicCard } from '../../lib/dynamic-cards/dynamicCardRegistry'
@@ -287,6 +287,7 @@ export function Tier2CardRuntime({ definition, config }: Tier2Props) {
   const [CardComponent, setCardComponent] = useState<CardComponent | null>(null)
   const [compiling, setCompiling] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const cleanupRef = useRef<(() => void) | undefined>()
 
   useEffect(() => {
     let cancelled = false
@@ -325,12 +326,17 @@ export function Tier2CardRuntime({ definition, config }: Tier2Props) {
         return
       }
 
+      cleanupRef.current = componentResult.cleanup
       setCardComponent(() => componentResult.component)
       setCompiling(false)
     }
 
     compile()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+      // Clean up any timers the card created
+      cleanupRef.current?.()
+    }
   }, [definition.sourceCode, definition.compiledCode])
 
   if (compiling) {

--- a/web/src/lib/dynamic-cards/compiler.ts
+++ b/web/src/lib/dynamic-cards/compiler.ts
@@ -13,8 +13,10 @@ const BLOCKED_GLOBALS = [
   'eval', 'Function', 'importScripts',
   'localStorage', 'sessionStorage', 'indexedDB', 'caches',
   'navigator', 'location', 'history',
-  // setTimeout/setInterval/clearTimeout/clearInterval are provided as safe
-  // wrappers via getDynamicScope() — NOT blocked here.
+  // Timer APIs: listed for fail-closed safety. Safe wrappers in getDynamicScope()
+  // override these via the `if (!(name in scope))` guard in the merge loop below.
+  // If the wrappers are ever removed from scope, these fall back to blocking.
+  'setTimeout', 'setInterval', 'clearTimeout', 'clearInterval',
   'requestAnimationFrame',
   'postMessage', 'crypto',
 ] as const
@@ -51,6 +53,10 @@ export async function compileCardCode(tsx: string): Promise<CompileResult> {
 export function createCardComponent(compiledCode: string): DynamicComponentResult {
   try {
     const scope = getDynamicScope()
+
+    // Extract the timer cleanup function before freezing
+    const timerCleanup = scope.__timerCleanup as (() => void) | undefined
+    delete scope.__timerCleanup
 
     // Freeze each scope value that is an object to prevent prototype pollution
     // (shallow freeze — we freeze the scope map itself, not deep internals of React)
@@ -89,7 +95,7 @@ export function createCardComponent(compiledCode: string): DynamicComponentResul
       }
     }
 
-    return { component, error: null }
+    return { component, error: null, cleanup: timerCleanup }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     return { component: null, error: `Runtime error: ${message}` }

--- a/web/src/lib/dynamic-cards/scope.ts
+++ b/web/src/lib/dynamic-cards/scope.ts
@@ -13,25 +13,77 @@ import { Pagination } from '../../components/ui/Pagination'
 /** Minimum allowed interval for setInterval in dynamic cards (ms) */
 const MIN_INTERVAL_MS = 1_000
 
-/** Safe setTimeout wrapper — delegates to the real window.setTimeout */
-function safeSetTimeout(callback: TimerHandler, delay?: number, ...args: unknown[]): number {
-  return window.setTimeout(callback, delay, ...args)
+/** Maximum concurrent timers a single card sandbox scope can hold */
+const MAX_ACTIVE_TIMERS = 20
+
+/** Validate delay is a finite number, defaulting to 0 if NaN/undefined */
+function sanitizeDelay(delay: unknown): number {
+  const n = Number(delay)
+  return Number.isFinite(n) ? n : 0
 }
 
-/** Safe clearTimeout wrapper */
-function safeClearTimeout(id: number | undefined): void {
-  window.clearTimeout(id)
-}
+/**
+ * Creates a sandboxed timer API set with:
+ * - String callback rejection (prevents eval-like code execution)
+ * - NaN delay protection (sanitized to 0)
+ * - setInterval clamped to MIN_INTERVAL_MS minimum
+ * - Per-scope timer tracking with MAX_ACTIVE_TIMERS cap
+ * - clearAll() for bulk cleanup on card unmount
+ */
+export function createTimerScope() {
+  const activeTimers = new Set<number>()
 
-/** Safe setInterval wrapper — enforces MIN_INTERVAL_MS minimum to prevent tight loops */
-function safeSetInterval(callback: TimerHandler, delay?: number, ...args: unknown[]): number {
-  const clamped = Math.max(delay ?? 0, MIN_INTERVAL_MS)
-  return window.setInterval(callback, clamped, ...args)
-}
+  function trackTimer(id: number): number {
+    activeTimers.add(id)
+    return id
+  }
 
-/** Safe clearInterval wrapper */
-function safeClearInterval(id: number | undefined): void {
-  window.clearInterval(id)
+  function safeSetTimeout(callback: unknown, delay?: unknown, ...args: unknown[]): number {
+    if (typeof callback !== 'function') {
+      throw new TypeError('setTimeout callback must be a function (string callbacks are blocked)')
+    }
+    if (activeTimers.size >= MAX_ACTIVE_TIMERS) {
+      throw new Error(`Timer limit exceeded (max ${MAX_ACTIVE_TIMERS} concurrent timers per card)`)
+    }
+    const id = window.setTimeout((...a: unknown[]) => {
+      activeTimers.delete(id)
+      ;(callback as (...a: unknown[]) => void)(...a)
+    }, sanitizeDelay(delay), ...args)
+    return trackTimer(id)
+  }
+
+  function safeClearTimeout(id: number | undefined): void {
+    if (id != null) activeTimers.delete(id)
+    window.clearTimeout(id)
+  }
+
+  function safeSetInterval(callback: unknown, delay?: unknown, ...args: unknown[]): number {
+    if (typeof callback !== 'function') {
+      throw new TypeError('setInterval callback must be a function (string callbacks are blocked)')
+    }
+    if (activeTimers.size >= MAX_ACTIVE_TIMERS) {
+      throw new Error(`Timer limit exceeded (max ${MAX_ACTIVE_TIMERS} concurrent timers per card)`)
+    }
+    const clamped = Math.max(sanitizeDelay(delay), MIN_INTERVAL_MS)
+    const id = window.setInterval(callback as (...a: unknown[]) => void, clamped, ...args)
+    return trackTimer(id)
+  }
+
+  function safeClearInterval(id: number | undefined): void {
+    if (id != null) activeTimers.delete(id)
+    window.clearInterval(id)
+  }
+
+  /** Clear all timers created by this scope (called on card unmount) */
+  function clearAll(): void {
+    for (const id of activeTimers) {
+      window.clearTimeout(id)
+      window.clearInterval(id)
+    }
+    activeTimers.clear()
+  }
+
+  return { safeSetTimeout, safeClearTimeout, safeSetInterval, safeClearInterval, clearAll }
 }
 
 /**
@@ -42,6 +94,8 @@ function safeClearInterval(id: number | undefined): void {
  * or other browser APIs directly.
  */
 export function getDynamicScope(): Record<string, unknown> {
+  const timers = createTimerScope()
+
   return {
     // React core
     React,
@@ -66,10 +120,15 @@ export function getDynamicScope(): Record<string, unknown> {
     Skeleton,
     Pagination,
 
-    // Safe timer APIs (setInterval clamped to MIN_INTERVAL_MS minimum)
-    setTimeout: safeSetTimeout,
-    clearTimeout: safeClearTimeout,
-    setInterval: safeSetInterval,
-    clearInterval: safeClearInterval,
+    // Safe timer APIs — function-only callbacks, NaN-safe delays,
+    // setInterval clamped to MIN_INTERVAL_MS, max MAX_ACTIVE_TIMERS per card.
+    // These override the BLOCKED_GLOBALS entries via the `if (!(name in scope))` check.
+    setTimeout: timers.safeSetTimeout,
+    clearTimeout: timers.safeClearTimeout,
+    setInterval: timers.safeSetInterval,
+    clearInterval: timers.safeClearInterval,
+
+    // Internal: used by CardWrapper to clean up leaked timers on unmount
+    __timerCleanup: timers.clearAll,
   }
 }

--- a/web/src/lib/dynamic-cards/types.ts
+++ b/web/src/lib/dynamic-cards/types.ts
@@ -114,4 +114,6 @@ export interface DynamicComponentResult {
   component: ComponentType<CardComponentProps> | null
   /** Error message (if compilation or evaluation failed) */
   error: string | null
+  /** Cleanup function to clear sandboxed timers on unmount */
+  cleanup?: () => void
 }


### PR DESCRIPTION
## Summary
Addresses all 4 Copilot review comments on #2951:

1. **String callback rejection** — `setTimeout`/`setInterval` now throw `TypeError` for non-function callbacks, closing the `eval`-like code execution hole via `setTimeout("malicious code")`
2. **NaN delay protection** — `sanitizeDelay()` uses `Number.isFinite` to guard against `NaN` defeating the interval clamp
3. **Fail-closed blocklist** — Timer names re-added to `BLOCKED_GLOBALS` so removing wrappers from scope falls back to blocking (not exposing raw browser timers)
4. **Timer leak protection** — Per-card timer registry with `MAX_ACTIVE_TIMERS` cap (20) and auto-cleanup on card unmount

## Test plan
- [ ] `setTimeout("alert(1)")` throws TypeError (not eval)
- [ ] `setInterval(fn, NaN)` clamps to 1s (not 0)
- [ ] Creating 21+ timers throws limit error
- [ ] Card unmount clears all active timers
- [ ] Normal `setTimeout`/`setInterval` with function callbacks still work