### PR TITLE
🐛 Fix mission timestamp showing creation time instead of last activity

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionListItem.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionListItem.tsx
@@ -109,7 +109,7 @@ export function MissionListItem({ mission, isActive, onClick, onDismiss, onExpan
               <span className="text-xs text-purple-400">@{mission.cluster}</span>
             )}
             <span className="text-2xs text-muted-foreground/70">
-              {mission.createdAt.toLocaleDateString()} {mission.createdAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+              {mission.updatedAt.toLocaleDateString()} {mission.updatedAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
             </span>
           </div>
         </button>


### PR DESCRIPTION
## Summary
- The mission sidebar list was displaying `mission.createdAt` as the timestamp for each mission entry
- When a user added a chat message to an older mission, it correctly moved to the top of the list (sorted by `updatedAt`) but the displayed timestamp still showed the original creation time
- Changed `MissionListItem` to render `mission.updatedAt` so the timestamp reflects the most recent activity (message sent, status change, etc.)

Fixes #4078

## Test plan
- [ ] Open the mission sidebar and start a new mission — timestamp should show the current time
- [ ] Send a follow-up message to an older mission — the timestamp should update to the current time and the mission should move to the top of the list
- [ ] Verify that completed/failed missions retain their last-updated timestamp