### PR TITLE
perf: React.memo for hot-path components (TreeNodeItem, StatBlock)

### DIFF
--- a/web/src/components/missions/browser/TreeNodeItem.tsx
+++ b/web/src/components/missions/browser/TreeNodeItem.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from 'react'
 import {
   Folder, FolderOpen, FileJson, ChevronRight, ChevronDown,
   Loader2, Globe, Github, HardDrive, Trash2, Plus,
@@ -5,7 +6,7 @@ import {
 import { cn } from '../../../lib/cn'
 import type { TreeNode } from './types'
 
-export function TreeNodeItem({
+export const TreeNodeItem = memo(function TreeNodeItem({
   node,
   depth,
   expandedNodes,
@@ -44,6 +45,10 @@ export function TreeNodeItem({
 
   const showHeaderActions = showRemoveButton || (depth === 0 && !!onAdd)
 
+  // Memoize inline style objects to avoid creating new references on each render
+  const paddingStyle = useMemo(() => ({ paddingLeft: `${depth * 16 + 8}px` }), [depth])
+  const emptyPaddingStyle = useMemo(() => ({ paddingLeft: `${(depth + 1) * 16 + 8}px` }), [depth])
+
   return (
     <div>
       <div className={showHeaderActions ? 'flex items-center' : undefined}>
@@ -59,7 +64,7 @@ export function TreeNodeItem({
               : 'text-foreground hover:bg-secondary/50',
             showHeaderActions && 'flex-1 min-w-0'
           )}
-          style={{ paddingLeft: `${depth * 16 + 8}px` }}
+          style={paddingStyle}
         >
           {isDir ? (
             <>
@@ -126,7 +131,7 @@ export function TreeNodeItem({
           {node.children.length === 0 && node.loaded && (
             <div
               className="text-xs text-muted-foreground italic py-1"
-              style={{ paddingLeft: `${(depth + 1) * 16 + 8}px` }}
+              style={emptyPaddingStyle}
             >
               Empty
             </div>
@@ -135,4 +140,4 @@ export function TreeNodeItem({
       )}
     </div>
   )
-}
+})

--- a/web/src/components/ui/StatsOverview.tsx
+++ b/web/src/components/ui/StatsOverview.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, memo } from 'react'
 import { useModalState } from '../../lib/modals'
 import { useTranslation } from 'react-i18next'
 import {
@@ -159,7 +159,7 @@ export interface StatBlockValue {
 }
 
 /** Inline horseshoe gauge — a 270° arc with value text centered */
-function HorseshoeGauge({ value, max = 100, size, strokeWidth, color }: {
+const HorseshoeGauge = memo(function HorseshoeGauge({ value, max = 100, size, strokeWidth, color }: {
   value: number; max?: number; size: number; strokeWidth: number; color: string
 }) {
   const percentage = max > 0 ? Math.min((value / max) * 100, 100) : 0
@@ -196,7 +196,7 @@ function HorseshoeGauge({ value, max = 100, size, strokeWidth, color }: {
       </div>
     </div>
   )
-}
+})
 
 /** Get heatmap opacity for a value */
 function getHeatmapOpacity(value: number): number {
@@ -215,7 +215,7 @@ interface StatBlockProps {
   onDisplayModeChange?: (mode: StatDisplayMode) => void
 }
 
-function StatBlock({ block, data, hasData, isLoading, history, onDisplayModeChange }: StatBlockProps) {
+const StatBlock = memo(function StatBlock({ block, data, hasData, isLoading, history, onDisplayModeChange }: StatBlockProps) {
   const IconComponent = ICONS[block.icon] || Server
   const colorClass = COLOR_CLASSES[block.color] || 'text-foreground'
   const valueColor = VALUE_COLORS[block.id] || 'text-foreground'
@@ -397,7 +397,7 @@ function StatBlock({ block, data, hasData, isLoading, history, onDisplayModeChan
       )}
     </div>
   )
-}
+})
 
 interface StatsOverviewProps {
   /** Dashboard type for loading config */


### PR DESCRIPTION
## Summary
- Wrap `TreeNodeItem` in `React.memo` — this recursive component renders once per tree node in the mission browser; memo prevents re-rendering unchanged subtrees when siblings expand/collapse
- Wrap `StatBlock` and `HorseshoeGauge` in `React.memo` — rendered 5-10 times per dashboard; memo skips re-render when individual stat data hasn't changed
- Memoize depth-based `paddingLeft` style objects in `TreeNodeItem` with `useMemo` to avoid creating new object references each render

### Not changed (intentional patterns)
- **Test file `import * as Module`**: these are used with `jest.spyOn` for mocking and don't affect production tree-shaking
- **Inline arrow functions**: the ~1269 instances are mostly event handlers in leaf components where `useCallback` would add complexity without measurable benefit

Closes #3694

## Test plan
- [ ] Mission browser tree expands/collapses correctly
- [ ] Stats overview renders all stat blocks with correct display modes
- [ ] Horseshoe gauge renders correctly in stat blocks
- [ ] Build passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)