### PR TITLE
fix: use route constants and strengthen drilldown nav tests

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -433,10 +433,10 @@ function App() {
           stack (no DashboardProvider, AlertsProvider, MissionProvider,
           CardEventProvider, etc.). This cuts initial JS from ~1.8MB to
           ~200KB and eliminates cold-start API calls. */}
-      <Route path="/missions/:missionId" element={
+      <Route path={ROUTES.MISSION} element={
         <LightweightShell><MissionLandingPage /></LightweightShell>
       } />
-      <Route path="/missions" element={
+      <Route path={ROUTES.MISSIONS} element={
         <LightweightShell><MissionBrowseLink /></LightweightShell>
       } />
 
@@ -470,79 +470,79 @@ function FullDashboardApp() {
       <ChunkErrorBoundary>
       <Suspense fallback={<LoadingFallback />}>
       <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route path="/welcome" element={<Welcome />} />
-        <Route path="/from-lens" element={<FromLens />} />
-        <Route path="/from-headlamp" element={<FromHeadlamp />} />
-        <Route path="/from-holmesgpt" element={<FromHolmesGPT />} />
-        <Route path="/feature-inspektorgadget" element={<FeatureInspektorGadget />} />
-        <Route path="/feature-kagent" element={<FeatureKagent />} />
-        <Route path="/white-label" element={<WhiteLabel />} />
-        <Route path="/auth/callback" element={<AuthCallback />} />
+        <Route path={ROUTES.LOGIN} element={<Login />} />
+        <Route path={ROUTES.WELCOME} element={<Welcome />} />
+        <Route path={ROUTES.FROM_LENS} element={<FromLens />} />
+        <Route path={ROUTES.FROM_HEADLAMP} element={<FromHeadlamp />} />
+        <Route path={ROUTES.FROM_HOLMESGPT} element={<FromHolmesGPT />} />
+        <Route path={ROUTES.FEATURE_INSPEKTORGADGET} element={<FeatureInspektorGadget />} />
+        <Route path={ROUTES.FEATURE_KAGENT} element={<FeatureKagent />} />
+        <Route path={ROUTES.WHITE_LABEL} element={<WhiteLabel />} />
+        <Route path={ROUTES.AUTH_CALLBACK} element={<AuthCallback />} />
         {/* PWA Mini Dashboard - lightweight widget mode (no auth required for local monitoring) */}
-        <Route path="/widget" element={<MiniDashboard />} />
+        <Route path={ROUTES.WIDGET} element={<MiniDashboard />} />
 
         {/* Layout route — all dashboard routes share a single Layout instance.
             KeepAliveOutlet preserves component state across navigations so that
             warm-nav is near-instant (no unmount/remount). */}
         <Route element={<ProtectedRoute><Layout /></ProtectedRoute>}>
           <Route index element={<Dashboard />} />
-          <Route path="/custom-dashboard/:id" element={<CustomDashboard />} />
+          <Route path={ROUTES.CUSTOM_DASHBOARD} element={<CustomDashboard />} />
           {/* Test routes — rendered with Layout but not cached by KeepAlive */}
-          <Route path="/__perf/all-cards" element={<AllCardsPerfTest />} />
-          <Route path="/__compliance/all-cards" element={<CompliancePerfTest />} />
-          <Route path="/clusters" element={<Clusters />} />
-          <Route path="/workloads" element={<Workloads />} />
-          <Route path="/nodes" element={<Nodes />} />
-          <Route path="/deployments" element={<Deployments />} />
-          <Route path="/pods" element={<Pods />} />
-          <Route path="/services" element={<Services />} />
-          <Route path="/operators" element={<Operators />} />
-          <Route path="/helm" element={<HelmReleases />} />
-          <Route path="/logs" element={<Logs />} />
-          <Route path="/compute" element={<Compute />} />
-          <Route path="/compute/compare" element={<ClusterComparisonPage />} />
-          <Route path="/storage" element={<Storage />} />
-          <Route path="/network" element={<Network />} />
-          <Route path="/events" element={<Events />} />
-          <Route path="/security" element={<Security />} />
-          <Route path="/gitops" element={<GitOps />} />
-          <Route path="/alerts" element={<Alerts />} />
-          <Route path="/cost" element={<Cost />} />
-          <Route path="/security-posture" element={<Compliance />} />
+          <Route path={ROUTES.PERF_ALL_CARDS} element={<AllCardsPerfTest />} />
+          <Route path={ROUTES.PERF_COMPLIANCE} element={<CompliancePerfTest />} />
+          <Route path={ROUTES.CLUSTERS} element={<Clusters />} />
+          <Route path={ROUTES.WORKLOADS} element={<Workloads />} />
+          <Route path={ROUTES.NODES} element={<Nodes />} />
+          <Route path={ROUTES.DEPLOYMENTS} element={<Deployments />} />
+          <Route path={ROUTES.PODS} element={<Pods />} />
+          <Route path={ROUTES.SERVICES} element={<Services />} />
+          <Route path={ROUTES.OPERATORS} element={<Operators />} />
+          <Route path={ROUTES.HELM} element={<HelmReleases />} />
+          <Route path={ROUTES.LOGS} element={<Logs />} />
+          <Route path={ROUTES.COMPUTE} element={<Compute />} />
+          <Route path={ROUTES.COMPUTE_COMPARE} element={<ClusterComparisonPage />} />
+          <Route path={ROUTES.STORAGE} element={<Storage />} />
+          <Route path={ROUTES.NETWORK} element={<Network />} />
+          <Route path={ROUTES.EVENTS} element={<Events />} />
+          <Route path={ROUTES.SECURITY} element={<Security />} />
+          <Route path={ROUTES.GITOPS} element={<GitOps />} />
+          <Route path={ROUTES.ALERTS} element={<Alerts />} />
+          <Route path={ROUTES.COST} element={<Cost />} />
+          <Route path={ROUTES.SECURITY_POSTURE} element={<Compliance />} />
           {/* Legacy route for backwards compatibility */}
-          <Route path="/compliance" element={<Compliance />} />
-          <Route path="/data-compliance" element={<DataCompliance />} />
-          <Route path="/gpu-reservations" element={<GPUReservations />} />
-          <Route path="/history" element={<CardHistoryWithRestore />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/users" element={<UserManagementPage />} />
-          <Route path="/namespaces" element={<NamespaceManager />} />
-          <Route path="/arcade" element={<Arcade />} />
-          <Route path="/deploy" element={<Deploy />} />
-          <Route path="/ai-ml" element={<AIML />} />
-          <Route path="/ai-agents" element={<AIAgents />} />
-          <Route path="/llm-d-benchmarks" element={<LLMdBenchmarks />} />
-          <Route path="/cluster-admin" element={<ClusterAdmin />} />
-          <Route path="/ci-cd" element={<CICD />} />
-          <Route path="/insights" element={<Insights />} />
-          <Route path="/multi-tenancy" element={<MultiTenancy />} />
-          <Route path="/marketplace" element={<Marketplace />} />
+          <Route path={ROUTES.COMPLIANCE} element={<Compliance />} />
+          <Route path={ROUTES.DATA_COMPLIANCE} element={<DataCompliance />} />
+          <Route path={ROUTES.GPU_RESERVATIONS} element={<GPUReservations />} />
+          <Route path={ROUTES.HISTORY} element={<CardHistoryWithRestore />} />
+          <Route path={ROUTES.SETTINGS} element={<Settings />} />
+          <Route path={ROUTES.USERS} element={<UserManagementPage />} />
+          <Route path={ROUTES.NAMESPACES} element={<NamespaceManager />} />
+          <Route path={ROUTES.ARCADE} element={<Arcade />} />
+          <Route path={ROUTES.DEPLOY} element={<Deploy />} />
+          <Route path={ROUTES.AI_ML} element={<AIML />} />
+          <Route path={ROUTES.AI_AGENTS} element={<AIAgents />} />
+          <Route path={ROUTES.LLM_D_BENCHMARKS} element={<LLMdBenchmarks />} />
+          <Route path={ROUTES.CLUSTER_ADMIN} element={<ClusterAdmin />} />
+          <Route path={ROUTES.CI_CD} element={<CICD />} />
+          <Route path={ROUTES.INSIGHTS} element={<Insights />} />
+          <Route path={ROUTES.MULTI_TENANCY} element={<MultiTenancy />} />
+          <Route path={ROUTES.MARKETPLACE} element={<Marketplace />} />
           {/* Dev test routes for unified framework validation */}
-          <Route path="/test/unified-card" element={<UnifiedCardTest />} />
-          <Route path="/test/unified-stats" element={<UnifiedStatsTest />} />
-          <Route path="/test/unified-dashboard" element={<UnifiedDashboardTest />} />
+          <Route path={ROUTES.TEST_UNIFIED_CARD} element={<UnifiedCardTest />} />
+          <Route path={ROUTES.TEST_UNIFIED_STATS} element={<UnifiedStatsTest />} />
+          <Route path={ROUTES.TEST_UNIFIED_DASHBOARD} element={<UnifiedDashboardTest />} />
           {/* Mission deep-link: /missions/install-prometheus → opens MissionBrowser.
               Must be inside ProtectedRoute so auth is verified before redirect,
               and the ?mission= param survives the OAuth round-trip. */}
           {/* Mission routes moved outside ProtectedRoute for the landing page */}
           {/* /issue, /issues, /feedback open the feedback modal on the dashboard */}
-          <Route path="/issue" element={<IssueRedirect />} />
-          <Route path="/issues" element={<IssueRedirect />} />
-          <Route path="/feedback" element={<IssueRedirect />} />
+          <Route path={ROUTES.ISSUE} element={<IssueRedirect />} />
+          <Route path={ROUTES.ISSUES} element={<IssueRedirect />} />
+          <Route path={ROUTES.FEEDBACK} element={<IssueRedirect />} />
           {/* /feature, /features open the feedback modal on the feature tab */}
-          <Route path="/feature" element={<FeatureRedirect />} />
-          <Route path="/features" element={<FeatureRedirect />} />
+          <Route path={ROUTES.FEATURE} element={<FeatureRedirect />} />
+          <Route path={ROUTES.FEATURES} element={<FeatureRedirect />} />
         </Route>
 
         <Route path="*" element={<Navigate to={ROUTES.HOME} replace />} />

--- a/web/src/components/compute/Compute.tsx
+++ b/web/src/components/compute/Compute.tsx
@@ -9,6 +9,7 @@ import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useU
 import { StatBlockValue } from '../ui/StatsOverview'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
+import { ROUTES } from '../../config/routes'
 import { useTranslation } from 'react-i18next'
 
 const COMPUTE_CARDS_KEY = 'kubestellar-compute-cards'
@@ -164,7 +165,7 @@ export function Compute() {
 
   const handleCompare = useCallback(() => {
     if (selectedForComparison.length >= 2) {
-      navigate(`/compute/compare?clusters=${selectedForComparison.join(',')}`)
+      navigate(`${ROUTES.COMPUTE_COMPARE}?clusters=${selectedForComparison.join(',')}`)
     }
   }, [selectedForComparison, navigate])
 

--- a/web/src/components/drilldown/DrillDownModal.test.tsx
+++ b/web/src/components/drilldown/DrillDownModal.test.tsx
@@ -1,6 +1,26 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import React from 'react'
 import * as DrillDownModalModule from './DrillDownModal'
 import { useDrillDown, DrillDownProvider } from '../../hooks/useDrillDown'
+import type { DrillDownView } from '../../hooks/useDrillDown'
+
+vi.mock('../../lib/analytics', () => ({
+  emitDrillDownOpened: vi.fn(),
+  emitDrillDownClosed: vi.fn(),
+}))
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <DrillDownProvider>{children}</DrillDownProvider>
+)
+
+function makeView(overrides: Partial<DrillDownView> = {}): DrillDownView {
+  return {
+    type: overrides.type ?? 'cluster',
+    title: overrides.title ?? 'test-cluster',
+    data: overrides.data ?? { cluster: 'ctx/test-cluster' },
+  }
+}
 
 describe('DrillDownModal Component', () => {
   it('exports DrillDownModal component', () => {
@@ -13,5 +33,50 @@ describe('DrillDownModal Component', () => {
     expect(typeof DrillDownProvider).toBe('function')
     expect(useDrillDown).toBeDefined()
     expect(typeof useDrillDown).toBe('function')
+  })
+
+  it('pop navigates back through the drilldown stack', () => {
+    const { result } = renderHook(() => useDrillDown(), { wrapper })
+
+    // Open first view
+    act(() => result.current.open(makeView({ title: 'Cluster A', type: 'cluster' })))
+    expect(result.current.state.stack).toHaveLength(1)
+
+    // Push second view
+    act(() => result.current.push(makeView({ title: 'Pod X', type: 'pod', data: { cluster: 'ctx/a', namespace: 'default', pod: 'pod-x' } })))
+    expect(result.current.state.stack).toHaveLength(2)
+    expect(result.current.state.currentView?.title).toBe('Pod X')
+
+    // Pop should go back to first view
+    act(() => result.current.pop())
+    expect(result.current.state.stack).toHaveLength(1)
+    expect(result.current.state.currentView?.title).toBe('Cluster A')
+    expect(result.current.state.isOpen).toBe(true)
+  })
+
+  it('goTo navigates to a specific breadcrumb index', () => {
+    const { result } = renderHook(() => useDrillDown(), { wrapper })
+
+    act(() => result.current.open(makeView({ title: 'Cluster', type: 'cluster' })))
+    act(() => result.current.push(makeView({ title: 'Namespace', type: 'namespace', data: { cluster: 'ctx/a', namespace: 'default' } })))
+    act(() => result.current.push(makeView({ title: 'Pod', type: 'pod', data: { cluster: 'ctx/a', namespace: 'default', pod: 'p1' } })))
+    expect(result.current.state.stack).toHaveLength(3)
+
+    // Jump back to first breadcrumb
+    act(() => result.current.goTo(0))
+    expect(result.current.state.stack).toHaveLength(1)
+    expect(result.current.state.currentView?.title).toBe('Cluster')
+  })
+
+  it('close clears the entire stack', () => {
+    const { result } = renderHook(() => useDrillDown(), { wrapper })
+
+    act(() => result.current.open(makeView({ title: 'Cluster', type: 'cluster' })))
+    act(() => result.current.push(makeView({ title: 'Pod', type: 'pod', data: { cluster: 'ctx/a', namespace: 'default', pod: 'p1' } })))
+
+    act(() => result.current.close())
+    expect(result.current.state.isOpen).toBe(false)
+    expect(result.current.state.stack).toHaveLength(0)
+    expect(result.current.state.currentView).toBeNull()
   })
 })

--- a/web/src/config/routes.ts
+++ b/web/src/config/routes.ts
@@ -84,6 +84,9 @@ export const ROUTES = {
   WELCOME: '/welcome',
   FROM_LENS: '/from-lens',
   FROM_HEADLAMP: '/from-headlamp',
+  FROM_HOLMESGPT: '/from-holmesgpt',
+  FEATURE_INSPEKTORGADGET: '/feature-inspektorgadget',
+  FEATURE_KAGENT: '/feature-kagent',
   WHITE_LABEL: '/white-label',
 
   // Multi-Tenancy


### PR DESCRIPTION
## Summary
- Replace all hardcoded route strings in `App.tsx` Route definitions with `ROUTES` constants from `config/routes.ts` for type-safety and single-source-of-truth routing
- Add three missing route constants: `FROM_HOLMESGPT`, `FEATURE_INSPEKTORGADGET`, `FEATURE_KAGENT`
- Update `Compute.tsx` to use `ROUTES.COMPUTE_COMPARE` instead of a hardcoded string
- Expand `DrillDownModal.test.tsx` with tests verifying back navigation (`pop`), breadcrumb jump (`goTo`), and close behavior

## Context
Issue #3693 flagged 16 drilldown views as "missing back navigation." Investigation shows the `DrillDownModal` wrapper already provides:
- A back button (chevron) that calls `pop()` or `close()`
- Clickable breadcrumb trail with `goTo(index)` for jumping to any ancestor
- Keyboard shortcuts (Backspace/Space for back, Esc for close)
- A close (X) button

The individual view files don't need their own back buttons because the modal shell handles it. The real gap was hardcoded route strings and insufficient test coverage for the navigation stack.

Closes #3693

## Test plan
- [x] `npm run build` passes
- [x] All 73 drilldown/navigation tests pass (`vitest run`)
- [ ] Verify routes still work in browser after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)