### PR TITLE
fix: add CostDrillDown view for cost stat clicks

### DIFF
--- a/web/src/components/drilldown/DrillDownModal.tsx
+++ b/web/src/components/drilldown/DrillDownModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, Suspense } from 'react'
 import { safeLazy } from '../../lib/safeLazy'
 import { useTranslation } from 'react-i18next'
-import { Box, Server, Layers, Rocket, FileText, Zap, Cpu, Lock, User, Bell, Ship, GitBranch, Settings, Shield, Package } from 'lucide-react'
+import { Box, Server, Layers, Rocket, FileText, Zap, Cpu, Lock, User, Bell, Ship, GitBranch, Settings, Shield, Package, DollarSign } from 'lucide-react'
 import { useDrillDown } from '../../hooks/useDrillDown'
 import { useMobile } from '../../hooks/useMobile'
 // Lazy load large components (>300 lines) for better performance
@@ -24,6 +24,7 @@ const HelmReleaseDrillDown = safeLazy(() => import('./views/HelmReleaseDrillDown
 const ConfigMapDrillDown = safeLazy(() => import('./views/ConfigMapDrillDown'), 'ConfigMapDrillDown')
 const BuildpackDrillDown = safeLazy(() => import('./views/BuildpackDrillDown'), 'BuildpackDrillDown')
 const RBACDrillDown = safeLazy(() => import('./views/RBACDrillDown'), 'RBACDrillDown')
+const CostDrillDown = safeLazy(() => import('./views/CostDrillDown'), 'CostDrillDown')
 
 const EventsDrillDown = safeLazy(() => import('./views/EventsDrillDown'), 'EventsDrillDown')
 
@@ -80,6 +81,7 @@ const getViewIcon = (type: string) => {
     case 'buildpack': return <Package className="w-4 h-4 text-blue-400" />
     case 'crd': return <Package className="w-4 h-4 text-purple-400" />
     case 'drift': return <GitBranch className="w-4 h-4 text-orange-400" />
+    case 'cost': return <DollarSign className="w-4 h-4 text-green-400" />
     // Multi-cluster summary views
     case 'all-clusters': return <Server className="w-4 h-4 text-blue-400" />
     case 'all-namespaces': return <Layers className="w-4 h-4 text-purple-400" />
@@ -207,6 +209,8 @@ export function DrillDownModal() {
         return <DriftDrillDown data={data} />
       case 'rbac':
         return <RBACDrillDown data={data} />
+      case 'cost':
+        return <CostDrillDown data={data} />
       // Multi-cluster summary views
       case 'all-clusters':
       case 'all-namespaces':

--- a/web/src/components/drilldown/views/CostDrillDown.tsx
+++ b/web/src/components/drilldown/views/CostDrillDown.tsx
@@ -1,0 +1,122 @@
+import { useDrillDownActions } from '../../../hooks/useDrillDown'
+import { ClusterBadge } from '../../ui/ClusterBadge'
+import { Server, DollarSign, Cpu, HardDrive, Zap } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  data: Record<string, unknown>
+}
+
+interface CostRow {
+  label: string
+  value: string
+  icon: typeof Cpu
+  color: string
+}
+
+export function CostDrillDown({ data }: Props) {
+  const { t } = useTranslation()
+  const cluster = data.cluster as string
+  const { drillToCluster } = useDrillDownActions()
+
+  const monthly = data.monthly as number | undefined
+  const daily = data.daily as number | undefined
+  const hourly = data.hourly as number | undefined
+  const cpus = data.cpus as number | undefined
+  const memory = data.memory as number | undefined
+  const gpus = data.gpus as number | undefined
+  const provider = data.provider as string | undefined
+  const costType = data.costType as string | undefined
+  const totalMonthly = data.totalMonthly as number | undefined
+
+  const isClusterView = cluster !== 'all'
+
+  const rows: CostRow[] = []
+  if (monthly !== undefined) {
+    rows.push({ label: 'Monthly', value: `$${Math.round(monthly).toLocaleString()}`, icon: DollarSign, color: 'text-green-400' })
+  }
+  if (totalMonthly !== undefined && !isClusterView) {
+    rows.push({ label: 'Total Monthly', value: `$${Math.round(totalMonthly).toLocaleString()}`, icon: DollarSign, color: 'text-green-400' })
+  }
+  if (daily !== undefined) {
+    rows.push({ label: 'Daily', value: `$${daily.toFixed(2)}`, icon: DollarSign, color: 'text-blue-400' })
+  }
+  if (hourly !== undefined) {
+    rows.push({ label: 'Hourly', value: `$${hourly.toFixed(4)}`, icon: DollarSign, color: 'text-purple-400' })
+  }
+  if (cpus !== undefined) {
+    rows.push({ label: 'CPUs', value: `${cpus} cores`, icon: Cpu, color: 'text-cyan-400' })
+  }
+  if (memory !== undefined) {
+    rows.push({ label: 'Memory', value: `${memory} GB`, icon: HardDrive, color: 'text-orange-400' })
+  }
+  if (gpus !== undefined && gpus > 0) {
+    rows.push({ label: 'GPUs', value: `${gpus}`, icon: Zap, color: 'text-yellow-400' })
+  }
+
+  return (
+    <div className="flex flex-col h-full -m-6">
+      {/* Header */}
+      <div className="px-6 pt-6 pb-4">
+        <div className="flex items-center gap-6 text-sm">
+          {costType && (
+            <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-green-500/10 border border-green-500/20">
+              <DollarSign className="w-4 h-4 text-green-400" />
+              <span className="text-muted-foreground">Type</span>
+              <span className="font-mono text-green-400 capitalize">{costType}</span>
+            </div>
+          )}
+          {provider && (
+            <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-blue-500/10 border border-blue-500/20">
+              <Server className="w-4 h-4 text-blue-400" />
+              <span className="text-muted-foreground">Provider</span>
+              <span className="font-mono text-blue-400 capitalize">{provider}</span>
+            </div>
+          )}
+          {isClusterView && (
+            <button
+              onClick={() => drillToCluster(cluster)}
+              className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+            >
+              <Server className="w-4 h-4 text-blue-400" />
+              <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
+              <ClusterBadge cluster={cluster.split('/').pop() || cluster} size="sm" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Cost Breakdown */}
+      <div className="flex-1 overflow-y-auto p-6 space-y-6">
+        {rows.length > 0 ? (
+          <div className="space-y-3">
+            <h3 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
+              <DollarSign className="w-4 h-4 text-green-400" />
+              Cost Breakdown
+            </h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {rows.map(row => {
+                const Icon = row.icon
+                return (
+                  <div key={row.label} className="p-4 rounded-lg bg-secondary/30 border border-border">
+                    <div className="flex items-center gap-2 mb-1">
+                      <Icon className={`w-4 h-4 ${row.color}`} />
+                      <span className="text-xs text-muted-foreground">{row.label}</span>
+                    </div>
+                    <div className={`text-lg font-mono font-semibold ${row.color}`}>{row.value}</div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        ) : (
+          <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
+            <p className="text-yellow-400">No cost data available</p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default CostDrillDown


### PR DESCRIPTION
## Summary
- `drillToCost()` uses `type: 'cost'` but there was no matching case in DrillDownModal and no CostDrillDown component — clicks on cost stats or cluster costs showed "Unknown view type"
- Created `CostDrillDown` that displays cost breakdown (monthly/daily/hourly, CPUs, memory, GPUs, provider)
- Added `case 'cost':` to DrillDownModal switch and cost icon to breadcrumbs

## Test plan
- [ ] Click a cost stat in the Cost dashboard — should open CostDrillDown with cost details
- [ ] Click a cluster row in ClusterCosts card — should show that cluster's cost breakdown
- [ ] No TypeScript or lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)