### PR TITLE
🐛 Fix missing isRefreshing in NetworkPolicyCoverage card

### DIFF
--- a/web/src/components/cards/NetworkPolicyCoverage.tsx
+++ b/web/src/components/cards/NetworkPolicyCoverage.tsx
@@ -14,7 +14,7 @@ interface NamespaceCoverage {
 
 export function NetworkPolicyCoverage() {
   const { t } = useTranslation('cards')
-  const { pods, isLoading: podsLoading, isDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedPods()
+  const { pods, isLoading: podsLoading, isRefreshing, isDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedPods()
   const { networkpolicies, isLoading: policiesLoading, isFailed: policiesFailed } = useNetworkPolicies()
   const [showUncovered, setShowUncovered] = useState(false)
 
@@ -25,6 +25,7 @@ export function NetworkPolicyCoverage() {
 
   const { showSkeleton } = useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: pods.length > 0,
     isDemoData: isDemoFallback,
     isFailed,


### PR DESCRIPTION
## Summary

- Destructure `isRefreshing` from `useCachedPods()` and pass it to `useCardLoadingState()` in the `NetworkPolicyCoverage` card
- Without this, the card does not show the background refresh indicator when cached data is being updated, inconsistent with the established pattern used by other cards (e.g., `WarningEvents`, `ClusterGroups`)

Fixes #4001

## Test plan

- [ ] Verify the NetworkPolicyCoverage card shows the refreshing indicator during background data updates
- [ ] Verify no regressions in card loading/skeleton states
- [ ] Verify build passes (`npm run build`)