### PR TITLE
feat: tabbed AI Agents dashboard with kagent/kagenti in agent dropdown

### DIFF
--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { ChevronDown, Check, Loader2, Sparkles } from 'lucide-react'
 import { useMissions } from '../../hooks/useMissions'
 import { useDemoMode, getDemoMode } from '../../hooks/useDemoMode'
+import { useKagentBackend } from '../../hooks/useKagentBackend'
 import { AgentIcon } from './AgentIcon'
 import type { AgentInfo } from '../../types/agent'
 import { cn } from '../../lib/cn'
@@ -19,6 +20,7 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
   const { t } = useTranslation()
   const { agents, selectedAgent, agentsLoading, selectAgent, connectToAgent } = useMissions()
   const { isDemoMode: isDemoModeHook } = useDemoMode()
+  const { kagentAvailable, kagentiAvailable, selectedKagentAgent, selectedKagentiAgent } = useKagentBackend()
   // Synchronous fallback prevents flash during React transitions
   const isDemoMode = isDemoModeHook || getDemoMode()
   const { isOpen, close: closeDropdown, toggle: toggleDropdown } = useModalState()
@@ -31,9 +33,30 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
   // Stash the agent name the user intended to select when approval was triggered
   const pendingAgentRef = useRef<string | null>(null)
 
-  // Only show agents that are available (installed CLI-based agents).
-  // API-key-driven agents are hidden — they can't execute commands to diagnose/repair clusters.
-  const visibleAgents = agents.filter(a => a.available)
+  // Merge local agents with in-cluster backends (kagent, kagenti)
+  const visibleAgents = useMemo(() => {
+    const local = agents.filter(a => a.available)
+    const inCluster: AgentInfo[] = []
+    if (kagentAvailable) {
+      inCluster.push({
+        name: 'kagent',
+        displayName: selectedKagentAgent ? `Kagent (${selectedKagentAgent.name})` : 'Kagent',
+        description: 'In-cluster AI agent via kagent',
+        provider: 'kagent',
+        available: true,
+      })
+    }
+    if (kagentiAvailable) {
+      inCluster.push({
+        name: 'kagenti',
+        displayName: selectedKagentiAgent ? `Kagenti (${selectedKagentiAgent.name})` : 'Kagenti',
+        description: 'In-cluster AI agent via kagenti',
+        provider: 'kagenti',
+        available: true,
+      })
+    }
+    return [...local, ...inCluster]
+  }, [agents, kagentAvailable, kagentiAvailable, selectedKagentAgent, selectedKagentiAgent])
 
   // Sort: selected agent first, then available agents, then unavailable
   const sortedAgents = useMemo(() => {
@@ -169,7 +192,7 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
         <div
           role="listbox"
           aria-label={t('agent.selectAgent')}
-          className="absolute z-50 top-full mt-1 right-0 w-72 max-h-[calc(100vh-8rem)] rounded-lg bg-card border border-border shadow-lg overflow-hidden flex flex-col"
+          className="absolute z-50 top-full mt-1 right-0 w-96 max-h-[calc(100vh-8rem)] rounded-lg bg-card border border-border shadow-lg overflow-hidden flex flex-col"
           onKeyDown={(e) => {
             if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
             e.preventDefault()

--- a/web/src/components/layout/navbar/AgentStatusIndicator.tsx
+++ b/web/src/components/layout/navbar/AgentStatusIndicator.tsx
@@ -196,7 +196,7 @@ export function AgentStatusIndicator() {
 
       {/* Agent status dropdown */}
       {showAgentStatus && (
-        <div ref={dropdownRef} className="absolute top-full right-0 mt-2 w-72 bg-card border border-border rounded-lg shadow-xl z-50">
+        <div ref={dropdownRef} className="absolute top-full right-0 mt-2 w-96 bg-card border border-border rounded-lg shadow-xl z-50">
           {/* Demo Mode Toggle */}
           <div className="p-3 border-b border-border">
             <div className="flex items-center justify-between">

--- a/web/src/config/cards/index.ts
+++ b/web/src/config/cards/index.ts
@@ -370,6 +370,14 @@ export const CARD_PROJECT_TAGS: Record<string, string[]> = {
   kagenti_security: ['kubestellar', 'kagenti'],
   kagenti_security_posture: ['kubestellar', 'kagenti'],
   kagenti_topology: ['kubestellar', 'kagenti'],
+  // Kagent CRD cards (component-only, shared with kagent project)
+  kagent_status: ['kubestellar', 'kagent'],
+  kagent_agent_fleet: ['kubestellar', 'kagent'],
+  kagent_tool_registry: ['kubestellar', 'kagent'],
+  kagent_model_providers: ['kubestellar', 'kagent'],
+  kagent_agent_discovery: ['kubestellar', 'kagent'],
+  kagent_security: ['kubestellar', 'kagent'],
+  kagent_topology: ['kubestellar', 'kagent'],
 }
 
 /**

--- a/web/src/config/dashboards/ai-agents.ts
+++ b/web/src/config/dashboards/ai-agents.ts
@@ -1,6 +1,6 @@
 /**
  * AI Agents Dashboard Configuration
- * Tabbed view: Kagent | Kagenti
+ * Tabbed view: Kagenti | Kagent
  */
 import type { UnifiedDashboardConfig } from '../../lib/unified/types'
 
@@ -15,23 +15,8 @@ export const aiAgentsDashboardConfig: UnifiedDashboardConfig = {
   // Default cards (used when no tab is active / fallback)
   cards: [],
 
-  // Tabbed layout — Kagent and Kagenti each get their own card set
+  // Tabbed layout — Kagenti first, Kagent second
   tabs: [
-    {
-      id: 'kagent',
-      label: 'Kagent',
-      icon: 'kagent',
-      installUrl: 'https://github.com/kagent-dev/kagent',
-      cards: [
-        { id: 'kagent-status-1', cardType: 'kagent_status', title: 'Kagent Overview', position: { w: 4, h: 5 } },
-        { id: 'kagent-fleet-1', cardType: 'kagent_agent_fleet', title: 'Agent Fleet', position: { w: 8, h: 5 } },
-        { id: 'kagent-tools-1', cardType: 'kagent_tool_registry', title: 'Tool Servers', position: { w: 4, h: 4 } },
-        { id: 'kagent-models-1', cardType: 'kagent_model_providers', title: 'Model Providers', position: { w: 4, h: 4 } },
-        { id: 'kagent-discovery-1', cardType: 'kagent_agent_discovery', title: 'Agent Discovery', position: { w: 4, h: 4 } },
-        { id: 'kagent-security-1', cardType: 'kagent_security', title: 'Security', position: { w: 4, h: 4 } },
-        { id: 'kagent-topology-1', cardType: 'kagent_topology', title: 'Agent Topology', position: { w: 8, h: 4 } },
-      ],
-    },
     {
       id: 'kagenti',
       label: 'Kagenti',
@@ -43,8 +28,23 @@ export const aiAgentsDashboardConfig: UnifiedDashboardConfig = {
         { id: 'kagenti-builds-1', cardType: 'kagenti_build_pipeline', title: 'Build Pipeline', position: { w: 4, h: 4 } },
         { id: 'kagenti-tools-1', cardType: 'kagenti_tool_registry', title: 'MCP Tool Registry', position: { w: 4, h: 4 } },
         { id: 'kagenti-discovery-1', cardType: 'kagenti_agent_discovery', title: 'Agent Discovery', position: { w: 4, h: 4 } },
-        { id: 'kagenti-security-1', cardType: 'kagenti_security', title: 'Security Posture', position: { w: 4, h: 4 } },
-        { id: 'kagenti-topology-1', cardType: 'kagenti_topology', title: 'Agent Topology', position: { w: 8, h: 4 } },
+        { id: 'kagenti-security-1', cardType: 'kagenti_security', title: 'Security Posture', position: { w: 6, h: 4 } },
+        { id: 'kagenti-topology-1', cardType: 'kagenti_topology', title: 'Agent Topology', position: { w: 6, h: 4 } },
+      ],
+    },
+    {
+      id: 'kagent',
+      label: 'Kagent',
+      icon: 'kagent',
+      installUrl: 'https://github.com/kagent-dev/kagent',
+      cards: [
+        { id: 'kagent-status-1', cardType: 'kagent_status', title: 'Kagent Overview', position: { w: 4, h: 5 } },
+        { id: 'kagent-fleet-1', cardType: 'kagent_agent_fleet', title: 'Agent Fleet', position: { w: 8, h: 5 } },
+        { id: 'kagent-tools-1', cardType: 'kagent_tool_registry', title: 'Tool Servers', position: { w: 4, h: 4 } },
+        { id: 'kagent-models-1', cardType: 'kagent_model_providers', title: 'Model Providers', position: { w: 4, h: 4 } },
+        { id: 'kagent-discovery-1', cardType: 'kagent_agent_discovery', title: 'Agent Discovery', position: { w: 4, h: 4 } },
+        { id: 'kagent-security-1', cardType: 'kagent_security', title: 'Security', position: { w: 6, h: 4 } },
+        { id: 'kagent-topology-1', cardType: 'kagent_topology', title: 'Agent Topology', position: { w: 6, h: 4 } },
       ],
     },
   ],

--- a/web/src/lib/unified/dashboard/DashboardGrid.tsx
+++ b/web/src/lib/unified/dashboard/DashboardGrid.tsx
@@ -4,7 +4,7 @@
  * Renders a responsive grid of cards with optional drag-and-drop support.
  */
 
-import { useMemo, useState, useCallback, useEffect } from 'react'
+import { useMemo, useState, useCallback, useEffect, Suspense } from 'react'
 import {
   DndContext,
   closestCenter,
@@ -27,6 +27,8 @@ import { CSS } from '@dnd-kit/utilities'
 import type { DashboardCardPlacement, DashboardFeatures } from '../types'
 import { UnifiedCard } from '../card'
 import { getCardConfig } from '../../../config/cards'
+import { getCardComponent } from '../../../components/cards/cardRegistry'
+import { CardWrapper } from '../../../components/cards/CardWrapper'
 import { DashboardHealthIndicator } from '../../../components/dashboard/DashboardHealthIndicator'
 import { useDashboardHealth } from '../../../hooks/useDashboardHealth'
 
@@ -216,7 +218,6 @@ function DashboardCardWrapper({
 
   const rawW = Math.min(12, Math.max(3, placement.position.w))
   const effectiveW = isNarrow && rawW < 6 ? 6 : rawW
-  const colSpan = `col-span-${effectiveW}`
 
   // Calculate height (each row unit = 100px) — use inline style because
   // Tailwind JIT can't detect dynamically constructed arbitrary classes.
@@ -226,9 +227,12 @@ function DashboardCardWrapper({
   const cardTypeKey = placement.cardType || (placement as { card_type?: string }).card_type
   const cardConfig = cardTypeKey ? getCardConfig(cardTypeKey) : undefined
 
-  // Style for drag transform + min-height
+  // Style for drag transform + min-height + grid column span
+  // Use inline gridColumn instead of Tailwind col-span-* classes because
+  // dynamic class names (col-span-${n}) aren't detected by Tailwind JIT.
   const style: React.CSSProperties = {
     minHeight: `${minHeightPx}px`,
+    gridColumn: `span ${effectiveW} / span ${effectiveW}`,
     ...(isDraggable
       ? {
           transform: CSS.Transform.toString(transform),
@@ -238,12 +242,15 @@ function DashboardCardWrapper({
       : {}),
   }
 
-  if (!cardConfig) {
+  // Fallback: component-only cards (no config file) render directly via CardWrapper
+  const DirectComponent = !cardConfig && cardTypeKey ? getCardComponent(cardTypeKey) : undefined
+
+  if (!cardConfig && !DirectComponent) {
     return (
       <div
         ref={setNodeRef}
         style={style}
-        className={`${colSpan} glass rounded-lg p-4 flex items-center justify-center text-muted-foreground`}
+        className="glass rounded-lg p-4 flex items-center justify-center text-muted-foreground"
       >
         Unknown card type: {cardTypeKey || 'undefined'}
       </div>
@@ -254,7 +261,7 @@ function DashboardCardWrapper({
     <div
       ref={setNodeRef}
       style={style}
-      className={`${colSpan} ${isOverlay ? 'shadow-2xl' : ''}`}
+      className={isOverlay ? 'shadow-2xl' : ''}
       {...(isDraggable ? attributes : {})}
     >
       <div className="relative h-full group">
@@ -305,12 +312,25 @@ function DashboardCardWrapper({
         )}
 
         {/* The actual card */}
-        <UnifiedCard
-          config={cardConfig}
-          instanceConfig={placement.config as Record<string, unknown> | undefined}
-          title={placement.title}
-          className="h-full glass rounded-lg"
-        />
+        {cardConfig ? (
+          <UnifiedCard
+            config={cardConfig}
+            instanceConfig={placement.config as Record<string, unknown> | undefined}
+            title={placement.title}
+            className="h-full glass rounded-lg"
+          />
+        ) : DirectComponent ? (
+          <CardWrapper
+            cardId={placement.id}
+            cardType={cardTypeKey!}
+            title={placement.title}
+            cardWidth={placement.position.w}
+          >
+            <Suspense fallback={<div className="h-full animate-pulse" />}>
+              <DirectComponent config={placement.config as Record<string, unknown> | undefined} />
+            </Suspense>
+          </CardWrapper>
+        ) : null}
 
         {/* Loading overlay */}
         {isLoading && !isOverlay && (

--- a/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
+++ b/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
@@ -335,8 +335,8 @@ export function UnifiedDashboard({
         isLoading={isLoading}
       />
 
-      {/* Empty state */}
-      {cards.length === 0 && (
+      {/* Empty state — only show when no tabs and no cards */}
+      {cards.length === 0 && !hasTabs && (
         <div className="flex flex-col items-center justify-center py-16 text-center">
           <Activity className="w-12 h-12 text-muted-foreground mb-4" />
           <h3 className="text-lg font-medium text-foreground mb-2">

--- a/web/src/types/agent.ts
+++ b/web/src/types/agent.ts
@@ -19,6 +19,8 @@ export type AgentProvider =
   | 'raycast'         // Raycast
   | 'open-webui'      // Open WebUI
   | 'bob'             // Bob (discovery-only)
+  | 'kagent'          // Kagent (in-cluster)
+  | 'kagenti'         // Kagenti (in-cluster)
 
 // Capability flags matching backend ProviderCapability
 export const AgentCapabilityChat = 1


### PR DESCRIPTION
## Summary
- **Tabbed AI Agents dashboard**: Kagenti tab first, Kagent tab second — each with 7 cards
- **Component-only card rendering**: DashboardGrid now falls back to `CardWrapper + getCardComponent()` for cards without config files (kagent, kagenti, benchmark cards), fixing "Unknown card type" errors
- **Inline grid columns**: Replaced dynamic `col-span-${n}` Tailwind classes (undetectable by JIT) with inline `gridColumn` CSS
- **Agent selector dropdown**: Kagent/kagenti in-cluster backends now appear alongside local agents
- **Wider dropdowns**: Both AgentSelector and AgentStatusIndicator widened from `w-72` to `w-96` to prevent text overflow
- **Empty state fix**: "No cards configured" message hidden when dashboard uses tabs

## Test plan
- [ ] AI Agents page shows two tabs: Kagenti (first) and Kagent (second)
- [ ] Cards render with proper borders, title bars, and CardWrapper controls (Demo badge, expand, configure, kebab)
- [ ] Card widths fill rows correctly (4+8=12, 4+4+4=12, 6+6=12)
- [ ] Agent selector dropdown shows kagent/kagenti when backends are available
- [ ] AgentStatusIndicator dropdown text no longer overflows
- [ ] No "No cards configured" message appears below tabbed cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)