### PR TITLE
fix: correct broken Go tests causing release workflow failure

### DIFF
--- a/pkg/api/handlers/gitops_test.go
+++ b/pkg/api/handlers/gitops_test.go
@@ -45,10 +45,13 @@ func TestGitOps_ListHelmHistory_Validation_MissingRelease(t *testing.T) {
 
 	resp, err := app.Test(req, fiberTestTimeout)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	// When release is empty the handler returns 200 with an empty history
+	// so callers querying before their data context hydrates get a valid response.
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	body, _ := io.ReadAll(resp.Body)
-	assert.Contains(t, string(body), "release parameter is required")
+	var body map[string][]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Empty(t, body["history"])
 }
 
 func TestGitOps_ListHelmHistory_Validation_InvalidClusterName(t *testing.T) {

--- a/pkg/api/handlers/workloads_test.go
+++ b/pkg/api/handlers/workloads_test.go
@@ -230,6 +230,23 @@ func TestScaleWorkload(t *testing.T) {
 	handler := NewWorkloadHandlers(env.K8sClient, env.Hub, env.Store)
 	env.App.Post("/api/workloads/scale", handler.ScaleWorkload)
 
+	scheme := newK8sScheme()
+
+	// Inject a dynamic client with a Deployment so ScaleWorkload can find and patch it.
+	deploy := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "scale-app", Namespace: "default"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: func(i int32) *int32 { return &i }(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "scale"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "scale"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "nginx"}}},
+			},
+		},
+	}
+	injectDynamicClusterWithObjects(env, "scale-cluster", scheme, []runtime.Object{deploy})
+
 	// Payload
 	payload := map[string]interface{}{
 		"workloadName":   "scale-app",
@@ -306,8 +323,11 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	var listResp map[string][]map[string]interface{}
 	body, _ := io.ReadAll(resp.Body)
 	json.Unmarshal(body, &listResp)
-	assert.Equal(t, 1, len(listResp["groups"]))
-	assert.Equal(t, "group1", listResp["groups"][0]["name"])
+	// ListClusterGroups prepends the built-in "all-healthy-clusters" group,
+	// so we expect 2 groups total: the built-in one plus "group1".
+	assert.Equal(t, 2, len(listResp["groups"]))
+	assert.Equal(t, "all-healthy-clusters", listResp["groups"][0]["name"])
+	assert.Equal(t, "group1", listResp["groups"][1]["name"])
 
 	updatePayload := map[string]interface{}{
 		"name":     "group1",
@@ -340,10 +360,12 @@ func TestClusterGroupsCRUD(t *testing.T) {
 	resp, err = env.App.Test(req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	var listRespEmpty map[string][]interface{}
-	bodyEmpty, _ := io.ReadAll(resp.Body)
-	json.Unmarshal(bodyEmpty, &listRespEmpty)
-	assert.Empty(t, listRespEmpty["groups"])
+	var listRespAfterDelete map[string][]map[string]interface{}
+	bodyAfterDelete, _ := io.ReadAll(resp.Body)
+	json.Unmarshal(bodyAfterDelete, &listRespAfterDelete)
+	// After deleting "group1", only the built-in group should remain.
+	assert.Equal(t, 1, len(listRespAfterDelete["groups"]))
+	assert.Equal(t, "all-healthy-clusters", listRespAfterDelete["groups"][0]["name"])
 }
 
 func TestEvaluateClusterQuery(t *testing.T) {


### PR DESCRIPTION
## Summary
- **TestGitOps_ListHelmHistory_Validation_MissingRelease**: The handler was updated to return `200` with an empty history array when the `release` query param is missing (graceful for React mount hydration), but the test still expected `400`. Updated test to match.
- **TestScaleWorkload**: The test targeted `scale-cluster` which had no dynamic client injected, so `ScaleWorkload` couldn't find the deployment and returned `success: false`. Fixed by injecting a fake dynamic client with a Deployment object.
- **TestClusterGroupsCRUD**: `ListClusterGroups` now prepends a built-in `all-healthy-clusters` group. Updated assertions to expect 2 groups after create (built-in + user-created) and 1 group after delete (built-in only).

All three tests now pass. Full `go test ./...` suite passes cleanly.

## Test plan
- [x] Verified all three previously-failing tests pass locally
- [x] Verified full `go test ./...` passes with no regressions

Closes #3611

🤖 Generated with [Claude Code](https://claude.com/claude-code)