### PR TITLE
fix: mission explorer import losing steps (stale closure)

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -159,7 +159,8 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   // Scan state
   const [isScanning, setIsScanning] = useState(false)
   const [scanResult, setScanResult] = useState<FileScanResult | null>(null)
-  const [pendingImport, setPendingImport] = useState<MissionExport | null>(null)
+  const [, setPendingImport] = useState<MissionExport | null>(null)
+  const pendingImportRef = useRef<MissionExport | null>(null)
 
   // Improve mission dialog state
   const [showImproveDialog, setShowImproveDialog] = useState(false)
@@ -689,6 +690,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
 
   const handleImport = useCallback(async (mission: MissionExport, raw?: string) => {
     setPendingImport(mission)
+    pendingImportRef.current = mission
     setIsScanning(true)
 
     // If steps are empty (index-only metadata), fetch full content first
@@ -698,6 +700,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
         const fetched = await fetchMissionContent(mission)
         resolvedMission = fetched.mission
         setPendingImport(resolvedMission)
+        pendingImportRef.current = resolvedMission
       } catch {
         // Fall through with index-only mission — validation will catch the empty steps
       }
@@ -738,13 +741,16 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   }, [])
 
   const handleScanComplete = useCallback((result: FileScanResult) => {
-    if (result.valid && pendingImport) {
-      emitSolutionImported(pendingImport.title, pendingImport.cncfProject)
-      onImport(pendingImport)
+    // Use ref to avoid stale closure — pendingImport state may not have
+    // updated yet when scan completes synchronously after async fetch
+    const mission = pendingImportRef.current
+    if (result.valid && mission) {
+      emitSolutionImported(mission.title, mission.cncfProject)
+      onImport(mission)
       onClose()
     }
     setIsScanning(false)
-  }, [pendingImport, onImport, onClose])
+  }, [onImport, onClose])
 
   const handleScanDismiss = useCallback(() => {
     setIsScanning(false)


### PR DESCRIPTION
## Summary

- Fixes mission import from explorer card view silently losing steps, resulting in "no steps" when running the imported mission
- Root cause: `handleScanComplete` captured `pendingImport` from a stale React state closure — the async `fetchMissionContent` updated state with the full mission (including steps), but the scan callback still had the old index-only mission (steps: [])
- Fix: use `pendingImportRef` alongside state so `handleScanComplete` always reads the latest resolved mission

## Test plan

- [ ] Open Mission Explorer, search for "kagent"
- [ ] Click Import on the kagent install card (NOT through detail view)
- [ ] Verify mission imports with 4 steps
- [ ] Run the mission — AI should receive all 4 install steps
- [ ] Verify import from detail view still works (regression check)
- [ ] Verify import via URL `/mission/install-kagent` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)