### PR TITLE
✨ Expand card-standard ratchet for isRefreshing + add concurrency safety tests (P1-A, P2-A)

### DIFF
--- a/web/src/lib/utils/__tests__/concurrency.test.ts
+++ b/web/src/lib/utils/__tests__/concurrency.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Concurrent mutation safety tests for settledWithConcurrency.
+ *
+ * Verifies that the worker-pool implementation in concurrency.ts:
+ * - Preserves result ordering regardless of task completion times
+ * - Collects all results from a shared accumulator without data loss
+ * - Isolates errors so one failing task does not corrupt others
+ * - Respects the concurrency limit (never exceeds N simultaneous tasks)
+ * - Handles edge cases (empty input, single task, all failures)
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  settledWithConcurrency,
+  mapSettledWithConcurrency,
+  DEFAULT_CLUSTER_CONCURRENCY,
+} from '../concurrency'
+
+// ── Named constants (no magic numbers) ─────────────────────────────────────
+
+/** Number of tasks for ordering / accumulation tests */
+const TASK_COUNT = 20
+
+/** Maximum simulated delay in ms for variable-duration tasks */
+const MAX_SIMULATED_DELAY_MS = 50
+
+/** Concurrency limit used in most tests */
+const TEST_CONCURRENCY = 3
+
+/** Concurrency limit of 1 forces sequential execution */
+const SEQUENTIAL_CONCURRENCY = 1
+
+/** Small delay to let the event loop tick between task starts */
+const TICK_DELAY_MS = 5
+
+/** Number of tasks for the concurrency-limit stress test */
+const CONCURRENCY_STRESS_TASK_COUNT = 30
+
+/** Expected default concurrency from the module */
+const EXPECTED_DEFAULT_CONCURRENCY = 8
+
+/** Sentinel value returned by successful tasks */
+const SUCCESS_SENTINEL = 'ok'
+
+/** Error message used by intentionally failing tasks */
+const DELIBERATE_ERROR_MSG = 'deliberate failure'
+
+/** Index of the task that fails in mixed-result tests */
+const FAILING_TASK_INDEX = 2
+
+/** Number of tasks in mixed-result tests (some succeed, one fails) */
+const MIXED_TASK_COUNT = 5
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Create a task that resolves after `ms` milliseconds with `value`. */
+function delayedTask<T>(value: T, ms: number): () => Promise<T> {
+  return () => new Promise<T>((resolve) => setTimeout(() => resolve(value), ms))
+}
+
+/** Create a task that rejects after `ms` milliseconds with `reason`. */
+function failingTask(reason: string, ms: number): () => Promise<never> {
+  return () =>
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error(reason)), ms))
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('settledWithConcurrency', () => {
+  describe('result ordering', () => {
+    it('results maintain correct index ordering with varying task durations', async () => {
+      // Tasks complete in reverse order (last task finishes first)
+      const tasks = Array.from({ length: TASK_COUNT }, (_, i) =>
+        delayedTask(i, MAX_SIMULATED_DELAY_MS - i),
+      )
+
+      const results = await settledWithConcurrency(tasks, TEST_CONCURRENCY)
+
+      expect(results).toHaveLength(TASK_COUNT)
+      for (let i = 0; i < TASK_COUNT; i++) {
+        expect(results[i].status).toBe('fulfilled')
+        if (results[i].status === 'fulfilled') {
+          expect((results[i] as PromiseSettledResult<number> & { status: 'fulfilled' }).value).toBe(i)
+        }
+      }
+    })
+
+    it('preserves order when concurrency equals task count (all concurrent)', async () => {
+      const tasks = Array.from({ length: TASK_COUNT }, (_, i) =>
+        delayedTask(`result-${i}`, Math.random() * MAX_SIMULATED_DELAY_MS),
+      )
+
+      const results = await settledWithConcurrency(tasks, TASK_COUNT)
+
+      for (let i = 0; i < TASK_COUNT; i++) {
+        expect(results[i].status).toBe('fulfilled')
+        if (results[i].status === 'fulfilled') {
+          expect(
+            (results[i] as PromiseSettledResult<string> & { status: 'fulfilled' }).value,
+          ).toBe(`result-${i}`)
+        }
+      }
+    })
+  })
+
+  describe('shared accumulator integrity', () => {
+    it('collects all results without data loss', async () => {
+      const tasks = Array.from({ length: TASK_COUNT }, (_, i) =>
+        delayedTask(i * i, TICK_DELAY_MS),
+      )
+
+      const results = await settledWithConcurrency(tasks, TEST_CONCURRENCY)
+
+      expect(results).toHaveLength(TASK_COUNT)
+
+      const values = results
+        .filter((r): r is PromiseSettledResult<number> & { status: 'fulfilled' } => r.status === 'fulfilled')
+        .map((r) => r.value)
+
+      // Every expected value should be present exactly once
+      for (let i = 0; i < TASK_COUNT; i++) {
+        expect(values).toContain(i * i)
+      }
+      // No duplicates
+      expect(new Set(values).size).toBe(TASK_COUNT)
+    })
+
+    it('accumulates results correctly with sequential concurrency (limit=1)', async () => {
+      const tasks = Array.from({ length: TASK_COUNT }, (_, i) =>
+        delayedTask(i, TICK_DELAY_MS),
+      )
+
+      const results = await settledWithConcurrency(tasks, SEQUENTIAL_CONCURRENCY)
+
+      expect(results).toHaveLength(TASK_COUNT)
+      for (let i = 0; i < TASK_COUNT; i++) {
+        const r = results[i]
+        expect(r.status).toBe('fulfilled')
+        if (r.status === 'fulfilled') {
+          expect((r as PromiseSettledResult<number> & { status: 'fulfilled' }).value).toBe(i)
+        }
+      }
+    })
+  })
+
+  describe('error isolation', () => {
+    it('error in one task does not corrupt results of other tasks', async () => {
+      const tasks: Array<() => Promise<string>> = Array.from(
+        { length: MIXED_TASK_COUNT },
+        (_, i) =>
+          i === FAILING_TASK_INDEX
+            ? failingTask(DELIBERATE_ERROR_MSG, TICK_DELAY_MS)
+            : delayedTask(`${SUCCESS_SENTINEL}-${i}`, TICK_DELAY_MS),
+      )
+
+      const results = await settledWithConcurrency(tasks, TEST_CONCURRENCY)
+
+      expect(results).toHaveLength(MIXED_TASK_COUNT)
+
+      // The failing task should be rejected
+      expect(results[FAILING_TASK_INDEX].status).toBe('rejected')
+      const rejected = results[FAILING_TASK_INDEX] as PromiseSettledResult<string> & { status: 'rejected' }
+      expect(rejected.reason).toBeInstanceOf(Error)
+      expect((rejected.reason as Error).message).toBe(DELIBERATE_ERROR_MSG)
+
+      // All other tasks should be fulfilled with correct values
+      for (let i = 0; i < MIXED_TASK_COUNT; i++) {
+        if (i === FAILING_TASK_INDEX) continue
+        expect(results[i].status).toBe('fulfilled')
+        const fulfilled = results[i] as PromiseSettledResult<string> & { status: 'fulfilled' }
+        expect(fulfilled.value).toBe(`${SUCCESS_SENTINEL}-${i}`)
+      }
+    })
+
+    it('handles all tasks failing without throwing', async () => {
+      const tasks = Array.from({ length: TEST_CONCURRENCY }, (_, i) =>
+        failingTask(`error-${i}`, TICK_DELAY_MS),
+      )
+
+      const results = await settledWithConcurrency(tasks, TEST_CONCURRENCY)
+
+      expect(results).toHaveLength(TEST_CONCURRENCY)
+      for (const r of results) {
+        expect(r.status).toBe('rejected')
+      }
+    })
+  })
+
+  describe('concurrency limit enforcement', () => {
+    it('never exceeds the specified concurrency limit', async () => {
+      let activeTasks = 0
+      let peakConcurrency = 0
+
+      const tasks = Array.from(
+        { length: CONCURRENCY_STRESS_TASK_COUNT },
+        () => async () => {
+          activeTasks++
+          if (activeTasks > peakConcurrency) {
+            peakConcurrency = activeTasks
+          }
+          // Yield to the event loop so other workers can start
+          await new Promise<void>((resolve) => setTimeout(resolve, TICK_DELAY_MS))
+          activeTasks--
+          return SUCCESS_SENTINEL
+        },
+      )
+
+      const results = await settledWithConcurrency(tasks, TEST_CONCURRENCY)
+
+      expect(peakConcurrency).toBeLessThanOrEqual(TEST_CONCURRENCY)
+      expect(peakConcurrency).toBeGreaterThan(0)
+      expect(results).toHaveLength(CONCURRENCY_STRESS_TASK_COUNT)
+      expect(results.every((r) => r.status === 'fulfilled')).toBe(true)
+    })
+
+    it('with concurrency=1, tasks run sequentially (peak=1)', async () => {
+      let activeTasks = 0
+      let peakConcurrency = 0
+
+      const tasks = Array.from({ length: MIXED_TASK_COUNT }, () => async () => {
+        activeTasks++
+        if (activeTasks > peakConcurrency) {
+          peakConcurrency = activeTasks
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, TICK_DELAY_MS))
+        activeTasks--
+        return SUCCESS_SENTINEL
+      })
+
+      await settledWithConcurrency(tasks, SEQUENTIAL_CONCURRENCY)
+
+      expect(peakConcurrency).toBe(SEQUENTIAL_CONCURRENCY)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('empty input array returns empty results', async () => {
+      const results = await settledWithConcurrency([], TEST_CONCURRENCY)
+      expect(results).toEqual([])
+    })
+
+    it('single task returns single result', async () => {
+      const tasks = [delayedTask(SUCCESS_SENTINEL, TICK_DELAY_MS)]
+      const results = await settledWithConcurrency(tasks, TEST_CONCURRENCY)
+
+      expect(results).toHaveLength(1)
+      expect(results[0].status).toBe('fulfilled')
+      if (results[0].status === 'fulfilled') {
+        expect(
+          (results[0] as PromiseSettledResult<string> & { status: 'fulfilled' }).value,
+        ).toBe(SUCCESS_SENTINEL)
+      }
+    })
+
+    it('uses DEFAULT_CLUSTER_CONCURRENCY when no concurrency param given', () => {
+      expect(DEFAULT_CLUSTER_CONCURRENCY).toBe(EXPECTED_DEFAULT_CONCURRENCY)
+    })
+  })
+})
+
+describe('mapSettledWithConcurrency', () => {
+  it('maps items with correct index and preserves order', async () => {
+    const items = Array.from({ length: TASK_COUNT }, (_, i) => i)
+
+    const results = await mapSettledWithConcurrency(
+      items,
+      async (item, index) => {
+        await new Promise<void>((resolve) => setTimeout(resolve, TICK_DELAY_MS))
+        // Verify the index parameter matches the item position
+        expect(index).toBe(item)
+        return item * item
+      },
+      TEST_CONCURRENCY,
+    )
+
+    expect(results).toHaveLength(TASK_COUNT)
+    for (let i = 0; i < TASK_COUNT; i++) {
+      const r = results[i]
+      expect(r.status).toBe('fulfilled')
+      if (r.status === 'fulfilled') {
+        expect((r as PromiseSettledResult<number> & { status: 'fulfilled' }).value).toBe(i * i)
+      }
+    }
+  })
+
+  it('isolates errors in map function the same as settledWithConcurrency', async () => {
+    const items = Array.from({ length: MIXED_TASK_COUNT }, (_, i) => i)
+
+    const results = await mapSettledWithConcurrency(
+      items,
+      async (item) => {
+        if (item === FAILING_TASK_INDEX) {
+          throw new Error(DELIBERATE_ERROR_MSG)
+        }
+        return `${SUCCESS_SENTINEL}-${item}`
+      },
+      TEST_CONCURRENCY,
+    )
+
+    expect(results[FAILING_TASK_INDEX].status).toBe('rejected')
+
+    for (let i = 0; i < MIXED_TASK_COUNT; i++) {
+      if (i === FAILING_TASK_INDEX) continue
+      expect(results[i].status).toBe('fulfilled')
+    }
+  })
+})

--- a/web/src/test/card-loading-standard.test.ts
+++ b/web/src/test/card-loading-standard.test.ts
@@ -150,9 +150,46 @@ const KNOWN_VIOLATIONS: Record<string, Set<string>> = {
   'buildpacks-status/BuildpacksStatus.tsx': new Set(['missing-isRefreshing']),
 }
 
+/**
+ * Known failure-wiring violations — cards that use useCached or useClusters hooks
+ * but do NOT pass isFailed and consecutiveFailures to useCardLoadingState.
+ *
+ * Same ratchet rules as KNOWN_VIOLATIONS: this list MUST ONLY SHRINK.
+ */
+const KNOWN_FAILURE_VIOLATIONS: Record<string, Set<string>> = {
+  'ClusterComparison.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'ClusterGroups.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'ClusterLocations.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'ClusterNetwork.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'console-missions/ConsoleKubeconfigAuditCard.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'console-missions/ConsoleOfflineDetectionCard.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'CrossClusterPolicyComparison.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'FleetComplianceHeatmap.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'GPUNamespaceAllocations.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'GPUStatus.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'GPUWorkloads.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'HelmValuesDiff.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'insights/CrossClusterEventCorrelation.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'Kubectl.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'KustomizationStatus.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'Missions.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'NamespaceEvents.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'NamespaceMonitor.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'NamespaceQuotas.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'NamespaceRBAC.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'OPAPolicies.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'OverlayComparison.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'RecommendedPolicies.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'ResourceMarshall.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'ResourceTrend.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'ResourceUsage.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+  'workload-detection/LLMModels.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
+}
+
 /** Check if a violation is known (grandfathered in) */
 function isKnownViolation(rel: string, check: string): boolean {
-  return KNOWN_VIOLATIONS[rel]?.has(check) ?? false
+  return (KNOWN_VIOLATIONS[rel]?.has(check) ?? false)
+    || (KNOWN_FAILURE_VIOLATIONS[rel]?.has(check) ?? false)
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -298,6 +335,50 @@ describe('Card Loading State Gold Standard', () => {
     }
   })
 
+  describe('isFailed must be wired', () => {
+    for (const filePath of filesWithLoadingHook) {
+      const basename = path.basename(filePath)
+      if (NO_CACHED_HOOK_EXEMPT.has(basename)) continue
+
+      const rel = relPath(filePath)
+      const src = fs.readFileSync(filePath, 'utf-8')
+
+      if (!usesCachedHook(src) && !usesClustersHook(src)) continue
+
+      it(`${rel}: isFailed wired in useCardLoadingState`, () => {
+        if (isKnownViolation(rel, 'missing-isFailed')) return // grandfathered
+
+        const calls = extractLoadingStateCalls(src)
+        if (calls.length === 0) return
+
+        const hasFailed = calls.some(call => call.includes('isFailed'))
+        expect(hasFailed, `${rel}: missing isFailed in useCardLoadingState`).toBe(true)
+      })
+    }
+  })
+
+  describe('consecutiveFailures must be wired', () => {
+    for (const filePath of filesWithLoadingHook) {
+      const basename = path.basename(filePath)
+      if (NO_CACHED_HOOK_EXEMPT.has(basename)) continue
+
+      const rel = relPath(filePath)
+      const src = fs.readFileSync(filePath, 'utf-8')
+
+      if (!usesCachedHook(src) && !usesClustersHook(src)) continue
+
+      it(`${rel}: consecutiveFailures wired in useCardLoadingState`, () => {
+        if (isKnownViolation(rel, 'missing-consecutiveFailures')) return // grandfathered
+
+        const calls = extractLoadingStateCalls(src)
+        if (calls.length === 0) return
+
+        const hasConsecutiveFailures = calls.some(call => call.includes('consecutiveFailures'))
+        expect(hasConsecutiveFailures, `${rel}: missing consecutiveFailures in useCardLoadingState`).toBe(true)
+      })
+    }
+  })
+
   describe('No hardcoded isLoading: false', () => {
     for (const filePath of filesWithLoadingHook) {
       const rel = relPath(filePath)
@@ -323,8 +404,7 @@ describe('Card Loading State Gold Standard', () => {
   })
 
   describe('Ratchet: known violations must not grow', () => {
-    it('no new violations should be added to KNOWN_VIOLATIONS', () => {
-      // Count total known violations
+    it('total KNOWN_VIOLATIONS count must not increase', () => {
       let totalKnown = 0
       for (const checks of Object.values(KNOWN_VIOLATIONS)) {
         totalKnown += checks.size
@@ -335,6 +415,29 @@ describe('Card Loading State Gold Standard', () => {
       // the count dropped, that's great — update the expected count!
       const EXPECTED_KNOWN_VIOLATION_COUNT = 77
       expect(totalKnown).toBeLessThanOrEqual(EXPECTED_KNOWN_VIOLATION_COUNT)
+    })
+
+    it('isRefreshing violation count must not increase', () => {
+      let refreshCount = 0
+      for (const checks of Object.values(KNOWN_VIOLATIONS)) {
+        if (checks.has('missing-isRefreshing')) refreshCount++
+      }
+
+      // Separate ratchet for isRefreshing violations. MUST ONLY DECREASE.
+      const EXPECTED_REFRESH_VIOLATION_COUNT = 28
+      expect(refreshCount).toBeLessThanOrEqual(EXPECTED_REFRESH_VIOLATION_COUNT)
+    })
+
+    it('isFailed/consecutiveFailures violation count must not increase', () => {
+      let failureCount = 0
+      for (const checks of Object.values(KNOWN_FAILURE_VIOLATIONS)) {
+        failureCount += checks.size
+      }
+
+      // Separate ratchet for failure-wiring violations. MUST ONLY DECREASE.
+      // Each card entry has 2 violations (missing-isFailed + missing-consecutiveFailures).
+      const EXPECTED_FAILURE_VIOLATION_COUNT = 54
+      expect(failureCount).toBeLessThanOrEqual(EXPECTED_FAILURE_VIOLATION_COUNT)
     })
   })
 })


### PR DESCRIPTION
## Summary

- **P1-A**: Extends the card-loading-standard ratchet test with separate tracking for `isRefreshing`, `isFailed`, and `consecutiveFailures` violations. Previously, `missing-isRefreshing` violations were lumped into the total 77 `KNOWN_VIOLATIONS` count. Now they have a dedicated ratchet (`EXPECTED_REFRESH_VIOLATION_COUNT = 28`) and a new `KNOWN_FAILURE_VIOLATIONS` map tracks 27 cards missing `isFailed`/`consecutiveFailures` wiring (`EXPECTED_FAILURE_VIOLATION_COUNT = 54`). All ratchets only go down.
- **P2-A**: Adds unit tests for `settledWithConcurrency` verifying result ordering, shared accumulator integrity, error isolation, concurrency limit enforcement, and edge cases. All numeric literals use named constants.

## Test plan

- [x] `npx vitest run src/test/card-loading-standard.test.ts` -- 639 tests pass
- [x] `npx vitest run src/lib/utils/__tests__/concurrency.test.ts` -- 13 tests pass
- [x] `npm run build` -- passes
- [x] `npm run lint` -- no new errors/warnings from changed files
- [x] Pre-existing test failure in `useMetricsHistory.test.ts` is confirmed on main (not introduced here)