### PR TITLE
fix: AI Card Creation JSON extraction failures (#3610)

### DIFF
--- a/web/src/lib/ai/extractJson.ts
+++ b/web/src/lib/ai/extractJson.ts
@@ -3,7 +3,8 @@
  *
  * AI models typically return JSON inside ```json fences with
  * surrounding explanatory text. This utility extracts and parses
- * the JSON using multiple strategies.
+ * the JSON using multiple strategies, handling common quirks like
+ * trailing commas, markdown fences, and mixed prose.
  */
 
 export interface ExtractResult<T> {
@@ -11,77 +12,113 @@ export interface ExtractResult<T> {
   error: string | null
 }
 
-export function extractJsonFromMarkdown<T = unknown>(text: string): ExtractResult<T> {
-  // Strategy 1: Look for ```json ... ``` fenced blocks
-  const jsonBlockRegex = /```json\s*\n?([\s\S]*?)```/g
-  const matches: string[] = []
-  let match: RegExpExecArray | null
+/**
+ * Strip trailing commas before closing braces/brackets — a common
+ * AI model quirk that produces invalid JSON.
+ */
+function stripTrailingCommas(json: string): string {
+  return json.replace(/,\s*([\]}])/g, '$1')
+}
 
-  while ((match = jsonBlockRegex.exec(text)) !== null) {
-    matches.push(match[1].trim())
-  }
-
-  // Try parsing each match (last match is often the final/correct one)
-  for (let i = matches.length - 1; i >= 0; i--) {
-    try {
-      const parsed = JSON.parse(matches[i]) as T
-      return { data: parsed, error: null }
-    } catch {
-      // continue to next match
-    }
-  }
-
-  // Strategy 2: Find raw JSON object/array in text via brace depth matching
-  const firstBrace = text.indexOf('{')
-  const firstBracket = text.indexOf('[')
-  const startIdx = Math.min(
-    firstBrace >= 0 ? firstBrace : Infinity,
-    firstBracket >= 0 ? firstBracket : Infinity,
-  )
-
-  if (startIdx < Infinity) {
-    const openChar = text[startIdx]
-    const closeChar = openChar === '{' ? '}' : ']'
-    let depth = 0
-    let inString = false
-    let escaped = false
-
-    for (let i = startIdx; i < text.length; i++) {
-      const ch = text[i]
-
-      if (escaped) {
-        escaped = false
-        continue
-      }
-      if (ch === '\\') {
-        escaped = true
-        continue
-      }
-      if (ch === '"') {
-        inString = !inString
-        continue
-      }
-      if (inString) continue
-
-      if (ch === openChar) depth++
-      if (ch === closeChar) depth--
-
-      if (depth === 0) {
-        try {
-          const parsed = JSON.parse(text.substring(startIdx, i + 1)) as T
-          return { data: parsed, error: null }
-        } catch {
-          break
-        }
-      }
-    }
-  }
-
-  // Strategy 3: Try parsing the entire text as JSON
+/**
+ * Attempt JSON.parse with fallback to trailing-comma cleanup.
+ */
+function tryParse<T>(raw: string): T | null {
   try {
-    const parsed = JSON.parse(text.trim()) as T
-    return { data: parsed, error: null }
+    return JSON.parse(raw) as T
   } catch {
+    // noop — try cleanup
+  }
+  try {
+    return JSON.parse(stripTrailingCommas(raw)) as T
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Use brace/bracket depth tracking to extract the outermost JSON
+ * value starting at `startIdx`. Returns the substring or null.
+ */
+function extractByDepth(text: string, startIdx: number): string | null {
+  const openChar = text[startIdx]
+  const closeChar = openChar === '{' ? '}' : ']'
+  let depth = 0
+  let inString = false
+  let escaped = false
+
+  for (let i = startIdx; i < text.length; i++) {
+    const ch = text[i]
+
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (ch === '\\' && inString) {
+      escaped = true
+      continue
+    }
+    if (ch === '"') {
+      inString = !inString
+      continue
+    }
+    if (inString) continue
+
+    if (ch === openChar) depth++
+    if (ch === closeChar) depth--
+
+    if (depth === 0) {
+      return text.substring(startIdx, i + 1)
+    }
+  }
+  return null
+}
+
+export function extractJsonFromMarkdown<T = unknown>(text: string): ExtractResult<T> {
+  if (!text || !text.trim()) {
     return { data: null, error: 'Could not extract valid JSON from AI response.' }
   }
+
+  // Strategy 1: Try parsing the entire text as-is (fast path)
+  const directParse = tryParse<T>(text.trim())
+  if (directParse !== null) {
+    return { data: directParse, error: null }
+  }
+
+  // Strategy 2: Extract from ```json ... ``` or ``` ... ``` fenced blocks
+  const fencedBlockRegex = /```(?:json)?\s*\n?([\s\S]*?)```/g
+  const fencedMatches: string[] = []
+  let match: RegExpExecArray | null
+
+  while ((match = fencedBlockRegex.exec(text)) !== null) {
+    const content = match[1].trim()
+    if (content) fencedMatches.push(content)
+  }
+
+  // Try parsing each fenced match (last match is often the final/correct one)
+  for (let i = fencedMatches.length - 1; i >= 0; i--) {
+    const parsed = tryParse<T>(fencedMatches[i])
+    if (parsed !== null) {
+      return { data: parsed, error: null }
+    }
+  }
+
+  // Strategy 3: Find ALL JSON objects/arrays in the text via brace depth
+  // matching — try each candidate until one parses successfully
+  for (let pos = 0; pos < text.length; pos++) {
+    const ch = text[pos]
+    if (ch !== '{' && ch !== '[') continue
+
+    const candidate = extractByDepth(text, pos)
+    if (candidate) {
+      const parsed = tryParse<T>(candidate)
+      if (parsed !== null) {
+        return { data: parsed, error: null }
+      }
+      // Skip past this candidate and keep searching
+      pos += candidate.length - 1
+    }
+  }
+
+  return { data: null, error: 'Could not extract valid JSON from AI response.' }
 }


### PR DESCRIPTION
## Summary

Closes #3610

AI Card Creation was failing with *"Could not extract valid JSON from AI response"* because the JSON extraction logic was too brittle. This PR rewrites `extractJsonFromMarkdown` to be significantly more robust:

- **Direct parse fast-path** — tries `JSON.parse` on the full text first
- **Fenced code blocks** — matches both ` ```json ` and plain ` ``` ` fences
- **Trailing comma cleanup** — strips trailing commas before `]` or `}` (common AI quirk)
- **Full-text scan** — finds ALL `{` / `[` candidates via brace-depth tracking instead of stopping at the first one
- **Escape fix** — backslash escaping now only applies inside quoted strings

## Test plan

- [x] `npm run build` passes
- [ ] Create a card via AI assist and verify JSON is extracted successfully
- [ ] Test with responses that include markdown prose around the JSON
- [ ] Test with responses that use ` ``` ` fences without the `json` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)