### PR TITLE
fix: remove competing demo mode transitions from useLocalAgent

### DIFF
--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
 import { isDemoModeForced } from './useDemoMode'
-import { setDemoMode } from '../lib/demoMode'
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { TRANSITION_DELAY_MS } from '../lib/constants/network'
 import { emitAgentConnected, emitAgentDisconnected, emitAgentProvidersDetected, emitConversionStep } from '../lib/analytics'
@@ -239,8 +238,7 @@ class AgentManager {
             status: 'connected',
             error: null,
           })
-          // Agent is live — exit demo mode (respects explicit user preference)
-          setDemoMode(false)
+          // Demo mode transition is handled by Layout based on agentStatus changes
           emitAgentConnected(data.version || 'unknown', data.clusters || 0)
           emitAgentProvidersDetected(data.availableProviders || [])
         } else if (wasConnecting) {
@@ -252,8 +250,6 @@ class AgentManager {
             status: 'connected',
             error: null,
           })
-          // Agent is live — exit demo mode (respects explicit user preference)
-          setDemoMode(false)
           emitAgentConnected(data.version || 'unknown', data.clusters || 0)
           emitAgentProvidersDetected(data.availableProviders || [])
           // Stamp the first-ever agent connection for time-based nudges
@@ -294,8 +290,7 @@ class AgentManager {
           health: DEMO_DATA,
           error: 'Local agent not available',
         })
-        // Agent gone — fall back to demo mode (respects explicit user preference)
-        setDemoMode(true)
+        // Demo mode fallback is handled by Layout based on agentStatus changes
         // Slow down polling when disconnected to avoid spamming console errors
         this.adjustPollInterval(DISCONNECTED_POLL_INTERVAL)
       }


### PR DESCRIPTION
Closes #3225

## Summary
- Removed `setDemoMode(true/false)` calls from `useLocalAgent.ts` that were competing with Layout's coordinated demo mode management
- Layout already tracks auto-enabled demo mode via `demoAutoEnabledRef` and handles transitions with proper hysteresis (8s grace period for manual toggle-off)
- `useLocalAgent` was bypassing that tracking, causing demo mode to get stuck ON when the agent temporarily disconnected (e.g., browser tab backgrounded)

## Root cause
When the agent health check failed (tab backgrounded, network blip), `useLocalAgent` called `setDemoMode(true)` which set `localStorage['kc-demo-mode'] = 'true'`. When the agent reconnected, `useLocalAgent` called `setDemoMode(false)` **without** `userInitiated = true`, which was blocked by the guard in `demoMode.ts` line 138 that prevents auto-disabling when localStorage has `'true'`. Meanwhile, Layout's auto-disable check at line 197 required `demoAutoEnabledRef.current === true`, but that ref was only set by Layout's own enable path, not by useLocalAgent's.

## Test plan
- [ ] Start console with agent running, verify live data loads
- [ ] Background the tab for ~30s, return -- verify console returns to live data (not stuck in demo)
- [ ] Manually toggle demo mode on/off -- verify it still works correctly
- [ ] Disconnect agent entirely -- verify demo mode auto-enables
- [ ] Reconnect agent -- verify demo mode auto-disables

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>