### PR TITLE
⚠️ breaking: rename 'solution' missions → 'fixer', solutions/ → fixes/

### DIFF
--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -241,7 +241,7 @@ func (h *MissionsHandler) githubGet(url string, clientToken string) (*http.Respo
 // ---------- Browse knowledge base ----------
 
 // BrowseConsoleKB lists directory contents from the kubestellar/console-kb repo.
-// GET /api/missions/browse?path=solutions
+// GET /api/missions/browse?path=fixes
 //
 // Responses are cached server-side for missionsCacheTTL to eliminate redundant
 // GitHub API calls. On rate-limit errors (403/429), stale cache entries are
@@ -360,10 +360,10 @@ func (h *MissionsHandler) BrowseConsoleKB(c *fiber.Ctx) error {
 // ---------- Get a single file ----------
 
 // GetMissionFile fetches raw file content from the kubestellar/console-kb repo.
-// GET /api/missions/file?path=solutions/cncf-generated/kubernetes/kubernetes-42873.json
+// GET /api/missions/file?path=fixes/cncf-generated/kubernetes/kubernetes-42873.json
 //
 // Responses are cached server-side for missionsCacheTTL to avoid redundant
-// GitHub raw content fetches. The solutions/index.json file is the most critical
+// GitHub raw content fetches. The fixes/index.json file is the most critical
 // cache entry — it is fetched once and serves all mission browser listings,
 // eliminating the N+1 request pattern.
 func (h *MissionsHandler) GetMissionFile(c *fiber.Ctx) error {

--- a/pkg/api/handlers/missions_test.go
+++ b/pkg/api/handlers/missions_test.go
@@ -340,7 +340,7 @@ func TestMissions_BrowseConsoleKB_CacheHit(t *testing.T) {
 	handler.githubAPIURL = mock.URL
 
 	// First request — should call GitHub (MISS)
-	req1, err := http.NewRequest("GET", "/api/missions/browse?path=solutions", nil)
+	req1, err := http.NewRequest("GET", "/api/missions/browse?path=fixes", nil)
 	require.NoError(t, err)
 	resp1, err := app.Test(req1, 5000)
 	require.NoError(t, err)
@@ -349,7 +349,7 @@ func TestMissions_BrowseConsoleKB_CacheHit(t *testing.T) {
 	assert.Equal(t, int32(1), callCount.Load(), "first request should call GitHub")
 
 	// Second request — should serve from cache (HIT), NOT call GitHub again
-	req2, err := http.NewRequest("GET", "/api/missions/browse?path=solutions", nil)
+	req2, err := http.NewRequest("GET", "/api/missions/browse?path=fixes", nil)
 	require.NoError(t, err)
 	resp2, err := app.Test(req2, 5000)
 	require.NoError(t, err)
@@ -379,7 +379,7 @@ func TestMissions_GetMissionFile_CacheHit(t *testing.T) {
 	handler.githubRawURL = mock.URL
 
 	// First request — MISS
-	req1, err := http.NewRequest("GET", "/api/missions/file?path=solutions/index.json", nil)
+	req1, err := http.NewRequest("GET", "/api/missions/file?path=fixes/index.json", nil)
 	require.NoError(t, err)
 	resp1, err := app.Test(req1, 5000)
 	require.NoError(t, err)
@@ -388,7 +388,7 @@ func TestMissions_GetMissionFile_CacheHit(t *testing.T) {
 	assert.Equal(t, int32(1), callCount.Load())
 
 	// Second request — HIT
-	req2, err := http.NewRequest("GET", "/api/missions/file?path=solutions/index.json", nil)
+	req2, err := http.NewRequest("GET", "/api/missions/file?path=fixes/index.json", nil)
 	require.NoError(t, err)
 	resp2, err := app.Test(req2, 5000)
 	require.NoError(t, err)

--- a/web/e2e/nightly/mission-explorer-import.spec.ts
+++ b/web/e2e/nightly/mission-explorer-import.spec.ts
@@ -10,7 +10,7 @@ import { test, expect, type Page } from '@playwright/test'
  * imported missions to lose steps in the card view.
  *
  * Approach:
- *   1. Fetch the real solutions/index.json via the API proxy
+ *   1. Fetch the real fixes/index.json via the API proxy
  *   2. Pick 25 random install missions (these always have steps)
  *   3. Fetch each mission file and verify steps survive normalization
  *   4. Run 3 full UI-driven imports through the Mission Browser dialog
@@ -143,12 +143,12 @@ async function setupDemoMode(page: Page) {
 }
 
 /**
- * Fetch the solutions index from the real API proxy.
+ * Fetch the fixes index from the real API proxy.
  * Returns the full list of index entries.
  */
-async function fetchSolutionsIndex(page: Page): Promise<IndexEntry[]> {
+async function fetchFixesIndex(page: Page): Promise<IndexEntry[]> {
   const resp = await page.request.get(
-    '/api/missions/file?path=solutions%2Findex.json',
+    '/api/missions/file?path=fixes%2Findex.json',
     { timeout: 30_000 }
   )
   expect(resp.ok(), `Index fetch failed: ${resp.status()}`).toBeTruthy()
@@ -204,7 +204,7 @@ test.describe('Mission Explorer Import (Nightly)', () => {
     await page.waitForLoadState('domcontentloaded')
 
     // 1. Fetch real index
-    const allMissions = await fetchSolutionsIndex(page)
+    const allMissions = await fetchFixesIndex(page)
 
     // 2. Filter to install missions (these should always have steps)
     const installMissions = allMissions.filter(
@@ -320,7 +320,7 @@ test.describe('Mission Explorer Import (Nightly)', () => {
     await page.goto('/')
     await page.waitForLoadState('domcontentloaded')
 
-    const allMissions = await fetchSolutionsIndex(page)
+    const allMissions = await fetchFixesIndex(page)
     const installMissions = allMissions.filter(
       (m) => m.missionClass === 'install'
     )

--- a/web/netlify/functions/analytics-dashboard.mts
+++ b/web/netlify/functions/analytics-dashboard.mts
@@ -72,7 +72,7 @@ interface DashboardData {
     login: number;
     commandCopied: number;
     agentConnected: number;
-    solutionViewed: number;
+    fixerViewed: number;
     missionStarted: number;
   };
   cncfOutreach: {
@@ -405,7 +405,7 @@ async function fetchDashboardData(
             "login",
             "ksc_install_command_copied",
             "ksc_agent_connected",
-            "ksc_solution_viewed",
+            "ksc_fixer_viewed",
             "ksc_mission_started",
             "page_view",
             "first_visit",
@@ -801,7 +801,7 @@ async function fetchDashboardData(
       login: funnelMap["login"] || 0,
       commandCopied: funnelMap["ksc_install_command_copied"] || 0,
       agentConnected: funnelMap["ksc_agent_connected"] || 0,
-      solutionViewed: funnelMap["ksc_solution_viewed"] || 0,
+      fixerViewed: funnelMap["ksc_fixer_viewed"] || 0,
       missionStarted: funnelMap["ksc_mission_started"] || 0,
     },
     cncfOutreach: cncfRows

--- a/web/netlify/functions/missions-browse.mts
+++ b/web/netlify/functions/missions-browse.mts
@@ -1,7 +1,7 @@
 /**
  * Netlify Function: Missions Browse Proxy
  *
- * GET /api/missions/browse?path=solutions
+ * GET /api/missions/browse?path=fixes
  * Lists directory contents from kubestellar/console-kb via GitHub Contents API.
  * Caches responses in Netlify Blobs to avoid hitting GitHub on every request.
  * No GITHUB_TOKEN required — the repo is public.

--- a/web/netlify/functions/missions-file.mts
+++ b/web/netlify/functions/missions-file.mts
@@ -1,7 +1,7 @@
 /**
  * Netlify Function: Missions File Proxy
  *
- * GET /api/missions/file?path=solutions/index.json&ref=master
+ * GET /api/missions/file?path=fixes/index.json&ref=master
  * Fetches raw file content from kubestellar/console-kb on GitHub.
  * Caches responses in Netlify Blobs to avoid hitting GitHub on every request.
  * No GITHUB_TOKEN required — the repo is public.

--- a/web/public/analytics.html
+++ b/web/public/analytics.html
@@ -590,7 +590,7 @@
         { label: 'Login', value: funnel.login, color: FUNNEL_COLORS[1] },
         { label: 'Command Copied', value: funnel.commandCopied || 0, color: FUNNEL_COLORS[2] },
         { label: 'Agent Connected', value: funnel.agentConnected, color: FUNNEL_COLORS[3] },
-        { label: 'Solution Viewed', value: funnel.solutionViewed, color: FUNNEL_COLORS[4] },
+        { label: 'Fixer Viewed', value: funnel.fixerViewed, color: FUNNEL_COLORS[4] },
         { label: 'Mission Started', value: funnel.missionStarted, color: FUNNEL_COLORS[5] },
       ];
       const maxFunnel = Math.max(...funnelSteps.map(s => s.value), 1);

--- a/web/src/components/agent/AgentSelector.tsx
+++ b/web/src/components/agent/AgentSelector.tsx
@@ -92,15 +92,15 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
 
   // Known KB paths for install missions
   const INSTALL_MISSION_PATHS: Record<string, string[]> = {
-    'install-kagent': ['solutions/cncf-install/install-kagent.json'],
-    'install-kagenti': ['solutions/platform-install/install-kagenti.json'],
+    'install-kagent': ['fixes/cncf-install/install-kagent.json'],
+    'install-kagenti': ['fixes/platform-install/install-kagenti.json'],
   }
 
   const openInstallGuide = useCallback(async (missionId: string) => {
     closeDropdown()
     setInstallGuideLoading(true)
     setInstallGuideError(false)
-    const paths = INSTALL_MISSION_PATHS[missionId] || [`solutions/cncf-install/${missionId}.json`, `solutions/platform-install/${missionId}.json`]
+    const paths = INSTALL_MISSION_PATHS[missionId] || [`fixes/cncf-install/${missionId}.json`, `fixes/platform-install/${missionId}.json`]
     for (const path of paths) {
       try {
         const res = await fetch(`/api/missions/file?path=${encodeURIComponent(path)}`, { signal: AbortSignal.timeout(5000) })
@@ -132,7 +132,7 @@ export function AgentSelector({ compact = false, className = '' }: AgentSelector
   const handleInstallMission = useCallback(async (missionId: string, displayName: string) => {
     closeDropdown()
     // Fetch the actual mission content
-    const paths = INSTALL_MISSION_PATHS[missionId] || [`solutions/cncf-install/${missionId}.json`, `solutions/platform-install/${missionId}.json`]
+    const paths = INSTALL_MISSION_PATHS[missionId] || [`fixes/cncf-install/${missionId}.json`, `fixes/platform-install/${missionId}.json`]
     let missionData: MissionExport | null = null
     for (const path of paths) {
       try {

--- a/web/src/components/cards/multi-tenancy/missionLoader.ts
+++ b/web/src/components/cards/multi-tenancy/missionLoader.ts
@@ -14,12 +14,12 @@ const MISSION_FETCH_TIMEOUT_MS = 10_000
 
 /** Console-kb paths for missions (legacy keys used by multi-tenancy cards) */
 export const MISSION_PATHS: Record<string, string> = {
-  ovn: 'solutions/cncf-install/install-ovn-kubernetes.json',
-  kubeflex: 'solutions/platform-install/platform-kubeflex.json',
-  k3s: 'solutions/platform-install/platform-k3s.json',
-  'kubeconfig-prune': 'solutions/troubleshoot/kubeconfig-prune.json',
-  kubevirt: 'solutions/cncf-install/install-kubevirt.json',
-  'multi-tenancy': 'solutions/multi-cluster/multi-tenancy-setup.json',
+  ovn: 'fixes/cncf-install/install-ovn-kubernetes.json',
+  kubeflex: 'fixes/platform-install/platform-kubeflex.json',
+  k3s: 'fixes/platform-install/platform-k3s.json',
+  'kubeconfig-prune': 'fixes/troubleshoot/kubeconfig-prune.json',
+  kubevirt: 'fixes/cncf-install/install-kubevirt.json',
+  'multi-tenancy': 'fixes/multi-cluster/multi-tenancy-setup.json',
 }
 
 /**

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -224,8 +224,8 @@ export function MissionSidebar() {
       'cost-optimization', 'networking', 'observability', 'workloads',
     ]
     const paths = [
-      ...KB_DIRS.map(dir => `solutions/${dir}/${directImportSlug}.json`),
-      `solutions/${directImportSlug}.json`,
+      ...KB_DIRS.map(dir => `fixes/${dir}/${directImportSlug}.json`),
+      `fixes/${directImportSlug}.json`,
     ]
 
     const tryImport = async () => {
@@ -258,7 +258,7 @@ export function MissionSidebar() {
 
       // Fallback: search index.json for nested paths
       try {
-        const res = await fetch('/api/missions/file?path=solutions/index.json', {
+        const res = await fetch('/api/missions/file?path=fixes/index.json', {
           signal: AbortSignal.timeout(MISSION_FILE_FETCH_TIMEOUT_MS),
         })
         if (res.ok) {

--- a/web/src/components/mission-control/FixerDefinitionPanel.tsx
+++ b/web/src/components/mission-control/FixerDefinitionPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * SolutionDefinitionPanel — Phase 1 of Mission Control.
+ * FixerDefinitionPanel — Phase 1 of Mission Control.
  *
  * Left: textarea + AI suggestions + PayloadGrid.
  * Right: Info panel showing hovered project details, mission steps, and alternatives.
@@ -26,7 +26,7 @@ const PLACEHOLDER_EXAMPLES = [
   'Edge computing platform with lightweight clusters and workload distribution...',
 ]
 
-interface SolutionDefinitionPanelProps {
+interface FixerDefinitionPanelProps {
   state: MissionControlState
   onDescriptionChange: (desc: string) => void
   onTitleChange: (title: string) => void
@@ -40,7 +40,7 @@ interface SolutionDefinitionPanelProps {
   installedProjects?: Set<string>
 }
 
-export function SolutionDefinitionPanel({
+export function FixerDefinitionPanel({
   state,
   onDescriptionChange,
   onTitleChange,
@@ -52,7 +52,7 @@ export function SolutionDefinitionPanel({
   aiStreaming,
   planningMission,
   installedProjects,
-}: SolutionDefinitionPanelProps) {
+}: FixerDefinitionPanelProps) {
   const [placeholderIdx, setPlaceholderIdx] = useState(0)
   const [showManualAdd, setShowManualAdd] = useState(false)
   const [manualName, setManualName] = useState('')
@@ -179,7 +179,7 @@ export function SolutionDefinitionPanel({
         {state.projects.length === 0 && (
           <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground/50">
             <Layers className="w-6 h-6 mb-2" />
-            <p className="text-[10px] text-center">Describe your solution to get started</p>
+            <p className="text-[10px] text-center">Describe your fix to get started</p>
           </div>
         )}
       </div>
@@ -190,7 +190,7 @@ export function SolutionDefinitionPanel({
         <div>
           <h2 className="text-2xl font-bold mb-1">Define Your Mission</h2>
           <p className="text-sm text-muted-foreground">
-            Describe the solution you want to deploy. AI will suggest the best CNCF
+            Describe the fix you want to deploy. AI will suggest the best CNCF
             projects and dependencies.
           </p>
         </div>

--- a/web/src/components/mission-control/FlightPlanBlueprint.tsx
+++ b/web/src/components/mission-control/FlightPlanBlueprint.tsx
@@ -71,9 +71,9 @@ function shortenClusterName(name: string): string {
 /** Resolve kbPath for a project — tries explicit kbPath, then convention-based lookup */
 function resolveKbPath(proj: PP): string | undefined {
   if (proj.kbPath) return proj.kbPath
-  // Convention: solutions/cncf-install/install-{name}.json
+  // Convention: fixes/cncf-install/install-{name}.json
   const slug = proj.name.toLowerCase().replace(/\s+/g, '-')
-  return `solutions/cncf-install/install-${slug}.json`
+  return `fixes/cncf-install/install-${slug}.json`
 }
 
 interface FlightPlanBlueprintProps {
@@ -1267,16 +1267,16 @@ function ProjectInfoPanel({ info, edges }: { info: ProjectHoverInfo; edges?: Dep
 
     const candidates: string[] = []
     if (info.kbPath) candidates.push(info.kbPath)
-    candidates.push(`solutions/cncf-install/install-${slug}.json`)
+    candidates.push(`fixes/cncf-install/install-${slug}.json`)
     // Try with abbreviation suffix: open-policy-agent → open-policy-agent-opa
     const parts = slug.split('-')
     if (parts.length >= 2) {
       const abbrev = parts.map(p => p[0]).join('')
-      candidates.push(`solutions/cncf-install/install-${slug}-${abbrev}.json`)
+      candidates.push(`fixes/cncf-install/install-${slug}-${abbrev}.json`)
     }
     // Try without trailing "-operator"
     if (slug.endsWith('-operator')) {
-      candidates.push(`solutions/cncf-install/install-${slug.replace(/-operator$/, '')}.json`)
+      candidates.push(`fixes/cncf-install/install-${slug.replace(/-operator$/, '')}.json`)
     }
 
     const tryNext = (idx: number) => {

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -1,7 +1,7 @@
 /**
  * MissionControlDialog — Full-screen overlay with 3-phase stepper.
  *
- * Phase 1: Define Your Mission (solution description + AI payload suggestions)
+ * Phase 1: Define Your Mission (fix description + AI payload suggestions)
  * Phase 2: Chart Your Course (cluster assignment + readiness)
  * Phase 3: Flight Plan (SVG blueprint + deploy)
  */
@@ -23,7 +23,7 @@ import { cn } from '../../lib/cn'
 import { Button } from '../ui/Button'
 import { useToast } from '../ui/Toast'
 import { useMissionControl } from './useMissionControl'
-import { SolutionDefinitionPanel } from './SolutionDefinitionPanel'
+import { FixerDefinitionPanel } from './FixerDefinitionPanel'
 import { ClusterAssignmentPanel } from './ClusterAssignmentPanel'
 import { FlightPlanBlueprint } from './FlightPlanBlueprint'
 import { LaunchSequence } from './LaunchSequence'
@@ -44,7 +44,7 @@ const PHASE_STEPS: {
     key: 'define',
     label: 'Define Mission',
     icon: <Target className="w-4 h-4" />,
-    description: 'Describe your solution and select projects',
+    description: 'Describe your fix and select projects',
   },
   {
     key: 'assign',
@@ -216,7 +216,7 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
             <AnimatePresence mode="wait">
               {state.phase === 'define' && (
                 <PhaseWrapper key="define">
-                  <SolutionDefinitionPanel
+                  <FixerDefinitionPanel
                     state={state}
                     onDescriptionChange={mc.setDescription}
                     onTitleChange={mc.setTitle}

--- a/web/src/components/mission-control/PayloadGrid.tsx
+++ b/web/src/components/mission-control/PayloadGrid.tsx
@@ -44,7 +44,7 @@ export function PayloadGrid({
         <Package className="w-10 h-10 mb-3 opacity-40" />
         <p className="text-sm">No projects selected yet</p>
         <p className="text-xs mt-1">
-          Describe your solution and let AI suggest projects, or add them manually
+          Describe your fix and let AI suggest projects, or add them manually
         </p>
       </div>
     )

--- a/web/src/components/mission-control/types.ts
+++ b/web/src/components/mission-control/types.ts
@@ -2,7 +2,7 @@
  * Mission Control: Multi-Cluster Solutions Orchestrator
  *
  * Type definitions for the 3-phase wizard:
- *   Phase 1: Define Solution (payload selection)
+ *   Phase 1: Define Fix (payload selection)
  *   Phase 2: Assign Clusters (readiness + assignment)
  *   Phase 3: Flight Plan (blueprint + deploy)
  */
@@ -20,7 +20,7 @@ export interface PayloadProject {
   reason: string
   /** CNCF landscape category */
   category: string
-  /** Is this required for the solution or optional? */
+  /** Is this required for the fix or optional? */
   priority: 'required' | 'recommended' | 'optional'
   /** Other project names this depends on (e.g. ["helm"]) */
   dependencies: string[]
@@ -100,9 +100,9 @@ export type OverlayMode = 'architecture' | 'compute' | 'storage' | 'network' | '
 export interface MissionControlState {
   /** Current wizard phase */
   phase: WizardPhase
-  /** User's natural-language solution description */
+  /** User's natural-language fix description */
   description: string
-  /** Solution title (derived from description or user-edited) */
+  /** Fix title (derived from description or user-edited) */
   title: string
   /** Selected payload projects */
   projects: PayloadProject[]

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -282,7 +282,7 @@ export function useMissionControl() {
         ? `\n\nIMPORTANT — Cluster inspection results (helm releases already installed across clusters):\n${JSON.stringify(helmReleases.map(r => ({ name: r.name, chart: r.chart, namespace: r.namespace, status: r.status, cluster: r.cluster })), null, 2)}\n\nFor each suggested project, check if it is already installed on the clusters. Include a "Cluster Inspection Summary" table in your analysis showing which components are Running vs Not installed on each cluster.`
         : ''
 
-      const prompt = `You are helping plan a Kubernetes solution deployment.
+      const prompt = `You are helping plan a Kubernetes fix deployment.
 User's goal: "${description}"
 ${existingContext}${helmContext}
 
@@ -323,7 +323,7 @@ Include real CNCF projects only. Consider dependencies between projects.`
       if (!missionId) {
         missionId = startMission({
           title: 'Mission Control Planning',
-          description: 'AI-assisted solution planning',
+          description: 'AI-assisted fix planning',
           type: 'custom',
           initialPrompt: prompt,
         })

--- a/web/src/components/missions/FixerCard.tsx
+++ b/web/src/components/missions/FixerCard.tsx
@@ -1,5 +1,5 @@
 /**
- * SolutionCard — Card for browsing solution missions (troubleshoot, repair, analyze, etc.).
+ * FixerCard — Card for browsing fixer missions (troubleshoot, repair, analyze, etc.).
  * Shows type badge, category, tags, description, and import button.
  */
 
@@ -19,7 +19,7 @@ const TYPE_COLORS: Record<string, { bg: string; color: string }> = {
   custom: { bg: 'bg-gray-500/15', color: 'text-muted-foreground' },
 }
 
-interface SolutionCardProps {
+interface FixerCardProps {
   mission: MissionExport
   onImport: () => void
   onSelect: () => void
@@ -27,7 +27,7 @@ interface SolutionCardProps {
   compact?: boolean
 }
 
-export function SolutionCard({ mission, onImport, onSelect, onCopyLink, compact }: SolutionCardProps) {
+export function FixerCard({ mission, onImport, onSelect, onCopyLink, compact }: FixerCardProps) {
   const [linkCopied, setLinkCopied] = useState(false)
   const typeStyle = TYPE_COLORS[mission.type] ?? TYPE_COLORS.custom
   const linkCopiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)

--- a/web/src/components/missions/ImproveMissionDialog.tsx
+++ b/web/src/components/missions/ImproveMissionDialog.tsx
@@ -62,7 +62,7 @@ function buildIssueUrl(
     ``,
     `---`,
     `_This issue was created via the KubeStellar Console "Improve this AI Mission" feature._`,
-    `_Mission file: \`solutions/cncf-install/install-${(mission.cncfProject || 'unknown').toLowerCase().replace(/[^a-z0-9]+/g, '-')}.json\`_`,
+    `_Mission file: \`fixes/cncf-install/install-${(mission.cncfProject || 'unknown').toLowerCase().replace(/[^a-z0-9]+/g, '-')}.json\`_`,
   ].filter(Boolean).join('\n')
 
   const labels = ['ai-mission', 'community-improvement', section !== 'general' ? section : ''].filter(Boolean).join(',')

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -16,12 +16,12 @@ import { useAuth } from '../../lib/auth'
 import { matchMissionsToCluster } from '../../lib/missions/matcher'
 import { useClusterContext } from '../../hooks/useClusterContext'
 import {
-  emitSolutionBrowsed,
-  emitSolutionViewed,
-  emitSolutionImported,
-  emitSolutionImportError,
-  emitSolutionGitHubLink,
-  emitSolutionLinkCopied,
+  emitFixerBrowsed,
+  emitFixerViewed,
+  emitFixerImported,
+  emitFixerImportError,
+  emitFixerGitHubLink,
+  emitFixerLinkCopied,
 } from '../../lib/analytics'
 import type {
   MissionExport,
@@ -34,7 +34,7 @@ import { fullScan } from '../../lib/missions/scanner/index'
 import { ScanProgressOverlay } from './ScanProgressOverlay'
 import { CollapsibleSection } from '../ui/CollapsibleSection'
 import { InstallerCard } from './InstallerCard'
-import { SolutionCard } from './SolutionCard'
+import { FixerCard } from './FixerCard'
 import { MissionDetailView } from './MissionDetailView'
 import { ImproveMissionDialog } from './ImproveMissionDialog'
 import { useTranslation } from 'react-i18next'
@@ -181,18 +181,18 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   // Tab state
   const [activeTab, setActiveTab] = useState<BrowserTab>('recommended')
 
-  // Installer & Solution missions — backed by module-level cache
+  // Installer & Fixer missions — backed by module-level cache
   const [installerMissions, setInstallerMissions] = useState<MissionExport[]>(missionCache.installers)
-  const [solutionMissions, setSolutionMissions] = useState<MissionExport[]>(missionCache.fixes)
+  const [fixerMissions, setFixerMissions] = useState<MissionExport[]>(missionCache.fixes)
   const [, forceUpdate] = useState(0)
   const loadingInstallers = !missionCache.installersDone
-  const loadingSolutions = !missionCache.fixesDone
+  const loadingFixers = !missionCache.fixesDone
   const [missionFetchError, setMissionFetchError] = useState<string | null>(missionCache.fetchError)
   const [installerCategoryFilter, setInstallerCategoryFilter] = useState<string>('All')
   const [installerMaturityFilter, setInstallerMaturityFilter] = useState<string>('All')
-  const [solutionTypeFilter, setSolutionTypeFilter] = useState<string>('All')
+  const [fixerTypeFilter, setFixerTypeFilter] = useState<string>('All')
   const [installerSearch, setInstallerSearch] = useState('')
-  const [solutionSearch, setSolutionSearch] = useState('')
+  const [fixerSearch, setFixerSearch] = useState('')
 
   // ============================================================================
   // Initialize tree when dialog opens
@@ -205,7 +205,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       {
         id: 'community',
         name: 'KubeStellar Community',
-        path: 'solutions',
+        path: 'fixes',
         type: 'directory',
         source: 'community',
         loaded: false,
@@ -279,7 +279,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       if (allMissions.length === 0) {
         if (!missionCache.fixesDone) {
           setLoadingRecommendations(true)
-          setSearchProgress({ step: 'Scanning', detail: 'Loading solutions...', found: 0, scanned: 0 })
+          setSearchProgress({ step: 'Scanning', detail: 'Loading fixes...', found: 0, scanned: 0 })
         }
         return
       }
@@ -293,7 +293,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
         const done = missionCache.fixesDone
         setSearchProgress({
           step: done ? 'Done' : 'Scanning',
-          detail: `${allMissions.length} solutions`,
+          detail: `${allMissions.length} fixes`,
           found: allMissions.length,
           scanned: allMissions.length,
         })
@@ -310,7 +310,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       const done = missionCache.fixesDone
       setSearchProgress({
         step: done ? 'Done' : 'Scanning',
-        detail: `${allMissions.length} solutions`,
+        detail: `${allMissions.length} fixes`,
         found: allMissions.length,
         scanned: allMissions.length,
       })
@@ -331,12 +331,12 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
 
     // Sync local state from cache immediately (covers re-open with cached data)
     setInstallerMissions([...missionCache.installers])
-    setSolutionMissions([...missionCache.fixes])
+    setFixerMissions([...missionCache.fixes])
 
     // Listen for incremental updates from the background fetch
     const listener = () => {
       setInstallerMissions([...missionCache.installers])
-      setSolutionMissions([...missionCache.fixes])
+      setFixerMissions([...missionCache.fixes])
       setMissionFetchError(missionCache.fetchError)
       forceUpdate(n => n + 1)
     }
@@ -382,7 +382,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
     e.stopPropagation()
     const url = getMissionShareUrl(mission)
     copyToClipboard(url)
-    emitSolutionLinkCopied(mission.title, mission.cncfProject)
+    emitFixerLinkCopied(mission.title, mission.cncfProject)
   }, [])
 
   // ============================================================================
@@ -432,7 +432,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       // Exact slug match
       if (getMissionSlug(m) === slug) return 1
 
-      // cncfProject match (installers only — solutions use slug/title matching)
+      // cncfProject match (installers only — fixers use slug/title matching)
       if (isInstaller) {
         const project = (m.cncfProject || '').toLowerCase()
         const slugProject = slug.replace(/^install-/, '')
@@ -458,7 +458,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       return best
     }
 
-    // Search installers first, then solutions
+    // Search installers first, then fixers
     const installerMatch = findBest(installerMissions, true)
     if (installerMatch) {
       setActiveTab('installers')
@@ -467,27 +467,27 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       return
     }
 
-    const solutionMatch = findBest(solutionMissions, false)
-    if (solutionMatch) {
+    const fixerMatch = findBest(fixerMissions, false)
+    if (fixerMatch) {
       setActiveTab('fixes')
-      selectCardMission(solutionMatch)
+      selectCardMission(fixerMatch)
       deepLinkSlugRef.current = null // consumed
       return
     }
 
     // No match yet — switch to installers tab while data loads
-    if (installerMissions.length === 0 && solutionMissions.length === 0 && activeTab !== 'installers') {
+    if (installerMissions.length === 0 && fixerMissions.length === 0 && activeTab !== 'installers') {
       setActiveTab('installers')
     }
-  }, [initialMission, isOpen, installerMissions, solutionMissions, selectedMission, activeTab, selectCardMission])
+  }, [initialMission, isOpen, installerMissions, fixerMissions, selectedMission, activeTab, selectCardMission])
 
   // ============================================================================
-  // Filtered installer & solution lists
+  // Filtered installer & fixer lists
   // ============================================================================
 
   // Effective search: local tab search overrides global search
   const effectiveInstallerSearch = installerSearch || searchQuery
-  const effectiveSolutionSearch = solutionSearch || searchQuery
+  const effectiveFixerSearch = fixerSearch || searchQuery
 
   // AND search: each space-separated term must match somewhere in the mission
   const andMatch = (text: string, query: string) => {
@@ -515,16 +515,16 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
     return list
   }, [installerMissions, installerCategoryFilter, installerMaturityFilter, effectiveInstallerSearch])
 
-  const filteredSolutions = useMemo(() => {
-    let list = solutionMissions
-    if (solutionTypeFilter !== 'All') {
-      list = list.filter(m => m.type === solutionTypeFilter.toLowerCase())
+  const filteredFixers = useMemo(() => {
+    let list = fixerMissions
+    if (fixerTypeFilter !== 'All') {
+      list = list.filter(m => m.type === fixerTypeFilter.toLowerCase())
     }
-    if (effectiveSolutionSearch) {
-      list = list.filter(m => matchesMission(m, effectiveSolutionSearch))
+    if (effectiveFixerSearch) {
+      list = list.filter(m => matchesMission(m, effectiveFixerSearch))
     }
     return list
-  }, [solutionMissions, solutionTypeFilter, effectiveSolutionSearch])
+  }, [fixerMissions, fixerTypeFilter, effectiveFixerSearch])
 
   // ============================================================================
   // Tree expansion & lazy loading
@@ -629,7 +629,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
     setShowRaw(false)
 
     if (node.type === 'directory') {
-      emitSolutionBrowsed(node.path)
+      emitFixerBrowsed(node.path)
       setLoading(true)
       try {
         if (node.source === 'community') {
@@ -682,10 +682,10 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
         const validation = validateMissionExport(parsed)
         if (validation.valid) {
           setSelectedMission(validation.data)
-          emitSolutionViewed(validation.data.title, validation.data.cncfProject)
+          emitFixerViewed(validation.data.title, validation.data.cncfProject)
         } else {
           setSelectedMission(parsed as MissionExport)
-          emitSolutionViewed((parsed as MissionExport).title ?? node.name, (parsed as MissionExport).cncfProject)
+          emitFixerViewed((parsed as MissionExport).title ?? node.name, (parsed as MissionExport).cncfProject)
         }
       } catch {
         setRawContent(null)
@@ -730,7 +730,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       const missionTitle = (toValidate as Record<string, unknown>)?.title as string
         ?? (toValidate as Record<string, unknown>)?.name as string
         ?? 'unknown'
-      emitSolutionImportError(
+      emitFixerImportError(
         missionTitle,
         validation.errors.length,
         validation.errors[0]?.message ?? 'unknown',
@@ -757,7 +757,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
     // updated yet when scan completes synchronously after async fetch
     const mission = pendingImportRef.current
     if (result.valid && mission) {
-      emitSolutionImported(mission.title, mission.cncfProject)
+      emitFixerImported(mission.title, mission.cncfProject)
       onImport(mission)
       onClose()
     }
@@ -1286,7 +1286,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
               <span className="text-2xs bg-secondary px-1.5 py-0.5 rounded-full min-w-[28px] text-center tabular-nums">{installerMissions.length || '–'}</span>
             )}
             {tab.id === 'fixes' && (
-              <span className="text-2xs bg-secondary px-1.5 py-0.5 rounded-full min-w-[28px] text-center tabular-nums">{solutionMissions.length || '–'}</span>
+              <span className="text-2xs bg-secondary px-1.5 py-0.5 rounded-full min-w-[28px] text-center tabular-nums">{fixerMissions.length || '–'}</span>
             )}
           </button>
         ))}
@@ -1491,7 +1491,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                         : 'GitHub token is invalid or expired'}
                     </p>
                     <p className="text-muted-foreground">
-                      The solution browser needs a GitHub personal access token to fetch missions.
+                      The fix browser needs a GitHub personal access token to fetch missions.
                       Add one to your <code className="px-1.5 py-0.5 bg-white/10 rounded text-xs font-mono">.env</code> file and restart the console:
                     </p>
                     <ol className="text-muted-foreground list-decimal list-inside space-y-1.5 ml-1">
@@ -1527,7 +1527,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
             {/* Recommended for You */}
             {!selectedMission && (recommendations.length > 0 || loadingRecommendations) && (
               <CollapsibleSection
-                title={hasCluster ? 'Recommended for Your Cluster' : 'Explore CNCF Solutions'}
+                title={hasCluster ? 'Recommended for Your Cluster' : 'Explore CNCF Fixes'}
                 defaultOpen={true}
                 badge={
                   <span className="flex items-center gap-2 text-xs text-purple-400">
@@ -1551,7 +1551,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                   <p className="text-xs text-muted-foreground mb-3 -mt-1">
                     {hasCluster
                       ? '🎯 Matched based on your cluster resources, labels, and detected issues'
-                      : '🌐 Showing popular CNCF community solutions — connect a cluster for personalized recommendations'}
+                      : '🌐 Showing popular CNCF community fixes — connect a cluster for personalized recommendations'}
                   </p>
                 )}
                 {loadingRecommendations ? (
@@ -1613,14 +1613,14 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
             {!selectedMission && !loading && (
               <div className="flex items-center gap-2 mb-4 px-1">
                 <a
-                  href="https://github.com/kubestellar/console-kb/tree/master/solutions"
+                  href="https://github.com/kubestellar/console-kb/tree/master/fixes"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-purple-400 transition-colors"
-                  onClick={() => emitSolutionGitHubLink()}
+                  onClick={() => emitFixerGitHubLink()}
                 >
                   <ExternalLink className="w-3.5 h-3.5" />
-                  Browse all solutions on GitHub
+                  Browse all fixes on GitHub
                 </a>
                 {searchProgress.step === 'Done' && searchProgress.found > 0 && (
                   <span className="text-xs text-muted-foreground/60 ml-auto">
@@ -1759,25 +1759,25 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
             )}
 
             {/* ============================================================ */}
-            {/* SOLUTIONS TAB */}
+            {/* FIXES TAB */}
             {/* ============================================================ */}
             {!selectedMission && activeTab === 'fixes' && (
               <div className="space-y-4">
-                {/* Solution filters */}
+                {/* Fixer filters */}
                 <div className="flex flex-wrap items-center gap-2">
                   <div className="flex-1 relative min-w-[200px]">
                     <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
                     <input
                       type="text"
-                      value={solutionSearch}
-                      onChange={(e) => setSolutionSearch(e.target.value)}
-                      placeholder="Search solutions…"
+                      value={fixerSearch}
+                      onChange={(e) => setFixerSearch(e.target.value)}
+                      placeholder="Search fixes…"
                       className="w-full pl-10 pr-4 py-1.5 bg-secondary border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
                     />
                   </div>
                   <select
-                    value={solutionTypeFilter}
-                    onChange={(e) => setSolutionTypeFilter(e.target.value)}
+                    value={fixerTypeFilter}
+                    onChange={(e) => setFixerTypeFilter(e.target.value)}
                     className="px-2.5 py-1.5 text-xs bg-secondary border border-border rounded-lg text-foreground"
                   >
                     {CATEGORY_FILTERS.map(cat => (
@@ -1787,33 +1787,33 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                 </div>
 
                 {/* Fetch error banner */}
-                {missionFetchError && solutionMissions.length === 0 && (
+                {missionFetchError && fixerMissions.length === 0 && (
                   <MissionFetchErrorBanner message={missionFetchError} />
                 )}
 
-                {/* Solution grid */}
-                {loadingSolutions && filteredSolutions.length === 0 ? (
+                {/* Fixer grid */}
+                {loadingFixers && filteredFixers.length === 0 ? (
                   <div className="flex items-center gap-2 text-sm text-muted-foreground py-8 justify-center">
                     <Loader2 className="w-4 h-4 animate-spin text-purple-400" />
-                    Loading solutions…
+                    Loading fixes…
                   </div>
-                ) : filteredSolutions.length === 0 && !loadingSolutions ? (
-                  <EmptyState message={solutionMissions.length > 0 ? 'No solutions match your filters' : 'No solution missions found'} />
+                ) : filteredFixers.length === 0 && !loadingFixers ? (
+                  <EmptyState message={fixerMissions.length > 0 ? 'No fixes match your filters' : 'No fixer missions found'} />
                 ) : (
                   <>
-                    {loadingSolutions && (
+                    {loadingFixers && (
                       <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
                         <Loader2 className="w-4 h-4 animate-spin text-purple-400" />
-                        Loading… {solutionMissions.length} found so far
+                        Loading… {fixerMissions.length} found so far
                       </div>
                     )}
                     <VirtualizedMissionGrid
-                      items={filteredSolutions}
+                      items={filteredFixers}
                       viewMode={viewMode}
                       maxColumns={3}
                       className="flex-1 h-[calc(90vh-280px)]"
                       renderItem={(mission) => (
-                        <SolutionCard
+                        <FixerCard
                           mission={mission}
                           compact={viewMode === 'list'}
                           onSelect={() => selectCardMission(mission)}
@@ -1826,9 +1826,9 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                 )}
 
                 {/* Count footer */}
-                {filteredSolutions.length > 0 && (
+                {filteredFixers.length > 0 && (
                   <p className="text-xs text-muted-foreground text-center pt-2">
-                    {loadingSolutions ? `${filteredSolutions.length} loaded…` : `Showing ${filteredSolutions.length} of ${solutionMissions.length} solution missions`}
+                    {loadingFixers ? `${filteredFixers.length} loaded…` : `Showing ${filteredFixers.length} of ${fixerMissions.length} fixer missions`}
                   </p>
                 )}
               </div>

--- a/web/src/components/missions/MissionLandingPage.tsx
+++ b/web/src/components/missions/MissionLandingPage.tsx
@@ -112,22 +112,22 @@ const TABS: TabDef[] = [
 function getPreferredPaths(slug: string): string[] {
   if (slug.startsWith('install-')) {
     return [
-      `solutions/cncf-install/${slug}.json`,
-      `solutions/platform-install/${slug}.json`,
+      `fixes/cncf-install/${slug}.json`,
+      `fixes/platform-install/${slug}.json`,
     ]
   }
   if (slug.startsWith('platform-')) {
-    return [`solutions/platform-install/${slug}.json`]
+    return [`fixes/platform-install/${slug}.json`]
   }
   // For cncf-generated missions, the slug often starts with the project name
   // e.g., "karmada-1234-some-issue" → cncf-generated/karmada/karmada-1234-some-issue.json
   const projectHint = slug.split('-')[0]
   return [
-    `solutions/cncf-generated/${projectHint}/${slug}.json`,
-    `solutions/security/${slug}.json`,
-    `solutions/troubleshoot/${slug}.json`,
-    `solutions/llm-d/${slug}.json`,
-    `solutions/multi-cluster/${slug}.json`,
+    `fixes/cncf-generated/${projectHint}/${slug}.json`,
+    `fixes/security/${slug}.json`,
+    `fixes/troubleshoot/${slug}.json`,
+    `fixes/llm-d/${slug}.json`,
+    `fixes/multi-cluster/${slug}.json`,
   ]
 }
 
@@ -153,7 +153,7 @@ async function fetchMissionBySlug(slug: string): Promise<{ mission: MissionExpor
 
   // Fallback: search index.json for missions in unexpected directories
   try {
-    const res = await fetch('/api/missions/file?path=solutions/index.json', {
+    const res = await fetch('/api/missions/file?path=fixes/index.json', {
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     })
     if (res.ok) {

--- a/web/src/components/missions/ShareMissionDialog.tsx
+++ b/web/src/components/missions/ShareMissionDialog.tsx
@@ -86,7 +86,7 @@ function missionToMarkdown(mission: MissionExport): string {
   ]
 
   if (mission.resolution?.summary) {
-    lines.push('## Solution', mission.resolution.summary, '')
+    lines.push('## Fix', mission.resolution.summary, '')
   }
 
   if (mission.steps.length > 0) {

--- a/web/src/components/missions/SubmitToKBDialog.tsx
+++ b/web/src/components/missions/SubmitToKBDialog.tsx
@@ -157,8 +157,8 @@ function resolutionToKBFormat(
     steps,
   }
 
-  // Add troubleshooting section for solution-class missions
-  if (missionClass === 'solution' && resolution.resolution.summary) {
+  // Add troubleshooting section for fixer-class missions
+  if (missionClass === 'fixer' && resolution.resolution.summary) {
     mission.troubleshooting = [
       {
         title: resolution.issueSignature.type,
@@ -207,7 +207,7 @@ function generateFilename(title: string, missionClass: MissionClass): string {
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-|-$/g, '')
     .slice(0, 60)
-  const prefix = missionClass === 'install' ? 'install' : 'solution'
+  const prefix = missionClass === 'install' ? 'install' : 'fixer'
   return `${prefix}-${slug}.json`
 }
 
@@ -218,7 +218,7 @@ function buildGitHubNewFileUrl(
   description: string,
 ): string {
   // GitHub new file URL: /new/{branch}/{path}?filename=...&value=...&message=...
-  const directory = filepath.includes('/') ? filepath.substring(0, filepath.lastIndexOf('/')) : 'solutions'
+  const directory = filepath.includes('/') ? filepath.substring(0, filepath.lastIndexOf('/')) : 'fixes'
   const filename = filepath.includes('/') ? filepath.substring(filepath.lastIndexOf('/') + 1) : filepath
 
   const params = new URLSearchParams({
@@ -232,7 +232,7 @@ function buildGitHubNewFileUrl(
 }
 
 export function SubmitToKBDialog({ resolution, isOpen, onClose }: SubmitToKBDialogProps) {
-  const [missionClass, setMissionClass] = useState<MissionClass>('solution')
+  const [missionClass, setMissionClass] = useState<MissionClass>('fixer')
   const [cncfProject, setCncfProject] = useState('')
   const [filename, setFilename] = useState('')
   const [scanResult, setScanResult] = useState<FileScanResult | null>(null)
@@ -261,7 +261,7 @@ export function SubmitToKBDialog({ resolution, isOpen, onClose }: SubmitToKBDial
   )
 
   // Determine the target directory based on mission class
-  const targetDir = missionClass === 'install' ? 'solutions/cncf-install' : 'solutions/troubleshoot'
+  const targetDir = missionClass === 'install' ? 'fixes/cncf-install' : 'fixes/troubleshoot'
   const fullPath = `${targetDir}/${filename}`
 
   // Run security scan
@@ -362,17 +362,17 @@ export function SubmitToKBDialog({ resolution, isOpen, onClose }: SubmitToKBDial
             </label>
             <div className="flex gap-3">
               <button
-                onClick={() => setMissionClass('solution')}
+                onClick={() => setMissionClass('fixer')}
                 className={cn(
                   'flex-1 flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg border transition-colors',
-                  missionClass === 'solution'
+                  missionClass === 'fixer'
                     ? 'bg-purple-500/20 border-purple-500/50 text-purple-400'
                     : 'bg-secondary/50 border-border text-muted-foreground hover:text-foreground',
                 )}
               >
                 <Tag className="w-4 h-4" />
                 <div className="text-left">
-                  <span className="text-sm font-medium block">Solution</span>
+                  <span className="text-sm font-medium block">Fixer</span>
                   <span className="text-2xs opacity-70">Troubleshooting fix</span>
                 </div>
               </button>

--- a/web/src/components/missions/browser/VirtualizedMissionGrid.tsx
+++ b/web/src/components/missions/browser/VirtualizedMissionGrid.tsx
@@ -3,7 +3,7 @@
  *
  * Uses @tanstack/react-virtual to only render visible rows, dramatically
  * reducing DOM nodes and improving performance for large mission lists
- * (hundreds of installers/solutions).
+ * (hundreds of installers/fixes).
  *
  * Grid mode: groups items into rows based on container width and column count,
  * then virtualizes by row.
@@ -51,7 +51,7 @@ interface VirtualizedMissionGridProps<T> {
   viewMode: ViewMode
   /** Render a single card */
   renderItem: (item: T, index: number) => React.ReactNode
-  /** Maximum columns in grid mode (e.g. 4 for installers, 3 for solutions) */
+  /** Maximum columns in grid mode (e.g. 4 for installers, 3 for fixes) */
   maxColumns?: number
   /** Custom estimated row height for grid mode */
   gridRowHeight?: number

--- a/web/src/components/missions/browser/missionCache.ts
+++ b/web/src/components/missions/browser/missionCache.ts
@@ -77,11 +77,11 @@ export function notifyCacheListeners() {
   missionCache.listeners.forEach(fn => fn())
 }
 
-/** Path to the pre-built solutions index (single file, ~400KB) */
-const SOLUTIONS_INDEX_PATH = 'solutions/index.json'
+/** Path to the pre-built fixes index (single file, ~400KB) */
+const FIXES_INDEX_PATH = 'fixes/index.json'
 
 /**
- * Index entry shape from solutions/index.json — lightweight metadata
+ * Index entry shape from fixes/index.json — lightweight metadata
  * for browsing without loading full mission files.
  */
 interface IndexEntry {
@@ -121,7 +121,7 @@ function indexEntryToMission(entry: IndexEntry): MissionExport {
     tags: entry.tags || [],
     category: entry.category,
     cncfProject: entry.cncfProjects?.[0],
-    missionClass: entry.missionClass === 'install' ? 'install' : 'solution',
+    missionClass: entry.missionClass === 'install' ? 'install' : 'fixer',
     difficulty: entry.difficulty,
     installMethods: entry.installMethods,
     author: entry.author,
@@ -199,7 +199,7 @@ async function fetchAllFromIndex() {
     // Use direct fetch — /api/missions/file is a public endpoint and should not
     // be gated by the api.get() backend-availability check (which can block when
     // the health check hasn't resolved yet on initial page load).
-    const url = `/api/missions/file?path=${encodeURIComponent(SOLUTIONS_INDEX_PATH)}`
+    const url = `/api/missions/file?path=${encodeURIComponent(FIXES_INDEX_PATH)}`
     const response = await fetch(url, { signal: AbortSignal.timeout(INDEX_FETCH_TIMEOUT_MS) })
     if (!response.ok) throw new Error(`Index fetch failed: ${response.status}`)
     const parsed = await response.json()
@@ -277,7 +277,7 @@ interface RecommendationCacheEntry {
   /** Cached recommendation results */
   recommendations: MissionMatch[]
   /** Number of fixes when recommendations were computed (invalidation key) */
-  solutionCount: number
+  fixerCount: number
   /** Timestamp of last computation */
   computedAt: number
   /** Fingerprint of the cluster context used to compute recommendations */
@@ -307,13 +307,13 @@ let recommendationCacheEntry: RecommendationCacheEntry | null = null
 
 /**
  * Get cached recommendations if the cache is still valid.
- * Returns null if the cache is stale, empty, the solution count has changed
+ * Returns null if the cache is stale, empty, the fixer count has changed
  * (indicating new data was fetched), or the cluster context has changed.
  */
 export function getCachedRecommendations(clusterCtx: ClusterContext | null): MissionMatch[] | null {
   if (!recommendationCacheEntry) return null
   // Invalidate if fixes changed (new data arrived)
-  if (recommendationCacheEntry.solutionCount !== missionCache.fixes.length) return null
+  if (recommendationCacheEntry.fixerCount !== missionCache.fixes.length) return null
   // Invalidate if TTL expired
   if (Date.now() - recommendationCacheEntry.computedAt > RECOMMENDATION_CACHE_TTL_MS) return null
   // Invalidate if cluster context changed (different cluster, new operators, etc.)
@@ -327,7 +327,7 @@ export function getCachedRecommendations(clusterCtx: ClusterContext | null): Mis
 export function setCachedRecommendations(recommendations: MissionMatch[], clusterCtx: ClusterContext | null) {
   recommendationCacheEntry = {
     recommendations,
-    solutionCount: missionCache.fixes.length,
+    fixerCount: missionCache.fixes.length,
     computedAt: Date.now(),
     clusterFingerprint: computeClusterFingerprint(clusterCtx),
   }

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -902,40 +902,40 @@ export function emitMissionRated(missionType: string, rating: string) {
 
 // ── Mission Browser / Knowledge Base ──────────────────────────────
 
-export function emitSolutionSearchStarted(clusterConnected: boolean) {
-  send('ksc_solution_search', { cluster_connected: clusterConnected })
+export function emitFixerSearchStarted(clusterConnected: boolean) {
+  send('ksc_fixer_search', { cluster_connected: clusterConnected })
 }
 
-export function emitSolutionSearchCompleted(found: number, scanned: number) {
-  send('ksc_solution_search_done', { found, scanned })
+export function emitFixerSearchCompleted(found: number, scanned: number) {
+  send('ksc_fixer_search_done', { found, scanned })
 }
 
-export function emitSolutionBrowsed(path: string) {
-  send('ksc_solution_browsed', { path })
+export function emitFixerBrowsed(path: string) {
+  send('ksc_fixer_browsed', { path })
 }
 
-export function emitSolutionViewed(title: string, cncfProject?: string) {
-  send('ksc_solution_viewed', { title, cncf_project: cncfProject ?? '' })
+export function emitFixerViewed(title: string, cncfProject?: string) {
+  send('ksc_fixer_viewed', { title, cncf_project: cncfProject ?? '' })
 }
 
-export function emitSolutionImported(title: string, cncfProject?: string) {
-  send('ksc_solution_imported', { title, cncf_project: cncfProject ?? '' })
+export function emitFixerImported(title: string, cncfProject?: string) {
+  send('ksc_fixer_imported', { title, cncf_project: cncfProject ?? '' })
 }
 
-export function emitSolutionImportError(title: string, errorCount: number, firstError: string) {
-  send('ksc_solution_import_error', {
+export function emitFixerImportError(title: string, errorCount: number, firstError: string) {
+  send('ksc_fixer_import_error', {
     title,
     error_count: String(errorCount),
     first_error: firstError.slice(0, 100),
   })
 }
 
-export function emitSolutionLinkCopied(title: string, cncfProject?: string) {
-  send('ksc_solution_link_copied', { title, cncf_project: cncfProject ?? '' })
+export function emitFixerLinkCopied(title: string, cncfProject?: string) {
+  send('ksc_fixer_link_copied', { title, cncf_project: cncfProject ?? '' })
 }
 
-export function emitSolutionGitHubLink() {
-  send('ksc_solution_github_link')
+export function emitFixerGitHubLink() {
+  send('ksc_fixer_github_link')
 }
 
 // ── Auth ───────────────────────────────────────────────────────────

--- a/web/src/lib/cards/cardInstallMap.ts
+++ b/web/src/lib/cards/cardInstallMap.ts
@@ -19,85 +19,85 @@ export interface CardInstallInfo {
  */
 export const CARD_INSTALL_MAP: Record<string, CardInstallInfo> = {
   // OPA / Open Policy Agent
-  opa_policies: { project: 'Open Policy Agent (OPA)', missionKey: 'install-open-policy-agent-opa', kbPaths: ['solutions/cncf-install/install-open-policy-agent-opa.json'] },
-  opa_violations: { project: 'Open Policy Agent (OPA)', missionKey: 'install-open-policy-agent-opa', kbPaths: ['solutions/cncf-install/install-open-policy-agent-opa.json'] },
+  opa_policies: { project: 'Open Policy Agent (OPA)', missionKey: 'install-open-policy-agent-opa', kbPaths: ['fixes/cncf-install/install-open-policy-agent-opa.json'] },
+  opa_violations: { project: 'Open Policy Agent (OPA)', missionKey: 'install-open-policy-agent-opa', kbPaths: ['fixes/cncf-install/install-open-policy-agent-opa.json'] },
 
   // Kyverno
-  kyverno_policies: { project: 'Kyverno', missionKey: 'install-kyverno', kbPaths: ['solutions/cncf-install/install-kyverno.json'] },
-  kyverno_violations: { project: 'Kyverno', missionKey: 'install-kyverno', kbPaths: ['solutions/cncf-install/install-kyverno.json'] },
+  kyverno_policies: { project: 'Kyverno', missionKey: 'install-kyverno', kbPaths: ['fixes/cncf-install/install-kyverno.json'] },
+  kyverno_violations: { project: 'Kyverno', missionKey: 'install-kyverno', kbPaths: ['fixes/cncf-install/install-kyverno.json'] },
 
   // Falco
-  falco_alerts: { project: 'Falco', missionKey: 'install-falco', kbPaths: ['solutions/cncf-install/install-falco.json'] },
-  falco_events: { project: 'Falco', missionKey: 'install-falco', kbPaths: ['solutions/cncf-install/install-falco.json'] },
+  falco_alerts: { project: 'Falco', missionKey: 'install-falco', kbPaths: ['fixes/cncf-install/install-falco.json'] },
+  falco_events: { project: 'Falco', missionKey: 'install-falco', kbPaths: ['fixes/cncf-install/install-falco.json'] },
 
   // Istio / Service Mesh
-  istio_traffic: { project: 'Istio', missionKey: 'install-istio', kbPaths: ['solutions/cncf-install/install-istio.json'] },
-  istio_policies: { project: 'Istio', missionKey: 'install-istio', kbPaths: ['solutions/cncf-install/install-istio.json'] },
-  service_mesh: { project: 'Istio', missionKey: 'install-istio', kbPaths: ['solutions/cncf-install/install-istio.json'] },
+  istio_traffic: { project: 'Istio', missionKey: 'install-istio', kbPaths: ['fixes/cncf-install/install-istio.json'] },
+  istio_policies: { project: 'Istio', missionKey: 'install-istio', kbPaths: ['fixes/cncf-install/install-istio.json'] },
+  service_mesh: { project: 'Istio', missionKey: 'install-istio', kbPaths: ['fixes/cncf-install/install-istio.json'] },
 
   // Cert Manager
-  cert_manager: { project: 'cert-manager', missionKey: 'install-cert-manager', kbPaths: ['solutions/cncf-install/install-cert-manager.json'] },
+  cert_manager: { project: 'cert-manager', missionKey: 'install-cert-manager', kbPaths: ['fixes/cncf-install/install-cert-manager.json'] },
 
   // External Secrets
-  external_secrets: { project: 'External Secrets Operator', missionKey: 'install-external-secrets', kbPaths: ['solutions/cncf-install/install-external-secrets.json'] },
+  external_secrets: { project: 'External Secrets Operator', missionKey: 'install-external-secrets', kbPaths: ['fixes/cncf-install/install-external-secrets.json'] },
 
   // Argo CD / GitOps
-  gitops_drift: { project: 'Argo CD', missionKey: 'install-argo-cd', kbPaths: ['solutions/cncf-install/install-argo-cd.json'] },
-  argocd_apps: { project: 'Argo CD', missionKey: 'install-argo-cd', kbPaths: ['solutions/cncf-install/install-argo-cd.json'] },
-  argocd_sync: { project: 'Argo CD', missionKey: 'install-argo-cd', kbPaths: ['solutions/cncf-install/install-argo-cd.json'] },
+  gitops_drift: { project: 'Argo CD', missionKey: 'install-argo-cd', kbPaths: ['fixes/cncf-install/install-argo-cd.json'] },
+  argocd_apps: { project: 'Argo CD', missionKey: 'install-argo-cd', kbPaths: ['fixes/cncf-install/install-argo-cd.json'] },
+  argocd_sync: { project: 'Argo CD', missionKey: 'install-argo-cd', kbPaths: ['fixes/cncf-install/install-argo-cd.json'] },
 
   // Flux
-  flux_status: { project: 'Flux', missionKey: 'install-flux', kbPaths: ['solutions/cncf-install/install-flux.json'] },
-  flux_sources: { project: 'Flux', missionKey: 'install-flux', kbPaths: ['solutions/cncf-install/install-flux.json'] },
+  flux_status: { project: 'Flux', missionKey: 'install-flux', kbPaths: ['fixes/cncf-install/install-flux.json'] },
+  flux_sources: { project: 'Flux', missionKey: 'install-flux', kbPaths: ['fixes/cncf-install/install-flux.json'] },
 
   // Prometheus / Monitoring
-  prometheus_alerts: { project: 'Prometheus', missionKey: 'install-prometheus', kbPaths: ['solutions/cncf-install/install-prometheus.json'] },
-  prometheus_rules: { project: 'Prometheus', missionKey: 'install-prometheus', kbPaths: ['solutions/cncf-install/install-prometheus.json'] },
+  prometheus_alerts: { project: 'Prometheus', missionKey: 'install-prometheus', kbPaths: ['fixes/cncf-install/install-prometheus.json'] },
+  prometheus_rules: { project: 'Prometheus', missionKey: 'install-prometheus', kbPaths: ['fixes/cncf-install/install-prometheus.json'] },
 
   // Grafana
-  grafana_dashboards: { project: 'Grafana', missionKey: 'install-grafana', kbPaths: ['solutions/cncf-install/install-grafana.json'] },
+  grafana_dashboards: { project: 'Grafana', missionKey: 'install-grafana', kbPaths: ['fixes/cncf-install/install-grafana.json'] },
 
   // Helm
-  helm_releases: { project: 'Helm', missionKey: 'install-helm', kbPaths: ['solutions/cncf-install/install-helm.json'] },
-  helm_history: { project: 'Helm', missionKey: 'install-helm', kbPaths: ['solutions/cncf-install/install-helm.json'] },
+  helm_releases: { project: 'Helm', missionKey: 'install-helm', kbPaths: ['fixes/cncf-install/install-helm.json'] },
+  helm_history: { project: 'Helm', missionKey: 'install-helm', kbPaths: ['fixes/cncf-install/install-helm.json'] },
 
   // Tekton / CI-CD
-  tekton_pipelines: { project: 'Tekton', missionKey: 'install-tekton', kbPaths: ['solutions/cncf-install/install-tekton.json'] },
-  tekton_runs: { project: 'Tekton', missionKey: 'install-tekton', kbPaths: ['solutions/cncf-install/install-tekton.json'] },
+  tekton_pipelines: { project: 'Tekton', missionKey: 'install-tekton', kbPaths: ['fixes/cncf-install/install-tekton.json'] },
+  tekton_runs: { project: 'Tekton', missionKey: 'install-tekton', kbPaths: ['fixes/cncf-install/install-tekton.json'] },
 
   // KubeVirt
-  kubevirt_status: { project: 'KubeVirt', missionKey: 'install-kubevirt', kbPaths: ['solutions/cncf-install/install-kubevirt.json'] },
-  kubevirt_vms: { project: 'KubeVirt', missionKey: 'install-kubevirt', kbPaths: ['solutions/cncf-install/install-kubevirt.json'] },
+  kubevirt_status: { project: 'KubeVirt', missionKey: 'install-kubevirt', kbPaths: ['fixes/cncf-install/install-kubevirt.json'] },
+  kubevirt_vms: { project: 'KubeVirt', missionKey: 'install-kubevirt', kbPaths: ['fixes/cncf-install/install-kubevirt.json'] },
 
   // KubeFlex
-  kubeflex_status: { project: 'KubeFlex', missionKey: 'platform-kubeflex', kbPaths: ['solutions/platform-install/platform-kubeflex.json'] },
+  kubeflex_status: { project: 'KubeFlex', missionKey: 'platform-kubeflex', kbPaths: ['fixes/platform-install/platform-kubeflex.json'] },
 
   // OVN
-  ovn_status: { project: 'OVN-Kubernetes', missionKey: 'install-ovn-kubernetes', kbPaths: ['solutions/cncf-install/install-ovn-kubernetes.json'] },
+  ovn_status: { project: 'OVN-Kubernetes', missionKey: 'install-ovn-kubernetes', kbPaths: ['fixes/cncf-install/install-ovn-kubernetes.json'] },
 
   // Vault
-  vault_secrets: { project: 'HashiCorp Vault', missionKey: 'install-vault', kbPaths: ['solutions/cncf-install/install-vault.json'] },
+  vault_secrets: { project: 'HashiCorp Vault', missionKey: 'install-vault', kbPaths: ['fixes/cncf-install/install-vault.json'] },
 
   // NVIDIA GPU Operator
-  gpu_overview: { project: 'NVIDIA GPU Operator', missionKey: 'install-nvidia-gpu-operator', kbPaths: ['solutions/cncf-install/install-nvidia-gpu-operator.json'] },
-  gpu_reservations: { project: 'NVIDIA GPU Operator', missionKey: 'install-nvidia-gpu-operator', kbPaths: ['solutions/cncf-install/install-nvidia-gpu-operator.json'] },
+  gpu_overview: { project: 'NVIDIA GPU Operator', missionKey: 'install-nvidia-gpu-operator', kbPaths: ['fixes/cncf-install/install-nvidia-gpu-operator.json'] },
+  gpu_reservations: { project: 'NVIDIA GPU Operator', missionKey: 'install-nvidia-gpu-operator', kbPaths: ['fixes/cncf-install/install-nvidia-gpu-operator.json'] },
 
   // LLM-d
-  llmd_flow: { project: 'LLM-d', missionKey: 'install-llm-d', kbPaths: ['solutions/platform-install/platform-llm-d.json'] },
-  llmd_benchmarks: { project: 'LLM-d', missionKey: 'install-llm-d', kbPaths: ['solutions/platform-install/platform-llm-d.json'] },
-  pareto_frontier: { project: 'LLM-d', missionKey: 'install-llm-d', kbPaths: ['solutions/platform-install/platform-llm-d.json'] },
+  llmd_flow: { project: 'LLM-d', missionKey: 'install-llm-d', kbPaths: ['fixes/platform-install/platform-llm-d.json'] },
+  llmd_benchmarks: { project: 'LLM-d', missionKey: 'install-llm-d', kbPaths: ['fixes/platform-install/platform-llm-d.json'] },
+  pareto_frontier: { project: 'LLM-d', missionKey: 'install-llm-d', kbPaths: ['fixes/platform-install/platform-llm-d.json'] },
 
   // Kagent / Kagenti
-  kagent_status: { project: 'Kagent', missionKey: 'install-kagent', kbPaths: ['solutions/cncf-install/install-kagent.json'] },
-  kagenti_status: { project: 'Kagenti', missionKey: 'install-kagenti', kbPaths: ['solutions/platform-install/install-kagenti.json'] },
+  kagent_status: { project: 'Kagent', missionKey: 'install-kagent', kbPaths: ['fixes/cncf-install/install-kagent.json'] },
+  kagenti_status: { project: 'Kagenti', missionKey: 'install-kagenti', kbPaths: ['fixes/platform-install/install-kagenti.json'] },
 
   // Trivy
-  trivy_scan: { project: 'Trivy', missionKey: 'install-trivy', kbPaths: ['solutions/cncf-install/install-trivy.json'] },
-  image_vulnerabilities: { project: 'Trivy', missionKey: 'install-trivy', kbPaths: ['solutions/cncf-install/install-trivy.json'] },
+  trivy_scan: { project: 'Trivy', missionKey: 'install-trivy', kbPaths: ['fixes/cncf-install/install-trivy.json'] },
+  image_vulnerabilities: { project: 'Trivy', missionKey: 'install-trivy', kbPaths: ['fixes/cncf-install/install-trivy.json'] },
 
   // Crossplane
-  crossplane_status: { project: 'Crossplane', missionKey: 'install-crossplane', kbPaths: ['solutions/cncf-install/install-crossplane.json'] },
+  crossplane_status: { project: 'Crossplane', missionKey: 'install-crossplane', kbPaths: ['fixes/cncf-install/install-crossplane.json'] },
 
   // Knative
-  knative_services: { project: 'Knative', missionKey: 'install-knative', kbPaths: ['solutions/cncf-install/install-knative.json'] },
+  knative_services: { project: 'Knative', missionKey: 'install-knative', kbPaths: ['fixes/cncf-install/install-knative.json'] },
 }

--- a/web/src/lib/missions/matcher.ts
+++ b/web/src/lib/missions/matcher.ts
@@ -45,7 +45,7 @@ const RESOURCE_TO_PROJECTS: Record<string, string[]> = {
   kubestellar: ['kubestellar', 'multi-cluster', 'edge'],
 }
 
-/** Map issue patterns to solution categories */
+/** Map issue patterns to fix categories */
 const ISSUE_TO_CATEGORIES: Record<string, string[]> = {
   crashloopbackoff: ['troubleshoot', 'debugging', 'pod-restart'],
   oomkilled: ['resources', 'memory', 'limits', 'troubleshoot'],

--- a/web/src/lib/missions/types.ts
+++ b/web/src/lib/missions/types.ts
@@ -18,7 +18,7 @@ export interface MissionStep {
   validation?: string
 }
 
-export type MissionClass = 'solution' | 'install'
+export type MissionClass = 'fixer' | 'install'
 
 export interface MissionExport {
   version: string


### PR DESCRIPTION
## Summary
- Renames `MissionClass` type value from `'solution'` to `'fixer'`
- Renames all KB paths from `solutions/` to `fixes/` (API queries, card install map, landing page, etc.)
- Renames components: `SolutionCard` → `FixerCard`, `SolutionDefinitionPanel` → `FixerDefinitionPanel`
- Renames analytics functions: `emitSolution*` → `emitFixer*`, GA4 events `ksc_solution_*` → `ksc_fixer_*`
- Renames variables: `solutionMissions` → `fixerMissions`, `filteredSolutions` → `filteredFixers`, etc.
- Updates Go backend comments + test paths
- Updates Netlify functions + analytics dashboard
- Updates E2E tests + user-facing strings

28 files changed across frontend, backend, Netlify, and tests.

## Breaking change
Requires companion PR kubestellar/console-kb#1828 to be merged first (renames `solutions/` → `fixes/` directory in the KB repo).

## What stays unchanged
- "Resolution" system (saved outcomes) — different concept, untouched
- "Mission Control — Multi-Cluster Solutions Orchestrator" subtitle
- SudokuGame "solution" (unrelated)
- GitHub issue template "Proposed Solution" field (generic template)

## Test plan
- [x] `npm run build` passes
- [x] `go build ./...` passes
- [ ] Mission Browser "Fixes" tab loads from `fixes/index.json`
- [ ] Card install map points to correct `fixes/` KB paths
- [ ] Analytics events fire with `ksc_fixer_*` names