### PR TITLE
fix: use warm cache data instead of regenerating demo data

### DIFF
--- a/web/src/components/cards/llmd/HardwareLeaderboard.tsx
+++ b/web/src/components/cards/llmd/HardwareLeaderboard.tsx
@@ -12,7 +12,6 @@ import { Trophy, ChevronUp, ChevronDown, ArrowUpDown } from 'lucide-react'
 import { useReportCardDataState } from '../CardDataContext'
 import { useCachedBenchmarkReports } from '../../../hooks/useBenchmarkData'
 import {
-  generateBenchmarkReports,
   generateLeaderboardRows,
   CONFIG_COLORS,
   type LeaderboardRow,
@@ -55,8 +54,10 @@ function SortIcon({ active, dir }: { active: boolean; dir: SortDirection }) {
 
 export function HardwareLeaderboard() {
   const { t } = useTranslation()
-  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useCachedBenchmarkReports()
-  const effectiveReports = useMemo(() => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []), [isDemoFallback, liveReports])
+  const { data: reports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useCachedBenchmarkReports()
+  // Use hook data directly — it already returns cached live data or demo fallback.
+  // Calling generateBenchmarkReports() here would bypass the warm cache (#3397).
+  const effectiveReports = useMemo(() => reports ?? [], [reports])
   useReportCardDataState({ isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing, hasData: effectiveReports.length > 0 })
 
   const [sortKey, setSortKey] = useState<SortKey>('score')

--- a/web/src/components/cards/llmd/LatencyBreakdown.tsx
+++ b/web/src/components/cards/llmd/LatencyBreakdown.tsx
@@ -14,9 +14,6 @@ import { Clock, AlertTriangle } from 'lucide-react'
 import { useReportCardDataState } from '../CardDataContext'
 import { useCachedBenchmarkReports } from '../../../hooks/useBenchmarkData'
 import {
-  generateBenchmarkReports,
-} from '../../../lib/llmd/benchmarkMockData'
-import {
   groupByExperiment,
   getFilterOptions,
   type ScalingPoint,
@@ -65,11 +62,10 @@ function CustomTooltip({ active, payload, label, unit }: {
 
 export function LatencyBreakdown() {
   const { t } = useTranslation()
-  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useCachedBenchmarkReports()
-  const effectiveReports = useMemo(
-    () => isDemoFallback ? generateBenchmarkReports() : (liveReports ?? []),
-    [isDemoFallback, liveReports]
-  )
+  const { data: reports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useCachedBenchmarkReports()
+  // Use hook data directly — it already returns cached live data or demo fallback.
+  // Calling generateBenchmarkReports() here would bypass the warm cache (#3397).
+  const effectiveReports = useMemo(() => reports ?? [], [reports])
   useReportCardDataState({
     isDemoData: isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing,
     hasData: effectiveReports.length > 0,

--- a/web/src/components/cards/llmd/ParetoFrontier.tsx
+++ b/web/src/components/cards/llmd/ParetoFrontier.tsx
@@ -13,7 +13,6 @@ import { Download, RotateCcw } from 'lucide-react'
 import { useReportCardDataState } from '../CardDataContext'
 import { useCachedBenchmarkReports } from '../../../hooks/useBenchmarkData'
 import {
-  generateBenchmarkReports,
   extractParetoPoints,
   computeParetoFrontier,
   HARDWARE_COLORS,
@@ -254,11 +253,10 @@ export function ParetoFrontier({ config }: ParetoFrontierProps) {
   const chartRef = useRef<ReactECharts>(null)
 
   // ---- Data ----
-  const { data: liveReports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useCachedBenchmarkReports()
-  const effectiveReports = useMemo(
-    () => (isDemoFallback ? generateBenchmarkReports() : (liveReports ?? [])),
-    [isDemoFallback, liveReports],
-  )
+  const { data: reports, isDemoFallback, isFailed, consecutiveFailures, isLoading, isRefreshing } = useCachedBenchmarkReports()
+  // Use hook data directly — it already returns cached live data or demo fallback.
+  // Calling generateBenchmarkReports() here would bypass the warm cache (#3397).
+  const effectiveReports = useMemo(() => reports ?? [], [reports])
   useReportCardDataState({
     isDemoData: isDemoFallback,
     isFailed,

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -1175,8 +1175,12 @@ export function useCache<T>({
   // the live fetch runs in the background.  This avoids skeleton flicker for
   // "demo until X is installed" cards — they render demo content instantly and
   // swap to real data only if the fetch returns non-empty results.
+  // IMPORTANT: Only apply when current data is empty — if the store already has
+  // real cached data (e.g. from initialData populated via localStorage), showing
+  // demo data would discard that warm cache (#3397).
+  const hasNonEmptyData = Array.isArray(state.data) ? (state.data as unknown[]).length > 0 : !!state.data
   const showOptimisticDemo = effectiveEnabled && demoWhenEmpty && stableDemoData !== undefined
-    && state.isLoading
+    && state.isLoading && !hasNonEmptyData
 
   return {
     data: !effectiveEnabled ? demoDisplayData


### PR DESCRIPTION
Closes #3397

## Summary
- Three benchmark cards (HardwareLeaderboard, LatencyBreakdown, ParetoFrontier) bypassed the cache by calling `generateBenchmarkReports()` when `isDemoFallback` was true, instead of using the hook's `data` which already contains cached live data or the correct demo fallback.
- `useCache`'s `showOptimisticDemo` flag was overriding non-empty initial data (e.g., from localStorage) with demo data during the loading phase, causing `nightly_e2e_status` and similar cards to flash demo data on warm navigation.

## Test plan
- [ ] Navigate to a dashboard with benchmark cards, verify cached data persists on re-navigation
- [ ] Verify nightly E2E status card shows cached data on warm navigation (not demo data)
- [ ] Run `./scripts/cache-test.sh --dev` to confirm compliance test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)