### PR TITLE
fix: hide empty preview panel in AddCardModal when no card hovered

### DIFF
--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -1478,9 +1478,9 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
                 </div>
               </div>
 
-              {/* Right side - Preview Panel (always rendered) */}
-              <div className="w-64 border-l border-border pl-4 flex-shrink-0">
-                {hoveredCard ? (
+              {/* Right side - Preview Panel (only shown when hovering a card) */}
+              {hoveredCard && (
+                <div className="w-64 border-l border-border pl-4 flex-shrink-0">
                   <div>
                     <div className="text-2xs text-muted-foreground uppercase tracking-wide mb-2">{t('dashboard.addCard.preview')}</div>
 
@@ -1506,13 +1506,8 @@ export function AddCardModal({ isOpen, onClose, onAddCards, existingCardTypes = 
                       </div>
                     </div>
                   </div>
-                ) : (
-                  <div className="h-full flex flex-col items-center justify-center text-muted-foreground py-8">
-                    <LayoutGrid className="w-8 h-8 mb-2 opacity-30" />
-                    <p className="text-xs text-center">{t('dashboard.addCard.hoverToPreview')}</p>
-                  </div>
-                )}
-              </div>
+                </div>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
Closes #3765

## Summary
- The right-side preview panel in the AddCardModal Browse tab was always rendered, showing a sparse empty placeholder (just a small icon and "hover to preview" text) when no card was hovered, creating dead space
- Changed the panel to only render when a card is actually being hovered, letting the card catalog expand to use the full modal width by default
- When the user hovers over a card, the preview panel appears with the card preview and details as before

## Test plan
- [x] Build passes (`npm run build`)
- [x] Existing unit tests pass
- [ ] Open the Add Card modal, verify no dead space on the right when Browse tab is active and no card is hovered
- [ ] Hover over a card in the catalog, verify the preview panel appears on the right with card details
- [ ] Move mouse away from cards, verify preview panel disappears cleanly