### PR TITLE
fix: add missing test files for AI providers

### DIFF
--- a/pkg/agent/provider_bob_test.go
+++ b/pkg/agent/provider_bob_test.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestBobProvider_Basics(t *testing.T) {
+	p := &BobProvider{}
+
+	if p.Name() != "bob" {
+		t.Errorf("Expected 'bob', got %q", p.Name())
+	}
+	if p.DisplayName() != "Bob (Local)" {
+		t.Errorf("Expected 'Bob (Local)', got %q", p.DisplayName())
+	}
+	if p.Provider() != "bob" {
+		t.Errorf("Expected 'bob', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestBobProvider_NotInstalled(t *testing.T) {
+	p := &BobProvider{} // No cliPath set
+
+	if p.IsAvailable() {
+		t.Error("Expected IsAvailable=false when CLI is not installed")
+	}
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestBobProvider_ChatNotInstalled(t *testing.T) {
+	p := &BobProvider{} // No cliPath set
+
+	_, err := p.Chat(t.Context(), &ChatRequest{Prompt: "hi"})
+	if err == nil {
+		t.Error("Expected error when CLI is not installed")
+	}
+}
+
+func TestBobProvider_DescriptionWithVersion(t *testing.T) {
+	p := &BobProvider{version: "1.2.3"}
+	desc := p.Description()
+	if desc == "" {
+		t.Error("Description should not be empty")
+	}
+	if !containsSubstring(desc, "1.2.3") {
+		t.Errorf("Description should contain version, got %q", desc)
+	}
+}
+
+func TestBobProvider_Interface(t *testing.T) {
+	var _ AIProvider = &BobProvider{}
+}
+
+func TestBobProvider_CleanBobOutput(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "removes debug lines",
+			input: "loaded global modes\nHello world\n---output---",
+			want:  "Hello world",
+		},
+		{
+			name:  "preserves normal content",
+			input: "This is a response.",
+			want:  "This is a response.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cleanBobOutput(tt.input)
+			if got != tt.want {
+				t.Errorf("cleanBobOutput() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/agent/provider_claudecode_test.go
+++ b/pkg/agent/provider_claudecode_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestClaudeCodeProvider_Basics(t *testing.T) {
+	p := &ClaudeCodeProvider{}
+
+	if p.Name() != "claude-code" {
+		t.Errorf("Expected 'claude-code', got %q", p.Name())
+	}
+	if p.DisplayName() != "Claude Code (Local)" {
+		t.Errorf("Expected 'Claude Code (Local)', got %q", p.DisplayName())
+	}
+	if p.Provider() != "anthropic-local" {
+		t.Errorf("Expected 'anthropic-local', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestClaudeCodeProvider_NotInstalled(t *testing.T) {
+	p := &ClaudeCodeProvider{} // No cliPath set
+
+	if p.IsAvailable() {
+		t.Error("Expected IsAvailable=false when CLI is not installed")
+	}
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+	if p.Capabilities()&CapabilityToolExec == 0 {
+		t.Error("Expected CapabilityToolExec to be set")
+	}
+}
+
+func TestClaudeCodeProvider_ChatNotInstalled(t *testing.T) {
+	p := &ClaudeCodeProvider{} // No cliPath set
+
+	_, err := p.Chat(t.Context(), &ChatRequest{Prompt: "hi"})
+	if err == nil {
+		t.Error("Expected error when CLI is not installed")
+	}
+}
+
+func TestClaudeCodeProvider_DescriptionWithVersion(t *testing.T) {
+	p := &ClaudeCodeProvider{version: "2.0.0"}
+	desc := p.Description()
+	if !containsSubstring(desc, "2.0.0") {
+		t.Errorf("Description should contain version, got %q", desc)
+	}
+}
+
+func TestClaudeCodeProvider_Interface(t *testing.T) {
+	var _ AIProvider = &ClaudeCodeProvider{}
+}
+
+func TestCleanEnvForCLI(t *testing.T) {
+	env := cleanEnvForCLI()
+	for _, e := range env {
+		if len(e) >= 10 && e[:10] == "CLAUDECODE=" {
+			t.Error("cleanEnvForCLI should filter out CLAUDECODE= entries")
+		}
+	}
+}

--- a/pkg/agent/provider_claudedesktop_test.go
+++ b/pkg/agent/provider_claudedesktop_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestClaudeDesktopProvider_Basics(t *testing.T) {
+	p := &ClaudeDesktopProvider{}
+
+	if p.Name() != "claude-desktop" {
+		t.Errorf("Expected 'claude-desktop', got %q", p.Name())
+	}
+	if p.DisplayName() != "Claude Desktop" {
+		t.Errorf("Expected 'Claude Desktop', got %q", p.DisplayName())
+	}
+	if p.Provider() != "anthropic" {
+		t.Errorf("Expected 'anthropic', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestClaudeDesktopProvider_Capabilities(t *testing.T) {
+	p := &ClaudeDesktopProvider{}
+
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestClaudeDesktopProvider_Interface(t *testing.T) {
+	var _ AIProvider = &ClaudeDesktopProvider{}
+}

--- a/pkg/agent/provider_cline_test.go
+++ b/pkg/agent/provider_cline_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestClineProvider_Basics(t *testing.T) {
+	p := &ClineProvider{}
+
+	if p.Name() != "cline" {
+		t.Errorf("Expected 'cline', got %q", p.Name())
+	}
+	if p.DisplayName() != "Cline" {
+		t.Errorf("Expected 'Cline', got %q", p.DisplayName())
+	}
+	if p.Provider() != "cline" {
+		t.Errorf("Expected 'cline', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestClineProvider_Capabilities(t *testing.T) {
+	p := &ClineProvider{}
+
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestClineProvider_Interface(t *testing.T) {
+	var _ AIProvider = &ClineProvider{}
+}

--- a/pkg/agent/provider_codex_test.go
+++ b/pkg/agent/provider_codex_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestCodexProvider_Basics(t *testing.T) {
+	p := &CodexProvider{}
+
+	if p.Name() != "codex" {
+		t.Errorf("Expected 'codex', got %q", p.Name())
+	}
+	if p.DisplayName() != "Codex" {
+		t.Errorf("Expected 'Codex', got %q", p.DisplayName())
+	}
+	if p.Provider() != "openai-cli" {
+		t.Errorf("Expected 'openai-cli', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestCodexProvider_NotInstalled(t *testing.T) {
+	p := &CodexProvider{} // No cliPath set
+
+	if p.IsAvailable() {
+		t.Error("Expected IsAvailable=false when CLI is not installed")
+	}
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+	if p.Capabilities()&CapabilityToolExec == 0 {
+		t.Error("Expected CapabilityToolExec to be set")
+	}
+}
+
+func TestCodexProvider_ChatNotInstalled(t *testing.T) {
+	p := &CodexProvider{} // No cliPath set
+
+	_, err := p.Chat(t.Context(), &ChatRequest{Prompt: "hi"})
+	if err == nil {
+		t.Error("Expected error when CLI is not installed")
+	}
+}
+
+func TestCodexProvider_DescriptionWithVersion(t *testing.T) {
+	p := &CodexProvider{version: "0.5.0"}
+	desc := p.Description()
+	if !containsSubstring(desc, "0.5.0") {
+		t.Errorf("Description should contain version, got %q", desc)
+	}
+}
+
+func TestCodexProvider_Interface(t *testing.T) {
+	var _ AIProvider = &CodexProvider{}
+}

--- a/pkg/agent/provider_continue_test.go
+++ b/pkg/agent/provider_continue_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestContinueProvider_Basics(t *testing.T) {
+	p := &ContinueProvider{}
+
+	if p.Name() != "continue" {
+		t.Errorf("Expected 'continue', got %q", p.Name())
+	}
+	if p.DisplayName() != "Continue" {
+		t.Errorf("Expected 'Continue', got %q", p.DisplayName())
+	}
+	if p.Provider() != "continue" {
+		t.Errorf("Expected 'continue', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestContinueProvider_Capabilities(t *testing.T) {
+	p := &ContinueProvider{}
+
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestContinueProvider_Interface(t *testing.T) {
+	var _ AIProvider = &ContinueProvider{}
+}

--- a/pkg/agent/provider_copilotcli_test.go
+++ b/pkg/agent/provider_copilotcli_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestCopilotCLIProvider_Basics(t *testing.T) {
+	p := &CopilotCLIProvider{}
+
+	if p.Name() != "copilot-cli" {
+		t.Errorf("Expected 'copilot-cli', got %q", p.Name())
+	}
+	if p.DisplayName() != "Copilot CLI" {
+		t.Errorf("Expected 'Copilot CLI', got %q", p.DisplayName())
+	}
+	if p.Provider() != "github-cli" {
+		t.Errorf("Expected 'github-cli', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestCopilotCLIProvider_NotInstalled(t *testing.T) {
+	p := &CopilotCLIProvider{} // No cliPath set
+
+	if p.IsAvailable() {
+		t.Error("Expected IsAvailable=false when CLI is not installed")
+	}
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+	if p.Capabilities()&CapabilityToolExec == 0 {
+		t.Error("Expected CapabilityToolExec to be set")
+	}
+}
+
+func TestCopilotCLIProvider_ChatNotInstalled(t *testing.T) {
+	p := &CopilotCLIProvider{} // No cliPath set
+
+	_, err := p.Chat(t.Context(), &ChatRequest{Prompt: "hi"})
+	if err == nil {
+		t.Error("Expected error when CLI is not installed")
+	}
+}
+
+func TestCopilotCLIProvider_DescriptionWithVersion(t *testing.T) {
+	p := &CopilotCLIProvider{version: "0.0.418"}
+	desc := p.Description()
+	if !containsSubstring(desc, "0.0.418") {
+		t.Errorf("Description should contain version, got %q", desc)
+	}
+}
+
+func TestCopilotCLIProvider_Interface(t *testing.T) {
+	var _ AIProvider = &CopilotCLIProvider{}
+}

--- a/pkg/agent/provider_cursor_test.go
+++ b/pkg/agent/provider_cursor_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestCursorProvider_Basics(t *testing.T) {
+	p := &CursorProvider{}
+
+	if p.Name() != "cursor" {
+		t.Errorf("Expected 'cursor', got %q", p.Name())
+	}
+	if p.DisplayName() != "Cursor" {
+		t.Errorf("Expected 'Cursor', got %q", p.DisplayName())
+	}
+	if p.Provider() != "anysphere" {
+		t.Errorf("Expected 'anysphere', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestCursorProvider_Capabilities(t *testing.T) {
+	p := &CursorProvider{}
+
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestCursorProvider_Interface(t *testing.T) {
+	var _ AIProvider = &CursorProvider{}
+}

--- a/pkg/agent/provider_geminicli_test.go
+++ b/pkg/agent/provider_geminicli_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestGeminiCLIProvider_Basics(t *testing.T) {
+	p := &GeminiCLIProvider{}
+
+	if p.Name() != "gemini-cli" {
+		t.Errorf("Expected 'gemini-cli', got %q", p.Name())
+	}
+	if p.DisplayName() != "Gemini CLI" {
+		t.Errorf("Expected 'Gemini CLI', got %q", p.DisplayName())
+	}
+	if p.Provider() != "google-cli" {
+		t.Errorf("Expected 'google-cli', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestGeminiCLIProvider_NotInstalled(t *testing.T) {
+	p := &GeminiCLIProvider{} // No cliPath set
+
+	if p.IsAvailable() {
+		t.Error("Expected IsAvailable=false when CLI is not installed")
+	}
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+	if p.Capabilities()&CapabilityToolExec == 0 {
+		t.Error("Expected CapabilityToolExec to be set")
+	}
+}
+
+func TestGeminiCLIProvider_ChatNotInstalled(t *testing.T) {
+	p := &GeminiCLIProvider{} // No cliPath set
+
+	_, err := p.Chat(t.Context(), &ChatRequest{Prompt: "hi"})
+	if err == nil {
+		t.Error("Expected error when CLI is not installed")
+	}
+}
+
+func TestGeminiCLIProvider_DescriptionWithVersion(t *testing.T) {
+	p := &GeminiCLIProvider{version: "1.0.0"}
+	desc := p.Description()
+	if !containsSubstring(desc, "1.0.0") {
+		t.Errorf("Description should contain version, got %q", desc)
+	}
+}
+
+func TestGeminiCLIProvider_Interface(t *testing.T) {
+	var _ AIProvider = &GeminiCLIProvider{}
+}

--- a/pkg/agent/provider_ghcopilot_test.go
+++ b/pkg/agent/provider_ghcopilot_test.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestGHCopilotProvider_Basics(t *testing.T) {
+	p := &GHCopilotProvider{}
+
+	if p.Name() != "gh-copilot" {
+		t.Errorf("Expected 'gh-copilot', got %q", p.Name())
+	}
+	if p.DisplayName() != "GitHub Copilot Agents" {
+		t.Errorf("Expected 'GitHub Copilot Agents', got %q", p.DisplayName())
+	}
+	if p.Provider() != "github" {
+		t.Errorf("Expected 'github', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestGHCopilotProvider_NotInstalled(t *testing.T) {
+	p := &GHCopilotProvider{} // No ghPath set
+
+	if p.IsAvailable() {
+		t.Error("Expected IsAvailable=false when gh CLI or copilot extension is not found")
+	}
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+	if p.Capabilities()&CapabilityToolExec == 0 {
+		t.Error("Expected CapabilityToolExec to be set")
+	}
+}
+
+func TestGHCopilotProvider_GHWithoutCopilot(t *testing.T) {
+	p := &GHCopilotProvider{
+		ghPath:           "/usr/bin/gh",
+		copilotAvailable: false,
+	}
+
+	if p.IsAvailable() {
+		t.Error("Expected IsAvailable=false when copilot extension is not available")
+	}
+}
+
+func TestGHCopilotProvider_ChatNotAvailable(t *testing.T) {
+	p := &GHCopilotProvider{} // No ghPath set
+
+	_, err := p.StreamChat(t.Context(), &ChatRequest{Prompt: "hi"}, nil)
+	if err == nil {
+		t.Error("Expected error when gh copilot is not available")
+	}
+}
+
+func TestGHCopilotProvider_Interface(t *testing.T) {
+	var _ AIProvider = &GHCopilotProvider{}
+}

--- a/pkg/agent/provider_goose_test.go
+++ b/pkg/agent/provider_goose_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestGooseProvider_Basics(t *testing.T) {
+	p := &GooseProvider{}
+
+	if p.Name() != "goose" {
+		t.Errorf("Expected 'goose', got %q", p.Name())
+	}
+	if p.DisplayName() != "Goose" {
+		t.Errorf("Expected 'Goose', got %q", p.DisplayName())
+	}
+	if p.Provider() != "block" {
+		t.Errorf("Expected 'block', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestGooseProvider_NotInstalled(t *testing.T) {
+	p := &GooseProvider{} // No cliPath set
+
+	if p.IsAvailable() {
+		t.Error("Expected IsAvailable=false when CLI is not installed")
+	}
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+	if p.Capabilities()&CapabilityToolExec == 0 {
+		t.Error("Expected CapabilityToolExec to be set")
+	}
+}
+
+func TestGooseProvider_ChatNotInstalled(t *testing.T) {
+	p := &GooseProvider{} // No cliPath set
+
+	_, err := p.Chat(t.Context(), &ChatRequest{Prompt: "hi"})
+	if err == nil {
+		t.Error("Expected error when CLI is not installed")
+	}
+}
+
+func TestGooseProvider_DescriptionWithVersion(t *testing.T) {
+	p := &GooseProvider{version: "1.0.5"}
+	desc := p.Description()
+	if !containsSubstring(desc, "1.0.5") {
+		t.Errorf("Description should contain version, got %q", desc)
+	}
+}
+
+func TestGooseProvider_Interface(t *testing.T) {
+	var _ AIProvider = &GooseProvider{}
+}

--- a/pkg/agent/provider_jetbrains_test.go
+++ b/pkg/agent/provider_jetbrains_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestJetBrainsProvider_Basics(t *testing.T) {
+	p := &JetBrainsProvider{}
+
+	if p.Name() != "jetbrains" {
+		t.Errorf("Expected 'jetbrains', got %q", p.Name())
+	}
+	if p.DisplayName() != "JetBrains IDEs" {
+		t.Errorf("Expected 'JetBrains IDEs', got %q", p.DisplayName())
+	}
+	if p.Provider() != "jetbrains" {
+		t.Errorf("Expected 'jetbrains', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestJetBrainsProvider_Capabilities(t *testing.T) {
+	p := &JetBrainsProvider{}
+
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestJetBrainsProvider_Interface(t *testing.T) {
+	var _ AIProvider = &JetBrainsProvider{}
+}

--- a/pkg/agent/provider_openwebui_test.go
+++ b/pkg/agent/provider_openwebui_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestOpenWebUIProvider_Basics(t *testing.T) {
+	p := &OpenWebUIProvider{}
+
+	if p.Name() != "open-webui" {
+		t.Errorf("Expected 'open-webui', got %q", p.Name())
+	}
+	if p.DisplayName() != "Open WebUI" {
+		t.Errorf("Expected 'Open WebUI', got %q", p.DisplayName())
+	}
+	if p.Provider() != "open-webui" {
+		t.Errorf("Expected 'open-webui', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestOpenWebUIProvider_Capabilities(t *testing.T) {
+	p := &OpenWebUIProvider{}
+
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestOpenWebUIProvider_Interface(t *testing.T) {
+	var _ AIProvider = &OpenWebUIProvider{}
+}

--- a/pkg/agent/provider_raycast_test.go
+++ b/pkg/agent/provider_raycast_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestRaycastProvider_Basics(t *testing.T) {
+	p := &RaycastProvider{}
+
+	if p.Name() != "raycast" {
+		t.Errorf("Expected 'raycast', got %q", p.Name())
+	}
+	if p.DisplayName() != "Raycast" {
+		t.Errorf("Expected 'Raycast', got %q", p.DisplayName())
+	}
+	if p.Provider() != "raycast" {
+		t.Errorf("Expected 'raycast', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestRaycastProvider_Capabilities(t *testing.T) {
+	p := &RaycastProvider{}
+
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestRaycastProvider_Interface(t *testing.T) {
+	var _ AIProvider = &RaycastProvider{}
+}

--- a/pkg/agent/provider_test_helpers_test.go
+++ b/pkg/agent/provider_test_helpers_test.go
@@ -1,0 +1,8 @@
+package agent
+
+import "strings"
+
+// containsSubstring checks if s contains substr (test helper).
+func containsSubstring(s, substr string) bool {
+	return strings.Contains(s, substr)
+}

--- a/pkg/agent/provider_vscode_test.go
+++ b/pkg/agent/provider_vscode_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestVSCodeProvider_Basics(t *testing.T) {
+	p := &VSCodeProvider{}
+
+	if p.Name() != "vscode" {
+		t.Errorf("Expected 'vscode', got %q", p.Name())
+	}
+	if p.DisplayName() != "VS Code" {
+		t.Errorf("Expected 'VS Code', got %q", p.DisplayName())
+	}
+	if p.Provider() != "microsoft" {
+		t.Errorf("Expected 'microsoft', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestVSCodeProvider_Capabilities(t *testing.T) {
+	p := &VSCodeProvider{}
+
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestVSCodeProvider_Interface(t *testing.T) {
+	var _ AIProvider = &VSCodeProvider{}
+}

--- a/pkg/agent/provider_windsurf_test.go
+++ b/pkg/agent/provider_windsurf_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestWindsurfProvider_Basics(t *testing.T) {
+	p := &WindsurfProvider{}
+
+	if p.Name() != "windsurf" {
+		t.Errorf("Expected 'windsurf', got %q", p.Name())
+	}
+	if p.DisplayName() != "Windsurf" {
+		t.Errorf("Expected 'Windsurf', got %q", p.DisplayName())
+	}
+	if p.Provider() != "codeium" {
+		t.Errorf("Expected 'codeium', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestWindsurfProvider_Capabilities(t *testing.T) {
+	p := &WindsurfProvider{}
+
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestWindsurfProvider_Interface(t *testing.T) {
+	var _ AIProvider = &WindsurfProvider{}
+}

--- a/pkg/agent/provider_zed_test.go
+++ b/pkg/agent/provider_zed_test.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestZedProvider_Basics(t *testing.T) {
+	p := &ZedProvider{}
+
+	if p.Name() != "zed" {
+		t.Errorf("Expected 'zed', got %q", p.Name())
+	}
+	if p.DisplayName() != "Zed" {
+		t.Errorf("Expected 'Zed', got %q", p.DisplayName())
+	}
+	if p.Provider() != "zed" {
+		t.Errorf("Expected 'zed', got %q", p.Provider())
+	}
+	if p.Description() == "" {
+		t.Error("Description should not be empty")
+	}
+}
+
+func TestZedProvider_Capabilities(t *testing.T) {
+	p := &ZedProvider{}
+
+	if p.Capabilities()&CapabilityChat == 0 {
+		t.Error("Expected CapabilityChat to be set")
+	}
+}
+
+func TestZedProvider_Interface(t *testing.T) {
+	var _ AIProvider = &ZedProvider{}
+}


### PR DESCRIPTION
Closes #3828

## Summary
- Added test files for 17 AI providers that were missing them: Bob, Claude Code, Claude Desktop, Cline, Codex, Continue, Copilot CLI, Cursor, Gemini CLI, GitHub Copilot, Goose, JetBrains, Open WebUI, Raycast, VS Code, Windsurf, and Zed
- Each test verifies AIProvider interface compliance, correct metadata return values (Name, DisplayName, Provider, Description), capability flags, and for CLI-based providers: correct behavior when CLI is not installed
- Added a shared test helper file for common assertions

## Test plan
- [x] `go test ./pkg/agent/...` passes with all new tests
- [x] `go build ./...` compiles successfully
- [x] Existing tests remain unaffected

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>