### PR TITLE
🐛 Fix 'Failed to load dashboard' error when switching dashboards

### DIFF
--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -324,10 +324,13 @@ export function CustomDashboard() {
       const isExpectedFailure = error instanceof BackendUnavailableError ||
         error instanceof UnauthenticatedError ||
         (error instanceof Error && (
+          error.message.includes('Request timeout') ||
           error.message.includes('Failed to fetch') ||
           error.message.includes('NetworkError') ||
           error.message.includes('Load failed') ||
-          error.message.includes('HTTP request to an HTTPS server')
+          error.message.includes('HTTP request to an HTTPS server') ||
+          error.message.includes('API error:') ||
+          error.message.includes('Invalid JSON')
         ))
       if (!isExpectedFailure) {
         console.error('Failed to load dashboard:', error)

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -524,11 +524,17 @@ export function Dashboard() {
     }
   }
 
-  // Load dashboard on mount and when navigating back to the page
-  // Always background refresh — localCards are pre-populated from localStorage/defaults
+  // Load dashboard on mount and when navigating back to the page.
+  // Always background refresh — localCards are pre-populated from localStorage/defaults.
+  // Guard: KeepAlive keeps this component mounted even when the user navigates to
+  // a different route.  location.key changes on EVERY navigation, not just when
+  // returning to "/".  Without the pathname check the API call fires while the
+  // dashboard is hidden and any failure shows a confusing toast.
   useEffect(() => {
+    const isHomeDashboard = location.pathname === '/' || location.pathname === ''
+    if (!isHomeDashboard) return
     loadDashboard(true)
-  }, [location.key]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [location.key, location.pathname]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Keep cache and localStorage in sync when cards are modified locally
   useEffect(() => {
@@ -606,7 +612,7 @@ export function Dashboard() {
       if (dashboards && dashboards.length > 0) {
         const defaultDashboard = dashboards.find((d) => d.is_default) || dashboards[0]
         const { data } = await api.get<DashboardData>(`/api/dashboards/${defaultDashboard.id}`)
-        const apiCards = data.cards.length > 0 ? data.cards : getDemoCards()
+        const apiCards = (data.cards && data.cards.length > 0) ? data.cards : getDemoCards()
         setDashboard(data)
 
         // ALWAYS preserve local-only cards (not yet persisted to backend)
@@ -643,11 +649,17 @@ export function Dashboard() {
           error.message.includes('Failed to fetch') ||
           error.message.includes('NetworkError') ||
           error.message.includes('Load failed') ||
-          error.message.includes('HTTP request to an HTTPS server')
+          error.message.includes('HTTP request to an HTTPS server') ||
+          error.message.includes('API error:') ||
+          error.message.includes('Invalid JSON')
         ))
       if (!isExpectedFailure) {
         console.error('Failed to load dashboard:', error)
-        showToast('Failed to load dashboard', 'error')
+        // Only show toast for foreground loads — background refreshes should
+        // fail silently to avoid confusing the user with unexpected errors.
+        if (!isBackground) {
+          showToast('Failed to load dashboard', 'error')
+        }
       }
       // Preserve local-only cards even on error, only add demo cards if needed
       setLocalCards((prevCards) => {


### PR DESCRIPTION
## Summary

Fixes the "Failed to load dashboard" toast error that appeared every time users navigated between dashboards.

**Root cause**: The KeepAlive outlet keeps the main Dashboard component mounted (but hidden) when the user navigates away. The `loadDashboard` effect depended on `location.key`, which changes on **every** navigation — not just when returning to `/`. This caused a background API call to fire while the dashboard was invisible, and any failure surfaced as a confusing error toast.

**Fixes applied**:
- Guard `loadDashboard` effect with a pathname check — only fires when `"/"` is the active route
- Guard `data.cards` access against `undefined`/`null` to prevent TypeError on malformed API responses
- Suppress error toasts during background refreshes — only show them for explicit foreground loads
- Add `Request timeout`, `API error:`, and `Invalid JSON` to expected-failure lists in both `Dashboard.tsx` and `CustomDashboard.tsx`

## Test plan

- [ ] Navigate from home dashboard to Clusters, Nodes, Workloads, etc. — no "Failed to load dashboard" toast should appear
- [ ] Navigate back to home dashboard — cards should load normally without error
- [ ] Open a custom dashboard and navigate away — no error toast
- [ ] Verify demo mode still works correctly on console.kubestellar.io
- [ ] Verify that genuine foreground load failures (e.g., first visit with broken backend) still show the toast