### PR TITLE
🐛 Add Karmada Ops to sidebar search, rename Compliance to Sec. Compliance

### DIFF
--- a/web/src/components/layout/SidebarCustomizer.tsx
+++ b/web/src/components/layout/SidebarCustomizer.tsx
@@ -135,7 +135,8 @@ const KNOWN_ROUTES: KnownRoute[] = [
   { href: '/ci-cd', name: 'CI/CD', description: 'Continuous integration and deployment pipelines, Prow jobs, and GitHub workflows', icon: 'GitPullRequest', category: 'Core Dashboards' },
   { href: '/ai-agents', name: 'AI Agents', description: 'Kagenti agent platform — deploy, secure, and manage AI agents across clusters', icon: 'Bot', category: 'Core Dashboards' },
   { href: '/llm-d-benchmarks', name: 'llm-d Benchmarks', description: 'LLM inference benchmarks — throughput, latency, and GPU utilization across clouds and accelerators', icon: 'TrendingUp', category: 'Core Dashboards' },
-  { href: '/compliance', name: 'Compliance', description: 'Regulatory compliance, audit logs, and policy enforcement', icon: 'ClipboardCheck', category: 'Core Dashboards' },
+  { href: '/compliance', name: 'Sec. Compliance', description: 'Security compliance, regulatory audits, and policy enforcement', icon: 'ClipboardCheck', category: 'Core Dashboards' },
+  { href: '/karmada-ops', name: 'Karmada Ops', description: 'Multi-cluster orchestration, AI inference, and data platform operations', icon: 'Globe', category: 'Core Dashboards' },
   { href: '/cluster-admin', name: 'Cluster Admin', description: 'Multi-cluster operations, control plane health, node debugging, and infrastructure management', icon: 'ShieldAlert', category: 'Core Dashboards' },
   { href: '/multi-tenancy', name: 'Multi-Tenancy', description: 'Tenant isolation with OVN-Kubernetes, KubeFlex, K3s, and KubeVirt', icon: 'Users', category: 'Core Dashboards' },
   // Resource Pages

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -52,7 +52,7 @@ const DEFAULT_PRIMARY_NAV: SidebarItem[] = [
   { id: 'dashboard', name: 'Dashboard', icon: 'LayoutDashboard', href: '/', type: 'link', order: 0 },
   { id: 'clusters', name: 'My Clusters', icon: 'Server', href: '/clusters', type: 'link', order: 1 },
   { id: 'cluster-admin', name: 'Cluster Admin', icon: 'ShieldAlert', href: '/cluster-admin', type: 'link', order: 2 },
-  { id: 'compliance', name: 'Compliance', icon: 'ClipboardCheck', href: '/compliance', type: 'link', order: 2.5 },
+  { id: 'compliance', name: 'Sec. Compliance', icon: 'ClipboardCheck', href: '/compliance', type: 'link', order: 2.5 },
   { id: 'deploy', name: 'Deploy', icon: 'Rocket', href: '/deploy', type: 'link', order: 3 },
   { id: 'insights', name: 'Insights', icon: 'Lightbulb', href: '/insights', type: 'link', order: 3.5 },
   { id: 'ai-ml', name: 'AI/ML', icon: 'Sparkles', href: '/ai-ml', type: 'link', order: 4 },


### PR DESCRIPTION
## Summary
- Add Karmada Ops to `KNOWN_ROUTES` in sidebar customizer — was missing from search results
- Rename "Compliance" to "Sec. Compliance" in sidebar nav and customizer to distinguish from Data Compliance

## Test plan
- [ ] Search "Karmada" in sidebar customizer — should now find Karmada Ops
- [ ] Sidebar shows "Sec. Compliance" instead of "Compliance"