### PR TITLE
fix: make dashboard respond to AI mission sidebar resize

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -9,7 +9,6 @@ import { useSidebarConfig, SIDEBAR_COLLAPSED_WIDTH_PX, SIDEBAR_DEFAULT_WIDTH_PX 
 import { useMobile } from '../../hooks/useMobile'
 import { useNavigationHistory } from '../../hooks/useNavigationHistory'
 import { useLastRoute } from '../../hooks/useLastRoute'
-import { useMissions } from '../../hooks/useMissions'
 import { useDemoMode, isDemoModeForced, hasRealToken } from '../../hooks/useDemoMode'
 import { setDemoMode } from '../../lib/demoMode'
 import { hasApprovedAgents } from '../agent/AgentApprovalDialog'
@@ -95,7 +94,8 @@ export function Layout({ children }: LayoutProps) {
   const { config } = useSidebarConfig()
   const { isMobile } = useMobile()
   const sidebarWidthPx = isMobile ? 0 : (config.collapsed ? SIDEBAR_COLLAPSED_WIDTH_PX : (config.width ?? SIDEBAR_DEFAULT_WIDTH_PX))
-  const { isSidebarOpen: isMissionSidebarOpen, isSidebarMinimized: isMissionSidebarMinimized, isFullScreen: isMissionFullScreen } = useMissions()
+  // Mission sidebar width is communicated via CSS custom property --mission-sidebar-width
+  // set by MissionSidebar.tsx — no need to read sidebar state from the hook here.
   const { isDemoMode, toggleDemoMode } = useDemoMode()
   const { status: agentStatus } = useLocalAgent()
   const { deduplicatedClusters } = useClusters()
@@ -456,13 +456,9 @@ export function Layout({ children }: LayoutProps) {
       {/* Offline Mode Banner - positioned in main content area only */}
       {showOfflineBanner && (
         <div
-          style={{ top: offlineBannerTop, left: sidebarWidthPx }}
-          className={cn(
-            "fixed z-20 bg-background border-b border-orange-500/20 transition-[right] duration-300",
-          // Adjust right edge when mission sidebar is open (desktop only)
-          !isMobile && isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen ? "right-[680px]" : "right-0",
-          !isMobile && isMissionSidebarOpen && isMissionSidebarMinimized && !isMissionFullScreen && "right-12"
-        )}>
+          style={{ top: offlineBannerTop, left: sidebarWidthPx, right: 'var(--mission-sidebar-width, 0px)' }}
+          className="fixed z-20 bg-background border-b border-orange-500/20 transition-[right] duration-300"
+        >
           <div className="flex flex-wrap items-center justify-between gap-2 py-1.5 px-3 md:px-4">
             <div className="flex items-center gap-2 min-w-0">
               <WifiOff className="w-4 h-4 text-orange-400 shrink-0" />
@@ -507,13 +503,9 @@ export function Layout({ children }: LayoutProps) {
         </PageErrorBoundary>
         <main
           id="main-content"
-          style={{ marginLeft: sidebarWidthPx }}
-          className={cn(
-            'relative flex-1 p-4 pb-24 md:p-6 md:pb-28 transition-[margin] duration-300 overflow-y-auto scroll-enhanced min-w-0',
-            // Don't apply right margin when fullscreen is active or on mobile
-            !isMobile && isMissionSidebarOpen && !isMissionSidebarMinimized && !isMissionFullScreen && 'mr-[680px]',
-            !isMobile && isMissionSidebarOpen && isMissionSidebarMinimized && !isMissionFullScreen && 'mr-12'
-          )}>
+          style={{ marginLeft: sidebarWidthPx, marginRight: 'var(--mission-sidebar-width, 0px)' }}
+          className="relative flex-1 p-4 pb-24 md:p-6 md:pb-28 transition-[margin] duration-300 overflow-y-auto scroll-enhanced min-w-0"
+        >
           <NavigationProgress />
           {children ? (
             <PageErrorBoundary>

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -48,13 +48,13 @@ import { MISSION_FILE_FETCH_TIMEOUT_MS } from '../../missions/browser/missionCac
 import { isDemoMode } from '../../../lib/demoMode'
 
 const SIDEBAR_MIN_WIDTH = 380
-const SIDEBAR_MAX_WIDTH = 1200
-const SIDEBAR_DEFAULT_WIDTH = 680
+const SIDEBAR_MAX_WIDTH = 800
+const SIDEBAR_DEFAULT_WIDTH = 480
 const SIDEBAR_WIDTH_KEY = 'ksc-mission-sidebar-width'
 
 function loadSavedWidth(): number {
   const maxW = typeof window !== 'undefined'
-    ? Math.min(SIDEBAR_MAX_WIDTH, window.innerWidth * 0.85)
+    ? Math.min(SIDEBAR_MAX_WIDTH, window.innerWidth * 0.6)
     : SIDEBAR_MAX_WIDTH
   try {
     const saved = localStorage.getItem(SIDEBAR_WIDTH_KEY)
@@ -78,10 +78,24 @@ export function MissionSidebar() {
   const [isResizing, setIsResizing] = useState(false)
   const latestWidthRef = useRef(sidebarWidth)
 
+  // Publish sidebar width as a CSS custom property so Layout.tsx can
+  // adjust main-content margins without needing context plumbing.
+  useEffect(() => {
+    const root = document.documentElement
+    if (!isMobile && isSidebarOpen && !isSidebarMinimized && !isFullScreen) {
+      root.style.setProperty('--mission-sidebar-width', `${sidebarWidth}px`)
+    } else if (!isMobile && isSidebarOpen && isSidebarMinimized && !isFullScreen) {
+      root.style.setProperty('--mission-sidebar-width', '48px')
+    } else {
+      root.style.setProperty('--mission-sidebar-width', '0px')
+    }
+    return () => { root.style.removeProperty('--mission-sidebar-width') }
+  }, [isMobile, isSidebarOpen, isSidebarMinimized, isFullScreen, sidebarWidth])
+
   // Re-clamp sidebar width when viewport is resized
   useEffect(() => {
     const onResize = () => {
-      const maxW = Math.min(SIDEBAR_MAX_WIDTH, window.innerWidth * 0.85)
+      const maxW = Math.min(SIDEBAR_MAX_WIDTH, window.innerWidth * 0.6)
       setSidebarWidth((w) => {
         const clamped = Math.min(w, maxW)
         latestWidthRef.current = clamped
@@ -95,13 +109,14 @@ export function MissionSidebar() {
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
     setIsResizing(true)
+    document.documentElement.dataset.missionResizing = '1'
     const startX = e.clientX
     const startWidth = sidebarWidth
 
     const onMouseMove = (ev: MouseEvent) => {
       // Sidebar is on the right, so dragging left increases width
       const delta = startX - ev.clientX
-      const maxW = Math.min(SIDEBAR_MAX_WIDTH, window.innerWidth * 0.85)
+      const maxW = Math.min(SIDEBAR_MAX_WIDTH, window.innerWidth * 0.6)
       const newWidth = Math.max(SIDEBAR_MIN_WIDTH, Math.min(maxW, startWidth + delta))
       latestWidthRef.current = newWidth
       setSidebarWidth(newWidth)
@@ -109,6 +124,7 @@ export function MissionSidebar() {
 
     const onMouseUp = () => {
       setIsResizing(false)
+      delete document.documentElement.dataset.missionResizing
       document.removeEventListener('mousemove', onMouseMove)
       document.removeEventListener('mouseup', onMouseUp)
       document.body.style.cursor = ''


### PR DESCRIPTION
## Summary
- The main content area now dynamically adjusts when the mission sidebar is resized, preventing overlap and ensuring toolbar buttons remain visible
- Reduces max sidebar width from 1200px/85vw to 800px/60vw and default from 680px to 480px to prevent excessive panel growth
- Replaces hardcoded `mr-[680px]` in Layout.tsx with a CSS custom property (`--mission-sidebar-width`) set by MissionSidebar, so the dashboard margin always tracks the actual sidebar width

## Test plan
- [ ] Open AI missions sidebar and resize it — main dashboard content should shrink/grow accordingly with no overlap
- [ ] Resize sidebar to minimum — verify buttons and controls remain visible (min 380px)
- [ ] Resize sidebar to maximum — verify it caps at 800px or 60% of viewport, whichever is smaller
- [ ] Toggle fullscreen mode — main content should reclaim full width
- [ ] Minimize sidebar — main content should show correct narrow margin (48px)
- [ ] Check offline banner positioning adjusts with sidebar resize
- [ ] Test on mobile — sidebar should behave as bottom sheet, no regressions

Closes #3735

🤖 Generated with [Claude Code](https://claude.com/claude-code)