### PR TITLE
🐛 Remove active users widget from navbar, widen agent setup modal

### DIFF
--- a/web/src/components/agent/AgentSetupDialog.tsx
+++ b/web/src/components/agent/AgentSetupDialog.tsx
@@ -96,7 +96,7 @@ export function AgentSetupDialog() {
   }
 
   return (
-    <BaseModal isOpen={show} onClose={() => handleDismiss(false)} size="md">
+    <BaseModal isOpen={show} onClose={() => handleDismiss(false)} size="lg">
       <BaseModal.Header
         title={t('agentSetup.welcomeTitle')}
         description={t('agentSetup.welcomeDescription')}

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -27,7 +27,6 @@ import { TokenUsageWidget } from './TokenUsageWidget'
 import { ClusterFilterPanel } from './ClusterFilterPanel'
 import { AgentStatusIndicator } from './AgentStatusIndicator'
 import { UpdateIndicator } from './UpdateIndicator'
-import { ActiveUsersWidget } from './ActiveUsersWidget'
 import { ROUTES } from '../../../config/routes'
 
 export function Navbar() {
@@ -119,9 +118,6 @@ export function Navbar() {
           {/* Token Usage */}
           <TokenUsageWidget />
 
-          {/* Active Users */}
-          <ActiveUsersWidget />
-
           {/* Feature Request (includes notifications) */}
           <FeatureRequestButton />
         </div>
@@ -200,9 +196,6 @@ export function Navbar() {
                   </div>
                   <div className="px-3 py-2">
                     <TokenUsageWidget />
-                  </div>
-                  <div className="px-3 py-2">
-                    <ActiveUsersWidget />
                   </div>
                   <div className="px-3 py-2">
                     <FeatureRequestButton />


### PR DESCRIPTION
## Summary
- Remove `ActiveUsersWidget` from both desktop and mobile navbar layouts
- Widen `AgentSetupDialog` from `md` to `lg` so footer buttons aren't cramped

## Test plan
- [ ] Verify active users count no longer appears in top navbar
- [ ] Verify agent setup modal buttons have adequate spacing