### PR TITLE
🐛 Add cancelling state to mission cancellation flow

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -20,6 +20,7 @@ import {
   RotateCcw,
   StopCircle,
   ListChecks,
+  Loader2,
 } from 'lucide-react'
 import { useMissions, type Mission } from '../../../hooks/useMissions'
 import { useAuth } from '../../../lib/auth'
@@ -405,8 +406,14 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               {t('missionChat.terminateSession', { defaultValue: 'Terminate Session' })}
             </button>
           )}
+          {mission.status === 'cancelling' && (
+            <span className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium bg-orange-500/15 text-orange-400 border border-orange-500/30 rounded-lg">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              Cancelling...
+            </span>
+          )}
           <div className={cn('flex items-center gap-1', config.color)}>
-            <StatusIcon className={cn('w-4 h-4', mission.status === 'running' && 'animate-spin')} />
+            <StatusIcon className={cn('w-4 h-4', (mission.status === 'running' || mission.status === 'cancelling') && 'animate-spin')} />
             <span className="text-xs">{config.label}</span>
           </div>
         </div>
@@ -591,7 +598,12 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
       {/* Input / Actions — hidden when Run button is inline above */}
       {!(mission.status === 'saved' && mission.messages.length === 0) && (
       <div className="p-4 border-t border-border flex-shrink-0 bg-card min-w-0">
-        {mission.status === 'running' ? (
+        {mission.status === 'cancelling' ? (
+          <div className="flex items-center justify-center gap-2 py-3">
+            <Loader2 className="w-4 h-4 animate-spin text-orange-400" />
+            <span className="text-sm text-orange-400">Cancelling mission...</span>
+          </div>
+        ) : mission.status === 'running' ? (
           <div className="flex flex-col gap-2">
             <div className="flex gap-2 min-w-0">
               <input

--- a/web/src/components/layout/mission-sidebar/MissionListItem.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionListItem.tsx
@@ -5,6 +5,7 @@ import {
   Maximize2,
   Trash2,
   StopCircle,
+  Loader2,
 } from 'lucide-react'
 import type { Mission } from '../../../hooks/useMissions'
 import { cn } from '../../../lib/cn'
@@ -71,6 +72,11 @@ export function MissionListItem({ mission, isActive, onClick, onDismiss, onExpan
           <TypeIcon className="w-3 h-3 text-muted-foreground flex-shrink-0" />
           <span className="text-sm font-medium text-foreground truncate">{mission.title}</span>
         </button>
+        {mission.status === 'cancelling' && (
+          <span className="p-0.5 flex-shrink-0" title="Cancelling...">
+            <Loader2 className="w-3.5 h-3.5 text-orange-400 animate-spin" />
+          </span>
+        )}
         {mission.status === 'running' && onTerminate && (
           <button
             onClick={(e) => { e.stopPropagation(); onTerminate() }}

--- a/web/src/components/layout/mission-sidebar/types.ts
+++ b/web/src/components/layout/mission-sidebar/types.ts
@@ -30,6 +30,7 @@ export const THINKING_MESSAGES = [
 export const STATUS_CONFIG: Record<MissionStatus, { icon: typeof Loader2; color: string; label: string }> = {
   pending: { icon: Clock, color: 'text-yellow-400', label: 'Starting...' },
   running: { icon: Loader2, color: 'text-blue-400', label: 'Running' },
+  cancelling: { icon: Loader2, color: 'text-orange-400', label: 'Cancelling...' },
   waiting_input: { icon: MessageSquare, color: 'text-purple-400', label: 'Waiting for input' },
   completed: { icon: CheckCircle, color: 'text-green-400', label: 'Completed' },
   failed: { icon: AlertCircle, color: 'text-red-400', label: 'Failed' },

--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -437,9 +437,9 @@ describe('sendMessage', () => {
       })
 
       const mission = result.current.missions.find(m => m.id === missionId)
-      expect(mission?.status).toBe('failed')
+      expect(mission?.status).toBe('cancelling')
       const systemMessages = mission?.messages.filter(m => m.role === 'system') ?? []
-      expect(systemMessages.some(m => m.content.includes('cancelled'))).toBe(true)
+      expect(systemMessages.some(m => m.content.includes('Cancellation requested'))).toBe(true)
     },
   )
 })
@@ -447,7 +447,7 @@ describe('sendMessage', () => {
 // ── cancelMission ─────────────────────────────────────────────────────────────
 
 describe('cancelMission', () => {
-  it('sets mission status to failed with a system message', async () => {
+  it('sets mission status to cancelling with a system message', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
     const { missionId } = await startMissionWithConnection(result)
 
@@ -456,10 +456,57 @@ describe('cancelMission', () => {
     })
 
     const mission = result.current.missions.find(m => m.id === missionId)
-    expect(mission?.status).toBe('failed')
+    expect(mission?.status).toBe('cancelling')
     const lastMsg = mission?.messages[mission.messages.length - 1]
     expect(lastMsg?.role).toBe('system')
-    expect(lastMsg?.content).toContain('Mission cancelled by user.')
+    expect(lastMsg?.content).toContain('Cancellation requested')
+  })
+
+  it('transitions to failed after backend cancel_ack', async () => {
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    const { missionId } = await startMissionWithConnection(result)
+
+    act(() => {
+      result.current.cancelMission(missionId)
+    })
+    expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('cancelling')
+
+    // Simulate backend acknowledgment
+    act(() => {
+      MockWebSocket.lastInstance?.simulateMessage({
+        id: `cancel-ack-${Date.now()}`,
+        type: 'cancel_ack',
+        payload: { sessionId: missionId, success: true },
+      })
+    })
+
+    const mission = result.current.missions.find(m => m.id === missionId)
+    expect(mission?.status).toBe('failed')
+    const systemMessages = mission?.messages.filter(m => m.role === 'system') ?? []
+    expect(systemMessages.some(m => m.content.includes('Mission cancelled by user.'))).toBe(true)
+  })
+
+  it('transitions to failed after cancel ack timeout', async () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useMissions(), { wrapper })
+    const { missionId } = await startMissionWithConnection(result)
+
+    act(() => {
+      result.current.cancelMission(missionId)
+    })
+    expect(result.current.missions.find(m => m.id === missionId)?.status).toBe('cancelling')
+
+    // Advance past the cancel ack timeout (10s)
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+
+    const mission = result.current.missions.find(m => m.id === missionId)
+    expect(mission?.status).toBe('failed')
+    const systemMessages = mission?.messages.filter(m => m.role === 'system') ?? []
+    expect(systemMessages.some(m => m.content.includes('backend did not confirm'))).toBe(true)
+
+    vi.useRealTimers()
   })
 
   it('sends cancel_chat over WebSocket when connected', async () => {
@@ -488,7 +535,7 @@ describe('cancelMission', () => {
     expect(MockWebSocket.lastInstance?.close).not.toHaveBeenCalled()
   })
 
-  it('falls back to HTTP POST when WebSocket is not open', () => {
+  it('falls back to HTTP POST when WebSocket is not open', async () => {
     const missionId = seedMission({ status: 'running' })
     const { result } = renderHook(() => useMissions(), { wrapper })
 
@@ -500,8 +547,14 @@ describe('cancelMission', () => {
       expect.stringContaining('/cancel-chat'),
       expect.objectContaining({ method: 'POST' }),
     )
+    // Should be in cancelling state initially (HTTP response will finalize)
     const mission = result.current.missions.find(m => m.id === missionId)
-    expect(mission?.status).toBe('failed')
+    expect(mission?.status).toBe('cancelling')
+
+    // Let the fetch promise resolve to finalize
+    await act(async () => { await Promise.resolve() })
+    const missionAfter = result.current.missions.find(m => m.id === missionId)
+    expect(missionAfter?.status).toBe('failed')
   })
 })
 

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -10,7 +10,7 @@ import { scanForMaliciousContent } from '../lib/missions/scanner/malicious'
 import { runPreflightCheck, type PreflightError } from '../lib/missions/preflightCheck'
 import { kubectlProxy } from '../lib/kubectlProxy'
 
-export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'saved' | 'blocked'
+export type MissionStatus = 'pending' | 'running' | 'waiting_input' | 'completed' | 'failed' | 'saved' | 'blocked' | 'cancelling'
 
 export interface MissionMessage {
   id: string
@@ -168,6 +168,12 @@ const MISSION_TIMEOUT_CHECK_INTERVAL_MS = 15_000 // 15 seconds
  * failed early with an actionable message (#3079).
  */
 const MISSION_INACTIVITY_TIMEOUT_MS = 90_000 // 90 seconds of stream silence
+/**
+ * Maximum time (ms) the frontend waits for backend acknowledgment after sending
+ * a cancel request. If the backend doesn't respond within this window, the
+ * frontend transitions the mission from 'cancelling' to 'failed' as a safety net.
+ */
+const CANCEL_ACK_TIMEOUT_MS = 10_000 // 10 seconds
 
 // Load missions from localStorage
 function loadMissions(): Mission[] {
@@ -195,6 +201,23 @@ function loadMissions(): Mission[] {
             context: { ...mission.context, needsReconnect: true }
           }
         }
+        // Missions stuck in 'cancelling' after a page reload should be finalized
+        if (mission.status === 'cancelling') {
+          return {
+            ...mission,
+            status: 'failed',
+            currentStep: undefined,
+            messages: [
+              ...mission.messages,
+              {
+                id: `msg-${Date.now()}`,
+                role: 'system' as const,
+                content: 'Mission cancelled by user (page was reloaded during cancellation).',
+                timestamp: new Date(),
+              }
+            ]
+          }
+        }
         return mission
       })
     }
@@ -220,9 +243,9 @@ function saveMissions(missions: Mission[]) {
       && (e.name === 'QuotaExceededError' || e.code === 22)
     if (isQuotaError) {
       console.warn('[Missions] localStorage quota exceeded, pruning old missions')
-      // Keep active missions (pending/running/waiting_input/blocked) unconditionally
+      // Keep active missions (pending/running/cancelling/waiting_input/blocked) unconditionally
       const active = missions.filter(m =>
-        m.status === 'running' || m.status === 'pending' || m.status === 'waiting_input' || m.status === 'blocked'
+        m.status === 'running' || m.status === 'pending' || m.status === 'waiting_input' || m.status === 'blocked' || m.status === 'cancelling'
       )
       // Keep saved/library missions unconditionally — they are small (no chat history)
       const saved = missions.filter(m => m.status === 'saved')
@@ -286,6 +309,8 @@ export function MissionProvider({ children }: { children: ReactNode }) {
   const pendingRequests = useRef<Map<string, string>>(new Map()) // requestId -> missionId
   // Track last stream timestamp per mission to detect tool-use gaps (for creating new chat bubbles)
   const lastStreamTimestamp = useRef<Map<string, number>>(new Map()) // missionId -> timestamp
+  // Track cancel acknowledgment timeouts — missionId -> timeout handle
+  const cancelTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
   // Ref to always hold the latest missions state — avoids stale closure in sendMessage (#3322)
   const missionsRef = useRef<Mission[]>(missions)
   missionsRef.current = missions
@@ -626,6 +651,35 @@ Install the console locally with the KubeStellar Console agent to use AI mission
     }
   }, [])
 
+  // Finalize a cancelling mission — transitions from 'cancelling' to 'failed'
+  // and clears any pending cancel timeout.
+  const finalizeCancellation = useCallback((missionId: string, message: string) => {
+    // Clear the timeout if one is pending
+    const timeout = cancelTimeouts.current.get(missionId)
+    if (timeout) {
+      clearTimeout(timeout)
+      cancelTimeouts.current.delete(missionId)
+    }
+
+    setMissions(prev => prev.map(m =>
+      m.id === missionId && m.status === 'cancelling' ? {
+        ...m,
+        status: 'failed',
+        currentStep: undefined,
+        updatedAt: new Date(),
+        messages: [
+          ...m.messages,
+          {
+            id: `msg-${Date.now()}`,
+            role: 'system',
+            content: message,
+            timestamp: new Date(),
+          }
+        ]
+      } : m
+    ))
+  }, [])
+
   // Handle messages from the agent
   const handleAgentMessage = useCallback((message: { id: string; type: string; payload?: unknown }) => {
     // Handle agent-related messages (no mission ID needed)
@@ -671,11 +725,44 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       return
     }
 
+    // Handle cancel acknowledgment from backend — the cancel_chat request uses
+    // a different ID format (cancel-*) so it won't be in pendingRequests. Match
+    // the session ID from the payload instead.
+    if (message.type === 'cancel_ack' || message.type === 'cancel_confirmed') {
+      const payload = message.payload as { sessionId?: string; success?: boolean; message?: string }
+      const cancelledMissionId = payload.sessionId
+      if (cancelledMissionId) {
+        if (payload.success === false) {
+          finalizeCancellation(cancelledMissionId, payload.message || 'Mission cancellation failed — the backend reported an error.')
+        } else {
+          finalizeCancellation(cancelledMissionId, 'Mission cancelled by user.')
+        }
+      }
+      return
+    }
+
     const missionId = pendingRequests.current.get(message.id)
     if (!missionId) return
 
     setMissions(prev => prev.map(m => {
       if (m.id !== missionId) return m
+
+      // If the mission is in 'cancelling' state and we receive a terminal message
+      // (result, error, or stream-done), treat it as backend confirmation of the
+      // cancellation. This handles backends that don't send an explicit cancel_ack.
+      if (m.status === 'cancelling') {
+        const isTerminalMessage =
+          message.type === 'result' ||
+          message.type === 'error' ||
+          (message.type === 'stream' && (message.payload as { done?: boolean })?.done)
+        if (isTerminalMessage) {
+          pendingRequests.current.delete(message.id)
+          finalizeCancellation(missionId, 'Mission cancelled by user.')
+          return m // finalizeCancellation handles the state update via setMissions
+        }
+        // Ignore non-terminal messages (progress, partial stream) while cancelling
+        return m
+      }
 
       if (message.type === 'progress') {
         // Progress update from agent (e.g., "Querying cluster...", "Analyzing logs...")
@@ -914,7 +1001,7 @@ Install the console locally with the KubeStellar Console agent to use AI mission
 
       return m
     }))
-  }, [markMissionAsUnread])
+  }, [markMissionAsUnread, finalizeCancellation])
 
   // Keep the ref in sync so ensureConnection always calls the latest handler
   handleAgentMessageRef.current = handleAgentMessage
@@ -1377,6 +1464,8 @@ Install the console locally with the KubeStellar Console agent to use AI mission
 
   // Cancel a running mission — sends cancel signal to backend to kill agent process.
   // Uses WebSocket if connected, otherwise falls back to HTTP POST endpoint.
+  // Sets status to 'cancelling' immediately, then waits for backend acknowledgment
+  // before transitioning to final 'failed' state. Falls back to a timeout if no ack.
   const cancelMission = useCallback((missionId: string) => {
     // Try WebSocket first (fastest path when connected)
     if (wsRef.current?.readyState === WebSocket.OPEN) {
@@ -1386,35 +1475,50 @@ Install the console locally with the KubeStellar Console agent to use AI mission
         payload: { sessionId: missionId },
       }))
     } else {
-      // HTTP fallback — WS may be disconnected during long agent runs
+      // HTTP fallback — WS may be disconnected during long agent runs.
+      // Use the response to determine if cancellation succeeded.
       fetch(`${LOCAL_AGENT_HTTP_URL}/cancel-chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sessionId: missionId }),
+      }).then(response => {
+        if (response.ok) {
+          finalizeCancellation(missionId, 'Mission cancelled by user.')
+        } else {
+          finalizeCancellation(missionId, 'Mission cancellation failed — backend returned an error. The mission may still be running.')
+        }
       }).catch(() => {
-        // Best-effort: if both WS and HTTP fail, the local state update
-        // still marks the mission as cancelled in the UI
+        // Both WS and HTTP failed — finalize with a warning
+        finalizeCancellation(missionId, 'Mission cancelled by user (backend unreachable — cancellation may not have taken effect).')
       })
     }
 
+    // Transition to 'cancelling' immediately for visual feedback
     setMissions(prev => prev.map(m =>
       m.id === missionId ? {
         ...m,
-        status: 'failed',
-        currentStep: undefined,
+        status: 'cancelling',
+        currentStep: 'Cancelling mission...',
         updatedAt: new Date(),
         messages: [
           ...m.messages,
           {
             id: `msg-${Date.now()}`,
             role: 'system',
-            content: 'Mission cancelled by user.',
+            content: 'Cancellation requested — waiting for backend confirmation...',
             timestamp: new Date(),
           }
         ]
       } : m
     ))
-  }, [])
+
+    // Safety-net timeout: if the backend never acknowledges, finalize after CANCEL_ACK_TIMEOUT_MS
+    const timeoutHandle = setTimeout(() => {
+      cancelTimeouts.current.delete(missionId)
+      finalizeCancellation(missionId, 'Mission cancelled by user (backend did not confirm cancellation in time).')
+    }, CANCEL_ACK_TIMEOUT_MS)
+    cancelTimeouts.current.set(missionId, timeoutHandle)
+  }, [finalizeCancellation])
 
   // Send a follow-up message
   const sendMessage = useCallback((missionId: string, content: string) => {
@@ -1615,13 +1719,20 @@ Install the console locally with the KubeStellar Console agent to use AI mission
   // Get active mission object
   const activeMission = missions.find(m => m.id === activeMissionId) || null
 
-  // Cleanup on unmount — close WebSocket and cancel any pending reconnection timer (#3318)
+  // Cleanup on unmount — close WebSocket, cancel pending reconnection timer (#3318),
+  // and clear any pending cancel acknowledgment timeouts
   useEffect(() => {
+    const cancelTimeoutsRef = cancelTimeouts.current
     return () => {
       if (wsReconnectTimer.current) {
         clearTimeout(wsReconnectTimer.current)
         wsReconnectTimer.current = null
       }
+      // Clear all cancel acknowledgment timeouts
+      for (const timeout of cancelTimeoutsRef.values()) {
+        clearTimeout(timeout)
+      }
+      cancelTimeoutsRef.clear()
       wsRef.current?.close()
     }
   }, [])


### PR DESCRIPTION
## Summary

Fixes #4123, #4125, #4126.

The mission cancel flow previously jumped straight from `running` to `failed` without an intermediate state or backend confirmation. This introduces a `cancelling` state in the mission status state machine that provides immediate visual feedback while waiting for backend acknowledgment before transitioning to the final `failed` state.

**Changes:**
- Add `cancelling` to the `MissionStatus` type union and `STATUS_CONFIG` (orange spinner, "Cancelling..." label)
- `cancelMission()` now sets status to `cancelling` immediately, sends the cancel signal (WS or HTTP), and starts a 10s safety-net timeout
- Backend acknowledgment handled via `cancel_ack`/`cancel_confirmed` message types, or by detecting terminal messages (`result`/`error`/`stream.done`) while in `cancelling` state
- HTTP fallback uses the response status to finalize cancellation (success vs error vs unreachable)
- Missions stuck in `cancelling` after a page reload are finalized to `failed` during localStorage hydration
- UI: cancel button hidden during `cancelling` (replaced with orange spinner), chat footer shows cancelling state, list items show animated spinner
- Non-terminal messages (progress, partial stream chunks) are ignored while cancelling
- All cancel timeout handles are cleaned up on provider unmount

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] All 66 existing + new tests pass (`vitest run useMissions.test.tsx`)
- [x] Build succeeds (`npm run build`)
- [x] No new lint errors introduced
- [ ] Manual: Start a mission, click Cancel, verify "Cancelling..." spinner appears
- [ ] Manual: Confirm status transitions to "Failed" after backend ack or timeout
- [ ] Manual: Reload page during cancelling state, verify mission shows as failed

Closes #4123
Closes #4125
Closes #4126