### PR TITLE
fix: batch consecutive setState calls to prevent UI flicker

### DIFF
--- a/web/src/components/clusters/components/ClusterGroups.tsx
+++ b/web/src/components/clusters/components/ClusterGroups.tsx
@@ -30,26 +30,26 @@ export function ClusterGroups({
   onDeleteGroup,
 }: ClusterGroupsProps) {
   const { t: _t } = useTranslation()
-  const [showGroupForm, setShowGroupForm] = useState(false)
-  const [newGroupName, setNewGroupName] = useState('')
-  const [newGroupClusters, setNewGroupClusters] = useState<string[]>([])
+  const [formState, setFormState] = useState({
+    showForm: false,
+    name: '',
+    clusters: [] as string[],
+  })
+
+  const resetForm = () => setFormState({ showForm: false, name: '', clusters: [] })
 
   const handleCreateGroup = () => {
-    if (newGroupName.trim() && newGroupClusters.length > 0) {
-      onAddGroup({ name: newGroupName.trim(), clusters: newGroupClusters })
-      setShowGroupForm(false)
-      setNewGroupName('')
-      setNewGroupClusters([])
+    if (formState.name.trim() && formState.clusters.length > 0) {
+      onAddGroup({ name: formState.name.trim(), clusters: formState.clusters })
+      resetForm()
     }
   }
 
   const handleCancel = () => {
-    setShowGroupForm(false)
-    setNewGroupName('')
-    setNewGroupClusters([])
+    resetForm()
   }
 
-  if (clusterGroups.length === 0 && !showGroupForm) {
+  if (clusterGroups.length === 0 && !formState.showForm) {
     return null
   }
 
@@ -65,7 +65,7 @@ export function ClusterGroups({
           {showGroups ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
         </button>
         <button
-          onClick={() => setShowGroupForm(!showGroupForm)}
+          onClick={() => setFormState(prev => ({ ...prev, showForm: !prev.showForm }))}
           className="flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors"
         >
           <Plus className="w-3.5 h-3.5" />
@@ -76,29 +76,29 @@ export function ClusterGroups({
       {showGroups && (
         <div className="space-y-2">
           {/* New Group Form */}
-          {showGroupForm && (
+          {formState.showForm && (
             <div className="glass p-4 rounded-lg space-y-3">
               <input
                 type="text"
                 placeholder="Group name..."
-                value={newGroupName}
-                onChange={(e) => setNewGroupName(e.target.value)}
+                value={formState.name}
+                onChange={(e) => setFormState(prev => ({ ...prev, name: e.target.value }))}
                 className="w-full px-3 py-2 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
                 autoFocus
               />
               <div className="text-xs text-muted-foreground mb-1">Select clusters for this group:</div>
               <div className="flex flex-wrap gap-2">
                 {clusters.map((cluster) => {
-                  const isInGroup = newGroupClusters.includes(cluster.name)
+                  const isInGroup = formState.clusters.includes(cluster.name)
                   const unreachable = isClusterUnreachable(cluster)
                   return (
                     <button
                       key={cluster.name}
                       onClick={() => {
                         if (isInGroup) {
-                          setNewGroupClusters(prev => prev.filter(c => c !== cluster.name))
+                          setFormState(prev => ({ ...prev, clusters: prev.clusters.filter(c => c !== cluster.name) }))
                         } else {
-                          setNewGroupClusters(prev => [...prev, cluster.name])
+                          setFormState(prev => ({ ...prev, clusters: [...prev.clusters, cluster.name] }))
                         }
                       }}
                       className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors ${
@@ -128,7 +128,7 @@ export function ClusterGroups({
                 </button>
                 <button
                   onClick={handleCreateGroup}
-                  disabled={!newGroupName.trim() || newGroupClusters.length === 0}
+                  disabled={!formState.name.trim() || formState.clusters.length === 0}
                   className="flex items-center gap-1 px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/80 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   <Check className="w-3.5 h-3.5" />

--- a/web/src/components/clusters/components/RenameModal.tsx
+++ b/web/src/components/clusters/components/RenameModal.tsx
@@ -14,33 +14,31 @@ interface RenameModalProps {
 export function RenameModal({ isOpen = true, clusterName, currentDisplayName, onClose, onRename }: RenameModalProps) {
   const { t: _t } = useTranslation()
   const [newName, setNewName] = useState(currentDisplayName)
-  const [isRenaming, setIsRenaming] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [status, setStatus] = useState<{ renaming: boolean; error: string | null }>({ renaming: false, error: null })
 
   const handleRename = async () => {
     if (!newName.trim()) {
-      setError('Name cannot be empty')
+      setStatus(prev => ({ ...prev, error: 'Name cannot be empty' }))
       return
     }
     if (newName.includes(' ')) {
-      setError('Name cannot contain spaces')
+      setStatus(prev => ({ ...prev, error: 'Name cannot contain spaces' }))
       return
     }
     if (newName.trim() === currentDisplayName) {
-      setError('Name is unchanged')
+      setStatus(prev => ({ ...prev, error: 'Name is unchanged' }))
       return
     }
 
-    setIsRenaming(true)
-    setError(null)
+    setStatus({ renaming: true, error: null })
 
     try {
       await onRename(clusterName, newName.trim())
       onClose()
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to rename context')
+      setStatus({ renaming: false, error: err instanceof Error ? err.message : 'Failed to rename context' })
     } finally {
-      setIsRenaming(false)
+      setStatus(prev => ({ ...prev, renaming: false }))
     }
   }
 
@@ -72,7 +70,7 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
           />
         </div>
 
-        {error && <p className="text-sm text-red-400 mb-4">{error}</p>}
+        {status.error && <p className="text-sm text-red-400 mb-4">{status.error}</p>}
 
         <p className="text-xs text-muted-foreground">This updates your kubeconfig via the local agent.</p>
       </BaseModal.Content>
@@ -85,10 +83,10 @@ export function RenameModal({ isOpen = true, clusterName, currentDisplayName, on
           </button>
           <button
             onClick={handleRename}
-            disabled={isRenaming || !newName.trim()}
+            disabled={status.renaming || !newName.trim()}
             className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm bg-primary text-primary-foreground hover:bg-primary/80 disabled:opacity-50"
           >
-            {isRenaming ? <><Loader2 className="w-4 h-4 animate-spin" />Renaming...</> : <><Check className="w-4 h-4" />Rename</>}
+            {status.renaming ? <><Loader2 className="w-4 h-4 animate-spin" />Renaming...</> : <><Check className="w-4 h-4" />Rename</>}
           </button>
         </div>
       </BaseModal.Footer>


### PR DESCRIPTION
Closes #3739

## Summary
- Consolidated three separate `useState` calls in `ClusterGroups.tsx` (`showGroupForm`, `newGroupName`, `newGroupClusters`) into a single `formState` object so that create/cancel actions update all fields in one render
- Consolidated `isRenaming` and `error` state in `RenameModal.tsx` into a single `status` object so that the rename-start transition (set renaming + clear error) is a single state update
- All existing tests pass (7/7 in RenameModal.test.tsx)

## Test plan
- [x] `npm run build` passes
- [x] RenameModal unit tests pass (7/7)
- [x] TypeScript type-check clean