### PR TITLE
fix: add compliance drilldown to TrestleScan card

### DIFF
--- a/web/src/components/cards/TrestleScan.tsx
+++ b/web/src/components/cards/TrestleScan.tsx
@@ -16,6 +16,7 @@ import { useCardLoadingState } from './CardDataContext'
 import { useTrestle, type OscalProfile } from '../../hooks/useTrestle'
 import { useMissions } from '../../hooks/useMissions'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
+import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 
 interface CardConfig {
@@ -50,6 +51,7 @@ export function TrestleScan({ config: _config }: CardConfig) {
   const { statuses, aggregated, isLoading, isRefreshing, installed, isDemoData, lastRefresh, clustersChecked, totalClusters } = useTrestle()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
+  const { drillToCompliance } = useDrillDownActions()
   const [expandedProfile, setExpandedProfile] = useState<string | null>(null)
 
   /** Whether all clusters have been checked */
@@ -243,33 +245,51 @@ Please proceed step by step. Start with verifying prerequisites (Python 3.9+, ku
       {/* Overall Score */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <div className="flex flex-col items-center">
+          <button
+            onClick={() => drillToCompliance('', {})}
+            className="flex flex-col items-center hover:opacity-80 transition-opacity cursor-pointer"
+            title="View all compliance controls"
+          >
             <span className={`text-3xl font-bold ${scoreColor}`}>{filtered.overallScore}%</span>
             <span className={`text-xs ${scoreColor}`}>{scoreLabel}</span>
-          </div>
+          </button>
           <div className="text-xs text-muted-foreground">
-            <div className="flex items-center gap-1">
+            <button
+              onClick={() => drillToCompliance('pass', {})}
+              className="flex items-center gap-1 hover:text-green-400 transition-colors cursor-pointer"
+              title="View passing controls"
+            >
               <CheckCircle className="w-3 h-3 text-green-400" />
               <span>{filtered.passedControls} passed</span>
-            </div>
-            <div className="flex items-center gap-1">
+            </button>
+            <button
+              onClick={() => drillToCompliance('fail', {})}
+              className="flex items-center gap-1 hover:text-red-400 transition-colors cursor-pointer"
+              title="View failing controls"
+            >
               <XCircle className="w-3 h-3 text-red-400" />
               <span>{filtered.failedControls} failed</span>
-            </div>
+            </button>
             {filtered.otherControls > 0 && (
-              <div className="flex items-center gap-1">
+              <button
+                onClick={() => drillToCompliance('other', {})}
+                className="flex items-center gap-1 hover:text-foreground transition-colors cursor-pointer"
+                title="View other controls"
+              >
                 <Info className="w-3 h-3 text-muted-foreground" />
                 <span>{filtered.otherControls} other</span>
-              </div>
+              </button>
             )}
           </div>
         </div>
-        <StatusBadge
-          color={filtered.overallScore >= SCORE_GOOD_THRESHOLD ? 'green' : filtered.overallScore >= SCORE_WARNING_THRESHOLD ? 'yellow' : 'red'}
-          size="xs"
-        >
-          {filtered.totalControls} controls
-        </StatusBadge>
+        <button onClick={() => drillToCompliance('', {})} className="cursor-pointer" title="View all compliance controls">
+          <StatusBadge
+            color={filtered.overallScore >= SCORE_GOOD_THRESHOLD ? 'green' : filtered.overallScore >= SCORE_WARNING_THRESHOLD ? 'yellow' : 'red'}
+            size="xs"
+          >
+            {filtered.totalControls} controls
+          </StatusBadge>
+        </button>
       </div>
 
       {/* Compliance Context Banner */}

--- a/web/src/components/drilldown/DrillDownModal.tsx
+++ b/web/src/components/drilldown/DrillDownModal.tsx
@@ -25,6 +25,7 @@ const ConfigMapDrillDown = safeLazy(() => import('./views/ConfigMapDrillDown'), 
 const BuildpackDrillDown = safeLazy(() => import('./views/BuildpackDrillDown'), 'BuildpackDrillDown')
 const RBACDrillDown = safeLazy(() => import('./views/RBACDrillDown'), 'RBACDrillDown')
 const CostDrillDown = safeLazy(() => import('./views/CostDrillDown'), 'CostDrillDown')
+const ComplianceDrillDown = safeLazy(() => import('./views/ComplianceDrillDown'), 'ComplianceDrillDown')
 
 const EventsDrillDown = safeLazy(() => import('./views/EventsDrillDown'), 'EventsDrillDown')
 
@@ -77,6 +78,7 @@ const getViewIcon = (type: string) => {
     case 'argoapp': return <GitBranch className="w-4 h-4 text-orange-400" />
     case 'operator': return <Settings className="w-4 h-4 text-purple-400" />
     case 'policy': return <Shield className="w-4 h-4 text-blue-400" />
+    case 'compliance': return <Shield className="w-4 h-4 text-teal-400" />
     case 'kustomization': return <Layers className="w-4 h-4 text-blue-400" />
     case 'buildpack': return <Package className="w-4 h-4 text-blue-400" />
     case 'crd': return <Package className="w-4 h-4 text-purple-400" />
@@ -198,6 +200,8 @@ export function DrillDownModal() {
         return <OperatorDrillDown data={data} />
       case 'policy':
         return <PolicyDrillDown data={data} />
+      case 'compliance':
+        return <ComplianceDrillDown data={data} />
       case 'kustomization':
         return <KustomizationDrillDown data={data} />
       case 'buildpack':

--- a/web/src/components/drilldown/views/ComplianceDrillDown.tsx
+++ b/web/src/components/drilldown/views/ComplianceDrillDown.tsx
@@ -1,0 +1,505 @@
+/**
+ * Compliance Trestle drilldown view.
+ *
+ * Shows individual OSCAL control results with filtering by status, severity,
+ * cluster, and profile. Supports sorting and pagination. Opened from the
+ * TrestleScan card when clicking a stat (passed/failed/other count).
+ */
+
+import { useState, useMemo } from 'react'
+import {
+  Shield, CheckCircle, XCircle, AlertCircle, Info,
+  ChevronUp, ChevronDown, ChevronLeft, ChevronRight,
+  Search, X, Filter,
+} from 'lucide-react'
+import { useTrestle, type OscalControlResult } from '../../../hooks/useTrestle'
+import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
+import { StatusBadge } from '../../ui/StatusBadge'
+import { cn } from '../../../lib/cn'
+
+interface Props {
+  data: Record<string, unknown>
+}
+
+type SortField = 'controlId' | 'severity' | 'status' | 'cluster' | 'profile'
+type SortDir = 'asc' | 'desc'
+
+/** Controls per page */
+const PAGE_SIZE = 25
+
+const SEVERITY_ORDER: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 }
+const STATUS_ORDER: Record<string, number> = { fail: 0, other: 1, 'not-applicable': 2, pass: 3 }
+
+function severityColor(s?: string): string {
+  switch (s) {
+    case 'critical': return 'text-red-400 bg-red-500/15 border-red-500/30'
+    case 'high': return 'text-orange-400 bg-orange-500/15 border-orange-500/30'
+    case 'medium': return 'text-yellow-400 bg-yellow-500/15 border-yellow-500/30'
+    case 'low': return 'text-blue-400 bg-blue-500/15 border-blue-500/30'
+    default: return 'text-muted-foreground bg-secondary border-border'
+  }
+}
+
+function statusIcon(status: string) {
+  switch (status) {
+    case 'pass': return <CheckCircle className="w-4 h-4 text-green-400" />
+    case 'fail': return <XCircle className="w-4 h-4 text-red-400" />
+    case 'other': return <AlertCircle className="w-4 h-4 text-yellow-400" />
+    case 'not-applicable': return <Info className="w-4 h-4 text-muted-foreground" />
+    default: return <AlertCircle className="w-4 h-4 text-muted-foreground" />
+  }
+}
+
+function statusLabel(status: string) {
+  switch (status) {
+    case 'pass': return 'Pass'
+    case 'fail': return 'Fail'
+    case 'other': return 'Other'
+    case 'not-applicable': return 'N/A'
+    default: return status
+  }
+}
+
+interface ControlRow extends OscalControlResult {
+  cluster: string
+}
+
+export function ComplianceDrillDown({ data }: Props) {
+  const filterStatus = (data.filterStatus as string) || ''
+  const { statuses } = useTrestle()
+  const { selectedClusters } = useGlobalFilters()
+
+  // Filters
+  const [statusFilter, setStatusFilter] = useState<string>(filterStatus)
+  const [severityFilter, setSeverityFilter] = useState<string>('')
+  const [clusterFilter, setClusterFilter] = useState<string>('')
+  const [profileFilter, setProfileFilter] = useState<string>('')
+  const [searchQuery, setSearchQuery] = useState('')
+  const [showFilters, setShowFilters] = useState(false)
+
+  // Sort
+  const [sortField, setSortField] = useState<SortField>('severity')
+  const [sortDir, setSortDir] = useState<SortDir>('asc')
+
+  // Pagination
+  const [page, setPage] = useState(0)
+
+  // Build flat list with cluster info
+  const allRows = useMemo(() => {
+    const rows: ControlRow[] = []
+    for (const [clusterName, clusterStatus] of Object.entries(statuses)) {
+      if (!clusterStatus.installed) continue
+      if (selectedClusters.length > 0 && !selectedClusters.includes(clusterName)) continue
+      for (const cr of clusterStatus.controlResults) {
+        rows.push({ ...cr, cluster: clusterName })
+      }
+    }
+    return rows
+  }, [statuses, selectedClusters])
+
+  // Unique values for filter dropdowns
+  const uniqueClusters = useMemo(() => [...new Set(allRows.map(r => r.cluster))].sort(), [allRows])
+  const uniqueProfiles = useMemo(() => [...new Set(allRows.map(r => r.profile).filter(Boolean))].sort(), [allRows])
+  const uniqueStatuses = useMemo(() => [...new Set(allRows.map(r => r.status))].sort(), [allRows])
+
+  // Filtered rows
+  const filteredRows = useMemo(() => {
+    let rows = allRows
+    if (statusFilter) rows = rows.filter(r => r.status === statusFilter)
+    if (severityFilter) rows = rows.filter(r => r.severity === severityFilter)
+    if (clusterFilter) rows = rows.filter(r => r.cluster === clusterFilter)
+    if (profileFilter) rows = rows.filter(r => r.profile === profileFilter)
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase()
+      rows = rows.filter(r =>
+        r.controlId.toLowerCase().includes(q) ||
+        r.title.toLowerCase().includes(q) ||
+        (r.description || '').toLowerCase().includes(q)
+      )
+    }
+    return rows
+  }, [allRows, statusFilter, severityFilter, clusterFilter, profileFilter, searchQuery])
+
+  // Sorted rows
+  const sortedRows = useMemo(() => {
+    const sorted = [...filteredRows]
+    sorted.sort((a, b) => {
+      let cmp = 0
+      switch (sortField) {
+        case 'controlId':
+          cmp = a.controlId.localeCompare(b.controlId)
+          break
+        case 'severity':
+          cmp = (SEVERITY_ORDER[a.severity || 'medium'] ?? 2) - (SEVERITY_ORDER[b.severity || 'medium'] ?? 2)
+          break
+        case 'status':
+          cmp = (STATUS_ORDER[a.status] ?? 2) - (STATUS_ORDER[b.status] ?? 2)
+          break
+        case 'cluster':
+          cmp = a.cluster.localeCompare(b.cluster)
+          break
+        case 'profile':
+          cmp = (a.profile || '').localeCompare(b.profile || '')
+          break
+      }
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+    return sorted
+  }, [filteredRows, sortField, sortDir])
+
+  // Paginated rows
+  const totalPages = Math.ceil(sortedRows.length / PAGE_SIZE)
+  const pagedRows = useMemo(
+    () => sortedRows.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
+    [sortedRows, page],
+  )
+
+  // Reset page when filters change
+  const resetPage = () => setPage(0)
+
+  // Sort toggle
+  const toggleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortField(field)
+      setSortDir('asc')
+    }
+    resetPage()
+  }
+
+  const SortIndicator = ({ field }: { field: SortField }) => {
+    if (sortField !== field) return <ChevronUp className="w-3 h-3 opacity-20" />
+    return sortDir === 'asc'
+      ? <ChevronUp className="w-3 h-3" />
+      : <ChevronDown className="w-3 h-3" />
+  }
+
+  // Summary stats
+  const passCount = filteredRows.filter(r => r.status === 'pass').length
+  const failCount = filteredRows.filter(r => r.status === 'fail').length
+  const otherCount = filteredRows.filter(r => r.status === 'other' || r.status === 'not-applicable').length
+  const activeFilters = [statusFilter, severityFilter, clusterFilter, profileFilter, searchQuery].filter(Boolean).length
+
+  return (
+    <div className="flex flex-col h-full -m-6">
+      {/* Header */}
+      <div className="px-6 pt-6 pb-4">
+        <div className="flex items-center gap-3 mb-4">
+          <Shield className="w-6 h-6 text-teal-400" />
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">OSCAL Compliance Controls</h2>
+            <p className="text-sm text-muted-foreground">
+              Individual check results from Compliance Trestle assessments
+            </p>
+          </div>
+        </div>
+
+        {/* Summary stats */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+          <button
+            onClick={() => { setStatusFilter(''); resetPage() }}
+            className={cn(
+              'p-3 rounded-lg border transition-colors text-left',
+              !statusFilter ? 'border-teal-500/40 bg-teal-500/10' : 'border-border bg-card/50 hover:border-border/80'
+            )}
+          >
+            <div className="text-xl font-bold text-foreground">{filteredRows.length}</div>
+            <div className="text-xs text-muted-foreground">Total Controls</div>
+          </button>
+          <button
+            onClick={() => { setStatusFilter(statusFilter === 'pass' ? '' : 'pass'); resetPage() }}
+            className={cn(
+              'p-3 rounded-lg border transition-colors text-left',
+              statusFilter === 'pass' ? 'border-green-500/40 bg-green-500/10' : 'border-border bg-card/50 hover:border-border/80'
+            )}
+          >
+            <div className="text-xl font-bold text-green-400">{passCount}</div>
+            <div className="text-xs text-muted-foreground">Passing</div>
+          </button>
+          <button
+            onClick={() => { setStatusFilter(statusFilter === 'fail' ? '' : 'fail'); resetPage() }}
+            className={cn(
+              'p-3 rounded-lg border transition-colors text-left',
+              statusFilter === 'fail' ? 'border-red-500/40 bg-red-500/10' : 'border-border bg-card/50 hover:border-border/80'
+            )}
+          >
+            <div className="text-xl font-bold text-red-400">{failCount}</div>
+            <div className="text-xs text-muted-foreground">Failing</div>
+          </button>
+          <button
+            onClick={() => { setStatusFilter(statusFilter === 'other' ? '' : 'other'); resetPage() }}
+            className={cn(
+              'p-3 rounded-lg border transition-colors text-left',
+              statusFilter === 'other' ? 'border-yellow-500/40 bg-yellow-500/10' : 'border-border bg-card/50 hover:border-border/80'
+            )}
+          >
+            <div className="text-xl font-bold text-yellow-400">{otherCount}</div>
+            <div className="text-xs text-muted-foreground">Other / N/A</div>
+          </button>
+        </div>
+
+        {/* Search + filter toggle */}
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1">
+            <Search className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" />
+            <input
+              type="text"
+              placeholder="Search by control ID, title, or description..."
+              value={searchQuery}
+              onChange={e => { setSearchQuery(e.target.value); resetPage() }}
+              className="w-full pl-9 pr-8 py-2 rounded-lg border border-border bg-card/50 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+            {searchQuery && (
+              <button
+                onClick={() => { setSearchQuery(''); resetPage() }}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+          <button
+            onClick={() => setShowFilters(!showFilters)}
+            className={cn(
+              'flex items-center gap-1.5 px-3 py-2 rounded-lg border text-sm transition-colors',
+              showFilters || activeFilters > 0
+                ? 'border-teal-500/40 bg-teal-500/10 text-teal-400'
+                : 'border-border bg-card/50 text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <Filter className="w-4 h-4" />
+            Filters
+            {activeFilters > 0 && (
+              <span className="ml-1 px-1.5 py-0.5 rounded-full bg-teal-500/20 text-teal-400 text-xs font-medium">
+                {activeFilters}
+              </span>
+            )}
+          </button>
+        </div>
+
+        {/* Filter dropdowns */}
+        {showFilters && (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mt-3">
+            <select
+              value={statusFilter}
+              onChange={e => { setStatusFilter(e.target.value); resetPage() }}
+              className="px-3 py-2 rounded-lg border border-border bg-card/50 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              <option value="">All Statuses</option>
+              {uniqueStatuses.map(s => (
+                <option key={s} value={s}>{statusLabel(s)}</option>
+              ))}
+            </select>
+            <select
+              value={severityFilter}
+              onChange={e => { setSeverityFilter(e.target.value); resetPage() }}
+              className="px-3 py-2 rounded-lg border border-border bg-card/50 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              <option value="">All Severities</option>
+              <option value="critical">Critical</option>
+              <option value="high">High</option>
+              <option value="medium">Medium</option>
+              <option value="low">Low</option>
+            </select>
+            <select
+              value={clusterFilter}
+              onChange={e => { setClusterFilter(e.target.value); resetPage() }}
+              className="px-3 py-2 rounded-lg border border-border bg-card/50 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              <option value="">All Clusters</option>
+              {uniqueClusters.map(c => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+            <select
+              value={profileFilter}
+              onChange={e => { setProfileFilter(e.target.value); resetPage() }}
+              className="px-3 py-2 rounded-lg border border-border bg-card/50 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              <option value="">All Profiles</option>
+              {uniqueProfiles.map(p => (
+                <option key={p} value={p}>{p}</option>
+              ))}
+            </select>
+
+            {activeFilters > 0 && (
+              <button
+                onClick={() => {
+                  setStatusFilter('')
+                  setSeverityFilter('')
+                  setClusterFilter('')
+                  setProfileFilter('')
+                  setSearchQuery('')
+                  resetPage()
+                }}
+                className="text-xs text-muted-foreground hover:text-foreground transition-colors col-span-2 md:col-span-4 text-left"
+              >
+                Clear all filters
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Table */}
+      <div className="flex-1 overflow-y-auto px-6">
+        {pagedRows.length === 0 ? (
+          <div className="text-center py-16 text-muted-foreground">
+            <Shield className="w-12 h-12 mx-auto mb-3 opacity-30" />
+            <p className="font-medium">No controls match filters</p>
+            <p className="text-xs mt-1">Try adjusting your search or filter criteria</p>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-border overflow-hidden">
+            {/* Table header */}
+            <div className="grid grid-cols-[1fr_2fr_100px_100px_120px_120px] gap-px bg-border text-xs font-medium text-muted-foreground">
+              <button onClick={() => toggleSort('controlId')} className="flex items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+                Control <SortIndicator field="controlId" />
+              </button>
+              <div className="px-3 py-2 bg-card/80">Description</div>
+              <button onClick={() => toggleSort('status')} className="flex items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+                Status <SortIndicator field="status" />
+              </button>
+              <button onClick={() => toggleSort('severity')} className="flex items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+                Severity <SortIndicator field="severity" />
+              </button>
+              <button onClick={() => toggleSort('cluster')} className="flex items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+                Cluster <SortIndicator field="cluster" />
+              </button>
+              <button onClick={() => toggleSort('profile')} className="flex items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+                Profile <SortIndicator field="profile" />
+              </button>
+            </div>
+
+            {/* Table rows */}
+            {pagedRows.map((row, i) => (
+              <div
+                key={`${row.cluster}-${row.controlId}-${i}`}
+                className={cn(
+                  'grid grid-cols-[1fr_2fr_100px_100px_120px_120px] gap-px text-sm',
+                  row.status === 'fail' ? 'bg-red-500/5' : 'bg-transparent',
+                  'hover:bg-card/40 transition-colors'
+                )}
+              >
+                <div className="px-3 py-2.5 font-mono text-xs font-medium text-foreground truncate">
+                  {row.controlId}
+                </div>
+                <div className="px-3 py-2.5 text-xs text-muted-foreground truncate" title={row.description || row.title}>
+                  {row.title}
+                </div>
+                <div className="px-3 py-2.5 flex items-center gap-1.5">
+                  {statusIcon(row.status)}
+                  <span className="text-xs">{statusLabel(row.status)}</span>
+                </div>
+                <div className="px-3 py-2.5">
+                  {row.severity && (
+                    <span className={cn('px-2 py-0.5 rounded text-xs font-medium border', severityColor(row.severity))}>
+                      {row.severity}
+                    </span>
+                  )}
+                </div>
+                <div className="px-3 py-2.5">
+                  <StatusBadge color="blue" size="xs">
+                    {row.cluster.split('/').pop() || row.cluster}
+                  </StatusBadge>
+                </div>
+                <div className="px-3 py-2.5 text-xs text-muted-foreground truncate" title={row.profile}>
+                  {row.profile || '-'}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="px-6 py-3 border-t border-border flex items-center justify-between text-sm text-muted-foreground">
+          <span>
+            Showing {page * PAGE_SIZE + 1}--{Math.min((page + 1) * PAGE_SIZE, sortedRows.length)} of {sortedRows.length} controls
+          </span>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setPage(0)}
+              disabled={page === 0}
+              className="p-1.5 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              title="First page"
+            >
+              <ChevronLeft className="w-4 h-4" />
+              <ChevronLeft className="w-4 h-4 -ml-3" />
+            </button>
+            <button
+              onClick={() => setPage(p => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="p-1.5 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              title="Previous page"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <span className="px-3 text-xs">
+              Page {page + 1} of {totalPages}
+            </span>
+            <button
+              onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+              disabled={page >= totalPages - 1}
+              className="p-1.5 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              title="Next page"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => setPage(totalPages - 1)}
+              disabled={page >= totalPages - 1}
+              className="p-1.5 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+              title="Last page"
+            >
+              <ChevronRight className="w-4 h-4" />
+              <ChevronRight className="w-4 h-4 -ml-3" />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Per-cluster breakdown */}
+      {uniqueClusters.length > 1 && (
+        <div className="px-6 py-3 border-t border-border">
+          <p className="text-xs text-muted-foreground mb-2">Per-cluster breakdown</p>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+            {uniqueClusters.map(cluster => {
+              const clusterRows = filteredRows.filter(r => r.cluster === cluster)
+              const cPass = clusterRows.filter(r => r.status === 'pass').length
+              const cFail = clusterRows.filter(r => r.status === 'fail').length
+              const cTotal = clusterRows.length
+              const cScore = cTotal > 0 ? Math.round((cPass / cTotal) * 100) : 0
+              return (
+                <button
+                  key={cluster}
+                  onClick={() => { setClusterFilter(clusterFilter === cluster ? '' : cluster); resetPage() }}
+                  className={cn(
+                    'p-2 rounded-lg border text-left transition-colors',
+                    clusterFilter === cluster ? 'border-blue-500/40 bg-blue-500/10' : 'border-border bg-card/50 hover:border-border/80'
+                  )}
+                >
+                  <div className="text-xs font-medium text-foreground truncate">{cluster.split('/').pop() || cluster}</div>
+                  <div className="flex items-center gap-2 mt-1">
+                    <span className="text-xs text-green-400">{cPass} pass</span>
+                    <span className="text-xs text-red-400">{cFail} fail</span>
+                    <span className={cn(
+                      'text-xs font-bold ml-auto',
+                      cScore >= 80 ? 'text-green-400' : cScore >= 60 ? 'text-yellow-400' : 'text-red-400'
+                    )}>
+                      {cScore}%
+                    </span>
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ComplianceDrillDown

--- a/web/src/hooks/useDrillDown.tsx
+++ b/web/src/hooks/useDrillDown.tsx
@@ -31,6 +31,7 @@ export type DrillDownViewType =
   | 'drift'
   // Phase 2: Policy and compliance views
   | 'policy'
+  | 'compliance'
   | 'crd'
   // Phase 2: Alerting and monitoring views
   | 'alert'
@@ -225,6 +226,8 @@ function getViewKey(view: DrillDownView): string {
     // Phase 2: Policy and compliance views
     case 'policy':
       return `policy:${data.cluster}:${data.namespace || ''}:${data.policy}`
+    case 'compliance':
+      return `compliance:${data.filterStatus || 'all'}`
     case 'crd':
       return `crd:${data.cluster}:${data.crd}`
     // Phase 2: Alerting and monitoring views
@@ -535,6 +538,18 @@ export function useDrillDownActions() {
     })
   }, [openOrPush])
 
+  const drillToCompliance = useCallback((filterStatus?: string, complianceData?: Record<string, unknown>) => {
+    const title = filterStatus
+      ? `${filterStatus.charAt(0).toUpperCase() + filterStatus.slice(1)} Controls`
+      : 'OSCAL Compliance Controls'
+    openOrPush({
+      type: 'compliance',
+      title,
+      subtitle: 'Compliance Trestle Assessment',
+      data: { filterStatus, ...complianceData },
+    })
+  }, [openOrPush])
+
   const drillToCRD = useCallback((cluster: string, crd: string, crdData?: Record<string, unknown>) => {
     openOrPush({
       type: 'crd',
@@ -760,6 +775,7 @@ export function useDrillDownActions() {
     drillToBuildpack,
     drillToDrift,
     drillToPolicy,
+    drillToCompliance,
     drillToCRD,
     drillToAlert,
     drillToAlertRule,

--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -47,6 +47,8 @@ export interface OscalControlResult {
   title: string
   status: 'pass' | 'fail' | 'other' | 'not-applicable'
   description?: string
+  severity?: 'critical' | 'high' | 'medium' | 'low'
+  profile?: string
 }
 
 export interface OscalProfile {
@@ -125,6 +127,64 @@ function clearCache(): void {
 
 // ── Demo data ────────────────────────────────────────────────────────────
 
+/** Demo NIST 800-53 control families for realistic demo data */
+const DEMO_CONTROL_FAMILIES = [
+  { id: 'AC', name: 'Access Control', controls: ['AC-1','AC-2','AC-3','AC-4','AC-5','AC-6','AC-7','AC-8','AC-11','AC-12','AC-14','AC-17','AC-18','AC-19','AC-20','AC-21','AC-22'] },
+  { id: 'AU', name: 'Audit and Accountability', controls: ['AU-1','AU-2','AU-3','AU-4','AU-5','AU-6','AU-7','AU-8','AU-9','AU-11','AU-12'] },
+  { id: 'AT', name: 'Awareness and Training', controls: ['AT-1','AT-2','AT-3','AT-4'] },
+  { id: 'CM', name: 'Configuration Management', controls: ['CM-1','CM-2','CM-3','CM-4','CM-5','CM-6','CM-7','CM-8','CM-9','CM-10','CM-11'] },
+  { id: 'CP', name: 'Contingency Planning', controls: ['CP-1','CP-2','CP-3','CP-4','CP-6','CP-7','CP-8','CP-9','CP-10'] },
+  { id: 'IA', name: 'Identification and Authentication', controls: ['IA-1','IA-2','IA-3','IA-4','IA-5','IA-6','IA-7','IA-8'] },
+  { id: 'IR', name: 'Incident Response', controls: ['IR-1','IR-2','IR-3','IR-4','IR-5','IR-6','IR-7','IR-8'] },
+  { id: 'MA', name: 'Maintenance', controls: ['MA-1','MA-2','MA-3','MA-4','MA-5','MA-6'] },
+  { id: 'MP', name: 'Media Protection', controls: ['MP-1','MP-2','MP-3','MP-4','MP-5','MP-6','MP-7'] },
+  { id: 'PE', name: 'Physical and Environmental Protection', controls: ['PE-1','PE-2','PE-3','PE-4','PE-6','PE-8','PE-9','PE-10','PE-11','PE-12','PE-13','PE-14','PE-15','PE-16'] },
+  { id: 'PL', name: 'Planning', controls: ['PL-1','PL-2','PL-4','PL-8'] },
+  { id: 'PS', name: 'Personnel Security', controls: ['PS-1','PS-2','PS-3','PS-4','PS-5','PS-6','PS-7','PS-8'] },
+  { id: 'RA', name: 'Risk Assessment', controls: ['RA-1','RA-2','RA-3','RA-5'] },
+  { id: 'SA', name: 'System and Services Acquisition', controls: ['SA-1','SA-2','SA-3','SA-4','SA-5','SA-8','SA-9','SA-10','SA-11'] },
+  { id: 'SC', name: 'System and Communications Protection', controls: ['SC-1','SC-2','SC-4','SC-5','SC-7','SC-8','SC-10','SC-12','SC-13','SC-15','SC-17','SC-18','SC-19','SC-20','SC-21','SC-22','SC-23','SC-28','SC-39'] },
+  { id: 'SI', name: 'System and Information Integrity', controls: ['SI-1','SI-2','SI-3','SI-4','SI-5','SI-7','SI-8','SI-10','SI-11','SI-12','SI-16'] },
+  { id: 'SR', name: 'Supply Chain Risk Management', controls: ['SR-1','SR-2','SR-3','SR-5','SR-6','SR-8','SR-10','SR-11','SR-12'] },
+]
+
+const DEMO_SEVERITIES: Array<'critical' | 'high' | 'medium' | 'low'> = ['critical', 'high', 'medium', 'low']
+
+/** Deterministic pseudo-random from seed */
+function demoRand(seed: number): number {
+  const x = Math.sin(seed * 9301 + 49297) * 233280
+  return x - Math.floor(x)
+}
+
+function generateDemoControlResults(cluster: string, total: number, passed: number, failed: number, _other: number): OscalControlResult[] {
+  const results: OscalControlResult[] = []
+  const clusterSeed = cluster.split('').reduce((a, c) => a + c.charCodeAt(0), 0)
+  let idx = 0
+  const profiles = ['NIST 800-53 rev5', 'FedRAMP Moderate']
+
+  for (const family of DEMO_CONTROL_FAMILIES) {
+    for (const controlId of family.controls) {
+      if (idx >= total) break
+      const rand = demoRand(clusterSeed + idx)
+      let status: 'pass' | 'fail' | 'other'
+      if (idx < passed) status = 'pass'
+      else if (idx < passed + failed) status = 'fail'
+      else status = 'other'
+
+      results.push({
+        controlId,
+        title: `${family.name}: ${controlId}`,
+        description: `Ensure ${family.name.toLowerCase()} control ${controlId} requirements are satisfied`,
+        status,
+        severity: DEMO_SEVERITIES[Math.floor(rand * 4)],
+        profile: profiles[idx % 2 === 0 ? 0 : 1],
+      })
+      idx++
+    }
+  }
+  return results
+}
+
 function getDemoStatus(cluster: string): TrestleClusterStatus {
   const seed = cluster.length
   const score = DEMO_OVERALL_SCORE + (seed % 15) - 7
@@ -158,7 +218,7 @@ function getDemoStatus(cluster: string): TrestleClusterStatus {
     passedControls: passed,
     failedControls: failed,
     otherControls: other,
-    controlResults: [],
+    controlResults: generateDemoControlResults(cluster, total, passed, failed, other),
     lastAssessment: new Date(Date.now() - (seed % 60) * 60_000).toISOString(),
   }
 }
@@ -265,18 +325,21 @@ async function fetchSingleCluster(cluster: string): Promise<TrestleClusterStatus
                 const controlStatus = String(r.status || r.state || 'other').toLowerCase()
                 const controlId = String(r.controlId || r.control || r.id || '')
                 const title = String(r.title || r.description || controlId)
+                const description = String(r.description || r.title || '')
+                const severity = (String(r.severity || r.priority || 'medium').toLowerCase()) as 'critical' | 'high' | 'medium' | 'low'
 
                 if (controlStatus === 'pass' || controlStatus === 'satisfied') {
                   passed++
-                  controlResults.push({ controlId, title, status: 'pass' })
+                  controlResults.push({ controlId, title, status: 'pass', description, severity, profile: profileName })
                 } else if (controlStatus === 'fail' || controlStatus === 'not-satisfied') {
                   failed++
-                  controlResults.push({ controlId, title, status: 'fail' })
+                  controlResults.push({ controlId, title, status: 'fail', description, severity, profile: profileName })
                 } else {
                   other++
                   controlResults.push({
                     controlId, title,
                     status: controlStatus === 'not-applicable' ? 'not-applicable' : 'other',
+                    description, severity, profile: profileName,
                   })
                 }
               }


### PR DESCRIPTION
## Summary
- Adds an interactive drilldown panel to the Compliance Trestle (trestle_scan) card that opens when clicking any stat (passing, failing, other counts, total controls, or score)
- Lists individual OSCAL controls with rule ID, description, severity, cluster, and status in a sortable, filterable, paginated table
- Includes filters by status, severity, cluster, and profile plus full-text search
- Shows per-cluster breakdown with pass/fail counts and compliance score
- Generates realistic NIST 800-53 demo control results for demo mode

Closes #3623

## Test plan
- [ ] Verify clicking "passed", "failed", "other" counts on the TrestleScan card opens the drilldown filtered to that status
- [ ] Verify clicking the score percentage or "controls" badge opens the drilldown with no filter
- [ ] Verify filter dropdowns (status, severity, cluster, profile) work correctly
- [ ] Verify sorting by each column header works
- [ ] Verify pagination controls work when there are more than 25 controls
- [ ] Verify search filters by control ID, title, and description
- [ ] Verify per-cluster breakdown section appears with multiple clusters
- [ ] Verify demo mode shows realistic NIST 800-53 control data
- [ ] Verify build passes with `cd web && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)