### PR TITLE
fix: add draggable resize handle to AI missions sidebar

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -53,14 +53,17 @@ const SIDEBAR_DEFAULT_WIDTH = 680
 const SIDEBAR_WIDTH_KEY = 'ksc-mission-sidebar-width'
 
 function loadSavedWidth(): number {
+  const maxW = typeof window !== 'undefined'
+    ? Math.min(SIDEBAR_MAX_WIDTH, window.innerWidth * 0.85)
+    : SIDEBAR_MAX_WIDTH
   try {
     const saved = localStorage.getItem(SIDEBAR_WIDTH_KEY)
     if (saved) {
       const w = Number(saved)
-      if (w >= SIDEBAR_MIN_WIDTH && w <= SIDEBAR_MAX_WIDTH) return w
+      if (w >= SIDEBAR_MIN_WIDTH && w <= SIDEBAR_MAX_WIDTH) return Math.min(w, maxW)
     }
   } catch { /* ignore */ }
-  return SIDEBAR_DEFAULT_WIDTH
+  return Math.min(SIDEBAR_DEFAULT_WIDTH, maxW)
 }
 
 export function MissionSidebar() {
@@ -73,6 +76,21 @@ export function MissionSidebar() {
   // Resizable sidebar width (desktop non-fullscreen only)
   const [sidebarWidth, setSidebarWidth] = useState(loadSavedWidth)
   const [isResizing, setIsResizing] = useState(false)
+  const latestWidthRef = useRef(sidebarWidth)
+
+  // Re-clamp sidebar width when viewport is resized
+  useEffect(() => {
+    const onResize = () => {
+      const maxW = Math.min(SIDEBAR_MAX_WIDTH, window.innerWidth * 0.85)
+      setSidebarWidth((w) => {
+        const clamped = Math.min(w, maxW)
+        latestWidthRef.current = clamped
+        return clamped
+      })
+    }
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
 
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
@@ -85,6 +103,7 @@ export function MissionSidebar() {
       const delta = startX - ev.clientX
       const maxW = Math.min(SIDEBAR_MAX_WIDTH, window.innerWidth * 0.85)
       const newWidth = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxW, startWidth + delta))
+      latestWidthRef.current = newWidth
       setSidebarWidth(newWidth)
     }
 
@@ -94,11 +113,8 @@ export function MissionSidebar() {
       document.removeEventListener('mouseup', onMouseUp)
       document.body.style.cursor = ''
       document.body.style.userSelect = ''
-      // Persist final width
-      setSidebarWidth((w) => {
-        try { localStorage.setItem(SIDEBAR_WIDTH_KEY, String(w)) } catch { /* ignore */ }
-        return w
-      })
+      // Persist final width using ref to avoid state-updater side effects
+      try { localStorage.setItem(SIDEBAR_WIDTH_KEY, String(latestWidthRef.current)) } catch { /* ignore */ }
     }
 
     document.body.style.cursor = 'col-resize'
@@ -456,8 +472,11 @@ export function MissionSidebar() {
       {!isMobile && !isFullScreen && isSidebarOpen && (
         <div
           onMouseDown={handleResizeStart}
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={t('missionSidebar.resizeHandleTooltip')}
+          title={t('missionSidebar.resizeHandleTooltip')}
           className="absolute top-0 left-0 bottom-0 w-1.5 cursor-col-resize z-50 group"
-          title="Drag to resize"
         >
           <div className="absolute inset-y-0 left-0 w-0.5 bg-border group-hover:bg-primary/50 transition-colors" />
         </div>

--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -1541,7 +1541,8 @@
     "mission": "mission",
     "missions": "missions",
     "missionCount_one": "{{count}} mission",
-    "missionCount_other": "{{count}} missions"
+    "missionCount_other": "{{count}} missions",
+    "resizeHandleTooltip": "Drag to resize"
   },
   "feedback": {
     "share": "Share",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1587,7 +1587,8 @@
     "mission": "mission",
     "missions": "missions",
     "missionCount_one": "{{count}} mission",
-    "missionCount_other": "{{count}} missions"
+    "missionCount_other": "{{count}} missions",
+    "resizeHandleTooltip": "Drag to resize"
   },
   "feedback": {
     "share": "Share",

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -1541,7 +1541,8 @@
     "mission": "mission",
     "missions": "missions",
     "missionCount_one": "{{count}} mission",
-    "missionCount_other": "{{count}} missions"
+    "missionCount_other": "{{count}} missions",
+    "resizeHandleTooltip": "Drag to resize"
   },
   "feedback": {
     "share": "Share",

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -1541,7 +1541,8 @@
     "mission": "mission",
     "missions": "missions",
     "missionCount_one": "{{count}} mission",
-    "missionCount_other": "{{count}} missions"
+    "missionCount_other": "{{count}} missions",
+    "resizeHandleTooltip": "Drag to resize"
   },
   "feedback": {
     "share": "Share",

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -1541,7 +1541,8 @@
     "mission": "mission",
     "missions": "missions",
     "missionCount_one": "{{count}} mission",
-    "missionCount_other": "{{count}} missions"
+    "missionCount_other": "{{count}} missions",
+    "resizeHandleTooltip": "Drag to resize"
   },
   "feedback": {
     "share": "Share",

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -1541,7 +1541,8 @@
     "mission": "mission",
     "missions": "missions",
     "missionCount_one": "{{count}} mission",
-    "missionCount_other": "{{count}} missions"
+    "missionCount_other": "{{count}} missions",
+    "resizeHandleTooltip": "Drag to resize"
   },
   "feedback": {
     "share": "Share",

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -1541,7 +1541,8 @@
     "mission": "mission",
     "missions": "missions",
     "missionCount_one": "{{count}} mission",
-    "missionCount_other": "{{count}} missions"
+    "missionCount_other": "{{count}} missions",
+    "resizeHandleTooltip": "Drag to resize"
   },
   "feedback": {
     "share": "Share",

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -1541,7 +1541,8 @@
     "mission": "mission",
     "missions": "missions",
     "missionCount_one": "{{count}} mission",
-    "missionCount_other": "{{count}} missions"
+    "missionCount_other": "{{count}} missions",
+    "resizeHandleTooltip": "Drag to resize"
   },
   "feedback": {
     "share": "Share",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -1541,7 +1541,8 @@
     "mission": "mission",
     "missions": "missions",
     "missionCount_one": "{{count}} mission",
-    "missionCount_other": "{{count}} missions"
+    "missionCount_other": "{{count}} missions",
+    "resizeHandleTooltip": "Drag to resize"
   },
   "feedback": {
     "share": "Share",


### PR DESCRIPTION
- [x] Initial PR: add draggable resize handle to AI missions sidebar
- [x] Fix `loadSavedWidth()` to clamp against `Math.min(SIDEBAR_MAX_WIDTH, window.innerWidth * 0.85)` — prevents overflow on smaller viewports after saving a large width
- [x] Add viewport `resize` listener to re-clamp `sidebarWidth` when the browser window changes size
- [x] Fix `onMouseUp` — use `latestWidthRef` ref to track current width during drag; write to `localStorage` once on mouseup using the ref (avoids React 18 state-updater side effect)
- [x] Add `role="separator"`, `aria-orientation="vertical"`, `aria-label={t('missionSidebar.resizeHandleTooltip')}`, `title={t(...)}` to resize handle div
- [x] Add `resizeHandleTooltip` translation key to all 9 locale files

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Send tasks to Copilot coding agent from [Slack](https://gh.io/cca-slack-docs) and [Teams](https://gh.io/cca-teams-docs) to turn conversations into code. Copilot posts an update in your thread when it's finished.