### PR TITLE
fix: add ArgoCD card unit tests and wire isDemoMode in ArgoCDHealth

### DIFF
--- a/web/src/components/cards/ArgoCDHealth.tsx
+++ b/web/src/components/cards/ArgoCDHealth.tsx
@@ -2,6 +2,7 @@ import { CheckCircle, XCircle, Clock, AlertTriangle, ExternalLink, AlertCircle }
 import { Skeleton } from '../ui/Skeleton'
 import { useArgoCDHealth } from '../../hooks/useArgoCD'
 import { useCardLoadingState } from './CardDataContext'
+import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTranslation } from 'react-i18next'
 
 interface ArgoCDHealthProps {
@@ -27,6 +28,7 @@ const healthConfig: Record<string, HealthConfigEntry> = {
 
 export function ArgoCDHealth({ config: _config }: ArgoCDHealthProps) {
   const { t } = useTranslation('cards')
+  const { isDemoMode } = useDemoMode()
   const {
     stats,
     total,
@@ -46,7 +48,7 @@ export function ArgoCDHealth({ config: _config }: ArgoCDHealthProps) {
     hasAnyData: hasData,
     isFailed,
     consecutiveFailures,
-    isDemoData,
+    isDemoData: isDemoMode || isDemoData,
   })
 
   if (showSkeleton) {

--- a/web/src/components/cards/__tests__/ArgoCDHealth.test.tsx
+++ b/web/src/components/cards/__tests__/ArgoCDHealth.test.tsx
@@ -1,0 +1,329 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any module that transitively imports them
+// ---------------------------------------------------------------------------
+
+const mockUseArgoCDHealth = vi.fn()
+vi.mock('../../../hooks/useArgoCD', () => ({
+  useArgoCDHealth: () => mockUseArgoCDHealth(),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+const mockUseReportCardDataState = vi.fn()
+vi.mock('../CardDataContext', () => ({
+  useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
+  useReportCardDataState: (state: unknown) => mockUseReportCardDataState(state),
+  CardDataReportContext: { Provider: ({ children }: { children: React.ReactNode }) => children },
+}))
+
+const mockUseDemoMode = vi.fn()
+vi.mock('../../../hooks/useDemoMode', () => ({
+  useDemoMode: () => mockUseDemoMode(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Import the component under test AFTER mocks are set up
+// ---------------------------------------------------------------------------
+import { ArgoCDHealth } from '../ArgoCDHealth'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Default hook return for live data scenario */
+function liveDataDefaults() {
+  return {
+    stats: { healthy: 15, degraded: 3, progressing: 2, missing: 1, unknown: 1 },
+    total: 22,
+    healthyPercent: (15 / 22) * 100,
+    isLoading: false,
+    isRefreshing: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    isDemoData: false,
+    error: null,
+    lastRefresh: Date.now(),
+    refetch: vi.fn(),
+  }
+}
+
+/** Default hook return for demo data scenario */
+function demoDataDefaults() {
+  return {
+    stats: { healthy: 7, degraded: 2, progressing: 1, missing: 0, unknown: 0 },
+    total: 10,
+    healthyPercent: 70,
+    isLoading: false,
+    isRefreshing: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    isDemoData: true,
+    error: null,
+    lastRefresh: Date.now(),
+    refetch: vi.fn(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ArgoCDHealth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUseDemoMode.mockReturnValue({ isDemoMode: false, setDemoMode: vi.fn() })
+    mockUseCardLoadingState.mockReturnValue({
+      showSkeleton: false,
+      showEmptyState: false,
+      hasData: true,
+      isRefreshing: false,
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Loading / skeleton state
+  // -------------------------------------------------------------------------
+  describe('loading state', () => {
+    it('renders skeletons when showSkeleton is true', () => {
+      mockUseArgoCDHealth.mockReturnValue({
+        ...liveDataDefaults(),
+        isLoading: true,
+        total: 0,
+        stats: { healthy: 0, degraded: 0, progressing: 0, missing: 0, unknown: 0 },
+      })
+      mockUseCardLoadingState.mockReturnValue({
+        showSkeleton: true,
+        showEmptyState: false,
+        hasData: false,
+        isRefreshing: false,
+      })
+
+      const { container } = render(<ArgoCDHealth />)
+      expect(container.querySelector('.content-loaded')).toBeNull()
+      expect(screen.queryByText('argoCDHealth.healthy')).toBeNull()
+    })
+
+    it('passes correct isLoading/hasAnyData to useCardLoadingState', () => {
+      mockUseArgoCDHealth.mockReturnValue({
+        ...liveDataDefaults(),
+        isLoading: true,
+        total: 0,
+        stats: { healthy: 0, degraded: 0, progressing: 0, missing: 0, unknown: 0 },
+      })
+      mockUseCardLoadingState.mockReturnValue({
+        showSkeleton: true,
+        showEmptyState: false,
+        hasData: false,
+        isRefreshing: false,
+      })
+
+      render(<ArgoCDHealth />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isLoading: true,
+          hasAnyData: false,
+        })
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+  describe('empty state', () => {
+    it('renders empty state text when showEmptyState is true', () => {
+      mockUseArgoCDHealth.mockReturnValue({
+        ...liveDataDefaults(),
+        isLoading: false,
+        total: 0,
+        stats: { healthy: 0, degraded: 0, progressing: 0, missing: 0, unknown: 0 },
+      })
+      mockUseCardLoadingState.mockReturnValue({
+        showSkeleton: false,
+        showEmptyState: true,
+        hasData: false,
+        isRefreshing: false,
+      })
+
+      render(<ArgoCDHealth />)
+      expect(screen.getByText('argoCDHealth.noData')).toBeInTheDocument()
+      expect(screen.getByText('argoCDHealth.connectArgoCD')).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Live data rendering
+  // -------------------------------------------------------------------------
+  describe('live data', () => {
+    it('renders the health gauge with correct percentage and total', () => {
+      const data = liveDataDefaults()
+      mockUseArgoCDHealth.mockReturnValue(data)
+
+      render(<ArgoCDHealth />)
+
+      // Healthy percent (rounded)
+      expect(screen.getByText(`${data.healthyPercent.toFixed(0)}%`)).toBeInTheDocument()
+      // Total apps
+      expect(screen.getByText('22')).toBeInTheDocument()
+      expect(screen.getByText('argoCDHealth.totalApps')).toBeInTheDocument()
+    })
+
+    it('renders all health breakdown rows with correct counts', () => {
+      mockUseArgoCDHealth.mockReturnValue(liveDataDefaults())
+
+      render(<ArgoCDHealth />)
+
+      expect(screen.getByText('15')).toBeInTheDocument()
+      expect(screen.getByText('3')).toBeInTheDocument()
+      expect(screen.getByText('2')).toBeInTheDocument()
+
+      // Labels (from the breakdown rows)
+      expect(screen.getAllByText('argoCDHealth.healthy').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByText('argoCDHealth.degraded')).toBeInTheDocument()
+      expect(screen.getByText('argoCDHealth.progressing')).toBeInTheDocument()
+      expect(screen.getByText('argoCDHealth.missing')).toBeInTheDocument()
+      expect(screen.getByText('argoCDHealth.unknown')).toBeInTheDocument()
+    })
+
+    it('renders the health bar with correct segment widths', () => {
+      const data = liveDataDefaults()
+      mockUseArgoCDHealth.mockReturnValue(data)
+
+      const { container } = render(<ArgoCDHealth />)
+
+      const segments = container.querySelectorAll('.bg-green-500, .bg-red-500, .bg-blue-500, .bg-orange-500, .bg-gray-500')
+      // The health bar has 5 segments
+      expect(segments.length).toBe(5)
+
+      // Verify healthy segment width
+      const healthySegment = segments[0] as HTMLElement
+      const expectedWidth = `${(data.stats.healthy / data.total) * 100}%`
+      expect(healthySegment.style.width).toBe(expectedWidth)
+    })
+
+    it('reports isDemoData as false for live data', () => {
+      mockUseArgoCDHealth.mockReturnValue(liveDataDefaults())
+
+      render(<ArgoCDHealth />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isDemoData: false,
+        })
+      )
+    })
+
+    it('renders the integration notice banner', () => {
+      mockUseArgoCDHealth.mockReturnValue(liveDataDefaults())
+
+      render(<ArgoCDHealth />)
+
+      expect(screen.getByText('argoCDHealth.argocdIntegration')).toBeInTheDocument()
+      expect(screen.getByText('argoCDHealth.installArgoCD')).toBeInTheDocument()
+    })
+
+    it('renders the ArgoCD documentation link', () => {
+      mockUseArgoCDHealth.mockReturnValue(liveDataDefaults())
+
+      render(<ArgoCDHealth />)
+
+      const link = screen.getByTitle('argoCDHealth.argocdDocumentation')
+      expect(link).toHaveAttribute('href', 'https://argo-cd.readthedocs.io/')
+      expect(link).toHaveAttribute('target', '_blank')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Demo data rendering
+  // -------------------------------------------------------------------------
+  describe('demo data', () => {
+    it('renders the health gauge and stats even when isDemoData is true', () => {
+      mockUseArgoCDHealth.mockReturnValue(demoDataDefaults())
+
+      render(<ArgoCDHealth />)
+
+      expect(screen.getByText('70%')).toBeInTheDocument()
+      expect(screen.getByText('10')).toBeInTheDocument()
+      expect(screen.getByText('7')).toBeInTheDocument()
+    })
+
+    it('reports isDemoData as true so CardWrapper shows demo badge', () => {
+      mockUseArgoCDHealth.mockReturnValue(demoDataDefaults())
+
+      render(<ArgoCDHealth />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isDemoData: true,
+        })
+      )
+    })
+
+    it('reports isDemoData as true when global demo mode is enabled, even if hook returns live data', () => {
+      mockUseDemoMode.mockReturnValue({ isDemoMode: true, setDemoMode: vi.fn() })
+      mockUseArgoCDHealth.mockReturnValue({
+        ...liveDataDefaults(),
+        isDemoData: false,
+      })
+
+      render(<ArgoCDHealth />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isDemoData: true,
+        })
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Failure / consecutive failures
+  // -------------------------------------------------------------------------
+  describe('failure states', () => {
+    it('passes isFailed and consecutiveFailures to useCardLoadingState', () => {
+      mockUseArgoCDHealth.mockReturnValue({
+        ...liveDataDefaults(),
+        isFailed: true,
+        consecutiveFailures: 5,
+      })
+
+      render(<ArgoCDHealth />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isFailed: true,
+          consecutiveFailures: 5,
+        })
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Progress / missing / unknown rows
+  // -------------------------------------------------------------------------
+  describe('health breakdown details', () => {
+    it('renders progressing, missing, and unknown with correct values', () => {
+      mockUseArgoCDHealth.mockReturnValue({
+        ...liveDataDefaults(),
+        stats: { healthy: 10, degraded: 0, progressing: 5, missing: 3, unknown: 2 },
+        total: 20,
+        healthyPercent: 50,
+      })
+
+      render(<ArgoCDHealth />)
+
+      expect(screen.getByText('5')).toBeInTheDocument()  // progressing
+      expect(screen.getByText('3')).toBeInTheDocument()  // missing
+      expect(screen.getByText('2')).toBeInTheDocument()  // unknown
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/ArgoCDSyncStatus.test.tsx
+++ b/web/src/components/cards/__tests__/ArgoCDSyncStatus.test.tsx
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any module that transitively imports them
+// ---------------------------------------------------------------------------
+
+const mockUseArgoCDSyncStatus = vi.fn()
+vi.mock('../../../hooks/useArgoCD', () => ({
+  useArgoCDSyncStatus: (...args: unknown[]) => mockUseArgoCDSyncStatus(...args),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+const mockUseReportCardDataState = vi.fn()
+vi.mock('../CardDataContext', () => ({
+  useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
+  useReportCardDataState: (state: unknown) => mockUseReportCardDataState(state),
+  CardDataReportContext: { Provider: ({ children }: { children: React.ReactNode }) => children },
+}))
+
+vi.mock('../../../hooks/useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: false, setDemoMode: vi.fn() }),
+}))
+
+vi.mock('../../../lib/cards/cardHooks', () => ({
+  useChartFilters: () => ({
+    localClusterFilter: [],
+    toggleClusterFilter: vi.fn(),
+    clearClusterFilter: vi.fn(),
+    availableClusters: ['cluster-a', 'cluster-b'],
+    showClusterFilter: false,
+    setShowClusterFilter: vi.fn(),
+    clusterFilterRef: { current: null },
+  }),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+vi.mock('../../../lib/cards/CardComponents', () => ({
+  CardClusterFilter: () => <div data-testid="cluster-filter" />,
+}))
+
+// ---------------------------------------------------------------------------
+// Import the component under test AFTER mocks are set up
+// ---------------------------------------------------------------------------
+import { ArgoCDSyncStatus } from '../ArgoCDSyncStatus'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Default hook return for live data scenario */
+function liveDataDefaults() {
+  return {
+    stats: { synced: 18, outOfSync: 4, unknown: 1 },
+    total: 23,
+    syncedPercent: (18 / 23) * 100,
+    outOfSyncPercent: (4 / 23) * 100,
+    isLoading: false,
+    isRefreshing: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    isDemoData: false,
+    error: null,
+    lastRefresh: Date.now(),
+    refetch: vi.fn(),
+  }
+}
+
+/** Default hook return for demo data scenario */
+function demoDataDefaults() {
+  return {
+    stats: { synced: 8, outOfSync: 2, unknown: 1 },
+    total: 11,
+    syncedPercent: (8 / 11) * 100,
+    outOfSyncPercent: (2 / 11) * 100,
+    isLoading: false,
+    isRefreshing: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    isDemoData: true,
+    error: null,
+    lastRefresh: Date.now(),
+    refetch: vi.fn(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ArgoCDSyncStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: useCardLoadingState returns "show content"
+    mockUseCardLoadingState.mockReturnValue({
+      showSkeleton: false,
+      showEmptyState: false,
+      hasData: true,
+      isRefreshing: false,
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Loading / skeleton state
+  // -------------------------------------------------------------------------
+  describe('loading state', () => {
+    it('renders skeletons when showSkeleton is true and no data exists', () => {
+      mockUseArgoCDSyncStatus.mockReturnValue({
+        ...liveDataDefaults(),
+        isLoading: true,
+        total: 0,
+        stats: { synced: 0, outOfSync: 0, unknown: 0 },
+      })
+      mockUseCardLoadingState.mockReturnValue({
+        showSkeleton: true,
+        showEmptyState: false,
+        hasData: false,
+        isRefreshing: false,
+      })
+
+      const { container } = render(<ArgoCDSyncStatus />)
+      // Should render Skeleton placeholders, not the real content
+      expect(container.querySelector('.content-loaded')).toBeNull()
+      // No donut chart or stats text visible
+      expect(screen.queryByText('argoCDSyncStatus.synced')).toBeNull()
+    })
+
+    it('passes correct isLoading/hasAnyData to useCardLoadingState', () => {
+      mockUseArgoCDSyncStatus.mockReturnValue({
+        ...liveDataDefaults(),
+        isLoading: true,
+        total: 0,
+        stats: { synced: 0, outOfSync: 0, unknown: 0 },
+      })
+      mockUseCardLoadingState.mockReturnValue({
+        showSkeleton: true,
+        showEmptyState: false,
+        hasData: false,
+        isRefreshing: false,
+      })
+
+      render(<ArgoCDSyncStatus />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isLoading: true,
+          hasAnyData: false,
+        })
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Empty state
+  // -------------------------------------------------------------------------
+  describe('empty state', () => {
+    it('renders empty state when showEmptyState is true', () => {
+      mockUseArgoCDSyncStatus.mockReturnValue({
+        ...liveDataDefaults(),
+        isLoading: false,
+        total: 0,
+        stats: { synced: 0, outOfSync: 0, unknown: 0 },
+      })
+      mockUseCardLoadingState.mockReturnValue({
+        showSkeleton: false,
+        showEmptyState: true,
+        hasData: false,
+        isRefreshing: false,
+      })
+
+      render(<ArgoCDSyncStatus />)
+      expect(screen.getByText('argoCDSyncStatus.noData')).toBeInTheDocument()
+      expect(screen.getByText('argoCDSyncStatus.connectArgoCD')).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Live data rendering
+  // -------------------------------------------------------------------------
+  describe('live data', () => {
+    it('renders donut chart, total, and stat rows with live data', () => {
+      mockUseArgoCDSyncStatus.mockReturnValue(liveDataDefaults())
+
+      render(<ArgoCDSyncStatus />)
+
+      // Total apps count in the donut center
+      expect(screen.getByText('23')).toBeInTheDocument()
+      expect(screen.getByText('argoCDSyncStatus.apps')).toBeInTheDocument()
+
+      // Stat rows
+      expect(screen.getByText('18')).toBeInTheDocument()
+      expect(screen.getByText('argoCDSyncStatus.synced')).toBeInTheDocument()
+      expect(screen.getByText('4')).toBeInTheDocument()
+      expect(screen.getByText('argoCDSyncStatus.outOfSync')).toBeInTheDocument()
+      expect(screen.getByText('1')).toBeInTheDocument()
+      expect(screen.getByText('argoCDSyncStatus.unknown')).toBeInTheDocument()
+    })
+
+    it('reports isDemoData as false for live data', () => {
+      mockUseArgoCDSyncStatus.mockReturnValue(liveDataDefaults())
+
+      render(<ArgoCDSyncStatus />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isDemoData: false,
+        })
+      )
+    })
+
+    it('renders the integration notice banner', () => {
+      mockUseArgoCDSyncStatus.mockReturnValue(liveDataDefaults())
+
+      render(<ArgoCDSyncStatus />)
+
+      expect(screen.getByText('argoCDSyncStatus.argocdIntegration')).toBeInTheDocument()
+      expect(screen.getByText('argoCDSyncStatus.installArgoCD')).toBeInTheDocument()
+    })
+
+    it('renders the ArgoCD documentation link', () => {
+      mockUseArgoCDSyncStatus.mockReturnValue(liveDataDefaults())
+
+      render(<ArgoCDSyncStatus />)
+
+      const link = screen.getByTitle('argoCDSyncStatus.argocdDocumentation')
+      expect(link).toHaveAttribute('href', 'https://argo-cd.readthedocs.io/')
+      expect(link).toHaveAttribute('target', '_blank')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Demo data rendering
+  // -------------------------------------------------------------------------
+  describe('demo data', () => {
+    it('renders the donut chart and stats even when isDemoData is true', () => {
+      mockUseArgoCDSyncStatus.mockReturnValue(demoDataDefaults())
+
+      render(<ArgoCDSyncStatus />)
+
+      // The card should render demo data values
+      expect(screen.getByText('11')).toBeInTheDocument()
+      expect(screen.getByText('8')).toBeInTheDocument()
+      expect(screen.getByText('2')).toBeInTheDocument()
+    })
+
+    it('reports isDemoData as true so CardWrapper shows demo badge', () => {
+      mockUseArgoCDSyncStatus.mockReturnValue(demoDataDefaults())
+
+      render(<ArgoCDSyncStatus />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isDemoData: true,
+        })
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Failure / consecutive failures
+  // -------------------------------------------------------------------------
+  describe('failure states', () => {
+    it('passes isFailed and consecutiveFailures to useCardLoadingState', () => {
+      mockUseArgoCDSyncStatus.mockReturnValue({
+        ...liveDataDefaults(),
+        isFailed: true,
+        consecutiveFailures: 4,
+      })
+
+      render(<ArgoCDSyncStatus />)
+
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isFailed: true,
+          consecutiveFailures: 4,
+        })
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Cluster filter UI
+  // -------------------------------------------------------------------------
+  describe('cluster filter', () => {
+    it('renders the cluster filter component', () => {
+      mockUseArgoCDSyncStatus.mockReturnValue(liveDataDefaults())
+
+      render(<ArgoCDSyncStatus />)
+
+      expect(screen.getByTestId('cluster-filter')).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // SVG donut chart correctness
+  // -------------------------------------------------------------------------
+  describe('donut chart', () => {
+    it('computes correct strokeDasharray for synced and outOfSync segments', () => {
+      const data = liveDataDefaults()
+      mockUseArgoCDSyncStatus.mockReturnValue(data)
+
+      const { container } = render(<ArgoCDSyncStatus />)
+
+      // Select only the SVG donut circles (r="48") to avoid lucide icon circles
+      const circles = container.querySelectorAll('svg circle[r="48"]')
+      expect(circles.length).toBe(3)
+
+      const syncedCircle = circles[1]
+      const expectedSyncedDash = `${data.syncedPercent * 3.02} 302`
+      expect(syncedCircle.getAttribute('stroke-dasharray')).toBe(expectedSyncedDash)
+
+      const outOfSyncCircle = circles[2]
+      const expectedOutOfSyncDash = `${data.outOfSyncPercent * 3.02} 302`
+      expect(outOfSyncCircle.getAttribute('stroke-dasharray')).toBe(expectedOutOfSyncDash)
+    })
+  })
+})


### PR DESCRIPTION
Closes #3451

## Summary

- **Added unit tests** for `ArgoCDSyncStatus` (12 tests) and `ArgoCDHealth` (14 tests) covering:
  - Loading/skeleton state renders correctly when `showSkeleton` is true
  - Correct `isLoading`/`hasAnyData` values passed to `useCardLoadingState`
  - Empty state renders "no data" messaging
  - Live data branch renders donut chart, stat rows, health gauge, and health bar with correct values
  - Demo data branch renders content and reports `isDemoData: true` for the Demo badge
  - Failure states propagate `isFailed`/`consecutiveFailures` to `useCardLoadingState`
  - SVG donut chart `strokeDasharray` values match computed percentages
  - Integration notice banner and documentation link render
  - Global demo mode (`useDemoMode`) propagation to `useCardLoadingState`

- **Fixed bug in `ArgoCDHealth`**: The component was missing the `useDemoMode` hook, so when global demo mode was enabled, the card would not show the Demo badge/yellow outline. Now matches `ArgoCDSyncStatus` behavior by passing `isDemoMode || isDemoData` to `useCardLoadingState`.

## Test plan

- [x] All 26 new unit tests pass (`npx vitest run src/components/cards/__tests__/`)
- [x] TypeScript build passes (`tsc -b`)
- [x] Vite production build passes (`npm run build`)