### PR TITLE
fix: require admin role for GitHub token and settings endpoints

### DIFF
--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 
+	"github.com/kubestellar/console/pkg/api/middleware"
 	"github.com/kubestellar/console/pkg/settings"
+	"github.com/kubestellar/console/pkg/store"
 )
 
 const (
@@ -41,12 +43,15 @@ var allowedGitHubPrefixes = []string{
 type GitHubProxyHandler struct {
 	// serverToken is the configured FEEDBACK_GITHUB_TOKEN (or GITHUB_TOKEN alias) from env
 	serverToken string
+	// store is used for admin role checks on token management endpoints
+	store store.Store
 }
 
 // NewGitHubProxyHandler creates a new GitHub API proxy handler.
-func NewGitHubProxyHandler(serverToken string) *GitHubProxyHandler {
+func NewGitHubProxyHandler(serverToken string, s store.Store) *GitHubProxyHandler {
 	return &GitHubProxyHandler{
 		serverToken: serverToken,
+		store:       s,
 	}
 }
 
@@ -180,6 +185,13 @@ func (h *GitHubProxyHandler) Proxy(c *fiber.Ctx) error {
 // to the encrypted server-side settings file. The token is NOT stored in
 // localStorage after this migration.
 func (h *GitHubProxyHandler) SaveToken(c *fiber.Ctx) error {
+	// Global token management requires console admin role
+	currentUserID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(currentUserID)
+	if err != nil || currentUser == nil || currentUser.Role != "admin" {
+		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
+	}
+
 	var body struct {
 		Token string `json:"token"`
 	}
@@ -216,6 +228,13 @@ func (h *GitHubProxyHandler) SaveToken(c *fiber.Ctx) error {
 // DeleteToken handles DELETE /api/github/token — removes the user-provided
 // GitHub PAT from server-side settings.
 func (h *GitHubProxyHandler) DeleteToken(c *fiber.Ctx) error {
+	// Global token management requires console admin role
+	currentUserID := middleware.GetUserID(c)
+	currentUser, err := h.store.GetUser(currentUserID)
+	if err != nil || currentUser == nil || currentUser.Role != "admin" {
+		return fiber.NewError(fiber.StatusForbidden, "Console admin access required")
+	}
+
 	sm := settings.GetSettingsManager()
 	if sm == nil {
 		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -582,7 +582,7 @@ func (s *Server) setupRoutes() {
 	api.Put("/me", user.UpdateCurrentUser)
 
 	// GitHub API proxy — keeps PAT server-side, frontend calls /api/github/*
-	githubProxy := handlers.NewGitHubProxyHandler(s.config.GitHubToken)
+	githubProxy := handlers.NewGitHubProxyHandler(s.config.GitHubToken, s.store)
 	api.Get("/github/token/status", githubProxy.HasToken)
 	api.Post("/github/token", githubProxy.SaveToken)
 	api.Delete("/github/token", githubProxy.DeleteToken)


### PR DESCRIPTION
Closes #3248
Closes #3249

## Summary

- Add admin authorization checks to `POST /api/github/token` (SaveToken) and `DELETE /api/github/token` (DeleteToken) endpoints in the `GitHubProxyHandler`. Previously any authenticated user could modify or delete the global GitHub PAT used across the system.
- The `GET /api/github/token/status` endpoint remains open to all authenticated users since it only returns a boolean indicating whether a token is configured (no secrets exposed).
- The settings endpoints (`GET/PUT /settings`, `POST /settings/export`, `POST /settings/import`) already had admin checks -- no changes needed there.

## Changes

- **`pkg/api/handlers/github_proxy.go`**: Added `store.Store` dependency to `GitHubProxyHandler` for user role lookups. Added admin role checks (matching the pattern used in `settings.go` and `rbac.go`) to `SaveToken` and `DeleteToken` methods. Non-admin users now receive a 403 Forbidden response.
- **`pkg/api/server.go`**: Updated `NewGitHubProxyHandler` call to pass `s.store` for admin role verification.

## Test plan

- [ ] Verify `go build ./...` passes (confirmed locally)
- [ ] Login as a non-admin user and confirm `POST /api/github/token` returns 403
- [ ] Login as a non-admin user and confirm `DELETE /api/github/token` returns 403
- [ ] Login as an admin user and confirm both endpoints still work normally
- [ ] Confirm `GET /api/github/token/status` remains accessible to all authenticated users

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>