### PR TITLE
fix: make Kyverno policy rows open insights drilldown view

### DIFF
--- a/web/src/components/cards/KyvernoPolicies.tsx
+++ b/web/src/components/cards/KyvernoPolicies.tsx
@@ -19,6 +19,7 @@ import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { StatusBadge } from '../ui/StatusBadge'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { KyvernoDetailModal } from './kyverno/KyvernoDetailModal'
+import { useDrillDownActions } from '../../hooks/useDrillDown'
 import type { KyvernoPolicy } from '../../hooks/useKyverno'
 
 interface KyvernoPoliciesProps {
@@ -30,6 +31,7 @@ function KyvernoPoliciesInternal({ config: _config }: KyvernoPoliciesProps) {
   const { statuses, isLoading, isRefreshing, lastRefresh, installed, hasErrors, isDemoData, refetch, clustersChecked, totalClusters } = useKyverno()
   const { startMission } = useMissions()
   const { selectedClusters } = useGlobalFilters()
+  const { drillToPolicy } = useDrillDownActions()
   const [localSearch, setLocalSearch] = useState('')
   const [modalCluster, setModalCluster] = useState<string | null>(null)
 
@@ -141,6 +143,18 @@ Please proceed step by step.`,
       case 'audit': return 'bg-yellow-500/20 text-yellow-400'
       default: return 'bg-blue-500/20 text-blue-400'
     }
+  }
+
+  const handlePolicyClick = (policy: KyvernoPolicy) => {
+    drillToPolicy(policy.cluster, policy.namespace, policy.name, {
+      policyType: 'kyverno',
+      kind: policy.kind,
+      status: policy.status,
+      category: policy.category,
+      description: policy.description,
+      violationCount: policy.violations,
+      background: policy.background,
+    })
   }
 
   const getCategoryColor = (category: string) => {
@@ -279,11 +293,11 @@ Please proceed step by step.`,
           <div
             key={`${policy.cluster}-${policy.name}-${i}`}
             className="p-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer"
-            onClick={() => setModalCluster(policy.cluster)}
+            onClick={() => handlePolicyClick(policy)}
             role="button"
             aria-label={`View Kyverno policy: ${policy.name} on ${policy.cluster}`}
             tabIndex={0}
-            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setModalCluster(policy.cluster) } }}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handlePolicyClick(policy) } }}
           >
             <div className="flex items-center justify-between mb-1">
               <div className="flex items-center gap-2">

--- a/web/src/components/cards/kyverno/KyvernoDetailModal.tsx
+++ b/web/src/components/cards/kyverno/KyvernoDetailModal.tsx
@@ -8,12 +8,13 @@
  * Follows the ClusterOPAModal pattern using BaseModal compound components.
  */
 
-import { useState, useMemo } from 'react'
-import { Shield, FileCheck, BarChart3, Search, ExternalLink, Sparkles } from 'lucide-react'
+import { useState, useMemo, useCallback } from 'react'
+import { Shield, FileCheck, BarChart3, Search, ExternalLink, Sparkles, AlertTriangle, ChevronRight } from 'lucide-react'
 import { BaseModal } from '../../../lib/modals'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { RefreshButton } from '../../ui/RefreshIndicator'
 import { useMissions } from '../../../hooks/useMissions'
+import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import type { KyvernoClusterStatus, KyvernoPolicy, KyvernoPolicyReport } from '../../../hooks/useKyverno'
 
 type KyvernoTab = 'policies' | 'reports'
@@ -41,6 +42,20 @@ export function KyvernoDetailModal({
   const [activeTab, setActiveTab] = useState<KyvernoTab>('policies')
   const [search, setSearch] = useState('')
   const { startMission } = useMissions()
+  const { drillToPolicy } = useDrillDownActions()
+
+  const handlePolicyClick = useCallback((policy: KyvernoPolicy) => {
+    onClose()
+    drillToPolicy(policy.cluster, policy.namespace, policy.name, {
+      policyType: 'kyverno',
+      kind: policy.kind,
+      status: policy.status,
+      category: policy.category,
+      description: policy.description,
+      violationCount: policy.violations,
+      background: policy.background,
+    })
+  }, [onClose, drillToPolicy])
 
   const tabs = [
     { id: 'policies' as const, label: 'Policies', icon: FileCheck, badge: status.totalPolicies },
@@ -177,7 +192,7 @@ Please proceed step by step.`,
             ) : (
               <div className="space-y-2">
                 {filteredPolicies.map((policy, i) => (
-                  <PolicyRow key={`${policy.name}-${i}`} policy={policy} getStatusColor={getStatusColor} getCategoryColor={getCategoryColor} />
+                  <PolicyRow key={`${policy.name}-${i}`} policy={policy} getStatusColor={getStatusColor} getCategoryColor={getCategoryColor} onClick={handlePolicyClick} />
                 ))}
               </div>
             )}
@@ -243,13 +258,22 @@ function PolicyRow({
   policy,
   getStatusColor,
   getCategoryColor,
+  onClick,
 }: {
   policy: KyvernoPolicy
   getStatusColor: (s: string) => 'green' | 'yellow' | 'blue'
   getCategoryColor: (c: string) => string
+  onClick: (policy: KyvernoPolicy) => void
 }) {
   return (
-    <div className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors">
+    <div
+      className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+      onClick={() => onClick(policy)}
+      role="button"
+      aria-label={`View policy insights: ${policy.name}`}
+      tabIndex={0}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(policy) } }}
+    >
       <div className="flex items-center justify-between mb-1">
         <div className="flex items-center gap-2 min-w-0">
           <span className="text-sm font-medium text-foreground truncate">{policy.name}</span>
@@ -258,7 +282,14 @@ function PolicyRow({
           </StatusBadge>
         </div>
         <div className="flex items-center gap-2 flex-shrink-0">
+          {policy.violations > 0 && (
+            <span className="flex items-center gap-1 text-xs text-yellow-400">
+              <AlertTriangle className="w-3 h-3" />
+              {policy.violations}
+            </span>
+          )}
           <span className="text-xs text-muted-foreground">{policy.kind}</span>
+          <ChevronRight className="w-3.5 h-3.5 text-muted-foreground/50 group-hover:text-purple-400 transition-colors" />
         </div>
       </div>
       {policy.description && (


### PR DESCRIPTION
Closes #3805

## Summary
- Clicking a Kyverno policy row in the card now opens the `PolicyDrillDown` view (overview, violations, spec, AI analysis) instead of the cluster-level modal
- Clicking a policy row in the `KyvernoDetailModal` (cluster modal) now also navigates to the `PolicyDrillDown` with full insights, closing the modal first
- Policy rows in the modal now display violation counts and a chevron indicator to signal clickability
- Uses the existing `drillToPolicy` action from `useDrillDownActions`, passing Kyverno-specific metadata (kind, status, category, description, violation count)

## Test plan
- [ ] Click a policy row in the Kyverno Policies card -- verify the PolicyDrillDown opens with policy name, status, violations, and spec tabs
- [ ] Click a cluster badge to open the cluster modal, then click a policy row -- verify the modal closes and PolicyDrillDown opens
- [ ] Verify policies with violations show the violation count badge and chevron in the modal
- [ ] Verify keyboard navigation (Enter/Space) works on policy rows
- [ ] Verify the drilldown shows correct data for both ClusterPolicy and namespaced Policy types

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>