### PR TITLE
fix: ControlPlaneHealth uses showSkeleton from useCardLoadingState

### DIFF
--- a/web/src/components/cards/ControlPlaneHealth.tsx
+++ b/web/src/components/cards/ControlPlaneHealth.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCachedPods } from '../../hooks/useCachedData'
 import { useClusters } from '../../hooks/useMCP'
+import { Skeleton } from '../ui/Skeleton'
 import { useCardLoadingState } from './CardDataContext'
 
 const CP_LABELS: Record<string, string[]> = {
@@ -19,7 +20,7 @@ export function ControlPlaneHealth() {
   const [selectedCluster, setSelectedCluster] = useState<string | null>(null)
 
   const hasData = pods.length > 0
-  useCardLoadingState({
+  const { showSkeleton } = useCardLoadingState({
     isLoading: isLoading && !hasData,
     isRefreshing,
     hasAnyData: hasData,
@@ -58,11 +59,11 @@ export function ControlPlaneHealth() {
 
   const managedCluster = componentStatus.every(c => c.total === 0) && clusters.length > 0
 
-  if (isLoading && pods.length === 0) {
+  if (showSkeleton) {
     return (
       <div className="space-y-2 p-1">
         {[1, 2, 3, 4, 5].map(i => (
-          <div key={i} className="h-8 rounded bg-muted/50 animate-pulse" />
+          <Skeleton key={i} variant="rounded" height={32} />
         ))}
       </div>
     )


### PR DESCRIPTION
Closes #3796

## Summary
- Destructure `showSkeleton` from `useCardLoadingState` instead of ignoring the return value
- Replace the custom `isLoading && pods.length === 0` guard with `if (showSkeleton)`
- Replace the hand-rolled `animate-pulse` divs with the `<Skeleton>` component used by all other cards

## Test plan
- [ ] Verify ControlPlaneHealth card shows the standard Skeleton loading state on first load
- [ ] Verify cached data displays instantly on revisit with refresh animation
- [ ] Verify demo mode still shows Demo badge and yellow outline

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>