### PR TITLE
🐛 Fix text truncation in AI Missions sidebar

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -592,7 +592,7 @@ export function MissionSidebar() {
         </div>
       ) : activeMission ? (
         <div className={cn(
-          "flex-1 flex min-h-0",
+          "flex-1 flex min-h-0 min-w-0 overflow-hidden",
           isFullScreen && "w-full"
         )}>
           {/* Fullscreen: show saved missions panel on left */}
@@ -651,7 +651,7 @@ export function MissionSidebar() {
               </div>
             </div>
           )}
-          <div className="flex-1 flex flex-col min-h-0">
+          <div className="flex-1 flex flex-col min-h-0 min-w-0">
             {/* Back to list if multiple missions */}
             {missions.length > 1 && (
               <button


### PR DESCRIPTION
## Summary

- Added `min-w-0 overflow-hidden` to the mission chat flex-row wrapper
- Added `min-w-0` to the inner chat column container
- Without these, flex children could overflow the 680px sidebar boundary, causing text to be cut off at the right edge

## Test plan
- [x] Open AI Missions sidebar → send a message → text wraps within panel boundaries
- [x] Long code blocks and URLs wrap correctly
- [x] Fullscreen mode unaffected