### PR TITLE
fix: wire useCardLoadingState in DNSHealth card

### DIFF
--- a/web/src/components/cards/DNSHealth.tsx
+++ b/web/src/components/cards/DNSHealth.tsx
@@ -1,10 +1,19 @@
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCachedPods } from '../../hooks/useCachedData'
+import { useCardLoadingState } from './CardDataContext'
 
 export function DNSHealth() {
   const { t } = useTranslation('cards')
-  const { pods, isLoading } = useCachedPods(undefined, 'kube-system')
+  const { pods, isLoading, isRefreshing, isDemoFallback, isFailed, consecutiveFailures } = useCachedPods(undefined, 'kube-system')
+  const { showSkeleton } = useCardLoadingState({
+    isLoading,
+    isRefreshing,
+    hasAnyData: pods.length > 0,
+    isDemoData: isDemoFallback,
+    isFailed,
+    consecutiveFailures,
+  })
 
   const dnsPods = useMemo(() => {
     return pods.filter(p =>
@@ -22,7 +31,7 @@ export function DNSHealth() {
     return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b))
   }, [dnsPods])
 
-  if (isLoading && pods.length === 0) {
+  if (showSkeleton) {
     return (
       <div className="space-y-2 p-1">
         {[1, 2, 3].map(i => (


### PR DESCRIPTION
## Summary
- DNSHealth card was bypassing `useCardLoadingState` entirely, using a manual `isLoading && pods.length === 0` check instead
- Wired `useCardLoadingState` with all required fields: `isLoading`, `isRefreshing`, `isDemoData`, `hasAnyData`, `isFailed`, `consecutiveFailures`
- Now uses `showSkeleton` for loading state, consistent with EtcdStatus and all other cards
- Enables proper skeleton rendering, Demo badge, failure badge, and refresh icon animation

Closes #3673

## Test plan
- [ ] Verify loading skeleton appears on first visit with API keys
- [ ] Verify Demo badge + yellow outline appear in demo mode
- [ ] Verify refresh icon animates during background data refresh
- [ ] Verify failure badge appears after consecutive fetch failures
- [ ] Build passes: `cd web && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)