### PR TITLE
fix: fail test scripts when zero tests are executed

### DIFF
--- a/scripts/api-contract-test.sh
+++ b/scripts/api-contract-test.sh
@@ -241,7 +241,9 @@ EOF
 # Summary
 # ============================================================================
 
-if [ "$FAILED" -eq 0 ]; then
+if [ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
+  echo -e "${RED}${BOLD}No tests were executed${NC}"
+elif [ "$FAILED" -eq 0 ]; then
   echo -e "${GREEN}${BOLD}All ${PASSED} tested endpoints passed contract validation${NC}"
   if [ "$SKIPPED" -gt 0 ]; then
     echo -e "${DIM}  (${SKIPPED} skipped — auth required or connection failed)${NC}"
@@ -255,5 +257,6 @@ echo "Reports:"
 echo "  JSON:     $REPORT_JSON"
 echo "  Summary:  $REPORT_MD"
 
+[ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ] && exit 1
 [ "$FAILED" -gt 0 ] && exit 1
 exit 0

--- a/scripts/api-fuzz-test.sh
+++ b/scripts/api-fuzz-test.sh
@@ -153,7 +153,9 @@ done
 # Summary
 # ============================================================================
 
-if [ "$FAILED" -eq 0 ]; then
+if [ "$TOTAL" -eq 0 ]; then
+  echo -e "${RED}${BOLD}No fuzz targets were executed${NC}"
+elif [ "$FAILED" -eq 0 ]; then
   echo -e "${GREEN}${BOLD}All ${TOTAL} fuzz targets passed${NC}"
 else
   echo -e "${RED}${BOLD}${FAILED}/${TOTAL} fuzz targets found crashes${NC}"
@@ -164,5 +166,6 @@ echo "Reports:"
 echo "  JSON:     $REPORT_JSON"
 echo "  Summary:  $REPORT_MD"
 
+[ "$TOTAL" -eq 0 ] && exit 1
 [ "$FAILED" -gt 0 ] && exit 1
 exit 0

--- a/scripts/auth-lifecycle-test.sh
+++ b/scripts/auth-lifecycle-test.sh
@@ -243,7 +243,9 @@ EOF
 # Summary
 # ============================================================================
 
-if [ "$FAILED" -eq 0 ]; then
+if [ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
+  echo -e "${RED}${BOLD}No tests were executed${NC}"
+elif [ "$FAILED" -eq 0 ]; then
   echo -e "${GREEN}${BOLD}All ${PASSED} auth lifecycle checks passed${NC}"
 else
   echo -e "${RED}${BOLD}${FAILED}/${TOTAL} auth lifecycle checks failed${NC}"
@@ -254,5 +256,6 @@ echo "Reports:"
 echo "  JSON:     $REPORT_JSON"
 echo "  Summary:  $REPORT_MD"
 
+[ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ] && exit 1
 [ "$FAILED" -gt 0 ] && exit 1
 exit 0

--- a/scripts/error-boundary-test.sh
+++ b/scripts/error-boundary-test.sh
@@ -201,7 +201,9 @@ EOF
 # Summary
 # ============================================================================
 
-if [ "$FAILED" -eq 0 ]; then
+if [ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
+  echo -e "${RED}${BOLD}No tests were executed${NC}"
+elif [ "$FAILED" -eq 0 ]; then
   echo -e "${GREEN}${BOLD}All ${PASSED} error boundary checks passed${NC}"
   [ "$SKIPPED" -gt 0 ] && echo -e "${DIM}  (${SKIPPED} skipped — frontend not running)${NC}"
 else
@@ -213,5 +215,6 @@ echo "Reports:"
 echo "  JSON:     $REPORT_JSON"
 echo "  Summary:  $REPORT_MD"
 
+[ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ] && exit 1
 [ "$FAILED" -gt 0 ] && exit 1
 exit 0

--- a/scripts/helm-lint-test.sh
+++ b/scripts/helm-lint-test.sh
@@ -305,7 +305,9 @@ EOF
 # Summary
 # ============================================================================
 
-if [ "$FAILED" -eq 0 ]; then
+if [ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
+  echo -e "${RED}${BOLD}No tests were executed${NC}"
+elif [ "$FAILED" -eq 0 ]; then
   echo -e "${GREEN}${BOLD}All ${PASSED} Helm chart checks passed${NC}"
 else
   echo -e "${RED}${BOLD}${FAILED}/${TOTAL} Helm chart checks failed${NC}"
@@ -316,5 +318,6 @@ echo "Reports:"
 echo "  JSON:     $REPORT_JSON"
 echo "  Summary:  $REPORT_MD"
 
+[ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ] && exit 1
 [ "$FAILED" -gt 0 ] && exit 1
 exit 0

--- a/scripts/mission-security-test.sh
+++ b/scripts/mission-security-test.sh
@@ -215,7 +215,9 @@ EOF
 # Summary
 # ============================================================================
 
-if [ "$FAILED" -eq 0 ]; then
+if [ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
+  echo -e "${RED}${BOLD}No tests were executed${NC}"
+elif [ "$FAILED" -eq 0 ]; then
   echo -e "${GREEN}${BOLD}All ${PASSED} mission security checks passed${NC}"
 else
   echo -e "${RED}${BOLD}${FAILED}/${TOTAL} mission security checks failed${NC}"
@@ -226,5 +228,6 @@ echo "Reports:"
 echo "  JSON:     $REPORT_JSON"
 echo "  Summary:  $REPORT_MD"
 
+[ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ] && exit 1
 [ "$FAILED" -gt 0 ] && exit 1
 exit 0

--- a/scripts/settings-migration-test.sh
+++ b/scripts/settings-migration-test.sh
@@ -228,7 +228,9 @@ EOF
 # Summary
 # ============================================================================
 
-if [ "$FAILED" -eq 0 ]; then
+if [ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
+  echo -e "${RED}${BOLD}No tests were executed${NC}"
+elif [ "$FAILED" -eq 0 ]; then
   echo -e "${GREEN}${BOLD}All ${PASSED} settings migration checks passed${NC}"
 else
   echo -e "${RED}${BOLD}${FAILED}/${TOTAL} settings migration checks failed${NC}"
@@ -239,5 +241,6 @@ echo "Reports:"
 echo "  JSON:     $REPORT_JSON"
 echo "  Summary:  $REPORT_MD"
 
+[ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ] && exit 1
 [ "$FAILED" -gt 0 ] && exit 1
 exit 0

--- a/scripts/update-lifecycle-test.sh
+++ b/scripts/update-lifecycle-test.sh
@@ -364,7 +364,9 @@ EOF
 # Summary
 # ============================================================================
 
-if [ "$FAILED" -eq 0 ]; then
+if [ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
+  echo -e "${RED}${BOLD}No tests were executed${NC}"
+elif [ "$FAILED" -eq 0 ]; then
   echo -e "${GREEN}${BOLD}All ${PASSED} update lifecycle checks passed${NC}"
 else
   echo -e "${RED}${BOLD}${FAILED}/${TOTAL} update lifecycle checks failed${NC}"
@@ -375,5 +377,6 @@ echo "Reports:"
 echo "  JSON:     $REPORT_JSON"
 echo "  Summary:  $REPORT_MD"
 
+[ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ] && exit 1
 [ "$FAILED" -gt 0 ] && exit 1
 exit 0

--- a/scripts/websocket-resilience-test.sh
+++ b/scripts/websocket-resilience-test.sh
@@ -222,7 +222,9 @@ EOF
 # Summary
 # ============================================================================
 
-if [ "$FAILED" -eq 0 ]; then
+if [ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ]; then
+  echo -e "${RED}${BOLD}No tests were executed${NC}"
+elif [ "$FAILED" -eq 0 ]; then
   echo -e "${GREEN}${BOLD}All ${PASSED} WebSocket tests passed${NC}"
   [ "$SKIPPED" -gt 0 ] && echo -e "${DIM}  (${SKIPPED} skipped — server not running or tool not available)${NC}"
 else
@@ -234,5 +236,6 @@ echo "Reports:"
 echo "  JSON:     $REPORT_JSON"
 echo "  Summary:  $REPORT_MD"
 
+[ "$PASSED" -eq 0 ] && [ "$FAILED" -eq 0 ] && exit 1
 [ "$FAILED" -gt 0 ] && exit 1
 exit 0


### PR DESCRIPTION
Closes #3245

## Summary
- Add a zero-test guard to 9 test scripts that previously exited 0 when no tests ran
- When both `PASSED` and `FAILED` counters are zero, scripts now print "No tests were executed" and exit 1
- This prevents false-positive PASS results when tests are not matched or skipped entirely

**Scripts updated:**
- `auth-lifecycle-test.sh`
- `mission-security-test.sh`
- `helm-lint-test.sh`
- `websocket-resilience-test.sh`
- `error-boundary-test.sh`
- `update-lifecycle-test.sh`
- `settings-migration-test.sh`
- `api-contract-test.sh`
- `api-fuzz-test.sh`

## Test plan
- [ ] Run any of the above scripts in an environment where no tests can execute (e.g., missing deps) and verify it exits 1 with "No tests were executed"
- [ ] Run normally and verify scripts still pass when tests do execute