### PR TITLE
fix: propagate dashboard Auto checkbox to card cache auto-refresh

### DIFF
--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -48,6 +48,7 @@ import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
 import { DashboardHeader } from '../shared/DashboardHeader'
 import { DashboardHealthIndicator } from './DashboardHealthIndicator'
 import { useDashboardUndoRedo } from '../../hooks/useUndoRedo'
+import { setAutoRefreshPaused } from '../../lib/cache'
 
 interface Card {
   id: string
@@ -316,6 +317,12 @@ export function CustomDashboard() {
   useEffect(() => {
     loadDashboard()
   }, [loadDashboard])
+
+  // Propagate auto-refresh state to global cache layer
+  useEffect(() => {
+    setAutoRefreshPaused(!autoRefresh)
+    return () => { setAutoRefreshPaused(false) }
+  }, [autoRefresh])
 
   // Auto-refresh
   useEffect(() => {

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -68,6 +68,7 @@ import { DeployConfirmDialog } from '../deploy/DeployConfirmDialog'
 import { DashboardHealthIndicator } from './DashboardHealthIndicator'
 import { useCardGridNavigation } from '../../hooks/useCardGridNavigation'
 import { useModalState } from '../../lib/modals'
+import { setAutoRefreshPaused } from '../../lib/cache'
 
 // Module-level cache for dashboard data (survives navigation)
 interface CachedDashboard {
@@ -222,9 +223,15 @@ export function Dashboard() {
   })
   const autoRefreshIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  // Persist auto-refresh setting
+  // Persist auto-refresh setting and propagate to global cache layer.
+  // When the user unchecks "Auto", all card cache intervals are also paused.
   useEffect(() => {
     safeSetItem('dashboard-auto-refresh', String(autoRefresh))
+    setAutoRefreshPaused(!autoRefresh)
+    return () => {
+      // Re-enable auto-refresh when the Dashboard unmounts (e.g., navigating away)
+      setAutoRefreshPaused(false)
+    }
   }, [autoRefresh])
 
   // Auto-refresh interval

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -106,6 +106,41 @@ function getEffectiveInterval(
 }
 
 // ============================================================================
+// Global Auto-Refresh Pause
+// ============================================================================
+
+/**
+ * When true, all cache auto-refresh intervals are suppressed.
+ * Controlled by the dashboard "Auto" checkbox. Manual refetch() calls
+ * and initial data loads still work — only periodic background refreshes
+ * are paused.
+ */
+let globalAutoRefreshPaused = false
+const autoRefreshPauseListeners = new Set<(paused: boolean) => void>()
+
+function notifyAutoRefreshPauseListeners() {
+  autoRefreshPauseListeners.forEach(fn => fn(globalAutoRefreshPaused))
+}
+
+/** Check whether auto-refresh is globally paused. */
+export function isAutoRefreshPaused(): boolean {
+  return globalAutoRefreshPaused
+}
+
+/** Pause or resume all cache auto-refresh intervals. */
+export function setAutoRefreshPaused(paused: boolean): void {
+  if (globalAutoRefreshPaused === paused) return
+  globalAutoRefreshPaused = paused
+  notifyAutoRefreshPauseListeners()
+}
+
+/** Subscribe to auto-refresh pause state changes. Returns unsubscribe fn. */
+export function subscribeAutoRefreshPaused(cb: (paused: boolean) => void): () => void {
+  autoRefreshPauseListeners.add(cb)
+  return () => autoRefreshPauseListeners.delete(cb)
+}
+
+// ============================================================================
 // Types
 // ============================================================================
 
@@ -808,6 +843,11 @@ export function useCache<T>({
   // Subscribe to demo mode - this ensures we re-render when demo mode changes
   const demoMode = useSyncExternalStore(subscribeDemoMode, isDemoMode, isDemoMode)
 
+  // Subscribe to global auto-refresh pause (dashboard "Auto" checkbox)
+  const autoRefreshGloballyPaused = useSyncExternalStore(
+    subscribeAutoRefreshPaused, isAutoRefreshPaused, isAutoRefreshPaused
+  )
+
   // Effective enabled: both the passed prop AND not in demo mode
   // liveInDemoMode bypasses the demo check for cards backed by serverless functions
   const effectiveEnabled = enabled && (!demoMode || liveInDemoMode)
@@ -892,13 +932,14 @@ export function useCache<T>({
     const unregisterRefetch = registerRefetch(`cache:${key}`, refetch)
 
     // Auto-refresh interval
-    // The interval restarts when consecutiveFailures changes (backoff kicks in)
-    if (autoRefresh) {
+    // The interval restarts when consecutiveFailures changes (backoff kicks in).
+    // Suppressed when the dashboard "Auto" checkbox is unchecked (global pause).
+    if (autoRefresh && !autoRefreshGloballyPaused) {
       const intervalId = setInterval(refetch, effectiveInterval)
       return () => { clearInterval(intervalId); unregisterRefetch() }
     }
     return () => unregisterRefetch()
-  }, [effectiveEnabled, autoRefresh, effectiveInterval, refetch, store, key, state.consecutiveFailures])
+  }, [effectiveEnabled, autoRefresh, autoRefreshGloballyPaused, effectiveInterval, refetch, store, key, state.consecutiveFailures])
 
   // Cleanup non-shared stores on unmount
   useEffect(() => {

--- a/web/src/lib/dashboards/dashboardHooks.ts
+++ b/web/src/lib/dashboards/dashboardHooks.ts
@@ -11,6 +11,7 @@ import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { dashboardSync } from './dashboardSync'
 import { DashboardCard, DashboardCardPlacement, NewCardInput } from './types'
 import { useDashboardUndoRedo } from '../../hooks/useUndoRedo'
+import { setAutoRefreshPaused } from '../cache'
 
 // Re-export dashboardSync for use in auth context (clear cache on logout)
 export { dashboardSync } from './dashboardSync'
@@ -336,6 +337,13 @@ export function useDashboardAutoRefresh(
   initialEnabled: boolean = true
 ): UseDashboardAutoRefreshResult {
   const [autoRefresh, setAutoRefresh] = useState(initialEnabled)
+
+  // Propagate auto-refresh state to global cache layer so card-level
+  // cache intervals are also paused when the user unchecks "Auto".
+  useEffect(() => {
+    setAutoRefreshPaused(!autoRefresh)
+    return () => { setAutoRefreshPaused(false) }
+  }, [autoRefresh])
 
   useEffect(() => {
     if (!autoRefresh) return


### PR DESCRIPTION
Closes #3224

## Summary
- The dashboard "Auto" checkbox only controlled a 30-second dashboard-level refresh interval, but each card's `useCache` hook ran its own independent auto-refresh timer (15s-10min depending on data category)
- Unchecking "Auto" did not stop these per-card timers, causing continuous background data updates
- Added a global auto-refresh pause signal to the cache layer that all card caches respect
- When any dashboard unchecks "Auto", all periodic cache refreshes stop; manual refresh and initial data loads still work

## Changes
| File | What |
|------|------|
| `web/src/lib/cache/index.ts` | New `setAutoRefreshPaused()` / `isAutoRefreshPaused()` / `subscribeAutoRefreshPaused()` API; `useCache` gates its interval on the global pause state |
| `web/src/components/dashboard/Dashboard.tsx` | Propagates `autoRefresh` state to global cache pause |
| `web/src/lib/dashboards/dashboardHooks.ts` | Propagates from `useDashboardAutoRefresh` shared hook (used by DashboardPage, DashboardRuntime, Clusters, Deploy) |
| `web/src/components/dashboard/CustomDashboard.tsx` | Propagates from its own `autoRefresh` state |

## Test plan
- [ ] Load dashboard with Auto checked -- verify cards refresh periodically (network tab shows requests)
- [ ] Uncheck Auto -- verify all periodic requests stop (no new network requests after ~30s)
- [ ] Click manual refresh button -- verify it still works with Auto unchecked
- [ ] Re-check Auto -- verify periodic refreshes resume
- [ ] Navigate away from dashboard -- verify auto-refresh re-enables (cleanup runs)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>