### PR TITLE
🐛 Fix warmup hang when exec credential plugin blocks indefinitely

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -1095,7 +1095,16 @@ func (m *MultiClusterClient) WarmupHealthCache() {
 		}(cl.Name, cl.Context)
 	}
 
-	wg.Wait()
+	// Wait for all probes to finish, but give up when the overall context deadline
+	// fires. This prevents a single hung exec-plugin (e.g. oci credential helper)
+	// from blocking server startup indefinitely.
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-ctx.Done():
+		log.Printf("[Warmup] timed out waiting for all cluster probes — continuing startup")
+	}
 
 	m.mu.RLock()
 	reachable, unreachable := 0, 0


### PR DESCRIPTION
## Summary
- `WarmupHealthCache` probes all clusters in parallel then calls `wg.Wait()`
- If one cluster's `GetClient()` blocks forever (OCI/exec credential helper with no timeout), `wg.Wait()` never returns → server stuck at `{"status":"starting"}` forever
- Fix: run `wg.Wait()` in a goroutine and `select` on `ctx.Done()`, so the 8s overall warmup timeout always unblocks startup

## Root cause
The 11th cluster in the kubeconfig uses an exec-based credential provider that hangs. The probe goroutine acquires `m.mu.Lock()` inside `GetClient()`, then calls `ClientConfig()` which spawns the credential helper. If the helper doesn't exit, the goroutine blocks indefinitely holding the lock — and `wg.Wait()` never completes.

## Test plan
- [ ] Start backend with a kubeconfig that includes an unreachable/hung exec-credential cluster — server should start within ~10s instead of hanging forever
- [ ] Normal startup with reachable clusters still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)