### PR TITLE
fix: correct websocket resilience test package path and pattern

### DIFF
--- a/scripts/websocket-resilience-test.sh
+++ b/scripts/websocket-resilience-test.sh
@@ -112,7 +112,7 @@ echo -e "${BOLD}Go WebSocket handler tests:${NC}"
 
 WS_TEST_OUTPUT="$TMPDIR_WS/go-ws-tests.txt"
 WS_TEST_EXIT=0
-go test ./pkg/api/handlers/... -run "TestWebSocket\|TestHub\|TestHandle" -v -timeout 30s > "$WS_TEST_OUTPUT" 2>&1 || WS_TEST_EXIT=$?
+go test ./pkg/agent/... -run "TestServer_HandleWebSocket" -v -timeout 30s > "$WS_TEST_OUTPUT" 2>&1 || WS_TEST_EXIT=$?
 
 # Count pass/fail from Go test output
 GO_PASSED=$(grep -c "^--- PASS:" "$WS_TEST_OUTPUT" 2>/dev/null) || GO_PASSED=0


### PR DESCRIPTION
Closes #3459

## Summary

- The nightly `websocket-resilience-test` was failing because the Go test command targeted the wrong package (`./pkg/api/handlers/...`) with a pattern (`TestWebSocket|TestHub|TestHandle`) that matched zero tests
- The actual WebSocket handler tests (`TestServer_HandleWebSocket_OPTIONS`, `TestServer_HandleWebSocket_Unauthorized`) live in `./pkg/agent/...`
- Updated the `go test` invocation in `scripts/websocket-resilience-test.sh` to use the correct package path and test name pattern

## Test plan

- [x] Ran `bash scripts/websocket-resilience-test.sh` locally -- 2 Go tests matched and passed
- [x] `npm run build` passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>