### PR TITLE
fix: replace raw string type literals with protocol.Type* constants in mixed-mode chat

### DIFF
--- a/pkg/agent/protocol/messages.go
+++ b/pkg/agent/protocol/messages.go
@@ -19,9 +19,15 @@ const (
 	TypeResult        MessageType = "result"
 	TypeError         MessageType = "error"
 	TypeStream        MessageType = "stream"
+	TypeStreamChunk   MessageType = "stream_chunk"   // Streaming response chunk
+	TypeStreamEnd     MessageType = "stream_end"     // End of streaming response
 	TypeProgress      MessageType = "progress"       // Tool activity/progress events
 	TypeAgentSelected MessageType = "agent_selected" // Agent selection confirmed
 	TypeAgentsList    MessageType = "agents_list"    // List of available agents
+
+	// Mixed-mode chat types
+	TypeMixedModeThinking  MessageType = "mixed_mode_thinking"  // Thinking agent phase indicator
+	TypeMixedModeExecuting MessageType = "mixed_mode_executing" // Execution agent phase indicator
 )
 
 // Message is the base message structure for WebSocket communication

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -3051,7 +3051,7 @@ func (s *Server) handleMixedModeChat(ctx context.Context, conn *websocket.Conn, 
 	// Phase 1: Send thinking phase indicator
 	safeWrite(protocol.Message{
 		ID:   msg.ID,
-		Type: "mixed_mode_thinking",
+		Type: protocol.TypeMixedModeThinking,
 		Payload: map[string]interface{}{
 			"agent":   thinkingProvider.DisplayName(),
 			"phase":   "thinking",
@@ -3092,7 +3092,7 @@ User request: %s`, req.Prompt)
 	// Stream the thinking response
 	safeWrite(protocol.Message{
 		ID:   msg.ID,
-		Type: "stream_chunk",
+		Type: protocol.TypeStreamChunk,
 		Payload: map[string]interface{}{
 			"content": fmt.Sprintf("**🧠 %s Analysis:**\n%s\n\n", thinkingProvider.DisplayName(), thinkingResp.Content),
 			"agent":   thinkingAgent,
@@ -3115,7 +3115,7 @@ User request: %s`, req.Prompt)
 		// No commands to execute - just return thinking response
 		safeWrite(protocol.Message{
 			ID:   msg.ID,
-			Type: "stream_end",
+			Type: protocol.TypeStreamEnd,
 			Payload: map[string]interface{}{
 				"agent": thinkingAgent,
 				"phase": "complete",
@@ -3127,7 +3127,7 @@ User request: %s`, req.Prompt)
 	// Phase 2: Execute commands via CLI agent
 	safeWrite(protocol.Message{
 		ID:   msg.ID,
-		Type: "mixed_mode_executing",
+		Type: protocol.TypeMixedModeExecuting,
 		Payload: map[string]interface{}{
 			"agent":    execProvider.DisplayName(),
 			"phase":    "executing",
@@ -3157,7 +3157,7 @@ User request: %s`, req.Prompt)
 		execContent = fmt.Sprintf("Execution Error: %v", err)
 		safeWrite(protocol.Message{
 			ID:   msg.ID,
-			Type: "stream_chunk",
+			Type: protocol.TypeStreamChunk,
 			Payload: map[string]interface{}{
 				"content": fmt.Sprintf("\n**🔧 %s Execution Error:** %v\n", execProvider.DisplayName(), err),
 				"agent":   executionAgent,
@@ -3170,7 +3170,7 @@ User request: %s`, req.Prompt)
 		}
 		safeWrite(protocol.Message{
 			ID:   msg.ID,
-			Type: "stream_chunk",
+			Type: protocol.TypeStreamChunk,
 			Payload: map[string]interface{}{
 				"content": fmt.Sprintf("**🔧 %s Output:**\n```\n%s\n```\n\n", execProvider.DisplayName(), execContent),
 				"agent":   executionAgent,
@@ -3182,7 +3182,7 @@ User request: %s`, req.Prompt)
 	// Phase 3: Feed results back to thinking agent for analysis
 	safeWrite(protocol.Message{
 		ID:   msg.ID,
-		Type: "mixed_mode_thinking",
+		Type: protocol.TypeMixedModeThinking,
 		Payload: map[string]interface{}{
 			"agent":   thinkingProvider.DisplayName(),
 			"phase":   "analyzing",
@@ -3213,7 +3213,7 @@ Command output:
 	} else if analysisResp != nil {
 		safeWrite(protocol.Message{
 			ID:   msg.ID,
-			Type: "stream_chunk",
+			Type: protocol.TypeStreamChunk,
 			Payload: map[string]interface{}{
 				"content": fmt.Sprintf("**🧠 %s Summary:**\n%s", thinkingProvider.DisplayName(), analysisResp.Content),
 				"agent":   thinkingAgent,
@@ -3225,7 +3225,7 @@ Command output:
 	// End stream
 	safeWrite(protocol.Message{
 		ID:   msg.ID,
-		Type: "stream_end",
+		Type: protocol.TypeStreamEnd,
 		Payload: map[string]interface{}{
 			"agent": thinkingAgent,
 			"phase": "complete",


### PR DESCRIPTION
Closes #3832

## Summary
- Added four new `protocol.MessageType` constants to `pkg/agent/protocol/messages.go`: `TypeStreamChunk`, `TypeStreamEnd`, `TypeMixedModeThinking`, and `TypeMixedModeExecuting`
- Replaced all 9 bare string literals (`"stream_chunk"`, `"stream_end"`, `"mixed_mode_thinking"`, `"mixed_mode_executing"`) in `handleMixedModeChat` with the corresponding `protocol.Type*` constants

## Test plan
- [x] `go build ./...` passes
- [ ] Verify mixed-mode chat still works end-to-end (message types are unchanged at the wire level since the constants resolve to the same string values)

Generated with [Claude Code](https://claude.com/claude-code)