### PR TITLE
fix: clear stale 'Refresh failed' when cached data exists

### DIFF
--- a/web/src/components/cards/NodeDebug.tsx
+++ b/web/src/components/cards/NodeDebug.tsx
@@ -66,11 +66,12 @@ type TabMode = 'inspect' | 'exec'
 
 export function NodeDebug() {
   const { t } = useTranslation('cards')
-  const { nodes, isLoading, isDemoFallback, isFailed, consecutiveFailures } = useCachedNodes()
+  const { nodes, isLoading, isRefreshing, isDemoFallback, isFailed, consecutiveFailures } = useCachedNodes()
   const { execute } = useKubectl()
   const { showToast } = useToast()
   const { showSkeleton } = useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: nodes.length > 0,
     isDemoData: isDemoFallback,
     isFailed,

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -493,7 +493,13 @@ class CacheStore<T> {
           isLoading: false,
           isRefreshing: true, // Will fetch latest in background
           lastRefresh: entry.timestamp,
+          // Clear stale failure state — we have cached data to show.
+          // Matches error handler logic: when hasData, isFailed=false.
+          isFailed: false,
+          consecutiveFailures: 0,
         })
+        // Persist the reset so next page load doesn't start with stale failures
+        this.saveMeta({ consecutiveFailures: 0, lastSuccessfulRefresh: entry.timestamp })
       }
     } catch {
       // Ignore errors, will use initial data with isLoading=true


### PR DESCRIPTION
## Summary

- **Cache bug fix**: When `CacheStore.loadFromStorage()` finds cached data, it now clears `isFailed` and `consecutiveFailures`. Previously, if fetches failed 3+ times in a prior session, the "Refresh failed" badge persisted on next page load despite cached data being available.
- **NodeDebug fix**: Adds missing `isRefreshing` prop to `useCardLoadingState` call per card guidelines.

## Root cause

`CacheStore` constructor initializes `isFailed` from persisted meta (`consecutiveFailures >= 3`). The `loadFromStorage()` method loaded cached data but didn't clear `isFailed` — its `setState` only updated `data`, `isLoading`, `isRefreshing`. Since `setState` is a shallow merge, `isFailed: true` survived.

Users saw cached data with a "Refresh failed" badge until the next fetch completed — confusing UX.

## Test plan

- [ ] Load dashboard with a card that previously had 3+ consecutive failures
- [ ] Verify "Refresh failed" badge does NOT appear when cached data loads
- [ ] Verify NodeDebug card shows refresh animation during background updates
- [ ] `npm run build && npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)