### PR TITLE
fix: use Button component in mission-control components

### DIFF
--- a/web/src/components/mission-control/AssignmentMatrix.tsx
+++ b/web/src/components/mission-control/AssignmentMatrix.tsx
@@ -5,6 +5,7 @@
 
 import { cn } from '../../lib/cn'
 import { Check } from 'lucide-react'
+import { Button } from '../ui/Button'
 import type { ClusterInfo } from '../../hooks/mcp/types'
 import type { PayloadProject, ClusterAssignment } from './types'
 
@@ -104,17 +105,19 @@ export function AssignmentMatrix({
                     className="p-2 border-b border-border/50 text-center"
                   >
                     <div className="flex items-center justify-center gap-1.5">
-                      <button
+                      <Button
+                        variant="ghost"
+                        size="sm"
                         onClick={() => onToggle(cluster.name, project.name, !assigned)}
                         className={cn(
-                          'w-7 h-7 rounded-lg border transition-all flex items-center justify-center',
+                          '!w-7 !h-7 !p-0 rounded-lg border',
                           assigned
                             ? 'bg-primary/20 border-primary/50 text-primary hover:bg-primary/30'
                             : 'border-border hover:border-primary/30 hover:bg-primary/5 text-transparent hover:text-primary/30'
                         )}
-                      >
-                        <Check className="w-3.5 h-3.5" />
-                      </button>
+                        title={assigned ? 'Unassign project' : 'Assign project'}
+                        icon={<Check className="w-3.5 h-3.5" />}
+                      />
                       {dot && (
                         <span
                           className={cn('w-2 h-2 rounded-full flex-shrink-0', dot.color)}

--- a/web/src/components/mission-control/ClusterAssignmentPanel.tsx
+++ b/web/src/components/mission-control/ClusterAssignmentPanel.tsx
@@ -148,20 +148,22 @@ export function ClusterAssignmentPanel({
         <div className="flex items-center gap-2">
           {/* View toggle */}
           <div className="flex items-center rounded-lg border border-border overflow-hidden">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => setViewMode('cards')}
-              className={`p-1.5 ${viewMode === 'cards' ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:text-foreground'}`}
+              className={`!p-1.5 !rounded-none ${viewMode === 'cards' ? 'bg-primary/10 text-primary' : ''}`}
               title="Card view"
-            >
-              <LayoutGrid className="w-4 h-4" />
-            </button>
-            <button
+              icon={<LayoutGrid className="w-4 h-4" />}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={() => setViewMode('matrix')}
-              className={`p-1.5 ${viewMode === 'matrix' ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:text-foreground'}`}
+              className={`!p-1.5 !rounded-none ${viewMode === 'matrix' ? 'bg-primary/10 text-primary' : ''}`}
               title="Matrix view"
-            >
-              <Table className="w-4 h-4" />
-            </button>
+              icon={<Table className="w-4 h-4" />}
+            />
           </div>
 
           {/* Add/remove clusters */}
@@ -192,13 +194,14 @@ export function ClusterAssignmentPanel({
                         <span className="text-xs font-medium" title={c.name}>{clusterDisplayName(c.name)}</span>
                         <span className="text-[10px] text-muted-foreground">{c.distribution || 'k8s'}</span>
                       </div>
-                      <button
+                      <Button
+                        variant="ghost"
+                        size="sm"
                         onClick={() => setExcludedClusters((prev) => new Set([...prev, c.name]))}
-                        className="text-muted-foreground hover:text-destructive p-0.5 rounded"
+                        className="!p-0.5 text-muted-foreground hover:text-destructive"
                         title="Remove from mission"
-                      >
-                        <X className="w-3 h-3" />
-                      </button>
+                        icon={<X className="w-3 h-3" />}
+                      />
                     </div>
                   ))}
 
@@ -218,16 +221,18 @@ export function ClusterAssignmentPanel({
                             <span className="text-xs font-medium text-muted-foreground" title={c.name}>{clusterDisplayName(c.name)}</span>
                             <span className="text-[10px] text-muted-foreground">{c.distribution || 'k8s'}</span>
                           </div>
-                          <button
+                          <Button
+                            variant="ghost"
+                            size="sm"
                             onClick={() => setExcludedClusters((prev) => {
                               const next = new Set(prev)
                               next.delete(c.name)
                               return next
                             })}
-                            className="text-[10px] px-2 py-0.5 rounded bg-primary/10 text-primary hover:bg-primary/20"
+                            className="!text-[10px] !px-2 !py-0.5 bg-primary/10 text-primary hover:bg-primary/20"
                           >
                             Add
-                          </button>
+                          </Button>
                         </div>
                       ))}
                     </>

--- a/web/src/components/mission-control/PayloadCard.tsx
+++ b/web/src/components/mission-control/PayloadCard.tsx
@@ -7,6 +7,7 @@ import { useState, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import { motion } from 'framer-motion'
 import { X, Star, ChevronDown, ArrowLeftRight } from 'lucide-react'
+import { Button } from '../ui/Button'
 import { cn } from '../../lib/cn'
 import { MATURITY_CONFIG, CNCF_CATEGORY_GRADIENTS } from '../../lib/cncf-constants'
 import type { PayloadProject } from './types'
@@ -116,13 +117,14 @@ export function PayloadCard({ project, onRemove, onUpdatePriority, onHover, onCl
             <div className="flex items-center gap-2">
               <h4 className="text-sm font-medium truncate">{project.displayName}</h4>
               {/* Remove button */}
-              <button
+              <Button
+                variant="ghost"
+                size="sm"
                 onClick={onRemove}
-                className="opacity-0 group-hover:opacity-100 p-0.5 rounded hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-all"
+                className="opacity-0 group-hover:opacity-100 !p-0.5 rounded hover:bg-destructive/20 text-muted-foreground hover:text-destructive"
                 title="Remove"
-              >
-                <X className="w-3 h-3" />
-              </button>
+                icon={<X className="w-3 h-3" />}
+              />
             </div>
             <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
               {project.reason}
@@ -179,40 +181,44 @@ export function PayloadCard({ project, onRemove, onUpdatePriority, onHover, onCl
 
           {/* Priority dropdown */}
           <div className="relative ml-auto">
-            <button
+            <Button
+              variant="ghost"
+              size="sm"
               onClick={(e) => {
                 e.stopPropagation()
                 setShowPriorityMenu(!showPriorityMenu)
               }}
               className={cn(
-                'text-[10px] px-1.5 py-0.5 rounded-full border font-medium flex items-center gap-0.5 cursor-pointer',
+                '!text-[10px] !px-1.5 !py-0.5 rounded-full border !gap-0.5 cursor-pointer',
                 PRIORITY_STYLES[project.priority]
               )}
+              icon={project.priority === 'required' ? <Star className="w-2.5 h-2.5" /> : undefined}
+              iconRight={<ChevronDown className={cn('w-2.5 h-2.5 transition-transform', showPriorityMenu && 'rotate-180')} />}
             >
-              {project.priority === 'required' && <Star className="w-2.5 h-2.5" />}
               {project.priority}
-              <ChevronDown className={cn('w-2.5 h-2.5 transition-transform', showPriorityMenu && 'rotate-180')} />
-            </button>
+            </Button>
             {showPriorityMenu && (
               <>
                 {/* Backdrop to close on outside click */}
                 <div className="fixed inset-0 z-20" onClick={() => setShowPriorityMenu(false)} />
                 <div className="absolute right-0 bottom-full mb-1 bg-slate-900 border border-border rounded-lg shadow-lg py-1 z-30 min-w-[100px]">
                   {(['required', 'recommended', 'optional'] as const).map((p) => (
-                    <button
+                    <Button
                       key={p}
+                      variant="ghost"
+                      size="sm"
                       onClick={(e) => {
                         e.stopPropagation()
                         onUpdatePriority(p)
                         setShowPriorityMenu(false)
                       }}
                       className={cn(
-                        'w-full text-left text-xs px-3 py-1.5 hover:bg-secondary transition-colors capitalize',
+                        'w-full !justify-start !text-xs !px-3 !py-1.5 !rounded-none capitalize',
                         project.priority === p && 'font-medium text-primary'
                       )}
                     >
                       {p}
-                    </button>
+                    </Button>
                   ))}
                 </div>
               </>


### PR DESCRIPTION
## Summary
- Replaced raw `<button>` elements with the shared `<Button>` UI component in three mission-control files: `PayloadCard`, `AssignmentMatrix`, and `ClusterAssignmentPanel`
- Maps existing className styles to Button `variant`, `size`, `icon`, and `iconRight` props while preserving visual appearance via className overrides
- Keeps the PR focused on the mission-control components specifically called out in the Auto-QA issue

## Files changed
- `web/src/components/mission-control/PayloadCard.tsx` — 3 raw buttons converted (remove, priority dropdown trigger, priority menu items)
- `web/src/components/mission-control/AssignmentMatrix.tsx` — 1 raw button converted (assignment toggle checkbox)
- `web/src/components/mission-control/ClusterAssignmentPanel.tsx` — 4 raw buttons converted (view mode toggles, cluster remove, cluster add)

## Test plan
- [ ] Verify PayloadCard remove button (X) appears on hover and removes the card
- [ ] Verify priority dropdown opens/closes and changes priority
- [ ] Verify AssignmentMatrix toggle buttons assign/unassign projects
- [ ] Verify view mode toggle switches between card and matrix views
- [ ] Verify cluster picker add/remove buttons work correctly
- [ ] Run `cd web && npm run build` — confirmed passing

Closes #3684

🤖 Generated with [Claude Code](https://claude.com/claude-code)