### PR TITLE
fix: surface error details from swallowed catch blocks in useDependencies

### DIFF
--- a/web/src/hooks/useDependencies.ts
+++ b/web/src/hooks/useDependencies.ts
@@ -130,6 +130,9 @@ export function useResolveDependencies() {
     // grid row and causing the browser to scroll to the top of the page.
 
     try {
+      let restError: unknown
+      let agentError: unknown
+
       // Try backend REST API first (works when JWT auth is available)
       try {
         setProgressMessage('Scanning pod spec for references…')
@@ -144,6 +147,7 @@ export function useResolveDependencies() {
         setData(result)
         return result
       } catch (restErr) {
+        restError = restErr
         console.warn('[useDependencies] REST API failed, trying agent:', restErr)
       }
 
@@ -156,10 +160,18 @@ export function useResolveDependencies() {
           return agentResult
         }
       } catch (agentErr) {
+        agentError = agentErr
         console.warn('[useDependencies] Agent resolve-deps failed:', agentErr)
       }
 
-      setError(new Error('No data source available for dependency resolution'))
+      // Both sources failed — build a descriptive error for UI consumers
+      const details: string[] = []
+      if (restError) details.push(`REST API: ${restError instanceof Error ? restError.message : String(restError)}`)
+      if (agentError) details.push(`Agent: ${agentError instanceof Error ? agentError.message : String(agentError)}`)
+      const message = details.length > 0
+        ? `Dependency resolution failed (${details.join('; ')})`
+        : 'No data source available for dependency resolution'
+      setError(new Error(message))
       return null
     } finally {
       setIsLoading(false)


### PR DESCRIPTION
## Summary
- Captures specific error messages from both REST API and agent fallback catch blocks in `useDependencies.ts`
- When both data sources fail, the `error` state now includes actionable details (e.g. "Dependency resolution failed (REST API: REST 503; Agent: timeout)") instead of a generic message
- Retains `console.warn` calls for developer debugging alongside the new user-facing error context

## Test plan
- [ ] Verify that when both REST API and agent fail, the DeployConfirmDialog shows specific error details (not just "No data source available")
- [ ] Verify that when only REST fails and agent succeeds, no error is surfaced
- [ ] Verify that console.warn messages still appear in browser devtools for debugging
- [ ] Run `cd web && npm run build` — confirms clean compilation

Closes #3727

🤖 Generated with [Claude Code](https://claude.com/claude-code)