### PR TITLE
🌱 Re-add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # KubeStellar Console
 
 ![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/clubanderson/b9a9ae8469f1897a22d5a40629bc1e82/raw/coverage-badge.json)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/kubestellar/console/badge)](https://securityscorecards.dev/viewer/?uri=github.com/kubestellar/console)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12343/badge)](https://www.bestpractices.dev/projects/12343)
 
 AI-powered multi-cluster Kubernetes dashboard with guided install missions for 250+ CNCF projects.


### PR DESCRIPTION
Re-adds the scorecard badge using api.securityscorecards.dev. The scorecard workflow already exists — badge will populate after next scan.