### PR TITLE
🐛 Re-validate imported mission content before execution (#2956)

### DIFF
--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -5,6 +5,7 @@ import { addCategoryTokens, setActiveTokenCategory } from './useTokenUsage'
 import { detectIssueSignature, findSimilarResolutionsStandalone, generateResolutionPromptContext } from './useResolutions'
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
+import { scanForMaliciousContent } from '../lib/missions/scanner/malicious'
 
 export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'saved'
 
@@ -993,6 +994,36 @@ Install the console locally with the KubeStellar Console agent to use AI mission
   const runSavedMission = useCallback((missionId: string, cluster?: string) => {
     const mission = missions.find(m => m.id === missionId)
     if (!mission || mission.status !== 'saved') return
+
+    // Re-validate imported mission content before execution to catch
+    // malicious payloads that may have been modified after initial import scan
+    if (mission.importedFrom?.steps) {
+      const syntheticExport = {
+        version: 'kc-mission-v1',
+        title: mission.importedFrom.title || mission.title,
+        description: mission.importedFrom.description || mission.description,
+        type: mission.type,
+        tags: mission.importedFrom.tags || [],
+        steps: mission.importedFrom.steps.map(s => ({
+          title: s.title,
+          description: s.description,
+        })),
+      }
+      const findings = scanForMaliciousContent(syntheticExport)
+      if (findings.length > 0) {
+        setMissions(prev => prev.map(m => m.id === missionId ? {
+          ...m,
+          status: 'failed' as const,
+          messages: [...m.messages, {
+            id: `msg-${Date.now()}`,
+            role: 'system' as const,
+            content: `**Mission blocked:** Imported mission contains potentially unsafe content:\n\n${findings.map(f => `- ${f.message}: \`${f.match}\` (in ${f.location})`).join('\n')}\n\nPlease review and edit the mission before running.`,
+            timestamp: new Date(),
+          }]
+        } : m))
+        return
+      }
+    }
 
     const basePrompt = mission.importedFrom?.steps
       ? `${mission.description}\n\nSteps:\n${mission.importedFrom.steps.map((s, i) => `${i + 1}. ${s.title}: ${s.description}`).join('\n')}`


### PR DESCRIPTION
## Summary
Imported missions were validated for malicious content at import time but not re-validated before execution. This meant edited missions could bypass the security scanner.

## Fix
In `runSavedMission()`, added a re-validation step that runs `scanForMaliciousContent()` on imported mission steps before sending them to the AI agent. If malicious content is detected (XSS, privilege escalation, command injection, crypto miners, etc.), the mission is blocked with a detailed error message listing each finding.

Only triggers for missions with `importedFrom.steps` — regular chat missions are unaffected.

Closes #2956

## Test plan
- [ ] Import a clean mission → runs normally
- [ ] Import a mission with `curl | bash` in step description → blocked with findings
- [ ] Regular (non-imported) missions → unaffected