### PR TITLE
fix: validate MCP tool binaries and show install guidance on missing

### DIFF
--- a/pkg/mcp/bridge.go
+++ b/pkg/mcp/bridge.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
+	"os/exec"
 	"sync"
 	"time"
 )
@@ -102,31 +104,41 @@ func NewBridge(config BridgeConfig) *Bridge {
 	}
 }
 
-// Start initializes and starts all MCP clients
+// Start initializes and starts all MCP clients.
+// Binaries that are not found on PATH are skipped with a log message
+// rather than treated as a fatal error.
 func (b *Bridge) Start(ctx context.Context) error {
 	var wg sync.WaitGroup
 	errCh := make(chan error, 2)
 
-	// Start kubestellar-ops if path is configured
+	// Start kubestellar-ops if path is configured and binary exists
 	if b.config.KubestellarOpsPath != "" {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if err := b.startOpsClient(ctx); err != nil {
-				errCh <- fmt.Errorf("ops client: %w", err)
-			}
-		}()
+		if _, err := exec.LookPath(b.config.KubestellarOpsPath); err != nil {
+			log.Printf("kubestellar-ops binary not found on PATH (%q) — MCP ops tools will be unavailable. Install via: brew install kubestellar/tap/kubestellar-ops", b.config.KubestellarOpsPath)
+		} else {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := b.startOpsClient(ctx); err != nil {
+					errCh <- fmt.Errorf("ops client: %w", err)
+				}
+			}()
+		}
 	}
 
-	// Start kubestellar-deploy if path is configured
+	// Start kubestellar-deploy if path is configured and binary exists
 	if b.config.KubestellarDeployPath != "" {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if err := b.startDeployClient(ctx); err != nil {
-				errCh <- fmt.Errorf("deploy client: %w", err)
-			}
-		}()
+		if _, err := exec.LookPath(b.config.KubestellarDeployPath); err != nil {
+			log.Printf("kubestellar-deploy binary not found on PATH (%q) — MCP deploy tools will be unavailable. Install via: brew install kubestellar/tap/kubestellar-deploy", b.config.KubestellarDeployPath)
+		} else {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := b.startDeployClient(ctx); err != nil {
+					errCh <- fmt.Errorf("deploy client: %w", err)
+				}
+			}()
+		}
 	}
 
 	wg.Wait()
@@ -508,22 +520,42 @@ func (b *Bridge) Status() map[string]interface{} {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	status := map[string]interface{}{
-		"opsClient": map[string]interface{}{
-			"available": b.opsClient != nil && b.opsClient.IsReady(),
-			"toolCount": 0,
-		},
-		"deployClient": map[string]interface{}{
-			"available": b.deployClient != nil && b.deployClient.IsReady(),
-			"toolCount": 0,
-		},
+	opsAvailable := b.opsClient != nil && b.opsClient.IsReady()
+	deployAvailable := b.deployClient != nil && b.deployClient.IsReady()
+
+	opsStatus := map[string]interface{}{
+		"available": opsAvailable,
+		"toolCount": 0,
+	}
+	deployStatus := map[string]interface{}{
+		"available": deployAvailable,
+		"toolCount": 0,
 	}
 
-	if b.opsClient != nil && b.opsClient.IsReady() {
-		status["opsClient"].(map[string]interface{})["toolCount"] = len(b.opsClient.Tools())
+	// Add installation hint when binary is not on PATH
+	if !opsAvailable {
+		if _, err := exec.LookPath(b.config.KubestellarOpsPath); err != nil {
+			opsStatus["reason"] = "binary not found on PATH"
+			opsStatus["install"] = "brew install kubestellar/tap/kubestellar-ops"
+		}
 	}
-	if b.deployClient != nil && b.deployClient.IsReady() {
-		status["deployClient"].(map[string]interface{})["toolCount"] = len(b.deployClient.Tools())
+	if !deployAvailable {
+		if _, err := exec.LookPath(b.config.KubestellarDeployPath); err != nil {
+			deployStatus["reason"] = "binary not found on PATH"
+			deployStatus["install"] = "brew install kubestellar/tap/kubestellar-deploy"
+		}
+	}
+
+	status := map[string]interface{}{
+		"opsClient":    opsStatus,
+		"deployClient": deployStatus,
+	}
+
+	if opsAvailable {
+		opsStatus["toolCount"] = len(b.opsClient.Tools())
+	}
+	if deployAvailable {
+		deployStatus["toolCount"] = len(b.deployClient.Tools())
 	}
 
 	return status

--- a/start.sh
+++ b/start.sh
@@ -311,6 +311,32 @@ if [ -x "$INSTALL_DIR/kc-agent" ]; then
     fi
 fi
 
+# Check for MCP tool binaries (kubestellar-ops, kubestellar-deploy)
+# These are optional but required for full MCP integration
+MCP_OPS_PATH="${KUBESTELLAR_OPS_PATH:-kubestellar-ops}"
+MCP_DEPLOY_PATH="${KUBESTELLAR_DEPLOY_PATH:-kubestellar-deploy}"
+MCP_MISSING=""
+
+if ! command -v "$MCP_OPS_PATH" &>/dev/null; then
+    MCP_MISSING="kubestellar-ops"
+fi
+if ! command -v "$MCP_DEPLOY_PATH" &>/dev/null; then
+    if [ -n "$MCP_MISSING" ]; then
+        MCP_MISSING="$MCP_MISSING and kubestellar-deploy"
+    else
+        MCP_MISSING="kubestellar-deploy"
+    fi
+fi
+
+if [ -n "$MCP_MISSING" ]; then
+    echo ""
+    echo "  Note: $MCP_MISSING not found on PATH."
+    echo "  MCP tools (Kubernetes ops and deploy) will be unavailable."
+    echo "  To install, follow Step 1 of the Quick Start guide:"
+    echo "    https://kubestellar.io/docs/console/overview/quick-start#step-1-install-kubestellar-mcp-tools"
+    echo ""
+fi
+
 # Generate JWT_SECRET if not set (required in production mode)
 if [ -z "$JWT_SECRET" ]; then
     if command -v openssl &>/dev/null; then


### PR DESCRIPTION
Closes #3082

## Summary
- **`pkg/mcp/bridge.go`**: Before starting each MCP client, validates the binary exists on PATH using `exec.LookPath`. Missing binaries are logged with brew install instructions and skipped gracefully (instead of failing with a confusing error). The `Status()` endpoint now includes `reason` and `install` fields when a client is unavailable, so the frontend can display actionable guidance.
- **`start.sh`**: After kc-agent starts, checks for `kubestellar-ops` and `kubestellar-deploy` on PATH and prints a clear message with a link to the Quick Start guide if missing.

## Root cause
Users following the Quick Start guide may not complete Step 1 (Install MCP Tools) or may interpret Options A and B as alternatives when both install different tools. When the binaries are absent, the console showed MCP servers as "failed" with no explanation of what was wrong or how to fix it.

## Test plan
- [x] `go build ./...` passes
- [x] `cd web && npm run build` passes
- [ ] CI checks pass
- [ ] With binaries missing: clear log message shown, MCP status endpoint returns `reason`/`install` fields
- [ ] With binaries present: MCP bridge starts normally as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)