### PR TITLE
fix: redirect title text to homepage instead of docs site

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, lazy, Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { Sun, Moon, Monitor, Menu, X, MoreVertical } from 'lucide-react'
+import { Sun, Moon, Monitor, Menu, X, MoreVertical, ExternalLink } from 'lucide-react'
 import { useAuth } from '../../../lib/auth'
 import { useSidebarConfig } from '../../../hooks/useSidebarConfig'
 import { useTheme } from '../../../hooks/useTheme'
@@ -71,14 +71,24 @@ export function Navbar() {
         >
           <LogoWithStar className="w-8 h-8 md:w-9 md:h-9" />
         </button>
+        <button
+          type="button"
+          onClick={() => navigate(ROUTES.HOME)}
+          className="hidden lg:flex flex-col leading-tight hover:opacity-80 transition-opacity text-left"
+          aria-label={t('navbar.goHome')}
+        >
+          <span className="text-base md:text-lg font-semibold text-foreground">{branding.appName}</span>
+          <span className="text-[10px] text-muted-foreground tracking-wide">{branding.tagline}</span>
+        </button>
         <a
           href={branding.docsUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="hidden lg:flex flex-col leading-tight hover:opacity-80 transition-opacity"
+          className="hidden lg:flex items-center p-1.5 hover:bg-secondary rounded-md transition-colors"
+          aria-label={t('navbar.viewDocs')}
+          title={t('navbar.viewDocs')}
         >
-          <span className="text-base md:text-lg font-semibold text-foreground">{branding.appName}</span>
-          <span className="text-[10px] text-muted-foreground tracking-wide">{branding.tagline}</span>
+          <ExternalLink className="w-3.5 h-3.5 text-muted-foreground" />
         </a>
       </div>
 

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -1557,7 +1557,8 @@
     "openMenu": "Open menu",
     "goHome": "Go to home dashboard",
     "themeToggle": "Theme: {{theme}} (click to toggle)",
-    "moreOptions": "More options"
+    "moreOptions": "More options",
+    "viewDocs": "View documentation"
   },
   "missionSidebar": {
     "expandSidebar": "Expand sidebar",


### PR DESCRIPTION
## Summary
- The "KubeStellar Console" title text in the navbar was wrapped in an `<a>` tag linking to the docs website. Clicking it navigated away from the app.
- Changed the title text to a `<button>` that navigates to the app homepage (`/`), consistent with the logo's behavior.
- Added a small external-link icon (`ExternalLink`) next to the title for quick access to the documentation site.

Closes #3723

## Test plan
- [ ] Click the "KubeStellar Console" title text in the navbar — should navigate to `/` (homepage)
- [ ] Click the logo icon — should also navigate to `/` (unchanged)
- [ ] Click the small external-link icon next to the title — should open docs site in a new tab
- [ ] Verify the external-link icon has a tooltip ("View documentation")
- [ ] Check on mobile (< lg breakpoint) — title and docs icon are hidden as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)