### PR TITLE
fix: prevent Benchmark card from showing demo data in live mode (#3328)

### DIFF
--- a/web/src/hooks/useBenchmarkData.ts
+++ b/web/src/hooks/useBenchmarkData.ts
@@ -215,7 +215,9 @@ export function useCachedBenchmarkReports() {
       const data = await res.json()
       return (data.reports ?? []) as BenchmarkReport[]
     },
-    demoWhenEmpty: true,
+    // Do NOT use demoWhenEmpty — in live (non-demo) mode an empty API response
+    // should render an empty/loading state, not silently inject demo data (#3328).
+    demoWhenEmpty: false,
   })
 
   // Use streamed data if we have any, otherwise fall back to cache/demo


### PR DESCRIPTION
## Summary
- Set `demoWhenEmpty: false` in `useCachedBenchmarkReports` so that an empty API/stream response in non-demo mode renders the "No benchmark data available" empty state instead of silently injecting demo data with a Demo badge.
- Demo data still appears correctly when the app is explicitly in demo mode (handled by the `useCache` enabled flag).

Closes #3328

## Test plan
- [ ] In non-demo mode with no benchmark backend, verify the card shows "No benchmark data available" instead of demo data
- [ ] In explicit demo mode, verify the card still shows demo benchmark data with the Demo badge
- [ ] Verify live streaming data still renders correctly when the benchmark backend is available

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>