### PR TITLE
fix: use subtle transparent hover backgrounds for sidebar icon buttons

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -564,7 +564,7 @@ export function Sidebar() {
               }
             }}
             aria-expanded={!config.collapsed}
-            className="p-1.5 rounded-full bg-background border border-border text-muted-foreground hover:text-foreground hover:bg-secondary shadow-md transition-colors"
+            className="p-1.5 rounded-full bg-background border border-border text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10 shadow-md transition-colors"
             title={config.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           >
             {config.collapsed ? <ChevronRight className="w-3.5 h-3.5" aria-hidden="true" /> : <ChevronLeft className="w-3.5 h-3.5" aria-hidden="true" />}
@@ -574,8 +574,8 @@ export function Sidebar() {
             className={cn(
               "p-1.5 rounded-full border border-border shadow-md transition-colors",
               isPinned
-                ? "bg-purple-900 text-purple-300 hover:bg-purple-800 border-purple-600"
-                : "bg-gray-800 text-muted-foreground hover:text-foreground hover:bg-gray-700 border-gray-600"
+                ? "bg-purple-500/15 text-purple-400 hover:bg-purple-500/25 border-purple-500/30"
+                : "bg-background text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10"
             )}
             title={isPinned ? 'Unpin sidebar (auto-collapse on mouse leave)' : 'Pin sidebar open'}
           >

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -434,7 +434,7 @@ export function MissionSidebar() {
       )}>
         <button
           onClick={expandSidebar}
-          className="p-2 hover:bg-secondary rounded transition-colors mb-4"
+          className="p-2 rounded transition-colors hover:bg-black/5 dark:hover:bg-white/10 mb-4"
           title={t('missionSidebar.expandSidebar')}
         >
           <PanelRightOpen className="w-5 h-5 text-muted-foreground" />
@@ -528,7 +528,7 @@ export function MissionSidebar() {
               "p-1.5 rounded transition-colors",
               showNewMission
                 ? "bg-primary text-primary-foreground"
-                : "hover:bg-secondary text-muted-foreground hover:text-foreground"
+                : "text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10"
             )}
             title={t('missionSidebar.startNewMission')}
           >
@@ -537,7 +537,7 @@ export function MissionSidebar() {
           {/* Browse Community Missions */}
           <button
             onClick={() => setShowBrowser(true)}
-            className="p-1.5 rounded transition-colors hover:bg-secondary text-muted-foreground hover:text-foreground"
+            className="p-1.5 rounded transition-colors text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10"
             title="Browse community missions"
           >
             <Globe className="w-4 h-4" />
@@ -545,7 +545,7 @@ export function MissionSidebar() {
           {/* Mission Control */}
           <button
             onClick={() => setShowMissionControl(true)}
-            className="p-1.5 rounded transition-colors hover:bg-secondary text-muted-foreground hover:text-foreground"
+            className="p-1.5 rounded transition-colors text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10"
             title="Mission Control — Multi-Cluster Solutions Orchestrator"
           >
             <Rocket className="w-4 h-4" />
@@ -556,7 +556,7 @@ export function MissionSidebar() {
             <button
               onClick={() => setFontSize(prev => prev === 'base' ? 'sm' : prev === 'lg' ? 'base' : 'sm')}
               disabled={fontSize === 'sm'}
-              className="p-1 hover:bg-secondary rounded transition-colors disabled:opacity-30"
+              className="p-1 rounded transition-colors disabled:opacity-30 hover:bg-black/5 dark:hover:bg-white/10"
               title={t('missionSidebar.decreaseFontSize')}
             >
               <Minus className="w-3 h-3 text-muted-foreground" />
@@ -565,7 +565,7 @@ export function MissionSidebar() {
             <button
               onClick={() => setFontSize(prev => prev === 'sm' ? 'base' : prev === 'base' ? 'lg' : 'lg')}
               disabled={fontSize === 'lg'}
-              className="p-1 hover:bg-secondary rounded transition-colors disabled:opacity-30"
+              className="p-1 rounded transition-colors disabled:opacity-30 hover:bg-black/5 dark:hover:bg-white/10"
               title={t('missionSidebar.increaseFontSize')}
             >
               <Plus className="w-3 h-3 text-muted-foreground" />
@@ -575,7 +575,7 @@ export function MissionSidebar() {
           {!isMobile && (isFullScreen ? (
             <button
               onClick={() => setFullScreen(false)}
-              className="p-1 hover:bg-secondary rounded transition-colors"
+              className="p-1 rounded transition-colors hover:bg-black/5 dark:hover:bg-white/10"
               title={t('missionSidebar.exitFullScreen')}
             >
               <Minimize2 className="w-5 h-5 text-muted-foreground" />
@@ -584,14 +584,14 @@ export function MissionSidebar() {
             <>
               <button
                 onClick={() => setFullScreen(true)}
-                className="p-1 hover:bg-secondary rounded transition-colors"
+                className="p-1 rounded transition-colors hover:bg-black/5 dark:hover:bg-white/10"
                 title={t('missionSidebar.fullScreen')}
               >
                 <Maximize2 className="w-5 h-5 text-muted-foreground" />
               </button>
               <button
                 onClick={minimizeSidebar}
-                className="p-1 hover:bg-secondary rounded transition-colors"
+                className="p-1 rounded transition-colors hover:bg-black/5 dark:hover:bg-white/10"
                 title={t('missionSidebar.minimizeSidebar')}
               >
                 <PanelRightClose className="w-5 h-5 text-muted-foreground" />
@@ -600,7 +600,7 @@ export function MissionSidebar() {
           ))}
           <button
             onClick={closeSidebar}
-            className="p-1 hover:bg-secondary rounded transition-colors"
+            className="p-1 rounded transition-colors hover:bg-black/5 dark:hover:bg-white/10"
             title={t('missionSidebar.closeSidebar')}
           >
             <X className="w-5 h-5 text-muted-foreground" />

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -52,7 +52,7 @@ export function Navbar() {
         {/* Hamburger menu - mobile only */}
         <button
           onClick={toggleMobileSidebar}
-          className="p-2 md:hidden hover:bg-secondary rounded-lg transition-colors"
+          className="p-2 md:hidden rounded-lg transition-colors hover:bg-black/5 dark:hover:bg-white/10"
           aria-label={config.isMobileOpen ? t('navbar.closeMenu') : t('navbar.openMenu')}
         >
           {config.isMobileOpen ? (


### PR DESCRIPTION
Closes #3762

## Summary
- Replace `hover:bg-secondary` and hardcoded `bg-gray-800`/`bg-purple-900` with transparent overlays (`hover:bg-black/5 dark:hover:bg-white/10`) on sidebar icon buttons
- Fix the sidebar pin button's hardcoded dark-mode colors that looked out of place in light mode
- Apply consistent hover styling across: navbar hamburger/close button, left sidebar collapse/pin buttons, and mission sidebar header icon buttons (close, minimize, fullscreen, font size, new mission, browse, mission control)

## Test plan
- [ ] Verify hover states on sidebar collapse/expand chevron button look natural in both light and dark themes
- [ ] Verify hover states on sidebar pin/unpin button blend with the background
- [ ] Verify navbar hamburger/close button hover on mobile
- [ ] Verify all mission sidebar header icon buttons have subtle hover backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)