### PR TITLE
feat: expose console version via /api/version and --version flag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,6 +40,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
+      - -X github.com/kubestellar/console/pkg/api.Version={{.Version}}
 
 archives:
   - id: kc-agent

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,11 @@ RUN go mod download
 # Copy source
 COPY . .
 
+# Build args for version
+ARG APP_VERSION=dev
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux go build -o console ./cmd/console
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X github.com/kubestellar/console/pkg/api.Version=${APP_VERSION}" -o console ./cmd/console
 
 # Build stage - Frontend
 FROM node:20-alpine AS frontend-builder

--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -21,7 +22,13 @@ func main() {
 	dbPath := flag.String("db", "", "Database path (default: ./data/console.db)")
 	watchdog := flag.Bool("watchdog", false, "Run as watchdog reverse proxy (serves fallback page when backend is down)")
 	backendPort := flag.Int("backend-port", watchdogDefaultBackendPort, "Backend port for watchdog to proxy to")
+	version := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
+
+	if *version {
+		fmt.Printf("console version %s\n", api.Version)
+		os.Exit(0)
+	}
 
 	// Watchdog mode: lightweight reverse proxy, no DB/k8s/MCP initialization
 	if *watchdog {

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -41,6 +42,32 @@ const (
 // Version is the build version, injected via ldflags at build time.
 // Used in /health response for stale-frontend detection.
 var Version = "dev"
+
+// buildInfo holds VCS metadata extracted from the Go binary at startup.
+var buildInfo struct {
+	GoVersion  string
+	VCSRevision string
+	VCSTime     string
+	VCSModified string
+}
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	buildInfo.GoVersion = info.GoVersion
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			buildInfo.VCSRevision = s.Value
+		case "vcs.time":
+			buildInfo.VCSTime = s.Value
+		case "vcs.modified":
+			buildInfo.VCSModified = s.Value
+		}
+	}
+}
 
 // Config holds server configuration
 type Config struct {
@@ -380,6 +407,10 @@ func (s *Server) setupRoutes() {
 		resp := fiber.Map{
 			"status":           "ok",
 			"version":          Version,
+			"go_version":       buildInfo.GoVersion,
+			"git_commit":       buildInfo.VCSRevision,
+			"git_time":         buildInfo.VCSTime,
+			"git_dirty":        buildInfo.VCSModified == "true",
 			"oauth_configured": s.config.GitHubClientID != "",
 			"in_cluster":       inCluster,
 			"install_method":   detectInstallMethod(inCluster),
@@ -422,6 +453,17 @@ func (s *Server) setupRoutes() {
 			resp["enabled_dashboards"] = presetDashboards
 		}
 		return c.JSON(resp)
+	})
+
+	// Version endpoint — lightweight, returns only build metadata
+	s.app.Get("/api/version", func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{
+			"version":    Version,
+			"go_version": buildInfo.GoVersion,
+			"git_commit": buildInfo.VCSRevision,
+			"git_time":   buildInfo.VCSTime,
+			"git_dirty":  buildInfo.VCSModified == "true",
+		})
 	})
 
 	// Auth routes (public)


### PR DESCRIPTION
## Summary
- Extract VCS metadata (git commit, time, dirty state) from Go binary via `runtime/debug.ReadBuildInfo()` at startup
- Add `/api/version` endpoint returning version, go_version, git_commit, git_time, git_dirty
- Enrich existing `/health` endpoint with the same build metadata fields
- Add `--version` flag to the console binary (matching kc-agent's existing flag)
- Fix `.goreleaser.yaml` to inject release version into console binary via ldflags (was missing — only kc-agent had it)
- Fix `Dockerfile` to pass `APP_VERSION` build arg to Go ldflags

Closes #3223

## Test plan
- [ ] `go build ./cmd/console && ./console --version` prints version
- [ ] `go build -ldflags="-X github.com/kubestellar/console/pkg/api.Version=v1.2.3" ./cmd/console && ./console --version` prints `v1.2.3`
- [ ] `curl localhost:8080/api/version` returns JSON with version, git_commit, go_version
- [ ] `curl localhost:8080/health` includes git_commit, git_time, git_dirty fields
- [ ] GoReleaser snapshot build injects version into console binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)