### PR TITLE
🐛 fix: standardize status color shades in PersistenceSection

### DIFF
--- a/web/src/components/settings/sections/PersistenceSection.tsx
+++ b/web/src/components/settings/sections/PersistenceSection.tsx
@@ -69,11 +69,11 @@ export function PersistenceSection() {
   const getHealthIcon = (health: ClusterHealth) => {
     switch (health) {
       case 'healthy':
-        return <Check className="w-4 h-4 text-green-500" />
+        return <Check className="w-4 h-4 text-green-400" />
       case 'degraded':
-        return <AlertCircle className="w-4 h-4 text-yellow-500" />
+        return <AlertCircle className="w-4 h-4 text-yellow-400" />
       case 'unreachable':
-        return <X className="w-4 h-4 text-red-500" />
+        return <X className="w-4 h-4 text-red-400" />
       default:
         return <AlertCircle className="w-4 h-4 text-muted-foreground" />
     }
@@ -119,7 +119,7 @@ export function PersistenceSection() {
 
       {error && (
         <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20 mb-4">
-          <p className="text-sm text-red-500">{error}</p>
+          <p className="text-sm text-red-400">{error}</p>
         </div>
       )}
 
@@ -295,7 +295,7 @@ export function PersistenceSection() {
                   <span className="text-foreground">
                     {status.activeCluster || t('settings.persistence.none')}
                     {status.failoverActive && (
-                      <span className="ml-2 text-xs text-yellow-500">{t('settings.persistence.failover')}</span>
+                      <span className="ml-2 text-xs text-yellow-400">{t('settings.persistence.failover')}</span>
                     )}
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- Standardizes status indicator color shades in `PersistenceSection.tsx` to match the rest of the settings sections
- Changes `text-green-500` -> `text-green-400`, `text-red-500` -> `text-red-400`, `text-yellow-500` -> `text-yellow-400` (5 occurrences)
- Every other settings section (OpsGenie, PagerDuty, Slack, Email, Browser, GitHubToken, Agent, LocalClusters, SettingsBackup, TokenUsage, Prediction) already uses `-400` shades consistently

## Context
The codebase standard for status text colors is `-400` (e.g., `text-green-400` with 705 occurrences vs `text-green-500` with 21). PersistenceSection was the only settings section using `-500` shades for its health icons, error message, and failover badge.

Other items flagged in #3890 were either already fixed (Kyverno error color) or are intentional design choices (violet in MissionControl, opacity `/10` vs `/20` matching `ModalSections.tsx` patterns).

Closes #3890

## Test plan
- [ ] Verify PersistenceSection health icons (healthy/degraded/unreachable) render with correct `-400` shade colors
- [ ] Verify error message text uses `text-red-400`
- [ ] Verify failover badge uses `text-yellow-400`
- [ ] TypeScript check passes (`npx tsc --noEmit`)