### PR TITLE
🐛 fix: 90s grace for agent disconnect, suppress install modal

### DIFF
--- a/web/src/components/agent/AgentSetupDialog.tsx
+++ b/web/src/components/agent/AgentSetupDialog.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import { copyToClipboard } from '../../lib/clipboard'
 import { isNetlifyDeployment } from '../../lib/demoMode'
+import { STORAGE_KEY_FIRST_AGENT_CONNECT } from '../../lib/constants/storage'
 
 const DISMISSED_KEY = 'kc-agent-setup-dismissed'
 const SNOOZED_KEY = 'kc-agent-setup-snoozed'
@@ -49,6 +50,10 @@ export function AgentSetupDialog() {
 
     // Don't show if already connected
     if (isConnected) return
+
+    // If the agent was ever connected, this is a transient disconnect — don't
+    // show the install modal. It's for first-time users who haven't installed.
+    if (safeGetItem(STORAGE_KEY_FIRST_AGENT_CONNECT)) return
 
     // Check if user previously dismissed permanently
     const dismissed = safeGetItem(DISMISSED_KEY)

--- a/web/src/hooks/useBackendHealth.ts
+++ b/web/src/hooks/useBackendHealth.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 
 export type BackendStatus = 'connected' | 'disconnected' | 'connecting'
 
@@ -122,15 +123,41 @@ class BackendHealthManager {
         throw new Error(`Backend returned ${response.status}`)
       }
     } catch {
-      this.failureCount++
-      if (this.failureCount >= FAILURE_THRESHOLD) {
-        this.setState({
-          status: 'disconnected',
-          lastCheck: new Date(),
-        })
+      // Before counting a failure, try the kc-agent health endpoint on a
+      // different origin (port 8585). The main /health fetch can time out
+      // when the browser's HTTP/1.1 connection pool (6 per origin) is
+      // saturated by long-running kubectl proxy requests on port 8080.
+      // The agent endpoint uses a separate connection pool.
+      const agentAlive = await this.checkAgentHealth()
+      if (agentAlive) {
+        // Agent is reachable → backend is likely fine, just connection-starved.
+        // Don't increment failure count.
+        this.setState({ status: 'connected', lastCheck: new Date() })
+      } else {
+        this.failureCount++
+        if (this.failureCount >= FAILURE_THRESHOLD) {
+          this.setState({
+            status: 'disconnected',
+            lastCheck: new Date(),
+          })
+        }
       }
     } finally {
       this.isChecking = false
+    }
+  }
+
+  /** Probe kc-agent on a separate origin to disambiguate real backend
+   *  downtime from browser connection-pool exhaustion on the main origin. */
+  private async checkAgentHealth(): Promise<boolean> {
+    try {
+      const res = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
+        method: 'GET',
+        signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+      })
+      return res.ok
+    } catch {
+      return false
     }
   }
 

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { isDemoModeForced } from './useDemoMode'
 import { setDemoMode } from '../lib/demoMode'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
-import { FETCH_DEFAULT_TIMEOUT_MS, TRANSITION_DELAY_MS } from '../lib/constants/network'
+import { TRANSITION_DELAY_MS } from '../lib/constants/network'
 import { emitAgentConnected, emitAgentDisconnected, emitAgentProvidersDetected, emitConversionStep } from '../lib/analytics'
 import { safeGetItem, safeSetItem } from '../lib/utils/localStorage'
 import { STORAGE_KEY_FIRST_AGENT_CONNECT } from '../lib/constants/storage'
@@ -42,7 +42,11 @@ export interface ConnectionEvent {
 
 const POLL_INTERVAL = 10000 // Check every 10 seconds when connected
 const DISCONNECTED_POLL_INTERVAL = 60000 // Check every 60 seconds when disconnected
-const FAILURE_THRESHOLD = 2 // Require 2 consecutive failures before disconnecting
+const FAILURE_THRESHOLD = 9 // Require 9 consecutive failures (~90s) before disconnecting
+// Short timeout for agent health checks — a healthy agent responds in <100ms.
+// Using the default 10s timeout causes false failures when the browser's
+// HTTP/1.1 connection pool (6 per origin) is saturated by concurrent requests.
+const AGENT_HEALTH_TIMEOUT_MS = 3000
 const SUCCESS_THRESHOLD = 2 // Require 2 consecutive successes before reconnecting (prevents flicker)
 const AGGRESSIVE_POLL_INTERVAL = 1000 // 1 second during aggressive detection burst
 const AGGRESSIVE_DETECT_DURATION = 10000 // 10 seconds of aggressive polling
@@ -214,7 +218,7 @@ class AgentManager {
       const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/health`, {
         method: 'GET',
         headers: { Accept: 'application/json' },
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+        signal: AbortSignal.timeout(AGENT_HEALTH_TIMEOUT_MS),
       })
 
       if (response.ok) {


### PR DESCRIPTION
## Summary
- **Agent health threshold**: Raised from 2→9 consecutive failures (~90s) before marking agent as disconnected. Reduced health check timeout from 10s→3s (healthy agent responds in <100ms, long timeout just blocks when connection pool is saturated).
- **Backend health fallback**: When backend health check fails, probes kc-agent on a separate origin (port 8585) as fallback. If agent is reachable, the backend is likely fine — just connection-starved. Prevents false "Connection lost" from HTTP/1.1 pool exhaustion.
- **Install modal suppression**: The "Welcome to KubeStellar Console" install modal no longer appears if the agent was ever connected in the past. Transient disconnects shouldn't prompt users to reinstall.

Follows up on #3190 which addressed the same HTTP/1.1 connection saturation root cause.

## Test plan
- [ ] Navigate rapidly between dashboards — agent stays connected, no demo mode flip
- [ ] No install modal appears during transient agent hiccups
- [ ] `npm run build && npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)