### PR TITLE
fix: use per-client write mutex in BroadcastToClients

### DIFF
--- a/pkg/agent/prediction_worker.go
+++ b/pkg/agent/prediction_worker.go
@@ -667,7 +667,9 @@ func (w *PredictionWorker) mergePredictions(byProvider map[string][]AIPrediction
 }
 
 // BroadcastToClients sends a message to all connected WebSocket clients.
-// Uses wsMux to prevent concurrent writes which cause gorilla/websocket to panic.
+// Uses per-client write mutexes to prevent gorilla/websocket panics from
+// concurrent writes without holding a global lock during I/O. A slow or
+// dead client no longer blocks broadcasts to other clients.
 // Dead connections are removed so they don't leak file descriptors.
 func (s *Server) BroadcastToClients(msgType string, payload interface{}) {
 	message := map[string]interface{}{
@@ -681,24 +683,30 @@ func (s *Server) BroadcastToClients(msgType string, payload interface{}) {
 		return
 	}
 
-	s.wsMux.Lock()
-	defer s.wsMux.Unlock()
-
+	// Snapshot current clients under read lock — no I/O while holding this.
 	s.clientsMux.RLock()
-	clients := make([]*websocket.Conn, 0, len(s.clients))
-	for conn := range s.clients {
-		clients = append(clients, conn)
+	type clientEntry struct {
+		conn *websocket.Conn
+		wsc  *wsClient
+	}
+	clients := make([]clientEntry, 0, len(s.clients))
+	for conn, wsc := range s.clients {
+		clients = append(clients, clientEntry{conn: conn, wsc: wsc})
 	}
 	s.clientsMux.RUnlock()
 
+	// Write to each client using its per-connection mutex + deadline.
+	// A slow client only blocks its own write, not other clients.
 	var dead []*websocket.Conn
-	for _, conn := range clients {
-		conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
-		if err := conn.WriteMessage(websocket.TextMessage, data); err != nil {
-			log.Printf("[Server] Error broadcasting to client %s: %v", conn.RemoteAddr(), err)
-			dead = append(dead, conn)
+	for _, c := range clients {
+		c.wsc.writeMu.Lock()
+		c.conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
+		if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
+			log.Printf("[Server] Error broadcasting to client %s: %v", c.conn.RemoteAddr(), err)
+			dead = append(dead, c.conn)
 		}
-		conn.SetWriteDeadline(time.Time{}) // clear for normal writes
+		c.conn.SetWriteDeadline(time.Time{}) // clear for normal writes
+		c.wsc.writeMu.Unlock()
 	}
 
 	// Remove dead clients so they don't accumulate

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -71,6 +71,13 @@ var defaultAllowedOrigins = []string{
 	"http://*.ibm.com",
 }
 
+// wsClient wraps a WebSocket connection with a per-connection write mutex
+// to prevent gorilla/websocket panics from concurrent writes without
+// requiring a global lock across all clients.
+type wsClient struct {
+	writeMu sync.Mutex
+}
+
 // Server is the local agent WebSocket server
 type Server struct {
 	config         Config
@@ -78,9 +85,8 @@ type Server struct {
 	kubectl        *KubectlProxy
 	k8sClient      *k8s.MultiClusterClient // For rich cluster data queries
 	registry       *Registry
-	clients        map[*websocket.Conn]bool
-	clientsMux     sync.RWMutex
-	wsMux          sync.Mutex // protects concurrent WebSocket writes
+	clients    map[*websocket.Conn]*wsClient
+	clientsMux sync.RWMutex
 	allowedOrigins []string
 	agentToken     string // Optional shared secret for authentication
 
@@ -178,7 +184,7 @@ func NewServer(cfg Config) (*Server, error) {
 		kubectl:        kubectl,
 		k8sClient:      k8sClient,
 		registry:       GetRegistry(),
-		clients:        make(map[*websocket.Conn]bool),
+		clients:        make(map[*websocket.Conn]*wsClient),
 		allowedOrigins: allowedOrigins,
 		agentToken:     agentToken,
 		sessionStart:   now,
@@ -1865,7 +1871,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	defer conn.Close()
 
 	s.clientsMux.Lock()
-	s.clients[conn] = true
+	s.clients[conn] = &wsClient{}
 	s.clientsMux.Unlock()
 
 	defer func() {


### PR DESCRIPTION
Closes #3368

## Summary
- Replaced the global `wsMux` lock in `BroadcastToClients` with per-client write mutexes (`wsClient` struct stored in the clients map).
- A slow or dead WebSocket client no longer blocks broadcasts to all other connected clients.
- Dead connections are still removed after write failures to prevent accumulation.

## Changes
- Added `wsClient` type with a `writeMu sync.Mutex` for per-connection write serialization.
- Changed `clients` map from `map[*websocket.Conn]bool` to `map[*websocket.Conn]*wsClient`.
- `BroadcastToClients` now snapshots clients under `clientsMux.RLock` (no I/O), then writes to each client using its own mutex with a write deadline.
- Removed the global `wsMux` field from `Server`.

## Test plan
- [ ] Connect multiple browser tabs to the agent WebSocket
- [ ] Throttle one tab's network and verify broadcasts still reach other tabs promptly
- [ ] Disconnect a client without clean close; verify it is cleaned up on next broadcast
- [ ] Confirm `go build ./...` passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>