### PR TITLE
🐛 fix: expand Resource Marshall to cover all dependency kinds (#2965)

### DIFF
--- a/web/src/hooks/useDependencies.ts
+++ b/web/src/hooks/useDependencies.ts
@@ -3,7 +3,7 @@ import { isAgentUnavailable } from './useLocalAgent'
 import { clusterCacheRef } from './mcp/shared'
 import { isDemoMode } from '../lib/demoMode'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { FETCH_DEFAULT_TIMEOUT_MS, MCP_HOOK_TIMEOUT_MS } from '../lib/constants/network'
 
 export interface ResolvedDependency {
   kind: string
@@ -28,7 +28,7 @@ function authHeaders(): Record<string, string> {
 }
 
 /** Fetch a JSON endpoint from the local agent with timeout. */
-async function agentFetch(path: string, timeout = 15000): Promise<Record<string, unknown>> {
+async function agentFetch(path: string, timeout = MCP_HOOK_TIMEOUT_MS): Promise<Record<string, unknown>> {
   const ctrl = new AbortController()
   const tid = setTimeout(() => ctrl.abort(), timeout)
   try {
@@ -62,14 +62,19 @@ async function resolveViaAgent(
 
   const params = `cluster=${encodeURIComponent(context)}&namespace=${encodeURIComponent(namespace)}`
 
-  // Fetch namespace resources in parallel
-  const [configmaps, secrets, serviceaccounts, services, pvcs, hpas] = await Promise.allSettled([
+  // Fetch namespace resources in parallel — includes all agent-supported kinds
+  const [
+    configmaps, secrets, serviceaccounts, services, pvcs, hpas,
+    ingresses, networkpolicies,
+  ] = await Promise.allSettled([
     agentFetch(`/configmaps?${params}`),
     agentFetch(`/secrets?${params}`),
     agentFetch(`/serviceaccounts?${params}`),
     agentFetch(`/services?${params}`),
     agentFetch(`/pvcs?${params}`),
     agentFetch(`/hpas?${params}`),
+    agentFetch(`/ingresses?${params}`),
+    agentFetch(`/networkpolicies?${params}`),
   ])
 
   const deps: ResolvedDependency[] = []
@@ -100,6 +105,8 @@ async function resolveViaAgent(
   extract(services, 'services', 'Service')
   extract(pvcs, 'pvcs', 'PersistentVolumeClaim')
   extract(hpas, 'hpas', 'HorizontalPodAutoscaler')
+  extract(ingresses, 'ingresses', 'Ingress')
+  extract(networkpolicies, 'networkpolicies', 'NetworkPolicy')
 
   return {
     workload: name,
@@ -144,6 +151,10 @@ export function useResolveDependencies() {
           { kind: 'Service', name: name, namespace, optional: false, order: 3 },
           { kind: 'HorizontalPodAutoscaler', name: `${name}-hpa`, namespace, optional: true, order: 4 },
           { kind: 'PersistentVolumeClaim', name: `${name}-data`, namespace, optional: true, order: 5 },
+          { kind: 'NetworkPolicy', name: `${name}-netpol`, namespace, optional: true, order: 6 },
+          { kind: 'StorageClass', name: 'fast-ssd', namespace, optional: true, order: 7 },
+          { kind: 'ResourceQuota', name: `${namespace}-quota`, namespace, optional: true, order: 8 },
+          { kind: 'PriorityClass', name: 'high-priority', namespace, optional: true, order: 9 },
         ],
         warnings: [],
       }

--- a/web/src/lib/resourceCategories.ts
+++ b/web/src/lib/resourceCategories.ts
@@ -19,6 +19,10 @@ import {
   Server,
   Blocks,
   ShieldAlert,
+  Database,
+  Scale,
+  ArrowUpDown,
+  Activity,
 } from 'lucide-react'
 import type { ResourceCategory } from '../types/workloadMonitor'
 
@@ -43,7 +47,10 @@ export const DEP_CATEGORIES: DependencyCategory[] = [
   { label: 'Configuration', kinds: ['ConfigMap', 'Secret'], icon: FileText, category: 'config' },
   { label: 'Networking', kinds: ['Service', 'Ingress', 'NetworkPolicy'], icon: Network, category: 'networking' },
   { label: 'Scaling & Availability', kinds: ['HorizontalPodAutoscaler', 'PodDisruptionBudget'], icon: Gauge, category: 'scaling' },
-  { label: 'Storage', kinds: ['PersistentVolumeClaim'], icon: HardDrive, category: 'storage' },
+  { label: 'Storage', kinds: ['PersistentVolumeClaim', 'StorageClass'], icon: HardDrive, category: 'storage' },
+  { label: 'Governance', kinds: ['ResourceQuota', 'LimitRange'], icon: Scale, category: 'governance' },
+  { label: 'Scheduling', kinds: ['PriorityClass'], icon: ArrowUpDown, category: 'scheduling' },
+  { label: 'Observability', kinds: ['ServiceMonitor', 'PodMonitor', 'PrometheusRule'], icon: Activity, category: 'observability' },
   { label: 'Custom Resources', kinds: ['CustomResourceDefinition'], icon: Blocks, category: 'crd' },
   { label: 'Admission Control', kinds: ['ValidatingWebhookConfiguration', 'MutatingWebhookConfiguration'], icon: ShieldAlert, category: 'admission' },
 ]
@@ -67,6 +74,13 @@ export const KIND_ICONS: Record<string, LucideIcon> = {
   HorizontalPodAutoscaler: Gauge,
   PodDisruptionBudget: Shield,
   PersistentVolumeClaim: HardDrive,
+  StorageClass: Database,
+  ResourceQuota: Scale,
+  LimitRange: Scale,
+  PriorityClass: ArrowUpDown,
+  ServiceMonitor: Activity,
+  PodMonitor: Activity,
+  PrometheusRule: Activity,
   CustomResourceDefinition: Blocks,
   ValidatingWebhookConfiguration: ShieldAlert,
   MutatingWebhookConfiguration: ShieldAlert,

--- a/web/src/types/workloadMonitor.ts
+++ b/web/src/types/workloadMonitor.ts
@@ -23,6 +23,9 @@ export type ResourceCategory =
   | 'storage'
   | 'crd'
   | 'admission'
+  | 'governance'
+  | 'scheduling'
+  | 'observability'
   | 'other'
 
 /** A Kubernetes resource being monitored with its health status */


### PR DESCRIPTION
## Summary
- **Agent fallback**: Added `Ingress` and `NetworkPolicy` fetches to the agent-based namespace scan (the only additional agent endpoints that exist beyond the original 6)
- **New categories**: Added `Governance` (ResourceQuota, LimitRange), `Scheduling` (PriorityClass), and `Observability` (ServiceMonitor, PodMonitor, PrometheusRule) categories with icons
- **Storage expanded**: Added `StorageClass` to the existing Storage category (PersistentVolume intentionally excluded — only the claim and StorageClass travel with workloads)
- **Icon mappings**: Added `KIND_ICONS` entries for all 7 new kinds (Database, Scale, ArrowUpDown, Activity from lucide-react)
- **Demo data**: Added demo entries for NetworkPolicy, StorageClass, ResourceQuota, PriorityClass so demo mode covers new categories
- **No magic numbers**: Replaced hardcoded `15000` timeout with `MCP_HOOK_TIMEOUT_MS` constant

Closes #2965

## Test plan
- [ ] Verify build passes (`npm run build`)
- [ ] Verify lint passes (`npm run lint`)
- [ ] Open Resource Marshall card in demo mode — confirm new kinds (StorageClass, ResourceQuota, PriorityClass, NetworkPolicy) appear with correct icons and category grouping
- [ ] Verify `KNOWN_DEPENDENCY_KINDS` includes all new kinds (used by card filtering)
- [ ] Verify agent fallback fetches 8 endpoints (configmaps, secrets, serviceaccounts, services, pvcs, hpas, ingresses, networkpolicies)