### PR TITLE
✨ Show active user count in navbar header

### DIFF
--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -12,6 +12,7 @@ import { LogoWithStar } from '../../ui/LogoWithStar'
 import { UserProfileDropdown } from '../UserProfileDropdown'
 import { AlertBadge } from '../../ui/AlertBadge'
 import { FeatureRequestButton } from '../../feedback'
+import { ActiveUsersWidget } from './ActiveUsersWidget'
 // Lazy-load SearchDropdown — it imports useSearchIndex which pulls in 5 MCP
 // modules (~135 KB). The search bar appears after the chunk loads (near-instant).
 const SearchDropdown = lazy(() =>
@@ -113,6 +114,9 @@ export function Navbar() {
 
         {/* Extended desktop items: lg+ (1024px) */}
         <div className="hidden lg:flex items-center gap-2">
+          {/* Active Users */}
+          <ActiveUsersWidget />
+
           {/* Update Indicator */}
           <UpdateIndicator />
 
@@ -194,7 +198,10 @@ export function Navbar() {
                     <div className="border-t border-border mx-3 my-1" />
                   </div>
 
-                  {/* Items hidden at <lg (1024px): update, token usage, feature request, tour */}
+                  {/* Items hidden at <lg (1024px): active users, update, token usage, feature request, tour */}
+                  <div className="px-3 py-2">
+                    <ActiveUsersWidget />
+                  </div>
                   <div className="px-3 py-2">
                     <UpdateIndicator />
                   </div>


### PR DESCRIPTION
## Summary
- Add `ActiveUsersWidget` to the Navbar header (lg+ breakpoint) for better visibility of active user count
- Also add it to the mobile overflow menu so it's accessible at all screen sizes
- Previously the active user count was only visible in the Sidebar footer, which is less prominent

Closes #3903

## Test plan
- [ ] Verify active user count appears in the top navbar on desktop (>= 1024px)
- [ ] Verify it appears in the mobile overflow menu (< 1024px)
- [ ] Verify the existing Sidebar user count still works
- [ ] Verify demo mode shows correct count