### PR TITLE
🐛 Register compliance hooks with mode transition system (#2947)

### DIFF
--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -14,6 +14,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { useDemoMode } from './useDemoMode'
+import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_KUBESCAPE_CACHE, STORAGE_KEY_KUBESCAPE_CACHE_TIME } from '../lib/constants/storage'
 
 /** Refresh interval for automatic polling (2 minutes) */
@@ -91,6 +92,16 @@ function saveToCache(statuses: Record<string, KubescapeClusterStatus>): void {
       localStorage.setItem(STORAGE_KEY_KUBESCAPE_CACHE, JSON.stringify(completed))
       localStorage.setItem(STORAGE_KEY_KUBESCAPE_CACHE_TIME, Date.now().toString())
     }
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/** Clear localStorage cache so stale data doesn't persist across mode transitions */
+function clearCache(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY_KUBESCAPE_CACHE)
+    localStorage.removeItem(STORAGE_KEY_KUBESCAPE_CACHE_TIME)
   } catch {
     // Ignore storage errors
   }
@@ -400,6 +411,28 @@ export function useKubescape() {
       setIsLoading(false)
     }
   }, [clusters.length, isDemoMode, clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Register with unified mode transition system so skeleton/refetch works
+  // in sync with all other cards when demo mode is toggled
+  useEffect(() => {
+    registerCacheReset('kubescape', () => {
+      clearCache()
+      setStatuses({})
+      setIsLoading(true)
+      setLastRefresh(null)
+      setClustersChecked(0)
+      initialLoadDone.current = false
+    })
+
+    const unregisterRefetch = registerRefetch('kubescape', () => {
+      refetch(false)
+    })
+
+    return () => {
+      unregisterCacheReset('kubescape')
+      unregisterRefetch()
+    }
+  }, [refetch])
 
   // Auto-refresh — always poll when clusters exist so we detect tools
   // that get installed later or clusters that become reachable

--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -18,6 +18,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { useDemoMode } from './useDemoMode'
+import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_TRESTLE_CACHE, STORAGE_KEY_TRESTLE_CACHE_TIME } from '../lib/constants/storage'
 
 /** Refresh interval for automatic polling (2 minutes) */
@@ -106,6 +107,16 @@ function saveToCache(statuses: Record<string, TrestleClusterStatus>): void {
       localStorage.setItem(STORAGE_KEY_TRESTLE_CACHE, JSON.stringify(completed))
       localStorage.setItem(STORAGE_KEY_TRESTLE_CACHE_TIME, Date.now().toString())
     }
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/** Clear localStorage cache so stale data doesn't persist across mode transitions */
+function clearCache(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY_TRESTLE_CACHE)
+    localStorage.removeItem(STORAGE_KEY_TRESTLE_CACHE_TIME)
   } catch {
     // Ignore storage errors
   }
@@ -423,6 +434,27 @@ export function useTrestle() {
     intervalRef.current = setInterval(() => fetchData(true), REFRESH_INTERVAL_MS)
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [fetchData])
+
+  // Register with unified mode transition system so skeleton/refetch works
+  // in sync with all other cards when demo mode is toggled
+  useEffect(() => {
+    registerCacheReset('trestle', () => {
+      clearCache()
+      setStatuses({})
+      setIsLoading(true)
+      setLastRefresh(null)
+      setClustersChecked(0)
+    })
+
+    const unregisterRefetch = registerRefetch('trestle', () => {
+      fetchData(false)
+    })
+
+    return () => {
+      unregisterCacheReset('trestle')
+      unregisterRefetch()
     }
   }, [fetchData])
 

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -14,6 +14,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { kubectlProxy } from '../lib/kubectlProxy'
 import { useDemoMode } from './useDemoMode'
+import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_TRIVY_CACHE, STORAGE_KEY_TRIVY_CACHE_TIME } from '../lib/constants/storage'
 
 /** Refresh interval for automatic polling (2 minutes) */
@@ -94,6 +95,16 @@ function saveToCache(statuses: Record<string, TrivyClusterStatus>): void {
       localStorage.setItem(STORAGE_KEY_TRIVY_CACHE, JSON.stringify(completed))
       localStorage.setItem(STORAGE_KEY_TRIVY_CACHE_TIME, Date.now().toString())
     }
+  } catch {
+    // Ignore storage errors
+  }
+}
+
+/** Clear localStorage cache so stale data doesn't persist across mode transitions */
+function clearCache(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY_TRIVY_CACHE)
+    localStorage.removeItem(STORAGE_KEY_TRIVY_CACHE_TIME)
   } catch {
     // Ignore storage errors
   }
@@ -334,6 +345,28 @@ export function useTrivy() {
       setIsLoading(false)
     }
   }, [clusters.length, isDemoMode, clustersLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Register with unified mode transition system so skeleton/refetch works
+  // in sync with all other cards when demo mode is toggled
+  useEffect(() => {
+    registerCacheReset('trivy', () => {
+      clearCache()
+      setStatuses({})
+      setIsLoading(true)
+      setLastRefresh(null)
+      setClustersChecked(0)
+      initialLoadDone.current = false
+    })
+
+    const unregisterRefetch = registerRefetch('trivy', () => {
+      refetch(false)
+    })
+
+    return () => {
+      unregisterCacheReset('trivy')
+      unregisterRefetch()
+    }
+  }, [refetch])
 
   // Auto-refresh — always poll when clusters exist so we detect tools
   // that get installed later or clusters that become reachable


### PR DESCRIPTION
## Summary
Compliance cards (Kubescape, Trivy, Trestle) kept showing demo data after switching from Demo to AI/live mode until page refresh.

## Root cause
Only `useKyverno` was registered with the mode transition system (`registerCacheReset` + `registerRefetch`). The other 3 hooks retained stale cached demo data when `toggleDemoMode()` called `clearAllRegisteredCaches()`.

## Fix
Added `clearCache()` and mode transition registration to all 3 hooks, matching the existing pattern in `useKyverno`:
- `useKubescape.ts` — clears localStorage cache, resets statuses, triggers refetch
- `useTrivy.ts` — clears localStorage cache, resets statuses, triggers refetch
- `useTrestle.ts` — clears localStorage cache, resets statuses, triggers refetch

Closes #2947

## Test plan
- [ ] Start in Demo mode on Compliance dashboard
- [ ] Switch to AI/live mode
- [ ] Compliance cards should clear demo data and show loading → live data (no page refresh needed)