### PR TITLE
feat: add fullscreen expand button to markdown preview

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef } from 'react'
-import { X, Bug, Sparkles, Loader2, ExternalLink, Bell, Check, Clock, GitPullRequest, GitMerge, Eye, Pencil, RefreshCw, MessageSquare, Settings, Github, Coins, Lightbulb, AlertCircle, AlertTriangle, Linkedin, Trophy, Monitor, BookOpen, ImagePlus, Trash2, Copy } from 'lucide-react'
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { X, Bug, Sparkles, Loader2, ExternalLink, Bell, Check, Clock, GitPullRequest, GitMerge, Eye, Pencil, RefreshCw, MessageSquare, Settings, Github, Coins, Lightbulb, AlertCircle, AlertTriangle, Linkedin, Trophy, Monitor, BookOpen, ImagePlus, Trash2, Copy, Maximize2 } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { StatusBadge } from '../ui/StatusBadge'
 import { BaseModal } from '../../lib/modals'
@@ -126,7 +126,23 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
   const [screenshots, setScreenshots] = useState<{ file: File; preview: string }[]>([])
   const [isDragOver, setIsDragOver] = useState(false)
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null)
+  const [isPreviewFullscreen, setIsPreviewFullscreen] = useState(false)
   const screenshotInputRef = useRef<HTMLInputElement>(null)
+  const fullscreenOverlayRef = useRef<HTMLDivElement>(null)
+
+  // Close fullscreen preview on Escape key
+  const handleFullscreenKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setIsPreviewFullscreen(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isPreviewFullscreen) {
+      document.addEventListener('keydown', handleFullscreenKeyDown)
+      return () => document.removeEventListener('keydown', handleFullscreenKeyDown)
+    }
+  }, [isPreviewFullscreen, handleFullscreenKeyDown])
 
   const handleScreenshotFiles = (files: FileList | null) => {
     if (!files) return
@@ -1345,6 +1361,17 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
                       <Eye className="w-3 h-3" />
                       Preview
                     </button>
+                    {descriptionTab === 'preview' && description.trim() && (
+                      <button
+                        type="button"
+                        onClick={() => setIsPreviewFullscreen(true)}
+                        className="ml-auto pb-1.5 text-muted-foreground hover:text-foreground transition-colors"
+                        title="Expand preview"
+                        aria-label="Expand preview to fullscreen"
+                      >
+                        <Maximize2 className="w-3.5 h-3.5" />
+                      </button>
+                    )}
                   </div>
                   {descriptionTab === 'write' ? (
                     <textarea
@@ -1569,6 +1596,68 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
         )}
         </div>
       </div>
+
+      {/* Fullscreen markdown preview overlay */}
+      {isPreviewFullscreen && (
+        <div
+          ref={fullscreenOverlayRef}
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === fullscreenOverlayRef.current) {
+              setIsPreviewFullscreen(false)
+            }
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Expanded markdown preview"
+        >
+          <div className="relative w-[90vw] h-[85vh] max-w-5xl bg-background border border-border rounded-xl shadow-2xl flex flex-col">
+            <div className="flex items-center justify-between px-5 py-3 border-b border-border">
+              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <Eye className="w-4 h-4" />
+                Markdown Preview
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsPreviewFullscreen(false)}
+                className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary/80 transition-colors"
+                aria-label="Close expanded preview"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto px-6 py-4 prose prose-invert prose-sm max-w-none">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm, remarkBreaks]}
+                components={{
+                  code({ className, children, ...props }) {
+                    const match = /language-(\w+)/.exec(className || '')
+                    const isInline = !match && !className
+                    return isInline ? (
+                      <code className="bg-black/20 px-1 rounded text-purple-300" {...props}>{children}</code>
+                    ) : (
+                      <pre className="bg-black/30 rounded-lg p-3 overflow-x-auto my-2">
+                        <code className={className} {...props}>{children}</code>
+                      </pre>
+                    )
+                  },
+                  table: ({ children }) => (
+                    <div className="overflow-x-auto w-full my-3 rounded border border-border">
+                      <table className="min-w-full border-collapse text-sm">{children}</table>
+                    </div>
+                  ),
+                  thead: ({ children }) => <thead className="bg-secondary/50">{children}</thead>,
+                  th: ({ children }) => <th className="px-3 py-2 text-left text-xs font-semibold border-b border-border">{children}</th>,
+                  td: ({ children }) => <td className="px-3 py-2 text-xs border-b border-border/50">{children}</td>,
+                  blockquote: ({ children }) => <blockquote className="border-l-4 border-purple-500/50 pl-3 my-3 text-muted-foreground italic">{children}</blockquote>,
+                }}
+              >
+                {description}
+              </ReactMarkdown>
+            </div>
+          </div>
+        </div>
+      )}
     </BaseModal>
   )
 }


### PR DESCRIPTION
Closes #3750

## Summary
- Adds an expand (Maximize2) icon button in the preview tab header, visible when the Preview tab is active and there is content to preview
- Clicking the button opens the markdown in a fullscreen overlay (90vw x 85vh) with the same ReactMarkdown renderer and styling
- The overlay can be closed via the X button, pressing Escape, or clicking outside the panel
- Fully keyboard accessible with proper ARIA attributes (`role="dialog"`, `aria-modal`, `aria-label`)

## Test plan
- [ ] Open the Feature Request modal, type markdown content, switch to Preview tab
- [ ] Verify the expand button appears in the top-right of the tab bar
- [ ] Click expand and verify the fullscreen overlay renders the same markdown
- [ ] Close via X button, Escape key, and clicking outside the overlay
- [ ] Verify the inline preview still works as before when not in fullscreen

Generated with [Claude Code](https://claude.com/claude-code)