### PR TITLE
fix: use isLoading && !hasData pattern in DNSHealth card

### DIFF
--- a/web/src/components/cards/DNSHealth.tsx
+++ b/web/src/components/cards/DNSHealth.tsx
@@ -6,10 +6,11 @@ import { useCardLoadingState } from './CardDataContext'
 export function DNSHealth() {
   const { t } = useTranslation('cards')
   const { pods, isLoading, isRefreshing, isDemoFallback, isFailed, consecutiveFailures } = useCachedPods(undefined, 'kube-system')
+  const hasData = pods.length > 0
   const { showSkeleton } = useCardLoadingState({
-    isLoading,
+    isLoading: isLoading && !hasData,
     isRefreshing,
-    hasAnyData: pods.length > 0,
+    hasAnyData: hasData,
     isDemoData: isDemoFallback,
     isFailed,
     consecutiveFailures,


### PR DESCRIPTION
Closes #3690

## Summary
- Replace bare `isLoading` shorthand with `isLoading: isLoading && !hasData` in `DNSHealth.tsx`'s `useCardLoadingState` call
- Extract `hasData` variable to avoid skeleton flash when cached pod data already exists
- Follows the standard pattern required by `card-loading-standard.test.ts`

## Test plan
- [x] `npx vitest run src/test/card-loading-standard.test.ts` — all 441 tests pass
- [x] `npm run build` — passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>