### PR TITLE
test: add unit tests for useGitHubRewards and useClusterData hooks

### DIFF
--- a/web/src/hooks/__tests__/useClusterData.test.ts
+++ b/web/src/hooks/__tests__/useClusterData.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the useClusterData hook.
+ *
+ * Validates aggregation of multiple MCP hooks, coalescing of undefined
+ * upstream values to empty arrays, and exposure of deduplicatedClusters.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before the module under test is imported.
+// Each MCP hook returns an object with a specific property name.
+// ---------------------------------------------------------------------------
+
+const mockUseClusters = vi.fn()
+const mockUsePods = vi.fn()
+const mockUseDeployments = vi.fn()
+const mockUseNamespaces = vi.fn()
+const mockUseEvents = vi.fn()
+const mockUseHelmReleases = vi.fn()
+const mockUseOperatorSubscriptions = vi.fn()
+const mockUseSecurityIssues = vi.fn()
+
+vi.mock('../useMCP', () => ({
+  useClusters: () => mockUseClusters(),
+  usePods: () => mockUsePods(),
+  useDeployments: () => mockUseDeployments(),
+  useNamespaces: () => mockUseNamespaces(),
+  useEvents: () => mockUseEvents(),
+  useHelmReleases: () => mockUseHelmReleases(),
+  useOperatorSubscriptions: () => mockUseOperatorSubscriptions(),
+  useSecurityIssues: () => mockUseSecurityIssues(),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Set all mocks to return the given shape (or defaults). */
+function setDefaults(overrides: Record<string, unknown> = {}) {
+  mockUseClusters.mockReturnValue({
+    clusters: overrides.clusters ?? [{ name: 'c1' }],
+    deduplicatedClusters: overrides.deduplicatedClusters ?? [{ name: 'c1' }],
+  })
+  mockUsePods.mockReturnValue({ pods: overrides.pods ?? [{ name: 'p1' }] })
+  mockUseDeployments.mockReturnValue({ deployments: overrides.deployments ?? [{ name: 'd1' }] })
+  mockUseNamespaces.mockReturnValue({ namespaces: overrides.namespaces ?? [{ name: 'ns1' }] })
+  mockUseEvents.mockReturnValue({ events: overrides.events ?? [{ reason: 'Scheduled' }] })
+  mockUseHelmReleases.mockReturnValue({ releases: overrides.releases ?? [{ name: 'h1' }] })
+  mockUseOperatorSubscriptions.mockReturnValue({ subscriptions: overrides.subscriptions ?? [{ name: 'o1' }] })
+  mockUseSecurityIssues.mockReturnValue({ issues: overrides.issues ?? [{ id: 's1' }] })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useClusterData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setDefaults()
+  })
+
+  // 1. Returns expected properties from upstream hooks
+  it('returns all aggregated properties from upstream MCP hooks', async () => {
+    const { useClusterData } = await import('../useClusterData')
+    const { result } = renderHook(() => useClusterData())
+
+    expect(result.current.clusters).toEqual([{ name: 'c1' }])
+    expect(result.current.deduplicatedClusters).toEqual([{ name: 'c1' }])
+    expect(result.current.pods).toEqual([{ name: 'p1' }])
+    expect(result.current.deployments).toEqual([{ name: 'd1' }])
+    expect(result.current.namespaces).toEqual([{ name: 'ns1' }])
+    expect(result.current.events).toEqual([{ reason: 'Scheduled' }])
+    expect(result.current.helmReleases).toEqual([{ name: 'h1' }])
+    expect(result.current.operatorSubscriptions).toEqual([{ name: 'o1' }])
+    expect(result.current.securityIssues).toEqual([{ id: 's1' }])
+  })
+
+  // 2. Coalesces undefined upstream values to empty arrays
+  it('coalesces undefined upstream values to empty arrays', async () => {
+    mockUseClusters.mockReturnValue({ clusters: undefined, deduplicatedClusters: undefined })
+    mockUsePods.mockReturnValue({ pods: undefined })
+    mockUseDeployments.mockReturnValue({ deployments: undefined })
+    mockUseNamespaces.mockReturnValue({ namespaces: undefined })
+    mockUseEvents.mockReturnValue({ events: undefined })
+    mockUseHelmReleases.mockReturnValue({ releases: undefined })
+    mockUseOperatorSubscriptions.mockReturnValue({ subscriptions: undefined })
+    mockUseSecurityIssues.mockReturnValue({ issues: undefined })
+
+    const { useClusterData } = await import('../useClusterData')
+    const { result } = renderHook(() => useClusterData())
+
+    expect(result.current.clusters).toEqual([])
+    expect(result.current.deduplicatedClusters).toEqual([])
+    expect(result.current.pods).toEqual([])
+    expect(result.current.deployments).toEqual([])
+    expect(result.current.namespaces).toEqual([])
+    expect(result.current.events).toEqual([])
+    expect(result.current.helmReleases).toEqual([])
+    expect(result.current.operatorSubscriptions).toEqual([])
+    expect(result.current.securityIssues).toEqual([])
+  })
+
+  // 3. Returns deduplicatedClusters from useClusters
+  it('returns deduplicatedClusters when provided by useClusters', async () => {
+    const deduped = [{ name: 'unique-cluster' }]
+    mockUseClusters.mockReturnValue({
+      clusters: [{ name: 'c1' }, { name: 'c1' }],
+      deduplicatedClusters: deduped,
+    })
+
+    const { useClusterData } = await import('../useClusterData')
+    const { result } = renderHook(() => useClusterData())
+
+    expect(result.current.deduplicatedClusters).toEqual(deduped)
+    expect(result.current.clusters).toHaveLength(2)
+  })
+
+  // 4. Mixed defined and undefined inputs
+  it('handles mixed defined and undefined upstream values', async () => {
+    mockUsePods.mockReturnValue({ pods: undefined })
+    mockUseEvents.mockReturnValue({ events: undefined })
+    // Rest keep their defaults from setDefaults()
+
+    const { useClusterData } = await import('../useClusterData')
+    const { result } = renderHook(() => useClusterData())
+
+    // Defined values pass through
+    expect(result.current.clusters).toEqual([{ name: 'c1' }])
+    expect(result.current.deployments).toEqual([{ name: 'd1' }])
+
+    // Undefined values coalesced
+    expect(result.current.pods).toEqual([])
+    expect(result.current.events).toEqual([])
+  })
+})

--- a/web/src/hooks/__tests__/useGitHubRewards.test.ts
+++ b/web/src/hooks/__tests__/useGitHubRewards.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the useGitHubRewards hook.
+ *
+ * Validates demo-user skip, unauthenticated skip, localStorage caching,
+ * successful fetch, error handling with stale cache retention, and
+ * periodic refresh via interval.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import type { GitHubRewardsResponse } from '../../types/rewards'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseAuth = vi.fn<[], { user: { github_login: string } | null; isAuthenticated: boolean }>()
+vi.mock('../../lib/auth', () => ({ useAuth: () => mockUseAuth() }))
+
+// Constants are simple values -- we mirror them here for localStorage setup.
+const STORAGE_KEY_TOKEN = 'token'
+const CACHE_KEY = 'github-rewards-cache'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSampleResponse(overrides: Partial<GitHubRewardsResponse> = {}): GitHubRewardsResponse {
+  return {
+    total_points: 1200,
+    contributions: [],
+    breakdown: { bug_issues: 2, feature_issues: 1, other_issues: 0, prs_opened: 3, prs_merged: 1 },
+    cached_at: '2025-01-01T00:00:00Z',
+    from_cache: false,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useGitHubRewards', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    localStorage.clear()
+    vi.stubGlobal('fetch', vi.fn())
+    // Default: authenticated, real user, token present
+    mockUseAuth.mockReturnValue({ user: { github_login: 'octocat' }, isAuthenticated: true })
+    localStorage.setItem(STORAGE_KEY_TOKEN, 'test-jwt')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // 1. Demo user skip
+  it('returns null and does not fetch for demo users', async () => {
+    mockUseAuth.mockReturnValue({ user: { github_login: 'demo-user' }, isAuthenticated: true })
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    const { result } = renderHook(() => useGitHubRewards())
+
+    expect(result.current.githubRewards).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  // 2. Unauthenticated skip
+  it('returns null and does not fetch when not authenticated', async () => {
+    mockUseAuth.mockReturnValue({ user: null, isAuthenticated: false })
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    const { result } = renderHook(() => useGitHubRewards())
+
+    expect(result.current.githubRewards).toBeNull()
+    expect(result.current.isLoading).toBe(false)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  // 3. Cached data loaded from localStorage on mount
+  it('returns cached data from localStorage on mount', async () => {
+    const cached = makeSampleResponse({ total_points: 999 })
+    localStorage.setItem(CACHE_KEY, JSON.stringify(cached))
+
+    // Prevent actual fetch from resolving during this test
+    vi.mocked(global.fetch).mockReturnValue(new Promise(() => {}))
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    const { result } = renderHook(() => useGitHubRewards())
+
+    // Cached value available synchronously (useState initialiser)
+    expect(result.current.githubRewards).not.toBeNull()
+    expect(result.current.githubRewards!.total_points).toBe(999)
+  })
+
+  // 4. Successful fetch updates state and writes cache
+  it('updates state and caches result on successful fetch', async () => {
+    const apiResponse = makeSampleResponse({ total_points: 1500 })
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(apiResponse),
+    } as Response)
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    const { result } = renderHook(() => useGitHubRewards())
+
+    await waitFor(() => {
+      expect(result.current.githubRewards).not.toBeNull()
+      expect(result.current.githubRewards!.total_points).toBe(1500)
+    })
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBeNull()
+
+    // Cache should have been written
+    const raw = localStorage.getItem(CACHE_KEY)
+    expect(raw).not.toBeNull()
+    expect(JSON.parse(raw!).total_points).toBe(1500)
+  })
+
+  // 5. Failed fetch sets error and retains stale cache
+  it('sets error but keeps stale cached data on fetch failure', async () => {
+    const stale = makeSampleResponse({ total_points: 800 })
+    localStorage.setItem(CACHE_KEY, JSON.stringify(stale))
+
+    vi.mocked(global.fetch).mockRejectedValue(new Error('Network down'))
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    const { result } = renderHook(() => useGitHubRewards())
+
+    await waitFor(() => {
+      expect(result.current.error).toBe('Network down')
+    })
+
+    expect(result.current.isLoading).toBe(false)
+
+    // Stale data retained
+    expect(result.current.githubRewards).not.toBeNull()
+    expect(result.current.githubRewards!.total_points).toBe(800)
+  })
+
+  // 6. Refreshes on interval (uses fake timers)
+  it('calls fetch again after the refresh interval', async () => {
+    vi.useFakeTimers()
+
+    const apiResponse = makeSampleResponse()
+    // Use a manually controlled promise so we can resolve it on demand
+    let resolveFirstFetch!: (v: Response) => void
+    const firstFetchPromise = new Promise<Response>((r) => { resolveFirstFetch = r })
+    vi.mocked(global.fetch).mockReturnValueOnce(firstFetchPromise)
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    renderHook(() => useGitHubRewards())
+
+    // Resolve the first fetch
+    await act(async () => {
+      resolveFirstFetch({
+        ok: true,
+        json: () => Promise.resolve(apiResponse),
+      } as Response)
+    })
+
+    const callsAfterMount = vi.mocked(global.fetch).mock.calls.length
+    expect(callsAfterMount).toBe(1)
+
+    // Set up the next fetch response
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(apiResponse),
+    } as Response)
+
+    // Advance by 10 minutes (REFRESH_INTERVAL_MS)
+    await act(async () => {
+      vi.advanceTimersByTime(10 * 60 * 1000)
+    })
+
+    expect(vi.mocked(global.fetch).mock.calls.length).toBeGreaterThan(callsAfterMount)
+
+    vi.useRealTimers()
+  })
+
+  // 7. Missing token -- no fetch
+  it('does not fetch when STORAGE_KEY_TOKEN is absent', async () => {
+    localStorage.removeItem(STORAGE_KEY_TOKEN)
+
+    const { useGitHubRewards } = await import('../useGitHubRewards')
+    const { result } = renderHook(() => useGitHubRewards())
+
+    // Give effect a chance to run
+    await act(async () => {
+      // no-op, just flush effects
+    })
+
+    expect(global.fetch).not.toHaveBeenCalled()
+    // Data stays null since no cache and no fetch
+    expect(result.current.githubRewards).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #3875

## Summary
- Adds 7 tests for `useGitHubRewards`: demo user skip, unauthenticated skip, cached localStorage data on mount, successful fetch with cache write, failed fetch retaining stale data, interval refresh via fake timers, and missing token skip.
- Adds 4 tests for `useClusterData`: full aggregation passthrough, undefined-to-empty-array coalescing, deduplicatedClusters exposure, and mixed defined/undefined inputs.

## Test plan
- [x] All 11 tests pass locally via `npx vitest run`
- [x] No changes to production code

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>