### PR TITLE
🐛 Fix data handling: error swallowing, webhook parsing, cluster discovery, demo fallback

### DIFF
--- a/pkg/api/handlers/admission_webhooks.go
+++ b/pkg/api/handlers/admission_webhooks.go
@@ -74,7 +74,11 @@ func (h *WebhookHandlers) ListWebhooks(c *fiber.Ctx) error {
 
 	clusters, err := h.k8sClient.DeduplicatedClusters(ctx)
 	if err != nil {
-		clusters, _ = h.k8sClient.ListClusters(ctx)
+		var listErr error
+		clusters, listErr = h.k8sClient.ListClusters(ctx)
+		if listErr != nil {
+			return c.Status(500).JSON(fiber.Map{"error": "cluster discovery failed", "isDemoData": false})
+		}
 	}
 
 	allWebhooks := make([]WebhookSummary, 0)
@@ -122,6 +126,7 @@ func parseWebhookFromUnstructured(item *unstructured.Unstructured, cluster, whTy
 	failurePolicy := "Fail"
 	matchPolicy := "Exact"
 	ruleCount := 0
+	policyExtracted := false
 
 	// The webhook list is under "webhooks" for both mutating and validating
 	if webhooks, ok := item.Object["webhooks"].([]interface{}); ok {
@@ -136,12 +141,15 @@ func parseWebhookFromUnstructured(item *unstructured.Unstructured, cluster, whTy
 				ruleCount += len(rules)
 			}
 
-			// Use failure policy from first webhook entry
-			if fp, ok := whMap["failurePolicy"].(string); ok && ruleCount <= len(webhooks) {
-				failurePolicy = fp
-			}
-			if mp, ok := whMap["matchPolicy"].(string); ok && ruleCount <= len(webhooks) {
-				matchPolicy = mp
+			// Use failure/match policy from the first webhook entry that has them
+			if !policyExtracted {
+				if fp, ok := whMap["failurePolicy"].(string); ok {
+					failurePolicy = fp
+				}
+				if mp, ok := whMap["matchPolicy"].(string); ok {
+					matchPolicy = mp
+				}
+				policyExtracted = true
 			}
 		}
 	}

--- a/pkg/api/handlers/crds.go
+++ b/pkg/api/handlers/crds.go
@@ -77,7 +77,11 @@ func (h *CRDHandlers) ListCRDs(c *fiber.Ctx) error {
 
 	clusters, err := h.k8sClient.DeduplicatedClusters(ctx)
 	if err != nil {
-		clusters, _ = h.k8sClient.ListClusters(ctx)
+		var listErr error
+		clusters, listErr = h.k8sClient.ListClusters(ctx)
+		if listErr != nil {
+			return c.Status(500).JSON(fiber.Map{"error": "cluster discovery failed", "isDemoData": false})
+		}
 	}
 	allCRDs := make([]CRDSummary, 0)
 

--- a/pkg/api/handlers/gateway.go
+++ b/pkg/api/handlers/gateway.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"log"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -55,6 +56,11 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 	// Get gateways across all clusters
 	list, err := h.k8sClient.ListGateways(ctx)
 	if err != nil {
+		// If we got partial results alongside errors, log and return what we have
+		if list != nil && len(list.Items) > 0 {
+			log.Printf("partial gateway list failure: %v", err)
+			return c.JSON(list)
+		}
 		return handleK8sError(c, err)
 	}
 
@@ -91,6 +97,11 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 	// Get routes across all clusters
 	list, err := h.k8sClient.ListHTTPRoutes(ctx)
 	if err != nil {
+		// If we got partial results alongside errors, log and return what we have
+		if list != nil && len(list.Items) > 0 {
+			log.Printf("partial httproute list failure: %v", err)
+			return c.JSON(list)
+		}
 		return handleK8sError(c, err)
 	}
 

--- a/pkg/api/handlers/service_exports.go
+++ b/pkg/api/handlers/service_exports.go
@@ -68,7 +68,11 @@ func (h *ServiceExportHandlers) ListServiceExports(c *fiber.Ctx) error {
 
 	clusters, err := h.k8sClient.DeduplicatedClusters(ctx)
 	if err != nil {
-		clusters, _ = h.k8sClient.ListClusters(ctx)
+		var listErr error
+		clusters, listErr = h.k8sClient.ListClusters(ctx)
+		if listErr != nil {
+			return c.Status(500).JSON(fiber.Map{"error": "cluster discovery failed", "isDemoData": false})
+		}
 	}
 
 	allExports := make([]ServiceExportSummary, 0)

--- a/pkg/k8s/gateway.go
+++ b/pkg/k8s/gateway.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,7 +11,9 @@ import (
 	"github.com/kubestellar/console/pkg/api/v1alpha1"
 )
 
-// ListGateways lists all Gateway resources across all clusters
+// ListGateways lists all Gateway resources across all clusters.
+// Per-cluster errors are collected and returned alongside any successful results
+// so that callers can surface partial failures instead of silently dropping data.
 func (m *MultiClusterClient) ListGateways(ctx context.Context) (*v1alpha1.GatewayList, error) {
 	m.mu.RLock()
 	clusters := make([]string, 0, len(m.clients))
@@ -22,6 +25,7 @@ func (m *MultiClusterClient) ListGateways(ctx context.Context) (*v1alpha1.Gatewa
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	gateways := make([]v1alpha1.Gateway, 0)
+	var errs []error
 
 	for _, clusterName := range clusters {
 		wg.Add(1)
@@ -30,6 +34,9 @@ func (m *MultiClusterClient) ListGateways(ctx context.Context) (*v1alpha1.Gatewa
 
 			clusterGateways, err := m.ListGatewaysForCluster(ctx, cluster, "")
 			if err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("cluster %s: %w", cluster, err))
+				mu.Unlock()
 				return
 			}
 
@@ -41,10 +48,15 @@ func (m *MultiClusterClient) ListGateways(ctx context.Context) (*v1alpha1.Gatewa
 
 	wg.Wait()
 
+	var combinedErr error
+	if len(errs) > 0 {
+		combinedErr = fmt.Errorf("gateway list errors: %v", errs)
+	}
+
 	return &v1alpha1.GatewayList{
 		Items:      gateways,
 		TotalCount: len(gateways),
-	}, nil
+	}, combinedErr
 }
 
 // ListGatewaysForCluster lists Gateway resources in a specific cluster
@@ -134,7 +146,9 @@ func (m *MultiClusterClient) parseGatewaysFromList(list interface{}, contextName
 	return gateways, nil
 }
 
-// ListHTTPRoutes lists all HTTPRoute resources across all clusters
+// ListHTTPRoutes lists all HTTPRoute resources across all clusters.
+// Per-cluster errors are collected and returned alongside any successful results
+// so that callers can surface partial failures instead of silently dropping data.
 func (m *MultiClusterClient) ListHTTPRoutes(ctx context.Context) (*v1alpha1.HTTPRouteList, error) {
 	m.mu.RLock()
 	clusters := make([]string, 0, len(m.clients))
@@ -146,6 +160,7 @@ func (m *MultiClusterClient) ListHTTPRoutes(ctx context.Context) (*v1alpha1.HTTP
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	routes := make([]v1alpha1.HTTPRoute, 0)
+	var errs []error
 
 	for _, clusterName := range clusters {
 		wg.Add(1)
@@ -154,6 +169,9 @@ func (m *MultiClusterClient) ListHTTPRoutes(ctx context.Context) (*v1alpha1.HTTP
 
 			clusterRoutes, err := m.ListHTTPRoutesForCluster(ctx, cluster, "")
 			if err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("cluster %s: %w", cluster, err))
+				mu.Unlock()
 				return
 			}
 
@@ -165,10 +183,15 @@ func (m *MultiClusterClient) ListHTTPRoutes(ctx context.Context) (*v1alpha1.HTTP
 
 	wg.Wait()
 
+	var combinedErr error
+	if len(errs) > 0 {
+		combinedErr = fmt.Errorf("httproute list errors: %v", errs)
+	}
+
 	return &v1alpha1.HTTPRouteList{
 		Items:      routes,
 		TotalCount: len(routes),
-	}, nil
+	}, combinedErr
 }
 
 // ListHTTPRoutesForCluster lists HTTPRoute resources in a specific cluster

--- a/web/src/hooks/useAdmissionWebhooks.ts
+++ b/web/src/hooks/useAdmissionWebhooks.ts
@@ -171,9 +171,11 @@ export function useAdmissionWebhooks(): UseAdmissionWebhooksResult {
 
       const data = (await res.json()) as WebhookListResponse
 
-      if (data.isDemoData || (data.webhooks || []).length === 0) {
-        throw new Error('No webhook data available')
+      if (data.isDemoData) {
+        throw new Error('Backend returned demo data indicator')
       }
+
+      // An empty array is a legitimate result (no webhooks configured)
 
       setWebhooks(data.webhooks || [])
       setIsDemoData(false)

--- a/web/src/hooks/useCRDs.ts
+++ b/web/src/hooks/useCRDs.ts
@@ -190,10 +190,12 @@ export function useCRDs(): UseCRDsResult {
 
       const data = (await res.json()) as CRDListResponse
 
-      if (data.isDemoData || (data.crds || []).length === 0) {
-        // API returned but no real data — fall through to demo
-        throw new Error('No CRD data available')
+      if (data.isDemoData) {
+        // API returned demo data indicator — fall through to demo
+        throw new Error('Backend returned demo data indicator')
       }
+
+      // An empty array is a legitimate result (no CRDs on cluster)
 
       setCRDs(data.crds || [])
       setIsDemoData(false)

--- a/web/src/hooks/useServiceExports.ts
+++ b/web/src/hooks/useServiceExports.ts
@@ -187,10 +187,12 @@ export function useServiceExports(): UseServiceExportsResult {
 
       const data = (await res.json()) as ServiceExportListResponse
 
-      if (data.isDemoData || (data.exports || []).length === 0) {
-        // API returned but no real data — fall through to demo
-        throw new Error('No ServiceExport data available')
+      if (data.isDemoData) {
+        // API returned demo data indicator — fall through to demo
+        throw new Error('Backend returned demo data indicator')
       }
+
+      // An empty array is a legitimate result (no ServiceExports configured)
 
       setExports(data.exports || [])
       setIsDemoData(false)


### PR DESCRIPTION
## Summary

Fixes four related data handling bugs that caused silent failures and incorrect UI state:

- **#4152 — Gateway/HTTPRoute errors silently become empty results**: `ListGateways()` and `ListHTTPRoutes()` now collect per-cluster errors and return them alongside partial results. The handler logs partial failures and surfaces total failures via `handleK8sError`.
- **#4153 — Webhook parser reports default policy instead of actual policy**: The `ruleCount <= len(webhooks)` condition was broken because `ruleCount` accumulates across all webhooks, quickly exceeding the entry count. Replaced with a simple `policyExtracted` boolean flag to capture policy from the first webhook entry.
- **#4154 — Cluster discovery failures return empty-success payloads**: When both `DeduplicatedClusters()` and `ListClusters()` fail, handlers now return HTTP 500 instead of 200 OK with empty data and `isDemoData: false`.
- **#4155 — Frontend treats legitimate empty datasets as failures**: Three hooks (`useAdmissionWebhooks`, `useCRDs`, `useServiceExports`) no longer throw on `length === 0`. Empty arrays are legitimate results. Demo data fallback only triggers when `isDemoData` is explicitly set by the backend.

## Test plan

- [x] Go tests pass (`go test ./pkg/k8s/... ./pkg/api/handlers/...`)
- [x] Frontend tests pass (`vitest run` for all three hook test files)
- [x] Frontend build succeeds
- [x] Lint error count unchanged from main

Closes #4152, Closes #4153, Closes #4154, Closes #4155