### PR TITLE
🐛 fix: frontend bugs — drilldown crash, demo banner, arcade resize, save resolution

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -96,13 +96,24 @@ const FULLSCREEN_EXPANDED_CARDS = new Set([
   'kube_craft', 'kube_doom', 'kube_kart',
 ])
 
+/** Dimensions of the card's content container (updated via ResizeObserver) */
+export interface CardContainerSize {
+  width: number
+  height: number
+}
+
 // Context to expose card expanded state to children
 interface CardExpandedContextType {
   isExpanded: boolean
+  /** Live dimensions of the expanded modal content container (0x0 when collapsed) */
+  containerSize: CardContainerSize
 }
-const CardExpandedContext = createContext<CardExpandedContextType>({ isExpanded: false })
+const CardExpandedContext = createContext<CardExpandedContextType>({
+  isExpanded: false,
+  containerSize: { width: 0, height: 0 },
+})
 
-/** Hook for child components to know if their parent card is expanded */
+/** Hook for child components to know if their parent card is expanded and get container size */
 export function useCardExpanded() {
   return useContext(CardExpandedContext)
 }
@@ -352,6 +363,25 @@ export function CardWrapper({
   const { status: agentStatus } = useLocalAgent()
   const isAgentConnected = agentStatus === 'connected'
   const [isExpanded, setIsExpanded] = useState(false)
+  /** Live container dimensions for expanded modal — games use this to scale their boards */
+  const [containerSize, setContainerSize] = useState<CardContainerSize>({ width: 0, height: 0 })
+  const expandedContentRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!isExpanded) {
+      setContainerSize({ width: 0, height: 0 })
+      return
+    }
+    const el = expandedContentRef.current
+    if (!el) return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect
+        setContainerSize({ width, height })
+      }
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [isExpanded])
   const [showBugReport, setShowBugReport] = useState(false)
   const [showInstallClusterSelect, setShowInstallClusterSelect] = useState(false)
   const [showInstallGuide, setShowInstallGuide] = useState<{ mission: { mission?: { title?: string; description?: string; steps?: { title?: string; description?: string }[] } } } | null>(null)
@@ -737,7 +767,7 @@ export function CardWrapper({
 
   return (
     <CardTypeContext.Provider value={cardType}>
-    <CardExpandedContext.Provider value={{ isExpanded }}>
+    <CardExpandedContext.Provider value={{ isExpanded, containerSize }}>
       <ForceLiveContext.Provider value={!!forceLive}>
       <CardDataReportContext.Provider value={reportCtx}>
         <>
@@ -1209,7 +1239,7 @@ export function CardWrapper({
                   : 'max-h-[calc(80vh-80px)]'
             )}>
               {/* Wrapper ensures children fill available space in expanded mode */}
-              <div className="flex-1 min-h-0 flex flex-col">
+              <div ref={expandedContentRef} className="flex-1 min-h-0 flex flex-col">
                 <DynamicCardErrorBoundary cardId={cardId || cardType}>
                   {children}
                 </DynamicCardErrorBoundary>

--- a/web/src/components/cards/Game2048.tsx
+++ b/web/src/components/cards/Game2048.tsx
@@ -177,7 +177,7 @@ function hasWon(grid: Grid): boolean {
 export function Game2048(_props: CardComponentProps) {
   const { t: _t } = useTranslation()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
-  const { isExpanded } = useCardExpanded()
+  const { isExpanded, containerSize } = useCardExpanded()
   const gameContainerRef = useRef<HTMLDivElement>(null)
   const [grid, setGrid] = useState<Grid>(initGame)
   const [score, setScore] = useState(0)
@@ -272,9 +272,31 @@ export function Game2048(_props: CardComponentProps) {
     setKeepPlaying(true)
   }, [])
 
-  const cellSize = isExpanded ? 80 : 48
-  const gap = isExpanded ? 8 : 4
-  const fontSize = isExpanded ? 'text-2xl' : 'text-sm'
+  /** Grid columns in 2048 */
+  const GRID_COLS = 4
+  /** Default cell size (px) when card is collapsed */
+  const DEFAULT_CELL_SIZE = 48
+  /** Gap between cells (px) when card is collapsed */
+  const DEFAULT_GAP = 4
+  /** Padding around the grid (px) */
+  const GRID_PADDING = 8
+  /** Vertical space reserved for header and controls hint (px) */
+  const CHROME_HEIGHT = 80
+
+  // When expanded, compute cell size from container dimensions to fill available space
+  const computedCellSize = (() => {
+    if (!isExpanded || containerSize.width === 0 || containerSize.height === 0) {
+      return DEFAULT_CELL_SIZE
+    }
+    const expandedGap = 8
+    const availW = containerSize.width - GRID_PADDING * 2 - expandedGap * (GRID_COLS - 1)
+    const availH = containerSize.height - CHROME_HEIGHT - GRID_PADDING * 2 - expandedGap * (GRID_COLS - 1)
+    const maxCell = Math.floor(Math.min(availW, availH) / GRID_COLS)
+    return Math.max(maxCell, DEFAULT_CELL_SIZE)
+  })()
+  const cellSize = computedCellSize
+  const gap = isExpanded ? 8 : DEFAULT_GAP
+  const fontSize = cellSize >= 64 ? 'text-2xl' : cellSize >= 48 ? 'text-lg' : 'text-sm'
 
   return (
     <div ref={gameContainerRef} className="h-full flex flex-col p-2 select-none">

--- a/web/src/components/cards/KubeSnake.tsx
+++ b/web/src/components/cards/KubeSnake.tsx
@@ -8,12 +8,19 @@ import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
 import { useGameKeys } from '../../hooks/useGameKeys'
 
 // Game constants
-const CANVAS_WIDTH = 400
-const CANVAS_HEIGHT = 400
+/** Default canvas resolution when the card is collapsed (px) */
+const DEFAULT_CANVAS_SIZE = 400
+/** Internal canvas width (logical pixels for game logic) */
+const CANVAS_WIDTH = DEFAULT_CANVAS_SIZE
+/** Internal canvas height (logical pixels for game logic) */
+const CANVAS_HEIGHT = DEFAULT_CANVAS_SIZE
 const GRID_SIZE = 20
+/** Logical pixel size of each grid cell */
 const CELL_SIZE = CANVAS_WIDTH / GRID_SIZE
 const INITIAL_SPEED = 150 // ms per move
 const MIN_SPEED = 60
+/** Vertical space reserved for stats bar and controls (px) */
+const SNAKE_CHROME_HEIGHT = 100
 
 // Colors (Kubernetes theme)
 const COLORS = {
@@ -36,7 +43,15 @@ type Direction = 'up' | 'down' | 'left' | 'right'
 export function KubeSnake() {
   const { t: _t } = useTranslation()
   useReportCardDataState({ hasData: true, isFailed: false, consecutiveFailures: 0, isDemoData: false })
-  const { isExpanded } = useCardExpanded()
+  const { isExpanded, containerSize } = useCardExpanded()
+
+  // Compute CSS scale factor so the canvas fills the expanded modal
+  const canvasScale = (() => {
+    if (!isExpanded || containerSize.width === 0 || containerSize.height === 0) return 1
+    const availW = containerSize.width
+    const availH = containerSize.height - SNAKE_CHROME_HEIGHT
+    return Math.max(1, Math.min(availW / DEFAULT_CANVAS_SIZE, availH / DEFAULT_CANVAS_SIZE))
+  })()
   const gameContainerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [gameState, setGameState] = useState<'idle' | 'playing' | 'paused' | 'gameover'>('idle')
@@ -320,7 +335,7 @@ export function KubeSnake() {
     <div ref={gameContainerRef} className="h-full flex flex-col">
       <div className={`flex flex-col items-center gap-3 ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
         {/* Stats bar */}
-        <div className="flex items-center justify-between w-full max-w-[400px] text-sm">
+        <div className="flex items-center justify-between w-full text-sm" style={{ maxWidth: isExpanded ? CANVAS_WIDTH * canvasScale : DEFAULT_CANVAS_SIZE }}>
           <div className="flex items-center gap-2">
             <Apple className="w-4 h-4 text-red-400" />
             <span className="font-bold text-lg">{score}</span>
@@ -336,13 +351,20 @@ export function KubeSnake() {
         </div>
 
         {/* Game canvas */}
-        <div className={`relative ${isExpanded ? 'flex-1 min-h-0' : ''}`}>
+        <div
+          className={`relative ${isExpanded ? 'flex-1 min-h-0' : ''}`}
+          style={isExpanded && canvasScale > 1
+            ? { width: CANVAS_WIDTH * canvasScale, height: CANVAS_HEIGHT * canvasScale }
+            : undefined}
+        >
           <canvas
             ref={canvasRef}
             width={CANVAS_WIDTH}
             height={CANVAS_HEIGHT}
             className="border border-border rounded"
-            style={isExpanded ? { width: '100%', height: '100%', objectFit: 'contain' } : undefined}
+            style={isExpanded && canvasScale > 1
+              ? { transform: `scale(${canvasScale})`, transformOrigin: 'top left' }
+              : undefined}
             tabIndex={0}
           />
 

--- a/web/src/components/drilldown/views/ClusterDrillDown.tsx
+++ b/web/src/components/drilldown/views/ClusterDrillDown.tsx
@@ -313,7 +313,7 @@ export function ClusterDrillDown({ data }: Props) {
                         <div className="text-xs text-muted-foreground mt-1">
                           {issue.namespace} • {issue.restarts} restarts
                         </div>
-                        {issue.issues.length > 0 && (
+                        {(issue.issues || []).length > 0 && (
                           <div className="text-xs text-red-400 mt-1">{(issue.issues || []).join(', ')}</div>
                         )}
                       </div>

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -405,7 +405,7 @@ export function Layout({ children }: LayoutProps) {
               </Button>
               <button
                 onClick={() => isDemoModeForced ? setShowSetupDialog(true) : toggleDemoMode()}
-                className="ml-1 md:ml-2 p-2 min-h-11 min-w-11 hover:bg-yellow-500/20 rounded transition-colors"
+                className="ml-1 md:ml-2 p-2 min-h-11 min-w-11 flex items-center justify-center hover:bg-yellow-500/20 rounded-full transition-colors"
                 aria-label={isDemoModeForced ? t('buttons.installConsole') : t('buttons.exitDemoMode')}
                 title={isDemoModeForced ? t('buttons.installConsole') : t('buttons.exitDemoMode')}
               >
@@ -443,7 +443,7 @@ export function Layout({ children }: LayoutProps) {
             </Button>
             <button
               onClick={() => setShowInClusterAgentDialog(true)}
-              className="sm:hidden ml-1 p-2 min-h-11 min-w-11 hover:bg-blue-500/20 rounded transition-colors"
+              className="sm:hidden ml-1 p-2 min-h-11 min-w-11 flex items-center justify-center hover:bg-blue-500/20 rounded-full transition-colors"
               aria-label="Open agent setup guide"
               title="Open agent setup guide"
             >
@@ -483,7 +483,7 @@ export function Layout({ children }: LayoutProps) {
               </button>
               <button
                 onClick={() => setOfflineBannerDismissed(true)}
-                className="p-2 min-h-11 min-w-11 hover:bg-orange-500/20 rounded transition-colors"
+                className="p-2 min-h-11 min-w-11 flex items-center justify-center hover:bg-orange-500/20 rounded-full transition-colors"
                 title="Dismiss"
               >
                 <X className="w-3.5 h-3.5 text-orange-400" />

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -41,6 +41,7 @@ import { MissionChat } from './MissionChat'
 import { ClusterSelectionDialog } from '../../missions/ClusterSelectionDialog'
 import { ResolutionKnowledgePanel } from '../../missions/ResolutionKnowledgePanel'
 import { ResolutionHistoryPanel } from '../../missions/ResolutionHistoryPanel'
+import { SaveResolutionDialog } from '../../missions/SaveResolutionDialog'
 import { useResolutions, detectIssueSignature } from '../../../hooks/useResolutions'
 import { useTranslation } from 'react-i18next'
 import { SAVED_TOAST_MS, FOCUS_DELAY_MS } from '../../../lib/constants/network'
@@ -151,6 +152,8 @@ export function MissionSidebar() {
   // Cluster selection for install missions
   const [pendingRunMissionId, setPendingRunMissionId] = useState<string | null>(null)
   const [isDirectImporting, setIsDirectImporting] = useState(false)
+  // Save Resolution dialog state (triggered from ResolutionKnowledgePanel "Save This Resolution" button)
+  const [showSaveResolutionDialog, setShowSaveResolutionDialog] = useState(false)
   // Resolution panel state (fullscreen left sidebar)
   const [resolutionPanelView, setResolutionPanelView] = useState<'related' | 'history'>('related')
   const { findSimilarResolutions, allResolutions } = useResolutions()
@@ -882,7 +885,7 @@ export function MissionSidebar() {
                       <ResolutionKnowledgePanel
                         relatedResolutions={relatedResolutions}
                         onApplyResolution={handleApplyResolution}
-                        onSaveNewResolution={() => {}}
+                        onSaveNewResolution={() => setShowSaveResolutionDialog(true)}
                       />
                     ) : (
                       <ResolutionHistoryPanel
@@ -1083,6 +1086,15 @@ export function MissionSidebar() {
             setPendingRunMissionId(null)
           }}
           onCancel={() => setPendingRunMissionId(null)}
+        />
+      )}
+
+      {/* Save Resolution Dialog — triggered from ResolutionKnowledgePanel "Save This Resolution" button */}
+      {activeMission && (
+        <SaveResolutionDialog
+          mission={activeMission}
+          isOpen={showSaveResolutionDialog}
+          onClose={() => setShowSaveResolutionDialog(false)}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

- **#3911 — Cluster Drilldown crash**: Added null guard on `issue.issues.length` in `ClusterDrillDown.tsx` to prevent "Cannot read properties of undefined (reading 'length')" when switching between unhealthy clusters
- **#3912 — Demo mode banner hover off-centre**: Added `flex items-center justify-center` and `rounded-full` to banner dismiss buttons in `Layout.tsx` so the hover highlight is centered on the icon
- **#3920 — Arcade games don't resize on maximize**: Added `containerSize` (via ResizeObserver) to `CardExpandedContext` in `CardWrapper.tsx`; updated `Game2048` to compute cell size from container dimensions and `KubeSnake` to use CSS transform scale
- **#3910 — Save Resolution button not working**: Replaced empty `onSaveNewResolution={() => {}}` handler in `MissionSidebar.tsx` with state + `SaveResolutionDialog` integration

## Test plan

- [ ] Open Cluster Drilldown, switch between unhealthy clusters rapidly — verify no crash
- [ ] Enable demo mode, hover over the X/dismiss button — verify hover highlight is centered
- [ ] Open any arcade game (2048, Snake), maximize the card — verify the game board scales to fill the modal
- [ ] Open an AI Mission in fullscreen, click "Save This Resolution" in the Knowledge panel — verify the dialog opens

Fixes #3911 #3912 #3920 #3910