### PR TITLE
fix: remove unregistered card types from INVENTORY.md

### DIFF
--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -153,8 +153,6 @@ The Auto-QA workflow uses this file to verify component consistency.
 | StrimziStatus | web/src/components/cards/strimzi_status/index.ts | `strimzi_status` |
 | KubeVelaStatus | web/src/components/cards/kubevela_status/index.ts | `kubevela_status` |
 | KarmadaStatus | web/src/components/cards/karmada_status/index.ts | `karmada_status` |
-| ThanosStatus | web/src/components/cards/thanos_status/index.tsx | `thanos_status` |
-| OpenFeatureStatus | web/src/components/cards/openfeature_status/index.ts | `openfeature_status` |
 | CrossplaneManagedResources | web/src/components/cards/crossplane-status/CrossplaneManagedResources.tsx | `crossplane_managed_resources` |
 
 ## Multi-Tenancy Cards


### PR DESCRIPTION
## Summary
- Removes `openfeature_status` and `thanos_status` entries from INVENTORY.md that are listed but not registered in the card registry source code
- Keeps INVENTORY.md consistent with actual card implementations

Closes #3605

## Test plan
- [ ] Verify INVENTORY.md no longer contains `openfeature_status` or `thanos_status` entries
- [ ] Confirm no other references to these entries are broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)