### PR TITLE
fix: add concurrency limiter to multi-cluster API requests

### DIFF
--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense, type ReactNode } from 'react'
+import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useMissions } from '../hooks/useMissions'
 import { useDemoMode } from '../hooks/useDemoMode'
 import type {
@@ -277,8 +278,8 @@ export function AlertsProvider({ children }: { children: ReactNode }) {
       const API_BASE = import.meta.env.VITE_API_BASE_URL || ''
       const results: Record<string, GPUHealthCheckResult[]> = {}
 
-      await Promise.allSettled(
-        currentClusters.map(async (cluster) => {
+      await settledWithConcurrency(
+        currentClusters.map((cluster) => async () => {
           try {
             const resp = await fetch(
               `${API_BASE}/api/mcp/gpu-nodes/health/cronjob/results?cluster=${encodeURIComponent(cluster.name)}`,

--- a/web/src/hooks/mcp/kagent_crds.ts
+++ b/web/src/hooks/mcp/kagent_crds.ts
@@ -1,3 +1,4 @@
+import { mapSettledWithConcurrency } from '../../lib/utils/concurrency'
 import { isAgentUnavailable, reportAgentDataSuccess } from '../useLocalAgent'
 import { clusterCacheRef, LOCAL_AGENT_URL } from './shared'
 import { useCache } from '../../lib/cache'
@@ -97,13 +98,14 @@ async function agentFetchAllClusters<T>(
     ? clusters.filter(c => c.name === specificCluster)
     : clusters
 
-  const results = await Promise.allSettled(
-    targets.map(async ({ name, context }) => {
+  const results = await mapSettledWithConcurrency(
+    targets,
+    async ({ name, context }) => {
       const data = await agentFetch<Record<string, unknown>>(path, context || name, namespace)
       if (!data) throw new Error('No data')
       const items = (data[key] || []) as T[]
       return items.map(item => ({ ...item, cluster: name }))
-    }),
+    },
   )
 
   const items: T[] = []

--- a/web/src/hooks/mcp/kagenti.ts
+++ b/web/src/hooks/mcp/kagenti.ts
@@ -1,4 +1,5 @@
 import { useMemo, useCallback } from 'react'
+import { mapSettledWithConcurrency } from '../../lib/utils/concurrency'
 import { isAgentUnavailable, reportAgentDataSuccess } from '../useLocalAgent'
 import { clusterCacheRef, LOCAL_AGENT_URL } from './shared'
 import { useCache } from '../../lib/cache'
@@ -154,13 +155,14 @@ async function agentFetchAllClusters<T>(
     ? clusters.filter(c => c.name === specificCluster)
     : clusters
 
-  const results = await Promise.allSettled(
-    targets.map(async ({ name, context }) => {
+  const results = await mapSettledWithConcurrency(
+    targets,
+    async ({ name, context }) => {
       const data = await agentFetch<Record<string, unknown>>(path, context || name, namespace)
       if (!data) throw new Error('No data')
       const items = (data[key] || []) as T[]
       return items.map(item => ({ ...item, cluster: name }))
-    }),
+    },
   )
 
   const items: T[] = []

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -24,6 +24,7 @@ import { clusterCacheRef } from './mcp/shared'
 import { isAgentUnavailable } from './useLocalAgent'
 import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_TOKEN } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS, KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
+import { settledWithConcurrency } from '../lib/utils/concurrency'
 import type {
   PodInfo,
   PodIssue,
@@ -167,8 +168,8 @@ async function fetchFromAllClusters<T>(
   const accumulated: T[] = []
   let failedCount = 0
 
-  // Fetch from each cluster in parallel, progressively reporting results
-  const promises = clusters.map(async (cluster) => {
+  // Fetch from each cluster with bounded concurrency, progressively reporting results
+  const tasks = clusters.map((cluster) => async () => {
     try {
       const data = await fetchAPI<Record<string, T[]>>(endpoint, { ...params, cluster })
       const items = data[resultKey] || []
@@ -182,7 +183,7 @@ async function fetchFromAllClusters<T>(
     }
   })
 
-  await Promise.allSettled(promises)
+  await settledWithConcurrency(tasks)
 
   // If every cluster fetch failed, throw so callers can try agent fallback
   if (accumulated.length === 0 && clusters.length > 0 && failedCount === clusters.length) {
@@ -335,7 +336,7 @@ async function fetchPodIssuesViaAgent(namespace?: string, onProgress?: (partial:
   if (clusters.length === 0) return []
   const accumulated: PodIssue[] = []
 
-  const promises = clusters.map(async ({ name, context }) => {
+  const tasks = clusters.map(({ name, context }) => async () => {
     const ctx = context || name
     const issues = await kubectlProxy.getPodIssues(ctx, namespace)
     // Always use the short name — kubectlProxy returns context path as cluster
@@ -345,7 +346,7 @@ async function fetchPodIssuesViaAgent(namespace?: string, onProgress?: (partial:
     return tagged
   })
 
-  await Promise.allSettled(promises)
+  await settledWithConcurrency(tasks)
   return accumulated
 }
 
@@ -356,7 +357,7 @@ async function fetchDeploymentsViaAgent(namespace?: string, onProgress?: (partia
   if (clusters.length === 0) return []
   const accumulated: Deployment[] = []
 
-  const promises = clusters.map(async ({ name, context }) => {
+  const tasks = clusters.map(({ name, context }) => async () => {
     const params = new URLSearchParams()
     params.append('cluster', context || name)
     if (namespace) params.append('namespace', namespace)
@@ -381,7 +382,7 @@ async function fetchDeploymentsViaAgent(namespace?: string, onProgress?: (partia
     return tagged
   })
 
-  await Promise.allSettled(promises)
+  await settledWithConcurrency(tasks)
   return accumulated
 }
 
@@ -557,11 +558,11 @@ export function useCachedEvents(
           const events = await kubectlProxy.getEvents(ctx, namespace, limit)
           return events.map(e => ({ ...e, cluster }))
         }
-        // Fetch from all clusters via agent
+        // Fetch from all clusters via agent with bounded concurrency
         const clusters = getAgentClusters()
         const allEvents: ClusterEvent[] = []
-        const results = await Promise.allSettled(
-          clusters.map(async (ci) => {
+        const results = await settledWithConcurrency(
+          clusters.map((ci) => async () => {
             const ctx = ci.context || ci.name
             const events = await kubectlProxy.getEvents(ctx, namespace, limit)
             return events.map(e => ({ ...e, cluster: ci.name }))
@@ -1345,7 +1346,7 @@ async function fetchLLMdServers(
   // useCache prevents calling fetchers in demo mode via effectiveEnabled
   const accumulated: LLMdServer[] = []
 
-  const promises = clusters.map(async (cluster) => {
+  const tasks = clusters.map((cluster) => async () => {
     try {
       const clusterServers = await fetchLLMdServersForCluster(cluster)
       accumulated.push(...clusterServers)
@@ -1361,7 +1362,7 @@ async function fetchLLMdServers(
     }
   })
 
-  await Promise.allSettled(promises)
+  await settledWithConcurrency(tasks)
   return accumulated
 }
 
@@ -1420,7 +1421,7 @@ async function fetchLLMdModels(
   // useCache prevents calling fetchers in demo mode via effectiveEnabled
   const accumulated: LLMdModel[] = []
 
-  const promises = clusters.map(async (cluster) => {
+  const tasks = clusters.map((cluster) => async () => {
     try {
       const response = await kubectlProxy.exec(['get', 'inferencepools', '-A', '-o', 'json'], { context: cluster, timeout: KUBECTL_EXTENDED_TIMEOUT_MS })
       if (response.exitCode !== 0) return []
@@ -1450,7 +1451,7 @@ async function fetchLLMdModels(
     }
   })
 
-  await Promise.allSettled(promises)
+  await settledWithConcurrency(tasks)
   return accumulated
 }
 
@@ -1507,7 +1508,7 @@ async function fetchWorkloadsFromAgent(onProgress?: (partial: Workload[]) => voi
   if (clusters.length === 0) return null
   const accumulated: Workload[] = []
 
-  const promises = clusters.map(async ({ name, context }) => {
+  const tasks = clusters.map(({ name, context }) => async () => {
     const params = new URLSearchParams()
     params.append('cluster', context || name)
 
@@ -1545,7 +1546,7 @@ async function fetchWorkloadsFromAgent(onProgress?: (partial: Workload[]) => voi
     return tagged
   })
 
-  await Promise.allSettled(promises)
+  await settledWithConcurrency(tasks)
   return accumulated.length > 0 ? accumulated : null
 }
 
@@ -1640,9 +1641,9 @@ async function fetchSecurityIssuesViaKubectl(cluster?: string, namespace?: strin
   const severityOrder: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3, info: 4 }
   const accumulated: SecurityIssue[] = []
 
-  const promises = clusters
+  const tasks = clusters
     .filter(c => !cluster || c.name === cluster)
-    .map(async ({ name, context }) => {
+    .map(({ name, context }) => async () => {
       const ctx = context || name
       // Get all pods and check for security issues
       const nsFlag = namespace ? ['-n', namespace] : ['-A']
@@ -1715,7 +1716,7 @@ async function fetchSecurityIssuesViaKubectl(cluster?: string, namespace?: strin
       return issues
     })
 
-  await Promise.allSettled(promises)
+  await settledWithConcurrency(tasks)
   // Final sort
   return accumulated.sort((a, b) => (severityOrder[a.severity] || 5) - (severityOrder[b.severity] || 5))
 }
@@ -3892,9 +3893,9 @@ async function fetchISO27001AuditViaKubectl(
 
   const accumulated: ISO27001Finding[] = []
 
-  const promises = clusters
+  const tasks = clusters
     .filter(c => !cluster || c.name === cluster)
-    .map(async ({ name, context }) => {
+    .map(({ name, context }) => async () => {
       try {
         const clusterFindings = await runISO27001ChecksForCluster(name, context || name)
         accumulated.push(...clusterFindings)
@@ -3906,7 +3907,7 @@ async function fetchISO27001AuditViaKubectl(
       }
     })
 
-  await Promise.allSettled(promises)
+  await settledWithConcurrency(tasks)
   return accumulated
 }
 

--- a/web/src/hooks/useKubescape.ts
+++ b/web/src/hooks/useKubescape.ts
@@ -4,7 +4,7 @@
  * Uses parallel cluster checks with progressive streaming:
  * - Phase 1: CRD/API existence check per cluster (3s timeout)
  * - Phase 2: Fetch ConfigurationScanSummaries from installed clusters (15s timeout)
- * - All clusters checked in parallel via Promise.allSettled
+ * - Clusters checked with bounded concurrency (default 8 parallel)
  * - Results stream to the card as each cluster completes
  * - localStorage cache with auto-refresh
  * - Demo fallback when no clusters are connected
@@ -13,6 +13,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { kubectlProxy } from '../lib/kubectlProxy'
+import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_KUBESCAPE_CACHE, STORAGE_KEY_KUBESCAPE_CACHE_TIME } from '../lib/constants/storage'
@@ -355,24 +356,23 @@ export function useKubescape() {
     }
     setClustersChecked(0)
 
-    // Check all clusters in parallel, stream results progressively
+    // Check all clusters with bounded concurrency, stream results progressively
     const allStatuses: Record<string, KubescapeClusterStatus> = {}
 
-    const promises = (clusters || []).map(cluster =>
-      fetchSingleCluster(cluster).then(status => {
-        allStatuses[cluster] = status
-        // Stream each result immediately — card re-renders progressively
-        setStatuses(prev => ({ ...prev, [cluster]: status }))
-        setClustersChecked(prev => prev + 1)
-        // Clear loading state once first cluster with data arrives
-        if (!initialLoadDone.current && status.installed) {
-          initialLoadDone.current = true
-          setIsLoading(false)
-        }
-      })
-    )
+    const tasks = (clusters || []).map(cluster => async () => {
+      const status = await fetchSingleCluster(cluster)
+      allStatuses[cluster] = status
+      // Stream each result immediately — card re-renders progressively
+      setStatuses(prev => ({ ...prev, [cluster]: status }))
+      setClustersChecked(prev => prev + 1)
+      // Clear loading state once first cluster with data arrives
+      if (!initialLoadDone.current && status.installed) {
+        initialLoadDone.current = true
+        setIsLoading(false)
+      }
+    })
 
-    await Promise.allSettled(promises)
+    await settledWithConcurrency(tasks)
 
     // Final: save complete cache and clear refresh state
     saveToCache(allStatuses)

--- a/web/src/hooks/useKyverno.ts
+++ b/web/src/hooks/useKyverno.ts
@@ -4,7 +4,7 @@
  * Uses parallel cluster checks with progressive streaming:
  * - Phase 1: CRD existence check per cluster (3s timeout)
  * - Phase 2: Fetch policies/reports from installed clusters (15s timeout)
- * - All clusters checked in parallel via Promise.allSettled
+ * - Clusters checked with bounded concurrency (default 8 parallel)
  * - Results stream to the card as each cluster completes
  * - localStorage cache with auto-refresh
  * - Demo fallback when no clusters are connected
@@ -13,6 +13,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { kubectlProxy } from '../lib/kubectlProxy'
+import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_KYVERNO_CACHE, STORAGE_KEY_KYVERNO_CACHE_TIME } from '../lib/constants/storage'
@@ -377,24 +378,23 @@ export function useKyverno() {
     }
     setClustersChecked(0)
 
-    // Check all clusters in parallel, stream results progressively
+    // Check all clusters with bounded concurrency, stream results progressively
     const allStatuses: Record<string, KyvernoClusterStatus> = {}
 
-    const promises = (clusters || []).map(cluster =>
-      fetchSingleCluster(cluster).then(status => {
-        allStatuses[cluster] = status
-        // Stream each result immediately — card re-renders progressively
-        setStatuses(prev => ({ ...prev, [cluster]: status }))
-        setClustersChecked(prev => prev + 1)
-        // Clear loading state once first cluster with data arrives
-        if (!initialLoadDone.current && status.installed) {
-          initialLoadDone.current = true
-          setIsLoading(false)
-        }
-      })
-    )
+    const tasks = (clusters || []).map(cluster => async () => {
+      const status = await fetchSingleCluster(cluster)
+      allStatuses[cluster] = status
+      // Stream each result immediately — card re-renders progressively
+      setStatuses(prev => ({ ...prev, [cluster]: status }))
+      setClustersChecked(prev => prev + 1)
+      // Clear loading state once first cluster with data arrives
+      if (!initialLoadDone.current && status.installed) {
+        initialLoadDone.current = true
+        setIsLoading(false)
+      }
+    })
 
-    await Promise.allSettled(promises)
+    await settledWithConcurrency(tasks)
 
     // Final: save complete cache and clear refresh state
     saveToCache(allStatuses)

--- a/web/src/hooks/useRBACFindings.ts
+++ b/web/src/hooks/useRBACFindings.ts
@@ -13,6 +13,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { kubectlProxy } from '../lib/kubectlProxy'
+import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_RBAC_CACHE, STORAGE_KEY_RBAC_CACHE_TIME } from '../lib/constants/storage'
@@ -307,23 +308,22 @@ export function useRBACFindings() {
 
       const allFindings: RBACFinding[] = []
 
-      // Check all clusters in parallel, stream results progressively
-      const promises = clusters.map(cluster =>
-        fetchSingleCluster(cluster).then(clusterFindings => {
-          allFindings.push(...clusterFindings)
-          // Stream each cluster's results immediately
-          setFindings(prev => {
-            const otherFindings = prev.filter(f => f.cluster !== cluster)
-            return [...otherFindings, ...clusterFindings]
-          })
-          if (!initialLoadDone.current && clusterFindings.length > 0) {
-            initialLoadDone.current = true
-            setIsLoading(false)
-          }
+      // Check all clusters with bounded concurrency, stream results progressively
+      const tasks = clusters.map(cluster => async () => {
+        const clusterFindings = await fetchSingleCluster(cluster)
+        allFindings.push(...clusterFindings)
+        // Stream each cluster's results immediately
+        setFindings(prev => {
+          const otherFindings = prev.filter(f => f.cluster !== cluster)
+          return [...otherFindings, ...clusterFindings]
         })
-      )
+        if (!initialLoadDone.current && clusterFindings.length > 0) {
+          initialLoadDone.current = true
+          setIsLoading(false)
+        }
+      })
 
-      await Promise.allSettled(promises)
+      await settledWithConcurrency(tasks)
 
       saveToCache(allFindings)
       initialLoadDone.current = true

--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -4,7 +4,7 @@
  * Uses parallel cluster checks with progressive streaming:
  * - Phase 1: CRD existence check per cluster (5s timeout)
  * - Phase 2: Fetch assessment data from installed clusters (15s timeout)
- * - All clusters checked in parallel via Promise.allSettled
+ * - Clusters checked with bounded concurrency (default 8 parallel)
  * - Results stream to the card as each cluster completes
  * - localStorage cache with auto-refresh
  * - Demo fallback when no clusters are connected
@@ -17,6 +17,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { kubectlProxy } from '../lib/kubectlProxy'
+import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_TRESTLE_CACHE, STORAGE_KEY_TRESTLE_CACHE_TIME } from '../lib/constants/storage'
@@ -374,23 +375,22 @@ export function useTrestle() {
       return
     }
 
-    // Real mode: check all clusters in parallel, stream results progressively
+    // Real mode: check all clusters with bounded concurrency, stream results progressively
     const allStatuses: Record<string, TrestleClusterStatus> = {}
 
-    const promises = (clusterNames || []).map(cluster =>
-      fetchSingleCluster(cluster).then(status => {
-        allStatuses[cluster] = status
-        if (mountedRef.current) {
-          // Stream each result immediately — card re-renders progressively
-          setStatuses(prev => ({ ...prev, [cluster]: status }))
-          setClustersChecked(prev => prev + 1)
-          // Clear initial loading after first result arrives
-          setIsLoading(false)
-        }
-      })
-    )
+    const tasks = (clusterNames || []).map(cluster => async () => {
+      const status = await fetchSingleCluster(cluster)
+      allStatuses[cluster] = status
+      if (mountedRef.current) {
+        // Stream each result immediately — card re-renders progressively
+        setStatuses(prev => ({ ...prev, [cluster]: status }))
+        setClustersChecked(prev => prev + 1)
+        // Clear initial loading after first result arrives
+        setIsLoading(false)
+      }
+    })
 
-    await Promise.allSettled(promises)
+    await settledWithConcurrency(tasks)
 
     if (mountedRef.current) {
       // If no cluster has Trestle installed, fall back to demo data so the

--- a/web/src/hooks/useTrivy.ts
+++ b/web/src/hooks/useTrivy.ts
@@ -4,7 +4,7 @@
  * Uses parallel cluster checks with progressive streaming:
  * - Phase 1: CRD existence check per cluster (3s timeout)
  * - Phase 2: Fetch VulnerabilityReports from installed clusters (15s timeout)
- * - All clusters checked in parallel via Promise.allSettled
+ * - Clusters checked with bounded concurrency (default 8 parallel)
  * - Results stream to the card as each cluster completes
  * - localStorage cache with auto-refresh
  * - Demo fallback when no clusters are connected
@@ -13,6 +13,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useClusters } from './useMCP'
 import { kubectlProxy } from '../lib/kubectlProxy'
+import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useDemoMode } from './useDemoMode'
 import { registerRefetch, registerCacheReset, unregisterCacheReset } from '../lib/modeTransition'
 import { STORAGE_KEY_TRIVY_CACHE, STORAGE_KEY_TRIVY_CACHE_TIME } from '../lib/constants/storage'
@@ -289,24 +290,23 @@ export function useTrivy() {
     }
     setClustersChecked(0)
 
-    // Check all clusters in parallel, stream results progressively
+    // Check all clusters with bounded concurrency, stream results progressively
     const allStatuses: Record<string, TrivyClusterStatus> = {}
 
-    const promises = (clusters || []).map(cluster =>
-      fetchSingleCluster(cluster).then(status => {
-        allStatuses[cluster] = status
-        // Stream each result immediately — card re-renders progressively
-        setStatuses(prev => ({ ...prev, [cluster]: status }))
-        setClustersChecked(prev => prev + 1)
-        // Clear loading state once first cluster with data arrives
-        if (!initialLoadDone.current && status.installed) {
-          initialLoadDone.current = true
-          setIsLoading(false)
-        }
-      })
-    )
+    const tasks = (clusters || []).map(cluster => async () => {
+      const status = await fetchSingleCluster(cluster)
+      allStatuses[cluster] = status
+      // Stream each result immediately — card re-renders progressively
+      setStatuses(prev => ({ ...prev, [cluster]: status }))
+      setClustersChecked(prev => prev + 1)
+      // Clear loading state once first cluster with data arrives
+      if (!initialLoadDone.current && status.installed) {
+        initialLoadDone.current = true
+        setIsLoading(false)
+      }
+    })
 
-    await Promise.allSettled(promises)
+    await settledWithConcurrency(tasks)
 
     // Final: save complete cache and clear refresh state
     saveToCache(allStatuses)

--- a/web/src/hooks/useUsers.ts
+++ b/web/src/hooks/useUsers.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { api } from '../lib/api'
+import { mapSettledWithConcurrency } from '../lib/utils/concurrency'
 import { getDemoMode } from './useDemoMode'
 import type {
   ConsoleUser,
@@ -342,9 +343,10 @@ export function useAllOpenShiftUsers(clusters: Array<{ name: string }>) {
     const allUsers: OpenShiftUser[] = []
     const failed: string[] = []
 
-    // Fetch from all clusters in parallel
-    const results = await Promise.allSettled(
-      clusters.map(async (cluster) => {
+    // Fetch from all clusters with bounded concurrency
+    const results = await mapSettledWithConcurrency(
+      clusters,
+      async (cluster) => {
         try {
           const { data } = await api.get<OpenShiftUser[]>(`/api/openshift/users?cluster=${cluster.name}`)
           return { cluster: cluster.name, users: data || [] }
@@ -352,7 +354,7 @@ export function useAllOpenShiftUsers(clusters: Array<{ name: string }>) {
           // Mark cluster as failed but don't break the whole fetch
           return { cluster: cluster.name, users: [] as OpenShiftUser[], failed: true }
         }
-      })
+      },
     )
 
     results.forEach((result) => {
@@ -538,9 +540,10 @@ export function useAllK8sServiceAccounts(clusters: Array<{ name: string }>) {
     const allSAs: K8sServiceAccount[] = []
     const failed: string[] = []
 
-    // Fetch from all clusters in parallel
-    const results = await Promise.allSettled(
-      clusters.map(async (cluster) => {
+    // Fetch from all clusters with bounded concurrency
+    const results = await mapSettledWithConcurrency(
+      clusters,
+      async (cluster) => {
         try {
           const { data } = await api.get<K8sServiceAccount[]>(`/api/rbac/service-accounts?cluster=${cluster.name}`, { timeout: 60000 })
           return { cluster: cluster.name, sas: data || [] }
@@ -548,7 +551,7 @@ export function useAllK8sServiceAccounts(clusters: Array<{ name: string }>) {
           // Mark cluster as failed but don't break the whole fetch
           return { cluster: cluster.name, sas: [] as K8sServiceAccount[], failed: true }
         }
-      })
+      },
     )
 
     results.forEach((result) => {

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { mapSettledWithConcurrency } from '../lib/utils/concurrency'
 import { isAgentUnavailable } from './useLocalAgent'
 import { clusterCacheRef } from './mcp/shared'
 import { isDemoMode } from '../lib/demoMode'
@@ -92,8 +93,9 @@ async function fetchWorkloadsViaAgent(opts?: {
     ? clusters.filter(c => c.name === opts.cluster)
     : clusters
 
-  const results = await Promise.allSettled(
-    targets.map(async ({ name, context }) => {
+  const results = await mapSettledWithConcurrency(
+    targets,
+    async ({ name, context }) => {
       const params = new URLSearchParams()
       params.append('cluster', context || name)
       if (opts?.namespace) params.append('namespace', opts.namespace)
@@ -127,7 +129,7 @@ async function fetchWorkloadsViaAgent(opts?: {
           createdAt: new Date().toISOString(),
         }
       })
-    })
+    },
   )
 
   const items: Workload[] = []

--- a/web/src/lib/utils/concurrency.ts
+++ b/web/src/lib/utils/concurrency.ts
@@ -1,0 +1,72 @@
+/**
+ * Concurrency-limited replacement for Promise.allSettled.
+ *
+ * In multi-cluster environments (50–150 clusters) the browser limits
+ * concurrent connections per origin (~6 in most browsers).  Firing all
+ * fetches at once causes heavy request queuing, degraded performance,
+ * and potential HTTP 429 (rate-limit) errors from backends.
+ *
+ * This module provides a drop-in concurrency limiter that caps the
+ * number of in-flight promises so the browser connection pool is not
+ * overwhelmed.
+ */
+
+/** Default maximum number of concurrent requests across clusters */
+export const DEFAULT_CLUSTER_CONCURRENCY = 8
+
+/**
+ * Execute an array of async tasks with bounded concurrency, returning
+ * results in the same format as `Promise.allSettled`.
+ *
+ * Uses a worker-pool pattern: `concurrency` workers pull from a shared
+ * queue, so fast-completing tasks do not leave workers idle.
+ *
+ * @param tasks   - Array of zero-arg async functions to execute
+ * @param concurrency - Max tasks running at one time (default 8)
+ * @returns PromiseSettledResult array in the same order as `tasks`
+ */
+export async function settledWithConcurrency<T>(
+  tasks: Array<() => Promise<T>>,
+  concurrency: number = DEFAULT_CLUSTER_CONCURRENCY,
+): Promise<PromiseSettledResult<T>[]> {
+  if (tasks.length === 0) return []
+
+  const results: PromiseSettledResult<T>[] = new Array(tasks.length)
+  let cursor = 0
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, tasks.length) },
+    async () => {
+      while (cursor < tasks.length) {
+        const idx = cursor++
+        try {
+          const value = await tasks[idx]()
+          results[idx] = { status: 'fulfilled', value }
+        } catch (reason) {
+          results[idx] = { status: 'rejected', reason }
+        }
+      }
+    },
+  )
+
+  await Promise.all(workers)
+  return results
+}
+
+/**
+ * Convenience wrapper: run `fn` over each item in `items` with bounded
+ * concurrency, settling all results.
+ *
+ * Equivalent to `Promise.allSettled(items.map(fn))` but with a cap on
+ * the number of concurrent invocations.
+ */
+export async function mapSettledWithConcurrency<TItem, TResult>(
+  items: TItem[],
+  fn: (item: TItem, index: number) => Promise<TResult>,
+  concurrency: number = DEFAULT_CLUSTER_CONCURRENCY,
+): Promise<PromiseSettledResult<TResult>[]> {
+  return settledWithConcurrency(
+    items.map((item, index) => () => fn(item, index)),
+    concurrency,
+  )
+}


### PR DESCRIPTION
Closes #3521

## Summary

- Introduces `settledWithConcurrency()` and `mapSettledWithConcurrency()` utilities in `web/src/lib/utils/concurrency.ts` — a worker-pool based concurrency limiter that caps parallel requests (default 8) while returning the same `PromiseSettledResult` interface as `Promise.allSettled`
- Replaces unbounded `Promise.allSettled(clusters.map(...))` calls across all multi-cluster fetch functions with the concurrency-limited variant
- Prevents browser connection pool exhaustion and HTTP 429 rate-limit errors in environments with 50–150 clusters

## Files changed

| File | Change |
|------|--------|
| `web/src/lib/utils/concurrency.ts` | New concurrency utility (worker-pool pattern) |
| `web/src/hooks/useCachedData.ts` | 8 multi-cluster fetch functions updated |
| `web/src/hooks/useKyverno.ts` | Cluster checks now concurrency-limited |
| `web/src/hooks/useTrivy.ts` | Cluster checks now concurrency-limited |
| `web/src/hooks/useKubescape.ts` | Cluster checks now concurrency-limited |
| `web/src/hooks/useTrestle.ts` | Cluster checks now concurrency-limited |
| `web/src/hooks/useRBACFindings.ts` | Cluster checks now concurrency-limited |
| `web/src/hooks/useUsers.ts` | User/SA fetches now concurrency-limited |
| `web/src/hooks/useWorkloads.ts` | Workload fetches now concurrency-limited |
| `web/src/hooks/mcp/kagenti.ts` | Agent fetches now concurrency-limited |
| `web/src/hooks/mcp/kagent_crds.ts` | Agent CRD fetches now concurrency-limited |
| `web/src/contexts/AlertsContext.tsx` | GPU health check fetches now concurrency-limited |

## Test plan

- [ ] Verify build passes (`npm run build`)
- [ ] Confirm dashboard loads correctly with connected clusters
- [ ] Verify progressive streaming still works (cards render as each cluster completes)
- [ ] Test with multiple clusters to confirm requests are batched (Network tab in DevTools should show max 8 concurrent requests per fetch cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)