### PR TITLE
fix: improve toast notification contrast and visibility

### DIFF
--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -107,23 +107,23 @@ function ToastItem({ toast, onRemove }: ToastItemProps) {
   }
 
   const colors: Record<ToastType, string> = {
-    success: 'bg-green-500/20 border-green-500/50 text-green-300',
-    error: 'bg-red-500/20 border-red-500/50 text-red-300',
-    warning: 'bg-yellow-500/20 border-yellow-500/50 text-yellow-300',
-    info: 'bg-blue-500/20 border-blue-500/50 text-blue-300',
+    success: 'bg-green-900/80 border-green-400/70 text-green-100',
+    error: 'bg-red-900/80 border-red-400/70 text-red-100',
+    warning: 'bg-yellow-900/80 border-yellow-400/70 text-yellow-100',
+    info: 'bg-blue-900/80 border-blue-400/70 text-blue-100',
   }
 
   const iconColors: Record<ToastType, string> = {
-    success: 'text-green-400',
-    error: 'text-red-400',
-    warning: 'text-yellow-400',
-    info: 'text-blue-400',
+    success: 'text-green-300',
+    error: 'text-red-300',
+    warning: 'text-yellow-300',
+    info: 'text-blue-300',
   }
 
   return (
     <div
       className={cn(
-        'flex items-center gap-3 px-4 py-3 rounded-lg border backdrop-blur-sm animate-fade-in-up min-w-[250px] max-w-[400px]',
+        'flex items-center gap-3 px-4 py-3 rounded-lg border backdrop-blur-sm shadow-lg animate-fade-in-up min-w-[250px] max-w-[400px]',
         colors[toast.type]
       )}
     >


### PR DESCRIPTION
Closes #3259

## Summary
- Increased toast background opacity from `/20` to `900/80` for a darker, more opaque backdrop
- Brightened text from `-300` to `-100` Tailwind shades for all toast types
- Strengthened border opacity from `/50` to `/70` for clearer delineation
- Bumped icon colors from `-400` to `-300` for better icon visibility
- Added `shadow-lg` to the toast container for additional visual pop

These changes improve WCAG contrast ratios so success/error/warning/info toasts are immediately noticeable against the dark UI background.

## Test plan
- [ ] Install a card from the marketplace and verify the success toast is clearly visible
- [ ] Trigger an error toast and verify red styling is high-contrast
- [ ] Check warning and info toasts for similar contrast improvement