### PR TITLE
🐛 Fix offline clusters styling in Stats Overview

### DIFF
--- a/web/src/components/ui/StatsBlockDefinitions.ts
+++ b/web/src/components/ui/StatsBlockDefinitions.ts
@@ -465,11 +465,11 @@ export const STAT_DISPLAY_MODE_DEFAULTS: Record<string, StatDisplayMode> = {
   'data-compliance:encryption_score': 'horseshoe',
   'data-compliance:gdpr_score': 'horseshoe',
 
-  // Clusters — trend and heatmap
+  // Clusters — trend for healthy/pods, numeric for status counts
   'clusters:healthy': 'sparkline',
   'clusters:pods': 'sparkline',
-  'clusters:unhealthy': 'heatmap',
-  'clusters:unreachable': 'heatmap',
+  'clusters:unhealthy': 'numeric',
+  'clusters:unreachable': 'numeric',
 
   // Workloads — trend delta for issues
   'workloads:critical': 'trend',


### PR DESCRIPTION
## Summary
- The Stats Overview bar's Offline (unreachable) block used the `heatmap` display mode by default, which fills the entire block with a solid color overlay — visually inconsistent with the other blocks that use the standard glass appearance.
- Changed the default display mode for both `unreachable` and `unhealthy` cluster stat blocks from `heatmap` to `numeric` so they match the uniform styling of the rest of the stats bar.

Fixes #4127

## Test plan
- [ ] Verify the Offline stat block in the Clusters page Stats Overview bar no longer has a solid color fill
- [ ] Verify the Unhealthy stat block also matches the glass styling of other blocks
- [ ] Confirm users can still manually switch individual stat blocks to heatmap mode via the mode picker if desired