### PR TITLE
fix: ClearAlert panic on variable-length device type suffixes

### DIFF
--- a/pkg/agent/device_tracker.go
+++ b/pkg/agent/device_tracker.go
@@ -492,20 +492,39 @@ func (t *DeviceTracker) ClearAlert(alertID string) bool {
 		delete(t.alerts, alertID)
 		// Also reset the max count to current to prevent re-alerting
 		// Extract node key from alert ID (format: "cluster/node/deviceType")
-		parts := alertID[:len(alertID)-len("/gpu")-1] // rough extraction
-		if counts, ok := t.maxCounts[parts]; ok {
+		lastSlash := strings.LastIndex(alertID, "/")
+		if lastSlash < 0 {
+			return true
+		}
+		nodeKey := alertID[:lastSlash]
+		deviceType := alertID[lastSlash+1:]
+		if counts, ok := t.maxCounts[nodeKey]; ok {
 			// Get current counts from latest history
-			if history, ok := t.history[parts]; ok && len(history) > 0 {
+			if history, ok := t.history[nodeKey]; ok && len(history) > 0 {
 				latest := history[len(history)-1].Counts
-				switch {
-				case alertID[len(alertID)-3:] == "gpu":
+				switch deviceType {
+				case "gpu":
 					counts.GPUCount = latest.GPUCount
-				case alertID[len(alertID)-3:] == "nic":
+				case "nic":
 					counts.NICCount = latest.NICCount
-				case alertID[len(alertID)-4:] == "nvme":
+				case "nvme":
 					counts.NVMECount = latest.NVMECount
+				case "infiniband":
+					counts.InfiniBandCount = latest.InfiniBandCount
+				case "sriov":
+					counts.SRIOVCapable = latest.SRIOVCapable
+				case "rdma":
+					counts.RDMAAvailable = latest.RDMAAvailable
+				case "mellanox":
+					counts.MellanoxPresent = latest.MellanoxPresent
+				case "mofed-driver":
+					counts.MOFEDReady = latest.MOFEDReady
+				case "gpu-driver":
+					counts.GPUDriverReady = latest.GPUDriverReady
+				case "spectrum-scale":
+					counts.SpectrumScale = latest.SpectrumScale
 				}
-				t.maxCounts[parts] = counts
+				t.maxCounts[nodeKey] = counts
 			}
 		}
 		return true


### PR DESCRIPTION
Closes #3289

## Summary

- Replace hard-coded string slicing (`alertID[:len(alertID)-len("/gpu")-1]`) with `strings.LastIndex(alertID, "/")` to correctly extract the node key and device type from alert IDs of any length
- Add a guard for alert IDs that contain no slash to prevent negative index panics
- Extend the `switch` statement in `ClearAlert` to handle all device types that `processSnapshot` generates alerts for: `infiniband`, `sriov`, `rdma`, `mellanox`, `mofed-driver`, `gpu-driver`, and `spectrum-scale` (previously only `gpu`, `nic`, and `nvme` were handled)

## Root cause

`ClearAlert()` assumed all device type suffixes were 3 characters long (like "gpu" or "nic"), stripping exactly `len("/gpu")+1 = 5` characters from the end of the alert ID. For longer suffixes like "spectrum-scale" (15 chars) or "mofed-driver" (12 chars), this produced a corrupted node key that wouldn't match any entry in `maxCounts`, so the baseline was never reset and the alert would immediately re-fire on the next scan. For very short alert IDs, the subtraction could produce a negative index, causing a runtime panic.

## Test plan

- [x] `go build ./...` passes
- [ ] Verify `ClearAlert("cluster/node/gpu")` still works correctly (existing behavior)
- [ ] Verify `ClearAlert("cluster/node/mofed-driver")` correctly resets `MOFEDReady` baseline
- [ ] Verify `ClearAlert("cluster/node/spectrum-scale")` correctly resets `SpectrumScale` baseline
- [ ] Verify `ClearAlert("malformed-no-slash")` returns `true` without panicking

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>