### PR TITLE
fix: FAB menu solid background, remove health indicator

### DIFF
--- a/web/src/components/dashboard/FloatingDashboardActions.tsx
+++ b/web/src/components/dashboard/FloatingDashboardActions.tsx
@@ -9,7 +9,6 @@ import { useFeatureHints } from '../../hooks/useFeatureHints'
 import { ResetMode } from '../../hooks/useDashboardReset'
 import { ResetDialog } from './ResetDialog'
 import { SidebarCustomizer } from '../layout/SidebarCustomizer'
-import { DashboardHealthIndicator } from './DashboardHealthIndicator'
 
 interface FloatingDashboardActionsProps {
   onAddCard: () => void
@@ -117,7 +116,7 @@ export function FloatingDashboardActions({
 
   const showResetOption = isCustomized && (onReset || onResetToDefaults)
 
-  const menuBtnClass = "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground bg-card hover:bg-secondary border border-border rounded-md shadow-md transition-all hover:shadow-lg whitespace-nowrap"
+  const menuBtnClass = "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-secondary rounded-md transition-colors whitespace-nowrap"
 
   return (
     <>
@@ -126,7 +125,7 @@ export function FloatingDashboardActions({
         {menu.isOpen && (
           <div
             role="menu"
-            className="flex flex-col gap-1.5 animate-in fade-in slide-in-from-bottom-2 duration-150"
+            className="flex flex-col gap-1.5 p-2 bg-card border border-border rounded-lg shadow-xl animate-in fade-in slide-in-from-bottom-2 duration-150"
             aria-label={t('dashboard.actions.dashboardActions')}
             onKeyDown={(e) => {
               if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
@@ -212,10 +211,6 @@ export function FloatingDashboardActions({
               <Plus className="w-3.5 h-3.5" />
               {t('dashboard.actions.addCard')}
             </button>
-            {/* Health status indicator at bottom of menu */}
-            <div className="pt-1 border-t border-border/50" role="presentation">
-              <DashboardHealthIndicator size="sm" />
-            </div>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Remove `DashboardHealthIndicator` ("12 critical issues") from the floating actions menu — not needed here
- Wrap the expanded menu in a solid `bg-card` container with `border border-border rounded-lg shadow-xl` so buttons have a clear, opaque background and don't get lost against card content
- Simplify individual button styles (removed per-button shadows/borders since the container provides visual grounding)

## Test plan
- [ ] Click the "+" FAB button — menu expands with a solid dark background box
- [ ] Menu items are clearly visible against any card background
- [ ] "Critical issues" indicator no longer appears in the menu
- [ ] All menu actions still work (Customize, Templates, Add Card, Export, Undo/Redo, Reset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)