### PR TITLE
fix: buildpacks card shows empty state instead of indefinite refresh

### DIFF
--- a/web/src/components/cards/buildpacks-status/BuildpacksStatus.tsx
+++ b/web/src/components/cards/buildpacks-status/BuildpacksStatus.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { CheckCircle, AlertTriangle, XCircle, Clock, ChevronRight, Server } from 'lucide-react'
+import { CheckCircle, AlertTriangle, XCircle, Clock, ChevronRight, Server, Package } from 'lucide-react'
 import { useClusters, BuildpackImage } from '../../../hooks/useMCP'
 import { useCachedBuildpackImages } from '../../../hooks/useCachedData'
 import { Skeleton } from '../../ui/Skeleton'
@@ -186,14 +186,16 @@ export function BuildpacksStatus({ config }: BuildpacksStatusProps) {
 
   if (showEmptyState) {
     return (
-      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
         {error ? (
           <>
+            <AlertTriangle className="w-6 h-6 text-red-400" />
             <p className="text-sm text-red-400">{error}</p>
             <p className="text-xs mt-1">{t('buildpacksStatus.loadFailed')}</p>
           </>
         ) : (
           <>
+            <Package className="w-8 h-8 text-muted-foreground/50" />
             <p className="text-sm">{t('buildpacksStatus.noImages')}</p>
             <p className="text-xs mt-1">
               {t('buildpacksStatus.createHint')}

--- a/web/src/hooks/useCachedData.ts
+++ b/web/src/hooks/useCachedData.ts
@@ -3595,8 +3595,18 @@ export function useCachedBuildpackImages(
     initialData: [] as BuildpackImage[],
     demoData: getDemoBuildpackImages(),
     fetcher: async () => {
-      const data = await fetchGitOpsAPI<{ images: BuildpackImage[] }>('buildpack-images', cluster ? { cluster } : undefined)
-      return data.images || []
+      try {
+        const data = await fetchGitOpsAPI<{ images: BuildpackImage[] }>('buildpack-images', cluster ? { cluster } : undefined)
+        return data.images || []
+      } catch (err) {
+        // When no buildpacks CRDs exist on any cluster, the API returns 404.
+        // Treat this as an empty result rather than an error so the card
+        // settles into its empty state instead of retrying indefinitely.
+        if (err instanceof Error && err.message.includes('404')) {
+          return []
+        }
+        throw err
+      }
     },
   })
 


### PR DESCRIPTION
## Summary
- When no buildpacks CRDs exist on any cluster, the API returns 404 which caused `fetchGitOpsAPI` to throw an error
- The cache layer would retry indefinitely, cycling between skeleton loading and failed state
- Fixed by catching 404 errors in `useCachedBuildpackImages` and returning an empty array so the card settles into its empty state
- Added a Package icon to the empty state for better visual feedback

Closes #3652

## Test plan
- [ ] Verify card shows "No Buildpack images" empty state when no buildpacks CRDs exist
- [ ] Verify card still loads normally when buildpacks CRDs are present
- [ ] Verify demo mode still shows demo buildpack data
- [ ] Verify card shows error state when API returns non-404 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)