### PR TITLE
feat: pass KUBECONFIG env var to kc-agent in startup scripts

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -152,7 +152,11 @@ fi
 # Start kc-agent
 if command -v kc-agent &>/dev/null; then
     echo "Starting kc-agent..."
-    kc-agent &
+    KC_AGENT_ARGS=()
+    if [ -n "$KUBECONFIG" ]; then
+        KC_AGENT_ARGS+=(--kubeconfig "$KUBECONFIG")
+    fi
+    kc-agent "${KC_AGENT_ARGS[@]}" &
     AGENT_PID=$!
     sleep 2
 else

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -327,8 +327,13 @@ AGENT_LOOP_PID=""
 if [ -n "$KC_AGENT_BIN" ]; then
     echo -e "${GREEN}Starting kc-agent ($KC_AGENT_BIN)...${NC}"
     (
+        # Pass KUBECONFIG from .env / environment as --kubeconfig flag
+        KC_AGENT_ARGS=()
+        if [ -n "$KUBECONFIG" ]; then
+            KC_AGENT_ARGS+=(--kubeconfig "$KUBECONFIG")
+        fi
         while true; do
-            "$KC_AGENT_BIN" &
+            "$KC_AGENT_BIN" "${KC_AGENT_ARGS[@]}" &
             CHILD=$!
             echo "[kc-agent] Started (PID $CHILD)"
             wait $CHILD


### PR DESCRIPTION
## Summary
- Both `start-dev.sh` and `startup-oauth.sh` now forward the `KUBECONFIG` environment variable to `kc-agent` via the `--kubeconfig` flag
- Users can set `KUBECONFIG=/path/to/kubeconfig` in `.env` and kc-agent will use it automatically
- If `KUBECONFIG` is not set, kc-agent falls back to `~/.kube/config` as before

## Test plan
- [ ] Set `KUBECONFIG=/path/to/custom/kubeconfig` in `.env`, run `./startup-oauth.sh`, verify kc-agent uses the custom path
- [ ] Remove `KUBECONFIG` from `.env`, verify kc-agent falls back to `~/.kube/config`
- [ ] Verify `start-dev.sh` behaves the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)