### PR TITLE
fix: resolve formatMemoryStat ReferenceError on /clusters

### DIFF
--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -357,16 +357,14 @@ export function Clusters() {
         }
       case 'memory':
         return {
-          value: hasData ? stats.totalMemoryGB : '-',
-          format: (v: number) => formatMemoryStat(v),
+          value: hasData ? formatMemoryStat(stats.totalMemoryGB) : '-',
           sublabel: 'allocatable',
           onClick: () => { emitClusterStatsDrillDown('memory'); window.location.href = '/compute' },
           isClickable: hasData,
         }
       case 'storage':
         return {
-          value: hasData ? stats.totalStorageGB : '-',
-          format: (v: number) => formatMemoryStat(v),
+          value: hasData ? formatMemoryStat(stats.totalStorageGB) : '-',
           sublabel: 'storage',
           onClick: () => { emitClusterStatsDrillDown('storage'); window.location.href = '/storage' },
           isClickable: hasData,

--- a/web/src/components/nodes/Nodes.tsx
+++ b/web/src/components/nodes/Nodes.tsx
@@ -68,7 +68,7 @@ export function Nodes() {
       case 'cpus':
         return { value: totalCPU, sublabel: t('common:nodes.cpuCores'), onClick: () => drillToAllNodes(), isClickable: totalCPU > 0 }
       case 'memory':
-        return { value: totalMemoryGB, format: (v: number) => formatMemoryStat(v), sublabel: t('common:common.memory'), onClick: () => drillToAllNodes(), isClickable: totalMemoryGB > 0 }
+        return { value: formatMemoryStat(totalMemoryGB), sublabel: t('common:common.memory'), onClick: () => drillToAllNodes(), isClickable: totalMemoryGB > 0 }
       case 'gpus':
         return { value: totalGPUs, sublabel: t('common:common.gpus'), onClick: () => drillToAllGPU(), isClickable: totalGPUs > 0 }
       case 'tpus':


### PR DESCRIPTION
Closes #3528

## Summary
- Fix `ReferenceError: Can't find variable: formatMemoryStat` (x21) on `/clusters` page
- The `format` callback on stat block values captured `formatMemoryStat` in a closure that executed later during rendering. When the browser served a stale Clusters chunk after a deploy, the closure's reference to the cross-chunk import could become invalid, causing Safari's "Can't find variable" ReferenceError
- Call `formatMemoryStat()` eagerly when building the stat value instead of deferring via a `format` callback
- Also fixes the identical pattern in Nodes.tsx

## Test plan
- [x] `npm run build` passes
- [ ] Visit `/clusters` page -- memory and storage stat blocks display formatted values (e.g. "30 GB", "1.2 TB")
- [ ] Visit `/compute` page -- memory stat block displays formatted values