### PR TITLE
fix: show user GitHub avatar in AI missions chat

### DIFF
--- a/web/src/components/layout/mission-sidebar/MemoizedMessage.tsx
+++ b/web/src/components/layout/mission-sidebar/MemoizedMessage.tsx
@@ -20,7 +20,7 @@ import {
 import type { MessageProps } from './types'
 
 // Memoized message component to prevent re-renders on scroll
-export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent, isFullScreen, fontSize, isLastAssistantMessage, missionStatus }: MessageProps) {
+export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent, isFullScreen, fontSize, isLastAssistantMessage, missionStatus, userAvatarUrl }: MessageProps) {
   // Memoize the parsed content to avoid re-parsing on every render
   const parsedContent = useMemo(() => {
     if (msg.role !== 'assistant') return null
@@ -118,7 +118,11 @@ export const MemoizedMessage = memo(function MemoizedMessage({ msg, missionAgent
         msg.role === 'user' ? 'bg-primary/20' : msg.role === 'assistant' ? 'bg-purple-500/20' : 'bg-yellow-500/20'
       )}>
         {msg.role === 'user' ? (
-          <User className="w-4 h-4 text-primary" />
+          userAvatarUrl ? (
+            <img src={userAvatarUrl} alt="User avatar" className="w-8 h-8 rounded-full" />
+          ) : (
+            <User className="w-4 h-4 text-primary" />
+          )
         ) : msg.role === 'assistant' ? (
           <AgentIcon provider={agentProvider} className="w-4 h-4" />
         ) : (

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -21,6 +21,7 @@ import {
   StopCircle,
 } from 'lucide-react'
 import { useMissions, type Mission } from '../../../hooks/useMissions'
+import { useAuth } from '../../../lib/auth'
 import { useDemoMode } from '../../../hooks/useDemoMode'
 import { isNetlifyDeployment } from '../../../lib/demoMode'
 import { useResolutions, detectIssueSignature } from '../../../hooks/useResolutions'
@@ -39,6 +40,7 @@ import { MemoizedMessage } from './MemoizedMessage'
 export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' as FontSize, onToggleFullScreen }: { mission: Mission; isFullScreen?: boolean; fontSize?: FontSize; onToggleFullScreen?: () => void }) {
   const { t } = useTranslation('common')
   const { sendMessage, retryPreflight, cancelMission, rateMission, setActiveMission, dismissMission, renameMission, runSavedMission, selectedAgent } = useMissions()
+  const { user } = useAuth()
   const { isDemoMode } = useDemoMode()
   const { findSimilarResolutions, recordUsage } = useResolutions()
   const [input, setInput] = useState('')
@@ -499,6 +501,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               fontSize={fontSize}
               isLastAssistantMessage={isLastAssistantMessage}
               missionStatus={mission.status}
+              userAvatarUrl={user?.avatar_url}
             />
           )
         })}

--- a/web/src/components/layout/mission-sidebar/types.ts
+++ b/web/src/components/layout/mission-sidebar/types.ts
@@ -101,4 +101,5 @@ export interface MessageProps {
   fontSize: FontSize
   isLastAssistantMessage?: boolean
   missionStatus?: string
+  userAvatarUrl?: string
 }


### PR DESCRIPTION
Closes #3766

## Summary
- Added the user's GitHub profile picture to their messages in the AI missions chat
- Reuses the same `avatar_url` from the auth context that powers the profile button
- Falls back to the generic `User` icon when no avatar URL is available (e.g., demo mode)

## Changes
- `types.ts`: Added `userAvatarUrl` optional prop to `MessageProps`
- `MemoizedMessage.tsx`: Render `<img>` with the avatar URL for user messages when available, otherwise show the default `User` icon
- `MissionChat.tsx`: Import `useAuth`, extract `user`, and pass `user?.avatar_url` to `MemoizedMessage`

## Test plan
- [ ] Log in with GitHub OAuth and open an AI mission chat
- [ ] Verify the user's GitHub profile picture appears next to their messages
- [ ] Verify the profile picture matches the one shown on the profile dropdown button
- [ ] Verify that in demo mode (no auth), the generic User icon still appears
- [ ] Verify assistant messages still show the correct agent icon