### PR TITLE
fix: guard SetOnReload and StartWatching behind successful LoadConfig

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -211,17 +211,17 @@ func NewServer(cfg Config) (*Server, error) {
 			// Warmup: probe all clusters to populate health cache before serving.
 			// Without this, first load hits ALL clusters (including offline) = 30s+ load.
 			k8sClient.WarmupHealthCache()
-		}
-		k8sClient.SetOnReload(func() {
-			hub.BroadcastAll(handlers.Message{
-				Type: "kubeconfig_changed",
-				Data: map[string]string{"message": "Kubeconfig updated"},
+			k8sClient.SetOnReload(func() {
+				hub.BroadcastAll(handlers.Message{
+					Type: "kubeconfig_changed",
+					Data: map[string]string{"message": "Kubeconfig updated"},
+				})
+				log.Println("Broadcasted kubeconfig change to all clients")
 			})
-			log.Println("Broadcasted kubeconfig change to all clients")
-		})
-		if err := k8sClient.StartWatching(); err != nil {
-			// Watcher fails when kubeconfig doesn't exist — already logged above
-			_ = err
+			if err := k8sClient.StartWatching(); err != nil {
+				// Watcher fails when kubeconfig doesn't exist — already logged above
+				_ = err
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes #3363

## Summary
- Moved `k8sClient.SetOnReload()` and `k8sClient.StartWatching()` calls inside the `LoadConfig()` success branch
- Previously these ran on a partially initialized client when `LoadConfig()` failed, which could cause nil pointer dereferences or other undefined behavior

## Test plan
- [ ] Start the server without a kubeconfig file — verify no panic or unexpected behavior
- [ ] Start the server with a valid kubeconfig — verify file watching and reload broadcast work normally

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>