### PR TITLE
🐛 fix: missions search, mission state UX, namespace dropdown

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -19,6 +19,7 @@ import {
   X,
   RotateCcw,
   StopCircle,
+  ListChecks,
 } from 'lucide-react'
 import { useMissions, type Mission } from '../../../hooks/useMissions'
 import { useAuth } from '../../../lib/auth'
@@ -459,31 +460,66 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
         onScroll={handleScroll}
         className="flex-1 overflow-y-auto scroll-enhanced p-4 space-y-4 min-h-0 min-w-0"
       >
-        {/* Inline Run button for saved missions with no conversation yet */}
+        {/* Inline Run button + mission steps for saved missions with no conversation yet (#3917) */}
         {mission.status === 'saved' && mission.messages.length === 0 && (
-          <div className="flex flex-col items-center gap-3 py-6">
-            <button
-              onClick={() => {
-                if (isNetlifyDeployment) {
-                  window.dispatchEvent(new CustomEvent('open-install'))
-                } else if (isDemoMode) {
-                  window.dispatchEvent(new CustomEvent('open-agent-setup'))
-                } else {
-                  runSavedMission(mission.id)
-                }
-              }}
-              className="flex items-center justify-center gap-2 px-8 py-3 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-all hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <Play className="w-4 h-4" />
-              Run Mission
-            </button>
-            <button
-              onClick={() => setActiveMission(null)}
-              className="flex items-center justify-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-            >
-              <ChevronLeft className="w-3 h-3" />
-              {t('missionChat.backToMissions')}
-            </button>
+          <div className="flex flex-col gap-4 py-4">
+            <div className="flex flex-col items-center gap-3">
+              <button
+                onClick={() => {
+                  if (isNetlifyDeployment) {
+                    window.dispatchEvent(new CustomEvent('open-install'))
+                  } else if (isDemoMode) {
+                    window.dispatchEvent(new CustomEvent('open-agent-setup'))
+                  } else {
+                    runSavedMission(mission.id)
+                  }
+                }}
+                className="flex items-center justify-center gap-2 px-8 py-3 text-sm font-semibold bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-all hover:scale-[1.02] active:scale-[0.98]"
+              >
+                <Play className="w-4 h-4" />
+                Run Mission
+              </button>
+              <button
+                onClick={() => setActiveMission(null)}
+                className="flex items-center justify-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+              >
+                <ChevronLeft className="w-3 h-3" />
+                {t('missionChat.backToMissions')}
+              </button>
+            </div>
+
+            {/* Mission steps overview — visible without AI provider (#3917) */}
+            {mission.importedFrom?.steps && mission.importedFrom.steps.length > 0 && (
+              <div className="mx-1 rounded-lg border border-border bg-secondary/30 overflow-hidden">
+                <div className="flex items-center gap-2 px-3 py-2 border-b border-border/50 bg-secondary/50">
+                  <ListChecks className="w-4 h-4 text-purple-400" />
+                  <span className="text-xs font-semibold text-foreground">
+                    {t('missionChat.missionSteps', { defaultValue: 'Mission Steps' })}
+                  </span>
+                  <span className="ml-auto text-2xs text-muted-foreground">
+                    {mission.importedFrom.steps.length} {mission.importedFrom.steps.length === 1 ? 'step' : 'steps'}
+                  </span>
+                </div>
+                <div className="p-2 space-y-2 max-h-[50vh] overflow-y-auto scroll-enhanced">
+                  {mission.importedFrom.steps.map((step, idx) => (
+                    <div
+                      key={idx}
+                      className="flex gap-2.5 p-2.5 rounded-md bg-background/50 border border-border/50"
+                    >
+                      <span className="flex-shrink-0 w-5 h-5 flex items-center justify-center rounded-full bg-purple-500/20 text-purple-400 text-2xs font-bold">
+                        {idx + 1}
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-foreground">{step.title}</p>
+                        {step.description && (
+                          <p className="text-xs text-muted-foreground mt-0.5 line-clamp-3 whitespace-pre-wrap">{step.description}</p>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
         )}
 

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -22,6 +22,7 @@ import {
   ShieldOff,
   BookOpen,
   Rocket,
+  Search,
 } from 'lucide-react'
 import { useSearchParams, useLocation } from 'react-router-dom'
 import { useMissions } from '../../../hooks/useMissions'
@@ -288,9 +289,17 @@ export function MissionSidebar() {
     tryImport().finally(() => setIsDirectImporting(false))
   }, [directImportSlug]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Split missions into saved (library) and active
-  const savedMissions = missions.filter(m => m.status === 'saved')
-  const activeMissions = missions.filter(m => m.status !== 'saved')
+  // Mission list search filter (#3944)
+  const [missionSearchQuery, setMissionSearchQuery] = useState('')
+
+  // Split missions into saved (library) and active, applying search filter
+  const matchesSearch = useCallback((m: Mission) => {
+    if (!missionSearchQuery.trim()) return true
+    const q = missionSearchQuery.toLowerCase()
+    return m.title.toLowerCase().includes(q) || m.description.toLowerCase().includes(q)
+  }, [missionSearchQuery])
+  const savedMissions = missions.filter(m => m.status === 'saved' && matchesSearch(m))
+  const activeMissions = missions.filter(m => m.status !== 'saved' && matchesSearch(m))
 
   const handleImportMission = useCallback((mission: MissionExport) => {
     const missionType = mission.missionClass === 'install' ? 'deploy' as const
@@ -913,6 +922,29 @@ export function MissionSidebar() {
           "flex-1 overflow-y-auto scroll-enhanced p-2 space-y-2",
           isFullScreen && "max-w-3xl mx-auto w-full"
         )}>
+          {/* Mission search filter (#3944) */}
+          {missions.length > 1 && (
+            <div className="relative px-1 pb-1">
+              <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+              <input
+                type="text"
+                value={missionSearchQuery}
+                onChange={(e) => setMissionSearchQuery(e.target.value)}
+                placeholder={t('missionSidebar.searchMissions', { defaultValue: 'Search missions...' })}
+                className="w-full pl-8 pr-8 py-1.5 text-sm bg-secondary/50 border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary/50"
+              />
+              {missionSearchQuery && (
+                <button
+                  onClick={() => setMissionSearchQuery('')}
+                  className="absolute right-3.5 top-1/2 -translate-y-1/2 p-0.5 hover:bg-secondary rounded transition-colors"
+                  title={t('common.clear', { defaultValue: 'Clear' })}
+                >
+                  <X className="w-3 h-3 text-muted-foreground" />
+                </button>
+              )}
+            </div>
+          )}
+
           {/* Saved missions section */}
           {savedMissions.length > 0 && (
             <div className="mb-3">
@@ -1008,9 +1040,16 @@ export function MissionSidebar() {
           )}
 
           {/* Empty state when only saved missions, no active */}
-          {activeMissions.length === 0 && savedMissions.length > 0 && (
+          {activeMissions.length === 0 && savedMissions.length > 0 && !missionSearchQuery && (
             <div className="text-center py-4">
               <p className="text-xs text-muted-foreground">No active missions. Click <strong>Run</strong> on a saved mission to start it.</p>
+            </div>
+          )}
+          {/* No search results */}
+          {missionSearchQuery && savedMissions.length === 0 && activeMissions.length === 0 && (
+            <div className="text-center py-6">
+              <Search className="w-6 h-6 text-muted-foreground/40 mx-auto mb-2" />
+              <p className="text-xs text-muted-foreground">{t('missionSidebar.noSearchResults', { defaultValue: 'No missions match your search.' })}</p>
             </div>
           )}
         </div>

--- a/web/src/hooks/mcp/namespaces.ts
+++ b/web/src/hooks/mcp/namespaces.ts
@@ -107,25 +107,41 @@ export function useNamespaces(cluster?: string, forceLive = false) {
       }
     }
 
-    // Fall back to REST API
+    // Fall back to REST API — merge pod-based namespaces with cluster cache
+    // to include namespaces that have no running pods (#3945)
     try {
-      const { data } = await api.get<{ pods: PodInfo[] }>(`/api/mcp/pods?cluster=${encodeURIComponent(cluster)}`)
       const nsSet = new Set<string>()
-      data.pods?.forEach(pod => {
-        if (pod.namespace) nsSet.add(pod.namespace)
-      })
-      setNamespaces(Array.from(nsSet).sort())
-      setError(null)
-    } catch (err) {
-      // Try cluster cache namespaces as last resort
+
+      // Seed with cluster cache namespaces (discovered during health checks)
+      // so namespaces without pods still appear in the dropdown
       const cachedCluster = clusterCacheRef.clusters.find(c => c.name === cluster)
-      if (cachedCluster?.namespaces && cachedCluster.namespaces.length > 0) {
-        setNamespaces(cachedCluster.namespaces)
+      if (cachedCluster?.namespaces) {
+        for (const ns of cachedCluster.namespaces) {
+          nsSet.add(ns)
+        }
+      }
+
+      // Also add namespaces from pods (may discover recently created namespaces
+      // that the cache hasn't seen yet)
+      try {
+        const { data } = await api.get<{ pods: PodInfo[] }>(`/api/mcp/pods?cluster=${encodeURIComponent(cluster)}`)
+        for (const pod of (data.pods || [])) {
+          if (pod.namespace) nsSet.add(pod.namespace)
+        }
+      } catch {
+        // Non-fatal: we may still have cache namespaces above
+      }
+
+      if (nsSet.size > 0) {
+        setNamespaces(Array.from(nsSet).sort())
         setError(null)
       } else {
         setNamespaces(['default', 'kube-system'])
         setError(null)
       }
+    } catch {
+      setNamespaces(['default', 'kube-system'])
+      setError(null)
     } finally {
       setIsLoading(false)
     }


### PR DESCRIPTION
## Summary

- **#3944 — Mission search**: Added a search/filter input at the top of the AI Missions sidebar list. Filters both saved and active missions by title and description in real-time. Shows a "no results" state when the query matches nothing. Includes a clear button.
- **#3917 — Mission state UX without AI**: Saved missions now display their imported steps (title + description) in a structured list view, so users can review what the mission will do without needing an AI provider connected. The "Run Mission" button remains prominent above the steps.
- **#3945 — Namespace dropdown**: The GPU reservation namespace dropdown now merges namespaces from the cluster cache (populated during health checks) with pod-based namespaces from the REST API fallback. This ensures namespaces that exist but have no running pods still appear in the dropdown.

## Changes

| File | Change |
|------|--------|
| `web/src/components/layout/mission-sidebar/MissionSidebar.tsx` | Search input + filtering logic for mission list |
| `web/src/components/layout/mission-sidebar/MissionChat.tsx` | Mission steps overview panel for saved missions |
| `web/src/hooks/mcp/namespaces.ts` | Merge cluster cache with pod-based namespace discovery |

## Test plan

- [ ] Open AI Missions sidebar with 2+ missions, verify search input appears and filters by title/description
- [ ] Clear search with X button, verify all missions reappear
- [ ] Import a community mission (e.g. install-prometheus), open it — verify steps are shown below Run button
- [ ] Select "None" as AI agent, verify steps are still visible
- [ ] Open GPU Reservations, select a cluster, verify namespace dropdown includes namespaces without pods
- [ ] Build passes: `npm run build`

Fixes #3944 #3917 #3945