### PR TITLE
fix: clear all caches on demo mode toggle to prevent data leakage

### DIFF
--- a/web/src/hooks/mcp/operators.ts
+++ b/web/src/hooks/mcp/operators.ts
@@ -3,7 +3,7 @@ import { api } from '../../lib/api'
 import { isDemoMode } from '../../lib/demoMode'
 import { fetchSSE } from '../../lib/sseClient'
 import { useDemoMode } from '../useDemoMode'
-import { registerRefetch } from '../../lib/modeTransition'
+import { registerRefetch, registerCacheReset } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { clusterCacheRef, subscribeClusterCache } from './shared'
 import type { Operator, OperatorSubscription } from './types'
@@ -11,6 +11,18 @@ import type { Operator, OperatorSubscription } from './types'
 // localStorage cache keys
 const OPERATORS_CACHE_KEY = 'kubestellar-operators-cache'
 const SUBSCRIPTIONS_CACHE_KEY = 'kubestellar-subscriptions-cache'
+
+// ── Mode transition: clear localStorage caches when demo mode is toggled ────
+if (typeof window !== 'undefined') {
+  registerCacheReset('operators', () => {
+    try {
+      localStorage.removeItem(OPERATORS_CACHE_KEY)
+      localStorage.removeItem(SUBSCRIPTIONS_CACHE_KEY)
+    } catch {
+      // Ignore storage errors
+    }
+  })
+}
 
 // REST fallback timeout (SSE is preferred but REST needs generous timeout for large clusters)
 const OPERATOR_REST_TIMEOUT = 120000

--- a/web/src/hooks/mcp/security.ts
+++ b/web/src/hooks/mcp/security.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { fetchSSE } from '../../lib/sseClient'
 import { isDemoMode } from '../../lib/demoMode'
 import { useDemoMode } from '../useDemoMode'
-import { registerRefetch } from '../../lib/modeTransition'
+import { registerRefetch, registerCacheReset } from '../../lib/modeTransition'
 import { STORAGE_KEY_TOKEN } from '../../lib/constants'
 import { MIN_REFRESH_INDICATOR_MS, REFRESH_INTERVAL_MS, getEffectiveInterval } from './shared'
 import { MCP_HOOK_TIMEOUT_MS } from '../../lib/constants/network'
@@ -11,6 +11,17 @@ import type { SecurityIssue, GitOpsDrift } from './types'
 // LocalStorage cache keys
 const GITOPS_DRIFTS_CACHE_KEY = 'kc-gitops-drifts-cache'
 const CACHE_TTL_MS = 30000 // 30 seconds before stale
+
+// ── Mode transition: clear localStorage caches when demo mode is toggled ────
+if (typeof window !== 'undefined') {
+  registerCacheReset('security', () => {
+    try {
+      localStorage.removeItem(GITOPS_DRIFTS_CACHE_KEY)
+    } catch {
+      // Ignore storage errors
+    }
+  })
+}
 
 // Load from localStorage
 function loadGitOpsDriftsFromStorage(): { data: GitOpsDrift[], timestamp: number } {

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -398,13 +398,29 @@ export function isSQLiteWorkerActive(): boolean {
 // ============================================================================
 
 /**
- * Clear all in-memory cache stores. Called by mode transition coordinator
- * when demo mode is toggled (in either direction).
- * This ensures cards get fresh data for the new mode.
+ * Clear all in-memory AND persistent cache stores. Called by mode transition
+ * coordinator when demo mode is toggled (in either direction).
+ *
+ * This ensures no stale real-cluster data leaks into demo mode (and vice versa).
+ * Steps:
+ * 1. Wipe the persistent backend (SQLite / IndexedDB) so no old entries
+ *    can be reloaded on future page loads or storage-load cycles.
+ * 2. Clear the preloaded metadata map (failure counters, etc.).
+ * 3. Reset every in-memory CacheStore to its initial (empty) state WITHOUT
+ *    reloading from storage (the storage was just cleared).
  */
 function clearAllInMemoryCaches(): void {
+  // 1. Clear persistent storage (fire-and-forget)
+  cacheStorage.clear().catch((e) => {
+    console.error('[Cache] Failed to clear persistent storage during mode transition:', e)
+  })
+
+  // 2. Clear metadata
+  preloadedMetaMap.clear()
+
+  // 3. Reset every in-memory store WITHOUT reloading from (now-empty) storage
   for (const store of cacheRegistry.values()) {
-    (store as CacheStore<unknown>).resetToInitialData()
+    (store as CacheStore<unknown>).resetForModeTransition()
   }
 }
 
@@ -580,6 +596,30 @@ class CacheStore<T> {
     if (this.persist) {
       this.storageLoadPromise = this.loadFromStorage()
     }
+  }
+
+  /**
+   * Reset store for a demo/live mode transition WITHOUT reloading from
+   * persistent storage.  Used when persistent storage has already been
+   * cleared by the mode transition coordinator, so there is nothing
+   * useful to reload.
+   *
+   * The next fetch cycle will populate the store with appropriate data
+   * (demo data via useCache or live data from the backend).
+   */
+  resetForModeTransition(): void {
+    this.resetVersion++
+    this.fetchingRef = false
+    this.initialDataLoaded = false
+    this.storageLoadPromise = null
+    this.setState({
+      data: this.initialData,
+      isLoading: true,
+      isRefreshing: false,
+      error: null,
+      isFailed: false,
+      consecutiveFailures: 0,
+    })
   }
 
   // Fetching


### PR DESCRIPTION
Closes #3252

## Summary

When toggling demo mode, cached real-cluster data could leak through because:

1. **Persistent storage (SQLite/IndexedDB) was never cleared** during mode transitions -- only in-memory state was reset. After reset, the unified cache layer would eagerly reload stale data from persistent storage.

2. **Operators and security MCP hooks** maintained their own localStorage caches (`kubestellar-operators-cache`, `kubestellar-subscriptions-cache`, `kc-gitops-drifts-cache`) but did not register with the mode transition coordinator, so their caches were never cleared on demo toggle.

## Changes

- **`web/src/lib/cache/index.ts`**: 
  - `clearAllInMemoryCaches()` now also clears persistent storage (SQLite/IndexedDB) and the preloaded metadata map before resetting in-memory stores
  - Added `resetForModeTransition()` method to `CacheStore` that resets state without reloading from persistent storage (since it was just cleared)

- **`web/src/hooks/mcp/operators.ts`**: Registered cache reset handler to clear `OPERATORS_CACHE_KEY` and `SUBSCRIPTIONS_CACHE_KEY` from localStorage on mode toggle

- **`web/src/hooks/mcp/security.ts`**: Registered cache reset handler to clear `GITOPS_DRIFTS_CACHE_KEY` from localStorage on mode toggle

## Test plan

- [ ] Connect to a real cluster, load workload/operator data, then toggle demo mode on -- verify only demo data appears
- [ ] Toggle demo mode off -- verify real data is fetched fresh (no stale cached data)
- [ ] Verify build passes: `cd web && npm run build`