### PR TITLE
fix: add confirmation dialog before deleting AI missions

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -25,6 +25,7 @@ import { useDemoMode } from '../../../hooks/useDemoMode'
 import { isNetlifyDeployment } from '../../../lib/demoMode'
 import { useResolutions, detectIssueSignature } from '../../../hooks/useResolutions'
 import { cn } from '../../../lib/cn'
+import { ConfirmDialog } from '../../../lib/modals'
 import { MAX_MESSAGE_SIZE_CHARS } from '../../../lib/constants'
 import { AgentBadge, AgentIcon } from '../../agent/AgentIcon'
 import { SaveResolutionDialog } from '../../missions/SaveResolutionDialog'
@@ -55,6 +56,8 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
   const [showSetupDialog, setShowSetupDialog] = useState(false)
   // Message validation error (e.g. too long)
   const [inputError, setInputError] = useState<string | null>(null)
+  // Delete confirmation
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
 
   // Title editing state
   const [isEditingTitle, setIsEditingTitle] = useState(false)
@@ -372,10 +375,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
             <Download className="w-4 h-4 text-muted-foreground" />
           </button>
           <button
-            onClick={() => {
-              dismissMission(mission.id)
-              setActiveMission(null)
-            }}
+            onClick={() => setShowDeleteConfirm(true)}
             className="p-1 hover:bg-red-500/20 rounded transition-colors"
             title="Delete mission"
           >
@@ -851,6 +851,21 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
     <SetupInstructionsDialog
       isOpen={showSetupDialog}
       onClose={() => setShowSetupDialog(false)}
+    />
+
+    {/* Delete confirmation dialog */}
+    <ConfirmDialog
+      isOpen={showDeleteConfirm}
+      onClose={() => setShowDeleteConfirm(false)}
+      onConfirm={() => {
+        setShowDeleteConfirm(false)
+        dismissMission(mission.id)
+        setActiveMission(null)
+      }}
+      title="Delete Mission"
+      message="Are you sure you want to delete this mission? This action cannot be undone."
+      confirmLabel="Delete"
+      variant="danger"
     />
     </>
   )

--- a/web/src/components/layout/mission-sidebar/MissionListItem.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionListItem.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import {
   ChevronRight,
   ChevronDown,
@@ -7,6 +8,7 @@ import {
 } from 'lucide-react'
 import type { Mission } from '../../../hooks/useMissions'
 import { cn } from '../../../lib/cn'
+import { ConfirmDialog } from '../../../lib/modals'
 import { STATUS_CONFIG, TYPE_ICONS } from './types'
 
 export function MissionListItem({ mission, isActive, onClick, onDismiss, onExpand, onTerminate, isCollapsed, onToggleCollapse }: {
@@ -19,11 +21,25 @@ export function MissionListItem({ mission, isActive, onClick, onDismiss, onExpan
   isCollapsed: boolean
   onToggleCollapse: () => void
 }) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const config = STATUS_CONFIG[mission.status] || STATUS_CONFIG.pending
   const StatusIcon = config.icon
   const TypeIcon = TYPE_ICONS[mission.type] || TYPE_ICONS.custom
 
   return (
+    <>
+    <ConfirmDialog
+      isOpen={showDeleteConfirm}
+      onClose={() => setShowDeleteConfirm(false)}
+      onConfirm={() => {
+        setShowDeleteConfirm(false)
+        onDismiss()
+      }}
+      title="Delete Mission"
+      message="Are you sure you want to delete this mission? This action cannot be undone."
+      confirmLabel="Delete"
+      variant="danger"
+    />
     <div
       className={cn(
         'w-full text-left rounded-lg transition-colors',
@@ -73,7 +89,7 @@ export function MissionListItem({ mission, isActive, onClick, onDismiss, onExpan
           <Maximize2 className="w-3.5 h-3.5 text-muted-foreground" />
         </button>
         <button
-          onClick={(e) => { e.stopPropagation(); onDismiss() }}
+          onClick={(e) => { e.stopPropagation(); setShowDeleteConfirm(true) }}
           className="p-0.5 hover:bg-red-500/20 rounded transition-colors flex-shrink-0"
           title="Delete mission"
         >
@@ -99,5 +115,6 @@ export function MissionListItem({ mission, isActive, onClick, onDismiss, onExpan
         </button>
       )}
     </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- Add confirmation dialog before deleting AI missions in both the sidebar list (`MissionListItem`) and the chat view (`MissionChat`)
- Uses the existing `ConfirmDialog` component with `variant="danger"` for consistent UX
- Delete only proceeds after explicit user confirmation

## Test plan
- [ ] Click Delete (trash icon) on a mission in the sidebar list — confirmation dialog appears
- [ ] Click Cancel — mission is NOT deleted
- [ ] Click Delete in dialog — mission is deleted
- [ ] Click Delete (trash icon) in the mission chat header — confirmation dialog appears
- [ ] Cancel and confirm work correctly in chat view as well

Closes #3661

🤖 Generated with [Claude Code](https://claude.com/claude-code)