### PR TITLE
🐛 fix: address Copilot review feedback from PRs #4105, #4106, #4107

### DIFF
--- a/web/src/components/cards/ComplianceDrift.tsx
+++ b/web/src/components/cards/ComplianceDrift.tsx
@@ -245,7 +245,7 @@ export function ComplianceDrift({ config: _config }: CardConfig) {
             onClick={() => handleDriftClick(d)}
             role="button"
             tabIndex={0}
-            aria-label={`View drift details: ${d.cluster} ${d.tool} score ${d.value}% ${d.direction === 'above' ? 'above' : 'below'} fleet average`}
+            aria-label={t('complianceDrift.viewDriftDetailsAria', { cluster: d.cluster, tool: d.tool, value: d.value, direction: d.direction === 'above' ? t('complianceDrift.aboveFleetAverage') : t('complianceDrift.belowFleetAverage') })}
             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleDriftClick(d) } }}
           >
             {d.direction === 'above' ? (

--- a/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx
@@ -131,7 +131,7 @@ export function K3sStatus() {
         <div
           role="button"
           tabIndex={0}
-          aria-label={`K3s status: ${isHealthy ? 'healthy' : 'degraded'}. Click to view details.`}
+          aria-label={t('k3sStatus.statusAriaLabel', { status: isHealthy ? t('k3sStatus.healthy') : t('k3sStatus.degraded') })}
           onClick={openDetailModal}
           onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium cursor-pointer hover:bg-secondary/50 transition-colors ${
@@ -155,7 +155,7 @@ export function K3sStatus() {
       </div>
 
       {/* Top metrics */}
-      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label="View K3s pod metrics" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label={t('k3sStatus.viewPodMetrics')} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <MetricTile
           label={t('k3sStatus.totalPods')}
           value={data.podCount}
@@ -182,7 +182,7 @@ export function K3sStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('k3sStatus.serverPodList')}</p>
           <div className="space-y-1.5 max-h-40 overflow-y-auto scrollbar-thin">
             {serverPods.map((pod) => (
-              <div key={pod.name} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={`View K3s server pod ${pod.name}`} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+              <div key={pod.name} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={t('k3sStatus.viewServerPod', { name: pod.name })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
                 <span className="text-foreground truncate flex-1" title={pod.name}>
                   {pod.name}
                 </span>

--- a/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx
@@ -154,7 +154,7 @@ export function KubevirtStatus() {
         <div
           role="button"
           tabIndex={0}
-          aria-label={`KubeVirt status: ${isHealthy ? 'healthy' : 'degraded'}. Click to view details.`}
+          aria-label={t('kubevirtStatus.statusAriaLabel', { status: isHealthy ? t('kubevirtStatus.healthy') : t('kubevirtStatus.degraded') })}
           onClick={openDetailModal}
           onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium cursor-pointer hover:bg-secondary/50 transition-colors ${
@@ -178,7 +178,7 @@ export function KubevirtStatus() {
       </div>
 
       {/* Top metrics: infra pods */}
-      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label="View KubeVirt infrastructure metrics" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label={t('kubevirtStatus.viewInfraMetrics')} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <MetricTile
           label={t('kubevirtStatus.infraPods')}
           value={data.podCount}
@@ -200,7 +200,7 @@ export function KubevirtStatus() {
       </div>
 
       {/* Bottom metrics: VM state breakdown */}
-      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label="View virtual machine state breakdown" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label={t('kubevirtStatus.viewVmBreakdown')} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <MetricTile
           label={t('kubevirtStatus.runningVMs')}
           value={runningVMs}
@@ -229,7 +229,7 @@ export function KubevirtStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('kubevirtStatus.vmList')}</p>
           <div className="space-y-1.5 max-h-40 overflow-y-auto scrollbar-thin">
             {vms.map((vm) => (
-              <div key={`${vm.namespace}/${vm.name}`} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={`View VM ${vm.name} in ${vm.namespace}`} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+              <div key={`${vm.namespace}/${vm.name}`} className="flex items-center justify-between text-xs gap-2 px-2 py-1.5 rounded bg-secondary/30 cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label={t('kubevirtStatus.viewVm', { name: vm.name, namespace: vm.namespace })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
                 <div className="flex flex-col min-w-0 flex-1">
                   <span className="text-foreground truncate" title={vm.name}>
                     {vm.name}

--- a/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
+++ b/web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx
@@ -158,10 +158,10 @@ export function MultiTenancyOverview() {
   return (
     <div className="h-full flex flex-col gap-3">
       {/* Overall score header */}
-      <div className="flex items-center justify-between px-2 py-1.5 bg-secondary/30 rounded-lg cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-label="View multi-tenancy isolation score details" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex items-center justify-between px-2 py-1.5 bg-secondary/30 rounded-lg cursor-pointer hover:bg-secondary/50 transition-colors" role="button" tabIndex={0} aria-labelledby="multi-tenancy-isolation-score-header" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <div className="flex items-center gap-2">
           <Shield className="w-4 h-4 text-cyan-400" />
-          <span className="text-xs font-medium text-foreground">
+          <span className="text-xs font-medium text-foreground" id="multi-tenancy-isolation-score-header">
             {t('cards:multiTenancy.isolationScore', 'Isolation Score')}
           </span>
         </div>

--- a/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
+++ b/web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx
@@ -132,7 +132,7 @@ export function OvnStatus() {
         <div
           role="button"
           tabIndex={0}
-          aria-label={`OVN status: ${isHealthy ? 'healthy' : 'degraded'}. Click to view details.`}
+          aria-label={t('ovnStatus.statusAriaLabel', { status: isHealthy ? t('ovnStatus.healthy') : t('ovnStatus.degraded') })}
           onClick={openDetailModal}
           onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}
           className={`flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium cursor-pointer hover:bg-secondary/50 transition-colors ${
@@ -156,7 +156,7 @@ export function OvnStatus() {
       </div>
 
       {/* Metric tiles */}
-      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label="View OVN pod metrics" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label={t('ovnStatus.viewPodMetrics')} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <MetricTile
           label={t('ovnStatus.ovnPods')}
           value={data.podCount}
@@ -178,7 +178,7 @@ export function OvnStatus() {
       </div>
 
       {/* UDN summary */}
-      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label="View OVN UDN network summary" onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+      <div className="flex gap-3 cursor-pointer hover:bg-secondary/50 transition-colors rounded-lg" role="button" tabIndex={0} aria-label={t('ovnStatus.viewUdnSummary')} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
         <MetricTile
           label={t('ovnStatus.udnCount')}
           value={(data.udns || []).length}
@@ -205,7 +205,7 @@ export function OvnStatus() {
           <p className="text-xs font-medium text-muted-foreground">{t('ovnStatus.udnList')}</p>
           <div className="space-y-1.5 max-h-32 overflow-y-auto scrollbar-thin">
             {(data.udns || []).map((udn) => (
-              <div key={udn.name} className="flex items-center justify-between text-xs gap-2 cursor-pointer hover:bg-secondary/50 transition-colors rounded px-1 -mx-1" role="button" tabIndex={0} aria-label={`View UDN ${udn.name}`} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
+              <div key={udn.name} className="flex items-center justify-between text-xs gap-2 cursor-pointer hover:bg-secondary/50 transition-colors rounded px-1 -mx-1" role="button" tabIndex={0} aria-label={t('ovnStatus.viewUdn', { name: udn.name })} onClick={openDetailModal} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetailModal() } }}>
                 <span className="text-muted-foreground truncate flex-1" title={udn.name}>
                   {udn.name}
                 </span>

--- a/web/src/components/clusters/components/CardConfigModal.tsx
+++ b/web/src/components/clusters/components/CardConfigModal.tsx
@@ -30,7 +30,7 @@ export function CardConfigModal({
   }
 
   return (
-    <BaseModal isOpen={true} onClose={onClose} size="sm" closeOnBackdrop={false}>
+    <BaseModal isOpen={true} onClose={onClose} size="sm" closeOnBackdrop={false} enableBackspace={false}>
       <BaseModal.Header
         title={`Configure ${formatCardTitle(card.card_type)}`}
         icon={Settings}

--- a/web/src/components/clusters/components/ClusterGrid.tsx
+++ b/web/src/components/clusters/components/ClusterGrid.tsx
@@ -119,10 +119,13 @@ function CopyCmd({ text }: { text: string }) {
     <button
       onClick={handleCopy}
       className="inline-flex items-center p-0.5 rounded hover:bg-black/5 dark:hover:bg-white/10 text-muted-foreground hover:text-foreground transition-colors"
-      title={copied ? 'Copied!' : `Copy: ${text}`}
-      aria-label={copied ? 'Copied!' : `Copy: ${text}`}
+      title="Copy command to clipboard"
+      aria-label="Copy command to clipboard"
     >
       {copied ? <Check className="w-2.5 h-2.5 text-green-400" /> : <Copy className="w-2.5 h-2.5" />}
+      <span aria-live="polite" className="sr-only">
+        {copied ? 'Copied!' : ''}
+      </span>
     </button>
   )
 }

--- a/web/src/lib/modals/BaseModal.tsx
+++ b/web/src/lib/modals/BaseModal.tsx
@@ -79,6 +79,7 @@ export function BaseModal({
   children,
   closeOnBackdrop = true,
   closeOnEscape = true,
+  enableBackspace = true,
 }: BaseModalProps) {
   const backdropRef = useRef<HTMLDivElement>(null)
   const modalRef = useRef<HTMLDivElement>(null)
@@ -88,7 +89,7 @@ export function BaseModal({
     isOpen,
     onClose,
     enableEscape: closeOnEscape,
-    enableBackspace: true,
+    enableBackspace,
     disableBodyScroll: true,
   })
 

--- a/web/src/lib/modals/types.ts
+++ b/web/src/lib/modals/types.ts
@@ -285,6 +285,8 @@ export interface BaseModalProps {
   closeOnBackdrop?: boolean
   /** Whether to close on Escape key */
   closeOnEscape?: boolean
+  /** Whether to enable Backspace/Space to close (default true) */
+  enableBackspace?: boolean
 }
 
 export interface ModalHeaderProps {

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -2909,7 +2909,11 @@
     "syncedJustNow": "just now",
     "syncedMinutesAgo": "{{count}}m ago",
     "syncedHoursAgo": "{{count}}h ago",
-    "syncedDaysAgo": "{{count}}d ago"
+    "syncedDaysAgo": "{{count}}d ago",
+    "statusAriaLabel": "OVN status: {{status}}. Click to view details.",
+    "viewPodMetrics": "View OVN pod metrics",
+    "viewUdnSummary": "View OVN UDN network summary",
+    "viewUdn": "View UDN {{name}}"
   },
   "kubeFlexStatus": {
     "fetchError": "Failed to fetch KubeFlex status",
@@ -2950,7 +2954,10 @@
     "syncedJustNow": "just now",
     "syncedMinutesAgo": "{{count}}m ago",
     "syncedHoursAgo": "{{count}}h ago",
-    "syncedDaysAgo": "{{count}}d ago"
+    "syncedDaysAgo": "{{count}}d ago",
+    "statusAriaLabel": "K3s status: {{status}}. Click to view details.",
+    "viewPodMetrics": "View K3s pod metrics",
+    "viewServerPod": "View K3s server pod {{name}}"
   },
   "kubevirtStatus": {
     "fetchError": "Failed to fetch KubeVirt status",
@@ -2971,7 +2978,11 @@
     "syncedJustNow": "just now",
     "syncedMinutesAgo": "{{count}}m ago",
     "syncedHoursAgo": "{{count}}h ago",
-    "syncedDaysAgo": "{{count}}d ago"
+    "syncedDaysAgo": "{{count}}d ago",
+    "statusAriaLabel": "KubeVirt status: {{status}}. Click to view details.",
+    "viewInfraMetrics": "View KubeVirt infrastructure metrics",
+    "viewVmBreakdown": "View virtual machine state breakdown",
+    "viewVm": "View VM {{name}} in {{namespace}}"
   },
   "kyvernoPolicies": {
     "scanningClusters": "Scanning clusters..."
@@ -3032,7 +3043,10 @@
     "noDeviations": "No significant compliance deviations detected across the fleet",
     "driftDescription": "Flags clusters deviating from fleet average. Drift indicates inconsistent security posture that needs investigation.",
     "scanningInProgress": "Scanning...",
-    "retry": "Retry"
+    "retry": "Retry",
+    "viewDriftDetailsAria": "View drift details: {{cluster}} {{tool}} score {{value}}% {{direction}}",
+    "aboveFleetAverage": "above fleet average",
+    "belowFleetAverage": "below fleet average"
   },
   "maintenanceWindows": {
     "maintenance": "Maintenance",


### PR DESCRIPTION
## Summary
Follow-up fixes for Copilot review comments on three merged PRs:

- **PR #4105** (aria-label accessibility): Replace all hardcoded English `aria-label` strings with `t()` i18n calls in OvnStatus, KubevirtStatus, K3sStatus, and ComplianceDrift. Use `aria-labelledby` for MultiTenancyOverview isolation score header. Stabilize CopyCmd `aria-label` to a constant "Copy command to clipboard" with an `aria-live` region for the "Copied!" feedback state.
- **PR #4106** (revert active users): No code changes needed (comment was about PR description only).
- **PR #4107** (modal safety): Add `enableBackspace` prop to `BaseModal` so form modals like `CardConfigModal` can opt out of Space/Backspace-to-close behavior, preventing accidental closure when interacting with `<select>` and button controls.

### Files changed
- `web/src/lib/modals/types.ts` — new `enableBackspace` prop on `BaseModalProps`
- `web/src/lib/modals/BaseModal.tsx` — wire `enableBackspace` prop through to `useModalNavigation`
- `web/src/components/clusters/components/CardConfigModal.tsx` — set `enableBackspace={false}`
- `web/src/components/clusters/components/ClusterGrid.tsx` — stable aria-label + aria-live on CopyCmd
- `web/src/components/cards/multi-tenancy/ovn-status/OvnStatus.tsx` — i18n aria-labels
- `web/src/components/cards/multi-tenancy/kubevirt-status/KubevirtStatus.tsx` — i18n aria-labels
- `web/src/components/cards/multi-tenancy/k3s-status/K3sStatus.tsx` — i18n aria-labels
- `web/src/components/cards/multi-tenancy/multi-tenancy-overview/MultiTenancyOverview.tsx` — `aria-labelledby`
- `web/src/components/cards/ComplianceDrift.tsx` — i18n aria-labels
- `web/src/locales/en/cards.json` — new i18n keys for all localized aria-labels

## Test plan
- [ ] Verify screen reader announces stable "Copy command to clipboard" label on CopyCmd buttons
- [ ] Verify "Copied!" announced via aria-live when copy button is clicked
- [ ] Verify all multi-tenancy card aria-labels render correctly in English
- [ ] Verify CardConfigModal does NOT close on Space or Backspace keypress
- [ ] Verify other modals still close on Space/Backspace as before
- [ ] Run `npx tsc --noEmit` — passes clean