### PR TITLE
🐛 fix: markdown preview now matches GitHub rendering (#3974)

### DIFF
--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -1385,33 +1385,9 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
                       disabled={isSubmitting}
                     />
                   ) : (
-                    <div className="w-full h-[200px] overflow-y-auto px-3 py-2 bg-secondary/50 border border-border rounded-lg text-sm prose prose-invert prose-sm max-w-none">
+                    <div className="w-full h-[200px] overflow-y-auto px-3 py-2 bg-secondary/50 border border-border rounded-lg ghmd">
                       {description.trim() ? (
-                        <ReactMarkdown
-                          remarkPlugins={[remarkGfm, remarkBreaks]}
-                          components={{
-                            code({ className, children, ...props }) {
-                              const match = /language-(\w+)/.exec(className || '')
-                              const isInline = !match && !className
-                              return isInline ? (
-                                <code className="bg-black/20 px-1 rounded text-purple-300" {...props}>{children}</code>
-                              ) : (
-                                <pre className="bg-black/30 rounded-lg p-3 overflow-x-auto my-2">
-                                  <code className={className} {...props}>{children}</code>
-                                </pre>
-                              )
-                            },
-                            table: ({ children }) => (
-                              <div className="overflow-x-auto w-full my-3 rounded border border-border">
-                                <table className="min-w-full border-collapse text-sm">{children}</table>
-                              </div>
-                            ),
-                            thead: ({ children }) => <thead className="bg-secondary/50">{children}</thead>,
-                            th: ({ children }) => <th className="px-3 py-2 text-left text-xs font-semibold border-b border-border">{children}</th>,
-                            td: ({ children }) => <td className="px-3 py-2 text-xs border-b border-border/50">{children}</td>,
-                            blockquote: ({ children }) => <blockquote className="border-l-4 border-purple-500/50 pl-3 my-3 text-muted-foreground italic">{children}</blockquote>,
-                          }}
-                        >
+                        <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                           {description}
                         </ReactMarkdown>
                       ) : (
@@ -1625,32 +1601,8 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
                 <X className="w-4 h-4" />
               </button>
             </div>
-            <div className="flex-1 overflow-y-auto px-6 py-4 prose prose-invert prose-sm max-w-none">
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm, remarkBreaks]}
-                components={{
-                  code({ className, children, ...props }) {
-                    const match = /language-(\w+)/.exec(className || '')
-                    const isInline = !match && !className
-                    return isInline ? (
-                      <code className="bg-black/20 px-1 rounded text-purple-300" {...props}>{children}</code>
-                    ) : (
-                      <pre className="bg-black/30 rounded-lg p-3 overflow-x-auto my-2">
-                        <code className={className} {...props}>{children}</code>
-                      </pre>
-                    )
-                  },
-                  table: ({ children }) => (
-                    <div className="overflow-x-auto w-full my-3 rounded border border-border">
-                      <table className="min-w-full border-collapse text-sm">{children}</table>
-                    </div>
-                  ),
-                  thead: ({ children }) => <thead className="bg-secondary/50">{children}</thead>,
-                  th: ({ children }) => <th className="px-3 py-2 text-left text-xs font-semibold border-b border-border">{children}</th>,
-                  td: ({ children }) => <td className="px-3 py-2 text-xs border-b border-border/50">{children}</td>,
-                  blockquote: ({ children }) => <blockquote className="border-l-4 border-purple-500/50 pl-3 my-3 text-muted-foreground italic">{children}</blockquote>,
-                }}
-              >
+            <div className="flex-1 overflow-y-auto px-6 py-4 ghmd">
+              <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                 {description}
               </ReactMarkdown>
             </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1727,3 +1727,88 @@
   }
 }
 
+
+/* GitHub-flavored markdown preview (dark mode) */
+.ghmd {
+  color: #e6edf3;
+  font-size: 14px;
+  line-height: 1.6;
+  word-wrap: break-word;
+}
+.ghmd h1, .ghmd h2, .ghmd h3, .ghmd h4, .ghmd h5, .ghmd h6 {
+  margin-top: 24px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  line-height: 1.25;
+  color: #e6edf3;
+}
+.ghmd h1 { font-size: 2em; padding-bottom: 0.3em; border-bottom: 1px solid #30363d; }
+.ghmd h2 { font-size: 1.5em; padding-bottom: 0.3em; border-bottom: 1px solid #30363d; }
+.ghmd h3 { font-size: 1.25em; }
+.ghmd h4 { font-size: 1em; }
+.ghmd p { margin-top: 0; margin-bottom: 16px; }
+.ghmd a { color: #58a6ff; text-decoration: none; }
+.ghmd a:hover { text-decoration: underline; }
+.ghmd ul, .ghmd ol { padding-left: 2em; margin-top: 0; margin-bottom: 16px; }
+.ghmd li { margin-top: 0.25em; }
+.ghmd li + li { margin-top: 0.25em; }
+.ghmd blockquote {
+  margin: 0 0 16px;
+  padding: 0 1em;
+  color: #8b949e;
+  border-left: 0.25em solid #30363d;
+}
+.ghmd hr {
+  height: 0.25em;
+  padding: 0;
+  margin: 24px 0;
+  background-color: #30363d;
+  border: 0;
+}
+.ghmd code:not(pre code) {
+  padding: 0.2em 0.4em;
+  margin: 0;
+  font-size: 85%;
+  background-color: rgba(110, 118, 129, 0.4);
+  border-radius: 6px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+.ghmd pre {
+  padding: 16px;
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  background-color: #161b22;
+  border-radius: 6px;
+  margin-bottom: 16px;
+}
+.ghmd pre code {
+  padding: 0;
+  margin: 0;
+  font-size: 100%;
+  background-color: transparent;
+  border-radius: 0;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+.ghmd table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  margin-bottom: 16px;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+  display: block;
+}
+.ghmd table th, .ghmd table td {
+  padding: 6px 13px;
+  border: 1px solid #30363d;
+}
+.ghmd table th {
+  font-weight: 600;
+  background-color: #161b22;
+}
+.ghmd table tr { background-color: transparent; border-top: 1px solid #21262d; }
+.ghmd table tr:nth-child(2n) { background-color: #161b22; }
+.ghmd img { max-width: 100%; box-sizing: border-box; }
+.ghmd strong { font-weight: 600; color: #e6edf3; }
+.ghmd em { font-style: italic; }


### PR DESCRIPTION
## Summary
- Adds `.ghmd` CSS class that replicates GitHub's dark-mode markdown styling (headings, code blocks, tables, blockquotes, links, lists, horizontal rules)
- Replaces non-functional `prose prose-invert` classes (`@tailwindcss/typography` is not installed, so they had no effect)
- Fixes inline-vs-block code detection that broke for fenced code blocks without a language specifier
- Simplifies ReactMarkdown usage by removing all custom component overrides — CSS handles everything

## Test plan
- [ ] Open Contribute > Bug Report dialog
- [ ] Type markdown with headings, code blocks, tables, lists, blockquotes
- [ ] Switch to Preview tab — verify rendering matches GitHub's dark mode
- [ ] Click expand (fullscreen) — verify same styling applies
- [ ] Compare with same markdown rendered on GitHub

Closes #3974