### PR TITLE
🐛 Address Copilot review feedback on #4100

### DIFF
--- a/web/src/components/cards/OperatorStatus.tsx
+++ b/web/src/components/cards/OperatorStatus.tsx
@@ -190,7 +190,7 @@ function OperatorStatusInternal({ config: _config }: OperatorStatusProps) {
           <button
             onClick={() => refetch()}
             disabled={isRefreshing}
-            className="mt-1 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 transition-colors disabled:opacity-50"
+            className="mt-1 flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
             {t('common:common.retry', 'Retry')}

--- a/web/src/components/deploy/Deploy.tsx
+++ b/web/src/components/deploy/Deploy.tsx
@@ -165,7 +165,7 @@ export function Deploy() {
       })
     } catch (err) {
       console.error('Deploy failed:', err)
-      const errorMessage = err instanceof Error ? err.message : 'Deploy failed'
+      const errorMessage = (err instanceof Error && err.message.trim()) ? err.message.trim() : 'Deploy failed'
       showToast(errorMessage, 'error')
       publishCardEvent({
         type: 'deploy:result',

--- a/web/src/components/drilldown/views/EventsDrillDown.tsx
+++ b/web/src/components/drilldown/views/EventsDrillDown.tsx
@@ -148,7 +148,7 @@ export function EventsDrillDown({ data }: Props) {
     setTimeout(() => setCopied(false), UI_FEEDBACK_TIMEOUT_MS)
   }
 
-  if (isLoading) {
+  if (isLoading && events.length === 0 && !error) {
     return <EventsSkeleton />
   }
 

--- a/web/src/components/drilldown/views/YAMLDrillDown.tsx
+++ b/web/src/components/drilldown/views/YAMLDrillDown.tsx
@@ -83,7 +83,7 @@ export function YAMLDrillDown({ data }: Props) {
     emitDataExported('yaml_download', resourceType)
   }
 
-  if (isLoading) {
+  if (isLoading && !yaml) {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="spinner w-8 h-8" />


### PR DESCRIPTION
## Summary

Addresses all 4 Copilot review comments on #4100:

1. **YAMLDrillDown** — Full-page spinner only on initial load (`!yaml`), toolbar stays visible during refresh so `animate-spin` on RefreshCw is actually visible
2. **EventsDrillDown** — Skeleton only when no events and no error, retry button stays visible during refetch with spinning icon
3. **Deploy.tsx** — Empty error message guard: `err.message.trim() || 'Deploy failed'`
4. **OperatorStatus.tsx** — Added `disabled:cursor-not-allowed` for UX consistency with other disabled buttons

## Test plan
- [ ] YAMLDrillDown: click refresh while YAML is displayed → spinner on icon, content stays
- [ ] EventsDrillDown: click retry on error → spinner on icon, error UI stays until success
- [ ] Deploy: trigger error with empty message → toast shows "Deploy failed"
- [ ] OperatorStatus: disabled retry button shows not-allowed cursor