### PR TITLE
🐛 fix: screenshots not uploaded in Contribute modal

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -312,18 +312,17 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
       return
     }
 
-    // Append screenshot note to description if screenshots were attached
-    const screenshotNote = screenshots.length > 0
-      ? `\n\n---\n**Screenshots**: ${screenshots.length} screenshot(s) attached — paste images into this issue.`
-      : ''
-    const finalDesc = extractedDesc + screenshotNote
+    // Collect base64 data URIs for screenshots so the backend can upload
+    // them to GitHub and embed them directly in the created issue.
+    const screenshotDataURIs = screenshots.map(s => s.preview)
 
     try {
       const result = await createRequest({
         title: extractedTitle,
-        description: finalDesc,
+        description: extractedDesc,
         request_type: requestType,
         target_repo: targetRepo,
+        ...(screenshotDataURIs.length > 0 && { screenshots: screenshotDataURIs }),
       })
       setSuccess({ issueUrl: result.github_issue_url })
       // Show thank-you for 5s (extended to give time to copy screenshots) then switch to Updates tab


### PR DESCRIPTION
## Summary
Root cause of #3637: `FeatureRequestModal.tsx` (the main Contribute modal) called `createRequest()` **without passing the `screenshots` field**. It appended placeholder text instead:

```
Screenshots: 1 screenshot(s) attached — paste images into this issue.
```

The backend never received the data URIs and had nothing to upload. The simpler `FeedbackModal.tsx` correctly passed screenshots — but most users submit through `FeatureRequestModal`.

**Fix:** Pass `screenshots: screenshotDataURIs` to `createRequest()` so the backend uploads them via GitHub Contents API and embeds them as `![Screenshot](url)` in the issue body.

## Verified via CDP E2E
1. Launched Chrome with CDP (remote-debugging-port=9222)
2. Navigated to console, logged in via dev-mode
3. Submitted bug report with screenshot via browser JS
4. Confirmed issue #3978 was created with embedded `![Screenshot 1](https://raw.githubusercontent.com/...)` 
5. Image is visible in the GitHub issue

## Test plan
- [x] `npm run build` passes
- [x] CDP E2E: submit bug with screenshot → image appears in GitHub issue
- [x] Backend upload returns valid `download_url`
- [ ] Manual test: open Contribute modal, attach screenshot, submit, verify in created issue

Fixes #3637