### PR TITLE
🐛 Remove broken OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # KubeStellar Console
 
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/clubanderson/b9a9ae8469f1897a22d5a40629bc1e82/raw/coverage-badge.json)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/kubestellar/console/badge)](https://scorecard.dev/viewer/?uri=github.com/kubestellar/console)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12343/badge)](https://www.bestpractices.dev/projects/12343)
 
 AI-powered multi-cluster Kubernetes dashboard with guided install missions for 250+ CNCF projects.


### PR DESCRIPTION
Repo isn't enrolled in OpenSSF Scorecard — badge showed 'invalid repo path'. Removed until the scorecard-action workflow is set up. Best Practices badge (passing) is kept.