### PR TITLE
fix: warn users about non-interactive terminal in agent missions

### DIFF
--- a/pkg/agent/provider.go
+++ b/pkg/agent/provider.go
@@ -157,4 +157,11 @@ Your job is to help users with:
 - Executing kubectl commands and interpreting their output
 
 Be concise but thorough. When dealing with Kubernetes resources, provide YAML examples when helpful.
-Format your responses using markdown for better readability.`
+Format your responses using markdown for better readability.
+
+IMPORTANT: You are running in a non-interactive terminal that does NOT support stdin input.
+Never run commands that require interactive user input (prompts, confirmations, login flows).
+Always use non-interactive flags such as --yes, -y, --non-interactive, --no-input, --batch, or
+pipe "yes" when necessary. If a tool requires interactive authentication (e.g., browser-based
+OAuth login), instruct the user to complete that step manually in their own terminal first,
+then retry the mission.`

--- a/pkg/agent/provider_copilotcli.go
+++ b/pkg/agent/provider_copilotcli.go
@@ -190,9 +190,16 @@ func (c *CopilotCLIProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 
 	// If stdout was empty but stderr has content, the CLI may have failed
 	if content == "" && waitErr != nil {
-		errMsg := stderrContent.String()
+		errMsg := strings.TrimSpace(stderrContent.String())
 		if errMsg != "" {
-			return nil, fmt.Errorf("copilot CLI failed: %s", strings.TrimSpace(errMsg))
+			// Detect authentication/login prompts that require interactive input
+			lower := strings.ToLower(errMsg)
+			if strings.Contains(lower, "login") || strings.Contains(lower, "auth") ||
+				strings.Contains(lower, "sign in") || strings.Contains(lower, "token") ||
+				strings.Contains(lower, "authenticate") {
+				return nil, fmt.Errorf("copilot CLI requires authentication. Please run 'gh auth login' in your own terminal first, then retry this mission. Error: %s", errMsg)
+			}
+			return nil, fmt.Errorf("copilot CLI failed: %s", errMsg)
 		}
 		return nil, fmt.Errorf("copilot CLI returned empty response (exit: %v)", waitErr)
 	}

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -911,6 +911,16 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       }
     }
 
+    // Remind the agent that it runs in a non-interactive terminal (no stdin).
+    // This prevents commands that prompt for user input from hanging (#3767).
+    const isInstallMission = params.type === 'deploy' || /install/i.test(params.title)
+    if (isInstallMission) {
+      enhancedPrompt += '\n\nIMPORTANT: You are running in a non-interactive terminal with NO stdin support. ' +
+        'Never run commands that require interactive input (login prompts, confirmation dialogs, browser OAuth flows). ' +
+        'Always use non-interactive flags (--yes, -y, --non-interactive, --no-input, --batch) or pipe "yes" where needed. ' +
+        'If a step requires interactive authentication, stop and tell the user to complete it manually in their own terminal first.'
+    }
+
     // Auto-match and inject resolution context for relevant mission types
     let matchedResolutions: MatchedResolution[] = []
 
@@ -952,6 +962,17 @@ Install the console locally with the KubeStellar Console agent to use AI mission
         timestamp: new Date(),
       }
     ]
+
+    // Warn the user that interactive terminal input is not supported (#3767)
+    if (isInstallMission) {
+      initialMessages.push({
+        id: `msg-${Date.now()}-nointeractive`,
+        role: 'system',
+        content: '**Non-interactive mode:** This terminal does not support interactive input. ' +
+          'If a tool requires browser-based login or manual confirmation, the agent will ask you to run that step in your own terminal first.',
+        timestamp: new Date(),
+      })
+    }
 
     // Add system message if resolutions were auto-matched
     if (matchedResolutions.length > 0) {


### PR DESCRIPTION
Closes #3767

## Summary
- Add non-interactive instruction to the default AI system prompt so all providers avoid running commands that need stdin input
- Inject an explicit non-interactive reminder into deploy/install mission prompts sent to the agent
- Show a system message in mission chat warning users that interactive terminal input is not supported
- Improve Copilot CLI error detection to surface auth-related failures with actionable guidance (e.g., "run `gh auth login` in your own terminal first")

## Test plan
- [ ] Start a deploy/install mission and verify the "Non-interactive mode" system message appears in chat
- [ ] Verify the AI agent avoids interactive commands and suggests manual steps when auth is needed
- [ ] Verify Go build passes: `go build ./...`
- [ ] Verify frontend build passes: `cd web && npm run build`

Generated with Claude Code