### PR TITLE
fix: prefer command-executing agents over copilot-cli for AI missions

### DIFF
--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -177,6 +177,35 @@ func (r *Registry) List() []ProviderInfo {
 	return result
 }
 
+// suggestOnlyAgents are agents that return command suggestions as text rather
+// than executing them. They should not be the default when better options exist.
+var suggestOnlyAgents = map[string]bool{
+	"copilot-cli": true,
+	"gh-copilot":  true,
+}
+
+// promoteExecutingDefault checks if the current default agent only suggests
+// commands (e.g. copilot-cli) and, if so, promotes the first available agent
+// that can actually execute commands to be the default (#3609).
+func (r *Registry) promoteExecutingDefault() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if !suggestOnlyAgents[r.defaultAgent] {
+		return // current default is fine
+	}
+
+	// Look for a better agent that actually executes commands
+	for name, provider := range r.providers {
+		if provider.IsAvailable() && !suggestOnlyAgents[name] &&
+			provider.Capabilities().HasCapability(CapabilityToolExec) {
+			r.defaultAgent = name
+			return
+		}
+	}
+	// No better option found — keep copilot-cli as fallback
+}
+
 // ListAvailable returns only providers that are configured and ready
 func (r *Registry) ListAvailable() []ProviderInfo {
 	if r == nil {
@@ -226,16 +255,21 @@ type ProviderInfo struct {
 func InitializeProviders() error {
 	registry := GetRegistry()
 
-	// Register tool-capable agents FIRST so they become the default
-	// Tool-capable agents can execute kubectl, helm, and other commands
+	// Register tool-capable agents FIRST so they become the default.
+	// Tool-capable agents can execute kubectl, helm, and other commands.
+	// Order matters: the first available agent becomes the default.
 	registry.Register(NewClaudeCodeProvider())
 	registry.Register(NewBobProvider())
 
 	// Register CLI-based tool-capable agents
 	registry.Register(NewCodexProvider())
-	registry.Register(NewCopilotCLIProvider())
 	registry.Register(NewGeminiCLIProvider())
 	registry.Register(NewAntigravityProvider())
+
+	// Register copilot-cli LAST among tool-capable agents.
+	// copilot-cli suggests commands as text rather than executing them,
+	// so it should only be the default when no other agent is available (#3609).
+	registry.Register(NewCopilotCLIProvider())
 	// GHCopilot is deprecated — the gh-copilot extension runs but executes no commands
 
 	// NOTE: API-only agents (Claude API, OpenAI, Gemini) and IDE-based agents
@@ -251,6 +285,10 @@ func InitializeProviders() error {
 			fmt.Printf("Warning: Could not set default agent %s: %v\n", defaultAgent, err)
 		}
 	}
+
+	// If the default ended up as copilot-cli but a better agent is available,
+	// prefer the agent that can actually execute commands (#3609).
+	registry.promoteExecutingDefault()
 
 	// Ensure at least one provider is available
 	if !registry.HasAvailableProviders() {

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -3161,14 +3161,45 @@ func (s *Server) isToolCapableAgent(agentName string) bool {
 	return provider.Capabilities().HasCapability(CapabilityToolExec)
 }
 
-// findToolCapableAgent finds an available agent with tool execution capabilities
+// findToolCapableAgent finds the best available agent with tool execution capabilities.
+// Agents that can execute commands directly (claude-code, codex, gemini-cli) are
+// preferred over agents that only suggest commands (copilot-cli). This prevents
+// missions from returning kubectl suggestions instead of executing them (#3609).
 func (s *Server) findToolCapableAgent() string {
-	// Check all registered providers for tool execution capability
-	for _, info := range s.registry.List() {
+	// Priority order: agents that execute commands directly first,
+	// then agents that may only suggest commands.
+	preferredOrder := []string{"claude-code", "codex", "gemini-cli", "antigravity", "bob"}
+	suggestOnlyAgents := []string{"copilot-cli", "gh-copilot"}
+
+	allProviders := s.registry.List()
+
+	// First pass: try preferred agents in priority order
+	for _, name := range preferredOrder {
+		for _, info := range allProviders {
+			if info.Name == name && info.Available && ProviderCapability(info.Capabilities).HasCapability(CapabilityToolExec) {
+				return info.Name
+			}
+		}
+	}
+
+	// Second pass: any tool-capable agent that is NOT in the suggest-only list
+	suggestOnly := make(map[string]bool, len(suggestOnlyAgents))
+	for _, name := range suggestOnlyAgents {
+		suggestOnly[name] = true
+	}
+	for _, info := range allProviders {
+		if ProviderCapability(info.Capabilities).HasCapability(CapabilityToolExec) && info.Available && !suggestOnly[info.Name] {
+			return info.Name
+		}
+	}
+
+	// Last resort: even suggest-only agents are better than nothing
+	for _, info := range allProviders {
 		if ProviderCapability(info.Capabilities).HasCapability(CapabilityToolExec) && info.Available {
 			return info.Name
 		}
 	}
+
 	return ""
 }
 

--- a/web/src/components/gitops/GitOps.tsx
+++ b/web/src/components/gitops/GitOps.tsx
@@ -103,16 +103,36 @@ export function GitOps() {
     setLastUpdated(new Date())
   }, [refetch])
 
-  // Detect drift for all apps on mount (skip in demo mode - no backend)
+  // Detect drift for all apps on mount (skip in demo mode - no backend).
+  // Guard: verify backend is reachable first to avoid slow sequential failures
+  // that block the UI and add latency (#3609).
   useEffect(() => {
     if (getDemoMode()) return
 
+    let cancelled = false
+
     async function detectAllDrift() {
+      // Quick health check — skip drift detection entirely if backend is down
+      try {
+        const health = await fetch('/api/health', { signal: AbortSignal.timeout(3000) })
+        if (!health.ok) {
+          setIsDetecting(false)
+          return
+        }
+      } catch {
+        setIsDetecting(false)
+        return
+      }
+
+      if (cancelled) return
+
       setIsDetecting(true)
       const results = new Map<string, DriftResult>()
       const configs = getGitOpsAppConfigs()
 
-      for (const appConfig of configs) {
+      // Run drift checks in parallel with individual timeouts instead of
+      // sequential requests, reducing total latency significantly.
+      const promises = configs.map(async (appConfig) => {
         try {
           const response = await api.post<{
             drifted: boolean
@@ -124,23 +144,25 @@ export function GitOps() {
             namespace: appConfig.namespace,
             cluster: appConfig.cluster || undefined,
           })
-
-          results.set(appConfig.name, {
-            drifted: response.data.drifted,
-            resources: response.data.resources || [],
-          })
+          return { name: appConfig.name, result: { drifted: response.data.drifted, resources: response.data.resources || [] } as DriftResult }
         } catch {
-          results.set(appConfig.name, { drifted: false, resources: [], error: 'Failed to detect drift' })
-          showToast(`Failed to detect drift for ${appConfig.name}`, 'error')
+          return { name: appConfig.name, result: { drifted: false, resources: [], error: 'Failed to detect drift' } as DriftResult }
         }
+      })
+
+      const settled = await Promise.all(promises)
+      if (cancelled) return
+
+      for (const { name, result } of settled) {
+        results.set(name, result)
       }
 
-      // React 18+ automatically batches state updates in async functions
       setDriftResults(results)
       setIsDetecting(false)
     }
 
     detectAllDrift()
+    return () => { cancelled = true }
   }, [])
 
   // Handle sync action - open the sync dialog

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useCallback, useRef, useEffect, ReactNode } from 'react'
 import type { AgentInfo, AgentsListPayload, AgentSelectedPayload, ChatStreamPayload } from '../types/agent'
+import { AgentCapabilityToolExec } from '../types/agent'
 import { getDemoMode } from './useDemoMode'
 import { addCategoryTokens, setActiveTokenCategory } from './useTokenUsage'
 import { detectIssueSignature, findSimilarResolutionsStandalone, generateResolutionPromptContext } from './useResolutions'
@@ -610,8 +611,18 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       const persisted = localStorage.getItem(SELECTED_AGENT_KEY)
       const hasAvailableAgent = payload.agents.some(a => a.available)
       const persistedAvailable = persisted && persisted !== 'none' && payload.agents.some(a => a.name === persisted && a.available)
-      const firstAvailable = hasAvailableAgent ? (payload.agents.find(a => a.available)?.name || null) : null
-      const resolved = persistedAvailable ? persisted : (payload.selected || payload.defaultAgent || firstAvailable)
+
+      // When auto-selecting, prefer agents that execute commands directly over
+      // agents that only suggest commands (e.g. copilot-cli). This prevents
+      // missions from returning kubectl commands as text instead of running them (#3609).
+      const SUGGEST_ONLY_AGENTS = new Set(['copilot-cli', 'gh-copilot'])
+      const bestAvailable = hasAvailableAgent
+        ? (payload.agents.find(a => a.available && ((a.capabilities ?? 0) & AgentCapabilityToolExec) !== 0 && !SUGGEST_ONLY_AGENTS.has(a.name))?.name
+          || payload.agents.find(a => a.available && !SUGGEST_ONLY_AGENTS.has(a.name))?.name
+          || payload.agents.find(a => a.available)?.name
+          || null)
+        : null
+      const resolved = persistedAvailable ? persisted : (payload.selected || payload.defaultAgent || bestAvailable)
       setSelectedAgent(resolved)
       // If we restored a persisted agent that differs from the server's selection, tell the server
       if (persistedAvailable && persisted !== payload.selected && wsRef.current?.readyState === WebSocket.OPEN) {


### PR DESCRIPTION
## Summary

Fixes #3609 — AI Missions was falling back to `copilot-cli` which returns kubectl command suggestions as text instead of executing them, causing both incorrect behavior and high latency.

- **Backend agent routing**: `findToolCapableAgent()` now uses a priority list (claude-code > codex > gemini-cli > antigravity > bob) before falling back to suggest-only agents like copilot-cli
- **Backend default promotion**: New `promoteExecutingDefault()` ensures copilot-cli never becomes the default agent when a command-executing agent is available
- **Frontend agent selection**: Auto-selection logic now prefers agents with `ToolExec` capability that aren't in the suggest-only set
- **GitOps latency**: Drift detection now runs checks in parallel (not sequentially) with a health-check guard to skip when backend is unreachable

## Test plan

- [ ] With both claude-code and copilot-cli installed, verify claude-code is selected as default agent
- [ ] Start an AI mission asking to "list pods" — verify it executes `kubectl get pods` rather than suggesting it as text
- [ ] With only copilot-cli installed, verify it still works as a fallback
- [ ] Verify GitOps drift detection loads faster with parallel requests
- [ ] Run `cd web && npm run build` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)