### PR TITLE
fix: add mission preflight permission check with structured error taxonomy

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -28,6 +28,7 @@ import { cn } from '../../../lib/cn'
 import { ConfirmDialog } from '../../../lib/modals'
 import { MAX_MESSAGE_SIZE_CHARS } from '../../../lib/constants'
 import { AgentBadge, AgentIcon } from '../../agent/AgentIcon'
+import { PreflightFailure } from '../../missions/PreflightFailure'
 import { SaveResolutionDialog } from '../../missions/SaveResolutionDialog'
 import { SetupInstructionsDialog } from '../../setup/SetupInstructionsDialog'
 import { STATUS_CONFIG, TYPE_ICONS } from './types'
@@ -37,7 +38,7 @@ import { MemoizedMessage } from './MemoizedMessage'
 
 export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' as FontSize, onToggleFullScreen }: { mission: Mission; isFullScreen?: boolean; fontSize?: FontSize; onToggleFullScreen?: () => void }) {
   const { t } = useTranslation('common')
-  const { sendMessage, cancelMission, rateMission, setActiveMission, dismissMission, renameMission, runSavedMission, selectedAgent } = useMissions()
+  const { sendMessage, retryPreflight, cancelMission, rateMission, setActiveMission, dismissMission, renameMission, runSavedMission, selectedAgent } = useMissions()
   const { isDemoMode } = useDemoMode()
   const { findSimilarResolutions, recordUsage } = useResolutions()
   const [input, setInput] = useState('')
@@ -502,6 +503,17 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
           )
         })}
 
+        {/* Preflight failure panel when mission is blocked (#3742) */}
+        {mission.status === 'blocked' && mission.preflightError && (
+          <div className="px-1">
+            <PreflightFailure
+              error={mission.preflightError}
+              context={mission.cluster}
+              onRetry={() => retryPreflight(mission.id)}
+            />
+          </div>
+        )}
+
         {/* Typing indicator when agent is working - uses currently selected agent */}
         {mission.status === 'running' && (
           <div className="flex gap-3">
@@ -653,6 +665,27 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
             >
               <ChevronLeft className="w-3 h-3" />
               {t('missionChat.backToMissions')}
+            </button>
+          </div>
+        ) : mission.status === 'blocked' ? (
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-amber-400">{config.label}</span>
+              <span className="text-muted-foreground">Fix the issue above, then retry</span>
+            </div>
+            <button
+              onClick={() => retryPreflight(mission.id)}
+              className="w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-semibold bg-amber-600/20 text-amber-300 border border-amber-500/30 rounded-lg hover:bg-amber-600/30 transition-colors"
+            >
+              <RotateCcw className="w-4 h-4" />
+              Retry Preflight Check
+            </button>
+            <button
+              onClick={() => dismissMission(mission.id)}
+              className="flex items-center justify-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              <X className="w-3 h-3" />
+              Dismiss Mission
             </button>
           </div>
         ) : mission.status === 'failed' ? (

--- a/web/src/components/layout/mission-sidebar/types.ts
+++ b/web/src/components/layout/mission-sidebar/types.ts
@@ -11,6 +11,7 @@ import {
   Sparkles,
   Hammer,
   Bookmark,
+  ShieldAlert,
 } from 'lucide-react'
 import type { Mission, MissionStatus, MissionMessage } from '../../../hooks/useMissions'
 
@@ -32,6 +33,7 @@ export const STATUS_CONFIG: Record<MissionStatus, { icon: typeof Loader2; color:
   waiting_input: { icon: MessageSquare, color: 'text-purple-400', label: 'Waiting for input' },
   completed: { icon: CheckCircle, color: 'text-green-400', label: 'Completed' },
   failed: { icon: AlertCircle, color: 'text-red-400', label: 'Failed' },
+  blocked: { icon: ShieldAlert, color: 'text-amber-400', label: 'Blocked — permissions' },
   saved: { icon: Bookmark, color: 'text-yellow-400', label: 'Saved' },
 }
 

--- a/web/src/components/missions/PreflightFailure.tsx
+++ b/web/src/components/missions/PreflightFailure.tsx
@@ -1,0 +1,219 @@
+/**
+ * PreflightFailure — Renders a structured preflight error with remediation actions.
+ *
+ * Displayed inside the mission chat when a preflight permission check fails,
+ * replacing the generic error message with targeted guidance.
+ */
+
+import { useState, useCallback } from 'react'
+import {
+  ShieldAlert,
+  KeyRound,
+  Clock,
+  ShieldX,
+  MapPin,
+  WifiOff,
+  AlertTriangle,
+  Copy,
+  Check,
+  RotateCcw,
+  ExternalLink,
+  Info,
+} from 'lucide-react'
+import type { PreflightError, PreflightErrorCode, RemediationAction } from '../../lib/missions/preflightCheck'
+import { getRemediationActions } from '../../lib/missions/preflightCheck'
+import { cn } from '../../lib/cn'
+
+// ============================================================================
+// Icon / color mapping per error code
+// ============================================================================
+
+const ERROR_DISPLAY: Record<PreflightErrorCode, { icon: typeof ShieldAlert; color: string; bgColor: string; title: string }> = {
+  MISSING_CREDENTIALS: {
+    icon: KeyRound,
+    color: 'text-amber-400',
+    bgColor: 'bg-amber-500/10',
+    title: 'Missing Credentials',
+  },
+  EXPIRED_CREDENTIALS: {
+    icon: Clock,
+    color: 'text-orange-400',
+    bgColor: 'bg-orange-500/10',
+    title: 'Expired Credentials',
+  },
+  RBAC_DENIED: {
+    icon: ShieldX,
+    color: 'text-red-400',
+    bgColor: 'bg-red-500/10',
+    title: 'Permission Denied',
+  },
+  CONTEXT_NOT_FOUND: {
+    icon: MapPin,
+    color: 'text-purple-400',
+    bgColor: 'bg-purple-500/10',
+    title: 'Context Not Found',
+  },
+  CLUSTER_UNREACHABLE: {
+    icon: WifiOff,
+    color: 'text-blue-400',
+    bgColor: 'bg-blue-500/10',
+    title: 'Cluster Unreachable',
+  },
+  UNKNOWN_EXECUTION_FAILURE: {
+    icon: AlertTriangle,
+    color: 'text-gray-400',
+    bgColor: 'bg-gray-500/10',
+    title: 'Preflight Check Failed',
+  },
+}
+
+// ============================================================================
+// Action button renderer
+// ============================================================================
+
+function ActionButton({
+  action,
+  onRetry,
+}: {
+  action: RemediationAction
+  onRetry?: () => void
+}) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(() => {
+    if (action.codeSnippet) {
+      navigator.clipboard.writeText(action.codeSnippet).catch(() => {
+        // Fallback: select text in a temporary textarea
+      })
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }, [action.codeSnippet])
+
+  const iconMap = {
+    copy: copied ? Check : Copy,
+    retry: RotateCcw,
+    link: ExternalLink,
+    info: Info,
+  }
+  const Icon = iconMap[action.actionType]
+
+  if (action.actionType === 'info') {
+    return (
+      <div className="flex items-start gap-2 text-xs text-gray-300">
+        <Icon size={14} className="mt-0.5 shrink-0 text-gray-400" />
+        <span>{action.description}</span>
+      </div>
+    )
+  }
+
+  if (action.actionType === 'retry') {
+    return (
+      <button
+        onClick={onRetry}
+        className="flex items-center gap-2 rounded-md bg-blue-600/20 px-3 py-1.5 text-xs font-medium text-blue-300 transition-colors hover:bg-blue-600/30"
+      >
+        <Icon size={14} />
+        {action.label}
+      </button>
+    )
+  }
+
+  if (action.actionType === 'link' && action.href) {
+    return (
+      <a
+        href={action.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-2 text-xs text-blue-400 hover:underline"
+      >
+        <Icon size={14} />
+        {action.label}
+      </a>
+    )
+  }
+
+  // Copy action
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-gray-300">{action.label}</span>
+        {action.codeSnippet && (
+          <button
+            onClick={handleCopy}
+            className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-gray-400 transition-colors hover:bg-gray-700 hover:text-gray-200"
+          >
+            <Icon size={12} />
+            {copied ? 'Copied' : 'Copy'}
+          </button>
+        )}
+      </div>
+      <p className="text-xs text-gray-400">{action.description}</p>
+      {action.codeSnippet && (
+        <pre className="mt-1 overflow-x-auto rounded-md bg-gray-900/70 p-2 text-xs text-gray-300">
+          <code>{action.codeSnippet}</code>
+        </pre>
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export interface PreflightFailureProps {
+  error: PreflightError
+  context?: string
+  onRetry?: () => void
+}
+
+export function PreflightFailure({ error, context, onRetry }: PreflightFailureProps) {
+  const display = ERROR_DISPLAY[error.code]
+  const Icon = display.icon
+  const actions = getRemediationActions(error, context)
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border border-gray-700/50 p-4',
+        display.bgColor,
+      )}
+      data-testid="preflight-failure"
+      data-error-code={error.code}
+    >
+      {/* Header */}
+      <div className="mb-3 flex items-center gap-2">
+        <Icon size={18} className={display.color} />
+        <h4 className="text-sm font-semibold text-gray-100">
+          {display.title}
+        </h4>
+        <span className="ml-auto rounded bg-gray-800/80 px-2 py-0.5 text-[10px] font-mono text-gray-500">
+          {error.code}
+        </span>
+      </div>
+
+      {/* Error message */}
+      <p className="mb-3 text-xs leading-relaxed text-gray-300">
+        {error.message}
+      </p>
+
+      {/* Context info */}
+      {context && (
+        <p className="mb-3 text-xs text-gray-500">
+          Cluster context: <code className="rounded bg-gray-800 px-1 py-0.5 text-gray-400">{context}</code>
+        </p>
+      )}
+
+      {/* Remediation actions */}
+      {actions.length > 0 && (
+        <div className="space-y-3 border-t border-gray-700/30 pt-3">
+          <p className="text-xs font-medium text-gray-400">How to fix:</p>
+          {actions.map((action, i) => (
+            <ActionButton key={i} action={action} onRetry={onRetry} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -35,6 +35,16 @@ vi.mock('../lib/analytics', () => ({
   emitMissionRated: vi.fn(),
 }))
 
+vi.mock('../lib/missions/preflightCheck', () => ({
+  runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
+  classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
+  getRemediationActions: vi.fn().mockReturnValue([]),
+}))
+
+vi.mock('../lib/kubectlProxy', () => ({
+  kubectlProxy: { exec: vi.fn() },
+}))
+
 // ── Mock WebSocket ─────────────────────────────────────────────────────────────
 
 class MockWebSocket {
@@ -100,6 +110,8 @@ async function startMissionWithConnection(
   act(() => {
     missionId = result.current.startMission(defaultParams)
   })
+  // Flush microtask queue so the preflight .then() chain resolves (#3742)
+  await act(async () => { await Promise.resolve() })
   await act(async () => {
     MockWebSocket.lastInstance?.simulateOpen()
   })

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -7,8 +7,10 @@ import { detectIssueSignature, findSimilarResolutionsStandalone, generateResolut
 import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { emitMissionStarted, emitMissionCompleted, emitMissionError, emitMissionRated } from '../lib/analytics'
 import { scanForMaliciousContent } from '../lib/missions/scanner/malicious'
+import { runPreflightCheck, type PreflightError } from '../lib/missions/preflightCheck'
+import { kubectlProxy } from '../lib/kubectlProxy'
 
-export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'saved'
+export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'saved' | 'blocked'
 
 export interface MissionMessage {
   id: string
@@ -53,6 +55,8 @@ export interface Mission {
   agent?: string
   /** Resolutions that were auto-matched for this mission */
   matchedResolutions?: MatchedResolution[]
+  /** Structured preflight error when mission is blocked */
+  preflightError?: PreflightError
   /** Original imported mission data (for saved/library missions) */
   importedFrom?: {
     title: string
@@ -90,6 +94,7 @@ interface MissionContextValue {
   saveMission: (params: SaveMissionParams) => string
   runSavedMission: (missionId: string, cluster?: string) => void
   sendMessage: (missionId: string, content: string) => void
+  retryPreflight: (missionId: string) => void
   cancelMission: (missionId: string) => void
   dismissMission: (missionId: string) => void
   renameMission: (missionId: string, newTitle: string) => void
@@ -211,9 +216,9 @@ function saveMissions(missions: Mission[]) {
       && (e.name === 'QuotaExceededError' || e.code === 22)
     if (isQuotaError) {
       console.warn('[Missions] localStorage quota exceeded, pruning old missions')
-      // Keep active missions (pending/running/waiting_input) unconditionally
+      // Keep active missions (pending/running/waiting_input/blocked) unconditionally
       const active = missions.filter(m =>
-        m.status === 'running' || m.status === 'pending' || m.status === 'waiting_input'
+        m.status === 'running' || m.status === 'pending' || m.status === 'waiting_input' || m.status === 'blocked'
       )
       // Keep saved/library missions unconditionally — they are small (no chat history)
       const saved = missions.filter(m => m.status === 'saved')
@@ -983,6 +988,61 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     setIsSidebarMinimized(false)
     emitMissionStarted(params.type, selectedAgent || defaultAgent || 'unknown')
 
+    // Run preflight permission check for missions that target a cluster.
+    // This catches missing credentials, expired tokens, RBAC denials, etc.
+    // before the agent starts executing mutating steps (#3742).
+    const missionNeedsCluster = !!params.cluster || ['deploy', 'repair', 'upgrade'].includes(params.type)
+    const preflightPromise = missionNeedsCluster
+      ? runPreflightCheck(
+          (args, opts) => kubectlProxy.exec(args, opts),
+          params.cluster?.split(',')[0]?.trim(),
+        )
+      : Promise.resolve({ ok: true } as { ok: true })
+
+    preflightPromise.then(preflight => {
+      if (!preflight.ok && 'error' in preflight && preflight.error) {
+        // Preflight failed — block the mission with a structured error
+        setMissions(prev => prev.map(m =>
+          m.id === missionId ? {
+            ...m,
+            status: 'blocked' as MissionStatus,
+            currentStep: 'Preflight check failed',
+            preflightError: preflight.error,
+            messages: [
+              ...m.messages,
+              {
+                id: `msg-${Date.now()}-preflight`,
+                role: 'system' as const,
+                content: `**Preflight Check Failed**\n\nThe mission cannot proceed because cluster access verification failed. See the details below for how to fix this.\n\nError: ${preflight.error?.message || 'Unknown error'}`,
+                timestamp: new Date(),
+              }
+            ]
+          } : m
+        ))
+        emitMissionError(params.type, preflight.error?.code || 'preflight_unknown')
+        return
+      }
+
+      // Preflight passed — proceed to send to agent
+      executeMission(missionId, enhancedPrompt, params)
+    }).catch(() => {
+      // Preflight itself threw unexpectedly — still allow mission to proceed
+      // (don't block on preflight infrastructure failures)
+      executeMission(missionId, enhancedPrompt, params)
+    })
+
+    return missionId
+  }, [ensureConnection])
+
+  /**
+   * Internal: send mission to agent after preflight passes.
+   * Extracted from startMission to allow reuse from retryPreflight.
+   */
+  const executeMission = useCallback((
+    missionId: string,
+    enhancedPrompt: string,
+    params: { context?: Record<string, unknown>; type?: string },
+  ) => {
     // Send to agent
     ensureConnection().then(() => {
       const requestId = `claude-${Date.now()}`
@@ -1050,9 +1110,90 @@ Install the console locally with the KubeStellar Console agent to use AI mission
         } : m
       ))
     })
-
-    return missionId
   }, [ensureConnection])
+
+  /**
+   * Retry preflight check for a blocked mission.
+   * If preflight passes, transitions the mission to running and sends to agent.
+   */
+  const retryPreflight = useCallback((missionId: string) => {
+    const mission = missionsRef.current.find(m => m.id === missionId)
+    if (!mission || mission.status !== 'blocked') return
+
+    // Transition to pending while we re-check
+    setMissions(prev => prev.map(m =>
+      m.id === missionId ? {
+        ...m,
+        status: 'pending' as MissionStatus,
+        currentStep: 'Re-running preflight check...',
+        preflightError: undefined,
+      } : m
+    ))
+
+    const clusterContext = mission.cluster?.split(',')[0]?.trim()
+
+    runPreflightCheck(
+      (args, opts) => kubectlProxy.exec(args, opts),
+      clusterContext,
+    ).then(preflight => {
+      if (!preflight.ok && 'error' in preflight && preflight.error) {
+        // Still failing — re-block
+        setMissions(prev => prev.map(m =>
+          m.id === missionId ? {
+            ...m,
+            status: 'blocked' as MissionStatus,
+            currentStep: 'Preflight check failed',
+            preflightError: preflight.error,
+            messages: [
+              ...m.messages,
+              {
+                id: `msg-${Date.now()}-preflight-retry`,
+                role: 'system' as const,
+                content: `**Preflight Check Still Failing**\n\nError: ${preflight.error?.message || 'Unknown error'}`,
+                timestamp: new Date(),
+              }
+            ]
+          } : m
+        ))
+        return
+      }
+
+      // Preflight passed — build prompt and execute
+      const lastUserMsg = mission.messages.find(m => m.role === 'user')
+      let prompt = lastUserMsg?.content || mission.description
+      if (mission.cluster) {
+        const clusterList = mission.cluster.split(',').map(c => c.trim()).filter(Boolean)
+        if (clusterList.length === 1) {
+          prompt = `Target cluster: ${clusterList[0]}\nIMPORTANT: All kubectl commands MUST use --context=${clusterList[0]}\n\n${prompt}`
+        } else {
+          prompt = `Target clusters: ${clusterList.join(', ')}\nIMPORTANT: Perform the following on each cluster using their respective kubectl contexts.\n\n${prompt}`
+        }
+      }
+
+      setMissions(prev => prev.map(m =>
+        m.id === missionId ? {
+          ...m,
+          preflightError: undefined,
+          messages: [
+            ...m.messages,
+            {
+              id: `msg-${Date.now()}-preflight-ok`,
+              role: 'system' as const,
+              content: '**Preflight check passed** — proceeding with mission execution.',
+              timestamp: new Date(),
+            }
+          ]
+        } : m
+      ))
+
+      executeMission(missionId, prompt, { context: mission.context, type: mission.type })
+    }).catch(() => {
+      // Preflight threw unexpectedly — allow mission to proceed
+      const lastUserMsg = mission.messages.find(m => m.role === 'user')
+      const prompt = lastUserMsg?.content || mission.description
+      executeMission(missionId, prompt, { context: mission.context, type: mission.type })
+    })
+  }, [executeMission])
 
   // Save a mission to library without running it
   const saveMission = useCallback((params: SaveMissionParams): string => {
@@ -1459,6 +1600,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       saveMission,
       runSavedMission,
       sendMessage,
+      retryPreflight,
       cancelMission,
       dismissMission,
       renameMission,
@@ -1505,6 +1647,7 @@ const MISSIONS_FALLBACK: MissionContextValue = {
   saveMission: () => '',
   runSavedMission: () => {},
   sendMessage: () => {},
+  retryPreflight: () => {},
   cancelMission: () => {},
   dismissMission: () => {},
   renameMission: () => {},

--- a/web/src/lib/missions/__tests__/preflightCheck.test.ts
+++ b/web/src/lib/missions/__tests__/preflightCheck.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  classifyKubectlError,
+  runPreflightCheck,
+  getRemediationActions,
+  type PreflightError,
+  type PreflightErrorCode,
+} from '../preflightCheck'
+
+// ============================================================================
+// classifyKubectlError
+// ============================================================================
+
+describe('classifyKubectlError', () => {
+  it('classifies missing kubeconfig as MISSING_CREDENTIALS', () => {
+    const result = classifyKubectlError(
+      'error: no configuration has been provided, try setting KUBERNETES_MASTER environment variable',
+      '',
+      1,
+    )
+    expect(result.code).toBe('MISSING_CREDENTIALS')
+  })
+
+  it('classifies missing .kube/config file as MISSING_CREDENTIALS', () => {
+    const result = classifyKubectlError(
+      'stat /home/user/.kube/config: no such file or directory',
+      '',
+      1,
+    )
+    expect(result.code).toBe('MISSING_CREDENTIALS')
+  })
+
+  it('classifies expired certificate as EXPIRED_CREDENTIALS', () => {
+    const result = classifyKubectlError(
+      'Unable to connect to the server: x509: certificate has expired or is not yet valid',
+      '',
+      1,
+    )
+    expect(result.code).toBe('EXPIRED_CREDENTIALS')
+  })
+
+  it('classifies expired token as EXPIRED_CREDENTIALS', () => {
+    const result = classifyKubectlError(
+      'error: You must be logged in to the server (the token has expired)',
+      '',
+      1,
+    )
+    expect(result.code).toBe('EXPIRED_CREDENTIALS')
+  })
+
+  it('classifies expired refresh token as EXPIRED_CREDENTIALS', () => {
+    const result = classifyKubectlError(
+      'error: refresh token has expired, please re-authenticate',
+      '',
+      1,
+    )
+    expect(result.code).toBe('EXPIRED_CREDENTIALS')
+  })
+
+  it('classifies RBAC forbidden as RBAC_DENIED', () => {
+    const result = classifyKubectlError(
+      'Error from server (Forbidden): clusterroles.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:default:console" cannot list resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope',
+      '',
+      1,
+    )
+    expect(result.code).toBe('RBAC_DENIED')
+    expect(result.details?.verb).toBe('list')
+    expect(result.details?.resource).toBe('clusterroles')
+    expect(result.details?.apiGroup).toBe('rbac.authorization.k8s.io')
+  })
+
+  it('classifies namespace-scoped RBAC denial', () => {
+    const result = classifyKubectlError(
+      'Error from server (Forbidden): User "dev-user" cannot create pods in the namespace "production"',
+      '',
+      1,
+    )
+    expect(result.code).toBe('RBAC_DENIED')
+    expect(result.details?.verb).toBe('create')
+    expect(result.details?.resource).toBe('pods')
+    expect(result.details?.namespace).toBe('production')
+  })
+
+  it('classifies context not found as CONTEXT_NOT_FOUND', () => {
+    const result = classifyKubectlError(
+      'error: context "staging-cluster" not found',
+      '',
+      1,
+    )
+    expect(result.code).toBe('CONTEXT_NOT_FOUND')
+    expect(result.details?.requestedContext).toBe('staging-cluster')
+  })
+
+  it('classifies connection refused as CLUSTER_UNREACHABLE', () => {
+    const result = classifyKubectlError(
+      'The connection to the server 192.168.1.100:6443 was refused - did you specify the right host or port?',
+      '',
+      1,
+    )
+    expect(result.code).toBe('CLUSTER_UNREACHABLE')
+  })
+
+  it('classifies DNS resolution failure as CLUSTER_UNREACHABLE', () => {
+    const result = classifyKubectlError(
+      'dial tcp: lookup api.mycluster.example.com: no such host',
+      '',
+      1,
+    )
+    expect(result.code).toBe('CLUSTER_UNREACHABLE')
+  })
+
+  it('classifies i/o timeout as CLUSTER_UNREACHABLE', () => {
+    const result = classifyKubectlError(
+      'Unable to connect to the server: dial tcp 10.0.0.1:6443: i/o timeout',
+      '',
+      1,
+    )
+    expect(result.code).toBe('CLUSTER_UNREACHABLE')
+  })
+
+  it('classifies TLS handshake timeout as CLUSTER_UNREACHABLE', () => {
+    const result = classifyKubectlError(
+      'Unable to connect to the server: net/http: TLS handshake timeout',
+      '',
+      1,
+    )
+    expect(result.code).toBe('CLUSTER_UNREACHABLE')
+  })
+
+  it('falls back to UNKNOWN_EXECUTION_FAILURE for unrecognized errors', () => {
+    const result = classifyKubectlError(
+      'some completely unexpected error message',
+      '',
+      1,
+    )
+    expect(result.code).toBe('UNKNOWN_EXECUTION_FAILURE')
+    expect(result.message).toContain('some completely unexpected error message')
+  })
+
+  it('uses stdout when stderr is empty', () => {
+    const result = classifyKubectlError(
+      '',
+      'error: context "missing" does not exist',
+      1,
+    )
+    expect(result.code).toBe('CONTEXT_NOT_FOUND')
+  })
+})
+
+// ============================================================================
+// runPreflightCheck
+// ============================================================================
+
+describe('runPreflightCheck', () => {
+  it('returns ok:true when kubectl auth can-i succeeds', async () => {
+    const exec = vi.fn().mockResolvedValue({
+      output: 'Resources  Non-Resource URLs  Resource Names  Verbs\n*.*  []  []  [*]',
+      exitCode: 0,
+    })
+
+    const result = await runPreflightCheck(exec, 'my-cluster')
+    expect(result.ok).toBe(true)
+    expect(result.context).toBe('my-cluster')
+    expect(exec).toHaveBeenCalledWith(
+      ['auth', 'can-i', '--list', '--no-headers'],
+      { context: 'my-cluster', timeout: 10_000, priority: true },
+    )
+  })
+
+  it('returns structured error when kubectl fails with RBAC error', async () => {
+    const exec = vi.fn().mockResolvedValue({
+      output: '',
+      exitCode: 1,
+      error: 'Error from server (Forbidden): User "test" cannot list resource "pods" in API group "" at the cluster scope',
+    })
+
+    const result = await runPreflightCheck(exec, 'prod')
+    expect(result.ok).toBe(false)
+    expect(result.error?.code).toBe('RBAC_DENIED')
+    expect(result.context).toBe('prod')
+  })
+
+  it('handles connection-level exceptions as CLUSTER_UNREACHABLE', async () => {
+    const exec = vi.fn().mockRejectedValue(new Error('Not connected to local agent'))
+
+    const result = await runPreflightCheck(exec)
+    expect(result.ok).toBe(false)
+    expect(result.error?.code).toBe('CLUSTER_UNREACHABLE')
+  })
+
+  it('handles agent timeout as CLUSTER_UNREACHABLE', async () => {
+    const exec = vi.fn().mockRejectedValue(new Error('Connection timeout after 2500ms'))
+
+    const result = await runPreflightCheck(exec)
+    expect(result.ok).toBe(false)
+    expect(result.error?.code).toBe('CLUSTER_UNREACHABLE')
+  })
+
+  it('classifies non-connection errors from exceptions', async () => {
+    const exec = vi.fn().mockRejectedValue(new Error('stat /home/user/.kube/config: no such file or directory'))
+
+    const result = await runPreflightCheck(exec)
+    expect(result.ok).toBe(false)
+    expect(result.error?.code).toBe('MISSING_CREDENTIALS')
+  })
+})
+
+// ============================================================================
+// getRemediationActions
+// ============================================================================
+
+describe('getRemediationActions', () => {
+  const errorCodes: PreflightErrorCode[] = [
+    'MISSING_CREDENTIALS',
+    'EXPIRED_CREDENTIALS',
+    'RBAC_DENIED',
+    'CONTEXT_NOT_FOUND',
+    'CLUSTER_UNREACHABLE',
+    'UNKNOWN_EXECUTION_FAILURE',
+  ]
+
+  it.each(errorCodes)('returns non-empty actions for %s', (code) => {
+    const error: PreflightError = { code, message: 'test' }
+    const actions = getRemediationActions(error)
+    expect(actions.length).toBeGreaterThan(0)
+    // Every error type should have a retry action
+    expect(actions.some(a => a.actionType === 'retry')).toBe(true)
+  })
+
+  it('generates RBAC snippet when verb and resource are provided', () => {
+    const error: PreflightError = {
+      code: 'RBAC_DENIED',
+      message: 'forbidden',
+      details: { verb: 'create', resource: 'clusterpolicies', apiGroup: 'kyverno.io' },
+    }
+    const actions = getRemediationActions(error)
+    const copyAction = actions.find(a => a.actionType === 'copy' && a.codeSnippet?.includes('ClusterRole'))
+    expect(copyAction).toBeDefined()
+    expect(copyAction?.codeSnippet).toContain('kyverno.io')
+    expect(copyAction?.codeSnippet).toContain('clusterpolicies')
+    expect(copyAction?.codeSnippet).toContain('create')
+  })
+
+  it('includes context name in CONTEXT_NOT_FOUND remediation', () => {
+    const error: PreflightError = {
+      code: 'CONTEXT_NOT_FOUND',
+      message: 'context "staging" not found',
+      details: { requestedContext: 'staging' },
+    }
+    const actions = getRemediationActions(error)
+    expect(actions.some(a => a.description.includes('staging'))).toBe(true)
+  })
+
+  it('includes context in credential refresh commands', () => {
+    const error: PreflightError = {
+      code: 'EXPIRED_CREDENTIALS',
+      message: 'token expired',
+    }
+    const actions = getRemediationActions(error, 'prod-cluster')
+    const copyAction = actions.find(a => a.actionType === 'copy')
+    expect(copyAction?.codeSnippet).toContain('prod-cluster')
+  })
+})

--- a/web/src/lib/missions/preflightCheck.ts
+++ b/web/src/lib/missions/preflightCheck.ts
@@ -1,0 +1,441 @@
+/**
+ * Mission Preflight Check
+ *
+ * Validates Kubernetes cluster access before executing mutating mission steps.
+ * Returns structured error codes with remediation guidance so the UI can show
+ * targeted help instead of generic failure messages.
+ */
+
+// ============================================================================
+// Error Taxonomy
+// ============================================================================
+
+export type PreflightErrorCode =
+  | 'MISSING_CREDENTIALS'
+  | 'EXPIRED_CREDENTIALS'
+  | 'RBAC_DENIED'
+  | 'CONTEXT_NOT_FOUND'
+  | 'CLUSTER_UNREACHABLE'
+  | 'UNKNOWN_EXECUTION_FAILURE'
+
+export interface PreflightError {
+  code: PreflightErrorCode
+  message: string
+  /** Additional details (e.g., denied verb/resource, available contexts) */
+  details?: Record<string, unknown>
+}
+
+export interface PreflightResult {
+  ok: boolean
+  error?: PreflightError
+  /** The cluster context that was checked */
+  context?: string
+}
+
+// ============================================================================
+// Error Classification
+// ============================================================================
+
+/**
+ * Classify stderr/stdout from a kubectl command into a structured error code.
+ *
+ * The classifier checks patterns in priority order — more specific patterns
+ * (expired certs, RBAC) are checked before generic connectivity errors.
+ */
+export function classifyKubectlError(
+  stderr: string,
+  stdout: string,
+  exitCode: number,
+): PreflightError {
+  const combined = `${stderr} ${stdout}`.toLowerCase()
+
+  // --- Missing credentials / kubeconfig ---
+  if (
+    combined.includes('no configuration has been provided') ||
+    combined.includes('kubeconfig') && combined.includes('not found') ||
+    combined.includes('stat') && combined.includes('.kube/config') && combined.includes('no such file') ||
+    combined.includes('invalid configuration') && combined.includes('no configuration') ||
+    combined.includes('the connection to the server localhost:8080 was refused') && !combined.includes('context')
+  ) {
+    return {
+      code: 'MISSING_CREDENTIALS',
+      message: 'No Kubernetes credentials found. A kubeconfig file is required to connect to a cluster.',
+    }
+  }
+
+  // --- Expired credentials / certificates ---
+  if (
+    combined.includes('certificate has expired') ||
+    combined.includes('x509: certificate') && (combined.includes('expired') || combined.includes('not yet valid')) ||
+    combined.includes('token has expired') ||
+    combined.includes('token is expired') ||
+    combined.includes('unable to connect to the server') && combined.includes('tls') && combined.includes('expired') ||
+    combined.includes('credentials have expired') ||
+    combined.includes('refresh token') && combined.includes('expired')
+  ) {
+    return {
+      code: 'EXPIRED_CREDENTIALS',
+      message: 'Kubernetes credentials have expired. You need to re-authenticate with your cluster.',
+    }
+  }
+
+  // --- RBAC denied ---
+  if (
+    combined.includes('forbidden') ||
+    combined.includes('is forbidden') ||
+    combined.includes('cannot') && combined.includes('in the namespace') ||
+    combined.includes('user') && combined.includes('cannot') && (combined.includes('get') || combined.includes('list') || combined.includes('create') || combined.includes('delete') || combined.includes('update') || combined.includes('patch')) ||
+    (exitCode !== 0 && combined.includes('error from server (forbidden)'))
+  ) {
+    // Try to extract verb and resource from the error message
+    const details: Record<string, unknown> = {}
+
+    // Pattern: "User "xxx" cannot <verb> resource "<resource>" in API group "<group>"
+    const rbacMatch = combined.match(
+      /cannot\s+(get|list|create|delete|update|patch|watch)\s+resource\s+"([^"]+)"\s+in\s+api\s+group\s+"([^"]*)"/i
+    )
+    if (rbacMatch) {
+      details.verb = rbacMatch[1]
+      details.resource = rbacMatch[2]
+      details.apiGroup = rbacMatch[3] || 'core'
+    }
+
+    // Pattern: "User "xxx" cannot <verb> <resource> in the namespace "xxx"
+    const nsMatch = combined.match(
+      /cannot\s+(get|list|create|delete|update|patch|watch)\s+(\S+)\s+in\s+the\s+namespace\s+"([^"]+)"/i
+    )
+    if (nsMatch && !rbacMatch) {
+      details.verb = nsMatch[1]
+      details.resource = nsMatch[2]
+      details.namespace = nsMatch[3]
+    }
+
+    return {
+      code: 'RBAC_DENIED',
+      message: 'Your Kubernetes user does not have permission to perform the required operations.',
+      details: Object.keys(details).length > 0 ? details : undefined,
+    }
+  }
+
+  // --- Context not found ---
+  if (
+    combined.includes('context') && combined.includes('not found') ||
+    combined.includes('context') && combined.includes('does not exist') ||
+    combined.includes('no context exists with the name') ||
+    combined.includes('error: context') && combined.includes('not found')
+  ) {
+    // Try to extract the context name
+    const ctxMatch = combined.match(/context\s+"([^"]+)"\s+(?:not found|does not exist)/i)
+    return {
+      code: 'CONTEXT_NOT_FOUND',
+      message: ctxMatch
+        ? `Kubernetes context "${ctxMatch[1]}" was not found in your kubeconfig.`
+        : 'The specified Kubernetes context was not found in your kubeconfig.',
+      details: ctxMatch ? { requestedContext: ctxMatch[1] } : undefined,
+    }
+  }
+
+  // --- Cluster unreachable (network/DNS/TLS) ---
+  if (
+    combined.includes('connection refused') ||
+    combined.includes('was refused') ||
+    combined.includes('no such host') ||
+    combined.includes('i/o timeout') ||
+    combined.includes('dial tcp') && combined.includes('timeout') ||
+    combined.includes('unable to connect to the server') ||
+    combined.includes('tls handshake timeout') ||
+    combined.includes('net/http: tls handshake timeout') ||
+    combined.includes('context deadline exceeded') ||
+    combined.includes('the server was unable to return a response') ||
+    combined.includes('eof') && combined.includes('connect')
+  ) {
+    return {
+      code: 'CLUSTER_UNREACHABLE',
+      message: 'Unable to reach the Kubernetes cluster. This may be a network, DNS, or firewall issue.',
+    }
+  }
+
+  // --- Fallback ---
+  return {
+    code: 'UNKNOWN_EXECUTION_FAILURE',
+    message: stderr.trim() || stdout.trim() || 'An unknown error occurred while checking cluster access.',
+  }
+}
+
+// ============================================================================
+// Remediation Guidance
+// ============================================================================
+
+export interface RemediationAction {
+  label: string
+  description: string
+  /** If set, render a code block the user can copy */
+  codeSnippet?: string
+  /** Action type for the UI to render the right control */
+  actionType: 'copy' | 'retry' | 'link' | 'info'
+  /** URL for link-type actions */
+  href?: string
+}
+
+/**
+ * Return targeted remediation actions for a given preflight error code.
+ */
+export function getRemediationActions(error: PreflightError, context?: string): RemediationAction[] {
+  switch (error.code) {
+    case 'MISSING_CREDENTIALS':
+      return [
+        {
+          label: 'Set up kubeconfig',
+          description: 'Ensure your kubeconfig file exists at ~/.kube/config or set the KUBECONFIG environment variable.',
+          codeSnippet: 'export KUBECONFIG=~/.kube/config',
+          actionType: 'copy',
+        },
+        {
+          label: 'Configure cluster access',
+          description: 'If using a cloud provider, run the appropriate login command to generate credentials.',
+          codeSnippet: context
+            ? `# For GKE:\ngcloud container clusters get-credentials <CLUSTER_NAME>\n# For EKS:\naws eks update-kubeconfig --name <CLUSTER_NAME>\n# For AKS:\naz aks get-credentials --resource-group <RG> --name <CLUSTER_NAME>`
+            : `kubectl config view`,
+          actionType: 'copy',
+        },
+        {
+          label: 'Retry preflight check',
+          description: 'After configuring credentials, retry the preflight check.',
+          actionType: 'retry',
+        },
+      ]
+
+    case 'EXPIRED_CREDENTIALS':
+      return [
+        {
+          label: 'Refresh credentials',
+          description: 'Your cluster credentials have expired. Re-authenticate with your identity provider.',
+          codeSnippet: context
+            ? `# Re-authenticate for context: ${context}\nkubectl config use-context ${context}\n# Then run your cloud provider login command`
+            : `# Re-run your cloud provider login command\n# For GKE: gcloud auth login && gcloud container clusters get-credentials <CLUSTER>\n# For EKS: aws sso login && aws eks update-kubeconfig --name <CLUSTER>`,
+          actionType: 'copy',
+        },
+        {
+          label: 'Retry preflight check',
+          description: 'After refreshing credentials, retry the preflight check.',
+          actionType: 'retry',
+        },
+      ]
+
+    case 'RBAC_DENIED': {
+      const actions: RemediationAction[] = [
+        {
+          label: 'Required permissions',
+          description: error.details?.verb
+            ? `Your user needs "${error.details.verb}" permission on "${error.details.resource}" resources${error.details.apiGroup && error.details.apiGroup !== 'core' ? ` in API group "${error.details.apiGroup}"` : ''}.`
+            : 'Your user needs additional RBAC permissions to perform the required operations.',
+          actionType: 'info',
+        },
+      ]
+
+      // Generate a least-privilege RBAC snippet when we have details
+      if (error.details?.verb && error.details?.resource) {
+        const rbacYaml = generateRBACSnippet(
+          error.details.verb as string,
+          error.details.resource as string,
+          (error.details.apiGroup as string) || '',
+          (error.details.namespace as string) || undefined,
+        )
+        actions.push({
+          label: 'Copy RBAC manifest',
+          description: 'Apply this ClusterRoleBinding to grant the minimum required permissions.',
+          codeSnippet: rbacYaml,
+          actionType: 'copy',
+        })
+      }
+
+      actions.push({
+        label: 'Retry preflight check',
+        description: 'After updating RBAC permissions, retry the preflight check.',
+        actionType: 'retry',
+      })
+
+      return actions
+    }
+
+    case 'CONTEXT_NOT_FOUND':
+      return [
+        {
+          label: 'List available contexts',
+          description: error.details?.requestedContext
+            ? `Context "${error.details.requestedContext}" was not found. List available contexts to find the correct one.`
+            : 'The specified context was not found. List available contexts to find the correct one.',
+          codeSnippet: 'kubectl config get-contexts',
+          actionType: 'copy',
+        },
+        {
+          label: 'Retry preflight check',
+          description: 'After selecting the correct context, retry the preflight check.',
+          actionType: 'retry',
+        },
+      ]
+
+    case 'CLUSTER_UNREACHABLE':
+      return [
+        {
+          label: 'Check connectivity',
+          description: 'Verify network connectivity to the cluster API server.',
+          codeSnippet: context
+            ? `kubectl --context=${context} cluster-info`
+            : 'kubectl cluster-info',
+          actionType: 'copy',
+        },
+        {
+          label: 'Check VPN or firewall',
+          description: 'If the cluster is behind a VPN or firewall, ensure you are connected and the API server port is accessible.',
+          actionType: 'info',
+        },
+        {
+          label: 'Retry preflight check',
+          description: 'After resolving connectivity issues, retry the preflight check.',
+          actionType: 'retry',
+        },
+      ]
+
+    case 'UNKNOWN_EXECUTION_FAILURE':
+    default:
+      return [
+        {
+          label: 'View error details',
+          description: error.message,
+          actionType: 'info',
+        },
+        {
+          label: 'Retry preflight check',
+          description: 'Try running the preflight check again.',
+          actionType: 'retry',
+        },
+      ]
+  }
+}
+
+// ============================================================================
+// RBAC Snippet Generator
+// ============================================================================
+
+function generateRBACSnippet(
+  verb: string,
+  resource: string,
+  apiGroup: string,
+  namespace?: string,
+): string {
+  const kind = namespace ? 'Role' : 'ClusterRole'
+  const bindingKind = namespace ? 'RoleBinding' : 'ClusterRoleBinding'
+  const namePrefix = `console-mission-${resource}-${verb}`
+
+  let yaml = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ${kind}
+metadata:
+  name: ${namePrefix}`
+
+  if (namespace) {
+    yaml += `\n  namespace: ${namespace}`
+  }
+
+  yaml += `
+rules:
+  - apiGroups: ["${apiGroup}"]
+    resources: ["${resource}"]
+    verbs: ["${verb}"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ${bindingKind}
+metadata:
+  name: ${namePrefix}-binding`
+
+  if (namespace) {
+    yaml += `\n  namespace: ${namespace}`
+  }
+
+  yaml += `
+subjects:
+  - kind: User
+    name: <YOUR_USER>  # Replace with your username
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ${kind}
+  name: ${namePrefix}
+  apiGroup: rbac.authorization.k8s.io`
+
+  return yaml
+}
+
+// ============================================================================
+// Preflight Runner
+// ============================================================================
+
+interface KubectlExecFn {
+  (args: string[], options?: { context?: string; timeout?: number; priority?: boolean }): Promise<{
+    output: string
+    exitCode: number
+    error?: string
+  }>
+}
+
+/**
+ * Run a preflight permission check against a cluster context.
+ *
+ * Executes `kubectl auth can-i --list` to verify the agent has access to the
+ * cluster. If that fails, the error is classified into a structured error code
+ * with remediation actions.
+ *
+ * @param kubectlExec - Function to execute kubectl commands (typically kubectlProxy.exec)
+ * @param context     - Optional cluster context to check
+ */
+export async function runPreflightCheck(
+  kubectlExec: KubectlExecFn,
+  context?: string,
+): Promise<PreflightResult> {
+  try {
+    const args = ['auth', 'can-i', '--list', '--no-headers']
+    const result = await kubectlExec(args, {
+      context,
+      timeout: 10_000,
+      priority: true,
+    })
+
+    if (result.exitCode !== 0) {
+      const error = classifyKubectlError(
+        result.error || '',
+        result.output || '',
+        result.exitCode,
+      )
+      return { ok: false, error, context }
+    }
+
+    return { ok: true, context }
+  } catch (err) {
+    // Connection-level failures (WebSocket down, agent unavailable)
+    const message = err instanceof Error ? err.message : String(err)
+
+    // Classify the error message itself
+    const error = classifyKubectlError(message, '', 1)
+
+    // If the classifier returned UNKNOWN but we know it's a connection issue,
+    // override to CLUSTER_UNREACHABLE
+    const lowerMessage = message.toLowerCase()
+    if (
+      error.code === 'UNKNOWN_EXECUTION_FAILURE' &&
+      (lowerMessage.includes('not connected') ||
+        lowerMessage.includes('connection') ||
+        lowerMessage.includes('timeout') ||
+        lowerMessage.includes('unavailable'))
+    ) {
+      return {
+        ok: false,
+        error: {
+          code: 'CLUSTER_UNREACHABLE',
+          message: 'Unable to reach the local agent or Kubernetes cluster.',
+        },
+        context,
+      }
+    }
+
+    return { ok: false, error, context }
+  }
+}


### PR DESCRIPTION
Closes #3742

## Summary
- Adds a **preflight permission check** before executing mutating mission steps -- missions targeting a cluster (`deploy`, `repair`, `upgrade`, or any mission with a `cluster` param) now validate `kubectl auth can-i --list` before sending work to the AI agent
- Introduces a **structured error taxonomy** with 6 stable error codes: `MISSING_CREDENTIALS`, `EXPIRED_CREDENTIALS`, `RBAC_DENIED`, `CONTEXT_NOT_FOUND`, `CLUSTER_UNREACHABLE`, `UNKNOWN_EXECUTION_FAILURE`
- Adds a **PreflightFailure UI component** that renders targeted remediation actions per error type (copy commands, RBAC manifests, retry button)
- Adds a new `blocked` mission status -- blocked missions show the preflight failure panel and can be retried after fixing the underlying issue
- Non-cluster missions (`analyze`, `troubleshoot` without cluster context) skip the preflight check entirely

## New files
- `web/src/lib/missions/preflightCheck.ts` -- error classifier, preflight runner, remediation action generator, RBAC snippet generator
- `web/src/lib/missions/__tests__/preflightCheck.test.ts` -- 28 unit tests covering all error codes, the preflight runner, and remediation actions
- `web/src/components/missions/PreflightFailure.tsx` -- UI component for blocked missions

## Modified files
- `web/src/hooks/useMissions.tsx` -- added `blocked` status, `preflightError` field on Mission, `retryPreflight` action, preflight gate in `startMission`, extracted `executeMission` helper
- `web/src/hooks/useMissions.test.tsx` -- added mocks for new imports, fixed test helper for async preflight chain
- `web/src/components/layout/mission-sidebar/types.ts` -- added `blocked` to STATUS_CONFIG
- `web/src/components/layout/mission-sidebar/MissionChat.tsx` -- renders PreflightFailure panel and retry button for blocked missions

## Test plan
- [x] 28 new unit tests for error classification, preflight runner, and remediation actions -- all pass
- [x] 64 existing useMissions tests -- all pass (no regressions)
- [x] TypeScript build passes
- [ ] Manual: start a deploy mission without kubeconfig -- should show MISSING_CREDENTIALS with remediation
- [ ] Manual: start a deploy mission with expired token -- should show EXPIRED_CREDENTIALS
- [ ] Manual: fix the issue and click "Retry Preflight Check" -- mission should proceed

Generated with [Claude Code](https://claude.com/claude-code)