### PR TITLE
fix: warning_events card guideline compliance

### DIFF
--- a/web/src/components/cards/WarningEvents.tsx
+++ b/web/src/components/cards/WarningEvents.tsx
@@ -3,10 +3,9 @@ import { AlertTriangle, CheckCircle2, AlertCircle } from 'lucide-react'
 import { useCachedEvents } from '../../hooks/useCachedData'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { RefreshButton } from '../ui/RefreshIndicator'
-import { Skeleton } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
-import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
+import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardSkeleton, CardAIActions } from '../../lib/cards/CardComponents'
 import type { ClusterEvent } from '../../hooks/useMCP'
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../ui/StatusBadge'
@@ -53,6 +52,7 @@ export function WarningEvents() {
   // Report data state to CardWrapper for failure badge rendering
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
+    isRefreshing,
     isDemoData: isDemoFallback,
     hasAnyData: events.length > 0,
     isFailed,
@@ -105,13 +105,7 @@ export function WarningEvents() {
   })
 
   if (showSkeleton) {
-    return (
-      <div className="space-y-3 p-1">
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-10 w-full" />
-        <Skeleton className="h-10 w-full" />
-      </div>
-    )
+    return <CardSkeleton type="list" rows={3} showHeader showSearch />
   }
 
   if (showEmptyState) {


### PR DESCRIPTION
## Summary
- Replace raw `<Skeleton>` elements with `<CardSkeleton>` component (G9)
- Add `isRefreshing` to `useCardLoadingState` call for refresh animation (G10)
- Remove unused `Skeleton` import

## Card Audit: warning_events

| Criterion | Result | Notes |
|-----------|--------|-------|
| G1 Search | PASS | Uses CardSearchInput |
| G2 Sort | PASS | Uses CardControlsRow with time/count/reason |
| G3 Sort direction | PASS | sortDirection wired via cardControls |
| G4 Cluster filter | PASS | Uses CardControlsRow clusterFilter |
| G5 Pagination | PASS | Uses CardPaginationFooter |
| G6 Refresh indicator | PASS | Uses RefreshButton |
| G7 Demo data | PASS | useCachedEvents provides demo fallback |
| G8 Cache-first | PASS | useCachedEvents implements SWR |
| G9 Skeleton | FIXED | Was using raw Skeleton, now uses CardSkeleton |
| G10 Hook wiring | FIXED | Added missing isRefreshing |

*Generated by card-test agent, cycle 2*

🤖 Generated with [Claude Code](https://claude.com/claude-code)