### PR TITLE
🐛 Fix sidebar collapse and pin icons overlapping with sidebar content 

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -545,8 +545,8 @@ export function Sidebar() {
       {/* Collapse + Pin controls — top-right of sidebar, above resize handle */}
       {!isMobile && !isMissionFullScreen && (
         <div
-          className="fixed top-[4.5rem] z-[45] flex flex-col gap-1.5 items-center"
-          style={{ left: sidebarWidth - 14 }}
+          className="fixed top-[4.5rem] z-[45] flex flex-col gap-1.5 items-center transition-[left] duration-300"
+          style={{ left: sidebarWidth + 4 }}
         >
           <button
             data-testid="sidebar-collapse-toggle"


### PR DESCRIPTION
  ### 📌 Fixes                                                                                                                                                                                                                                                                                                                                                                                                                            
  Fixes #3886
  ---

  ### 📝 Summary of Changes

  - Fixed collapse chevron and pin icons overlapping with sidebar content
  - Adjusted button container positioning from `sidebarWidth - 14` to `sidebarWidth + 4` so icons render outside the sidebar border
  - Added smooth `transition-[left]` to keep icons in sync with sidebar collapse/expand animation

  ---

  ### Changes Made

  - [x] Fixed icon positioning in `web/src/components/layout/Sidebar.tsx`

  ---

  ### Checklist

  - [x] I used a coding agent (Claude Code) to generate/review this code
  - [x] I have reviewed the project's contribution guidelines
  - [x] New cards target console-marketplace, not this repo
  - [x] isDemoData is wired correctly (cards show Demo badge when using demo data)
  - [x] I have tested the changes locally and ensured they work as expected
  - [x] All commits are signed with DCO (`git commit -s`)

  ---

  ### Screenshots or Logs (if applicable)

  **Before:**
  
<img width="1918" height="890" alt="image" src="https://github.com/user-attachments/assets/dcabbe60-0533-4683-bbc1-15f14b7ddec7" />


  **After:**
 
<img width="1918" height="971" alt="image" src="https://github.com/user-attachments/assets/86588907-dc4d-476c-afb2-a527198186b0" />

  ---

  ### 👀 Reviewer Notes

 The collapse (`<`) and pin icons were positioned at `sidebarWidth - 14`, placing them half-inside the sidebar. Changed to `sidebarWidth + 4` so they sit just outside the sidebar border. Added `transition-[left] 
  duration-300` to match the sidebar's existing collapse animation.