### PR TITLE
fix: replace raw button elements with shared Button component

### DIFF
--- a/web/src/components/dashboard/CardRecommendations.tsx
+++ b/web/src/components/dashboard/CardRecommendations.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Clock, ChevronDown, ChevronUp, X, Plus, AlertTriangle, Info, Lightbulb, Timer } from 'lucide-react'
+import { Button } from '../ui/Button'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useCardRecommendations, CardRecommendation } from '../../hooks/useCardRecommendations'
 import { useSnoozedRecommendations } from '../../hooks/useSnoozedRecommendations'
@@ -227,13 +228,14 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
             <Timer className="w-3 h-3" />
             {countdown}s
           </span>
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={<ChevronUp className="w-3.5 h-3.5" />}
             onClick={() => { setMinimized(true); safeSetItem(STORAGE_KEY_RECS_COLLAPSED, 'true') }}
-            className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
             title="Minimize"
-          >
-            <ChevronUp className="w-3.5 h-3.5" />
-          </button>
+            className="p-1"
+          />
         </div>
       </div>
 
@@ -287,28 +289,30 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
 
                     {/* Action buttons */}
                     <div className="flex flex-wrap gap-1.5">
-                      <button
+                      <Button
+                        variant="primary"
+                        size="sm"
+                        icon={<Plus className="w-3 h-3" />}
+                        loading={isAdding}
                         onClick={() => handleAddCard(rec)}
-                        disabled={isAdding}
-                        className="flex-1 px-2 py-1.5 rounded text-xs font-medium transition-colors flex items-center justify-center gap-1 bg-primary hover:bg-primary/80 text-white disabled:opacity-50"
+                        className="flex-1"
                       >
-                        <Plus className="w-3 h-3" />
                         {isAdding ? t('dashboard.recommendations.adding') : t('buttons.addCard')}
-                      </button>
-                      <button
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        icon={<Clock className="w-3 h-3" />}
                         onClick={(e) => handleSnooze(e, rec)}
-                        className="px-2 py-1.5 rounded text-xs font-medium bg-secondary/50 hover:bg-secondary transition-colors"
                         title={t('dashboard.recommendations.snooze')}
-                      >
-                        <Clock className="w-3 h-3" />
-                      </button>
-                      <button
+                      />
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        icon={<X className="w-3 h-3" />}
                         onClick={handleDismiss}
-                        className="px-2 py-1.5 rounded text-xs font-medium bg-secondary/50 hover:bg-secondary transition-colors"
                         title={t('dashboard.recommendations.dismiss')}
-                      >
-                        <X className="w-3 h-3" />
-                      </button>
+                      />
                     </div>
                   </div>
                 </div>

--- a/web/src/components/dashboard/DashboardCards.tsx
+++ b/web/src/components/dashboard/DashboardCards.tsx
@@ -107,14 +107,15 @@ export function DashboardCards({
       {/* Header with toggle and actions */}
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2">
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
+            icon={<LayoutGrid className="w-4 h-4" />}
+            iconRight={showCards ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
             onClick={() => setShowCards(!showCards)}
-            className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
           >
-            <LayoutGrid className="w-4 h-4" />
-            <span>{sectionTitle} ({cards.length})</span>
-            {showCards ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-          </button>
+            {sectionTitle} ({cards.length})
+          </Button>
           {/* Health indicator */}
           <DashboardHealthIndicator size="sm" />
         </div>

--- a/web/src/components/ui/StatBlockModePicker.tsx
+++ b/web/src/components/ui/StatBlockModePicker.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import { Settings, Hash, TrendingUp, CircleDot, BarChart3, ArrowUpDown, Layers } from 'lucide-react'
+import { Button } from './Button'
 import type { StatDisplayMode } from './StatsBlockDefinitions'
 import { useModalState } from '../../lib/modals'
 
@@ -111,15 +112,15 @@ export function StatBlockModePicker({ currentMode, availableModes, onModeChange 
 
   return (
     <>
-      <button
+      <Button
         ref={triggerRef}
+        variant="ghost"
+        size="sm"
+        icon={<Settings className="w-3 h-3" />}
         onClick={handleToggle}
-        className="absolute top-1.5 right-1.5 p-1 rounded opacity-0 group-hover:opacity-100 hover:bg-secondary/80 text-muted-foreground hover:text-foreground transition-all z-10"
         title="Change display mode"
-        aria-label="Change display mode"
-      >
-        <Settings className="w-3 h-3" />
-      </button>
+        className="absolute top-1.5 right-1.5 p-1 opacity-0 group-hover:opacity-100 transition-all z-10"
+      />
       {isOpen && createPortal(
         <div
           ref={popoverRef}


### PR DESCRIPTION
Closes #3188

## Summary
- Replace raw `<button>` elements with the shared `Button` component in three files explicitly called out in the issue: `CardRecommendations.tsx`, `DashboardCards.tsx`, and `StatBlockModePicker.tsx`
- Converts 6 raw buttons total: minimize, add-card, snooze, dismiss (CardRecommendations), section toggle (DashboardCards), and settings gear (StatBlockModePicker)
- Uses appropriate Button variants (`primary`, `secondary`, `ghost`) and features (`icon`, `iconRight`, `loading`) for consistent styling, hover states, and accessibility

## Test plan
- [ ] CardRecommendations panel renders correctly with minimize, add, snooze, and dismiss buttons
- [ ] DashboardCards section toggle expands/collapses with chevron icon
- [ ] StatBlockModePicker gear icon appears on hover and opens popover
- [ ] `npm run build` passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)