### PR TITLE
fix: update FilterTabs test to match i18n translation keys

### DIFF
--- a/web/src/components/clusters/components/FilterTabs.test.tsx
+++ b/web/src/components/clusters/components/FilterTabs.test.tsx
@@ -62,7 +62,7 @@ describe('FilterTabs', () => {
 
   it('calls onSortByChange when sort dropdown changes', () => {
     const { props } = renderFilterTabs({ sortBy: 'custom' })
-    const select = screen.getByDisplayValue('Custom')
+    const select = screen.getByDisplayValue('common.custom')
 
     fireEvent.change(select, { target: { value: 'health' } })
     expect(props.onSortByChange).toHaveBeenCalledWith('health')


### PR DESCRIPTION
Closes #3850
Closes #3854

## Summary

- PR #3789 extracted hardcoded strings like "Custom", "Health", "Provider" to i18n translation keys (`t('common.custom')`, etc.)
- The `FilterTabs.test.tsx` mock for `react-i18next` returns the translation key itself (e.g., `common.custom` instead of `Custom`)
- Updated `screen.getByDisplayValue('Custom')` to `screen.getByDisplayValue('common.custom')` to match the mocked i18n output

## Test plan

- [x] `npx vitest run src/components/clusters/components/FilterTabs.test.tsx` passes (6/6 tests)
- [x] `npm run build` passes