### PR TITLE
🐛 Suppress AgentSetupDialog auto-show on Netlify; update button text

### DIFF
--- a/web/src/components/agent/AgentSetupDialog.tsx
+++ b/web/src/components/agent/AgentSetupDialog.tsx
@@ -8,6 +8,7 @@ import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
 import { useTranslation } from 'react-i18next'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import { copyToClipboard } from '../../lib/clipboard'
+import { isNetlifyDeployment } from '../../lib/demoMode'
 
 const DISMISSED_KEY = 'kc-agent-setup-dismissed'
 const SNOOZED_KEY = 'kc-agent-setup-snoozed'
@@ -40,6 +41,9 @@ export function AgentSetupDialog() {
   }, [])
 
   useEffect(() => {
+    // Never auto-show on Netlify — no agent can be installed there
+    if (isNetlifyDeployment) return
+
     // Only show after initial connection check completes
     if (status === 'connecting') return
 

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -686,11 +686,8 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
                   className="w-full flex items-center justify-center gap-2 px-4 py-2.5 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
                 >
                   <Play className="w-4 h-4" />
-                  Install KubeStellar Console
+                  Install KubeStellar Console to Run This Mission
                 </button>
-                <p className="text-xs text-center text-muted-foreground px-2">
-                  Run this mission against your own clusters
-                </p>
               </div>
             ) : isDemoMode ? (
               <div className="flex flex-col gap-2">

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -11,7 +11,7 @@ import {
   Minus,
   Plus,
   Type,
-  MessageSquarePlus,
+  Sparkles,
   Send,
   Globe,
   Bookmark,
@@ -403,7 +403,7 @@ export function MissionSidebar() {
             )}
             title={t('missionSidebar.startNewMission')}
           >
-            <MessageSquarePlus className="w-4 h-4" />
+            <Sparkles className="w-4 h-4" />
           </button>
           {/* Browse Community Missions */}
           <button
@@ -586,7 +586,7 @@ export function MissionSidebar() {
                 }}
                 className="flex items-center gap-2 px-4 py-2 text-sm font-medium bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
               >
-                <MessageSquarePlus className="w-4 h-4" />
+                <Sparkles className="w-4 h-4" />
                 {t('missionSidebar.startCustomMission')}
               </button>
             )}


### PR DESCRIPTION
## Summary
- `AgentSetupDialog` no longer auto-pops on `console.kubestellar.io` — no agent can be installed there so the dialog was noise. Can still be opened manually via the `open-agent-setup` event (used on localhost with demo mode).
- Netlify saved mission button text updated: **"Install KubeStellar Console to Run This Mission"** — clearer intent

## Test plan
- [ ] `console.kubestellar.io`: import a mission → button says "Install KubeStellar Console to Run This Mission", agent dialog does NOT auto-pop, clicking the button opens the install dialog
- [ ] Localhost, demo mode: "Install Agent & Run Mission" still opens AgentSetupDialog on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)