### PR TITLE
fix: smooth banner close button hover animation

### DIFF
--- a/web/src/components/dashboard/GettingStartedBanner.tsx
+++ b/web/src/components/dashboard/GettingStartedBanner.tsx
@@ -99,7 +99,7 @@ export function GettingStartedBanner({
         </div>
         <button
           onClick={handleDismiss}
-          className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors flex-shrink-0 min-h-11 min-w-11 flex items-center justify-center"
+          className="p-1.5 rounded-md hover:bg-secondary/80 text-muted-foreground hover:text-foreground transition-colors duration-150 flex-shrink-0 flex items-center justify-center"
           aria-label="Dismiss"
         >
           <X className="w-3.5 h-3.5" />

--- a/web/src/components/dashboard/PostConnectBanner.tsx
+++ b/web/src/components/dashboard/PostConnectBanner.tsx
@@ -120,7 +120,7 @@ export function PostConnectBanner({
         </div>
         <button
           onClick={handleDismiss}
-          className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors flex-shrink-0 min-h-11 min-w-11 flex items-center justify-center"
+          className="p-1.5 rounded-md hover:bg-secondary/80 text-muted-foreground hover:text-foreground transition-colors duration-150 flex-shrink-0 flex items-center justify-center"
           aria-label="Dismiss"
         >
           <X className="w-3.5 h-3.5" />

--- a/web/src/components/updates/UpdateProgressBanner.tsx
+++ b/web/src/components/updates/UpdateProgressBanner.tsx
@@ -59,7 +59,7 @@ export function UpdateProgressBanner({ progress, onDismiss }: UpdateProgressBann
           setVisible(false)
           onDismiss()
         }}
-        className="p-1 hover:bg-secondary/50 rounded shrink-0"
+        className="p-1 hover:bg-secondary/50 rounded shrink-0 transition-colors duration-150"
       >
         <X className="w-3 h-3" />
       </button>


### PR DESCRIPTION
## Summary
- Removed oversized `min-h-11 min-w-11` (44px) touch targets from GettingStartedBanner and PostConnectBanner dismiss buttons that caused a jarring hover highlight over a large area around a small 14px icon
- Replaced with proportional `p-1.5 rounded-md` padding and explicit `transition-colors duration-150` for a smooth hover effect
- Added missing `transition-colors duration-150` to UpdateProgressBanner dismiss button which had no transition at all

## Test plan
- [ ] Hover over the dismiss (X) button on the Getting Started banner — hover highlight should appear smoothly and be proportional to the icon
- [ ] Hover over the dismiss (X) button on the Post-Connect banner — same smooth behavior
- [ ] Hover over the dismiss (X) button on the Update Progress banner — smooth color transition
- [ ] Verify dismiss buttons still work correctly on click

Closes #3734

🤖 Generated with [Claude Code](https://claude.com/claude-code)