### PR TITLE
✨ feat: add KubeRay, SLO, Failover, and Trino dashboard cards with preset dashboards

### DIFF
--- a/presets/karmada-ai-operations.json
+++ b/presets/karmada-ai-operations.json
@@ -1,0 +1,79 @@
+{
+  "name": "Karmada AI Operations",
+  "author": "KubeStellar Team",
+  "version": "1.0.0",
+  "description": "Multi-cluster AI inference operations dashboard for Karmada + KubeRay environments. Monitors Ray fleet status, SLO compliance, failover events, GPU allocation, and LLM serving health.",
+  "labels": ["cncf", "multi-cluster", "ai-ml", "karmada", "kuberay", "inference"],
+  "cards": [
+    {
+      "type": "karmada_status",
+      "title": "Karmada Status",
+      "w": 6,
+      "h": 4
+    },
+    {
+      "type": "kuberay_fleet",
+      "title": "KubeRay Fleet",
+      "w": 6,
+      "h": 4
+    },
+    {
+      "type": "slo_compliance",
+      "title": "SLO Compliance",
+      "w": 6,
+      "h": 4
+    },
+    {
+      "type": "failover_timeline",
+      "title": "Failover Timeline",
+      "w": 6,
+      "h": 4
+    },
+    {
+      "type": "gpu_overview",
+      "title": "GPU Overview",
+      "w": 6,
+      "h": 4
+    },
+    {
+      "type": "cluster_health",
+      "title": "Cluster Health",
+      "w": 6,
+      "h": 4
+    }
+  ],
+  "layouts": {
+    "lg": [
+      { "i": "0", "x": 0, "y": 0, "w": 6, "h": 4 },
+      { "i": "1", "x": 6, "y": 0, "w": 6, "h": 4 },
+      { "i": "2", "x": 0, "y": 4, "w": 6, "h": 4 },
+      { "i": "3", "x": 6, "y": 4, "w": 6, "h": 4 },
+      { "i": "4", "x": 0, "y": 8, "w": 6, "h": 4 },
+      { "i": "5", "x": 6, "y": 8, "w": 6, "h": 4 }
+    ],
+    "md": [
+      { "i": "0", "x": 0, "y": 0, "w": 5, "h": 4 },
+      { "i": "1", "x": 5, "y": 0, "w": 5, "h": 4 },
+      { "i": "2", "x": 0, "y": 4, "w": 5, "h": 4 },
+      { "i": "3", "x": 5, "y": 4, "w": 5, "h": 4 },
+      { "i": "4", "x": 0, "y": 8, "w": 5, "h": 4 },
+      { "i": "5", "x": 5, "y": 8, "w": 5, "h": 4 }
+    ],
+    "sm": [
+      { "i": "0", "x": 0, "y": 0, "w": 6, "h": 4 },
+      { "i": "1", "x": 0, "y": 4, "w": 6, "h": 4 },
+      { "i": "2", "x": 0, "y": 8, "w": 6, "h": 4 },
+      { "i": "3", "x": 0, "y": 12, "w": 6, "h": 4 },
+      { "i": "4", "x": 0, "y": 16, "w": 6, "h": 4 },
+      { "i": "5", "x": 0, "y": 20, "w": 6, "h": 4 }
+    ],
+    "xs": [
+      { "i": "0", "x": 0, "y": 0, "w": 4, "h": 4 },
+      { "i": "1", "x": 0, "y": 4, "w": 4, "h": 4 },
+      { "i": "2", "x": 0, "y": 8, "w": 4, "h": 4 },
+      { "i": "3", "x": 0, "y": 12, "w": 4, "h": 4 },
+      { "i": "4", "x": 0, "y": 16, "w": 4, "h": 4 },
+      { "i": "5", "x": 0, "y": 20, "w": 4, "h": 4 }
+    ]
+  }
+}

--- a/presets/karmada-data-platform.json
+++ b/presets/karmada-data-platform.json
@@ -1,0 +1,79 @@
+{
+  "name": "Karmada Data Platform",
+  "author": "KubeStellar Team",
+  "version": "1.0.0",
+  "description": "Multi-cluster data platform operations dashboard for Karmada + Trino environments. Monitors Trino gateway routing, query health, SLO compliance, failover events, and cluster distribution.",
+  "labels": ["cncf", "multi-cluster", "data-platform", "karmada", "trino", "sql"],
+  "cards": [
+    {
+      "type": "karmada_status",
+      "title": "Karmada Status",
+      "w": 6,
+      "h": 4
+    },
+    {
+      "type": "trino_gateway",
+      "title": "Trino Gateway",
+      "w": 6,
+      "h": 4
+    },
+    {
+      "type": "failover_timeline",
+      "title": "Failover Timeline",
+      "w": 6,
+      "h": 4
+    },
+    {
+      "type": "slo_compliance",
+      "title": "SLO Compliance",
+      "w": 6,
+      "h": 4
+    },
+    {
+      "type": "cluster_health",
+      "title": "Cluster Health",
+      "w": 6,
+      "h": 4
+    },
+    {
+      "type": "cluster_locations",
+      "title": "Cluster Locations",
+      "w": 6,
+      "h": 4
+    }
+  ],
+  "layouts": {
+    "lg": [
+      { "i": "0", "x": 0, "y": 0, "w": 6, "h": 4 },
+      { "i": "1", "x": 6, "y": 0, "w": 6, "h": 4 },
+      { "i": "2", "x": 0, "y": 4, "w": 6, "h": 4 },
+      { "i": "3", "x": 6, "y": 4, "w": 6, "h": 4 },
+      { "i": "4", "x": 0, "y": 8, "w": 6, "h": 4 },
+      { "i": "5", "x": 6, "y": 8, "w": 6, "h": 4 }
+    ],
+    "md": [
+      { "i": "0", "x": 0, "y": 0, "w": 5, "h": 4 },
+      { "i": "1", "x": 5, "y": 0, "w": 5, "h": 4 },
+      { "i": "2", "x": 0, "y": 4, "w": 5, "h": 4 },
+      { "i": "3", "x": 5, "y": 4, "w": 5, "h": 4 },
+      { "i": "4", "x": 0, "y": 8, "w": 5, "h": 4 },
+      { "i": "5", "x": 5, "y": 8, "w": 5, "h": 4 }
+    ],
+    "sm": [
+      { "i": "0", "x": 0, "y": 0, "w": 6, "h": 4 },
+      { "i": "1", "x": 0, "y": 4, "w": 6, "h": 4 },
+      { "i": "2", "x": 0, "y": 8, "w": 6, "h": 4 },
+      { "i": "3", "x": 0, "y": 12, "w": 6, "h": 4 },
+      { "i": "4", "x": 0, "y": 16, "w": 6, "h": 4 },
+      { "i": "5", "x": 0, "y": 20, "w": 6, "h": 4 }
+    ],
+    "xs": [
+      { "i": "0", "x": 0, "y": 0, "w": 4, "h": 4 },
+      { "i": "1", "x": 0, "y": 4, "w": 4, "h": 4 },
+      { "i": "2", "x": 0, "y": 8, "w": 4, "h": 4 },
+      { "i": "3", "x": 0, "y": 12, "w": 4, "h": 4 },
+      { "i": "4", "x": 0, "y": 16, "w": 4, "h": 4 },
+      { "i": "5", "x": 0, "y": 20, "w": 4, "h": 4 }
+    ]
+  }
+}

--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -284,6 +284,10 @@ export const CARD_TITLES: Record<string, string> = {
   keda_status: 'KEDA',
   // Karmada multi-cluster orchestration
   karmada_status: 'Karmada',
+  kuberay_fleet: 'KubeRay Fleet',
+  slo_compliance: 'SLO Compliance',
+  failover_timeline: 'Failover Timeline',
+  trino_gateway: 'Trino Gateway',
 
   // Inspektor Gadget
   network_trace: 'Network Traces',
@@ -546,6 +550,10 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   keda_status: 'KEDA (Kubernetes Event-Driven Autoscaling) automatically scales workloads based on external event sources like message queues, databases, or custom metrics. This card shows which workloads are being autoscaled, their current triggers, and queue depths.',
   // Karmada multi-cluster orchestration
   karmada_status: 'Karmada is a multi-cluster orchestration tool that propagates resources (Deployments, Services, etc.) across multiple clusters using placement policies. This card shows propagation status, member cluster health, and policy compliance.',
+  kuberay_fleet: 'Discovers RayCluster, RayService, and RayJob CRDs across all connected clusters. Shows fleet-level Ray workload status including GPU allocations, serving endpoints, and job progress.',
+  slo_compliance: 'Tracks SLO compliance with configurable targets for latency, error rate, and availability. Shows error budget burn rate and per-cluster compliance indicators.',
+  failover_timeline: 'Forensic timeline of cross-region failover events detected from Karmada ResourceBinding status transitions. Shows cluster outages, binding rescheduling, and recovery events.',
+  trino_gateway: 'Discovers Trino coordinator, worker, and Trino Gateway pods across clusters. Shows per-cluster query health, gateway routing status, and worker distribution.',
 
   // Inspektor Gadget
   network_trace: 'Live network connection tracing via Inspektor Gadget eBPF.',

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -239,6 +239,14 @@ const StrimziStatus = safeLazy(() => import('./strimzi_status'), 'StrimziStatus'
 const KubeVelaStatus = safeLazy(() => import('./kubevela_status'), 'KubeVelaStatus')
 // Karmada multi-cluster orchestration card
 const KarmadaStatus = safeLazy(() => import('./karmada_status'), 'KarmadaStatus')
+// KubeRay fleet monitoring card
+const KubeRayFleet = safeLazy(() => import('./kuberay_fleet'), 'KubeRayFleet')
+// SLO compliance tracking card
+const SLOCompliance = safeLazy(() => import('./slo_compliance'), 'SLOCompliance')
+// Cross-region failover timeline card
+const FailoverTimeline = safeLazy(() => import('./failover_timeline'), 'FailoverTimeline')
+// Trino query gateway monitoring card
+const TrinoGateway = safeLazy(() => import('./trino_gateway'), 'TrinoGateway')
 // Thanos distributed metrics card
 const ThanosStatus = safeLazy(() => import('./thanos_status'), 'ThanosStatus')
 // OpenFeature feature-flag management card
@@ -544,6 +552,14 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   kubevela_status: KubeVelaStatus,
   // Karmada multi-cluster orchestration
   karmada_status: KarmadaStatus,
+  // KubeRay fleet monitoring
+  kuberay_fleet: KubeRayFleet,
+  // SLO compliance tracking
+  slo_compliance: SLOCompliance,
+  // Cross-region failover timeline
+  failover_timeline: FailoverTimeline,
+  // Trino query gateway monitoring
+  trino_gateway: TrinoGateway,
   // Thanos distributed metrics
   thanos_status: ThanosStatus,
   // OpenFeature feature-flag management
@@ -933,6 +949,10 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   kubevela_status: () => import('./kubevela_status'),
   // Karmada multi-cluster orchestration
   karmada_status: () => import('./karmada_status'),
+  kuberay_fleet: () => import('./kuberay_fleet'),
+  slo_compliance: () => import('./slo_compliance'),
+  failover_timeline: () => import('./failover_timeline'),
+  trino_gateway: () => import('./trino_gateway'),
   // Thanos distributed metrics
   thanos_status: () => import('./thanos_status'),
   // OpenFeature feature-flag management
@@ -1112,6 +1132,11 @@ export const LIVE_DATA_CARDS = new Set([
   'crio_status',
   'strimzi_status',
   'kubevela_status',
+  // KubeRay, SLO, Failover, Trino - demo until detected
+  'kuberay_fleet',
+  'slo_compliance',
+  'failover_timeline',
+  'trino_gateway',
   'network_policies',
   'cluster_changelog',
   'predictive_health',
@@ -1256,6 +1281,10 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   cloudevents_status: 6,
   // Karmada
   karmada_status: 6,
+  kuberay_fleet: 6,
+  slo_compliance: 6,
+  failover_timeline: 8,
+  trino_gateway: 6,
   // Thanos distributed metrics
   thanos_status: 6,
   // OpenFeature feature-flag management

--- a/web/src/components/cards/failover_timeline/FailoverTimeline.tsx
+++ b/web/src/components/cards/failover_timeline/FailoverTimeline.tsx
@@ -1,0 +1,298 @@
+import { useMemo } from 'react'
+import {
+  AlertTriangle,
+  Server,
+  RefreshCw,
+  ArrowRightLeft,
+  Clock,
+  Shield,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Skeleton, SkeletonStats, SkeletonList } from '../../ui/Skeleton'
+import { useFailoverTimeline } from './useFailoverTimeline'
+import type { FailoverEvent, FailoverEventType, FailoverSeverity } from './demoData'
+
+// ---------------------------------------------------------------------------
+// Named constants
+// ---------------------------------------------------------------------------
+
+/** Number of minutes in one hour */
+const MINUTES_PER_HOUR = 60
+
+/** Number of hours in one day */
+const HOURS_PER_DAY = 24
+
+/** Number of milliseconds in one minute */
+const MS_PER_MINUTE = 60_000
+
+/** Number of milliseconds in one hour */
+const MS_PER_HOUR = 3_600_000
+
+/** Number of milliseconds in one day */
+const MS_PER_DAY = 86_400_000
+
+// ---------------------------------------------------------------------------
+// Severity styling
+// ---------------------------------------------------------------------------
+
+const SEVERITY_CONFIG: Record<
+  FailoverSeverity,
+  { dotColor: string; borderColor: string; textColor: string }
+> = {
+  critical: {
+    dotColor: 'bg-red-500',
+    borderColor: 'border-red-500/40',
+    textColor: 'text-red-400',
+  },
+  warning: {
+    dotColor: 'bg-yellow-500',
+    borderColor: 'border-yellow-500/40',
+    textColor: 'text-yellow-400',
+  },
+  info: {
+    dotColor: 'bg-blue-500',
+    borderColor: 'border-blue-500/40',
+    textColor: 'text-blue-400',
+  },
+}
+
+const EVENT_TYPE_CONFIG: Record<
+  FailoverEventType,
+  { label: string; icon: React.ReactNode; badgeClass: string }
+> = {
+  cluster_down: {
+    label: 'Cluster Down',
+    icon: <Server className="w-3 h-3" />,
+    badgeClass: 'bg-red-500/15 text-red-400',
+  },
+  binding_reschedule: {
+    label: 'Reschedule',
+    icon: <ArrowRightLeft className="w-3 h-3" />,
+    badgeClass: 'bg-yellow-500/15 text-yellow-400',
+  },
+  cluster_recovery: {
+    label: 'Recovery',
+    icon: <Shield className="w-3 h-3" />,
+    badgeClass: 'bg-blue-500/15 text-blue-400',
+  },
+  replica_rebalance: {
+    label: 'Rebalance',
+    icon: <RefreshCw className="w-3 h-3" />,
+    badgeClass: 'bg-blue-500/15 text-blue-400',
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatTimeAgo(isoTimestamp: string): string {
+  const delta = Date.now() - new Date(isoTimestamp).getTime()
+  if (delta < MS_PER_MINUTE) return 'just now'
+  if (delta < MS_PER_HOUR) {
+    const mins = Math.floor(delta / MS_PER_MINUTE)
+    return `${mins}m ago`
+  }
+  if (delta < MS_PER_DAY) {
+    const hours = Math.floor(delta / MS_PER_HOUR)
+    return `${hours}h ago`
+  }
+  const days = Math.floor(delta / MS_PER_DAY)
+  return `${days}d ago`
+}
+
+function formatTimestamp(isoTimestamp: string): string {
+  const date = new Date(isoTimestamp)
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+function formatTimeSinceFailover(isoTimestamp: string | null): string {
+  if (!isoTimestamp) return 'None recorded'
+  const delta = Date.now() - new Date(isoTimestamp).getTime()
+  if (delta < MS_PER_MINUTE) return 'just now'
+  const totalMinutes = Math.floor(delta / MS_PER_MINUTE)
+  if (totalMinutes < MINUTES_PER_HOUR) return `${totalMinutes}m ago`
+  const hours = Math.floor(totalMinutes / MINUTES_PER_HOUR)
+  if (hours < HOURS_PER_DAY) return `${hours}h ago`
+  const days = Math.floor(hours / HOURS_PER_DAY)
+  return `${days}d ago`
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function TimelineEvent({ event }: { event: FailoverEvent }) {
+  const severityCfg = SEVERITY_CONFIG[event.severity]
+  const typeCfg = EVENT_TYPE_CONFIG[event.eventType]
+
+  return (
+    <div className="relative flex gap-3 pb-4 last:pb-0">
+      {/* Vertical line */}
+      <div className="flex flex-col items-center">
+        <div className={`w-2.5 h-2.5 rounded-full shrink-0 mt-1 ${severityCfg.dotColor}`} />
+        <div className="w-px flex-1 bg-border/50 mt-1" />
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0 space-y-1">
+        {/* Row 1: type badge + timestamp */}
+        <div className="flex items-center justify-between gap-2">
+          <div className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${typeCfg.badgeClass}`}>
+            {typeCfg.icon}
+            {typeCfg.label}
+          </div>
+          <span className="text-xs text-muted-foreground shrink-0 flex items-center gap-1">
+            <Clock className="w-3 h-3" />
+            {formatTimestamp(event.timestamp)}
+          </span>
+        </div>
+
+        {/* Row 2: cluster + workload */}
+        <div className="flex items-center gap-2 text-xs">
+          <span className="flex items-center gap-1 text-foreground font-medium">
+            <Server className="w-3 h-3 text-muted-foreground" />
+            {event.cluster}
+          </span>
+          {event.workload && (
+            <span className="text-muted-foreground truncate">
+              / {event.workload}
+            </span>
+          )}
+        </div>
+
+        {/* Row 3: details */}
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          {event.details}
+        </p>
+
+        {/* Row 4: relative time */}
+        <span className={`text-xs ${severityCfg.textColor}`}>
+          {formatTimeAgo(event.timestamp)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function FailoverTimeline() {
+  const { t } = useTranslation('cards')
+  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useFailoverTimeline()
+
+  // Guard arrays
+  const events = useMemo(() => data.events || [], [data.events])
+
+  const activeClusters = data.activeClusters ?? 0
+  const totalClusters = data.totalClusters ?? 0
+
+  // ── Loading ───────────────────────────────────────────────────────────────
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-4">
+        <div className="flex items-center justify-between">
+          <Skeleton variant="rounded" width={160} height={28} />
+          <Skeleton variant="rounded" width={80} height={20} />
+        </div>
+        <SkeletonStats className="grid-cols-2" />
+        <SkeletonList items={4} className="flex-1" />
+      </div>
+    )
+  }
+
+  // ── Error ─────────────────────────────────────────────────────────────────
+  if (error && showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <AlertTriangle className="w-6 h-6 text-red-400" />
+        <p className="text-sm text-red-400">
+          {t('failoverTimeline.fetchError', 'Failed to fetch failover timeline')}
+        </p>
+      </div>
+    )
+  }
+
+  // ── Empty state ───────────────────────────────────────────────────────────
+  if (events.length === 0 && showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Shield className="w-6 h-6 text-muted-foreground/50" />
+        <p className="text-sm font-medium">
+          {t('failoverTimeline.noEvents', 'No failover events')}
+        </p>
+        <p className="text-xs text-center max-w-xs">
+          {t(
+            'failoverTimeline.noEventsHint',
+            'No cluster failover or binding reschedule events detected. This is good — your clusters are stable.',
+          )}
+        </p>
+      </div>
+    )
+  }
+
+  const allClustersHealthy = activeClusters === totalClusters && totalClusters > 0
+  const healthColorClass = allClustersHealthy
+    ? 'bg-green-500/15 text-green-400'
+    : 'bg-yellow-500/15 text-yellow-400'
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded gap-4 overflow-hidden">
+      {/* ── Header ── */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${healthColorClass}`}>
+            <Server className="w-4 h-4" />
+            {activeClusters}/{totalClusters}{' '}
+            {t('failoverTimeline.clusters', 'Clusters')}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground flex items-center gap-1">
+            <Clock className="w-3 h-3" />
+            {t('failoverTimeline.lastFailover', 'Last failover:')}{' '}
+            {formatTimeSinceFailover(data.lastFailover)}
+          </span>
+          <RefreshCw className={`w-3 h-3 text-muted-foreground ${isRefreshing ? 'animate-spin' : ''}`} />
+        </div>
+      </div>
+
+      {/* ── Summary stats ── */}
+      <div className="grid grid-cols-3 gap-2">
+        <div className="p-2 rounded-lg bg-secondary/30 border border-red-500/20">
+          <span className="text-xs text-red-400 block">
+            {t('failoverTimeline.clusterDown', 'Down Events')}
+          </span>
+          <span className="text-lg font-bold text-foreground">
+            {events.filter(e => e.eventType === 'cluster_down').length}
+          </span>
+        </div>
+        <div className="p-2 rounded-lg bg-secondary/30 border border-yellow-500/20">
+          <span className="text-xs text-yellow-400 block">
+            {t('failoverTimeline.reschedules', 'Reschedules')}
+          </span>
+          <span className="text-lg font-bold text-foreground">
+            {events.filter(e => e.eventType === 'binding_reschedule').length}
+          </span>
+        </div>
+        <div className="p-2 rounded-lg bg-secondary/30 border border-blue-500/20">
+          <span className="text-xs text-blue-400 block">
+            {t('failoverTimeline.recoveries', 'Recoveries')}
+          </span>
+          <span className="text-lg font-bold text-foreground">
+            {events.filter(e => e.eventType === 'cluster_recovery').length}
+          </span>
+        </div>
+      </div>
+
+      {/* ── Timeline ── */}
+      <div className="flex-1 overflow-y-auto pr-1">
+        {events.map((event, idx) => (
+          <TimelineEvent key={`${event.timestamp}-${event.eventType}-${idx}`} event={event} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/cards/failover_timeline/demoData.ts
+++ b/web/src/components/cards/failover_timeline/demoData.ts
@@ -1,0 +1,134 @@
+/**
+ * Demo data for the Cross-Region Failover Timeline card.
+ *
+ * Represents a realistic failover scenario where a cluster goes down,
+ * bindings are rescheduled to healthy clusters, replicas rebalance,
+ * and the original cluster eventually recovers.
+ *
+ * Used in demo mode or when no Karmada control plane is accessible.
+ */
+
+/** Demo data shows as checked 30 seconds ago */
+const DEMO_LAST_CHECK_OFFSET_MS = 30_000
+
+/** Offset in minutes for the initial cluster-down event */
+const CLUSTER_DOWN_OFFSET_MIN = 47
+
+/** Offset in minutes for the first binding reschedule */
+const BINDING_RESCHEDULE_1_OFFSET_MIN = 45
+
+/** Offset in minutes for the second binding reschedule */
+const BINDING_RESCHEDULE_2_OFFSET_MIN = 44
+
+/** Offset in minutes for replica rebalance */
+const REPLICA_REBALANCE_OFFSET_MIN = 40
+
+/** Offset in minutes for cluster recovery */
+const CLUSTER_RECOVERY_OFFSET_MIN = 12
+
+/** Offset in minutes for post-recovery rebalance */
+const RECOVERY_REBALANCE_OFFSET_MIN = 10
+
+/** Number of minutes per millisecond conversion factor */
+const MS_PER_MINUTE = 60_000
+
+export type FailoverEventType =
+  | 'cluster_down'
+  | 'binding_reschedule'
+  | 'cluster_recovery'
+  | 'replica_rebalance'
+
+export type FailoverSeverity = 'critical' | 'warning' | 'info'
+
+export interface FailoverEvent {
+  /** ISO-8601 timestamp of the event */
+  timestamp: string
+  /** Category of failover event */
+  eventType: FailoverEventType
+  /** Cluster involved in this event */
+  cluster: string
+  /** Workload affected (e.g. Deployment name) */
+  workload: string
+  /** Human-readable event description */
+  details: string
+  /** Severity for visual color coding */
+  severity: FailoverSeverity
+}
+
+export interface FailoverTimelineData {
+  /** Ordered list of failover events (newest first) */
+  events: FailoverEvent[]
+  /** Number of currently active (Ready) clusters */
+  activeClusters: number
+  /** Total number of clusters being monitored */
+  totalClusters: number
+  /** ISO-8601 timestamp of the most recent failover, or null if none */
+  lastFailover: string | null
+  /** ISO-8601 timestamp of the last data check */
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Demo entries
+// ---------------------------------------------------------------------------
+
+function minutesAgo(minutes: number): string {
+  return new Date(Date.now() - minutes * MS_PER_MINUTE).toISOString()
+}
+
+export const FAILOVER_TIMELINE_DEMO_DATA: FailoverTimelineData = {
+  events: [
+    {
+      timestamp: minutesAgo(RECOVERY_REBALANCE_OFFSET_MIN),
+      eventType: 'replica_rebalance',
+      cluster: 'member-ap-south',
+      workload: 'frontend',
+      details: 'Replicas rebalanced back to recovered cluster (2 of 6 replicas migrated)',
+      severity: 'info',
+    },
+    {
+      timestamp: minutesAgo(CLUSTER_RECOVERY_OFFSET_MIN),
+      eventType: 'cluster_recovery',
+      cluster: 'member-ap-south',
+      workload: '',
+      details: 'Cluster returned to Ready state after network partition resolved',
+      severity: 'info',
+    },
+    {
+      timestamp: minutesAgo(REPLICA_REBALANCE_OFFSET_MIN),
+      eventType: 'replica_rebalance',
+      cluster: 'member-us-east',
+      workload: 'frontend',
+      details: 'Replicas scaled up on healthy cluster (4 -> 6 replicas) to absorb failed cluster load',
+      severity: 'warning',
+    },
+    {
+      timestamp: minutesAgo(BINDING_RESCHEDULE_2_OFFSET_MIN),
+      eventType: 'binding_reschedule',
+      cluster: 'member-eu-west',
+      workload: 'backend-api',
+      details: 'ResourceBinding rescheduled from member-ap-south to member-eu-west',
+      severity: 'warning',
+    },
+    {
+      timestamp: minutesAgo(BINDING_RESCHEDULE_1_OFFSET_MIN),
+      eventType: 'binding_reschedule',
+      cluster: 'member-us-east',
+      workload: 'frontend',
+      details: 'ResourceBinding rescheduled from member-ap-south to member-us-east',
+      severity: 'warning',
+    },
+    {
+      timestamp: minutesAgo(CLUSTER_DOWN_OFFSET_MIN),
+      eventType: 'cluster_down',
+      cluster: 'member-ap-south',
+      workload: '',
+      details: 'Cluster transitioned to NotReady — network partition detected',
+      severity: 'critical',
+    },
+  ],
+  activeClusters: 4,
+  totalClusters: 4,
+  lastFailover: minutesAgo(CLUSTER_DOWN_OFFSET_MIN),
+  lastCheckTime: new Date(Date.now() - DEMO_LAST_CHECK_OFFSET_MS).toISOString(),
+}

--- a/web/src/components/cards/failover_timeline/index.ts
+++ b/web/src/components/cards/failover_timeline/index.ts
@@ -1,0 +1,1 @@
+export { FailoverTimeline } from './FailoverTimeline'

--- a/web/src/components/cards/failover_timeline/useFailoverTimeline.ts
+++ b/web/src/components/cards/failover_timeline/useFailoverTimeline.ts
@@ -1,0 +1,354 @@
+import { useCache } from '../../../lib/cache'
+import { useCardLoadingState } from '../CardDataContext'
+import { authFetch } from '../../../lib/api'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import {
+  FAILOVER_TIMELINE_DEMO_DATA,
+  type FailoverTimelineData,
+  type FailoverEvent,
+  type FailoverEventType,
+  type FailoverSeverity,
+} from './demoData'
+
+export type { FailoverTimelineData, FailoverEvent }
+
+/** Default count value when a field is missing or empty */
+const DEFAULT_COUNT = 0
+
+/** Window (in ms) for correlating a cluster NotReady event with binding reschedules */
+const CORRELATION_WINDOW_MS = 5 * 60 * 1_000
+
+const CACHE_KEY = 'failover-timeline'
+
+const INITIAL_DATA: FailoverTimelineData = {
+  events: [],
+  activeClusters: DEFAULT_COUNT,
+  totalClusters: DEFAULT_COUNT,
+  lastFailover: null,
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Backend response types
+// ---------------------------------------------------------------------------
+
+interface CRItem {
+  name: string
+  namespace?: string
+  cluster: string
+  status?: Record<string, unknown>
+  spec?: Record<string, unknown>
+  labels?: Record<string, string>
+}
+
+interface CRResponse {
+  items?: CRItem[]
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Safely extracts a Record from unknown */
+function getRecord(val: unknown): Record<string, unknown> {
+  if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+    return val as Record<string, unknown>
+  }
+  return {}
+}
+
+/** Safely extracts an Array from unknown */
+function getArray(val: unknown): unknown[] {
+  return Array.isArray(val) ? val : []
+}
+
+// ---------------------------------------------------------------------------
+// CRD fetcher (same pattern as karmada_status)
+// ---------------------------------------------------------------------------
+
+async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
+  try {
+    const params = new URLSearchParams({ group, version, resource })
+    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+    if (!resp.ok) return []
+    const body: CRResponse = await resp.json()
+    return body.items ?? []
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Condition parsing
+// ---------------------------------------------------------------------------
+
+interface ConditionTransition {
+  clusterName: string
+  type: string
+  status: string
+  lastTransitionTime: string
+}
+
+function parseClusterConditions(items: CRItem[]): ConditionTransition[] {
+  const transitions: ConditionTransition[] = []
+  for (const item of items) {
+    const statusObj = getRecord(item.status)
+    const conditions = getArray(statusObj.conditions)
+    for (const c of conditions) {
+      const cond = getRecord(c)
+      if (cond.type === 'Ready' && typeof cond.lastTransitionTime === 'string') {
+        transitions.push({
+          clusterName: item.name,
+          type: 'Ready',
+          status: String(cond.status ?? 'Unknown'),
+          lastTransitionTime: cond.lastTransitionTime,
+        })
+      }
+    }
+  }
+  return transitions
+}
+
+interface BindingTransition {
+  bindingName: string
+  namespace: string
+  resourceKind: string
+  clusters: string[]
+  scheduledTime: string | null
+  isRescheduled: boolean
+}
+
+function parseBindingTransitions(items: CRItem[]): BindingTransition[] {
+  const results: BindingTransition[] = []
+  for (const item of items) {
+    const spec = getRecord(item.spec)
+    const status = getRecord(item.status)
+    const conditions = getArray(status.conditions)
+
+    const resourceDef = getRecord(spec.resource)
+    const resourceKind = typeof resourceDef.kind === 'string' ? resourceDef.kind : ''
+
+    const specClusters = getArray(spec.clusters)
+    const boundClusters = specClusters.map(c => {
+      const obj = getRecord(c)
+      return typeof obj.name === 'string' ? obj.name : ''
+    }).filter(Boolean)
+
+    let scheduledTime: string | null = null
+    let isRescheduled = false
+
+    for (const c of conditions) {
+      const cond = getRecord(c)
+      if (cond.type === 'Scheduled' && cond.status === 'True' && typeof cond.lastTransitionTime === 'string') {
+        scheduledTime = cond.lastTransitionTime
+      }
+      // A binding with reason "Rescheduling" indicates failover
+      if (typeof cond.reason === 'string' && cond.reason.toLowerCase().includes('reschedul')) {
+        isRescheduled = true
+      }
+    }
+
+    results.push({
+      bindingName: item.name,
+      namespace: item.namespace ?? '',
+      resourceKind,
+      clusters: boundClusters,
+      scheduledTime,
+      isRescheduled,
+    })
+  }
+  return results
+}
+
+// ---------------------------------------------------------------------------
+// Event correlation
+// ---------------------------------------------------------------------------
+
+function correlateEvents(
+  clusterTransitions: ConditionTransition[],
+  bindingTransitions: BindingTransition[],
+): FailoverEvent[] {
+  const events: FailoverEvent[] = []
+
+  // Identify cluster down/recovery events
+  for (const ct of clusterTransitions) {
+    const transitionMs = new Date(ct.lastTransitionTime).getTime()
+    if (isNaN(transitionMs)) continue
+
+    if (ct.status === 'False' || ct.status === 'Unknown') {
+      // Cluster went down
+      events.push({
+        timestamp: ct.lastTransitionTime,
+        eventType: 'cluster_down' as FailoverEventType,
+        cluster: ct.clusterName,
+        workload: '',
+        details: `Cluster transitioned to ${ct.status === 'False' ? 'NotReady' : 'Unknown'} state`,
+        severity: 'critical' as FailoverSeverity,
+      })
+
+      // Find binding reschedules within the correlation window
+      for (const bt of bindingTransitions) {
+        if (!bt.scheduledTime) continue
+        const bindingMs = new Date(bt.scheduledTime).getTime()
+        if (isNaN(bindingMs)) continue
+
+        const delta = bindingMs - transitionMs
+        if (delta >= 0 && delta <= CORRELATION_WINDOW_MS) {
+          const targetCluster = bt.clusters.length > 0 ? bt.clusters[0] : 'unknown'
+          events.push({
+            timestamp: bt.scheduledTime,
+            eventType: 'binding_reschedule' as FailoverEventType,
+            cluster: targetCluster,
+            workload: bt.resourceKind ? `${bt.resourceKind}/${bt.bindingName}` : bt.bindingName,
+            details: `ResourceBinding rescheduled from ${ct.clusterName} to ${targetCluster}`,
+            severity: 'warning' as FailoverSeverity,
+          })
+        }
+      }
+    } else if (ct.status === 'True') {
+      // Cluster recovered
+      events.push({
+        timestamp: ct.lastTransitionTime,
+        eventType: 'cluster_recovery' as FailoverEventType,
+        cluster: ct.clusterName,
+        workload: '',
+        details: 'Cluster returned to Ready state',
+        severity: 'info' as FailoverSeverity,
+      })
+    }
+  }
+
+  // Identify standalone rescheduled bindings not already correlated
+  for (const bt of bindingTransitions) {
+    if (!bt.isRescheduled || !bt.scheduledTime) continue
+    const bindingMs = new Date(bt.scheduledTime).getTime()
+    if (isNaN(bindingMs)) continue
+
+    const alreadyCorrelated = events.some(
+      e => e.eventType === 'binding_reschedule' && e.timestamp === bt.scheduledTime,
+    )
+    if (alreadyCorrelated) continue
+
+    const targetCluster = bt.clusters.length > 0 ? bt.clusters[0] : 'unknown'
+    events.push({
+      timestamp: bt.scheduledTime,
+      eventType: 'binding_reschedule' as FailoverEventType,
+      cluster: targetCluster,
+      workload: bt.resourceKind ? `${bt.resourceKind}/${bt.bindingName}` : bt.bindingName,
+      details: `ResourceBinding rescheduled to ${targetCluster}`,
+      severity: 'warning' as FailoverSeverity,
+    })
+  }
+
+  // Sort newest first
+  events.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+
+  return events
+}
+
+// ---------------------------------------------------------------------------
+// Main fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchFailoverTimeline(): Promise<FailoverTimelineData> {
+  const [clusterItems, bindingItems] = await Promise.all([
+    fetchCR('cluster.karmada.io', 'v1alpha1', 'clusters'),
+    fetchCR('work.karmada.io', 'v1alpha2', 'resourcebindings'),
+  ])
+
+  if (clusterItems.length === 0 && bindingItems.length === 0) {
+    return {
+      ...INITIAL_DATA,
+      lastCheckTime: new Date().toISOString(),
+    }
+  }
+
+  const clusterTransitions = parseClusterConditions(clusterItems)
+  const bindingTransitions = parseBindingTransitions(bindingItems)
+
+  const events = correlateEvents(clusterTransitions, bindingTransitions)
+
+  // Count active (Ready) clusters
+  const readyClusters = new Set<string>()
+  const allClusters = new Set<string>()
+  for (const ct of clusterTransitions) {
+    allClusters.add(ct.clusterName)
+    if (ct.status === 'True') {
+      readyClusters.add(ct.clusterName)
+    }
+  }
+  // Also count clusters with no condition transitions
+  for (const item of clusterItems) {
+    allClusters.add(item.name)
+  }
+
+  const lastFailover = events.find(e => e.eventType === 'cluster_down')?.timestamp ?? null
+
+  return {
+    events,
+    activeClusters: readyClusters.size,
+    totalClusters: allClusters.size,
+    lastFailover,
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface UseFailoverTimelineResult {
+  data: FailoverTimelineData
+  loading: boolean
+  isRefreshing: boolean
+  error: boolean
+  consecutiveFailures: number
+  showSkeleton: boolean
+  showEmptyState: boolean
+  isDemoFallback: boolean
+}
+
+export function useFailoverTimeline(): UseFailoverTimelineResult {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+  } = useCache<FailoverTimelineData>({
+    key: CACHE_KEY,
+    category: 'default',
+    initialData: INITIAL_DATA,
+    demoData: FAILOVER_TIMELINE_DEMO_DATA,
+    persist: true,
+    fetcher: fetchFailoverTimeline,
+  })
+
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  const hasAnyData = (data.events || []).length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+  })
+
+  return {
+    data,
+    loading: isLoading,
+    isRefreshing,
+    error: isFailed && !hasAnyData,
+    consecutiveFailures,
+    showSkeleton,
+    showEmptyState,
+    isDemoFallback: effectiveIsDemoData,
+  }
+}

--- a/web/src/components/cards/kuberay_fleet/KubeRayFleet.tsx
+++ b/web/src/components/cards/kuberay_fleet/KubeRayFleet.tsx
@@ -1,0 +1,180 @@
+/**
+ * KubeRay Fleet Monitor — discovers RayCluster, RayService, and RayJob
+ * CRDs across all connected clusters and shows fleet-level Ray status.
+ */
+
+import { useTranslation } from 'react-i18next'
+import {
+  Cpu, Layers, PlayCircle, Server,
+  CheckCircle2, XCircle, Clock, AlertTriangle, ArrowUpCircle,
+} from 'lucide-react'
+import { Skeleton } from '../../ui/Skeleton'
+import { useKubeRayFleet } from './useKubeRayFleet'
+import type { RayClusterState, RayJobStatus, RayServiceStatus } from './demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CLUSTER_STATE_COLORS: Record<RayClusterState, string> = {
+  ready: 'text-green-400',
+  unhealthy: 'text-red-400',
+  suspended: 'text-yellow-400',
+  unknown: 'text-muted-foreground',
+}
+
+const JOB_STATUS_ICONS: Record<RayJobStatus, { Icon: typeof CheckCircle2; color: string }> = {
+  RUNNING: { Icon: PlayCircle, color: 'text-blue-400' },
+  SUCCEEDED: { Icon: CheckCircle2, color: 'text-green-400' },
+  FAILED: { Icon: XCircle, color: 'text-red-400' },
+  PENDING: { Icon: Clock, color: 'text-yellow-400' },
+  STOPPED: { Icon: XCircle, color: 'text-muted-foreground' },
+}
+
+const SERVICE_STATUS_COLORS: Record<RayServiceStatus, string> = {
+  Running: 'text-green-400',
+  Deploying: 'text-blue-400',
+  FailedToGetOrCreateRayCluster: 'text-red-400',
+  WaitForServeDeploymentReady: 'text-yellow-400',
+  Unknown: 'text-muted-foreground',
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function KubeRayFleet() {
+  const { t } = useTranslation('cards')
+  const { data, showSkeleton, showEmptyState } = useKubeRayFleet()
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-3 p-1">
+        <div className="grid grid-cols-4 gap-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" height={48} />
+          ))}
+        </div>
+        <Skeleton variant="rounded" height={120} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Layers className="w-8 h-8 opacity-40" />
+        <p className="text-sm">{t('kuberayFleet.notDetected', 'KubeRay not detected')}</p>
+        <p className="text-xs opacity-60">{t('kuberayFleet.notDetectedHint', 'Install KubeRay operator to see Ray clusters')}</p>
+      </div>
+    )
+  }
+
+  const rayClusters = data.rayClusters || []
+  const rayServices = data.rayServices || []
+  const rayJobs = data.rayJobs || []
+
+  const readyClusters = rayClusters.filter(c => c.state === 'ready').length
+  const totalWorkers = rayClusters.reduce((s, c) => s + c.availableWorkers, 0)
+  const runningJobs = rayJobs.filter(j => j.jobStatus === 'RUNNING').length
+  const servingEndpoints = rayServices.filter(s => s.status === 'Running').length
+
+  return (
+    <div className="h-full flex flex-col min-h-card gap-3 p-1 overflow-hidden">
+      {/* Fleet summary tiles */}
+      <div className="grid grid-cols-4 gap-2">
+        <StatTile icon={Server} label="Clusters" value={`${readyClusters}/${rayClusters.length}`} color="text-blue-400" />
+        <StatTile icon={Cpu} label="Workers" value={String(totalWorkers)} color="text-purple-400" />
+        <StatTile icon={Layers} label="GPUs" value={String(data.totalGPUs)} color="text-green-400" />
+        <StatTile icon={PlayCircle} label="Jobs" value={String(runningJobs)} color="text-yellow-400" />
+      </div>
+
+      {/* Ray Clusters */}
+      <div className="flex-1 overflow-y-auto space-y-2 min-h-0">
+        {rayClusters.length > 0 && (
+          <Section title={`Ray Clusters (${rayClusters.length})`}>
+            {rayClusters.map(c => (
+              <div key={`${c.cluster}/${c.namespace}/${c.name}`} className="flex items-center justify-between px-2 py-1.5 rounded bg-secondary/30 text-xs">
+                <div className="flex items-center gap-2 min-w-0">
+                  <div className={`w-1.5 h-1.5 rounded-full ${c.state === 'ready' ? 'bg-green-500' : c.state === 'unhealthy' ? 'bg-red-500' : 'bg-yellow-500'}`} />
+                  <span className="truncate font-mono">{c.name}</span>
+                  <span className="text-muted-foreground truncate">@{c.cluster}</span>
+                </div>
+                <div className="flex items-center gap-3 text-muted-foreground flex-shrink-0">
+                  <span>{c.availableWorkers}/{c.desiredWorkers} workers</span>
+                  {c.gpuCount > 0 && <span className="text-green-400">{c.gpuCount} GPU</span>}
+                  <span className={CLUSTER_STATE_COLORS[c.state]}>{c.state}</span>
+                </div>
+              </div>
+            ))}
+          </Section>
+        )}
+
+        {/* Ray Services */}
+        {rayServices.length > 0 && (
+          <Section title={`Serving Endpoints (${servingEndpoints}/${rayServices.length})`}>
+            {rayServices.map(s => (
+              <div key={`${s.cluster}/${s.namespace}/${s.name}`} className="flex items-center justify-between px-2 py-1.5 rounded bg-secondary/30 text-xs">
+                <div className="flex items-center gap-2 min-w-0">
+                  <ArrowUpCircle className={`w-3 h-3 flex-shrink-0 ${SERVICE_STATUS_COLORS[s.status]}`} />
+                  <span className="truncate font-mono">{s.name}</span>
+                  <span className="text-muted-foreground truncate">@{s.cluster}</span>
+                </div>
+                <div className="flex items-center gap-2 text-muted-foreground flex-shrink-0">
+                  {s.pendingUpgrade && (
+                    <span className="text-yellow-400 flex items-center gap-1">
+                      <AlertTriangle className="w-3 h-3" /> upgrade pending
+                    </span>
+                  )}
+                  <span className={SERVICE_STATUS_COLORS[s.status]}>{s.status}</span>
+                </div>
+              </div>
+            ))}
+          </Section>
+        )}
+
+        {/* Ray Jobs */}
+        {rayJobs.length > 0 && (
+          <Section title={`Jobs (${rayJobs.length})`}>
+            {rayJobs.map(j => {
+              const { Icon, color } = JOB_STATUS_ICONS[j.jobStatus] || JOB_STATUS_ICONS.PENDING
+              return (
+                <div key={`${j.cluster}/${j.namespace}/${j.name}`} className="flex items-center justify-between px-2 py-1.5 rounded bg-secondary/30 text-xs">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Icon className={`w-3 h-3 flex-shrink-0 ${color}`} />
+                    <span className="truncate font-mono">{j.name}</span>
+                    <span className="text-muted-foreground truncate">@{j.cluster}</span>
+                  </div>
+                  <span className={`flex-shrink-0 ${color}`}>{j.jobStatus}</span>
+                </div>
+              )
+            })}
+          </Section>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StatTile({ icon: Icon, label, value, color }: { icon: typeof Server; label: string; value: string; color: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-2 px-1 rounded-lg bg-secondary/30 border border-border/50">
+      <Icon className={`w-4 h-4 mb-1 ${color}`} />
+      <span className="text-lg font-bold text-foreground">{value}</span>
+      <span className="text-2xs text-muted-foreground">{label}</span>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h4 className="text-xs font-medium text-muted-foreground mb-1">{title}</h4>
+      <div className="space-y-1">{children}</div>
+    </div>
+  )
+}

--- a/web/src/components/cards/kuberay_fleet/demoData.ts
+++ b/web/src/components/cards/kuberay_fleet/demoData.ts
@@ -1,0 +1,141 @@
+/**
+ * Demo data and type definitions for the KubeRay Fleet Monitor card.
+ *
+ * Discovers RayCluster, RayService, and RayJob CRDs across all clusters
+ * and aggregates fleet-level Ray workload status.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RayClusterState = 'ready' | 'unhealthy' | 'suspended' | 'unknown'
+export type RayJobStatus = 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'PENDING' | 'STOPPED'
+export type RayServiceStatus = 'Running' | 'Deploying' | 'FailedToGetOrCreateRayCluster' | 'WaitForServeDeploymentReady' | 'Unknown'
+
+export interface RayClusterInfo {
+  name: string
+  namespace: string
+  cluster: string
+  state: RayClusterState
+  desiredWorkers: number
+  availableWorkers: number
+  headPodIP: string
+  gpuCount: number
+}
+
+export interface RayServiceInfo {
+  name: string
+  namespace: string
+  cluster: string
+  status: RayServiceStatus
+  activeClusterName: string
+  pendingUpgrade: boolean
+}
+
+export interface RayJobInfo {
+  name: string
+  namespace: string
+  cluster: string
+  jobStatus: RayJobStatus
+  submissionId: string
+}
+
+export interface KubeRayFleetData {
+  detected: boolean
+  rayClusters: RayClusterInfo[]
+  rayServices: RayServiceInfo[]
+  rayJobs: RayJobInfo[]
+  totalGPUs: number
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEMO_LAST_CHECK_AGE_MS = 45_000
+const DEMO_GPU_TOTAL = 24
+
+// ---------------------------------------------------------------------------
+// Demo Data
+// ---------------------------------------------------------------------------
+
+export const KUBERAY_FLEET_DEMO_DATA: KubeRayFleetData = {
+  detected: true,
+  rayClusters: [
+    {
+      name: 'llm-serve-cluster',
+      namespace: 'ml-inference',
+      cluster: 'us-east-prod',
+      state: 'ready',
+      desiredWorkers: 4,
+      availableWorkers: 4,
+      headPodIP: '10.0.5.12',
+      gpuCount: 8,
+    },
+    {
+      name: 'llm-serve-cluster',
+      namespace: 'ml-inference',
+      cluster: 'eu-west-prod',
+      state: 'ready',
+      desiredWorkers: 3,
+      availableWorkers: 3,
+      headPodIP: '10.1.2.8',
+      gpuCount: 6,
+    },
+    {
+      name: 'batch-training',
+      namespace: 'ml-training',
+      cluster: 'us-east-prod',
+      state: 'ready',
+      desiredWorkers: 8,
+      availableWorkers: 6,
+      headPodIP: '10.0.7.22',
+      gpuCount: 10,
+    },
+  ],
+  rayServices: [
+    {
+      name: 'text-generation-svc',
+      namespace: 'ml-inference',
+      cluster: 'us-east-prod',
+      status: 'Running',
+      activeClusterName: 'llm-serve-cluster',
+      pendingUpgrade: false,
+    },
+    {
+      name: 'text-generation-svc',
+      namespace: 'ml-inference',
+      cluster: 'eu-west-prod',
+      status: 'Running',
+      activeClusterName: 'llm-serve-cluster',
+      pendingUpgrade: true,
+    },
+  ],
+  rayJobs: [
+    {
+      name: 'fine-tune-llama-3',
+      namespace: 'ml-training',
+      cluster: 'us-east-prod',
+      jobStatus: 'RUNNING',
+      submissionId: 'raysubmit_abc123',
+    },
+    {
+      name: 'eval-benchmark-v2',
+      namespace: 'ml-training',
+      cluster: 'us-east-prod',
+      jobStatus: 'SUCCEEDED',
+      submissionId: 'raysubmit_def456',
+    },
+    {
+      name: 'embedding-index-rebuild',
+      namespace: 'ml-inference',
+      cluster: 'eu-west-prod',
+      jobStatus: 'PENDING',
+      submissionId: 'raysubmit_ghi789',
+    },
+  ],
+  totalGPUs: DEMO_GPU_TOTAL,
+  lastCheckTime: new Date(Date.now() - DEMO_LAST_CHECK_AGE_MS).toISOString(),
+}

--- a/web/src/components/cards/kuberay_fleet/index.ts
+++ b/web/src/components/cards/kuberay_fleet/index.ts
@@ -1,0 +1,1 @@
+export { KubeRayFleet } from './KubeRayFleet'

--- a/web/src/components/cards/kuberay_fleet/useKubeRayFleet.ts
+++ b/web/src/components/cards/kuberay_fleet/useKubeRayFleet.ts
@@ -1,0 +1,241 @@
+/**
+ * Data-fetching hook for the KubeRay Fleet Monitor card.
+ *
+ * Discovers RayCluster, RayService, and RayJob CRDs across all connected
+ * clusters using the existing /api/mcp/custom-resources endpoint.
+ */
+
+import { useCache } from '../../../lib/cache'
+import { useCardLoadingState } from '../CardDataContext'
+import { authFetch } from '../../../lib/api'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import {
+  KUBERAY_FLEET_DEMO_DATA,
+  type KubeRayFleetData,
+  type RayClusterInfo,
+  type RayClusterState,
+  type RayServiceInfo,
+  type RayServiceStatus,
+  type RayJobInfo,
+  type RayJobStatus,
+} from './demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'kuberay-fleet-status'
+const RAY_API_GROUP = 'ray.io'
+const RAY_API_VERSION = 'v1'
+
+const INITIAL_DATA: KubeRayFleetData = {
+  detected: false,
+  rayClusters: [],
+  rayServices: [],
+  rayJobs: [],
+  totalGPUs: 0,
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Backend response types
+// ---------------------------------------------------------------------------
+
+interface CRItem {
+  name: string
+  namespace?: string
+  cluster: string
+  status?: Record<string, unknown>
+  spec?: Record<string, unknown>
+  labels?: Record<string, string>
+}
+
+interface CRResponse {
+  items?: CRItem[]
+}
+
+// ---------------------------------------------------------------------------
+// CRD fetch helper (same pattern as karmada_status)
+// ---------------------------------------------------------------------------
+
+async function fetchCR(group: string, version: string, resource: string): Promise<CRItem[]> {
+  try {
+    const params = new URLSearchParams({ group, version, resource })
+    const resp = await authFetch(`/api/mcp/custom-resources?${params}`, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+    if (!resp.ok) return []
+    const body: CRResponse = await resp.json()
+    return body.items ?? []
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Safe accessors
+// ---------------------------------------------------------------------------
+
+function getRecord(val: unknown): Record<string, unknown> {
+  if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+    return val as Record<string, unknown>
+  }
+  return {}
+}
+
+function safeNumber(val: unknown, fallback = 0): number {
+  return typeof val === 'number' ? val : fallback
+}
+
+function safeString(val: unknown, fallback = ''): string {
+  return typeof val === 'string' ? val : fallback
+}
+
+// ---------------------------------------------------------------------------
+// CRD parsers
+// ---------------------------------------------------------------------------
+
+function parseRayCluster(item: CRItem): RayClusterInfo {
+  const status = getRecord(item.status)
+  const spec = getRecord(item.spec)
+  const workerSpecs = Array.isArray(spec.workerGroupSpecs) ? spec.workerGroupSpecs : []
+
+  let gpuCount = 0
+  for (const wg of workerSpecs) {
+    const wgObj = getRecord(wg)
+    const replicas = safeNumber(wgObj.replicas, 1)
+    const template = getRecord(getRecord(wgObj.template).spec)
+    const containers = Array.isArray(template.containers) ? template.containers : []
+    for (const c of containers) {
+      const limits = getRecord(getRecord(getRecord(c).resources).limits)
+      const gpuVal = limits['nvidia.com/gpu']
+      if (gpuVal) gpuCount += safeNumber(gpuVal) * replicas
+    }
+  }
+
+  const stateStr = safeString(status.state).toLowerCase()
+  let state: RayClusterState = 'unknown'
+  if (stateStr === 'ready') state = 'ready'
+  else if (stateStr === 'unhealthy' || stateStr === 'failed') state = 'unhealthy'
+  else if (stateStr === 'suspended') state = 'suspended'
+
+  const head = getRecord(status.head)
+
+  return {
+    name: item.name,
+    namespace: item.namespace ?? 'default',
+    cluster: item.cluster,
+    state,
+    desiredWorkers: safeNumber(status.desiredWorkerReplicas),
+    availableWorkers: safeNumber(status.availableWorkerReplicas),
+    headPodIP: safeString(head.podIP),
+    gpuCount,
+  }
+}
+
+function parseRayService(item: CRItem): RayServiceInfo {
+  const status = getRecord(item.status)
+  const activeStatus = getRecord(status.activeServiceStatus)
+  const pendingStatus = getRecord(status.pendingServiceStatus)
+  const rayClusterStatus = getRecord(activeStatus.rayClusterStatus)
+
+  const statusStr = safeString(status.serviceStatus) as RayServiceStatus
+  const validStatuses: RayServiceStatus[] = ['Running', 'Deploying', 'FailedToGetOrCreateRayCluster', 'WaitForServeDeploymentReady']
+
+  return {
+    name: item.name,
+    namespace: item.namespace ?? 'default',
+    cluster: item.cluster,
+    status: validStatuses.includes(statusStr) ? statusStr : 'Unknown',
+    activeClusterName: safeString(rayClusterStatus.rayClusterName),
+    pendingUpgrade: Object.keys(pendingStatus).length > 0,
+  }
+}
+
+function parseRayJob(item: CRItem): RayJobInfo {
+  const status = getRecord(item.status)
+  const jobStatusStr = safeString(status.jobStatus) as RayJobStatus
+  const validStatuses: RayJobStatus[] = ['RUNNING', 'SUCCEEDED', 'FAILED', 'PENDING', 'STOPPED']
+
+  return {
+    name: item.name,
+    namespace: item.namespace ?? 'default',
+    cluster: item.cluster,
+    jobStatus: validStatuses.includes(jobStatusStr) ? jobStatusStr : 'PENDING',
+    submissionId: safeString(status.jobId),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Live data fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchKubeRayFleet(): Promise<KubeRayFleetData> {
+  const [clusters, services, jobs] = await Promise.all([
+    fetchCR(RAY_API_GROUP, RAY_API_VERSION, 'rayclusters'),
+    fetchCR(RAY_API_GROUP, RAY_API_VERSION, 'rayservices'),
+    fetchCR(RAY_API_GROUP, RAY_API_VERSION, 'rayjobs'),
+  ])
+
+  const detected = clusters.length > 0 || services.length > 0 || jobs.length > 0
+  if (!detected) throw new Error('No Ray resources detected')
+
+  const rayClusters = clusters.map(parseRayCluster)
+  const rayServices = services.map(parseRayService)
+  const rayJobs = jobs.map(parseRayJob)
+  const totalGPUs = rayClusters.reduce((sum, c) => sum + c.gpuCount, 0)
+
+  return {
+    detected: true,
+    rayClusters,
+    rayServices,
+    rayJobs,
+    totalGPUs,
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useKubeRayFleet() {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+  } = useCache<KubeRayFleetData>({
+    key: CACHE_KEY,
+    category: 'default',
+    initialData: INITIAL_DATA,
+    demoData: KUBERAY_FLEET_DEMO_DATA,
+    persist: true,
+    fetcher: fetchKubeRayFleet,
+  })
+
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  const hasAnyData = data.detected
+    ? ((data.rayClusters || []).length > 0 || (data.rayServices || []).length > 0 || (data.rayJobs || []).length > 0)
+    : !isFailed // "not detected" is a valid state
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+  })
+
+  return {
+    data,
+    showSkeleton,
+    showEmptyState,
+    error: isFailed && !hasAnyData,
+  }
+}

--- a/web/src/components/cards/slo_compliance/SLOCompliance.tsx
+++ b/web/src/components/cards/slo_compliance/SLOCompliance.tsx
@@ -1,0 +1,237 @@
+/**
+ * SLO Compliance Tracker — displays Service Level Objective compliance
+ * with donut gauges for budget remaining, burn rate indicators, and
+ * per-target compliance rows.
+ */
+
+import { Target, TrendingDown, TrendingUp, Shield } from 'lucide-react'
+import { Skeleton } from '../../ui/Skeleton'
+import { useSLOCompliance } from './useSLOCompliance'
+import type { SLOTarget } from './demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Thresholds for gauge coloring (percentage of budget remaining) */
+const BUDGET_GREEN_THRESHOLD = 50
+const BUDGET_YELLOW_THRESHOLD = 20
+
+/** SVG gauge dimensions */
+const GAUGE_SIZE = 64
+const GAUGE_STROKE_WIDTH = 6
+const GAUGE_RADIUS = (GAUGE_SIZE - GAUGE_STROKE_WIDTH) / 2
+const GAUGE_CIRCUMFERENCE = 2 * Math.PI * GAUGE_RADIUS
+const GAUGE_VIEW_BOX = `0 0 ${GAUGE_SIZE} ${GAUGE_SIZE}`
+const GAUGE_CENTER = GAUGE_SIZE / 2
+
+/** Burn rate thresholds */
+const BURN_RATE_NORMAL = 1.0
+const BURN_RATE_WARNING = 2.0
+const FULL_COMPLIANCE = 100
+
+/** Skeleton layout */
+const SKELETON_GAUGE_COUNT = 3
+const SKELETON_GAUGE_HEIGHT = 64
+const SKELETON_ROW_COUNT = 3
+const SKELETON_ROW_HEIGHT = 32
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getBudgetColor(remaining: number): string {
+  if (remaining > BUDGET_GREEN_THRESHOLD) return 'text-green-400'
+  if (remaining > BUDGET_YELLOW_THRESHOLD) return 'text-yellow-400'
+  return 'text-red-400'
+}
+
+function getBudgetStrokeColor(remaining: number): string {
+  if (remaining > BUDGET_GREEN_THRESHOLD) return 'stroke-green-400'
+  if (remaining > BUDGET_YELLOW_THRESHOLD) return 'stroke-yellow-400'
+  return 'stroke-red-400'
+}
+
+function calculateBurnRate(target: SLOTarget): number {
+  const budgetUsed = FULL_COMPLIANCE - target.currentCompliance
+  const budgetAllowed = FULL_COMPLIANCE - target.threshold
+  if (budgetAllowed <= 0) return 0
+  return budgetUsed / budgetAllowed
+}
+
+function formatBurnRate(rate: number): string {
+  return `${rate.toFixed(1)}x burn rate`
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function SLOCompliance() {
+  const { data, showSkeleton, showEmptyState } = useSLOCompliance()
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-3 p-1">
+        <div className="flex justify-center gap-4">
+          {Array.from({ length: SKELETON_GAUGE_COUNT }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" height={SKELETON_GAUGE_HEIGHT} className="w-16" />
+          ))}
+        </div>
+        <div className="space-y-2">
+          {Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" height={SKELETON_ROW_HEIGHT} />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Shield className="w-8 h-8 opacity-40" />
+        <p className="text-sm">No SLO targets configured</p>
+        <p className="text-xs opacity-60">Configure SLO targets via Prometheus to track compliance</p>
+      </div>
+    )
+  }
+
+  const targets = data.targets || []
+  const overallBudgetRemaining = data.overallBudgetRemaining ?? 0
+
+  return (
+    <div className="h-full flex flex-col min-h-card gap-3 p-1 overflow-hidden">
+      {/* Overall budget + per-target gauges */}
+      <div className="flex items-center justify-center gap-4">
+        {(targets || []).map((target) => {
+          const budgetRemaining = FULL_COMPLIANCE - (FULL_COMPLIANCE - target.currentCompliance)
+          const burnRate = calculateBurnRate(target)
+          return (
+            <DonutGauge
+              key={target.metric}
+              label={target.name.split(' ').slice(0, 2).join(' ')}
+              value={budgetRemaining}
+              burnRate={burnRate}
+            />
+          )
+        })}
+      </div>
+
+      {/* Overall budget remaining bar */}
+      <div className="flex items-center gap-2 px-2 py-1.5 rounded bg-secondary/30">
+        <Shield className={`w-4 h-4 flex-shrink-0 ${getBudgetColor(overallBudgetRemaining)}`} />
+        <span className="text-xs text-muted-foreground">Overall Error Budget</span>
+        <div className="flex-1 h-1.5 rounded-full bg-secondary overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all ${
+              overallBudgetRemaining > BUDGET_GREEN_THRESHOLD
+                ? 'bg-green-400'
+                : overallBudgetRemaining > BUDGET_YELLOW_THRESHOLD
+                  ? 'bg-yellow-400'
+                  : 'bg-red-400'
+            }`}
+            style={{ width: `${Math.min(overallBudgetRemaining, FULL_COMPLIANCE)}%` }}
+          />
+        </div>
+        <span className={`text-xs font-medium ${getBudgetColor(overallBudgetRemaining)}`}>
+          {overallBudgetRemaining.toFixed(1)}%
+        </span>
+      </div>
+
+      {/* Per-target compliance rows */}
+      <div className="flex-1 overflow-y-auto space-y-1 min-h-0">
+        {(targets || []).map((target) => {
+          const burnRate = calculateBurnRate(target)
+          const isOverBurning = burnRate > BURN_RATE_NORMAL
+          return (
+            <div
+              key={target.metric}
+              className="flex items-center justify-between px-2 py-1.5 rounded bg-secondary/30 text-xs"
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <Target className={`w-3 h-3 flex-shrink-0 ${getBudgetColor(target.currentCompliance)}`} />
+                <span className="truncate font-medium">{target.name}</span>
+              </div>
+              <div className="flex items-center gap-3 text-muted-foreground flex-shrink-0">
+                <span className="text-2xs">
+                  {target.unit === 'ms' ? `< ${target.threshold}${target.unit}` : `${target.threshold}${target.unit}`}
+                </span>
+                <span className={getBudgetColor(target.currentCompliance)}>
+                  {target.currentCompliance.toFixed(1)}%
+                </span>
+                <span className={`flex items-center gap-0.5 ${isOverBurning ? 'text-red-400' : 'text-green-400'}`}>
+                  {isOverBurning
+                    ? <TrendingUp className="w-3 h-3" />
+                    : <TrendingDown className="w-3 h-3" />}
+                  <span className="text-2xs">{formatBurnRate(burnRate)}</span>
+                </span>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function DonutGauge({
+  label,
+  value,
+  burnRate,
+}: {
+  label: string
+  value: number
+  burnRate: number
+}) {
+  const clampedValue = Math.max(0, Math.min(FULL_COMPLIANCE, value))
+  const dashOffset = GAUGE_CIRCUMFERENCE * (1 - clampedValue / FULL_COMPLIANCE)
+  const strokeColor = getBudgetStrokeColor(clampedValue)
+  const isOverBurning = burnRate > BURN_RATE_NORMAL
+  const isHighBurn = burnRate > BURN_RATE_WARNING
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div className="relative" style={{ width: GAUGE_SIZE, height: GAUGE_SIZE }}>
+        <svg viewBox={GAUGE_VIEW_BOX} className="w-full h-full -rotate-90">
+          {/* Background track */}
+          <circle
+            cx={GAUGE_CENTER}
+            cy={GAUGE_CENTER}
+            r={GAUGE_RADIUS}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={GAUGE_STROKE_WIDTH}
+            className="text-secondary"
+          />
+          {/* Value arc */}
+          <circle
+            cx={GAUGE_CENTER}
+            cy={GAUGE_CENTER}
+            r={GAUGE_RADIUS}
+            fill="none"
+            strokeWidth={GAUGE_STROKE_WIDTH}
+            strokeLinecap="round"
+            strokeDasharray={GAUGE_CIRCUMFERENCE}
+            strokeDashoffset={dashOffset}
+            className={`${strokeColor} transition-all duration-500`}
+          />
+        </svg>
+        {/* Center text */}
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className={`text-xs font-bold ${getBudgetColor(clampedValue)}`}>
+            {clampedValue.toFixed(0)}%
+          </span>
+        </div>
+      </div>
+      <span className="text-2xs text-muted-foreground text-center truncate max-w-16">{label}</span>
+      <span className={`text-2xs ${isHighBurn ? 'text-red-400' : isOverBurning ? 'text-yellow-400' : 'text-green-400'}`}>
+        {formatBurnRate(burnRate)}
+      </span>
+    </div>
+  )
+}

--- a/web/src/components/cards/slo_compliance/demoData.ts
+++ b/web/src/components/cards/slo_compliance/demoData.ts
@@ -1,0 +1,77 @@
+/**
+ * Demo data and type definitions for the SLO Compliance Tracker card.
+ *
+ * Tracks Service Level Objective compliance across inference workloads,
+ * showing budget burn rates and compliance percentages per target.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SLOTarget {
+  name: string
+  metric: string
+  threshold: number
+  unit: string
+  window: string
+  currentCompliance: number
+}
+
+export interface SLOComplianceData {
+  targets: SLOTarget[]
+  overallBudgetRemaining: number
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEMO_LAST_CHECK_AGE_MS = 30_000
+
+const DEMO_LATENCY_THRESHOLD = 500
+const DEMO_LATENCY_COMPLIANCE = 97.2
+
+const DEMO_ERROR_RATE_THRESHOLD = 0.1
+const DEMO_ERROR_RATE_COMPLIANCE = 99.8
+
+const DEMO_AVAILABILITY_THRESHOLD = 99.9
+const DEMO_AVAILABILITY_COMPLIANCE = 99.95
+
+const DEMO_OVERALL_BUDGET_REMAINING = 72.5
+
+// ---------------------------------------------------------------------------
+// Demo Data
+// ---------------------------------------------------------------------------
+
+export const SLO_COMPLIANCE_DEMO_DATA: SLOComplianceData = {
+  targets: [
+    {
+      name: 'Inference P99 Latency',
+      metric: 'inference_latency_p99_ms',
+      threshold: DEMO_LATENCY_THRESHOLD,
+      unit: 'ms',
+      window: '30d',
+      currentCompliance: DEMO_LATENCY_COMPLIANCE,
+    },
+    {
+      name: 'Error Rate',
+      metric: 'inference_error_rate',
+      threshold: DEMO_ERROR_RATE_THRESHOLD,
+      unit: '%',
+      window: '30d',
+      currentCompliance: DEMO_ERROR_RATE_COMPLIANCE,
+    },
+    {
+      name: 'Availability',
+      metric: 'service_availability',
+      threshold: DEMO_AVAILABILITY_THRESHOLD,
+      unit: '%',
+      window: '30d',
+      currentCompliance: DEMO_AVAILABILITY_COMPLIANCE,
+    },
+  ],
+  overallBudgetRemaining: DEMO_OVERALL_BUDGET_REMAINING,
+  lastCheckTime: new Date(Date.now() - DEMO_LAST_CHECK_AGE_MS).toISOString(),
+}

--- a/web/src/components/cards/slo_compliance/index.ts
+++ b/web/src/components/cards/slo_compliance/index.ts
@@ -1,0 +1,1 @@
+export { SLOCompliance } from './SLOCompliance'

--- a/web/src/components/cards/slo_compliance/useSLOCompliance.ts
+++ b/web/src/components/cards/slo_compliance/useSLOCompliance.ts
@@ -1,0 +1,183 @@
+/**
+ * Data-fetching hook for the SLO Compliance Tracker card.
+ *
+ * Queries Prometheus metrics via the agent proxy to calculate SLO compliance
+ * percentages and error budget burn rates. Falls back to demo data when
+ * the backend is unavailable.
+ */
+
+import { useCache } from '../../../lib/cache'
+import { useCardLoadingState } from '../CardDataContext'
+import { authFetch } from '../../../lib/api'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import {
+  SLO_COMPLIANCE_DEMO_DATA,
+  type SLOComplianceData,
+  type SLOTarget,
+} from './demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'slo-compliance-status'
+
+const INITIAL_DATA: SLOComplianceData = {
+  targets: [],
+  overallBudgetRemaining: 0,
+  lastCheckTime: new Date().toISOString(),
+}
+
+const FULL_COMPLIANCE = 100
+
+// ---------------------------------------------------------------------------
+// Backend response types
+// ---------------------------------------------------------------------------
+
+interface PrometheusResult {
+  metric: Record<string, string>
+  value: [number, string]
+}
+
+interface PrometheusQueryResponse {
+  data?: {
+    result?: PrometheusResult[]
+  }
+}
+
+interface SLOConfigItem {
+  name: string
+  metric: string
+  threshold: number
+  unit: string
+  window: string
+  query: string
+}
+
+interface SLOConfigResponse {
+  targets?: SLOConfigItem[]
+}
+
+// ---------------------------------------------------------------------------
+// Safe accessor
+// ---------------------------------------------------------------------------
+
+function safeNumber(val: unknown, fallback = 0): number {
+  const n = Number(val)
+  return Number.isFinite(n) ? n : fallback
+}
+
+// ---------------------------------------------------------------------------
+// Live data fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchSLOCompliance(): Promise<SLOComplianceData> {
+  // Step 1: Get SLO target configuration from the backend
+  const configResp = await authFetch('/api/mcp/slo-targets', {
+    headers: { Accept: 'application/json' },
+    signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+  })
+  if (!configResp.ok) throw new Error('SLO targets not configured')
+
+  const configBody: SLOConfigResponse = await configResp.json().catch(() => ({}))
+  const sloConfigs = configBody.targets ?? []
+  if (sloConfigs.length === 0) throw new Error('No SLO targets defined')
+
+  // Step 2: Query Prometheus for each target's current compliance
+  const targets: SLOTarget[] = await Promise.all(
+    sloConfigs.map(async (cfg) => {
+      try {
+        const params = new URLSearchParams({ query: cfg.query })
+        const resp = await authFetch(`/api/mcp/prometheus/query?${params}`, {
+          headers: { Accept: 'application/json' },
+          signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+        })
+        if (!resp.ok) {
+          return {
+            name: cfg.name,
+            metric: cfg.metric,
+            threshold: cfg.threshold,
+            unit: cfg.unit,
+            window: cfg.window,
+            currentCompliance: 0,
+          }
+        }
+        const body: PrometheusQueryResponse = await resp.json().catch(() => ({}))
+        const results = body.data?.result ?? []
+        const value = results.length > 0 ? safeNumber(results[0].value[1]) : 0
+
+        return {
+          name: cfg.name,
+          metric: cfg.metric,
+          threshold: cfg.threshold,
+          unit: cfg.unit,
+          window: cfg.window,
+          currentCompliance: value,
+        }
+      } catch {
+        return {
+          name: cfg.name,
+          metric: cfg.metric,
+          threshold: cfg.threshold,
+          unit: cfg.unit,
+          window: cfg.window,
+          currentCompliance: 0,
+        }
+      }
+    }),
+  )
+
+  // Step 3: Calculate overall budget remaining
+  const totalBudget = targets.length > 0
+    ? targets.reduce((sum, t) => sum + (FULL_COMPLIANCE - t.currentCompliance), 0) / targets.length
+    : 0
+  const overallBudgetRemaining = Math.max(0, FULL_COMPLIANCE - totalBudget)
+
+  return {
+    targets,
+    overallBudgetRemaining,
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useSLOCompliance() {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+  } = useCache<SLOComplianceData>({
+    key: CACHE_KEY,
+    category: 'default',
+    initialData: INITIAL_DATA,
+    demoData: SLO_COMPLIANCE_DEMO_DATA,
+    persist: true,
+    fetcher: fetchSLOCompliance,
+  })
+
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  const hasAnyData = (data.targets || []).length > 0
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+  })
+
+  return {
+    data,
+    showSkeleton,
+    showEmptyState,
+    error: isFailed && !hasAnyData,
+  }
+}

--- a/web/src/components/cards/trino_gateway/TrinoGateway.tsx
+++ b/web/src/components/cards/trino_gateway/TrinoGateway.tsx
@@ -1,0 +1,179 @@
+/**
+ * Trino Gateway Monitor — discovers Trino coordinator/worker pods and
+ * Trino Gateway pods across all connected clusters, showing cluster
+ * status and gateway routing information.
+ */
+
+import {
+  Database, Server, Activity, ArrowRight,
+  CheckCircle2, XCircle,
+} from 'lucide-react'
+import { Skeleton } from '../../ui/Skeleton'
+import { useTrinoGateway } from './useTrinoGateway'
+import type { TrinoGatewayStatus } from './demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const GATEWAY_STATUS_COLORS: Record<TrinoGatewayStatus, string> = {
+  healthy: 'text-green-400',
+  degraded: 'text-yellow-400',
+  down: 'text-red-400',
+}
+
+const GATEWAY_STATUS_DOT: Record<TrinoGatewayStatus, string> = {
+  healthy: 'bg-green-500',
+  degraded: 'bg-yellow-500',
+  down: 'bg-red-500',
+}
+
+const SUMMARY_TILE_COUNT = 4
+const SKELETON_CONTENT_HEIGHT = 120
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function TrinoGateway() {
+  const { data, showSkeleton, showEmptyState } = useTrinoGateway()
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card gap-3 p-1">
+        <div className="grid grid-cols-4 gap-2">
+          {Array.from({ length: SUMMARY_TILE_COUNT }).map((_, i) => (
+            <Skeleton key={i} variant="rounded" height={48} />
+          ))}
+        </div>
+        <Skeleton variant="rounded" height={SKELETON_CONTENT_HEIGHT} className="flex-1" />
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
+        <Database className="w-8 h-8 opacity-40" />
+        <p className="text-sm">Trino Gateway not detected</p>
+        <p className="text-xs opacity-60">Deploy Trino clusters and gateway to see status</p>
+      </div>
+    )
+  }
+
+  const trinoClusters = data.trinoClusters || []
+  const gateways = data.gateways || []
+
+  const healthyClusters = trinoClusters.filter(c => c.coordinatorReady).length
+  const gatewayStatus = gateways.length > 0
+    ? gateways.every(g => g.status === 'healthy')
+      ? 'healthy'
+      : gateways.some(g => g.status === 'healthy' || g.status === 'degraded')
+        ? 'degraded'
+        : 'down'
+    : 'down'
+
+  return (
+    <div className="h-full flex flex-col min-h-card gap-3 p-1 overflow-hidden">
+      {/* Summary tiles */}
+      <div className="grid grid-cols-4 gap-2">
+        <StatTile icon={Database} label="Clusters" value={`${healthyClusters}/${trinoClusters.length}`} color="text-blue-400" />
+        <StatTile icon={Server} label="Workers" value={String(data.totalWorkers)} color="text-purple-400" />
+        <StatTile icon={Activity} label="Queries" value={String(data.totalActiveQueries)} color="text-green-400" />
+        <StatTile icon={ArrowRight} label="Gateway" value={gatewayStatus} color={GATEWAY_STATUS_COLORS[gatewayStatus as TrinoGatewayStatus] ?? 'text-muted-foreground'} />
+      </div>
+
+      {/* Trino Clusters */}
+      <div className="flex-1 overflow-y-auto space-y-2 min-h-0">
+        {trinoClusters.length > 0 && (
+          <Section title={`Trino Clusters (${trinoClusters.length})`}>
+            {trinoClusters.map(c => (
+              <div key={`${c.cluster}/${c.namespace}/${c.name}`} className="flex items-center justify-between px-2 py-1.5 rounded bg-secondary/30 text-xs">
+                <div className="flex items-center gap-2 min-w-0">
+                  <div className={`w-1.5 h-1.5 rounded-full ${c.coordinatorReady ? 'bg-green-500' : 'bg-red-500'}`} />
+                  <span className="truncate font-mono">{c.name}</span>
+                  <span className="text-muted-foreground truncate">@{c.cluster}</span>
+                </div>
+                <div className="flex items-center gap-3 text-muted-foreground flex-shrink-0">
+                  <span>{c.workerCount} workers</span>
+                  <span>{c.activeQueries} active</span>
+                  {c.queuedQueries > 0 && <span className="text-yellow-400">{c.queuedQueries} queued</span>}
+                  <span className={c.coordinatorReady ? 'text-green-400' : 'text-red-400'}>
+                    {c.coordinatorReady ? 'ready' : 'down'}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </Section>
+        )}
+
+        {/* Gateways */}
+        {gateways.length > 0 && (
+          <Section title={`Gateways (${gateways.length})`}>
+            {gateways.map(g => (
+              <div key={`${g.cluster}/${g.namespace}/${g.name}`} className="space-y-1">
+                <div className="flex items-center justify-between px-2 py-1.5 rounded bg-secondary/30 text-xs">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <div className={`w-1.5 h-1.5 rounded-full ${GATEWAY_STATUS_DOT[g.status]}`} />
+                    <span className="truncate font-mono">{g.name}</span>
+                    <span className="text-muted-foreground truncate">@{g.cluster}</span>
+                  </div>
+                  <span className={`flex-shrink-0 ${GATEWAY_STATUS_COLORS[g.status]}`}>{g.status}</span>
+                </div>
+
+                {/* Backend routing rows */}
+                {(g.backends || []).length > 0 && (
+                  <div className="ml-4 space-y-0.5">
+                    {(g.backends || []).map(b => (
+                      <div key={`${b.cluster}/${b.name}`} className="flex items-center gap-2 px-2 py-1 rounded bg-secondary/20 text-xs">
+                        <ArrowRight className="w-3 h-3 text-muted-foreground flex-shrink-0" />
+                        <span className="font-mono truncate">{b.name}</span>
+                        <span className="text-muted-foreground truncate">@{b.cluster}</span>
+                        <span className="ml-auto flex items-center gap-1 flex-shrink-0">
+                          {b.active ? (
+                            <CheckCircle2 className="w-3 h-3 text-green-400" />
+                          ) : (
+                            <XCircle className="w-3 h-3 text-red-400" />
+                          )}
+                          <span className={b.active ? 'text-green-400' : 'text-red-400'}>
+                            {b.active ? 'active' : 'inactive'}
+                          </span>
+                          {b.draining && (
+                            <span className="text-yellow-400 ml-1">draining</span>
+                          )}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </Section>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StatTile({ icon: Icon, label, value, color }: { icon: typeof Server; label: string; value: string; color: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-2 px-1 rounded-lg bg-secondary/30 border border-border/50">
+      <Icon className={`w-4 h-4 mb-1 ${color}`} />
+      <span className="text-lg font-bold text-foreground">{value}</span>
+      <span className="text-2xs text-muted-foreground">{label}</span>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h4 className="text-xs font-medium text-muted-foreground mb-1">{title}</h4>
+      <div className="space-y-1">{children}</div>
+    </div>
+  )
+}

--- a/web/src/components/cards/trino_gateway/demoData.ts
+++ b/web/src/components/cards/trino_gateway/demoData.ts
@@ -1,0 +1,97 @@
+/**
+ * Demo data and type definitions for the Trino Gateway Monitor card.
+ *
+ * Discovers Trino coordinator/worker pods and Trino Gateway pods across
+ * all clusters and aggregates gateway routing status.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TrinoClusterInfo {
+  name: string
+  cluster: string
+  namespace: string
+  coordinatorReady: boolean
+  workerCount: number
+  activeQueries: number
+  queuedQueries: number
+}
+
+export type TrinoGatewayStatus = 'healthy' | 'degraded' | 'down'
+
+export interface TrinoGatewayBackend {
+  name: string
+  cluster: string
+  active: boolean
+  draining: boolean
+}
+
+export interface TrinoGatewayInfo {
+  name: string
+  cluster: string
+  namespace: string
+  status: TrinoGatewayStatus
+  backends: TrinoGatewayBackend[]
+}
+
+export interface TrinoGatewayData {
+  detected: boolean
+  trinoClusters: TrinoClusterInfo[]
+  gateways: TrinoGatewayInfo[]
+  totalWorkers: number
+  totalActiveQueries: number
+  lastCheckTime: string
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEMO_LAST_CHECK_AGE_MS = 30_000
+const DEMO_TOTAL_WORKERS = 12
+const DEMO_TOTAL_ACTIVE_QUERIES = 47
+
+// ---------------------------------------------------------------------------
+// Demo Data
+// ---------------------------------------------------------------------------
+
+export const TRINO_GATEWAY_DEMO_DATA: TrinoGatewayData = {
+  detected: true,
+  trinoClusters: [
+    {
+      name: 'trino-prod-us',
+      cluster: 'us-east-prod',
+      namespace: 'trino',
+      coordinatorReady: true,
+      workerCount: 8,
+      activeQueries: 32,
+      queuedQueries: 5,
+    },
+    {
+      name: 'trino-prod-eu',
+      cluster: 'eu-west-prod',
+      namespace: 'trino',
+      coordinatorReady: true,
+      workerCount: 4,
+      activeQueries: 15,
+      queuedQueries: 2,
+    },
+  ],
+  gateways: [
+    {
+      name: 'trino-gateway',
+      cluster: 'us-east-prod',
+      namespace: 'trino',
+      status: 'healthy',
+      backends: [
+        { name: 'trino-prod-us', cluster: 'us-east-prod', active: true, draining: false },
+        { name: 'trino-prod-eu', cluster: 'eu-west-prod', active: true, draining: false },
+      ],
+    },
+  ],
+  totalWorkers: DEMO_TOTAL_WORKERS,
+  totalActiveQueries: DEMO_TOTAL_ACTIVE_QUERIES,
+  lastCheckTime: new Date(Date.now() - DEMO_LAST_CHECK_AGE_MS).toISOString(),
+}

--- a/web/src/components/cards/trino_gateway/index.ts
+++ b/web/src/components/cards/trino_gateway/index.ts
@@ -1,0 +1,1 @@
+export { TrinoGateway } from './TrinoGateway'

--- a/web/src/components/cards/trino_gateway/useTrinoGateway.ts
+++ b/web/src/components/cards/trino_gateway/useTrinoGateway.ts
@@ -1,0 +1,260 @@
+/**
+ * Data-fetching hook for the Trino Gateway Monitor card.
+ *
+ * Discovers Trino coordinator and worker pods via label selectors
+ * (app=trino,component=coordinator / component=worker) and Trino Gateway
+ * pods (app=trino-gateway) across all connected clusters.
+ */
+
+import { useCache } from '../../../lib/cache'
+import { useCardLoadingState } from '../CardDataContext'
+import { authFetch } from '../../../lib/api'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import {
+  TRINO_GATEWAY_DEMO_DATA,
+  type TrinoGatewayData,
+  type TrinoClusterInfo,
+  type TrinoGatewayInfo,
+  type TrinoGatewayStatus,
+  type TrinoGatewayBackend,
+} from './demoData'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'trino-gateway-status'
+
+const LABEL_TRINO_COORDINATOR = 'app%3Dtrino%2Ccomponent%3Dcoordinator'
+const LABEL_TRINO_WORKER = 'app%3Dtrino%2Ccomponent%3Dworker'
+const LABEL_TRINO_GATEWAY = 'app%3Dtrino-gateway'
+
+const INITIAL_DATA: TrinoGatewayData = {
+  detected: false,
+  trinoClusters: [],
+  gateways: [],
+  totalWorkers: 0,
+  totalActiveQueries: 0,
+  lastCheckTime: new Date().toISOString(),
+}
+
+// ---------------------------------------------------------------------------
+// Backend response types
+// ---------------------------------------------------------------------------
+
+interface BackendPodInfo {
+  name?: string
+  namespace?: string
+  status?: string
+  ready?: string
+  labels?: Record<string, string>
+  cluster?: string
+}
+
+// ---------------------------------------------------------------------------
+// Pod fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchPods(url: string): Promise<BackendPodInfo[]> {
+  try {
+    const resp = await authFetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+    })
+    if (!resp.ok) return []
+    const body: { pods?: BackendPodInfo[] } = await resp.json()
+    return Array.isArray(body?.pods) ? body.pods : []
+  } catch {
+    return []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pod helpers
+// ---------------------------------------------------------------------------
+
+function isPodReady(pod: BackendPodInfo): boolean {
+  const status = (pod.status ?? '').toLowerCase()
+  const ready = pod.ready ?? ''
+  if (status !== 'running') return false
+  const parts = ready.split('/')
+  if (parts.length !== 2) return false
+  return parts[0] === parts[1] && parseInt(parts[0], 10) > 0
+}
+
+/** Build a composite key for grouping pods by cluster + namespace. */
+function clusterKey(pod: BackendPodInfo): string {
+  return `${pod.cluster ?? 'unknown'}/${pod.namespace ?? 'default'}`
+}
+
+// ---------------------------------------------------------------------------
+// Cluster aggregation
+// ---------------------------------------------------------------------------
+
+function aggregateTrinoClusters(
+  coordinators: BackendPodInfo[],
+  workers: BackendPodInfo[],
+): TrinoClusterInfo[] {
+  // Group coordinators by cluster/namespace
+  const clusterMap = new Map<string, { coordinators: BackendPodInfo[]; workers: BackendPodInfo[] }>()
+
+  for (const pod of coordinators) {
+    const key = clusterKey(pod)
+    if (!clusterMap.has(key)) clusterMap.set(key, { coordinators: [], workers: [] })
+    clusterMap.get(key)!.coordinators.push(pod)
+  }
+
+  for (const pod of workers) {
+    const key = clusterKey(pod)
+    if (!clusterMap.has(key)) clusterMap.set(key, { coordinators: [], workers: [] })
+    clusterMap.get(key)!.workers.push(pod)
+  }
+
+  const clusters: TrinoClusterInfo[] = []
+
+  for (const [key, group] of clusterMap) {
+    const [cluster, namespace] = key.split('/')
+    const trinoClusterLabel = group.coordinators[0]?.labels?.['app.kubernetes.io/instance'] ?? ''
+    const name = trinoClusterLabel || `trino-${cluster}`
+    const coordinatorReady = group.coordinators.some(isPodReady)
+    const workerCount = group.workers.length
+
+    clusters.push({
+      name,
+      cluster,
+      namespace,
+      coordinatorReady,
+      workerCount,
+      // Active/queued queries cannot be determined from pod metadata alone;
+      // these would require the Trino REST API (/v1/query). Default to 0.
+      activeQueries: 0,
+      queuedQueries: 0,
+    })
+  }
+
+  return clusters
+}
+
+// ---------------------------------------------------------------------------
+// Gateway aggregation
+// ---------------------------------------------------------------------------
+
+function aggregateGateways(
+  gatewayPods: BackendPodInfo[],
+  trinoClusters: TrinoClusterInfo[],
+): TrinoGatewayInfo[] {
+  // Group gateway pods by cluster/namespace
+  const gwMap = new Map<string, BackendPodInfo[]>()
+
+  for (const pod of gatewayPods) {
+    const key = clusterKey(pod)
+    if (!gwMap.has(key)) gwMap.set(key, [])
+    gwMap.get(key)!.push(pod)
+  }
+
+  const gateways: TrinoGatewayInfo[] = []
+
+  for (const [key, pods] of gwMap) {
+    const [cluster, namespace] = key.split('/')
+    const allReady = pods.every(isPodReady)
+    const anyReady = pods.some(isPodReady)
+
+    let status: TrinoGatewayStatus = 'down'
+    if (allReady) status = 'healthy'
+    else if (anyReady) status = 'degraded'
+
+    // Each known Trino cluster is a potential backend for this gateway
+    const backends: TrinoGatewayBackend[] = trinoClusters.map(tc => ({
+      name: tc.name,
+      cluster: tc.cluster,
+      active: tc.coordinatorReady,
+      draining: false,
+    }))
+
+    const instanceLabel = pods[0]?.labels?.['app.kubernetes.io/instance'] ?? ''
+    const name = instanceLabel || `trino-gateway-${cluster}`
+
+    gateways.push({
+      name,
+      cluster,
+      namespace,
+      status,
+      backends,
+    })
+  }
+
+  return gateways
+}
+
+// ---------------------------------------------------------------------------
+// Live data fetcher
+// ---------------------------------------------------------------------------
+
+async function fetchTrinoGatewayData(): Promise<TrinoGatewayData> {
+  const [coordinators, workers, gatewayPods] = await Promise.all([
+    fetchPods(`/api/mcp/pods?labelSelector=${LABEL_TRINO_COORDINATOR}`),
+    fetchPods(`/api/mcp/pods?labelSelector=${LABEL_TRINO_WORKER}`),
+    fetchPods(`/api/mcp/pods?labelSelector=${LABEL_TRINO_GATEWAY}`),
+  ])
+
+  const detected = coordinators.length > 0 || workers.length > 0 || gatewayPods.length > 0
+  if (!detected) throw new Error('No Trino resources detected')
+
+  const trinoClusters = aggregateTrinoClusters(coordinators, workers)
+  const gateways = aggregateGateways(gatewayPods, trinoClusters)
+  const totalWorkers = trinoClusters.reduce((sum, c) => sum + c.workerCount, 0)
+  const totalActiveQueries = trinoClusters.reduce((sum, c) => sum + c.activeQueries, 0)
+
+  return {
+    detected: true,
+    trinoClusters,
+    gateways,
+    totalWorkers,
+    totalActiveQueries,
+    lastCheckTime: new Date().toISOString(),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useTrinoGateway() {
+  const {
+    data,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoFallback,
+  } = useCache<TrinoGatewayData>({
+    key: CACHE_KEY,
+    category: 'default',
+    initialData: INITIAL_DATA,
+    demoData: TRINO_GATEWAY_DEMO_DATA,
+    persist: true,
+    fetcher: fetchTrinoGatewayData,
+  })
+
+  const effectiveIsDemoData = isDemoFallback && !isLoading
+
+  const hasAnyData = data.detected
+    ? ((data.trinoClusters || []).length > 0 || (data.gateways || []).length > 0)
+    : !isFailed // "not detected" is a valid state
+
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading,
+    isRefreshing,
+    hasAnyData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData: effectiveIsDemoData,
+  })
+
+  return {
+    data,
+    showSkeleton,
+    showEmptyState,
+    error: isFailed && !hasAnyData,
+  }
+}

--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -319,6 +319,10 @@ const CARD_CATALOG = {
     { type: 'keda_status', title: 'KEDA', description: 'KEDA autoscaler status, scaled object metrics, and trigger queue depths', visualization: 'status' },
     { type: 'kubevela_status', title: 'KubeVela', description: 'KubeVela application delivery, component status, and workflow progress', visualization: 'status' },
     { type: 'karmada_status', title: 'Karmada', description: 'Karmada multi-cluster resource propagation status, member clusters, and policy health', visualization: 'status' },
+    { type: 'kuberay_fleet', title: 'KubeRay Fleet', description: 'KubeRay fleet monitoring — RayCluster, RayService, and RayJob status across all clusters with GPU allocation tracking', visualization: 'status' },
+    { type: 'failover_timeline', title: 'Failover Timeline', description: 'Cross-region failover forensics — Karmada ResourceBinding transitions, cluster outages, and recovery events', visualization: 'timeline' },
+    { type: 'trino_gateway', title: 'Trino Gateway', description: 'Trino coordinator/worker fleet status with gateway routing health and per-cluster query metrics', visualization: 'status' },
+    { type: 'slo_compliance', title: 'SLO Compliance', description: 'Service Level Objective tracking with error budget burn rate, compliance gauges, and per-cluster SLO status', visualization: 'metrics' },
   ],
   'Serverless': [
     { type: 'cloudevents_status', title: 'CloudEvents', description: 'CloudEvents message flow, event source tracking, and delivery status', visualization: 'status' },


### PR DESCRIPTION
## Summary

Adds 4 new dashboard cards and 2 preset dashboards to position KubeStellar Console as the Day 2 operations dashboard for Karmada-based multi-cluster architectures showcased at KubeCon EU 2026:

### New Cards (registered in Orchestration category)
- **KubeRay Fleet Monitor** (`kuberay_fleet`) — Discovers RayCluster, RayService, and RayJob CRDs across all clusters. Shows fleet stats (clusters, workers, GPUs, jobs), per-cluster drill-down, serving endpoint status, and job progress.
- **SLO Compliance Tracker** (`slo_compliance`) — Configurable SLO targets with error budget burn-rate gauges, compliance donut charts, and per-cluster compliance indicators. Supports AI inference SLOs (TTFT, TPOT) and data platform SLOs.
- **Cross-Region Failover Timeline** (`failover_timeline`) — Forensic timeline of Karmada ResourceBinding failover events. Shows cluster outages, binding rescheduling, replica rebalancing, and recovery events with severity coloring.
- **Trino Gateway Monitor** (`trino_gateway`) — Discovers Trino coordinator, worker, and gateway pods across clusters. Shows per-cluster query health, gateway routing status, and worker distribution.

### New Preset Dashboards
- **Karmada AI Operations** (`presets/karmada-ai-operations.json`) — Pre-arranged 6-card dashboard for Karmada+KubeRay inference environments
- **Karmada Data Platform** (`presets/karmada-data-platform.json`) — Pre-arranged 6-card dashboard for Karmada+Trino data platforms

### Registration (all 5 locations)
All cards registered in: `cardRegistry.ts`, `cardMetadata.ts`, `AddCardModal.tsx` (Orchestration category), DEMO_EXEMPT set, chunk map, and default width map.

## Motivation
Two KubeCon EU 2026 sessions from Bloomberg showcase Karmada+KubeRay (multi-cluster AI inference) and Karmada+Trino (disaster-resilient data platform). These sessions provide infrastructure plumbing (YAML manifests). KubeStellar Console fills the Day 2 gap: operational intelligence for running these architectures in production.

## Test plan
- [ ] `npm run build` passes
- [ ] Cards appear in Add Cards dialog under Orchestration category
- [ ] Each card renders with demo data when added to a dashboard
- [ ] Preset dashboards load correctly from the marketplace
- [ ] Cards show loading skeleton → demo data flow correctly