### PR TITLE
fix: guard against NaN in GPU drilldown display (#3764)

### DIFF
--- a/web/src/components/charts/Gauge.tsx
+++ b/web/src/components/charts/Gauge.tsx
@@ -21,7 +21,10 @@ export function Gauge({
   thresholds = { warning: 70, critical: 90 },
   invertColors = false,
 }: GaugeProps) {
-  const percentage = max > 0 ? Math.min((value / max) * 100, 100) : 0
+  // Guard against NaN/undefined values that can occur with incomplete API data
+  const safeValue = Number.isFinite(value) ? value : 0
+  const safeMax = Number.isFinite(max) && max > 0 ? max : 100
+  const percentage = Math.min((safeValue / safeMax) * 100, 100)
   const rotation = (percentage / 100) * 180 - 90 // -90 to 90 degrees
 
   const getColor = () => {
@@ -82,7 +85,7 @@ export function Gauge({
         {/* Value display */}
         <div className="absolute inset-0 flex items-end justify-center pb-1">
           <span className={`font-bold ${s.fontSize} ${color.text}`}>
-            {Math.round(value)}
+            {Math.round(safeValue)}
             <span className="text-sm text-muted-foreground">{unit}</span>
           </span>
         </div>

--- a/web/src/components/drilldown/views/ClusterDrillDown.tsx
+++ b/web/src/components/drilldown/views/ClusterDrillDown.tsx
@@ -89,8 +89,8 @@ export function ClusterDrillDown({ data }: Props) {
       if (!map[type]) {
         map[type] = { total: 0, allocated: 0, nodes: 0 }
       }
-      map[type].total += node.gpuCount
-      map[type].allocated += node.gpuAllocated
+      map[type].total += node.gpuCount || 0
+      map[type].allocated += node.gpuAllocated || 0
       map[type].nodes += 1
     })
     return map
@@ -226,8 +226,8 @@ export function ClusterDrillDown({ data }: Props) {
     )
   }
 
-  const totalGPUs = clusterGPUNodes.reduce((sum, n) => sum + n.gpuCount, 0)
-  const allocatedGPUs = clusterGPUNodes.reduce((sum, n) => sum + n.gpuAllocated, 0)
+  const totalGPUs = clusterGPUNodes.reduce((sum, n) => sum + (n.gpuCount || 0), 0)
+  const allocatedGPUs = clusterGPUNodes.reduce((sum, n) => sum + (n.gpuAllocated || 0), 0)
 
   return (
     <div className="space-y-6">

--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -359,26 +359,36 @@ export function useGPUNodes(cluster?: string) {
 
       if (!existing) {
         // First time seeing this node - ensure gpuAllocated doesn't exceed gpuCount
+        // Guard against undefined/NaN values from incomplete API data
+        const count = node.gpuCount || 0
+        const allocated = node.gpuAllocated || 0
         seenNodes.set(nodeKey, {
           ...node,
-          gpuAllocated: Math.min(node.gpuAllocated, node.gpuCount)
+          gpuCount: count,
+          gpuAllocated: Math.min(allocated, count)
         })
       } else if (isShortName && !existingIsShortName) {
         // New entry has short cluster name, existing has long - prefer short
+        const count = node.gpuCount || 0
+        const allocated = node.gpuAllocated || 0
         seenNodes.set(nodeKey, {
           ...node,
-          gpuAllocated: Math.min(node.gpuAllocated, node.gpuCount)
+          gpuCount: count,
+          gpuAllocated: Math.min(allocated, count)
         })
       } else if (!isShortName && existingIsShortName) {
         // Existing has short name, keep it - don't replace
       } else {
         // Both have same type of name - keep the one with more reasonable data
         const existingValid = existing.gpuAllocated <= existing.gpuCount
-        const newValid = node.gpuAllocated <= node.gpuCount
+        const newCount = node.gpuCount || 0
+        const newAllocated = node.gpuAllocated || 0
+        const newValid = newAllocated <= newCount
         if (newValid && !existingValid) {
           seenNodes.set(nodeKey, {
             ...node,
-            gpuAllocated: Math.min(node.gpuAllocated, node.gpuCount)
+            gpuCount: newCount,
+            gpuAllocated: Math.min(newAllocated, newCount)
           })
         }
       }


### PR DESCRIPTION
Closes #3764

## Summary
- Add `Number.isFinite()` guards in the `Gauge` component to prevent NaN from being rendered when `value` or `max` are undefined/NaN
- Add `|| 0` fallbacks in `ClusterDrillDown` GPU aggregation (`gpuByType`, `totalGPUs`, `allocatedGPUs`) to handle missing `gpuCount`/`gpuAllocated` fields
- Add `|| 0` fallbacks in `compute.ts` GPU node deduplication to prevent `Math.min(undefined, undefined)` producing NaN

## Root cause
When GPU node data from the MCP API has missing or undefined `gpuCount`/`gpuAllocated` fields, arithmetic operations (`+=`, `Math.min`, `Math.round`) propagate NaN through to the UI, displaying "NaN" in the "GPUs by type" section of the cluster health drilldown.

## Test plan
- [x] TypeScript compilation passes
- [x] Full build passes (`npm run build`)
- [x] All 21 compute.ts tests pass
- [ ] Manually verify cluster drilldown shows "0" instead of "NaN" when GPU data is incomplete

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>