### PR TITLE
fix: add missing token revocation methods to MockStore (#3851, #3852)

### DIFF
--- a/pkg/test/mock_store.go
+++ b/pkg/test/mock_store.go
@@ -150,4 +150,8 @@ func (m *MockStore) GetBulkUtilizationSnapshots(reservationIDs []string) (map[st
 func (m *MockStore) DeleteOldUtilizationSnapshots(before time.Time) (int64, error) { return 0, nil }
 func (m *MockStore) ListActiveGPUReservations() ([]models.GPUReservation, error)   { return nil, nil }
 
+func (m *MockStore) RevokeToken(jti string, expiresAt time.Time) error { return nil }
+func (m *MockStore) IsTokenRevoked(jti string) (bool, error)           { return false, nil }
+func (m *MockStore) CleanupExpiredTokens() (int64, error)              { return 0, nil }
+
 func (m *MockStore) Close() error { return nil }


### PR DESCRIPTION
Closes #3851
Closes #3852

## Summary

- Added stub implementations of `RevokeToken`, `IsTokenRevoked`, and `CleanupExpiredTokens` to `test.MockStore`
- These methods were added to the `store.Store` interface in PR #3823 but the mock was not updated, causing build failures in all handler tests
- Since `eventsTestStore`, `gpuTestStore`, and `feedbackStoreStub` all embed `MockStore`, this single change fixes all affected test files

## Test plan

- [x] `go test ./pkg/api/handlers/...` passes
- [x] `go build ./...` passes
- [x] `bash scripts/auth-lifecycle-test.sh` -- all 8 checks pass
- [x] `bash scripts/settings-migration-test.sh` -- all 8 checks pass