### PR TITLE
fix: agent dropdown not working in AI Missions sidebar

### DIFF
--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -42,6 +42,9 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
     typeof window !== 'undefined' ? safeGetItem(PREV_AGENT_KEY) : null
   )
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+  const [dropdownPos, setDropdownPos] = useState<{ top: number; right: number } | null>(null)
   const [showApproval, setShowApproval] = useState(false)
   // Provider connection lifecycle tracking
   const { connectionState, startConnection, retry, reset: resetConnection, dismiss: dismissConnection } = useProviderConnection()
@@ -189,16 +192,31 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
     }
   }, [isOpen, agents.length, agentsLoading, isDemoMode, connectToAgent])
 
-  // Close dropdown when clicking outside
+  // Close dropdown when clicking outside (check both trigger and portal panel)
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      const target = event.target as Node
+      if (
+        dropdownRef.current && !dropdownRef.current.contains(target) &&
+        (!panelRef.current || !panelRef.current.contains(target))
+      ) {
         closeDropdown()
       }
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [closeDropdown])
+
+  // Compute dropdown position when opened (portal needs absolute screen coords)
+  useEffect(() => {
+    if (isOpen && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect()
+      setDropdownPos({
+        top: rect.bottom + 4, // 4px gap (mt-1 equivalent)
+        right: window.innerWidth - rect.right,
+      })
+    }
+  }, [isOpen])
 
   // Close on escape
   useEffect(() => {
@@ -354,6 +372,7 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
     <>
     <div ref={dropdownRef} className={cn('relative flex items-center gap-1', className, isGreyedOut && 'opacity-40 pointer-events-none')}>
       <button
+        ref={buttonRef}
         onClick={() => !isDemoMode && toggleDropdown()}
         aria-haspopup="listbox"
         aria-expanded={isOpen}
@@ -381,11 +400,13 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
         )} />
       </button>
 
-      {isOpen && (
+      {isOpen && dropdownPos && createPortal(
         <div
+          ref={panelRef}
           role="listbox"
           aria-label={t('agent.selectAgent')}
-          className="absolute z-50 top-full mt-1 right-0 w-96 max-h-[calc(100vh-8rem)] rounded-lg bg-card border border-border shadow-lg overflow-hidden flex flex-col"
+          className="fixed z-[9999] w-96 max-h-[calc(100vh-8rem)] rounded-lg bg-card border border-border shadow-lg overflow-hidden flex flex-col"
+          style={{ top: dropdownPos.top, right: dropdownPos.right }}
           onKeyDown={(e) => {
             if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
             e.preventDefault()
@@ -579,7 +600,8 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
               )}
             </div>
           )}
-        </div>
+        </div>,
+        document.body
       )}
     </div>
     <AgentApprovalDialog


### PR DESCRIPTION
Closes #3783

## Summary

- The AgentSelector dropdown was invisible when clicked inside the AI Missions sidebar because the sidebar container (`overflow-hidden`) and its toolbar wrapper (`overflow-hidden`) clipped the absolutely-positioned dropdown panel
- Fixed by rendering the dropdown via `createPortal` to `document.body` with `fixed` positioning computed from the trigger button's bounding rect
- Updated the click-outside handler to also check the portal panel ref so clicks inside the dropdown don't close it

## Test plan

- [ ] Open the Dashboard -- verify the agent dropdown still works as before
- [ ] Open AI Missions sidebar -- click the agent dropdown -- verify it opens and shows the list of agents
- [ ] Select an agent from the sidebar dropdown -- verify selection works
- [ ] Click outside the dropdown -- verify it closes
- [ ] Press Escape -- verify it closes
- [ ] Resize the browser window and re-open -- verify the dropdown stays aligned to the button

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>