### PR TITLE
fix: fail test scripts when zero tests are executed

### DIFF
--- a/scripts/auth-lifecycle-test.sh
+++ b/scripts/auth-lifecycle-test.sh
@@ -65,9 +65,12 @@ JWT_PASSED=$(grep -c "^--- PASS:" "$JWT_OUTPUT" 2>/dev/null || true)
 JWT_FAILED_COUNT=$(grep -c "^--- FAIL:" "$JWT_OUTPUT" 2>/dev/null || true)
 
 TOTAL=$((TOTAL + 1))
-if [ "$JWT_EXIT" -eq 0 ]; then
+if [ "$JWT_EXIT" -eq 0 ] && [ "$JWT_PASSED" -gt 0 ]; then
   echo -e "  ${GREEN}✓${NC}  JWT middleware tests passed (${JWT_PASSED} tests)"
   PASSED=$((PASSED + 1))
+elif [ "$JWT_EXIT" -eq 0 ] && [ "$JWT_PASSED" -eq 0 ]; then
+  echo -e "  ${YELLOW}⚠️ ${NC} JWT middleware — zero tests matched (exit 0 but 0 tests ran)"
+  FAILED=$((FAILED + 1))
 else
   echo -e "  ${RED}❌${NC} JWT middleware tests failed (${JWT_FAILED_COUNT} failures)"
   grep "^--- FAIL:" "$JWT_OUTPUT" 2>/dev/null | while IFS= read -r line; do
@@ -91,12 +94,12 @@ go test ./pkg/api/handlers/... -run "TestAuth|TestOAuth|TestLogin|TestCallback" 
 AUTH_PASSED=$(grep -c "^--- PASS:" "$AUTH_OUTPUT" 2>/dev/null || true)
 
 TOTAL=$((TOTAL + 1))
-if [ "$AUTH_EXIT" -eq 0 ]; then
+if [ "$AUTH_EXIT" -eq 0 ] && [ "$AUTH_PASSED" -gt 0 ]; then
   echo -e "  ${GREEN}✓${NC}  Auth handler tests passed (${AUTH_PASSED} tests)"
   PASSED=$((PASSED + 1))
-elif [ "$AUTH_PASSED" -eq 0 ]; then
-  echo -e "  ${DIM}⊘  No auth handler tests matched — skipping${NC}"
-  # Don't count as failure if no tests matched
+elif [ "$AUTH_EXIT" -eq 0 ] && [ "$AUTH_PASSED" -eq 0 ]; then
+  echo -e "  ${YELLOW}⚠️ ${NC} Auth handler tests — zero tests matched"
+  FAILED=$((FAILED + 1))
 else
   echo -e "  ${RED}❌${NC} Auth handler tests failed"
   grep "FAIL" "$AUTH_OUTPUT" 2>/dev/null | head -5 | while IFS= read -r line; do
@@ -120,13 +123,12 @@ go test ./pkg/api/handlers/... -run "TestWebSocket|TestHub" -v -timeout 30s > "$
 WS_PASSED=$(grep -c "^--- PASS:" "$WS_OUTPUT" 2>/dev/null || true)
 
 TOTAL=$((TOTAL + 1))
-if [ "$WS_EXIT" -eq 0 ]; then
-  if [ "$WS_PASSED" -gt 0 ]; then
-    echo -e "  ${GREEN}✓${NC}  WebSocket auth tests passed (${WS_PASSED} tests)"
-  else
-    echo -e "  ${DIM}⊘  No WebSocket auth tests matched${NC}"
-  fi
+if [ "$WS_EXIT" -eq 0 ] && [ "$WS_PASSED" -gt 0 ]; then
+  echo -e "  ${GREEN}✓${NC}  WebSocket auth tests passed (${WS_PASSED} tests)"
   PASSED=$((PASSED + 1))
+elif [ "$WS_EXIT" -eq 0 ] && [ "$WS_PASSED" -eq 0 ]; then
+  echo -e "  ${YELLOW}⚠️ ${NC} WebSocket auth tests — zero tests matched"
+  FAILED=$((FAILED + 1))
 else
   echo -e "  ${RED}❌${NC} WebSocket auth tests failed"
   grep "FAIL" "$WS_OUTPUT" 2>/dev/null | head -5 | while IFS= read -r line; do

--- a/scripts/websocket-resilience-test.sh
+++ b/scripts/websocket-resilience-test.sh
@@ -118,8 +118,10 @@ go test ./pkg/api/handlers/... -run "TestWebSocket\|TestHub\|TestHandle" -v -tim
 GO_PASSED=$(grep -c "^--- PASS:" "$WS_TEST_OUTPUT" 2>/dev/null || true)
 GO_FAILED=$(grep -c "^--- FAIL:" "$WS_TEST_OUTPUT" 2>/dev/null || true)
 
-if [ "$WS_TEST_EXIT" -eq 0 ]; then
+if [ "$WS_TEST_EXIT" -eq 0 ] && [ "$GO_PASSED" -gt 0 ]; then
   run_test "Go WebSocket handler tests (${GO_PASSED} tests)" "pass" ""
+elif [ "$WS_TEST_EXIT" -eq 0 ] && [ "$GO_PASSED" -eq 0 ]; then
+  run_test "Go WebSocket handler tests" "fail" "exit 0 but zero tests matched"
 elif [ "$GO_PASSED" -eq 0 ] && [ "$GO_FAILED" -eq 0 ]; then
   run_test "Go WebSocket handler tests" "skip" "no matching tests found"
 else


### PR DESCRIPTION
Closes #3394

## Summary
- `auth-lifecycle-test.sh` and `websocket-resilience-test.sh` reported PASS when `go test` exited 0 but matched zero tests (e.g., when test patterns don't match any functions in the package)
- Now all Go test phases verify that at least one test actually ran (`PASSED > 0`) before reporting success
- When exit code is 0 but zero tests matched, the phase is reported as a failure with a clear warning message

## Test plan
- [ ] Run `./scripts/auth-lifecycle-test.sh` and verify it fails if no Go tests match
- [ ] Run `./scripts/websocket-resilience-test.sh` and verify the same behavior
- [ ] Verify that when tests DO match, the scripts still report PASS correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)