### PR TITLE
🐛 Show clear auth error in AI Missions instead of raw JSON

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -2212,7 +2212,8 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 				return
 			}
 			log.Printf("[Chat] streaming execution error for %s: %v", agentName, err)
-			safeWrite(ctx, s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s", agentName)))
+			code, msg2 := classifyProviderError(err)
+			safeWrite(ctx, s.errorResponse(msg.ID, code, msg2))
 			return
 		}
 
@@ -2236,7 +2237,8 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 				return
 			}
 			log.Printf("[Chat] execution error for %s: %v", agentName, err)
-			safeWrite(ctx, s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s", agentName)))
+			code, msg2 := classifyProviderError(err)
+			safeWrite(ctx, s.errorResponse(msg.ID, code, msg2))
 			return
 		}
 	}
@@ -2553,6 +2555,37 @@ func (s *Server) errorResponse(id, code, message string) protocol.Message {
 			Message: message,
 		},
 	}
+}
+
+// classifyProviderError inspects an AI provider error and returns a
+// specific error code + user-friendly message.  This lets the frontend
+// show targeted guidance (e.g. "run /login") instead of a raw JSON blob.
+func classifyProviderError(err error) (code, message string) {
+	errText := strings.ToLower(err.Error())
+
+	// Authentication / token expiry (HTTP 401 / 403)
+	if strings.Contains(errText, "status 401") ||
+		strings.Contains(errText, "status 403") ||
+		strings.Contains(errText, "authentication_error") ||
+		strings.Contains(errText, "permission_error") ||
+		strings.Contains(errText, "oauth token") ||
+		strings.Contains(errText, "token has expired") ||
+		strings.Contains(errText, "invalid x-api-key") ||
+		strings.Contains(errText, "invalid_api_key") ||
+		strings.Contains(errText, "unauthorized") {
+		return "authentication_error", "Failed to authenticate. API Error: " + err.Error()
+	}
+
+	// Rate limit (HTTP 429)
+	if strings.Contains(errText, "status 429") ||
+		strings.Contains(errText, "rate_limit") ||
+		strings.Contains(errText, "rate limit") ||
+		strings.Contains(errText, "too many requests") ||
+		strings.Contains(errText, "resource_exhausted") {
+		return "rate_limit", "Rate limit exceeded. " + err.Error()
+	}
+
+	return "execution_error", "Failed to get response from AI provider. " + err.Error()
 }
 
 // handleMixedModeChat orchestrates a dual-agent chat:

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -773,12 +773,33 @@ Install the console locally with the KubeStellar Console agent to use AI mission
         let errorContent = payload.message || 'Unknown error'
         if (payload.code === 'no_agent' || payload.code === 'agent_unavailable') {
           errorContent = `${payload.message}\n\n[Configure API Keys →](/settings)\n\nAdd your API key for Claude, OpenAI, or Gemini to use AI missions.`
+        } else if (payload.code === 'authentication_error') {
+          errorContent = '**Authentication Error — Agent CLI Needs Attention**\n\nThis is not a console issue. The AI agent\'s API token has expired or is invalid.\n\n**To fix:** Run `/login` in your Claude Code terminal to refresh your OAuth token, or update your API key in [Settings →](/settings).\n\nOnce re-authenticated, retry your message.'
         } else if (payload.code === 'mission_timeout') {
           errorContent = `**Mission Timed Out**\n\n${payload.message}\n\nYou can:\n- **Retry** the mission with the same or a different prompt\n- **Try a simpler request** that requires less processing\n- **Check your AI provider** configuration in [Settings](/settings)`
         }
 
-        // Detect rate limit / quota errors from the AI provider (HTTP 429)
+        // Pattern-match common API provider errors for user-friendly messages
         const combinedErrorText = `${payload.code || ''} ${payload.message || ''}`.toLowerCase()
+
+        // Detect authentication / token expiry errors (HTTP 401/403)
+        const isAuthError =
+          combinedErrorText.includes('401') ||
+          combinedErrorText.includes('403') ||
+          combinedErrorText.includes('authentication_error') ||
+          combinedErrorText.includes('permission_error') ||
+          combinedErrorText.includes('oauth token') ||
+          combinedErrorText.includes('token has expired') ||
+          combinedErrorText.includes('invalid x-api-key') ||
+          combinedErrorText.includes('invalid_api_key') ||
+          combinedErrorText.includes('unauthorized') ||
+          combinedErrorText.includes('failed to authenticate')
+
+        if (isAuthError) {
+          errorContent = '**Authentication Error — Agent CLI Needs Attention**\n\nThis is not a console issue. The AI agent\'s API token has expired or is invalid.\n\n**To fix:** Run `/login` in your Claude Code terminal to refresh your OAuth token, or update your API key in [Settings →](/settings).\n\nOnce re-authenticated, retry your message.'
+        }
+
+        // Detect rate limit / quota errors from the AI provider (HTTP 429)
         const isRateLimit =
           combinedErrorText.includes('429') ||
           combinedErrorText.includes('rate limit') ||


### PR DESCRIPTION
## Summary

- **Backend**: New `classifyProviderError()` helper inspects AI provider errors and returns specific error codes (`authentication_error`, `rate_limit`) instead of generic `execution_error`. Also passes the actual error message through to the frontend instead of swallowing it with "Failed to execute claude".
- **Frontend**: Detects `authentication_error` code (and pattern-matches 401/403/OAuth/token expired) and shows a clear message: **"Authentication Error — Agent CLI Needs Attention"** with instructions to run `/login` or update the API key in Settings. Explicitly states "This is not a console issue."

### Before
Raw JSON blob displayed as an assistant message:
```
Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"OAuth token has expired...
```

### After
Formatted system message:
> **Authentication Error — Agent CLI Needs Attention**
>
> This is not a console issue. The AI agent's API token has expired or is invalid.
>
> **To fix:** Run `/login` in your Claude Code terminal to refresh your OAuth token, or update your API key in Settings.

## Test plan
- [ ] Expire an OAuth token and send a mission message → verify friendly auth error appears
- [ ] Verify rate limit errors still show rate limit message
- [ ] Verify timeout errors still show timeout message
- [ ] `go build ./...` passes
- [ ] `npm run build` passes