### PR TITLE
fix: resolve consistency-test magic numbers and unguarded join

### DIFF
--- a/web/src/components/cards/EtcdStatus.tsx
+++ b/web/src/components/cards/EtcdStatus.tsx
@@ -139,7 +139,7 @@ export function EtcdStatus() {
       })}
       {clustersWithoutEtcd.length > 0 && (
         <div className="mt-1 px-2 py-1.5 rounded-lg bg-muted/20 text-xs text-muted-foreground">
-          <span className="font-medium">{clustersWithoutEtcd.join(', ')}</span>
+          <span className="font-medium">{(clustersWithoutEtcd ?? []).join(', ')}</span>
           {' — '}
           {clustersWithoutEtcd.some(c => isManagedCluster(pods, c))
             ? t('etcdStatus.managedByProvider')

--- a/web/src/components/cards/UpgradeStatus.tsx
+++ b/web/src/components/cards/UpgradeStatus.tsx
@@ -13,6 +13,8 @@ import { useCardLoadingState } from './CardDataContext'
 import { LOCAL_AGENT_WS_URL } from '../../lib/constants'
 import { useTranslation } from 'react-i18next'
 
+const WS_CONNECTION_TIMEOUT_MS = 5000
+
 interface UpgradeStatusProps {
   config?: Record<string, unknown>
 }
@@ -117,7 +119,7 @@ function createVersionWsHandle(): VersionWsHandle {
           if (destroyed) { clearInterval(checkInterval); reject(new Error('Handle destroyed')); return }
           if (ws?.readyState === WebSocket.OPEN) { clearInterval(checkInterval); resolve(ws) }
         }, 100)
-        setTimeout(() => { clearInterval(checkInterval); reject(new Error('WebSocket connection timeout')) }, 5000)
+        setTimeout(() => { clearInterval(checkInterval); reject(new Error('WebSocket connection timeout')) }, WS_CONNECTION_TIMEOUT_MS)
       })
     }
 

--- a/web/src/components/missions/PreflightFailure.tsx
+++ b/web/src/components/missions/PreflightFailure.tsx
@@ -6,6 +6,8 @@
  */
 
 import { useState, useCallback } from 'react'
+
+const COPY_FEEDBACK_MS = 2000
 import {
   ShieldAlert,
   KeyRound,
@@ -86,7 +88,7 @@ function ActionButton({
         // Fallback: select text in a temporary textarea
       })
       setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
+      setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
     }
   }, [action.codeSnippet])
 


### PR DESCRIPTION
Closes #3776
Closes #3777

## Summary
- **Phase 1 fix (magic numbers):** Extract `COPY_FEEDBACK_MS` constant in `PreflightFailure.tsx` (was bare `2000`) and `WS_CONNECTION_TIMEOUT_MS` in `UpgradeStatus.tsx` (was bare `5000`)
- **Phase 3 fix (join guard):** Add `?? []` guard on `clustersWithoutEtcd.join()` in `EtcdStatus.tsx`

## Test plan
- [x] `bash scripts/consistency-test.sh` passes with 0 errors (11 warnings unchanged)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)