### PR TITLE
fix: add Terminate Session button to AI Missions

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -18,6 +18,7 @@ import {
   Check,
   X,
   RotateCcw,
+  StopCircle,
 } from 'lucide-react'
 import { useMissions, type Mission } from '../../../hooks/useMissions'
 import { useDemoMode } from '../../../hooks/useDemoMode'
@@ -389,6 +390,17 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               <Maximize2 className="w-4 h-4 text-muted-foreground" />
             </button>
           )}
+          {mission.status === 'running' && (
+            <button
+              onClick={() => cancelMission(mission.id)}
+              className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium bg-red-500/15 hover:bg-red-500/25 text-red-400 border border-red-500/30 rounded-lg transition-colors"
+              title={t('missionChat.terminateSession', { defaultValue: 'Terminate Session' })}
+              data-testid="terminate-session-btn"
+            >
+              <StopCircle className="w-3.5 h-3.5" />
+              {t('missionChat.terminateSession', { defaultValue: 'Terminate Session' })}
+            </button>
+          )}
           <div className={cn('flex items-center gap-1', config.color)}>
             <StatusIcon className={cn('w-4 h-4', mission.status === 'running' && 'animate-spin')} />
             <span className="text-xs">{config.label}</span>
@@ -552,9 +564,11 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
             <div className="flex items-center justify-end">
               <button
                 onClick={() => cancelMission(mission.id)}
-                className="text-xs text-red-400 hover:text-red-300 px-2 py-1 rounded hover:bg-red-500/10 transition-colors"
+                className="flex items-center gap-1.5 text-xs text-red-400 hover:text-red-300 px-2 py-1 rounded hover:bg-red-500/10 transition-colors"
+                data-testid="terminate-session-inline-btn"
               >
-                {t('missionChat.cancel')}
+                <StopCircle className="w-3 h-3" />
+                {t('missionChat.terminateSession', { defaultValue: 'Terminate Session' })}
               </button>
             </div>
           </div>

--- a/web/src/components/layout/mission-sidebar/MissionListItem.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionListItem.tsx
@@ -3,17 +3,19 @@ import {
   ChevronDown,
   Maximize2,
   Trash2,
+  StopCircle,
 } from 'lucide-react'
 import type { Mission } from '../../../hooks/useMissions'
 import { cn } from '../../../lib/cn'
 import { STATUS_CONFIG, TYPE_ICONS } from './types'
 
-export function MissionListItem({ mission, isActive, onClick, onDismiss, onExpand, isCollapsed, onToggleCollapse }: {
+export function MissionListItem({ mission, isActive, onClick, onDismiss, onExpand, onTerminate, isCollapsed, onToggleCollapse }: {
   mission: Mission
   isActive: boolean
   onClick: () => void
   onDismiss: () => void
   onExpand: () => void
+  onTerminate?: () => void
   isCollapsed: boolean
   onToggleCollapse: () => void
 }) {
@@ -53,6 +55,16 @@ export function MissionListItem({ mission, isActive, onClick, onDismiss, onExpan
           <TypeIcon className="w-3 h-3 text-muted-foreground flex-shrink-0" />
           <span className="text-sm font-medium text-foreground truncate">{mission.title}</span>
         </button>
+        {mission.status === 'running' && onTerminate && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onTerminate() }}
+            className="p-0.5 hover:bg-red-500/20 rounded transition-colors flex-shrink-0"
+            title="Terminate Session"
+            data-testid="terminate-session-list-btn"
+          >
+            <StopCircle className="w-3.5 h-3.5 text-red-400 hover:text-red-300" />
+          </button>
+        )}
         <button
           onClick={(e) => { e.stopPropagation(); onExpand() }}
           className="p-0.5 hover:bg-secondary/50 rounded transition-colors flex-shrink-0"

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -49,7 +49,7 @@ import { isDemoMode } from '../../../lib/demoMode'
 
 export function MissionSidebar() {
   const { t } = useTranslation(['common'])
-  const { missions, activeMission, isSidebarOpen, isSidebarMinimized, isFullScreen, setActiveMission, closeSidebar, dismissMission, minimizeSidebar, expandSidebar, setFullScreen, selectedAgent, startMission, saveMission, runSavedMission, openSidebar, sendMessage } = useMissions()
+  const { missions, activeMission, isSidebarOpen, isSidebarMinimized, isFullScreen, setActiveMission, closeSidebar, dismissMission, cancelMission, minimizeSidebar, expandSidebar, setFullScreen, selectedAgent, startMission, saveMission, runSavedMission, openSidebar, sendMessage } = useMissions()
   const { isMobile } = useMobile()
   const [collapsedMissions, setCollapsedMissions] = useState<Set<string>>(new Set())
   const [fontSize, setFontSize] = useState<FontSize>('base')
@@ -875,6 +875,7 @@ export function MissionSidebar() {
                     }
                   }}
                   onDismiss={() => dismissMission(mission.id)}
+                  onTerminate={() => cancelMission(mission.id)}
                   onExpand={() => {
                     if (mission.title === 'Mission Control Planning') {
                       setShowMissionControl(true)


### PR DESCRIPTION
## Summary
- Adds a prominent **Terminate Session** button (with `StopCircle` icon) in the mission chat header when a mission is running
- Upgrades the previously hard-to-find "Cancel" text link in the input area to a visible "Terminate Session" link with icon
- Adds a stop icon button in the mission list item for quick termination without opening the chat
- The terminate action sends a cancel signal via WebSocket (or HTTP fallback), aborts pending requests, and resets UI state

Closes #3608

## Test plan
- [ ] Start an AI mission and verify the "Terminate Session" button appears in the chat header
- [ ] Click "Terminate Session" and verify the mission is cancelled with a system message
- [ ] Verify the inline terminate link appears below the input area during a running mission
- [ ] Verify the stop icon appears on running missions in the sidebar list view
- [ ] Verify the button disappears when mission is not in "running" state
- [ ] Run `npm run build` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)