### PR TITLE
fix: sort env var keys for deterministic warning order

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -1201,7 +1202,13 @@ func getEnvOrDefault(key, defaultVal string) string {
 // set.  This helps fork and enterprise deployers notice that the defaults
 // point to the upstream kubestellar repositories so they can override them.
 func warnDefaultEnvVars(vars map[string]string) {
-	for envVar, defaultVal := range vars {
+	keys := make([]string, 0, len(vars))
+	for k := range vars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, envVar := range keys {
+		defaultVal := vars[envVar]
 		if os.Getenv(envVar) == "" {
 			log.Printf("WARNING: %s is not set, using default %q — "+
 				"set this env var for fork/enterprise deployments to avoid "+


### PR DESCRIPTION
Closes #3364

## Summary
- Sort map keys in `warnDefaultEnvVars()` before iterating, so log warnings are emitted in a stable, deterministic order across runs.
- Go map iteration order is randomized, which made CI log parsing fragile.

## Test plan
- [ ] Run the console and verify warnings appear in alphabetical order by env var name
- [ ] Confirm `go build ./...` passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>