### PR TITLE
feat: add play/stop/restart controls for local clusters

### DIFF
--- a/pkg/agent/local_clusters.go
+++ b/pkg/agent/local_clusters.go
@@ -364,6 +364,130 @@ func (m *LocalClusterManager) createMinikubeCluster(name string) error {
 	return nil
 }
 
+// StartCluster starts a stopped local cluster with phased progress broadcasting
+func (m *LocalClusterManager) StartCluster(tool, name string) error {
+	m.broadcastProgress(tool, name, "validating", fmt.Sprintf("Preparing to start cluster '%s'...", name), progressValidating)
+
+	m.broadcastProgress(tool, name, "starting", fmt.Sprintf("Starting %s cluster '%s'...", tool, name), progressCreating)
+
+	switch tool {
+	case "kind":
+		return m.startKindCluster(name)
+	case "k3d":
+		return m.startK3dCluster(name)
+	case "minikube":
+		return m.startMinikubeCluster(name)
+	default:
+		return fmt.Errorf("unsupported tool: %s", tool)
+	}
+}
+
+func (m *LocalClusterManager) startKindCluster(name string) error {
+	// kind clusters run as Docker containers — start all containers with the cluster label
+	cmd := execCommand("docker", "start", name+"-control-plane")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to start kind cluster containers: %s", stderr.String())
+	}
+	// Also start any worker nodes
+	for i := 1; i <= 10; i++ {
+		workerName := fmt.Sprintf("%s-worker%s", name, func() string {
+			if i == 1 {
+				return ""
+			}
+			return fmt.Sprintf("%d", i)
+		}())
+		cmd := execCommand("docker", "start", workerName)
+		if err := cmd.Run(); err != nil {
+			break // No more workers
+		}
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) startK3dCluster(name string) error {
+	cmd := execCommand("k3d", "cluster", "start", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("k3d start failed: %s", stderr.String())
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) startMinikubeCluster(name string) error {
+	cmd := execCommand("minikube", "start", "--profile", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("minikube start failed: %s", stderr.String())
+	}
+	return nil
+}
+
+// StopCluster stops a running local cluster with phased progress broadcasting
+func (m *LocalClusterManager) StopCluster(tool, name string) error {
+	m.broadcastProgress(tool, name, "validating", fmt.Sprintf("Preparing to stop cluster '%s'...", name), progressValidating)
+
+	m.broadcastProgress(tool, name, "stopping", fmt.Sprintf("Stopping %s cluster '%s'...", tool, name), progressCreating)
+
+	switch tool {
+	case "kind":
+		return m.stopKindCluster(name)
+	case "k3d":
+		return m.stopK3dCluster(name)
+	case "minikube":
+		return m.stopMinikubeCluster(name)
+	default:
+		return fmt.Errorf("unsupported tool: %s", tool)
+	}
+}
+
+func (m *LocalClusterManager) stopKindCluster(name string) error {
+	// kind clusters run as Docker containers — stop all containers with the cluster label
+	cmd := execCommand("docker", "stop", name+"-control-plane")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to stop kind cluster containers: %s", stderr.String())
+	}
+	// Also stop any worker nodes
+	for i := 1; i <= 10; i++ {
+		workerName := fmt.Sprintf("%s-worker%s", name, func() string {
+			if i == 1 {
+				return ""
+			}
+			return fmt.Sprintf("%d", i)
+		}())
+		cmd := execCommand("docker", "stop", workerName)
+		if err := cmd.Run(); err != nil {
+			break // No more workers
+		}
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) stopK3dCluster(name string) error {
+	cmd := execCommand("k3d", "cluster", "stop", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("k3d stop failed: %s", stderr.String())
+	}
+	return nil
+}
+
+func (m *LocalClusterManager) stopMinikubeCluster(name string) error {
+	cmd := execCommand("minikube", "stop", "--profile", name)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("minikube stop failed: %s", stderr.String())
+	}
+	return nil
+}
+
 // DeleteCluster deletes a local cluster with phased progress broadcasting
 func (m *LocalClusterManager) DeleteCluster(tool, name string) error {
 	// Phase 1: Validating

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -370,6 +370,7 @@ func (s *Server) Start() error {
 	// Local cluster management endpoints
 	mux.HandleFunc("/local-cluster-tools", s.handleLocalClusterTools)
 	mux.HandleFunc("/local-clusters", s.handleLocalClusters)
+	mux.HandleFunc("/local-cluster-lifecycle", s.handleLocalClusterLifecycle)
 
 	// vCluster management endpoints
 	mux.HandleFunc("/vcluster/list", s.handleVClusterList)
@@ -4605,6 +4606,94 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+// handleLocalClusterLifecycle handles start/stop/restart for local clusters
+func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Request) {
+	s.setCORSHeaders(w, r)
+	w.Header().Set("Content-Type", "application/json")
+
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Tool   string `json:"tool"`
+		Name   string `json:"name"`
+		Action string `json:"action"` // "start", "stop", "restart"
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Tool == "" || req.Name == "" || req.Action == "" {
+		http.Error(w, "tool, name, and action are required", http.StatusBadRequest)
+		return
+	}
+	if req.Action != "start" && req.Action != "stop" && req.Action != "restart" {
+		http.Error(w, "action must be start, stop, or restart", http.StatusBadRequest)
+		return
+	}
+
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("[LocalClusters] recovered from panic during %s of cluster %s: %v", req.Action, req.Name, r)
+			}
+		}()
+
+		var err error
+		switch req.Action {
+		case "start":
+			err = s.localClusters.StartCluster(req.Tool, req.Name)
+		case "stop":
+			err = s.localClusters.StopCluster(req.Tool, req.Name)
+		case "restart":
+			err = s.localClusters.StopCluster(req.Tool, req.Name)
+			if err == nil {
+				err = s.localClusters.StartCluster(req.Tool, req.Name)
+			}
+		}
+
+		if err != nil {
+			log.Printf("[LocalClusters] Failed to %s cluster %s: %v", req.Action, req.Name, err)
+			errMsg := sanitizeClusterError(err)
+			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
+				"tool":     req.Tool,
+				"name":     req.Name,
+				"status":   "failed",
+				"message":  errMsg,
+				"progress": 0,
+			})
+		} else {
+			log.Printf("[LocalClusters] %s cluster %s completed", req.Action, req.Name)
+			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
+				"tool":     req.Tool,
+				"name":     req.Name,
+				"status":   "done",
+				"message":  fmt.Sprintf("Cluster '%s' %sed successfully", req.Name, req.Action),
+				"progress": 100,
+			})
+		}
+	}()
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":  req.Action + "ing",
+		"tool":    req.Tool,
+		"name":    req.Name,
+		"message": fmt.Sprintf("Cluster %s started. You will be notified when it completes.", req.Action),
+	})
 }
 
 // handleVClusterList returns all vCluster instances

--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useEffect, useRef, useCallback } from 'react'
-import { Pencil, Globe, User, ShieldAlert, ChevronRight, Star, WifiOff, RefreshCw, ExternalLink, AlertCircle, Cpu, Box, Server, KeyRound, Copy, Check, GripVertical } from 'lucide-react'
+import { Pencil, Globe, User, ShieldAlert, ChevronRight, Star, WifiOff, RefreshCw, ExternalLink, AlertCircle, Cpu, Box, Server, KeyRound, Copy, Check, GripVertical, Play, Square, RotateCcw } from 'lucide-react'
 import {
   DndContext,
   closestCenter,
@@ -26,6 +26,7 @@ import { CloudProviderIcon, detectCloudProvider, getProviderLabel, getProviderCo
 import { useTranslation } from 'react-i18next'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { copyToClipboard } from '../../../lib/clipboard'
+import { useLocalClusterTools } from '../../../hooks/useLocalClusterTools'
 
 // Guarantees spinner runs for at least 1 full rotation (1s) even if data returns faster.
 // Uses refs for condition checks to avoid stale closure issues when refreshing
@@ -121,6 +122,95 @@ function CopyCmd({ text }: { text: string }) {
     </button>
   )
 }
+
+// Local cluster platforms that support lifecycle controls
+const LOCAL_PLATFORMS = new Set(['kind', 'minikube', 'k3s'])
+
+// Map cloud provider to the tool name used by the backend
+function providerToTool(provider: string): string | null {
+  switch (provider) {
+    case 'kind': return 'kind'
+    case 'minikube': return 'minikube'
+    case 'k3s': return 'k3d' // k3s clusters detected from name may be k3d-managed
+    default: return null
+  }
+}
+
+// Inline play/stop/restart controls for local clusters
+const LocalClusterControls = memo(function LocalClusterControls({
+  clusterName,
+  provider,
+  unreachable,
+}: {
+  clusterName: string
+  provider: string
+  unreachable: boolean
+}) {
+  const { clusterLifecycle, clusters } = useLocalClusterTools()
+  const [actionInProgress, setActionInProgress] = useState<string | null>(null)
+  const tool = providerToTool(provider)
+
+  if (!tool) return null
+
+  // Try to find the cluster in local clusters list for accurate tool/name mapping
+  const localCluster = clusters.find(c =>
+    clusterName.includes(c.name) || c.name.includes(clusterName.replace(/^kind-/, ''))
+  )
+  const effectiveTool = localCluster?.tool || tool
+  const effectiveName = localCluster?.name || clusterName.replace(/^kind-/, '')
+  const isStopped = localCluster?.status === 'stopped' || unreachable
+
+  const handleAction = async (action: 'start' | 'stop' | 'restart', e: React.MouseEvent) => {
+    e.stopPropagation()
+    setActionInProgress(action)
+    await clusterLifecycle(effectiveTool, effectiveName, action)
+    setActionInProgress(null)
+  }
+
+  return (
+    <div className="flex items-center gap-0.5" onClick={(e) => e.stopPropagation()}>
+      {isStopped ? (
+        <button
+          onClick={(e) => handleAction('start', e)}
+          disabled={!!actionInProgress}
+          className={`p-1 rounded transition-colors ${
+            actionInProgress === 'start'
+              ? 'text-green-400 bg-green-500/20'
+              : 'text-muted-foreground hover:text-green-400 hover:bg-green-500/20'
+          }`}
+          title="Start cluster"
+        >
+          <Play className={`w-3.5 h-3.5 ${actionInProgress === 'start' ? 'animate-pulse' : ''}`} />
+        </button>
+      ) : (
+        <button
+          onClick={(e) => handleAction('stop', e)}
+          disabled={!!actionInProgress}
+          className={`p-1 rounded transition-colors ${
+            actionInProgress === 'stop'
+              ? 'text-red-400 bg-red-500/20'
+              : 'text-muted-foreground hover:text-red-400 hover:bg-red-500/20'
+          }`}
+          title="Stop cluster"
+        >
+          <Square className={`w-3 h-3 ${actionInProgress === 'stop' ? 'animate-pulse' : ''}`} />
+        </button>
+      )}
+      <button
+        onClick={(e) => handleAction('restart', e)}
+        disabled={!!actionInProgress}
+        className={`p-1 rounded transition-colors ${
+          actionInProgress === 'restart'
+            ? 'text-blue-400 bg-blue-500/20'
+            : 'text-muted-foreground hover:text-blue-400 hover:bg-blue-500/20'
+        }`}
+        title="Restart cluster"
+      >
+        <RotateCcw className={`w-3.5 h-3.5 ${actionInProgress === 'restart' ? 'animate-spin' : ''}`} />
+      </button>
+    </div>
+  )
+})
 
 interface GPUInfo {
   total: number
@@ -376,7 +466,16 @@ const FullClusterCard = memo(function FullClusterCard({
           )}
           <div className="flex items-center justify-between text-xs">
             <span className="text-muted-foreground">Source: {cluster.source || 'kubeconfig'}</span>
-            <span title={t('common.viewDetails')}><ChevronRight className="w-4 h-4 text-primary" /></span>
+            <div className="flex items-center gap-2">
+              {LOCAL_PLATFORMS.has(provider) && (
+                <LocalClusterControls
+                  clusterName={cluster.name}
+                  provider={provider}
+                  unreachable={unreachable}
+                />
+              )}
+              <span title={t('common.viewDetails')}><ChevronRight className="w-4 h-4 text-primary" /></span>
+            </div>
           </div>
         </div>
       </div>
@@ -538,6 +637,13 @@ const ListClusterCard = memo(function ListClusterCard({
 
           {/* Actions */}
           <div className="flex items-center gap-1 flex-shrink-0">
+            {LOCAL_PLATFORMS.has(provider) && (
+              <LocalClusterControls
+                clusterName={cluster.name}
+                provider={provider}
+                unreachable={unreachable}
+              />
+            )}
             {onRefreshCluster && (
               <button
                 onClick={(e) => { e.stopPropagation(); onRefreshCluster() }}

--- a/web/src/hooks/useLocalClusterTools.ts
+++ b/web/src/hooks/useLocalClusterTools.ts
@@ -197,6 +197,45 @@ export function useLocalClusterTools() {
     }
   }, [isConnected, isDemoMode])
 
+  // Lifecycle action (start/stop/restart) on a local cluster
+  const clusterLifecycle = useCallback(async (tool: string, name: string, action: 'start' | 'stop' | 'restart'): Promise<boolean> => {
+    // In demo mode (without agent connected), simulate the action
+    if (isDemoMode && !isConnected) {
+      setError(null)
+      await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS))
+      return true
+    }
+
+    if (!isConnected) {
+      return false
+    }
+
+    setError(null)
+
+    try {
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/local-cluster-lifecycle`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tool, name, action }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+
+      if (response.ok) {
+        // Refresh clusters list after action starts
+        setTimeout(() => fetchClusters(), UI_FEEDBACK_TIMEOUT_MS)
+        return true
+      } else {
+        const text = await response.text()
+        setError(text)
+        return false
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : `Failed to ${action} cluster`
+      setError(message)
+      return false
+    }
+  }, [isConnected, isDemoMode, fetchClusters])
+
   // Delete a cluster
   const deleteCluster = useCallback(async (tool: string, name: string): Promise<boolean> => {
     // In demo mode (without agent connected), simulate cluster deletion
@@ -536,6 +575,7 @@ export function useLocalClusterTools() {
     dismissProgress,
     createCluster,
     deleteCluster,
+    clusterLifecycle,
     refresh,
     // vCluster state and actions
     vclusterInstances,


### PR DESCRIPTION
## Summary
- Adds inline **play/stop/restart** lifecycle controls for local clusters (kind, minikube, k3d) on the My Clusters page
- Backend: new `/local-cluster-lifecycle` POST endpoint in kc-agent that dispatches start/stop/restart to the appropriate CLI tool (kind via Docker, k3d native, minikube native)
- Frontend: `LocalClusterControls` component renders inline with cluster cards in grid, list, and compact layout modes. Detects local platforms via existing `detectCloudProvider` logic.
- Hook: `clusterLifecycle()` method added to `useLocalClusterTools` for start/stop/restart actions with progress broadcasting

Closes #3545

## Test plan
- [ ] Verify play/stop/restart buttons appear only on kind, minikube, and k3s/k3d cluster cards
- [ ] Test stopping a kind cluster (verifies Docker container stop)
- [ ] Test starting a stopped minikube cluster
- [ ] Test restart on a k3d cluster
- [ ] Verify buttons don't appear on cloud-provider clusters (EKS, GKE, AKS)
- [ ] Verify demo mode simulation works without agent connected
- [ ] Check all layout modes (grid, list, compact, wide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)