### PR TITLE
🐛 fix: MissionCTA test failure

### DIFF
--- a/web/src/components/dashboard/MissionCTA.test.tsx
+++ b/web/src/components/dashboard/MissionCTA.test.tsx
@@ -13,6 +13,7 @@ vi.mock('../../hooks/useMissions', () => ({
 
 vi.mock('../../lib/utils/localStorage', () => ({
   safeGetItem: vi.fn(() => null),
+  safeSetItem: vi.fn(() => true),
 }))
 
 describe('MissionCTA Component', () => {


### PR DESCRIPTION
## Summary
- Added missing `safeSetItem` mock to the `localStorage` module mock in `MissionCTA.test.tsx`
- The component's `handleDismiss()` calls `safeSetItem()` but the test only mocked `safeGetItem`, causing a Vitest "No export defined on mock" error when the dismiss button test fired

## Root Cause
The `vi.mock('../../lib/utils/localStorage')` block only returned `safeGetItem` but not `safeSetItem`. When the "hides when dismiss button is clicked" test clicked the dismiss button, `handleDismiss()` called `safeSetItem(DISMISSED_KEY, 'true')` which threw because the mock didn't define that export.

## Test plan
- [x] `npx vitest run src/components/dashboard/MissionCTA.test.tsx` — 6/6 tests pass, 0 errors
- [x] `npm run build` — passes
- [x] `npm run lint` on changed file — clean

Fixes #3002