### PR TITLE
🐛 fix: separate Playwright concurrency groups for nightly vs push runs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,6 +15,11 @@ on:
       - 'web/**'
       - '.github/workflows/playwright.yml'
 
+# Separate concurrency groups: nightly/manual runs won't be cancelled by push/PR runs
+concurrency:
+  group: playwright-${{ github.event_name == 'schedule' && 'nightly' || github.event_name == 'workflow_dispatch' && 'manual' || github.ref }}
+  cancel-in-progress: true
+
 env:
   CI: true
 


### PR DESCRIPTION
## Summary

- Nightly cross-browser (Firefox/WebKit) runs were getting cancelled by push-triggered runs from merged PRs on main
- Both event types shared the same implicit concurrency — a push to main would cancel an in-progress nightly/manual dispatch run
- Adds explicit concurrency group: `nightly` and `manual` dispatch runs get their own groups, push/PR runs use `github.ref`

## Test plan

- [ ] Merge this PR, then `gh workflow run "Playwright E2E Tests"` — Firefox/WebKit jobs should complete without being cancelled by any concurrent pushes to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)