### PR TITLE
fix: prevent scale validation bypass when args start with flags

### DIFF
--- a/pkg/agent/kubectl.go
+++ b/pkg/agent/kubectl.go
@@ -213,26 +213,32 @@ func (k *KubectlProxy) validateArgs(args []string) bool {
 
 	// Special case: scale command - only allow for specific resource types
 	if command == "scale" {
-		if len(args) < 2 {
-			return false // Need at least "scale <resource>"
+		// Extract positional (non-flag) arguments after "scale"
+		// Flags start with "-" and are skipped; we need the first positional arg
+		// to be a valid scalable resource type.
+		var firstPositional string
+		for _, a := range args[1:] {
+			if strings.HasPrefix(a, "-") {
+				continue
+			}
+			firstPositional = strings.ToLower(a)
+			break
 		}
-		// Scale can have format: scale deployment/name or scale --replicas=N deployment name
-		resourceArg := strings.ToLower(args[1])
+		if firstPositional == "" {
+			return false // No resource type found
+		}
 		// Handle "scale deployment/myapp" format
-		if strings.Contains(resourceArg, "/") {
-			parts := strings.SplitN(resourceArg, "/", 2)
-			resourceType := parts[0]
-			if !allowedScaleResources[resourceType] {
+		if strings.Contains(firstPositional, "/") {
+			parts := strings.SplitN(firstPositional, "/", 2)
+			if !allowedScaleResources[parts[0]] {
 				return false
 			}
-		} else if !strings.HasPrefix(resourceArg, "--") {
+		} else {
 			// Handle "scale deployment myapp" format
-			if !allowedScaleResources[resourceArg] {
+			if !allowedScaleResources[firstPositional] {
 				return false
 			}
 		}
-		// If it starts with --, we'll check the next non-flag argument
-		// For simplicity, we'll allow it as long as a valid resource type appears somewhere
 	}
 
 	// Block any args that might execute arbitrary commands

--- a/pkg/agent/kubectl_test.go
+++ b/pkg/agent/kubectl_test.go
@@ -160,6 +160,12 @@ func TestKubectlProxy_ValidateArgs(t *testing.T) {
 		{[]string{"describe", "pod", "foo"}, true},
 		{[]string{"scale", "deployment", "foo", "--replicas=3"}, true},
 		{[]string{"scale", "sts/foo", "--replicas=3"}, true},
+		{[]string{"scale", "--replicas=3", "deployment", "foo"}, true},
+		{[]string{"scale", "--replicas=3", "deploy/foo"}, true},
+		{[]string{"scale", "--replicas=3", "secrets", "mysecret"}, false},  // Issue #3649: flags-first bypass
+		{[]string{"scale", "--replicas=3", "configmap", "mycm"}, false},    // Issue #3649: flags-first bypass
+		{[]string{"scale", "secret", "mysecret", "--replicas=3"}, false},   // Non-scalable resource
+		{[]string{"scale", "--replicas=3"}, false},                          // No resource type
 		{[]string{"delete", "pod", "foo"}, true},
 
 		// Blocked cases


### PR DESCRIPTION
## Summary
- Fixes #3649: When `scale` args started with `--` (e.g., `scale --replicas=3 secrets mysecret`), the resource type check was skipped, allowing any resource type to be scaled
- The fix extracts the first positional (non-flag) argument regardless of where flags appear, and always validates it against `allowedScaleResources`
- Added test cases covering the bypass scenario and edge cases

## Test plan
- [x] Existing tests pass (`go test ./pkg/agent/...`)
- [x] New test cases verify flags-first bypass is blocked (secrets, configmaps)
- [x] New test cases verify valid flags-first usage still works (deployment, deploy/foo)
- [x] Build passes (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)