### PR TITLE
fix: use current-context as default cluster in Kubectl terminal

### DIFF
--- a/web/src/components/cards/Kubectl.tsx
+++ b/web/src/components/cards/Kubectl.tsx
@@ -67,10 +67,11 @@ export function Kubectl() {
     }
   }, [])
 
-  // Set default context when clusters are loaded
+  // Set default context when clusters are loaded — prefer the user's current-context
   useEffect(() => {
     if (clusters.length > 0 && !selectedContext) {
-      setSelectedContext(clusters[0].name)
+      const currentCtx = clusters.find(c => c.isCurrent)
+      setSelectedContext(currentCtx ? currentCtx.name : clusters[0].name)
     }
   }, [clusters, selectedContext])
 


### PR DESCRIPTION
Closes #3833

## Summary
- The Kubectl terminal card previously defaulted to `clusters[0]`, whose position in the array depends on API response ordering and deduplication sort (namespace count first, then `isCurrent`). This caused the selected cluster to appear random on every refresh.
- Now the component finds the cluster with `isCurrent === true` (the user's kubeconfig current-context) and uses that as the default. Falls back to `clusters[0]` only if no current context is set.

## Test plan
- [ ] Open the Kubectl terminal card -- verify it defaults to your kubeconfig current-context cluster
- [ ] Refresh the page -- verify the same cluster remains selected
- [ ] If only one cluster is connected, verify it is selected by default

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>