### PR TITLE
fix: add /cluster-admin to perf tests and GPUOverview mock data

### DIFF
--- a/web/e2e/perf/all-cards-ttfi.spec.ts
+++ b/web/e2e/perf/all-cards-ttfi.spec.ts
@@ -76,6 +76,7 @@ const MOCK_DATA: Record<string, Record<string, unknown[]>> = {
   'deployment-issues': { issues: [] },
   services: { services: [{ name: 'nginx-svc', namespace: 'default', cluster: MOCK_CLUSTER }] },
   'security-issues': { issues: [{ name: 'nginx-1', namespace: 'default', cluster: MOCK_CLUSTER }] },
+  'gpu-nodes': { nodes: [{ name: 'gpu-node-1', cluster: MOCK_CLUSTER, gpuType: 'NVIDIA A100', gpuCount: 4, gpuAllocated: 2, labels: {} }] },
 }
 
 function buildSSEResponse(endpoint: string): string {

--- a/web/e2e/perf/dashboard-perf.spec.ts
+++ b/web/e2e/perf/dashboard-perf.spec.ts
@@ -48,6 +48,7 @@ const DASHBOARDS = [
   { id: 'ai-agents', name: 'AI Agents', route: '/ai-agents' },
   { id: 'data-compliance', name: 'Data Compliance', route: '/data-compliance' },
   { id: 'arcade', name: 'Arcade', route: '/arcade' },
+  { id: 'cluster-admin', name: 'Cluster Admin', route: '/cluster-admin' },
 ]
 
 // Max cards to measure per dashboard (prevent very long tests)


### PR DESCRIPTION
## Summary
- Adds `/cluster-admin` dashboard to `dashboard-perf.spec.ts` DASHBOARDS list so TTFI baselines are tracked
- Adds `gpu-nodes` entry to `all-cards-ttfi.spec.ts` MOCK_DATA so GPUOverview card renders with data during perf tests

Fixes #3559, fixes #3560, fixes #3561

## Test plan
- [ ] Run `npx playwright test dashboard-perf` — verify cluster-admin appears in results
- [ ] Run `npx playwright test all-cards-ttfi` — verify GPUOverview renders with mock data

🤖 Generated with [Claude Code](https://claude.com/claude-code)