### PR TITLE
🐛 Improve agent message dedup: handle gap-split streams + add tests

### DIFF
--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -271,6 +271,63 @@ describe('startMission', () => {
     expect(emitMissionCompleted).toHaveBeenCalled()
   })
 
+  it('does not duplicate response when stream is followed by result with same content', async () => {
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    const { requestId } = await startMissionWithConnection(result)
+
+    // Simulate streaming chunks
+    act(() => {
+      MockWebSocket.lastInstance?.simulateMessage({
+        id: requestId,
+        type: 'stream',
+        payload: { content: 'vCluster CLI is installed and upgraded successfully.' },
+      })
+    })
+
+    // Stream done
+    act(() => {
+      MockWebSocket.lastInstance?.simulateMessage({
+        id: requestId,
+        type: 'stream',
+        payload: { content: '', done: true },
+      })
+    })
+
+    const messagesAfterStream = result.current.missions[0].messages.filter(m => m.role === 'assistant')
+    expect(messagesAfterStream).toHaveLength(1)
+
+    // Now simulate the result message with the same content
+    act(() => {
+      MockWebSocket.lastInstance?.simulateMessage({
+        id: requestId,
+        type: 'result',
+        payload: { content: 'vCluster CLI is installed and upgraded successfully.' },
+      })
+    })
+
+    const messagesAfterResult = result.current.missions[0].messages.filter(m => m.role === 'assistant')
+    // Should still be 1 assistant message, not 2
+    expect(messagesAfterResult).toHaveLength(1)
+  })
+
+  it('adds result message when no prior streaming occurred', async () => {
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    const { requestId } = await startMissionWithConnection(result)
+
+    // Result without prior streaming
+    act(() => {
+      MockWebSocket.lastInstance?.simulateMessage({
+        id: requestId,
+        type: 'result',
+        payload: { content: 'Task completed.' },
+      })
+    })
+
+    const assistantMessages = result.current.missions[0].messages.filter(m => m.role === 'assistant')
+    expect(assistantMessages).toHaveLength(1)
+    expect(assistantMessages[0].content).toBe('Task completed.')
+  })
+
   it('transitions mission to failed on error message', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
     const { requestId } = await startMissionWithConnection(result)

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -728,12 +728,18 @@ Install the console locally with the KubeStellar Console agent to use AI mission
         }
 
         const resultContent = chatPayload.content || (payload as { output?: string }).output || 'Task completed.'
-        const lastMsg = m.messages[m.messages.length - 1]
-        const DEDUP_PREFIX_LEN = 100
-        // Skip adding result message if the content was already received via streaming
-        const alreadyStreamed = lastMsg?.role === 'assistant' &&
+        // Check ALL assistant messages since the last user message for streamed content
+        // (streaming may split into multiple bubbles due to tool-use gaps)
+        const lastUserIdx = m.messages.map(msg => msg.role).lastIndexOf('user')
+        const streamedSinceUser = m.messages
+          .slice(lastUserIdx + 1)
+          .filter(msg => msg.role === 'assistant')
+          .map(msg => msg.content)
+          .join('')
+        // Skip adding result message if content was already received via streaming
+        const alreadyStreamed = streamedSinceUser.length > 0 &&
           resultContent.length > 0 &&
-          lastMsg.content.includes(resultContent.slice(0, DEDUP_PREFIX_LEN))
+          streamedSinceUser.startsWith(resultContent.slice(0, Math.min(resultContent.length, streamedSinceUser.length)))
 
         return {
           ...m,


### PR DESCRIPTION
Follow-up to #2957 addressing Copilot review feedback.

## Changes
1. **Dedup now checks ALL assistant messages since the last user message** — handles gap-split streaming where tool use creates multiple message bubbles (previously only checked the last message)
2. **Uses `startsWith` comparison** instead of `includes` on a prefix for stricter matching
3. **Added 2 tests**:
   - Stream chunks + result with same content → exactly 1 assistant message (not 2)
   - Result without prior streaming → still adds the message normally

All 64 tests pass.

## Test plan
- [x] `npx vitest run src/hooks/useMissions.test.tsx` — 64 passed