### PR TITLE
🐛 fix: scope rewards to current year only (match leaderboard)

### DIFF
--- a/pkg/api/handlers/rewards.go
+++ b/pkg/api/handlers/rewards.go
@@ -237,7 +237,9 @@ type searchResponse struct {
 // searchItems queries GitHub Search API with pagination.
 // itemType is "issue" or "pr".
 func (h *RewardsHandler) searchItems(login, itemType, token string) ([]searchItem, error) {
-	query := fmt.Sprintf("author:%s %s type:%s", login, h.orgs, itemType)
+	// Scope to current year only — matches the leaderboard at kubestellar.io/leaderboard
+	yearStart := fmt.Sprintf("%d-01-01", time.Now().Year())
+	query := fmt.Sprintf("author:%s %s type:%s created:>=%s", login, h.orgs, itemType, yearStart)
 	allItems := make([]searchItem, 0)
 
 	for page := 1; page <= rewardsMaxPages; page++ {


### PR DESCRIPTION
## Summary
Console rewards API counted all-time contributions while the leaderboard at kubestellar.io only counts the current year. Users saw inflated point totals (e.g., 26,200 in console vs 8,400 on leaderboard).

Adds `created:>=YYYY-01-01` filter to the GitHub Search query so the console matches the leaderboard exactly.

## Test plan
- [ ] Rewards points in console match leaderboard at kubestellar.io/leaderboard
- [ ] Points reset to current-year only after cache expires (10 min)