### PR TITLE
🐛 Fix modal safety issues — prevent accidental close and add Escape handlers

### DIFF
--- a/web/src/components/cards/kyverno/KyvernoDetailModal.tsx
+++ b/web/src/components/cards/kyverno/KyvernoDetailModal.tsx
@@ -128,7 +128,7 @@ Please proceed step by step.`,
   }
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="lg">
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false}>
       <BaseModal.Header
         title={`Kyverno — ${clusterName}`}
         icon={Shield}

--- a/web/src/components/cards/llmd/StackSelector.tsx
+++ b/web/src/components/cards/llmd/StackSelector.tsx
@@ -212,16 +212,26 @@ export function StackSelector() {
   const dropdownRef = useRef<HTMLDivElement>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
 
-  // Close dropdown on outside click
+  // Close dropdown on outside click or Escape key
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
         closeDropdown()
       }
     }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape' && isOpen) {
+        event.preventDefault()
+        closeDropdown()
+      }
+    }
     document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [closeDropdown])
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [closeDropdown, isOpen])
 
   // Focus search input when dropdown opens
   useEffect(() => {

--- a/web/src/components/cards/rss/RSSFeed.tsx
+++ b/web/src/components/cards/rss/RSSFeed.tsx
@@ -128,6 +128,24 @@ function RSSFeedInternal({ config }: RSSFeedProps) {
   const hasData = items.length > 0
   useCardLoadingState({ isLoading: isLoading && !hasData, isRefreshing, hasAnyData: hasData, isDemoData: isDemoMode })
 
+  // Close overlay panels on Escape key
+  useEffect(() => {
+    const hasOpenOverlay = showSettings || showFeedSelector || showFilterEditor || showSourceFilter || showAggregateCreator
+    if (!hasOpenOverlay) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        if (showAggregateCreator) setShowAggregateCreator(false)
+        else if (showFilterEditor) setShowFilterEditor(false)
+        else if (showSourceFilter) setShowSourceFilter(false)
+        else if (showFeedSelector) setShowFeedSelector(false)
+        else if (showSettings) setShowSettings(false)
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [showSettings, showFeedSelector, showFilterEditor, showSourceFilter, showAggregateCreator])
+
   const activeFeed = feeds[activeFeedIndex] || feeds[0]
 
   // Get cache key for current feed

--- a/web/src/components/clusters/components/CardConfigModal.tsx
+++ b/web/src/components/clusters/components/CardConfigModal.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
-import { X } from 'lucide-react'
+import { Settings } from 'lucide-react'
 import { DashboardCard } from '../../../lib/dashboards'
 import { formatCardTitle } from '../../../lib/formatCardTitle'
-import { useModalNavigation } from '../../../lib/modals/useModalNavigation'
+import { BaseModal } from '../../../lib/modals'
 import { useTranslation } from 'react-i18next'
 
 export interface CardConfigModalCluster {
@@ -25,27 +25,20 @@ export function CardConfigModal({
   const { t } = useTranslation()
   const [config, setConfig] = useState<Record<string, unknown>>(card.config || {})
 
-  // Use standardized modal keyboard navigation (Escape to close, body scroll lock)
-  useModalNavigation({ isOpen: true, onClose, enableEscape: true, enableBackspace: false })
-
   const handleSave = () => {
     onSave(config)
   }
 
   return (
-    <div 
-      className="fixed inset-0 bg-black/60 backdrop-blur-2xl flex items-center justify-center z-50" 
-    >
-      <div role="dialog" aria-modal="true" className="glass p-6 rounded-lg w-[500px] max-h-[80vh] overflow-auto" onClick={e => e.stopPropagation()}>
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold text-foreground">
-            Configure {formatCardTitle(card.card_type)}
-          </h3>
-          <button onClick={onClose} className="text-muted-foreground hover:text-foreground">
-            <X className="w-5 h-5" />
-          </button>
-        </div>
+    <BaseModal isOpen={true} onClose={onClose} size="sm" closeOnBackdrop={false}>
+      <BaseModal.Header
+        title={`Configure ${formatCardTitle(card.card_type)}`}
+        icon={Settings}
+        onClose={onClose}
+        showBack={false}
+      />
 
+      <BaseModal.Content>
         <div className="space-y-4">
           {/* Cluster Filter */}
           <div>
@@ -107,8 +100,11 @@ export function CardConfigModal({
             />
           </div>
         </div>
+      </BaseModal.Content>
 
-        <div className="flex justify-end gap-2 mt-6">
+      <BaseModal.Footer showKeyboardHints>
+        <div className="flex-1" />
+        <div className="flex gap-2">
           <button
             onClick={onClose}
             className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground"
@@ -122,7 +118,7 @@ export function CardConfigModal({
             Save Configuration
           </button>
         </div>
-      </div>
-    </div>
+      </BaseModal.Footer>
+    </BaseModal>
   )
 }

--- a/web/src/components/deploy/Deploy.tsx
+++ b/web/src/components/deploy/Deploy.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect } from 'react'
+import { useState, useCallback, useMemo, useRef } from 'react'
 import type { DragEndEvent } from '@dnd-kit/core'
 import { useClusterGroups } from '../../hooks/useClusterGroups'
 import { useClusters, useDeployments } from '../../hooks/useMCP'
@@ -14,6 +14,7 @@ import { useDeployWorkload } from '../../hooks/useWorkloads'
 import { usePersistence } from '../../hooks/usePersistence'
 import { useWorkloadDeployments, useManagedWorkloads } from '../../hooks/useConsoleCRs'
 import { useToast } from '../ui/Toast'
+import { useModalNavigation, useModalFocusTrap } from '../../lib/modals/useModalNavigation'
 import { useTranslation } from 'react-i18next'
 
 const DEPLOY_CARDS_KEY = 'kubestellar-deploy-cards'
@@ -230,18 +231,19 @@ export function Deploy() {
     setGroupPickerWorkload(workload)
   }, [])
 
-  // Handle Escape key to close group picker modal
-  useEffect(() => {
-    if (!groupPickerWorkload) return
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        setGroupPickerWorkload(null)
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [groupPickerWorkload])
+  // Group picker modal ref for focus trap
+  const groupPickerRef = useRef<HTMLDivElement>(null)
+
+  // Standardized keyboard navigation (Escape to close) and body scroll lock
+  useModalNavigation({
+    isOpen: groupPickerWorkload !== null,
+    onClose: () => setGroupPickerWorkload(null),
+    enableEscape: true,
+    enableBackspace: false,
+  })
+
+  // Trap focus within group picker modal
+  useModalFocusTrap(groupPickerRef as React.RefObject<HTMLElement>, groupPickerWorkload !== null)
 
   return (
     <DashboardPage
@@ -277,8 +279,8 @@ export function Deploy() {
 
       {/* Group Picker — shown when workload is dropped on the card but not a specific group */}
       {groupPickerWorkload && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="presentation" onClick={() => setGroupPickerWorkload(null)}>
-          <div className="bg-card border border-border rounded-xl shadow-2xl w-full max-w-sm mx-4 p-5" role="dialog" aria-modal="true" aria-labelledby="group-picker-dialog-title" onClick={e => e.stopPropagation()}>
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm" onClick={() => setGroupPickerWorkload(null)}>
+          <div ref={groupPickerRef} className="bg-card border border-border rounded-xl shadow-2xl w-full max-w-sm mx-4 p-5" role="dialog" aria-modal="true" aria-labelledby="group-picker-dialog-title" onClick={e => e.stopPropagation()}>
             <h3 id="group-picker-dialog-title" className="text-base font-medium text-foreground mb-1">
               Choose a cluster group
             </h3>

--- a/web/src/components/rewards/GitHubInvite.tsx
+++ b/web/src/components/rewards/GitHubInvite.tsx
@@ -111,6 +111,7 @@ export function GitHubInviteModal({ isOpen, onClose }: GitHubInviteProps) {
         aria-modal="true"
         aria-labelledby={GITHUB_INVITE_MODAL_TITLE_ID}
         className="bg-card border border-border rounded-xl shadow-2xl w-full max-w-md mx-4 overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border bg-secondary/30">

--- a/web/src/components/storage/Storage.tsx
+++ b/web/src/components/storage/Storage.tsx
@@ -50,7 +50,7 @@ function PVCListModal({ isOpen, onClose, pvcs, title, statusFilter = 'all', onSe
   }
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="lg">
+    <BaseModal isOpen={isOpen} onClose={onClose} size="lg" closeOnBackdrop={false}>
       <BaseModal.Header
         title={title}
         description={`${filteredPVCs.length} PVC${filteredPVCs.length !== 1 ? 's' : ''}`}


### PR DESCRIPTION
## Summary
- **CardConfigModal**: Migrated from raw `<div>` to `BaseModal` with `closeOnBackdrop={false}`, gaining Escape key handling, focus trap, `aria-modal`, and portal rendering
- **GitHubInvite**: Added `stopPropagation` on modal content to prevent backdrop clicks from dismissing the form
- **KyvernoDetailModal / PVCListModal**: Disabled backdrop close on modals that have search inputs
- **Deploy group picker**: Replaced manual `useEffect` Escape handler with standardized `useModalNavigation` and `useModalFocusTrap` hooks
- **StackSelector dropdown**: Added Escape key handler to close the dropdown
- **RSSFeed**: Added Escape key handler for all overlay panels (settings, filter editor, feed selector, source filter, aggregate creator)

## Test plan
- [ ] Open CardConfigModal, verify Escape closes it, backdrop click does NOT close it
- [ ] Open GitHubInvite modal, verify clicking backdrop does NOT close the form
- [ ] Open KyvernoDetailModal, verify backdrop click does NOT close it
- [ ] Open PVC list modal on Storage page, verify backdrop click does NOT close it
- [ ] Open Deploy page, drop a workload to trigger group picker, verify Escape closes it and focus is trapped
- [ ] Open StackSelector dropdown on llm-d page, verify Escape closes it
- [ ] Open RSSFeed card settings panel, verify Escape closes it

Closes #3953