### PR TITLE
✨ Move Source/PR buttons to detail view, clean up tree sidebar

### DIFF
--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -1604,6 +1604,17 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                     (r) => r.mission.title === selectedMission.title
                   )?.matchPercent}
                   shareUrl={getMissionShareUrl(selectedMission)}
+                  {...(() => {
+                    if (!selectedPath?.startsWith('github/')) return {}
+                    const parts = selectedPath.replace('github/', '').split('/')
+                    if (parts.length < 3) return {}
+                    const [owner, repo, ...rest] = parts
+                    const filePath = rest.join('/')
+                    return {
+                      githubSourceUrl: `https://github.com/${owner}/${repo}/blob/main/${filePath}`,
+                      githubEditUrl: `https://github.com/${owner}/${repo}/edit/main/${filePath}`,
+                    }
+                  })()}
                 />
                 {showImproveDialog && (
                   <ImproveMissionDialog

--- a/web/src/components/missions/MissionDetailView.tsx
+++ b/web/src/components/missions/MissionDetailView.tsx
@@ -25,6 +25,7 @@ import {
   Shield,
   MessageSquarePlus,
   Link,
+  GitPullRequest,
 } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { StatusBadge } from '../ui/StatusBadge'
@@ -67,6 +68,10 @@ interface MissionDetailViewProps {
   error?: string | null
   /** Retry callback for re-fetching failed mission content */
   onRetry?: () => void
+  /** GitHub source URL for viewing the file */
+  githubSourceUrl?: string
+  /** GitHub edit URL for creating a PR */
+  githubEditUrl?: string
 }
 
 // Extract code blocks from markdown-style description
@@ -207,6 +212,8 @@ export function MissionDetailView({
   loading = false,
   error = null,
   onRetry,
+  githubSourceUrl,
+  githubEditUrl,
 }: MissionDetailViewProps) {
   const [linkCopied, setLinkCopied] = useState(false)
   const linkCopiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -313,6 +320,18 @@ export function MissionDetailView({
               {linkCopied ? <Check className="w-3.5 h-3.5" /> : <Link className="w-3.5 h-3.5" />}
               {linkCopied ? 'Copied!' : 'Share'}
             </button>
+          )}
+          {githubSourceUrl && (
+            <a href={githubSourceUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg border border-border text-muted-foreground hover:text-foreground transition-colors" title="View source file on GitHub">
+              <ExternalLink className="w-3.5 h-3.5" />
+              Source
+            </a>
+          )}
+          {githubEditUrl && (
+            <a href={githubEditUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg border border-green-500/30 text-green-400 hover:bg-green-500/10 transition-colors" title="Edit and create a PR on GitHub">
+              <GitPullRequest className="w-3.5 h-3.5" />
+              PR
+            </a>
           )}
           <button
             onClick={onToggleRaw}

--- a/web/src/components/missions/browser/TreeNodeItem.tsx
+++ b/web/src/components/missions/browser/TreeNodeItem.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from 'react'
 import {
   Folder, FolderOpen, FileJson, FileCode, FileText, ChevronRight, ChevronDown,
-  Loader2, Globe, Github, HardDrive, Trash2, Plus, RefreshCw, ExternalLink, GitPullRequest,
+  Loader2, Globe, Github, HardDrive, Trash2, Plus, RefreshCw,
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import type { TreeNode } from './types'
@@ -123,40 +123,7 @@ export const TreeNodeItem = memo(function TreeNodeItem({
             <RefreshCw className={`w-3 h-3 ${node.loading ? 'animate-spin' : ''}`} />
           </button>
         )}
-        {/* GitHub file action buttons — view source and edit/PR */}
-        {!isDir && node.source === 'github' && node.path.split('/').length >= 3 && (() => {
-          const parts = node.path.split('/')
-          const owner = parts[0]
-          const repo = parts[1]
-          const filePath = parts.slice(2).join('/')
-          const sourceUrl = `https://github.com/${owner}/${repo}/blob/main/${filePath}`
-          const editUrl = `https://github.com/${owner}/${repo}/edit/main/${filePath}`
-          return (
-            <>
-              <a
-                href={sourceUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
-                className="p-1 min-h-7 min-w-7 rounded hover:bg-blue-500/20 text-muted-foreground hover:text-blue-400 transition-colors flex-shrink-0 flex items-center justify-center"
-                title="View source on GitHub"
-              >
-                <ExternalLink className="w-3 h-3" />
-              </a>
-              <a
-                href={editUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
-                className="p-1 min-h-7 min-w-7 rounded hover:bg-green-500/20 text-muted-foreground hover:text-green-400 transition-colors flex-shrink-0 flex items-center justify-center"
-                title="Edit and create PR on GitHub"
-              >
-                <GitPullRequest className="w-3 h-3" />
-              </a>
-            </>
-          )
-        })()}
-        {showRemoveButton && (
+        {showRemoveButton && isDir && (
           <button
             onClick={(e) => {
               e.stopPropagation()


### PR DESCRIPTION
## Summary
- Remove source, PR, delete icons from file rows in tree sidebar
- Add **Source** and **PR** buttons in the detail view header (next to Share/View Raw/Import)
- Delete button stays only on repo-level directory nodes

## Test plan
- [ ] Click a file in sample-runbooks → detail view shows Source + PR buttons
- [ ] Source opens GitHub blob view in new tab
- [ ] PR opens GitHub edit view in new tab
- [ ] File rows in tree show only icon + name (no action buttons)
- [ ] Repo-level node still shows delete (trash) button