### PR TITLE
fix: fail nightly health check on zero cards

### DIFF
--- a/web/e2e/nightly/dashboard-health.spec.ts
+++ b/web/e2e/nightly/dashboard-health.spec.ts
@@ -221,7 +221,7 @@ test.describe('Nightly Dashboard Health', () => {
       // Check cards rendered (only for dashboards that should have cards)
       if (route.expectCards && metrics.cardCount === 0) {
         issues.push('No cards detected')
-        if (result.status !== 'fail') result.status = 'warn'
+        result.status = 'fail'
       }
 
       result.details = issues.length > 0 ? issues.join('; ') : 'OK'
@@ -236,6 +236,9 @@ test.describe('Nightly Dashboard Health', () => {
       // Assertions
       expect(pageErrors, `Unhandled exceptions on ${route.path}: ${pageErrors.join('; ')}`).toHaveLength(0)
       expect(metrics.hasContent, `${route.path} appears blank (text length < ${MIN_PAGE_TEXT_LENGTH})`).toBe(true)
+      if (route.expectCards) {
+        expect(metrics.cardCount, `${route.path} rendered zero cards — expected at least one`).toBeGreaterThan(0)
+      }
     })
   }
 


### PR DESCRIPTION
## Summary
- Changes zero-card detection from `warn` to `fail` status for dashboards with `expectCards: true`
- Adds `expect(cardCount).toBeGreaterThan(0)` assertion so the test actually fails in CI
- Previously a completely broken dashboard rendering zero cards would only show as a warning

Fixes #3562

## Test plan
- [ ] Run nightly health check — verify dashboards with cards pass, and a dashboard with no cards would fail
- [ ] Verify Arcade/Settings (expectCards: false) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)