### PR TITLE
fix: add freshness indicators and wire demo mode subscription

### DIFF
--- a/web/src/components/cards/ChartVersions.tsx
+++ b/web/src/components/cards/ChartVersions.tsx
@@ -3,6 +3,7 @@ import { Package } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
 import { useCachedHelmReleases } from '../../hooks/useCachedData'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { CardSkeleton, CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { useCardLoadingState } from './CardDataContext'
@@ -42,6 +43,7 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
     consecutiveFailures,
     isDemoFallback: isDemoData,
     isRefreshing,
+    lastRefresh,
   } = useCachedHelmReleases()
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
@@ -139,7 +141,12 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
     <div className="h-full flex flex-col min-h-card content-loaded">
       {/* Header */}
       <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-2" />
+        <RefreshIndicator
+          isRefreshing={isRefreshing}
+          lastUpdated={lastRefresh ? new Date(lastRefresh) : null}
+          size="sm"
+          showLabel={true}
+        />
         <CardControlsRow
           clusterIndicator={{
             selectedCount: localClusterFilter.length,

--- a/web/src/components/cards/ClusterComparison.tsx
+++ b/web/src/components/cards/ClusterComparison.tsx
@@ -5,6 +5,7 @@ import { useCachedGPUNodes } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { Skeleton } from '../ui/Skeleton'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -18,7 +19,7 @@ interface ClusterComparisonProps {
 export function ClusterComparison({ config }: ClusterComparisonProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { deduplicatedClusters: rawClusters, isLoading: clustersLoading } = useClusters()
-  const { nodes: gpuNodes, isDemoFallback, isRefreshing } = useCachedGPUNodes()
+  const { nodes: gpuNodes, isDemoFallback, isRefreshing, lastRefresh } = useCachedGPUNodes()
   const [selectedClusters, setSelectedClusters] = useState<string[]>(config?.clusters || [])
   const { isDemoMode } = useDemoMode()
 
@@ -136,6 +137,12 @@ export function ClusterComparison({ config }: ClusterComparisonProps) {
     <div className="h-full flex flex-col min-h-card content-loaded overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-end mb-4">
+        <RefreshIndicator
+          isRefreshing={isRefreshing}
+          lastUpdated={lastRefresh ? new Date(lastRefresh) : null}
+          size="sm"
+          showLabel={true}
+        />
       </div>
 
       {/* Cluster selector */}

--- a/web/src/components/cards/GPUStatus.tsx
+++ b/web/src/components/cards/GPUStatus.tsx
@@ -6,6 +6,7 @@ import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import { StatusBadge } from '../ui/StatusBadge'
 import { Skeleton } from '../ui/Skeleton'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter } from '../../lib/cards/CardComponents'
 import { useCardLoadingState } from './CardDataContext'
@@ -40,6 +41,7 @@ export function GPUStatus({ config }: GPUStatusProps) {
     isLoading: hookLoading,
     isDemoFallback,
     isRefreshing,
+    lastRefresh,
   } = useCachedGPUNodes(cluster)
   const { drillToCluster } = useDrillDownActions()
 
@@ -177,6 +179,12 @@ export function GPUStatus({ config }: GPUStatusProps) {
           <StatusBadge color="purple">
             {t('gpuStatus.clusterCount', { count: totalItems })}
           </StatusBadge>
+          <RefreshIndicator
+            isRefreshing={isRefreshing}
+            lastUpdated={lastRefresh ? new Date(lastRefresh) : null}
+            size="sm"
+            showLabel={false}
+          />
         </div>
         <CardControlsRow
           clusterIndicator={{

--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -8,6 +8,7 @@ import { useCardLoadingState } from './CardDataContext'
 import { useCardData, commonComparators } from '../../lib/cards/cardHooks'
 import { CardSearchInput, CardControlsRow, CardPaginationFooter, CardAIActions } from '../../lib/cards/CardComponents'
 import { ClusterBadge } from '../ui/ClusterBadge'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useTranslation } from 'react-i18next'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 
@@ -71,7 +72,7 @@ function getStatusColor(status: string) {
 
 function PVCStatusInternal() {
   const { t } = useTranslation()
-  const { pvcs, isLoading, isRefreshing, error, consecutiveFailures, isFailed, isDemoFallback } = useCachedPVCs()
+  const { pvcs, isLoading, isRefreshing, error, consecutiveFailures, isFailed, isDemoFallback, lastRefresh } = useCachedPVCs()
   const { drillToPVC } = useDrillDownActions()
   const { isDemoMode: demoMode } = useDemoMode()
 
@@ -179,7 +180,15 @@ function PVCStatusInternal() {
     <div className="h-full flex flex-col">
       {/* Controls */}
       <div className="flex items-center justify-between mb-4">
-        <span className="text-sm font-medium text-muted-foreground">{totalItems} PVCs</span>
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-muted-foreground">{totalItems} PVCs</span>
+          <RefreshIndicator
+            isRefreshing={isRefreshing}
+            lastUpdated={lastRefresh ? new Date(lastRefresh) : null}
+            size="sm"
+            showLabel={false}
+          />
+        </div>
         <CardControlsRow
           clusterIndicator={localClusterFilter.length > 0 ? {
             selectedCount: localClusterFilter.length,

--- a/web/src/components/cards/openfeature_status/OpenFeatureStatus.tsx
+++ b/web/src/components/cards/openfeature_status/OpenFeatureStatus.tsx
@@ -1,6 +1,7 @@
-import { CheckCircle, AlertTriangle, RefreshCw, Flag, Server, Activity } from 'lucide-react'
+import { CheckCircle, AlertTriangle, Flag, Server, Activity } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../ui/Skeleton'
+import { RefreshIndicator } from '../../ui/RefreshIndicator'
 import { useOpenFeatureStatus } from './useOpenFeatureStatus'
 import { useDemoMode } from '../../../hooks/useDemoMode'
 import { MetricTile } from '../../../lib/cards/CardComponents'
@@ -12,30 +13,13 @@ const SKELETON_HEADER_HEIGHT = 36
 const SKELETON_METRIC_HEIGHT = 80
 const SKELETON_TABLE_HEIGHT = 120
 
-
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('openFeature.syncedJustNow')
-    const minute = 60_000
-    const hour = 60 * minute
-    const day = 24 * hour
-    if (diff < minute) return t('openFeature.syncedJustNow')
-    if (diff < hour) return t('openFeature.syncedMinutesAgo', { count: Math.floor(diff / minute) })
-    if (diff < day) return t('openFeature.syncedHoursAgo', { count: Math.floor(diff / hour) })
-    return t('openFeature.syncedDaysAgo', { count: Math.floor(diff / day) })
-  }
-}
-
 export function OpenFeatureStatus() {
   const { t } = useTranslation('cards')
   // useDemoMode provides explicit demo mode awareness; useOpenFeatureStatus also
   // handles demo data internally via useCache, but we reference isDemoMode here
   // to suppress the "not-installed" state when demo data is being shown.
   const { isDemoMode } = useDemoMode()
-  const formatRelativeTime = useFormatRelativeTime()
-  const { data, error, showSkeleton, showEmptyState, isRefreshing } = useOpenFeatureStatus()
+  const { data, error, showSkeleton, showEmptyState, isRefreshing, lastRefresh } = useOpenFeatureStatus()
 
   if (showSkeleton) {
     return (
@@ -102,10 +86,12 @@ export function OpenFeatureStatus() {
           )}
           {healthLabel}
         </div>
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          {isRefreshing && <RefreshCw className="w-3 h-3 animate-spin" />}
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
-        </div>
+        <RefreshIndicator
+          isRefreshing={isRefreshing}
+          lastUpdated={lastRefresh ? new Date(lastRefresh) : null}
+          size="sm"
+          showLabel={true}
+        />
       </div>
 
       {/* Metric tiles */}

--- a/web/src/components/cards/openfeature_status/useOpenFeatureStatus.ts
+++ b/web/src/components/cards/openfeature_status/useOpenFeatureStatus.ts
@@ -231,12 +231,13 @@ export interface UseOpenFeatureStatusResult {
   data: OpenFeatureStatus
   error: boolean
   isRefreshing: boolean
+  lastRefresh: number | null
   showSkeleton: boolean
   showEmptyState: boolean
 }
 
 export function useOpenFeatureStatus(): UseOpenFeatureStatusResult {
-  const { data, isLoading, isRefreshing, isFailed, consecutiveFailures, isDemoFallback } = useCache<OpenFeatureStatus>({
+  const { data, isLoading, isRefreshing, isFailed, consecutiveFailures, isDemoFallback, lastRefresh } = useCache<OpenFeatureStatus>({
     key: CACHE_KEY,
     fetcher: fetchOpenFeatureStatus,
     demoData: OPENFEATURE_DEMO_DATA,
@@ -262,6 +263,7 @@ export function useOpenFeatureStatus(): UseOpenFeatureStatusResult {
     data,
     error: isFailed && !hasAnyData,
     isRefreshing,
+    lastRefresh,
     showSkeleton,
     showEmptyState,
   }

--- a/web/src/components/cards/strimzi_status/StrimziStatus.tsx
+++ b/web/src/components/cards/strimzi_status/StrimziStatus.tsx
@@ -1,27 +1,14 @@
-import { CheckCircle, AlertTriangle, RefreshCw, Database, Activity, Users, Server } from 'lucide-react'
+import { CheckCircle, AlertTriangle, Database, Activity, Users, Server } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '../../ui/Skeleton'
+import { RefreshIndicator } from '../../ui/RefreshIndicator'
 import { MetricTile } from '../../../lib/cards/CardComponents'
 import { useStrimziStatus } from './useStrimziStatus'
+import { useDemoMode } from '../../../hooks/useDemoMode'
 import type { StrimziTopic, StrimziConsumerGroup } from './demoData'
 
 const GROUP_LAG_WARNING_THRESHOLD = 100
 const TOTAL_LAG_WARNING_THRESHOLD = 200
-
-function useFormatRelativeTime() {
-  const { t } = useTranslation('cards')
-  return (isoString: string): string => {
-    const diff = Date.now() - new Date(isoString).getTime()
-    if (isNaN(diff) || diff < 0) return t('strimziStatus.syncedJustNow', 'just now')
-    const minute = 60_000
-    const hour = 60 * minute
-    const day = 24 * hour
-    if (diff < minute) return t('strimziStatus.syncedJustNow', 'just now')
-    if (diff < hour) return t('strimziStatus.syncedMinutesAgo', '{{count}}m ago', { count: Math.floor(diff / minute) })
-    if (diff < day) return t('strimziStatus.syncedHoursAgo', '{{count}}h ago', { count: Math.floor(diff / hour) })
-    return t('strimziStatus.syncedDaysAgo', '{{count}}d ago', { count: Math.floor(diff / day) })
-  }
-}
 
 function TopicRow({ topic }: { topic: StrimziTopic }) {
   const { t } = useTranslation('cards')
@@ -84,8 +71,9 @@ function ConsumerGroupRow({ group }: { group: StrimziConsumerGroup }) {
 
 export function StrimziStatus() {
   const { t } = useTranslation('cards')
-  const formatRelativeTime = useFormatRelativeTime()
-  const { data, error, showSkeleton, showEmptyState, isRefreshing } = useStrimziStatus()
+  // Subscribe to demo mode so the component re-renders when demo mode toggles
+  const { isDemoMode } = useDemoMode()
+  const { data, error, showSkeleton, showEmptyState, isRefreshing, lastRefresh } = useStrimziStatus()
 
   if (showSkeleton) {
     return (
@@ -112,7 +100,7 @@ export function StrimziStatus() {
     )
   }
 
-  if (data.health === 'not-installed') {
+  if (data.health === 'not-installed' && !isDemoMode) {
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
         <Database className="w-6 h-6 text-muted-foreground/50" />
@@ -150,10 +138,12 @@ export function StrimziStatus() {
             <span className="opacity-70 text-xs font-normal">&middot; {data.clusterName}</span>
           )}
         </div>
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-          {isRefreshing && <RefreshCw className="w-3 h-3 animate-spin" />}
-          <span>{formatRelativeTime(data.lastCheckTime)}</span>
-        </div>
+        <RefreshIndicator
+          isRefreshing={isRefreshing}
+          lastUpdated={lastRefresh ? new Date(lastRefresh) : null}
+          size="sm"
+          showLabel={true}
+        />
       </div>
 
       {/* Key metrics */}

--- a/web/src/components/cards/strimzi_status/useStrimziStatus.ts
+++ b/web/src/components/cards/strimzi_status/useStrimziStatus.ts
@@ -190,6 +190,7 @@ export interface UseStrimziStatusResult {
   data: StrimziStatus
   loading: boolean
   isRefreshing: boolean
+  lastRefresh: number | null
   error: boolean
   consecutiveFailures: number
   showSkeleton: boolean
@@ -197,7 +198,7 @@ export interface UseStrimziStatusResult {
 }
 
 export function useStrimziStatus(): UseStrimziStatusResult {
-  const { data, isLoading, isRefreshing, isFailed, consecutiveFailures, isDemoFallback } =
+  const { data, isLoading, isRefreshing, isFailed, consecutiveFailures, isDemoFallback, lastRefresh } =
     useCache<StrimziStatus>({
       key: CACHE_KEY,
       category: 'default',
@@ -224,6 +225,7 @@ export function useStrimziStatus(): UseStrimziStatusResult {
     data,
     loading: isLoading,
     isRefreshing,
+    lastRefresh,
     error: isFailed && !hasAnyData,
     consecutiveFailures,
     showSkeleton,

--- a/web/src/components/cards/weather/Weather.tsx
+++ b/web/src/components/cards/weather/Weather.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next'
 import { WeatherAnimation, getWeatherCondition, getConditionColor } from './WeatherAnimation'
 import { WEATHER_API } from '../../../config/externalApis'
 import { useCardLoadingState } from '../CardDataContext'
+import { RefreshIndicator } from '../../ui/RefreshIndicator'
 import { useCache } from '../../../lib/cache'
 import { FETCH_EXTERNAL_TIMEOUT_MS } from '../../../lib/constants'
 import type {
@@ -119,7 +120,7 @@ export function Weather({ config }: { config?: WeatherConfig }) {
   }, [units, forecastLength])
 
   const weatherCacheKey = `weather:${currentLocation.latitude}:${currentLocation.longitude}:${units}:${forecastLength}`
-  const { data: weatherData, isLoading, isRefreshing, isFailed, isDemoFallback, refetch } = useCache<WeatherData>({
+  const { data: weatherData, isLoading, isRefreshing, isFailed, isDemoFallback, lastRefresh, refetch } = useCache<WeatherData>({
     key: weatherCacheKey,
     category: 'default',
     initialData: INITIAL_WEATHER,
@@ -711,7 +712,7 @@ export function Weather({ config }: { config?: WeatherConfig }) {
       </div>
 
       {/* Footer */}
-      <div className="mt-3 pt-2 border-t border-border/30 text-xs text-center text-muted-foreground">
+      <div className="mt-3 pt-2 border-t border-border/30 text-xs text-muted-foreground flex items-center justify-between">
         <a
           href="https://open-meteo.com"
           target="_blank"
@@ -721,6 +722,12 @@ export function Weather({ config }: { config?: WeatherConfig }) {
           Weather data from Open-Meteo
           <ExternalLink className="w-3 h-3" />
         </a>
+        <RefreshIndicator
+          isRefreshing={isRefreshing}
+          lastUpdated={lastRefresh ? new Date(lastRefresh) : null}
+          size="xs"
+          showLabel={true}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Closes #3276

- **Add RefreshIndicator** to 7 card components that use caching but previously had no freshness display: `PVCStatus`, `GPUStatus`, `ClusterComparison`, `ChartVersions`, `OpenFeatureStatus`, `StrimziStatus`, and `Weather`
- **Replace custom inline refresh UI** in `OpenFeatureStatus` and `StrimziStatus` (inline `RefreshCw` spinner + `useFormatRelativeTime` function) with the shared `RefreshIndicator` component used by all other cards
- **Wire `useDemoMode` subscription** in `StrimziStatus` so it re-renders when demo mode toggles and correctly suppresses the "not-installed" state during demo mode (matching the pattern already used by `OpenFeatureStatus`)
- **Add `lastRefresh`** to `UseStrimziStatusResult` and `UseOpenFeatureStatusResult` hook interfaces so components can pass the cache timestamp to `RefreshIndicator`

## Test plan

- [ ] Verify PVCStatus, GPUStatus, ClusterComparison, ChartVersions cards show a clock icon with "Updated Xs ago" in their header area
- [ ] Verify OpenFeatureStatus and StrimziStatus cards show `RefreshIndicator` instead of the old inline spinner/timestamp
- [ ] Verify Weather card shows `RefreshIndicator` in the footer next to the Open-Meteo attribution
- [ ] Toggle demo mode on/off and verify StrimziStatus renders demo data (no longer stuck on "not-installed")
- [ ] Confirm build passes with `cd web && npm run build`

Generated with [Claude Code](https://claude.com/claude-code)