### PR TITLE
🐛 Return graceful degraded response for unreachable clusters instead of 500

### DIFF
--- a/pkg/api/handlers/gateway.go
+++ b/pkg/api/handlers/gateway.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -44,8 +43,7 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 		// Get gateways for specific cluster
 		gateways, err := h.k8sClient.ListGatewaysForCluster(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		return c.JSON(fiber.Map{
 			"items":      gateways,
@@ -57,8 +55,7 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 	// Get gateways across all clusters
 	list, err := h.k8sClient.ListGateways(ctx)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(list)
@@ -82,8 +79,7 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 		// Get routes for specific cluster
 		routes, err := h.k8sClient.ListHTTPRoutesForCluster(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		return c.JSON(fiber.Map{
 			"items":      routes,
@@ -95,8 +91,7 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 	// Get routes across all clusters
 	list, err := h.k8sClient.ListHTTPRoutes(ctx)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(list)
@@ -114,8 +109,7 @@ func (h *GatewayHandlers) GetGatewayAPIStatus(c *fiber.Ctx) error {
 
 	clusters, _, err := h.k8sClient.HealthyClusters(ctx)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	type clusterGatewayStatus struct {
@@ -153,8 +147,7 @@ func (h *GatewayHandlers) GetGateway(c *fiber.Ctx) error {
 
 	gateways, err := h.k8sClient.ListGatewaysForCluster(ctx, cluster, namespace)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	for _, gw := range gateways {
@@ -182,8 +175,7 @@ func (h *GatewayHandlers) GetHTTPRoute(c *fiber.Ctx) error {
 
 	routes, err := h.k8sClient.ListHTTPRoutesForCluster(ctx, cluster, namespace)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	for _, route := range routes {

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -520,8 +520,7 @@ func (h *GitOpsHandlers) StreamOperators(c *fiber.Ctx) error {
 
 	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	c.Set("Content-Type", "text/event-stream")
@@ -781,8 +780,7 @@ func (h *GitOpsHandlers) StreamOperatorSubscriptions(c *fiber.Ctx) error {
 
 	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	c.Set("Content-Type", "text/event-stream")
@@ -917,8 +915,7 @@ func (h *GitOpsHandlers) StreamHelmReleases(c *fiber.Ctx) error {
 
 	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	c.Set("Content-Type", "text/event-stream")
@@ -1008,8 +1005,7 @@ func (h *GitOpsHandlers) DetectDrift(c *fiber.Ctx) error {
 	// Fall back to kubectl diff
 	result, err := h.detectDriftViaKubectl(ctx, req)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(result)
@@ -1180,8 +1176,7 @@ func (h *GitOpsHandlers) Sync(c *fiber.Ctx) error {
 	// Fall back to kubectl apply
 	result, err := h.syncViaKubectl(ctx, req)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(result)

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -57,6 +57,27 @@ func waitWithDeadline(wg *sync.WaitGroup, cancel context.CancelFunc, deadline ti
 	}
 }
 
+// handleK8sError inspects a Kubernetes API error and returns the appropriate
+// HTTP response. Cluster-connectivity errors (network, auth, timeout,
+// certificate) are returned as 200 with a "clusterStatus":"unavailable"
+// payload so the frontend can show a degraded state instead of a broken page.
+// All other errors are returned as 500 Internal Server Error.
+func handleK8sError(c *fiber.Ctx, err error) error {
+	errType := k8s.ClassifyError(err.Error())
+	switch errType {
+	case "network", "auth", "timeout", "certificate":
+		log.Printf("cluster unavailable (%s): %v", errType, err)
+		return c.JSON(fiber.Map{
+			"clusterStatus": "unavailable",
+			"errorType":     errType,
+			"errorMessage":  err.Error(),
+		})
+	default:
+		log.Printf("internal error: %v", err)
+		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+	}
+}
+
 // MCPHandlers handles MCP-related API endpoints
 type MCPHandlers struct {
 	bridge    *mcp.Bridge
@@ -130,8 +151,7 @@ func (h *MCPHandlers) ListClusters(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, err := h.k8sClient.ListClusters(ctx)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 
 		// Enrich with cached health data only — never block on live health
@@ -191,8 +211,7 @@ func (h *MCPHandlers) GetClusterHealth(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		health, err := h.k8sClient.GetClusterHealth(ctx, cluster)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		return c.JSON(health)
 	}
@@ -214,8 +233,7 @@ func (h *MCPHandlers) GetAllClusterHealth(c *fiber.Ctx) error {
 
 		health, err := h.k8sClient.GetAllClusterHealth(ctx)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		return c.JSON(fiber.Map{"health": health})
 	}
@@ -252,8 +270,7 @@ func (h *MCPHandlers) GetPods(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -289,8 +306,7 @@ func (h *MCPHandlers) GetPods(c *fiber.Ctx) error {
 
 		pods, err := h.k8sClient.GetPods(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if pods == nil {
 			pods = make([]k8s.PodInfo, 0)
@@ -329,8 +345,7 @@ func (h *MCPHandlers) FindPodIssues(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -366,8 +381,7 @@ func (h *MCPHandlers) FindPodIssues(c *fiber.Ctx) error {
 
 		issues, err := h.k8sClient.FindPodIssues(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if issues == nil {
 			issues = make([]k8s.PodIssue, 0)
@@ -392,8 +406,7 @@ func (h *MCPHandlers) GetGPUNodes(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -429,8 +442,7 @@ func (h *MCPHandlers) GetGPUNodes(c *fiber.Ctx) error {
 
 		nodes, err := h.k8sClient.GetGPUNodes(ctx, cluster)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if nodes == nil {
 			nodes = make([]k8s.GPUNode, 0)
@@ -453,8 +465,7 @@ func (h *MCPHandlers) GetGPUNodeHealth(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -490,8 +501,7 @@ func (h *MCPHandlers) GetGPUNodeHealth(c *fiber.Ctx) error {
 
 		nodes, err := h.k8sClient.GetGPUNodeHealth(ctx, cluster)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if nodes == nil {
 			nodes = make([]k8s.GPUNodeHealthStatus, 0)
@@ -522,8 +532,7 @@ func (h *MCPHandlers) GetGPUHealthCronJobStatus(c *fiber.Ctx) error {
 
 	status, err := h.k8sClient.GetGPUHealthCronJobStatus(ctx, cluster)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 	return c.JSON(fiber.Map{"status": status})
 }
@@ -555,8 +564,7 @@ func (h *MCPHandlers) InstallGPUHealthCronJob(c *fiber.Ctx) error {
 	defer cancel()
 
 	if err := h.k8sClient.InstallGPUHealthCronJob(ctx, body.Cluster, body.Namespace, body.Schedule, body.Tier); err != nil {
-		log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(fiber.Map{"success": true, "message": fmt.Sprintf("GPU health CronJob installed on %s (tier %d)", body.Cluster, body.Tier)})
@@ -587,8 +595,7 @@ func (h *MCPHandlers) UninstallGPUHealthCronJob(c *fiber.Ctx) error {
 	defer cancel()
 
 	if err := h.k8sClient.UninstallGPUHealthCronJob(ctx, body.Cluster, body.Namespace); err != nil {
-		log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(fiber.Map{"success": true, "message": fmt.Sprintf("GPU health CronJob removed from %s", body.Cluster)})
@@ -615,8 +622,7 @@ func (h *MCPHandlers) GetGPUHealthCronJobResults(c *fiber.Ctx) error {
 
 	status, err := h.k8sClient.GetGPUHealthCronJobStatus(ctx, cluster)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 	return c.JSON(fiber.Map{"results": status.LastResults, "cluster": cluster})
 }
@@ -635,8 +641,7 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatus(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -672,8 +677,7 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatus(c *fiber.Ctx) error {
 
 		status, err := h.k8sClient.GetNVIDIAOperatorStatus(ctx, cluster)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		return c.JSON(fiber.Map{"operators": []*k8s.NVIDIAOperatorStatus{status}, "source": "k8s"})
 	}
@@ -695,8 +699,7 @@ func (h *MCPHandlers) GetNodes(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -732,8 +735,7 @@ func (h *MCPHandlers) GetNodes(c *fiber.Ctx) error {
 
 		nodes, err := h.k8sClient.GetNodes(ctx, cluster)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if nodes == nil {
 			nodes = make([]k8s.NodeInfo, 0)
@@ -760,8 +762,7 @@ func (h *MCPHandlers) FindDeploymentIssues(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -796,8 +797,7 @@ func (h *MCPHandlers) FindDeploymentIssues(c *fiber.Ctx) error {
 		defer cancel()
 		issues, err := h.k8sClient.FindDeploymentIssues(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if issues == nil {
 			issues = make([]k8s.DeploymentIssue, 0)
@@ -823,8 +823,7 @@ func (h *MCPHandlers) GetDeployments(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -859,8 +858,7 @@ func (h *MCPHandlers) GetDeployments(c *fiber.Ctx) error {
 		defer cancel()
 		deployments, err := h.k8sClient.GetDeployments(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if deployments == nil {
 			deployments = make([]k8s.Deployment, 0)
@@ -885,8 +883,7 @@ func (h *MCPHandlers) GetServices(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -922,8 +919,7 @@ func (h *MCPHandlers) GetServices(c *fiber.Ctx) error {
 
 		services, err := h.k8sClient.GetServices(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if services == nil {
 			services = make([]k8s.Service, 0)
@@ -948,8 +944,7 @@ func (h *MCPHandlers) GetJobs(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -985,8 +980,7 @@ func (h *MCPHandlers) GetJobs(c *fiber.Ctx) error {
 
 		jobs, err := h.k8sClient.GetJobs(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if jobs == nil {
 			jobs = make([]k8s.Job, 0)
@@ -1011,8 +1005,7 @@ func (h *MCPHandlers) GetHPAs(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -1048,8 +1041,7 @@ func (h *MCPHandlers) GetHPAs(c *fiber.Ctx) error {
 
 		hpas, err := h.k8sClient.GetHPAs(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if hpas == nil {
 			hpas = make([]k8s.HPA, 0)
@@ -1074,8 +1066,7 @@ func (h *MCPHandlers) GetConfigMaps(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -1111,8 +1102,7 @@ func (h *MCPHandlers) GetConfigMaps(c *fiber.Ctx) error {
 
 		configmaps, err := h.k8sClient.GetConfigMaps(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if configmaps == nil {
 			configmaps = make([]k8s.ConfigMap, 0)
@@ -1137,8 +1127,7 @@ func (h *MCPHandlers) GetSecrets(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -1174,8 +1163,7 @@ func (h *MCPHandlers) GetSecrets(c *fiber.Ctx) error {
 
 		secrets, err := h.k8sClient.GetSecrets(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if secrets == nil {
 			secrets = make([]k8s.Secret, 0)
@@ -1200,8 +1188,7 @@ func (h *MCPHandlers) GetServiceAccounts(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -1237,8 +1224,7 @@ func (h *MCPHandlers) GetServiceAccounts(c *fiber.Ctx) error {
 
 		serviceAccounts, err := h.k8sClient.GetServiceAccounts(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if serviceAccounts == nil {
 			serviceAccounts = make([]k8s.ServiceAccount, 0)
@@ -1263,8 +1249,7 @@ func (h *MCPHandlers) GetPVCs(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -1300,8 +1285,7 @@ func (h *MCPHandlers) GetPVCs(c *fiber.Ctx) error {
 
 		pvcs, err := h.k8sClient.GetPVCs(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if pvcs == nil {
 			pvcs = make([]k8s.PVC, 0)
@@ -1325,8 +1309,7 @@ func (h *MCPHandlers) GetPVs(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -1362,8 +1345,7 @@ func (h *MCPHandlers) GetPVs(c *fiber.Ctx) error {
 
 		pvs, err := h.k8sClient.GetPVs(ctx, cluster)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if pvs == nil {
 			pvs = make([]k8s.PV, 0)
@@ -1388,8 +1370,7 @@ func (h *MCPHandlers) GetResourceQuotas(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -1425,8 +1406,7 @@ func (h *MCPHandlers) GetResourceQuotas(c *fiber.Ctx) error {
 
 		quotas, err := h.k8sClient.GetResourceQuotas(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if quotas == nil {
 			quotas = make([]k8s.ResourceQuota, 0)
@@ -1451,8 +1431,7 @@ func (h *MCPHandlers) GetLimitRanges(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -1488,8 +1467,7 @@ func (h *MCPHandlers) GetLimitRanges(c *fiber.Ctx) error {
 
 		ranges, err := h.k8sClient.GetLimitRanges(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if ranges == nil {
 			ranges = make([]k8s.LimitRange, 0)
@@ -1546,8 +1524,7 @@ func (h *MCPHandlers) CreateOrUpdateResourceQuota(c *fiber.Ctx) error {
 
 		quota, err := h.k8sClient.CreateOrUpdateResourceQuota(ctx, req.Cluster, spec)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 
 		return c.JSON(fiber.Map{"resourceQuota": quota, "source": "k8s"})
@@ -1572,8 +1549,7 @@ func (h *MCPHandlers) DeleteResourceQuota(c *fiber.Ctx) error {
 
 		err := h.k8sClient.DeleteResourceQuota(ctx, cluster, namespace, name)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 
 		return c.JSON(fiber.Map{"deleted": true, "name": name, "namespace": namespace, "cluster": cluster})
@@ -1605,8 +1581,7 @@ func (h *MCPHandlers) GetPodLogs(c *fiber.Ctx) error {
 
 		logs, err := h.k8sClient.GetPodLogs(ctx, cluster, namespace, pod, container, int64(tailLines))
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		return c.JSON(fiber.Map{"logs": logs, "source": "k8s"})
 	}
@@ -1645,8 +1620,7 @@ func (h *MCPHandlers) GetEvents(c *fiber.Ctx) error {
 			// via multiple kubeconfig contexts (e.g. "vllm-d" and its long OpenShift name)
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			if len(clusters) == 0 {
@@ -1700,8 +1674,7 @@ func (h *MCPHandlers) GetEvents(c *fiber.Ctx) error {
 
 		events, err := h.k8sClient.GetEvents(ctx, cluster, namespace, limit)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if events == nil {
 			events = make([]k8s.Event, 0)
@@ -1741,8 +1714,7 @@ func (h *MCPHandlers) GetWarningEvents(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			if len(clusters) == 0 {
@@ -1795,8 +1767,7 @@ func (h *MCPHandlers) GetWarningEvents(c *fiber.Ctx) error {
 
 		events, err := h.k8sClient.GetWarningEvents(ctx, cluster, namespace, limit)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if events == nil {
 			events = make([]k8s.Event, 0)
@@ -1823,8 +1794,7 @@ func (h *MCPHandlers) CheckSecurityIssues(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -1860,8 +1830,7 @@ func (h *MCPHandlers) CheckSecurityIssues(c *fiber.Ctx) error {
 
 		issues, err := h.k8sClient.CheckSecurityIssues(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if issues == nil {
 			issues = make([]k8s.SecurityIssue, 0)
@@ -2008,8 +1977,7 @@ func (h *MCPHandlers) CallOpsTool(c *fiber.Ctx) error {
 
 	result, err := h.bridge.CallOpsTool(ctx, req.Name, req.Arguments)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(result)
@@ -2036,8 +2004,7 @@ func (h *MCPHandlers) CallDeployTool(c *fiber.Ctx) error {
 
 	result, err := h.bridge.CallDeployTool(ctx, req.Name, req.Arguments)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(result)
@@ -2059,8 +2026,7 @@ func (h *MCPHandlers) GetFlatcarNodes(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -2096,8 +2062,7 @@ func (h *MCPHandlers) GetFlatcarNodes(c *fiber.Ctx) error {
 
 		nodes, err := h.k8sClient.GetFlatcarNodes(ctx, cluster)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		return c.JSON(fiber.Map{"nodes": nodes, "source": "k8s"})
 	}
@@ -2119,8 +2084,7 @@ func (h *MCPHandlers) GetReplicaSets(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -2156,8 +2120,7 @@ func (h *MCPHandlers) GetReplicaSets(c *fiber.Ctx) error {
 
 		items, err := h.k8sClient.GetReplicaSets(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if items == nil {
 			items = make([]k8s.ReplicaSet, 0)
@@ -2182,8 +2145,7 @@ func (h *MCPHandlers) GetStatefulSets(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -2219,8 +2181,7 @@ func (h *MCPHandlers) GetStatefulSets(c *fiber.Ctx) error {
 
 		items, err := h.k8sClient.GetStatefulSets(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if items == nil {
 			items = make([]k8s.StatefulSet, 0)
@@ -2245,8 +2206,7 @@ func (h *MCPHandlers) GetDaemonSets(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -2282,8 +2242,7 @@ func (h *MCPHandlers) GetDaemonSets(c *fiber.Ctx) error {
 
 		items, err := h.k8sClient.GetDaemonSets(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if items == nil {
 			items = make([]k8s.DaemonSet, 0)
@@ -2308,8 +2267,7 @@ func (h *MCPHandlers) GetCronJobs(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -2345,8 +2303,7 @@ func (h *MCPHandlers) GetCronJobs(c *fiber.Ctx) error {
 
 		items, err := h.k8sClient.GetCronJobs(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if items == nil {
 			items = make([]k8s.CronJob, 0)
@@ -2371,8 +2328,7 @@ func (h *MCPHandlers) GetIngresses(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -2408,8 +2364,7 @@ func (h *MCPHandlers) GetIngresses(c *fiber.Ctx) error {
 
 		items, err := h.k8sClient.GetIngresses(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if items == nil {
 			items = make([]k8s.Ingress, 0)
@@ -2434,8 +2389,7 @@ func (h *MCPHandlers) GetNetworkPolicies(c *fiber.Ctx) error {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 			if err != nil {
-				log.Printf("internal error: %v", err)
-				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+				return handleK8sError(c, err)
 			}
 
 			var wg sync.WaitGroup
@@ -2471,8 +2425,7 @@ func (h *MCPHandlers) GetNetworkPolicies(c *fiber.Ctx) error {
 
 		items, err := h.k8sClient.GetNetworkPolicies(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-			return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		if items == nil {
 			items = make([]k8s.NetworkPolicy, 0)

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -162,6 +162,36 @@ func TestMCPGetPods_InternalErrorIsSanitized(t *testing.T) {
 	assert.Equal(t, "internal server error", payload["error"])
 }
 
+func TestMCPGetPods_NetworkErrorReturnsUnavailable(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/pods", handler.GetPods)
+
+	k8sClient, err := env.K8sClient.GetClient("test-cluster")
+	require.NoError(t, err)
+
+	fakeClient, ok := k8sClient.(*k8sfake.Clientset)
+	require.True(t, ok, "expected fake clientset for test-cluster")
+
+	// Simulate a network error (connection refused) — should NOT return 500
+	fakeClient.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("dial tcp 127.0.0.1:6443: connect: connection refused")
+	})
+
+	req, err := http.NewRequest("GET", "/api/mcp/pods?cluster=test-cluster", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "network errors should return 200, not 500")
+
+	var payload map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	assert.Equal(t, "unavailable", payload["clusterStatus"])
+	assert.Equal(t, "network", payload["errorType"])
+	assert.Contains(t, payload["errorMessage"], "connection refused")
+}
+
 func TestMCPGetDaemonSets_SingleClusterEmptyIsArray(t *testing.T) {
 	env := setupTestEnv(t)
 	handler := NewMCPHandlers(nil, env.K8sClient)
@@ -203,4 +233,91 @@ func TestMCPGetEvents_SingleClusterEmptyIsArray(t *testing.T) {
 	events, ok := payload["events"].([]interface{})
 	require.True(t, ok, "events should be a JSON array, not null")
 	assert.Len(t, events, 0)
+}
+
+func TestMCPGetEvents_NetworkErrorReturnsUnavailable(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/events", handler.GetEvents)
+
+	k8sClient, err := env.K8sClient.GetClient("test-cluster")
+	require.NoError(t, err)
+
+	fakeClient, ok := k8sClient.(*k8sfake.Clientset)
+	require.True(t, ok, "expected fake clientset for test-cluster")
+
+	// Simulate a connection-refused error — should NOT return 500
+	fakeClient.PrependReactor("list", "events", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("dial tcp 127.0.0.1:6443: connect: connection refused")
+	})
+
+	req, err := http.NewRequest("GET", "/api/mcp/events?cluster=test-cluster&limit=10", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "network errors should return 200, not 500")
+
+	var payload map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	assert.Equal(t, "unavailable", payload["clusterStatus"])
+	assert.Equal(t, "network", payload["errorType"])
+}
+
+func TestMCPGetNodes_NetworkErrorReturnsUnavailable(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/nodes", handler.GetNodes)
+
+	k8sClient, err := env.K8sClient.GetClient("test-cluster")
+	require.NoError(t, err)
+
+	fakeClient, ok := k8sClient.(*k8sfake.Clientset)
+	require.True(t, ok, "expected fake clientset for test-cluster")
+
+	// Simulate a connection-refused error — should NOT return 500
+	fakeClient.PrependReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("dial tcp 10.0.0.1:443: connect: connection refused")
+	})
+
+	req, err := http.NewRequest("GET", "/api/mcp/nodes?cluster=test-cluster", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "network errors should return 200, not 500")
+
+	var payload map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	assert.Equal(t, "unavailable", payload["clusterStatus"])
+	assert.Equal(t, "network", payload["errorType"])
+}
+
+func TestMCPGetPods_AuthErrorReturnsUnavailable(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/pods", handler.GetPods)
+
+	k8sClient, err := env.K8sClient.GetClient("test-cluster")
+	require.NoError(t, err)
+
+	fakeClient, ok := k8sClient.(*k8sfake.Clientset)
+	require.True(t, ok, "expected fake clientset for test-cluster")
+
+	// Simulate an auth error — should NOT return 500
+	fakeClient.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("Unauthorized: token expired")
+	})
+
+	req, err := http.NewRequest("GET", "/api/mcp/pods?cluster=test-cluster", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "auth errors should return 200, not 500")
+
+	var payload map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	assert.Equal(t, "unavailable", payload["clusterStatus"])
+	assert.Equal(t, "auth", payload["errorType"])
 }

--- a/pkg/api/handlers/mcs.go
+++ b/pkg/api/handlers/mcs.go
@@ -47,8 +47,7 @@ func (h *MCSHandlers) ListServiceExports(c *fiber.Ctx) error {
 		// Get exports for specific cluster
 		exports, err := h.k8sClient.ListServiceExportsForCluster(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		return c.JSON(fiber.Map{
 			"items":      exports,
@@ -60,8 +59,7 @@ func (h *MCSHandlers) ListServiceExports(c *fiber.Ctx) error {
 	// Get exports across all clusters
 	list, err := h.k8sClient.ListServiceExports(ctx)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(list)
@@ -85,8 +83,7 @@ func (h *MCSHandlers) ListServiceImports(c *fiber.Ctx) error {
 		// Get imports for specific cluster
 		imports, err := h.k8sClient.ListServiceImportsForCluster(ctx, cluster, namespace)
 		if err != nil {
-			log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+			return handleK8sError(c, err)
 		}
 		return c.JSON(fiber.Map{
 			"items":      imports,
@@ -98,8 +95,7 @@ func (h *MCSHandlers) ListServiceImports(c *fiber.Ctx) error {
 	// Get imports across all clusters
 	list, err := h.k8sClient.ListServiceImports(ctx)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(list)
@@ -117,8 +113,7 @@ func (h *MCSHandlers) GetMCSStatus(c *fiber.Ctx) error {
 
 	clusters, _, err := h.k8sClient.HealthyClusters(ctx)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	type clusterMCSStatus struct {
@@ -156,8 +151,7 @@ func (h *MCSHandlers) GetServiceExport(c *fiber.Ctx) error {
 
 	exports, err := h.k8sClient.ListServiceExportsForCluster(ctx, cluster, namespace)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	for _, export := range exports {
@@ -185,8 +179,7 @@ func (h *MCSHandlers) GetServiceImport(c *fiber.Ctx) error {
 
 	imports, err := h.k8sClient.ListServiceImportsForCluster(ctx, cluster, namespace)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	for _, imp := range imports {

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -68,8 +68,7 @@ func (h *WorkloadHandlers) ListWorkloads(c *fiber.Ctx) error {
 
 	workloads, err := h.k8sClient.ListWorkloads(ctx, cluster, namespace, workloadType)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(workloads)
@@ -91,8 +90,7 @@ func (h *WorkloadHandlers) GetWorkload(c *fiber.Ctx) error {
 
 	workload, err := h.k8sClient.GetWorkload(ctx, cluster, namespace, name)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	if workload == nil {
@@ -158,8 +156,7 @@ func (h *WorkloadHandlers) DeployWorkload(c *fiber.Ctx) error {
 
 	result, err := h.k8sClient.DeployWorkload(ctx, req.SourceCluster, req.Namespace, req.WorkloadName, req.TargetClusters, req.Replicas, opts)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(result)
@@ -185,8 +182,7 @@ func (h *WorkloadHandlers) ResolveDependencies(c *fiber.Ctx) error {
 			log.Printf("not found: %v", err)
 		return c.Status(404).JSON(fiber.Map{"error": "not found"})
 		}
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	type depDTO struct {
@@ -243,8 +239,7 @@ func (h *WorkloadHandlers) MonitorWorkload(c *fiber.Ctx) error {
 			log.Printf("not found: %v", err)
 		return c.Status(404).JSON(fiber.Map{"error": "not found"})
 		}
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(result)
@@ -266,8 +261,7 @@ func (h *WorkloadHandlers) GetDeployStatus(c *fiber.Ctx) error {
 
 	workload, err := h.k8sClient.GetWorkload(ctx, cluster, namespace, name)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	if workload == nil {
@@ -970,8 +964,7 @@ func (h *WorkloadHandlers) ScaleWorkload(c *fiber.Ctx) error {
 
 	result, err := h.k8sClient.ScaleWorkload(ctx, req.Namespace, req.WorkloadName, req.TargetClusters, req.Replicas)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(result)
@@ -999,8 +992,7 @@ func (h *WorkloadHandlers) DeleteWorkload(c *fiber.Ctx) error {
 	defer cancel()
 
 	if err := h.k8sClient.DeleteWorkload(ctx, cluster, namespace, name); err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(fiber.Map{
@@ -1023,8 +1015,7 @@ func (h *WorkloadHandlers) GetClusterCapabilities(c *fiber.Ctx) error {
 
 	capabilities, err := h.k8sClient.GetClusterCapabilities(ctx)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(capabilities)
@@ -1042,8 +1033,7 @@ func (h *WorkloadHandlers) ListBindingPolicies(c *fiber.Ctx) error {
 
 	policies, err := h.k8sClient.ListBindingPolicies(ctx)
 	if err != nil {
-		log.Printf("internal error: %v", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return handleK8sError(c, err)
 	}
 
 	return c.JSON(policies)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -1299,6 +1299,12 @@ func (m *MultiClusterClient) GetDynamicClient(contextName string) (dynamic.Inter
 	return client, nil
 }
 
+// ClassifyError determines the error type from an error message.
+// Returns one of: "timeout", "auth", "network", "certificate", or "unknown".
+func ClassifyError(errMsg string) string {
+	return classifyError(errMsg)
+}
+
 // classifyError determines the error type from an error message
 func classifyError(errMsg string) string {
 	lowerMsg := strings.ToLower(errMsg)


### PR DESCRIPTION
## Summary
- Cluster-connectivity errors (network, auth, timeout, certificate) on single-cluster API queries now return HTTP 200 with `clusterStatus: "unavailable"` instead of HTTP 500
- Adds `handleK8sError()` helper in handlers that classifies errors via `k8s.ClassifyError()` and returns the appropriate response
- Exports `ClassifyError` from the k8s package for use by handlers
- Applies fix across all MCP handlers (pods, nodes, events, GPU, deployments, services, etc.), workloads, gateway, gitops, and MCS handlers (91 error paths total)
- Adds 4 new tests: network error on pods/events/nodes, auth error on pods

Fixes #4135 #4136 #4137 #4138

## Details
When a vcluster (or any cluster) is unreachable, the API was returning:
```json
HTTP 500 {"error": "internal server error"}
```

Now it returns:
```json
HTTP 200 {"clusterStatus": "unavailable", "errorType": "network", "errorMessage": "dial tcp ...: connection refused"}
```

Non-connectivity errors (e.g. unexpected server errors) still return 500.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./pkg/...` passes
- [x] `go test ./pkg/...` passes (agent failure is pre-existing)
- [x] New test: `TestMCPGetPods_NetworkErrorReturnsUnavailable` - network error returns 200 + unavailable
- [x] New test: `TestMCPGetEvents_NetworkErrorReturnsUnavailable` - events endpoint same
- [x] New test: `TestMCPGetNodes_NetworkErrorReturnsUnavailable` - nodes endpoint same
- [x] New test: `TestMCPGetPods_AuthErrorReturnsUnavailable` - auth error returns 200 + unavailable
- [x] Existing test: `TestMCPGetPods_InternalErrorIsSanitized` still passes (non-connectivity errors remain 500)