### PR TITLE
fix: apply all four filters in filterItems convenience method

### DIFF
--- a/web/src/hooks/useGlobalFilters.tsx
+++ b/web/src/hooks/useGlobalFilters.tsx
@@ -94,7 +94,7 @@ interface GlobalFiltersContextType {
   filterBySeverity: <T extends { severity?: string }>(items: T[]) => T[]
   filterByStatus: <T extends { status?: string }>(items: T[]) => T[]
   filterByCustomText: <T extends Record<string, unknown>>(items: T[], searchFields?: string[]) => T[]
-  filterItems: <T extends { cluster?: string; severity?: string }>(items: T[]) => T[]
+  filterItems: <T extends { cluster?: string; severity?: string; status?: string } & Record<string, unknown>>(items: T[]) => T[]
 }
 
 const GlobalFiltersContext = createContext<GlobalFiltersContextType | null>(null)
@@ -419,12 +419,14 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
     )
   }, [customFilter])
 
-  const filterItems = useCallback(<T extends { cluster?: string; severity?: string }>(items: T[]): T[] => {
+  const filterItems = useCallback(<T extends { cluster?: string; severity?: string; status?: string } & Record<string, unknown>>(items: T[]): T[] => {
     let filtered = items
     filtered = filterByCluster(filtered)
     filtered = filterBySeverity(filtered)
+    filtered = filterByStatus(filtered)
+    filtered = filterByCustomText(filtered)
     return filtered
-  }, [filterByCluster, filterBySeverity])
+  }, [filterByCluster, filterBySeverity, filterByStatus, filterByCustomText])
 
   const contextValue = useMemo(() => ({
     // Cluster filtering


### PR DESCRIPTION
Closes #3352

## Summary

- `filterItems` in `useGlobalFilters.tsx` only applied `filterByCluster` and `filterBySeverity`, silently ignoring active status and custom text filters
- Added `filterByStatus` and `filterByCustomText` calls to `filterItems`, and updated the type constraint and dependency array accordingly
- This is a re-application of the fix from PR #3423, which was closed due to a merge conflict after PR #3421 landed

## Test plan

- [ ] Set a status filter and verify items are filtered correctly when using `filterItems`
- [ ] Type into the custom text search box and verify items are filtered correctly
- [ ] Verify that cluster and severity filters still work as before

Generated with [Claude Code](https://claude.com/claude-code)