### PR TITLE
🐛 fix: eliminate race condition in ISO 27001 parallel cluster audit (#3968)

### DIFF
--- a/web/src/hooks/useCachedISO27001.ts
+++ b/web/src/hooks/useCachedISO27001.ts
@@ -265,15 +265,17 @@ async function fetchISO27001AuditViaKubectl(
   const clusters = getAgentClusters()
   if (clusters.length === 0) return []
 
-  const accumulated: ISO27001Finding[] = []
+  // Each task returns its own findings array to avoid shared-state mutation.
+  // Progressive updates are built by collecting all fulfilled results so far.
+  const completed: ISO27001Finding[][] = []
 
   const tasks = clusters
     .filter(c => !cluster || c.name === cluster)
     .map(({ name, context }) => async () => {
       try {
         const clusterFindings = await runISO27001ChecksForCluster(name, context || name)
-        accumulated.push(...clusterFindings)
-        onProgress?.([...accumulated])
+        completed.push(clusterFindings)
+        onProgress?.(completed.flat())
         return clusterFindings
       } catch (err) {
         console.error(`[ISO27001] Audit failed for cluster ${name}:`, err)
@@ -281,8 +283,10 @@ async function fetchISO27001AuditViaKubectl(
       }
     })
 
-  await settledWithConcurrency(tasks)
-  return accumulated
+  const results = await settledWithConcurrency(tasks)
+  return results
+    .filter((r): r is PromiseFulfilledResult<ISO27001Finding[]> => r.status === 'fulfilled')
+    .flatMap(r => r.value)
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes shared mutable array (`accumulated`) being mutated concurrently from parallel cluster tasks in `fetchISO27001AuditViaKubectl`
- Each parallel task now returns its own findings array independently
- Final results are collected from settled promises via `flatMap`, eliminating interleaved `push` corruption
- Progressive `onProgress` updates still work by flattening all completed results so far

## Test plan
- [ ] Connect 5+ clusters via kc-agent
- [ ] Open the ISO 27001 audit card
- [ ] Verify findings count is consistent across page reloads
- [ ] Verify progressive loading still shows partial results as clusters complete

Closes #3968