### PR TITLE
fix: prevent malformed multi-line output from grep -c in test scripts

### DIFF
--- a/scripts/auth-lifecycle-test.sh
+++ b/scripts/auth-lifecycle-test.sh
@@ -61,8 +61,8 @@ JWT_OUTPUT="$TMPDIR_AUTH/jwt-tests.txt"
 JWT_EXIT=0
 go test ./pkg/api/middleware/... -run "TestJWTAuth|TestValidateJWT|TestGetContext" -v -timeout 30s > "$JWT_OUTPUT" 2>&1 || JWT_EXIT=$?
 
-JWT_PASSED=$(grep -c "^--- PASS:" "$JWT_OUTPUT" 2>/dev/null || echo "0")
-JWT_FAILED_COUNT=$(grep -c "^--- FAIL:" "$JWT_OUTPUT" 2>/dev/null || echo "0")
+JWT_PASSED=$(grep -c "^--- PASS:" "$JWT_OUTPUT" 2>/dev/null || true)
+JWT_FAILED_COUNT=$(grep -c "^--- FAIL:" "$JWT_OUTPUT" 2>/dev/null || true)
 
 TOTAL=$((TOTAL + 1))
 if [ "$JWT_EXIT" -eq 0 ]; then
@@ -88,7 +88,7 @@ AUTH_OUTPUT="$TMPDIR_AUTH/auth-handler-tests.txt"
 AUTH_EXIT=0
 go test ./pkg/api/handlers/... -run "TestAuth|TestOAuth|TestLogin|TestCallback" -v -timeout 30s > "$AUTH_OUTPUT" 2>&1 || AUTH_EXIT=$?
 
-AUTH_PASSED=$(grep -c "^--- PASS:" "$AUTH_OUTPUT" 2>/dev/null || echo "0")
+AUTH_PASSED=$(grep -c "^--- PASS:" "$AUTH_OUTPUT" 2>/dev/null || true)
 
 TOTAL=$((TOTAL + 1))
 if [ "$AUTH_EXIT" -eq 0 ]; then
@@ -117,7 +117,7 @@ WS_OUTPUT="$TMPDIR_AUTH/ws-auth-tests.txt"
 WS_EXIT=0
 go test ./pkg/api/handlers/... -run "TestWebSocket|TestHub" -v -timeout 30s > "$WS_OUTPUT" 2>&1 || WS_EXIT=$?
 
-WS_PASSED=$(grep -c "^--- PASS:" "$WS_OUTPUT" 2>/dev/null || echo "0")
+WS_PASSED=$(grep -c "^--- PASS:" "$WS_OUTPUT" 2>/dev/null || true)
 
 TOTAL=$((TOTAL + 1))
 if [ "$WS_EXIT" -eq 0 ]; then

--- a/scripts/error-boundary-test.sh
+++ b/scripts/error-boundary-test.sh
@@ -94,7 +94,7 @@ if [ -f "web/e2e/compliance/error-resilience.spec.ts" ]; then
 
     TOTAL=$((TOTAL + 1))
     if [ "$PW_EXIT" -eq 0 ]; then
-      PW_PASSED=$(grep -c "✓\|passed" "$PW_OUTPUT" 2>/dev/null || echo "0")
+      PW_PASSED=$(grep -c "✓\|passed" "$PW_OUTPUT" 2>/dev/null || true)
       echo -e "  ${GREEN}✓${NC}  Error resilience tests passed (${PW_PASSED} checks)"
       PASSED=$((PASSED + 1))
     else

--- a/scripts/helm-lint-test.sh
+++ b/scripts/helm-lint-test.sh
@@ -93,8 +93,8 @@ else
   helm lint "$CHART_DIR" > "$LINT_OUTPUT" 2>&1 || LINT_EXIT=$?
 fi
 
-LINT_WARNINGS=$(grep -c "\[WARNING\]" "$LINT_OUTPUT" 2>/dev/null || echo "0")
-LINT_ERRORS=$(grep -c "\[ERROR\]" "$LINT_OUTPUT" 2>/dev/null || echo "0")
+LINT_WARNINGS=$(grep -c "\[WARNING\]" "$LINT_OUTPUT" 2>/dev/null || true)
+LINT_ERRORS=$(grep -c "\[ERROR\]" "$LINT_OUTPUT" 2>/dev/null || true)
 
 TOTAL=$((TOTAL + 1))
 if [ "$LINT_EXIT" -eq 0 ]; then
@@ -123,7 +123,7 @@ helm template test-release "$CHART_DIR" > "$TEMPLATE_OUTPUT" 2>&1 || TEMPLATE_EX
 
 TOTAL=$((TOTAL + 1))
 if [ "$TEMPLATE_EXIT" -eq 0 ]; then
-  RESOURCE_COUNT=$(grep -c "^kind:" "$TEMPLATE_OUTPUT" 2>/dev/null || echo "0")
+  RESOURCE_COUNT=$(grep -c "^kind:" "$TEMPLATE_OUTPUT" 2>/dev/null || true)
   echo -e "  ${GREEN}✓${NC}  Template renders successfully (${RESOURCE_COUNT} resources)"
   PASSED=$((PASSED + 1))
 else

--- a/scripts/license-compliance-test.sh
+++ b/scripts/license-compliance-test.sh
@@ -170,7 +170,8 @@ except Exception:
   # Check for blocked licenses in Go deps (if go-licenses was used)
   GO_FLAGGED=0
   if command -v go-licenses &>/dev/null; then
-    GO_FLAGGED=$(grep -ciE "$BLOCKED_LICENSES" "$GO_LICENSE_OUTPUT" 2>/dev/null || echo "0")
+    GO_FLAGGED=$(grep -ciE "$BLOCKED_LICENSES" "$GO_LICENSE_OUTPUT" 2>/dev/null || true)
+    GO_FLAGGED=${GO_FLAGGED:-0}
   fi
 
   if [ "$GO_FLAGGED" -gt 0 ]; then

--- a/scripts/mission-security-test.sh
+++ b/scripts/mission-security-test.sh
@@ -59,8 +59,8 @@ VITEST_EXIT=0
 npx vitest run src/lib/missions/__tests__/ --reporter=verbose > "$VITEST_OUTPUT" 2>&1 || VITEST_EXIT=$?
 cd ..
 
-VITEST_PASSED=$(grep -c "✓\|✅\|PASS" "$VITEST_OUTPUT" 2>/dev/null || echo "0")
-VITEST_FAILED_COUNT=$(grep -c "✗\|❌\|FAIL" "$VITEST_OUTPUT" 2>/dev/null || echo "0")
+VITEST_PASSED=$(grep -c "✓\|✅\|PASS" "$VITEST_OUTPUT" 2>/dev/null || true)
+VITEST_FAILED_COUNT=$(grep -c "✗\|❌\|FAIL" "$VITEST_OUTPUT" 2>/dev/null || true)
 
 TOTAL=$((TOTAL + 1))
 if [ "$VITEST_EXIT" -eq 0 ]; then

--- a/scripts/settings-migration-test.sh
+++ b/scripts/settings-migration-test.sh
@@ -61,8 +61,8 @@ CRYPTO_OUTPUT="$TMPDIR_SM/crypto-tests.txt"
 CRYPTO_EXIT=0
 go test ./pkg/settings/... -run "TestEncryptDecrypt|TestDecrypt|TestEnsureKeyFile|TestKeyFingerprint" -v -timeout 30s > "$CRYPTO_OUTPUT" 2>&1 || CRYPTO_EXIT=$?
 
-CRYPTO_PASSED=$(grep -c "^--- PASS:" "$CRYPTO_OUTPUT" 2>/dev/null || echo "0")
-CRYPTO_FAILED_COUNT=$(grep -c "^--- FAIL:" "$CRYPTO_OUTPUT" 2>/dev/null || echo "0")
+CRYPTO_PASSED=$(grep -c "^--- PASS:" "$CRYPTO_OUTPUT" 2>/dev/null || true)
+CRYPTO_FAILED_COUNT=$(grep -c "^--- FAIL:" "$CRYPTO_OUTPUT" 2>/dev/null || true)
 
 TOTAL=$((TOTAL + 1))
 if [ "$CRYPTO_EXIT" -eq 0 ]; then
@@ -88,8 +88,8 @@ HANDLER_OUTPUT="$TMPDIR_SM/handler-tests.txt"
 HANDLER_EXIT=0
 go test ./pkg/api/handlers/... -run "TestGetSettings|TestSaveSettings|TestExportImport|TestSettingsFileError" -v -timeout 30s > "$HANDLER_OUTPUT" 2>&1 || HANDLER_EXIT=$?
 
-HANDLER_PASSED=$(grep -c "^--- PASS:" "$HANDLER_OUTPUT" 2>/dev/null || echo "0")
-HANDLER_FAILED_COUNT=$(grep -c "^--- FAIL:" "$HANDLER_OUTPUT" 2>/dev/null || echo "0")
+HANDLER_PASSED=$(grep -c "^--- PASS:" "$HANDLER_OUTPUT" 2>/dev/null || true)
+HANDLER_FAILED_COUNT=$(grep -c "^--- FAIL:" "$HANDLER_OUTPUT" 2>/dev/null || true)
 
 TOTAL=$((TOTAL + 1))
 if [ "$HANDLER_EXIT" -eq 0 ]; then

--- a/scripts/update-lifecycle-test.sh
+++ b/scripts/update-lifecycle-test.sh
@@ -61,8 +61,8 @@ TEST_OUTPUT="$TMPDIR_UL/update-tests.txt"
 TEST_EXIT=0
 go test ./pkg/agent/... -run "TestTriggerNow|TestIsUpdating|TestStatus" -v -timeout 30s > "$TEST_OUTPUT" 2>&1 || TEST_EXIT=$?
 
-GO_PASSED=$(grep -c "^--- PASS:" "$TEST_OUTPUT" 2>/dev/null || echo "0")
-GO_FAILED_COUNT=$(grep -c "^--- FAIL:" "$TEST_OUTPUT" 2>/dev/null || echo "0")
+GO_PASSED=$(grep -c "^--- PASS:" "$TEST_OUTPUT" 2>/dev/null || true)
+GO_FAILED_COUNT=$(grep -c "^--- FAIL:" "$TEST_OUTPUT" 2>/dev/null || true)
 
 TOTAL=$((TOTAL + 1))
 if [ "$TEST_EXIT" -eq 0 ]; then

--- a/scripts/websocket-resilience-test.sh
+++ b/scripts/websocket-resilience-test.sh
@@ -115,8 +115,8 @@ WS_TEST_EXIT=0
 go test ./pkg/api/handlers/... -run "TestWebSocket\|TestHub\|TestHandle" -v -timeout 30s > "$WS_TEST_OUTPUT" 2>&1 || WS_TEST_EXIT=$?
 
 # Count pass/fail from Go test output
-GO_PASSED=$(grep -c "^--- PASS:" "$WS_TEST_OUTPUT" 2>/dev/null || echo "0")
-GO_FAILED=$(grep -c "^--- FAIL:" "$WS_TEST_OUTPUT" 2>/dev/null || echo "0")
+GO_PASSED=$(grep -c "^--- PASS:" "$WS_TEST_OUTPUT" 2>/dev/null || true)
+GO_FAILED=$(grep -c "^--- FAIL:" "$WS_TEST_OUTPUT" 2>/dev/null || true)
 
 if [ "$WS_TEST_EXIT" -eq 0 ]; then
   run_test "Go WebSocket handler tests (${GO_PASSED} tests)" "pass" ""


### PR DESCRIPTION
Closes #3244

## Summary
- Replace `$(grep -c ... || echo "0")` with `$(grep -c ... || true)` across 8 test scripts
- The old pattern produced `0\n0` (two lines) when grep found no matches, because grep outputs "0" then `echo "0"` adds another -- this broke shell arithmetic comparisons with "integer expression expected"
- The new pattern uses `|| true` to suppress the non-zero exit code while keeping grep's single-line "0" output intact

**Scripts fixed:**
- `auth-lifecycle-test.sh` (4 instances)
- `error-boundary-test.sh` (1 instance)
- `helm-lint-test.sh` (3 instances)
- `mission-security-test.sh` (2 instances)
- `settings-migration-test.sh` (4 instances)
- `update-lifecycle-test.sh` (2 instances)
- `websocket-resilience-test.sh` (2 instances)
- `license-compliance-test.sh` (1 instance)

## Test plan
- [ ] Run `./scripts/run-all-tests.sh --fast` and confirm no "integer expression expected" errors
- [ ] Run individual scripts (e.g., `./scripts/helm-lint-test.sh`) where grep matches zero lines and verify clean numeric output