### PR TITLE
fix: show real cluster errors instead of generic "operation failed"

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -4237,18 +4237,19 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 			}()
 			if err := s.localClusters.CreateCluster(req.Tool, req.Name); err != nil {
 				log.Printf("[LocalClusters] Failed to create cluster %s with %s: %v", req.Name, req.Tool, err)
+				errMsg := sanitizeClusterError(err)
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 					"tool":     req.Tool,
 					"name":     req.Name,
 					"status":   "failed",
-					"message":  "operation failed",
+					"message":  errMsg,
 					"progress": 0,
 				})
 				// Keep backwards-compat event
 				s.BroadcastToClients("local_cluster_error", map[string]string{
 					"tool":  req.Tool,
 					"name":  req.Name,
-					"error": "internal server error",
+					"error": errMsg,
 				})
 			} else {
 				log.Printf("[LocalClusters] Created cluster %s with %s", req.Name, req.Tool)
@@ -4293,18 +4294,19 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 			}()
 			if err := s.localClusters.DeleteCluster(tool, name); err != nil {
 				log.Printf("[LocalClusters] Failed to delete cluster %s: %v", name, err)
+				errMsg := sanitizeClusterError(err)
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 					"tool":     tool,
 					"name":     name,
 					"status":   "failed",
-					"message":  "operation failed",
+					"message":  errMsg,
 					"progress": 0,
 				})
 				// Keep backwards-compat event
 				s.BroadcastToClients("local_cluster_error", map[string]string{
 					"tool":  tool,
 					"name":  name,
-					"error": "internal server error",
+					"error": errMsg,
 				})
 			} else {
 				log.Printf("[LocalClusters] Deleted cluster %s", name)
@@ -4409,7 +4411,7 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 				"tool":     "vcluster",
 				"name":     req.Name,
 				"status":   "failed",
-				"message":  "operation failed",
+				"message":  sanitizeClusterError(err),
 				"progress": progressFailed,
 			})
 		} else {
@@ -4574,7 +4576,7 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 				"tool":     "vcluster",
 				"name":     req.Name,
 				"status":   "failed",
-				"message":  "operation failed",
+				"message":  sanitizeClusterError(err),
 				"progress": progressFailed,
 			})
 		} else {

--- a/web/src/lib/clusterErrors.test.ts
+++ b/web/src/lib/clusterErrors.test.ts
@@ -28,6 +28,12 @@ describe('friendlyErrorMessage', () => {
     expect(friendlyErrorMessage(raw)).toContain('lowercase letters')
   })
 
+  it('maps kind-specific cluster name validation errors', () => {
+    const raw = "kind create failed: ERROR: failed to create cluster: 'Demo' is not a valid cluster name, cluster names must match ^[a-z0-9.-]+$"
+    expect(friendlyErrorMessage(raw)).toContain('lowercase letters')
+    expect(friendlyErrorMessage(raw)).toContain('hyphens')
+  })
+
   it('maps executable-not-found errors', () => {
     const raw = 'exec: "kind": executable file not found in $PATH'
     expect(friendlyErrorMessage(raw)).toContain('not found on the system PATH')

--- a/web/src/lib/clusterErrors.ts
+++ b/web/src/lib/clusterErrors.ts
@@ -10,9 +10,9 @@ export function friendlyErrorMessage(raw: string): string {
     return 'Docker is not running. Please start Docker Desktop or Rancher Desktop and try again.'
   }
 
-  // Cluster name validation - RFC-1123 subdomain
-  if (/invalid.*name|must consist of lower case alphanumeric/i.test(raw)) {
-    return 'Invalid cluster name. Use only lowercase letters, numbers, and hyphens (e.g. "my-cluster-1").'
+  // Cluster name validation - RFC-1123 subdomain / kind regex
+  if (/invalid.*name|must consist of lower case alphanumeric|not a valid cluster name|cluster names must match/i.test(raw)) {
+    return 'Invalid cluster name. Use only lowercase letters, numbers, dots, or hyphens (e.g. "my-cluster-1").'
   }
 
   // Cluster already exists


### PR DESCRIPTION
Closes #3331

## Summary
- **Backend:** Replace all hardcoded `"operation failed"` and `"internal server error"` strings in WebSocket broadcasts with `sanitizeClusterError(err)` output across local cluster create/delete and vCluster create/delete failure paths (6 call sites in `pkg/agent/server.go`).
- **Frontend:** Extend `friendlyErrorMessage()` pattern matching to also recognise kind's specific error format (`"not a valid cluster name, cluster names must match ^[a-z0-9.-]+$"`), and update the friendly message to mention dots as valid characters.
- **Tests:** Add new test case for kind-specific cluster name validation error.

## Test plan
- [x] `go build ./...` passes
- [x] `npm run build` passes
- [x] `vitest run clusterErrors.test.ts` -- all 10 tests pass (including new kind-specific pattern test)
- [ ] Manual: Create cluster with invalid name (e.g. uppercase) in Settings > Local Clusters -- verify actionable error appears in banner

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>