### PR TITLE
fix: preserve manual cluster assignments during AI parsing and health filtering

### DIFF
--- a/web/src/components/mission-control/FlightPlanBlueprint.tsx
+++ b/web/src/components/mission-control/FlightPlanBlueprint.tsx
@@ -498,33 +498,34 @@ export function FlightPlanBlueprint({
   const svgId = useId().replace(/:/g, '')
   const { clusters } = useClusters()
 
-  // Filter out unhealthy clusters and redistribute orphaned projects to healthy ones
+  // Filter out explicitly unhealthy clusters and redistribute orphaned projects to healthy ones
   const healthyState = useMemo(() => {
     let assignments = state.assignments
-    const healthyNames = clusters?.length
-      ? new Set(clusters.filter(c => c.healthy !== false).map(c => c.name))
-      : null
+    // Only build the unhealthy set from clusters that are explicitly marked unhealthy/unreachable.
+    // Clusters not present in the clusters list (e.g. not yet loaded) are left alone so that
+    // user-assigned projects are never silently dropped.
+    const unhealthyNames = clusters?.length
+      ? new Set(clusters.filter(c => c.healthy === false || c.reachable === false).map(c => c.name))
+      : new Set<string>()
 
-    // Filter unhealthy clusters
-    if (healthyNames) {
-      const hasUnhealthy = assignments.some(a => a.projectNames.length > 0 && !healthyNames.has(a.clusterName))
-      if (hasUnhealthy) {
-        const orphanedProjects: string[] = []
-        const healthyAssignments = assignments.filter(a => {
-          if (healthyNames.has(a.clusterName)) return true
-          orphanedProjects.push(...a.projectNames)
-          return false
-        }).map(a => ({ ...a, projectNames: [...a.projectNames] }))
-        if (orphanedProjects.length > 0 && healthyAssignments.length > 0) {
-          orphanedProjects.forEach((p, i) => {
-            const target = healthyAssignments[i % healthyAssignments.length]
-            if (!target.projectNames.includes(p)) {
-              target.projectNames.push(p)
-            }
-          })
-        }
-        assignments = healthyAssignments
+    // Only filter out explicitly unhealthy clusters
+    const hasUnhealthy = assignments.some(a => a.projectNames.length > 0 && unhealthyNames.has(a.clusterName))
+    if (hasUnhealthy) {
+      const orphanedProjects: string[] = []
+      const healthyAssignments = assignments.filter(a => {
+        if (!unhealthyNames.has(a.clusterName)) return true
+        orphanedProjects.push(...a.projectNames)
+        return false
+      }).map(a => ({ ...a, projectNames: [...a.projectNames] }))
+      if (orphanedProjects.length > 0 && healthyAssignments.length > 0) {
+        orphanedProjects.forEach((p, i) => {
+          const target = healthyAssignments[i % healthyAssignments.length]
+          if (!target.projectNames.includes(p)) {
+            target.projectNames.push(p)
+          }
+        })
       }
+      assignments = healthyAssignments
     }
 
     // Allow projects on multiple clusters — composite keys handle positioning

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -178,10 +178,9 @@ export function useMissionControl() {
         setState((prev) => {
           const aiAssignments = parsed.assignments!
           const aiClusterNames = new Set(aiAssignments.map(a => a.clusterName))
-          // Preserve clusters from prev state that AI didn't mention
+          // Keep clusters the AI didn't mention as-is (user may have manually edited them)
           const preserved = prev.assignments
             .filter(a => !aiClusterNames.has(a.clusterName))
-            .map(a => ({ ...a, projectNames: [] as string[], warnings: [] as string[] }))
           return {
             ...prev,
             assignments: [...aiAssignments, ...preserved],


### PR DESCRIPTION
## Summary
- Stop clearing `projectNames` and `warnings` for clusters the AI didn't mention — preserves manual checkbox edits
- Switch health filter from allowlist (drop unknown clusters) to blocklist (only drop explicitly unhealthy) — clusters with assigned projects are never silently dropped

Fixes: 2 clusters with selections in Phase 2, but only 1 showing in Phase 3

## Test plan
- [ ] Open Mission Control, define a solution, proceed to Phase 2
- [ ] Run AI Suggest & Refine — AI assigns projects to one cluster
- [ ] Manually check projects on the second cluster
- [ ] Proceed to Phase 3 — both clusters should appear in the Flight Plan
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)