### PR TITLE
Fix WCAG AA color contrast for reduced-opacity text

### DIFF
--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -937,7 +937,7 @@ function CardPreview({ card }: { card: HoveredCard }) {
               <path
                 d="M0,30 L10,25 L20,28 L30,15 L40,20 L50,10 L60,18 L70,12 L80,8 L90,15 L100,5 L100,40 L0,40 Z"
                 fill="currentColor"
-                className="text-purple-400/40"
+                className="text-purple-400/60"
               />
             </svg>
           </div>

--- a/web/src/components/deploy/DeployConfirmDialog.tsx
+++ b/web/src/components/deploy/DeployConfirmDialog.tsx
@@ -282,7 +282,7 @@ export function DeployConfirmDialog({
             className={cn(
               'px-4 py-2 text-sm rounded-lg transition-colors flex items-center gap-2',
               isLoading
-                ? 'bg-blue-500/10 text-blue-400/40 cursor-not-allowed'
+                ? 'bg-blue-500/10 text-blue-400/60 cursor-not-allowed'
                 : 'bg-blue-500/20 hover:bg-blue-500/30 text-blue-400',
             )}
           >

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -609,7 +609,7 @@ export function MissionSidebar() {
 
       {missions.length === 0 ? (
         <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
-          <Sparkles className="w-10 h-10 text-purple-400/40 mb-4" />
+          <Sparkles className="w-10 h-10 text-purple-400/60 mb-4" />
           <p className="text-muted-foreground">{t('missionSidebar.noActiveMissions')}</p>
           <p className="text-xs text-muted-foreground/70 mt-1">
             {t('missionSidebar.startMissionPrompt')}


### PR DESCRIPTION
## Summary
- Increased opacity from `/40` to `/60` on three text/icon elements that failed WCAG AA 4.5:1 contrast ratio checks:
  - `AddCardModal.tsx` — SVG fill area (`text-purple-400/40` → `/60`)
  - `MissionSidebar.tsx` — decorative Sparkles icon (`text-purple-400/40` → `/60`)
  - `DeployConfirmDialog.tsx` — disabled deploy button text (`text-blue-400/40` → `/60`)
- Verified that the 20 flagged `text-slate-200/300` instances are all on dark backgrounds (`bg-[#0f172a]`, `bg-slate-800/900`) and already meet WCAG AA contrast requirements — no changes needed.

Closes #3683

## Test plan
- [ ] Verify AddCardModal card type previews still look correct with updated SVG opacity
- [ ] Verify MissionSidebar empty state icon is visible
- [ ] Verify DeployConfirmDialog disabled button text is readable but still appears disabled
- [ ] Run `npm run build` — confirmed passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)