### PR TITLE
fix: use cancellable context in exec WebSocket to prevent goroutine and SPDY leaks

### DIFF
--- a/pkg/api/handlers/exec.go
+++ b/pkg/api/handlers/exec.go
@@ -270,11 +270,17 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 	// Send initial terminal size
 	sizeQueue.ch <- remotecommand.TerminalSize{Width: init.Cols, Height: init.Rows}
 
+	// Create a cancellable context so that when the WebSocket client disconnects,
+	// the exec stream is cancelled promptly — preventing goroutine and SPDY leaks.
+	execCtx, execCancel := context.WithCancel(context.Background())
+	defer execCancel()
+
 	// Start a goroutine to read WebSocket messages and route them
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		defer close(stdinCh)
+		defer execCancel() // cancel exec stream when client disconnects
 		for {
 			_, rawMsg, err := c.ReadMessage()
 			if err != nil {
@@ -317,7 +323,7 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 		streamOpts.TerminalSizeQueue = sizeQueue
 	}
 
-	execErr := executor.StreamWithContext(context.Background(), streamOpts)
+	execErr := executor.StreamWithContext(execCtx, streamOpts)
 
 	// Send exit message
 	exitCode := 0


### PR DESCRIPTION
Closes #3292

## Summary

- Replace `context.Background()` with a cancellable context (`context.WithCancel`) in the pod exec handler (`pkg/api/handlers/exec.go`)
- Wire `execCancel()` into the WebSocket read goroutine via `defer`, so when the client disconnects the exec stream's context is cancelled immediately
- This tears down the SPDY connection to the K8s API server, preventing leaked goroutines and file descriptors

## Root Cause

`executor.StreamWithContext(context.Background(), ...)` used a context that never expires. When a WebSocket client disconnected (browser tab close, network partition), the read goroutine would exit and close `stdinCh`, but the `StreamWithContext` call could block indefinitely if the remote shell was hung — leaking a goroutine, WebSocket connection, and SPDY connection per orphaned session.

## Changes

**`pkg/api/handlers/exec.go`:**
- Create `execCtx, execCancel := context.WithCancel(context.Background())` before the read goroutine
- Add `defer execCancel()` on the main path (safety net)
- Add `defer execCancel()` inside the read goroutine (primary cancellation path — fires when client disconnects)
- Pass `execCtx` to `executor.StreamWithContext()` instead of `context.Background()`

## Test plan

- [ ] Open a pod exec terminal session via the console UI
- [ ] Execute `sleep 99999` inside the shell
- [ ] Close the browser tab (ungraceful disconnect)
- [ ] Verify the exec goroutine and SPDY connection are cleaned up on the server side
- [ ] `go build ./...` passes