### PR TITLE
feat: show kagent/kagenti in AI agent selector dropdown

### DIFF
--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { ChevronDown, Check, Loader2, Sparkles } from 'lucide-react'
 import { useMissions } from '../../hooks/useMissions'
 import { useDemoMode, getDemoMode } from '../../hooks/useDemoMode'
+import { useKagentBackend } from '../../hooks/useKagentBackend'
 import { AgentIcon } from './AgentIcon'
 import type { AgentInfo } from '../../types/agent'
 import { cn } from '../../lib/cn'
@@ -31,9 +32,33 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
   // Stash the agent name the user intended to select when approval was triggered
   const pendingAgentRef = useRef<string | null>(null)
 
-  // Only show agents that are available (installed CLI-based agents).
-  // API-key-driven agents are hidden — they can't execute commands to diagnose/repair clusters.
-  const visibleAgents = agents.filter(a => a.available)
+  // In-cluster agent backends (kagent / kagenti)
+  const { kagentAvailable, kagentiAvailable, selectedKagentAgent, selectedKagentiAgent } = useKagentBackend()
+
+  // Merge local agents with in-cluster backends
+  const visibleAgents = useMemo(() => {
+    const local = agents.filter(a => a.available)
+    const inCluster: AgentInfo[] = []
+    if (kagentAvailable) {
+      inCluster.push({
+        name: 'kagent',
+        displayName: selectedKagentAgent ? `Kagent (${selectedKagentAgent.name})` : 'Kagent',
+        description: 'In-cluster AI agent via kagent',
+        provider: 'kagent',
+        available: true,
+      })
+    }
+    if (kagentiAvailable) {
+      inCluster.push({
+        name: 'kagenti',
+        displayName: selectedKagentiAgent ? `Kagenti (${selectedKagentiAgent.name})` : 'Kagenti',
+        description: 'In-cluster AI agent via kagenti',
+        provider: 'kagenti',
+        available: true,
+      })
+    }
+    return [...local, ...inCluster]
+  }, [agents, kagentAvailable, kagentiAvailable, selectedKagentAgent, selectedKagentiAgent])
 
   // Sort: selected agent first, then available agents, then unavailable
   const sortedAgents = useMemo(() => {

--- a/web/src/hooks/useProviderHealth.ts
+++ b/web/src/hooks/useProviderHealth.ts
@@ -114,6 +114,8 @@ const AI_PROVIDER_NAMES: Record<string, string> = {
   gemini: 'Google (Gemini)',
   bob: 'Bob (Built-in)',
   'anthropic-local': 'Claude Code (Local)',
+  kagent: 'Kagent (In-Cluster)',
+  kagenti: 'Kagenti (In-Cluster)',
 }
 
 /** Normalize AI provider ID for dedup and status lookup */

--- a/web/src/types/agent.ts
+++ b/web/src/types/agent.ts
@@ -19,6 +19,8 @@ export type AgentProvider =
   | 'raycast'         // Raycast
   | 'open-webui'      // Open WebUI
   | 'bob'             // Bob (discovery-only)
+  | 'kagent'          // Kagent (in-cluster)
+  | 'kagenti'         // Kagenti (in-cluster)
 
 // Capability flags matching backend ProviderCapability
 export const AgentCapabilityChat = 1


### PR DESCRIPTION
## Summary
- Adds kagent and kagenti as selectable options in the navbar AI agent dropdown when detected in-cluster
- They appear alongside local agents (e.g., Claude Code) with their platform icons
- Shows the selected kagent/kagenti agent name in parentheses when one is picked
- Adds `kagent` and `kagenti` to the `AgentProvider` type union and provider health display names

## Test plan
- [ ] `npm run build` passes
- [ ] When kagent is detected, it shows in the AI agent dropdown with purple hexagon icon
- [ ] When kagenti is detected, it shows with green mesh icon
- [ ] Local agents (Claude Code) still appear and work as before
- [ ] When neither is detected, dropdown is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)