### PR TITLE
fix: add missing table header to markdown summary in run-all-tests.sh

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -356,16 +356,19 @@ cat > "$REPORT_MD" << EOF
 
 ## Suites
 
+| Suite | Status |
+|-------|--------|
 EOF
 
-# Add suite results to markdown using recorded exit-code status (not log parsing)
+# Add suite results to markdown using the SUITE_STATUS associative array
+# which records the actual exit-code-based pass/fail/skip for each suite.
 for script in "${ALL_SCRIPTS[@]}" "${PLAYWRIGHT_SCRIPTS[@]}"; do
   SUITE_NAME=$(basename "$script" .sh)
   STATUS="${SUITE_STATUS[$SUITE_NAME]:-skip}"
   case "$STATUS" in
-    pass) echo "| \`${SUITE_NAME}\` | PASS |" >> "$REPORT_MD" ;;
-    fail) echo "| \`${SUITE_NAME}\` | FAIL |" >> "$REPORT_MD" ;;
-    *)    echo "| \`${SUITE_NAME}\` | SKIP |" >> "$REPORT_MD" ;;
+    pass) echo "| \`${SUITE_NAME}\` | :white_check_mark: PASS |" >> "$REPORT_MD" ;;
+    fail) echo "| \`${SUITE_NAME}\` | :x: FAIL |" >> "$REPORT_MD" ;;
+    *)    echo "| \`${SUITE_NAME}\` | :fast_forward: SKIP |" >> "$REPORT_MD" ;;
   esac
 done
 


### PR DESCRIPTION
Closes #3396

## Summary
- The Suites section in the markdown report (`/tmp/all-tests-summary.md`) was missing the table header row and separator (`| Suite | Status |` / `|-------|--------|`), causing markdown renderers to display the results as plain text rather than a formatted table.
- Added emoji status indicators (checkmark/x/skip) for clearer visual distinction between PASS/FAIL/SKIP statuses.

## Test plan
- [ ] Run `./scripts/run-all-tests.sh --fast` and inspect `/tmp/all-tests-summary.md`
- [ ] Verify the Suites table renders correctly in a markdown viewer
- [ ] Compare status in `/tmp/all-tests-report.json` with `/tmp/all-tests-summary.md` to confirm they match

🤖 Generated with [Claude Code](https://claude.com/claude-code)