### PR TITLE
fix: restrict useDashboardHealth polling to dashboard pages only

### DIFF
--- a/web/src/components/dashboard/CreateDashboardModal.tsx
+++ b/web/src/components/dashboard/CreateDashboardModal.tsx
@@ -20,6 +20,26 @@ export function CreateDashboardModal({
   onCreate,
   existingNames = [],
 }: CreateDashboardModalProps) {
+  // Only mount inner content (and its hooks) when the modal is open.
+  // This avoids health-check API polling when the modal is closed.
+  if (!isOpen) return null
+
+  return (
+    <CreateDashboardModalInner
+      isOpen={isOpen}
+      onClose={onClose}
+      onCreate={onCreate}
+      existingNames={existingNames}
+    />
+  )
+}
+
+function CreateDashboardModalInner({
+  isOpen,
+  onClose,
+  onCreate,
+  existingNames = [],
+}: CreateDashboardModalProps) {
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [selectedTemplate, setSelectedTemplate] = useState<DashboardTemplate | null>(null)

--- a/web/src/hooks/useDashboardContext.tsx
+++ b/web/src/hooks/useDashboardContext.tsx
@@ -1,5 +1,4 @@
 import { createContext, useContext, useState, useCallback, ReactNode } from 'react'
-import { useDashboardHealth, type DashboardHealthInfo } from './useDashboardHealth'
 
 // Card to be restored from history
 export interface PendingRestoreCard {
@@ -28,9 +27,6 @@ interface DashboardContextType {
   pendingRestoreCard: PendingRestoreCard | null
   setPendingRestoreCard: (card: PendingRestoreCard | null) => void
   clearPendingRestoreCard: () => void
-
-  // Aggregated dashboard health status
-  health: DashboardHealthInfo
 }
 
 const DashboardContext = createContext<DashboardContextType | null>(null)
@@ -40,8 +36,6 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const [pendingOpenAddCardModal, setPendingOpenAddCardModalState] = useState(false)
   const [isTemplatesModalOpen, setIsTemplatesModalOpen] = useState(false)
   const [pendingRestoreCard, setPendingRestoreCardState] = useState<PendingRestoreCard | null>(null)
-
-  const health = useDashboardHealth()
 
   const openAddCardModal = useCallback(() => {
     setIsAddCardModalOpen(true)
@@ -85,7 +79,6 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         pendingRestoreCard,
         setPendingRestoreCard,
         clearPendingRestoreCard,
-        health,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- Removed the unused `health` field from `DashboardProvider` context, which was calling `useDashboardHealth()` on every page since the provider wraps the entire app
- Gated `CreateDashboardModal` inner content behind `isOpen` so health-check API polling (clusters, alerts, pod issues) only runs while the modal is visible
- All dashboard components that need health data already call `useDashboardHealth()` directly and are only mounted on dashboard routes, so no behavior changes on dashboard pages

Closes #3670

## Test plan
- [ ] Verify dashboard health indicator still shows correct status on the main dashboard
- [ ] Verify custom dashboards still display health indicators
- [ ] Open Network tab on a non-dashboard page (e.g., Settings, Alerts) and confirm no cluster/pod-issue polling requests
- [ ] Open the Create Dashboard modal from the sidebar and confirm health alert banner still appears when system has issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)