### PR TITLE
fix: deduplicate polling intervals across MCP hooks

### DIFF
--- a/web/src/hooks/mcp/buildpacks.ts
+++ b/web/src/hooks/mcp/buildpacks.ts
@@ -4,6 +4,7 @@ import { useDemoMode } from '../useDemoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { MIN_REFRESH_INDICATOR_MS, getEffectiveInterval } from './shared'
+import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
 
 export interface BuildpackImage {
@@ -276,9 +277,11 @@ export function useBuildpackImages(cluster?: string) {
       refetch()
     }
 
-    const interval = setInterval(
+    // Poll for buildpack images (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `buildpackImages:${cluster || 'all'}`,
+      getEffectiveInterval(BUILDPACK_REFRESH_INTERVAL_MS),
       () => refetch(true),
-      getEffectiveInterval(BUILDPACK_REFRESH_INTERVAL_MS)
     )
 
     const unregister = registerRefetch(
@@ -287,7 +290,7 @@ export function useBuildpackImages(cluster?: string) {
     )
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregister()
     }
   }, [refetch, cluster])

--- a/web/src/hooks/mcp/clusters.ts
+++ b/web/src/hooks/mcp/clusters.ts
@@ -25,6 +25,7 @@ import {
   setHealthCheckFailures,
 } from './shared'
 import type { ClusterCache } from './shared'
+import { subscribePolling } from './pollingManager'
 
 // Hook to get MCP status
 export function useMCPStatus() {
@@ -47,9 +48,13 @@ export function useMCPStatus() {
     }
 
     fetchStatus()
-    // Poll every 2 minutes
-    const interval = setInterval(fetchStatus, getEffectiveInterval(REFRESH_INTERVAL_MS))
-    return () => clearInterval(interval)
+    // Poll MCP status (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      'mcpStatus',
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      fetchStatus,
+    )
+    return () => unsubscribePolling()
   }, [])
 
   return { status, isLoading, error }
@@ -129,13 +134,16 @@ export function useClusters() {
   }, [])
 
   // Poll cluster data periodically to keep dashboard fresh
+  // (shared interval prevents duplicates across components)
   useEffect(() => {
-    const pollInterval = setInterval(() => {
-      fullFetchClusters()
-    }, getEffectiveInterval(CLUSTER_POLL_INTERVAL_MS))
+    const unsubscribePolling = subscribePolling(
+      'clusters',
+      getEffectiveInterval(CLUSTER_POLL_INTERVAL_MS),
+      () => fullFetchClusters(),
+    )
 
     return () => {
-      clearInterval(pollInterval)
+      unsubscribePolling()
     }
   }, [])
 

--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -7,6 +7,7 @@ import { useDemoMode } from '../useDemoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { GPU_POLL_INTERVAL_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef } from './shared'
+import { subscribePolling } from './pollingManager'
 import { MCP_EXTENDED_TIMEOUT_MS, MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
 import type { GPUNode, NodeInfo, NVIDIAOperatorStatus } from './types'
 
@@ -320,10 +321,12 @@ export function useGPUNodes(cluster?: string) {
       fetchGPUNodes(cluster)
     }
 
-    // Poll GPU node data periodically
-    const pollInterval = setInterval(() => {
-      fetchGPUNodes(cluster, 'poll')
-    }, getEffectiveInterval(GPU_POLL_INTERVAL_MS))
+    // Poll GPU node data periodically (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `gpuNodes:${cluster || 'all'}`,
+      getEffectiveInterval(GPU_POLL_INTERVAL_MS),
+      () => fetchGPUNodes(cluster, 'poll'),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`gpu-nodes:${cluster || 'all'}`, () => {
@@ -332,7 +335,7 @@ export function useGPUNodes(cluster?: string) {
 
     return () => {
       gpuNodeSubscribers.delete(handleUpdate)
-      clearInterval(pollInterval)
+      unsubscribePolling()
       unregisterRefetch()
     }
   }, [cluster])

--- a/web/src/hooks/mcp/crossplane.ts
+++ b/web/src/hooks/mcp/crossplane.ts
@@ -3,6 +3,7 @@ import { isNetlifyDeployment, isDemoMode } from '../../lib/demoMode'
 import { useDemoMode } from '../useDemoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { MIN_REFRESH_INDICATOR_MS, getEffectiveInterval } from './shared'
+import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
 
 export interface CrossplaneManagedResource {
@@ -285,9 +286,11 @@ export function useCrossplaneManagedResources(cluster?: string) {
       refetch()
     }
 
-    const interval = setInterval(
+    // Poll for Crossplane managed resources (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `crossplaneManaged:${cluster || 'all'}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
       () => refetch(true),
-      getEffectiveInterval(REFRESH_INTERVAL_MS)
     )
 
     const unregister = registerRefetch(
@@ -296,7 +299,7 @@ export function useCrossplaneManagedResources(cluster?: string) {
     )
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregister()
     }
   }, [refetch, cluster])

--- a/web/src/hooks/mcp/events.ts
+++ b/web/src/hooks/mcp/events.ts
@@ -6,6 +6,7 @@ import { useDemoMode } from '../useDemoMode'
 import { registerRefetch } from '../../lib/modeTransition'
 import { registerCacheReset } from '../../lib/modeTransition'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL } from './shared'
+import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
 import type { ClusterEvent } from './types'
 
@@ -206,14 +207,18 @@ export function useEvents(cluster?: string, namespace?: string, limit = 20) {
   useEffect(() => {
     const hasCachedData = eventsCache && eventsCache.key === cacheKey
     refetch(!!hasCachedData) // silent=true if we have cached data
-    // Poll every 30 seconds for events
-    const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for events (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `events:${cacheKey}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => refetch(true),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`events:${cacheKey}`, () => refetch(false))
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
     }
   }, [refetch, cacheKey])
@@ -349,14 +354,18 @@ export function useWarningEvents(cluster?: string, namespace?: string, limit = 2
   useEffect(() => {
     const hasCachedData = warningEventsCache && warningEventsCache.key === cacheKey
     refetch(!!hasCachedData) // silent=true if we have cached data
-    // Poll every 30 seconds for events
-    const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for warning events (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `warningEvents:${cacheKey}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => refetch(true),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`warning-events:${cacheKey}`, () => refetch(false))
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
     }
   }, [refetch, cacheKey])

--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -5,6 +5,7 @@ import { useDemoMode } from '../useDemoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { MIN_REFRESH_INDICATOR_MS, getEffectiveInterval } from './shared'
+import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS, SHORT_DELAY_MS, FOCUS_DELAY_MS } from '../../lib/constants/network'
 import type { HelmRelease, HelmHistoryEntry } from './types'
 
@@ -294,13 +295,18 @@ export function useHelmReleases(cluster?: string) {
       refetch()
     }
 
-    const interval = setInterval(() => refetch(true), getEffectiveInterval(HELM_REFRESH_INTERVAL_MS))
+    // Poll for Helm releases (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `helmReleases:${cluster || 'all'}`,
+      getEffectiveInterval(HELM_REFRESH_INTERVAL_MS),
+      () => refetch(true),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`helm-releases:${cluster || 'all'}`, () => refetch(false))
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
     }
   }, [refetch, cluster])

--- a/web/src/hooks/mcp/networking.ts
+++ b/web/src/hooks/mcp/networking.ts
@@ -7,6 +7,7 @@ import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef } from './shared'
+import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS, DEPLOY_ABORT_TIMEOUT_MS } from '../../lib/constants/network'
 import type { Service, Ingress, NetworkPolicy } from './types'
 
@@ -290,8 +291,12 @@ export function useServices(cluster?: string, namespace?: string) {
     const hasCachedData = servicesCache && servicesCache.key === cacheKey
     refetch(!!hasCachedData) // silent=true if we have cached data
 
-    // Poll every 30 seconds for service updates
-    const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for service updates (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `services:${cacheKey}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => refetch(true),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`services:${cacheKey}`, () => {
@@ -299,7 +304,7 @@ export function useServices(cluster?: string, namespace?: string) {
     })
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
     }
   }, [refetch, cacheKey])

--- a/web/src/hooks/mcp/pollingManager.ts
+++ b/web/src/hooks/mcp/pollingManager.ts
@@ -1,0 +1,87 @@
+// ---------------------------------------------------------------------------
+// Shared Polling Manager
+// ---------------------------------------------------------------------------
+//
+// Deduplicates polling intervals across multiple React hook instances.
+// When two components mount the same hook (e.g. usePods for the same
+// cluster/namespace), each creates its own setInterval, causing duplicate
+// API requests every tick.
+//
+// This module maintains a single setInterval per unique cache key.
+// Components subscribe/unsubscribe; the interval starts on first subscriber
+// and stops when the last one leaves.
+// ---------------------------------------------------------------------------
+
+interface PollingEntry {
+  /** The active interval handle, or null when no subscribers */
+  intervalId: ReturnType<typeof setInterval> | null
+  /** Set of callback references for current subscribers */
+  subscribers: Set<() => void>
+  /** The polling interval in milliseconds */
+  intervalMs: number
+}
+
+/** Map from cache key to its polling entry */
+const pollingRegistry = new Map<string, PollingEntry>()
+
+/**
+ * Subscribe to a shared polling interval for the given cache key.
+ *
+ * - On the first subscriber for a key, a single setInterval is created.
+ * - On subsequent subscribers, no new interval is created; they piggy-back
+ *   on the existing one.
+ * - Returns an unsubscribe function. When the last subscriber unsubscribes,
+ *   the interval is cleared.
+ *
+ * @param key        Unique cache key (e.g. "pods:cluster-1:default")
+ * @param intervalMs Polling interval in milliseconds
+ * @param callback   Function to call on each tick (typically `() => refetch(true)`)
+ * @returns          Unsubscribe function to call on cleanup / unmount
+ */
+export function subscribePolling(
+  key: string,
+  intervalMs: number,
+  callback: () => void,
+): () => void {
+  let entry = pollingRegistry.get(key)
+
+  if (!entry) {
+    // First subscriber for this key — create the entry (interval starts below)
+    entry = {
+      intervalId: null,
+      subscribers: new Set(),
+      intervalMs,
+    }
+    pollingRegistry.set(key, entry)
+  }
+
+  entry.subscribers.add(callback)
+
+  // Start the interval if this is the first subscriber
+  if (entry.subscribers.size === 1 && entry.intervalId === null) {
+    entry.intervalId = setInterval(() => {
+      // Notify all current subscribers on each tick
+      const current = pollingRegistry.get(key)
+      if (current) {
+        current.subscribers.forEach(cb => cb())
+      }
+    }, intervalMs)
+  }
+
+  // Return unsubscribe function
+  return () => {
+    const current = pollingRegistry.get(key)
+    if (!current) return
+
+    current.subscribers.delete(callback)
+
+    // If no subscribers remain, stop the interval and clean up
+    if (current.subscribers.size === 0) {
+      if (current.intervalId !== null) {
+        clearInterval(current.intervalId)
+        current.intervalId = null
+      }
+      pollingRegistry.delete(key)
+    }
+  }
+}

--- a/web/src/hooks/mcp/security.ts
+++ b/web/src/hooks/mcp/security.ts
@@ -5,6 +5,7 @@ import { useDemoMode } from '../useDemoMode'
 import { registerRefetch, registerCacheReset } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { MIN_REFRESH_INDICATOR_MS, REFRESH_INTERVAL_MS, getEffectiveInterval } from './shared'
+import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
 import type { SecurityIssue, GitOpsDrift } from './types'
 
@@ -263,8 +264,12 @@ export function useGitOpsDrifts(cluster?: string, namespace?: string) {
       refetch(false)
     }
 
-    // Poll every 30 seconds
-    const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for GitOps drifts (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `gitopsDrifts:${cluster || 'all'}:${namespace || 'all'}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => refetch(true),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`gitops-drifts:${cluster || 'all'}:${namespace || 'all'}`, () => {
@@ -272,7 +277,7 @@ export function useGitOpsDrifts(cluster?: string, namespace?: string) {
     })
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
     }
   }, [refetch, cluster, namespace])

--- a/web/src/hooks/mcp/storage.ts
+++ b/web/src/hooks/mcp/storage.ts
@@ -5,6 +5,7 @@ import { isDemoMode } from '../../lib/demoMode'
 import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { REFRESH_INTERVAL_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef } from './shared'
+import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
 import type { PVC, PV, ResourceQuota, LimitRange, ResourceQuotaSpec } from './types'
 
@@ -311,10 +312,12 @@ export function usePVCs(cluster?: string, namespace?: string) {
 
     doFetch()
 
-    // Poll for PVC updates
-    const interval = setInterval(() => {
-      if (!cancelled) refetch(true)
-    }, getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for PVC updates (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `pvcs:${cacheKey}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => { if (!cancelled) refetch(true) },
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`pvcs:${cacheKey}`, () => {
@@ -323,7 +326,7 @@ export function usePVCs(cluster?: string, namespace?: string) {
 
     return () => {
       cancelled = true
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
     }
   }, [refetch, cacheKey])
@@ -397,7 +400,12 @@ export function usePVs(cluster?: string) {
 
   useEffect(() => {
     refetch()
-    const interval = setInterval(refetch, getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for PV updates (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `pvs:${cluster || 'all'}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => refetch(),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`pvs:${cluster || 'all'}`, () => {
@@ -405,7 +413,7 @@ export function usePVs(cluster?: string) {
     })
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
     }
   }, [refetch, cluster])
@@ -452,7 +460,12 @@ export function useResourceQuotas(cluster?: string, namespace?: string, forceLiv
 
   useEffect(() => {
     refetch()
-    const interval = setInterval(refetch, getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for resource quota updates (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `resourceQuotas:${cluster || 'all'}:${namespace || 'all'}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => refetch(),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`resource-quotas:${cluster || 'all'}:${namespace || 'all'}`, () => {
@@ -460,7 +473,7 @@ export function useResourceQuotas(cluster?: string, namespace?: string, forceLiv
     })
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
     }
   }, [refetch, cluster, namespace])
@@ -505,7 +518,12 @@ export function useLimitRanges(cluster?: string, namespace?: string) {
 
   useEffect(() => {
     refetch()
-    const interval = setInterval(refetch, getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for limit range updates (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `limitRanges:${cluster || 'all'}:${namespace || 'all'}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => refetch(),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`limit-ranges:${cluster || 'all'}:${namespace || 'all'}`, () => {
@@ -513,7 +531,7 @@ export function useLimitRanges(cluster?: string, namespace?: string) {
     })
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
     }
   }, [refetch, cluster, namespace])

--- a/web/src/hooks/mcp/workloads.ts
+++ b/web/src/hooks/mcp/workloads.ts
@@ -7,6 +7,7 @@ import { registerCacheReset, registerRefetch } from '../../lib/modeTransition'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { REFRESH_INTERVAL_MS, MIN_REFRESH_INDICATOR_MS, getEffectiveInterval, LOCAL_AGENT_URL, clusterCacheRef, fetchWithRetry } from './shared'
+import { subscribePolling } from './pollingManager'
 import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
 import type { PodInfo, PodIssue, Deployment, DeploymentIssue, Job, HPA, ReplicaSet, StatefulSet, DaemonSet, CronJob } from './types'
 
@@ -372,8 +373,12 @@ export function usePods(cluster?: string, namespace?: string, sortBy: 'restarts'
   useEffect(() => {
     const hasCachedData = podsCache && podsCache.key === cacheKey
     refetch(!!hasCachedData) // silent=true if we have cached data
-    // Poll for pod updates
-    const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for pod updates (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `pods:${cacheKey}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => refetch(true),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`pods:${cacheKey}`, () => {
@@ -381,7 +386,7 @@ export function usePods(cluster?: string, namespace?: string, sortBy: 'restarts'
     })
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
       sseAbortRef.current?.abort()
     }
@@ -505,8 +510,12 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
   useEffect(() => {
     const hasCachedData = podsCache && podsCache.key === cacheKey
     refetch(!!hasCachedData) // silent=true if we have cached data
-    // Poll for pod updates
-    const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for pod updates (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `allPods:${cacheKey}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => refetch(true),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`allPods:${cacheKey}`, () => {
@@ -514,7 +523,7 @@ export function useAllPods(cluster?: string, namespace?: string, forceLive = fal
     })
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
       sseAbortRef.current?.abort()
     }
@@ -698,8 +707,12 @@ export function usePodIssues(cluster?: string, namespace?: string) {
   useEffect(() => {
     const hasCachedData = podIssuesCache && podIssuesCache.key === cacheKey
     refetch(!!hasCachedData) // silent=true if we have cached data
-    // Poll every 30 seconds for pod issue updates
-    const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for pod issue updates (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `podIssues:${cacheKey}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => refetch(true),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`podIssues:${cacheKey}`, () => {
@@ -707,7 +720,7 @@ export function usePodIssues(cluster?: string, namespace?: string) {
     })
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
       sseAbortRef.current?.abort()
     }
@@ -853,8 +866,12 @@ export function useDeploymentIssues(cluster?: string, namespace?: string) {
   useEffect(() => {
     const hasCachedData = deploymentIssuesCache && deploymentIssuesCache.key === cacheKey
     refetch(!!hasCachedData) // silent=true if we have cached data
-    // Poll every 30 seconds for deployment issues
-    const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for deployment issues (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `deploymentIssues:${cacheKey}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => refetch(true),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`deploymentIssues:${cacheKey}`, () => {
@@ -862,7 +879,7 @@ export function useDeploymentIssues(cluster?: string, namespace?: string) {
     })
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
       sseAbortRef.current?.abort()
     }
@@ -1108,8 +1125,12 @@ export function useDeployments(cluster?: string, namespace?: string) {
     // If we have cached data, do a silent refresh
     const hasCachedData = deploymentsCache && deploymentsCache.key === cacheKey
     refetch(hasCachedData ? true : false)
-    // Poll every 30 seconds for deployment updates
-    const interval = setInterval(() => refetch(true), getEffectiveInterval(REFRESH_INTERVAL_MS))
+    // Poll for deployment updates (shared interval prevents duplicates across components)
+    const unsubscribePolling = subscribePolling(
+      `deployments:${cacheKey}`,
+      getEffectiveInterval(REFRESH_INTERVAL_MS),
+      () => refetch(true),
+    )
 
     // Register for unified mode transition refetch
     const unregisterRefetch = registerRefetch(`deployments:${cacheKey}`, () => {
@@ -1117,7 +1138,7 @@ export function useDeployments(cluster?: string, namespace?: string) {
     })
 
     return () => {
-      clearInterval(interval)
+      unsubscribePolling()
       unregisterRefetch()
     }
   }, [refetch, cacheKey])


### PR DESCRIPTION
Fixes #3251

## Summary

- Introduces a shared `PollingManager` (`web/src/hooks/mcp/pollingManager.ts`) that maintains a single `setInterval` per unique cache key
- Components subscribe/unsubscribe to the shared interval; the interval starts on first subscriber and stops when the last one leaves
- Updated **all 19 `setInterval` calls** across 10 MCP hook files to use `subscribePolling()` instead of creating raw intervals

## Problem

When multiple React components mount the same MCP data hook (e.g., two dashboard cards both calling `usePods` for the same cluster/namespace), each hook instance created its own `setInterval`. This caused duplicate API requests on every polling tick, leading to unnecessary API load and performance degradation.

## Files changed

| File | Hooks updated |
|------|-------------|
| `pollingManager.ts` | New shared polling manager module |
| `workloads.ts` | `usePods`, `useAllPods`, `usePodIssues`, `useDeploymentIssues`, `useDeployments` |
| `events.ts` | `useEvents`, `useWarningEvents` |
| `networking.ts` | `useServices` |
| `storage.ts` | `usePVCs`, `usePVs`, `useResourceQuotas`, `useLimitRanges` |
| `security.ts` | `useGitOpsDrifts` |
| `helm.ts` | `useHelmReleases` |
| `buildpacks.ts` | `useBuildpackImages` |
| `compute.ts` | `useGPUNodes` |
| `crossplane.ts` | `useCrossplaneManagedResources` |
| `clusters.ts` | `useMCPStatus`, `useClusters` |

## Test plan

- [ ] Verify build passes (`cd web && npm run build`)
- [ ] Mount multiple cards using the same hook (e.g., two pod-related cards) and confirm only one polling interval fires per cache key (visible in DevTools Network tab)
- [ ] Verify polling stops when all consumers of a key unmount
- [ ] Verify mode transitions (demo/live) still trigger refetch correctly
- [ ] Verify cache reset notifications still work

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>