### PR TITLE
🐛 fix: auth security — JWT revocation, token leak, stale tokens

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -252,25 +252,22 @@ func (s *Server) checkOrigin(r *http.Request) bool {
 	return false
 }
 
-// validateToken checks the authentication token (if configured)
+// validateToken checks the authentication token (if configured).
+// Tokens are accepted ONLY via the Authorization header to keep secrets out
+// of server logs, browser history, and proxy access logs (#3895).
 func (s *Server) validateToken(r *http.Request) bool {
 	// If no token configured, skip token validation
 	if s.agentToken == "" {
 		return true
 	}
 
-	// Check Authorization header first
+	// Accept token exclusively from the Authorization header
 	authHeader := r.Header.Get("Authorization")
 	if strings.HasPrefix(authHeader, "Bearer ") {
 		token := strings.TrimPrefix(authHeader, "Bearer ")
 		if token == s.agentToken {
 			return true
 		}
-	}
-
-	// Check query parameter as fallback (for WebSocket connections)
-	if r.URL.Query().Get("token") == s.agentToken {
-		return true
 	}
 
 	return false

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"log"
 	"strings"
 	"sync"
@@ -256,8 +257,13 @@ func WebSocketUpgrade() fiber.Handler {
 	}
 }
 
-// ValidateJWT validates a JWT token string and returns the claims
-// Used for WebSocket connections where token is passed via query param
+// ErrTokenRevoked is returned when a validated JWT has been server-side revoked.
+var ErrTokenRevoked = fmt.Errorf("token has been revoked")
+
+// ValidateJWT validates a JWT token string and returns the claims.
+// Used for WebSocket connections where token is passed via query param.
+// This performs the same revocation check as the HTTP JWTAuth middleware
+// so that revoked tokens are rejected on WebSocket/exec paths too (#3894).
 func ValidateJWT(tokenString, secret string) (*UserClaims, error) {
 	token, err := jwt.ParseWithClaims(tokenString, &UserClaims{}, func(token *jwt.Token) (interface{}, error) {
 		return []byte(secret), nil
@@ -274,6 +280,12 @@ func ValidateJWT(tokenString, secret string) (*UserClaims, error) {
 	claims, ok := token.Claims.(*UserClaims)
 	if !ok {
 		return nil, jwt.ErrTokenInvalidClaims
+	}
+
+	// Check if token has been revoked (server-side logout) — mirrors the
+	// check in JWTAuth middleware so WS/exec paths are equally protected.
+	if claims.ID != "" && IsTokenRevoked(claims.ID) {
+		return nil, ErrTokenRevoked
 	}
 
 	return claims, nil

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -38,14 +38,25 @@ export class UnauthorizedError extends Error {
 
 // Debounce 401 handling to avoid multiple simultaneous logouts
 let handling401 = false
+/** Safety cap: reset the 401 debounce flag after this many ms so future
+ *  auth failures aren't permanently silenced if the redirect doesn't fire (#3899). */
+const HANDLING_401_RESET_MS = 10_000
 
 /**
  * Handle 401 Unauthorized responses by clearing auth state and redirecting to login.
  * This is debounced to avoid multiple simultaneous logouts from parallel API calls.
+ * The flag auto-resets after HANDLING_401_RESET_MS so a failed redirect doesn't
+ * permanently block all API calls.
  */
 function handle401(): void {
   if (handling401) return
   handling401 = true
+
+  // Auto-reset the flag after a safety timeout so the app isn't permanently
+  // blocked if the redirect fails (e.g. service-worker intercept, popup blocker).
+  setTimeout(() => {
+    handling401 = false
+  }, HANDLING_401_RESET_MS)
 
   console.warn('[API] Received 401 Unauthorized - token invalid or expired, logging out')
 

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -329,12 +329,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return
       }
       showExpiryWarningBanner(async () => {
+        // Re-read the token at click time instead of using the stale closure
+        // value — the token may have been silently refreshed since the banner
+        // was shown (#3909).
+        const freshToken = localStorage.getItem(STORAGE_KEY_TOKEN)
+        if (!freshToken || freshToken === DEMO_TOKEN_VALUE) return
         try {
           const response = await fetch('/auth/refresh', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              Authorization: `Bearer ${currentToken}`,
+              Authorization: `Bearer ${freshToken}`,
             },
             signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
           })

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -93,7 +93,6 @@ function parseSSEChunk(
  */
 export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
   const { url, params, onClusterData, onDone, itemsKey, signal } = options
-  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
 
   const searchParams = new URLSearchParams()
   if (params) {
@@ -170,18 +169,22 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
       })
     }
 
-    const headers: Record<string, string> = {
-      Accept: 'text/event-stream',
-    }
-    if (token) {
-      headers.Authorization = `Bearer ${token}`
-    }
-
     /**
      * Execute one SSE fetch attempt. On recoverable errors, schedules a retry
      * with exponential backoff up to SSE_MAX_RECONNECT_ATTEMPTS.
+     *
+     * The auth token is read from localStorage on EVERY attempt so that
+     * reconnects after a silent token refresh use the fresh token (#3897).
      */
     const attempt = (attemptNumber: number): void => {
+      const headers: Record<string, string> = {
+        Accept: 'text/event-stream',
+      }
+      const currentToken = localStorage.getItem(STORAGE_KEY_TOKEN)
+      if (currentToken) {
+        headers.Authorization = `Bearer ${currentToken}`
+      }
+
       fetch(fullUrl, {
         headers,
         signal: timeoutController.signal,


### PR DESCRIPTION
## Summary

Fixes 5 auth/security bugs:

- **#3894** — `ValidateJWT()` (used by WebSocket and exec handlers) now checks the token revocation cache, matching the HTTP `JWTAuth` middleware behavior. Previously, revoked tokens were still accepted on WS/exec paths.
- **#3895** — Agent `validateToken()` no longer accepts tokens via `?token=` URL query parameter. Tokens are accepted only via `Authorization` header to keep secrets out of server logs and proxy access logs.
- **#3899** — The `handling401` debounce flag in the API client now auto-resets after 10s. Previously, if the login redirect failed (popup blocker, service worker, etc.), the flag stayed `true` permanently and silenced all future 401 handling.
- **#3897** — SSE client re-reads the auth token from `localStorage` on each reconnect attempt instead of capturing it once at connection time. Reconnects after a silent token refresh now use the fresh token.
- **#3909** — The session-expiry banner's "Refresh Now" button reads the current token from `localStorage` at click time instead of using the stale closure value captured when the banner was rendered.

## Test plan

- [ ] Verify Go build: `go build ./...`
- [ ] Verify frontend build: `cd web && npm run build`
- [ ] Revoke a JWT and confirm WebSocket connections are rejected (fix #3894)
- [ ] Confirm agent endpoints reject requests with `?token=` query param (fix #3895)
- [ ] Simulate a blocked redirect after 401 and verify subsequent API calls still trigger logout (fix #3899)
- [ ] Trigger SSE reconnect after token refresh and verify fresh token is used (fix #3897)
- [ ] Let session-expiry banner appear, refresh token via another tab, click "Refresh Now" — verify it sends the fresh token (fix #3909)