### PR TITLE
🐛 Add missing widget API routes that redirected to SPA catch-all

### DIFF
--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/kubestellar/console/pkg/api/v1alpha1"
 	"github.com/kubestellar/console/pkg/k8s"
 	"github.com/kubestellar/console/pkg/mcp"
 )
@@ -2713,4 +2714,37 @@ func (h *MCPHandlers) GetResourceYAML(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(fiber.Map{"yaml": "", "source": "stub"})
+}
+
+// GetWorkloads returns an aggregate view of workloads (Deployments, StatefulSets,
+// DaemonSets) from clusters. This is the non-streaming counterpart of
+// GetWorkloadsStream, used by the widget export system (/api/mcp/workloads).
+func (h *MCPHandlers) GetWorkloads(c *fiber.Ctx) error {
+	if isDemoMode(c) {
+		return demoResponse(c, "workloads", getDemoWorkloads())
+	}
+
+	if h.k8sClient == nil {
+		return c.Status(503).JSON(fiber.Map{"error": "No cluster access available"})
+	}
+
+	cluster := c.Query("cluster")
+	namespace := c.Query("namespace")
+	workloadType := c.Query("type")
+
+	ctx, cancel := context.WithTimeout(c.Context(), maxResponseDeadline)
+	defer cancel()
+
+	list, err := h.k8sClient.ListWorkloads(ctx, cluster, namespace, workloadType)
+	if err != nil {
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+	}
+
+	workloads := list.Items
+	if workloads == nil {
+		workloads = make([]v1alpha1.Workload, 0)
+	}
+
+	return c.JSON(fiber.Map{"workloads": workloads, "source": "k8s"})
 }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -737,6 +737,16 @@ func (s *Server) setupRoutes() {
 	api.Get("/mcp/pod-network-stats", mcpHandlers.GetPodNetworkStats)
 	api.Get("/mcp/resource-yaml", mcpHandlers.GetResourceYAML)
 
+	// Widget-friendly aliases — the widget registry references these shorter
+	// paths.  Without explicit routes they fall through to the SPA catch-all
+	// which returns index.html (HTTP 307), breaking exported widgets.
+	// See: #4140, #4141, #4142
+	api.Get("/mcp/workloads", mcpHandlers.GetWorkloads)
+	api.Get("/mcp/security", mcpHandlers.CheckSecurityIssues)
+	api.Get("/mcp/storage", mcpHandlers.GetPVCs)
+	api.Get("/mcp/network", mcpHandlers.GetNetworkPolicies)
+	api.Get("/mcp/namespaces", namespaces.ListNamespaces)
+
 	// SSE streaming variants — stream per-cluster results as they arrive
 	api.Get("/mcp/pods/stream", mcpHandlers.GetPodsStream)
 	api.Get("/mcp/pod-issues/stream", mcpHandlers.FindPodIssuesStream)


### PR DESCRIPTION
## Summary
- Widget endpoints `/api/mcp/workloads`, `/api/mcp/security`, `/api/mcp/storage`, `/api/mcp/network`, and `/api/mcp/namespaces` had no backend route registrations, causing requests to fall through to the SPA catch-all and return HTTP 307 redirects instead of JSON data
- Added a new `GetWorkloads` handler that aggregates Deployments, StatefulSets, and DaemonSets (non-streaming counterpart of `GetWorkloadsStream`)
- Registered 4 additional route aliases mapping widget paths to existing handlers: `/mcp/security` -> `CheckSecurityIssues`, `/mcp/storage` -> `GetPVCs`, `/mcp/network` -> `GetNetworkPolicies`, `/mcp/namespaces` -> `ListNamespaces`

Fixes #4140, #4141, #4142

## Test plan
- [x] `go build ./pkg/...` passes
- [x] `go test ./pkg/api/handlers/...` passes (all handler tests)
- [x] `npx tsc --noEmit` passes (frontend type check)
- [ ] Verify each endpoint returns JSON instead of redirect: `curl -s http://localhost:8080/api/mcp/workloads`, `/security`, `/storage`, `/network`, `/namespaces`
- [ ] Verify exported Ubersicht widgets using these endpoints fetch data correctly