### PR TITLE
fix: ensure touch targets meet 44px WCAG 2.5.5 minimum

### DIFF
--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -173,7 +173,7 @@ const LocalClusterControls = memo(function LocalClusterControls({
         <button
           onClick={(e) => handleAction('start', e)}
           disabled={!!actionInProgress}
-          className={`p-1 rounded transition-colors ${
+          className={`p-2 min-h-11 min-w-11 flex items-center justify-center rounded transition-colors ${
             actionInProgress === 'start'
               ? 'text-green-400 bg-green-500/20'
               : 'text-muted-foreground hover:text-green-400 hover:bg-green-500/20'
@@ -186,7 +186,7 @@ const LocalClusterControls = memo(function LocalClusterControls({
         <button
           onClick={(e) => handleAction('stop', e)}
           disabled={!!actionInProgress}
-          className={`p-1 rounded transition-colors ${
+          className={`p-2 min-h-11 min-w-11 flex items-center justify-center rounded transition-colors ${
             actionInProgress === 'stop'
               ? 'text-red-400 bg-red-500/20'
               : 'text-muted-foreground hover:text-red-400 hover:bg-red-500/20'
@@ -199,7 +199,7 @@ const LocalClusterControls = memo(function LocalClusterControls({
       <button
         onClick={(e) => handleAction('restart', e)}
         disabled={!!actionInProgress}
-        className={`p-1 rounded transition-colors ${
+        className={`p-2 min-h-11 min-w-11 flex items-center justify-center rounded transition-colors ${
           actionInProgress === 'restart'
             ? 'text-blue-400 bg-blue-500/20'
             : 'text-muted-foreground hover:text-blue-400 hover:bg-blue-500/20'

--- a/web/src/components/drilldown/views/ComplianceDrillDown.tsx
+++ b/web/src/components/drilldown/views/ComplianceDrillDown.tsx
@@ -354,20 +354,20 @@ export function ComplianceDrillDown({ data }: Props) {
           <div className="rounded-lg border border-border overflow-hidden">
             {/* Table header */}
             <div className="grid grid-cols-[1fr_2fr_100px_100px_120px_120px] gap-px bg-border text-xs font-medium text-muted-foreground">
-              <button onClick={() => toggleSort('controlId')} className="flex items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+              <button onClick={() => toggleSort('controlId')} className="flex items-center gap-1 px-3 py-2 min-h-11 bg-card/80 hover:bg-card transition-colors">
                 Control <SortIndicator field="controlId" />
               </button>
-              <div className="px-3 py-2 bg-card/80">Description</div>
-              <button onClick={() => toggleSort('status')} className="flex items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+              <div className="px-3 py-2 min-h-11 bg-card/80">Description</div>
+              <button onClick={() => toggleSort('status')} className="flex items-center gap-1 px-3 py-2 min-h-11 bg-card/80 hover:bg-card transition-colors">
                 Status <SortIndicator field="status" />
               </button>
-              <button onClick={() => toggleSort('severity')} className="flex items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+              <button onClick={() => toggleSort('severity')} className="flex items-center gap-1 px-3 py-2 min-h-11 bg-card/80 hover:bg-card transition-colors">
                 Severity <SortIndicator field="severity" />
               </button>
-              <button onClick={() => toggleSort('cluster')} className="flex items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+              <button onClick={() => toggleSort('cluster')} className="flex items-center gap-1 px-3 py-2 min-h-11 bg-card/80 hover:bg-card transition-colors">
                 Cluster <SortIndicator field="cluster" />
               </button>
-              <button onClick={() => toggleSort('profile')} className="flex items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+              <button onClick={() => toggleSort('profile')} className="flex items-center gap-1 px-3 py-2 min-h-11 bg-card/80 hover:bg-card transition-colors">
                 Profile <SortIndicator field="profile" />
               </button>
             </div>


### PR DESCRIPTION
Closes #3738

## Summary
- Add `min-h-11 min-w-11` (44px) to cluster lifecycle icon buttons (start/stop/restart) in `ClusterGrid.tsx` and increase padding from `p-1` to `p-2` with centered flex layout
- Add `min-h-11` (44px) to all compliance table sort buttons and the description header in `ComplianceDrillDown.tsx`
- ResourceBadges already had the fix applied (conditional min-h-11/min-w-11 when clickable)

## Test plan
- [ ] Cluster grid start/stop/restart buttons are at least 44px touch targets
- [ ] Compliance drilldown sort headers meet minimum touch target size
- [ ] No visual regressions in desktop layout

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>