### PR TITLE
🐛 Fix duplicate folder rendering in Mission Explorer (#2952, #2953, #2964)

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -8,7 +8,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import {
   Search, X, Upload, Filter, Grid3X3, List, Sparkles, CheckCircle,
-  Loader2, Plus, Trash2, ExternalLink, RefreshCw,
+  Loader2, Plus, ExternalLink, RefreshCw,
 } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { api } from '../../lib/api'
@@ -1283,6 +1283,17 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                       selectedPath={selectedPath}
                       onToggle={toggleNode}
                       onSelect={selectNode}
+                      onRemove={node.id === 'github' ? (child) => {
+                        const updated = watchedRepos.filter(r => r !== child.path)
+                        setWatchedRepos(updated)
+                        saveWatchedRepos(updated)
+                        showToast(`Removed repository "${child.path}"`, 'info')
+                      } : node.id === 'local' ? (child) => {
+                        const updated = watchedPaths.filter(p => p !== child.path)
+                        setWatchedPaths(updated)
+                        saveWatchedPaths(updated)
+                        showToast(`Removed path "${child.path}"`, 'info')
+                      } : undefined}
                     />
                   </div>
                   {/* Add button for repos and local */}
@@ -1365,64 +1376,6 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                     </form>
                   </div>
                 )}
-
-                {/* Remove buttons for watched children */}
-                {node.id === 'github' && expandedNodes.has('github') && node.children?.map((child) => (
-                  watchedRepos.includes(child.path) ? (
-                    <div key={`remove-${child.id}`} className="flex items-center ml-6">
-                      <div className="flex-1 min-w-0">
-                        <TreeNodeItem
-                          node={child}
-                          depth={1}
-                          expandedNodes={expandedNodes}
-                          selectedPath={selectedPath}
-                          onToggle={toggleNode}
-                          onSelect={selectNode}
-                        />
-                      </div>
-                      <button
-                        onClick={() => {
-                          const updated = watchedRepos.filter(r => r !== child.path)
-                          setWatchedRepos(updated)
-                          saveWatchedRepos(updated)
-                          showToast(`Removed repository "${child.path}"`, 'info')
-                        }}
-                        className="p-2 min-h-11 min-w-11 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors flex-shrink-0"
-                        title="Remove from watched"
-                      >
-                        <Trash2 className="w-3 h-3" />
-                      </button>
-                    </div>
-                  ) : null
-                ))}
-                {node.id === 'local' && expandedNodes.has('local') && node.children?.map((child) => (
-                  watchedPaths.includes(child.path) ? (
-                    <div key={`remove-${child.id}`} className="flex items-center ml-6">
-                      <div className="flex-1 min-w-0">
-                        <TreeNodeItem
-                          node={child}
-                          depth={1}
-                          expandedNodes={expandedNodes}
-                          selectedPath={selectedPath}
-                          onToggle={toggleNode}
-                          onSelect={selectNode}
-                        />
-                      </div>
-                      <button
-                        onClick={() => {
-                          const updated = watchedPaths.filter(p => p !== child.path)
-                          setWatchedPaths(updated)
-                          saveWatchedPaths(updated)
-                          showToast(`Removed path "${child.path}"`, 'info')
-                        }}
-                        className="p-2 min-h-11 min-w-11 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors flex-shrink-0"
-                        title="Remove from watched"
-                      >
-                        <Trash2 className="w-3 h-3" />
-                      </button>
-                    </div>
-                  ) : null
-                ))}
               </div>
             ))}
           </div>

--- a/web/src/components/missions/browser/TreeNodeItem.tsx
+++ b/web/src/components/missions/browser/TreeNodeItem.tsx
@@ -1,6 +1,6 @@
 import {
   Folder, FolderOpen, FileJson, ChevronRight, ChevronDown,
-  Loader2, Globe, Github, HardDrive,
+  Loader2, Globe, Github, HardDrive, Trash2,
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import type { TreeNode } from './types'
@@ -12,6 +12,7 @@ export function TreeNodeItem({
   selectedPath,
   onToggle,
   onSelect,
+  onRemove,
 }: {
   node: TreeNode
   depth: number
@@ -19,10 +20,13 @@ export function TreeNodeItem({
   selectedPath: string | null
   onToggle: (node: TreeNode) => void
   onSelect: (node: TreeNode) => void
+  /** Optional callback to remove a watched path/repo. When provided and the node is a watched child (source is 'local' or 'github'), a delete button is rendered. */
+  onRemove?: (node: TreeNode) => void
 }) {
   const isExpanded = expandedNodes.has(node.id)
   const isSelected = selectedPath === node.id
   const isDir = node.type === 'directory'
+  const showRemoveButton = onRemove && depth > 0 && (node.source === 'local' || node.source === 'github')
 
   const sourceIcon = () => {
     switch (node.source) {
@@ -37,43 +41,58 @@ export function TreeNodeItem({
 
   return (
     <div>
-      <button
-        onClick={() => {
-          if (isDir) onToggle(node)
-          onSelect(node)
-        }}
-        className={cn(
-          'w-full flex items-center gap-1.5 px-2 py-1.5 rounded-md text-sm transition-colors text-left',
-          isSelected
-            ? 'bg-purple-500/15 text-purple-400'
-            : 'text-foreground hover:bg-secondary/50'
+      <div className={showRemoveButton ? 'flex items-center' : undefined}>
+        <button
+          onClick={() => {
+            if (isDir) onToggle(node)
+            onSelect(node)
+          }}
+          className={cn(
+            'w-full flex items-center gap-1.5 px-2 py-1.5 rounded-md text-sm transition-colors text-left',
+            isSelected
+              ? 'bg-purple-500/15 text-purple-400'
+              : 'text-foreground hover:bg-secondary/50',
+            showRemoveButton && 'flex-1 min-w-0'
+          )}
+          style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        >
+          {isDir ? (
+            <>
+              {node.loading ? (
+                <Loader2 className="w-3.5 h-3.5 text-muted-foreground animate-spin flex-shrink-0" />
+              ) : isExpanded ? (
+                <ChevronDown className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
+              ) : (
+                <ChevronRight className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
+              )}
+              {isExpanded ? (
+                <FolderOpen className="w-4 h-4 text-yellow-400 flex-shrink-0" />
+              ) : (
+                <Folder className="w-4 h-4 text-yellow-400 flex-shrink-0" />
+              )}
+            </>
+          ) : (
+            <>
+              <span className="w-3.5 flex-shrink-0" />
+              <FileJson className="w-4 h-4 text-blue-400 flex-shrink-0" />
+            </>
+          )}
+          <span className="truncate flex-1">{node.name}</span>
+          {depth === 0 && sourceIcon()}
+        </button>
+        {showRemoveButton && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onRemove(node)
+            }}
+            className="p-2 min-h-11 min-w-11 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors flex-shrink-0"
+            title="Remove from watched"
+          >
+            <Trash2 className="w-3 h-3" />
+          </button>
         )}
-        style={{ paddingLeft: `${depth * 16 + 8}px` }}
-      >
-        {isDir ? (
-          <>
-            {node.loading ? (
-              <Loader2 className="w-3.5 h-3.5 text-muted-foreground animate-spin flex-shrink-0" />
-            ) : isExpanded ? (
-              <ChevronDown className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
-            ) : (
-              <ChevronRight className="w-3.5 h-3.5 text-muted-foreground flex-shrink-0" />
-            )}
-            {isExpanded ? (
-              <FolderOpen className="w-4 h-4 text-yellow-400 flex-shrink-0" />
-            ) : (
-              <Folder className="w-4 h-4 text-yellow-400 flex-shrink-0" />
-            )}
-          </>
-        ) : (
-          <>
-            <span className="w-3.5 flex-shrink-0" />
-            <FileJson className="w-4 h-4 text-blue-400 flex-shrink-0" />
-          </>
-        )}
-        <span className="truncate flex-1">{node.name}</span>
-        {depth === 0 && sourceIcon()}
-      </button>
+      </div>
 
       {isDir && isExpanded && node.children && (
         <div>
@@ -86,6 +105,7 @@ export function TreeNodeItem({
               selectedPath={selectedPath}
               onToggle={onToggle}
               onSelect={onSelect}
+              onRemove={onRemove}
             />
           ))}
           {node.children.length === 0 && node.loaded && (


### PR DESCRIPTION
## Summary
Fixes three related bugs in the Mission Explorer tree view caused by folders being rendered twice.

## Root cause
"Local Files" and "GitHub" children were rendered once by `TreeNodeItem`'s recursive rendering, and a second time by manual loops in `MissionBrowser.tsx` that re-rendered `TreeNodeItem` alongside delete buttons. This dual rendering caused:
- **#2952**: Creating a folder showed it twice
- **#2953**: Deleting one duplicate removed both (same underlying data)
- **#2964**: Inconsistent expand/collapse (shared state, two renderings)

## Fix
- Removed the redundant manual rendering loops (56 lines)
- Added `onRemove` callback prop to `TreeNodeItem` for delete button support
- Delete buttons now render inline within the single tree rendering pass

Closes #2952, #2953, #2964

## Test plan
- [ ] Add a folder in Local Files — should appear once
- [ ] Delete a folder — only that folder removed
- [ ] Expand/collapse — consistent behavior, no duplicates