### PR TITLE
feat: add per-profile controls dialog to OSCAL card

### DIFF
--- a/web/src/components/cards/DataComplianceCards.tsx
+++ b/web/src/components/cards/DataComplianceCards.tsx
@@ -115,7 +115,7 @@ export function VaultSecrets({ config: _config }: CardConfig) {
   }, [clusters, isDemoMode])
 
   useCardLoadingState({
-    isLoading,
+    isLoading: isLoading && !vaultStatus.installed,
     hasAnyData: true,
     isDemoData: isDemoMode,
   })
@@ -289,7 +289,7 @@ export function ExternalSecrets({ config: _config }: CardConfig) {
   }, [clusters, isDemoMode])
 
   useCardLoadingState({
-    isLoading,
+    isLoading: isLoading && !esoStatus.installed,
     hasAnyData: true,
     isDemoData: isDemoMode,
   })

--- a/web/src/components/cards/TrestleScan.test.tsx
+++ b/web/src/components/cards/TrestleScan.test.tsx
@@ -16,6 +16,7 @@ import type { TrestleClusterStatus, OscalProfile } from '../../hooks/useTrestle'
 
 const mockStartMission = vi.fn()
 const mockUseCardLoadingState = vi.fn()
+const mockDrillToCompliance = vi.fn()
 
 vi.mock('../../hooks/useTrestle', () => ({
   useTrestle: vi.fn(),
@@ -23,6 +24,10 @@ vi.mock('../../hooks/useTrestle', () => ({
 
 vi.mock('../../hooks/useMissions', () => ({
   useMissions: () => ({ startMission: mockStartMission }),
+}))
+
+vi.mock('../../hooks/useDrillDown', () => ({
+  useDrillDownActions: () => ({ drillToCompliance: mockDrillToCompliance }),
 }))
 
 vi.mock('../../hooks/useGlobalFilters', () => ({
@@ -323,7 +328,29 @@ describe('TrestleScan', () => {
       setTrestleReturn()
 
       render(<TrestleScan />)
-      expect(screen.getByText('100 controls')).toBeInTheDocument()
+      const controlsBadges = screen.getAllByText('100 controls')
+      expect(controlsBadges.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('clicking total controls opens compliance drilldown', async () => {
+      const user = userEvent.setup()
+      setTrestleReturn()
+
+      render(<TrestleScan />)
+      const allControlsButtons = screen.getAllByTitle('View all compliance controls')
+      await user.click(allControlsButtons[0])
+
+      expect(mockDrillToCompliance).toHaveBeenCalledWith('', {})
+    })
+
+    it('each profile has controls button that opens compliance drilldown with profile context', async () => {
+      const user = userEvent.setup()
+      setTrestleReturn()
+
+      render(<TrestleScan />)
+      await user.click(screen.getByTitle('View NIST 800-53 rev5 controls'))
+
+      expect(mockDrillToCompliance).toHaveBeenCalledWith('', { profile: 'NIST 800-53 rev5' })
     })
   })
 
@@ -386,6 +413,23 @@ describe('TrestleScan', () => {
       await user.click(screen.getByText('Profile B'))
       expect(screen.getByText('80 pass')).toBeInTheDocument()
       expect(screen.queryByText('50 pass')).not.toBeInTheDocument()
+    })
+
+    it('expanded pass/fail/other chips open compliance dialog with profile + status', async () => {
+      const user = userEvent.setup()
+      setTrestleReturn()
+
+      render(<TrestleScan />)
+      await user.click(screen.getByText('NIST 800-53 rev5'))
+
+      await user.click(screen.getByTitle('View passing controls for NIST 800-53 rev5'))
+      expect(mockDrillToCompliance).toHaveBeenCalledWith('pass', { profile: 'NIST 800-53 rev5' })
+
+      await user.click(screen.getByTitle('View failing controls for NIST 800-53 rev5'))
+      expect(mockDrillToCompliance).toHaveBeenCalledWith('fail', { profile: 'NIST 800-53 rev5' })
+
+      await user.click(screen.getByTitle('View other controls for NIST 800-53 rev5'))
+      expect(mockDrillToCompliance).toHaveBeenCalledWith('other', { profile: 'NIST 800-53 rev5' })
     })
   })
 

--- a/web/src/components/cards/TrestleScan.tsx
+++ b/web/src/components/cards/TrestleScan.tsx
@@ -313,25 +313,45 @@ Please proceed step by step. Start with verifying prerequisites (Python 3.9+, ku
           const isExpanded = expandedProfile === profile.name
 
           return (
-            <button
+            <div
               key={profile.name}
-              onClick={() => setExpandedProfile(isExpanded ? null : profile.name)}
               className="w-full text-left p-2.5 rounded-lg border border-border/50 hover:border-border transition-colors bg-secondary/20"
             >
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Shield className="w-3.5 h-3.5 text-teal-400" />
-                  <span className="text-xs font-medium text-foreground">{profile.name}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className={`text-xs font-bold ${
-                    profileScore >= SCORE_GOOD_THRESHOLD ? 'text-green-400' :
-                    profileScore >= SCORE_WARNING_THRESHOLD ? 'text-yellow-400' : 'text-red-400'
-                  }`}>
-                    {profileScore}%
-                  </span>
-                  <ChevronRight className={`w-3 h-3 text-muted-foreground transition-transform ${isExpanded ? 'rotate-90' : ''}`} />
-                </div>
+              <div className="flex items-center justify-between gap-2">
+                <button
+                  onClick={() => setExpandedProfile(isExpanded ? null : profile.name)}
+                  className="flex-1 text-left"
+                  title={`Toggle ${profile.name} details`}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <Shield className="w-3.5 h-3.5 text-teal-400" />
+                      <span className="text-xs font-medium text-foreground">{profile.name}</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className={`text-xs font-bold ${
+                        profileScore >= SCORE_GOOD_THRESHOLD ? 'text-green-400' :
+                        profileScore >= SCORE_WARNING_THRESHOLD ? 'text-yellow-400' : 'text-red-400'
+                      }`}>
+                        {profileScore}%
+                      </span>
+                      <ChevronRight className={`w-3 h-3 text-muted-foreground transition-transform ${isExpanded ? 'rotate-90' : ''}`} />
+                    </div>
+                  </div>
+                </button>
+
+                <button
+                  onClick={() => drillToCompliance('', { profile: profile.name })}
+                  className="cursor-pointer"
+                  title={`View ${profile.name} controls`}
+                >
+                  <StatusBadge
+                    color={profileScore >= SCORE_GOOD_THRESHOLD ? 'green' : profileScore >= SCORE_WARNING_THRESHOLD ? 'yellow' : 'red'}
+                    size="xs"
+                  >
+                    {profile.totalControls} controls
+                  </StatusBadge>
+                </button>
               </div>
 
               {/* Progress bar */}
@@ -348,21 +368,33 @@ Please proceed step by step. Start with verifying prerequisites (Python 3.9+, ku
               {/* Expanded details */}
               {isExpanded && (
                 <div className="mt-2 grid grid-cols-3 gap-2 text-xs">
-                  <div className="flex items-center gap-1 text-green-400">
+                  <button
+                    onClick={() => drillToCompliance('pass', { profile: profile.name })}
+                    className="flex items-center gap-1 text-green-400 hover:opacity-80 transition-opacity cursor-pointer"
+                    title={`View passing controls for ${profile.name}`}
+                  >
                     <CheckCircle className="w-3 h-3" />
                     <span>{profile.controlsPassed} pass</span>
-                  </div>
-                  <div className="flex items-center gap-1 text-red-400">
+                  </button>
+                  <button
+                    onClick={() => drillToCompliance('fail', { profile: profile.name })}
+                    className="flex items-center gap-1 text-red-400 hover:opacity-80 transition-opacity cursor-pointer"
+                    title={`View failing controls for ${profile.name}`}
+                  >
                     <XCircle className="w-3 h-3" />
                     <span>{profile.controlsFailed} fail</span>
-                  </div>
-                  <div className="flex items-center gap-1 text-muted-foreground">
+                  </button>
+                  <button
+                    onClick={() => drillToCompliance('other', { profile: profile.name })}
+                    className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                    title={`View other controls for ${profile.name}`}
+                  >
                     <Info className="w-3 h-3" />
                     <span>{profile.controlsOther} other</span>
-                  </div>
+                  </button>
                 </div>
               )}
-            </button>
+            </div>
           )
         })}
       </div>


### PR DESCRIPTION
## Summary
- Add clickable "N controls" StatusBadge on each OSCAL profile row that opens the compliance drilldown filtered to that profile
- Make expanded pass/fail/other chips drill into the profile-scoped compliance view
- Fix pre-existing bare `isLoading` violation in `DataComplianceCards.tsx` that caused the `card-standard` CI check to fail on any cards/ PR

Closes #3680

Based on the work from @Abhishek-Punhani in #3681 — thank you for the contribution!

## Test plan
- [x] `npx vitest run src/components/cards/TrestleScan.test.tsx` — 39 tests pass (3 new drilldown tests)
- [x] `npx vitest run src/test/card-loading-standard.test.ts` — 437 tests pass (DataComplianceCards fix)
- [x] `npm run build` — clean build
- [ ] Verify per-profile controls button opens drilldown filtered to that profile
- [ ] Verify expanded pass/fail/other chips open drilldown with profile + status filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)