### PR TITLE
fix: upload screenshots to GitHub in bug reports (closes #3637)

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -147,7 +148,7 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 	}
 
 	// Create GitHub issue (route to the correct repo)
-	issueNumber, _, err := h.createGitHubIssueInRepo(request, user, h.repoOwner, targetRepoName)
+	issueNumber, _, err := h.createGitHubIssueInRepo(request, user, h.repoOwner, targetRepoName, input.Screenshots)
 	if err != nil {
 		log.Printf("Failed to create GitHub issue: %v", err)
 		// Clean up the orphaned database record
@@ -1479,7 +1480,7 @@ func (h *FeedbackHandler) handleDeploymentStatus(payload map[string]interface{})
 
 // createGitHubIssue creates an issue on GitHub
 func (h *FeedbackHandler) createGitHubIssue(request *models.FeatureRequest, user *models.User) (int, string, error) {
-	return h.createGitHubIssueInRepo(request, user, h.repoOwner, h.repoName)
+	return h.createGitHubIssueInRepo(request, user, h.repoOwner, h.repoName, nil)
 }
 
 // createGitHubIssueInRepo creates a GitHub issue in the specified repository.
@@ -1489,7 +1490,7 @@ func (h *FeedbackHandler) createGitHubIssue(request *models.FeatureRequest, user
 // If the initial request with labels fails due to insufficient label permissions
 // (HTTP 403 on the "label" resource), the function retries without labels so
 // the issue is still created. Labels can be added later by a maintainer.
-func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest, user *models.User, repoOwner, repoName string) (int, string, error) {
+func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest, user *models.User, repoOwner, repoName string, screenshots []string) (int, string, error) {
 	// Determine labels based on request type and target repo
 	var labels []string
 	isDocs := request.TargetRepo == models.TargetRepoDocs
@@ -1517,6 +1518,23 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 		repoLabel = "Console Documentation"
 	}
 
+	// Upload screenshots to GitHub and build markdown image references
+	screenshotMarkdown := ""
+	if len(screenshots) > 0 {
+		var imageLines []string
+		for i, dataURI := range screenshots {
+			url, err := h.uploadScreenshotToGitHub(repoOwner, repoName, request.ID.String(), i, dataURI)
+			if err != nil {
+				log.Printf("[Feedback] Failed to upload screenshot %d: %v", i+1, err)
+				continue
+			}
+			imageLines = append(imageLines, fmt.Sprintf("![Screenshot %d](%s)", i+1, url))
+		}
+		if len(imageLines) > 0 {
+			screenshotMarkdown = "\n\n## Screenshots\n\n" + strings.Join(imageLines, "\n\n")
+		}
+	}
+
 	issueBody := fmt.Sprintf(`## User Request
 
 **Type:** %s
@@ -1526,11 +1544,11 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 
 ## Description
 
-%s
+%s%s
 
 ---
 *This issue was automatically created from the KubeStellar Console.*
-`, request.RequestType, repoLabel, user.GitHubLogin, request.ID.String(), request.Description)
+`, request.RequestType, repoLabel, user.GitHubLogin, request.ID.String(), request.Description, screenshotMarkdown)
 
 	// First attempt: create issue with labels
 	number, htmlURL, err := h.postGitHubIssue(repoOwner, repoName, request.Title, issueBody, labels)
@@ -1595,6 +1613,82 @@ func (h *FeedbackHandler) postGitHubIssue(repoOwner, repoName, title, body strin
 	}
 
 	return result.Number, result.HTMLURL, nil
+}
+
+// uploadScreenshotToGitHub uploads a base64 data-URI screenshot to the
+// repository via the GitHub Contents API and returns the raw download URL
+// that can be embedded in issue markdown.
+//
+// Files are stored under .github/screenshots/{requestID}/ to keep them
+// organized and to avoid polluting the main source tree.
+func (h *FeedbackHandler) uploadScreenshotToGitHub(repoOwner, repoName, requestID string, index int, dataURI string) (string, error) {
+	// Parse data URI: "data:image/png;base64,iVBOR..."
+	parts := strings.SplitN(dataURI, ",", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid data URI format")
+	}
+
+	// Extract MIME type to determine file extension
+	ext := "png" // default
+	header := parts[0]
+	if strings.Contains(header, "image/jpeg") || strings.Contains(header, "image/jpg") {
+		ext = "jpg"
+	} else if strings.Contains(header, "image/gif") {
+		ext = "gif"
+	} else if strings.Contains(header, "image/webp") {
+		ext = "webp"
+	}
+
+	// The base64 content (GitHub Contents API expects raw base64, no wrapping)
+	b64Content := parts[1]
+
+	// Validate that the base64 content is actually valid
+	if _, err := base64.StdEncoding.DecodeString(b64Content); err != nil {
+		return "", fmt.Errorf("invalid base64 content: %w", err)
+	}
+
+	filePath := fmt.Sprintf(".github/screenshots/%s/screenshot-%d.%s", requestID, index+1, ext)
+
+	payload := map[string]string{
+		"message": fmt.Sprintf("Add screenshot %d for issue %s", index+1, requestID),
+		"content": b64Content,
+	}
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal upload payload: %w", err)
+	}
+
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/contents/%s", repoOwner, repoName, filePath)
+
+	req, err := http.NewRequest("PUT", apiURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+h.getEffectiveToken())
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("GitHub Contents API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Content struct {
+			DownloadURL string `json:"download_url"`
+		} `json:"content"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode upload response: %w", err)
+	}
+
+	return result.Content.DownloadURL, nil
 }
 
 // isLabelPermissionError checks whether the error from the GitHub API is a

--- a/pkg/models/feedback.go
+++ b/pkg/models/feedback.go
@@ -112,6 +112,9 @@ type CreateFeatureRequestInput struct {
 	Description string      `json:"description" validate:"required,min=20,max=5000"`
 	RequestType RequestType `json:"request_type" validate:"required,oneof=bug feature"`
 	TargetRepo  TargetRepo  `json:"target_repo,omitempty"`
+	// Screenshots contains base64-encoded data URIs (e.g. "data:image/png;base64,...")
+	// that will be uploaded to GitHub and embedded in the issue body.
+	Screenshots []string `json:"screenshots,omitempty"`
 }
 
 // SubmitFeedbackInput is the input for submitting PR feedback

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -5,8 +5,8 @@
  * directly via the server-side GitHub token. This means users do not need to
  * be logged into GitHub — the issue is created automatically.
  *
- * Screenshots are auto-copied to the clipboard and the created issue URL is
- * provided so the user can paste them in one click.
+ * Screenshots are uploaded to GitHub via the backend and embedded directly
+ * in the created issue as markdown images.
  */
 
 import { useState, useEffect, useRef } from 'react'
@@ -149,19 +149,19 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
     setSubmitError(null)
 
     try {
-      // Build description with screenshot note if applicable
-      const screenshotNote = screenshots.length > 0
-        ? `\n\n---\n**Screenshots**: ${screenshots.length} screenshot(s) were attached in the console — please paste them into this issue.`
-        : ''
-      const fullDescription = `${description.trim()}${screenshotNote}`
+      // Collect base64 data URIs for any attached screenshots so the
+      // backend can upload them to GitHub and embed them in the issue.
+      const screenshotDataURIs = screenshots.map(s => s.preview)
 
       // Submit via backend API — creates GitHub issue directly using the
       // server-side token. No GitHub login required from the user.
+      // Screenshots are uploaded server-side and embedded as images.
       const result = await createRequest({
         title: title.trim(),
-        description: fullDescription,
+        description: description.trim(),
         request_type: type,
         target_repo: 'console',
+        ...(screenshotDataURIs.length > 0 && { screenshots: screenshotDataURIs }),
       })
 
       emitFeedbackSubmitted(type)
@@ -169,17 +169,6 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
       // Award coins based on type
       const action = type === 'bug' ? 'bug_report' : 'feature_suggestion'
       awardCoins(action as 'bug_report' | 'feature_suggestion', { title, type })
-
-      // Auto-copy first screenshot to clipboard so user can paste it into the issue
-      if (screenshots.length > 0) {
-        try {
-          const res = await fetch(screenshots[0].preview, { signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
-          const blob = await res.blob()
-          await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })])
-        } catch {
-          // Best-effort — clipboard may not be available
-        }
-      }
 
       // Clear draft on successful submit
       localStorage.removeItem(DRAFT_KEY)
@@ -299,38 +288,14 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                 </a>
               )}
 
-              {/* Screenshot paste helper — auto-copied first screenshot */}
+              {/* Screenshot confirmation */}
               {screenshots.length > 0 && (
-                <div className="mb-4 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
-                  <p className="text-xs text-amber-400 font-medium mb-2">
+                <div className="mb-4 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
+                  <p className="text-xs text-green-400 font-medium">
                     {screenshots.length === 1
-                      ? 'Screenshot copied to clipboard!'
-                      : `First screenshot copied to clipboard! ${screenshots.length - 1} more below.`}
+                      ? 'Screenshot uploaded and attached to the issue.'
+                      : `${screenshots.length} screenshots uploaded and attached to the issue.`}
                   </p>
-                  <p className="text-xs text-muted-foreground mb-2">
-                    Open the issue above and paste (Ctrl+V / Cmd+V) to attach {screenshots.length === 1 ? 'it' : 'them'}.
-                  </p>
-                  <div className="flex flex-wrap gap-2 justify-center">
-                    {screenshots.map((s, i) => (
-                      <div key={i} className="relative group w-16 h-16 flex-shrink-0">
-                        <img
-                          src={s.preview}
-                          alt={`Screenshot ${i + 1}`}
-                          className="w-16 h-16 object-cover rounded border border-border"
-                        />
-                        <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 bg-black/60 rounded transition-opacity">
-                          <button
-                            type="button"
-                            onClick={() => void copyScreenshotToClipboard(s.preview, i)}
-                            className="p-1.5 rounded-md bg-secondary/80 text-foreground hover:bg-secondary transition-colors"
-                            title="Copy to clipboard"
-                          >
-                            {copiedIndex === i ? <Check className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3" />}
-                          </button>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
                 </div>
               )}
 
@@ -487,7 +452,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                     <ExternalLink className="w-4 h-4 text-blue-400 flex-shrink-0" />
                     <span className="text-muted-foreground">
                       {screenshots.length > 0
-                        ? 'A GitHub issue will be created automatically. Your first screenshot will be copied to clipboard so you can paste it into the issue.'
+                        ? 'A GitHub issue will be created automatically with your screenshots attached.'
                         : 'A GitHub issue will be created automatically. No GitHub login required.'}
                     </span>
                   </div>

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -77,6 +77,8 @@ export interface CreateFeatureRequestInput {
   description: string
   request_type: RequestType
   target_repo?: TargetRepo
+  /** Base64 data-URI screenshots to upload and embed in the GitHub issue */
+  screenshots?: string[]
 }
 
 export interface SubmitFeedbackInput {


### PR DESCRIPTION
## Summary
- Screenshots attached via the Console feedback modal are now uploaded to GitHub and embedded directly in the created issue as markdown images
- Backend uploads each screenshot to `.github/screenshots/{requestID}/` via the GitHub Contents API, then includes the download URLs as `![screenshot](url)` in the issue body
- Frontend sends base64 data URIs to the backend instead of showing a "please paste" placeholder message

Closes #3637

## Test plan
- [ ] Submit a bug report with 1+ screenshots attached — verify the created GitHub issue contains the actual images (not a placeholder message)
- [ ] Submit a bug report without screenshots — verify issue is created normally with no screenshot section
- [ ] Verify screenshots appear correctly in the GitHub issue markdown (rendered images, not broken links)
- [ ] Verify `npm run build` passes cleanly
- [ ] Verify `go build ./pkg/...` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)