### PR TITLE
fix: set TLS MinVersion to 1.2 in ping handler HTTP client

### DIFF
--- a/pkg/api/handlers/ping.go
+++ b/pkg/api/handlers/ping.go
@@ -18,7 +18,7 @@ import (
 var pingClient = &http.Client{
 	Timeout: 5 * time.Second,
 	Transport: &http.Transport{
-		TLSClientConfig:   &tls.Config{InsecureSkipVerify: false},
+		TLSClientConfig:   &tls.Config{MinVersion: tls.VersionTLS12},
 		DisableKeepAlives: true,
 		DialContext: (&net.Dialer{
 			Timeout: 5 * time.Second,


### PR DESCRIPTION
Closes #3853

## Summary
- Set `MinVersion: tls.VersionTLS12` on the `tls.Config` in `pkg/api/handlers/ping.go` to fix the gosec finding "TLS MinVersion too low"
- Removed the redundant `InsecureSkipVerify: false` (it's the zero-value default)
- Verified with `scripts/gosec-test.sh` — no HIGH findings remain

## Test plan
- [x] `go build ./...` passes
- [x] `scripts/gosec-test.sh` reports no security issues
- [x] `cd web && npm run build` passes