### PR TITLE
✨ Add refresh button on watched repos and local directories in Mission Explorer

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -1398,6 +1398,27 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                       saveWatchedPaths(updated)
                       showToast(`Removed path "${child.path}"`, 'info')
                     } : undefined}
+                    onRefresh={(node.id === 'github' || node.id === 'local') ? (child) => {
+                      // Mark node as unloaded to force re-fetch
+                      setTreeNodes((prev) =>
+                        updateNodeInTree(prev, child.id, {
+                          loaded: false,
+                          loading: false,
+                          children: [],
+                        })
+                      )
+                      // Collapse and re-expand to trigger load
+                      setExpandedNodes((prev) => {
+                        const next = new Set(prev)
+                        next.delete(child.id)
+                        return next
+                      })
+                      // Re-expand after a tick to trigger the useEffect
+                      setTimeout(() => {
+                        toggleNode(child)
+                        selectNode(child)
+                      }, 50)
+                    } : undefined}
                     onAdd={node.id === 'github' ? () => setAddingRepo(!addingRepo)
                       : node.id === 'local' ? () => setAddingPath(!addingPath)
                       : undefined}

--- a/web/src/components/missions/browser/TreeNodeItem.tsx
+++ b/web/src/components/missions/browser/TreeNodeItem.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from 'react'
 import {
   Folder, FolderOpen, FileJson, ChevronRight, ChevronDown,
-  Loader2, Globe, Github, HardDrive, Trash2, Plus,
+  Loader2, Globe, Github, HardDrive, Trash2, Plus, RefreshCw,
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import type { TreeNode } from './types'
@@ -14,6 +14,7 @@ export const TreeNodeItem = memo(function TreeNodeItem({
   onToggle,
   onSelect,
   onRemove,
+  onRefresh,
   onAdd,
 }: {
   node: TreeNode
@@ -24,6 +25,8 @@ export const TreeNodeItem = memo(function TreeNodeItem({
   onSelect: (node: TreeNode) => void
   /** Optional callback to remove a watched path/repo. When provided and the node is a watched child (source is 'local' or 'github'), a delete button is rendered. */
   onRemove?: (node: TreeNode) => void
+  /** Optional callback to refresh a node's contents (re-fetch from GitHub or re-scan local dir). */
+  onRefresh?: (node: TreeNode) => void
   /** Optional callback for the root-level add (+) button. Rendered in the header row when depth===0. */
   onAdd?: () => void
 }) {
@@ -31,6 +34,7 @@ export const TreeNodeItem = memo(function TreeNodeItem({
   const isSelected = selectedPath === node.id
   const isDir = node.type === 'directory'
   const showRemoveButton = onRemove && depth > 0 && (node.source === 'local' || node.source === 'github')
+  const showRefreshButton = onRefresh && depth > 0 && isDir && (node.source === 'local' || node.source === 'github')
 
   const sourceIcon = () => {
     switch (node.source) {
@@ -43,7 +47,7 @@ export const TreeNodeItem = memo(function TreeNodeItem({
     }
   }
 
-  const showHeaderActions = showRemoveButton || (depth === 0 && !!onAdd)
+  const showHeaderActions = showRemoveButton || showRefreshButton || (depth === 0 && !!onAdd)
 
   // Memoize inline style objects to avoid creating new references on each render
   const paddingStyle = useMemo(() => ({ paddingLeft: `${depth * 16 + 8}px` }), [depth])
@@ -100,6 +104,18 @@ export const TreeNodeItem = memo(function TreeNodeItem({
             <Plus className="w-3.5 h-3.5" />
           </button>
         )}
+        {showRefreshButton && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onRefresh(node)
+            }}
+            className="p-1.5 min-h-8 min-w-8 rounded hover:bg-blue-500/20 text-muted-foreground hover:text-blue-400 transition-colors flex-shrink-0"
+            title="Refresh contents"
+          >
+            <RefreshCw className={`w-3 h-3 ${node.loading ? 'animate-spin' : ''}`} />
+          </button>
+        )}
         {showRemoveButton && (
           <button
             onClick={(e) => {
@@ -126,6 +142,7 @@ export const TreeNodeItem = memo(function TreeNodeItem({
               onToggle={onToggle}
               onSelect={onSelect}
               onRemove={onRemove}
+              onRefresh={onRefresh}
             />
           ))}
           {node.children.length === 0 && node.loaded && (


### PR DESCRIPTION
## Summary

- Adds a refresh (↻) button next to each watched GitHub repo and local directory in the Mission Explorer tree sidebar
- Button spins while loading, re-fetches the node's contents from GitHub API or local filesystem
- Also includes the tab-hiding fix from #4050: directory listing now properly replaces tab content when a repo is selected

Follow-up to #4045 (YAML/MD support) and #4047 (Contents API fix).

## Test plan

- [ ] Add a GitHub repo as a watched repo → verify refresh button appears next to it
- [ ] Click refresh → verify spinner shows and contents re-load
- [ ] Add a local directory → verify refresh button appears
- [ ] Verify KubeStellar Community root node does NOT show refresh button