### PR TITLE
🐛 fix: extract magic number to named constant

### DIFF
--- a/web/src/components/dashboard/CardFactoryModal.tsx
+++ b/web/src/components/dashboard/CardFactoryModal.tsx
@@ -32,6 +32,7 @@ interface CardFactoryModalProps {
 type Tab = 'declarative' | 'code' | 'ai' | 'manage'
 
 const SAVE_MESSAGE_TIMEOUT_MS = 3000 // Duration to display save/error messages before auto-clearing
+const COPY_FEEDBACK_TIMEOUT_MS = 2000 // Duration to show "copied" feedback before resetting
 
 const EXAMPLE_TSX = `// Example: Simple counter card
 export default function MyCard({ config }) {
@@ -572,7 +573,7 @@ const T2_TEMPLATES: T2Template[] = [
     try {
       navigator?.clipboard?.writeText?.(getCommand(f))
       setCopied(f.id)
-      setTimeout(() => setCopied(null), 2000)
+      setTimeout(() => setCopied(null), ${COPY_FEEDBACK_TIMEOUT_MS})
     } catch {}
   }
 


### PR DESCRIPTION
## Summary
- Extracted bare `2000` magic number in `CardFactoryModal.tsx` (Port Forward Tracker template) to a named constant `COPY_FEEDBACK_TIMEOUT_MS`
- The constant is interpolated into the template string via `${COPY_FEEDBACK_TIMEOUT_MS}` so the generated card code still receives the numeric value
- Fixes the consistency test Phase 1 (Magic Numbers) violation

## Test plan
- [x] `npm run build` passes
- [x] `consistency-test.sh` passes with 0 errors, 0 warnings
- [ ] Verify Port Forward Tracker card's copy button still shows brief "copied" feedback

Fixes #3001