### PR TITLE
feat: queue-based Copilot assignment with concurrency control

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -18,9 +18,64 @@ permissions:
   pull-requests: write
 
 jobs:
-  ai-fix:
+  # Queue issues for Copilot assignment (processed by copilot-queue.yml)
+  queue-for-copilot:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issues' &&
+       contains(github.event.issue.labels.*.name, 'ai-fix-requested') &&
+       contains(github.event.issue.labels.*.name, 'triage/accepted')) ||
+      github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Add to Copilot queue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CONSOLE_AUTO || secrets.GITHUB_TOKEN }}
+          script: |
+            const issueNumber = context.eventName === 'workflow_dispatch'
+              ? parseInt('${{ inputs.issue_number }}', 10)
+              : context.payload.issue?.number;
+
+            if (!issueNumber) {
+              core.info('No issue number found, skipping');
+              return;
+            }
+
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+            });
+
+            const labels = issue.labels.map(l => l.name);
+
+            // Skip if already queued or being processed
+            if (labels.includes('ai-queued') || labels.includes('ai-processing') || labels.includes('ai-pr-ready')) {
+              core.info(`#${issueNumber}: already queued or in progress, skipping`);
+              return;
+            }
+
+            // Check required label
+            if (!labels.includes('ai-fix-requested') && context.eventName !== 'workflow_dispatch') {
+              core.info(`#${issueNumber}: missing ai-fix-requested label, skipping`);
+              return;
+            }
+
+            // Add to queue
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['ai-queued'],
+            });
+
+            core.info(`#${issueNumber}: added to Copilot queue`);
+
+  # Keep the PR linking job from the reusable workflow
+  update-issue-on-pr:
+    if: github.event_name == 'pull_request_target'
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
-      issue_number: ${{ github.event.inputs.issue_number || '' }}
+      issue_number: ''
     secrets:
       token: ${{ secrets.CONSOLE_AUTO || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/copilot-retry.yml
+++ b/.github/workflows/copilot-retry.yml
@@ -1,73 +1,156 @@
-name: Copilot Assignment Retry
+name: Copilot Queue Processor
 
-# Retries Copilot assignments that failed with the generic "ruleset violation" error.
-# Copilot intermittently fails to start (~20-30% of assignments) and gives a misleading
-# error. This workflow detects those failures and retries by unassigning/reassigning.
+# Processes the Copilot assignment queue. Issues get ai-queued label from
+# ai-fix.yml or ga4-error-monitor.yml, and this workflow assigns Copilot
+# one at a time with spacing to avoid concurrent session failures.
 #
-# Requires CONSOLE_AUTO secret (PAT with repo scope) — GITHUB_TOKEN cannot assign Copilot.
+# Also retries failed assignments (Copilot "ruleset violation" errors).
+#
+# Requires CONSOLE_AUTO secret (PAT with repo scope).
 
 on:
   schedule:
-    - cron: '*/15 * * * *' # Every 15 minutes
+    - cron: '*/5 * * * *' # Every 5 minutes
   workflow_dispatch:
 
 env:
-  # Maximum concurrent Copilot sessions before we skip retrying
+  # Maximum concurrent Copilot sessions
   MAX_CONCURRENT_SESSIONS: 2
   # Maximum retry attempts per issue
   MAX_RETRIES: 3
+  # Seconds between assignments in a single run
+  ASSIGNMENT_DELAY_S: 120
 
 permissions:
   contents: read
   issues: write
+  pull-requests: read
 
 jobs:
-  retry-failed:
+  process-queue:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
+    # Prevent overlapping runs
+    concurrency:
+      group: copilot-queue
+      cancel-in-progress: false
 
     steps:
-      - name: Retry failed Copilot assignments
+      - name: Process Copilot queue and retry failures
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.CONSOLE_AUTO }}
           script: |
             const maxConcurrent = parseInt(process.env.MAX_CONCURRENT_SESSIONS);
             const maxRetries = parseInt(process.env.MAX_RETRIES);
+            const delayS = parseInt(process.env.ASSIGNMENT_DELAY_S);
             const repo = { owner: context.repo.owner, repo: context.repo.repo };
-            const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
 
-            // ── Step 1: Check active Copilot sessions ──
-            const { data: recentPRs } = await github.rest.pulls.list({
+            // ── Helper: assign Copilot to an issue ──
+            async function assignCopilot(issueNumber) {
+              await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
+                ...repo,
+                issue_number: issueNumber,
+                assignees: ['copilot-swe-agent[bot]'],
+                agent_assignment: {
+                  target_repo: `${repo.owner}/${repo.repo}`,
+                  base_branch: 'main',
+                },
+              });
+            }
+
+            // ── Step 1: Count active Copilot sessions ──
+            const { data: openPRs } = await github.rest.pulls.list({
               ...repo,
               state: 'open',
               sort: 'created',
               direction: 'desc',
-              per_page: 20,
+              per_page: 30,
             });
 
             const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
-            const activeSessions = recentPRs.filter(pr =>
+            let activeSessions = openPRs.filter(pr =>
               pr.user.login === 'copilot-swe-agent[bot]' &&
               new Date(pr.created_at) > oneHourAgo
             ).length;
 
-            core.info(`Active Copilot sessions (PRs created in last hour): ${activeSessions}`);
-            if (activeSessions >= maxConcurrent) {
-              core.info(`Skipping retries — ${activeSessions} active sessions (max: ${maxConcurrent})`);
-              return;
-            }
-
-            // ── Step 2: Find issues where Copilot failed to start ──
+            // Also count issues with ai-processing that DON'T have a PR yet
+            // (Copilot is working but hasn't pushed a PR)
             const { data: processingIssues } = await github.rest.issues.listForRepo({
               ...repo,
               labels: 'ai-processing',
               state: 'open',
               per_page: 20,
-              sort: 'updated',
-              direction: 'asc',
+            });
+            const activeAssignments = processingIssues.filter(i =>
+              (i.assignees || []).some(a => a.login === 'Copilot') &&
+              !i.labels.some(l => l.name === 'ai-queued') &&
+              !i.labels.some(l => l.name === 'ai-stalled')
+            ).length;
+
+            activeSessions = Math.max(activeSessions, activeAssignments);
+            core.info(`Active Copilot sessions: ${activeSessions} (max: ${maxConcurrent})`);
+
+            let assigned = 0;
+
+            // ── Step 2: Process queued issues (new assignments) ──
+            const { data: queuedIssues } = await github.rest.issues.listForRepo({
+              ...repo,
+              labels: 'ai-queued',
+              state: 'open',
+              per_page: 20,
+              sort: 'created',
+              direction: 'asc', // oldest first (FIFO)
             });
 
+            core.info(`Queued issues: ${queuedIssues.length}`);
+
+            for (const issue of queuedIssues) {
+              if (activeSessions + assigned >= maxConcurrent) {
+                core.info(`Session limit reached (${activeSessions + assigned}/${maxConcurrent}), ${queuedIssues.length - queuedIssues.indexOf(issue)} issue(s) remain in queue`);
+                break;
+              }
+
+              core.info(`#${issue.number}: assigning Copilot from queue`);
+
+              try {
+                await assignCopilot(issue.number);
+
+                // Update labels: remove ai-queued, add ai-processing
+                await github.rest.issues.removeLabel({
+                  ...repo,
+                  issue_number: issue.number,
+                  name: 'ai-queued',
+                }).catch(() => {});
+
+                await github.rest.issues.addLabels({
+                  ...repo,
+                  issue_number: issue.number,
+                  labels: ['ai-processing', 'ai-awaiting-fix'],
+                });
+
+                core.info(`#${issue.number}: Copilot assigned successfully`);
+                assigned++;
+
+                // Delay before next assignment
+                if (delayS > 0) {
+                  core.info(`Waiting ${delayS}s before next assignment...`);
+                  await new Promise(r => setTimeout(r, delayS * 1000));
+                }
+              } catch (e) {
+                core.warning(`#${issue.number}: assignment failed: ${e.message}`);
+                // Leave ai-queued label so it gets retried next run
+              }
+            }
+
+            // ── Step 3: Retry failed assignments ──
+            if (activeSessions + assigned >= maxConcurrent) {
+              core.info('Session limit reached, skipping retry pass');
+              core.info(`Queue processor complete: ${assigned} assigned, ${queuedIssues.length - assigned} still queued`);
+              return;
+            }
+
+            // Find issues where Copilot failed to start
             const { data: awaitingIssues } = await github.rest.issues.listForRepo({
               ...repo,
               labels: 'ai-awaiting-fix',
@@ -77,44 +160,45 @@ jobs:
               direction: 'asc',
             });
 
-            const candidates = [...processingIssues, ...awaitingIssues];
-            // Deduplicate by issue number
+            // Merge with processing issues, deduplicate
+            const retryPool = [...processingIssues, ...awaitingIssues];
             const seen = new Set();
-            const unique = candidates.filter(i => {
+            const retryCandidates = retryPool.filter(i => {
               if (seen.has(i.number)) return false;
               seen.add(i.number);
+              // Skip issues still in the queue (handled above)
+              if (i.labels.some(l => l.name === 'ai-queued')) return false;
               return true;
             });
 
-            core.info(`Found ${unique.length} candidate issue(s) to check`);
-            let retried = 0;
+            const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000);
 
-            for (const issue of unique) {
-              // Skip very recent issues (avoid racing with initial assignment)
-              if (new Date(issue.created_at) > new Date(fiveMinAgo)) {
-                core.info(`#${issue.number}: too recent, skipping`);
-                continue;
+            for (const issue of retryCandidates) {
+              if (activeSessions + assigned >= maxConcurrent) {
+                core.info('Session limit reached, stopping retries');
+                break;
               }
 
-              // Check retry count from labels
+              // Skip very recent issues
+              if (new Date(issue.created_at) > fiveMinAgo) continue;
+
+              // Check retry count
               const labels = issue.labels.map(l => l.name);
-              const retryLabels = labels.filter(l => l.startsWith('ai-retry-'));
-              const retryCount = retryLabels.length;
+              const retryCount = labels.filter(l => l.startsWith('ai-retry-')).length;
 
               if (retryCount >= maxRetries) {
-                // Max retries reached — ensure ai-needs-human is set
                 if (!labels.includes('ai-needs-human')) {
                   await github.rest.issues.addLabels({
                     ...repo,
                     issue_number: issue.number,
                     labels: ['ai-needs-human'],
                   });
-                  core.warning(`#${issue.number}: max retries (${maxRetries}) reached, marked as needs-human`);
+                  core.warning(`#${issue.number}: max retries reached, marked as needs-human`);
                 }
                 continue;
               }
 
-              // Check if Copilot posted the "encountered an error" message
+              // Check if Copilot failed to start
               const { data: comments } = await github.rest.issues.listComments({
                 ...repo,
                 issue_number: issue.number,
@@ -127,100 +211,62 @@ jobs:
               );
 
               if (!failedToStart) {
-                // Also check: has Copilot been assigned but never commented at all?
+                // Check for stalled assignment (assigned but no comment after 30min)
                 const copilotAssigned = (issue.assignees || []).some(a => a.login === 'Copilot');
                 const copilotCommented = comments.some(c => c.user.login === 'Copilot');
                 const issueAge = Date.now() - new Date(issue.created_at).getTime();
-                const stalledNoComment = copilotAssigned && !copilotCommented && issueAge > 30 * 60 * 1000;
-
-                if (!stalledNoComment) continue;
-                core.info(`#${issue.number}: Copilot assigned ${Math.round(issueAge / 60000)}m ago with no response`);
+                if (!(copilotAssigned && !copilotCommented && issueAge > 30 * 60 * 1000)) continue;
+                core.info(`#${issue.number}: stalled ${Math.round(issueAge / 60000)}m with no Copilot response`);
               }
 
-              // Check: does this issue already have a PR?
+              // Skip if already has a PR
               const { data: timeline } = await github.rest.issues.listEventsForTimeline({
                 ...repo,
                 issue_number: issue.number,
                 per_page: 50,
               });
-              const hasPR = timeline.some(e =>
-                e.event === 'cross-referenced' &&
-                e.source?.issue?.pull_request
-              );
-              if (hasPR) {
+              if (timeline.some(e => e.event === 'cross-referenced' && e.source?.issue?.pull_request)) {
                 core.info(`#${issue.number}: already has a linked PR, skipping`);
                 continue;
               }
 
-              // Respect concurrent session limit
-              if (activeSessions + retried >= maxConcurrent) {
-                core.info(`Concurrent session limit reached, stopping retries`);
-                break;
-              }
+              // Retry assignment
+              core.info(`#${issue.number}: retrying (attempt ${retryCount + 1}/${maxRetries})`);
 
-              // ── Step 3: Retry assignment ──
-              core.info(`#${issue.number}: retrying Copilot assignment (attempt ${retryCount + 1}/${maxRetries})`);
-
-              // Unassign Copilot
               try {
                 await github.rest.issues.removeAssignees({
                   ...repo,
                   issue_number: issue.number,
                   assignees: ['Copilot'],
-                });
-              } catch (e) {
-                core.warning(`#${issue.number}: could not unassign Copilot: ${e.message}`);
-              }
+                }).catch(() => {});
 
-              // Brief pause before reassigning
-              await new Promise(resolve => setTimeout(resolve, 10000));
+                await new Promise(r => setTimeout(r, 10000));
+                await assignCopilot(issue.number);
 
-              // Reassign Copilot
-              try {
-                await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
-                  ...repo,
-                  issue_number: issue.number,
-                  assignees: ['copilot-swe-agent[bot]'],
-                  agent_assignment: {
-                    target_repo: `${repo.owner}/${repo.repo}`,
-                    base_branch: 'main',
-                  },
-                });
-
-                // Track retry count
                 await github.rest.issues.addLabels({
                   ...repo,
                   issue_number: issue.number,
                   labels: [`ai-retry-${retryCount + 1}`],
                 });
 
-                // Remove stalled label if present
                 if (labels.includes('ai-stalled')) {
-                  try {
-                    await github.rest.issues.removeLabel({
-                      ...repo,
-                      issue_number: issue.number,
-                      name: 'ai-stalled',
-                    });
-                  } catch (e) { /* label might not exist */ }
+                  await github.rest.issues.removeLabel({
+                    ...repo,
+                    issue_number: issue.number,
+                    name: 'ai-stalled',
+                  }).catch(() => {});
                 }
 
                 core.info(`#${issue.number}: Copilot reassigned (attempt ${retryCount + 1})`);
-                retried++;
-              } catch (e) {
-                core.error(`#${issue.number}: reassignment failed: ${e.message}`);
-                await github.rest.issues.createComment({
-                  ...repo,
-                  issue_number: issue.number,
-                  body: `⚠️ Copilot retry ${retryCount + 1}/${maxRetries} failed: ${e.message}`,
-                });
-              }
+                assigned++;
 
-              // Delay between retries to avoid concurrent session conflicts
-              if (retried > 0) {
-                core.info('Waiting 120s before next retry...');
-                await new Promise(resolve => setTimeout(resolve, 120000));
+                if (delayS > 0) {
+                  core.info(`Waiting ${delayS}s before next assignment...`);
+                  await new Promise(r => setTimeout(r, delayS * 1000));
+                }
+              } catch (e) {
+                core.error(`#${issue.number}: retry failed: ${e.message}`);
               }
             }
 
-            core.info(`Copilot retry complete: ${retried} issue(s) retried`);
+            core.info(`Queue processor complete: ${assigned} assigned this run`);

--- a/.github/workflows/ga4-error-monitor.yml
+++ b/.github/workflows/ga4-error-monitor.yml
@@ -32,8 +32,6 @@ env:
   MAX_ISSUES_PER_RUN: 3
   # Hours to look back for errors
   LOOKBACK_HOURS: 2
-  # Seconds between Copilot assignments to avoid rate limiting
-  COPILOT_ASSIGNMENT_DELAY_S: 120
 
 permissions:
   contents: read
@@ -343,31 +341,16 @@ jobs:
 
               core.info(`Created issue #${issue.number}: ${title}`);
 
-              // Auto-assign Copilot coding agent
-              try {
-                await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issue.number,
-                  assignees: ['copilot-swe-agent[bot]'],
-                  agent_assignment: {
-                    target_repo: `${context.repo.owner}/${context.repo.repo}`,
-                    base_branch: 'main',
-                  },
-                });
-                core.info(`Assigned Copilot to #${issue.number}`);
-              } catch (e) {
-                core.warning(`Could not assign Copilot to #${issue.number}: ${e.message}`);
-              }
+              // Queue for Copilot assignment (processed by copilot-queue.yml)
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['ai-queued'],
+              });
+              core.info(`#${issue.number}: added to Copilot queue`);
 
               created++;
-
-              // Throttle between Copilot assignments to avoid concurrent session failures.
-              const delaySeconds = parseInt(process.env.COPILOT_ASSIGNMENT_DELAY_S || '120');
-              if (created < maxIssues && delaySeconds > 0) {
-                core.info(`Waiting ${delaySeconds}s before next Copilot assignment...`);
-                await new Promise(resolve => setTimeout(resolve, delaySeconds * 1000));
-              }
             }
 
             core.info(`GA4 Error Monitor complete: ${created} issue(s) created from ${spikes.length} spike(s).`);


### PR DESCRIPTION
## Summary

- Issues now get `ai-queued` label instead of immediate Copilot assignment
- New **Copilot Queue Processor** runs every 5 minutes, assigns Copilot in FIFO order
- Respects `MAX_CONCURRENT_SESSIONS: 2` — won't assign more if 2 sessions are active
- You can triage-accept a whole batch of issues and they'll process automatically
- Also retries failed assignments (up to 3 attempts)

**Flow:** `triage/accepted` label → `ai-queued` label → queue processor assigns Copilot → `ai-processing`

## Changes

- **`ai-fix.yml`**: Adds `ai-queued` label instead of calling reusable-ai-fix directly
- **`copilot-retry.yml`**: Renamed to queue processor — handles both new assignments and retries with concurrency control
- **`ga4-error-monitor.yml`**: Adds `ai-queued` instead of direct Copilot assignment

## Test plan

- [ ] Triage-accept 5+ issues at once — confirm they get `ai-queued` label
- [ ] Trigger `copilot-queue` via workflow_dispatch — confirm it assigns up to 2 issues
- [ ] Wait for next scheduled run — confirm it picks up remaining queued issues
- [ ] Verify failed assignments get retried on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)