### PR TITLE
✨ Mission Explorer UX: resizable sidebar, file icons, source/PR links, YAML formatting

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -79,7 +79,9 @@ const CATEGORY_FILTERS = [
   'Custom',
 ] as const
 
-const SIDEBAR_WIDTH = 280
+const DEFAULT_SIDEBAR_WIDTH = 280
+const MIN_SIDEBAR_WIDTH = 180
+const MAX_SIDEBAR_WIDTH = 500
 const WATCHED_REPOS_KEY = 'kc_mission_watched_repos'
 const WATCHED_PATHS_KEY = 'kc_mission_watched_paths'
 
@@ -147,6 +149,10 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
   const [viewMode, setViewMode] = useState<ViewMode>(isMobile ? 'list' : 'grid')
   const [showFilters, setShowFilters] = useState(!isMobile)
+
+  // Sidebar resize
+  const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH)
+  const isDraggingRef = useRef(false)
 
   // Tree state
   const [treeNodes, setTreeNodes] = useState<TreeNode[]>([])
@@ -1393,8 +1399,8 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
       <div className="flex-1 flex overflow-hidden">
         {/* Left sidebar — file tree (hidden on mobile, shown on md+) */}
         <div
-          className="hidden md:flex flex-col border-r border-border bg-card overflow-y-auto"
-          style={{ width: SIDEBAR_WIDTH, minWidth: SIDEBAR_WIDTH }}
+          className="hidden md:flex flex-col border-r border-border bg-card overflow-y-auto relative"
+          style={{ width: sidebarWidth, minWidth: MIN_SIDEBAR_WIDTH, maxWidth: MAX_SIDEBAR_WIDTH }}
         >
           <div className="p-3 space-y-1">
             {treeNodes.map((node) => (
@@ -1419,25 +1425,26 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                       showToast(`Removed path "${child.path}"`, 'info')
                     } : undefined}
                     onRefresh={(node.id === 'github' || node.id === 'local') ? (child) => {
-                      // Mark node as unloaded to force re-fetch
+                      // Reset node to unloaded state and collapse
                       setTreeNodes((prev) =>
                         updateNodeInTree(prev, child.id, {
                           loaded: false,
                           loading: false,
                           children: [],
+                          isEmpty: false,
                         })
                       )
-                      // Collapse and re-expand to trigger load
                       setExpandedNodes((prev) => {
                         const next = new Set(prev)
                         next.delete(child.id)
                         return next
                       })
-                      // Re-expand after a tick to trigger the useEffect
+                      // Re-expand with a fresh node reference so toggleNode sees loaded=false
                       setTimeout(() => {
-                        toggleNode(child)
-                        selectNode(child)
-                      }, 50)
+                        const freshNode: TreeNode = { ...child, loaded: false, loading: false, children: [] }
+                        toggleNode(freshNode)
+                        selectNode(freshNode)
+                      }, 100)
                     } : undefined}
                     onAdd={node.id === 'github' ? () => setAddingRepo(!addingRepo)
                       : node.id === 'local' ? () => setAddingPath(!addingPath)
@@ -1536,6 +1543,30 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
             />
           </div>
         </div>
+
+        {/* Sidebar resize handle */}
+        <div
+          className="hidden md:block w-1 cursor-col-resize hover:bg-purple-500/30 active:bg-purple-500/50 transition-colors flex-shrink-0"
+          onMouseDown={(e) => {
+            e.preventDefault()
+            isDraggingRef.current = true
+            const startX = e.clientX
+            const startWidth = sidebarWidth
+            const onMouseMove = (moveEvent: MouseEvent) => {
+              if (!isDraggingRef.current) return
+              const delta = moveEvent.clientX - startX
+              const newWidth = Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, startWidth + delta))
+              setSidebarWidth(newWidth)
+            }
+            const onMouseUp = () => {
+              isDraggingRef.current = false
+              document.removeEventListener('mousemove', onMouseMove)
+              document.removeEventListener('mouseup', onMouseUp)
+            }
+            document.addEventListener('mousemove', onMouseMove)
+            document.addEventListener('mouseup', onMouseUp)
+          }}
+        />
 
         {/* Right panel */}
         <div className="flex-1 flex flex-col overflow-hidden relative bg-background">

--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -159,10 +159,17 @@ function StepCard({ step, index, accentColor }: { step: MissionStep; index: numb
         ))}
         {step.command && (
           <div className="relative mt-2">
-            <code className="block p-2 rounded bg-background text-xs text-foreground font-mono border border-border">
-              {step.command}
-            </code>
+            <pre className="block p-2 rounded bg-background text-xs text-foreground font-mono border border-border whitespace-pre-wrap overflow-x-auto">{step.command}</pre>
             <CopyButton text={step.command} />
+          </div>
+        )}
+        {step.yaml && (
+          <div className="relative mt-2">
+            <div className="flex items-center gap-1.5 mb-1">
+              <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">YAML</span>
+            </div>
+            <pre className="p-3 rounded-lg bg-background text-xs text-foreground font-mono border border-border overflow-x-auto whitespace-pre-wrap">{step.yaml}</pre>
+            <CopyButton text={step.yaml} />
           </div>
         )}
       </div>

--- a/web/src/components/missions/browser/TreeNodeItem.tsx
+++ b/web/src/components/missions/browser/TreeNodeItem.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from 'react'
 import {
-  Folder, FolderOpen, FileJson, ChevronRight, ChevronDown,
-  Loader2, Globe, Github, HardDrive, Trash2, Plus, RefreshCw,
+  Folder, FolderOpen, FileJson, FileCode, FileText, ChevronRight, ChevronDown,
+  Loader2, Globe, Github, HardDrive, Trash2, Plus, RefreshCw, ExternalLink, GitPullRequest,
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import type { TreeNode } from './types'
@@ -85,13 +85,20 @@ export const TreeNodeItem = memo(function TreeNodeItem({
                 <Folder className="w-4 h-4 text-yellow-400 flex-shrink-0" />
               )}
             </>
-          ) : (
-            <>
-              <span className="w-3.5 flex-shrink-0" />
-              <FileJson className="w-4 h-4 text-blue-400 flex-shrink-0" />
-            </>
-          )}
-          <span className="truncate flex-1">{node.name}</span>
+          ) : (() => {
+            const lower = node.name.toLowerCase()
+            const isYaml = lower.endsWith('.yaml') || lower.endsWith('.yml')
+            const isMd = lower.endsWith('.md')
+            const Icon = isYaml ? FileCode : isMd ? FileText : FileJson
+            const color = isYaml ? 'text-orange-400' : isMd ? 'text-emerald-400' : 'text-blue-400'
+            return (
+              <>
+                <span className="w-3.5 flex-shrink-0" />
+                <Icon className={`w-4 h-4 ${color} flex-shrink-0`} />
+              </>
+            )
+          })()}
+          <span className="truncate flex-1" title={node.name}>{node.name}</span>
           {depth === 0 && sourceIcon()}
         </button>
         {/* Root-level add button — rendered in the header row so it stays anchored to the header */}
@@ -116,6 +123,39 @@ export const TreeNodeItem = memo(function TreeNodeItem({
             <RefreshCw className={`w-3 h-3 ${node.loading ? 'animate-spin' : ''}`} />
           </button>
         )}
+        {/* GitHub file action buttons — view source and edit/PR */}
+        {!isDir && node.source === 'github' && node.path.split('/').length >= 3 && (() => {
+          const parts = node.path.split('/')
+          const owner = parts[0]
+          const repo = parts[1]
+          const filePath = parts.slice(2).join('/')
+          const sourceUrl = `https://github.com/${owner}/${repo}/blob/main/${filePath}`
+          const editUrl = `https://github.com/${owner}/${repo}/edit/main/${filePath}`
+          return (
+            <>
+              <a
+                href={sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                className="p-1 min-h-7 min-w-7 rounded hover:bg-blue-500/20 text-muted-foreground hover:text-blue-400 transition-colors flex-shrink-0 flex items-center justify-center"
+                title="View source on GitHub"
+              >
+                <ExternalLink className="w-3 h-3" />
+              </a>
+              <a
+                href={editUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                className="p-1 min-h-7 min-w-7 rounded hover:bg-green-500/20 text-muted-foreground hover:text-green-400 transition-colors flex-shrink-0 flex items-center justify-center"
+                title="Edit and create PR on GitHub"
+              >
+                <GitPullRequest className="w-3 h-3" />
+              </a>
+            </>
+          )
+        })()}
         {showRemoveButton && (
           <button
             onClick={(e) => {

--- a/web/src/lib/missions/fileParser.ts
+++ b/web/src/lib/missions/fileParser.ts
@@ -303,7 +303,7 @@ function wrapCRsAsMission(crDocuments: Record<string, unknown>[]): ParseResult {
         ? `Apply ${kind} resource for ${project.displayName}`
         : `Apply ${kind} resource (${doc.apiVersion})`,
       yaml: yaml.dump(doc, { indent: 2, lineWidth: -1 }),
-      command: `kubectl apply -f - <<'EOF'\n${yaml.dump(doc, { indent: 2, lineWidth: -1 })}EOF`,
+      command: `kubectl apply -f ${name ? name + '.yaml' : '<filename>.yaml'}`,
     }
   })
 


### PR DESCRIPTION
## Summary

UX improvements for the Mission Explorer file browsing experience:

**Tree sidebar:**
- File-type icons: orange for YAML, green for MD, blue for JSON
- Hover tooltips on truncated filenames
- Resizable sidebar (drag the edge, 180px–500px range)
- Source (↗) and PR (⑂) buttons on GitHub files — opens view/edit on GitHub
- Refresh button properly re-fetches contents instead of just toggling

**Detail view:**
- `step.yaml` now renders as a separate formatted YAML block with proper indentation
- `step.command` uses `<pre>` for newline preservation
- kubectl command is a simple `kubectl apply -f <name>.yaml` instead of heredoc

## Test plan
- [ ] Expand sample-runbooks → YAML files show orange icon, MD files show green
- [ ] Hover a truncated filename → full name appears in tooltip
- [ ] Drag sidebar edge → resizes between 180–500px
- [ ] Click ↗ on a file → opens GitHub source in new tab
- [ ] Click ⑂ on a file → opens GitHub edit view in new tab
- [ ] Click ray-cluster.yaml → YAML section shows properly indented content
- [ ] Click refresh → re-fetches and shows files (not just collapse/expand)