### PR TITLE
fix: align QA tuner category taxonomy with consumer focus areas

### DIFF
--- a/.github/auto-qa-tuning.json
+++ b/.github/auto-qa-tuning.json
@@ -3,17 +3,45 @@
   "last_updated": "2026-03-29T03:59:27Z",
   "rolling_window_days": 30,
   "categories": {
-    "other": {
-      "merged": 97,
-      "closed": 111,
-      "acceptance_rate": 0.47,
+    "performance": {
+      "merged": 8,
+      "closed": 6,
+      "acceptance_rate": 0.57,
       "status": "normal",
-      "last_evaluated": "2026-03-29T03:59:27Z"
+      "last_evaluated": "2026-03-28T03:48:11Z"
     },
     "security": {
       "merged": 18,
       "closed": 17,
       "acceptance_rate": 0.51,
+      "status": "normal",
+      "last_evaluated": "2026-03-29T03:59:27Z"
+    },
+    "a11y": {
+      "merged": 27,
+      "closed": 16,
+      "acceptance_rate": 0.63,
+      "status": "normal",
+      "last_evaluated": "2026-03-29T03:59:27Z"
+    },
+    "operator": {
+      "merged": 0,
+      "closed": 0,
+      "acceptance_rate": 0.5,
+      "status": "normal",
+      "last_evaluated": "2026-03-29T03:59:27Z"
+    },
+    "sre": {
+      "merged": 0,
+      "closed": 0,
+      "acceptance_rate": 0.5,
+      "status": "normal",
+      "last_evaluated": "2026-03-29T03:59:27Z"
+    },
+    "features": {
+      "merged": 0,
+      "closed": 0,
+      "acceptance_rate": 0.5,
       "status": "normal",
       "last_evaluated": "2026-03-29T03:59:27Z"
     },
@@ -24,47 +52,12 @@
       "status": "normal",
       "last_evaluated": "2026-03-29T03:59:27Z"
     },
-    "performance": {
-      "merged": 8,
-      "closed": 6,
-      "acceptance_rate": 0.57,
-      "status": "normal",
-      "last_evaluated": "2026-03-28T03:48:11Z"
-    },
     "consistency": {
       "merged": 15,
       "closed": 16,
       "acceptance_rate": 0.48,
       "status": "normal",
       "last_evaluated": "2026-03-29T03:59:27Z"
-    },
-    "dom-errors": {
-      "merged": 5,
-      "closed": 2,
-      "acceptance_rate": 0.71,
-      "status": "normal",
-      "last_evaluated": "2026-03-25T03:48:55Z"
-    },
-    "a11y": {
-      "merged": 22,
-      "closed": 14,
-      "acceptance_rate": 0.61,
-      "status": "normal",
-      "last_evaluated": "2026-03-29T03:59:27Z"
-    },
-    "ui-design": {
-      "merged": 7,
-      "closed": 11,
-      "acceptance_rate": 0.39,
-      "status": "normal",
-      "last_evaluated": "2026-03-26T03:57:14Z"
-    },
-    "testing": {
-      "merged": 14,
-      "closed": 16,
-      "acceptance_rate": 0.47,
-      "status": "normal",
-      "last_evaluated": "2026-03-25T03:48:55Z"
     }
   },
   "weekly_insights": {
@@ -335,15 +328,14 @@
     }
   ],
   "rotation_weights": {
-    "other": 0.71,
-    "security": 0.77,
-    "resilience": 0.74,
     "performance": 0.86,
-    "consistency": 0.72,
-    "dom-errors": 1.07,
+    "security": 0.77,
     "a11y": 0.92,
-    "ui-design": 0.59,
-    "testing": 0.71
+    "operator": 1.0,
+    "sre": 1.0,
+    "features": 1.0,
+    "resilience": 0.74,
+    "consistency": 0.72
   },
   "max_issues_override": 2,
   "pr_guidance": "Keep changes under 50 lines (size S) for best acceptance rate. Split larger fixes into multiple PRs."

--- a/.github/workflows/auto-qa-tuner.yml
+++ b/.github/workflows/auto-qa-tuner.yml
@@ -102,15 +102,15 @@ jobs:
           categorize_title() {
             local title="$1"
             title_lower=$(echo "$title" | tr '[:upper:]' '[:lower:]')
-            if echo "$title_lower" | grep -qE 'aria|a11y|accessibility|keyboard nav|screen reader'; then echo "a11y"
+            if echo "$title_lower" | grep -qE 'aria|a11y|accessibility|keyboard nav|screen reader|dom nest|html|semantic'; then echo "a11y"
             elif echo "$title_lower" | grep -qE 'security|hardcoded|credential|token|vuln|cve'; then echo "security"
             elif echo "$title_lower" | grep -qE 'performance|lazy|unused dep|bundle|optim'; then echo "performance"
-            elif echo "$title_lower" | grep -qE 'dom nest|html|semantic'; then echo "dom-errors"
-            elif echo "$title_lower" | grep -qE 'loading|spinner|skeleton|refresh'; then echo "ui-design"
+            elif echo "$title_lower" | grep -qE 'operator|workflow|helm|deploy|cluster|kubeconfig'; then echo "operator"
+            elif echo "$title_lower" | grep -qE 'test|coverage|monitor|alert|observ|sre'; then echo "sre"
+            elif echo "$title_lower" | grep -qE 'feat|enhance|ui-design|loading|spinner|skeleton|refresh|design'; then echo "features"
             elif echo "$title_lower" | grep -qE 'error|catch|resilience|toast|feedback'; then echo "resilience"
             elif echo "$title_lower" | grep -qE 'inventory|consistency|demo'; then echo "consistency"
-            elif echo "$title_lower" | grep -qE 'test|coverage'; then echo "testing"
-            else echo "other"
+            else echo "operator"
             fi
           }
 


### PR DESCRIPTION
Closes #3862

## Summary

- **rotation_weights** in `.github/auto-qa-tuning.json` now uses the same 8 categories as the consumer's focus area list in `.github/workflows/auto-qa.yml` line 114: `performance`, `security`, `a11y`, `operator`, `sre`, `features`, `resilience`, `consistency`
- **categories** section in the tuning config updated to match (merged `dom-errors` stats into `a11y`; initialized `operator`/`sre`/`features` with neutral values)
- **categorize_title()** in `.github/workflows/auto-qa-tuner.yml` updated to classify PRs into the consumer's 8 categories instead of the old taxonomy (`dom-errors`, `ui-design`, `testing`, `other` are removed)

## Problem

The consumer workflow selects a daily focus area from 8 categories and looks up its weight in `rotation_weights`. Three categories (`operator`, `sre`, `features`) had no weight entries, so they silently defaulted to 1.0. Four tuning categories (`other`, `dom-errors`, `ui-design`, `testing`) had weights computed by the tuner but were never used by the consumer. The tuner would also overwrite the weights on each run using its own category set, perpetuating the mismatch.

## Test plan

- [ ] Verify `auto-qa-tuning.json` is valid JSON
- [ ] Verify the 8 keys in `rotation_weights` match the AREAS array in `auto-qa.yml` line 114
- [ ] Verify the 8 keys in `categories` match `rotation_weights`
- [ ] Verify `categorize_title()` in `auto-qa-tuner.yml` outputs only the 8 consumer categories