### PR TITLE
✨ Add subtle engagement psychology: visit streak + rotating tips (#3791)

### DIFF
--- a/web/src/components/dashboard/GettingStartedBanner.tsx
+++ b/web/src/components/dashboard/GettingStartedBanner.tsx
@@ -17,8 +17,9 @@ import {
   STORAGE_KEY_GETTING_STARTED_DISMISSED,
   STORAGE_KEY_HINTS_SUPPRESSED,
 } from '../../lib/constants/storage'
-import { emitGettingStartedShown, emitGettingStartedActioned } from '../../lib/analytics'
+import { emitGettingStartedShown, emitGettingStartedActioned, emitTipShown } from '../../lib/analytics'
 import { DASHBOARD_CONFIGS } from '../../config/dashboards/index'
+import { getRandomTip } from '../../lib/tips'
 
 const DASHBOARD_COUNT = Object.keys(DASHBOARD_CONFIGS).length
 
@@ -38,13 +39,17 @@ export function GettingStartedBanner({
   )
   const emittedRef = useRef(false)
 
+  // Pick a random tip once on mount (stable across re-renders)
+  const [randomTip] = useState(() => getRandomTip())
+
   // Emit analytics once on first render
   useEffect(() => {
     if (!dismissed && !emittedRef.current) {
       emittedRef.current = true
       emitGettingStartedShown()
+      emitTipShown('dashboard', randomTip.tip)
     }
-  }, [dismissed])
+  }, [dismissed, randomTip.tip])
 
   const [hintsSuppressed] = useState(
     () => safeGetItem(STORAGE_KEY_HINTS_SUPPRESSED) === 'true'
@@ -123,6 +128,11 @@ export function GettingStartedBanner({
           </button>
         ))}
       </div>
+
+      {/* Rotating tip — subtle, single line */}
+      <p className="text-xs text-muted-foreground mt-3">
+        {'\uD83D\uDCA1'} {randomTip.tip}
+      </p>
     </div>
   )
 }

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -27,6 +27,7 @@ import { TokenUsageWidget } from './TokenUsageWidget'
 import { ClusterFilterPanel } from './ClusterFilterPanel'
 import { AgentStatusIndicator } from './AgentStatusIndicator'
 import { UpdateIndicator } from './UpdateIndicator'
+import { StreakBadge } from './StreakBadge'
 import { ROUTES } from '../../../config/routes'
 
 export function Navbar() {
@@ -114,6 +115,9 @@ export function Navbar() {
         <div className="hidden lg:flex items-center gap-2">
           {/* Update Indicator */}
           <UpdateIndicator />
+
+          {/* Visit Streak */}
+          <StreakBadge />
 
           {/* Token Usage */}
           <TokenUsageWidget />

--- a/web/src/components/layout/navbar/StreakBadge.tsx
+++ b/web/src/components/layout/navbar/StreakBadge.tsx
@@ -1,0 +1,27 @@
+/**
+ * StreakBadge — tiny flame + number in the navbar showing consecutive
+ * daily visits. Only visible when streak >= 2 (showing "1" is meaningless).
+ *
+ * Intentionally minimal: text-xs text-muted-foreground. Blends in,
+ * doesn't demand attention.
+ */
+
+import { useVisitStreak } from '../../../hooks/useVisitStreak'
+
+/** Minimum streak to display the badge — showing "1" is meaningless */
+const MIN_DISPLAY_STREAK = 2
+
+export function StreakBadge() {
+  const { streak } = useVisitStreak()
+
+  if (streak < MIN_DISPLAY_STREAK) return null
+
+  return (
+    <span
+      className="text-xs text-muted-foreground select-none"
+      title={`${streak}-day streak`}
+    >
+      {'\uD83D\uDD25'} {streak}
+    </span>
+  )
+}

--- a/web/src/hooks/useVisitStreak.ts
+++ b/web/src/hooks/useVisitStreak.ts
@@ -1,0 +1,83 @@
+/**
+ * useVisitStreak — tracks consecutive daily visits in localStorage.
+ *
+ * On load:
+ *   - If lastVisitDate is yesterday, increment streak.
+ *   - If lastVisitDate is today, no change.
+ *   - If lastVisitDate is older (or missing), reset streak to 1.
+ *
+ * Fires GA4 `ksc_streak_day` event when the streak increments.
+ */
+
+import { useState } from 'react'
+import { safeGetJSON, safeSetJSON } from '../lib/utils/localStorage'
+import { STORAGE_KEY_VISIT_STREAK } from '../lib/constants/storage'
+import { emitStreakDay } from '../lib/analytics'
+
+/** Number of milliseconds in one day */
+const MS_PER_DAY = 86_400_000
+
+interface StreakData {
+  /** Last visit date in YYYY-MM-DD format */
+  lastVisitDate: string
+  /** Current consecutive-day streak count */
+  currentStreak: number
+}
+
+/** Format a Date as YYYY-MM-DD in the user's local timezone */
+function toDateString(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+/** Calculate the streak on mount (runs once via useState initializer) */
+function calculateStreak(): number {
+  const today = toDateString(new Date())
+  const stored = safeGetJSON<StreakData>(STORAGE_KEY_VISIT_STREAK)
+
+  if (!stored || !stored.lastVisitDate) {
+    // First visit ever — start at 1
+    safeSetJSON<StreakData>(STORAGE_KEY_VISIT_STREAK, {
+      lastVisitDate: today,
+      currentStreak: 1,
+    })
+    return 1
+  }
+
+  if (stored.lastVisitDate === today) {
+    // Already visited today — no change
+    return stored.currentStreak
+  }
+
+  // Check if lastVisitDate was yesterday
+  const lastDate = new Date(stored.lastVisitDate)
+  const now = new Date()
+  // Normalize both to midnight to compare calendar days
+  const lastMidnight = new Date(lastDate.getFullYear(), lastDate.getMonth(), lastDate.getDate())
+  const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate())
+  const diffMs = todayMidnight.getTime() - lastMidnight.getTime()
+
+  /** Exactly one calendar day difference */
+  const isYesterday = diffMs === MS_PER_DAY
+
+  const newStreak = isYesterday ? stored.currentStreak + 1 : 1
+
+  safeSetJSON<StreakData>(STORAGE_KEY_VISIT_STREAK, {
+    lastVisitDate: today,
+    currentStreak: newStreak,
+  })
+
+  // Fire GA4 event when streak actually increments (not resets)
+  if (isYesterday) {
+    emitStreakDay(newStreak)
+  }
+
+  return newStreak
+}
+
+export function useVisitStreak(): { streak: number } {
+  const [streak] = useState(calculateStreak)
+  return { streak }
+}

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -2013,3 +2013,8 @@ export function emitWhiteLabelCommandCopy(tab: string, step: number, command: st
 export function emitTipShown(page: string, tip: string) {
   send('ksc_tip_shown', { page, tip })
 }
+
+/** Fired when user's visit streak increments (consecutive days visiting) */
+export function emitStreakDay(streakCount: number) {
+  send('ksc_streak_day', { streak_count: streakCount })
+}

--- a/web/src/lib/constants/storage.ts
+++ b/web/src/lib/constants/storage.ts
@@ -61,6 +61,8 @@ export const STORAGE_KEY_POST_CONNECT_DISMISSED = 'kc-post-connect-dismissed'
 export const STORAGE_KEY_DEMO_CTA_DISMISSED = 'kc-demo-cta-dismissed'
 export const STORAGE_KEY_ADOPTER_NUDGE_DISMISSED = 'kc-adopter-nudge-dismissed'
 export const STORAGE_KEY_FIRST_AGENT_CONNECT = 'kc-first-agent-connect'
+export const STORAGE_KEY_VISIT_STREAK = 'ksc-visit-streak'
+export const STORAGE_KEY_SEEN_TIPS = 'ksc-seen-tips'
 
 // ── Notification dedup ────────────────────────────────────────────────
 export const STORAGE_KEY_NOTIFIED_ALERT_KEYS = 'kc-notified-alert-keys'

--- a/web/src/lib/tips.ts
+++ b/web/src/lib/tips.ts
@@ -1,0 +1,55 @@
+/**
+ * Rotating "Did you know?" tips for the dashboard Getting Started banner.
+ *
+ * Tips cycle through all entries before repeating. Seen tips are tracked
+ * in localStorage so the user always sees a fresh tip on each visit.
+ */
+
+import { safeGetJSON, safeSetJSON } from './utils/localStorage'
+import { STORAGE_KEY_SEEN_TIPS } from './constants/storage'
+
+export const TIPS: string[] = [
+  'You can drag cards to rearrange your dashboard',
+  'Try the GPU Reservations calendar for scheduling',
+  'Use Cmd+K to search anything in the console',
+  'The Arcade has Kubernetes-themed games for breaks',
+  'You can create custom dashboards from the sidebar',
+  'AI Missions can diagnose and repair cluster issues',
+  'Click any card header to expand it full-screen',
+  'The RBAC Explorer visualizes cluster permissions',
+  'You can export mission results as markdown',
+  'Deploy supports multi-cluster rollouts with phased deployment',
+  'Try browsing the Marketplace for pre-built mission packs',
+  'The Performance Timeline card tracks benchmark trends over time',
+  'You can pin frequently-used cards to the top of your dashboard',
+  'The global cluster filter in the navbar applies to all cards at once',
+  'Token usage breakdown shows which AI features use the most tokens',
+  'Right-click any cluster row to see quick actions',
+  'The Compliance dashboard shows OPA, Kyverno, and Kubescape policies',
+  'You can import and export dashboard layouts as JSON',
+]
+
+/**
+ * Returns a tip the user hasn't seen recently. Cycles through all tips
+ * before repeating. Returns the tip string and its index in the TIPS array.
+ */
+export function getRandomTip(): { tip: string; index: number } {
+  const seenIndices = safeGetJSON<number[]>(STORAGE_KEY_SEEN_TIPS) || []
+
+  // Find tips the user hasn't seen yet
+  const unseenIndices = TIPS.map((_, i) => i).filter(i => !(seenIndices || []).includes(i))
+
+  // If all tips have been seen, reset and start fresh
+  if (unseenIndices.length === 0) {
+    const firstIndex = Math.floor(Math.random() * TIPS.length)
+    safeSetJSON<number[]>(STORAGE_KEY_SEEN_TIPS, [firstIndex])
+    return { tip: TIPS[firstIndex], index: firstIndex }
+  }
+
+  // Pick a random unseen tip
+  const randomUnseen = unseenIndices[Math.floor(Math.random() * unseenIndices.length)]
+  const updatedSeen = [...(seenIndices || []), randomUnseen]
+  safeSetJSON<number[]>(STORAGE_KEY_SEEN_TIPS, updatedSeen)
+
+  return { tip: TIPS[randomUnseen], index: randomUnseen }
+}


### PR DESCRIPTION
## Summary

- **Visit streak badge** (navbar): Small flame emoji + day count next to TokenUsageWidget, showing consecutive daily visits. Only appears when streak >= 2. Tracks in localStorage, fires `ksc_streak_day` GA4 event on increment.
- **Rotating tips** (Getting Started banner): A single "Did you know?" line at the bottom of the existing Welcome banner. Cycles through 18 tips without repeating until all are shown. Fires `ksc_tip_shown` GA4 event.
- Both features use `text-xs text-muted-foreground` styling — minimal, non-intrusive, blends in.

Fixes #3791

## Files changed

| File | Change |
|------|--------|
| `web/src/hooks/useVisitStreak.ts` | New hook — tracks consecutive daily visits in localStorage |
| `web/src/components/layout/navbar/StreakBadge.tsx` | New component — renders streak badge (hidden if < 2 days) |
| `web/src/lib/tips.ts` | New module — 18 tips with seen-tip cycling via localStorage |
| `web/src/lib/constants/storage.ts` | Added `STORAGE_KEY_VISIT_STREAK` and `STORAGE_KEY_SEEN_TIPS` |
| `web/src/lib/analytics.ts` | Added `emitStreakDay()` GA4 event |
| `web/src/components/layout/navbar/Navbar.tsx` | Added `<StreakBadge />` in extended desktop items |
| `web/src/components/dashboard/GettingStartedBanner.tsx` | Added rotating tip line at bottom of banner |

## Test plan

- [ ] Visit the console — streak badge should NOT appear (streak = 1)
- [ ] Set localStorage `ksc-visit-streak` to `{"lastVisitDate":"YYYY-MM-DD","currentStreak":3}` with yesterday's date, reload — badge should show fire emoji + 4
- [ ] Verify streak resets to 1 after missing a day
- [ ] Verify Getting Started banner shows a tip line at the bottom
- [ ] Reload multiple times — tips should rotate (no immediate repeats)
- [ ] Verify GA4 events fire: `ksc_streak_day`, `ksc_tip_shown`
- [ ] Build passes (`npm run build`)
- [ ] No new lint errors in changed files