### PR TITLE
fix: deduplicate utility functions between Dashboard.tsx and dashboardUtils.ts

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -31,7 +31,7 @@ import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useDashboardContext } from '../../hooks/useDashboardContext'
 import { DashboardDropZone } from './DashboardDropZone'
 import { useToast } from '../ui/Toast'
-import { CARD_COMPONENTS, prefetchCardChunks } from '../cards/cardRegistry'
+import { prefetchCardChunks } from '../cards/cardRegistry'
 import { ROUTES } from '../../config/routes'
 import { getDefaultCardsForDashboard } from '../../config/dashboards'
 import { safeLazy } from '../../lib/safeLazy'
@@ -47,6 +47,7 @@ import { FloatingDashboardActions } from './FloatingDashboardActions'
 import { DashboardTemplate } from './templates'
 import { SortableCard, DragPreviewCard } from './SharedSortableCard'
 import type { Card, DashboardData } from './dashboardUtils'
+import { isLocalOnlyCard, mapVisualizationToCardType, getDefaultCardSize, getDemoCards } from './dashboardUtils'
 import { useDashboardReset } from '../../hooks/useDashboardReset'
 import { useDashboardUndoRedo } from '../../hooks/useUndoRedo'
 import { WelcomeCard } from './WelcomeCard'
@@ -595,16 +596,6 @@ export function Dashboard() {
     }
   }, [searchParams, setSearchParams, openAddCardModal, location.pathname])
 
-  // Helper to check if a card ID is a local-only (not persisted) card
-  const isLocalOnlyCard = (cardId: string) => {
-    return cardId.startsWith('new-') ||
-           cardId.startsWith('template-') ||
-           cardId.startsWith('restored-') ||
-           cardId.startsWith('ai-') ||
-           cardId.startsWith('rec-') ||
-           cardId.startsWith('default-') ||
-           cardId.startsWith('demo-')
-  }
 
   const loadDashboard = async (isBackground: boolean = false) => {
     if (!isBackground) {
@@ -1204,142 +1195,3 @@ export function Dashboard() {
   )
 }
 
-function mapVisualizationToCardType(visualization: string, type: string): string {
-  // First, check if the type is a valid registered card - if so, use it directly
-  if (type && CARD_COMPONENTS[type]) {
-    return type
-  }
-
-  // Fall back to visualization mapping for AI-generated or unknown types
-  const mapping: Record<string, string> = {
-    gauge: 'resource_usage',
-    timeseries: 'cluster_metrics',
-    events: 'event_stream',
-    donut: 'app_status',
-    bar: 'cluster_metrics',
-    status: 'cluster_health',
-    table: 'pod_issues',
-    sparkline: 'cluster_metrics',
-  }
-  return mapping[visualization] || type
-}
-
-// Get recommended default size for specific card types
-function getDefaultCardSize(cardType: string): { w: number; h: number } {
-  const cardSizes: Record<string, { w: number; h: number }> = {
-    // Full-width cards (12 cols) - hierarchical/complex views
-    cluster_resource_tree: { w: 12, h: 6 },
-
-    // Extra-wide cards (8 cols) - tables with many columns
-    pvc_status: { w: 8, h: 3 },
-    service_status: { w: 8, h: 3 },
-    security_issues: { w: 8, h: 4 },
-    deployment_issues: { w: 8, h: 3 },
-    user_management: { w: 8, h: 4 },
-    operator_subscriptions: { w: 8, h: 3 },
-    helm_values_diff: { w: 8, h: 4 },
-    chart_versions: { w: 8, h: 3 },
-    namespace_rbac: { w: 8, h: 4 },
-    alert_rules: { w: 8, h: 4 },
-    pod_issues: { w: 8, h: 3 },
-    top_pods: { w: 8, h: 3 },
-
-    // Wide cards (6 cols) - time series, events, medium tables
-    cluster_metrics: { w: 6, h: 3 },
-    events_timeline: { w: 6, h: 3 },
-    pod_health_trend: { w: 6, h: 3 },
-    resource_trend: { w: 6, h: 3 },
-    gpu_usage_trend: { w: 6, h: 3 },
-    gpu_utilization: { w: 6, h: 3 },
-    event_stream: { w: 6, h: 4 },
-    helm_history: { w: 6, h: 3 },
-    namespace_events: { w: 6, h: 4 },
-    gpu_inventory: { w: 6, h: 3 },
-    gpu_workloads: { w: 6, h: 3 },
-    deployment_status: { w: 6, h: 3 },
-    app_status: { w: 6, h: 3 },
-    kustomization_status: { w: 6, h: 3 },
-    gitops_drift: { w: 6, h: 3 },
-    cluster_comparison: { w: 6, h: 3 },
-    cluster_costs: { w: 6, h: 3 },
-    opencost_overview: { w: 6, h: 3 },
-    kubecost_overview: { w: 6, h: 3 },
-    overlay_comparison: { w: 6, h: 3 },
-    argocd_applications: { w: 6, h: 3 },
-
-    // Standard cards (4 cols) - status, gauges, donut charts
-    cluster_health: { w: 4, h: 3 },
-    cluster_focus: { w: 4, h: 3 },
-    resource_usage: { w: 4, h: 3 },
-    resource_capacity: { w: 4, h: 3 },
-    gpu_overview: { w: 4, h: 3 },
-    gpu_status: { w: 4, h: 3 },
-    storage_overview: { w: 4, h: 3 },
-    network_overview: { w: 4, h: 3 },
-    cluster_network: { w: 4, h: 3 },
-    helm_release_status: { w: 4, h: 3 },
-    operator_status: { w: 4, h: 3 },
-    crd_health: { w: 4, h: 3 },
-    namespace_overview: { w: 4, h: 3 },
-    namespace_quotas: { w: 4, h: 3 },
-    active_alerts: { w: 4, h: 3 },
-    argocd_sync_status: { w: 4, h: 3 },
-    argocd_health: { w: 4, h: 3 },
-    opa_policies: { w: 4, h: 3 },
-    kyverno_policies: { w: 4, h: 3 },
-    deployment_progress: { w: 4, h: 3 },
-    upgrade_status: { w: 4, h: 3 },
-    compute_overview: { w: 4, h: 3 },
-    console_ai_issues: { w: 4, h: 4 },
-    console_ai_kubeconfig_audit: { w: 4, h: 3 },
-    console_ai_health_check: { w: 4, h: 3 },
-  }
-  return cardSizes[cardType] || { w: 4, h: 3 }
-}
-
-function getDemoCards(): Card[] {
-  return [
-    {
-      id: 'demo-1',
-      card_type: 'cluster_health',
-      config: {},
-      position: { x: 0, y: 0, w: 4, h: 2 },
-    },
-    {
-      id: 'demo-2',
-      card_type: 'resource_usage',
-      config: {},
-      position: { x: 4, y: 0, w: 4, h: 2 },
-    },
-    {
-      id: 'demo-3',
-      card_type: 'event_stream',
-      config: {},
-      position: { x: 8, y: 0, w: 4, h: 2 },
-    },
-    {
-      id: 'demo-4',
-      card_type: 'cluster_metrics',
-      config: {},
-      position: { x: 0, y: 2, w: 6, h: 2 },
-    },
-    {
-      id: 'demo-5',
-      card_type: 'deployment_status',
-      config: {},
-      position: { x: 6, y: 2, w: 6, h: 2 },
-    },
-    {
-      id: 'demo-6',
-      card_type: 'pod_issues',
-      config: {},
-      position: { x: 0, y: 4, w: 4, h: 2 },
-    },
-    {
-      id: 'demo-7',
-      card_type: 'app_status',
-      config: {},
-      position: { x: 4, y: 4, w: 4, h: 2 },
-    },
-  ]
-}

--- a/web/src/components/dashboard/dashboardUtils.ts
+++ b/web/src/components/dashboard/dashboardUtils.ts
@@ -22,6 +22,7 @@ export function isLocalOnlyCard(cardId: string): boolean {
          cardId.startsWith('restored-') ||
          cardId.startsWith('ai-') ||
          cardId.startsWith('rec-') ||
+         cardId.startsWith('default-') ||
          cardId.startsWith('demo-')
 }
 
@@ -101,9 +102,9 @@ export function getDefaultCardSize(cardType: string): { w: number; h: number } {
     deployment_progress: { w: 4, h: 3 },
     upgrade_status: { w: 4, h: 3 },
     compute_overview: { w: 4, h: 3 },
-    klaude_issues: { w: 4, h: 4 },
-    klaude_kubeconfig_audit: { w: 4, h: 3 },
-    klaude_health_check: { w: 4, h: 3 },
+    console_ai_issues: { w: 4, h: 4 },
+    console_ai_kubeconfig_audit: { w: 4, h: 3 },
+    console_ai_health_check: { w: 4, h: 3 },
   }
   return cardSizes[cardType] || { w: 4, h: 3 }
 }


### PR DESCRIPTION
## Summary
- Removed triple-duplicated `isLocalOnlyCard`, `mapVisualizationToCardType`, `getDefaultCardSize`, and `getDemoCards` functions from `Dashboard.tsx`
- Consolidated all four functions in `dashboardUtils.ts` with the correct/complete logic
- Fixed `isLocalOnlyCard` in `dashboardUtils.ts` to include the missing `default-` prefix check
- Fixed `getDefaultCardSize` in `dashboardUtils.ts` to use `console_ai_*` card type names (was incorrectly using `klaude_*`)

Closes #3669

## Test plan
- [ ] Verify dashboard loads correctly with no console errors
- [ ] Verify cards with `default-` prefixed IDs are correctly identified as local-only
- [ ] Verify `console_ai_issues`, `console_ai_kubeconfig_audit`, and `console_ai_health_check` cards get correct default sizes
- [ ] Run `npm run build` -- passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)