### PR TITLE
🐛 Fix Save Resolution failing with hardcoded 'claude' agent fallback

### DIFF
--- a/web/src/components/missions/SaveResolutionDialog.tsx
+++ b/web/src/components/missions/SaveResolutionDialog.tsx
@@ -112,7 +112,7 @@ Return ONLY valid JSON, no markdown code blocks or explanation.`
         payload: {
           prompt: prompt,
           sessionId: `resolution-${mission.id}`,
-          agent: mission.agent || 'claude',
+          agent: mission.agent || undefined,
         }
       }))
     }


### PR DESCRIPTION
## Summary

`SaveResolutionDialog.tsx` hardcoded `agent: 'claude'` when `mission.agent` was unset. The `claude` API provider isn't registered in the agent registry (only CLI-based agents like copilot-cli, claude-cli are), so this always fails with "Claude provider not configured - ANTHROPIC_API_KEY not set".

Changed to `agent: undefined` — the backend's agent selection logic (`GetSelectedAgent` → default agent) picks whatever provider is actually available.

Fixes #4079

## Test plan
- [ ] Run a mission without setting ANTHROPIC_API_KEY → Save Resolution should work using the default agent
- [ ] Run a mission with copilot-cli → Save Resolution should use copilot-cli (not fall back to 'claude')