### PR TITLE
🐛 Fix docs issue creation auth and coin tracking consistency (#3034, #3036)

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -1505,6 +1505,10 @@ func (h *FeedbackHandler) createGitHubIssue(request *models.FeatureRequest, user
 // createGitHubIssueInRepo creates a GitHub issue in the specified repository.
 // For documentation issues (target_repo=docs), it uses documentation-appropriate
 // labels instead of the AI fix pipeline labels.
+//
+// If the initial request with labels fails due to insufficient label permissions
+// (HTTP 403 on the "label" resource), the function retries without labels so
+// the issue is still created. Labels can be added later by a maintainer.
 func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest, user *models.User, repoOwner, repoName string) (int, string, error) {
 	// Determine labels based on request type and target repo
 	var labels []string
@@ -1548,19 +1552,37 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 *This issue was automatically created from the KubeStellar Console.*
 `, request.RequestType, repoLabel, user.GitHubLogin, request.ID.String(), request.Description)
 
+	// First attempt: create issue with labels
+	number, htmlURL, err := h.postGitHubIssue(repoOwner, repoName, request.Title, issueBody, labels)
+	if err != nil && isLabelPermissionError(err) {
+		// The token lacks permission to create/apply labels on this repo.
+		// Retry without labels — the issue body includes the request type
+		// so maintainers can triage and label it manually.
+		log.Printf("[Feedback] Label permission denied on %s/%s, retrying without labels", repoOwner, repoName)
+		number, htmlURL, err = h.postGitHubIssue(repoOwner, repoName, request.Title, issueBody, nil)
+	}
+
+	return number, htmlURL, err
+}
+
+// postGitHubIssue sends a POST request to the GitHub Issues API.
+// If labels is nil or empty, the "labels" field is omitted from the payload.
+func (h *FeedbackHandler) postGitHubIssue(repoOwner, repoName, title, body string, labels []string) (int, string, error) {
 	payload := map[string]interface{}{
-		"title":  request.Title,
-		"body":   issueBody,
-		"labels": labels,
+		"title": title,
+		"body":  body,
+	}
+	if len(labels) > 0 {
+		payload["labels"] = labels
 	}
 
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
 		return 0, "", fmt.Errorf("failed to marshal issue payload: %w", err)
 	}
-	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues", repoOwner, repoName)
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues", repoOwner, repoName)
 
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return 0, "", err
 	}
@@ -1577,11 +1599,11 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, readErr := io.ReadAll(resp.Body)
+		respBody, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
-			body = []byte("(failed to read response body)")
+			respBody = []byte("(failed to read response body)")
 		}
-		return 0, "", fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(body))
+		return 0, "", fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	var result struct {
@@ -1593,6 +1615,18 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 	}
 
 	return result.Number, result.HTMLURL, nil
+}
+
+// isLabelPermissionError checks whether the error from the GitHub API is a
+// 403 caused by insufficient permissions to create labels. The GitHub API
+// returns: {"message":"You do not have permission to create labels on this
+// repository.","errors":[{"resource":"Repository","field":"label","code":"unauthorized"}]}
+func isLabelPermissionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "403") && strings.Contains(msg, "label")
 }
 
 // addPRComment adds a comment to a GitHub PR

--- a/web/src/hooks/useRewards.tsx
+++ b/web/src/hooks/useRewards.tsx
@@ -204,17 +204,31 @@ export function RewardsProvider({ children }: { children: ReactNode }) {
     return rewards.events.slice(0, RECENT_EVENTS_LIMIT)
   }, [rewards])
 
-  // Dedup: subtract console-submitted bug/feature coins that are already in GitHub data
+  // Dedup: subtract console-submitted bug/feature coins that overlap with GitHub data.
+  // Only dedup the *actual* overlap — the minimum of localStorage event count and
+  // GitHub contribution count for each category. This prevents under-counting when
+  // GitHub hasn't indexed an issue yet or classifies it differently due to label timing.
   const consoleSubmittedOffset = useMemo(() => {
     if (!rewards || !githubRewards) return 0
-    const bugEvents = rewards.events.filter(e => e.action === 'bug_report').length
-    const featureEvents = rewards.events.filter(e => e.action === 'feature_suggestion').length
-    return (bugEvents * REWARD_ACTIONS.bug_report.coins) + (featureEvents * REWARD_ACTIONS.feature_suggestion.coins)
+
+    const localBugCount = (rewards.events || []).filter(e => e.action === 'bug_report').length
+    const localFeatureCount = (rewards.events || []).filter(e => e.action === 'feature_suggestion').length
+
+    const githubBugCount = githubRewards.breakdown?.bug_issues ?? 0
+    const githubFeatureCount = githubRewards.breakdown?.feature_issues ?? 0
+
+    // Only dedup entries that appear in BOTH sources (the overlap)
+    const bugOverlap = Math.min(localBugCount, githubBugCount)
+    const featureOverlap = Math.min(localFeatureCount, githubFeatureCount)
+
+    return (bugOverlap * REWARD_ACTIONS.bug_report.coins) + (featureOverlap * REWARD_ACTIONS.feature_suggestion.coins)
   }, [rewards, githubRewards])
 
-  // Merged total: localStorage coins - dedup offset + GitHub coins
+  // Merged total: localStorage coins - dedup offset + GitHub coins.
+  // The dedup offset removes only the overlapping bug/feature coins from
+  // localStorage to avoid double-counting with the GitHub-sourced total.
   const mergedTotalCoins = useMemo(() => {
-    const localCoins = rewards?.totalCoins || 0
+    const localCoins = rewards?.totalCoins ?? 0
     if (!githubRewards) return localCoins
     return Math.max(0, localCoins - consoleSubmittedOffset) + githubPoints
   }, [rewards?.totalCoins, consoleSubmittedOffset, githubPoints, githubRewards])


### PR DESCRIPTION
## Summary

- **Fixes #3036**: Issue creation in the docs repo (`kubestellar/docs`) fails with HTTP 403 because the feedback token lacks permission to create labels on that repository. The `createGitHubIssueInRepo` backend function now detects label permission errors and retries without labels, allowing the issue to be created successfully. Maintainers can add labels afterward.
- **Fixes #3034**: Coin tracking was inconsistent between the console and the leaderboard because the dedup logic assumed all console-submitted bug/feature events had a matching entry in GitHub data. When GitHub hadn't indexed the issue yet or classified it differently (due to label timing), the dedup over-subtracted coins from the local total. The fix uses `Math.min(localCount, githubCount)` per category to only dedup the actual overlap.

## Test plan

- [ ] Create a bug report targeting "Console Docs" in the feedback modal and verify it succeeds (previously returned 403)
- [ ] Verify that coin count in the console matches the sum of: localStorage-only activities + GitHub contributions (no double-counting, no under-counting)
- [ ] Verify coin display remains correct when GitHub rewards API returns 0 (e.g., new user with no GitHub activity)
- [ ] Verify existing console issue creation (targeting "Console App") still works with labels applied
- [ ] Build passes (`npm run build`) with 0 errors
- [ ] Lint passes (`npm run lint`) with 0 new errors
- [ ] Go tests pass (`go test ./pkg/api/handlers/...`)