### PR TITLE
fix: split events and resources into tabs in drilldown views

### DIFF
--- a/web/src/components/drilldown/views/ClusterDrillDown.tsx
+++ b/web/src/components/drilldown/views/ClusterDrillDown.tsx
@@ -6,10 +6,12 @@ import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { StatusIndicator } from '../../charts/StatusIndicator'
 import { Gauge } from '../../charts/Gauge'
 import { useTranslation } from 'react-i18next'
+import { cn } from '../../../lib/cn'
 import { LOADING_TIMEOUT_MS } from '../../../lib/constants/network'
 
 // Resource tree lens/view options
 type TreeLens = 'all' | 'issues' | 'nodes' | 'workloads' | 'storage' | 'network'
+type ClusterTab = 'events' | 'resources'
 
 interface Props {
   data: Record<string, unknown>
@@ -24,7 +26,7 @@ export function ClusterDrillDown({ data }: Props) {
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(['cluster', 'nodes', 'namespaces']))
   const [searchFilter, setSearchFilter] = useState('')
   const [activeLens, setActiveLens] = useState<TreeLens>('all')
-  const [showResourceTree, setShowResourceTree] = useState(false)
+  const [activeTab, setActiveTab] = useState<ClusterTab>('events')
 
   // Safeguard timeout to prevent infinite loading - show content after 5 seconds max
   const [loadingTimedOut, setLoadingTimedOut] = useState(false)
@@ -287,63 +289,6 @@ export function ClusterDrillDown({ data }: Props) {
         </div>
       )}
 
-      {/* Recent Events Section */}
-      <div>
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="text-lg font-semibold text-foreground">{t('drilldown.fields.recentEvents')}</h3>
-          <button
-            onClick={() => drillToEvents(clusterName)}
-            className="text-sm text-purple-400 hover:text-purple-300 transition-colors"
-          >
-            View All →
-          </button>
-        </div>
-        {eventsLoading ? (
-          <div className="space-y-2 animate-pulse">
-            {[1, 2, 3].map(i => (
-              <div key={i} className="p-3 rounded-lg bg-card/30 border border-border">
-                <div className="h-4 w-32 bg-secondary rounded mb-2" />
-                <div className="h-3 w-full bg-secondary/50 rounded" />
-              </div>
-            ))}
-          </div>
-        ) : clusterEvents.length === 0 ? (
-          <div className="p-4 rounded-lg bg-card/30 border border-border text-center text-muted-foreground text-sm">
-            No recent events
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {clusterEvents.slice(0, 5).map((event, i) => (
-              <div
-                key={i}
-                className={`p-3 rounded-lg border-l-4 cursor-pointer hover:bg-card/50 transition-colors ${
-                  event.type === 'Warning'
-                    ? 'bg-yellow-500/10 border-l-yellow-500'
-                    : 'bg-card/30 border-l-green-500'
-                }`}
-                onClick={() => drillToEvents(clusterName)}
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
-                    <StatusIndicator status={event.type === 'Warning' ? 'warning' : 'healthy'} size="sm" />
-                    <span className="font-medium text-foreground text-sm">{event.reason}</span>
-                  </div>
-                  {event.count > 1 && (
-                    <span className="text-xs px-2 py-0.5 rounded bg-card text-muted-foreground">
-                      x{event.count}
-                    </span>
-                  )}
-                </div>
-                <div className="text-xs text-muted-foreground mt-1 truncate">
-                  {event.namespace}/{event.object}
-                </div>
-                <p className="text-xs text-foreground mt-1 line-clamp-1">{event.message}</p>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-
       {/* Issues Section */}
       {(podIssues.length > 0 || clusterDeploymentIssues.length > 0) && (
         <div>
@@ -475,25 +420,100 @@ export function ClusterDrillDown({ data }: Props) {
         </div>
       )}
 
-      {/* Resource Tree Section */}
-      <div className="border-t border-border pt-6">
-        <div className="flex items-center justify-between mb-4">
-          <button
-            onClick={() => setShowResourceTree(!showResourceTree)}
-            className="flex items-center gap-2 text-lg font-semibold text-foreground hover:text-primary transition-colors"
-          >
-            {showResourceTree ? <ChevronDown className="w-5 h-5" /> : <ChevronRight className="w-5 h-5" />}
-            <Layers className="w-5 h-5 text-purple-400" />
-            Resource Tree
-            {issueCounts.total > 0 && (
-              <StatusBadge color="red" size="xs" rounded="full" className="ml-2">
-                {issueCounts.total} issues
-              </StatusBadge>
-            )}
-          </button>
+      {/* Tabs for Events and Resources */}
+      <div className="border-t border-border pt-4">
+        <div className="border-b border-border mb-4">
+          <div className="flex gap-0">
+            {([
+              { id: 'events' as ClusterTab, label: t('drilldown.fields.recentEvents'), count: clusterEvents.length },
+              { id: 'resources' as ClusterTab, label: 'Resource Tree', count: issueCounts.total > 0 ? issueCounts.total : undefined },
+            ]).map(tab => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={cn(
+                  'px-4 py-2 text-sm font-medium flex items-center gap-2 border-b-2 transition-colors',
+                  activeTab === tab.id
+                    ? 'text-primary border-primary'
+                    : 'text-muted-foreground border-transparent hover:text-foreground hover:border-border'
+                )}
+              >
+                {tab.label}
+                {tab.count !== undefined && tab.count > 0 && (
+                  <span className={cn(
+                    'text-xs px-1.5 py-0.5 rounded-full',
+                    activeTab === tab.id
+                      ? 'bg-primary/20 text-primary'
+                      : tab.id === 'resources' ? 'bg-red-500/20 text-red-400' : 'bg-secondary text-muted-foreground'
+                  )}>
+                    {tab.count}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
         </div>
 
-        {showResourceTree && (
+        {/* Events Tab */}
+        {activeTab === 'events' && (
+          <div>
+            <div className="flex justify-end mb-3">
+              <button
+                onClick={() => drillToEvents(clusterName)}
+                className="text-sm text-purple-400 hover:text-purple-300 transition-colors"
+              >
+                View All →
+              </button>
+            </div>
+            {eventsLoading ? (
+              <div className="space-y-2 animate-pulse">
+                {[1, 2, 3].map(i => (
+                  <div key={i} className="p-3 rounded-lg bg-card/30 border border-border">
+                    <div className="h-4 w-32 bg-secondary rounded mb-2" />
+                    <div className="h-3 w-full bg-secondary/50 rounded" />
+                  </div>
+                ))}
+              </div>
+            ) : clusterEvents.length === 0 ? (
+              <div className="p-4 rounded-lg bg-card/30 border border-border text-center text-muted-foreground text-sm">
+                No recent events
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {clusterEvents.slice(0, 10).map((event, i) => (
+                  <div
+                    key={i}
+                    className={`p-3 rounded-lg border-l-4 cursor-pointer hover:bg-card/50 transition-colors ${
+                      event.type === 'Warning'
+                        ? 'bg-yellow-500/10 border-l-yellow-500'
+                        : 'bg-card/30 border-l-green-500'
+                    }`}
+                    onClick={() => drillToEvents(clusterName)}
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <StatusIndicator status={event.type === 'Warning' ? 'warning' : 'healthy'} size="sm" />
+                        <span className="font-medium text-foreground text-sm">{event.reason}</span>
+                      </div>
+                      {event.count > 1 && (
+                        <span className="text-xs px-2 py-0.5 rounded bg-card text-muted-foreground">
+                          x{event.count}
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-muted-foreground mt-1 truncate">
+                      {event.namespace}/{event.object}
+                    </div>
+                    <p className="text-xs text-foreground mt-1 line-clamp-1">{event.message}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Resources Tab */}
+        {activeTab === 'resources' && (
           <div className="space-y-4">
             {/* Search and Filters */}
             <div className="flex flex-col md:flex-row gap-3">

--- a/web/src/components/drilldown/views/NamespaceDrillDown.tsx
+++ b/web/src/components/drilldown/views/NamespaceDrillDown.tsx
@@ -1,10 +1,14 @@
-import { useMemo } from 'react'
-import { ChevronRight } from 'lucide-react'
-import { usePodIssues, useDeploymentIssues, useEvents } from '../../../hooks/useMCP'
+import { useMemo, useState } from 'react'
+import { ChevronRight, Search, Box, Network, HardDrive, Layers } from 'lucide-react'
+import { usePodIssues, useDeploymentIssues, useEvents, useDeployments, useServices, usePVCs, usePods } from '../../../hooks/useMCP'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { StatusIndicator } from '../../charts/StatusIndicator'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { useTranslation } from 'react-i18next'
+import { cn } from '../../../lib/cn'
+
+type TabType = 'issues' | 'events' | 'resources'
+type ResourceFilter = 'all' | 'pods' | 'deployments' | 'services' | 'pvcs'
 
 interface Props {
   data: Record<string, unknown>
@@ -16,9 +20,20 @@ export function NamespaceDrillDown({ data }: Props) {
   const namespace = data.namespace as string
   const { drillToDeployment, drillToPod, drillToEvents } = useDrillDownActions()
 
+  const [activeTab, setActiveTab] = useState<TabType>('issues')
+  const [resourceFilter, setResourceFilter] = useState<ResourceFilter>('all')
+  const [resourceSearch, setResourceSearch] = useState('')
+
   const { issues: allPodIssues } = usePodIssues(cluster)
   const { issues: allDeploymentIssues } = useDeploymentIssues()
   const { events } = useEvents(cluster, namespace, 20)
+
+  // Resource hooks for the Resources tab
+  const clusterShort = cluster.split('/').pop() || cluster
+  const { deployments: allDeployments } = useDeployments(clusterShort, namespace)
+  const { services: allServices } = useServices(clusterShort, namespace)
+  const { pvcs: allPVCs } = usePVCs(clusterShort, namespace)
+  const { pods: allPods } = usePods(clusterShort, namespace)
 
   const podIssues = useMemo(() =>
     allPodIssues.filter(p => p.namespace === namespace),
@@ -35,6 +50,49 @@ export function NamespaceDrillDown({ data }: Props) {
     events.filter(e => e.namespace === namespace),
     [events, namespace]
   )
+
+  // Filtered resources for the Resources tab
+  const filteredDeployments = useMemo(() => {
+    if (resourceFilter !== 'all' && resourceFilter !== 'deployments') return []
+    let deps = allDeployments || []
+    if (resourceSearch) {
+      deps = deps.filter(d => d.name.toLowerCase().includes(resourceSearch.toLowerCase()))
+    }
+    return deps
+  }, [allDeployments, resourceFilter, resourceSearch])
+
+  const filteredServices = useMemo(() => {
+    if (resourceFilter !== 'all' && resourceFilter !== 'services') return []
+    let svcs = allServices || []
+    if (resourceSearch) {
+      svcs = svcs.filter(s => s.name.toLowerCase().includes(resourceSearch.toLowerCase()))
+    }
+    return svcs
+  }, [allServices, resourceFilter, resourceSearch])
+
+  const filteredPVCs = useMemo(() => {
+    if (resourceFilter !== 'all' && resourceFilter !== 'pvcs') return []
+    let pvcs = allPVCs || []
+    if (resourceSearch) {
+      pvcs = pvcs.filter(p => p.name.toLowerCase().includes(resourceSearch.toLowerCase()))
+    }
+    return pvcs
+  }, [allPVCs, resourceFilter, resourceSearch])
+
+  const filteredPods = useMemo(() => {
+    if (resourceFilter !== 'all' && resourceFilter !== 'pods') return []
+    let pods = allPods || []
+    if (resourceSearch) {
+      pods = pods.filter(p => p.name.toLowerCase().includes(resourceSearch.toLowerCase()))
+    }
+    return pods
+  }, [allPods, resourceFilter, resourceSearch])
+
+  const tabs: { id: TabType; label: string; count: number }[] = [
+    { id: 'issues', label: 'Issues', count: podIssues.length + deploymentIssues.length },
+    { id: 'events', label: t('drilldown.fields.recentEvents'), count: nsEvents.length },
+    { id: 'resources', label: 'Resources', count: (allDeployments?.length || 0) + (allServices?.length || 0) + (allPVCs?.length || 0) + (allPods?.length || 0) },
+  ]
 
   return (
     <div className="space-y-6">
@@ -54,123 +112,320 @@ export function NamespaceDrillDown({ data }: Props) {
         </div>
       </div>
 
-      {/* Quick Actions */}
-      <div className="flex flex-wrap gap-2">
-        <button
-          onClick={() => drillToEvents(cluster, namespace)}
-          className="px-4 py-2 rounded-lg bg-card/50 border border-border text-sm text-foreground hover:bg-card transition-colors"
-        >
-          View All Events
-        </button>
+      {/* Tabs */}
+      <div className="border-b border-border">
+        <div className="flex gap-0">
+          {tabs.map(tab => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={cn(
+                'px-4 py-2 text-sm font-medium flex items-center gap-2 border-b-2 transition-colors',
+                activeTab === tab.id
+                  ? 'text-primary border-primary'
+                  : 'text-muted-foreground border-transparent hover:text-foreground hover:border-border'
+              )}
+            >
+              {tab.label}
+              {tab.count > 0 && (
+                <span className={cn(
+                  'text-xs px-1.5 py-0.5 rounded-full',
+                  activeTab === tab.id
+                    ? 'bg-primary/20 text-primary'
+                    : 'bg-secondary text-muted-foreground'
+                )}>
+                  {tab.count}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
       </div>
 
-      {/* Deployment Issues */}
-      {deploymentIssues.length > 0 && (
-        <div>
-          <h3 className="text-lg font-semibold text-foreground mb-4">Deployment Issues</h3>
-          <div className="space-y-2">
-            {deploymentIssues.map((issue, i) => (
-              <div
-                key={i}
-                onClick={() => drillToDeployment(cluster, namespace, issue.name, { ...issue })}
-                className="p-4 rounded-lg bg-orange-500/10 border border-orange-500/20 cursor-pointer hover:bg-orange-500/20 transition-colors"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="font-semibold text-foreground">{issue.name}</span>
-                      <StatusBadge color="orange" size="xs">
-                        {issue.readyReplicas}/{issue.replicas} ready
-                      </StatusBadge>
-                    </div>
-                    {issue.reason && (
-                      <div className="text-sm text-muted-foreground">Reason: {issue.reason}</div>
-                    )}
-                    {issue.message && (
-                      <div className="text-xs text-orange-400 mt-1">{issue.message}</div>
-                    )}
-                  </div>
-                  <ChevronRight className="w-5 h-5 text-muted-foreground flex-shrink-0 ml-4" />
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* Pod Issues */}
-      {podIssues.length > 0 && (
-        <div>
-          <h3 className="text-lg font-semibold text-foreground mb-4">Pod Issues</h3>
-          <div className="space-y-2">
-            {podIssues.map((issue, i) => (
-              <div
-                key={i}
-                onClick={() => drillToPod(cluster, namespace, issue.name, { ...issue })}
-                className="p-4 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="font-semibold text-foreground">{issue.name}</span>
-                      <StatusBadge color="red" size="xs">
-                        {issue.status}
-                      </StatusBadge>
-                    </div>
-                    <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                      <span>{issue.restarts} restarts</span>
-                      {issue.reason && <span>• {issue.reason}</span>}
-                    </div>
-                    {issue.issues.length > 0 && (
-                      <div className="flex flex-wrap gap-1 mt-2">
-                        {issue.issues.map((iss, j) => (
-                          <StatusBadge key={j} color="red" size="xs">
-                            {iss}
+      {/* Tab Content */}
+      {activeTab === 'issues' && (
+        <div className="space-y-6">
+          {/* Deployment Issues */}
+          {deploymentIssues.length > 0 && (
+            <div>
+              <h3 className="text-lg font-semibold text-foreground mb-4">Deployment Issues</h3>
+              <div className="space-y-2">
+                {deploymentIssues.map((issue, i) => (
+                  <div
+                    key={i}
+                    onClick={() => drillToDeployment(cluster, namespace, issue.name, { ...issue })}
+                    className="p-4 rounded-lg bg-orange-500/10 border border-orange-500/20 cursor-pointer hover:bg-orange-500/20 transition-colors"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="font-semibold text-foreground">{issue.name}</span>
+                          <StatusBadge color="orange" size="xs">
+                            {issue.readyReplicas}/{issue.replicas} ready
                           </StatusBadge>
-                        ))}
+                        </div>
+                        {issue.reason && (
+                          <div className="text-sm text-muted-foreground">Reason: {issue.reason}</div>
+                        )}
+                        {issue.message && (
+                          <div className="text-xs text-orange-400 mt-1">{issue.message}</div>
+                        )}
                       </div>
-                    )}
+                      <ChevronRight className="w-5 h-5 text-muted-foreground flex-shrink-0 ml-4" />
+                    </div>
                   </div>
-                  <ChevronRight className="w-5 h-5 text-muted-foreground flex-shrink-0 ml-4" />
-                </div>
+                ))}
               </div>
-            ))}
-          </div>
+            </div>
+          )}
+
+          {/* Pod Issues */}
+          {podIssues.length > 0 && (
+            <div>
+              <h3 className="text-lg font-semibold text-foreground mb-4">Pod Issues</h3>
+              <div className="space-y-2">
+                {podIssues.map((issue, i) => (
+                  <div
+                    key={i}
+                    onClick={() => drillToPod(cluster, namespace, issue.name, { ...issue })}
+                    className="p-4 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="font-semibold text-foreground">{issue.name}</span>
+                          <StatusBadge color="red" size="xs">
+                            {issue.status}
+                          </StatusBadge>
+                        </div>
+                        <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                          <span>{issue.restarts} restarts</span>
+                          {issue.reason && <span>• {issue.reason}</span>}
+                        </div>
+                        {issue.issues.length > 0 && (
+                          <div className="flex flex-wrap gap-1 mt-2">
+                            {issue.issues.map((iss, j) => (
+                              <StatusBadge key={j} color="red" size="xs">
+                                {iss}
+                              </StatusBadge>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                      <ChevronRight className="w-5 h-5 text-muted-foreground flex-shrink-0 ml-4" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Empty State */}
+          {deploymentIssues.length === 0 && podIssues.length === 0 && (
+            <div className="text-center py-12">
+              <div className="text-6xl mb-4">✨</div>
+              <p className="text-lg text-foreground">All clear!</p>
+              <p className="text-sm text-muted-foreground">No issues found in this namespace</p>
+            </div>
+          )}
         </div>
       )}
 
-      {/* Recent Events */}
-      {nsEvents.length > 0 && (
-        <div>
-          <h3 className="text-lg font-semibold text-foreground mb-4">{t('drilldown.fields.recentEvents')}</h3>
-          <div className="space-y-2">
-            {nsEvents.slice(0, 10).map((event, i) => (
-              <div
-                key={i}
-                className={`p-3 rounded-lg border-l-4 ${
-                  event.type === 'Warning'
-                    ? 'bg-yellow-500/10 border-l-yellow-500'
-                    : 'bg-card/50 border-l-green-500'
-                }`}
-              >
-                <div className="flex items-center gap-2">
-                  <StatusIndicator status={event.type === 'Warning' ? 'warning' : 'healthy'} size="sm" />
-                  <span className="font-medium text-foreground text-sm">{event.reason}</span>
-                  <span className="text-xs text-muted-foreground">on {event.object}</span>
-                </div>
-                <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{event.message}</p>
-              </div>
-            ))}
+      {activeTab === 'events' && (
+        <div className="space-y-4">
+          {/* Quick action to view full events drilldown */}
+          <div className="flex justify-end">
+            <button
+              onClick={() => drillToEvents(cluster, namespace)}
+              className="px-4 py-2 rounded-lg bg-card/50 border border-border text-sm text-foreground hover:bg-card transition-colors"
+            >
+              View All Events
+            </button>
           </div>
+
+          {nsEvents.length > 0 ? (
+            <div className="space-y-2">
+              {nsEvents.map((event, i) => (
+                <div
+                  key={i}
+                  className={`p-3 rounded-lg border-l-4 ${
+                    event.type === 'Warning'
+                      ? 'bg-yellow-500/10 border-l-yellow-500'
+                      : 'bg-card/50 border-l-green-500'
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <StatusIndicator status={event.type === 'Warning' ? 'warning' : 'healthy'} size="sm" />
+                    <span className="font-medium text-foreground text-sm">{event.reason}</span>
+                    <span className="text-xs text-muted-foreground">on {event.object}</span>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{event.message}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-12">
+              <p className="text-sm text-muted-foreground">No recent events in this namespace</p>
+            </div>
+          )}
         </div>
       )}
 
-      {/* Empty State */}
-      {deploymentIssues.length === 0 && podIssues.length === 0 && nsEvents.length === 0 && (
-        <div className="text-center py-12">
-          <div className="text-6xl mb-4">✨</div>
-          <p className="text-lg text-foreground">All clear!</p>
-          <p className="text-sm text-muted-foreground">No issues found in this namespace</p>
+      {activeTab === 'resources' && (
+        <div className="space-y-4">
+          {/* Search and Filter Controls */}
+          <div className="flex flex-col md:flex-row gap-3">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+              <input
+                type="text"
+                value={resourceSearch}
+                onChange={(e) => setResourceSearch(e.target.value)}
+                placeholder="Search resources..."
+                className="w-full pl-10 pr-4 py-2 bg-secondary rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-purple-500/50"
+              />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {([
+                { id: 'all' as ResourceFilter, label: 'All', icon: Layers },
+                { id: 'pods' as ResourceFilter, label: 'Pods', icon: Box },
+                { id: 'deployments' as ResourceFilter, label: 'Deployments', icon: Box },
+                { id: 'services' as ResourceFilter, label: 'Services', icon: Network },
+                { id: 'pvcs' as ResourceFilter, label: 'PVCs', icon: HardDrive },
+              ]).map(filter => (
+                <button
+                  key={filter.id}
+                  onClick={() => setResourceFilter(filter.id)}
+                  className={cn(
+                    'flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg border transition-colors',
+                    resourceFilter === filter.id
+                      ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
+                      : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  <filter.icon className="w-3.5 h-3.5" />
+                  {filter.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Pods */}
+          {filteredPods.length > 0 && (
+            <div>
+              <h4 className="text-sm font-medium text-muted-foreground mb-2">Pods ({filteredPods.length})</h4>
+              <div className="space-y-1">
+                {filteredPods.slice(0, 20).map((pod, i) => (
+                  <div
+                    key={i}
+                    onClick={() => drillToPod(cluster, namespace, pod.name, { ...pod })}
+                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
+                  >
+                    <div className={`w-2 h-2 rounded-full ${pod.status === 'Running' ? 'bg-green-400' : pod.status === 'Pending' ? 'bg-yellow-400' : 'bg-red-400'}`} />
+                    <Box className="w-3 h-3 text-green-400" />
+                    <span className="text-sm text-foreground">{pod.name}</span>
+                    <StatusBadge
+                      color={pod.status === 'Running' ? 'green' : pod.status === 'Pending' ? 'yellow' : 'red'}
+                      size="xs"
+                    >
+                      {pod.status}
+                    </StatusBadge>
+                    <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+                  </div>
+                ))}
+                {filteredPods.length > 20 && (
+                  <div className="text-xs text-muted-foreground p-2">+{filteredPods.length - 20} more pods...</div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Deployments */}
+          {filteredDeployments.length > 0 && (
+            <div>
+              <h4 className="text-sm font-medium text-muted-foreground mb-2">Deployments ({filteredDeployments.length})</h4>
+              <div className="space-y-1">
+                {filteredDeployments.slice(0, 20).map((dep, i) => (
+                  <div
+                    key={i}
+                    onClick={() => drillToDeployment(cluster, namespace, dep.name, { ...dep })}
+                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
+                  >
+                    <Box className="w-3 h-3 text-blue-400" />
+                    <span className="text-sm text-foreground">{dep.name}</span>
+                    <span className={`text-xs ${dep.readyReplicas === dep.replicas ? 'text-green-400' : 'text-yellow-400'}`}>
+                      {dep.readyReplicas}/{dep.replicas}
+                    </span>
+                    <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+                  </div>
+                ))}
+                {filteredDeployments.length > 20 && (
+                  <div className="text-xs text-muted-foreground p-2">+{filteredDeployments.length - 20} more deployments...</div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Services */}
+          {filteredServices.length > 0 && (
+            <div>
+              <h4 className="text-sm font-medium text-muted-foreground mb-2">Services ({filteredServices.length})</h4>
+              <div className="space-y-1">
+                {filteredServices.slice(0, 20).map((svc, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
+                  >
+                    <Network className="w-3 h-3 text-blue-400" />
+                    <span className="text-sm text-foreground">{svc.name}</span>
+                    <StatusBadge color="blue" size="xs">{svc.type}</StatusBadge>
+                    <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+                  </div>
+                ))}
+                {filteredServices.length > 20 && (
+                  <div className="text-xs text-muted-foreground p-2">+{filteredServices.length - 20} more services...</div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* PVCs */}
+          {filteredPVCs.length > 0 && (
+            <div>
+              <h4 className="text-sm font-medium text-muted-foreground mb-2">PVCs ({filteredPVCs.length})</h4>
+              <div className="space-y-1">
+                {filteredPVCs.slice(0, 20).map((pvc, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
+                  >
+                    <HardDrive className="w-3 h-3 text-green-400" />
+                    <span className="text-sm text-foreground">{pvc.name}</span>
+                    <StatusBadge
+                      color={pvc.status === 'Bound' ? 'green' : 'yellow'}
+                      size="xs"
+                    >
+                      {pvc.status}
+                    </StatusBadge>
+                    {pvc.capacity && <span className="text-xs text-muted-foreground">{pvc.capacity}</span>}
+                    <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+                  </div>
+                ))}
+                {filteredPVCs.length > 20 && (
+                  <div className="text-xs text-muted-foreground p-2">+{filteredPVCs.length - 20} more PVCs...</div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Empty State */}
+          {filteredPods.length === 0 && filteredDeployments.length === 0 && filteredServices.length === 0 && filteredPVCs.length === 0 && (
+            <div className="text-center py-12">
+              <p className="text-sm text-muted-foreground">
+                {resourceSearch ? 'No resources match the current search' : 'No resources found in this namespace'}
+              </p>
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- **ClusterDrillDown**: Replaces the stacked Recent Events section and collapsible Resource Tree with an "Events" / "Resource Tree" tab bar, so users can switch between them instead of scrolling
- **NamespaceDrillDown**: Replaces the single "View All Events" button and stacked layout with three tabs — Issues, Events, and Resources. The new Resources tab shows pods, deployments, services, and PVCs with search and type filtering
- Fixes the "View all in \<namespace\>" button which previously only showed events (#3646)

## Test plan
- [ ] Open a cluster drilldown and verify Events and Resource Tree are in separate tabs
- [ ] Switch between tabs and confirm content renders correctly
- [ ] Open a namespace drilldown and verify Issues, Events, and Resources tabs appear
- [ ] In the Resources tab, test filtering by resource type (Pods, Deployments, Services, PVCs)
- [ ] In the Resources tab, test the search filter
- [ ] Verify clicking "View all in \<namespace\>" from the cluster Resource Tree opens the namespace drilldown with tabs

Closes #3646
Closes #3647

🤖 Generated with [Claude Code](https://claude.com/claude-code)