### PR TITLE
🐛 fix: scope nightly cross-browser to preview-compatible tests

### DIFF
--- a/.github/workflows/playwright-nightly.yml
+++ b/.github/workflows/playwright-nightly.yml
@@ -48,7 +48,7 @@ jobs:
     name: Cross-Browser (${{ matrix.browser }})
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -84,7 +84,13 @@ jobs:
           npx wait-on http://localhost:4173 --timeout 60000
 
       - name: Run Playwright tests (${{ matrix.browser }})
-        run: npx playwright test --project=${{ matrix.browser }} --retries=0 --timeout=30000
+        run: |
+          npx playwright test --project=${{ matrix.browser }} --retries=0 --timeout=30000 \
+            e2e/smoke.spec.ts \
+            e2e/responsive-regression.spec.ts \
+            e2e/spa-routes.spec.ts \
+            e2e/Login.spec.ts \
+            e2e/Dashboard.spec.ts
         env:
           PLAYWRIGHT_BASE_URL: http://localhost:4173
 


### PR DESCRIPTION
## Summary
- Scopes nightly Firefox/WebKit tests to 5 preview-compatible spec files instead of running all tests
- Tests run: smoke, responsive-regression, spa-routes, login, dashboard
- Reverts job timeout back to 20 minutes (sufficient for scoped tests)

## Why
Running all ~100+ test specs against a backend-less preview server causes Firefox/WebKit to exceed the job timeout. Many tests hang waiting for WebSocket/API connections that don't exist in preview mode, and even with `--retries=0 --timeout=30s`, the cumulative timeout across all hanging tests exceeds the limit.

The 5 selected specs cover the key cross-browser regression categories:
- **smoke.spec.ts** — route loading, console errors
- **responsive-regression.spec.ts** — layout at 4 viewport sizes (#2982, #2999, #3035)
- **spa-routes.spec.ts** — all 44 routes render without 404/blank (#3046)
- **Login.spec.ts** — auth flow rendering
- **Dashboard.spec.ts** — main page rendering

## Test plan
- [ ] Trigger `playwright-nightly.yml` manually
- [ ] Verify Firefox and WebKit jobs complete within 20 minutes
- [ ] Verify test results show individual pass/fail (not blanket cancellation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)