### PR TITLE
🐛 Fix Auto-QA issues: refresh animation + error handling

### DIFF
--- a/web/src/components/cards/OperatorStatus.tsx
+++ b/web/src/components/cards/OperatorStatus.tsx
@@ -189,9 +189,10 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
           <p className="text-xs">{t('operatorStatus.errorLoadingHint', 'Failed after {{count}} attempts', { count: consecutiveFailures })}</p>
           <button
             onClick={() => refetch()}
-            className="mt-1 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 transition-colors"
+            disabled={isRefreshing}
+            className="mt-1 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 transition-colors disabled:opacity-50"
           >
-            <RefreshCw className="w-3 h-3" />
+            <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
             {t('common:common.retry', 'Retry')}
           </button>
         </div>

--- a/web/src/components/deploy/Deploy.tsx
+++ b/web/src/components/deploy/Deploy.tsx
@@ -165,12 +165,14 @@ export function Deploy() {
       })
     } catch (err) {
       console.error('Deploy failed:', err)
+      const errorMessage = err instanceof Error ? err.message : 'Deploy failed'
+      showToast(errorMessage, 'error')
       publishCardEvent({
         type: 'deploy:result',
         payload: {
           id: deployId,
           success: false,
-          message: err instanceof Error ? err.message : 'Deploy failed',
+          message: errorMessage,
           deployedTo: [],
           failedClusters: targetClusters,
         },

--- a/web/src/components/drilldown/views/EventsDrillDown.tsx
+++ b/web/src/components/drilldown/views/EventsDrillDown.tsx
@@ -169,7 +169,7 @@ export function EventsDrillDown({ data }: Props) {
               onClick={() => refetch?.()}
               className="flex items-center gap-2 px-4 py-2 rounded-lg bg-card border border-border text-sm hover:bg-card/80 transition-colors"
             >
-              <RefreshCw className="w-4 h-4" />
+              <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
               Retry
             </button>
           </div>

--- a/web/src/components/drilldown/views/YAMLDrillDown.tsx
+++ b/web/src/components/drilldown/views/YAMLDrillDown.tsx
@@ -131,7 +131,7 @@ export function YAMLDrillDown({ data }: Props) {
             className="p-2 rounded-lg bg-card/50 border border-border hover:bg-card transition-colors"
             title={t('common.refresh')}
           >
-            <RefreshCw className="w-4 h-4 text-muted-foreground" />
+            <RefreshCw className={`w-4 h-4 text-muted-foreground ${isLoading ? 'animate-spin' : ''}`} />
           </button>
           <button
             onClick={handleCopy}


### PR DESCRIPTION
## Summary
- **#3905 (Refresh animation)**: Tie `animate-spin` to loading state on RefreshCw icons in `YAMLDrillDown`, `EventsDrillDown`, and `OperatorStatus` retry buttons so users see visual loading feedback when data is being fetched
- **#3907 (DOM nesting)**: Thoroughly audited all flagged items — all were false positives from the static analysis tool (status icons misidentified as refresh buttons, valid inline HTML flagged as block-in-p violations, backdrop divs with `role="presentation"` flagged as missing accessibility, HTML template strings flagged as nested headings)
- **#3913 (Silent failures)**: Add toast notification on deploy failure in `Deploy.tsx` so users see the error immediately instead of only via card events. Other flagged items already have proper error handling (setError state, error boundaries, graceful cache fallbacks)

### Files changed
- `web/src/components/drilldown/views/YAMLDrillDown.tsx` — animate-spin on refresh button
- `web/src/components/drilldown/views/EventsDrillDown.tsx` — animate-spin on retry button
- `web/src/components/cards/OperatorStatus.tsx` — animate-spin + disabled state on retry button
- `web/src/components/deploy/Deploy.tsx` — toast on deploy failure

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed)
- [ ] Verify YAML drilldown refresh button spins while loading
- [ ] Verify Events drilldown retry button spins while loading
- [ ] Verify Operator Status retry button spins and is disabled while refreshing
- [ ] Verify deploy failure shows error toast

Closes #3905, closes #3907, closes #3913