### PR TITLE
feat: multi-cluster selection, drag-to-reorder, GB→TB formatting, UI polish

### DIFF
--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -10,6 +10,7 @@ name: Auto-QA Agent
 #   3=Operator Usefulness, 4=SRE/Multi-Cluster,
 #   5=Feature Recommendations, 6=Resilience, 7=Consistency
 # Layer 7 (weekly): Self-improvement analysis based on recent PR patterns
+# Layer 8 (always): Adoption psychology — curiosity, discovery, stickiness
 #
 # Issues auto-assign Copilot and feed into the automation pipeline.
 #
@@ -30,7 +31,7 @@ on:
         default: false
         type: boolean
       focus_override:
-        description: 'Override focus (performance|security|a11y|operator|sre|features|resilience|consistency|none)'
+        description: 'Override focus (performance|security|a11y|operator|sre|features|resilience|consistency|adoption|none)'
         required: false
         default: ''
         type: string
@@ -3239,6 +3240,138 @@ jobs:
             echo "Event parity looks good"
           fi
 
+      # ── Layer 8: Adoption & Engagement Psychology ───────────────────
+      # Scans the codebase for opportunities to apply psychological
+      # techniques (variable rewards, curiosity gaps, progress loops,
+      # social proof, etc.) that improve discovery, stickiness, and
+      # long-term adoption — inspired by patterns that make social
+      # platforms engaging.
+
+      - name: "Adoption: Engagement psychology opportunities"
+        id: focus_adoption_psychology
+        working-directory: web
+        continue-on-error: true
+        run: |
+          echo "Scanning for adoption & engagement psychology opportunities..."
+          ISSUES=""
+
+          # ── 1. Variable Reward / Surprise & Delight ──
+          # Look for pages that always show the same static content with
+          # no dynamic highlights, tips, or rotating recommendations.
+          STATIC_PAGES=""
+          for page_dir in src/components/dashboard src/components/clusters src/components/deploy src/components/compliance src/components/ai-ml src/components/arcade; do
+            if [ -d "$page_dir" ]; then
+              PAGE_NAME=$(basename "$page_dir")
+              # Check if page has any dynamic tip/highlight/recommendation/surprise element
+              HAS_DYNAMIC=$(grep -rlE "tip(s)?[Oo]f[Tt]he[Dd]ay|didYouKnow|randomTip|spotlight|featured|shuffle|random|rotate.*suggestion|surprise" "$page_dir" 2>/dev/null | head -1 || true)
+              if [ -z "$HAS_DYNAMIC" ]; then
+                STATIC_PAGES="${STATIC_PAGES}  - \`${PAGE_NAME}\`: no variable-reward elements (tips, spotlights, rotating highlights)\n"
+              fi
+            fi
+          done
+          if [ -n "$STATIC_PAGES" ]; then
+            ISSUES="${ISSUES}### Missing Variable Rewards (Surprise & Delight)\nThese pages show the same content every visit — adding rotating tips, \"did you know\" facts, or spotlight features would create curiosity and repeat engagement:\n${STATIC_PAGES}\n**Psychology:** Variable ratio reinforcement (slot machine effect) keeps users coming back because they never know what they'll discover next.\n\n"
+          fi
+
+          # ── 2. Progress & Completion Loops ──
+          # Check if there are progress indicators, streaks, or completion
+          # tracking beyond basic onboarding.
+          HAS_STREAK=$(grep -rl "streak\|consecutive.*day\|login.*count\|daily.*reward\|visit.*count" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -1 || true)
+          HAS_PROGRESS_BEYOND_TOUR=$(grep -rlE "progress[Bb]ar|completionPercent|mastery|level[Uu]p|achievement|badge[s]?[Ee]arned|xp\b|experience.*point" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v "tour\|welcome\|getting-started\|onboard" | head -1 || true)
+          HAS_COMPLETION=$(grep -rl "checklist\|setup.*complete\|profile.*complete\|configuration.*score" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -1 || true)
+
+          PROGRESS_GAPS=""
+          if [ -z "$HAS_STREAK" ]; then
+            PROGRESS_GAPS="${PROGRESS_GAPS}  - **No streak/consistency tracking**: Users have no reason to return daily. A \"3-day streak\" badge or activity heatmap creates commitment loops.\n"
+          fi
+          if [ -z "$HAS_PROGRESS_BEYOND_TOUR" ]; then
+            PROGRESS_GAPS="${PROGRESS_GAPS}  - **No mastery/progression system**: Beyond onboarding, users have no sense of progression. A skills tree, exploration percentage, or feature mastery meter would drive deeper engagement.\n"
+          fi
+          if [ -z "$HAS_COMPLETION" ]; then
+            PROGRESS_GAPS="${PROGRESS_GAPS}  - **No setup completeness score**: Users don't know how much of the platform they've configured. A \"Your console is 60% set up\" prompt creates the Zeigarnik effect — the urge to complete unfinished tasks.\n"
+          fi
+          if [ -n "$PROGRESS_GAPS" ]; then
+            ISSUES="${ISSUES}### Missing Progress & Completion Loops\n${PROGRESS_GAPS}\n**Psychology:** The endowed progress effect and Zeigarnik effect drive users to complete sequences they've started. Instagram's activity status and GitHub's contribution graph use this.\n\n"
+          fi
+
+          # ── 3. Social Proof & Community Signals ──
+          # Check for community/social proof elements.
+          HAS_SOCIAL=$(grep -rlE "other.*users|popular|trending|most.*used|community|adopted.*by|used.*by.*teams|star[s]?.*count|fork[s]?.*count" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -1 || true)
+          HAS_ACTIVITY_FEED=$(grep -rlE "activity.*feed|recent.*activity|live.*feed|event.*stream|what.*others" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -1 || true)
+
+          SOCIAL_GAPS=""
+          if [ -z "$HAS_SOCIAL" ]; then
+            SOCIAL_GAPS="${SOCIAL_GAPS}  - **No social proof signals**: Show \"Used by N teams\" or \"Most popular card this week\" to validate user choices and drive feature discovery.\n"
+          fi
+          if [ -z "$HAS_ACTIVITY_FEED" ]; then
+            SOCIAL_GAPS="${SOCIAL_GAPS}  - **No activity feed**: A lightweight \"Recent activity\" or \"What's happening\" panel creates FOMO and shows the platform is alive.\n"
+          fi
+          if [ -n "$SOCIAL_GAPS" ]; then
+            ISSUES="${ISSUES}### Missing Social Proof & Community Signals\n${SOCIAL_GAPS}\n**Psychology:** Social proof (Cialdini) — people follow what others do. Reddit's upvotes, GitHub's stars, and LinkedIn's \"N people viewed your profile\" all leverage this.\n\n"
+          fi
+
+          # ── 4. Curiosity Gaps & Discovery Triggers ──
+          # Check for elements that tease undiscovered features.
+          HAS_TEASER=$(grep -rlE "unlock|discover|hidden|sneak.*peek|coming.*soon|preview|try.*new|new.*feature|beta.*badge|explore.*more|see.*what" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -3 || true)
+          HAS_EASTER_EGG=$(grep -rlE "easter.*egg|secret|konami|hidden.*feature|surprise.*mode" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -1 || true)
+
+          CURIOSITY_GAPS=""
+          if [ -z "$HAS_TEASER" ]; then
+            CURIOSITY_GAPS="${CURIOSITY_GAPS}  - **No feature teasers**: Partially revealed features (\"Unlock AI insights by connecting a cluster\") create information gaps that users feel compelled to close.\n"
+          fi
+          if [ -z "$HAS_EASTER_EGG" ]; then
+            CURIOSITY_GAPS="${CURIOSITY_GAPS}  - **No easter eggs or discovery moments**: Hidden features that users stumble upon create word-of-mouth sharing and delight. Even small ones (Konami code, hidden theme) build cult following.\n"
+          fi
+          if [ -n "$CURIOSITY_GAPS" ]; then
+            ISSUES="${ISSUES}### Missing Curiosity Gaps & Discovery Triggers\n${CURIOSITY_GAPS}\n**Psychology:** The information gap theory (Loewenstein) — curiosity is the gap between what we know and what we want to know. Facebook's notification badges and Reddit's \"N new comments\" exploit this.\n\n"
+          fi
+
+          # ── 5. Personalization & Investment ──
+          # Check if users can invest effort that makes the product
+          # more valuable to them over time (IKEA effect).
+          HAS_CUSTOMIZATION=$(grep -rlE "custom.*layout|user.*preference|personali[sz]|my.*dashboard|favorite|bookmark|pin|saved.*view" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -1 || true)
+          HAS_STORED_VALUE=$(grep -rlE "history|recent.*search|saved.*filter|custom.*card|user.*config|workspace" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -1 || true)
+
+          INVEST_GAPS=""
+          if [ -z "$HAS_CUSTOMIZATION" ]; then
+            INVEST_GAPS="${INVEST_GAPS}  - **No deep customization**: Users who invest effort customizing a tool feel ownership (IKEA effect) and are less likely to churn.\n"
+          fi
+          if [ -z "$HAS_STORED_VALUE" ]; then
+            INVEST_GAPS="${INVEST_GAPS}  - **No stored value accumulation**: Search history, saved filters, and custom views create switching costs. The more a user invests, the harder it is to leave.\n"
+          fi
+          if [ -n "$INVEST_GAPS" ]; then
+            ISSUES="${ISSUES}### Missing Investment & Stored Value\n${INVEST_GAPS}\n**Psychology:** The IKEA effect and sunk cost — users value things they've built. Pinterest boards, Spotify playlists, and Reddit karma all create investment that prevents churn.\n\n"
+          fi
+
+          # ── 6. Trigger & Notification Hooks ──
+          # Check for re-engagement triggers.
+          HAS_REENGAGEMENT=$(grep -rlE "notification|remind|alert.*config|digest|email.*pref|push.*notif|webhook.*user|come.*back" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -1 || true)
+          HAS_IDLE_PROMPT=$(grep -rlE "idle|inactive|welcome.*back|time.*since|last.*visit|miss.*you|catch.*up" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -1 || true)
+
+          TRIGGER_GAPS=""
+          if [ -z "$HAS_REENGAGEMENT" ]; then
+            TRIGGER_GAPS="${TRIGGER_GAPS}  - **No re-engagement triggers**: No notification preferences, digest settings, or alert configurations to bring users back.\n"
+          fi
+          if [ -z "$HAS_IDLE_PROMPT" ]; then
+            TRIGGER_GAPS="${TRIGGER_GAPS}  - **No welcome-back experience**: Users who return after absence see no acknowledgment or catch-up summary. A \"While you were away...\" panel drives re-engagement.\n"
+          fi
+          if [ -n "$TRIGGER_GAPS" ]; then
+            ISSUES="${ISSUES}### Missing Re-engagement Triggers\n${TRIGGER_GAPS}\n**Psychology:** Fogg's behavior model — behavior requires trigger + motivation + ability. External triggers (notifications, digests) bring users back; internal triggers form through habit loops.\n\n"
+          fi
+
+          # ── Emit results ──
+          if [ -n "$ISSUES" ]; then
+            # Count total suggestions
+            SUGGESTION_COUNT=$(echo -e "$ISSUES" | grep -c "^###" || echo "0")
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "count=$SUGGESTION_COUNT" >> "$GITHUB_OUTPUT"
+            printf "%b" "$ISSUES" > /tmp/focus-adoption-psychology.txt
+            echo "Found $SUGGESTION_COUNT adoption psychology opportunities"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No adoption psychology gaps detected — engagement patterns look solid"
+          fi
+
       # ── Ensure Labels Exist ────────────────────────────────────────
 
       - name: Ensure labels exist
@@ -3283,6 +3416,7 @@ jobs:
             "auto-qa:bundle-size:3B82F6:Bundle chunk size issues"
             "auto-qa:large-files:6B7280:Oversized source files"
             "auto-qa:import-cost:F59E0B:Import patterns that hurt tree-shaking"
+            "auto-qa:adoption:FF1493:Adoption & engagement psychology improvement"
           )
           for entry in "${LABELS[@]}"; do
             IFS=: read -r NAME COLOR DESC <<< "$entry"
@@ -3373,6 +3507,9 @@ jobs:
           FOCUS_ARIA_GAPS: ${{ steps.focus_aria_gaps.outputs.found }}
           FOCUS_MODAL_SAFETY: ${{ steps.focus_modal_safety.outputs.found }}
           FOCUS_EVENT_PARITY: ${{ steps.focus_event_parity.outputs.found }}
+          # Adoption psychology
+          FOCUS_ADOPTION: ${{ steps.focus_adoption_psychology.outputs.found }}
+          FOCUS_ADOPTION_COUNT: ${{ steps.focus_adoption_psychology.outputs.count }}
           # A11y focus
           FOCUS_COLOR_CONTRAST: ${{ steps.focus_color_contrast.outputs.found }}
           # Performance focus (additional)
@@ -4323,6 +4460,33 @@ jobs:
                    'Consider using actual <button> elements instead of divs',
                    'Ensure all interactive elements are keyboard accessible'], true),
                 labels: ['enhancement', 'ai-fix-requested', 'help wanted', 'auto-qa', 'triage/accepted', 'auto-qa:event-parity'],
+              });
+            }
+
+            // Adoption & Engagement Psychology (every run)
+            if (process.env.FOCUS_ADOPTION === 'true') {
+              const count = process.env.FOCUS_ADOPTION_COUNT || '?';
+              checks.push({
+                title: `${prefix} ${count} adoption & engagement psychology opportunities found`,
+                body: [
+                  `## Auto-QA [Adoption]: Engagement Psychology Audit`,
+                  '',
+                  `**Detected:** ${now} | **Focus:** Adoption Psychology | **Commit:** \`${sha}\` | **Run:** [View](${runUrl})`,
+                  '',
+                  readOutput('/tmp/focus-adoption-psychology.txt'),
+                  '',
+                  '### Implementation Guidance',
+                  '- Pick **one** suggestion and implement it as a small, self-contained UX improvement',
+                  '- Measure impact via GA4 events (add `ksc_` tracking for the new engagement feature)',
+                  '- Prefer lightweight implementations — a "did you know" tooltip is better than a full gamification system',
+                  '- Reference: Nir Eyal\'s Hook Model (Trigger → Action → Variable Reward → Investment)',
+                  ...(prGuidance ? ['', `> **PR Guidance:** ${prGuidance}`] : []),
+                  '',
+                  '---',
+                  `*This issue was automatically created by the [Auto-QA workflow](${runUrl}) during **Adoption Psychology** analysis.*`,
+                  '*Labels `help wanted` enable contributors to pick this up.*',
+                ].join('\n'),
+                labels: ['enhancement', 'help wanted', 'auto-qa', 'triage/accepted', 'auto-qa:adoption'],
               });
             }
 

--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -13,6 +13,7 @@ import { useModalState } from '../../lib/modals'
 import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
 import { AgentApprovalDialog, hasApprovedAgents } from './AgentApprovalDialog'
 import { MissionDetailView } from '../missions/MissionDetailView'
+import { ClusterSelectionDialog } from '../missions/ClusterSelectionDialog'
 
 interface AgentSelectorProps {
   compact?: boolean
@@ -21,7 +22,7 @@ interface AgentSelectorProps {
 
 export function AgentSelector({ compact = false, className = '' }: AgentSelectorProps) {
   const { t } = useTranslation()
-  const { agents, selectedAgent, agentsLoading, selectAgent, connectToAgent, startMission } = useMissions()
+  const { agents, selectedAgent, agentsLoading, selectAgent, connectToAgent, startMission, openSidebar } = useMissions()
   const { isDemoMode: isDemoModeHook } = useDemoMode()
   const { kagentAvailable, kagentiAvailable, selectedKagentAgent, selectedKagentiAgent } = useKagentBackend()
   // Synchronous fallback prevents flash during React transitions
@@ -39,6 +40,8 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
   const [installGuide, setInstallGuide] = useState<{ mission: MissionExport; raw: string } | null>(null)
   const [installGuideLoading, setInstallGuideLoading] = useState(false)
   const [installGuideShowRaw, setInstallGuideShowRaw] = useState(false)
+  // Cluster selection for AI install
+  const [pendingInstall, setPendingInstall] = useState<{ missionId: string; displayName: string; mission: MissionExport } | null>(null)
 
   // Merge local agents with in-cluster backends (kagent, kagenti)
   // Always show kagent/kagenti — when not installed, they appear with an install link
@@ -46,20 +49,20 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
     const local = agents.filter(a => a.available)
     const inCluster: AgentInfo[] = [
       {
-        name: 'kagent',
-        displayName: selectedKagentAgent ? `Kagent (${selectedKagentAgent.name})` : 'Kagent',
-        description: kagentAvailable ? 'In-cluster AI agent via kagent' : 'Install kagent for in-cluster AI agents',
-        provider: 'kagent',
-        available: kagentAvailable,
-        installMissionId: kagentAvailable ? undefined : 'install-kagent',
-      },
-      {
         name: 'kagenti',
         displayName: selectedKagentiAgent ? `Kagenti (${selectedKagentiAgent.name})` : 'Kagenti',
         description: kagentiAvailable ? 'In-cluster AI agent via kagenti' : 'Install kagenti for in-cluster AI agents',
         provider: 'kagenti',
         available: kagentiAvailable,
         installMissionId: kagentiAvailable ? undefined : 'install-kagenti',
+      },
+      {
+        name: 'kagent',
+        displayName: selectedKagentAgent ? `Kagent (${selectedKagentAgent.name})` : 'Kagent',
+        description: kagentAvailable ? 'In-cluster AI agent via kagent' : 'Install kagent for in-cluster AI agents',
+        provider: 'kagent',
+        available: kagentAvailable,
+        installMissionId: kagentAvailable ? undefined : 'install-kagent',
       },
     ]
     return [...local, ...inCluster]
@@ -105,15 +108,37 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
     setInstallGuideLoading(false)
   }, [closeDropdown])
 
-  const handleInstallMission = useCallback((missionId: string, displayName: string) => {
-    startMission({
-      title: `Install ${displayName}`,
-      description: `Install ${displayName} in the cluster using AI mission`,
-      type: 'deploy',
-      initialPrompt: `/mission/${missionId}`,
-    })
+  const handleInstallMission = useCallback(async (missionId: string, displayName: string) => {
     closeDropdown()
-  }, [startMission, closeDropdown])
+    // Fetch the actual mission content
+    const paths = INSTALL_MISSION_PATHS[missionId] || [`solutions/cncf-install/${missionId}.json`, `solutions/platform-install/${missionId}.json`]
+    let missionData: MissionExport | null = null
+    for (const path of paths) {
+      try {
+        const res = await fetch(`/api/missions/file?path=${encodeURIComponent(path)}`, { signal: AbortSignal.timeout(5000) })
+        if (!res.ok) continue
+        const raw = await res.text()
+        const parsed = JSON.parse(raw)
+        const nested = parsed.mission || {}
+        missionData = {
+          version: parsed.version || '1.0',
+          title: nested.title || parsed.title || displayName,
+          description: nested.description || parsed.description || `Install ${displayName}`,
+          type: 'deploy',
+          tags: nested.tags || parsed.tags || [],
+          steps: nested.steps || parsed.steps || [],
+        }
+        break
+      } catch { continue }
+    }
+    if (!missionData) {
+      // Fallback: start with simple prompt
+      startMission({ title: `Install ${displayName}`, description: `Install ${displayName} in the cluster`, type: 'deploy', initialPrompt: `Install ${displayName} in the cluster` })
+      return
+    }
+    // Show cluster selection dialog before running
+    setPendingInstall({ missionId, displayName, mission: missionData })
+  }, [closeDropdown, startMission])
 
   // Sort: selected agent first, then available agents, then unavailable
   const sortedAgents = useMemo(() => {
@@ -124,7 +149,9 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
       // Available before unavailable
       if (a.available && !b.available) return -1
       if (!a.available && b.available) return 1
-      // Alphabetical within same group
+      // Kagenti before kagent, then alphabetical
+      if (a.provider === 'kagenti' && b.provider === 'kagent') return -1
+      if (a.provider === 'kagent' && b.provider === 'kagenti') return 1
       return a.displayName.localeCompare(b.displayName)
     })
   }, [visibleAgents, selectedAgent])
@@ -451,6 +478,27 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
         </div>
       </div>,
       document.body
+    )}
+    {/* Cluster selection for AI install */}
+    {pendingInstall && (
+      <ClusterSelectionDialog
+        open
+        missionTitle={`Install ${pendingInstall.displayName}`}
+        onSelect={(clusters) => {
+          const m = pendingInstall.mission
+          const stepsText = (m.steps ?? []).map((s, i) => `${i + 1}. ${s.title}${s.description ? ': ' + s.description : ''}`).join('\n') || m.description
+          startMission({
+            title: `Install ${pendingInstall.displayName}`,
+            description: m.description,
+            type: 'deploy',
+            cluster: clusters.length > 0 ? clusters.join(',') : undefined,
+            initialPrompt: stepsText,
+          })
+          openSidebar()
+          setPendingInstall(null)
+        }}
+        onCancel={() => setPendingInstall(null)}
+      />
     )}
     </>
   )

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useState, useEffect, useCallback, useRef, useMemo, createContext, useContext, ComponentType, Suspense, lazy } from 'react'
 import { createPortal } from 'react-dom'
 import {
-  Maximize2, MoreVertical, Clock, Settings, Trash2, RefreshCw, MoveHorizontal, ChevronRight, ChevronDown, Info, Download, Link2, Bug, AlertTriangle,
+  Maximize2, MoreVertical, Clock, Settings, Trash2, RefreshCw, MoveHorizontal, ChevronRight, ChevronDown, Info, Download, Link2, Bug, AlertTriangle, Sparkles, X,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { CARD_TITLES, CARD_DESCRIPTIONS, DEMO_EXEMPT_CARDS } from './cardMetadata'
@@ -21,6 +21,11 @@ import { ChatMessage } from './CardChat'
 import { CardSkeleton, type CardSkeletonProps } from '../../lib/cards/CardComponents'
 import { isCardExportable } from '../../lib/widgets/widgetRegistry'
 import { emitCardExpanded, emitCardRefreshed } from '../../lib/analytics'
+import { useMissions } from '../../hooks/useMissions'
+import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { CARD_INSTALL_MAP } from '../../lib/cards/cardInstallMap'
+import { loadMissionPrompt } from '../cards/multi-tenancy/missionLoader'
+import { ClusterSelectionDialog } from '../missions/ClusterSelectionDialog'
 // Lazy-load the widget export modal (~42 KB + code generator ~30 KB) — only when user exports
 const WidgetExportModal = lazy(() =>
   import('../widgets/WidgetExportModal').then(m => ({ default: m.WidgetExportModal }))
@@ -331,8 +336,14 @@ export function CardWrapper({
   children,
 }: CardWrapperProps) {
   const { t } = useTranslation(['cards', 'common'])
+  const { startMission, openSidebar } = useMissions()
+  const { status: agentStatus } = useLocalAgent()
+  const isAgentConnected = agentStatus === 'connected'
   const [isExpanded, setIsExpanded] = useState(false)
   const [showBugReport, setShowBugReport] = useState(false)
+  const [showInstallClusterSelect, setShowInstallClusterSelect] = useState(false)
+  const [showInstallGuide, setShowInstallGuide] = useState<{ mission: { mission?: { title?: string; description?: string; steps?: { title?: string; description?: string }[] } } } | null>(null)
+  const installInfo = CARD_INSTALL_MAP[cardType]
 
   // Register expand trigger for keyboard navigation
   useEffect(() => {
@@ -1068,6 +1079,42 @@ export function CardWrapper({
                         </Suspense>
                       </DynamicCardErrorBoundary>
                     </div>
+                    {/* Demo CTA — install prompt for live data */}
+                    {showDemoIndicator && !shouldShowSkeleton && !DEMO_EXEMPT_CARDS.has(cardType) && (
+                      <div className="mt-auto pt-2 border-t border-yellow-500/10">
+                        <button
+                          onClick={async (e) => {
+                            e.stopPropagation()
+                            if (isAgentConnected && installInfo) {
+                              // Agent available: show cluster selector, then start AI mission
+                              setShowInstallClusterSelect(true)
+                            } else if (installInfo) {
+                              // No agent: try to load KB guide and show manual steps
+                              try {
+                                const resp = await fetch(`/console-kb/${installInfo.kbPaths[0]}`)
+                                if (resp.ok) {
+                                  const data = await resp.json()
+                                  setShowInstallGuide({ mission: data })
+                                }
+                              } catch { /* ignore fetch error */ }
+                            } else {
+                              // Generic fallback: start AI mission
+                              startMission({
+                                title: `Set up ${title} for live data`,
+                                description: `Install and configure the components needed for live data`,
+                                type: 'deploy',
+                                initialPrompt: `The user is viewing the "${title}" dashboard card which is currently showing demo data. Help them install and configure whatever is needed to get live data for this card.`,
+                              })
+                              openSidebar()
+                            }
+                          }}
+                          className="w-full flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs text-yellow-400/80 hover:text-yellow-300 hover:bg-yellow-500/10 rounded transition-colors"
+                        >
+                          <Sparkles className="w-3 h-3" />
+                          <span>Install {installInfo?.project ?? 'components'} for live data</span>
+                        </button>
+                      </div>
+                    )}
                   </>
                 ) : (
                   // Show skeleton during lazy mount (before IntersectionObserver fires)
@@ -1167,6 +1214,60 @@ export function CardWrapper({
                 cardType={cardType}
               />
             </Suspense>
+          )}
+
+          {/* Install CTA: cluster selection dialog (agent available) */}
+          {showInstallClusterSelect && installInfo && (
+            <ClusterSelectionDialog
+              open={showInstallClusterSelect}
+              onCancel={() => setShowInstallClusterSelect(false)}
+              onSelect={async (clusters) => {
+                setShowInstallClusterSelect(false)
+                const prompt = await loadMissionPrompt(
+                  installInfo.missionKey,
+                  `Install and configure ${installInfo.project} for live data on the "${title}" dashboard card.`,
+                  installInfo.kbPaths,
+                )
+                const clusterContext = clusters.length > 0
+                  ? `\n\n**Target cluster(s):** ${clusters.join(', ')}\n\nPlease install on ${clusters.length === 1 ? `cluster "${clusters[0]}"` : `the following clusters: ${clusters.join(', ')}`}.`
+                  : ''
+                startMission({
+                  title: `Install ${installInfo.project}`,
+                  description: `Install and configure ${installInfo.project}`,
+                  type: 'deploy',
+                  cluster: clusters.length > 0 ? clusters.join(',') : undefined,
+                  initialPrompt: prompt + clusterContext,
+                })
+                openSidebar()
+              }}
+              missionTitle={`Install ${installInfo.project}`}
+            />
+          )}
+
+          {/* Install CTA: manual guide modal (no agent) */}
+          {showInstallGuide && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setShowInstallGuide(null)}>
+              <div className="bg-card border border-border rounded-xl shadow-2xl max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto p-6" onClick={e => e.stopPropagation()}>
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="text-lg font-semibold">{showInstallGuide.mission.mission?.title ?? `Install ${installInfo?.project ?? 'Component'}`}</h3>
+                  <button onClick={() => setShowInstallGuide(null)} className="p-1 hover:bg-secondary rounded"><X className="w-4 h-4" /></button>
+                </div>
+                {showInstallGuide.mission.mission?.description && (
+                  <p className="text-sm text-muted-foreground mb-4">{showInstallGuide.mission.mission.description}</p>
+                )}
+                <ol className="space-y-4">
+                  {(showInstallGuide.mission.mission?.steps ?? []).map((step: { title?: string; description?: string }, i: number) => (
+                    <li key={i} className="flex gap-3">
+                      <span className="flex-shrink-0 w-6 h-6 rounded-full bg-purple-500/20 text-purple-400 text-xs flex items-center justify-center font-medium">{i + 1}</span>
+                      <div className="flex-1 min-w-0">
+                        {step.title && <p className="text-sm font-medium mb-1">{step.title}</p>}
+                        {step.description && <div className="text-sm text-muted-foreground whitespace-pre-wrap">{step.description}</div>}
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            </div>
           )}
 
           {/* Per-card bug/feature report modal */}

--- a/web/src/components/cards/ResourceCapacity.tsx
+++ b/web/src/components/cards/ResourceCapacity.tsx
@@ -135,7 +135,7 @@ export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
 
   // Build resource items list
   const resourceItems = useMemo(() => {
-    const formatBytes = (v: number) => v >= 1024 ? `${(v / 1024).toFixed(1)} TB` : `${Math.round(v)} GB`
+    const formatGB = (v: number) => v >= 1024 ? `${(v / 1024).toFixed(1)} TB` : `${Math.round(v)} GB`
 
     const items: ResourceItem[] = []
 
@@ -163,7 +163,7 @@ export function ResourceCapacity({ config: _config }: ResourceCapacityProps) {
         capacity: totals.memoryGB,
         unit: 'GB',
         color: 'purple',
-        format: formatBytes,
+        format: formatGB,
       })
     }
 

--- a/web/src/components/cards/ResourceTrend.tsx
+++ b/web/src/components/cards/ResourceTrend.tsx
@@ -300,12 +300,12 @@ export function ResourceTrend() {
           </div>
           <span className="text-sm font-bold text-foreground">{hasReachableClusters ? currentTotals.cpuCores : '-'}</span>
         </div>
-        <div className="p-2 rounded-lg bg-green-500/10 border border-green-500/20" title={hasReachableClusters ? `${currentTotals.memoryGB.toFixed(0)} GB memory total` : 'No reachable clusters'}>
+        <div className="p-2 rounded-lg bg-green-500/10 border border-green-500/20" title={hasReachableClusters ? `${currentTotals.memoryGB.toFixed(2)} GB memory total` : 'No reachable clusters'}>
           <div className="flex items-center gap-1 mb-1">
             <MemoryStick className="w-3 h-3 text-green-400" />
             <span className="text-xs text-green-400">Mem</span>
           </div>
-          <span className="text-sm font-bold text-foreground">{hasReachableClusters ? `${currentTotals.memoryGB.toFixed(0)}G` : '-'}</span>
+          <span className="text-sm font-bold text-foreground">{hasReachableClusters ? (currentTotals.memoryGB >= 1024 ? `${(currentTotals.memoryGB / 1024).toFixed(1)}T` : `${currentTotals.memoryGB.toFixed(0)}G`) : '-'}</span>
         </div>
         <div className="p-2 rounded-lg bg-purple-500/10 border border-purple-500/20" title={hasReachableClusters ? `${currentTotals.pods} pods running` : 'No reachable clusters'}>
           <div className="flex items-center gap-1 mb-1">

--- a/web/src/components/cards/multi-tenancy/missionLoader.ts
+++ b/web/src/components/cards/multi-tenancy/missionLoader.ts
@@ -12,7 +12,7 @@ import type { MissionExport } from '../../../lib/missions/types'
 /** Timeout for fetching a mission file from console-kb (ms) */
 const MISSION_FETCH_TIMEOUT_MS = 10_000
 
-/** Console-kb paths for missions */
+/** Console-kb paths for missions (legacy keys used by multi-tenancy cards) */
 export const MISSION_PATHS: Record<string, string> = {
   ovn: 'solutions/cncf-install/install-ovn-kubernetes.json',
   kubeflex: 'solutions/platform-install/platform-kubeflex.json',
@@ -27,13 +27,18 @@ export const MISSION_PATHS: Record<string, string> = {
  * expected by startMission(). Returns the mission steps as a formatted
  * prompt that the AI agent can follow.
  *
+ * Accepts either a componentKey (looked up in MISSION_PATHS) or a
+ * kbPaths array (tried in order) for direct path resolution.
+ *
  * Falls back to the raw text prompt if the fetch fails.
  */
 export async function loadMissionPrompt(
   componentKey: string,
   fallbackPrompt: string,
+  kbPaths?: string[],
 ): Promise<string> {
-  const path = MISSION_PATHS[componentKey]
+  // Try kbPaths first, then legacy MISSION_PATHS lookup
+  const path = kbPaths?.[0] ?? MISSION_PATHS[componentKey]
   if (!path) return fallbackPrompt
 
   try {

--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -13,6 +13,7 @@ import {
   type ClusterLayoutMode,
 } from './components'
 import { isClusterUnreachable, isClusterHealthy } from './utils'
+import { detectCloudProvider, getProviderLabel } from '../ui/CloudProviderIcon'
 import { useMissions } from '../../hooks/useMissions'
 import { useApiKeyCheck, ApiKeyPromptModal } from '../cards/console-missions/shared'
 import { loadMissionPrompt } from '../cards/multi-tenancy/missionLoader'
@@ -27,10 +28,11 @@ import { usePermissions } from '../../hooks/usePermissions'
 import { ClusterCardSkeleton } from '../ui/ClusterCardSkeleton'
 import { useIsModeSwitching } from '../../lib/unified/demo'
 import { useTranslation } from 'react-i18next'
-import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_CLUSTER_LAYOUT, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_CLUSTER_LAYOUT, STORAGE_KEY_CLUSTER_ORDER, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
 import { useModalState } from '../../lib/modals'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
 import type { StatBlockValue } from '../ui/StatsOverview'
+import { formatMemoryStat } from '../../lib/formatStats'
 
 // Storage key for cluster page cards
 const CLUSTERS_CARDS_KEY = 'kubestellar-clusters-cards'
@@ -92,8 +94,18 @@ export function Clusters() {
     }
     setSearchParams(searchParams, { replace: true })
   }, [searchParams, setSearchParams])
-  const [sortBy, setSortBy] = useState<'name' | 'nodes' | 'pods' | 'health'>('name')
+  const [sortBy, setSortBy] = useState<'name' | 'nodes' | 'pods' | 'health' | 'provider' | 'custom'>(() => {
+    // Default to custom if user has a saved order
+    const savedOrder = localStorage.getItem(STORAGE_KEY_CLUSTER_ORDER)
+    return savedOrder ? 'custom' : 'name'
+  })
   const [sortAsc, setSortAsc] = useState(true)
+  const [customOrder, setCustomOrder] = useState<string[]>(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY_CLUSTER_ORDER)
+      return saved ? JSON.parse(saved) : []
+    } catch { return [] }
+  })
   const [layoutMode, setLayoutMode] = useState<ClusterLayoutMode>(() => {
     const stored = localStorage.getItem(STORAGE_KEY_CLUSTER_LAYOUT)
     return (stored as ClusterLayoutMode) || 'grid'
@@ -129,6 +141,12 @@ export function Clusters() {
     refetch()
   }
 
+  const handleReorder = useCallback((newOrder: string[]) => {
+    setCustomOrder(newOrder)
+    setSortBy('custom')
+    localStorage.setItem(STORAGE_KEY_CLUSTER_ORDER, JSON.stringify(newOrder))
+  }, [])
+
   const filteredClusters = useMemo(() => {
     let result = clusters || []
 
@@ -158,30 +176,50 @@ export function Clusters() {
     }
 
     // Sort
-    result = [...result].sort((a, b) => {
-      let cmp = 0
-      switch (sortBy) {
-        case 'name':
-          cmp = a.name.localeCompare(b.name)
-          break
-        case 'nodes':
-          cmp = (a.nodeCount || 0) - (b.nodeCount || 0)
-          break
-        case 'pods':
-          cmp = (a.podCount || 0) - (b.podCount || 0)
-          break
-        case 'health': {
-          const aHealth = isClusterUnreachable(a) ? 0 : isClusterHealthy(a) ? 2 : 1
-          const bHealth = isClusterUnreachable(b) ? 0 : isClusterHealthy(b) ? 2 : 1
-          cmp = aHealth - bHealth
-          break
+    if (sortBy === 'custom' && customOrder.length > 0) {
+      // Use custom order: items in customOrder come first in that order,
+      // items not in customOrder are appended alphabetically
+      const orderMap = new Map(customOrder.map((name, i) => [name, i]))
+      result = [...result].sort((a, b) => {
+        const aIdx = orderMap.get(a.name)
+        const bIdx = orderMap.get(b.name)
+        if (aIdx !== undefined && bIdx !== undefined) return aIdx - bIdx
+        if (aIdx !== undefined) return -1
+        if (bIdx !== undefined) return 1
+        return a.name.localeCompare(b.name)
+      })
+    } else {
+      result = [...result].sort((a, b) => {
+        let cmp = 0
+        switch (sortBy) {
+          case 'name':
+            cmp = a.name.localeCompare(b.name)
+            break
+          case 'nodes':
+            cmp = (a.nodeCount || 0) - (b.nodeCount || 0)
+            break
+          case 'pods':
+            cmp = (a.podCount || 0) - (b.podCount || 0)
+            break
+          case 'health': {
+            const aHealth = isClusterUnreachable(a) ? 0 : isClusterHealthy(a) ? 2 : 1
+            const bHealth = isClusterUnreachable(b) ? 0 : isClusterHealthy(b) ? 2 : 1
+            cmp = aHealth - bHealth
+            break
+          }
+          case 'provider': {
+            const aProvider = getProviderLabel((a.distribution as ReturnType<typeof detectCloudProvider>) || detectCloudProvider(a.name, a.server, a.namespaces, a.user))
+            const bProvider = getProviderLabel((b.distribution as ReturnType<typeof detectCloudProvider>) || detectCloudProvider(b.name, b.server, b.namespaces, b.user))
+            cmp = aProvider.localeCompare(bProvider)
+            break
+          }
         }
-      }
-      return sortAsc ? cmp : -cmp
-    })
+        return sortAsc ? cmp : -cmp
+      })
+    }
 
     return result
-  }, [clusters, filter, globalSelectedClusters, isAllClustersSelected, customFilter, sortBy, sortAsc])
+  }, [clusters, filter, globalSelectedClusters, isAllClustersSelected, customFilter, sortBy, sortAsc, customOrder])
 
   // Get GPU count per cluster
   const gpuByCluster = useMemo(() => {
@@ -191,8 +229,8 @@ export function Clusters() {
       if (!map[clusterKey]) {
         map[clusterKey] = { total: 0, allocated: 0 }
       }
-      map[clusterKey].total += node.gpuCount
-      map[clusterKey].allocated += node.gpuAllocated
+      map[clusterKey].total += node.gpuCount || 0
+      map[clusterKey].allocated += node.gpuAllocated || 0
     })
     return map
   }, [gpuNodes])
@@ -319,14 +357,16 @@ export function Clusters() {
         }
       case 'memory':
         return {
-          value: hasData ? `${Math.round(stats.totalMemoryGB)} GB` : '-',
+          value: hasData ? stats.totalMemoryGB : '-',
+          format: (v: number) => formatMemoryStat(v),
           sublabel: 'allocatable',
           onClick: () => { emitClusterStatsDrillDown('memory'); window.location.href = '/compute' },
           isClickable: hasData,
         }
       case 'storage':
         return {
-          value: hasData ? `${Math.round(stats.totalStorageGB)} GB` : '-',
+          value: hasData ? stats.totalStorageGB : '-',
+          format: (v: number) => formatMemoryStat(v),
           sublabel: 'storage',
           onClick: () => { emitClusterStatsDrillDown('storage'); window.location.href = '/storage' },
           isClickable: hasData,
@@ -430,6 +470,7 @@ export function Clusters() {
                   setLayoutMode(mode)
                   localStorage.setItem(STORAGE_KEY_CLUSTER_LAYOUT, mode)
                 }}
+                onAddCluster={() => setShowAddCluster(true)}
               />
               {filteredClusters.length === 0 && !isLoading && !showSkeletonContent ? (
                 <EmptyClusterState onAddCluster={() => setShowAddCluster(true)} />
@@ -444,6 +485,7 @@ export function Clusters() {
                   onSelectCluster={setSelectedCluster}
                   onRenameCluster={setRenamingCluster}
                   onRefreshCluster={refreshSingleCluster}
+                  onReorder={handleReorder}
                 />
               )}
             </>
@@ -603,15 +645,6 @@ export function Clusters() {
       lastUpdated={lastUpdated}
       hasData={stats.hasResourceData || stats.total > 0}
       beforeCards={beforeCardsContent}
-      rightExtra={
-        <button
-          onClick={() => setShowAddCluster(true)}
-          className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-purple-600 hover:bg-purple-500 text-white transition-colors"
-        >
-          <Plus className="w-4 h-4" />
-          {t('cluster.addCluster')}
-        </button>
-      }
       emptyState={{
         title: 'Cluster Dashboard',
         description: 'Add cards to monitor cluster health, resource usage, and workload status.',

--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -1,5 +1,23 @@
-import { memo, useState, useEffect, useRef } from 'react'
-import { Pencil, Globe, User, ShieldAlert, ChevronRight, Star, WifiOff, RefreshCw, ExternalLink, AlertCircle, Cpu, Box, Server, KeyRound, Copy, Check } from 'lucide-react'
+import { memo, useState, useEffect, useRef, useCallback } from 'react'
+import { Pencil, Globe, User, ShieldAlert, ChevronRight, Star, WifiOff, RefreshCw, ExternalLink, AlertCircle, Cpu, Box, Server, KeyRound, Copy, Check, GripVertical } from 'lucide-react'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  rectSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { FlashingValue } from '../../ui/FlashingValue'
 import { ClusterInfo } from '../../../hooks/useMCP'
 import { StatusIndicator } from '../../charts/StatusIndicator'
@@ -120,6 +138,7 @@ interface ClusterGridProps {
   onSelectCluster: (clusterName: string) => void
   onRenameCluster: (clusterName: string) => void
   onRefreshCluster?: (clusterName: string) => void
+  onReorder?: (clusterNames: string[]) => void
   layoutMode?: ClusterLayoutMode
 }
 
@@ -133,6 +152,7 @@ interface ClusterCardProps {
   onSelectCluster: () => void
   onRenameCluster: () => void
   onRefreshCluster?: () => void
+  dragHandle?: React.ReactNode
   layoutMode: ClusterLayoutMode
 }
 
@@ -146,6 +166,7 @@ const FullClusterCard = memo(function FullClusterCard({
   onSelectCluster,
   onRenameCluster,
   onRefreshCluster,
+  dragHandle,
 }: Omit<ClusterCardProps, 'layoutMode'>) {
   const { t } = useTranslation()
   const loading = isClusterLoading(cluster)
@@ -165,7 +186,7 @@ const FullClusterCard = memo(function FullClusterCard({
   return (
     <div
       onClick={onSelectCluster}
-      className="relative p-[1px] rounded-lg cursor-pointer transition-all hover:scale-[1.02] overflow-hidden"
+      className="relative p-[1px] rounded-lg cursor-pointer transition-all hover:scale-[1.02] overflow-hidden h-full"
       style={{
         /* Card view: prominent gradient — provider at 50%, theme at 38% */
         background: `linear-gradient(135deg, color-mix(in srgb, ${providerColor} 50%, transparent) 0%, color-mix(in srgb, ${themeColor} 38%, transparent) 100%)`,
@@ -185,6 +206,7 @@ const FullClusterCard = memo(function FullClusterCard({
         </div>
         <div className="flex items-start justify-between mb-4 relative z-10">
           <div className="flex items-center gap-3">
+            {dragHandle}
             {/* Status indicator with refresh button below */}
             <div className="flex flex-col items-center gap-2 flex-shrink-0">
               {initialLoading ? (
@@ -370,6 +392,7 @@ const ListClusterCard = memo(function ListClusterCard({
   isClusterAdmin,
   onSelectCluster,
   onRefreshCluster,
+  dragHandle,
 }: Omit<ClusterCardProps, 'layoutMode' | 'isConnected' | 'onRenameCluster'>) {
   const { t } = useTranslation()
   const loading = isClusterLoading(cluster)
@@ -406,6 +429,7 @@ const ListClusterCard = memo(function ListClusterCard({
           <CloudProviderIcon provider={provider} size={64} />
         </div>
         <div className="flex items-center gap-4">
+          {dragHandle}
           {/* Status indicator */}
           <div className="flex-shrink-0">
             {initialLoading ? (
@@ -546,6 +570,7 @@ const CompactClusterCard = memo(function CompactClusterCard({
   cluster,
   gpuInfo,
   onSelectCluster,
+  dragHandle,
 }: Omit<ClusterCardProps, 'layoutMode' | 'isConnected' | 'permissionsLoading' | 'isClusterAdmin' | 'onRenameCluster' | 'onRefreshCluster'>) {
   const { t } = useTranslation()
   const unreachable = isClusterUnreachable(cluster)
@@ -569,6 +594,7 @@ const CompactClusterCard = memo(function CompactClusterCard({
       <div className="relative glass p-3 rounded-lg h-full overflow-hidden">
         {/* Header */}
         <div className="flex items-center gap-2 mb-2">
+          {dragHandle}
           {isTokenExpired(cluster) ? (
             <span title="Token Expired"><KeyRound className="w-3 h-3 text-red-400" /></span>
           ) : unreachable ? (
@@ -632,6 +658,43 @@ const CompactClusterCard = memo(function CompactClusterCard({
   )
 })
 
+// Sortable wrapper for individual cluster items
+function SortableClusterItem({ id, children, onReorder }: { id: string; children: (dragHandle: React.ReactNode) => React.ReactNode; onReorder?: (names: string[]) => void }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    position: 'relative' as const,
+    zIndex: isDragging ? 10 : undefined,
+  }
+
+  const dragHandle = onReorder ? (
+    <button
+      {...attributes}
+      {...listeners}
+      className="p-0.5 rounded hover:bg-secondary/80 cursor-grab active:cursor-grabbing flex-shrink-0 touch-none"
+      title="Drag to reorder"
+    >
+      <GripVertical className="w-3.5 h-3.5 text-muted-foreground/50" />
+    </button>
+  ) : null
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      {children(dragHandle)}
+    </div>
+  )
+}
+
 export const ClusterGrid = memo(function ClusterGrid({
   clusters,
   gpuByCluster,
@@ -641,9 +704,25 @@ export const ClusterGrid = memo(function ClusterGrid({
   onSelectCluster,
   onRenameCluster,
   onRefreshCluster,
+  onReorder,
   layoutMode = 'grid',
 }: ClusterGridProps) {
   const { t } = useTranslation()
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id || !onReorder) return
+    const oldIndex = clusters.findIndex(c => c.name === active.id)
+    const newIndex = clusters.findIndex(c => c.name === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+    const reordered = arrayMove(clusters, oldIndex, newIndex)
+    onReorder(reordered.map(c => c.name))
+  }, [clusters, onReorder])
 
   if (clusters.length === 0) {
     return (
@@ -661,53 +740,66 @@ export const ClusterGrid = memo(function ClusterGrid({
     wide: 'grid grid-cols-1 lg:grid-cols-2 gap-4',
   }
 
+  const sortingStrategy = layoutMode === 'list' ? verticalListSortingStrategy : rectSortingStrategy
+  const clusterIds = clusters.map(c => c.name)
+
   return (
-    <div className={`${gridClasses[layoutMode]} mb-6`}>
-      {clusters.map((cluster) => {
-        const clusterKey = cluster.name.split('/')[0]
-        const gpuInfo = gpuByCluster[clusterKey] || gpuByCluster[cluster.name]
-        const clusterIsAdmin = isClusterAdmin(cluster.name)
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={clusterIds} strategy={sortingStrategy}>
+        <div className={`${gridClasses[layoutMode]} mb-6`}>
+          {clusters.map((cluster) => {
+            const clusterKey = cluster.name.split('/')[0]
+            const gpuInfo = gpuByCluster[clusterKey] || gpuByCluster[cluster.name]
+            const clusterIsAdmin = isClusterAdmin(cluster.name)
 
-        if (layoutMode === 'list') {
-          return (
-            <ListClusterCard
-              key={cluster.name}
-              cluster={cluster}
-              gpuInfo={gpuInfo}
-              permissionsLoading={permissionsLoading}
-              isClusterAdmin={clusterIsAdmin}
-              onSelectCluster={() => onSelectCluster(cluster.name)}
-              onRefreshCluster={onRefreshCluster ? () => onRefreshCluster(cluster.name) : undefined}
-            />
-          )
-        }
+            return (
+              <SortableClusterItem key={cluster.name} id={cluster.name} onReorder={onReorder}>
+                {(dragHandle) => {
+                  if (layoutMode === 'list') {
+                    return (
+                      <ListClusterCard
+                        cluster={cluster}
+                        gpuInfo={gpuInfo}
+                        permissionsLoading={permissionsLoading}
+                        isClusterAdmin={clusterIsAdmin}
+                        onSelectCluster={() => onSelectCluster(cluster.name)}
+                        onRefreshCluster={onRefreshCluster ? () => onRefreshCluster(cluster.name) : undefined}
+                        dragHandle={dragHandle}
+                      />
+                    )
+                  }
 
-        if (layoutMode === 'compact') {
-          return (
-            <CompactClusterCard
-              key={cluster.name}
-              cluster={cluster}
-              gpuInfo={gpuInfo}
-              onSelectCluster={() => onSelectCluster(cluster.name)}
-            />
-          )
-        }
+                  if (layoutMode === 'compact') {
+                    return (
+                      <CompactClusterCard
+                        cluster={cluster}
+                        gpuInfo={gpuInfo}
+                        onSelectCluster={() => onSelectCluster(cluster.name)}
+                        dragHandle={dragHandle}
+                      />
+                    )
+                  }
 
-        // grid and wide use the full card
-        return (
-          <FullClusterCard
-            key={cluster.name}
-            cluster={cluster}
-            gpuInfo={gpuInfo}
-            isConnected={isConnected}
-            permissionsLoading={permissionsLoading}
-            isClusterAdmin={clusterIsAdmin}
-            onSelectCluster={() => onSelectCluster(cluster.name)}
-            onRenameCluster={() => onRenameCluster(cluster.name)}
-            onRefreshCluster={onRefreshCluster ? () => onRefreshCluster(cluster.name) : undefined}
-          />
-        )
-      })}
-    </div>
+                  // grid and wide use the full card
+                  return (
+                    <FullClusterCard
+                      cluster={cluster}
+                      gpuInfo={gpuInfo}
+                      isConnected={isConnected}
+                      permissionsLoading={permissionsLoading}
+                      isClusterAdmin={clusterIsAdmin}
+                      onSelectCluster={() => onSelectCluster(cluster.name)}
+                      onRenameCluster={() => onRenameCluster(cluster.name)}
+                      onRefreshCluster={onRefreshCluster ? () => onRefreshCluster(cluster.name) : undefined}
+                      dragHandle={dragHandle}
+                    />
+                  )
+                }}
+              </SortableClusterItem>
+            )
+          })}
+        </div>
+      </SortableContext>
+    </DndContext>
   )
 })

--- a/web/src/components/clusters/components/FilterTabs.tsx
+++ b/web/src/components/clusters/components/FilterTabs.tsx
@@ -1,10 +1,10 @@
-import { WifiOff, SortAsc, SortDesc, LayoutGrid, List, Grid3X3, Columns } from 'lucide-react'
+import { WifiOff, SortAsc, SortDesc, LayoutGrid, List, Grid3X3, Columns, Plus } from 'lucide-react'
 import { ClusterStats } from './StatsOverview'
 import { ClusterLayoutMode } from './ClusterGrid'
 import { useTranslation } from 'react-i18next'
 
 export type FilterType = 'all' | 'healthy' | 'unhealthy' | 'unreachable'
-export type SortByType = 'name' | 'nodes' | 'pods' | 'health'
+export type SortByType = 'name' | 'nodes' | 'pods' | 'health' | 'provider' | 'custom'
 
 interface FilterTabsProps {
   stats: ClusterStats
@@ -16,6 +16,7 @@ interface FilterTabsProps {
   onSortAscChange: (asc: boolean) => void
   layoutMode?: ClusterLayoutMode
   onLayoutModeChange?: (mode: ClusterLayoutMode) => void
+  onAddCluster?: () => void
 }
 
 const LAYOUT_OPTIONS: { mode: ClusterLayoutMode; icon: typeof LayoutGrid; label: string }[] = [
@@ -35,6 +36,7 @@ export function FilterTabs({
   onSortAscChange,
   layoutMode = 'grid',
   onLayoutModeChange,
+  onAddCluster,
 }: FilterTabsProps) {
   const { t } = useTranslation()
   return (
@@ -82,8 +84,18 @@ export function FilterTabs({
         Offline ({stats.unreachable})
       </button>
 
-      {/* Sort and Layout selectors */}
+      {/* Add Cluster, Layout, and Sort */}
       <div className="ml-auto flex items-center gap-3">
+        {/* Add Cluster */}
+        {onAddCluster && (
+          <button
+            onClick={onAddCluster}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            Add Cluster
+          </button>
+        )}
         {/* Layout mode selector */}
         {onLayoutModeChange && (
           <div className="flex items-center gap-1 border-r border-border pr-3">
@@ -112,10 +124,12 @@ export function FilterTabs({
             onChange={(e) => onSortByChange(e.target.value as SortByType)}
             className="px-2 py-1.5 rounded-lg text-sm bg-card/50 border border-border text-foreground"
           >
+            <option value="custom">Custom</option>
             <option value="name">{t('common.name')}</option>
             <option value="nodes">{t('common.nodes')}</option>
             <option value="pods">{t('common.pods')}</option>
             <option value="health">Health</option>
+            <option value="provider">Provider</option>
           </select>
           <button
             onClick={() => onSortAscChange(!sortAsc)}
@@ -125,6 +139,7 @@ export function FilterTabs({
             {sortAsc ? <SortAsc className="w-4 h-4" /> : <SortDesc className="w-4 h-4" />}
           </button>
         </div>
+
       </div>
     </div>
   )

--- a/web/src/components/cost/Cost.tsx
+++ b/web/src/components/cost/Cost.tsx
@@ -11,9 +11,9 @@ import { getDefaultCards } from '../../config/dashboards'
 import { useTranslation } from 'react-i18next'
 import { TICK_INTERVAL_MS } from '../../lib/constants/network'
 import { safeGetJSON } from '../../lib/utils/localStorage'
+import { formatMemoryStat } from '../../lib/formatStats'
 
 /** GiB per TiB — used for storage unit display in cost blocks */
-const GB_PER_TB = 1_024
 
 const COST_CARDS_KEY = 'kubestellar-cost-cards'
 
@@ -149,9 +149,9 @@ export function Cost() {
       case 'cpu_cost':
         return { value: `$${Math.round(costStats.cpuMonthly).toLocaleString()}`, sublabel: `${costStats.totalCPU} cores`, onClick: () => drillToCostType('cpu'), isClickable: costStats.cpuMonthly > 0 }
       case 'memory_cost':
-        return { value: `$${Math.round(costStats.memoryMonthly).toLocaleString()}`, sublabel: `${costStats.totalMemoryGB} GB`, onClick: () => drillToCostType('memory'), isClickable: costStats.memoryMonthly > 0 }
+        return { value: `$${Math.round(costStats.memoryMonthly).toLocaleString()}`, sublabel: formatMemoryStat(costStats.totalMemoryGB), onClick: () => drillToCostType('memory'), isClickable: costStats.memoryMonthly > 0 }
       case 'storage_cost':
-        return { value: `$${Math.round(costStats.storageMonthly).toLocaleString()}`, sublabel: costStats.totalStorageGB >= GB_PER_TB ? `${(costStats.totalStorageGB / GB_PER_TB).toFixed(1)} TB` : `${Math.round(costStats.totalStorageGB)} GB`, onClick: () => drillToCostType('storage'), isClickable: costStats.storageMonthly > 0 }
+        return { value: `$${Math.round(costStats.storageMonthly).toLocaleString()}`, sublabel: formatMemoryStat(costStats.totalStorageGB), onClick: () => drillToCostType('storage'), isClickable: costStats.storageMonthly > 0 }
       case 'network_cost':
         return { value: '$0', sublabel: 'not tracked', isClickable: false }
       case 'gpu_cost':

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback, lazy, Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
 import { NavLink, useNavigate, useLocation } from 'react-router-dom'
-import { Plus, ChevronLeft, ChevronRight, CheckCircle2, AlertTriangle, WifiOff, GripVertical, X, User } from 'lucide-react'
+import { Plus, ChevronLeft, ChevronRight, CheckCircle2, AlertTriangle, WifiOff, GripVertical, X, User, Pin, PinOff } from 'lucide-react'
 import { iconRegistry } from '../../lib/icons'
 import { cn } from '../../lib/cn'
 import { SnoozedCards } from './SnoozedCards'
@@ -14,6 +14,7 @@ import type { SnoozedSwap } from '../../hooks/useSnoozedCards'
 import type { SnoozedRecommendation } from '../../hooks/useSnoozedRecommendations'
 import type { SnoozedMission } from '../../hooks/useSnoozedMissions'
 import { useActiveUsers } from '../../hooks/useActiveUsers'
+import { useMissions } from '../../hooks/useMissions'
 import { ROUTES } from '../../config/routes'
 import { DASHBOARD_CONFIGS } from '../../config/dashboards/index'
 import { emitSidebarNavigated, emitDashboardRenamed } from '../../lib/analytics'
@@ -44,10 +45,11 @@ const HREF_TO_DASHBOARD_ID: Record<string, string> = {
 }
 
 export function Sidebar() {
-  const { config, toggleCollapsed, reorderItems, updateItem, removeItem, closeMobileSidebar, setWidth } = useSidebarConfig()
+  const { config, toggleCollapsed, setCollapsed, reorderItems, updateItem, removeItem, closeMobileSidebar, setWidth } = useSidebarConfig()
   const { isMobile } = useMobile()
   const { deduplicatedClusters } = useClusters()
   const dashboardContext = useDashboardContextOptional()
+  const { isFullScreen: isMissionFullScreen } = useMissions()
   const { viewerCount, hasError: viewersError } = useActiveUsers()
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -59,6 +61,51 @@ export function Sidebar() {
       closeMobileSidebar()
     }
   }, [location.pathname, isMobile, closeMobileSidebar])
+
+  // Auto-hide: collapse sidebar when mouse leaves, expand on hover
+  const SIDEBAR_AUTO_HIDE_MS = 2000
+  const [isPinned, setIsPinned] = useState(() => {
+    try { return localStorage.getItem('sidebar-left-pinned') !== 'false' } catch { return true }
+  })
+  const autoHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearAutoHideTimer = useCallback(() => {
+    if (autoHideTimerRef.current) {
+      clearTimeout(autoHideTimerRef.current)
+      autoHideTimerRef.current = null
+    }
+  }, [])
+
+  const handleSidebarMouseEnter = useCallback(() => {
+    clearAutoHideTimer()
+    if (!isPinned && config.collapsed && !isMobile) {
+      setCollapsed(false)
+    }
+  }, [clearAutoHideTimer, isPinned, config.collapsed, isMobile, setCollapsed])
+
+  const handleSidebarMouseLeave = useCallback(() => {
+    if (!isPinned && !isMobile) {
+      clearAutoHideTimer()
+      autoHideTimerRef.current = setTimeout(() => {
+        setCollapsed(true)
+      }, SIDEBAR_AUTO_HIDE_MS)
+    }
+  }, [isPinned, isMobile, clearAutoHideTimer, setCollapsed])
+
+  const toggleSidebarPin = useCallback(() => {
+    setIsPinned(prev => {
+      const next = !prev
+      try { localStorage.setItem('sidebar-left-pinned', String(next)) } catch { /* ignore */ }
+      if (next) clearAutoHideTimer()
+      else if (!config.collapsed) {
+        // Start auto-hide when unpinning
+        autoHideTimerRef.current = setTimeout(() => setCollapsed(true), SIDEBAR_AUTO_HIDE_MS)
+      }
+      return next
+    })
+  }, [clearAutoHideTimer, config.collapsed, setCollapsed])
+
+  useEffect(() => () => clearAutoHideTimer(), [clearAutoHideTimer])
 
   // On mobile, always show expanded view; on desktop, respect collapsed state
   const isCollapsed = !isMobile && config.collapsed
@@ -371,6 +418,8 @@ export function Sidebar() {
       <aside
         data-testid="sidebar"
         data-tour="sidebar"
+        onMouseEnter={handleSidebarMouseEnter}
+        onMouseLeave={handleSidebarMouseLeave}
         className={cn(
           'fixed left-0 top-16 bottom-0 glass border-r border-border/50 overflow-y-auto scroll-enhanced z-40',
           !isResizing && 'transition-all duration-300',
@@ -382,15 +431,6 @@ export function Sidebar() {
           isMobile && config.isMobileOpen && 'translate-x-0'
         )}
         style={{ width: isMobile ? SIDEBAR_DEFAULT_WIDTH_PX : sidebarWidth }}>
-        {/* Collapse toggle - hidden on mobile */}
-        <button
-          data-testid="sidebar-collapse-toggle"
-          onClick={toggleCollapsed}
-          aria-expanded={!config.collapsed}
-          className="sticky top-2 float-right -mr-4 mb-4 p-1 rounded-full bg-secondary border border-border text-muted-foreground hover:text-foreground z-10 hidden md:block shadow-md"
-        >
-          {config.collapsed ? <ChevronRight className="w-4 h-4" aria-hidden="true" /> : <ChevronLeft className="w-4 h-4" aria-hidden="true" />}
-        </button>
 
         {/* Primary navigation */}
         <nav data-testid="sidebar-primary-nav" className="space-y-1">
@@ -484,7 +524,7 @@ export function Sidebar() {
 
         {/* Viewer count */}
         {!isCollapsed && (
-          <div className="mt-4 flex items-center justify-end">
+          <div className="mt-auto pt-4 flex items-center justify-center">
             <div
               className="flex items-center gap-1 px-2 text-muted-foreground/60"
               title={t('sidebar.activeViewers', { count: viewerCount })}
@@ -498,15 +538,57 @@ export function Sidebar() {
         )}
       </aside>
 
-      {/* Resize handle - drag to adjust sidebar width */}
+      {/* Collapse + Pin controls — top-right of sidebar, above resize handle */}
+      {!isMobile && !isMissionFullScreen && (
+        <div
+          className="fixed top-[4.5rem] z-[51] flex flex-col gap-1.5 items-center"
+          style={{ left: sidebarWidth - 18 }}
+        >
+          <button
+            data-testid="sidebar-collapse-toggle"
+            onClick={() => {
+              if (config.collapsed) {
+                // Expanding: also pin so it stays open
+                setCollapsed(false)
+                if (!isPinned) {
+                  setIsPinned(true)
+                  try { localStorage.setItem('sidebar-left-pinned', 'true') } catch { /* ignore */ }
+                  clearAutoHideTimer()
+                }
+              } else {
+                toggleCollapsed()
+              }
+            }}
+            aria-expanded={!config.collapsed}
+            className="p-1.5 rounded-full bg-background border border-border text-muted-foreground hover:text-foreground hover:bg-secondary shadow-md transition-colors"
+            title={config.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          >
+            {config.collapsed ? <ChevronRight className="w-3.5 h-3.5" aria-hidden="true" /> : <ChevronLeft className="w-3.5 h-3.5" aria-hidden="true" />}
+          </button>
+          <button
+            onClick={toggleSidebarPin}
+            className={cn(
+              "p-1.5 rounded-full border border-border shadow-md transition-colors",
+              isPinned
+                ? "bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 border-purple-500/30"
+                : "bg-background text-muted-foreground/50 hover:text-muted-foreground hover:bg-secondary"
+            )}
+            title={isPinned ? 'Unpin sidebar (auto-collapse on mouse leave)' : 'Pin sidebar open'}
+          >
+            {isPinned ? <Pin className="w-3.5 h-3.5" /> : <PinOff className="w-3.5 h-3.5" />}
+          </button>
+        </div>
+      )}
+
+      {/* Resize handle - drag to adjust sidebar width, starts below pin/collapse buttons */}
       {!isCollapsed && !isMobile && (
         <div
           onMouseDown={handleResizeStart}
           className={cn(
-            "fixed top-16 bottom-0 cursor-col-resize z-50 hover:bg-purple-500/30 transition-colors",
+            "fixed bottom-0 cursor-col-resize z-50 hover:bg-purple-500/30 transition-colors",
             isResizing && "bg-purple-500/50"
           )}
-          style={{ left: sidebarWidth - 3, width: 6 }}
+          style={{ top: 160, left: sidebarWidth - 3, width: 6 }}
         />
       )}
 

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -22,12 +22,10 @@ import {
 import { useMissions, type Mission } from '../../../hooks/useMissions'
 import { useDemoMode } from '../../../hooks/useDemoMode'
 import { isNetlifyDeployment } from '../../../lib/demoMode'
-import { useResolutions, detectIssueSignature, type Resolution } from '../../../hooks/useResolutions'
+import { useResolutions, detectIssueSignature } from '../../../hooks/useResolutions'
 import { cn } from '../../../lib/cn'
 import { MAX_MESSAGE_SIZE_CHARS } from '../../../lib/constants'
 import { AgentBadge, AgentIcon } from '../../agent/AgentIcon'
-import { ResolutionKnowledgePanel } from '../../missions/ResolutionKnowledgePanel'
-import { ResolutionHistoryPanel } from '../../missions/ResolutionHistoryPanel'
 import { SaveResolutionDialog } from '../../missions/SaveResolutionDialog'
 import { SetupInstructionsDialog } from '../../setup/SetupInstructionsDialog'
 import { STATUS_CONFIG, TYPE_ICONS } from './types'
@@ -39,7 +37,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
   const { t } = useTranslation('common')
   const { sendMessage, cancelMission, rateMission, setActiveMission, dismissMission, renameMission, runSavedMission, selectedAgent } = useMissions()
   const { isDemoMode } = useDemoMode()
-  const { findSimilarResolutions, recordUsage, allResolutions } = useResolutions()
+  const { findSimilarResolutions, recordUsage } = useResolutions()
   const [input, setInput] = useState('')
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const messagesContainerRef = useRef<HTMLDivElement>(null)
@@ -52,8 +50,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
   const savedInputRef = useRef('')
   // Resolution memory state
   const [showSaveDialog, setShowSaveDialog] = useState(false)
-  const [appliedResolutionId, setAppliedResolutionId] = useState<string | null>(null)
-  const [resolutionPanelView, setResolutionPanelView] = useState<'related' | 'history'>('related')
+  const [appliedResolutionId] = useState<string | null>(null)
   const [showSetupDialog, setShowSetupDialog] = useState(false)
   // Message validation error (e.g. too long)
   const [inputError, setInputError] = useState<string | null>(null)
@@ -78,14 +75,6 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
 
     return findSimilarResolutions(signature as { type: string }, { minSimilarity: 0.4, limit: 5 })
   }, [mission.title, mission.description, mission.messages, findSimilarResolutions])
-
-  // Handle applying a resolution
-  const handleApplyResolution = useCallback((resolution: Resolution) => {
-    setAppliedResolutionId(resolution.id)
-    // Inject the resolution into the chat as a user message
-    const applyMessage = `Please apply this saved resolution:\n\n**${resolution.title}**\n\n${resolution.resolution.summary}\n\nSteps:\n${resolution.resolution.steps.map((s, i) => `${i + 1}. ${s}`).join('\n')}${resolution.resolution.yaml ? `\n\nYAML:\n\`\`\`yaml\n${resolution.resolution.yaml}\n\`\`\`` : ''}`
-    sendMessage(mission.id, applyMessage)
-  }, [mission.id, sendMessage])
 
   // Save transcript as markdown file
   const saveTranscript = useCallback(() => {
@@ -324,70 +313,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
 
   return (
     <>
-    <div className={cn("flex flex-1 min-h-0 min-w-0", isFullScreen && "gap-4")}>
-      {/* Left panel for resolutions (fullscreen only) */}
-      {isFullScreen && (
-        <div className="flex flex-col">
-          {/* Panel toggle */}
-          <div className="flex mb-2 bg-secondary/50 rounded-lg p-0.5">
-            <button
-              onClick={() => setResolutionPanelView('related')}
-              className={cn(
-                "flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors flex items-center justify-center gap-1.5",
-                resolutionPanelView === 'related'
-                  ? "bg-card text-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              Related
-              {relatedResolutions.length > 0 && (
-                <span className={cn(
-                  "px-1.5 py-0.5 text-2xs rounded-full",
-                  resolutionPanelView === 'related'
-                    ? "bg-green-500/20 text-green-400"
-                    : "bg-muted text-muted-foreground"
-                )}>
-                  {relatedResolutions.length}
-                </span>
-              )}
-            </button>
-            <button
-              onClick={() => setResolutionPanelView('history')}
-              className={cn(
-                "flex-1 px-3 py-1.5 text-xs font-medium rounded-md transition-colors flex items-center justify-center gap-1.5",
-                resolutionPanelView === 'history'
-                  ? "bg-card text-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              All Saved
-              {allResolutions.length > 0 && (
-                <span className={cn(
-                  "px-1.5 py-0.5 text-2xs rounded-full",
-                  resolutionPanelView === 'history'
-                    ? "bg-primary/20 text-primary"
-                    : "bg-muted text-muted-foreground"
-                )}>
-                  {allResolutions.length}
-                </span>
-              )}
-            </button>
-          </div>
-          {/* Panel content */}
-          {resolutionPanelView === 'related' ? (
-            <ResolutionKnowledgePanel
-              relatedResolutions={relatedResolutions}
-              onApplyResolution={handleApplyResolution}
-              onSaveNewResolution={() => setShowSaveDialog(true)}
-            />
-          ) : (
-            <ResolutionHistoryPanel
-              onApplyResolution={handleApplyResolution}
-            />
-          )}
-        </div>
-      )}
-
+    <div className={cn("flex flex-1 min-h-0 min-w-0")}>
       {/* Main chat area */}
       <div className="flex flex-col flex-1 min-h-0 min-w-0">
       {/* Header */}

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import {
   X,
   ChevronRight,
@@ -20,6 +20,7 @@ import {
   CheckCircle2,
   Eye,
   ShieldOff,
+  BookOpen,
 } from 'lucide-react'
 import { useSearchParams, useLocation } from 'react-router-dom'
 import { useMissions } from '../../../hooks/useMissions'
@@ -36,6 +37,9 @@ import type { FontSize } from './types'
 import { MissionListItem } from './MissionListItem'
 import { MissionChat } from './MissionChat'
 import { ClusterSelectionDialog } from '../../missions/ClusterSelectionDialog'
+import { ResolutionKnowledgePanel } from '../../missions/ResolutionKnowledgePanel'
+import { ResolutionHistoryPanel } from '../../missions/ResolutionHistoryPanel'
+import { useResolutions, detectIssueSignature } from '../../../hooks/useResolutions'
 import { useTranslation } from 'react-i18next'
 import { SAVED_TOAST_MS, FOCUS_DELAY_MS } from '../../../lib/constants/network'
 import { MISSION_FILE_FETCH_TIMEOUT_MS } from '../../missions/browser/missionCache'
@@ -43,7 +47,7 @@ import { isDemoMode } from '../../../lib/demoMode'
 
 export function MissionSidebar() {
   const { t } = useTranslation(['common'])
-  const { missions, activeMission, isSidebarOpen, isSidebarMinimized, isFullScreen, setActiveMission, closeSidebar, dismissMission, minimizeSidebar, expandSidebar, setFullScreen, selectedAgent, startMission, saveMission, runSavedMission, openSidebar } = useMissions()
+  const { missions, activeMission, isSidebarOpen, isSidebarMinimized, isFullScreen, setActiveMission, closeSidebar, dismissMission, minimizeSidebar, expandSidebar, setFullScreen, selectedAgent, startMission, saveMission, runSavedMission, openSidebar, sendMessage } = useMissions()
   const { isMobile } = useMobile()
   const [collapsedMissions, setCollapsedMissions] = useState<Set<string>>(new Set())
   const [fontSize, setFontSize] = useState<FontSize>('base')
@@ -58,6 +62,26 @@ export function MissionSidebar() {
   const newMissionInputRef = useRef<HTMLTextAreaElement>(null)
   // Cluster selection for install missions
   const [pendingRunMissionId, setPendingRunMissionId] = useState<string | null>(null)
+  // Resolution panel state (fullscreen left sidebar)
+  const [resolutionPanelView, setResolutionPanelView] = useState<'related' | 'history'>('related')
+  const { findSimilarResolutions, allResolutions } = useResolutions()
+  const relatedResolutions = useMemo(() => {
+    if (!activeMission) return []
+    const content = [
+      activeMission.title,
+      activeMission.description,
+      ...activeMission.messages.slice(0, 3).map(m => m.content),
+    ].join('\n')
+    const signature = detectIssueSignature(content)
+    if (!signature.type || signature.type === 'Unknown') return []
+    return findSimilarResolutions(signature as { type: string }, { minSimilarity: 0.4, limit: 5 })
+  }, [activeMission?.title, activeMission?.description, activeMission?.messages, findSimilarResolutions])
+
+  const handleApplyResolution = useCallback((resolution: { title: string; resolution: { summary: string; steps: string[]; yaml?: string } }) => {
+    if (!activeMission) return
+    const applyMessage = `Please apply this saved resolution:\n\n**${resolution.title}**\n\n${resolution.resolution.summary}\n\nSteps:\n${resolution.resolution.steps.map((s: string, i: number) => `${i + 1}. ${s}`).join('\n')}${resolution.resolution.yaml ? `\n\nYAML:\n\`\`\`yaml\n${resolution.resolution.yaml}\n\`\`\`` : ''}`
+    sendMessage(activeMission.id, applyMessage)
+  }, [activeMission, sendMessage])
 
   // Deep-link: open MissionBrowser via ?mission= (specific) or ?browse=missions (explorer)
   // Direct import: ?import= fetches and imports mission directly (no browser popup)
@@ -268,6 +292,7 @@ export function MissionSidebar() {
       if (e.key === 'Escape') {
         if (isFullScreen) {
           setFullScreen(false)
+          closeSidebar()
         } else if (isSidebarOpen) {
           closeSidebar()
         }
@@ -313,7 +338,8 @@ export function MissionSidebar() {
   // Minimized sidebar view (thin strip) - desktop only
   if (isSidebarMinimized && !isMobile) {
     return (
-      <div className={cn(
+      <div
+        className={cn(
         "fixed top-16 right-0 bottom-0 w-12 bg-card/95 backdrop-blur-sm border-l border-border shadow-xl z-40 flex flex-col items-center py-4",
         "transition-transform duration-300 ease-in-out",
         !isSidebarOpen && "translate-x-full pointer-events-none"
@@ -572,7 +598,7 @@ export function MissionSidebar() {
 
       {missions.length === 0 ? (
         <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
-          <AgentIcon provider={getAgentProvider(selectedAgent)} className="w-12 h-12 opacity-50 mb-4" />
+          <Sparkles className="w-10 h-10 text-purple-400/40 mb-4" />
           <p className="text-muted-foreground">{t('missionSidebar.noActiveMissions')}</p>
           <p className="text-xs text-muted-foreground/70 mt-1">
             {t('missionSidebar.startMissionPrompt')}
@@ -595,7 +621,7 @@ export function MissionSidebar() {
               className="flex items-center gap-2 px-4 py-2 text-sm font-medium bg-secondary text-foreground rounded-lg hover:bg-secondary/80 transition-colors"
             >
               <Globe className="w-4 h-4" />
-              Browse Missions
+              Browse Community Missions
             </button>
           </div>
         </div>
@@ -604,59 +630,133 @@ export function MissionSidebar() {
           "flex-1 flex min-h-0 min-w-0 overflow-hidden",
           isFullScreen && "w-full"
         )}>
-          {/* Fullscreen: show saved missions panel on left */}
-          {isFullScreen && savedMissions.length > 0 && (
+          {/* Fullscreen: left sidebar with saved missions + related knowledge */}
+          {isFullScreen && (
             <div className="w-64 border-r border-border bg-secondary/20 flex flex-col overflow-hidden flex-shrink-0">
-              <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
-                <Bookmark className="w-4 h-4 text-purple-400" />
-                <span className="text-xs font-semibold text-foreground">Saved Missions</span>
-                <StatusBadge color="purple" size="xs" rounded="full" className="ml-auto">{savedMissions.length}</StatusBadge>
-              </div>
-              <div className="flex-1 overflow-y-auto scroll-enhanced p-1.5 space-y-1">
-                {savedMissions.map(m => (
-                  <div
-                    key={m.id}
-                    className="group p-2 rounded-lg hover:bg-purple-500/10 transition-colors cursor-pointer border border-transparent hover:border-purple-500/20"
-                    onClick={() => handleViewSavedMission(m)}
-                  >
-                    <div className="flex items-start gap-2">
-                      <Bookmark className="w-3.5 h-3.5 text-purple-400 mt-0.5 flex-shrink-0" />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-xs font-medium text-foreground truncate">{m.title}</p>
-                        {m.importedFrom?.cncfProject && (
-                          <p className="text-2xs text-muted-foreground truncate">{m.importedFrom.cncfProject}</p>
-                        )}
-                        {m.importedFrom?.tags && m.importedFrom.tags.length > 0 && (
-                          <div className="flex flex-wrap gap-0.5 mt-1">
-                            {m.importedFrom.tags.slice(0, 3).map(tag => (
-                              <span key={tag} className="text-[9px] px-1 py-0 bg-secondary rounded text-muted-foreground">{tag}</span>
-                            ))}
-                          </div>
-                        )}
-                      </div>
+              <div className="flex-1 overflow-y-auto scroll-enhanced">
+                {/* Saved Missions section */}
+                {savedMissions.length > 0 && (
+                  <div>
+                    <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
+                      <Bookmark className="w-4 h-4 text-purple-400" />
+                      <span className="text-xs font-semibold text-foreground">Saved Missions</span>
+                      <StatusBadge color="purple" size="xs" rounded="full" className="ml-auto">{savedMissions.length}</StatusBadge>
                     </div>
-                    <div className="flex items-center gap-1 mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
-                      <button
-                        onClick={(e) => { e.stopPropagation(); handleViewSavedMission(m) }}
-                        className="flex items-center gap-1 px-2 py-0.5 text-2xs text-muted-foreground hover:text-foreground rounded hover:bg-secondary transition-colors"
-                      >
-                        <Eye className="w-2.5 h-2.5" /> View
-                      </button>
-                      <button
-                        onClick={(e) => { e.stopPropagation(); handleRunMission(m.id) }}
-                        className="flex items-center gap-1 px-2 py-0.5 text-2xs font-medium bg-primary text-primary-foreground rounded hover:bg-primary/90 transition-colors"
-                      >
-                        <Play className="w-2.5 h-2.5" /> Run
-                      </button>
-                      <button
-                        onClick={(e) => { e.stopPropagation(); dismissMission(m.id) }}
-                        className="flex items-center gap-1 px-2 py-0.5 text-2xs text-muted-foreground hover:text-red-400 rounded hover:bg-red-500/10 transition-colors"
-                      >
-                        <Trash2 className="w-2.5 h-2.5" /> Remove
-                      </button>
+                    <div className="p-1.5 space-y-1">
+                      {savedMissions.map(m => (
+                        <div
+                          key={m.id}
+                          className="group p-2 rounded-lg hover:bg-purple-500/10 transition-colors cursor-pointer border border-transparent hover:border-purple-500/20"
+                          onClick={() => handleViewSavedMission(m)}
+                        >
+                          <div className="flex items-start gap-2">
+                            <Bookmark className="w-3.5 h-3.5 text-purple-400 mt-0.5 flex-shrink-0" />
+                            <div className="flex-1 min-w-0">
+                              <p className="text-xs font-medium text-foreground truncate">{m.title}</p>
+                              {m.importedFrom?.cncfProject && (
+                                <p className="text-2xs text-muted-foreground truncate">{m.importedFrom.cncfProject}</p>
+                              )}
+                              {m.importedFrom?.tags && m.importedFrom.tags.length > 0 && (
+                                <div className="flex flex-wrap gap-0.5 mt-1">
+                                  {m.importedFrom.tags.slice(0, 3).map(tag => (
+                                    <span key={tag} className="text-[9px] px-1 py-0 bg-secondary rounded text-muted-foreground">{tag}</span>
+                                  ))}
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-1 mt-1.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                            <button
+                              onClick={(e) => { e.stopPropagation(); handleViewSavedMission(m) }}
+                              className="flex items-center gap-1 px-2 py-0.5 text-2xs text-muted-foreground hover:text-foreground rounded hover:bg-secondary transition-colors"
+                            >
+                              <Eye className="w-2.5 h-2.5" /> View
+                            </button>
+                            <button
+                              onClick={(e) => { e.stopPropagation(); handleRunMission(m.id) }}
+                              className="flex items-center gap-1 px-2 py-0.5 text-2xs font-medium bg-primary text-primary-foreground rounded hover:bg-primary/90 transition-colors"
+                            >
+                              <Play className="w-2.5 h-2.5" /> Run
+                            </button>
+                            <button
+                              onClick={(e) => { e.stopPropagation(); dismissMission(m.id) }}
+                              className="flex items-center gap-1 px-2 py-0.5 text-2xs text-muted-foreground hover:text-red-400 rounded hover:bg-red-500/10 transition-colors"
+                            >
+                              <Trash2 className="w-2.5 h-2.5" /> Remove
+                            </button>
+                          </div>
+                        </div>
+                      ))}
                     </div>
                   </div>
-                ))}
+                )}
+
+                {/* Related Knowledge section */}
+                <div className={cn(savedMissions.length > 0 && "border-t border-border")}>
+                  <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
+                    <BookOpen className="w-4 h-4 text-purple-400" />
+                    <span className="text-xs font-semibold text-foreground">Knowledge</span>
+                  </div>
+                  {/* Toggle tabs */}
+                  <div className="flex mx-1.5 mt-1.5 bg-secondary/50 rounded-lg p-0.5">
+                    <button
+                      onClick={() => setResolutionPanelView('related')}
+                      className={cn(
+                        "flex-1 px-2 py-1 text-2xs font-medium rounded-md transition-colors flex items-center justify-center gap-1",
+                        resolutionPanelView === 'related'
+                          ? "bg-card text-foreground shadow-sm"
+                          : "text-muted-foreground hover:text-foreground"
+                      )}
+                    >
+                      Related
+                      {relatedResolutions.length > 0 && (
+                        <span className={cn(
+                          "px-1 py-0 text-[9px] rounded-full",
+                          resolutionPanelView === 'related'
+                            ? "bg-green-500/20 text-green-400"
+                            : "bg-muted text-muted-foreground"
+                        )}>
+                          {relatedResolutions.length}
+                        </span>
+                      )}
+                    </button>
+                    <button
+                      onClick={() => setResolutionPanelView('history')}
+                      className={cn(
+                        "flex-1 px-2 py-1 text-2xs font-medium rounded-md transition-colors flex items-center justify-center gap-1",
+                        resolutionPanelView === 'history'
+                          ? "bg-card text-foreground shadow-sm"
+                          : "text-muted-foreground hover:text-foreground"
+                      )}
+                    >
+                      All Saved
+                      {allResolutions.length > 0 && (
+                        <span className={cn(
+                          "px-1 py-0 text-[9px] rounded-full",
+                          resolutionPanelView === 'history'
+                            ? "bg-primary/20 text-primary"
+                            : "bg-muted text-muted-foreground"
+                        )}>
+                          {allResolutions.length}
+                        </span>
+                      )}
+                    </button>
+                  </div>
+                  {/* Panel content */}
+                  <div className="p-1.5">
+                    {resolutionPanelView === 'related' ? (
+                      <ResolutionKnowledgePanel
+                        relatedResolutions={relatedResolutions}
+                        onApplyResolution={handleApplyResolution}
+                        onSaveNewResolution={() => {}}
+                      />
+                    ) : (
+                      <ResolutionHistoryPanel
+                        onApplyResolution={handleApplyResolution}
+                      />
+                    )}
+                  </div>
+                </div>
               </div>
             </div>
           )}
@@ -824,8 +924,8 @@ export function MissionSidebar() {
         <ClusterSelectionDialog
           open
           missionTitle={pendingMission?.title ?? 'Mission'}
-          onSelect={(cluster) => {
-            runSavedMission(pendingRunMissionId, cluster || undefined)
+          onSelect={(clusters) => {
+            runSavedMission(pendingRunMissionId, clusters.length > 0 ? clusters.join(',') : undefined)
             setPendingRunMissionId(null)
           }}
           onCancel={() => setPendingRunMissionId(null)}

--- a/web/src/components/missions/ClusterSelectionDialog.tsx
+++ b/web/src/components/missions/ClusterSelectionDialog.tsx
@@ -1,10 +1,11 @@
 /**
- * ClusterSelectionDialog — Prompts the user to select a target cluster
+ * ClusterSelectionDialog — Prompts the user to select target clusters
  * before running an install-type mission.
+ * Supports multi-select, select all, invert, and deselect.
  */
 
-import { useState, useEffect } from 'react'
-import { X, Server, Check } from 'lucide-react'
+import { useState, useEffect, useMemo } from 'react'
+import { X, Server, Check, CheckCheck, RefreshCw, Search } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { useClusters } from '../../hooks/mcp/clusters'
 import { Button } from '../ui/Button'
@@ -15,27 +16,41 @@ const AUTO_SELECT_DELAY_MS = 600
 interface ClusterSelectionDialogProps {
   open: boolean
   missionTitle: string
-  onSelect: (cluster: string) => void
+  onSelect: (clusters: string[]) => void
   onCancel: () => void
 }
 
 export function ClusterSelectionDialog({ open, missionTitle, onSelect, onCancel }: ClusterSelectionDialogProps) {
   const { clusters, isLoading } = useClusters()
-  const [selected, setSelected] = useState<string | null>(null)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [search, setSearch] = useState('')
 
   // Filter to reachable/healthy clusters
   const onlineClusters = (clusters || []).filter(c => c.reachable !== false && c.healthy !== false)
   const offlineClusters = (clusters || []).filter(c => c.reachable === false || c.healthy === false)
 
+  // Search filtering
+  const filteredOnline = useMemo(() => {
+    if (!search.trim()) return onlineClusters
+    const q = search.toLowerCase()
+    return onlineClusters.filter(c => c.name.toLowerCase().includes(q) || (c.context && c.context.toLowerCase().includes(q)))
+  }, [onlineClusters, search])
+
+  const filteredOffline = useMemo(() => {
+    if (!search.trim()) return offlineClusters
+    const q = search.toLowerCase()
+    return offlineClusters.filter(c => c.name.toLowerCase().includes(q) || (c.context && c.context.toLowerCase().includes(q)))
+  }, [offlineClusters, search])
+
   // Auto-select if only one online cluster
   useEffect(() => {
-    if (onlineClusters.length === 1 && !selected) {
+    if (onlineClusters.length === 1 && selected.size === 0) {
       const timer = setTimeout(() => {
-        onSelect(onlineClusters[0].context || onlineClusters[0].name)
+        onSelect([onlineClusters[0].context || onlineClusters[0].name])
       }, AUTO_SELECT_DELAY_MS)
       return () => clearTimeout(timer)
     }
-  }, [onlineClusters, selected, onSelect])
+  }, [onlineClusters, selected.size, onSelect])
 
   // Close on Escape
   useEffect(() => {
@@ -47,20 +62,80 @@ export function ClusterSelectionDialog({ open, missionTitle, onSelect, onCancel 
 
   if (!open) return null
 
+  const toggleCluster = (id: string) => {
+    setSelected(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const selectAll = () => {
+    setSelected(new Set(onlineClusters.map(c => c.context || c.name)))
+  }
+
+  const deselectAll = () => {
+    setSelected(new Set())
+  }
+
+  const invertSelection = () => {
+    const allIds = onlineClusters.map(c => c.context || c.name)
+    setSelected(prev => new Set(allIds.filter(id => !prev.has(id))))
+  }
+
+  const allSelected = onlineClusters.length > 0 && selected.size === onlineClusters.length
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-2xl" onClick={onCancel}>
-      <div className="w-full max-w-md rounded-lg border border-border bg-card shadow-xl" onClick={e => e.stopPropagation()}>
+      <div className="w-full max-w-lg rounded-lg border border-border bg-card shadow-xl flex flex-col max-h-[80vh]" onClick={e => e.stopPropagation()}>
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-border flex-shrink-0">
           <div>
-            <h3 className="text-sm font-semibold text-foreground">Select Target Cluster</h3>
-            <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-[320px]">{missionTitle}</p>
+            <h3 className="text-sm font-semibold text-foreground">Select Target Clusters</h3>
+            <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-[380px]">{missionTitle}</p>
           </div>
           <Button variant="ghost" onClick={onCancel} className="p-1 rounded-md min-h-11 min-w-11" aria-label="Close" icon={<X className="w-4 h-4" />} />
         </div>
 
+        {/* Search + bulk actions */}
+        {onlineClusters.length > 5 && (
+          <div className="px-3 pt-3 flex-shrink-0">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
+              <input
+                type="text"
+                placeholder="Search clusters..."
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                className="w-full pl-8 pr-3 py-1.5 text-xs bg-secondary/50 border border-border rounded-md text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500"
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-center gap-1 px-3 pt-2 flex-shrink-0">
+          <button
+            onClick={allSelected ? deselectAll : selectAll}
+            className="flex items-center gap-1 px-2 py-1 text-2xs text-muted-foreground hover:text-foreground rounded hover:bg-secondary transition-colors"
+          >
+            <CheckCheck className="w-3 h-3" />
+            {allSelected ? 'Deselect All' : 'Select All'}
+          </button>
+          <button
+            onClick={invertSelection}
+            className="flex items-center gap-1 px-2 py-1 text-2xs text-muted-foreground hover:text-foreground rounded hover:bg-secondary transition-colors"
+          >
+            <RefreshCw className="w-3 h-3" />
+            Invert
+          </button>
+          {selected.size > 0 && (
+            <span className="ml-auto text-2xs text-purple-400">{selected.size} selected</span>
+          )}
+        </div>
+
         {/* Cluster list */}
-        <div className="p-3 max-h-64 overflow-y-auto space-y-1.5">
+        <div className="p-3 flex-1 overflow-y-auto scroll-enhanced space-y-1">
           {isLoading && (
             <p className="text-xs text-muted-foreground text-center py-4">Loading clusters...</p>
           )}
@@ -69,20 +144,26 @@ export function ClusterSelectionDialog({ open, missionTitle, onSelect, onCancel 
             <p className="text-xs text-muted-foreground text-center py-4">No online clusters found</p>
           )}
 
-          {onlineClusters.map(cluster => {
+          {filteredOnline.map(cluster => {
             const id = cluster.context || cluster.name
-            const isSelected = selected === id
+            const isSelected = selected.has(id)
             return (
               <button
                 key={id}
-                onClick={() => setSelected(id)}
+                onClick={() => toggleCluster(id)}
                 className={cn(
-                  'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg border text-left transition-all',
+                  'w-full flex items-center gap-3 px-3 py-2 rounded-lg border text-left transition-all',
                   isSelected
                     ? 'border-purple-500 bg-purple-500/10'
                     : 'border-border hover:border-purple-500/30 bg-secondary/30 hover:bg-secondary/50'
                 )}
               >
+                <div className={cn(
+                  "w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-colors",
+                  isSelected ? "bg-purple-500 border-purple-500" : "border-muted-foreground/40"
+                )}>
+                  {isSelected && <Check className="w-3 h-3 text-white" />}
+                </div>
                 <div className="relative flex-shrink-0">
                   <Server className="w-4 h-4 text-muted-foreground" />
                   <span className="absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full bg-green-500 ring-1 ring-card" />
@@ -93,19 +174,19 @@ export function ClusterSelectionDialog({ open, missionTitle, onSelect, onCancel 
                     <p className="text-2xs text-muted-foreground truncate">{cluster.context}</p>
                   )}
                 </div>
-                {isSelected && <Check className="w-4 h-4 text-purple-400 flex-shrink-0" />}
               </button>
             )
           })}
 
           {/* Show offline clusters as disabled */}
-          {offlineClusters.map(cluster => {
+          {filteredOffline.map(cluster => {
             const id = cluster.context || cluster.name
             return (
               <div
                 key={id}
-                className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-border/50 opacity-40 cursor-not-allowed"
+                className="flex items-center gap-3 px-3 py-2 rounded-lg border border-border/50 opacity-40 cursor-not-allowed"
               >
+                <div className="w-4 h-4 rounded border border-muted-foreground/20 flex-shrink-0" />
                 <div className="relative flex-shrink-0">
                   <Server className="w-4 h-4 text-muted-foreground" />
                   <span className="absolute -bottom-0.5 -right-0.5 w-2 h-2 rounded-full bg-red-500 ring-1 ring-card" />
@@ -120,20 +201,20 @@ export function ClusterSelectionDialog({ open, missionTitle, onSelect, onCancel 
         </div>
 
         {/* Actions */}
-        <div className="flex items-center justify-between px-4 py-3 border-t border-border">
+        <div className="flex items-center justify-between px-4 py-3 border-t border-border flex-shrink-0">
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => onSelect('')}
+            onClick={() => onSelect([])}
           >
             Skip (use current context)
           </Button>
           <button
-            onClick={() => selected && onSelect(selected)}
-            disabled={!selected}
+            onClick={() => onSelect(Array.from(selected))}
+            disabled={selected.size === 0}
             className="px-4 py-1.5 text-xs font-medium rounded bg-purple-600 hover:bg-purple-500 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
-            Run Mission
+            Run on {selected.size || '...'} cluster{selected.size !== 1 ? 's' : ''}
           </button>
         </div>
       </div>

--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -413,7 +413,7 @@ export function MissionDetailView({
                 {method}
               </span>
             ))}
-            {mission.tags
+            {(mission.tags || [])
               .filter((t) => !['installation', 'configuration', 'cncf'].includes(t))
               .slice(0, 4)
               .map((tag) => (

--- a/web/src/components/missions/ResolutionHistoryPanel.tsx
+++ b/web/src/components/missions/ResolutionHistoryPanel.tsx
@@ -72,7 +72,7 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
 
   if (totalResolutions === 0) {
     return (
-      <div className="w-72 flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
+      <div className="flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
         <div className="bg-card border border-border rounded-lg p-4">
           <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
             <BookMarked className="w-4 h-4 text-purple-400" />
@@ -93,7 +93,7 @@ export function ResolutionHistoryPanel({ onApplyResolution }: ResolutionHistoryP
   }
 
   return (
-    <div className="w-72 flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
+    <div className="flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
       <div className="bg-card border border-border rounded-lg p-4">
         <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
           <BookMarked className="w-4 h-4 text-purple-400" />

--- a/web/src/components/missions/ResolutionKnowledgePanel.tsx
+++ b/web/src/components/missions/ResolutionKnowledgePanel.tsx
@@ -45,7 +45,7 @@ export function ResolutionKnowledgePanel({
 
   if (relatedResolutions.length === 0) {
     return (
-      <div className="w-72 flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
+      <div className="flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
         <div className="bg-card border border-border rounded-lg p-4">
           <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
             <BookOpen className="w-4 h-4 text-purple-400" />
@@ -67,7 +67,7 @@ export function ResolutionKnowledgePanel({
   }
 
   return (
-    <div className="w-72 flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
+    <div className="flex-shrink-0 flex flex-col gap-4 overflow-y-auto scroll-enhanced">
       <div className="bg-card border border-border rounded-lg p-4">
         <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
           <BookOpen className="w-4 h-4 text-purple-400" />

--- a/web/src/components/missions/ShareMissionDialog.tsx
+++ b/web/src/components/missions/ShareMissionDialog.tsx
@@ -78,7 +78,7 @@ function missionToMarkdown(mission: MissionExport): string {
     `# ${mission.title}`,
     '',
     `**Type:** ${mission.type}`,
-    `**Tags:** ${mission.tags.join(', ')}`,
+    `**Tags:** ${(mission.tags || []).join(', ')}`,
     '',
     '## Problem',
     mission.description,

--- a/web/src/components/missions/browser/RecommendationCard.tsx
+++ b/web/src/components/missions/browser/RecommendationCard.tsx
@@ -99,7 +99,7 @@ export function RecommendationCard({
               {mission.metadata.maturity}
             </span>
           )}
-          {mission.tags.slice(0, 2).map((tag) => (
+          {(mission.tags || []).slice(0, 2).map((tag) => (
             <span key={tag} className="px-1.5 py-0.5 text-2xs rounded bg-secondary text-muted-foreground">
               {tag}
             </span>

--- a/web/src/components/nodes/Nodes.tsx
+++ b/web/src/components/nodes/Nodes.tsx
@@ -5,6 +5,7 @@ import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
 import { StatBlockValue } from '../ui/StatsOverview'
+import { formatMemoryStat } from '../../lib/formatStats'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
 import { useTranslation } from 'react-i18next'
@@ -67,7 +68,7 @@ export function Nodes() {
       case 'cpus':
         return { value: totalCPU, sublabel: t('common:nodes.cpuCores'), onClick: () => drillToAllNodes(), isClickable: totalCPU > 0 }
       case 'memory':
-        return { value: `${totalMemoryGB.toFixed(0)} GB`, sublabel: t('common:common.memory'), onClick: () => drillToAllNodes(), isClickable: totalMemoryGB > 0 }
+        return { value: totalMemoryGB, format: (v: number) => formatMemoryStat(v), sublabel: t('common:common.memory'), onClick: () => drillToAllNodes(), isClickable: totalMemoryGB > 0 }
       case 'gpus':
         return { value: totalGPUs, sublabel: t('common:common.gpus'), onClick: () => drillToAllGPU(), isClickable: totalGPUs > 0 }
       case 'tpus':

--- a/web/src/components/ui/StatBlockModePicker.tsx
+++ b/web/src/components/ui/StatBlockModePicker.tsx
@@ -81,7 +81,9 @@ export function StatBlockModePicker({ currentMode, availableModes, onModeChange 
     toggle()
   }
 
-  const handleSelect = (mode: StatDisplayMode) => {
+  const handleSelect = (e: React.MouseEvent, mode: StatDisplayMode) => {
+    e.stopPropagation()
+    e.preventDefault()
     onModeChange(mode)
     close()
   }
@@ -139,7 +141,7 @@ export function StatBlockModePicker({ currentMode, availableModes, onModeChange 
               <button
                 key={mode}
                 role="menuitem"
-                onClick={() => isAvailable && handleSelect(mode)}
+                onClick={(e) => isAvailable && handleSelect(e, mode)}
                 disabled={!isAvailable}
                 className={`w-full flex items-center gap-2.5 px-2 py-1.5 rounded text-xs transition-colors ${
                   isActive

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -154,6 +154,8 @@ export interface StatBlockValue {
   thresholds?: { warning: number; critical: number }
   /** Hint to the display mode picker about what modes are appropriate */
   modeHints?: StatDisplayMode[]
+  /** Optional formatter for display — when value is numeric but should display as a string (e.g., "30.5 TB") */
+  format?: (value: number) => string
 }
 
 /** Inline horseshoe gauge — a 270° arc with value text centered */
@@ -223,10 +225,13 @@ function StatBlock({ block, data, hasData, isLoading, history, onDisplayModeChan
   const mode: StatDisplayMode = block.displayMode || 'numeric'
   const availableModes = getAvailableModes(block.id, data)
 
-  const displayValue = hasData ? data.value : '-'
-  const numericValue = typeof data.value === 'number'
-    ? data.value
-    : parseFloat(String(data.value))
+  const rawValue = data.value
+  const displayValue = hasData
+    ? (data.format && typeof rawValue === 'number' ? data.format(rawValue) : rawValue)
+    : '-'
+  const numericValue = typeof rawValue === 'number'
+    ? rawValue
+    : parseFloat(String(rawValue))
   const maxValue = data.max ?? 100
 
   // Sparkline: fall back to numeric if not enough data yet

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -32,12 +32,15 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   const toastCounter = useRef(0)
   const showToast = useCallback((message: string, type: ToastType = 'success') => {
     const id = `toast-${Date.now()}-${++toastCounter.current}`
-    setToasts((prev) => [...prev, { id, message, type }])
+    setToasts((prev) => {
+      // Deduplicate: skip if an identical message+type is already visible
+      if (prev.some(t => t.message === message && t.type === type)) return prev
+      return [...prev, { id, message, type }]
+    })
 
-    // Auto-remove after 3 seconds
+    // Auto-remove after 3 seconds (timeout is harmless if toast was deduplicated)
     const timeoutId = window.setTimeout(() => {
       setToasts((prev) => prev.filter((t) => t.id !== id))
-      // Only delete if still in map (component may have unmounted)
       if (timeoutsRef.current.has(id)) {
         timeoutsRef.current.delete(id)
       }

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -884,8 +884,18 @@ Install the console locally with the KubeStellar Console agent to use AI mission
   const startMission = useCallback((params: StartMissionParams): string => {
     const missionId = `mission-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
 
-    // Auto-match and inject resolution context for relevant mission types
+    // Inject cluster targeting into the prompt sent to the agent
     let enhancedPrompt = params.initialPrompt
+    if (params.cluster) {
+      const clusterList = params.cluster.split(',').map(c => c.trim()).filter(Boolean)
+      if (clusterList.length === 1) {
+        enhancedPrompt = `Target cluster: ${clusterList[0]}\nIMPORTANT: All kubectl commands MUST use --context=${clusterList[0]}\n\n${enhancedPrompt}`
+      } else {
+        enhancedPrompt = `Target clusters: ${clusterList.join(', ')}\nIMPORTANT: Perform the following on each cluster using their respective kubectl contexts.\n\n${enhancedPrompt}`
+      }
+    }
+
+    // Auto-match and inject resolution context for relevant mission types
     let matchedResolutions: MatchedResolution[] = []
 
     // Match resolutions for troubleshooting-related missions (not deploy/upgrade)
@@ -1099,10 +1109,17 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       ? `${mission.description}\n\nSteps:\n${mission.importedFrom.steps.map((s, i) => `${i + 1}. ${s.title}: ${s.description}`).join('\n')}`
       : mission.description
 
-    // Inject cluster targeting context if a cluster was selected
-    const initialPrompt = cluster
-      ? `Target cluster: ${cluster}\n\nIMPORTANT: All kubectl commands MUST use --context=${cluster}\n\n${basePrompt}`
-      : basePrompt
+    // Inject cluster targeting context if cluster(s) were selected
+    let initialPrompt = basePrompt
+    if (cluster) {
+      const clusterList = cluster.split(',').map(c => c.trim()).filter(Boolean)
+      if (clusterList.length === 1) {
+        initialPrompt = `Target cluster: ${clusterList[0]}\n\nIMPORTANT: All kubectl commands MUST use --context=${clusterList[0]}\n\n${basePrompt}`
+      } else {
+        const contextFlags = clusterList.map(c => `--context=${c}`).join(', ')
+        initialPrompt = `Target clusters: ${clusterList.join(', ')}\n\nIMPORTANT: Perform the following on each cluster. Use these kubectl contexts: ${contextFlags}\n\n${basePrompt}`
+      }
+    }
 
     setMissions(prev => prev.map(m =>
       m.id === missionId ? {

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -403,6 +403,10 @@ export function useSidebarConfig() {
     setConfig((prev) => ({ ...prev, collapsed: !prev.collapsed }))
   }, [])
 
+  const setCollapsed = useCallback((collapsed: boolean) => {
+    setConfig((prev) => ({ ...prev, collapsed }))
+  }, [])
+
   const openMobileSidebar = useCallback(() => {
     setConfig((prev) => ({ ...prev, isMobileOpen: true }))
   }, [])
@@ -484,6 +488,7 @@ export function useSidebarConfig() {
     toggleClusterStatus,
     setWidth,
     toggleCollapsed,
+    setCollapsed,
     openMobileSidebar,
     closeMobileSidebar,
     toggleMobileSidebar,

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -369,8 +369,8 @@
 
 /* Scrollbar - uses theme variables */
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
 }
 
 ::-webkit-scrollbar-track {
@@ -386,21 +386,20 @@
   background: var(--scrollbar-thumb-hover);
 }
 
-/* Enhanced scrollbar for panels, sidebars, and dropdowns where
-   the default thin scrollbar is too hard to see/grab */
+/* Enhanced scrollbar for panels, sidebars, and dropdowns —
+   slim and subtle, only visible on hover/scroll */
 .scroll-enhanced::-webkit-scrollbar {
-  width: 12px;
+  width: 6px;
 }
 .scroll-enhanced::-webkit-scrollbar-track {
-  background: rgba(15, 23, 42, 0.5);
-  border-radius: 6px;
+  background: transparent;
 }
 .scroll-enhanced::-webkit-scrollbar-thumb {
-  background: rgba(100, 116, 139, 0.5);
-  border-radius: 6px;
+  background: rgba(100, 116, 139, 0.3);
+  border-radius: 3px;
 }
 .scroll-enhanced::-webkit-scrollbar-thumb:hover {
-  background: rgba(100, 116, 139, 0.75);
+  background: rgba(100, 116, 139, 0.55);
 }
 
 

--- a/web/src/lib/cards/cardInstallMap.ts
+++ b/web/src/lib/cards/cardInstallMap.ts
@@ -1,0 +1,103 @@
+/**
+ * Maps dashboard card types to the project/component they need installed for live data.
+ * Used by CardWrapper to show specific "Install X for live data" CTAs on demo cards.
+ *
+ * - `project`: Human-readable project name shown in the CTA
+ * - `missionKey`: Key passed to loadMissionPrompt() for AI install missions
+ * - `kbPaths`: Paths to console-kb JSON files (tried in order) for manual install guides
+ */
+
+export interface CardInstallInfo {
+  project: string
+  missionKey: string
+  kbPaths: string[]
+}
+
+/**
+ * Card type → install info mapping.
+ * Cards not in this map will show a generic "Install for live data" CTA.
+ */
+export const CARD_INSTALL_MAP: Record<string, CardInstallInfo> = {
+  // OPA / Open Policy Agent
+  opa_policies: { project: 'Open Policy Agent (OPA)', missionKey: 'install-open-policy-agent-opa', kbPaths: ['solutions/cncf-install/install-open-policy-agent-opa.json'] },
+  opa_violations: { project: 'Open Policy Agent (OPA)', missionKey: 'install-open-policy-agent-opa', kbPaths: ['solutions/cncf-install/install-open-policy-agent-opa.json'] },
+
+  // Kyverno
+  kyverno_policies: { project: 'Kyverno', missionKey: 'install-kyverno', kbPaths: ['solutions/cncf-install/install-kyverno.json'] },
+  kyverno_violations: { project: 'Kyverno', missionKey: 'install-kyverno', kbPaths: ['solutions/cncf-install/install-kyverno.json'] },
+
+  // Falco
+  falco_alerts: { project: 'Falco', missionKey: 'install-falco', kbPaths: ['solutions/cncf-install/install-falco.json'] },
+  falco_events: { project: 'Falco', missionKey: 'install-falco', kbPaths: ['solutions/cncf-install/install-falco.json'] },
+
+  // Istio / Service Mesh
+  istio_traffic: { project: 'Istio', missionKey: 'install-istio', kbPaths: ['solutions/cncf-install/install-istio.json'] },
+  istio_policies: { project: 'Istio', missionKey: 'install-istio', kbPaths: ['solutions/cncf-install/install-istio.json'] },
+  service_mesh: { project: 'Istio', missionKey: 'install-istio', kbPaths: ['solutions/cncf-install/install-istio.json'] },
+
+  // Cert Manager
+  cert_manager: { project: 'cert-manager', missionKey: 'install-cert-manager', kbPaths: ['solutions/cncf-install/install-cert-manager.json'] },
+
+  // External Secrets
+  external_secrets: { project: 'External Secrets Operator', missionKey: 'install-external-secrets', kbPaths: ['solutions/cncf-install/install-external-secrets.json'] },
+
+  // Argo CD / GitOps
+  gitops_drift: { project: 'Argo CD', missionKey: 'install-argo-cd', kbPaths: ['solutions/cncf-install/install-argo-cd.json'] },
+  argocd_apps: { project: 'Argo CD', missionKey: 'install-argo-cd', kbPaths: ['solutions/cncf-install/install-argo-cd.json'] },
+  argocd_sync: { project: 'Argo CD', missionKey: 'install-argo-cd', kbPaths: ['solutions/cncf-install/install-argo-cd.json'] },
+
+  // Flux
+  flux_status: { project: 'Flux', missionKey: 'install-flux', kbPaths: ['solutions/cncf-install/install-flux.json'] },
+  flux_sources: { project: 'Flux', missionKey: 'install-flux', kbPaths: ['solutions/cncf-install/install-flux.json'] },
+
+  // Prometheus / Monitoring
+  prometheus_alerts: { project: 'Prometheus', missionKey: 'install-prometheus', kbPaths: ['solutions/cncf-install/install-prometheus.json'] },
+  prometheus_rules: { project: 'Prometheus', missionKey: 'install-prometheus', kbPaths: ['solutions/cncf-install/install-prometheus.json'] },
+
+  // Grafana
+  grafana_dashboards: { project: 'Grafana', missionKey: 'install-grafana', kbPaths: ['solutions/cncf-install/install-grafana.json'] },
+
+  // Helm
+  helm_releases: { project: 'Helm', missionKey: 'install-helm', kbPaths: ['solutions/cncf-install/install-helm.json'] },
+  helm_history: { project: 'Helm', missionKey: 'install-helm', kbPaths: ['solutions/cncf-install/install-helm.json'] },
+
+  // Tekton / CI-CD
+  tekton_pipelines: { project: 'Tekton', missionKey: 'install-tekton', kbPaths: ['solutions/cncf-install/install-tekton.json'] },
+  tekton_runs: { project: 'Tekton', missionKey: 'install-tekton', kbPaths: ['solutions/cncf-install/install-tekton.json'] },
+
+  // KubeVirt
+  kubevirt_status: { project: 'KubeVirt', missionKey: 'install-kubevirt', kbPaths: ['solutions/cncf-install/install-kubevirt.json'] },
+  kubevirt_vms: { project: 'KubeVirt', missionKey: 'install-kubevirt', kbPaths: ['solutions/cncf-install/install-kubevirt.json'] },
+
+  // KubeFlex
+  kubeflex_status: { project: 'KubeFlex', missionKey: 'platform-kubeflex', kbPaths: ['solutions/platform-install/platform-kubeflex.json'] },
+
+  // OVN
+  ovn_status: { project: 'OVN-Kubernetes', missionKey: 'install-ovn-kubernetes', kbPaths: ['solutions/cncf-install/install-ovn-kubernetes.json'] },
+
+  // Vault
+  vault_secrets: { project: 'HashiCorp Vault', missionKey: 'install-vault', kbPaths: ['solutions/cncf-install/install-vault.json'] },
+
+  // NVIDIA GPU Operator
+  gpu_overview: { project: 'NVIDIA GPU Operator', missionKey: 'install-nvidia-gpu-operator', kbPaths: ['solutions/cncf-install/install-nvidia-gpu-operator.json'] },
+  gpu_reservations: { project: 'NVIDIA GPU Operator', missionKey: 'install-nvidia-gpu-operator', kbPaths: ['solutions/cncf-install/install-nvidia-gpu-operator.json'] },
+
+  // LLM-d
+  llmd_flow: { project: 'LLM-d', missionKey: 'install-llm-d', kbPaths: ['solutions/platform-install/platform-llm-d.json'] },
+  llmd_benchmarks: { project: 'LLM-d', missionKey: 'install-llm-d', kbPaths: ['solutions/platform-install/platform-llm-d.json'] },
+  pareto_frontier: { project: 'LLM-d', missionKey: 'install-llm-d', kbPaths: ['solutions/platform-install/platform-llm-d.json'] },
+
+  // Kagent / Kagenti
+  kagent_status: { project: 'Kagent', missionKey: 'install-kagent', kbPaths: ['solutions/cncf-install/install-kagent.json'] },
+  kagenti_status: { project: 'Kagenti', missionKey: 'install-kagenti', kbPaths: ['solutions/platform-install/install-kagenti.json'] },
+
+  // Trivy
+  trivy_scan: { project: 'Trivy', missionKey: 'install-trivy', kbPaths: ['solutions/cncf-install/install-trivy.json'] },
+  image_vulnerabilities: { project: 'Trivy', missionKey: 'install-trivy', kbPaths: ['solutions/cncf-install/install-trivy.json'] },
+
+  // Crossplane
+  crossplane_status: { project: 'Crossplane', missionKey: 'install-crossplane', kbPaths: ['solutions/cncf-install/install-crossplane.json'] },
+
+  // Knative
+  knative_services: { project: 'Knative', missionKey: 'install-knative', kbPaths: ['solutions/cncf-install/install-knative.json'] },
+}

--- a/web/src/lib/constants/storage.ts
+++ b/web/src/lib/constants/storage.ts
@@ -43,6 +43,7 @@ export const STORAGE_KEY_ANONYMOUS_USER_ID = 'kc-anonymous-user-id'
 export const STORAGE_KEY_CLUSTER_LAYOUT = 'kubestellar-cluster-layout-mode'
 export const STORAGE_KEY_NAV_HISTORY = 'kubestellar-nav-history'
 export const STORAGE_KEY_CLUSTER_PROVIDER_OVERRIDES = 'kubestellar-cluster-provider-overrides'
+export const STORAGE_KEY_CLUSTER_ORDER = 'kubestellar-cluster-order'
 export const STORAGE_KEY_MISSIONS_ACTIVE = 'kubestellar-missions-active'
 export const STORAGE_KEY_MISSIONS_HISTORY = 'kubestellar-missions-history'
 

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -66,6 +66,23 @@ export function formatBytes(bytes: number, decimals = 1): string {
 }
 
 /**
+ * Format a value already in GB to a smart string, auto-converting to TB when large.
+ * Returns { display, tooltip } so callers can show the short form and hover for detail.
+ */
+export function formatGBSmart(gb: number, decimals = 1): { display: string; tooltip: string } {
+  if (!Number.isFinite(gb) || gb <= 0) return { display: '0 GB', tooltip: '0 GB' }
+  if (gb >= 1024) {
+    const tb = gb / 1024
+    return {
+      display: `${tb.toFixed(decimals)} TB`,
+      tooltip: `${Math.round(gb).toLocaleString()} GB`,
+    }
+  }
+  const rounded = gb >= 10 ? Math.round(gb) : Number(gb.toFixed(decimals))
+  return { display: `${rounded} GB`, tooltip: `${gb.toFixed(2)} GB` }
+}
+
+/**
  * Format Kubernetes resource quantity (e.g., "16077540Ki") to human-readable string
  */
 export function formatK8sMemory(value: string): string {


### PR DESCRIPTION
## Summary
- **Multi-cluster selection**: Rewritten ClusterSelectionDialog with checkboxes, search, Select All/Invert/Deselect, bigger modal for large cluster lists
- **Cluster context in prompts**: Selected cluster names injected into mission prompts for all missions (install, saved, etc.)
- **Drag-to-reorder clusters**: Persistent cluster ordering via @dnd-kit with localStorage, Custom sort option
- **Provider sort**: New sort-by-provider option in cluster list
- **NaN GPU fix**: Guard against undefined gpuAllocated values
- **GB→TB auto-conversion**: Stat blocks use numeric values with format callbacks so sparkline/gauge modes work correctly
- **Resolution panel moved**: From MissionChat's separate column to MissionSidebar's left panel in fullscreen
- **Add Cluster button**: Moved inline with filter tabs (left of layout/sort controls)
- **Crash fixes**: mission.tags undefined guards, stat block mode picker stopPropagation
- **Agent dropdown**: kagenti before kagent, install missions use actual content
- **Scrollbar**: Thinner, more subtle styling
- **Equal-height cluster cards**: h-full on grid card outer div

## Test plan
- [ ] Open clusters page — verify Memory/Storage show TB values, not raw GB
- [ ] Switch stat block to sparkline mode — verify value still shows correctly
- [ ] Change display mode on stat block — verify parent modal doesn't open
- [ ] Drag cluster cards to reorder, reload page — verify order persists
- [ ] Sort by Provider — verify clusters group by cloud provider
- [ ] Open AI agent dropdown — verify kagenti appears before kagent
- [ ] Click Install for kagenti — verify cluster selection dialog appears with multi-select
- [ ] Select multiple clusters and run mission — verify cluster names in prompt
- [ ] Open fullscreen mission sidebar — verify resolution panel in left sidebar
- [ ] Verify Add Cluster button is left of layout/sort controls in filter tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)