### PR TITLE
fix: require agent approval when switching from demo to agent mode

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -12,6 +12,7 @@ import { useLastRoute } from '../../hooks/useLastRoute'
 import { useMissions } from '../../hooks/useMissions'
 import { useDemoMode, isDemoModeForced, hasRealToken } from '../../hooks/useDemoMode'
 import { setDemoMode } from '../../lib/demoMode'
+import { hasApprovedAgents } from '../agent/AgentApprovalDialog'
 import { useLocalAgent } from '../../hooks/useLocalAgent'
 import { useClusters } from '../../hooks/mcp/clusters'
 import { emitClusterInventory } from '../../lib/analytics'
@@ -193,7 +194,8 @@ export function Layout({ children }: LayoutProps) {
         demoAutoEnabledRef.current = true
         setDemoMode(true)
       }
-    } else if (agentStatus === 'connected' && isDemoMode && demoAutoEnabledRef.current) {
+    } else if (agentStatus === 'connected' && isDemoMode && demoAutoEnabledRef.current && hasApprovedAgents()) {
+      // Only auto-switch from demo → agent if user has previously approved agents
       demoAutoEnabledRef.current = false
       userToggledOffRef.current = false
       if (demoReEnableTimerRef.current) clearTimeout(demoReEnableTimerRef.current)

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -5,6 +5,7 @@ import { useMissions } from '../../../hooks/useMissions'
 import { useBackendHealth } from '../../../hooks/useBackendHealth'
 import { useDemoMode, isDemoModeForced, getDemoMode } from '../../../hooks/useDemoMode'
 import { SetupInstructionsDialog } from '../../setup/SetupInstructionsDialog'
+import { AgentApprovalDialog, hasApprovedAgents } from '../../agent/AgentApprovalDialog'
 import { cn } from '../../../lib/cn'
 import { useTranslation } from 'react-i18next'
 import { TOAST_DISMISS_MS } from '../../../lib/constants/network'
@@ -12,13 +13,14 @@ import { TOAST_DISMISS_MS } from '../../../lib/constants/network'
 export function AgentStatusIndicator() {
   const { t } = useTranslation(['common'])
   const { status: agentStatus, health: agentHealth, connectionEvents, isConnected, isDegraded, dataErrorCount, lastDataError } = useLocalAgent()
-  const { selectedAgent } = useMissions()
+  const { selectedAgent, agents } = useMissions()
   const { status: backendStatus, isConnected: isBackendConnected, isInClusterMode } = useBackendHealth()
   const { isDemoMode: isDemoModeHook, toggleDemoMode } = useDemoMode()
   // Synchronous fallback prevents flash of WifiOff icon during React transitions
   const isDemoMode = isDemoModeHook || getDemoMode()
   const [showAgentStatus, setShowAgentStatus] = useState(false)
   const [showSetupDialog, setShowSetupDialog] = useState(false)
+  const [showApprovalDialog, setShowApprovalDialog] = useState(false)
   const agentRef = useRef<HTMLDivElement>(null)
   const dropdownRef = useRef<HTMLDivElement>(null)
 
@@ -171,6 +173,10 @@ export function AgentStatusIndicator() {
                   if (isDemoModeForced && isDemoMode) {
                     setShowSetupDialog(true)
                     setShowAgentStatus(false)
+                  } else if (isDemoMode && !hasApprovedAgents()) {
+                    // Switching from demo → agent: require opt-in first
+                    setShowApprovalDialog(true)
+                    setShowAgentStatus(false)
                   } else {
                     toggleDemoMode()
                   }
@@ -320,6 +326,15 @@ export function AgentStatusIndicator() {
         </div>
       )}
       <SetupInstructionsDialog isOpen={showSetupDialog} onClose={() => setShowSetupDialog(false)} />
+      <AgentApprovalDialog
+        isOpen={showApprovalDialog}
+        agents={agents}
+        onApprove={() => {
+          setShowApprovalDialog(false)
+          toggleDemoMode()
+        }}
+        onCancel={() => setShowApprovalDialog(false)}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Demo pill toggle now checks `hasApprovedAgents()` before switching to agent mode
- Shows the approval dialog if user hasn't opted in yet
- Layout.tsx auto-switch (agent connects → exit demo) also gated behind prior approval
- Fixes: toggling demo off went straight to agent mode without opt-in

## Test plan
- [ ] Clear `kc_agents_approved` from localStorage
- [ ] Toggle demo mode off via the purple pill — approval dialog should appear
- [ ] Cancel the dialog — stays in demo mode
- [ ] Approve — switches to agent mode
- [ ] Subsequent toggles skip the dialog (approval persisted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)