### PR TITLE
🐛 Fix duplicate agent responses in mission chat

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -727,6 +727,14 @@ Install the console locally with the KubeStellar Console agent to use AI mission
           emitMissionCompleted(m.type, Math.round((Date.now() - m.createdAt.getTime()) / 1000))
         }
 
+        const resultContent = chatPayload.content || (payload as { output?: string }).output || 'Task completed.'
+        const lastMsg = m.messages[m.messages.length - 1]
+        const DEDUP_PREFIX_LEN = 100
+        // Skip adding result message if the content was already received via streaming
+        const alreadyStreamed = lastMsg?.role === 'assistant' &&
+          resultContent.length > 0 &&
+          lastMsg.content.includes(resultContent.slice(0, DEDUP_PREFIX_LEN))
+
         return {
           ...m,
           status: 'waiting_input' as MissionStatus,
@@ -734,12 +742,12 @@ Install the console locally with the KubeStellar Console agent to use AI mission
           updatedAt: new Date(),
           agent: chatPayload.agent || m.agent,
           tokenUsage,
-          messages: [
+          messages: alreadyStreamed ? m.messages : [
             ...m.messages,
             {
               id: `msg-${Date.now()}`,
               role: 'assistant' as const,
-              content: chatPayload.content || (payload as { output?: string }).output || 'Task completed.',
+              content: resultContent,
               timestamp: new Date(),
               agent: chatPayload.agent || m.agent,
             }


### PR DESCRIPTION
## Summary
Agent responses were appearing twice in the mission chat. The last message would be duplicated as shown in the screenshot.

## Root cause
When streaming is used, the backend sends the response in two ways:
1. `stream` messages with chunks of content, ending with `done: true`
2. A final `result` message with the complete content

The frontend was displaying both — the accumulated stream content AND the result message, causing duplication.

## Fix
In the `result` message handler, check if the last assistant message already contains the result content (from streaming). If so, skip adding the duplicate message.

## Test plan
- [ ] Send a message to the agent — response should appear once, not twice
- [ ] Non-streaming responses (short/simple) should still work correctly
- [ ] Verify streaming chunks still accumulate properly during response generation