### PR TITLE
🐛 fix: target vllm-d deploy runners with openshift label

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -100,7 +100,7 @@ jobs:
   deploy-vllm-d:
     needs: build
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-    runs-on: [self-hosted, kc]
+    runs-on: [self-hosted, kc, openshift]
     environment: vllm-d
 
     steps:


### PR DESCRIPTION
## Summary
- The `deploy-vllm-d` job used `runs-on: [self-hosted, kc]` which matched **both** vllm-d and scooter-cks runners
- When GitHub assigned the job to a scooter-cks runner, it failed because those runners have no RBAC and target the wrong cluster entirely
- This was the root cause of the intermittent "Runner SA lacks RBAC permissions" failures that have been misdiagnosed 4 times as a vllm-d RBAC issue
- Fix: add `openshift` label to the selector → `[self-hosted, kc, openshift]` — only vllm-d runners have this label

### Runner inventory
| Runner Set | Cluster | Labels |
|---|---|---|
| `npmh7` (2 pods) | vllm-d | `self-hosted, kc, openshift` |
| `dmcrj` (2 pods) | scooter-cks | `self-hosted, kc, cks, scooter` |
| `tsspd` (2 pods) | pok-prod | `self-hosted, kc-pok, openshift` |

## Test plan
- [ ] Merge and verify next deploy-vllm-d job succeeds
- [ ] Verify it always picks an `npmh7` runner (check runner name in job logs)