### PR TITLE
fix: Auto-QA card type check now finds object-key registrations

### DIFF
--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -1578,8 +1578,8 @@ jobs:
                 total|score|healthy|warning|critical|*_util|firing|pending|resolved|bound|installed|*_cost) continue ;;
               esac
 
-              # Search for this card type string in source
-              FOUND=$(grep -rl "'${ct}'\|\"${ct}\"" src/ 2>/dev/null | head -1 || true)
+              # Search for this card type string in source (quoted strings or object keys)
+              FOUND=$(grep -rlE "'${ct}'|\"${ct}\"|${ct}\s*:" src/ 2>/dev/null | head -1 || true)
               if [ -z "$FOUND" ]; then
                 UNREGISTERED="${UNREGISTERED}  - \`${ct}\` — in INVENTORY.md but not found in source code\n"
               fi


### PR DESCRIPTION
## Summary
- The Auto-QA inventory consistency check (`auto-qa.yml`) was reporting `openfeature_status` and `thanos_status` as "not found in source code" — a false positive.
- Root cause: the grep pattern only searched for card types as quoted strings (`'type'` or `"type"`), but these card types are registered as **unquoted object keys** (e.g., `openfeature_status: Component`) in `cardRegistry.ts` and `cardMetadata.ts`.
- Fix: switch from basic grep to extended regex (`grep -rlE`) and add an object-key pattern (`${ct}\s*:`) so all registration styles are detected.

Closes #3605

## Test plan
- [x] Verified the old pattern returns empty for `openfeature_status` and `thanos_status`
- [x] Verified the new pattern finds both in `cardRegistry.ts` and `cardMetadata.ts`
- [x] Ran the full card-type extraction loop locally — zero false positives remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)