### PR TITLE
fix: prevent game cards from swallowing keyboard input in dialogs

### DIFF
--- a/web/src/components/cards/ContainerTetris.tsx
+++ b/web/src/components/cards/ContainerTetris.tsx
@@ -249,6 +249,7 @@ function ContainerTetrisInternal(_props: CardComponentProps) {
   // Keyboard controls
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (!isPlaying || gameOver) return
 
       switch (e.key) {

--- a/web/src/components/cards/Game2048.tsx
+++ b/web/src/components/cards/Game2048.tsx
@@ -224,6 +224,7 @@ export function Game2048(_props: CardComponentProps) {
   // Keyboard controls
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (gameOver && !won) return
 
       switch (e.key) {

--- a/web/src/components/cards/KubeDoom.tsx
+++ b/web/src/components/cards/KubeDoom.tsx
@@ -516,6 +516,7 @@ export function KubeDoom() {
   // Keyboard handlers
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       const key = e.key.toLowerCase()
       if (['arrowup', 'arrowdown', 'arrowleft', 'arrowright', ' ', 'w', 'a', 's', 'd', 'q', 'e'].includes(key)) {
         e.preventDefault()

--- a/web/src/components/cards/KubeGalaga.tsx
+++ b/web/src/components/cards/KubeGalaga.tsx
@@ -454,6 +454,7 @@ export function KubeGalaga() {
   // Keyboard handlers
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' '].includes(e.key)) {
         e.preventDefault()
       }

--- a/web/src/components/cards/KubeKart.tsx
+++ b/web/src/components/cards/KubeKart.tsx
@@ -497,6 +497,7 @@ export function KubeKart() {
   // Keyboard handlers
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' '].includes(e.key)) {
         e.preventDefault()
       }

--- a/web/src/components/cards/KubeKong.tsx
+++ b/web/src/components/cards/KubeKong.tsx
@@ -636,6 +636,7 @@ export function KubeKong(_props: CardComponentProps) {
   // Keyboard controls
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' ', 'w', 'a', 's', 'd', 'W', 'A', 'S', 'D'].includes(e.key)) {
         e.preventDefault()
         keysRef.current.add(e.key)

--- a/web/src/components/cards/KubeMan.tsx
+++ b/web/src/components/cards/KubeMan.tsx
@@ -550,6 +550,7 @@ export function KubeMan(_props: CardComponentProps) {
   // Keyboard controls
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (!isPlaying) return
 
       const keyMap: Record<string, Direction> = {

--- a/web/src/components/cards/KubeSnake.tsx
+++ b/web/src/components/cards/KubeSnake.tsx
@@ -265,6 +265,7 @@ export function KubeSnake() {
   // Keyboard handlers
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'w', 'a', 's', 'd'].includes(e.key.toLowerCase())) {
         e.preventDefault()
       }

--- a/web/src/components/cards/Kubedle.tsx
+++ b/web/src/components/cards/Kubedle.tsx
@@ -225,6 +225,7 @@ export function Kubedle(_props: CardComponentProps) {
   // Physical keyboard
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (showStats || showHelp) return
       handleKey(e.key)
     }

--- a/web/src/components/cards/NodeInvaders.tsx
+++ b/web/src/components/cards/NodeInvaders.tsx
@@ -373,6 +373,7 @@ export function NodeInvaders(_props: CardComponentProps) {
   // Keyboard
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (['ArrowLeft', 'ArrowRight', 'ArrowUp', ' ', 'a', 'd', 'A', 'D'].includes(e.key)) {
         e.preventDefault()
         keysRef.current.add(e.key)

--- a/web/src/components/cards/PodBrothers.tsx
+++ b/web/src/components/cards/PodBrothers.tsx
@@ -472,6 +472,7 @@ export function PodBrothers() {
   // Keyboard handlers
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' '].includes(e.key)) {
         e.preventDefault()
       }

--- a/web/src/components/cards/PodCrosser.tsx
+++ b/web/src/components/cards/PodCrosser.tsx
@@ -493,6 +493,7 @@ export function PodCrosser(_props: CardComponentProps) {
   // Keyboard controls
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (!isPlaying || player.dead) return
 
       const { targetX, targetY } = player

--- a/web/src/components/onboarding/Tour.tsx
+++ b/web/src/components/onboarding/Tour.tsx
@@ -298,7 +298,10 @@ export function TourOverlay() {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         skipTour()
-      } else if (e.key === 'ArrowRight' || e.key === 'Enter') {
+        return
+      }
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
+      if (e.key === 'ArrowRight' || e.key === 'Enter') {
         nextStep()
       } else if (e.key === 'ArrowLeft') {
         prevStep()


### PR DESCRIPTION
## Summary
- Game card components (KubeSnake, KubeDoom, KubeKong, etc.) registered global `keydown` handlers that called `preventDefault()` on WASD and other character keys without checking if the user was typing in an input
- This blocked typing letters like 's', 'w', 'a', 'd' in the Add Cards search dialog and any other text input on the page
- Added `HTMLInputElement`/`HTMLTextAreaElement`/`contentEditable` target guard to all 13 affected keyboard handlers

## Files changed
`ContainerTetris`, `Game2048`, `KubeDoom`, `KubeGalaga`, `KubeKart`, `KubeKong`, `KubeMan`, `KubeSnake`, `Kubedle`, `NodeInvaders`, `PodBrothers`, `PodCrosser`, `Tour`

## Test plan
- [ ] Open dashboard with any game card present
- [ ] Open Add Cards dialog and type in search (all letters should work)
- [ ] Verify game keyboard controls still work when game card is focused
- [ ] Verify onboarding Tour arrow/enter keys still work when not in an input

🤖 Generated with [Claude Code](https://claude.com/claude-code)