### PR TITLE
✨ Differentiate saved mission CTA by deployment context

### DIFF
--- a/web/src/components/agent/AgentSetupDialog.tsx
+++ b/web/src/components/agent/AgentSetupDialog.tsx
@@ -32,6 +32,13 @@ export function AgentSetupDialog() {
     }
   }, [])
 
+  // Allow external triggers (e.g. from MissionChat saved state)
+  useEffect(() => {
+    const handler = () => setShow(true)
+    window.addEventListener('open-agent-setup', handler)
+    return () => window.removeEventListener('open-agent-setup', handler)
+  }, [])
+
   useEffect(() => {
     // Only show after initial connection check completes
     if (status === 'connecting') return

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react'
 import { useMissions, type Mission } from '../../../hooks/useMissions'
 import { useDemoMode } from '../../../hooks/useDemoMode'
+import { isNetlifyDeployment, setDemoMode } from '../../../lib/demoMode'
 import { useResolutions, detectIssueSignature, type Resolution } from '../../../hooks/useResolutions'
 import { cn } from '../../../lib/cn'
 import { MAX_MESSAGE_SIZE_CHARS } from '../../../lib/constants'
@@ -678,10 +679,33 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
           </div>
         ) : mission.status === 'saved' ? (
           <div className="flex flex-col gap-2">
-            {isDemoMode ? (
+            {isNetlifyDeployment ? (
               <p className="text-xs text-center text-muted-foreground px-2">
-                Mission imported. Install KubeStellar Console locally to run it against your clusters.
+                Mission imported.{' '}
+                <button
+                  onClick={() => window.dispatchEvent(new CustomEvent('open-install'))}
+                  className="underline hover:text-foreground transition-colors"
+                >
+                  Install KubeStellar Console locally
+                </button>{' '}
+                to run it against your clusters.
               </p>
+            ) : isDemoMode ? (
+              <div className="flex flex-col gap-2">
+                <button
+                  onClick={() => window.dispatchEvent(new CustomEvent('open-agent-setup'))}
+                  className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+                >
+                  <Play className="w-4 h-4" />
+                  Install Agent &amp; Run Mission
+                </button>
+                <button
+                  onClick={() => setDemoMode(false, true)}
+                  className="text-xs text-center text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Already have the agent? Turn off demo mode
+                </button>
+              </div>
             ) : (
               <button
                 onClick={() => runSavedMission(mission.id)}


### PR DESCRIPTION
## Summary
Three distinct states for the saved mission bottom action in `MissionChat`:

| Context | Behavior |
|---|---|
| `console.kubestellar.io` (forced demo) | Quiet text with clickable link → opens install-locally dialog |
| Localhost with demo mode on | "Install Agent & Run Mission" button → opens `AgentSetupDialog` + "Already have the agent? Turn off demo mode" link |
| Live mode (demo off) | "Run Mission" button → runs the mission |

Also adds `open-agent-setup` custom event listener to `AgentSetupDialog` so it can be triggered imperatively from any component (same pattern as `open-install`).

## Test plan
- [ ] `console.kubestellar.io`: import a mission, click the link → install dialog opens
- [ ] Localhost with demo mode ON: import a mission → see "Install Agent & Run Mission" button; click it → agent setup dialog opens
- [ ] Localhost with demo mode ON: click "Already have the agent? Turn off demo mode" → demo mode off, Run Mission button appears
- [ ] Localhost with demo mode OFF: import a mission → Run Mission button appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)