### PR TITLE
fix: prevent user section from being clipped at intermediate navbar widths

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -47,8 +47,8 @@ export function Navbar() {
 
   return (
     <nav data-tour="navbar" className="fixed top-0 left-0 right-0 h-16 glass z-50 px-3 md:px-6 flex items-center justify-between">
-      {/* Left side: Hamburger + Logo */}
-      <div className="flex items-center gap-2 md:gap-3">
+      {/* Left side: Hamburger + Logo — shrink-0 so logo is never compressed */}
+      <div className="flex items-center gap-2 md:gap-3 shrink-0">
         {/* Hamburger menu - mobile only */}
         <button
           onClick={toggleMobileSidebar}
@@ -82,13 +82,14 @@ export function Navbar() {
         </a>
       </div>
 
-      {/* Search - hidden on small mobile */}
-      <div className="hidden sm:block flex-1 max-w-md mx-4">
+      {/* Search - hidden on small mobile; min-w-0 lets it shrink when navbar is tight */}
+      <div className="hidden sm:block flex-1 min-w-0 max-w-md mx-4">
         <Suspense fallback={null}><SearchDropdown /></Suspense>
       </div>
 
-      {/* Right side */}
-      <div className="flex items-center gap-1 md:gap-3">
+      {/* Right side — shrink-0 prevents items (especially UserProfileDropdown)
+           from being squeezed invisible at intermediate widths (see #3191) */}
+      <div className="flex items-center gap-1 md:gap-3 shrink-0">
         {/* Core desktop items: md+ (768px) */}
         <div className="hidden md:flex items-center gap-2">
           {/* Global Filters (includes Clear Filters button) */}


### PR DESCRIPTION
Closes #3191

## Summary
- Added `shrink-0` to the left (logo) and right (actions + user) sections of the navbar so they never get compressed by the flex layout
- Added `min-w-0` to the search bar container so it absorbs the compression instead of the fixed-width controls
- At ~1024px all navbar items become visible simultaneously (both `md:flex` and `lg:flex` groups), and without shrink protection the `UserProfileDropdown` at the far right gets squeezed to zero width

## Test plan
- [ ] At window width ~1027px (just above the `lg` breakpoint), verify the user avatar + chevron are visible in the top bar
- [ ] At narrow widths (<768px), verify the overflow menu still works correctly
- [ ] At wide widths (>1280px), verify layout looks unchanged
- [ ] `npm run build` passes

Generated with [Claude Code](https://claude.com/claude-code)