### PR TITLE
fix: reject negative replica counts in handleScaleHTTP

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -1555,6 +1555,15 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if replicas < 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   "replicas must be a non-negative integer",
+		})
+		return
+	}
+
 	if cluster == "" || namespace == "" || name == "" {
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"success": false,


### PR DESCRIPTION
Closes #3831

## Summary

- `handleScaleHTTP` checked for int32 overflow on the GET query-param path but allowed negative replica values through on both POST and GET paths
- Added validation after both parsing paths to return HTTP 400 with a clear error message when `replicas < 0`

## Test plan

- [ ] Send `POST /scale` with `{"replicas": -1}` and verify 400 response
- [ ] Send `GET /scale?replicas=-5&cluster=x&namespace=y&name=z` and verify 400 response
- [ ] Send `POST /scale` with `{"replicas": 0}` (scale to zero) and verify it still works
- [ ] Send `POST /scale` with `{"replicas": 3}` and verify normal scaling works

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>