### PR TITLE
fix: event_summary card guideline compliance

### DIFF
--- a/web/src/components/cards/EventSummary.tsx
+++ b/web/src/components/cards/EventSummary.tsx
@@ -3,7 +3,7 @@ import { AlertTriangle, CheckCircle2, Activity, Server, ChevronDown, AlertCircle
 import { useCachedEvents } from '../../hooks/useCachedData'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { RefreshButton } from '../ui/RefreshIndicator'
-import { Skeleton } from '../ui/Skeleton'
+import { CardSkeleton } from '../../lib/cards/CardComponents'
 import { useChartFilters } from '../../lib/cards/cardHooks'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
@@ -25,6 +25,7 @@ export function EventSummary() {
   // Report state to CardWrapper for refresh animation
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
+    isRefreshing,
     isDemoData: isDemoFallback,
     hasAnyData: events.length > 0,
     isFailed: isFailed && events.length === 0,
@@ -78,13 +79,7 @@ export function EventSummary() {
   }, [filteredEvents])
 
   if (showSkeleton) {
-    return (
-      <div className="space-y-3 p-1">
-        <Skeleton className="h-16 w-full" />
-        <Skeleton className="h-4 w-3/4" />
-        <Skeleton className="h-4 w-1/2" />
-      </div>
-    )
+    return <CardSkeleton type="status" rows={3} showHeader={false} />
   }
 
   if (showEmptyState) {


### PR DESCRIPTION
## Summary
- Replace raw `<Skeleton>` elements with `CardSkeleton` component from `CardComponents` (G9)
- Add missing `isRefreshing` to `useCardLoadingState` call to enable refresh animation (G10)

## Card Audit: event_summary

| Criterion | Result | Notes |
|-----------|--------|-------|
| G1 Search | ✅ PASS | Summary/metric card with ≤5 items per section — exception applies |
| G2 Sort | ✅ PASS | Natural sort by count — not a sortable list card |
| G3 Sort direction | ✅ PASS | N/A — no sort controls needed |
| G4 Cluster filter | ⚠️ PARTIAL | Uses useChartFilters with custom inline dropdown instead of CardClusterFilter — functional but not using shared component |
| G5 Pagination | ✅ PASS | Summary card with ≤5 items — exception applies |
| G6 Refresh | ✅ PASS | Uses RefreshButton from RefreshIndicator module |
| G7 Demo data | ✅ PASS | Demo data provided by useCachedEvents hook fallback |
| G8 Cache-first | ✅ PASS | Uses useCachedEvents (SWR pattern) |
| G9 Skeleton | ✅ PASS (fixed) | Was using raw Skeleton — now uses CardSkeleton |
| G10 Hook wiring | ✅ PASS (fixed) | Added missing isRefreshing to useCardLoadingState |

*Generated by card-test agent, cycle 2*