### PR TITLE
fix: show partial data immediately in compliance cards

### DIFF
--- a/web/src/components/cards/ISO27001Audit.tsx
+++ b/web/src/components/cards/ISO27001Audit.tsx
@@ -104,14 +104,15 @@ export function ISO27001Audit({ config }: ISO27001AuditProps) {
     consecutiveFailures: cachedFailures,
   } = useCachedISO27001Audit(clusterConfig)
 
-  // 3. Switch between demo and live data
+  // 3. Switch between demo and live data (fall back to demo if fetch failed with no cache)
+  const useDemoData = isDemoMode || isDemoFallback
   const rawFindings = useMemo(
-    () => isDemoMode ? getDemoFindings() : cachedFindings,
-    [isDemoMode, cachedFindings]
+    () => useDemoData ? getDemoFindings() : cachedFindings,
+    [useDemoData, cachedFindings]
   )
-  const isLoading = isDemoMode ? false : cachedLoading
-  const isFailed = isDemoMode ? false : cachedFailed
-  const consecutiveFailures = isDemoMode ? 0 : cachedFailures
+  const isLoading = useDemoData ? false : cachedLoading
+  const isFailed = useDemoData ? false : cachedFailed
+  const consecutiveFailures = useDemoData ? 0 : cachedFailures
 
   // 4. Report card state
   const { showSkeleton, showEmptyState } = useCardLoadingState({

--- a/web/src/components/cards/RecommendedPolicies.tsx
+++ b/web/src/components/cards/RecommendedPolicies.tsx
@@ -257,17 +257,17 @@ Deploy to ALL clusters with Kyverno installed. Proceed step by step.`,
 
 function RecommendedPoliciesInternal({ config: _config }: CardConfig) {
   const { t } = useTranslation('cards')
-  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, isRefreshing: kyvernoRefreshing, installed: kyvernoInstalled, isDemoData: kyvernoDemoData, clustersChecked: kyvernoChecked, totalClusters: kyvernoTotal } = useKyverno()
-  const { isLoading: kubescapeLoading, isRefreshing: kubescapeRefreshing, installed: kubescapeInstalled, isDemoData: kubescapeDemoData, clustersChecked: kubescapeChecked, totalClusters: kubescapeTotal } = useKubescape()
-  const { isLoading: trivyLoading, isRefreshing: trivyRefreshing, installed: trivyInstalled, isDemoData: trivyDemoData, clustersChecked: trivyChecked, totalClusters: trivyTotal } = useTrivy()
+  const { statuses: kyvernoStatuses, isLoading: kyvernoLoading, installed: kyvernoInstalled, isDemoData: kyvernoDemoData, clustersChecked: kyvernoChecked, totalClusters: kyvernoTotal } = useKyverno()
+  const { isLoading: kubescapeLoading, installed: kubescapeInstalled, isDemoData: kubescapeDemoData, clustersChecked: kubescapeChecked, totalClusters: kubescapeTotal } = useKubescape()
+  const { isLoading: trivyLoading, installed: trivyInstalled, isDemoData: trivyDemoData, clustersChecked: trivyChecked, totalClusters: trivyTotal } = useTrivy()
   const { deduplicatedClusters } = useClusters()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
   const { isDemoMode } = useDemoMode()
   const [expandedCategory, setExpandedCategory] = useState<RecommendationCategory | null>(null)
 
-  const isLoading = kyvernoLoading || kubescapeLoading || trivyLoading
-  const isRefreshing = kyvernoRefreshing || kubescapeRefreshing || trivyRefreshing
+  // Card is only "loading" when ALL tools are still loading — show partial results ASAP
+  const isLoading = kyvernoLoading && kubescapeLoading && trivyLoading
   const isDemoData = isDemoMode || kyvernoDemoData || kubescapeDemoData || trivyDemoData
 
   /** Combined progressive streaming progress across all three tools */
@@ -396,8 +396,8 @@ Deploy each policy to every cluster where it's missing. Proceed cluster by clust
 
   // No tools installed — prompt to get started (but only after scanning is complete)
   if (!kyvernoInstalled && !kubescapeInstalled && !trivyInstalled && !isDemoData) {
-    // Still scanning — show loading state instead of definitive empty state
-    if (isLoading || isRefreshing) {
+    // Still scanning — show loading state only while NO tool has finished yet
+    if (isLoading) {
       return (
         <div className="space-y-3">
           <div className="flex flex-col items-center justify-center py-6 text-center">
@@ -465,8 +465,8 @@ Deploy each policy to every cluster where it's missing. Proceed cluster by clust
         )}
       </div>
 
-      {/* Inline progress ring while still scanning */}
-      {!allChecked && (isLoading || isRefreshing) && totalChecking > 0 && (
+      {/* Inline progress ring while still scanning remaining tools */}
+      {!allChecked && !isLoading && (kyvernoLoading || kubescapeLoading || trivyLoading) && totalChecking > 0 && (
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <ProgressRing progress={minChecked / totalChecking} size={14} strokeWidth={1.5} />
           <span>{t('recommendedPolicies.scanningClusters')}</span>


### PR DESCRIPTION
## Summary
- **RecommendedPolicies**: Changed `isLoading` from `||` (any loading) to `&&` (all loading) so partial results show as soon as any compliance tool finishes scanning
- **ISO27001Audit**: Falls back to demo data when fetch fails with no cache, instead of showing empty "No audit data" state

## Test plan
- [ ] Open Compliance dashboard in agent mode with slow/unreachable clusters
- [ ] RecommendedPolicies shows data as soon as first tool finishes (not stuck on "Scanning...")
- [ ] ISO27001 shows demo data (with Demo badge) when agent can't reach clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)