### PR TITLE
fix: add bounds checking for int32 conversion in replicas param

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"os/exec"
@@ -1461,8 +1462,15 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 		namespace = r.URL.Query().Get("namespace")
 		name = r.URL.Query().Get("name")
 		if r.URL.Query().Get("replicas") != "" {
-			n, _ := strconv.Atoi(r.URL.Query().Get("replicas"))
-			replicas = int32(n)
+			n, err := strconv.Atoi(r.URL.Query().Get("replicas"))
+			if err != nil || n < math.MinInt32 || n > math.MaxInt32 {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"success": false,
+					"error":   "invalid replicas value",
+				})
+				return
+			}
+			replicas = int32(n) // #nosec G109 -- bounds checked above
 		}
 	}
 


### PR DESCRIPTION
Closes #3691

## Summary
- Adds bounds checking (`math.MinInt32` / `math.MaxInt32`) before casting `strconv.Atoi` result to `int32` in `pkg/agent/server.go`
- Handles the previously-ignored `strconv.Atoi` error, returning a proper error response for invalid input
- Adds `#nosec G109` annotation to confirm the bounds check satisfies gosec

## Test plan
- [x] `go build ./...` passes
- [x] `bash scripts/gosec-test.sh` passes with no security issues