### PR TITLE
fix: remove cluster locations card from My Clusters dashboard

### DIFF
--- a/web/src/config/dashboards/clusters.ts
+++ b/web/src/config/dashboards/clusters.ts
@@ -17,7 +17,6 @@ export const clustersDashboardConfig: UnifiedDashboardConfig = {
     { id: 'cluster-metrics-1', cardType: 'cluster_metrics', position: { w: 6, h: 3 } },
     { id: 'cluster-comparison-1', cardType: 'cluster_comparison', position: { w: 6, h: 3 } },
     { id: 'provider-health-1', cardType: 'provider_health', position: { w: 4, h: 3 } },
-    { id: 'cluster-locations-1', cardType: 'cluster_locations', position: { w: 8, h: 4 } },
   ],
   features: {
     dragDrop: true,


### PR DESCRIPTION
## Summary
- Remove the cluster_locations card from the default My Clusters dashboard layout — it's not useful in its current state

## Test plan
- [ ] Navigate to My Clusters dashboard, verify cluster locations card is gone
- [ ] Card remains available in Add Card dialog for manual addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)