### PR TITLE
🐛 Fix dev mode bar overlapping navbar and content

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -20,6 +20,7 @@ import { useBackendHealth } from '../../hooks/useBackendHealth'
 import { useDeepLink } from '../../hooks/useDeepLink'
 import { cn } from '../../lib/cn'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+import { NAVBAR_HEIGHT_PX, BANNER_HEIGHT_PX, DEV_BAR_HEIGHT_PX } from '../../lib/constants/ui'
 import { CLOSE_ANIMATION_MS, UI_FEEDBACK_TIMEOUT_MS, TOAST_DISMISS_MS } from '../../lib/constants/network'
 import { TourOverlay, TourPrompt } from '../onboarding/Tour'
 import { TourProvider } from '../../hooks/useTour'
@@ -249,17 +250,17 @@ export function Layout({ children }: LayoutProps) {
   const showInClusterBanner = isInClusterMode && agentStatus === 'disconnected' && !isDemoMode
 
   // Banner stacking: each banner's top offset depends on how many banners above it are visible.
-  // Navbar is 64px (top-16). Each banner is ~36px tall.
-  // Z-index hierarchy: Navbar + dropdowns (z-50) > Network banner (z-40) > Demo banner (z-30) > In-cluster / Offline banner (z-20)
-  const NAVBAR_HEIGHT = 64
-  const BANNER_HEIGHT = 36
+  // Dev bar (20px) → Navbar (64px) → Banners (36px each).
+  // Z-index hierarchy: Dev bar (z-60) > Navbar + dropdowns (z-50) > Network banner (z-40) > Demo banner (z-30) > In-cluster / Offline banner (z-20)
+  // When dev mode bar is visible, everything fixed below it must shift down
+  const devBarOffset = __DEV_MODE__ ? DEV_BAR_HEIGHT_PX : 0
   // Stack order: Network (top) → Demo → In-cluster agent / Agent Offline (bottom)
-  const networkBannerTop = NAVBAR_HEIGHT
-  const demoBannerTop = NAVBAR_HEIGHT + (showNetworkBanner ? BANNER_HEIGHT : 0)
-  const inClusterBannerTop = NAVBAR_HEIGHT + (showNetworkBanner ? BANNER_HEIGHT : 0) + (isDemoMode ? BANNER_HEIGHT : 0)
-  const offlineBannerTop = NAVBAR_HEIGHT + (showNetworkBanner ? BANNER_HEIGHT : 0) + (isDemoMode ? BANNER_HEIGHT : 0) + (showInClusterBanner ? BANNER_HEIGHT : 0)
+  const networkBannerTop = devBarOffset + NAVBAR_HEIGHT_PX
+  const demoBannerTop = devBarOffset + NAVBAR_HEIGHT_PX + (showNetworkBanner ? BANNER_HEIGHT_PX : 0)
+  const inClusterBannerTop = devBarOffset + NAVBAR_HEIGHT_PX + (showNetworkBanner ? BANNER_HEIGHT_PX : 0) + (isDemoMode ? BANNER_HEIGHT_PX : 0)
+  const offlineBannerTop = devBarOffset + NAVBAR_HEIGHT_PX + (showNetworkBanner ? BANNER_HEIGHT_PX : 0) + (isDemoMode ? BANNER_HEIGHT_PX : 0) + (showInClusterBanner ? BANNER_HEIGHT_PX : 0)
   const activeBannerCount = (showNetworkBanner ? 1 : 0) + (isDemoMode ? 1 : 0) + (showInClusterBanner ? 1 : 0) + (showOfflineBanner ? 1 : 0)
-  const totalBannerHeight = activeBannerCount * BANNER_HEIGHT
+  const totalBannerHeight = activeBannerCount * BANNER_HEIGHT_PX
 
   // Show bottom snackbar when backend is down, or briefly after reconnecting.
   // Suppress during active updates — the backend is expected to be down while restarting.
@@ -318,7 +319,7 @@ export function Layout({ children }: LayoutProps) {
         ))}
       </div>
 
-      <Navbar />
+      <Navbar topOffset={devBarOffset} />
 
       {/* Auto-Update Progress Banner */}
       <UpdateProgressBanner progress={updateProgress} onDismiss={dismissUpdateProgress} />
@@ -491,7 +492,7 @@ export function Layout({ children }: LayoutProps) {
         </div>
       )}
 
-      <div className="flex flex-1 overflow-hidden transition-[padding-top] duration-300" style={{ paddingTop: NAVBAR_HEIGHT + totalBannerHeight }}>
+      <div className="flex flex-1 overflow-hidden transition-[padding-top] duration-300" style={{ paddingTop: devBarOffset + NAVBAR_HEIGHT_PX + totalBannerHeight }}>
         {/* Wrap Sidebar in PageErrorBoundary so stale-chunk errors
             (e.g. "Can't find variable: handleSidebarMouseEnter" from cached
             old bundles) are caught at page level instead of propagating to

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -29,8 +29,14 @@ import { AgentStatusIndicator } from './AgentStatusIndicator'
 import { UpdateIndicator } from './UpdateIndicator'
 import { StreakBadge } from './StreakBadge'
 import { ROUTES } from '../../../config/routes'
+import { NAVBAR_HEIGHT_PX } from '../../../lib/constants/ui'
 
-export function Navbar() {
+interface NavbarProps {
+  /** Pixel offset from top when a dev-mode bar or other element sits above the navbar */
+  topOffset?: number
+}
+
+export function Navbar({ topOffset = 0 }: NavbarProps) {
   const { user, logout } = useAuth()
   const navigate = useNavigate()
   const { theme, toggleTheme } = useTheme()
@@ -47,7 +53,7 @@ export function Navbar() {
   }, [location.pathname])
 
   return (
-    <nav data-tour="navbar" className="fixed top-0 left-0 right-0 h-16 glass z-50 px-3 md:px-6 flex items-center justify-between">
+    <nav data-tour="navbar" style={{ top: topOffset }} className="fixed left-0 right-0 h-16 glass z-50 px-3 md:px-6 flex items-center justify-between">
       {/* Left side: Hamburger + Logo — shrink-0 so logo is never compressed */}
       <div className="flex items-center gap-2 md:gap-3 shrink-0">
         {/* Hamburger menu - mobile only */}
@@ -166,7 +172,7 @@ export function Navbar() {
                 onClick={() => setShowMobileMore(false)}
               />
               {/* Bottom sheet menu on mobile */}
-              <div className={`fixed ${isMobile ? 'inset-x-0 bottom-0 rounded-t-2xl max-h-[60vh]' : 'right-4 top-16 w-64 rounded-lg'} bg-card border border-border shadow-xl z-50 overflow-hidden`}>
+              <div className={`fixed ${isMobile ? 'inset-x-0 bottom-0 rounded-t-2xl max-h-[60vh]' : 'right-4 w-64 rounded-lg'} bg-card border border-border shadow-xl z-50 overflow-hidden`} style={isMobile ? undefined : { top: topOffset + NAVBAR_HEIGHT_PX }}>
                 {/* Drag handle for mobile */}
                 {isMobile && (
                   <div className="flex justify-center py-2">

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -58,3 +58,11 @@ export const COPY_FEEDBACK_TIMEOUT_MS = 2000
 
 // ── Pagination ──────────────────────────────────────────────────────────
 export const DEFAULT_PAGE_SIZE = 5
+
+// ── Layout dimensions ──────────────────────────────────────────────────
+/** Height of the top navbar in pixels (h-16 = 64px) */
+export const NAVBAR_HEIGHT_PX = 64
+/** Height of each status banner (network, demo, offline) in pixels */
+export const BANNER_HEIGHT_PX = 36
+/** Height of the green dev-mode indicator bar in pixels (h-5 = 20px) */
+export const DEV_BAR_HEIGHT_PX = 20


### PR DESCRIPTION
## Summary
- The green dev-mode indicator bar was overlapping the fixed-position navbar because the navbar used `fixed top-0` while the dev bar was in the flex flow above it
- Status banners (network, demo, offline) and page content were also not accounting for the dev bar height, causing them to be positioned too high

## Changes
- Added `NAVBAR_HEIGHT_PX`, `BANNER_HEIGHT_PX`, `DEV_BAR_HEIGHT_PX` to shared UI constants (`lib/constants/ui.ts`) to eliminate magic numbers
- Computed `devBarOffset` in Layout and passed it to Navbar via a new `topOffset` prop
- Shifted the Navbar down by `devBarOffset` via inline `style={{ top: topOffset }}`
- Included `devBarOffset` in all banner `top` calculations and content `padding-top` so nothing overlaps the dev bar

Fixes #4149

## Test plan
- [ ] Run in dev mode (`npm run dev`) — verify green bar sits above navbar with no overlap
- [ ] Verify all status banners (demo mode, offline, network disconnected) stack correctly below the navbar
- [ ] Verify page content scrolls below all banners without being clipped
- [ ] Production build (`npm run build`) — verify no dev bar appears (dead-code eliminated)