### PR TITLE
fix: sort healthy clusters first in Cluster Comparison card

### DIFF
--- a/web/src/components/cards/ClusterComparison.tsx
+++ b/web/src/components/cards/ClusterComparison.tsx
@@ -52,6 +52,12 @@ export function ClusterComparison({ config }: ClusterComparisonProps) {
       )
     }
 
+    // Healthy clusters first, then alphabetical within each group
+    result.sort((a, b) => {
+      if (a.healthy !== b.healthy) return a.healthy ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+
     return result
   }, [rawClusters, globalSelectedClusters, isAllClustersSelected, customFilter])
 


### PR DESCRIPTION
## Summary
- Sort clusters healthy-first, then alphabetical within each group
- The default 3 clusters shown are now the ones most likely to have useful metrics rather than unreachable ones with zeroed-out data

## Test plan
- [ ] Card shows healthy (green dot) clusters before unhealthy ones
- [ ] Within healthy/unhealthy groups, clusters are alphabetical
- [ ] Manual cluster selection still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)