### PR TITLE
fix: remove Playwright-dependent test from --fast mode

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -56,7 +56,6 @@ declare -a FAST_SCRIPTS=(
   "scripts/consistency-test.sh"
   "scripts/helm-lint-test.sh"
   "scripts/license-compliance-test.sh"
-  "scripts/error-boundary-test.sh"
   "scripts/mission-security-test.sh"
   "scripts/card-registry-integrity-test.sh"
   "scripts/unit-test.sh"
@@ -80,10 +79,11 @@ declare -a SECURITY_SCRIPTS=(
   "scripts/security-headers-test.sh"
 )
 
-# Scripts that require a running server or are long-running
+# Scripts that require a running server, Playwright, or are long-running
 declare -a SLOW_SCRIPTS=(
   "scripts/api-contract-test.sh"
   "scripts/api-fuzz-test.sh"
+  "scripts/error-boundary-test.sh"
 )
 
 # Build full list


### PR DESCRIPTION
Closes #3246

## Summary
- Move `error-boundary-test.sh` from `FAST_SCRIPTS` to `SLOW_SCRIPTS` in `run-all-tests.sh`
- This script has a Phase 2 that runs Playwright error-resilience specs, which can time out waiting for a web server when run without browser infrastructure
- Fast mode should only include static checks, unit tests, and linting -- no Playwright

## Test plan
- [ ] Run `./scripts/run-all-tests.sh --fast` and verify error-boundary-test is NOT executed
- [ ] Run `./scripts/run-all-tests.sh` (full mode) and verify error-boundary-test IS executed