### PR TITLE
fix: require cluster selection in NodeDebug instead of silently defaulting

### DIFF
--- a/web/src/components/cards/NodeDebug.tsx
+++ b/web/src/components/cards/NodeDebug.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCachedNodes } from '../../hooks/useCachedData'
 import { useKubectl } from '../../hooks/useKubectl'
@@ -117,15 +117,30 @@ export function NodeDebug() {
   const clusters = Array.from(new Set(nodes.map(n => n.cluster).filter(Boolean))).sort()
   const clusterNodes = nodes.filter(n => !selectedCluster || n.cluster === selectedCluster)
 
+  // Resolve the effective cluster: explicit selection first, then the selected node's cluster.
+  // Never fall back to 'default' — that could silently target the wrong cluster.
+  const effectiveCluster = useMemo(() => {
+    if (selectedCluster) return selectedCluster
+    if (selectedNode) {
+      const nodeInfo = nodes.find(n => n.name === selectedNode)
+      return nodeInfo?.cluster || ''
+    }
+    return ''
+  }, [selectedCluster, selectedNode, nodes])
+
   const handleRun = useCallback(async (cmdFn: (node: string) => string[]) => {
     if (!selectedNode) return
+    if (!effectiveCluster) {
+      showToast(t('nodeDebug.clusterRequired'), 'error')
+      return
+    }
     const args = cmdFn(selectedNode)
     const cmdStr = `kubectl ${args.join(' ')}`
     setOutput(`$ ${cmdStr}\n\nRunning...`)
     setWasTruncated(false)
     setIsRunning(true)
     try {
-      const result = await execute(selectedCluster || 'default', args)
+      const result = await execute(effectiveCluster, args)
       const { text, truncated } = truncateOutput(result || 'Command completed')
       setOutput(`$ ${cmdStr}\n\n${text}`)
       setWasTruncated(truncated)
@@ -136,10 +151,14 @@ export function NodeDebug() {
     } finally {
       setIsRunning(false)
     }
-  }, [selectedNode, selectedCluster, execute, showToast, t])
+  }, [selectedNode, effectiveCluster, execute, showToast, t])
 
   const handleExec = useCallback(async (shellCmd: string) => {
     if (!selectedNode || !shellCmd.trim()) return
+    if (!effectiveCluster) {
+      showToast(t('nodeDebug.clusterRequired'), 'error')
+      return
+    }
     // kubectl debug node/<name> creates a privileged pod on the node
     const args = [
       `debug`, `node/${selectedNode}`,
@@ -151,7 +170,7 @@ export function NodeDebug() {
     setWasTruncated(false)
     setIsRunning(true)
     try {
-      const result = await execute(selectedCluster || 'default', args)
+      const result = await execute(effectiveCluster, args)
       const { text, truncated } = truncateOutput(result || 'Command completed (no output)')
       setOutput(`$ ${cmdStr}\n\n${text}`)
       setWasTruncated(truncated)
@@ -162,7 +181,7 @@ export function NodeDebug() {
     } finally {
       setIsRunning(false)
     }
-  }, [selectedNode, selectedCluster, execImage, execute, showToast, t])
+  }, [selectedNode, effectiveCluster, execImage, execute, showToast, t])
 
   if (showSkeleton) {
     return (
@@ -199,6 +218,13 @@ export function NodeDebug() {
           ))}
         </select>
       </div>
+
+      {/* Cluster resolution warning */}
+      {selectedNode && !effectiveCluster && (
+        <div className="px-2 py-1.5 text-xs rounded bg-yellow-500/10 border border-yellow-500/30 text-yellow-400">
+          {t('nodeDebug.clusterRequired')}
+        </div>
+      )}
 
       {/* Mode tabs */}
       <div className="flex gap-1">

--- a/web/src/locales/de/cards.json
+++ b/web/src/locales/de/cards.json
@@ -1900,7 +1900,8 @@
     "categoryKubernetes": "Kubernetes",
     "categoryNetwork": "Network",
     "categoryStorage": "Storage",
-    "commandCompleted": "Command completed"
+    "commandCompleted": "Command completed",
+    "clusterRequired": "Select a cluster before running commands — defaulting could target the wrong cluster"
   },
   "predictiveHealth": {
     "criticalCount": "{{count}} critical",

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -1916,7 +1916,8 @@
     "categoryKubernetes": "Kubernetes",
     "categoryNetwork": "Network",
     "categoryStorage": "Storage",
-    "commandCompleted": "Command completed"
+    "commandCompleted": "Command completed",
+    "clusterRequired": "Select a cluster before running commands — defaulting could target the wrong cluster"
   },
   "predictiveHealth": {
     "criticalCount": "{{count}} critical",

--- a/web/src/locales/es/cards.json
+++ b/web/src/locales/es/cards.json
@@ -1900,7 +1900,8 @@
     "categoryKubernetes": "Kubernetes",
     "categoryNetwork": "Network",
     "categoryStorage": "Storage",
-    "commandCompleted": "Command completed"
+    "commandCompleted": "Command completed",
+    "clusterRequired": "Select a cluster before running commands — defaulting could target the wrong cluster"
   },
   "predictiveHealth": {
     "criticalCount": "{{count}} critical",

--- a/web/src/locales/fr/cards.json
+++ b/web/src/locales/fr/cards.json
@@ -1900,7 +1900,8 @@
     "categoryKubernetes": "Kubernetes",
     "categoryNetwork": "Network",
     "categoryStorage": "Storage",
-    "commandCompleted": "Command completed"
+    "commandCompleted": "Command completed",
+    "clusterRequired": "Select a cluster before running commands — defaulting could target the wrong cluster"
   },
   "predictiveHealth": {
     "criticalCount": "{{count}} critical",

--- a/web/src/locales/hi/cards.json
+++ b/web/src/locales/hi/cards.json
@@ -1900,7 +1900,8 @@
     "categoryKubernetes": "Kubernetes",
     "categoryNetwork": "Network",
     "categoryStorage": "Storage",
-    "commandCompleted": "Command completed"
+    "commandCompleted": "Command completed",
+    "clusterRequired": "Select a cluster before running commands — defaulting could target the wrong cluster"
   },
   "predictiveHealth": {
     "criticalCount": "{{count}} critical",

--- a/web/src/locales/it/cards.json
+++ b/web/src/locales/it/cards.json
@@ -1900,7 +1900,8 @@
     "categoryKubernetes": "Kubernetes",
     "categoryNetwork": "Network",
     "categoryStorage": "Storage",
-    "commandCompleted": "Command completed"
+    "commandCompleted": "Command completed",
+    "clusterRequired": "Select a cluster before running commands — defaulting could target the wrong cluster"
   },
   "predictiveHealth": {
     "criticalCount": "{{count}} critical",

--- a/web/src/locales/ja/cards.json
+++ b/web/src/locales/ja/cards.json
@@ -1900,7 +1900,8 @@
     "categoryKubernetes": "Kubernetes",
     "categoryNetwork": "Network",
     "categoryStorage": "Storage",
-    "commandCompleted": "Command completed"
+    "commandCompleted": "Command completed",
+    "clusterRequired": "Select a cluster before running commands — defaulting could target the wrong cluster"
   },
   "predictiveHealth": {
     "criticalCount": "{{count}} critical",

--- a/web/src/locales/pt/cards.json
+++ b/web/src/locales/pt/cards.json
@@ -1900,7 +1900,8 @@
     "categoryKubernetes": "Kubernetes",
     "categoryNetwork": "Network",
     "categoryStorage": "Storage",
-    "commandCompleted": "Command completed"
+    "commandCompleted": "Command completed",
+    "clusterRequired": "Select a cluster before running commands — defaulting could target the wrong cluster"
   },
   "predictiveHealth": {
     "criticalCount": "{{count}} critical",

--- a/web/src/locales/zh/cards.json
+++ b/web/src/locales/zh/cards.json
@@ -1900,7 +1900,8 @@
     "categoryKubernetes": "Kubernetes",
     "categoryNetwork": "Network",
     "categoryStorage": "Storage",
-    "commandCompleted": "Command completed"
+    "commandCompleted": "Command completed",
+    "clusterRequired": "Select a cluster before running commands — defaulting could target the wrong cluster"
   },
   "predictiveHealth": {
     "criticalCount": "{{count}} critical",


### PR DESCRIPTION
Closes #3795

## Summary
- Removed the dangerous `selectedCluster || 'default'` fallback in both `handleRun` and `handleExec` that could silently execute kubectl commands against the wrong cluster
- Added `effectiveCluster` resolution that first checks the explicit cluster dropdown selection, then falls back to the selected node's `.cluster` metadata
- If no cluster can be determined, execution is blocked with an error toast and an inline yellow warning banner
- Added `clusterRequired` translation key to all 9 locale files

## Test plan
- [ ] Select a node from "All clusters" view where the node has cluster metadata -- commands should resolve the cluster automatically from the node
- [ ] Select a node that somehow has no cluster metadata and no cluster selected -- verify error toast appears and command is blocked
- [ ] Select a specific cluster from the dropdown, then select a node -- verify commands execute against the selected cluster
- [ ] Verify the yellow warning banner appears when a node is selected but no cluster can be resolved

Generated with Claude Code