### PR TITLE
fix: only fetch from confirmed-reachable clusters in security cards

### DIFF
--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -129,7 +129,7 @@ function getReachableClusters(): string[] {
   // Use local agent's cluster cache - it has up-to-date reachability info
   if (clusterCacheRef.clusters.length > 0) {
     return clusterCacheRef.clusters
-      .filter(c => c.reachable !== false && !c.name.includes('/'))
+      .filter(c => c.reachable === true && !c.name.includes('/'))
       .map(c => c.name)
   }
   return []
@@ -146,7 +146,7 @@ async function fetchClusters(): Promise<string[]> {
   // Fall back to backend API
   const data = await fetchAPI<{ clusters: Array<{ name: string; reachable?: boolean }> }>('clusters')
   return (data.clusters || [])
-    .filter(c => c.reachable !== false && !c.name.includes('/'))
+    .filter(c => c.reachable === true && !c.name.includes('/'))
     .map(c => c.name)
 }
 
@@ -320,7 +320,7 @@ function getAgentClusters(): Array<{ name: string; context?: string }> {
   // Skip long context-path names (contain '/') — these are duplicates of short-named aliases
   // e.g. "default/api-fmaas-vllm-d-...:6443/..." duplicates "vllm-d"
   return clusterCacheRef.clusters
-    .filter(c => c.reachable !== false && !c.name.includes('/'))
+    .filter(c => c.reachable === true && !c.name.includes('/'))
     .map(c => ({ name: c.name, context: c.context }))
 }
 
@@ -1499,7 +1499,7 @@ async function fetchWorkloadsFromAgent(onProgress?: (partial: Workload[]) => voi
   if (isAgentUnavailable()) return null
 
   const clusters = clusterCacheRef.clusters
-    .filter(c => c.reachable !== false && !c.name.includes('/'))
+    .filter(c => c.reachable === true && !c.name.includes('/'))
   if (clusters.length === 0) return null
   const accumulated: Workload[] = []
 

--- a/web/src/hooks/useCertManager.ts
+++ b/web/src/hooks/useCertManager.ts
@@ -225,7 +225,7 @@ export function useCertManager() {
 
   // Filter to reachable clusters
   const clusters = useMemo(() =>
-    allClusters.filter(c => c.reachable !== false).map(c => c.name),
+    allClusters.filter(c => c.reachable === true).map(c => c.name),
     [allClusters]
   )
 

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -334,7 +334,7 @@ export function useKubescape() {
   const fetchInProgress = useRef(false)
 
   const clusters = useMemo(() =>
-    allClusters.filter(c => c.reachable !== false).map(c => c.name),
+    allClusters.filter(c => c.reachable === true).map(c => c.name),
     [allClusters]
   )
 

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -356,7 +356,7 @@ export function useKyverno() {
   const fetchInProgress = useRef(false)
 
   const clusters = useMemo(() =>
-    allClusters.filter(c => c.reachable !== false).map(c => c.name),
+    allClusters.filter(c => c.reachable === true).map(c => c.name),
     [allClusters]
   )
 

--- a/web/src/hooks/useRBACFindings.ts
+++ b/web/src/hooks/useRBACFindings.ts
@@ -289,7 +289,7 @@ export function useRBACFindings() {
   const initialLoadDone = useRef(!!cachedData.current)
 
   const clusters = useMemo(() =>
-    allClusters.filter(c => c.reachable !== false).map(c => c.name),
+    allClusters.filter(c => c.reachable === true).map(c => c.name),
     [allClusters]
   )
 

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -268,7 +268,7 @@ export function useTrivy() {
   const fetchInProgress = useRef(false)
 
   const clusters = useMemo(() =>
-    allClusters.filter(c => c.reachable !== false).map(c => c.name),
+    allClusters.filter(c => c.reachable === true).map(c => c.name),
     [allClusters]
   )
 


### PR DESCRIPTION
## Summary
- Changed cluster reachability filter from `reachable !== false` to `reachable === true` in all security compliance hooks and shared data fetchers
- Prevents clusters with `reachable: undefined` (health check pending) from entering the kubectl proxy queue, where they timeout (4 concurrent, 10s each) and block reachable clusters
- Fixes "Refresh failed" on Trivy, Kubescape, Kyverno, RBAC, CertManager, and ISO 27001 cards when any cluster is unreachable

## Changed files
- `web/src/hooks/useTrivy.ts` — cluster filter
- `web/src/hooks/useKubescape.ts` — cluster filter
- `web/src/hooks/useKyverno.ts` — cluster filter
- `web/src/hooks/useRBACFindings.ts` — cluster filter
- `web/src/hooks/useCertManager.ts` — cluster filter
- `web/src/hooks/useCachedData.ts` — `getReachableClusters()`, `fetchClusters()`, `getAgentClusters()`, `fetchWorkloadsFromAgent()` shared helpers

## Test plan
- [ ] Start console with mix of reachable and unreachable clusters
- [ ] Verify security compliance cards load data from reachable clusters
- [ ] Verify no "Refresh failed" state when some clusters are unreachable
- [ ] Verify ISO 27001 audit card loads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)