### PR TITLE
fix: harden CORS origin matching to prevent prefix and wildcard bypass

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -614,17 +614,32 @@ func (s *Server) isAllowedOrigin(origin string) bool {
 }
 
 // matchOrigin checks if an origin matches an allowed pattern.
-// Supports prefix matching (e.g. "http://localhost" matches "http://localhost:5174")
-// and wildcard suffix matching (e.g. "https://*.ibm.com" matches "https://kc.apps.example.ibm.com").
+// For non-wildcard origins, requires an exact match or a match with an additional port
+// (e.g. "http://localhost" matches "http://localhost" and "http://localhost:5174" but NOT "http://localhost.attacker.com").
+// For wildcard patterns like "https://*.ibm.com", matches only a single subdomain level
+// (e.g. "https://kc.ibm.com" matches but "https://evil.kc.ibm.com" does not).
 func matchOrigin(origin, allowed string) bool {
-	// Wildcard matching: "https://*.ibm.com" matches any subdomain
+	// Wildcard matching: "https://*.ibm.com" matches a single-level subdomain
 	if idx := strings.Index(allowed, "*."); idx != -1 {
 		scheme := allowed[:idx]   // e.g. "https://"
 		suffix := allowed[idx+1:] // e.g. ".ibm.com"
-		return strings.HasPrefix(origin, scheme) && strings.HasSuffix(origin, suffix)
+		if !strings.HasPrefix(origin, scheme) || !strings.HasSuffix(origin, suffix) {
+			return false
+		}
+		// Extract the subdomain part between the scheme and the suffix
+		middle := origin[len(scheme) : len(origin)-len(suffix)]
+		// Must be non-empty and contain no dots (single-level subdomain only)
+		return len(middle) > 0 && !strings.Contains(middle, ".")
 	}
-	// Prefix matching (original behavior)
-	return strings.HasPrefix(origin, allowed)
+	// Exact match
+	if origin == allowed {
+		return true
+	}
+	// Allow the origin to have a port appended (e.g. allowed "http://localhost" matches "http://localhost:5174")
+	if strings.HasPrefix(origin, allowed) && len(origin) > len(allowed) && origin[len(allowed)] == ':' {
+		return true
+	}
+	return false
 }
 
 // handleClustersHTTP returns the list of kubeconfig contexts

--- a/pkg/agent/server_test.go
+++ b/pkg/agent/server_test.go
@@ -106,7 +106,7 @@ func TestServer_IsAllowedOrigin(t *testing.T) {
 	}{
 		{"http://localhost", true},
 		{"https://sub.ibm.com", true},
-		{"https://deep.sub.ibm.com", true}, // Wildcard matches multiple levels? Assuming implementation uses robust matching
+		{"https://deep.sub.ibm.com", false}, // Wildcard only matches single-level subdomain
 		{"http://ibm.com", false},          // Wrong scheme
 		{"https://google.com", false},
 		{"", false}, // Empty origin usually treated as allowed in checkOrigin logic, but isAllowedOrigin likely returns false map lookup
@@ -729,12 +729,16 @@ func TestMatchOrigin(t *testing.T) {
 		want    bool
 	}{
 		{"http://localhost:5174", "http://localhost", true},
+		{"http://localhost", "http://localhost", true},
+		{"http://localhost.attacker.com", "http://localhost", false}, // prefix bypass
 		{"https://app.ibm.com", "https://*.ibm.com", true},
-		{"https://deep.sub.ibm.com", "https://*.ibm.com", true},
-		{"http://ibm.com", "https://*.ibm.com", false},  // wrong scheme
-		{"https://ibm.com", "https://*.ibm.com", false}, // no subdomain, doesn't have .ibm.com suffix
+		{"https://deep.sub.ibm.com", "https://*.ibm.com", false}, // multi-level subdomain rejected
+		{"http://ibm.com", "https://*.ibm.com", false},           // wrong scheme
+		{"https://ibm.com", "https://*.ibm.com", false},          // no subdomain, doesn't have .ibm.com suffix
 		{"https://google.com", "https://*.ibm.com", false},
 		{"http://exact.com", "http://exact.com", true},
+		{"http://exact.com:8080", "http://exact.com", true},      // port variation allowed
+		{"http://exact.com.evil.com", "http://exact.com", false}, // suffix bypass rejected
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #3863

## Summary

- Changed non-wildcard origin matching from `strings.HasPrefix` to exact match with port variation support. `http://localhost` now matches `http://localhost` and `http://localhost:5174` but rejects `http://localhost.attacker.com`.
- Changed wildcard origin matching (`*.ibm.com`) to only allow single-level subdomains. `https://kc.ibm.com` matches but `https://evil.kc.ibm.com` does not.
- Added test cases covering the previously exploitable bypass scenarios.

## Test plan

- [x] `go build ./...` passes
- [x] `TestMatchOrigin` passes with new test cases for prefix bypass and multi-level subdomain rejection
- [x] `TestServer_IsAllowedOrigin` passes with updated expectations

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>