### PR TITLE
✨ CLI-only agents: enable tool execution and hide API-key agents

### DIFF
--- a/pkg/agent/provider_antigravity.go
+++ b/pkg/agent/provider_antigravity.go
@@ -68,7 +68,9 @@ func (a *AntigravityProvider) IsAvailable() bool {
 	return a.cliPath != ""
 }
 func (a *AntigravityProvider) Capabilities() ProviderCapability {
-	return CapabilityChat | CapabilityToolExec
+	// Antigravity is a VS Code-based IDE, not a standalone CLI agent.
+	// It cannot run commands headlessly via -p flag like Claude Code or Copilot CLI.
+	return CapabilityChat
 }
 
 func (a *AntigravityProvider) Refresh() {

--- a/pkg/agent/provider_bob.go
+++ b/pkg/agent/provider_bob.go
@@ -189,12 +189,11 @@ func (b *BobProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse
 	// Build prompt with history for context
 	fullPrompt := b.buildPromptWithHistory(req)
 
-	// Build command: bob "prompt" --chat-mode ask -o json
-	// --chat-mode ask: forces analysis mode (no tool execution), so Bob provides
-	// detailed diagnostic responses instead of lazy summaries like "Listed 17 item(s)."
+	// Build command: bob "prompt" --yolo -o json
+	// --yolo: auto-approve all tool actions so Bob can execute commands non-interactively
 	args := []string{
 		fullPrompt,
-		"--chat-mode", "ask",
+		"--yolo",
 		"-o", "json",
 	}
 

--- a/pkg/agent/provider_codex.go
+++ b/pkg/agent/provider_codex.go
@@ -101,7 +101,9 @@ func (c *CodexProvider) StreamChat(ctx context.Context, req *ChatRequest, onChun
 	execCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	cmd := exec.CommandContext(execCtx, c.cliPath, "--quiet", prompt)
+	// exec subcommand: non-interactive mode for codex
+	// --full-auto: allow tool execution without confirmation
+	cmd := exec.CommandContext(execCtx, c.cliPath, "exec", "--full-auto", prompt)
 	cmd.Env = append(os.Environ(), "NO_COLOR=1")
 
 	stdout, err := cmd.StdoutPipe()

--- a/pkg/agent/provider_copilotcli.go
+++ b/pkg/agent/provider_copilotcli.go
@@ -117,7 +117,9 @@ func (c *CopilotCLIProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 	// --silent: only output agent response (no usage stats)
 	// --no-ask-user: disable interactive prompts that would block
 	// --no-color: disable ANSI color codes
-	cmd := exec.CommandContext(ctx, c.cliPath, "-p", prompt, "--silent", "--no-ask-user", "--no-color")
+	// --allow-all-tools: allow tool execution without confirmation (required for non-interactive mode)
+	// --allow-all-paths: allow access to any file path for kubectl/helm operations
+	cmd := exec.CommandContext(ctx, c.cliPath, "-p", prompt, "--silent", "--no-ask-user", "--no-color", "--allow-all-tools", "--allow-all-paths")
 	cmd.Env = append(os.Environ(), "NO_COLOR=1")
 
 	stdout, err := cmd.StdoutPipe()

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -238,24 +238,11 @@ func InitializeProviders() error {
 	registry.Register(NewAntigravityProvider())
 	registry.Register(NewGHCopilotProvider())
 
-	// Register API-only agents (can generate text / used for missions, not execute commands)
-	registry.Register(NewClaudeProvider())
-	registry.Register(NewOpenAIProvider())
-	registry.Register(NewGeminiProvider())
-
-	// Register IDE/app-based agents (API chat, each with own key)
-	registry.Register(NewClaudeDesktopProvider())
-	registry.Register(NewCursorProvider())
-	registry.Register(NewVSCodeProvider())
-	registry.Register(NewWindsurfProvider())
-	registry.Register(NewClineProvider())
-	registry.Register(NewJetBrainsProvider())
-	registry.Register(NewZedProvider())
-	registry.Register(NewContinueProvider())
-	registry.Register(NewRaycastProvider())
-
-	// Register HTTP API-based agents
-	registry.Register(NewOpenWebUIProvider())
+	// NOTE: API-only agents (Claude API, OpenAI, Gemini) and IDE-based agents
+	// (Cursor, Windsurf, Cline, etc.) are intentionally not registered.
+	// They cannot execute commands to diagnose/repair clusters, which is the
+	// primary value of AI Missions. Only CLI-based agents that can take action
+	// are registered above.
 
 	// Set default agent based on environment or availability
 	if defaultAgent := os.Getenv("DEFAULT_AGENT"); defaultAgent != "" {

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -3274,26 +3274,11 @@ func (s *Server) handleGetKeysStatus(w http.ResponseWriter, r *http.Request) {
 		displayName string
 	}
 
-	// Base API providers always shown
-	providers := []providerDef{
-		{"claude", "Claude.ai (Anthropic)"},
-		{"openai", "ChatGPT (OpenAI)"},
-		{"gemini", "Gemini (Google)"},
-	}
-
-	// Add all registered providers that have API key support
-	apiProviders := []providerDef{
-		{"cursor", "Cursor (Anysphere)"},
-		{"vscode", "VS Code (Microsoft)"},
-		{"windsurf", "Windsurf (Codeium)"},
-		{"cline", "Cline"},
-		{"jetbrains", "JetBrains IDEs"},
-		{"zed", "Zed"},
-		{"continue", "Continue.dev"},
-		{"raycast", "Raycast"},
-		{"open-webui", "Open WebUI"},
-	}
-	providers = append(providers, apiProviders...)
+	// Only show CLI-based agents — API-key-driven agents are hidden because
+	// they cannot execute commands to diagnose/repair clusters.
+	// This list is intentionally empty; the keys endpoint remains functional
+	// for any future API providers but currently returns no keys.
+	providers := []providerDef{}
 
 	keys := make([]KeyStatus, 0, len(providers))
 	for _, p := range providers {

--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -1,10 +1,9 @@
 import { useRef, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { ChevronDown, Check, Loader2, Settings, Sparkles } from 'lucide-react'
+import { ChevronDown, Check, Loader2, Sparkles } from 'lucide-react'
 import { useMissions } from '../../hooks/useMissions'
 import { useDemoMode, getDemoMode } from '../../hooks/useDemoMode'
 import { AgentIcon } from './AgentIcon'
-import { APIKeySettings } from './APIKeySettings'
 import type { AgentInfo } from '../../types/agent'
 import { cn } from '../../lib/cn'
 import { useModalState } from '../../lib/modals'
@@ -22,19 +21,15 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
   // Synchronous fallback prevents flash during React transitions
   const isDemoMode = isDemoModeHook || getDemoMode()
   const { isOpen, close: closeDropdown, toggle: toggleDropdown } = useModalState()
-  const { isOpen: isSettingsOpen, open: openSettings, close: closeSettings } = useModalState()
   const PREV_AGENT_KEY = 'kc_previous_agent'
   const previousAgentRef = useRef<string | null>(
     typeof window !== 'undefined' ? safeGetItem(PREV_AGENT_KEY) : null
   )
   const dropdownRef = useRef<HTMLDivElement>(null)
 
-  // CLI-based agents (bob, claude-code) should be hidden when not available
-  // API-based agents (claude, openai, gemini) should still show so users can configure them
-  const CLI_BASED_PROVIDERS = ['bob']
-  const visibleAgents = agents.filter(a =>
-    a.available || !CLI_BASED_PROVIDERS.includes(a.provider)
-  )
+  // Only show agents that are available (installed CLI-based agents).
+  // API-key-driven agents are hidden — they can't execute commands to diagnose/repair clusters.
+  const visibleAgents = agents.filter(a => a.available)
 
   // Sort: selected agent first, then available agents, then unavailable
   const sortedAgents = useMemo(() => {
@@ -247,9 +242,6 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
                       )}
                     </div>
                     <p className={cn('text-xs truncate', agent.available ? 'text-muted-foreground' : 'text-muted-foreground/60')}>{agent.description}</p>
-                    {!agent.available && (
-                      <p className="text-xs text-destructive/70 mt-0.5">API key not configured</p>
-                    )}
                   </div>
                 </div>
               ))}
@@ -275,23 +267,9 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
               )}
             </div>
           )}
-          {/* Settings footer inside dropdown */}
-          <div className="border-t border-border">
-            <button
-              onClick={() => {
-                openSettings()
-                closeDropdown()
-              }}
-              className="w-full flex items-center gap-2 px-3 py-2 text-left text-sm text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors"
-            >
-              <Settings className="w-4 h-4" />
-              API Key Settings
-            </button>
-          </div>
         </div>
       )}
     </div>
-    {!isDemoMode && <APIKeySettings isOpen={isSettingsOpen} onClose={closeSettings} />}
     </>
   )
 }

--- a/web/src/components/settings/Settings.tsx
+++ b/web/src/components/settings/Settings.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useLocation, useNavigate } from 'react-router-dom'
 import {
   Cpu, TrendingUp, Coins, User, Bell, Shield,
-  Palette, Eye, Plug, Github, Key, LayoutGrid, Download, Database, Container, HardDrive,
+  Palette, Eye, Plug, Github, LayoutGrid, Download, Database, Container, HardDrive,
   CheckCircle, Loader2, AlertCircle, WifiOff, BarChart3, X,
 } from 'lucide-react'
 import { useAuth } from '../../lib/auth'
@@ -23,7 +23,6 @@ import {
   ProfileSection,
   AgentSection,
   GitHubTokenSection,
-  APIKeysSection,
   TokenUsageSection,
   ThemeSection,
   AccessibilitySection,
@@ -56,7 +55,6 @@ const SETTINGS_NAV = [
       { id: 'ai-mode-settings', labelKey: 'settings.nav.aiMode' as const, icon: Cpu },
       { id: 'prediction-settings', labelKey: 'settings.nav.predictions' as const, icon: TrendingUp },
       { id: 'agent-settings', labelKey: 'settings.nav.localAgent' as const, icon: Plug },
-      { id: 'api-keys-settings', labelKey: 'settings.nav.apiKeys' as const, icon: Key },
       { id: 'token-usage-settings', labelKey: 'settings.nav.tokenUsage' as const, icon: Coins },
     ],
   },
@@ -376,7 +374,6 @@ export function Settings() {
               resetSettings={resetPredictionSettings}
             />
             <AgentSection isConnected={isConnected} health={health} refresh={refresh} />
-            <APIKeysSection />
             <TokenUsageSection usage={usage} updateSettings={updateSettings} resetUsage={resetUsage} isDemoData={isDemoData} />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- **Copilot CLI**: Add `--allow-all-tools --allow-all-paths` flags so it can actually execute kubectl/helm commands instead of refusing with "permission denied"
- **Bob**: Replace `--chat-mode ask` (analysis-only) with `--yolo` (auto-approve tool actions)
- **Codex**: Use `exec --full-auto` subcommand instead of `--quiet` for non-interactive command execution
- **Antigravity**: Reclassify from tool-capable to chat-only (it's a VS Code-based IDE, not a CLI agent — `-p` flag doesn't work)
- **Remove API-key agents** from registry, agent selector, and settings — they can't execute commands to diagnose/repair clusters
- **Remove API Keys** settings section and nav item from the settings page

## Why
CLI agents that can take action (run kubectl, diagnose issues, repair clusters) are the primary value of AI Missions. API-only agents that just suggest commands without executing them are not useful in this context.

## Test plan
- [ ] Verify Copilot CLI can execute commands in AI Missions (e.g., "check nodes on pok-prod-01")
- [ ] Verify Bob can execute commands in AI Missions
- [ ] Verify Codex can execute commands in AI Missions  
- [ ] Verify agent dropdown only shows installed CLI agents
- [ ] Verify Settings page no longer shows API Keys section
- [ ] Verify no "API key not configured" messages appear