### PR TITLE
test: add test coverage for 5 critical components

### DIFF
--- a/web/src/components/PageErrorBoundary.test.tsx
+++ b/web/src/components/PageErrorBoundary.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { PageErrorBoundary } from './PageErrorBoundary'
+
+// Mock i18next
+vi.mock('i18next', () => ({
+  default: {
+    t: (_key: string, fallback: string) => fallback,
+  },
+}))
+
+// Mock analytics
+vi.mock('../lib/analytics', () => ({
+  emitError: vi.fn(),
+  markErrorReported: vi.fn(),
+}))
+
+// Mock chunkErrors — non-chunk errors should be caught by PageErrorBoundary
+vi.mock('../lib/chunkErrors', () => ({
+  isChunkLoadError: (error: Error) =>
+    error.message.includes('dynamically imported module'),
+}))
+
+describe('PageErrorBoundary', () => {
+  let originalLocation: Location
+
+  beforeEach(() => {
+    originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      value: { href: '', reload: vi.fn() },
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('renders children when there is no error', () => {
+    render(
+      <PageErrorBoundary>
+        <div>Hello World</div>
+      </PageErrorBoundary>,
+    )
+    expect(screen.getByText('Hello World')).toBeTruthy()
+  })
+
+  it('shows error UI when a non-chunk render error occurs', () => {
+    const ThrowError = () => {
+      throw new Error('Unexpected null reference')
+    }
+
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <PageErrorBoundary>
+        <ThrowError />
+      </PageErrorBoundary>,
+    )
+
+    expect(screen.getByText('This page encountered an error')).toBeTruthy()
+    expect(screen.getByText('Unexpected null reference')).toBeTruthy()
+    expect(screen.getByText('Try again')).toBeTruthy()
+    expect(screen.getByText('Dashboard')).toBeTruthy()
+    expect(screen.getByText('Reload')).toBeTruthy()
+  })
+
+  it('recovers when "Try again" is clicked', () => {
+    let shouldThrow = true
+    const MaybeThrow = () => {
+      if (shouldThrow) throw new Error('Render crash')
+      return <div>Recovered content</div>
+    }
+
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { rerender } = render(
+      <PageErrorBoundary>
+        <MaybeThrow />
+      </PageErrorBoundary>,
+    )
+
+    expect(screen.getByText('This page encountered an error')).toBeTruthy()
+
+    // Stop throwing and click Try again
+    shouldThrow = false
+    fireEvent.click(screen.getByText('Try again'))
+
+    rerender(
+      <PageErrorBoundary>
+        <MaybeThrow />
+      </PageErrorBoundary>,
+    )
+
+    expect(screen.getByText('Recovered content')).toBeTruthy()
+  })
+
+  it('navigates home when Dashboard button is clicked', () => {
+    const ThrowError = () => {
+      throw new Error('crash')
+    }
+
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <PageErrorBoundary>
+        <ThrowError />
+      </PageErrorBoundary>,
+    )
+
+    fireEvent.click(screen.getByText('Dashboard'))
+    expect(window.location.href).toBe('/')
+  })
+
+  it('reloads the page when Reload button is clicked', () => {
+    const ThrowError = () => {
+      throw new Error('crash')
+    }
+
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <PageErrorBoundary>
+        <ThrowError />
+      </PageErrorBoundary>,
+    )
+
+    fireEvent.click(screen.getByText('Reload'))
+    expect(window.location.reload).toHaveBeenCalled()
+  })
+
+  it('lets chunk load errors propagate (not caught)', () => {
+    const ThrowChunkError = () => {
+      throw new Error('Failed to fetch dynamically imported module /chunk-abc.js')
+    }
+
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => {
+      render(
+        <PageErrorBoundary>
+          <ThrowChunkError />
+        </PageErrorBoundary>,
+      )
+    }).toThrow('dynamically imported module')
+  })
+})

--- a/web/src/components/alerts/RunbookProgress.test.tsx
+++ b/web/src/components/alerts/RunbookProgress.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RunbookProgress } from './RunbookProgress'
+import type { EvidenceStepResult } from '../../lib/runbooks/types'
+
+describe('RunbookProgress', () => {
+  const makeStep = (
+    overrides: Partial<EvidenceStepResult> & { stepId: string; label: string },
+  ): EvidenceStepResult => ({
+    status: 'pending',
+    ...overrides,
+  })
+
+  it('renders title and step count', () => {
+    const steps: EvidenceStepResult[] = [
+      makeStep({ stepId: '1', label: 'Check pods', status: 'success' }),
+      makeStep({ stepId: '2', label: 'Check services', status: 'pending' }),
+    ]
+
+    render(<RunbookProgress title="DNS Investigation" steps={steps} />)
+
+    expect(screen.getByText('DNS Investigation')).toBeTruthy()
+    expect(screen.getByText('1/2 steps')).toBeTruthy()
+  })
+
+  it('renders all step labels', () => {
+    const steps: EvidenceStepResult[] = [
+      makeStep({ stepId: '1', label: 'Gather events', status: 'success' }),
+      makeStep({ stepId: '2', label: 'Check logs', status: 'running' }),
+      makeStep({ stepId: '3', label: 'Analyze', status: 'pending' }),
+    ]
+
+    render(<RunbookProgress title="Runbook" steps={steps} />)
+
+    expect(screen.getByText('Gather events')).toBeTruthy()
+    expect(screen.getByText('Check logs')).toBeTruthy()
+    expect(screen.getByText('Analyze')).toBeTruthy()
+  })
+
+  it('calculates progress correctly (completed = success + skipped + failed)', () => {
+    const steps: EvidenceStepResult[] = [
+      makeStep({ stepId: '1', label: 'Step 1', status: 'success' }),
+      makeStep({ stepId: '2', label: 'Step 2', status: 'skipped' }),
+      makeStep({ stepId: '3', label: 'Step 3', status: 'failed' }),
+      makeStep({ stepId: '4', label: 'Step 4', status: 'pending' }),
+    ]
+
+    render(<RunbookProgress title="Test" steps={steps} />)
+
+    // 3 of 4 completed = 75%
+    expect(screen.getByText('3/4 steps')).toBeTruthy()
+    const bar = document.querySelector('[style*="width"]')
+    expect((bar as HTMLElement).style.width).toBe('75%')
+  })
+
+  it('shows duration when available', () => {
+    const steps: EvidenceStepResult[] = [
+      makeStep({ stepId: '1', label: 'Fast step', status: 'success', durationMs: 450 }),
+      makeStep({ stepId: '2', label: 'Slow step', status: 'success', durationMs: 2500 }),
+    ]
+
+    render(<RunbookProgress title="Test" steps={steps} />)
+
+    expect(screen.getByText('450ms')).toBeTruthy()
+    expect(screen.getByText('2.5s')).toBeTruthy()
+  })
+
+  it('handles empty steps array', () => {
+    render(<RunbookProgress title="Empty Runbook" steps={[]} />)
+
+    expect(screen.getByText('Empty Runbook')).toBeTruthy()
+    expect(screen.getByText('0/0 steps')).toBeTruthy()
+  })
+})

--- a/web/src/components/clusters/components/FilterTabs.test.tsx
+++ b/web/src/components/clusters/components/FilterTabs.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FilterTabs, type FilterType, type SortByType } from './FilterTabs'
+import type { ClusterStats } from './StatsOverview'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const baseStats: ClusterStats = {
+  total: 10,
+  loading: 0,
+  healthy: 7,
+  unhealthy: 2,
+  unreachable: 1,
+  totalNodes: 20,
+  totalCPUs: 80,
+  totalMemoryGB: 256,
+  totalStorageGB: 1024,
+  totalPods: 200,
+  totalGPUs: 0,
+  allocatedGPUs: 0,
+}
+
+function renderFilterTabs(overrides: Partial<Parameters<typeof FilterTabs>[0]> = {}) {
+  const props = {
+    stats: baseStats,
+    filter: 'all' as FilterType,
+    onFilterChange: vi.fn(),
+    sortBy: 'name' as SortByType,
+    onSortByChange: vi.fn(),
+    sortAsc: true,
+    onSortAscChange: vi.fn(),
+    ...overrides,
+  }
+  const result = render(<FilterTabs {...props} />)
+  return { ...result, props }
+}
+
+describe('FilterTabs', () => {
+  it('renders all filter buttons with correct counts', () => {
+    renderFilterTabs()
+
+    expect(screen.getByText('All (10)')).toBeTruthy()
+    expect(screen.getByText('Healthy (7)')).toBeTruthy()
+    expect(screen.getByText('Unhealthy (2)')).toBeTruthy()
+    expect(screen.getByText(/Offline \(1\)/)).toBeTruthy()
+  })
+
+  it('calls onFilterChange with the correct filter type', () => {
+    const { props } = renderFilterTabs()
+
+    fireEvent.click(screen.getByText('Healthy (7)'))
+    expect(props.onFilterChange).toHaveBeenCalledWith('healthy')
+
+    fireEvent.click(screen.getByText('Unhealthy (2)'))
+    expect(props.onFilterChange).toHaveBeenCalledWith('unhealthy')
+
+    fireEvent.click(screen.getByText(/Offline \(1\)/))
+    expect(props.onFilterChange).toHaveBeenCalledWith('unreachable')
+  })
+
+  it('calls onSortByChange when sort dropdown changes', () => {
+    const { props } = renderFilterTabs({ sortBy: 'custom' })
+    const select = screen.getByDisplayValue('Custom')
+
+    fireEvent.change(select, { target: { value: 'health' } })
+    expect(props.onSortByChange).toHaveBeenCalledWith('health')
+  })
+
+  it('toggles sort direction when sort button is clicked', () => {
+    const { props } = renderFilterTabs({ sortAsc: true })
+    // The sort direction toggle button has a title
+    const toggleBtn = screen.getByTitle('Ascending')
+    fireEvent.click(toggleBtn)
+    expect(props.onSortAscChange).toHaveBeenCalledWith(false)
+  })
+
+  it('shows Add Cluster button when onAddCluster is provided', () => {
+    const onAddCluster = vi.fn()
+    renderFilterTabs({ onAddCluster })
+
+    const addBtn = screen.getByText('Add Cluster')
+    expect(addBtn).toBeTruthy()
+    fireEvent.click(addBtn)
+    expect(onAddCluster).toHaveBeenCalled()
+  })
+
+  it('does not show Add Cluster button when onAddCluster is not provided', () => {
+    renderFilterTabs()
+    expect(screen.queryByText('Add Cluster')).toBeNull()
+  })
+})

--- a/web/src/components/clusters/components/RenameModal.test.tsx
+++ b/web/src/components/clusters/components/RenameModal.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { RenameModal } from './RenameModal'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+// Mock BaseModal to render children directly (avoid portal complexity)
+vi.mock('../../../lib/modals', () => {
+  const Header = ({ title, onClose }: { title: string; onClose: () => void }) => (
+    <div>
+      <h2>{title}</h2>
+      <button onClick={onClose} aria-label="close-header">X</button>
+    </div>
+  )
+  const Content = ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+  const Footer = ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+
+  const BaseModal = ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) => {
+    if (!isOpen) return null
+    return <div data-testid="modal">{children}</div>
+  }
+  BaseModal.Header = Header
+  BaseModal.Content = Content
+  BaseModal.Footer = Footer
+
+  return { BaseModal }
+})
+
+describe('RenameModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    clusterName: 'cluster-1',
+    currentDisplayName: 'my-cluster',
+    onClose: vi.fn(),
+    onRename: vi.fn().mockResolvedValue(undefined),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the modal with current display name pre-filled', () => {
+    render(<RenameModal {...defaultProps} />)
+
+    expect(screen.getByText('Rename Context')).toBeTruthy()
+    expect(screen.getByDisplayValue('my-cluster')).toBeTruthy()
+    expect(screen.getByText(/my-cluster/)).toBeTruthy()
+  })
+
+  it('shows error when name is empty', async () => {
+    render(<RenameModal {...defaultProps} />)
+
+    const input = screen.getByDisplayValue('my-cluster')
+    fireEvent.change(input, { target: { value: '' } })
+
+    // The Rename button should be disabled when name is empty
+    const renameBtn = screen.getByText('Rename')
+    expect(renameBtn.closest('button')?.disabled).toBe(true)
+  })
+
+  it('shows error when name contains spaces', async () => {
+    render(<RenameModal {...defaultProps} />)
+
+    const input = screen.getByDisplayValue('my-cluster')
+    fireEvent.change(input, { target: { value: 'has space' } })
+
+    fireEvent.click(screen.getByText('Rename'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Name cannot contain spaces')).toBeTruthy()
+    })
+  })
+
+  it('shows error when name is unchanged', async () => {
+    render(<RenameModal {...defaultProps} />)
+
+    // Name is already 'my-cluster', click rename without changing
+    fireEvent.click(screen.getByText('Rename'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Name is unchanged')).toBeTruthy()
+    })
+  })
+
+  it('calls onRename and onClose on successful rename', async () => {
+    render(<RenameModal {...defaultProps} />)
+
+    const input = screen.getByDisplayValue('my-cluster')
+    fireEvent.change(input, { target: { value: 'new-name' } })
+    fireEvent.click(screen.getByText('Rename'))
+
+    await waitFor(() => {
+      expect(defaultProps.onRename).toHaveBeenCalledWith('cluster-1', 'new-name')
+      expect(defaultProps.onClose).toHaveBeenCalled()
+    })
+  })
+
+  it('shows error message when onRename rejects', async () => {
+    const failingRename = vi.fn().mockRejectedValue(new Error('Server error'))
+    render(<RenameModal {...defaultProps} onRename={failingRename} />)
+
+    const input = screen.getByDisplayValue('my-cluster')
+    fireEvent.change(input, { target: { value: 'new-name' } })
+    fireEvent.click(screen.getByText('Rename'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeTruthy()
+    })
+  })
+
+  it('does not render when isOpen is false', () => {
+    render(<RenameModal {...defaultProps} isOpen={false} />)
+    expect(screen.queryByText('Rename Context')).toBeNull()
+  })
+})

--- a/web/src/components/updates/UpdateProgressBanner.test.tsx
+++ b/web/src/components/updates/UpdateProgressBanner.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { UpdateProgressBanner } from './UpdateProgressBanner'
+import type { UpdateProgress } from '../../types/updates'
+
+vi.mock('../../lib/constants/network', () => ({
+  BANNER_DISMISS_MS: 5000,
+}))
+
+describe('UpdateProgressBanner', () => {
+  const onDismiss = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when progress is null', () => {
+    const { container } = render(
+      <UpdateProgressBanner progress={null} onDismiss={onDismiss} />,
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders nothing when status is idle', () => {
+    const progress: UpdateProgress = { status: 'idle', message: '', progress: 0 }
+    const { container } = render(
+      <UpdateProgressBanner progress={progress} onDismiss={onDismiss} />,
+    )
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders active progress with message and progress bar', () => {
+    const progress: UpdateProgress = {
+      status: 'pulling',
+      message: 'Pulling latest changes...',
+      progress: 45,
+    }
+    render(<UpdateProgressBanner progress={progress} onDismiss={onDismiss} />)
+
+    expect(screen.getByText('Pulling latest changes...')).toBeTruthy()
+    // Progress bar should be present with correct width
+    const bar = document.querySelector('[style*="width"]')
+    expect(bar).toBeTruthy()
+    expect((bar as HTMLElement).style.width).toBe('45%')
+  })
+
+  it('renders done state without progress bar', () => {
+    const progress: UpdateProgress = {
+      status: 'done',
+      message: 'Update complete!',
+      progress: 100,
+    }
+    render(<UpdateProgressBanner progress={progress} onDismiss={onDismiss} />)
+
+    expect(screen.getByText('Update complete!')).toBeTruthy()
+    // Done state should not show the progress bar container (no width style on inner bar)
+    // The progress bar is only rendered when isActive
+  })
+
+  it('renders failed state', () => {
+    const progress: UpdateProgress = {
+      status: 'failed',
+      message: 'Build failed',
+      progress: 60,
+    }
+    render(<UpdateProgressBanner progress={progress} onDismiss={onDismiss} />)
+
+    expect(screen.getByText('Build failed')).toBeTruthy()
+  })
+
+  it('calls onDismiss and hides when dismiss button is clicked', () => {
+    const progress: UpdateProgress = {
+      status: 'building',
+      message: 'Building...',
+      progress: 30,
+    }
+    const { container } = render(
+      <UpdateProgressBanner progress={progress} onDismiss={onDismiss} />,
+    )
+
+    // Click the dismiss (X) button
+    const dismissBtn = container.querySelector('button')
+    expect(dismissBtn).toBeTruthy()
+    fireEvent.click(dismissBtn!)
+
+    expect(onDismiss).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Adds test files for 5 components that were missing test coverage (30 tests total)
- **PageErrorBoundary** (6 tests): error catching, recovery via "Try again", navigation to dashboard, reload, chunk error passthrough
- **FilterTabs** (6 tests): filter button rendering/clicks, sort dropdown, sort direction toggle, Add Cluster button visibility
- **RenameModal** (7 tests): pre-filled input, empty/spaces/unchanged validation, successful rename flow, server error display, closed state
- **UpdateProgressBanner** (6 tests): null/idle states, active progress bar rendering, done/failed states, dismiss callback
- **RunbookProgress** (5 tests): title/step count, step labels, progress calculation (success+skipped+failed), duration formatting, empty steps

## Test plan
- [x] All 30 tests pass: `npx vitest run` on the 5 new test files
- [x] Build succeeds: `npm run build`
- [ ] CI passes

Closes #3687

🤖 Generated with [Claude Code](https://claude.com/claude-code)