### PR TITLE
🐛 Fix misleading 'No operators' empty state when fetch fails

### DIFF
--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -224,6 +224,8 @@ export function useCardLoadingState(options: CardLoadingStateOptions) {
     showEmptyState: !effectiveIsLoading && !hasAnyData,
     /** Whether data is being refreshed (has cache, fetching update) */
     isRefreshing: effectiveIsLoading && hasRealData,
+    /** Whether the loading safety-net timeout fired (data took too long) */
+    loadingTimedOut,
   }
 }
 

--- a/web/src/components/cards/OperatorStatus.tsx
+++ b/web/src/components/cards/OperatorStatus.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { CheckCircle, AlertTriangle, XCircle, RefreshCw, ArrowUpCircle, ChevronRight } from 'lucide-react'
+import { CheckCircle, AlertTriangle, AlertCircle, XCircle, RefreshCw, ArrowUpCircle, ChevronRight } from 'lucide-react'
 import { useClusters, Operator } from '../../hooks/useMCP'
 import { useCachedOperators } from '../../hooks/useCachedData'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -60,11 +60,11 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
   const { drillToOperator } = useDrillDownActions()
 
   // Fetch operators - pass undefined to get all clusters
-  const { operators: rawOperators, isLoading: operatorsLoading, isRefreshing, consecutiveFailures, isFailed, isDemoFallback: isDemoData } = useCachedOperators(undefined)
+  const { operators: rawOperators, isLoading: operatorsLoading, isRefreshing, consecutiveFailures, isFailed, isDemoFallback: isDemoData, refetch } = useCachedOperators(undefined)
 
   // Report card data state
   const hasData = rawOperators.length > 0
-  const { showSkeleton, showEmptyState } = useCardLoadingState({
+  const { showSkeleton, showEmptyState, loadingTimedOut } = useCardLoadingState({
     isLoading: (clustersLoading || operatorsLoading) && !hasData,
     isRefreshing,
     hasAnyData: hasData,
@@ -180,6 +180,23 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
   }
 
   if (showEmptyState) {
+    // When fetching failed or timed out, show error state instead of misleading "No operators"
+    if (isFailed || loadingTimedOut) {
+      return (
+        <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-3">
+          <AlertCircle className="w-8 h-8 text-red-400" />
+          <p className="text-sm">{t('operatorStatus.errorLoading', 'Unable to load operators')}</p>
+          <p className="text-xs">{t('operatorStatus.errorLoadingHint', 'Failed after {{count}} attempts', { count: consecutiveFailures })}</p>
+          <button
+            onClick={() => refetch()}
+            className="mt-1 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 transition-colors"
+          >
+            <RefreshCw className="w-3 h-3" />
+            {t('common:common.retry', 'Retry')}
+          </button>
+        </div>
+      )
+    }
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
         <p className="text-sm">{t('operatorStatus.noOperators')}</p>

--- a/web/src/components/cards/OperatorSubscriptions.tsx
+++ b/web/src/components/cards/OperatorSubscriptions.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Clock, AlertTriangle, Settings, ChevronRight } from 'lucide-react'
+import { Clock, AlertTriangle, AlertCircle, Settings, RefreshCw, ChevronRight } from 'lucide-react'
 import { useClusters, OperatorSubscription } from '../../hooks/useMCP'
 import { useCachedOperatorSubscriptions } from '../../hooks/useCachedData'
 import { Skeleton } from '../ui/Skeleton'
@@ -55,11 +55,11 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
   const { drillToOperator } = useDrillDownActions()
 
   // Fetch subscriptions - pass undefined to get all clusters
-  const { subscriptions: rawSubscriptions, isLoading: subscriptionsLoading, isRefreshing, consecutiveFailures, isFailed, isDemoFallback: isDemoData } = useCachedOperatorSubscriptions(undefined)
+  const { subscriptions: rawSubscriptions, isLoading: subscriptionsLoading, isRefreshing, consecutiveFailures, isFailed, isDemoFallback: isDemoData, refetch } = useCachedOperatorSubscriptions(undefined)
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const hasData = rawSubscriptions.length > 0
-  const { showSkeleton, showEmptyState } = useCardLoadingState({
+  const { showSkeleton, showEmptyState, loadingTimedOut } = useCardLoadingState({
     isLoading: (clustersLoading || subscriptionsLoading) && !hasData,
     isRefreshing,
     hasAnyData: hasData,
@@ -138,6 +138,23 @@ export function OperatorSubscriptions({ config: _config }: OperatorSubscriptions
   }
 
   if (showEmptyState) {
+    // When fetching failed or timed out, show error state instead of misleading "No subscriptions"
+    if (isFailed || loadingTimedOut) {
+      return (
+        <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-3">
+          <AlertCircle className="w-8 h-8 text-red-400" />
+          <p className="text-sm">{t('operatorSubscriptions.errorLoading', 'Unable to load subscriptions')}</p>
+          <p className="text-xs">{t('operatorSubscriptions.errorLoadingHint', 'Failed after {{count}} attempts', { count: consecutiveFailures })}</p>
+          <button
+            onClick={() => refetch()}
+            className="mt-1 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 transition-colors"
+          >
+            <RefreshCw className="w-3 h-3" />
+            {t('common:common.retry', 'Retry')}
+          </button>
+        </div>
+      )
+    }
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
         <p className="text-sm">{t('operatorSubscriptions.noSubscriptions')}</p>


### PR DESCRIPTION
## Summary
- Operator Status and Operator Subscription Status cards displayed "No operators" / "No Subscriptions" when the backend SSE fetch failed or the 30-second loading safety timeout fired — even though operators ARE installed on the clusters
- Now shows an error state with a retry button when `isFailed` or `loadingTimedOut`, distinguishing "data doesn't exist" from "couldn't load data"
- Exposes `loadingTimedOut` from `useCardLoadingState` so card components can differentiate timeout from genuine empty state

## Test plan
- [ ] Navigate to the Operators dashboard page
- [ ] Verify Operator Status card shows operators when backend is reachable
- [ ] Verify Operator Subscription Status card shows subscriptions when backend is reachable
- [ ] Disconnect from clusters (or stop backend), refresh — should see error state with retry button, NOT "No operators"
- [ ] Click retry button — should attempt to refetch