### PR TITLE
🐛 Address Copilot review comments: token security, double-cancel guard, nil checks

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -253,15 +253,18 @@ func (s *Server) checkOrigin(r *http.Request) bool {
 }
 
 // validateToken checks the authentication token (if configured).
-// Tokens are accepted ONLY via the Authorization header to keep secrets out
-// of server logs, browser history, and proxy access logs (#3895).
+// Tokens are accepted via the Authorization header for HTTP requests.
+// For WebSocket upgrades, tokens are also accepted via the ?token= query
+// parameter since browsers cannot set custom headers on WebSocket handshakes.
+// Query parameter tokens are restricted to Upgrade requests only to keep
+// secrets out of server logs, browser history, and proxy access logs (#3895).
 func (s *Server) validateToken(r *http.Request) bool {
 	// If no token configured, skip token validation
 	if s.agentToken == "" {
 		return true
 	}
 
-	// Check Authorization header first
+	// Check Authorization header (preferred for all requests)
 	authHeader := r.Header.Get("Authorization")
 	if strings.HasPrefix(authHeader, "Bearer ") {
 		token := strings.TrimPrefix(authHeader, "Bearer ")
@@ -270,9 +273,12 @@ func (s *Server) validateToken(r *http.Request) bool {
 		}
 	}
 
-	// Fall back to query parameter (for WebSocket connections that can't set headers)
-	if queryToken := r.URL.Query().Get("token"); queryToken != "" {
-		return queryToken == s.agentToken
+	// Fall back to query parameter ONLY for WebSocket upgrade requests
+	// (browsers cannot set custom headers on WebSocket handshakes)
+	if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		if queryToken := r.URL.Query().Get("token"); queryToken != "" {
+			return queryToken == s.agentToken
+		}
 	}
 
 	return false
@@ -618,7 +624,7 @@ func (s *Server) isAllowedOrigin(origin string) bool {
 // matchOrigin checks if an origin matches an allowed pattern.
 // For non-wildcard origins, requires an exact match or a match with an additional port
 // (e.g. "http://localhost" matches "http://localhost" and "http://localhost:5174" but NOT "http://localhost.attacker.com").
-// For wildcard patterns like "https://*.ibm.com", matches only a single subdomain level
+// For wildcard patterns like "https://*.ibm.com", matches any subdomain depth
 // (e.g. "https://kc.ibm.com" matches but "https://evil.kc.ibm.com" does not).
 func matchOrigin(origin, allowed string) bool {
 	// Wildcard matching: "https://*.ibm.com" matches any subdomain depth

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -2694,7 +2694,10 @@ func (h *MCPHandlers) GetWorkloads(c *fiber.Ctx) error {
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
-	workloads := list.Items
+	var workloads []v1alpha1.Workload
+	if list != nil {
+		workloads = list.Items
+	}
 	if workloads == nil {
 		workloads = make([]v1alpha1.Workload, 0)
 	}

--- a/pkg/k8s/workload.go
+++ b/pkg/k8s/workload.go
@@ -978,10 +978,9 @@ func (m *MultiClusterClient) GetClusterCapabilities(ctx context.Context) (*v1alp
 		cap.GPUCount = totalGPUs
 
 		// Use capacity from first node as representative for CPU/Memory
-		if len(nodes) > 0 {
-			cap.CPUCapacity = nodes[0].CPUCapacity
-			cap.MemCapacity = nodes[0].MemoryCapacity
-		}
+		// (nodes is guaranteed non-empty here — zero-node clusters are skipped above)
+		cap.CPUCapacity = nodes[0].CPUCapacity
+		cap.MemCapacity = nodes[0].MemoryCapacity
 
 		capabilities = append(capabilities, cap)
 	}

--- a/pkg/k8s/workload_scaling_test.go
+++ b/pkg/k8s/workload_scaling_test.go
@@ -153,7 +153,7 @@ func TestGetClusterCapabilities(t *testing.T) {
 	}
 }
 
-func TestGetClusterCapabilities_UnreachableCluster(t *testing.T) {
+func TestGetClusterCapabilities_ZeroNodeCluster(t *testing.T) {
 	m, _ := NewMultiClusterClient("")
 
 	// c1 has nodes — should be available

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -1467,6 +1467,9 @@ Install the console locally with the KubeStellar Console agent to use AI mission
   // Sets status to 'cancelling' immediately, then waits for backend acknowledgment
   // before transitioning to final 'failed' state. Falls back to a timeout if no ack.
   const cancelMission = useCallback((missionId: string) => {
+    // Guard against double-cancel: if already cancelling, don't schedule another timeout
+    if (cancelTimeouts.current.has(missionId)) return
+
     // Try WebSocket first (fastest path when connected)
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       wsRef.current.send(JSON.stringify({


### PR DESCRIPTION
## Summary

Addresses Copilot review comments from PRs #4099, #4143, #4145, #4146:

- **validateToken**: Restrict query param `?token=` to WebSocket upgrade requests only (was accepting on all HTTP endpoints, re-introducing #3895 risk). Updated stale doc comment.
- **matchOrigin**: Updated comment to reflect multi-level subdomain matching.
- **cancelMission**: Guard against double-cancel scheduling multiple timeouts for same mission.
- **GetWorkloads**: Nil guard on `ListWorkloads` result before accessing `.Items`.
- **GetClusterCapabilities**: Removed redundant `len(nodes)>0` guard, fixed test name from "UnreachableCluster" to "ZeroNodeCluster".

## Test plan
- [x] Go tests pass: `TestGetClusterCapabilities`, `TestGetClusterCapabilities_ZeroNodeCluster`
- [x] TypeScript compiles cleanly