### PR TITLE
fix: prevent card action buttons from being clipped after resize

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -772,10 +772,10 @@ export function CardWrapper({
           >
             {/* Header */}
             <div data-tour="card-header" className="flex items-center justify-between px-4 py-3 border-b border-border/50">
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 min-w-0">
                 {dragHandle}
-                {ResolvedIcon && <ResolvedIcon className={cn('w-4 h-4', resolvedIconColor)} />}
-                <h3 className="text-sm font-medium text-foreground">{title}</h3>
+                {ResolvedIcon && <ResolvedIcon className={cn('w-4 h-4 flex-shrink-0', resolvedIconColor)} />}
+                <h3 className="text-sm font-medium text-foreground truncate">{title}</h3>
                 <InfoTooltip text={description || t('messages.descriptionComingSoon', { title })} />
                 {/* Demo data indicator - shows if card uses demo data (respects child opt-out) */}
                 {showDemoIndicator && (
@@ -783,7 +783,7 @@ export function CardWrapper({
                     data-testid="demo-badge"
                     role="status"
                     aria-live="polite"
-                    className="text-2xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400"
+                    className="text-2xs px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-400 flex-shrink-0"
                     title={effectiveIsDemoData ? t('cardWrapper.demoBadgeTitle') : t('cardWrapper.demoModeTitle')}
                   >
                     {t('cardWrapper.demo')}
@@ -794,7 +794,7 @@ export function CardWrapper({
                   <span
                     role="status"
                     aria-live="polite"
-                    className="text-2xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400"
+                    className="text-2xs px-1.5 py-0.5 rounded bg-green-500/20 text-green-400 flex-shrink-0"
                     title={t('cardWrapper.liveBadgeTitle')}
                   >
                     {t('cardWrapper.live')}
@@ -805,7 +805,7 @@ export function CardWrapper({
                   <span
                     role="alert"
                     aria-live="assertive"
-                    className="text-2xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 flex items-center gap-1"
+                    className="text-2xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 flex items-center gap-1 flex-shrink-0"
                     title={t('cardWrapper.refreshFailedCount', { count: effectiveConsecutiveFailures })}
                   >
                     {t('cardWrapper.refreshFailed')}
@@ -825,7 +825,7 @@ export function CardWrapper({
                   ) : null
                 })()}
               </div>
-              <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1 flex-shrink-0">
                 {/* Collapse/expand button */}
                 <button
                   onClick={() => setCollapsed(!isCollapsed)}


### PR DESCRIPTION
Closes #3501

## Summary

- The card header's left side (title, badges) had no flex shrink constraints, so when a card was resized to a narrower width, the right-side action buttons (collapse, refresh, expand, bug report, kebab menu) were pushed outside the card's `overflow-hidden` boundary and became invisible
- Added `min-w-0` to the left header div and `truncate` to the title so long titles ellipsize instead of overflowing
- Added `flex-shrink-0` to the right header div (action buttons), badge spans, and the card icon so they are never compressed or clipped

## Test plan

- [ ] Resize a card to "Small (3 cols)" via the kebab menu — verify the three-dot menu icon remains visible
- [ ] Resize a card to "Full (12 cols)" and back to "Small" — verify all header buttons stay visible throughout
- [ ] Verify long card titles truncate with ellipsis instead of overflowing
- [ ] Verify Demo/Live/Failed badges are not squished on narrow cards