### PR TITLE
fix: align settings test with hidden providers, add fetch timeout

### DIFF
--- a/pkg/agent/server_test.go
+++ b/pkg/agent/server_test.go
@@ -458,20 +458,10 @@ func TestServer_SettingsHandlers(t *testing.T) {
 		t.Fatalf("Failed to decode keys status: %v", err)
 	}
 
-	foundOpenAI := false
-	for _, k := range resp.Keys {
-		if k.Provider == "openai" {
-			foundOpenAI = true
-			if !k.Configured {
-				t.Error("OpenAI should be configured")
-			}
-			if k.Valid == nil || !*k.Valid {
-				t.Error("OpenAI key should be valid (skipped validation)")
-			}
-		}
-	}
-	if !foundOpenAI {
-		t.Error("OpenAI provider not found in status response")
+	// API-key providers are intentionally hidden (only CLI-based agents shown),
+	// so the keys endpoint returns an empty list even when keys are configured.
+	if len(resp.Keys) != 0 {
+		t.Errorf("Expected empty keys list (API-key providers hidden), got %d entries", len(resp.Keys))
 	}
 }
 

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1091,7 +1091,7 @@ export function CardWrapper({
                             } else if (installInfo) {
                               // No agent: try to load KB guide and show manual steps
                               try {
-                                const resp = await fetch(`/console-kb/${installInfo.kbPaths[0]}`)
+                                const resp = await fetch(`/console-kb/${installInfo.kbPaths[0]}`, { signal: AbortSignal.timeout(10_000) })
                                 if (resp.ok) {
                                   const data = await resp.json()
                                   setShowInstallGuide({ mission: data })


### PR DESCRIPTION
## Summary
- **#3512 (Release failure)**: `TestServer_SettingsHandlers` expected OpenAI in the keys status response, but the kagenti provider commit intentionally hides API-key providers. Updated test to expect empty keys list.
- **#3513 (Nightly regression)**: Consistency test Phase 5 flagged a `fetch()` call in `CardWrapper.tsx:1094` without an `AbortSignal`. Added `AbortSignal.timeout(10_000)`.

Fixes #3512, Fixes #3513

## Test plan
- [x] `go test ./pkg/agent/ -run TestServer_SettingsHandlers` passes
- [x] Frontend builds successfully
- [ ] Nightly consistency test passes (Phase 5 fetch-signal check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)