### PR TITLE
fix: align dashboard scoring with leaderboard repos

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1198,7 +1198,7 @@ func LoadConfigFromEnv() Config {
 	warnDefaultEnvVars(map[string]string{
 		"FEEDBACK_REPO_OWNER":  "kubestellar",
 		"FEEDBACK_REPO_NAME":   "console",
-		"REWARDS_GITHUB_ORGS":  "repo:kubestellar/console repo:kubestellar/console-marketplace repo:kubestellar/console-kb",
+		"REWARDS_GITHUB_ORGS":  "repo:kubestellar/console repo:kubestellar/console-marketplace repo:kubestellar/console-kb repo:kubestellar/docs",
 	})
 
 	return Config{
@@ -1224,7 +1224,7 @@ func LoadConfigFromEnv() Config {
 		FeedbackRepoOwner:   getEnvOrDefault("FEEDBACK_REPO_OWNER", "kubestellar"),
 		FeedbackRepoName:    getEnvOrDefault("FEEDBACK_REPO_NAME", "console"),
 		// GitHub activity rewards
-		RewardsGitHubOrgs: getEnvOrDefault("REWARDS_GITHUB_ORGS", "org:kubestellar"),
+		RewardsGitHubOrgs: getEnvOrDefault("REWARDS_GITHUB_ORGS", "repo:kubestellar/console repo:kubestellar/console-marketplace repo:kubestellar/console-kb repo:kubestellar/docs"),
 		// Skip onboarding questionnaire for new users
 		SkipOnboarding: os.Getenv("SKIP_ONBOARDING") == "true",
 		// Benchmark data from Google Drive


### PR DESCRIPTION
## Summary
- Changes default `REWARDS_GITHUB_ORGS` from `org:kubestellar` (all repos) to the same 4 repos the leaderboard counts: `console`, `console-marketplace`, `console-kb`, `docs`
- This fixes the ~5,600 point discrepancy reported by @arnavgogia20 where the dashboard showed ~18,500 points but the leaderboard showed ~12,900
- Root cause: contributions in `kubestellar/ui` (10 PRs, 3 issues) were counted by the dashboard but not the leaderboard

## Test plan
- [ ] `go build ./...` passes
- [ ] Dashboard point total should now match leaderboard for affected contributors
- [ ] `REWARDS_GITHUB_ORGS` env var can still override the default

Fixes #3463

🤖 Generated with [Claude Code](https://claude.com/claude-code)