### PR TITLE
fix: route NetworkUtils ping through backend proxy for reliable measurements

### DIFF
--- a/pkg/api/handlers/ping.go
+++ b/pkg/api/handlers/ping.go
@@ -1,0 +1,145 @@
+package handlers
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// pingClient is a shared HTTP client for ping requests.
+// It follows redirects minimally and has a short timeout so that
+// the measured latency reflects actual network RTT.
+var pingClient = &http.Client{
+	Timeout: 5 * time.Second,
+	Transport: &http.Transport{
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: false},
+		DisableKeepAlives: true,
+		DialContext: (&net.Dialer{
+			Timeout: 5 * time.Second,
+		}).DialContext,
+	},
+	// Do not follow redirects — we only care about reachability
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
+
+// PingHandler performs a server-side HTTP HEAD request to measure latency
+// and reachability of a given URL. This avoids the browser's no-cors
+// limitation where opaque responses prevent reading status codes.
+//
+// Query parameters:
+//   - url: the target URL to ping (required)
+//
+// Returns JSON:
+//
+//	{
+//	  "url":        "https://example.com",
+//	  "status":     "success" | "timeout" | "error",
+//	  "statusCode": 200,
+//	  "latencyMs":  42,
+//	  "error":      ""
+//	}
+func PingHandler(c *fiber.Ctx) error {
+	rawURL := c.Query("url")
+	if rawURL == "" {
+		return c.Status(400).JSON(fiber.Map{"error": "url query parameter is required"})
+	}
+
+	// Ensure the URL has a scheme
+	if !strings.HasPrefix(rawURL, "http://") && !strings.HasPrefix(rawURL, "https://") {
+		rawURL = "https://" + rawURL
+	}
+
+	// Validate the URL to prevent SSRF against internal services
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid url"})
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid url: no host"})
+	}
+
+	// Block requests to private/internal IPs to prevent SSRF
+	if isPrivateHost(host) {
+		return c.Status(403).JSON(fiber.Map{"error": "pinging private/internal addresses is not allowed"})
+	}
+
+	// Perform the HEAD request and measure latency
+	start := time.Now()
+	req, err := http.NewRequest("HEAD", rawURL, nil)
+	if err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": fmt.Sprintf("invalid request: %v", err)})
+	}
+	req.Header.Set("User-Agent", "KubeStellar-Console-Ping/1.0")
+
+	resp, err := pingClient.Do(req)
+	latencyMs := time.Since(start).Milliseconds()
+
+	if err != nil {
+		// Distinguish timeout from other errors
+		status := "error"
+		errMsg := err.Error()
+		if isTimeoutError(err) {
+			status = "timeout"
+		}
+		return c.JSON(fiber.Map{
+			"url":       rawURL,
+			"status":    status,
+			"latencyMs": latencyMs,
+			"error":     errMsg,
+		})
+	}
+	defer resp.Body.Close()
+
+	// Any HTTP response means the host is reachable
+	return c.JSON(fiber.Map{
+		"url":        rawURL,
+		"status":     "success",
+		"statusCode": resp.StatusCode,
+		"latencyMs":  latencyMs,
+		"error":      "",
+	})
+}
+
+// isPrivateHost checks whether a hostname resolves to a private/loopback IP.
+func isPrivateHost(host string) bool {
+	// Block well-known internal hostnames
+	lower := strings.ToLower(host)
+	if lower == "localhost" || lower == "metadata.google.internal" ||
+		strings.HasSuffix(lower, ".internal") || strings.HasSuffix(lower, ".local") {
+		return true
+	}
+
+	// Resolve and check IPs
+	ips, err := net.LookupHost(host)
+	if err != nil {
+		return false // Let the actual request fail naturally
+	}
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			continue
+		}
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return true
+		}
+	}
+	return false
+}
+
+// isTimeoutError checks if an error is a timeout.
+func isTimeoutError(err error) bool {
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		return true
+	}
+	return strings.Contains(err.Error(), "timeout") || strings.Contains(err.Error(), "deadline exceeded")
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -557,6 +557,10 @@ func (s *Server) setupRoutes() {
 	s.app.Get("/api/ksc", handlers.UmamiScriptProxy)
 	s.app.Post("/api/send", handlers.UmamiCollectProxy)
 
+	// Network ping proxy (public — lightweight server-side HTTP HEAD for latency measurement)
+	// Avoids browser no-cors limitations that produce unreliable results
+	s.app.Get("/api/ping", handlers.PingHandler)
+
 	// MCP handlers (used in protected routes below)
 	mcpHandlers := handlers.NewMCPHandlers(s.bridge, s.k8sClient)
 	// SECURITY FIX: All MCP routes are now protected regardless of dev mode

--- a/web/src/components/cards/NetworkUtils.tsx
+++ b/web/src/components/cards/NetworkUtils.tsx
@@ -13,6 +13,8 @@ interface PingResult {
   latency: number | null
   status: 'success' | 'timeout' | 'error'
   timestamp: Date
+  statusCode?: number
+  error?: string
 }
 
 interface SavedHost {
@@ -126,41 +128,58 @@ export function NetworkUtils() {
     }
   }, [])
 
-  // Ping a single host using fetch timing
+  // Ping a single host via the backend proxy.
+  // The backend performs a real HTTP HEAD request and returns the actual
+  // status code and server-side measured latency, avoiding the browser's
+  // no-cors limitation where opaque responses hide failures.
   const pingHost = useCallback(async (host: string): Promise<PingResult> => {
-    const startTime = performance.now()
-
     try {
-      // Ensure URL has protocol
-      let url = host
-      if (!url.startsWith('http://') && !url.startsWith('https://')) {
-        url = 'https://' + url
+      // Ensure URL has protocol for the backend
+      let targetUrl = host
+      if (!targetUrl.startsWith('http://') && !targetUrl.startsWith('https://')) {
+        targetUrl = 'https://' + targetUrl
       }
 
       abortControllerRef.current = new AbortController()
       const timeoutId = setTimeout(() => abortControllerRef.current?.abort(), PING_TIMEOUT)
 
-      await fetch(url, {
-        method: 'HEAD',
-        mode: 'no-cors', // Allow cross-origin requests
-        cache: 'no-store',
-        signal: abortControllerRef.current.signal,
-      })
+      const response = await fetch(
+        `/api/ping?url=${encodeURIComponent(targetUrl)}`,
+        {
+          method: 'GET',
+          signal: abortControllerRef.current.signal,
+        }
+      )
 
       clearTimeout(timeoutId)
-      const endTime = performance.now()
-      const latency = Math.round(endTime - startTime)
+
+      if (!response.ok) {
+        const errorBody = await response.json().catch(() => ({ error: 'unknown error' })) as Record<string, string>
+        return {
+          host,
+          latency: null,
+          status: 'error',
+          timestamp: new Date(),
+          error: errorBody.error,
+        }
+      }
+
+      const data = await response.json() as {
+        status: 'success' | 'timeout' | 'error'
+        latencyMs: number
+        statusCode?: number
+        error?: string
+      }
 
       return {
         host,
-        latency,
-        status: 'success',
+        latency: data.status === 'success' ? data.latencyMs : null,
+        status: data.status,
         timestamp: new Date(),
+        statusCode: data.statusCode,
+        error: data.error || undefined,
       }
     } catch (error) {
-      const endTime = performance.now()
-      const latency = Math.round(endTime - startTime)
-
       if (error instanceof Error && error.name === 'AbortError') {
         return {
           host,
@@ -170,22 +189,12 @@ export function NetworkUtils() {
         }
       }
 
-      // Even with errors, we might have gotten a response (CORS blocks reading)
-      // If latency is reasonable, consider it a success
-      if (latency < PING_TIMEOUT - 100) {
-        return {
-          host,
-          latency,
-          status: 'success',
-          timestamp: new Date(),
-        }
-      }
-
       return {
         host,
         latency: null,
         status: 'error',
         timestamp: new Date(),
+        error: error instanceof Error ? error.message : 'unknown error',
       }
     }
   }, [])


### PR DESCRIPTION
## Summary

Closes #3799

- Adds a new `/api/ping` backend endpoint that performs server-side HTTP HEAD requests to measure actual latency and reachability
- Replaces the frontend's `fetch` with `mode: 'no-cors'` (which returns opaque responses and hides real status codes) with a call to the backend proxy
- Includes SSRF protection: blocks pings to private/internal IP addresses (localhost, link-local, RFC 1918 ranges)
- Returns real HTTP status codes and server-measured latency instead of unreliable browser-side timing

## What was wrong

With `mode: 'no-cors'`, the browser returns an opaque response -- you cannot read the HTTP status code. A host returning 404, 500, or even connection refused would show as "success" as long as the request completed within the timeout. Additionally, on line 175-183, even CORS errors were treated as "success" if latency was below the timeout threshold, making the tool essentially useless for diagnosing connectivity issues.

## Test plan

- [ ] Build passes (`go build ./...` and `cd web && npm run build`)
- [ ] Ping a valid host (e.g. `https://www.google.com`) -- should show success with realistic latency
- [ ] Ping an invalid host (e.g. `https://nonexistent.invalid`) -- should show error, not success
- [ ] Ping a host that returns 404/500 -- should show success (host is reachable) with the status code
- [ ] Attempt to ping `localhost` or `127.0.0.1` -- should be blocked by SSRF protection
- [ ] Continuous ping mode still works correctly

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>