### PR TITLE
fix: clean up game keyboard listeners on unmount to prevent key capture leak

### DIFF
--- a/web/src/components/cards/ContainerTetris.tsx
+++ b/web/src/components/cards/ContainerTetris.tsx
@@ -6,6 +6,7 @@ import { useReportCardDataState } from './CardDataContext'
 import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeys } from '../../hooks/useGameKeys'
 
 // Board dimensions
 const ROWS = 20
@@ -159,6 +160,7 @@ function ContainerTetrisInternal(_props: CardComponentProps) {
   const [isPaused, setIsPaused] = useState(false)
   const [isPlaying, setIsPlaying] = useState(false)
 
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const gameLoopRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   // Calculate drop speed based on level
@@ -246,52 +248,47 @@ function ContainerTetrisInternal(_props: CardComponentProps) {
     setTimeout(moveDown, 10)
   }, [piece, board, gameOver, isPaused, moveDown])
 
-  // Keyboard controls
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (!isPlaying || gameOver) return
+  // Keyboard controls — scoped to visible game container (KeepAlive-safe)
+  const handleTetrisKeyDown = useCallback((e: KeyboardEvent) => {
+    if (!isPlaying || gameOver) return
 
-      switch (e.key) {
-        case 'ArrowLeft':
-        case 'a':
-        case 'A':
-          e.preventDefault()
-          moveHorizontal(-1)
-          break
-        case 'ArrowRight':
-        case 'd':
-        case 'D':
-          e.preventDefault()
-          moveHorizontal(1)
-          break
-        case 'ArrowDown':
-        case 's':
-        case 'S':
-          e.preventDefault()
-          moveDown()
-          break
-        case 'ArrowUp':
-        case 'w':
-        case 'W':
-          e.preventDefault()
-          rotate()
-          break
-        case ' ':
-          e.preventDefault()
-          hardDrop()
-          break
-        case 'p':
-        case 'P':
-          e.preventDefault()
-          setIsPaused(p => !p)
-          break
-      }
+    switch (e.key) {
+      case 'ArrowLeft':
+      case 'a':
+      case 'A':
+        e.preventDefault()
+        moveHorizontal(-1)
+        break
+      case 'ArrowRight':
+      case 'd':
+      case 'D':
+        e.preventDefault()
+        moveHorizontal(1)
+        break
+      case 'ArrowDown':
+      case 's':
+      case 'S':
+        e.preventDefault()
+        moveDown()
+        break
+      case 'ArrowUp':
+      case 'w':
+      case 'W':
+        e.preventDefault()
+        rotate()
+        break
+      case ' ':
+        e.preventDefault()
+        hardDrop()
+        break
+      case 'p':
+      case 'P':
+        e.preventDefault()
+        setIsPaused(p => !p)
+        break
     }
-
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
   }, [isPlaying, gameOver, moveHorizontal, moveDown, rotate, hardDrop])
+  useGameKeys(gameContainerRef, { onKeyDown: handleTetrisKeyDown })
 
   // Game loop
   useEffect(() => {
@@ -359,7 +356,7 @@ function ContainerTetrisInternal(_props: CardComponentProps) {
   const displayBoard = renderBoard()
 
   return (
-    <div className="h-full flex flex-col p-2 select-none">
+    <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
       <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
         <div className="flex items-center gap-3 text-xs">

--- a/web/src/components/cards/FlappyPod.tsx
+++ b/web/src/components/cards/FlappyPod.tsx
@@ -5,6 +5,7 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeys } from '../../hooks/useGameKeys'
 
 // Game constants
 const GRAVITY = 0.5
@@ -26,6 +27,7 @@ export function FlappyPod(_props: CardComponentProps) {
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
 
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const gameLoopRef = useRef<number | null>(null)
   const pipeTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -209,22 +211,18 @@ export function FlappyPod(_props: CardComponentProps) {
     }
   }, [isPlaying, gameOver, gameWidth, gameHeight, endGame])
 
-  // Keyboard and click controls
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === ' ' || e.key === 'ArrowUp') {
-        e.preventDefault()
-        if (!isPlaying && !gameOver) {
-          startGame()
-        } else {
-          jump()
-        }
+  // Keyboard and click controls — scoped to visible game container (KeepAlive-safe)
+  const handleFlappyKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === ' ' || e.key === 'ArrowUp') {
+      e.preventDefault()
+      if (!isPlaying && !gameOver) {
+        startGame()
+      } else {
+        jump()
       }
     }
-
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
   }, [isPlaying, gameOver, startGame, jump])
+  useGameKeys(gameContainerRef, { onKeyDown: handleFlappyKeyDown })
 
   const handleClick = useCallback(() => {
     if (!isPlaying && !gameOver) {
@@ -235,7 +233,7 @@ export function FlappyPod(_props: CardComponentProps) {
   }, [isPlaying, gameOver, startGame, jump])
 
   return (
-    <div className="h-full flex flex-col p-2 select-none">
+    <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
       <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
         <div className="flex items-center gap-3 text-xs">

--- a/web/src/components/cards/Game2048.tsx
+++ b/web/src/components/cards/Game2048.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import { RotateCcw, Trophy, ArrowUp, ArrowDown, ArrowLeft, ArrowRight } from 'lucide-react'
 import { CardComponentProps } from './cardRegistry'
 import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeys } from '../../hooks/useGameKeys'
 
 type Grid = (number | null)[][]
 
@@ -177,6 +178,7 @@ export function Game2048(_props: CardComponentProps) {
   const { t: _t } = useTranslation()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const [grid, setGrid] = useState<Grid>(initGame)
   const [score, setScore] = useState(0)
   const [bestScore, setBestScore] = useState(() => {
@@ -221,43 +223,38 @@ export function Game2048(_props: CardComponentProps) {
     }
   }, [grid, score, bestScore, gameOver, won, keepPlaying])
 
-  // Keyboard controls
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (gameOver && !won) return
+  // Keyboard controls — scoped to visible game container (KeepAlive-safe)
+  const handle2048KeyDown = useCallback((e: KeyboardEvent) => {
+    if (gameOver && !won) return
 
-      switch (e.key) {
-        case 'ArrowUp':
-        case 'w':
-        case 'W':
-          e.preventDefault()
-          handleMove('up')
-          break
-        case 'ArrowDown':
-        case 's':
-        case 'S':
-          e.preventDefault()
-          handleMove('down')
-          break
-        case 'ArrowLeft':
-        case 'a':
-        case 'A':
-          e.preventDefault()
-          handleMove('left')
-          break
-        case 'ArrowRight':
-        case 'd':
-        case 'D':
-          e.preventDefault()
-          handleMove('right')
-          break
-      }
+    switch (e.key) {
+      case 'ArrowUp':
+      case 'w':
+      case 'W':
+        e.preventDefault()
+        handleMove('up')
+        break
+      case 'ArrowDown':
+      case 's':
+      case 'S':
+        e.preventDefault()
+        handleMove('down')
+        break
+      case 'ArrowLeft':
+      case 'a':
+      case 'A':
+        e.preventDefault()
+        handleMove('left')
+        break
+      case 'ArrowRight':
+      case 'd':
+      case 'D':
+        e.preventDefault()
+        handleMove('right')
+        break
     }
-
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
   }, [handleMove, gameOver, won])
+  useGameKeys(gameContainerRef, { onKeyDown: handle2048KeyDown })
 
   // New game
   const newGame = useCallback(() => {
@@ -280,7 +277,7 @@ export function Game2048(_props: CardComponentProps) {
   const fontSize = isExpanded ? 'text-2xl' : 'text-sm'
 
   return (
-    <div className="h-full flex flex-col p-2 select-none">
+    <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
       <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
         <div className="flex items-center gap-3 text-xs">

--- a/web/src/components/cards/KubeBert.tsx
+++ b/web/src/components/cards/KubeBert.tsx
@@ -4,6 +4,7 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeys } from '../../hooks/useGameKeys'
 
 // ─── Game Constants ───────────────────────────────────────────────────────────
 const PYRAMID_ROWS = 7
@@ -578,45 +579,40 @@ export function KubeBert() {
     startGameLoop()
   }, [stopIntervals, buildTileLabels, initTiles, startEnemies, startGameLoop])
 
-  // Keyboard controls
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (gameStateRef.current !== 'playing') return
+  // Keyboard controls — scoped to visible game container (KeepAlive-safe)
+  const handleBertKeyDown = useCallback((e: KeyboardEvent) => {
+    if (gameStateRef.current !== 'playing') return
 
-      // Q*bert uses diagonal movement mapped to arrow keys:
-      // Up = up-left, Right = up-right, Down = down-right, Left = down-left
-      switch (e.key) {
-        case 'ArrowUp':
-        case 'w':
-        case 'W':
-          e.preventDefault()
-          movePlayer('up-left')
-          break
-        case 'ArrowRight':
-        case 'd':
-        case 'D':
-          e.preventDefault()
-          movePlayer('up-right')
-          break
-        case 'ArrowDown':
-        case 's':
-        case 'S':
-          e.preventDefault()
-          movePlayer('down-right')
-          break
-        case 'ArrowLeft':
-        case 'a':
-        case 'A':
-          e.preventDefault()
-          movePlayer('down-left')
-          break
-      }
+    // Q*bert uses diagonal movement mapped to arrow keys:
+    // Up = up-left, Right = up-right, Down = down-right, Left = down-left
+    switch (e.key) {
+      case 'ArrowUp':
+      case 'w':
+      case 'W':
+        e.preventDefault()
+        movePlayer('up-left')
+        break
+      case 'ArrowRight':
+      case 'd':
+      case 'D':
+        e.preventDefault()
+        movePlayer('up-right')
+        break
+      case 'ArrowDown':
+      case 's':
+      case 'S':
+        e.preventDefault()
+        movePlayer('down-right')
+        break
+      case 'ArrowLeft':
+      case 'a':
+      case 'A':
+        e.preventDefault()
+        movePlayer('down-left')
+        break
     }
-
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
   }, [movePlayer])
+  useGameKeys(containerRef, { onKeyDown: handleBertKeyDown })
 
   // Resize canvas to container
   useEffect(() => {

--- a/web/src/components/cards/KubeDoom.tsx
+++ b/web/src/components/cards/KubeDoom.tsx
@@ -4,6 +4,7 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeys } from '../../hooks/useGameKeys'
 
 // Canvas dimensions
 const CANVAS_WIDTH = 480
@@ -92,6 +93,7 @@ export function KubeDoom() {
   const { t: _t } = useTranslation()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'gameover' | 'levelcomplete'>('idle')
   const [score, setScore] = useState(0)
@@ -513,31 +515,21 @@ export function KubeDoom() {
     return () => cancelAnimationFrame(animationRef.current)
   }, [gameState, update, render])
 
-  // Keyboard handlers
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      const key = e.key.toLowerCase()
-      if (['arrowup', 'arrowdown', 'arrowleft', 'arrowright', ' ', 'w', 'a', 's', 'd', 'q', 'e'].includes(key)) {
-        e.preventDefault()
-      }
-      keysRef.current.add(key)
-      if (key === ' ' && gameState === 'playing') {
-        shoot()
-      }
+  // Keyboard handlers — scoped to visible game container (KeepAlive-safe)
+  const handleDoomKeyDown = useCallback((e: KeyboardEvent) => {
+    const key = e.key.toLowerCase()
+    if (['arrowup', 'arrowdown', 'arrowleft', 'arrowright', ' ', 'w', 'a', 's', 'd', 'q', 'e'].includes(key)) {
+      e.preventDefault()
     }
-
-    const handleKeyUp = (e: KeyboardEvent) => {
-      keysRef.current.delete(e.key.toLowerCase())
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-    window.addEventListener('keyup', handleKeyUp)
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-      window.removeEventListener('keyup', handleKeyUp)
+    keysRef.current.add(key)
+    if (key === ' ' && gameState === 'playing') {
+      shoot()
     }
   }, [gameState, shoot])
+  const handleDoomKeyUp = useCallback((e: KeyboardEvent) => {
+    keysRef.current.delete(e.key.toLowerCase())
+  }, [])
+  useGameKeys(gameContainerRef, { onKeyDown: handleDoomKeyDown, onKeyUp: handleDoomKeyUp })
 
   // Render initial frame
   useEffect(() => {
@@ -563,7 +555,7 @@ export function KubeDoom() {
   }
 
   return (
-    <div className="h-full flex flex-col">
+    <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
         <div className="flex items-center justify-between w-full max-w-[480px] text-sm">

--- a/web/src/components/cards/KubeGalaga.tsx
+++ b/web/src/components/cards/KubeGalaga.tsx
@@ -6,6 +6,7 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeyTracking } from '../../hooks/useGameKeys'
 
 // Game constants
 const CANVAS_WIDTH = 400
@@ -63,6 +64,7 @@ export function KubeGalaga() {
   const { t: _t } = useTranslation()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'gameover' | 'levelcomplete'>('idle')
   const [score, setScore] = useState(0)
@@ -451,27 +453,8 @@ export function KubeGalaga() {
     return () => cancelAnimationFrame(animationRef.current)
   }, [gameState, update, render])
 
-  // Keyboard handlers
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' '].includes(e.key)) {
-        e.preventDefault()
-      }
-      keysRef.current.add(e.key.toLowerCase())
-    }
-
-    const handleKeyUp = (e: KeyboardEvent) => {
-      keysRef.current.delete(e.key.toLowerCase())
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-    window.addEventListener('keyup', handleKeyUp)
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-      window.removeEventListener('keyup', handleKeyUp)
-    }
-  }, [])
+  // Keyboard handlers — scoped to visible game container (KeepAlive-safe)
+  useGameKeyTracking(gameContainerRef, keysRef, { lowercase: true })
 
   // Render initial frame
   useEffect(() => {
@@ -500,7 +483,7 @@ export function KubeGalaga() {
   }
 
   return (
-    <div className="h-full flex flex-col">
+    <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
         <div className="flex items-center justify-between w-full max-w-[400px] text-sm">

--- a/web/src/components/cards/KubeKart.tsx
+++ b/web/src/components/cards/KubeKart.tsx
@@ -7,6 +7,7 @@ import { StatusBadge } from '../ui/StatusBadge'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeyTracking } from '../../hooks/useGameKeys'
 
 // Game constants
 const CANVAS_WIDTH = 400
@@ -67,6 +68,7 @@ export function KubeKart() {
   const { t } = useTranslation('cards')
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'countdown' | 'playing' | 'paused' | 'finished'>('idle')
   const [countdown, setCountdown] = useState(3)
@@ -494,27 +496,8 @@ export function KubeKart() {
     }
   }, [gameState, countdown])
 
-  // Keyboard handlers
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' '].includes(e.key)) {
-        e.preventDefault()
-      }
-      keysRef.current.add(e.key.toLowerCase())
-    }
-
-    const handleKeyUp = (e: KeyboardEvent) => {
-      keysRef.current.delete(e.key.toLowerCase())
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-    window.addEventListener('keyup', handleKeyUp)
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-      window.removeEventListener('keyup', handleKeyUp)
-    }
-  }, [])
+  // Keyboard handlers — scoped to visible game container (KeepAlive-safe)
+  useGameKeyTracking(gameContainerRef, keysRef, { lowercase: true })
 
   // Render initial frame
   useEffect(() => {
@@ -547,7 +530,7 @@ export function KubeKart() {
   }
 
   return (
-    <div className="h-full flex flex-col">
+    <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
         <div className="flex items-center justify-between w-full max-w-[400px] text-sm">

--- a/web/src/components/cards/KubeKong.tsx
+++ b/web/src/components/cards/KubeKong.tsx
@@ -5,6 +5,7 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeyTracking } from '../../hooks/useGameKeys'
 
 // Game constants
 const CANVAS_WIDTH = 280
@@ -93,6 +94,7 @@ export function KubeKong(_props: CardComponentProps) {
   const { t: _t } = useTranslation()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const gameLoopRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const keysRef = useRef<Set<string>>(new Set())
@@ -633,25 +635,10 @@ export function KubeKong(_props: CardComponentProps) {
     }
   }, [isPlaying, gameOver, getOnLadder, checkPlatformCollision, level, lives])
 
-  // Keyboard controls
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' ', 'w', 'a', 's', 'd', 'W', 'A', 'S', 'D'].includes(e.key)) {
-        e.preventDefault()
-        keysRef.current.add(e.key)
-      }
-    }
-    const handleKeyUp = (e: KeyboardEvent) => {
-      keysRef.current.delete(e.key)
-    }
-    window.addEventListener('keydown', handleKeyDown)
-    window.addEventListener('keyup', handleKeyUp)
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-      window.removeEventListener('keyup', handleKeyUp)
-    }
-  }, [])
+  // Keyboard controls — scoped to visible game container (KeepAlive-safe)
+  useGameKeyTracking(gameContainerRef, keysRef, {
+    preventDefaultKeys: ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' ', 'w', 'a', 's', 'd', 'W', 'A', 'S', 'D'],
+  })
 
   // Start game
   const startGame = useCallback(() => {
@@ -683,7 +670,7 @@ export function KubeKong(_props: CardComponentProps) {
   }, [draw])
 
   return (
-    <div className="h-full flex flex-col p-2 select-none">
+    <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">

--- a/web/src/components/cards/KubeMan.tsx
+++ b/web/src/components/cards/KubeMan.tsx
@@ -5,6 +5,7 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeys } from '../../hooks/useGameKeys'
 
 // Game constants
 const CELL_SIZE = 16
@@ -122,6 +123,7 @@ export function KubeMan(_props: CardComponentProps) {
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
 
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const gameLoopRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
@@ -548,35 +550,31 @@ export function KubeMan(_props: CardComponentProps) {
   }, [isPlaying, gameOver, draw, getGhostTarget])
 
   // Keyboard controls
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (!isPlaying) return
+  // Keyboard controls — scoped to visible game container (KeepAlive-safe)
+  const handleManKeyDown = useCallback((e: KeyboardEvent) => {
+    if (!isPlaying) return
 
-      const keyMap: Record<string, Direction> = {
-        ArrowUp: 'up',
-        ArrowDown: 'down',
-        ArrowLeft: 'left',
-        ArrowRight: 'right',
-        w: 'up',
-        W: 'up',
-        s: 'down',
-        S: 'down',
-        a: 'left',
-        A: 'left',
-        d: 'right',
-        D: 'right',
-      }
-
-      if (keyMap[e.key]) {
-        e.preventDefault()
-        setNextDir(keyMap[e.key])
-      }
+    const keyMap: Record<string, Direction> = {
+      ArrowUp: 'up',
+      ArrowDown: 'down',
+      ArrowLeft: 'left',
+      ArrowRight: 'right',
+      w: 'up',
+      W: 'up',
+      s: 'down',
+      S: 'down',
+      a: 'left',
+      A: 'left',
+      d: 'right',
+      D: 'right',
     }
 
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
+    if (keyMap[e.key]) {
+      e.preventDefault()
+      setNextDir(keyMap[e.key])
+    }
   }, [isPlaying])
+  useGameKeys(gameContainerRef, { onKeyDown: handleManKeyDown })
 
   // Start game
   const startGame = useCallback(() => {
@@ -612,7 +610,7 @@ export function KubeMan(_props: CardComponentProps) {
   }, [draw])
 
   return (
-    <div className="h-full flex flex-col p-2 select-none">
+    <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
       <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
         <div className="flex items-center gap-3 text-xs">

--- a/web/src/components/cards/KubePong.tsx
+++ b/web/src/components/cards/KubePong.tsx
@@ -5,6 +5,7 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeyTracking } from '../../hooks/useGameKeys'
 
 // Game constants
 const CANVAS_WIDTH = 400
@@ -44,6 +45,7 @@ export function KubePong() {
   const { t: _t } = useTranslation()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'finished'>('idle')
   const [playerScore, setPlayerScore] = useState(0)
@@ -276,27 +278,11 @@ export function KubePong() {
     return () => cancelAnimationFrame(animationRef.current)
   }, [gameState, update, render])
 
-  // Keyboard handlers
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (['ArrowUp', 'ArrowDown', ' '].includes(e.key)) {
-        e.preventDefault()
-      }
-      keysRef.current.add(e.key.toLowerCase())
-    }
-
-    const handleKeyUp = (e: KeyboardEvent) => {
-      keysRef.current.delete(e.key.toLowerCase())
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-    window.addEventListener('keyup', handleKeyUp)
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-      window.removeEventListener('keyup', handleKeyUp)
-    }
-  }, [])
+  // Keyboard handlers — scoped to visible game container (KeepAlive-safe)
+  useGameKeyTracking(gameContainerRef, keysRef, {
+    lowercase: true,
+    preventDefaultKeys: ['ArrowUp', 'ArrowDown', ' '],
+  })
 
   // Render initial frame
   useEffect(() => {
@@ -317,7 +303,7 @@ export function KubePong() {
   }
 
   return (
-    <div className="h-full flex flex-col">
+    <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
         <div className="flex items-center justify-between w-full max-w-[400px] text-sm">

--- a/web/src/components/cards/KubeSnake.tsx
+++ b/web/src/components/cards/KubeSnake.tsx
@@ -5,6 +5,7 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeys } from '../../hooks/useGameKeys'
 
 // Game constants
 const CANVAS_WIDTH = 400
@@ -36,6 +37,7 @@ export function KubeSnake() {
   const { t: _t } = useTranslation()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'gameover'>('idle')
   const [score, setScore] = useState(0)
@@ -274,32 +276,27 @@ export function KubeSnake() {
     return () => cancelAnimationFrame(gameLoopRef.current)
   }, [gameState, speed, moveSnake, render])
 
-  // Keyboard handlers
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'w', 'a', 's', 'd'].includes(e.key.toLowerCase())) {
-        e.preventDefault()
-      }
-
-      const key = e.key.toLowerCase()
-      const current = directionRef.current
-
-      // Prevent 180-degree turns
-      if ((key === 'arrowup' || key === 'w') && current !== 'down') {
-        nextDirectionRef.current = 'up'
-      } else if ((key === 'arrowdown' || key === 's') && current !== 'up') {
-        nextDirectionRef.current = 'down'
-      } else if ((key === 'arrowleft' || key === 'a') && current !== 'right') {
-        nextDirectionRef.current = 'left'
-      } else if ((key === 'arrowright' || key === 'd') && current !== 'left') {
-        nextDirectionRef.current = 'right'
-      }
+  // Keyboard handlers — scoped to visible game container (KeepAlive-safe)
+  const handleSnakeKeyDown = useCallback((e: KeyboardEvent) => {
+    if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'w', 'a', 's', 'd'].includes(e.key.toLowerCase())) {
+      e.preventDefault()
     }
 
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
+    const key = e.key.toLowerCase()
+    const current = directionRef.current
+
+    // Prevent 180-degree turns
+    if ((key === 'arrowup' || key === 'w') && current !== 'down') {
+      nextDirectionRef.current = 'up'
+    } else if ((key === 'arrowdown' || key === 's') && current !== 'up') {
+      nextDirectionRef.current = 'down'
+    } else if ((key === 'arrowleft' || key === 'a') && current !== 'right') {
+      nextDirectionRef.current = 'left'
+    } else if ((key === 'arrowright' || key === 'd') && current !== 'left') {
+      nextDirectionRef.current = 'right'
+    }
   }, [])
+  useGameKeys(gameContainerRef, { onKeyDown: handleSnakeKeyDown })
 
   // Render initial frame
   useEffect(() => {
@@ -320,7 +317,7 @@ export function KubeSnake() {
   }
 
   return (
-    <div className="h-full flex flex-col">
+    <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
         <div className="flex items-center justify-between w-full max-w-[400px] text-sm">

--- a/web/src/components/cards/Kubedle.tsx
+++ b/web/src/components/cards/Kubedle.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import { RotateCcw, HelpCircle, BarChart3, X } from 'lucide-react'
 import { CardComponentProps } from './cardRegistry'
 import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeys } from '../../hooks/useGameKeys'
 
 // 5-letter Kubernetes-themed words
 const WORD_LIST = [
@@ -128,6 +129,7 @@ export function Kubedle(_props: CardComponentProps) {
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
 
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const [targetWord, setTargetWord] = useState(getTodaysWord)
   const [guesses, setGuesses] = useState<string[]>([])
   const [currentGuess, setCurrentGuess] = useState('')
@@ -222,17 +224,12 @@ export function Kubedle(_props: CardComponentProps) {
     }
   }, [currentGuess, guesses, gameOver, targetWord])
 
-  // Physical keyboard
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (showStats || showHelp) return
-      handleKey(e.key)
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
+  // Physical keyboard — scoped to visible game container (KeepAlive-safe)
+  const handleKubedleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (showStats || showHelp) return
+    handleKey(e.key)
   }, [handleKey, showStats, showHelp])
+  useGameKeys(gameContainerRef, { onKeyDown: handleKubedleKeyDown })
 
   // New game
   const newGame = useCallback((practice: boolean = false) => {
@@ -250,7 +247,7 @@ export function Kubedle(_props: CardComponentProps) {
   const keySize = isExpanded ? 'min-w-[32px] h-10 text-sm' : 'min-w-[24px] h-8 text-xs'
 
   return (
-    <div className="h-full flex flex-col p-2 select-none">
+    <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       {/* Header */}
       <div className="flex items-center justify-between gap-2 mb-2">
         {practiceMode && (

--- a/web/src/components/cards/NodeInvaders.tsx
+++ b/web/src/components/cards/NodeInvaders.tsx
@@ -5,6 +5,7 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeyTracking } from '../../hooks/useGameKeys'
 
 // Game constants
 const CANVAS_WIDTH = 300
@@ -43,6 +44,7 @@ export function NodeInvaders(_props: CardComponentProps) {
   const { t: _t } = useTranslation()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const gameLoopRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const keysRef = useRef<Set<string>>(new Set())
@@ -370,25 +372,10 @@ export function NodeInvaders(_props: CardComponentProps) {
     }
   }, [isPlaying, gameOver, draw, initInvaders, initShields, canShoot, invaderSpeed])
 
-  // Keyboard
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (['ArrowLeft', 'ArrowRight', 'ArrowUp', ' ', 'a', 'd', 'A', 'D'].includes(e.key)) {
-        e.preventDefault()
-        keysRef.current.add(e.key)
-      }
-    }
-    const handleKeyUp = (e: KeyboardEvent) => {
-      keysRef.current.delete(e.key)
-    }
-    window.addEventListener('keydown', handleKeyDown)
-    window.addEventListener('keyup', handleKeyUp)
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-      window.removeEventListener('keyup', handleKeyUp)
-    }
-  }, [])
+  // Keyboard — scoped to visible game container (KeepAlive-safe)
+  useGameKeyTracking(gameContainerRef, keysRef, {
+    preventDefaultKeys: ['ArrowLeft', 'ArrowRight', 'ArrowUp', ' ', 'a', 'd', 'A', 'D'],
+  })
 
   // Start game
   const startGame = useCallback(() => {
@@ -413,7 +400,7 @@ export function NodeInvaders(_props: CardComponentProps) {
   }, [draw])
 
   return (
-    <div className="h-full flex flex-col p-2 select-none">
+    <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
         <div className="flex items-center gap-1.5">
           <Rocket className="w-4 h-4 text-cyan-400" />

--- a/web/src/components/cards/PodBrothers.tsx
+++ b/web/src/components/cards/PodBrothers.tsx
@@ -6,6 +6,7 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeyTracking } from '../../hooks/useGameKeys'
 
 // Game constants
 const CANVAS_WIDTH = 480
@@ -82,6 +83,7 @@ export function PodBrothers() {
   const { t: _t } = useTranslation()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'won' | 'lost'>('idle')
   const [score, setScore] = useState(0)
@@ -469,27 +471,8 @@ export function PodBrothers() {
     return () => cancelAnimationFrame(animationRef.current)
   }, [gameState, update, render])
 
-  // Keyboard handlers
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' '].includes(e.key)) {
-        e.preventDefault()
-      }
-      keysRef.current.add(e.key)
-    }
-
-    const handleKeyUp = (e: KeyboardEvent) => {
-      keysRef.current.delete(e.key)
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-    window.addEventListener('keyup', handleKeyUp)
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-      window.removeEventListener('keyup', handleKeyUp)
-    }
-  }, [])
+  // Keyboard handlers — scoped to visible game container (KeepAlive-safe)
+  useGameKeyTracking(gameContainerRef, keysRef)
 
   // Render initial frame
   useEffect(() => {
@@ -512,7 +495,7 @@ export function PodBrothers() {
   }
 
   return (
-    <div className="h-full flex flex-col">
+    <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
         <div className="flex items-center justify-between w-full max-w-[480px] text-sm">

--- a/web/src/components/cards/PodCrosser.tsx
+++ b/web/src/components/cards/PodCrosser.tsx
@@ -5,6 +5,7 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeys } from '../../hooks/useGameKeys'
 
 // Game constants
 const CANVAS_WIDTH = 280
@@ -65,6 +66,7 @@ export function PodCrosser(_props: CardComponentProps) {
   const { t: _t } = useTranslation()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const gameLoopRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
@@ -490,57 +492,52 @@ export function PodCrosser(_props: CardComponentProps) {
     }
   }, [isPlaying, gameOver, draw, level])
 
-  // Keyboard controls
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (!isPlaying || player.dead) return
+  // Keyboard controls — scoped to visible game container (KeepAlive-safe)
+  const handleCrosserKeyDown = useCallback((e: KeyboardEvent) => {
+    if (!isPlaying || player.dead) return
 
-      const { targetX, targetY } = player
-      let newTargetX = targetX
-      let newTargetY = targetY
+    const { targetX, targetY } = player
+    let newTargetX = targetX
+    let newTargetY = targetY
 
-      switch (e.key) {
-        case 'ArrowUp':
-        case 'w':
-        case 'W': {
-          newTargetY = Math.max(0, targetY - CELL_SIZE)
-          // Score for forward progress
-          const newRow = Math.floor(newTargetY / CELL_SIZE)
-          if (newRow < highestRow) {
-            setScore(s => s + 10)
-            setHighestRow(newRow)
-          }
-          break
+    switch (e.key) {
+      case 'ArrowUp':
+      case 'w':
+      case 'W': {
+        newTargetY = Math.max(0, targetY - CELL_SIZE)
+        // Score for forward progress
+        const newRow = Math.floor(newTargetY / CELL_SIZE)
+        if (newRow < highestRow) {
+          setScore(s => s + 10)
+          setHighestRow(newRow)
         }
-        case 'ArrowDown':
-        case 's':
-        case 'S':
-          newTargetY = Math.min((ROWS - 1) * CELL_SIZE, targetY + CELL_SIZE)
-          break
-        case 'ArrowLeft':
-        case 'a':
-        case 'A':
-          newTargetX = Math.max(0, targetX - CELL_SIZE)
-          break
-        case 'ArrowRight':
-        case 'd':
-        case 'D':
-          newTargetX = Math.min(CANVAS_WIDTH - PLAYER_SIZE, targetX + CELL_SIZE)
-          break
-        default:
-          return
+        break
       }
-
-      e.preventDefault()
-      // Only add the 4px lane offset when vertical position changed
-      const yOffset = newTargetY !== targetY ? 4 : 0
-      setPlayer(p => ({ ...p, targetX: newTargetX, targetY: newTargetY + yOffset, onLog: null }))
+      case 'ArrowDown':
+      case 's':
+      case 'S':
+        newTargetY = Math.min((ROWS - 1) * CELL_SIZE, targetY + CELL_SIZE)
+        break
+      case 'ArrowLeft':
+      case 'a':
+      case 'A':
+        newTargetX = Math.max(0, targetX - CELL_SIZE)
+        break
+      case 'ArrowRight':
+      case 'd':
+      case 'D':
+        newTargetX = Math.min(CANVAS_WIDTH - PLAYER_SIZE, targetX + CELL_SIZE)
+        break
+      default:
+        return
     }
 
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
+    e.preventDefault()
+    // Only add the 4px lane offset when vertical position changed
+    const yOffset = newTargetY !== targetY ? 4 : 0
+    setPlayer(p => ({ ...p, targetX: newTargetX, targetY: newTargetY + yOffset, onLog: null }))
   }, [isPlaying, player, highestRow])
+  useGameKeys(gameContainerRef, { onKeyDown: handleCrosserKeyDown })
 
   // Start game
   const startGame = useCallback(() => {
@@ -572,7 +569,7 @@ export function PodCrosser(_props: CardComponentProps) {
   }, [draw])
 
   return (
-    <div className="h-full flex flex-col p-2 select-none">
+    <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">

--- a/web/src/components/cards/PodPitfall.tsx
+++ b/web/src/components/cards/PodPitfall.tsx
@@ -5,6 +5,7 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
+import { useGameKeyTracking } from '../../hooks/useGameKeys'
 
 // Game constants
 const CANVAS_WIDTH = 320
@@ -55,6 +56,7 @@ export function PodPitfall(_props: CardComponentProps) {
   const { t: _t } = useTranslation()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
   const { isExpanded } = useCardExpanded()
+  const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const gameLoopRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const keysRef = useRef<Set<string>>(new Set())
@@ -506,25 +508,10 @@ export function PodPitfall(_props: CardComponentProps) {
     }
   }, [isPlaying, gameOver, draw, player.x, distance])
 
-  // Keyboard
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || (e.target instanceof HTMLElement && e.target.isContentEditable)) return
-      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' ', 'w', 'a', 's', 'd'].includes(e.key)) {
-        e.preventDefault()
-        keysRef.current.add(e.key)
-      }
-    }
-    const handleKeyUp = (e: KeyboardEvent) => {
-      keysRef.current.delete(e.key)
-    }
-    window.addEventListener('keydown', handleKeyDown)
-    window.addEventListener('keyup', handleKeyUp)
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown)
-      window.removeEventListener('keyup', handleKeyUp)
-    }
-  }, [])
+  // Keyboard — scoped to visible game container (KeepAlive-safe)
+  useGameKeyTracking(gameContainerRef, keysRef, {
+    preventDefaultKeys: ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' ', 'w', 'a', 's', 'd'],
+  })
 
   // Start game
   const startGame = useCallback(() => {
@@ -557,7 +544,7 @@ export function PodPitfall(_props: CardComponentProps) {
   }, [draw])
 
   return (
-    <div className="h-full flex flex-col p-2 select-none">
+    <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">
       <div className="flex items-center justify-between gap-2 mb-2 flex-wrap">
         <div className="flex items-center gap-3 text-xs">
           <div className="text-center">

--- a/web/src/hooks/useGameKeys.ts
+++ b/web/src/hooks/useGameKeys.ts
@@ -1,0 +1,128 @@
+/**
+ * useGameKeys — scoped keyboard listener for game card components.
+ *
+ * Problem: KeepAlive keeps dashboard pages mounted (with display:none) even
+ * after the user navigates away.  Game components that register global
+ * `window` keydown/keyup listeners therefore capture keys across the entire
+ * app — breaking text inputs, the kubectl terminal, and bug-report fields.
+ *
+ * Solution: this hook checks whether the game's container element is actually
+ * visible before forwarding keyboard events.  It also skips events whose
+ * target is an input, textarea, or contentEditable element.
+ *
+ * Usage (direct-action games):
+ *   const containerRef = useRef<HTMLDivElement>(null)
+ *   useGameKeys(containerRef, { onKeyDown: handler })
+ *
+ * Usage (key-tracking games):
+ *   const containerRef = useRef<HTMLDivElement>(null)
+ *   const keysRef = useRef<Set<string>>(new Set())
+ *   useGameKeyTracking(containerRef, keysRef)
+ */
+
+import { useEffect, RefObject, MutableRefObject } from 'react'
+
+/** Returns true if the element is inside a hidden KeepAlive container. */
+function isHiddenByKeepAlive(el: HTMLElement): boolean {
+  let node: HTMLElement | null = el
+  while (node) {
+    if (node.dataset?.keepaliveActive === 'false') return true
+    // Also check computed display — covers KeepAlive's display:none
+    if (node.style?.display === 'none') return true
+    node = node.parentElement
+  }
+  return false
+}
+
+function isEditableTarget(e: KeyboardEvent): boolean {
+  const t = e.target
+  if (t instanceof HTMLInputElement) return true
+  if (t instanceof HTMLTextAreaElement) return true
+  if (t instanceof HTMLElement && t.isContentEditable) return true
+  return false
+}
+
+interface GameKeyOptions {
+  onKeyDown?: (e: KeyboardEvent) => void
+  onKeyUp?: (e: KeyboardEvent) => void
+}
+
+/**
+ * Register scoped keydown/keyup listeners that only fire when the game
+ * container is visible (not hidden by KeepAlive) and the event target is
+ * not an editable element.
+ */
+export function useGameKeys(
+  containerRef: RefObject<HTMLElement | null>,
+  { onKeyDown, onKeyUp }: GameKeyOptions,
+) {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isEditableTarget(e)) return
+      if (!containerRef.current || isHiddenByKeepAlive(containerRef.current)) return
+      onKeyDown?.(e)
+    }
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (isEditableTarget(e)) return
+      if (!containerRef.current || isHiddenByKeepAlive(containerRef.current)) return
+      onKeyUp?.(e)
+    }
+
+    if (onKeyDown) window.addEventListener('keydown', handleKeyDown)
+    if (onKeyUp) window.addEventListener('keyup', handleKeyUp)
+
+    return () => {
+      if (onKeyDown) window.removeEventListener('keydown', handleKeyDown)
+      if (onKeyUp) window.removeEventListener('keyup', handleKeyUp)
+    }
+  }, [containerRef, onKeyDown, onKeyUp])
+}
+
+interface GameKeyTrackingOptions {
+  /** Keys for which preventDefault() is called (default: arrows + space). */
+  preventDefaultKeys?: string[]
+  /** When true, keys are stored/deleted as lowercase (default: false). */
+  lowercase?: boolean
+}
+
+/**
+ * Convenience wrapper for games that use a `keysRef` Set to track held keys.
+ * Adds keys on keydown, removes on keyup, and clears the set when the
+ * container becomes hidden.
+ */
+export function useGameKeyTracking(
+  containerRef: RefObject<HTMLElement | null>,
+  keysRef: MutableRefObject<Set<string>>,
+  options: GameKeyTrackingOptions = {},
+) {
+  const {
+    preventDefaultKeys = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', ' '],
+    lowercase = false,
+  } = options
+
+  useEffect(() => {
+    const preventSet = new Set(preventDefaultKeys)
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isEditableTarget(e)) return
+      if (!containerRef.current || isHiddenByKeepAlive(containerRef.current)) return
+      if (preventSet.has(e.key)) e.preventDefault()
+      keysRef.current.add(lowercase ? e.key.toLowerCase() : e.key)
+    }
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      keysRef.current.delete(lowercase ? e.key.toLowerCase() : e.key)
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
+      keysRef.current.clear()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [containerRef, keysRef])
+}


### PR DESCRIPTION
## Summary
- Extract game keyboard handling into a shared `useGameKeys` hook
- All 16 arcade game components now use the hook, which properly removes event listeners on unmount
- Prevents WASD/Space keys from being captured globally after visiting the Arcade dashboard

## Test plan
- [ ] Visit Arcade dashboard, play a game, navigate away — WASD/Space work in text inputs
- [ ] Game controls still work while playing
- [ ] All 16 arcade games function correctly

Closes #3717

🤖 Generated with [Claude Code](https://claude.com/claude-code)