### PR TITLE
fix: unify add card bubble position across all dashboard pages

### DIFF
--- a/web/src/lib/dashboards/DashboardComponents.tsx
+++ b/web/src/lib/dashboards/DashboardComponents.tsx
@@ -39,7 +39,7 @@ export const SortableDashboardCard = memo(function SortableDashboardCard({
   isRefreshing,
   onRefresh,
   lastUpdated,
-  onInsertBefore,
+  onInsertBefore: _onInsertBefore,
   onInsertAfter,
 }: SortableDashboardCardProps) {
   const {
@@ -69,22 +69,12 @@ export const SortableDashboardCard = memo(function SortableDashboardCard({
 
   return (
     <div ref={setNodeRef} style={style} className="relative group/card">
-      {onInsertBefore && (
-        <button
-          onClick={(e) => { e.stopPropagation(); onInsertBefore() }}
-          className="absolute top-1/2 -left-2.5 -translate-y-1/2 z-10 opacity-0 group-hover/card:opacity-100 transition-opacity w-5 h-5 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold shadow-md hover:scale-110"
-          aria-label="Insert card before this one"
-          title="Insert card here"
-        >
-          +
-        </button>
-      )}
       {onInsertAfter && (
         <button
           onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
-          className="absolute top-1/2 -right-2.5 -translate-y-1/2 z-10 opacity-0 group-hover/card:opacity-100 transition-opacity w-5 h-5 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-xs font-bold shadow-md hover:scale-110"
-          aria-label="Insert card after this one"
-          title="Insert card here"
+          className="absolute -top-2 -right-2 z-20 opacity-0 group-hover/card:opacity-100 transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
+          aria-label="Add card"
+          title="Add card here"
         >
           +
         </button>


### PR DESCRIPTION
Closes #3834

## Summary
- Moved the per-card "+" add card bubble from left/right edge positions to the top-right corner on all non-homepage dashboard pages (clusters, compliance, security, etc.)
- This matches the existing pattern used by the homepage dashboard (`SharedSortableCard.tsx`) and `CustomDashboard.tsx`, giving users a consistent hover interaction across every card view
- The single top-right bubble replaces the previous dual left+right edge buttons in `DashboardComponents.tsx`

## Test plan
- [ ] Navigate to any non-homepage dashboard page (e.g., Clusters, Compliance, Security)
- [ ] Hover over a card and verify the "+" bubble appears at the top-right corner
- [ ] Click the bubble and verify the Add Card modal opens
- [ ] Verify the homepage dashboard "+" bubble still works as before
- [ ] Verify no layout shift or z-index issues with the bubble

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>