### PR TITLE
🐛 fix: add missing aria-label attributes for accessibility

### DIFF
--- a/web/src/components/cards/ComplianceDrift.tsx
+++ b/web/src/components/cards/ComplianceDrift.tsx
@@ -245,6 +245,7 @@ export function ComplianceDrift({ config: _config }: CardConfig) {
             onClick={() => handleDriftClick(d)}
             role="button"
             tabIndex={0}
+            aria-label={`View drift details: ${d.cluster} ${d.tool} score ${d.value}% ${d.direction === 'above' ? 'above' : 'below'} fleet average`}
             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleDriftClick(d) } }}
           >
             {d.direction === 'above' ? (

--- a/web/src/components/cards/insights/CascadeImpactMap.tsx
+++ b/web/src/components/cards/insights/CascadeImpactMap.tsx
@@ -75,6 +75,7 @@ export function CascadeImpactMap() {
           key={insight.id}
           role="button"
           tabIndex={0}
+          aria-label={`View cascade impact: ${insight.title}`}
           onClick={() => setModalInsight(insight)}
           onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setModalInsight(insight) } }}
           className="group space-y-2 cursor-pointer hover:bg-secondary/30 rounded-lg p-1 -m-1 transition-colors"

--- a/web/src/components/cards/insights/ConfigDriftHeatmap.tsx
+++ b/web/src/components/cards/insights/ConfigDriftHeatmap.tsx
@@ -180,6 +180,7 @@ export function ConfigDriftHeatmap() {
             <div
               role="button"
               tabIndex={0}
+              aria-label={`View config drift insight: ${insight.title}`}
               onClick={() => setSelectedInsight(insight)}
               onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedInsight(insight) } }}
               className="group flex items-center gap-2 text-xs py-1 hover:bg-secondary/30 rounded px-1 cursor-pointer"

--- a/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
+++ b/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
@@ -151,6 +151,7 @@ export function CrossClusterEventCorrelation() {
               key={insight.id}
               role="button"
               tabIndex={0}
+              aria-label={`View event correlation: ${insight.title}`}
               onClick={() => setSelectedInsight(insight)}
               onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedInsight(insight) } }}
               className="group bg-red-500/5 border border-red-500/20 rounded-lg p-2.5 space-y-1 cursor-pointer hover:bg-red-500/10 transition-colors"

--- a/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
+++ b/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
@@ -87,6 +87,7 @@ export function ResourceImbalanceDetector() {
           key={insight.id}
           role="button"
           tabIndex={0}
+          aria-label={`View resource imbalance: ${insight.title}`}
           onClick={() => setModalInsight(insight)}
           onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setModalInsight(insight) } }}
           className="group space-y-2 cursor-pointer hover:bg-secondary/30 rounded-lg p-1 -m-1 transition-colors"

--- a/web/src/components/cards/insights/RestartCorrelationMatrix.tsx
+++ b/web/src/components/cards/insights/RestartCorrelationMatrix.tsx
@@ -81,6 +81,7 @@ export function RestartCorrelationMatrix() {
               key={insight.id}
               role="button"
               tabIndex={0}
+              aria-label={`View application bug insight: ${insight.title}`}
               onClick={() => setModalInsight(insight)}
               onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setModalInsight(insight) } }}
               className="group bg-yellow-500/5 border border-yellow-500/20 rounded-lg p-2.5 space-y-1 cursor-pointer hover:bg-yellow-500/10 transition-colors"
@@ -126,6 +127,7 @@ export function RestartCorrelationMatrix() {
               key={insight.id}
               role="button"
               tabIndex={0}
+              aria-label={`View infrastructure insight: ${insight.title}`}
               onClick={() => setModalInsight(insight)}
               onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setModalInsight(insight) } }}
               className="group bg-red-500/5 border border-red-500/20 rounded-lg p-2.5 space-y-1 cursor-pointer hover:bg-red-500/10 transition-colors"

--- a/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
@@ -131,6 +131,7 @@ export function K3sStatus() {
         <div
           role="button"
           tabIndex={0}
+          aria-label={`K3s status: ${isHealthy ? 'healthy' : 'degraded'}. Click to view details.`}
           onClick={openDetailModal}
           onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium cursor-pointer hover:bg-secondary/50 transition-colors ${
@@ -154,7 +155,7 @@ export function K3sStatus() {
       </div>
 
       {/* Top metrics */}
-      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label="View K3s pod metrics" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <MetricTile
           label={t('k3sStatus.totalPods')}
           value={data.podCount}
@@ -181,7 +182,7 @@ export function K3sStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('k3sStatus.serverPodList')}</p>
           <div className="space-y-1.5 max-h-40 overflow-y-auto scrollbar-thin">
             {serverPods.map((pod) => (
-              <div key={pod.name} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+              <div key={pod.name} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={`View K3s server pod ${pod.name}`} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
                 <span className="text-foreground truncate flex-1" title={pod.name}>
                   {pod.name}
                 </span>

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
@@ -154,6 +154,7 @@ export function KubevirtStatus() {
         <div
           role="button"
           tabIndex={0}
+          aria-label={`KubeVirt status: ${isHealthy ? 'healthy' : 'degraded'}. Click to view details.`}
           onClick={openDetailModal}
           onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium cursor-pointer hover:bg-secondary/50 transition-colors ${
@@ -177,7 +178,7 @@ export function KubevirtStatus() {
       </div>
 
       {/* Top metrics: infra pods */}
-      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label="View KubeVirt infrastructure metrics" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <MetricTile
           label={t('kubevirtStatus.infraPods')}
           value={data.podCount}
@@ -199,7 +200,7 @@ export function KubevirtStatus() {
       </div>
 
       {/* Bottom metrics: VM state breakdown */}
-      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label="View virtual machine state breakdown" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <MetricTile
           label={t('kubevirtStatus.runningVMs')}
           value={runningVMs}
@@ -228,7 +229,7 @@ export function KubevirtStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('kubevirtStatus.vmList')}</p>
           <div className="space-y-1.5 max-h-40 overflow-y-auto scrollbar-thin">
             {vms.map((vm) => (
-              <div key={`${vm.namespace}/${vm.name}`} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+              <div key={`${vm.namespace}/${vm.name}`} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={`View VM ${vm.name} in ${vm.namespace}`} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
                 <div className="flex flex-col min-w-0 flex-1">
                   <span className="text-foreground truncate" title={vm.name}>
                     {vm.name}

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
@@ -70,7 +70,7 @@ function ComponentBadge({ component, onClick }: { component: ComponentStatus; on
   const healthBg = HEALTH_BG[component.health] || HEALTH_BG.unknown
 
   return (
-    <div className={`p-2.5 rounded-lg border ${healthBg} flex items-center gap-2 cursor-pointer hover:bg-secondary/50 transition-colors`} role="button" tabIndex={0} onClick={onClick} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick?.() } }}>
+    <div className={`p-2.5 rounded-lg border ${healthBg} flex items-center gap-2 cursor-pointer hover:bg-secondary/50 transition-colors`} role="button" tabIndex={0} aria-label={`${component.name}: ${component.detected ? component.health : 'not detected'}`} onClick={onClick} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick?.() } }}>
       <IconComponent className={`w-4 h-4 ${healthColor}`} />
       <div className="flex-1 min-w-0">
         <div className="text-xs font-medium text-foreground truncate">{component.name}</div>
@@ -86,7 +86,7 @@ function ComponentBadge({ component, onClick }: { component: ComponentStatus; on
 /** Single isolation level row */
 function IsolationRow({ level, onClick }: { level: IsolationLevel; onClick?: () => void }) {
   return (
-    <div className="flex items-center justify-between py-1.5 cursor-pointer hover:bg-secondary/50 transition-colors rounded px-1 -mx-1" role="button" tabIndex={0} onClick={onClick} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick?.() } }}>
+    <div className="flex items-center justify-between py-1.5 cursor-pointer hover:bg-secondary/50 transition-colors rounded px-1 -mx-1" role="button" tabIndex={0} aria-label={`${level.type} isolation: ${level.status}`} onClick={onClick} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick?.() } }}>
       <div className="flex items-center gap-2">
         <IsolationStatusIcon status={level.status} />
         <span className="text-xs font-medium text-foreground">{level.type}</span>
@@ -158,7 +158,7 @@ export function MultiTenancyOverview() {
   return (
     <div className="h-full flex flex-col gap-3">
       {/* Overall score header */}
-      <div className="flex items-center justify-between px-2 py-1.5 bg-secondary/30 rounded-lg cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex items-center justify-between px-2 py-1.5 bg-secondary/30 rounded-lg cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label="View multi-tenancy isolation score details" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <div className="flex items-center gap-2">
           <Shield className="w-4 h-4 text-cyan-400" />
           <span className="text-xs font-medium text-foreground">

--- a/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
@@ -132,6 +132,7 @@ export function OvnStatus() {
         <div
           role="button"
           tabIndex={0}
+          aria-label={`OVN status: ${isHealthy ? 'healthy' : 'degraded'}. Click to view details.`}
           onClick={openDetailModal}
           onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium cursor-pointer hover:bg-secondary/50 transition-colors ${
@@ -155,7 +156,7 @@ export function OvnStatus() {
       </div>
 
       {/* Metric tiles */}
-      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label="View OVN pod metrics" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <MetricTile
           label={t('ovnStatus.ovnPods')}
           value={data.podCount}
@@ -177,7 +178,7 @@ export function OvnStatus() {
       </div>
 
       {/* UDN summary */}
-      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label="View OVN UDN network summary" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <MetricTile
           label={t('ovnStatus.udnCount')}
           value={(data.udns || []).length}
@@ -204,7 +205,7 @@ export function OvnStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('ovnStatus.udnList')}</p>
           <div className="space-y-1.5 max-h-32 overflow-y-auto scrollbar-thin">
             {(data.udns || []).map((udn) => (
-              <div key={udn.name} className="flex items-center justify-between text-xs gap-2 cursor-pointer hover:bg-secondary/50 transition-colors rounded px-1 -mx-1" role="button" tabIndex={0} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+              <div key={udn.name} className="flex items-center justify-between text-xs gap-2 cursor-pointer hover:bg-secondary/50 transition-colors rounded px-1 -mx-1" role="button" tabIndex={0} aria-label={`View UDN ${udn.name}`} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
                 <span className="text-muted-foreground truncate flex-1" title={udn.name}>
                   {udn.name}
                 </span>

--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -120,6 +120,7 @@ function CopyCmd({ text }: { text: string }) {
       onClick={handleCopy}
       className="inline-flex items-center p-0.5 rounded hover:bg-black/5 dark:hover:bg-white/10 text-muted-foreground hover:text-foreground transition-colors"
       title={copied ? 'Copied!' : `Copy: ${text}`}
+      aria-label={copied ? 'Copied!' : `Copy: ${text}`}
     >
       {copied ? <Check className="w-2.5 h-2.5 text-green-400" /> : <Copy className="w-2.5 h-2.5" />}
     </button>
@@ -182,8 +183,9 @@ const LocalClusterControls = memo(function LocalClusterControls({
               : 'text-muted-foreground hover:text-green-400 hover:bg-green-500/20'
           }`}
           title="Start cluster"
+          aria-label="Start cluster"
         >
-          <Play className={`w-3.5 h-3.5 ${actionInProgress === 'start' ? 'animate-pulse' : ''}`} />
+          <Play className={`w-3.5 h-3.5 ${actionInProgress === 'start' ? 'animate-pulse' : ''}`} aria-hidden="true" />
         </button>
       ) : (
         <button
@@ -195,8 +197,9 @@ const LocalClusterControls = memo(function LocalClusterControls({
               : 'text-muted-foreground hover:text-red-400 hover:bg-red-500/20'
           }`}
           title="Stop cluster"
+          aria-label="Stop cluster"
         >
-          <Square className={`w-3 h-3 ${actionInProgress === 'stop' ? 'animate-pulse' : ''}`} />
+          <Square className={`w-3 h-3 ${actionInProgress === 'stop' ? 'animate-pulse' : ''}`} aria-hidden="true" />
         </button>
       )}
       <button
@@ -208,8 +211,9 @@ const LocalClusterControls = memo(function LocalClusterControls({
             : 'text-muted-foreground hover:text-blue-400 hover:bg-blue-500/20'
         }`}
         title="Restart cluster"
+        aria-label="Restart cluster"
       >
-        <RotateCcw className={`w-3.5 h-3.5 ${actionInProgress === 'restart' ? 'animate-spin' : ''}`} />
+        <RotateCcw className={`w-3.5 h-3.5 ${actionInProgress === 'restart' ? 'animate-spin' : ''}`} aria-hidden="true" />
       </button>
     </div>
   )
@@ -345,8 +349,9 @@ const FullClusterCard = memo(function FullClusterCard({
                     'bg-secondary/50 text-muted-foreground hover:bg-secondary hover:text-foreground'
                   }`}
                   title={spinning ? t('common.refreshing') : unreachable ? t('common.retryConnection') : t('common.refreshClusterData')}
+                  aria-label={spinning ? t('common.refreshing') : unreachable ? t('common.retryConnection') : t('common.refreshClusterData')}
                 >
-                  <RefreshCw className={`w-3.5 h-3.5 ${spinning ? 'animate-spin' : ''}`} />
+                  <RefreshCw className={`w-3.5 h-3.5 ${spinning ? 'animate-spin' : ''}`} aria-hidden="true" />
                 </button>
               )}
             </div>
@@ -386,8 +391,9 @@ const FullClusterCard = memo(function FullClusterCard({
                     onClick={(e) => { e.stopPropagation(); onRenameCluster() }}
                     className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground flex-shrink-0"
                     title={t('common.renameContext')}
+                    aria-label={t('common.renameContext')}
                   >
-                    <Pencil className="w-3 h-3" />
+                    <Pencil className="w-3 h-3" aria-hidden="true" />
                   </button>
                 )}
               </div>
@@ -677,8 +683,9 @@ const ListClusterCard = memo(function ListClusterCard({
                   'text-muted-foreground hover:bg-secondary hover:text-foreground'
                 }`}
                 title={spinning ? t('common.refreshing') : t('common.refresh')}
+                aria-label={spinning ? t('common.refreshing') : t('common.refresh')}
               >
-                <RefreshCw className={`w-3.5 h-3.5 ${spinning ? 'animate-spin' : ''}`} />
+                <RefreshCw className={`w-3.5 h-3.5 ${spinning ? 'animate-spin' : ''}`} aria-hidden="true" />
               </button>
             )}
             {!permissionsLoading && !isClusterAdmin && !unreachable && (

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -388,6 +388,7 @@ export function Sidebar() {
                     onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); removeItem(item.id) } }}
                     className="p-1 rounded hover:bg-red-500/20 hover:text-red-400 text-muted-foreground/50 transition-colors"
                     title={t('sidebar.removeFromSidebar')}
+                    aria-label={t('sidebar.removeFromSidebar')}
                   >
                     <X className="w-3.5 h-3.5" aria-hidden="true" />
                   </span>


### PR DESCRIPTION
## Summary
- Add missing `aria-label` attributes to all `role="button"` elements that lacked them across 12 files
- Add `aria-label` and `aria-hidden="true"` to icon-only buttons in ClusterGrid (copy, start, stop, restart, refresh, rename)
- Fixes items flagged in #3857, #3949, #3951, #3958

### Files changed
- **Insight cards**: CrossClusterEventCorrelation, CascadeImpactMap, RestartCorrelationMatrix, ConfigDriftHeatmap, ResourceImbalanceDetector
- **Multi-tenancy cards**: KubevirtStatus, K3sStatus, MultiTenancyOverview, OvnStatus
- **Other**: ComplianceDrift, ClusterGrid, Sidebar

### What remains
- Issue #3949 arrow key navigation for dropdowns/tabs (larger scope, separate PR)
- Additional icon-only buttons in drilldown views could use `aria-label` (not flagged in these issues)

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Screen reader can announce all clickable elements in cluster grid, insight cards, and multi-tenancy cards
- [ ] Tab navigation reaches all interactive elements with `role="button"`

Closes #3951
Closes #3958
Relates to #3857, #3949