### PR TITLE
🐛 fix: prevent nightly cross-browser Playwright timeout

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -48,7 +48,7 @@ jobs:
     name: Cross-Browser (${{ matrix.browser }})
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -84,7 +84,7 @@ jobs:
           npx wait-on http://localhost:4173 --timeout 60000
 
       - name: Run Playwright tests (${{ matrix.browser }})
-        run: npx playwright test --project=${{ matrix.browser }}
+        run: npx playwright test --project=${{ matrix.browser }} --retries=0 --timeout=30000
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:4173
 


### PR DESCRIPTION
## Summary
- Increases nightly cross-browser job timeout from 20 to 30 minutes
- Sets `--retries=0` for nightly tests (just report pass/fail, no retries)
- Reduces per-test timeout from 60s to 30s (sufficient for page load checks)

## Why
Firefox/WebKit tests hang on WebSocket connection retries (no backend in preview mode). With 44 routes × 60s timeout × 2 retries, a few hanging routes cascade into exceeding the 20-minute job timeout, causing all tests to be killed and reported as "cancelled".

## Test plan
- [ ] Trigger `playwright-nightly.yml` manually
- [ ] Verify Firefox and WebKit jobs complete within 30 minutes
- [ ] Verify test results show individual pass/fail per test (not blanket cancellation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)