### PR TITLE
fix: reconcile marketplace help-wanted status with implemented cards

### DIFF
--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -3,6 +3,7 @@ import { api } from '../lib/api'
 import { addCustomTheme, removeCustomTheme } from '../lib/themes'
 import { emitMarketplaceInstall, emitMarketplaceRemove, emitMarketplaceInstallFailed } from '../lib/analytics'
 import { FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
+import { isCardTypeRegistered } from '../components/cards/cardRegistry'
 
 const REGISTRY_URL = 'https://raw.githubusercontent.com/kubestellar/console-marketplace/main/registry.json'
 const CACHE_KEY = 'kc-marketplace-registry'
@@ -60,9 +61,52 @@ interface CachedRegistry {
   fetchedAt: number
 }
 
+/**
+ * Maps marketplace item IDs to their implemented card type in the card registry.
+ * When the external marketplace registry still marks a card as "help-wanted" but
+ * the card has since been implemented in this repo, we auto-correct the status
+ * so the marketplace shows it as available instead of "not yet implemented."
+ *
+ * This avoids waiting for the external console-marketplace repo to catch up.
+ */
+const MARKETPLACE_TO_CARD_TYPE: Record<string, string> = {
+  'cncf-karmada': 'karmada_status',
+  'cncf-keda': 'keda_status',
+  'cncf-etcd': 'etcd_status',
+  'cncf-fluentd': 'fluentd_status',
+  'cncf-crio': 'crio_status',
+  'cncf-cloudevents': 'cloudevents_status',
+  'cncf-crossplane': 'crossplane_managed_resources',
+  'cncf-buildpacks': 'buildpacks_status',
+  'cncf-kubevirt': 'kubevirt_status',
+  'cncf-kubevela': 'kubevela_status',
+  'cncf-lima': 'lima_status',
+  'cncf-openfeature': 'openfeature_status',
+  'cncf-strimzi': 'strimzi_status',
+  'cncf-thanos': 'thanos_status',
+}
+
+/**
+ * Reconcile marketplace items against the local card registry.
+ * Items marked "help-wanted" whose cards are already implemented get
+ * promoted to "available" with the help-wanted tag removed.
+ */
+function reconcileImplementedCards(items: MarketplaceItem[]): MarketplaceItem[] {
+  return items.map(item => {
+    if (item.status !== 'help-wanted') return item
+    const cardType = MARKETPLACE_TO_CARD_TYPE[item.id]
+    if (!cardType || !isCardTypeRegistered(cardType)) return item
+    return {
+      ...item,
+      status: 'available' as MarketplaceItemStatus,
+      tags: item.tags.filter(t => t !== 'help-wanted'),
+    }
+  })
+}
+
 /** Merge items + presets from the registry into a single array */
 function mergeRegistryItems(registry: MarketplaceRegistry): MarketplaceItem[] {
-  return [...(registry.items || []), ...(registry.presets || [])]
+  return reconcileImplementedCards([...(registry.items || []), ...(registry.presets || [])])
 }
 
 interface InstalledEntry {


### PR DESCRIPTION
## Summary
- Fixes the marketplace showing Karmada (and 13 other CNCF cards) as "not yet implemented" with a "Contribute" button, even though the cards have already been implemented in the codebase
- Adds a reconciliation step in `useMarketplace` that checks marketplace items against the local card registry and auto-promotes implemented cards from `help-wanted` to `available`
- Covers: Karmada, KEDA, etcd, Fluentd, CRI-O, CloudEvents, Crossplane, Buildpacks, KubeVirt, KubeVela, Lima, OpenFeature, Strimzi, Thanos

## Details
The marketplace data is fetched from an external registry (`kubestellar/console-marketplace`). When new cards are implemented in this repo, the external registry can lag behind, leaving stale `help-wanted` entries. Rather than depending on the external repo to stay in sync, we now reconcile at fetch time: if a marketplace item is marked `help-wanted` but its corresponding card type is registered in the local card registry, the status is auto-corrected to `available` and the `help-wanted` tag is removed.

Closes #3644

## Test plan
- [ ] Open the Marketplace page and verify Karmada shows as an installable card preset (not "Help Wanted")
- [ ] Verify the CNCF progress banner count reflects the corrected implemented count
- [ ] Verify the "Help Wanted" filter no longer shows cards that are already implemented
- [ ] Run `npm run build` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)