### PR TITLE
fix: add auth and restrict CORS on cancel-chat and events endpoints

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -806,8 +806,10 @@ func (s *Server) handleEventsHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Note: Events endpoint doesn't require auth for local agent
-	// This allows the frontend to fetch events without backend auth
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 
 	if s.k8sClient == nil {
 		json.NewEncoder(w).Encode(map[string]interface{}{"events": []interface{}{}, "error": "k8s client not initialized"})
@@ -2744,9 +2746,12 @@ func (s *Server) handleCancelChat(conn *websocket.Conn, msg protocol.Message, wr
 // handleCancelChatHTTP is the HTTP fallback for cancelling in-progress chat sessions.
 // Used when the WebSocket connection is unavailable (e.g., disconnected during long agent runs).
 func (s *Server) handleCancelChatHTTP(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+	origin := r.Header.Get("Origin")
+	if s.isAllowedOrigin(origin) {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+	}
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 	w.Header().Set("Access-Control-Allow-Private-Network", "true")
 
 	if r.Method == "OPTIONS" {
@@ -2755,6 +2760,11 @@ func (s *Server) handleCancelChatHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if r.Method != "POST" {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if !s.validateToken(r) {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 


### PR DESCRIPTION
Closes #3829
Closes #3830

## Summary

- **#3829 (cancel-chat)**: `handleCancelChatHTTP` was using `Access-Control-Allow-Origin: *` and had no `validateToken` check, allowing any webpage to cancel any active chat session. Fixed by replacing the wildcard CORS header with origin-checked `isAllowedOrigin`, adding `Authorization` to allowed headers, and gating the handler behind `validateToken`.

- **#3830 (events)**: `handleEventsHTTP` was the only data endpoint that skipped `validateToken` when `KC_AGENT_TOKEN` is set. Added the same `validateToken` check used by all other data endpoints (`/clusters`, `/nodes`, `/pods`, etc.).

## Test plan

- [ ] With `KC_AGENT_TOKEN` set, verify `/cancel-chat` returns 401 without a valid Bearer token
- [ ] With `KC_AGENT_TOKEN` set, verify `/events` returns 401 without a valid Bearer token
- [ ] With valid token, both endpoints work as before
- [ ] CORS preflight on `/cancel-chat` returns the request origin (not `*`) when origin is allowed
- [ ] `go build ./...` passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>