### PR TITLE
🐛 fix: address Copilot review on #4011 — foreground first-load + preserve cards on bg failure

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -525,7 +525,6 @@ export function Dashboard() {
   }
 
   // Load dashboard on mount and when navigating back to the page.
-  // Always background refresh — localCards are pre-populated from localStorage/defaults.
   // Guard: KeepAlive keeps this component mounted even when the user navigates to
   // a different route.  location.key changes on EVERY navigation, not just when
   // returning to "/".  Without the pathname check the API call fires while the
@@ -533,7 +532,12 @@ export function Dashboard() {
   useEffect(() => {
     const isHomeDashboard = location.pathname === '/' || location.pathname === ''
     if (!isHomeDashboard) return
-    loadDashboard(true)
+    // Treat first load with no cached/local cards as a foreground load so that
+    // failures can surface a toast. Use warm/background refresh only when we
+    // already have something to show from cache or localStorage.
+    const hasCachedOrLocalCards =
+      ((dashboardCache?.cards?.length ?? 0) > 0) || localCards.length > 0
+    loadDashboard(hasCachedOrLocalCards)
   }, [location.key, location.pathname]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Keep cache and localStorage in sync when cards are modified locally
@@ -661,14 +665,18 @@ export function Dashboard() {
           showToast('Failed to load dashboard', 'error')
         }
       }
-      // Preserve local-only cards even on error, only add demo cards if needed
+      // On background refresh failure, preserve whatever cards we currently have
+      // to avoid silently resetting a persisted dashboard to demo cards.
+      // Only fall back to demo cards on foreground loads with nothing to show.
       setLocalCards((prevCards) => {
-        const localOnlyCards = prevCards.filter(c => isLocalOnlyCard(c.id))
-        if (localOnlyCards.length > 0) {
-          // Keep local cards, don't replace with demo
+        if (isBackground && prevCards.length > 0) {
           return prevCards
         }
-        // No local cards, use demo
+        const localOnlyCards = prevCards.filter(c => isLocalOnlyCard(c.id))
+        if (localOnlyCards.length > 0) {
+          return prevCards
+        }
+        // No cards at all, use demo
         const cards = getDemoCards()
         dashboardCache = { dashboard: null, cards, timestamp: Date.now() }
         return cards


### PR DESCRIPTION
## Summary
- Addresses Copilot review comments on #4011
- First load with no cached/local cards is now treated as a **foreground load** so failures surface a toast (previously all loads were background, meaning no toast was ever shown)
- Background refresh failures now **preserve current cards** instead of potentially resetting a persisted dashboard to demo cards (fixes silent data loss when backend is temporarily unavailable)

## Test plan
- [ ] Fresh visit (no cache) with backend down → should show "Failed to load dashboard" toast + demo cards
- [ ] Revisit (cache present) with backend down → should keep cached cards, no toast
- [ ] Normal operation: cached data shows instantly, refreshes in background