### PR TITLE
✨ feat: add dedicated Karmada Ops dashboard page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -54,6 +54,7 @@ const Cost = safeLazy(() => import('./components/cost/Cost'), 'Cost')
 const Compliance = safeLazy(() => import('./components/compliance/Compliance'), 'Compliance')
 const DataCompliance = safeLazy(() => import('./components/data-compliance/DataCompliance'), 'DataCompliance')
 const GPUReservations = safeLazy(() => import('./components/gpu/GPUReservations'), 'GPUReservations')
+const KarmadaOps = safeLazy(() => import('./components/karmada-ops/KarmadaOps'), 'KarmadaOps')
 const Nodes = safeLazy(() => import('./components/nodes/Nodes'), 'Nodes')
 const Deployments = safeLazy(() => import('./components/deployments/Deployments'), 'Deployments')
 const Services = safeLazy(() => import('./components/services/Services'), 'Services')
@@ -297,6 +298,7 @@ const ROUTE_TITLES: Record<string, string> = {
   '/ai-ml': 'AI/ML',
   '/ai-agents': 'AI Agents',
   '/ci-cd': 'CI/CD',
+  '/karmada-ops': 'Karmada Ops',
   '/llm-d-benchmarks': 'llm-d Benchmarks',
   '/multi-tenancy': 'Multi-Tenancy',
   '/arcade': 'Arcade',
@@ -514,6 +516,7 @@ function FullDashboardApp() {
           <Route path={ROUTES.COMPLIANCE} element={<Compliance />} />
           <Route path={ROUTES.DATA_COMPLIANCE} element={<DataCompliance />} />
           <Route path={ROUTES.GPU_RESERVATIONS} element={<GPUReservations />} />
+          <Route path={ROUTES.KARMADA_OPS} element={<KarmadaOps />} />
           <Route path={ROUTES.HISTORY} element={<CardHistoryWithRestore />} />
           <Route path={ROUTES.SETTINGS} element={<Settings />} />
           <Route path={ROUTES.USERS} element={<UserManagementPage />} />

--- a/web/src/components/karmada-ops/KarmadaOps.tsx
+++ b/web/src/components/karmada-ops/KarmadaOps.tsx
@@ -1,0 +1,70 @@
+/**
+ * Karmada Operations Dashboard Page
+ *
+ * Multi-cluster operations dashboard for Karmada-based environments.
+ * Monitors KubeRay fleet, Trino gateways, SLO compliance, and failover events.
+ */
+import { useCallback } from 'react'
+import { useClusters } from '../../hooks/useMCP'
+import { useUniversalStats, createMergedStatValueGetter } from '../../hooks/useUniversalStats'
+import { StatBlockValue } from '../ui/StatsOverview'
+import { DashboardPage } from '../../lib/dashboards/DashboardPage'
+import { getDefaultCards } from '../../config/dashboards'
+
+const KARMADA_OPS_CARDS_KEY = 'kubestellar-karmada-ops-cards'
+
+const DEFAULT_KARMADA_OPS_CARDS = getDefaultCards('karmada-ops')
+
+export function KarmadaOps() {
+  const { clusters, isLoading, isRefreshing: dataRefreshing, lastUpdated, refetch, error } = useClusters()
+  const { getStatValue: getUniversalStatValue } = useUniversalStats()
+
+  const reachableClusters = clusters.filter(c => c.reachable !== false)
+  const hasRealData = reachableClusters.length > 0
+  const isDemoData = !hasRealData && !isLoading
+
+  const getDashboardStatValue = useCallback((blockId: string): StatBlockValue => {
+    switch (blockId) {
+      case 'clusters':
+        return { value: reachableClusters.length, sublabel: 'clusters', isClickable: false }
+      default:
+        return { value: '-' }
+    }
+  }, [reachableClusters])
+
+  const getStatValue = useCallback(
+    (blockId: string) => createMergedStatValueGetter(getDashboardStatValue, getUniversalStatValue)(blockId),
+    [getDashboardStatValue, getUniversalStatValue]
+  )
+
+  return (
+    <DashboardPage
+      title="Karmada Ops"
+      subtitle="Multi-cluster orchestration, AI inference, and data platform operations"
+      icon="Globe"
+      storageKey={KARMADA_OPS_CARDS_KEY}
+      defaultCards={DEFAULT_KARMADA_OPS_CARDS}
+      statsType="karmada-ops"
+      getStatValue={getStatValue}
+      onRefresh={refetch}
+      isLoading={isLoading}
+      isRefreshing={dataRefreshing}
+      lastUpdated={lastUpdated}
+      hasData={hasRealData}
+      isDemoData={isDemoData}
+      emptyState={{
+        title: 'Karmada Operations',
+        description: 'Monitor Karmada multi-cluster orchestration, KubeRay inference fleet, Trino data platform, SLO compliance, and cross-region failover events.',
+      }}
+    >
+      {error && (
+        <div className="mb-4 p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400">
+          <div className="font-medium">Error loading cluster data</div>
+          <div className="text-sm text-muted-foreground">{error}</div>
+        </div>
+      )}
+    </DashboardPage>
+  )
+}
+
+export default KarmadaOps

--- a/web/src/components/ui/StatsBlockDefinitions.ts
+++ b/web/src/components/ui/StatsBlockDefinitions.ts
@@ -55,6 +55,7 @@ export type DashboardStatsType =
   | 'insights'
   | 'multi-tenancy'
   | 'ci-cd'
+  | 'karmada-ops'
 
 /**
  * Default stat blocks for the Clusters dashboard

--- a/web/src/config/dashboards/index.ts
+++ b/web/src/config/dashboards/index.ts
@@ -32,6 +32,7 @@ import { helmDashboardConfig } from './helm'
 import { alertsDashboardConfig } from './alerts'
 import { aiMlDashboardConfig } from './ai-ml'
 import { ciCdDashboardConfig } from './ci-cd'
+import { karmadaOpsDashboardConfig } from './karmada-ops'
 import { logsDashboardConfig } from './logs'
 import { dataComplianceDashboardConfig } from './data-compliance'
 import { arcadeDashboardConfig } from './arcade'
@@ -67,6 +68,7 @@ export const DASHBOARD_CONFIGS: DashboardConfigRegistry = {
   alerts: alertsDashboardConfig,
   'ai-ml': aiMlDashboardConfig,
   'ci-cd': ciCdDashboardConfig,
+  'karmada-ops': karmadaOpsDashboardConfig,
   logs: logsDashboardConfig,
   'data-compliance': dataComplianceDashboardConfig,
   arcade: arcadeDashboardConfig,
@@ -172,6 +174,7 @@ export {
   alertsDashboardConfig,
   aiMlDashboardConfig,
   ciCdDashboardConfig,
+  karmadaOpsDashboardConfig,
   logsDashboardConfig,
   dataComplianceDashboardConfig,
   arcadeDashboardConfig,

--- a/web/src/config/dashboards/karmada-ops.ts
+++ b/web/src/config/dashboards/karmada-ops.ts
@@ -1,0 +1,37 @@
+/**
+ * Karmada Operations Dashboard Configuration
+ *
+ * Multi-cluster operations dashboard for Karmada-based environments.
+ * Monitors KubeRay fleet, Trino gateways, SLO compliance, and failover events.
+ */
+import type { UnifiedDashboardConfig } from '../../lib/unified/types'
+
+export const karmadaOpsDashboardConfig: UnifiedDashboardConfig = {
+  id: 'karmada-ops',
+  name: 'Karmada Ops',
+  subtitle: 'Multi-cluster orchestration, AI inference, and data platform operations',
+  route: '/karmada-ops',
+  statsType: 'karmada-ops',
+  cards: [
+    // Top row: fleet overview
+    { id: 'karmada-status-1', cardType: 'karmada_status', title: 'Karmada Status', position: { w: 6, h: 4 } },
+    { id: 'kuberay-fleet-1', cardType: 'kuberay_fleet', title: 'KubeRay Fleet', position: { w: 6, h: 4 } },
+
+    // Middle row: operational intelligence
+    { id: 'slo-compliance-1', cardType: 'slo_compliance', title: 'SLO Compliance', position: { w: 6, h: 4 } },
+    { id: 'failover-timeline-1', cardType: 'failover_timeline', title: 'Failover Timeline', position: { w: 6, h: 4 } },
+
+    // Bottom row: data platform + cluster health
+    { id: 'trino-gateway-1', cardType: 'trino_gateway', title: 'Trino Gateway', position: { w: 6, h: 4 } },
+    { id: 'cluster-health-1', cardType: 'cluster_health', title: 'Cluster Health', position: { w: 6, h: 4 } },
+  ],
+  features: {
+    dragDrop: true,
+    addCard: true,
+    autoRefresh: true,
+    autoRefreshInterval: 30000,
+  },
+  storageKey: 'karmada-ops-dashboard-cards',
+}
+
+export default karmadaOpsDashboardConfig

--- a/web/src/config/routes.ts
+++ b/web/src/config/routes.ts
@@ -57,6 +57,7 @@ export const ROUTES = {
   AI_ML: '/ai-ml',
   AI_AGENTS: '/ai-agents',
   CI_CD: '/ci-cd',
+  KARMADA_OPS: '/karmada-ops',
   LLM_D_BENCHMARKS: '/llm-d-benchmarks',
   INSIGHTS: '/insights',
 

--- a/web/src/hooks/useSearchIndex.ts
+++ b/web/src/hooks/useSearchIndex.ts
@@ -80,6 +80,7 @@ const DASHBOARD_NAMES: Record<DashboardStatsType, string> = {
   insights: 'Insights',
   'multi-tenancy': 'Multi-Tenancy',
   'ci-cd': 'CI/CD',
+  'karmada-ops': 'Karmada Ops',
 }
 
 const DASHBOARD_ROUTES: Record<DashboardStatsType, string> = {
@@ -104,6 +105,7 @@ const DASHBOARD_ROUTES: Record<DashboardStatsType, string> = {
   insights: '/insights',
   'multi-tenancy': '/multi-tenancy',
   'ci-cd': '/ci-cd',
+  'karmada-ops': '/karmada-ops',
 }
 
 const ALL_STATS_DASHBOARD_TYPES: DashboardStatsType[] = [

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -76,6 +76,7 @@ export const DISCOVERABLE_DASHBOARDS: SidebarItem[] = [
   { id: 'events', name: 'Events', icon: 'Activity', href: '/events', type: 'link', order: 5 },
   { id: 'gitops', name: 'GitOps', icon: 'GitBranch', href: '/gitops', type: 'link', order: 6 },
   { id: 'gpu-reservations', name: 'GPU Reservations', icon: 'Cpu', href: '/gpu-reservations', type: 'link', order: 7 },
+  { id: 'karmada-ops', name: 'Karmada Ops', icon: 'Globe', href: '/karmada-ops', type: 'link', order: 8 },
   { id: 'helm', name: 'Helm', icon: 'Package', href: '/helm', type: 'link', order: 8 },
   { id: 'llm-d-benchmarks', name: 'llm-d Benchmarks', icon: 'TrendingUp', href: '/llm-d-benchmarks', type: 'link', order: 9 },
   { id: 'logs', name: 'Logs', icon: 'FileText', href: '/logs', type: 'link', order: 10 },


### PR DESCRIPTION
## Summary
Adds a dedicated **Karmada Ops** dashboard page at `/karmada-ops` that appears in the sidebar navigation. This provides a single-pane view for operating Karmada-based multi-cluster environments.

### Dashboard Layout (6 cards, 2x3 grid)
| Row | Left | Right |
|-----|------|-------|
| 1 | Karmada Status | KubeRay Fleet |
| 2 | SLO Compliance | Failover Timeline |
| 3 | Trino Gateway | Cluster Health |

### Registration (all 7 locations)
- `config/dashboards/karmada-ops.ts` — dashboard config
- `config/dashboards/index.ts` — DASHBOARD_CONFIGS registry
- `config/routes.ts` — ROUTES.KARMADA_OPS
- `hooks/useSidebarConfig.ts` — DISCOVERABLE_DASHBOARDS
- `hooks/useSearchIndex.ts` — DASHBOARD_NAMES + DASHBOARD_ROUTES
- `components/ui/StatsBlockDefinitions.ts` — DashboardStatsType union
- `App.tsx` — lazy import + Route + ROUTE_TITLES

## Test plan
- [ ] `npm run build` passes
- [ ] Navigate to `/karmada-ops` — dashboard loads with 6 cards
- [ ] Cards render with demo data (no clusters needed)
- [ ] Dashboard appears in sidebar "Customize" menu under discoverable dashboards
- [ ] Search for "Karmada" in global search — dashboard appears