### PR TITLE
fix: chain config-writing jobs to prevent race condition

### DIFF
--- a/.github/workflows/auto-qa-tuner.yml
+++ b/.github/workflows/auto-qa-tuner.yml
@@ -252,10 +252,12 @@ jobs:
   # Job B: Weekly Analysis — broader patterns, create report issue
   # ============================================================
   weekly-analysis:
+    needs: daily-feedback
     if: >
-      github.event.schedule == '0 4 * * 0' ||
-      (github.event_name == 'workflow_dispatch' &&
-       (inputs.job_override == 'weekly' || inputs.job_override == 'all'))
+      !failure() && !cancelled() &&
+      (github.event.schedule == '0 4 * * 0' ||
+       (github.event_name == 'workflow_dispatch' &&
+        (inputs.job_override == 'weekly' || inputs.job_override == 'all')))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -497,10 +499,12 @@ jobs:
   # Job C: CNCF Intelligence — scan landscape repos for patterns
   # ============================================================
   cncf-intelligence:
+    needs: weekly-analysis
     if: >
-      github.event.schedule == '0 5 * * 3' ||
-      (github.event_name == 'workflow_dispatch' &&
-       (inputs.job_override == 'cncf' || inputs.job_override == 'all'))
+      !failure() && !cancelled() &&
+      (github.event.schedule == '0 5 * * 3' ||
+       (github.event_name == 'workflow_dispatch' &&
+        (inputs.job_override == 'cncf' || inputs.job_override == 'all')))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Closes #3826

## Summary

- Added `needs: daily-feedback` to the `weekly-analysis` job and `needs: weekly-analysis` to the `cncf-intelligence` job in `auto-qa-tuner.yml`
- This chains the three config-writing jobs sequentially when `job_override=all`, preventing the last-writer-wins race on `.github/auto-qa-tuning.json`
- Uses `!failure() && !cancelled()` in each job's `if:` condition so that when a predecessor is **skipped** (e.g., only one job is triggered by schedule or a specific `job_override`), the dependent job still runs normally

## How it works

| Trigger | Behavior |
|---------|----------|
| `job_override=all` | Jobs run sequentially: daily-feedback -> weekly-analysis -> cncf-intelligence |
| `job_override=daily` | Only daily-feedback runs; weekly-analysis and cncf-intelligence are skipped by their own `if:` |
| `job_override=weekly` | daily-feedback is skipped (its `if:` is false), weekly-analysis runs (skipped predecessor does not block), cncf-intelligence is skipped by its own `if:` |
| `job_override=cncf` | daily-feedback and weekly-analysis are both skipped, cncf-intelligence runs |
| Schedule triggers | Each job runs only on its own cron schedule; the others are skipped |

## Test plan

- [ ] Trigger workflow with `job_override=all` and verify jobs run sequentially (not in parallel)
- [ ] Trigger with `job_override=daily` and verify only daily-feedback runs
- [ ] Trigger with `job_override=weekly` and verify only weekly-analysis runs
- [ ] Trigger with `job_override=cncf` and verify only cncf-intelligence runs