### PR TITLE
🐛 Fix silent error handling in ClusterRole update and sync endpoint

### DIFF
--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -785,13 +785,10 @@ func (h *ConsolePersistenceHandlers) SyncNow(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "Persistence not enabled"})
 	}
 
-	// TODO: Implement sync logic
-	// This would re-read all CRs and broadcast updates
-
-	now := time.Now()
-	return c.JSON(fiber.Map{
-		"synced":    true,
-		"syncedAt":  now,
+	// Sync logic is not yet implemented — return an honest status
+	return c.Status(501).JSON(fiber.Map{
+		"synced":    false,
+		"error":     "sync not implemented",
 		"namespace": h.persistenceStore.GetNamespace(),
 	})
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -2595,9 +2595,12 @@ func (m *MultiClusterClient) InstallGPUHealthCronJob(ctx context.Context, contex
 	if _, crErr := client.RbacV1().ClusterRoles().Create(ctx, cr, metav1.CreateOptions{}); crErr != nil {
 		if errors.IsAlreadyExists(crErr) {
 			existing, getErr := client.RbacV1().ClusterRoles().Get(ctx, gpuHealthClusterRole, metav1.GetOptions{})
-			if getErr == nil {
-				existing.Rules = rules
-				_, _ = client.RbacV1().ClusterRoles().Update(ctx, existing, metav1.UpdateOptions{})
+			if getErr != nil {
+				return fmt.Errorf("getting existing ClusterRole for update: %w", getErr)
+			}
+			existing.Rules = rules
+			if _, updateErr := client.RbacV1().ClusterRoles().Update(ctx, existing, metav1.UpdateOptions{}); updateErr != nil {
+				return fmt.Errorf("updating ClusterRole: %w", updateErr)
 			}
 		} else {
 			return fmt.Errorf("creating ClusterRole: %w", crErr)


### PR DESCRIPTION
## Summary
- **ClusterRole update error ignored (#4113):** The `InstallGPUHealthCronJob` function discarded the error from `ClusterRoles().Update()` with `_, _ =`. If the update failed, the system continued with outdated RBAC rules, which could cause subsequent GPU health job failures. Now both the Get and Update errors are checked and returned.
- **Sync endpoint reports false success (#4114):** The `SyncNow` handler returned `"synced": true` with a 200 status even though the sync logic was never implemented (just a TODO comment). Now returns 501 with `"synced": false` and an error message. The frontend already handles non-ok responses gracefully.

Fixes #4113
Fixes #4114

## Test plan
- [x] `go build ./pkg/...` compiles cleanly
- [x] `go test ./pkg/api/handlers/...` passes
- [x] `go test ./pkg/k8s/...` passes
- [x] Frontend `usePersistence.ts` already handles non-ok response from sync endpoint (falls through to return false)