### PR TITLE
🐛 Fix 3 security issues: scale auth, SSE cache namespace, JSON validation

### DIFF
--- a/pkg/agent/endpoint_auth_test.go
+++ b/pkg/agent/endpoint_auth_test.go
@@ -98,6 +98,7 @@ var sensitiveEndpoints = []struct {
 	{endpointKubeconfigImport, "POST"},
 	{endpointPods, "GET"},
 	{endpointNodes, "GET"},
+	{endpointScale, "POST"},
 }
 
 // endpointsLackingAuth are endpoints that SHOULD require auth but currently
@@ -106,9 +107,7 @@ var sensitiveEndpoints = []struct {
 var endpointsLackingAuth = []struct {
 	path   string
 	method string
-}{
-	{endpointScale, "POST"},
-}
+}{}
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"net/http"
 	"os"
 	"os/exec"
@@ -1520,8 +1519,8 @@ func (s *Server) handleResolveDepsHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleScaleHTTP scales a workload (Deployment or StatefulSet) to the given
-// replica count via the Kubernetes API. It accepts POST with JSON body or
-// GET with query parameters for convenience.
+// replica count via the Kubernetes API. Only POST with a JSON body is accepted;
+// GET-based mutations are rejected to prevent CSRF-style attacks (#4150).
 func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 	s.setCORSHeaders(w, r)
 	w.Header().Set("Content-Type", "application/json")
@@ -1529,6 +1528,24 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+
+	// SECURITY: Require auth — scaling is a mutating operation (#4150).
+	if !s.validateToken(r) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	// SECURITY: Only allow POST — GET mutations enable CSRF (#4150).
+	if r.Method != "POST" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   "POST required",
+		})
+		return
+	}
+
 	if s.k8sClient == nil {
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"success": false,
@@ -1537,43 +1554,28 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var req struct {
+		Cluster   string `json:"cluster"`
+		Namespace string `json:"namespace"`
+		Name      string `json:"name"`
+		Replicas  int32  `json:"replicas"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   "invalid request body",
+		})
+		return
+	}
+
 	var cluster, namespace, name string
 	var replicas int32
 
-	if r.Method == "POST" {
-		var req struct {
-			Cluster   string `json:"cluster"`
-			Namespace string `json:"namespace"`
-			Name      string `json:"name"`
-			Replicas  int32  `json:"replicas"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"success": false,
-				"error":   "invalid request body",
-			})
-			return
-		}
-		cluster = req.Cluster
-		namespace = req.Namespace
-		name = req.Name
-		replicas = req.Replicas
-	} else {
-		cluster = r.URL.Query().Get("cluster")
-		namespace = r.URL.Query().Get("namespace")
-		name = r.URL.Query().Get("name")
-		if r.URL.Query().Get("replicas") != "" {
-			n, err := strconv.Atoi(r.URL.Query().Get("replicas"))
-			if err != nil || n < math.MinInt32 || n > math.MaxInt32 {
-				json.NewEncoder(w).Encode(map[string]interface{}{
-					"success": false,
-					"error":   "invalid replicas value",
-				})
-				return
-			}
-			replicas = int32(n) // #nosec G109 -- bounds checked above
-		}
-	}
+	cluster = req.Cluster
+	namespace = req.Namespace
+	name = req.Name
+	replicas = req.Replicas
 
 	if replicas < 0 {
 		w.WriteHeader(http.StatusBadRequest)
@@ -1954,11 +1956,18 @@ func (s *Server) handleAutoUpdateTrigger(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Accept optional channel override from frontend
+	// Accept optional channel override from frontend.
+	// SECURITY: reject malformed JSON instead of silently using zero-value (#4156).
 	var body struct {
 		Channel string `json:"channel"`
 	}
-	_ = json.NewDecoder(r.Body).Decode(&body)
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON body"})
+			return
+		}
+	}
 	if !s.updateChecker.TriggerNow(body.Channel) {
 		w.WriteHeader(http.StatusConflict)
 		json.NewEncoder(w).Encode(map[string]interface{}{"success": false, "error": "update already in progress"})
@@ -4222,10 +4231,14 @@ func (s *Server) handlePredictionsAnalyze(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Parse optional providers from request body
+	// Parse optional providers from request body.
+	// SECURITY: reject malformed JSON instead of silently using zero-value (#4156).
 	var req AIAnalysisRequest
-	if r.Body != nil {
-		json.NewDecoder(r.Body).Decode(&req)
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid JSON body", http.StatusBadRequest)
+			return
+		}
 	}
 
 	if s.predictionWorker.IsAnalyzing() {

--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -17,6 +17,10 @@ type sseClusterStreamConfig struct {
 	// demoKey is the JSON key used in the SSE event data for the items array
 	// (e.g. "pods", "issues", "deployments").
 	demoKey string
+	// namespace is the optional namespace filter. When set it is included in
+	// the cache key so that requests for different namespaces on the same
+	// cluster do not return stale cross-namespace data (#4151).
+	namespace string
 	// clusterTimeout is the per-cluster fetch timeout.
 	clusterTimeout time.Duration
 }
@@ -158,7 +162,10 @@ func streamClusters(
 		// Spawn goroutines only for healthy/unknown clusters
 		var wg sync.WaitGroup
 		for _, cl := range healthy {
-			cacheKey := cfg.demoKey + ":" + cl.Name
+			// Include namespace in cache key to prevent cross-namespace
+			// data leakage when the same cluster is queried for different
+			// namespaces (#4151).
+			cacheKey := cfg.demoKey + ":" + cl.Name + ":" + cfg.namespace
 
 			// Check response cache — serve instantly if fresh
 			if cached := sseCacheGet(cacheKey); cached != nil {
@@ -286,6 +293,7 @@ func (h *MCPHandlers) GetPodsStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "pods",
+		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		pods, err := h.k8sClient.GetPods(ctx, cluster, namespace)
@@ -308,6 +316,7 @@ func (h *MCPHandlers) FindPodIssuesStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "issues",
+		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		issues, err := h.k8sClient.FindPodIssues(ctx, cluster, namespace)
@@ -330,6 +339,7 @@ func (h *MCPHandlers) GetDeploymentsStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "deployments",
+		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		deps, err := h.k8sClient.GetDeployments(ctx, cluster, namespace)
@@ -354,6 +364,7 @@ func (h *MCPHandlers) GetEventsStream(c *fiber.Ctx) error {
 
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "events",
+		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		events, err := h.k8sClient.GetEvents(ctx, cluster, namespace, limit)
@@ -376,6 +387,7 @@ func (h *MCPHandlers) GetServicesStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "services",
+		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		svcs, err := h.k8sClient.GetServices(ctx, cluster, namespace)
@@ -398,6 +410,7 @@ func (h *MCPHandlers) CheckSecurityIssuesStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "issues",
+		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		issues, err := h.k8sClient.CheckSecurityIssues(ctx, cluster, namespace)
@@ -420,6 +433,7 @@ func (h *MCPHandlers) FindDeploymentIssuesStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "issues",
+		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		issues, err := h.k8sClient.FindDeploymentIssues(ctx, cluster, namespace)
@@ -493,6 +507,7 @@ func (h *MCPHandlers) GetWarningEventsStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "events",
+		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		return h.k8sClient.GetWarningEvents(ctx, cluster, namespace, 50)
@@ -511,6 +526,7 @@ func (h *MCPHandlers) GetJobsStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "jobs",
+		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		return h.k8sClient.GetJobs(ctx, cluster, namespace)
@@ -529,6 +545,7 @@ func (h *MCPHandlers) GetConfigMapsStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "configmaps",
+		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		return h.k8sClient.GetConfigMaps(ctx, cluster, namespace)
@@ -547,6 +564,7 @@ func (h *MCPHandlers) GetSecretsStream(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "secrets",
+		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		return h.k8sClient.GetSecrets(ctx, cluster, namespace)
@@ -566,6 +584,7 @@ func (h *MCPHandlers) GetWorkloadsStream(c *fiber.Ctx) error {
 	workloadType := c.Query("type")
 	return streamClusters(c, h, sseClusterStreamConfig{
 		demoKey:        "workloads",
+		namespace:      namespace,
 		clusterTimeout: ssePerClusterTimeout,
 	}, func(ctx context.Context, cluster string) (interface{}, error) {
 		workloads, err := h.k8sClient.ListWorkloadsForCluster(ctx, cluster, namespace, workloadType)


### PR DESCRIPTION
## Summary

Fixes three security vulnerabilities reported in #4150, #4151, and #4156:

- **#4150 — Unauthenticated scale endpoint**: Added `validateToken` check to `/scale` and removed GET-based mutations (POST-only now). Previously, the scale endpoint accepted unauthenticated requests and allowed mutations via GET query parameters, enabling CSRF-style attacks. Moved `/scale` from `endpointsLackingAuth` to `sensitiveEndpoints` in the auth test suite.

- **#4151 — SSE cache key ignores namespace**: Added `namespace` field to `sseClusterStreamConfig` and included it in the cache key (`demoKey:cluster:namespace`). Previously, cache keys were only `demoKey:cluster`, so requests for different namespaces on the same cluster could return stale data from a previous namespace query.

- **#4156 — Malformed JSON silently accepted**: Added JSON decode error checking on `/auto-update/trigger` and `/predictions/analyze`. Previously, decode errors were discarded with `_`, causing malformed JSON payloads to produce zero-value structs and proceed with operations instead of returning 400.

## Test plan

- [x] All `TestEndpointAuth_*` tests pass — `/scale` now correctly rejects unauthenticated/bad-token requests
- [x] `TestScaleWorkload` handler test passes
- [x] `TestPredictionWorker` and `TestPredictionMetrics` pass
- [x] All `pkg/api/handlers` tests pass (SSE cache key change is backward-compatible)
- [x] `go build ./pkg/...` succeeds with no compilation errors

Closes #4150, closes #4151, closes #4156