### PR TITLE
fix: card fullscreen rendering, inline insertion, WASD guard

### DIFF
--- a/web/src/components/cards/KubeBert.tsx
+++ b/web/src/components/cards/KubeBert.tsx
@@ -556,6 +556,7 @@ export function KubeBert() {
   // Keyboard controls
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (gameStateRef.current !== 'playing') return
 
       // Q*bert uses diagonal movement mapped to arrow keys:

--- a/web/src/components/cards/KubeCraft3D.tsx
+++ b/web/src/components/cards/KubeCraft3D.tsx
@@ -371,6 +371,7 @@ export function KubeCraft3D() {
   // Handle keyboard events
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement || (event.target instanceof HTMLElement && event.target.isContentEditable)) return
       if (!isLocked) return
 
       switch (event.code) {

--- a/web/src/components/cards/KubePong.tsx
+++ b/web/src/components/cards/KubePong.tsx
@@ -279,6 +279,7 @@ export function KubePong() {
   // Keyboard handlers
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (['ArrowUp', 'ArrowDown', ' '].includes(e.key)) {
         e.preventDefault()
       }

--- a/web/src/components/cards/PodPitfall.tsx
+++ b/web/src/components/cards/PodPitfall.tsx
@@ -509,6 +509,7 @@ export function PodPitfall(_props: CardComponentProps) {
   // Keyboard
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
       if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' ', 'w', 'a', 's', 'd'].includes(e.key)) {
         e.preventDefault()
         keysRef.current.add(e.key)

--- a/web/src/components/cards/llmd/EPPRouting.tsx
+++ b/web/src/components/cards/llmd/EPPRouting.tsx
@@ -530,7 +530,7 @@ export function EPPRouting() {
   useReportCardDataState({ isDemoData: showDemoBadge, isFailed: false, consecutiveFailures: 0, hasData: true })
 
   // Build dynamic nodes from stack topology
-  const dynamicNodes = useMemo((): FlowNode[] => {
+  const rawNodes = useMemo((): FlowNode[] => {
     // Only show demo nodes if demo mode is ON
     if (!selectedStack && isDemoMode) {
       return NODES // Default demo nodes
@@ -648,6 +648,15 @@ export function EPPRouting() {
 
     return nodes
   }, [selectedStack, isDemoMode])
+
+  // Scale node positions wider when in fullscreen to fill the wider SVG viewBox
+  const dynamicNodes = useMemo(() => {
+    if (!isExpanded || rawNodes.length === 0) return rawNodes
+    return rawNodes.map(node => ({
+      ...node,
+      x: 10 + (node.x - 12) * (210 / 78),
+    }))
+  }, [rawNodes, isExpanded])
 
   // Toggle metric selection
   const toggleMetric = (metric: MetricType) => {
@@ -957,7 +966,7 @@ export function EPPRouting() {
       {/* Main visualization area */}
       <div className={`flex-1 relative ${isExpanded ? 'min-h-0' : 'min-h-[200px]'}`}>
         <svg
-          viewBox="-5 -10 120 130"
+          viewBox={isExpanded ? '-10 -10 240 110' : '-5 -10 120 130'}
           className="w-full h-full overflow-visible"
           preserveAspectRatio="xMidYMid meet"
           style={{ overflow: 'visible' }}

--- a/web/src/components/cards/llmd/KVCacheMonitor.tsx
+++ b/web/src/components/cards/llmd/KVCacheMonitor.tsx
@@ -642,7 +642,7 @@ export function KVCacheMonitor() {
       </div>
 
       {/* Summary stats with glow */}
-      <div className="grid grid-cols-4 gap-2 mb-4">
+      <div className={`grid grid-cols-4 mb-4 ${isExpanded ? 'gap-4' : 'gap-2'}`}>
         <div className="bg-secondary/60 backdrop-blur-sm rounded-lg p-2 text-center border border-border/50">
           <div className="text-lg font-bold text-white flex items-center justify-center gap-1">
             {aggregateMetrics.avgUtil}%
@@ -783,18 +783,25 @@ export function KVCacheMonitor() {
             <motion.div
               key="gauges"
               className={`h-full overflow-auto ${
-                stats.length <= 2 ? 'flex items-center justify-evenly gap-12' :
-                stats.length <= 3 ? 'grid grid-cols-3 gap-6 place-items-center' :
-                stats.length <= 6 ? 'grid grid-cols-3 gap-3 place-items-center' :
-                stats.length <= 9 ? 'grid grid-cols-3 gap-2 place-items-center' :
-                'grid grid-cols-4 gap-2 place-items-center'
+                isExpanded
+                  ? (stats.length <= 2 ? 'flex items-center justify-evenly gap-16' :
+                     stats.length <= 4 ? 'grid grid-cols-4 gap-8 place-items-center' :
+                     stats.length <= 6 ? 'grid grid-cols-3 gap-6 place-items-center' :
+                     'grid grid-cols-4 gap-4 place-items-center')
+                  : (stats.length <= 2 ? 'flex items-center justify-evenly gap-12' :
+                     stats.length <= 3 ? 'grid grid-cols-3 gap-6 place-items-center' :
+                     stats.length <= 6 ? 'grid grid-cols-3 gap-3 place-items-center' :
+                     stats.length <= 9 ? 'grid grid-cols-3 gap-2 place-items-center' :
+                     'grid grid-cols-4 gap-2 place-items-center')
               }`}
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
             >
-              {stats.slice(0, 12).map((stat) => {
-                const gaugeSize = stats.length <= 2 ? 120 : stats.length <= 3 ? 130 : stats.length <= 6 ? 110 : stats.length <= 9 ? 100 : 85
+              {stats.slice(0, isExpanded ? 20 : 12).map((stat) => {
+                const gaugeSize = isExpanded
+                  ? (stats.length <= 2 ? 200 : stats.length <= 4 ? 180 : stats.length <= 6 ? 160 : 140)
+                  : (stats.length <= 2 ? 120 : stats.length <= 3 ? 130 : stats.length <= 6 ? 110 : stats.length <= 9 ? 100 : 85)
                 return (
                   <div
                     key={stat.podName}
@@ -817,17 +824,24 @@ export function KVCacheMonitor() {
             <motion.div
               key="horseshoe"
               className={`grid h-full place-items-center overflow-auto ${
-                stats.length <= 2 ? 'grid-cols-2 gap-2' :
-                stats.length <= 3 ? 'grid-cols-3 gap-1' :
-                stats.length <= 6 ? 'grid-cols-3 gap-1' :
-                'grid-cols-4 gap-1'
+                isExpanded
+                  ? (stats.length <= 2 ? 'grid-cols-2 gap-6' :
+                     stats.length <= 4 ? 'grid-cols-4 gap-4' :
+                     stats.length <= 6 ? 'grid-cols-3 gap-4' :
+                     'grid-cols-4 gap-3')
+                  : (stats.length <= 2 ? 'grid-cols-2 gap-2' :
+                     stats.length <= 3 ? 'grid-cols-3 gap-1' :
+                     stats.length <= 6 ? 'grid-cols-3 gap-1' :
+                     'grid-cols-4 gap-1')
               }`}
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
             >
-              {stats.slice(0, 8).map((stat) => {
-                const gaugeSize = stats.length <= 2 ? 180 : stats.length <= 3 ? 160 : stats.length <= 6 ? 140 : 120
+              {stats.slice(0, isExpanded ? 16 : 8).map((stat) => {
+                const gaugeSize = isExpanded
+                  ? (stats.length <= 2 ? 240 : stats.length <= 4 ? 200 : stats.length <= 6 ? 180 : 160)
+                  : (stats.length <= 2 ? 180 : stats.length <= 3 ? 160 : stats.length <= 6 ? 140 : 120)
                 return (
                   <div
                     key={stat.podName}

--- a/web/src/components/cards/llmd/LLMdAIInsights.tsx
+++ b/web/src/components/cards/llmd/LLMdAIInsights.tsx
@@ -10,6 +10,7 @@ import { Brain, Lightbulb, AlertTriangle, TrendingUp, Gauge, MessageSquare, Chev
 import { StatusBadge } from '../../../components/ui/StatusBadge'
 import { useOptionalStack } from '../../../contexts/StackContext'
 import { useCardDemoState, useReportCardDataState } from '../CardDataContext'
+import { useCardExpanded } from '../CardWrapper'
 import { generateAIInsights, type AIInsight } from '../../../lib/llmd/mockData'
 import type { LLMdStack } from '../../../hooks/useStackDiscovery'
 import { useTranslation } from 'react-i18next'
@@ -327,6 +328,7 @@ export function LLMdAIInsights() {
   // Use showDemoBadge (true when global demo mode) rather than shouldUseDemoData (false when stack selected)
   useReportCardDataState({ isDemoData: showDemoBadge, isFailed: false, consecutiveFailures: 0, hasData: true })
 
+  const { isExpanded: isCardExpanded } = useCardExpanded()
   const [expandedId, setExpandedId] = useState<string | null>(null)
   const [chatInput, setChatInput] = useState('')
   const [chatHistory, setChatHistory] = useState<Array<{ role: 'user' | 'ai'; message: string }>>([])
@@ -452,9 +454,9 @@ export function LLMdAIInsights() {
       </div>
 
       {/* Insights list */}
-      <div className="flex-1 overflow-auto space-y-2 mb-4">
+      <div className={`flex-1 overflow-auto mb-4 ${isCardExpanded ? 'grid grid-cols-2 gap-3 auto-rows-min' : 'space-y-2'}`}>
         {insights.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full text-center">
+          <div className={`flex flex-col items-center justify-center h-full text-center ${isCardExpanded ? 'col-span-2' : ''}`}>
             <Settings2 size={32} className="text-muted-foreground mb-2" />
             <p className="text-sm text-muted-foreground">
               {reason === 'stack-not-selected'

--- a/web/src/components/cards/llmd/LLMdFlow.tsx
+++ b/web/src/components/cards/llmd/LLMdFlow.tsx
@@ -595,7 +595,7 @@ export function LLMdFlow() {
   useReportCardDataState({ isDemoData: showDemoBadge, isFailed: false, consecutiveFailures: 0, hasData: true })
 
   // Build dynamic node positions based on actual stack topology
-  const { nodePositions, connections, nodeLabels } = useMemo(() => {
+  const { nodePositions: rawPositions, connections, nodeLabels } = useMemo(() => {
     // Only show demo topology if demo mode is ON
     if (!selectedStack && isDemoMode) {
       return {
@@ -754,6 +754,17 @@ export function LLMdFlow() {
 
     return { nodePositions: positions, connections: conns, nodeLabels: labels }
   }, [selectedStack, isDemoMode])
+
+  // Scale node positions wider when in fullscreen to fill the wider SVG viewBox (240w vs 120w)
+  const nodePositions = useMemo(() => {
+    if (!isExpanded || Object.keys(rawPositions).length === 0) return rawPositions
+    const scaled: Record<string, { x: number; y: number }> = {}
+    for (const [key, pos] of Object.entries(rawPositions)) {
+      // Map from original x range (10-92) to expanded range (10-210)
+      scaled[key] = { x: 10 + (pos.x - 10) * (200 / 82), y: pos.y }
+    }
+    return scaled
+  }, [rawPositions, isExpanded])
 
   // Toggle metric selection
   const toggleMetric = (metric: MetricType) => {
@@ -962,7 +973,7 @@ export function LLMdFlow() {
   const showEmptyState = !selectedStack && !isDemoMode
 
   return (
-    <div className={`relative w-full h-full flex-1 bg-gradient-to-br from-background/50 to-secondary/30 rounded-lg ${isExpanded ? 'min-h-0' : 'min-h-[300px]'}`}>
+    <div className={`relative w-full h-full flex-1 flex flex-col bg-gradient-to-br from-background/50 to-secondary/30 rounded-lg ${isExpanded ? 'min-h-0' : 'min-h-[300px]'}`}>
       {/* Empty state overlay */}
       {showEmptyState && (
         <div className="absolute inset-0 flex flex-col items-center justify-center z-20 bg-background/60 backdrop-blur-sm">
@@ -1059,8 +1070,8 @@ export function LLMdFlow() {
 
       {/* SVG Flow Diagram - overflow visible allows labels to extend beyond viewBox */}
       <svg
-        viewBox="-5 -10 120 140"
-        className="w-full h-[calc(100%-2rem)] mt-8 overflow-visible"
+        viewBox={isExpanded ? '-10 -10 240 120' : '-5 -10 120 140'}
+        className={`w-full overflow-visible ${isExpanded ? 'flex-1 min-h-0 mt-2' : 'h-[calc(100%-2rem)] mt-8'}`}
         preserveAspectRatio="xMidYMid meet"
         style={{ overflow: 'visible' }}
       >

--- a/web/src/components/cards/llmd/PDDisaggregation.tsx
+++ b/web/src/components/cards/llmd/PDDisaggregation.tsx
@@ -386,7 +386,7 @@ export function PDDisaggregation() {
       {(isDemoMode || (selectedStack && hasDisaggregation)) && (
         <>
           {/* Metrics summary */}
-          <div className="grid grid-cols-5 gap-2 mb-4">
+          <div className={`grid grid-cols-5 mb-4 ${isExpanded ? 'gap-4' : 'gap-2'}`}>
             <div className="bg-purple-500/10 rounded-lg p-2 text-center">
               <div className="flex items-center justify-center gap-1 text-purple-400 mb-1">
                 <Cpu size={12} />
@@ -441,7 +441,7 @@ export function PDDisaggregation() {
                 <div className="w-3 h-3 rounded-full bg-purple-500" />
                 <span className="text-sm font-medium text-purple-400">{t('llmd.prefillServers')}</span>
               </div>
-              <div className="flex-1 space-y-2 overflow-auto">
+              <div className={`flex-1 overflow-auto ${isExpanded ? 'grid grid-cols-2 gap-3 auto-rows-min' : 'space-y-2'}`}>
                 {prefillServers.map(server => (
                   <ServerCard key={server.id} server={server} />
                 ))}
@@ -484,7 +484,7 @@ export function PDDisaggregation() {
                 <div className="w-3 h-3 rounded-full bg-green-500" />
                 <span className="text-sm font-medium text-green-400">{t('llmd.decodeServers')}</span>
               </div>
-              <div className="flex-1 space-y-2 overflow-auto">
+              <div className={`flex-1 overflow-auto ${isExpanded ? 'grid grid-cols-2 gap-3 auto-rows-min' : 'space-y-2'}`}>
                 {decodeServers.map(server => (
                   <ServerCard key={server.id} server={server} />
                 ))}

--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -75,9 +75,11 @@ interface SortableCardProps {
   isRefreshing?: boolean
   onRefresh?: () => void
   lastUpdated?: Date | null
+  onInsertBefore?: () => void
+  onInsertAfter?: () => void
 }
 
-function SortableCard({ card, onConfigure, onRemove, onWidthChange, isDragging, isRefreshing, onRefresh, lastUpdated }: SortableCardProps) {
+function SortableCard({ card, onConfigure, onRemove, onWidthChange, isDragging, isRefreshing, onRefresh, lastUpdated, onInsertBefore, onInsertAfter }: SortableCardProps) {
   const { t } = useTranslation()
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: card.id })
 
@@ -110,7 +112,27 @@ function SortableCard({ card, onConfigure, onRemove, onWidthChange, isDragging, 
 
   if (!CardComponent) {
     return (
-      <div ref={setNodeRef} style={style} className="relative">
+      <div ref={setNodeRef} style={style} className="relative group/card">
+        {onInsertBefore && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onInsertBefore() }}
+            className="absolute top-1/2 -left-2.5 -translate-y-1/2 z-10 opacity-0 group-hover/card:opacity-100 transition-opacity w-5 h-5 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold shadow-md hover:scale-110"
+            aria-label="Insert card before this one"
+            title="Insert card here"
+          >
+            +
+          </button>
+        )}
+        {onInsertAfter && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
+            className="absolute top-1/2 -right-2.5 -translate-y-1/2 z-10 opacity-0 group-hover/card:opacity-100 transition-opacity w-5 h-5 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold shadow-md hover:scale-110"
+            aria-label="Insert card after this one"
+            title="Insert card here"
+          >
+            +
+          </button>
+        )}
         <CardWrapper
           cardId={card.id}
           cardType={card.card_type}
@@ -132,7 +154,27 @@ function SortableCard({ card, onConfigure, onRemove, onWidthChange, isDragging, 
   }
 
   return (
-    <div ref={setNodeRef} style={style} className="relative">
+    <div ref={setNodeRef} style={style} className="relative group/card">
+      {onInsertBefore && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onInsertBefore() }}
+          className="absolute top-1/2 -left-2.5 -translate-y-1/2 z-10 opacity-0 group-hover/card:opacity-100 transition-opacity w-5 h-5 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold shadow-md hover:scale-110"
+          aria-label="Insert card before this one"
+          title="Insert card here"
+        >
+          +
+        </button>
+      )}
+      {onInsertAfter && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
+          className="absolute top-1/2 -right-2.5 -translate-y-1/2 z-10 opacity-0 group-hover/card:opacity-100 transition-opacity w-5 h-5 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold shadow-md hover:scale-110"
+          aria-label="Insert card after this one"
+          title="Insert card here"
+        >
+          +
+        </button>
+      )}
       {/* Drag handle */}
       <div
         {...attributes}
@@ -237,6 +279,11 @@ export function CustomDashboard() {
   const { isOpen: isTemplatesOpen, open: openTemplates, close: closeTemplates } = useModalState()
   const { isOpen: isDeleteConfirmOpen, open: openDeleteConfirm, close: closeDeleteConfirm } = useModalState()
   const [selectedCard, setSelectedCard] = useState<Card | null>(null)
+
+  // Inline card insertion
+  const [insertAtIndex, setInsertAtIndex] = useState<number | null>(null)
+  const insertAtIndexRef = useRef<number | null>(null)
+  insertAtIndexRef.current = insertAtIndex
 
   // Drag state
   const [activeId, setActiveId] = useState<string | null>(null)
@@ -350,7 +397,13 @@ export function CustomDashboard() {
 
     // Add to local state
     snapshot(cardsRef.current)
-    setCards(prev => [...prev, ...cardsToAdd])
+    const idx = insertAtIndexRef.current
+    if (idx !== null) {
+      setCards(prev => [...prev.slice(0, idx), ...cardsToAdd, ...prev.slice(idx)])
+      setInsertAtIndex(null)
+    } else {
+      setCards(prev => [...cardsToAdd, ...prev])
+    }
 
     // Persist to backend
     if (id) {
@@ -590,7 +643,7 @@ export function CustomDashboard() {
         >
           <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
             <div className="grid grid-cols-1 md:grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)]">
-              {cards.map((card) => (
+              {cards.map((card, index) => (
                 <SortableCard
                   key={card.id}
                   card={card}
@@ -601,6 +654,8 @@ export function CustomDashboard() {
                   isRefreshing={isRefreshing}
                   onRefresh={triggerRefresh}
                   lastUpdated={lastUpdated}
+                  onInsertBefore={() => { setInsertAtIndex(index); openAddCard() }}
+                  onInsertAfter={() => { setInsertAtIndex(index + 1); openAddCard() }}
                 />
               ))}
             </div>
@@ -659,7 +714,7 @@ export function CustomDashboard() {
       {/* Add Card Modal */}
       <AddCardModal
         isOpen={isAddCardOpen}
-        onClose={closeAddCard}
+        onClose={() => { closeAddCard(); setInsertAtIndex(null) }}
         onAddCards={handleAddCards}
         existingCardTypes={currentCardTypes}
       />

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -106,6 +106,7 @@ export function Dashboard() {
   })
   const [activeId, setActiveId] = useState<string | null>(null)
   const [isDragging, setIsDragging] = useState(false)
+  const [insertAtIndex, setInsertAtIndex] = useState<number | null>(null)
   const [_dragOverDashboard, setDragOverDashboard] = useState<string | null>(null)
   const { isOpen: isCreateDashboardOpen, open: openCreateDashboard, close: closeCreateDashboard } = useModalState()
   const { isOpen: isWidgetExportOpen, open: openWidgetExport, close: closeWidgetExport } = useModalState()
@@ -634,9 +635,14 @@ export function Dashboard() {
       recordCardAdded(card.id, card.card_type, card.title, card.config, dashboard?.id, dashboard?.name)
       emitCardAdded(card.card_type, 'add_modal')
     })
-    // Add new cards at the TOP of the dashboard (prepend)
+    // Insert cards at the specified position, or prepend to top
     snapshot(localCards)
-    setLocalCards((prev) => [...newCards, ...prev])
+    if (insertAtIndex !== null) {
+      setLocalCards((prev) => [...prev.slice(0, insertAtIndex), ...newCards, ...prev.slice(insertAtIndex)])
+      setInsertAtIndex(null)
+    } else {
+      setLocalCards((prev) => [...newCards, ...prev])
+    }
 
     // Persist to backend if dashboard exists
     if (dashboard?.id) {
@@ -985,7 +991,7 @@ export function Dashboard() {
             aria-label="Dashboard cards"
             className={`grid grid-cols-1 md:grid-cols-12 gap-4 auto-rows-[minmax(180px,auto)] ${showDragHint ? 'animate-shimmy' : ''}`}
           >
-            {localCards.map((card) => (
+            {localCards.map((card, index) => (
               <SortableCard
                 key={card.id}
                 card={card}
@@ -999,6 +1005,8 @@ export function Dashboard() {
                 onKeyDown={handleGridKeyDown}
                 registerRef={(el) => registerCardRef(card.id, el)}
                 registerExpandTrigger={(expand) => { expandTriggersRef.current.set(card.id, expand) }}
+                onInsertBefore={() => { setInsertAtIndex(index); openAddCardModal() }}
+                onInsertAfter={() => { setInsertAtIndex(index + 1); openAddCardModal() }}
               />
             ))}
 
@@ -1061,7 +1069,7 @@ export function Dashboard() {
       {/* Add Card Modal */}
       <AddCardModal
         isOpen={isAddCardModalOpen}
-        onClose={() => { closeAddCardModal(); setAddCardSearch('') }}
+        onClose={() => { closeAddCardModal(); setAddCardSearch(''); setInsertAtIndex(null) }}
         onAddCards={handleAddCards}
         existingCardTypes={currentCardTypes}
         initialSearch={addCardSearch}

--- a/web/src/components/dashboard/SharedSortableCard.tsx
+++ b/web/src/components/dashboard/SharedSortableCard.tsx
@@ -19,6 +19,8 @@ interface SortableCardProps {
   onKeyDown?: (e: KeyboardEvent) => void
   registerRef?: (el: HTMLElement | null) => void
   registerExpandTrigger?: (expand: () => void) => void
+  onInsertBefore?: () => void
+  onInsertAfter?: () => void
 }
 
 /** Below this width, clamp small cards to half-width (6 cols) for readability */
@@ -27,7 +29,7 @@ const NARROW_BREAKPOINT = 1024
 /** Minimum card column span at narrow viewports */
 const MIN_NARROW_COLS = 6
 
-export const SortableCard = memo(function SortableCard({ card, onConfigure, onRemove, onWidthChange, isDragging, isRefreshing, onRefresh, lastUpdated, onKeyDown, registerRef, registerExpandTrigger }: SortableCardProps) {
+export const SortableCard = memo(function SortableCard({ card, onConfigure, onRemove, onWidthChange, isDragging, isRefreshing, onRefresh, lastUpdated, onKeyDown, registerRef, registerExpandTrigger, onInsertBefore, onInsertAfter }: SortableCardProps) {
   const {
     attributes,
     listeners,
@@ -65,12 +67,32 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
     <div
       ref={(el) => { setNodeRef(el); registerRef?.(el) }}
       style={style}
-      className="h-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:rounded-xl"
+      className="relative group/card h-full outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:rounded-xl"
       tabIndex={0}
       role="gridcell"
       aria-label={formatCardTitle(card.card_type)}
       onKeyDown={onKeyDown}
     >
+      {onInsertBefore && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onInsertBefore() }}
+          className="absolute top-1/2 -left-2.5 -translate-y-1/2 z-10 opacity-0 group-hover/card:opacity-100 transition-opacity w-5 h-5 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold shadow-md hover:scale-110"
+          aria-label="Insert card before this one"
+          title="Insert card here"
+        >
+          +
+        </button>
+      )}
+      {onInsertAfter && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
+          className="absolute top-1/2 -right-2.5 -translate-y-1/2 z-10 opacity-0 group-hover/card:opacity-100 transition-opacity w-5 h-5 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold shadow-md hover:scale-110"
+          aria-label="Insert card after this one"
+          title="Insert card here"
+        >
+          +
+        </button>
+      )}
       <CardWrapper
         cardId={card.id}
         cardType={card.card_type}
@@ -119,7 +141,9 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
     prevProps.isDragging === nextProps.isDragging &&
     prevProps.isRefreshing === nextProps.isRefreshing &&
     prevProps.lastUpdated === nextProps.lastUpdated &&
-    prevProps.onKeyDown === nextProps.onKeyDown
+    prevProps.onKeyDown === nextProps.onKeyDown &&
+    prevProps.onInsertBefore === nextProps.onInsertBefore &&
+    prevProps.onInsertAfter === nextProps.onInsertAfter
   )
 })
 

--- a/web/src/lib/dashboards/DashboardComponents.tsx
+++ b/web/src/lib/dashboards/DashboardComponents.tsx
@@ -26,6 +26,8 @@ export interface SortableDashboardCardProps {
   isRefreshing?: boolean
   onRefresh?: () => void
   lastUpdated?: Date | null
+  onInsertBefore?: () => void
+  onInsertAfter?: () => void
 }
 
 export const SortableDashboardCard = memo(function SortableDashboardCard({
@@ -37,6 +39,8 @@ export const SortableDashboardCard = memo(function SortableDashboardCard({
   isRefreshing,
   onRefresh,
   lastUpdated,
+  onInsertBefore,
+  onInsertAfter,
 }: SortableDashboardCardProps) {
   const {
     attributes,
@@ -64,7 +68,27 @@ export const SortableDashboardCard = memo(function SortableDashboardCard({
   const CardComponent = CARD_COMPONENTS[card.card_type]
 
   return (
-    <div ref={setNodeRef} style={style}>
+    <div ref={setNodeRef} style={style} className="relative group/card">
+      {onInsertBefore && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onInsertBefore() }}
+          className="absolute top-1/2 -left-2.5 -translate-y-1/2 z-10 opacity-0 group-hover/card:opacity-100 transition-opacity w-5 h-5 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold shadow-md hover:scale-110"
+          aria-label="Insert card before this one"
+          title="Insert card here"
+        >
+          +
+        </button>
+      )}
+      {onInsertAfter && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
+          className="absolute top-1/2 -right-2.5 -translate-y-1/2 z-10 opacity-0 group-hover/card:opacity-100 transition-opacity w-5 h-5 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold shadow-md hover:scale-110"
+          aria-label="Insert card after this one"
+          title="Insert card here"
+        >
+          +
+        </button>
+      )}
       <CardWrapper
         cardId={card.id}
         cardType={card.card_type}

--- a/web/src/lib/dashboards/DashboardPage.tsx
+++ b/web/src/lib/dashboards/DashboardPage.tsx
@@ -166,12 +166,29 @@ export function DashboardPage({
     }
   }, [searchParams, setSearchParams, setShowAddCard, location.pathname])
 
+  // Inline card insertion
+  const [insertAtIndex, setInsertAtIndex] = useState<number | null>(null)
+  const insertAtIndexRef = useRef<number | null>(null)
+  insertAtIndexRef.current = insertAtIndex
+
   // Card handlers
   const handleAddCards = useCallback((newCards: Array<{ type: string; title: string; config: Record<string, unknown> }>) => {
-    addCards(newCards)
+    const idx = insertAtIndexRef.current
+    if (idx !== null) {
+      const cardsToAdd = newCards.map(c => ({
+        id: `card-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+        card_type: c.type,
+        config: c.config || {},
+        title: c.title,
+      }))
+      setCards(prev => [...prev.slice(0, idx), ...cardsToAdd, ...prev.slice(idx)])
+      setInsertAtIndex(null)
+    } else {
+      addCards(newCards)
+    }
     expandCards()
     setShowAddCard(false)
-  }, [addCards, expandCards, setShowAddCard])
+  }, [addCards, setCards, expandCards, setShowAddCard])
 
   const handleRemoveCard = useCallback((cardId: string) => {
     removeCard(cardId)
@@ -306,7 +323,7 @@ export function DashboardPage({
               >
                 <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
                   <div className="grid grid-cols-1 md:grid-cols-12 gap-4">
-                    {cards.map(card => (
+                    {cards.map((card, index) => (
                       <SortableDashboardCard
                         key={card.id}
                         card={card}
@@ -317,6 +334,8 @@ export function DashboardPage({
                         isRefreshing={isRefreshing}
                         onRefresh={triggerRefresh}
                         lastUpdated={lastUpdated}
+                        onInsertBefore={() => { setInsertAtIndex(index); setShowAddCard(true) }}
+                        onInsertAfter={() => { setInsertAtIndex(index + 1); setShowAddCard(true) }}
                       />
                     ))}
                   </div>
@@ -350,7 +369,7 @@ export function DashboardPage({
       {/* Add Card Modal */}
       <AddCardModal
         isOpen={showAddCard}
-        onClose={() => { setShowAddCard(false); setAddCardSearch('') }}
+        onClose={() => { setShowAddCard(false); setAddCardSearch(''); setInsertAtIndex(null) }}
         onAddCards={handleAddCards}
         existingCardTypes={cards.map(c => c.card_type)}
         initialSearch={addCardSearch}

--- a/web/src/lib/dashboards/DashboardRuntime.tsx
+++ b/web/src/lib/dashboards/DashboardRuntime.tsx
@@ -32,7 +32,7 @@
  * ```
  */
 
-import { ReactNode, useCallback, useMemo, useState } from 'react'
+import { ReactNode, useCallback, useMemo, useRef, useState } from 'react'
 import {
   DndContext,
   closestCenter,
@@ -158,6 +158,7 @@ export function DashboardRuntime({
 
   const {
     cards,
+    setCards,
     addCards,
     removeCard,
     configureCard,
@@ -182,6 +183,11 @@ export function DashboardRuntime({
     canUndo,
     canRedo,
   } = dashboard
+
+  // Inline card insertion
+  const [insertAtIndex, setInsertAtIndex] = useState<number | null>(null)
+  const insertAtIndexRef = useRef<number | null>(null)
+  insertAtIndexRef.current = insertAtIndex
 
   // Workload drag-drop state for deploying to clusters
   const [draggedWorkload, setDraggedWorkload] = useState<DraggedWorkload | null>(null)
@@ -255,18 +261,31 @@ export function DashboardRuntime({
     return () => ({ value: '-', sublabel: '' })
   }, [customGetStatValue, statsConfig?.type, data])
 
-  // Handle add cards
+  // Handle add cards (supports inline insertion at a specific index)
   const handleAddCards = useCallback((newCards: Array<{ type: string; title: string; config: Record<string, unknown> }>) => {
-    addCards(newCards.map(c => ({
-      type: c.type,
-      title: c.title,
-      config: c.config,
-    })))
+    const idx = insertAtIndexRef.current
+    if (idx !== null) {
+      // Insert at specific position
+      const cardsToAdd = newCards.map(c => ({
+        id: `card-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+        card_type: c.type,
+        config: c.config || {},
+        title: c.title,
+      }))
+      setCards(prev => [...prev.slice(0, idx), ...cardsToAdd, ...prev.slice(idx)])
+      setInsertAtIndex(null)
+    } else {
+      addCards(newCards.map(c => ({
+        type: c.type,
+        title: c.title,
+        config: c.config,
+      })))
+    }
     if (enableCardSections) {
       setShowCards(true)
     }
     setShowAddCard(false)
-  }, [addCards, setShowCards, setShowAddCard, enableCardSections])
+  }, [addCards, setCards, setShowCards, setShowAddCard, enableCardSections])
 
   // Handle template apply
   const handleApplyTemplate = useCallback((template: DashboardTemplate) => {
@@ -353,7 +372,7 @@ export function DashboardRuntime({
             >
               <SortableContext items={cards.map(c => c.id)} strategy={rectSortingStrategy}>
                 <DashboardCardsGrid>
-                  {cards.map(card => (
+                  {cards.map((card, index) => (
                     <SortableDashboardCard
                       key={card.id}
                       card={card}
@@ -361,6 +380,8 @@ export function DashboardRuntime({
                       onRemove={() => removeCard(card.id)}
                       onWidthChange={(w) => updateCardWidth(card.id, w)}
                       isDragging={dnd.activeId === card.id}
+                      onInsertBefore={() => { setInsertAtIndex(index); setShowAddCard(true) }}
+                      onInsertAfter={() => { setInsertAtIndex(index + 1); setShowAddCard(true) }}
                     />
                   ))}
                 </DashboardCardsGrid>
@@ -402,7 +423,7 @@ export function DashboardRuntime({
       {enableAddCard && (
         <AddCardModal
           isOpen={showAddCard}
-          onClose={() => setShowAddCard(false)}
+          onClose={() => { setShowAddCard(false); setInsertAtIndex(null) }}
           onAddCards={handleAddCards}
           existingCardTypes={cards.map(c => c.card_type)}
         />

--- a/web/src/lib/dashboards/dashboardHooks.ts
+++ b/web/src/lib/dashboards/dashboardHooks.ts
@@ -239,7 +239,7 @@ export function useDashboardCards(
 
     // If small number of cards, add all at once
     if (cardsToAdd.length <= BATCH_SIZE) {
-      setCards(prev => [...prev, ...cardsToAdd])
+      setCards(prev => [...cardsToAdd, ...prev])
       return
     }
 
@@ -249,7 +249,7 @@ export function useDashboardCards(
       const batch = cardsToAdd.slice(currentIndex, currentIndex + BATCH_SIZE)
       if (batch.length === 0) return
 
-      setCards(prev => [...prev, ...batch])
+      setCards(prev => [...batch, ...prev])
       currentIndex += BATCH_SIZE
 
       if (currentIndex < cardsToAdd.length) {

--- a/web/src/lib/modals/BaseModal.tsx
+++ b/web/src/lib/modals/BaseModal.tsx
@@ -63,8 +63,8 @@ const HEIGHT_CLASSES: Record<ModalSize, string> = {
   sm: 'max-h-[min(60vh,calc(100vh-2rem))]',
   md: 'max-h-[min(70vh,calc(100vh-2rem))]',
   lg: 'min-h-[80vh] max-h-[min(90vh,calc(100vh-2rem))]',
-  xl: 'max-h-[min(85vh,calc(100vh-2rem))]',
-  full: 'max-h-[calc(100vh-2rem)]',
+  xl: 'min-h-[85vh] max-h-[min(85vh,calc(100vh-2rem))]',
+  full: 'min-h-[95vh] max-h-[calc(100vh-2rem)]',
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- **Fullscreen rendering**: Fix 5 llm-d cards (LLMdFlow, EPPRouting, KVCacheMonitor, PDDisaggregation, LLMdAIInsights) to fill fullscreen modals — wider SVG viewBox, scaled positions, expanded grids. Add `min-h` to BaseModal `xl`/`full` sizes.
- **WASD input guard**: 4 game cards (KubeBert, KubeCraft3D, KubePong, PodPitfall) no longer capture WASD when typing in search/input fields.
- **Prepend on add**: New cards are added to the top of dashboards instead of the bottom.
- **Inline card insertion**: Hover any card to see `+` buttons on left/right edges — click to insert a new card at that position. Works across all 4 dashboard rendering paths (Dashboard, DashboardRuntime, DashboardPage, CustomDashboard).

## Test plan
- [x] Verified fullscreen expansion fills modal for all 5 llm-d cards via HMR
- [x] Verified WASD keys work in Add Card search without triggering game controls
- [x] Verified new cards prepend to top on `/ai-ml` and main dashboard
- [x] Verified `+` insert buttons appear on hover on all dashboards
- [x] TypeScript compiles cleanly (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)