### PR TITLE
fix: pod_issues card guideline compliance

### DIFF
--- a/web/src/components/cards/PodIssues.tsx
+++ b/web/src/components/cards/PodIssues.tsx
@@ -37,6 +37,7 @@ export function PodIssues() {
   const {
     issues: rawIssues,
     isLoading: hookLoading,
+    isRefreshing,
     isDemoFallback,
     isFailed,
     consecutiveFailures,
@@ -46,6 +47,7 @@ export function PodIssues() {
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: hookLoading,
+    isRefreshing,
     isDemoData: isDemoFallback,
     hasAnyData: rawIssues.length > 0,
     isFailed,


### PR DESCRIPTION
## Summary
- Added missing `isRefreshing` to `useCardLoadingState` call in PodIssues card
- The cache hook (`useCachedPodIssues`) returns `isRefreshing` but it was not being destructured or passed through, causing CardWrapper to fall back to a heuristic

## Criteria addressed
- **G10** (useCardLoadingState wiring): `isRefreshing` now explicitly passed

*Generated by card-test agent, cycle 2*