### PR TITLE
fix: wire lastRefresh through CardDataContext for header-level freshness display

### DIFF
--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -61,6 +61,8 @@ export interface CardDataState {
   hasData?: boolean
   /** Whether the card is displaying demo/mock data instead of real data */
   isDemoData?: boolean
+  /** Timestamp of the last successful data refresh (for "Updated Xm ago" display) */
+  lastUpdated?: Date | null
 }
 
 interface CardDataReportContextValue {
@@ -89,13 +91,13 @@ export function useForceLive(): boolean {
  * your cached data hook (e.g. useCachedPodIssues, useCachedDeployments).
  */
 export function useReportCardDataState(state: CardDataState) {
-  const { isFailed, consecutiveFailures, errorMessage, isLoading, isRefreshing, hasData, isDemoData } = state
+  const { isFailed, consecutiveFailures, errorMessage, isLoading, isRefreshing, hasData, isDemoData, lastUpdated } = state
   const ctx = useContext(CardDataReportContext)
   // useLayoutEffect runs synchronously before paint, ensuring cached data
   // is reported before CardWrapper decides to show skeleton
   useLayoutEffect(() => {
-    ctx.report({ isFailed, consecutiveFailures, errorMessage, isLoading, isRefreshing, hasData, isDemoData })
-  }, [ctx, isFailed, consecutiveFailures, errorMessage, isLoading, isRefreshing, hasData, isDemoData])
+    ctx.report({ isFailed, consecutiveFailures, errorMessage, isLoading, isRefreshing, hasData, isDemoData, lastUpdated })
+  }, [ctx, isFailed, consecutiveFailures, errorMessage, isLoading, isRefreshing, hasData, isDemoData, lastUpdated])
 }
 
 /**
@@ -116,6 +118,8 @@ export interface CardLoadingStateOptions {
   isDemoData?: boolean
   /** Whether the card is refreshing cached data in the background (overrides default isLoading && hasData) */
   isRefreshing?: boolean
+  /** Timestamp of the last successful data refresh (epoch ms). Displayed as "Xm ago" in the card header. */
+  lastRefresh?: number | null
 }
 
 /**
@@ -155,7 +159,11 @@ export function useCardLoadingState(options: CardLoadingStateOptions) {
     // Only cards that explicitly set isDemoData: false will opt-out.
     isDemoData,
     isRefreshing: isRefreshingOverride,
+    lastRefresh,
   } = options
+
+  // Convert epoch-ms timestamp to Date for CardWrapper's "Updated Xm ago" display
+  const lastUpdatedDate = typeof lastRefresh === 'number' ? new Date(lastRefresh) : null
 
   // Safety-net timeout: if the caller keeps isLoading=true for longer than
   // CARD_LOADING_TIMEOUT_MS (30s), force the card out of loading state.
@@ -202,6 +210,7 @@ export function useCardLoadingState(options: CardLoadingStateOptions) {
     isRefreshing: isRefreshingOverride ?? (effectiveIsLoading && hasData),
     hasData,
     isDemoData,
+    lastUpdated: lastUpdatedDate,
   })
 
   return {

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -786,12 +786,15 @@ export function CardWrapper({
                 {!onRefresh && (isVisuallySpinning || effectiveIsLoading || forceSkeletonForOffline) && !effectiveIsFailed && (
                   <RefreshCw className="w-3 h-3 text-blue-400 animate-spin" aria-hidden="true" />
                 )}
-                {/* Last updated indicator */}
-                {!isVisuallySpinning && !effectiveIsLoading && !effectiveIsFailed && lastUpdated && (
-                  <span className="text-2xs text-muted-foreground" title={lastUpdated.toLocaleString()}>
-                    {formatTimeAgo(lastUpdated)}
-                  </span>
-                )}
+                {/* Last updated indicator — use prop or child-reported timestamp */}
+                {(() => {
+                  const effectiveLastUpdated = lastUpdated ?? childDataState?.lastUpdated
+                  return !isVisuallySpinning && !effectiveIsLoading && !effectiveIsFailed && effectiveLastUpdated ? (
+                    <span className="text-2xs text-muted-foreground" title={effectiveLastUpdated.toLocaleString()}>
+                      {formatTimeAgo(effectiveLastUpdated)}
+                    </span>
+                  ) : null
+                })()}
               </div>
               <div className="flex items-center gap-1">
                 {/* Collapse/expand button */}

--- a/web/src/components/cards/ChartVersions.tsx
+++ b/web/src/components/cards/ChartVersions.tsx
@@ -54,6 +54,7 @@ export function ChartVersions({ config: _config }: ChartVersionsProps) {
     isFailed,
     consecutiveFailures,
     isDemoData,
+    lastRefresh,
   })
 
   // Transform Helm releases to chart info

--- a/web/src/components/cards/ClusterComparison.tsx
+++ b/web/src/components/cards/ClusterComparison.tsx
@@ -29,6 +29,7 @@ export function ClusterComparison({ config }: ClusterComparisonProps) {
     isRefreshing,
     hasAnyData: rawClusters.length > 0,
     isDemoData: isDemoMode || isDemoFallback,
+    lastRefresh,
   })
   const {
     selectedClusters: globalSelectedClusters,

--- a/web/src/components/cards/GPUStatus.tsx
+++ b/web/src/components/cards/GPUStatus.tsx
@@ -51,6 +51,7 @@ export function GPUStatus({ config }: GPUStatusProps) {
     isRefreshing,
     hasAnyData: rawNodes.length > 0,
     isDemoData: isDemoMode || isDemoFallback,
+    lastRefresh,
   })
 
   // Card-specific GPU type filter (not handled by useCardData)

--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -76,7 +76,7 @@ function PVCStatusInternal() {
   const { drillToPVC } = useDrillDownActions()
   const { isDemoMode: demoMode } = useDemoMode()
 
-  // Report card data state
+  // Report card data state (lastRefresh flows to CardWrapper header "Updated Xm ago")
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading,
     isRefreshing,
@@ -84,6 +84,7 @@ function PVCStatusInternal() {
     isFailed,
     consecutiveFailures,
     isDemoData: isDemoFallback || demoMode,
+    lastRefresh,
   })
 
   const {

--- a/web/src/components/cards/openfeature_status/useOpenFeatureStatus.ts
+++ b/web/src/components/cards/openfeature_status/useOpenFeatureStatus.ts
@@ -257,6 +257,7 @@ export function useOpenFeatureStatus(): UseOpenFeatureStatusResult {
     hasAnyData,
     isFailed,
     consecutiveFailures,
+    lastRefresh,
   })
 
   return {

--- a/web/src/components/cards/strimzi_status/useStrimziStatus.ts
+++ b/web/src/components/cards/strimzi_status/useStrimziStatus.ts
@@ -219,6 +219,7 @@ export function useStrimziStatus(): UseStrimziStatusResult {
     isFailed,
     consecutiveFailures,
     isDemoData: effectiveIsDemoData,
+    lastRefresh,
   })
 
   return {

--- a/web/src/components/cards/weather/Weather.tsx
+++ b/web/src/components/cards/weather/Weather.tsx
@@ -189,7 +189,7 @@ export function Weather({ config }: { config?: WeatherConfig }) {
   const currentWeather = weatherData.current
   const forecast = weatherData.forecast
   const hourlyForecast = weatherData.hourly
-  useCardLoadingState({ isLoading, isRefreshing, hasAnyData: !!currentWeather, isDemoData: isDemoFallback })
+  useCardLoadingState({ isLoading, isRefreshing, hasAnyData: !!currentWeather, isDemoData: isDemoFallback, lastRefresh })
 
   // Save locations to localStorage whenever they change
   useEffect(() => {


### PR DESCRIPTION
Fixes #3276

## Summary

- Add `lastUpdated` field to `CardDataState` and `lastRefresh` to `CardLoadingStateOptions` so cards can report their cache timestamp through the context system
- CardWrapper now reads `childDataState.lastUpdated` as a fallback when the `lastUpdated` prop is not provided, enabling automatic "Updated Xm ago" display in card headers
- Wire `lastRefresh` through `useCardLoadingState` in all flagged cards: PVCStatus, GPUStatus, ClusterComparison, ChartVersions, Weather, OpenFeatureStatus, StrimziStatus

## Test plan

- [ ] Verify cards show "Updated Xm ago" timestamp in the CardWrapper header bar after data loads
- [ ] Verify timestamp updates after a background refresh cycle
- [ ] Verify no timestamp shows during loading/skeleton state
- [ ] Verify no timestamp shows when card is in failed state
- [ ] Build passes (`tsc -b` clean, no type errors)

Signed-off-by: Claude <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>