### PR TITLE
fix: reduce false Connection lost and Save failed alerts

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -119,8 +119,8 @@ const DASHBOARD_CHUNKS: Record<string, () => Promise<unknown>> = {
   'marketplace': () => import('./components/marketplace/Marketplace'),
 }
 
-// Dashboard always prefetched (it's the home page)
-const ALWAYS_PREFETCH = new Set(['dashboard'])
+// Always prefetched regardless of enabled dashboards
+const ALWAYS_PREFETCH = new Set(['dashboard', 'settings', 'clusters'])
 
 // Prefetch lazy route chunks after initial page load.
 // Batched to avoid overwhelming the Vite dev server with simultaneous

--- a/web/src/hooks/useBackendHealth.ts
+++ b/web/src/hooks/useBackendHealth.ts
@@ -1,10 +1,13 @@
 import { useState, useEffect } from 'react'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 
 export type BackendStatus = 'connected' | 'disconnected' | 'connecting'
 
 const POLL_INTERVAL = 15000 // Check every 15 seconds
-const FAILURE_THRESHOLD = 3 // Require 3 consecutive failures before showing "Connection lost"
+const FAILURE_THRESHOLD = 4 // Require 4 consecutive failures before showing "Connection lost"
+// Short timeout for health checks — a healthy backend responds in <100ms.
+// Using the default 10s timeout causes false failures when the browser's
+// HTTP/1.1 connection pool (6 per origin) is saturated by SSE streams.
+const HEALTH_CHECK_TIMEOUT_MS = 3000
 
 interface BackendState {
   status: BackendStatus
@@ -79,7 +82,7 @@ class BackendHealthManager {
       const response = await fetch('/health', {
         method: 'GET',
         headers: { Accept: 'application/json' },
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+        signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
       })
 
       if (response.ok) {

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -124,12 +124,13 @@ async function fetchAPI<T>(
   return response.json()
 }
 
-// Get list of reachable clusters (prefer local agent data for accurate reachability)
+// Get list of reachable (or not-yet-checked) clusters (prefer local agent data for accurate reachability)
 function getReachableClusters(): string[] {
   // Use local agent's cluster cache - it has up-to-date reachability info
+  // Include reachable === undefined (health check pending) — same logic as getAgentClusters
   if (clusterCacheRef.clusters.length > 0) {
     return clusterCacheRef.clusters
-      .filter(c => c.reachable === true && !c.name.includes('/'))
+      .filter(c => c.reachable !== false && !c.name.includes('/'))
       .map(c => c.name)
   }
   return []
@@ -314,13 +315,16 @@ async function fetchRbacAPI<T>(
 // Agent-based fetchers (used when backend is unavailable but agent is connected)
 // ============================================================================
 
-/** Get reachable cluster names from the shared cluster cache (deduplicated) */
+/** Get reachable (or not-yet-checked) cluster names from the shared cluster cache (deduplicated) */
 function getAgentClusters(): Array<{ name: string; context?: string }> {
   // useCache prevents calling fetchers in demo mode via effectiveEnabled
   // Skip long context-path names (contain '/') — these are duplicates of short-named aliases
   // e.g. "default/api-fmaas-vllm-d-...:6443/..." duplicates "vllm-d"
+  // Include clusters with reachable === undefined (health check pending) to avoid
+  // race condition where cards fetch before health checks complete and cache empty results.
+  // This matches the backend's HealthyClusters() which treats unknown as healthy.
   return clusterCacheRef.clusters
-    .filter(c => c.reachable === true && !c.name.includes('/'))
+    .filter(c => c.reachable !== false && !c.name.includes('/'))
     .map(c => ({ name: c.name, context: c.context }))
 }
 

--- a/web/src/hooks/usePersistedSettings.ts
+++ b/web/src/hooks/usePersistedSettings.ts
@@ -15,7 +15,9 @@ const DEBOUNCE_MS = 1000
 
 export type SyncStatus = 'idle' | 'saving' | 'saved' | 'error' | 'offline'
 
-/** Fetch helper that routes settings calls to the local kc-agent (saves to ~/.kc/settings.json). */
+/** Fetch helper that routes settings calls to the local kc-agent (saves to ~/.kc/settings.json).
+ * Uses a generous timeout because the agent's HTTP/1.1 connection pool (6 per origin)
+ * can be saturated by concurrent cluster health/data requests during page transitions. */
 async function settingsFetch<T>(path: string, options?: RequestInit): Promise<T> {
   const response = await fetch(`${LOCAL_AGENT_HTTP_URL}${path}`, {
     ...options,
@@ -23,7 +25,7 @@ async function settingsFetch<T>(path: string, options?: RequestInit): Promise<T>
       'Content-Type': 'application/json',
       ...options?.headers,
     },
-    signal: options?.signal ?? AbortSignal.timeout(5000),
+    signal: options?.signal ?? AbortSignal.timeout(15000),
   })
   if (!response.ok) throw new Error(`HTTP ${response.status}`)
   return response.json()
@@ -54,29 +56,37 @@ export function usePersistedSettings() {
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const mountedRef = useRef(true)
 
-  // Save current localStorage state to backend (debounced)
+  // Save current localStorage state to backend (debounced, with retry)
   const saveToBackend = useCallback(() => {
     if (debounceTimer.current) {
       clearTimeout(debounceTimer.current)
     }
     setSyncStatus('saving')
     debounceTimer.current = setTimeout(async () => {
-      try {
-        const current = collectFromLocalStorage()
-        await settingsFetch('/settings', {
-          method: 'PUT',
-          body: JSON.stringify(current),
-        })
-        if (mountedRef.current) {
-          setSyncStatus('saved')
-          setLastSaved(new Date())
+      const current = collectFromLocalStorage()
+      // Retry once after a delay — transient failures are common during page
+      // transitions when the agent's connection pool is saturated.
+      for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+          await settingsFetch('/settings', {
+            method: 'PUT',
+            body: JSON.stringify(current),
+          })
+          if (mountedRef.current) {
+            setSyncStatus('saved')
+            setLastSaved(new Date())
+          }
+          return
+        } catch {
+          if (attempt === 0) {
+            await new Promise(r => setTimeout(r, 3000))
+          }
         }
-      } catch {
-        if (mountedRef.current) {
-          setSyncStatus('error')
-        }
-        console.debug('[settings] failed to persist to local agent')
       }
+      if (mountedRef.current) {
+        setSyncStatus('error')
+      }
+      console.debug('[settings] failed to persist to local agent')
     }, DEBOUNCE_MS)
   }, [])
 


### PR DESCRIPTION
## Summary
- **Health check resilience**: Reduced timeout from 10s to 3s and raised failure threshold from 3→4 consecutive failures before showing "Connection lost". The browser's HTTP/1.1 connection pool (6 per origin) gets saturated by SSE streams during page transitions, causing health checks to queue and time out.
- **Settings save retry**: Increased timeout from 5s to 15s and added 1 automatic retry with 3s delay for the same connection saturation reason ("Save failed" on Settings page).
- **Cluster reachable filter**: Changed `reachable === true` to `reachable !== false` so clusters with pending health checks aren't excluded, fixing empty cards (e.g. Workload Status) on initial load.
- **Prefetch settings/clusters**: Added 'settings' and 'clusters' to `ALWAYS_PREFETCH` to eliminate slow first-load of Settings page.

## Test plan
- [ ] Navigate between dashboards — no false "Connection lost" snackbar
- [ ] Open Settings page — loads quickly on first visit, no "Save failed"
- [ ] Workload Status card shows data on first load (not empty)
- [ ] `npm run build && npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)