### PR TITLE
🐛 Fix saved mission CTAs: prominent button, correct toast, mount AgentSetupDialog

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -25,6 +25,7 @@ import { TourOverlay, TourPrompt } from '../onboarding/Tour'
 import { TourProvider } from '../../hooks/useTour'
 import { SetupInstructionsDialog } from '../setup/SetupInstructionsDialog'
 import { InClusterAgentDialog } from '../setup/InClusterAgentDialog'
+import { AgentSetupDialog } from '../agent/AgentSetupDialog'
 import { KeepAliveOutlet } from './KeepAliveOutlet'
 import { UpdateProgressBanner } from '../updates/UpdateProgressBanner'
 import { useUpdateProgress } from '../../hooks/useUpdateProgress'
@@ -528,6 +529,9 @@ export function Layout({ children }: LayoutProps) {
         isOpen={showInClusterAgentDialog}
         onClose={() => setShowInClusterAgentDialog(false)}
       />
+
+      {/* Agent Setup Dialog — shown when agent not connected; also triggered by open-agent-setup event */}
+      <AgentSetupDialog />
 
       {/* Backend connection lost snackbar — fixed bottom center */}
       {showBackendBanner && (

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -680,16 +680,18 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
         ) : mission.status === 'saved' ? (
           <div className="flex flex-col gap-2">
             {isNetlifyDeployment ? (
-              <p className="text-xs text-center text-muted-foreground px-2">
-                Mission imported.{' '}
+              <div className="flex flex-col gap-2">
                 <button
                   onClick={() => window.dispatchEvent(new CustomEvent('open-install'))}
-                  className="underline hover:text-foreground transition-colors"
+                  className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
                 >
-                  Install KubeStellar Console locally
-                </button>{' '}
-                to run it against your clusters.
-              </p>
+                  <Play className="w-4 h-4" />
+                  Install KubeStellar Console
+                </button>
+                <p className="text-xs text-center text-muted-foreground px-2">
+                  Run this mission against your own clusters
+                </p>
+              </div>
             ) : isDemoMode ? (
               <div className="flex flex-col gap-2">
                 <button

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -554,7 +554,10 @@ export function MissionSidebar() {
           <p className="text-xs text-muted-foreground truncate mb-2">{showSavedToast}</p>
           {toastCountdown > 0 && (
             <p className="text-2xs text-muted-foreground/70 mb-2">
-              Your mission is ready. Click <strong className="text-foreground">Run</strong> below to start, or view its steps first.
+              {isDemoMode()
+                ? 'Use the button below to get started.'
+                : <>Your mission is ready. Click <strong className="text-foreground">Run</strong> below to start, or view its steps first.</>
+              }
             </p>
           )}
           <button


### PR DESCRIPTION
## Summary
Three fixes in one:

1. **console.kubestellar.io**: Replace the subtle text link with a full-width primary button: "Install KubeStellar Console" → opens install dialog
2. **Toast wording**: In demo mode, show "Use the button below to get started." instead of misleading "Click **Run** below"
3. **AgentSetupDialog**: Was defined but never mounted — added it to `Layout.tsx` so the `open-agent-setup` custom event actually works (fixes the "Install Agent & Run Mission" button on localhost with demo mode)

## Test plan
- [ ] console.kubestellar.io: import a mission → prominent "Install KubeStellar Console" button at bottom, toast says "Use the button below"
- [ ] Localhost, demo mode: import a mission → "Install Agent & Run Mission" button opens AgentSetupDialog
- [ ] Localhost, demo mode: "Already have the agent? Turn off demo mode" → demo off, Run Mission button appears
- [ ] Localhost, live mode: Run Mission button works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)