### PR TITLE
fix: remove visible background from pin and collapse sidebar buttons

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -564,7 +564,7 @@ export function Sidebar() {
               }
             }}
             aria-expanded={!config.collapsed}
-            className="p-1.5 rounded-full bg-background border border-border text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10 shadow-md transition-colors"
+            className="p-1.5 rounded-full border border-border text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10 shadow-md transition-colors"
             title={config.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           >
             {config.collapsed ? <ChevronRight className="w-3.5 h-3.5" aria-hidden="true" /> : <ChevronLeft className="w-3.5 h-3.5" aria-hidden="true" />}
@@ -575,7 +575,7 @@ export function Sidebar() {
               "p-1.5 rounded-full border border-border shadow-md transition-colors",
               isPinned
                 ? "bg-purple-500/15 text-purple-400 hover:bg-purple-500/25 border-purple-500/30"
-                : "bg-background text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10"
+                : "text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10"
             )}
             title={isPinned ? 'Unpin sidebar (auto-collapse on mouse leave)' : 'Pin sidebar open'}
           >


### PR DESCRIPTION
Closes #3787

## Summary
- Remove `bg-background` from the sidebar collapse/expand chevron button so it is transparent at rest
- Remove `bg-background` from the sidebar pin button (unpinned state) so it is transparent at rest
- Hover states remain unchanged (`hover:bg-black/5 dark:hover:bg-white/10`), matching the navbar hamburger button and other icon buttons fixed in PR #3772
- The pinned state still uses `bg-purple-500/15` to indicate it is active, which is intentional

## Test plan
- [ ] Verify the collapse/expand button has no visible background at rest in both light and dark themes
- [ ] Verify the pin button (unpinned) has no visible background at rest in both light and dark themes
- [ ] Verify hover states still show subtle backgrounds on both buttons
- [ ] Verify the pinned state still shows the purple tint

🤖 Generated with [Claude Code](https://claude.com/claude-code)