### PR TITLE
🐛 Fix GPU type display and inventory sort fields (#3030, #3031)

### DIFF
--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -12,15 +12,27 @@ import { useSnoozedAlerts, SNOOZE_DURATIONS, formatSnoozeRemaining, type SnoozeD
 import { useTranslation } from 'react-i18next'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 
-// Sort field options
-type SortField = 'severity' | 'nodeName' | 'cluster' | 'deviceType'
+// Sort field options — separated by view so only applicable fields are shown
+type SortField = 'severity' | 'nodeName' | 'cluster' | 'deviceType' | 'totalDevices'
 
-const SORT_OPTIONS: { value: SortField; label: string }[] = [
+/** Sort options applicable to the Alerts view */
+const ALERTS_SORT_OPTIONS: { value: SortField; label: string }[] = [
   { value: 'severity', label: 'Severity' },
   { value: 'nodeName', label: 'Node' },
   { value: 'cluster', label: 'Cluster' },
   { value: 'deviceType', label: 'Device' },
 ]
+
+/** Sort options applicable to the Inventory view (no severity/device — those are alert-only concepts) */
+const INVENTORY_SORT_OPTIONS: { value: SortField; label: string }[] = [
+  { value: 'nodeName', label: 'Node' },
+  { value: 'cluster', label: 'Cluster' },
+  { value: 'totalDevices', label: 'Total Devices' },
+]
+
+/** Default sort field for each view */
+const DEFAULT_ALERTS_SORT: SortField = 'severity'
+const DEFAULT_INVENTORY_SORT: SortField = 'totalDevices'
 
 // Get icon for device type
 function DeviceIcon({ deviceType, className }: { deviceType: string; className?: string }) {
@@ -107,7 +119,7 @@ export function HardwareHealthCard() {
   const [search, setSearch] = useState('')
   const [localClusterFilter, setLocalClusterFilter] = useState<string[]>([])
   const [showClusterFilter, setShowClusterFilter] = useState(false)
-  const [sortField, setSortField] = useState<SortField>('severity')
+  const [sortField, setSortField] = useState<SortField>(DEFAULT_INVENTORY_SORT)
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc')
   const [currentPage, setCurrentPage] = useState(1)
   const [itemsPerPage, setItemsPerPage] = useState<number | 'unlimited'>(5)
@@ -246,6 +258,19 @@ export function HardwareHealthCard() {
     }
   }, [activeAlertCount])
 
+  // Select sort options applicable to the current view
+  const currentSortOptions = viewMode === 'alerts' ? ALERTS_SORT_OPTIONS : INVENTORY_SORT_OPTIONS
+
+  // Reset sort field to the view-appropriate default when switching views
+  useEffect(() => {
+    const defaultSort = viewMode === 'alerts' ? DEFAULT_ALERTS_SORT : DEFAULT_INVENTORY_SORT
+    const validFields = (viewMode === 'alerts' ? ALERTS_SORT_OPTIONS : INVENTORY_SORT_OPTIONS).map(o => o.value)
+    // If current sort field is not valid for the new view, reset to default
+    if (!validFields.includes(sortField)) {
+      setSortField(defaultSort)
+    }
+  }, [viewMode]) // eslint-disable-line react-hooks/exhaustive-deps -- intentionally only reacts to viewMode changes
+
   // Get IDs of visible alerts for "Snooze All"
   const visibleAlertIds = useMemo(() => {
     return filteredAlerts.filter(a => !isSnoozed(a.id)).map(a => a.id)
@@ -345,6 +370,8 @@ export function HardwareHealthCard() {
   }
 
   // Sort inventory
+  /** Weight multiplier so GPU-heavy nodes sort above nodes with only other device types */
+  const GPU_SORT_WEIGHT = 100
   const sortedInventory = useMemo(() => {
     return [...filteredInventory].sort((a, b) => {
       let cmp = 0
@@ -355,12 +382,11 @@ export function HardwareHealthCard() {
         case 'cluster':
           cmp = a.cluster.localeCompare(b.cluster)
           break
-        case 'deviceType':
-        case 'severity':
+        case 'totalDevices':
         default: {
-          // Sort by total device count for inventory (GPUs prioritized, then other devices)
-          const aTotal = getTotalDevices(a.devices) + (a.devices.gpuCount * 100) // Weight GPUs higher
-          const bTotal = getTotalDevices(b.devices) + (b.devices.gpuCount * 100)
+          // Sort by total device count for inventory (GPUs prioritized via weight)
+          const aTotal = getTotalDevices(a.devices) + (a.devices.gpuCount * GPU_SORT_WEIGHT)
+          const bTotal = getTotalDevices(b.devices) + (b.devices.gpuCount * GPU_SORT_WEIGHT)
           cmp = aTotal - bTotal
           break
         }
@@ -567,7 +593,7 @@ export function HardwareHealthCard() {
           limit: itemsPerPage,
           onLimitChange: setItemsPerPage,
           sortBy: sortField,
-          sortOptions: SORT_OPTIONS,
+          sortOptions: currentSortOptions,
           onSortChange: (s) => setSortField(s as SortField),
           sortDirection,
           onSortDirectionChange: setSortDirection,

--- a/web/src/components/drilldown/views/GPUNodeDrillDown.tsx
+++ b/web/src/components/drilldown/views/GPUNodeDrillDown.tsx
@@ -31,23 +31,30 @@ function podStatusToIndicator(status: string): Status {
   return 'unknown'
 }
 
+/** Utilization percentage at or above which the indicator turns red */
+const HIGH_UTILIZATION_THRESHOLD_PCT = 90
+/** Utilization percentage at or above which the indicator turns yellow */
+const MODERATE_UTILIZATION_THRESHOLD_PCT = 50
+/** Multiplier to convert a ratio to a percentage */
+const PERCENT_MULTIPLIER = 100
+
 export function GPUNodeDrillDown({ data }: Props) {
   const { t } = useTranslation()
-  const cluster = data.cluster as string
-  const nodeName = data.node as string
-  const gpuType = data.gpuType as string
+  const cluster = (data.cluster as string) || ''
+  const nodeName = (data.node as string) || ''
+  const gpuType = (data.gpuType as string) || ''
   const gpuCount = (data.gpuCount as number) || 0
   const gpuAllocated = (data.gpuAllocated as number) || 0
   const { drillToEvents, drillToPod, drillToCluster } = useDrillDownActions()
   const clusterShort = cluster.split('/').pop() || cluster
 
-  const utilizationPercent = gpuCount > 0 ? Math.round((gpuAllocated / gpuCount) * 100) : 0
+  const utilizationPercent = gpuCount > 0 ? Math.round((gpuAllocated / gpuCount) * PERCENT_MULTIPLIER) : 0
 
   // Find GPU pods on this node
   const { pods: allPods } = useAllPods()
   const gpuPodsOnNode = useMemo(() => {
     const normalizedCluster = normalizeClusterName(cluster)
-    return allPods.filter(pod => {
+    return (allPods || []).filter(pod => {
       if (!pod.cluster || !pod.node) return false
       if (normalizeClusterName(pod.cluster) !== normalizedCluster) return false
       if (pod.node !== nodeName) return false
@@ -81,7 +88,7 @@ export function GPUNodeDrillDown({ data }: Props) {
             <div className="text-right">
               <div className="text-3xl font-bold text-foreground">{gpuAllocated}/{gpuCount}</div>
               <div className="text-sm text-muted-foreground">GPUs Allocated</div>
-              <div className={`text-sm ${utilizationPercent >= 90 ? 'text-red-400' : utilizationPercent >= 50 ? 'text-yellow-400' : 'text-green-400'}`}>
+              <div className={`text-sm ${utilizationPercent >= HIGH_UTILIZATION_THRESHOLD_PCT ? 'text-red-400' : utilizationPercent >= MODERATE_UTILIZATION_THRESHOLD_PCT ? 'text-yellow-400' : 'text-green-400'}`}>
                 {utilizationPercent}% utilization
               </div>
             </div>
@@ -105,7 +112,7 @@ export function GPUNodeDrillDown({ data }: Props) {
         </div>
         <div className="p-4 rounded-lg bg-card/50 border border-border">
           <div className="text-sm text-muted-foreground mb-2">GPU Type</div>
-          <div className="text-lg font-bold text-foreground truncate">{gpuType.split('-').slice(1, 2).join('')}</div>
+          <div className="text-lg font-bold text-foreground truncate">{gpuType || 'Unknown'}</div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- **GPU Type display** (`GPUNodeDrillDown.tsx`): The 4th metrics block "GPU Type" used `.split('-').slice(1, 2).join('')` to parse the GPU model string, which produced blank output for models without hyphens (e.g., "NVIDIA T4", "AMD GPU") and meaningless substrings for hyphenated models (e.g., only "SXM4" for "NVIDIA A100-SXM4-80GB"). Now displays the full `gpuType` string directly with an `'Unknown'` fallback.
- **Inventory sort fields** (`HardwareHealthCard.tsx`): The sort dropdown showed "Severity" and "Device" in Inventory view, which are alert-only concepts. Now each view has its own applicable sort options — Alerts: Severity/Node/Cluster/Device; Inventory: Node/Cluster/Total Devices. The sort field resets to the view-appropriate default when switching views.
- Replaced magic numbers (utilization thresholds, GPU sort weight) with named constants.
- Added undefined guard on `allPods` before `.filter()`.

Fixes #3030
Fixes #3031

## Test plan

- [ ] Open a GPU node drill-down for a node with gpuType "NVIDIA T4" — verify the GPU Type block shows the full string, not blank
- [ ] Open a GPU node drill-down for a node with gpuType "NVIDIA A100-SXM4-80GB" — verify it shows the full model name, not just "SXM4"
- [ ] Navigate to Hardware Health Card, select Inventory view — verify sort dropdown shows "Node", "Cluster", "Total Devices" (not "Severity" or "Device")
- [ ] Switch to Alerts view — verify sort dropdown shows "Severity", "Node", "Cluster", "Device"
- [ ] Switch between views — verify sort field resets appropriately and list re-sorts
- [ ] Build passes with zero errors
- [ ] Lint passes with zero new errors