### PR TITLE
fix: Pod Brothers game shows game over immediately on start

### DIFF
--- a/web/src/components/cards/PodBrothers.tsx
+++ b/web/src/components/cards/PodBrothers.tsx
@@ -50,7 +50,7 @@ const LEVEL_DATA = [
   [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
   [0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0],
   [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0],
-  [0, 6, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 4, 4],
+  [0, 0, 0, 6, 0, 6, 0, 0, 0, 0, 0, 0, 0, 4, 4],
   [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
   [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
 ]
@@ -107,6 +107,7 @@ export function PodBrothers() {
   const levelRef = useRef<number[][]>([])
   /** Frames remaining of spawn invincibility (prevents instant death on overlapping enemies) */
   const invincibilityRef = useRef<number>(0)
+  const livesRef = useRef<number>(3)
 
   // Initialize level
   const initLevel = useCallback(() => {
@@ -250,15 +251,17 @@ export function PodBrothers() {
 
     // Fall off screen
     if (player.y > CANVAS_HEIGHT) {
-      setLives(l => {
-        if (l <= 1) {
-          setGameState('lost')
-          setScore(s => { emitGameEnded('pod_brothers', 'loss', s); return s })
-          return 0
-        }
+      const currentLives = livesRef.current
+      if (currentLives <= 1) {
+        livesRef.current = 0
+        setLives(0)
+        setGameState('lost')
+        setScore(s => { emitGameEnded('pod_brothers', 'loss', s); return s })
+      } else {
+        livesRef.current = currentLives - 1
+        setLives(currentLives - 1)
         initLevel()
-        return l - 1
-      })
+      }
       return
     }
 
@@ -293,15 +296,17 @@ export function PodBrothers() {
           setScore(s => s + 200)
         } else if (invincibilityRef.current <= 0) {
           // Only take damage when not invincible
-          setLives(l => {
-            if (l <= 1) {
-              setGameState('lost')
-              setScore(s => { emitGameEnded('pod_brothers', 'loss', s); return s })
-              return 0
-            }
+          const currentLives = livesRef.current
+          if (currentLives <= 1) {
+            livesRef.current = 0
+            setLives(0)
+            setGameState('lost')
+            setScore(s => { emitGameEnded('pod_brothers', 'loss', s); return s })
+          } else {
+            livesRef.current = currentLives - 1
+            setLives(currentLives - 1)
             initLevel()
-            return l - 1
-          })
+          }
           return
         }
       }
@@ -500,8 +505,11 @@ export function PodBrothers() {
   }, [gameState, initLevel, render])
 
   const startGame = () => {
+    // Cancel any in-flight animation frame to prevent stale updates
+    cancelAnimationFrame(animationRef.current)
     initLevel()
     setScore(0)
+    livesRef.current = 3
     setLives(3)
     setGameState('playing')
     emitGameStarted('pod_brothers')


### PR DESCRIPTION
## Summary
- Moved goomba enemy away from player spawn point (col 1 -> col 3) so the player no longer starts inside an enemy hitbox
- Refactored life-loss logic to use a synchronous `livesRef` instead of calling `setGameState`/`initLevel` as side effects inside `setLives` updaters — React 18 StrictMode can double-invoke updaters, causing unpredictable game-over transitions
- Cancel any in-flight animation frame in `startGame()` to prevent stale game loop callbacks from interfering with retry

## Test plan
- [ ] Open the Arcade dashboard and launch Pod Brothers
- [ ] Verify the game starts normally (idle screen -> playing) without immediately showing "Game Over"
- [ ] Play until losing all lives, then click "Try Again" — verify the game restarts cleanly with 3 lives
- [ ] Play until reaching the flag — verify "Level Complete" shows and "Play Again" works
- [ ] Verify enemies still patrol and collisions still work after invincibility wears off

Closes #3716

🤖 Generated with [Claude Code](https://claude.com/claude-code)