### PR TITLE
fix: improve AI Mission failure UX — actionable errors and Retry button

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -17,6 +17,7 @@ import {
   Pencil,
   Check,
   X,
+  RotateCcw,
 } from 'lucide-react'
 import { useMissions, type Mission } from '../../../hooks/useMissions'
 import { useDemoMode } from '../../../hooks/useDemoMode'
@@ -277,6 +278,14 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
     // Keep focus on input after sending
     setTimeout(() => inputRef.current?.focus(), 0)
   }
+
+  const handleRetryMission = useCallback(() => {
+    // Find the original user prompt (first user message in the conversation)
+    const initialUserMessage = mission.messages.find(m => m.role === 'user')
+    const prompt = initialUserMessage?.content || ''
+    if (!prompt.trim()) return
+    sendMessage(mission.id, prompt)
+  }, [mission.id, mission.messages, sendMessage])
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -728,6 +737,15 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               <span className={cn(config.color)}>{config.label}</span>
               <span className="text-muted-foreground">{t('missionChat.switchAgentRetry')}</span>
             </div>
+            {mission.messages.some(m => m.role === 'user') && (
+              <button
+                onClick={handleRetryMission}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+              >
+                <RotateCcw className="w-4 h-4" />
+                {t('missionChat.retryMission', { defaultValue: 'Retry Mission' })}
+              </button>
+            )}
             <div className="flex gap-2 min-w-0">
               <input
                 ref={inputRef}

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -799,7 +799,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
         // Create helpful error message based on error code
         let errorContent = payload.message || 'Unknown error'
         if (payload.code === 'no_agent' || payload.code === 'agent_unavailable') {
-          errorContent = `${payload.message}\n\n[Configure API Keys →](/settings)\n\nAdd your API key for Claude, OpenAI, or Gemini to use AI missions.`
+          errorContent = `**Mission interrupted — agent not available**\n\nThe AI agent was disconnected or is not reachable. This often happens after a page refresh.\n\n**To fix:**\n1. Make sure your agent (e.g., Claude Code, bob) is running\n2. Select the agent from the top navbar\n3. Click **Retry Mission** below to rerun your request`
         } else if (payload.code === 'authentication_error') {
           errorContent = '**Authentication Error — Agent CLI Needs Attention**\n\nThis is not a console issue. The AI agent\'s API token has expired or is invalid.\n\n**To fix:** Run `/login` in your Claude Code terminal to refresh your OAuth token, or update your API key in [Settings →](/settings).\n\nOnce re-authenticated, retry your message.'
         } else if (payload.code === 'mission_timeout') {
@@ -838,7 +838,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
           combinedErrorText.includes('requests per min')
 
         if (isRateLimit) {
-          errorContent = '**AI Provider Rate Limit Exceeded**\n\nThe AI provider returned a quota/rate limit error (HTTP 429). Please wait a minute before retrying, or switch to a different AI provider.\n\n[Configure API Keys →](/settings)'
+          errorContent = '**AI Provider Rate Limit Exceeded**\n\nThe AI provider returned a quota/rate limit error (HTTP 429). Please wait a minute before retrying, or switch to a different AI provider.'
         }
 
         return {

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1453,6 +1453,7 @@
     "thanksFeedback": "Thanks for the feedback. Try a different approach or switch to another agent above.",
     "backToMissions": "Back to missions",
     "switchAgentRetry": "Switch agent above and retry",
+    "retryMission": "Retry Mission",
     "retryWithMessage": "Retry with message...",
     "typeMessage": "Type a message...",
     "originalRequest": "Original Request",


### PR DESCRIPTION
## Summary

Fixes #3152, #3153, and #3154 — three related AI Mission failure UX issues reported by users.

- **#3152**: The `no_agent`/`agent_unavailable` error code was displaying an outdated "Configure API Keys →" link even though the API key feature has been removed from the platform. This link was confusing users with non-existent configuration steps.
- **#3153**: Mission failure errors lacked actionable guidance, leaving users unsure how to recover.
- **#3154**: When a mission failed, there was no single-click way to retry — users had to manually retype their prompt.

### Changes

**`web/src/hooks/useMissions.tsx`**
- Updated `no_agent`/`agent_unavailable` error message to explain session interruption and provide steps to reconnect the agent (no API key references)
- Removed stale "Configure API Keys →" link from rate-limit error message

**`web/src/components/layout/mission-sidebar/MissionChat.tsx`**
- Added `RotateCcw` icon import
- Added `handleRetryMission` callback that finds the first user message and re-sends it via `sendMessage`
- Added a prominent "Retry Mission" button in the failed mission state (only shown when there is an original user message to replay)

**`web/src/locales/en/common.json`**
- Added `retryMission` translation key

## Test plan

- [ ] Start a mission, then refresh the page — verify the error now says "Mission interrupted — agent not available" with actionable steps instead of the stale API key link
- [ ] Confirm the "Retry Mission" button appears in the failed state and re-sends the original prompt on click
- [ ] Verify the send-your-own-message input still works in the failed state
- [ ] Confirm build passes (`cd web && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)