### PR TITLE
perf: prefetch dashboard route, card chunks, and data on sidebar hover

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -83,43 +83,8 @@ const UnifiedDashboardTest = safeLazy(() => import('./pages/UnifiedDashboardTest
 const AllCardsPerfTest = safeLazy(() => import('./pages/AllCardsPerfTest'), 'AllCardsPerfTest')
 const CompliancePerfTest = safeLazy(() => import('./pages/CompliancePerfTest'), 'CompliancePerfTest')
 
-// Dashboard ID → chunk import map for selective prefetching.
-// Only chunks for enabled dashboards are prefetched; disabled ones
-// still lazy-load on demand if the user navigates directly via URL.
-const DASHBOARD_CHUNKS: Record<string, () => Promise<unknown>> = {
-  'dashboard': () => import('./components/dashboard/Dashboard'),
-  'clusters': () => import('./components/clusters/Clusters'),
-  'workloads': () => import('./components/workloads/Workloads'),
-  'compute': () => import('./components/compute/Compute'),
-  'events': () => import('./components/events/Events'),
-  'nodes': () => import('./components/nodes/Nodes'),
-  'deployments': () => import('./components/deployments/Deployments'),
-  'pods': () => import('./components/pods/Pods'),
-  'services': () => import('./components/services/Services'),
-  'storage': () => import('./components/storage/Storage'),
-  'network': () => import('./components/network/Network'),
-  'security': () => import('./components/security/Security'),
-  'gitops': () => import('./components/gitops/GitOps'),
-  'alerts': () => import('./components/alerts/Alerts'),
-  'cost': () => import('./components/cost/Cost'),
-  'compliance': () => import('./components/compliance/Compliance'),
-  'operators': () => import('./components/operators/Operators'),
-  'helm': () => import('./components/helm/HelmReleases'),
-  'settings': () => import('./components/settings/Settings'),
-  'gpu-reservations': () => import('./components/gpu/GPUReservations'),
-  'data-compliance': () => import('./components/data-compliance/DataCompliance'),
-  'logs': () => import('./components/logs/Logs'),
-  'arcade': () => import('./components/arcade/Arcade'),
-  'deploy': () => import('./components/deploy/Deploy'),
-  'ai-ml': () => import('./components/aiml/AIML'),
-  'ai-agents': () => import('./components/aiagents/AIAgents'),
-  'llm-d-benchmarks': () => import('./components/llmd-benchmarks/LLMdBenchmarks'),
-  'cluster-admin': () => import('./components/cluster-admin/ClusterAdmin'),
-  'ci-cd': () => import('./components/cicd/CICD'),
-  'insights': () => import('./components/insights/Insights'),
-  'multi-tenancy': () => import('./components/multi-tenancy/MultiTenancy'),
-  'marketplace': () => import('./components/marketplace/Marketplace'),
-}
+// Dashboard ID → chunk import map (shared with hover prefetch in Sidebar)
+import { DASHBOARD_CHUNKS } from './lib/dashboardChunks'
 
 // Always prefetched regardless of enabled dashboards
 const ALWAYS_PREFETCH = new Set(['dashboard', 'settings', 'clusters'])
@@ -128,8 +93,8 @@ const ALWAYS_PREFETCH = new Set(['dashboard', 'settings', 'clusters'])
 // Batched to avoid overwhelming the Vite dev server with simultaneous
 // module transformation requests (which delays navigation on cold start).
 if (typeof window !== 'undefined') {
-  const PREFETCH_BATCH_SIZE = 5
-  const PREFETCH_BATCH_DELAY = 100
+  const PREFETCH_BATCH_SIZE = 8
+  const PREFETCH_BATCH_DELAY = 50
 
   const prefetchRoutes = async () => {
     // Wait for the enabled dashboards list from /health so we only

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import { useActiveUsers } from '../../hooks/useActiveUsers'
 import { ROUTES } from '../../config/routes'
 import { DASHBOARD_CONFIGS } from '../../config/dashboards/index'
 import { emitSidebarNavigated, emitDashboardRenamed } from '../../lib/analytics'
+import { prefetchDashboard } from '../../lib/prefetchDashboard'
 
 // Lazy-load SidebarCustomizer — it pulls in dnd-kit and heavy UI (~50 KB)
 const SidebarCustomizer = lazy(() =>
@@ -305,6 +306,7 @@ export function Sidebar() {
             to={item.href}
             onClick={() => emitSidebarNavigated(item.href)}
             onDoubleClick={(e) => handleDoubleClick(item, e)}
+            onMouseEnter={() => prefetchDashboard(item.href)}
             className={({ isActive }) => cn(
               'flex items-center gap-3 rounded-lg text-sm font-medium transition-all duration-200',
               isActive

--- a/web/src/lib/dashboardChunks.ts
+++ b/web/src/lib/dashboardChunks.ts
@@ -1,0 +1,41 @@
+/**
+ * Dashboard ID → route chunk import map.
+ *
+ * Shared by:
+ *  - App.tsx (startup batch prefetch of all enabled dashboards)
+ *  - prefetchDashboard.ts (hover prefetch of a single dashboard)
+ */
+export const DASHBOARD_CHUNKS: Record<string, () => Promise<unknown>> = {
+  'dashboard': () => import('../components/dashboard/Dashboard'),
+  'clusters': () => import('../components/clusters/Clusters'),
+  'workloads': () => import('../components/workloads/Workloads'),
+  'compute': () => import('../components/compute/Compute'),
+  'events': () => import('../components/events/Events'),
+  'nodes': () => import('../components/nodes/Nodes'),
+  'deployments': () => import('../components/deployments/Deployments'),
+  'pods': () => import('../components/pods/Pods'),
+  'services': () => import('../components/services/Services'),
+  'storage': () => import('../components/storage/Storage'),
+  'network': () => import('../components/network/Network'),
+  'security': () => import('../components/security/Security'),
+  'gitops': () => import('../components/gitops/GitOps'),
+  'alerts': () => import('../components/alerts/Alerts'),
+  'cost': () => import('../components/cost/Cost'),
+  'compliance': () => import('../components/compliance/Compliance'),
+  'operators': () => import('../components/operators/Operators'),
+  'helm': () => import('../components/helm/HelmReleases'),
+  'settings': () => import('../components/settings/Settings'),
+  'gpu-reservations': () => import('../components/gpu/GPUReservations'),
+  'data-compliance': () => import('../components/data-compliance/DataCompliance'),
+  'logs': () => import('../components/logs/Logs'),
+  'arcade': () => import('../components/arcade/Arcade'),
+  'deploy': () => import('../components/deploy/Deploy'),
+  'ai-ml': () => import('../components/aiml/AIML'),
+  'ai-agents': () => import('../components/aiagents/AIAgents'),
+  'llm-d-benchmarks': () => import('../components/llmd-benchmarks/LLMdBenchmarks'),
+  'cluster-admin': () => import('../components/cluster-admin/ClusterAdmin'),
+  'ci-cd': () => import('../components/cicd/CICD'),
+  'insights': () => import('../components/insights/Insights'),
+  'multi-tenancy': () => import('../components/multi-tenancy/MultiTenancy'),
+  'marketplace': () => import('../components/marketplace/Marketplace'),
+}

--- a/web/src/lib/prefetchCardData.ts
+++ b/web/src/lib/prefetchCardData.ts
@@ -16,10 +16,10 @@ import { coreFetchers, specialtyFetchers } from '../hooks/useCachedData'
 import { isDemoMode } from './demoMode'
 
 /** Delay before starting core data prefetch (after priority tier) */
-const CORE_PREFETCH_DELAY_MS = 400
-const SPECIALTY_DELAY_MS = 1_000
-const BACKGROUND_DELAY_MS = 5_000
-const PREFETCH_CONCURRENCY = 2
+const CORE_PREFETCH_DELAY_MS = 150
+const SPECIALTY_DELAY_MS = 500
+const BACKGROUND_DELAY_MS = 3_000
+const PREFETCH_CONCURRENCY = 3
 
 interface PrefetchEntry {
   key: string

--- a/web/src/lib/prefetchDashboard.ts
+++ b/web/src/lib/prefetchDashboard.ts
@@ -1,0 +1,96 @@
+/**
+ * Prefetch a dashboard's route chunk, card chunks, and data on sidebar hover.
+ *
+ * The 200-500ms hover-before-click gap is enough to start downloading assets
+ * and data in parallel, so by the time the user clicks, much of the work is
+ * already in-flight or complete.
+ */
+import { DASHBOARD_CHUNKS } from './dashboardChunks'
+import { DASHBOARD_CONFIGS } from '../config/dashboards/index'
+import { prefetchCache } from './cache'
+import { coreFetchers } from '../hooks/useCachedData'
+import { isDemoMode } from './demoMode'
+
+/** Map sidebar href to DASHBOARD_CHUNKS key */
+function hrefToChunkId(href: string): string {
+  if (href === '/') return 'dashboard'
+  return href.replace(/^\//, '')
+}
+
+/** Map sidebar href to DASHBOARD_CONFIGS key */
+const HREF_TO_CONFIG_ID: Record<string, string> = {
+  '/': 'main', '/compute': 'compute', '/security': 'security',
+  '/gitops': 'gitops', '/storage': 'storage', '/network': 'network',
+  '/events': 'events', '/workloads': 'workloads', '/operators': 'operators',
+  '/clusters': 'clusters', '/compliance': 'compliance', '/cost': 'cost',
+  '/gpu-reservations': 'gpu', '/nodes': 'nodes', '/deployments': 'deployments',
+  '/pods': 'pods', '/services': 'services', '/helm': 'helm',
+  '/alerts': 'alerts', '/ai-ml': 'ai-ml', '/ci-cd': 'ci-cd',
+  '/logs': 'logs', '/data-compliance': 'data-compliance', '/arcade': 'arcade',
+  '/deploy': 'deploy', '/ai-agents': 'ai-agents',
+  '/llm-d-benchmarks': 'llm-d-benchmarks', '/cluster-admin': 'cluster-admin',
+  '/insights': 'insights', '/multi-tenancy': 'multi-tenancy',
+  '/marketplace': 'marketplace',
+}
+
+/**
+ * Card type → cache entries to prefetch.
+ * Only covers card types that use data already available via coreFetchers,
+ * so we don't introduce new API calls or import heavyweight fetchers.
+ */
+const CARD_DATA_PREFETCH: Record<string, Array<{ key: string; fetcher: () => Promise<unknown> }>> = {
+  pod_issues:          [{ key: 'podIssues:all:all',        fetcher: coreFetchers.podIssues }],
+  top_pods:            [{ key: 'pods:all:all:100',          fetcher: coreFetchers.pods }],
+  event_stream:        [{ key: 'events:all:all:20',         fetcher: coreFetchers.events }],
+  event_summary:       [{ key: 'events:all:all:20',         fetcher: coreFetchers.events }],
+  recent_events:       [{ key: 'events:all:all:20',         fetcher: coreFetchers.events }],
+  events_timeline:     [{ key: 'events:all:all:20',         fetcher: coreFetchers.events }],
+  warning_events:      [{ key: 'events:all:all:20',         fetcher: coreFetchers.events }],
+  deployment_status:   [{ key: 'deployments:all:all',       fetcher: coreFetchers.deployments }],
+  deployment_issues:   [{ key: 'deploymentIssues:all:all',  fetcher: coreFetchers.deploymentIssues }],
+  deployment_progress: [{ key: 'deployments:all:all',       fetcher: coreFetchers.deployments }],
+  security_issues:     [{ key: 'securityIssues:all:all',    fetcher: coreFetchers.securityIssues }],
+  service_status:      [{ key: 'services:all:all',          fetcher: coreFetchers.services }],
+  resource_usage:      [{ key: 'pods:all:all:100',          fetcher: coreFetchers.pods }],
+  cluster_health:      [{ key: 'pods:all:all:100',          fetcher: coreFetchers.pods }],
+  app_status:          [{ key: 'deployments:all:all',       fetcher: coreFetchers.deployments }],
+}
+
+/** Avoid re-triggering for the same link on repeated hover */
+let lastPrefetchedHref: string | null = null
+
+export function prefetchDashboard(href: string): void {
+  if (href === lastPrefetchedHref) return
+  lastPrefetchedHref = href
+
+  // Demo mode uses synchronous data — no fetching needed
+  if (isDemoMode()) return
+
+  // Layer 1: Route chunk
+  const chunkId = hrefToChunkId(href)
+  DASHBOARD_CHUNKS[chunkId]?.()?.catch(() => {})
+
+  // Layer 2: Card component chunks
+  const configId = HREF_TO_CONFIG_ID[href]
+  const config = configId ? DASHBOARD_CONFIGS[configId] : null
+  if (config?.cards) {
+    const cardTypes = config.cards.map((c: { cardType: string }) => c.cardType)
+
+    // Dynamic import keeps the 195KB card registry out of the sidebar chunk
+    import('../components/cards/cardRegistry').then(m => {
+      m.prefetchCardChunks(cardTypes)
+    }).catch(() => {})
+
+    // Layer 3: Data for cards with known fetchers
+    const seen = new Set<string>()
+    for (const cardType of cardTypes) {
+      const entries = CARD_DATA_PREFETCH[cardType]
+      if (!entries) continue
+      for (const entry of entries) {
+        if (seen.has(entry.key)) continue
+        seen.add(entry.key)
+        prefetchCache(entry.key, entry.fetcher, []).catch(() => {})
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Dashboard navigation takes 10-25s on first visit due to sequential loading: route chunk → card chunks → data fetch
- Added hover-to-prefetch: when user hovers a sidebar link, all 3 layers start downloading in parallel during the 200-500ms before click
- Extracted `DASHBOARD_CHUNKS` to shared module so both App.tsx startup prefetch and Sidebar hover prefetch can use it
- Tuned startup prefetch: larger batches (8 vs 5), faster intervals (50ms vs 100ms), higher concurrency (3 vs 2)
- Reduced data prefetch delays: core 150ms (was 400ms), specialty 500ms (was 1s)

## How it works
1. User hovers sidebar link → `prefetchDashboard(href)` fires
2. **Layer 1**: Route chunk download starts (`DASHBOARD_CHUNKS[id]()`)
3. **Layer 2**: Card component chunks for that dashboard's cards start downloading
4. **Layer 3**: Data for common card types (pods, events, deployments) prefetched via cache
5. User clicks → most assets already in-flight or cached → dashboard renders faster

## Test plan
- [ ] Hover a sidebar link, verify Network tab shows chunk downloads starting
- [ ] Click the link, verify dashboard loads faster than without the change
- [ ] Rapid hover across multiple links — no errors or duplicate fetches
- [ ] KeepAlive still works (revisiting a dashboard is instant)
- [ ] Demo mode — no API fetches on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)