### PR TITLE
🐛 fix: use run_id for nightly Playwright concurrency group

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,9 +15,10 @@ on:
       - 'web/**'
       - '.github/workflows/playwright.yml'
 
-# Separate concurrency groups: nightly/manual runs won't be cancelled by push/PR runs
+# Nightly/manual runs get a unique concurrency group (run_id) so they are never
+# cancelled by push/PR runs. Push/PR runs share github.ref so newer ones cancel older.
 concurrency:
-  group: playwright-${{ github.event_name == 'schedule' && 'nightly' || github.event_name == 'workflow_dispatch' && 'manual' || github.ref }}
+  group: playwright-${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.run_id || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary

- Nightly cross-browser runs (Firefox/WebKit) keep getting cancelled by push-triggered runs on main
- Previous fix used a ternary expression that still resolved to `github.ref` for `workflow_dispatch`
- Now uses `github.run_id` for schedule/dispatch events — each nightly run gets a unique concurrency group and can never be cancelled by push/PR runs

## Test plan

- [ ] Merge, then `gh workflow run "Playwright E2E Tests"` — Firefox/WebKit should complete even if PRs merge to main during the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)