### PR TITLE
fix: shut down loading server in Shutdown() to prevent port leak

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1094,6 +1094,16 @@ func waitForPortRelease(port int, timeout time.Duration) error {
 // before services are torn down, giving the frontend time to notice.
 func (s *Server) Shutdown() error {
 	atomic.StoreInt32(&s.shuttingDown, 1)
+
+	// If Shutdown is called before Start, the temporary loading server
+	// is still running and holding the port. Shut it down first.
+	if s.loadingSrv != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), serverHealthTimeout)
+		defer cancel()
+		s.loadingSrv.Shutdown(ctx)
+		s.loadingSrv = nil
+	}
+
 	if s.gpuUtilWorker != nil {
 		s.gpuUtilWorker.Stop()
 	}


### PR DESCRIPTION
Closes #3360

## Summary
- Added a check in `Shutdown()` to close the temporary loading server if it is still running
- Previously, if `Shutdown()` was called before `Start()` (e.g., during init errors or signal handling), the loading server was never stopped and the port stayed bound
- The loading server is now cleaned up in both `Start()` (normal path) and `Shutdown()` (early exit path)

## Test plan
- [ ] Call `Shutdown()` before `Start()` and verify the port is released
- [ ] Normal startup/shutdown flow still works correctly
- [ ] No double-close panics (the nil check prevents shutting down an already-nil server)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>