### PR TITLE
fix: normalize nvidia-operators JSON key and add dashboard import rollback

### DIFF
--- a/pkg/api/handlers/dashboard.go
+++ b/pkg/api/handlers/dashboard.go
@@ -254,6 +254,8 @@ func (h *DashboardHandler) ImportDashboard(c *fiber.Ctx) error {
 			Position:    ce.Position,
 		}
 		if err := h.store.CreateCard(card); err != nil {
+			// Rollback: delete the partially-created dashboard and any cards
+			_ = h.store.DeleteDashboard(dashboard.ID)
 			return fiber.NewError(fiber.StatusInternalServerError, "Failed to create card")
 		}
 	}

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -657,7 +657,7 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatus(c *fiber.Ctx) error {
 			log.Printf("internal error: %v", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 		}
-		return c.JSON(fiber.Map{"operator": status, "source": "k8s"})
+		return c.JSON(fiber.Map{"operators": []*k8s.NVIDIAOperatorStatus{status}, "source": "k8s"})
 	}
 
 	return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})


### PR DESCRIPTION
## Summary
- **#3138**: Single-cluster `/api/mcp/nvidia-operators?cluster=X` now returns `"operators"` (array) instead of `"operator"` (singular object), matching the multi-cluster response shape and preventing frontend parse mismatches.
- **#3145**: `ImportDashboard` handler now rolls back the partially-created dashboard when a card creation fails mid-import, preventing orphaned records in the store.

## Test plan
- [ ] `go build ./cmd/console` passes
- [ ] Single-cluster nvidia-operators response uses `"operators"` key with array value
- [ ] Multi-cluster nvidia-operators response unchanged
- [ ] Dashboard import with invalid card data cleans up on failure

Closes #3138
Closes #3145

🤖 Generated with [Claude Code](https://claude.com/claude-code)