### PR TITLE
🐛 fix: expand rewards scope to all kubestellar repos

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1114,7 +1114,7 @@ func LoadConfigFromEnv() Config {
 		FeedbackRepoOwner:   getEnvOrDefault("FEEDBACK_REPO_OWNER", "kubestellar"),
 		FeedbackRepoName:    getEnvOrDefault("FEEDBACK_REPO_NAME", "console"),
 		// GitHub activity rewards
-		RewardsGitHubOrgs: getEnvOrDefault("REWARDS_GITHUB_ORGS", "repo:kubestellar/console repo:kubestellar/console-marketplace repo:kubestellar/console-kb"),
+		RewardsGitHubOrgs: getEnvOrDefault("REWARDS_GITHUB_ORGS", "org:kubestellar"),
 		// Skip onboarding questionnaire for new users
 		SkipOnboarding: os.Getenv("SKIP_ONBOARDING") == "true",
 		// Benchmark data from Google Drive


### PR DESCRIPTION
## Summary
Rewards search was limited to `repo:kubestellar/console repo:kubestellar/console-marketplace repo:kubestellar/console-kb`, so contributions to other repos like `kubestellar/docs` were not counted.

Changed default to `org:kubestellar` to cover all repos in the org.

Fixes contributor @ghanshyam2005singh's missing points from kubestellar/docs#1310.

## Test plan
- [ ] Contributions from kubestellar/docs now appear in rewards
- [ ] Contributions from kubestellar/console still appear
- [ ] Override via `REWARDS_GITHUB_ORGS` env var still works