### PR TITLE
fix: sidebar collapse/pin icons no longer cover popups

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -541,7 +541,7 @@ export function Sidebar() {
       {/* Collapse + Pin controls — top-right of sidebar, above resize handle */}
       {!isMobile && !isMissionFullScreen && (
         <div
-          className="fixed top-[4.5rem] z-[51] flex flex-col gap-1.5 items-center"
+          className="fixed top-[4.5rem] z-[45] flex flex-col gap-1.5 items-center"
           style={{ left: sidebarWidth - 18 }}
         >
           <button
@@ -585,7 +585,7 @@ export function Sidebar() {
         <div
           onMouseDown={handleResizeStart}
           className={cn(
-            "fixed bottom-0 cursor-col-resize z-50 hover:bg-purple-500/30 transition-colors",
+            "fixed bottom-0 cursor-col-resize z-[45] hover:bg-purple-500/30 transition-colors",
             isResizing && "bg-purple-500/50"
           )}
           style={{ top: 160, left: sidebarWidth - 3, width: 6 }}


### PR DESCRIPTION
## Summary
- Lowered the z-index of the sidebar collapse/pin icon buttons from `z-[51]` to `z-[45]` so they no longer appear above floating popups and modals (`z-50`)
- Lowered the sidebar resize handle from `z-50` to `z-[45]` to prevent it from competing with modal overlays
- The z-index hierarchy is now: sidebar body (`z-40`) < sidebar controls (`z-[45]`) < popups/modals (`z-50`+)

Closes #3636

## Test plan
- [ ] Open a card drilldown modal and confirm the sidebar collapse/pin icons do not appear above it
- [ ] Open a cluster detail popup and confirm sidebar controls are hidden behind it
- [ ] Verify the sidebar collapse/expand button still works correctly
- [ ] Verify the sidebar pin/unpin button still works correctly
- [ ] Verify the sidebar resize handle still functions when no modals are open

🤖 Generated with [Claude Code](https://claude.com/claude-code)