### PR TITLE
fix: add WebSocket ping/pong keepalive to prevent connection FD leak

### DIFF
--- a/pkg/agent/prediction_worker.go
+++ b/pkg/agent/prediction_worker.go
@@ -668,6 +668,7 @@ func (w *PredictionWorker) mergePredictions(byProvider map[string][]AIPrediction
 
 // BroadcastToClients sends a message to all connected WebSocket clients.
 // Uses wsMux to prevent concurrent writes which cause gorilla/websocket to panic.
+// Dead connections are removed so they don't leak file descriptors.
 func (s *Server) BroadcastToClients(msgType string, payload interface{}) {
 	message := map[string]interface{}{
 		"type":    msgType,
@@ -684,11 +685,30 @@ func (s *Server) BroadcastToClients(msgType string, payload interface{}) {
 	defer s.wsMux.Unlock()
 
 	s.clientsMux.RLock()
-	defer s.clientsMux.RUnlock()
-
+	clients := make([]*websocket.Conn, 0, len(s.clients))
 	for conn := range s.clients {
+		clients = append(clients, conn)
+	}
+	s.clientsMux.RUnlock()
+
+	var dead []*websocket.Conn
+	for _, conn := range clients {
+		conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
 		if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
-			log.Printf("[Server] Error broadcasting to client: %v", err)
+			log.Printf("[Server] Error broadcasting to client %s: %v", conn.RemoteAddr(), err)
+			dead = append(dead, conn)
 		}
+		conn.SetWriteDeadline(time.Time{}) // clear for normal writes
+	}
+
+	// Remove dead clients so they don't accumulate
+	if len(dead) > 0 {
+		s.clientsMux.Lock()
+		for _, conn := range dead {
+			delete(s.clients, conn)
+			conn.Close()
+		}
+		s.clientsMux.Unlock()
+		log.Printf("[Server] Removed %d dead client(s) during broadcast", len(dead))
 	}
 }

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -28,6 +28,9 @@ const (
 	healthCheckTimeout    = 2 * time.Second
 	registryTimeout       = 10 * time.Second
 	consoleHealthTimeout  = 5 * time.Second
+	wsPingInterval        = 30 * time.Second // how often to send WebSocket pings
+	wsPongTimeout         = 60 * time.Second // how long to wait for a pong before declaring dead
+	wsWriteTimeout        = 10 * time.Second // deadline for a single write (prevents blocking on dead conn)
 	stabilizationDelay    = 3 * time.Second
 	startupDelay          = 500 * time.Millisecond
 	metricsHistoryTick    = 10 * time.Minute
@@ -1878,6 +1881,37 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	// closed is set when the read loop exits; goroutines check it before writing
 	var closed atomic.Bool
 
+	// --- Ping/pong keepalive to detect dead connections ---
+	// Set initial read deadline; each pong resets it.
+	conn.SetReadDeadline(time.Now().Add(wsPongTimeout))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(wsPongTimeout))
+		return nil
+	})
+
+	// Pinger goroutine: sends pings periodically. Exits when connection closes
+	// or the read loop exits (stopPing closed).
+	stopPing := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(wsPingInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				writeMu.Lock()
+				conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
+				err := conn.WriteMessage(websocket.PingMessage, nil)
+				conn.SetWriteDeadline(time.Time{}) // clear deadline for normal writes
+				writeMu.Unlock()
+				if err != nil {
+					return // connection dead
+				}
+			case <-stopPing:
+				return
+			}
+		}
+	}()
+
 	for {
 		var msg protocol.Message
 		if err := conn.ReadJSON(&msg); err != nil {
@@ -1886,6 +1920,8 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			}
 			break
 		}
+		// Reset read deadline after each successful read (active client)
+		conn.SetReadDeadline(time.Now().Add(wsPongTimeout))
 
 		// For chat messages, run in a goroutine so cancel messages can be received
 		if msg.Type == protocol.TypeChat || msg.Type == protocol.TypeClaude {
@@ -1935,6 +1971,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	closed.Store(true)
+	close(stopPing) // signal pinger goroutine to exit
 
 	log.Printf("Client disconnected: %s", conn.RemoteAddr())
 }


### PR DESCRIPTION
## Summary
- kc-agent accumulated 384+ CLOSED file descriptors from dead WebSocket connections, causing slowness and blocking broadcasts to all clients
- Added ping/pong keepalive (30s ping interval, 60s pong timeout) to `handleWebSocket` — dead connections are detected and closed within 60s
- Added write deadlines and dead-client removal to `BroadcastToClients` — prevents one dead connection from stalling broadcasts to all clients
- Active streaming is unaffected: browsers respond to WebSocket pings automatically at the protocol level

## Test plan
- [x] `go build ./cmd/kc-agent/` compiles clean
- [ ] Open console in multiple tabs, close some tabs, verify connections are cleaned up within 60s
- [ ] Start a streaming AI chat, verify it completes normally with ping/pong active
- [ ] Kill network briefly, verify kc-agent detects and cleans up the dead connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)