### PR TITLE
✨ Enable coverage reporting in CI, add badge, gate new code at 80%

### DIFF
--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -1,0 +1,194 @@
+name: Coverage Gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'web/src/**'
+      - 'web/vite.config.ts'
+      - 'web/package.json'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: coverage-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '22'
+  # Minimum line coverage percentage required for modified files
+  COVERAGE_THRESHOLD: 80
+
+jobs:
+  coverage-gate:
+    if: github.repository == 'kubestellar/console'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Run tests with coverage
+        working-directory: web
+        run: npx vitest run --coverage
+        continue-on-error: true
+
+      - name: Check coverage for modified files
+        id: gate
+        working-directory: web
+        env:
+          THRESHOLD: ${{ env.COVERAGE_THRESHOLD }}
+        run: |
+          SUMMARY_FILE="coverage/coverage-summary.json"
+
+          if [ ! -f "$SUMMARY_FILE" ]; then
+            echo "::warning::No coverage summary found — tests may have failed"
+            echo "status=skip" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Get modified ts/tsx source files (not tests) relative to web/
+          MODIFIED_FILES=$(git diff --name-only origin/main...HEAD -- 'web/src/**/*.ts' 'web/src/**/*.tsx' \
+            | grep -v '\.test\.' \
+            | grep -v '\.spec\.' \
+            | grep -v 'src/test/' \
+            | sed 's|^web/||')
+
+          if [ -z "$MODIFIED_FILES" ]; then
+            echo "No modified source files to check."
+            echo "status=pass" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Modified source files:"
+          echo "$MODIFIED_FILES"
+          echo ""
+
+          # Parse coverage JSON and check each modified file
+          BELOW_THRESHOLD=""
+          REPORT_LINES=""
+          ALL_PASS=true
+
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+
+            # coverage-summary.json keys are relative paths from the coverage root
+            # Try the file path as-is first, then with leading ./
+            LINE_PCT=$(jq -r --arg f "$file" '
+              (.[$f] // .["./\($f)"] // null)
+              | if . then .lines.pct else null end
+            ' "$SUMMARY_FILE")
+
+            if [ "$LINE_PCT" = "null" ] || [ -z "$LINE_PCT" ]; then
+              REPORT_LINES="${REPORT_LINES}| \`${file}\` | — | No coverage data | :grey_question: |\n"
+              continue
+            fi
+
+            # Compare coverage against threshold (integer comparison)
+            LINE_PCT_INT=$(echo "$LINE_PCT" | cut -d. -f1)
+
+            if [ "$LINE_PCT_INT" -lt "$THRESHOLD" ]; then
+              REPORT_LINES="${REPORT_LINES}| \`${file}\` | ${LINE_PCT}% | ${THRESHOLD}% | :warning: Below threshold |\n"
+              BELOW_THRESHOLD="${BELOW_THRESHOLD}${file} (${LINE_PCT}%)\n"
+              ALL_PASS=false
+            else
+              REPORT_LINES="${REPORT_LINES}| \`${file}\` | ${LINE_PCT}% | ${THRESHOLD}% | :white_check_mark: |\n"
+            fi
+          done <<< "$MODIFIED_FILES"
+
+          # Write report to file for the comment step
+          {
+            echo "## Coverage Report for Modified Files"
+            echo ""
+            echo "| File | Coverage | Threshold | Status |"
+            echo "|------|----------|-----------|--------|"
+            echo -e "$REPORT_LINES"
+          } > /tmp/coverage-report.md
+
+          if [ "$ALL_PASS" = "true" ]; then
+            echo "" >> /tmp/coverage-report.md
+            echo ":tada: All modified files meet the ${THRESHOLD}% line coverage threshold." >> /tmp/coverage-report.md
+            echo "status=pass" >> "$GITHUB_OUTPUT"
+          else
+            echo "" >> /tmp/coverage-report.md
+            echo ":warning: **Some modified files are below the ${THRESHOLD}% line coverage threshold.**" >> /tmp/coverage-report.md
+            echo "Consider adding tests for the files listed above." >> /tmp/coverage-report.md
+            echo "" >> /tmp/coverage-report.md
+            echo "_This is a warning — it does not block the PR. Coverage requirements will become mandatory in a future update._" >> /tmp/coverage-report.md
+            echo "status=warn" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Also extract total coverage for the summary
+          TOTAL_LINE_PCT=$(jq -r '.total.lines.pct // "unknown"' "$SUMMARY_FILE")
+          echo "total_coverage=${TOTAL_LINE_PCT}" >> "$GITHUB_OUTPUT"
+
+          echo "--- Coverage Gate Result ---"
+          cat /tmp/coverage-report.md
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            web/coverage/coverage-summary.json
+            web/coverage/coverage-final.json
+          retention-days: 14
+
+      - name: Comment on PR
+        if: steps.gate.outputs.status != 'skip'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const reportPath = '/tmp/coverage-report.md';
+
+            if (!fs.existsSync(reportPath)) {
+              console.log('No coverage report to post');
+              return;
+            }
+
+            const body = fs.readFileSync(reportPath, 'utf8');
+            const marker = '<!-- coverage-gate-report -->';
+            const fullBody = `${marker}\n${body}`;
+
+            // Find and update existing comment or create new one
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: fullBody,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: fullBody,
+              });
+            }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # KubeStellar Console
 
+![Coverage](https://img.shields.io/badge/coverage-25%25-yellow)
+
 AI-powered multi-cluster Kubernetes dashboard with guided install missions for 250+ CNCF projects.
 
 [**Live Demo**](https://console.kubestellar.io) | [Contributing](CONTRIBUTING.md)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -55,6 +55,7 @@
         "@types/react-dom": "^18.3.5",
         "@types/three": "^0.183.1",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^4.1.2",
         "@vitest/ui": "^4.1.2",
         "autoprefixer": "^10.4.27",
         "eslint": "^9.17.0",
@@ -440,6 +441,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -2822,6 +2833,37 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -3182,6 +3224,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -5992,6 +6053,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {

--- a/web/package.json
+++ b/web/package.json
@@ -89,6 +89,7 @@
     "@types/react-dom": "^18.3.5",
     "@types/three": "^0.183.1",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^4.1.2",
     "@vitest/ui": "^4.1.2",
     "autoprefixer": "^10.4.27",
     "eslint": "^9.17.0",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -241,7 +241,7 @@ export default defineConfig(({ mode }) => ({
     },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'json-summary', 'html'],
       exclude: [
         'node_modules/',
         'e2e/',


### PR DESCRIPTION
## Summary

- **Coverage CI workflow**: New `.github/workflows/coverage-gate.yml` runs on PRs that touch `web/src/**`. It runs `vitest --coverage`, then parses the JSON summary to check line coverage of **only the files modified in the PR** against an 80% threshold.
- **Warning, not blocking**: Files below 80% are flagged in a PR comment but do **not** fail the build. This lets us ramp up coverage gradually without blocking existing work.
- **Coverage badge**: Added a static coverage badge to `README.md` (currently shows 25% — will be updated as coverage improves).
- **Vitest config**: Added `json-summary` reporter so the gate script can parse per-file coverage. Installed `@vitest/coverage-v8` as a devDependency.

## How it works

1. Workflow triggers on PRs to `main` that modify `web/src/**`, `web/vite.config.ts`, or `web/package.json`
2. Runs `npx vitest run --coverage` in the `web/` directory
3. Gets the list of modified `.ts`/`.tsx` files (excluding tests) via `git diff`
4. For each modified file, looks up line coverage in `coverage/coverage-summary.json`
5. Posts a markdown table as a PR comment showing each file's coverage vs the 80% threshold
6. Updates the same comment on subsequent pushes (no comment spam)

## Test plan

- [x] Verify YAML is valid (done locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Verify `npm run build` passes
- [ ] Verify workflow triggers on this PR and posts a coverage comment
- [ ] Verify modified files are correctly identified and coverage is reported