### PR TITLE
fix: expand GitHub API proxy allowlist with /user and /notifications

### DIFF
--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -30,10 +30,38 @@ var githubProxyAPIBase = getEnvOrDefault("GITHUB_API_BASE_URL", githubProxyAPIBa
 var githubProxyClient = &http.Client{Timeout: githubProxyTimeout}
 
 // allowedGitHubPrefixes restricts which GitHub API paths can be proxied.
-// Only read-only endpoints needed by the frontend are permitted.
+// Only read-only endpoints actually needed by the frontend are permitted.
+// Any path not matching one of these prefixes is rejected with 403 Forbidden.
 var allowedGitHubPrefixes = []string{
-	"/repos/",     // repo info, PRs, issues, releases, contributors, actions, git refs, compare
-	"/rate_limit", // token validation
+	"/repos/",        // repo info, PRs, issues, releases, contributors, actions, git refs, compare
+	"/rate_limit",    // rate-limit check / token validation
+	"/user",          // token validation (GET /user returns the authenticated user)
+	"/notifications", // notification badge (if used by frontend)
+}
+
+// isAllowedGitHubPath checks whether apiPath (which must start with "/")
+// matches one of the allowedGitHubPrefixes.
+//
+// Prefixes that end with "/" (e.g. "/repos/") use simple prefix matching.
+// Prefixes without a trailing "/" (e.g. "/user") match the exact path OR
+// the path followed by "/" (i.e. "/user" and "/user/..."), but NOT
+// longer stems (e.g. "/users/..." is rejected).
+func isAllowedGitHubPath(apiPath string) bool {
+	for _, prefix := range allowedGitHubPrefixes {
+		if strings.HasSuffix(prefix, "/") {
+			// Prefix ends with "/" — standard prefix match (e.g. "/repos/")
+			if strings.HasPrefix(apiPath, prefix) {
+				return true
+			}
+		} else {
+			// Exact-or-subpath match: "/user" matches "/user" and "/user/foo"
+			// but NOT "/users" or "/users/foo"
+			if apiPath == prefix || strings.HasPrefix(apiPath, prefix+"/") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // GitHubProxyHandler proxies read-only GitHub API requests through the backend,
@@ -100,16 +128,10 @@ func (h *GitHubProxyHandler) Proxy(c *fiber.Ctx) error {
 		})
 	}
 
-	// Security: only allow specific GitHub API prefixes
+	// Security: only allow specific GitHub API prefixes (see allowedGitHubPrefixes)
 	apiPath := "/" + path
-	allowed := false
-	for _, prefix := range allowedGitHubPrefixes {
-		if strings.HasPrefix(apiPath, prefix) {
-			allowed = true
-			break
-		}
-	}
-	if !allowed {
+	if !isAllowedGitHubPath(apiPath) {
+		log.Printf("[GitHubProxy] Blocked disallowed path: %s", apiPath)
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
 			"error": "GitHub API path not allowed",
 		})

--- a/pkg/api/handlers/github_proxy_test.go
+++ b/pkg/api/handlers/github_proxy_test.go
@@ -1,0 +1,39 @@
+package handlers
+
+import "testing"
+
+func TestIsAllowedGitHubPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		allowed bool
+	}{
+		// Allowed paths
+		{"repos prefix", "/repos/kubestellar/console/releases", true},
+		{"repos root", "/repos/", true},
+		{"rate_limit exact", "/rate_limit", true},
+		{"user exact", "/user", true},
+		{"user subpath", "/user/repos", true},
+		{"notifications exact", "/notifications", true},
+		{"notifications subpath", "/notifications/threads/123", true},
+
+		// Blocked paths
+		{"gists", "/gists", false},
+		{"orgs", "/orgs/kubestellar", false},
+		{"search", "/search/issues", false},
+		{"empty", "/", false},
+		{"admin", "/admin/users", false},
+		{"events", "/events", false},
+		{"emojis", "/emojis", false},
+		{"users endpoint", "/users/someuser", false},
+		{"graphql", "/graphql", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAllowedGitHubPath(tt.path)
+			if got != tt.allowed {
+				t.Errorf("isAllowedGitHubPath(%q) = %v, want %v", tt.path, got, tt.allowed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #3254

## Summary

- Adds `/user` and `/notifications` to the GitHub API proxy allowlist (`allowedGitHubPrefixes`) so the proxy permits token validation and notification endpoints alongside the existing `/repos/` and `/rate_limit` paths
- Extracts an `isAllowedGitHubPath()` helper function with boundary-safe matching: prefixes without a trailing `/` (like `/user`) match the exact path and sub-paths (`/user/repos`) but **not** longer stems (`/users/someuser`)
- Adds a log line when a disallowed path is blocked for observability
- Adds `github_proxy_test.go` with 17 test cases covering allowed and blocked path scenarios

## Test plan

- [x] `go test ./pkg/api/handlers/ -run TestIsAllowedGitHubPath -v` passes (17/17)
- [x] `go build ./...` succeeds
- [ ] Verify `/api/github/user` returns authenticated user info
- [ ] Verify `/api/github/gists` returns 403 Forbidden
- [ ] Verify `/api/github/users/someuser` returns 403 Forbidden (boundary check for `/user` prefix)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>