### PR TITLE
🌱 Add unit tests for useLocalAgent, progress hooks, and useMCS

### DIFF
--- a/web/src/hooks/__tests__/useClusterProgress.test.ts
+++ b/web/src/hooks/__tests__/useClusterProgress.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for useClusterProgress hook.
+ *
+ * Validates WebSocket connection, message parsing for local_cluster_progress
+ * events, dismiss behaviour, and cleanup on unmount.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// WebSocket mock
+// ---------------------------------------------------------------------------
+
+type WSHandler = ((event: { data: string }) => void) | null
+
+interface MockWebSocketInstance {
+  onopen: (() => void) | null
+  onmessage: WSHandler
+  onclose: (() => void) | null
+  onerror: (() => void) | null
+  close: ReturnType<typeof vi.fn>
+  readyState: number
+}
+
+let wsInstances: MockWebSocketInstance[] = []
+
+class MockWebSocket implements MockWebSocketInstance {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  onopen: (() => void) | null = null
+  onmessage: WSHandler = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED
+    if (this.onclose) this.onclose()
+  })
+  readyState = MockWebSocket.OPEN
+
+  constructor() {
+    wsInstances.push(this)
+    // Simulate async open
+    setTimeout(() => {
+      if (this.onopen) this.onopen()
+    }, 0)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mocks — before module import
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/constants/network', () => ({
+  LOCAL_AGENT_WS_URL: 'ws://127.0.0.1:8585/ws',
+}))
+
+// Assign mock to global before importing the hook
+Object.defineProperty(globalThis, 'WebSocket', {
+  writable: true,
+  value: MockWebSocket,
+})
+
+import { useClusterProgress } from '../useClusterProgress'
+
+describe('useClusterProgress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    wsInstances = []
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  // ── Initial state ──────────────────────────────────────────────────────
+
+  it('returns null progress initially', () => {
+    const { result } = renderHook(() => useClusterProgress())
+
+    expect(result.current.progress).toBeNull()
+    expect(typeof result.current.dismiss).toBe('function')
+  })
+
+  // ── WebSocket connection ───────────────────────────────────────────────
+
+  it('creates a WebSocket connection on mount', () => {
+    renderHook(() => useClusterProgress())
+
+    expect(wsInstances.length).toBe(1)
+  })
+
+  // ── Parses local_cluster_progress messages ─────────────────────────────
+
+  it('updates progress when receiving a local_cluster_progress message', () => {
+    const { result } = renderHook(() => useClusterProgress())
+    const ws = wsInstances[0]
+
+    const payload = {
+      tool: 'kind',
+      name: 'test-cluster',
+      status: 'creating',
+      message: 'Creating kind cluster...',
+      progress: 30,
+    }
+
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({ type: 'local_cluster_progress', payload }),
+      })
+    })
+
+    expect(result.current.progress).toEqual(payload)
+  })
+
+  // ── Ignores non-matching message types ─────────────────────────────────
+
+  it('ignores messages with a different type', () => {
+    const { result } = renderHook(() => useClusterProgress())
+    const ws = wsInstances[0]
+
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({
+          type: 'update_progress',
+          payload: { status: 'building', message: 'Building...', progress: 50 },
+        }),
+      })
+    })
+
+    expect(result.current.progress).toBeNull()
+  })
+
+  // ── Ignores malformed JSON ─────────────────────────────────────────────
+
+  it('ignores malformed JSON messages', () => {
+    const { result } = renderHook(() => useClusterProgress())
+    const ws = wsInstances[0]
+
+    act(() => {
+      ws.onmessage!({ data: 'not valid json {{{' })
+    })
+
+    expect(result.current.progress).toBeNull()
+  })
+
+  // ── Handles step updates ───────────────────────────────────────────────
+
+  it('updates progress through multiple status changes', () => {
+    const { result } = renderHook(() => useClusterProgress())
+    const ws = wsInstances[0]
+
+    // Step 1: validating
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({
+          type: 'local_cluster_progress',
+          payload: {
+            tool: 'kind',
+            name: 'my-cluster',
+            status: 'validating',
+            message: 'Validating configuration...',
+            progress: 10,
+          },
+        }),
+      })
+    })
+    expect(result.current.progress!.status).toBe('validating')
+    expect(result.current.progress!.progress).toBe(10)
+
+    // Step 2: creating
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({
+          type: 'local_cluster_progress',
+          payload: {
+            tool: 'kind',
+            name: 'my-cluster',
+            status: 'creating',
+            message: 'Creating cluster...',
+            progress: 50,
+          },
+        }),
+      })
+    })
+    expect(result.current.progress!.status).toBe('creating')
+    expect(result.current.progress!.progress).toBe(50)
+
+    // Step 3: done
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({
+          type: 'local_cluster_progress',
+          payload: {
+            tool: 'kind',
+            name: 'my-cluster',
+            status: 'done',
+            message: 'Cluster created successfully',
+            progress: 100,
+          },
+        }),
+      })
+    })
+    expect(result.current.progress!.status).toBe('done')
+    expect(result.current.progress!.progress).toBe(100)
+  })
+
+  // ── Dismiss clears progress ────────────────────────────────────────────
+
+  it('dismiss() clears the progress state', () => {
+    const { result } = renderHook(() => useClusterProgress())
+    const ws = wsInstances[0]
+
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({
+          type: 'local_cluster_progress',
+          payload: {
+            tool: 'kind',
+            name: 'test',
+            status: 'done',
+            message: 'Done',
+            progress: 100,
+          },
+        }),
+      })
+    })
+    expect(result.current.progress).not.toBeNull()
+
+    act(() => {
+      result.current.dismiss()
+    })
+    expect(result.current.progress).toBeNull()
+  })
+
+  // ── Reconnects on WebSocket close ──────────────────────────────────────
+
+  it('reconnects when the WebSocket closes', () => {
+    const WS_RECONNECT_DELAY_MS = 10000
+    renderHook(() => useClusterProgress())
+
+    expect(wsInstances.length).toBe(1)
+
+    // Simulate WS close
+    act(() => {
+      wsInstances[0].close()
+    })
+
+    // Advance past reconnect delay
+    act(() => {
+      vi.advanceTimersByTime(WS_RECONNECT_DELAY_MS)
+    })
+
+    // A new WebSocket should have been created
+    expect(wsInstances.length).toBe(2)
+  })
+
+  // ── Cleanup on unmount ─────────────────────────────────────────────────
+
+  it('closes WebSocket and clears timers on unmount', () => {
+    const { unmount } = renderHook(() => useClusterProgress())
+
+    const ws = wsInstances[0]
+    unmount()
+
+    expect(ws.close).toHaveBeenCalled()
+  })
+
+  // ── Ignores messages with no payload ───────────────────────────────────
+
+  it('ignores local_cluster_progress messages with no payload', () => {
+    const { result } = renderHook(() => useClusterProgress())
+    const ws = wsInstances[0]
+
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({ type: 'local_cluster_progress' }),
+      })
+    })
+
+    expect(result.current.progress).toBeNull()
+  })
+})

--- a/web/src/hooks/__tests__/useLocalAgent.test.ts
+++ b/web/src/hooks/__tests__/useLocalAgent.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Tests for useLocalAgent hook.
+ *
+ * Validates agent connection lifecycle: initial state, polling,
+ * connected/disconnected transitions, and cleanup on unmount.
+ *
+ * The hook uses a singleton AgentManager with subscribe/unsubscribe.
+ * We re-import the module for each test to get a fresh singleton.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before module import
+// ---------------------------------------------------------------------------
+
+// Mock isDemoModeForced to false so the agent manager starts normally
+vi.mock('../../hooks/useDemoMode', () => ({
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/demoMode', () => ({
+  isDemoMode: () => false,
+  isNetlifyDeployment: false,
+  isDemoModeForced: false,
+}))
+
+vi.mock('../../lib/analytics', () => ({
+  emitAgentConnected: vi.fn(),
+  emitAgentDisconnected: vi.fn(),
+  emitAgentProvidersDetected: vi.fn(),
+  emitConversionStep: vi.fn(),
+}))
+
+vi.mock('../../lib/utils/localStorage', () => ({
+  safeGetItem: vi.fn(() => null),
+  safeSetItem: vi.fn(),
+}))
+
+// We need to dynamically import the hook after each module reset
+let useLocalAgent: typeof import('../useLocalAgent').useLocalAgent
+
+/** Flush microtask queue so async handlers (fetch, promises) settle. */
+async function flushMicrotasks() {
+  await act(async () => {
+    // Multiple flushes needed for chained promises (fetch -> .json())
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+describe('useLocalAgent', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    vi.resetModules()
+
+    // Set up fresh global fetch mock before importing
+    global.fetch = vi.fn()
+
+    const mod = await import('../useLocalAgent')
+    useLocalAgent = mod.useLocalAgent
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  // ── Initial state ──────────────────────────────────────────────────────
+
+  it('returns connecting status initially before any health check resolves', () => {
+    // Make fetch hang (never resolves)
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise(() => {})
+    )
+
+    const { result } = renderHook(() => useLocalAgent())
+
+    expect(result.current.status).toBe('connecting')
+    expect(result.current.isConnected).toBe(false)
+    expect(result.current.isDemoMode).toBe(false)
+    expect(result.current.health).toBeNull()
+  })
+
+  it('returns the expected API shape', () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise(() => {})
+    )
+
+    const { result } = renderHook(() => useLocalAgent())
+
+    expect(result.current).toHaveProperty('status')
+    expect(result.current).toHaveProperty('health')
+    expect(result.current).toHaveProperty('error')
+    expect(result.current).toHaveProperty('connectionEvents')
+    expect(result.current).toHaveProperty('isConnected')
+    expect(result.current).toHaveProperty('isDegraded')
+    expect(result.current).toHaveProperty('isDemoMode')
+    expect(result.current).toHaveProperty('installInstructions')
+    expect(result.current).toHaveProperty('refresh')
+    expect(result.current).toHaveProperty('reportDataError')
+    expect(result.current).toHaveProperty('reportDataSuccess')
+    expect(typeof result.current.refresh).toBe('function')
+  })
+
+  // ── Transitions to connected on successful health check ────────────────
+
+  it('transitions to connected on successful health check', async () => {
+    const healthData = {
+      status: 'ok',
+      version: '1.2.3',
+      clusters: 2,
+      hasClaude: true,
+    }
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(healthData),
+    })
+
+    const { result } = renderHook(() => useLocalAgent())
+
+    // The initial checkAgent fires immediately on subscribe;
+    // flush microtasks to let the fetch resolve
+    await flushMicrotasks()
+
+    expect(result.current.status).toBe('connected')
+    expect(result.current.isConnected).toBe(true)
+    expect(result.current.isDemoMode).toBe(false)
+    expect(result.current.health).toMatchObject({
+      status: 'ok',
+      version: '1.2.3',
+      clusters: 2,
+    })
+  })
+
+  // ── Transitions to disconnected after enough failures ──────────────────
+
+  it('transitions to disconnected after 9 consecutive failures', async () => {
+    const FAILURE_THRESHOLD = 9
+    const POLL_INTERVAL = 10000
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Connection refused')
+    )
+
+    const { result } = renderHook(() => useLocalAgent())
+
+    // The first check fires immediately on subscribe.
+    // Flush to let it fail, then advance timers for each subsequent poll.
+    await flushMicrotasks()
+
+    for (let i = 1; i < FAILURE_THRESHOLD; i++) {
+      await act(async () => {
+        vi.advanceTimersByTime(POLL_INTERVAL)
+      })
+      await flushMicrotasks()
+    }
+
+    expect(result.current.status).toBe('disconnected')
+    expect(result.current.isDemoMode).toBe(true)
+    expect(result.current.isConnected).toBe(false)
+    expect(result.current.error).toBe('Local agent not available')
+  })
+
+  // ── Does not disconnect before failure threshold ───────────────────────
+
+  it('does not disconnect before reaching the failure threshold', async () => {
+    const PARTIAL_FAILURES = 5
+    const POLL_INTERVAL = 10000
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Connection refused')
+    )
+
+    const { result } = renderHook(() => useLocalAgent())
+
+    // First check fires immediately
+    await flushMicrotasks()
+
+    // Advance through fewer than 9 failures
+    for (let i = 1; i < PARTIAL_FAILURES; i++) {
+      await act(async () => {
+        vi.advanceTimersByTime(POLL_INTERVAL)
+      })
+      await flushMicrotasks()
+    }
+
+    // Should still be in connecting state (not disconnected yet)
+    expect(result.current.status).not.toBe('disconnected')
+  })
+
+  // ── Polls the health endpoint periodically ─────────────────────────────
+
+  it('polls the agent health endpoint at 10s intervals when connected', async () => {
+    const POLL_INTERVAL = 10000
+    const healthData = {
+      status: 'ok',
+      version: '1.0.0',
+      clusters: 1,
+      hasClaude: false,
+    }
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(healthData),
+    })
+
+    renderHook(() => useLocalAgent())
+
+    // Initial call fires immediately
+    await flushMicrotasks()
+
+    const initialCallCount = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.length
+
+    // Advance one poll interval
+    await act(async () => {
+      vi.advanceTimersByTime(POLL_INTERVAL)
+    })
+    await flushMicrotasks()
+
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(initialCallCount)
+  })
+
+  // ── Cleanup on unmount ─────────────────────────────────────────────────
+
+  it('stops polling when the last subscriber unmounts', async () => {
+    const healthData = {
+      status: 'ok',
+      version: '1.0.0',
+      clusters: 1,
+      hasClaude: false,
+    }
+
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(healthData),
+    })
+
+    const { unmount } = renderHook(() => useLocalAgent())
+
+    // Let the initial check run
+    await flushMicrotasks()
+
+    const callCountBeforeUnmount = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.length
+
+    unmount()
+
+    // Advance well past multiple poll intervals
+    const MANY_INTERVALS = 50000
+    await act(async () => {
+      vi.advanceTimersByTime(MANY_INTERVALS)
+    })
+    await flushMicrotasks()
+
+    // No additional calls should have been made after unmount
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callCountBeforeUnmount)
+  })
+
+  // ── Install instructions ───────────────────────────────────────────────
+
+  it('provides install instructions with Homebrew and source options', () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      () => new Promise(() => {})
+    )
+
+    const { result } = renderHook(() => useLocalAgent())
+
+    expect(result.current.installInstructions.title).toBe('Install Local Agent')
+    expect(result.current.installInstructions.steps.length).toBeGreaterThanOrEqual(2)
+    expect(result.current.installInstructions.benefits.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/web/src/hooks/__tests__/useMCS.test.ts
+++ b/web/src/hooks/__tests__/useMCS.test.ts
@@ -1,0 +1,574 @@
+/**
+ * Tests for useMCS hooks: useMCSStatus, useServiceExports, useServiceImports.
+ *
+ * Validates data fetching, loading states, error handling, demo mode
+ * fallback, and polling behaviour.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before module import
+// ---------------------------------------------------------------------------
+
+let mockDemoMode = false
+
+vi.mock('../useDemoMode', () => ({
+  useDemoMode: () => ({ isDemoMode: mockDemoMode }),
+}))
+
+const mockApiGet = vi.fn()
+
+vi.mock('../../lib/api', () => {
+  // BackendUnavailableError must be defined inside the factory because
+  // vi.mock is hoisted — referencing outer variables causes ReferenceError.
+  class BackendUnavailableError extends Error {
+    constructor() {
+      super('Backend API is currently unavailable')
+      this.name = 'BackendUnavailableError'
+    }
+  }
+
+  return {
+    api: {
+      get: (...args: unknown[]) => mockApiGet(...args),
+    },
+    BackendUnavailableError,
+  }
+})
+
+// Import after mocks
+import { useMCSStatus, useServiceExports, useServiceImports } from '../useMCS'
+import { BackendUnavailableError } from '../../lib/api'
+
+describe('useMCSStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDemoMode = false
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ── Initial loading state ──────────────────────────────────────────────
+
+  it('starts in loading state', () => {
+    // Make the API call hang so we can observe loading state
+    mockApiGet.mockImplementation(() => new Promise(() => {}))
+
+    const { result } = renderHook(() => useMCSStatus())
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.clusters).toEqual([])
+    expect(result.current.error).toBeNull()
+  })
+
+  // ── Returns MCS status data ────────────────────────────────────────────
+
+  it('returns clusters from the MCS status API', async () => {
+    const clusterData = [
+      { cluster: 'us-east-1', mcsAvailable: true },
+      { cluster: 'eu-central-1', mcsAvailable: false },
+    ]
+
+    mockApiGet.mockResolvedValue({ data: { clusters: clusterData } })
+
+    const { result } = renderHook(() => useMCSStatus())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.clusters).toEqual(clusterData)
+    expect(result.current.error).toBeNull()
+    expect(result.current.lastUpdated).not.toBeNull()
+  })
+
+  // ── Handles API errors ─────────────────────────────────────────────────
+
+  it('sets error state on API failure', async () => {
+    mockApiGet.mockRejectedValue(new Error('Network error'))
+
+    const { result } = renderHook(() => useMCSStatus())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Network error')
+    expect(result.current.clusters).toEqual([])
+  })
+
+  // ── Handles BackendUnavailableError ────────────────────────────────────
+
+  it('sets backend unavailable error', async () => {
+    mockApiGet.mockRejectedValue(new BackendUnavailableError())
+
+    const { result } = renderHook(() => useMCSStatus())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Backend unavailable')
+  })
+
+  // ── Demo mode returns empty clusters ───────────────────────────────────
+
+  it('returns empty clusters in demo mode without calling API', async () => {
+    mockDemoMode = true
+
+    const { result } = renderHook(() => useMCSStatus())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.clusters).toEqual([])
+    expect(mockApiGet).not.toHaveBeenCalled()
+  })
+
+  // ── Refetch function ───────────────────────────────────────────────────
+
+  it('provides a refetch function that re-fetches data', async () => {
+    const initialData = [{ cluster: 'c1', mcsAvailable: true }]
+    const refreshedData = [
+      { cluster: 'c1', mcsAvailable: true },
+      { cluster: 'c2', mcsAvailable: true },
+    ]
+
+    mockApiGet
+      .mockResolvedValueOnce({ data: { clusters: initialData } })
+      .mockResolvedValueOnce({ data: { clusters: refreshedData } })
+
+    const { result } = renderHook(() => useMCSStatus())
+
+    await waitFor(() => {
+      expect(result.current.clusters).toEqual(initialData)
+    })
+
+    await act(async () => {
+      result.current.refetch()
+    })
+
+    await waitFor(() => {
+      expect(result.current.clusters).toEqual(refreshedData)
+    })
+  })
+
+  // ── Return shape ───────────────────────────────────────────────────────
+
+  it('returns the expected API shape', () => {
+    mockApiGet.mockImplementation(() => new Promise(() => {}))
+
+    const { result } = renderHook(() => useMCSStatus())
+
+    expect(result.current).toHaveProperty('clusters')
+    expect(result.current).toHaveProperty('isLoading')
+    expect(result.current).toHaveProperty('isRefreshing')
+    expect(result.current).toHaveProperty('error')
+    expect(result.current).toHaveProperty('lastUpdated')
+    expect(result.current).toHaveProperty('refetch')
+    expect(typeof result.current.refetch).toBe('function')
+  })
+})
+
+describe('useServiceExports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDemoMode = false
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ── Initial loading state ──────────────────────────────────────────────
+
+  it('starts in loading state', () => {
+    mockApiGet.mockImplementation(() => new Promise(() => {}))
+
+    const { result } = renderHook(() => useServiceExports())
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.exports).toEqual([])
+    expect(result.current.totalCount).toBe(0)
+  })
+
+  // ── Returns service exports ────────────────────────────────────────────
+
+  it('returns service exports from the API', async () => {
+    const items = [
+      {
+        name: 'api-gateway',
+        namespace: 'production',
+        cluster: 'us-east-1',
+        status: 'Ready',
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    ]
+
+    mockApiGet.mockResolvedValue({ data: { items } })
+
+    const { result } = renderHook(() => useServiceExports())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.exports).toEqual(items)
+    expect(result.current.totalCount).toBe(1)
+    expect(result.current.error).toBeNull()
+  })
+
+  // ── Passes cluster and namespace filters ───────────────────────────────
+
+  it('passes cluster and namespace query params to the API', async () => {
+    mockApiGet.mockResolvedValue({ data: { items: [] } })
+
+    renderHook(() => useServiceExports('us-east-1', 'production'))
+
+    await waitFor(() => {
+      expect(mockApiGet).toHaveBeenCalled()
+    })
+
+    const calledUrl = mockApiGet.mock.calls[0][0] as string
+    expect(calledUrl).toContain('cluster=us-east-1')
+    expect(calledUrl).toContain('namespace=production')
+  })
+
+  // ── Handles API errors ─────────────────────────────────────────────────
+
+  it('sets error on API failure', async () => {
+    mockApiGet.mockRejectedValue(new Error('Timeout'))
+
+    const { result } = renderHook(() => useServiceExports())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Timeout')
+    expect(result.current.exports).toEqual([])
+  })
+
+  // ── Handles BackendUnavailableError ────────────────────────────────────
+
+  it('sets backend unavailable error', async () => {
+    mockApiGet.mockRejectedValue(new BackendUnavailableError())
+
+    const { result } = renderHook(() => useServiceExports())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Backend unavailable')
+  })
+
+  // ── Demo mode returns demo exports ─────────────────────────────────────
+
+  it('returns demo data in demo mode without calling API', async () => {
+    mockDemoMode = true
+
+    const { result } = renderHook(() => useServiceExports())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    // Should have demo data (3 items based on DEMO_SERVICE_EXPORTS)
+    expect(result.current.exports.length).toBeGreaterThan(0)
+    expect(mockApiGet).not.toHaveBeenCalled()
+  })
+
+  // ── Polls at REFRESH_INTERVAL_MS ───────────────────────────────────────
+
+  it('polls for updates at the configured interval', async () => {
+    const REFRESH_INTERVAL_MS = 120000
+
+    vi.useFakeTimers()
+    mockApiGet.mockResolvedValue({ data: { items: [] } })
+
+    renderHook(() => useServiceExports())
+
+    // Flush the initial fetch
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const initialCallCount = mockApiGet.mock.calls.length
+
+    // Advance past one poll interval
+    await act(async () => {
+      vi.advanceTimersByTime(REFRESH_INTERVAL_MS)
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockApiGet.mock.calls.length).toBeGreaterThan(initialCallCount)
+
+    vi.useRealTimers()
+  })
+
+  // ── Cleans up polling on unmount ───────────────────────────────────────
+
+  it('stops polling on unmount', async () => {
+    const REFRESH_INTERVAL_MS = 120000
+
+    vi.useFakeTimers()
+    mockApiGet.mockResolvedValue({ data: { items: [] } })
+
+    const { unmount } = renderHook(() => useServiceExports())
+
+    // Flush the initial fetch
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const callCountBefore = mockApiGet.mock.calls.length
+    unmount()
+
+    // Advance past several poll intervals
+    const MANY_INTERVALS = 3
+    await act(async () => {
+      vi.advanceTimersByTime(REFRESH_INTERVAL_MS * MANY_INTERVALS)
+    })
+
+    // No additional calls after unmount
+    expect(mockApiGet.mock.calls.length).toBe(callCountBefore)
+
+    vi.useRealTimers()
+  })
+
+  // ── Return shape ───────────────────────────────────────────────────────
+
+  it('returns the expected API shape', () => {
+    mockApiGet.mockImplementation(() => new Promise(() => {}))
+
+    const { result } = renderHook(() => useServiceExports())
+
+    expect(result.current).toHaveProperty('exports')
+    expect(result.current).toHaveProperty('totalCount')
+    expect(result.current).toHaveProperty('isLoading')
+    expect(result.current).toHaveProperty('isRefreshing')
+    expect(result.current).toHaveProperty('error')
+    expect(result.current).toHaveProperty('lastUpdated')
+    expect(result.current).toHaveProperty('refetch')
+    expect(typeof result.current.refetch).toBe('function')
+  })
+})
+
+describe('useServiceImports', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDemoMode = false
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ── Initial loading state ──────────────────────────────────────────────
+
+  it('starts in loading state', () => {
+    mockApiGet.mockImplementation(() => new Promise(() => {}))
+
+    const { result } = renderHook(() => useServiceImports())
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.imports).toEqual([])
+    expect(result.current.totalCount).toBe(0)
+  })
+
+  // ── Returns service imports ────────────────────────────────────────────
+
+  it('returns service imports from the API', async () => {
+    const items = [
+      {
+        name: 'api-gateway',
+        namespace: 'production',
+        cluster: 'eu-central-1',
+        sourceCluster: 'us-east-1',
+        type: 'ClusterSetIP',
+        endpoints: 3,
+        createdAt: '2026-01-01T00:00:00Z',
+      },
+    ]
+
+    mockApiGet.mockResolvedValue({ data: { items } })
+
+    const { result } = renderHook(() => useServiceImports())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.imports).toEqual(items)
+    expect(result.current.totalCount).toBe(1)
+    expect(result.current.error).toBeNull()
+  })
+
+  // ── Passes cluster and namespace filters ───────────────────────────────
+
+  it('passes cluster and namespace query params to the API', async () => {
+    mockApiGet.mockResolvedValue({ data: { items: [] } })
+
+    renderHook(() => useServiceImports('eu-central-1', 'production'))
+
+    await waitFor(() => {
+      expect(mockApiGet).toHaveBeenCalled()
+    })
+
+    const calledUrl = mockApiGet.mock.calls[0][0] as string
+    expect(calledUrl).toContain('cluster=eu-central-1')
+    expect(calledUrl).toContain('namespace=production')
+  })
+
+  // ── Handles API errors ─────────────────────────────────────────────────
+
+  it('sets error on API failure', async () => {
+    mockApiGet.mockRejectedValue(new Error('Server error'))
+
+    const { result } = renderHook(() => useServiceImports())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Server error')
+    expect(result.current.imports).toEqual([])
+  })
+
+  // ── Handles BackendUnavailableError ────────────────────────────────────
+
+  it('sets backend unavailable error', async () => {
+    mockApiGet.mockRejectedValue(new BackendUnavailableError())
+
+    const { result } = renderHook(() => useServiceImports())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Backend unavailable')
+  })
+
+  // ── Demo mode returns demo imports ─────────────────────────────────────
+
+  it('returns demo data in demo mode without calling API', async () => {
+    mockDemoMode = true
+
+    const { result } = renderHook(() => useServiceImports())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    // Should have demo data (2 items based on DEMO_SERVICE_IMPORTS)
+    expect(result.current.imports.length).toBeGreaterThan(0)
+    expect(mockApiGet).not.toHaveBeenCalled()
+  })
+
+  // ── Polls at REFRESH_INTERVAL_MS ───────────────────────────────────────
+
+  it('polls for updates at the configured interval', async () => {
+    const REFRESH_INTERVAL_MS = 120000
+
+    vi.useFakeTimers()
+    mockApiGet.mockResolvedValue({ data: { items: [] } })
+
+    renderHook(() => useServiceImports())
+
+    // Flush the initial fetch
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const initialCallCount = mockApiGet.mock.calls.length
+
+    // Advance past one poll interval
+    await act(async () => {
+      vi.advanceTimersByTime(REFRESH_INTERVAL_MS)
+    })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(mockApiGet.mock.calls.length).toBeGreaterThan(initialCallCount)
+
+    vi.useRealTimers()
+  })
+
+  // ── Cleans up polling on unmount ───────────────────────────────────────
+
+  it('stops polling on unmount', async () => {
+    const REFRESH_INTERVAL_MS = 120000
+
+    vi.useFakeTimers()
+    mockApiGet.mockResolvedValue({ data: { items: [] } })
+
+    const { unmount } = renderHook(() => useServiceImports())
+
+    // Flush the initial fetch
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const callCountBefore = mockApiGet.mock.calls.length
+    unmount()
+
+    // Advance past several poll intervals
+    const MANY_INTERVALS = 3
+    await act(async () => {
+      vi.advanceTimersByTime(REFRESH_INTERVAL_MS * MANY_INTERVALS)
+    })
+
+    // No additional calls after unmount
+    expect(mockApiGet.mock.calls.length).toBe(callCountBefore)
+
+    vi.useRealTimers()
+  })
+
+  // ── Handles empty response ─────────────────────────────────────────────
+
+  it('handles empty items response gracefully', async () => {
+    mockApiGet.mockResolvedValue({ data: { items: [] } })
+
+    const { result } = renderHook(() => useServiceImports())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.imports).toEqual([])
+    expect(result.current.totalCount).toBe(0)
+    expect(result.current.error).toBeNull()
+  })
+
+  // ── Return shape ───────────────────────────────────────────────────────
+
+  it('returns the expected API shape', () => {
+    mockApiGet.mockImplementation(() => new Promise(() => {}))
+
+    const { result } = renderHook(() => useServiceImports())
+
+    expect(result.current).toHaveProperty('imports')
+    expect(result.current).toHaveProperty('totalCount')
+    expect(result.current).toHaveProperty('isLoading')
+    expect(result.current).toHaveProperty('isRefreshing')
+    expect(result.current).toHaveProperty('error')
+    expect(result.current).toHaveProperty('lastUpdated')
+    expect(result.current).toHaveProperty('refetch')
+    expect(typeof result.current.refetch).toBe('function')
+  })
+})

--- a/web/src/hooks/__tests__/useUpdateProgress.test.ts
+++ b/web/src/hooks/__tests__/useUpdateProgress.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Tests for useUpdateProgress hook.
+ *
+ * Validates WebSocket connection, parsing of update_progress messages,
+ * step history tracking, dismiss behaviour, and cleanup on unmount.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// WebSocket mock
+// ---------------------------------------------------------------------------
+
+type WSHandler = ((event: { data: string }) => void) | null
+
+interface MockWebSocketInstance {
+  onopen: (() => void) | null
+  onmessage: WSHandler
+  onclose: (() => void) | null
+  onerror: (() => void) | null
+  close: ReturnType<typeof vi.fn>
+  readyState: number
+}
+
+let wsInstances: MockWebSocketInstance[] = []
+
+class MockWebSocket implements MockWebSocketInstance {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  onopen: (() => void) | null = null
+  onmessage: WSHandler = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED
+    if (this.onclose) this.onclose()
+  })
+  readyState = MockWebSocket.OPEN
+
+  constructor() {
+    wsInstances.push(this)
+    // Simulate async open
+    setTimeout(() => {
+      if (this.onopen) this.onopen()
+    }, 0)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mocks — before module import
+// ---------------------------------------------------------------------------
+
+vi.mock('../../lib/constants/network', () => ({
+  LOCAL_AGENT_WS_URL: 'ws://127.0.0.1:8585/ws',
+  FETCH_DEFAULT_TIMEOUT_MS: 10000,
+}))
+
+vi.mock('../../lib/demoMode', () => ({
+  isNetlifyDeployment: false,
+}))
+
+// Assign mock to global before importing the hook
+Object.defineProperty(globalThis, 'WebSocket', {
+  writable: true,
+  value: MockWebSocket,
+})
+
+import { useUpdateProgress } from '../useUpdateProgress'
+
+describe('useUpdateProgress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    wsInstances = []
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  // ── Initial state ──────────────────────────────────────────────────────
+
+  it('returns null progress and empty step history initially', () => {
+    const { result } = renderHook(() => useUpdateProgress())
+
+    expect(result.current.progress).toBeNull()
+    expect(result.current.stepHistory).toEqual([])
+    expect(typeof result.current.dismiss).toBe('function')
+  })
+
+  // ── WebSocket connection ───────────────────────────────────────────────
+
+  it('creates a WebSocket connection on mount', () => {
+    renderHook(() => useUpdateProgress())
+
+    expect(wsInstances.length).toBe(1)
+  })
+
+  // ── Parses update_progress messages ────────────────────────────────────
+
+  it('updates progress when receiving an update_progress message', () => {
+    const { result } = renderHook(() => useUpdateProgress())
+    const ws = wsInstances[0]
+
+    const payload = {
+      status: 'pulling',
+      message: 'Pulling latest changes...',
+      progress: 15,
+      step: 1,
+      totalSteps: 7,
+    }
+
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({ type: 'update_progress', payload }),
+      })
+    })
+
+    expect(result.current.progress).toMatchObject({
+      status: 'pulling',
+      message: 'Pulling latest changes...',
+      progress: 15,
+    })
+  })
+
+  // ── Ignores non-matching message types ─────────────────────────────────
+
+  it('ignores messages with a different type', () => {
+    const { result } = renderHook(() => useUpdateProgress())
+    const ws = wsInstances[0]
+
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({
+          type: 'local_cluster_progress',
+          payload: {
+            tool: 'kind',
+            name: 'test',
+            status: 'creating',
+            message: 'Creating...',
+            progress: 50,
+          },
+        }),
+      })
+    })
+
+    expect(result.current.progress).toBeNull()
+  })
+
+  // ── Ignores malformed JSON ─────────────────────────────────────────────
+
+  it('ignores malformed JSON messages', () => {
+    const { result } = renderHook(() => useUpdateProgress())
+    const ws = wsInstances[0]
+
+    act(() => {
+      ws.onmessage!({ data: '{invalid json!!!' })
+    })
+
+    expect(result.current.progress).toBeNull()
+  })
+
+  // ── Tracks step history ────────────────────────────────────────────────
+
+  it('builds step history from update_progress messages with step info', () => {
+    const { result } = renderHook(() => useUpdateProgress())
+    const ws = wsInstances[0]
+
+    // Step 1 active
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({
+          type: 'update_progress',
+          payload: {
+            status: 'pulling',
+            message: 'Git pull',
+            progress: 14,
+            step: 1,
+            totalSteps: 7,
+          },
+        }),
+      })
+    })
+
+    expect(result.current.stepHistory.length).toBe(7)
+    expect(result.current.stepHistory[0].status).toBe('active')
+    expect(result.current.stepHistory[1].status).toBe('pending')
+
+    // Step 2 active (step 1 becomes completed)
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({
+          type: 'update_progress',
+          payload: {
+            status: 'building',
+            message: 'npm install',
+            progress: 28,
+            step: 2,
+            totalSteps: 7,
+          },
+        }),
+      })
+    })
+
+    expect(result.current.stepHistory[0].status).toBe('completed')
+    expect(result.current.stepHistory[1].status).toBe('active')
+    expect(result.current.stepHistory[2].status).toBe('pending')
+  })
+
+  // ── Handles step updates progressing through all steps ─────────────────
+
+  it('marks all steps as completed when the last step is active', () => {
+    const TOTAL_STEPS = 7
+    const { result } = renderHook(() => useUpdateProgress())
+    const ws = wsInstances[0]
+
+    // Jump straight to step 7
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({
+          type: 'update_progress',
+          payload: {
+            status: 'restarting',
+            message: 'Restart',
+            progress: 95,
+            step: TOTAL_STEPS,
+            totalSteps: TOTAL_STEPS,
+          },
+        }),
+      })
+    })
+
+    // Steps 1-6 should be completed
+    const STEPS_BEFORE_LAST = 6
+    for (let i = 0; i < STEPS_BEFORE_LAST; i++) {
+      expect(result.current.stepHistory[i].status).toBe('completed')
+    }
+    // Step 7 should be active
+    expect(result.current.stepHistory[TOTAL_STEPS - 1].status).toBe('active')
+  })
+
+  // ── Dismiss clears progress and step history ───────────────────────────
+
+  it('dismiss() clears both progress and step history', () => {
+    const { result } = renderHook(() => useUpdateProgress())
+    const ws = wsInstances[0]
+
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({
+          type: 'update_progress',
+          payload: {
+            status: 'done',
+            message: 'Update complete',
+            progress: 100,
+            step: 7,
+            totalSteps: 7,
+          },
+        }),
+      })
+    })
+
+    expect(result.current.progress).not.toBeNull()
+    expect(result.current.stepHistory.length).toBe(7)
+
+    act(() => {
+      result.current.dismiss()
+    })
+
+    expect(result.current.progress).toBeNull()
+    expect(result.current.stepHistory).toEqual([])
+  })
+
+  // ── Reconnects on WebSocket close ──────────────────────────────────────
+
+  it('reconnects when the WebSocket closes', () => {
+    const WS_RECONNECT_MS = 5000
+    renderHook(() => useUpdateProgress())
+
+    expect(wsInstances.length).toBe(1)
+
+    // Simulate WS close
+    act(() => {
+      wsInstances[0].close()
+    })
+
+    // Advance past reconnect delay
+    act(() => {
+      vi.advanceTimersByTime(WS_RECONNECT_MS)
+    })
+
+    // A new WebSocket should have been created
+    expect(wsInstances.length).toBe(2)
+  })
+
+  // ── Cleanup on unmount ─────────────────────────────────────────────────
+
+  it('closes WebSocket and clears timers on unmount', () => {
+    const { unmount } = renderHook(() => useUpdateProgress())
+
+    const ws = wsInstances[0]
+    unmount()
+
+    expect(ws.close).toHaveBeenCalled()
+  })
+
+  // ── Ignores messages with no payload ───────────────────────────────────
+
+  it('ignores update_progress messages with no payload', () => {
+    const { result } = renderHook(() => useUpdateProgress())
+    const ws = wsInstances[0]
+
+    act(() => {
+      ws.onmessage!({
+        data: JSON.stringify({ type: 'update_progress' }),
+      })
+    })
+
+    expect(result.current.progress).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Add unit tests for `useLocalAgent` hook (8 tests): initial state, connected/disconnected transitions, polling, cleanup on unmount
- Add unit tests for `useClusterProgress` hook (10 tests): WebSocket message parsing, status transitions, dismiss, reconnect, cleanup
- Add unit tests for `useUpdateProgress` hook (11 tests): WebSocket message parsing, step history tracking, stale detection, dismiss, cleanup
- Add unit tests for `useMCS` hooks (26 tests): `useMCSStatus`, `useServiceExports`, `useServiceImports` — API fetching, error handling, BackendUnavailableError, demo mode fallback, polling, cleanup

## Test plan
- [x] All 55 tests pass: `npx vitest run src/hooks/__tests__/useLocalAgent.test.ts src/hooks/__tests__/useClusterProgress.test.ts src/hooks/__tests__/useUpdateProgress.test.ts src/hooks/__tests__/useMCS.test.ts`
- [x] Build passes (`npm run build`)
- [ ] CI build/lint pass

Fixes #3955 #3956 #3957