### PR TITLE
fix: use BackendPort in backendURL() for watchdog mode

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1037,7 +1037,11 @@ func (s *Server) backendURL() string {
 	if !s.config.DevMode && s.config.FrontendURL != "" {
 		return s.config.FrontendURL
 	}
-	return fmt.Sprintf("http://localhost:%d", s.config.Port)
+	port := s.config.Port
+	if s.config.BackendPort > 0 {
+		port = s.config.BackendPort
+	}
+	return fmt.Sprintf("http://localhost:%d", port)
 }
 
 // Start shuts down the temporary loading server and starts the real Fiber app.


### PR DESCRIPTION
Closes #3362

## Summary
- `backendURL()` now respects `BackendPort` when it is set (watchdog mode)
- Previously it always used `Port`, which broke OAuth callbacks when the server was actually listening on `BackendPort`

## Test plan
- [ ] Run in watchdog mode with `BackendPort` set and verify OAuth callback URL uses the correct port
- [ ] Run in normal mode (no `BackendPort`) and verify behavior is unchanged

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>