### PR TITLE
🐛 Fix deployment capabilities for unreachable clusters and health check gauge

### DIFF
--- a/pkg/k8s/workload.go
+++ b/pkg/k8s/workload.go
@@ -942,31 +942,45 @@ func (m *MultiClusterClient) GetClusterCapabilities(ctx context.Context) (*v1alp
 
 	for _, clusterName := range clusters {
 		cap := v1alpha1.ClusterCapability{
-			Cluster:   clusterName,
-			Available: true,
+			Cluster: clusterName,
 		}
 
 		// Get node info to determine capabilities
 		nodes, err := m.GetNodes(ctx, clusterName)
-		if err == nil {
-			cap.NodeCount = len(nodes)
+		if err != nil {
+			// Cluster is unreachable — mark unavailable
+			cap.Available = false
+			capabilities = append(capabilities, cap)
+			continue
+		}
 
-			// Sum up resources from all nodes
-			var totalGPUs int
-			for _, node := range nodes {
-				totalGPUs += node.GPUCount
-				// Use first node with GPU type as representative
-				if cap.GPUType == "" && node.GPUType != "" {
-					cap.GPUType = node.GPUType
-				}
-			}
-			cap.GPUCount = totalGPUs
+		cap.NodeCount = len(nodes)
 
-			// Use capacity from first node as representative for CPU/Memory
-			if len(nodes) > 0 {
-				cap.CPUCapacity = nodes[0].CPUCapacity
-				cap.MemCapacity = nodes[0].MemoryCapacity
+		// A cluster with zero nodes is not a viable deployment target
+		if cap.NodeCount == 0 {
+			cap.Available = false
+			capabilities = append(capabilities, cap)
+			continue
+		}
+
+		// Cluster is reachable and has nodes — mark available
+		cap.Available = true
+
+		// Sum up resources from all nodes
+		var totalGPUs int
+		for _, node := range nodes {
+			totalGPUs += node.GPUCount
+			// Use first node with GPU type as representative
+			if cap.GPUType == "" && node.GPUType != "" {
+				cap.GPUType = node.GPUType
 			}
+		}
+		cap.GPUCount = totalGPUs
+
+		// Use capacity from first node as representative for CPU/Memory
+		if len(nodes) > 0 {
+			cap.CPUCapacity = nodes[0].CPUCapacity
+			cap.MemCapacity = nodes[0].MemoryCapacity
 		}
 
 		capabilities = append(capabilities, cap)

--- a/pkg/k8s/workload_scaling_test.go
+++ b/pkg/k8s/workload_scaling_test.go
@@ -153,6 +153,54 @@ func TestGetClusterCapabilities(t *testing.T) {
 	}
 }
 
+func TestGetClusterCapabilities_UnreachableCluster(t *testing.T) {
+	m, _ := NewMultiClusterClient("")
+
+	// c1 has nodes — should be available
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+		Status: corev1.NodeStatus{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			},
+		},
+	}
+	fakeWithNodes := k8sfake.NewSimpleClientset(node)
+
+	// c2 has zero nodes — should be unavailable
+	fakeEmpty := k8sfake.NewSimpleClientset()
+
+	m.clients = map[string]kubernetes.Interface{
+		"c1": fakeWithNodes,
+		"c2": fakeEmpty,
+	}
+	m.rawConfig = &api.Config{Contexts: map[string]*api.Context{
+		"c1": {Cluster: "cl1"},
+		"c2": {Cluster: "cl2"},
+	}}
+
+	caps, err := m.GetClusterCapabilities(context.Background())
+	if err != nil {
+		t.Fatalf("GetClusterCapabilities failed: %v", err)
+	}
+	if len(caps.Items) != 2 {
+		t.Fatalf("Expected 2 capability items, got %d", len(caps.Items))
+	}
+
+	byCluster := make(map[string]bool)
+	for _, c := range caps.Items {
+		byCluster[c.Cluster] = c.Available
+	}
+
+	if !byCluster["c1"] {
+		t.Error("Expected c1 (has nodes) to be available=true")
+	}
+	if byCluster["c2"] {
+		t.Error("Expected c2 (zero nodes) to be available=false")
+	}
+}
+
 func TestNodeLabels_AddAndRemove(t *testing.T) {
 	scheme := runtime.NewScheme()
 	gvrMap := map[schema.GroupVersionResource]string{

--- a/web/src/components/cards/console-missions/ConsoleHealthCheckCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleHealthCheckCard.tsx
@@ -10,6 +10,7 @@ import { useApiKeyCheck, ApiKeyPromptModal } from './shared'
 import type { ConsoleMissionCardProps } from './shared'
 import { useCardLoadingState } from '../CardDataContext'
 import { useTranslation } from 'react-i18next'
+import { HorseshoeGauge } from '../llmd/shared/HorseshoeGauge'
 
 // Card 3: Cluster Health Check - Overall health assessment
 export function ConsoleHealthCheckCard(_props: ConsoleMissionCardProps) {
@@ -142,24 +143,14 @@ Please provide:
       <div className="flex items-center justify-end mb-4">
       </div>
 
-      {/* Health Score */}
+      {/* Health Score — horseshoe gauge */}
       <div className="flex items-center justify-center mb-4">
-        <div className={cn(
-          'w-20 h-20 rounded-full border-4 flex items-center justify-center',
-          healthScore >= 80 ? 'border-green-500 bg-green-500/10' :
-          healthScore >= 60 ? 'border-yellow-500 bg-yellow-500/10' :
-          'border-red-500 bg-red-500/10'
-        )}>
-          <div className="text-center">
-            <div className={cn(
-              'text-2xl font-bold',
-              healthScore >= 80 ? 'text-green-400' :
-              healthScore >= 60 ? 'text-yellow-400' :
-              'text-red-400'
-            )}>{healthScore}%</div>
-            <div className="text-2xs text-muted-foreground">{t('healthCheck.health')}</div>
-          </div>
-        </div>
+        <HorseshoeGauge
+          value={healthScore}
+          maxValue={100}
+          label={t('healthCheck.health')}
+          size={120}
+        />
       </div>
 
       {/* Quick Stats */}


### PR DESCRIPTION
## Summary
- **#4139**: `/api/workloads/capabilities` was unconditionally marking all clusters as `available=true`, even unreachable ones with `nodeCount=0`. Now clusters where `GetNodes` fails (unreachable) or returns zero nodes are correctly marked `available=false`.
- **#4131**: Replaced the full-circle health score display in the AI Health Check card with a horseshoe gauge (reusing the existing `HorseshoeGauge` component) for clearer visual communication, as requested.

## Test plan
- [x] Existing `TestGetClusterCapabilities` passes (cluster with nodes = available)
- [x] New `TestGetClusterCapabilities_UnreachableCluster` verifies zero-node cluster = unavailable
- [x] TypeScript compiles cleanly, card config tests pass
- [x] Frontend build succeeds

Fixes #4139
Fixes #4131