### PR TITLE
Fix Safari caching OAuth redirects

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -216,6 +216,10 @@ func (h *AuthHandler) GitHubLogin(c *fiber.Ctx) error {
 	storeOAuthState(state)
 
 	url := h.oauthConfig.AuthCodeURL(state)
+	// Prevent Safari from caching the 307 redirect (which contains a unique CSRF state).
+	// Without this, Safari reuses a stale redirect URL whose state was already consumed,
+	// causing CSRF validation to fail on the callback.
+	c.Set("Cache-Control", "no-store")
 	return c.Redirect(url, fiber.StatusTemporaryRedirect)
 }
 
@@ -301,6 +305,7 @@ func (h *AuthHandler) devModeLogin(c *fiber.Ctx) error {
 	h.setJWTCookie(c, jwtToken)
 
 	// Redirect to frontend with token
+	c.Set("Cache-Control", "no-store")
 	redirectURL := fmt.Sprintf("%s/auth/callback?token=%s&onboarded=%t", h.frontendURL, jwtToken, user.Onboarded)
 	return c.Redirect(redirectURL, fiber.StatusTemporaryRedirect)
 }
@@ -312,6 +317,7 @@ func (h *AuthHandler) oauthErrorRedirect(c *fiber.Ctx, errorCode, detail string)
 	if detail != "" {
 		q.Set("error_detail", detail)
 	}
+	c.Set("Cache-Control", "no-store")
 	return c.Redirect(h.frontendURL+"/login?"+q.Encode(), fiber.StatusTemporaryRedirect)
 }
 
@@ -431,6 +437,7 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 	h.setJWTCookie(c, jwtToken)
 
 	// Redirect to frontend with token
+	c.Set("Cache-Control", "no-store")
 	redirectURL := fmt.Sprintf("%s/auth/callback?token=%s&onboarded=%t", h.frontendURL, jwtToken, user.Onboarded)
 	return c.Redirect(redirectURL, fiber.StatusTemporaryRedirect)
 }


### PR DESCRIPTION
## Summary
- Safari aggressively caches 307 redirects when no `Cache-Control` header is present
- The `/auth/github` endpoint returns a 307 with a unique CSRF `state` param — Safari caches this and reuses a stale state on subsequent logins, causing CSRF validation to fail
- Chrome does not cache 307 redirects, so this only affected Safari
- Adds `Cache-Control: no-store` to all auth redirect responses (login, callback, error, dev-mode)

## Test plan
- [ ] Clear Safari cache, login with GitHub on Safari — should complete successfully
- [ ] Verify Chrome login still works
- [ ] Verify `curl -sI localhost:8081/auth/github` shows `Cache-Control: no-store`

🤖 Generated with [Claude Code](https://claude.com/claude-code)