### PR TITLE
🌱 feat: show git commit hash in sidebar next to viewer count

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -526,9 +526,9 @@ export function Sidebar() {
           </div>
         )}
 
-        {/* Viewer count */}
+        {/* Viewer count + commit hash */}
         {!isCollapsed && (
-          <div className="mt-auto pt-4 flex items-center justify-center">
+          <div className="mt-auto pt-4 flex items-center justify-center gap-2">
             <div
               className="flex items-center gap-1 px-2 text-muted-foreground/60"
               title={t('sidebar.activeViewers', { count: viewerCount })}
@@ -538,6 +538,9 @@ export function Sidebar() {
                 {viewersError ? '!' : viewersLoading ? '…' : viewerCount}
               </span>
             </div>
+            <span className="text-2xs text-muted-foreground/40 font-mono" title={`Commit: ${__COMMIT_HASH__}`}>
+              {__COMMIT_HASH__.substring(0, 7)}
+            </span>
           </div>
         )}
       </aside>


### PR DESCRIPTION
## Summary
- Displays the short (7-char) git commit hash next to the active viewer count at the bottom of the sidebar
- Uses the existing `__COMMIT_HASH__` global define from `vite.config.ts`
- Hover tooltip shows the full commit hash
- Helps quickly identify which build is deployed (e.g., on console.kubestellar.io)

## Test plan
- [ ] Sidebar shows commit hash (e.g., `9b8a49d`) next to the user count
- [ ] Hover shows full hash in tooltip
- [ ] Hash is hidden when sidebar is collapsed