### PR TITLE
fix: guard card.position access to prevent /deploy render errors

### DIFF
--- a/web/src/components/aiagents/AIAgents.tsx
+++ b/web/src/components/aiagents/AIAgents.tsx
@@ -20,7 +20,7 @@ function getTabDefaultCards(tabId: string) {
   return tab.cards.map(card => ({
     type: card.cardType,
     title: card.title,
-    position: { w: card.position.w, h: card.position.h },
+    position: { w: card.position?.w || 4, h: card.position?.h || 2 },
   }))
 }
 

--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -468,7 +468,7 @@ export function CustomDashboard() {
       card_type: tc.card_type,
       title: tc.title,
       config: tc.config || {},
-      position: { x: 0, y: 0, w: tc.position.w, h: tc.position.h }
+      position: { x: 0, y: 0, w: tc.position?.w || 4, h: tc.position?.h || 2 }
     }))
 
     snapshot(cardsRef.current)

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -757,7 +757,7 @@ export function Dashboard() {
     setLocalCards((prev) =>
       prev.map((c) =>
         c.id === cardId
-          ? { ...c, position: { ...c.position, w: newWidth } }
+          ? { ...c, position: { ...(c.position || { w: 4, h: 2 }), w: newWidth } }
           : c
       )
     )
@@ -768,7 +768,7 @@ export function Dashboard() {
         const card = localCards.find((c) => c.id === cardId)
         if (card) {
           await api.put(`/api/cards/${cardId}`, {
-            position: { ...card.position, w: newWidth }
+            position: { ...(card.position || { w: 4, h: 2 }), w: newWidth }
           })
         }
       } catch (error) {

--- a/web/src/components/dashboard/SharedSortableCard.tsx
+++ b/web/src/components/dashboard/SharedSortableCard.tsx
@@ -54,13 +54,15 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
     return () => mq.removeEventListener('change', handler)
   }, [])
 
-  const effectiveW = isNarrow && card.position.w < MIN_NARROW_COLS ? MIN_NARROW_COLS : card.position.w
+  const posW = card.position?.w || 4
+  const posH = card.position?.h || 2
+  const effectiveW = isNarrow && posW < MIN_NARROW_COLS ? MIN_NARROW_COLS : posW
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     gridColumn: `span ${effectiveW}`,
-    gridRow: `span ${card.position.h}`,
+    gridRow: `span ${posH}`,
     opacity: isDragging ? 0.5 : 1,
   }
 
@@ -103,7 +105,7 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
         title={card.title}
         isDemoData={DEMO_DATA_CARDS.has(card.card_type)}
         isLive={LIVE_DATA_CARDS.has(card.card_type)}
-        cardWidth={card.position.w}
+        cardWidth={card.position?.w || 4}
         isRefreshing={isRefreshing}
         onRefresh={onRefresh}
         lastUpdated={lastUpdated}
@@ -137,8 +139,8 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
   return (
     prevProps.card.id === nextProps.card.id &&
     prevProps.card.card_type === nextProps.card.card_type &&
-    prevProps.card.position.w === nextProps.card.position.w &&
-    prevProps.card.position.h === nextProps.card.position.h &&
+    (prevProps.card.position?.w || 4) === (nextProps.card.position?.w || 4) &&
+    (prevProps.card.position?.h || 2) === (nextProps.card.position?.h || 2) &&
     prevProps.card.title === nextProps.card.title &&
     prevProps.card.last_summary === nextProps.card.last_summary &&
     JSON.stringify(prevProps.card.config) === JSON.stringify(nextProps.card.config) &&
@@ -159,7 +161,7 @@ export function DragPreviewCard({ card }: { card: Card }) {
     <div
       className="rounded-lg glass border border-purple-500/50 p-4 shadow-xl"
       style={{
-        width: `${card.position.w * 100}px`,
+        width: `${(card.position?.w || 4) * 100}px`,
         minWidth: '200px',
         maxWidth: '400px',
       }}

--- a/web/src/components/dashboard/TemplatesModal.tsx
+++ b/web/src/components/dashboard/TemplatesModal.tsx
@@ -164,14 +164,14 @@ export function TemplatesModal({ isOpen, onClose, onApplyTemplate }: TemplatesMo
                   <div className="text-xs text-muted-foreground mb-2">{t('dashboard.templates.layoutPreview')}</div>
                   <div className="grid grid-cols-12 gap-1 min-h-[120px]">
                     {hoveredTemplate.cards.map((card, idx) => {
-                      const colSpan = Math.min(card.position.w, 12)
+                      const colSpan = Math.min(card.position?.w || 4, 12)
                       return (
                         <div
                           key={idx}
                           className={`rounded ${CARD_COLORS[card.card_type] || 'bg-gray-500/40 dark:bg-gray-900/40'} flex items-center justify-center p-1`}
                           style={{
                             gridColumn: `span ${colSpan}`,
-                            minHeight: `${card.position.h * 24}px`
+                            minHeight: `${(card.position?.h || 2) * 24}px`
                           }}
                         >
                           <span className="text-[9px] text-foreground/80 text-center leading-tight">

--- a/web/src/config/dashboards/index.ts
+++ b/web/src/config/dashboards/index.ts
@@ -119,7 +119,7 @@ export function getDefaultCards(dashboardId: string): Array<{ type: string; titl
   return config.cards.map(card => ({
     type: card.cardType,
     title: card.title,
-    position: { w: card.position.w, h: card.position.h },
+    position: { w: card.position?.w || 4, h: card.position?.h || 2 },
   }))
 }
 
@@ -136,10 +136,10 @@ export function getDefaultCardsForDashboard(dashboardId: string): Array<{ id: st
     card_type: card.cardType,
     config: {},
     position: {
-      x: card.position.x ?? (index % 3) * 4,
-      y: card.position.y ?? Math.floor(index / 3) * 3,
-      w: card.position.w,
-      h: card.position.h,
+      x: card.position?.x ?? (index % 3) * 4,
+      y: card.position?.y ?? Math.floor(index / 3) * 3,
+      w: card.position?.w || 4,
+      h: card.position?.h || 2,
     },
   }))
 }

--- a/web/src/hooks/useCardGridNavigation.ts
+++ b/web/src/hooks/useCardGridNavigation.ts
@@ -24,7 +24,7 @@ function computeGridLayout(cards: CardLike[], gridColumns: number): GridPosition
   let col = 0
 
   for (let i = 0; i < cards.length; i++) {
-    const w = Math.min(cards[i].position.w, gridColumns)
+    const w = Math.min(cards[i].position?.w || 4, gridColumns)
     if (col + w > gridColumns) {
       row++
       col = 0

--- a/web/src/lib/dashboards/dashboardHooks.ts
+++ b/web/src/lib/dashboards/dashboardHooks.ts
@@ -147,7 +147,12 @@ export function useDashboardCards(
     try {
       const stored = localStorage.getItem(storageKey)
       if (stored) {
-        return JSON.parse(stored)
+        const parsed = JSON.parse(stored) as DashboardCard[]
+        // Ensure every card has a position object (guards against old/corrupt data)
+        return parsed.map(c => ({
+          ...c,
+          position: c.position || { w: 4, h: 2 },
+        }))
       }
     } catch {
       // Fall through to return defaults

--- a/web/src/lib/dashboards/migrateStorageKey.ts
+++ b/web/src/lib/dashboards/migrateStorageKey.ts
@@ -63,12 +63,12 @@ export function ensureCardInDashboard(
     }
 
     // Shift existing cards down by the height of the new card
-    const shiftY = card.position.h
+    const shiftY = card.position?.h || 2
     const migrated = [
       card,
       ...cards.map(c => ({
         ...c,
-        position: { ...c.position, y: c.position.y + shiftY },
+        position: { ...(c.position || { w: 4, h: 2, x: 0, y: 0 }), y: (c.position?.y || 0) + shiftY },
       })),
     ]
 

--- a/web/src/lib/unified/dashboard/DashboardGrid.tsx
+++ b/web/src/lib/unified/dashboard/DashboardGrid.tsx
@@ -217,12 +217,12 @@ function DashboardCardWrapper({
     return () => mq.removeEventListener('change', handler)
   }, [])
 
-  const rawW = Math.min(12, Math.max(3, placement.position.w))
+  const rawW = Math.min(12, Math.max(3, placement.position?.w || 4))
   const effectiveW = isNarrow && rawW < 6 ? 6 : rawW
 
   // Calculate height (each row unit = 100px) — use inline style because
   // Tailwind JIT can't detect dynamically constructed arbitrary classes.
-  const minHeightPx = placement.position.h * 100
+  const minHeightPx = (placement.position?.h || 2) * 100
 
   // Get card config - support both cardType (new) and card_type (legacy localStorage)
   const cardTypeKey = placement.cardType || (placement as { card_type?: string }).card_type
@@ -289,7 +289,7 @@ function DashboardCardWrapper({
             cardId={placement.id}
             cardType={cardTypeKey!}
             title={placement.title}
-            cardWidth={placement.position.w}
+            cardWidth={placement.position?.w || 4}
             dragHandle={dragHandleNode}
             onRemove={onRemove}
             onConfigure={onConfigure}


### PR DESCRIPTION
## Summary
- Add optional chaining and fallback defaults (`{ w: 4, h: 2 }`) to all `card.position` access sites across 10 files
- Normalize `position` when loading cards from localStorage in `dashboardHooks.ts` to prevent cascading failures
- Fixes the root cause of all 5 GA4 `page_render` errors on `/deploy`: the `card.position` TypeError would abort module evaluation, causing downstream `useClusters` to be undefined

## GA4 errors fixed
| Error | Count | Root cause |
|-------|-------|------------|
| `undefined is not an object (evaluating 'e.position')` | x2 | `SharedSortableCard` memo comparator accessed `card.position.w` without guard |
| `undefined is not an object (evaluating 'card.position')` | x2 | Multiple components accessed `card.position.w`/`.h` on cards loaded from localStorage without position |
| `Can't find variable: useClusters` | x1 | Module evaluation aborted by earlier TypeError, leaving `useClusters` undefined |

## Files changed
- `SharedSortableCard.tsx` — optional chaining on all 5 position accesses
- `DashboardGrid.tsx` — optional chaining on `.w`, `.h`, `cardWidth`
- `dashboardHooks.ts` — normalize position on localStorage load
- `CustomDashboard.tsx`, `Dashboard.tsx`, `TemplatesModal.tsx` — optional chaining
- `config/dashboards/index.ts` — guards in `getDefaultCards` / `getDefaultCardsForDashboard`
- `useCardGridNavigation.ts`, `migrateStorageKey.ts`, `AIAgents.tsx` — optional chaining

## Test plan
- [ ] Navigate to `/deploy` — no console errors
- [ ] Clear localStorage for `kubestellar-deploy-cards`, reload `/deploy` — cards render with defaults
- [ ] Manually inject card data without `position` field into localStorage, reload — no crash
- [ ] Verify card drag-and-drop still works on `/deploy`
- [ ] `npm run build` passes cleanly

Closes #3598

🤖 Generated with [Claude Code](https://claude.com/claude-code)