### PR TITLE
🐛 Fix Mission Explorer: show GitHub repo file listing

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -1730,12 +1730,13 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                 entries={filteredEntries}
                 viewMode={viewMode}
                 onSelect={(entry) => {
+                  const entrySource = selectedPath?.startsWith('github/') ? 'github' as const : 'community' as const
                   const node: TreeNode = {
                     id: entry.path,
                     name: entry.name,
                     path: entry.path,
                     type: entry.type,
-                    source: 'community',
+                    source: entrySource,
                     loaded: entry.type === 'file',
                   }
                   if (entry.type === 'file') {
@@ -1851,7 +1852,7 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
             {/* ============================================================ */}
             {/* FIXES TAB */}
             {/* ============================================================ */}
-            {!selectedMission && !unstructuredContent && activeTab === 'fixes' && (
+            {!selectedMission && !unstructuredContent && filteredEntries.length === 0 && activeTab === 'fixes' && (
               <div className="space-y-4">
                 {/* Fixer filters */}
                 <div className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary

Fixes two issues preventing GitHub repo files from displaying in the Mission Explorer:

1. **Tab content hiding directory listing** — Recommended/Installers/Fixes tabs rendered on top of the DirectoryListing when a GitHub repo was selected. Added `filteredEntries.length === 0` guard so tabs only show when no directory is being browsed.

2. **Wrong source for file clicks** — Files in the DirectoryListing were hardcoded to `source: 'community'`, causing GitHub repo file clicks to fetch from console-kb instead of the GitHub Contents API. Now detects source from `selectedPath` prefix.

Follow-up to #4045 and #4047.

## Test plan

- [ ] Add `clubanderson/sample-runbooks` as a watched repo → click to expand → file listing appears in right panel
- [ ] Click a `.yaml` file → shows parsed mission or unstructured preview
- [ ] Click a `.md` file → shows parsed steps
- [ ] Switching back to KubeStellar Community tree → tab content reappears