### PR TITLE
🐛 Address Copilot comments: JSON body validation, SSE comment, error chains

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -1967,8 +1967,8 @@ func (s *Server) handleAutoUpdateTrigger(w http.ResponseWriter, r *http.Request)
 	var body struct {
 		Channel string `json:"channel"`
 	}
-	if r.Body != nil && r.ContentLength != 0 {
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil && err != io.EOF {
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON body"})
 			return
@@ -4240,9 +4240,11 @@ func (s *Server) handlePredictionsAnalyze(w http.ResponseWriter, r *http.Request
 	// Parse optional providers from request body.
 	// SECURITY: reject malformed JSON instead of silently using zero-value (#4156).
 	var req AIAnalysisRequest
-	if r.Body != nil && r.ContentLength != 0 {
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, "invalid JSON body", http.StatusBadRequest)
+	if r.Body != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON body"})
 			return
 		}
 	}

--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -17,9 +17,9 @@ type sseClusterStreamConfig struct {
 	// demoKey is the JSON key used in the SSE event data for the items array
 	// (e.g. "pods", "issues", "deployments").
 	demoKey string
-	// namespace is the optional namespace filter. When set it is included in
-	// the cache key so that requests for different namespaces on the same
-	// cluster do not return stale cross-namespace data (#4151).
+	// namespace is the optional namespace filter. Always included in the cache
+	// key (even when empty) so that requests for different namespaces on the
+	// same cluster do not return stale cross-namespace data (#4151).
 	namespace string
 	// clusterTimeout is the per-cluster fetch timeout.
 	clusterTimeout time.Duration

--- a/pkg/k8s/gateway.go
+++ b/pkg/k8s/gateway.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -50,7 +51,7 @@ func (m *MultiClusterClient) ListGateways(ctx context.Context) (*v1alpha1.Gatewa
 
 	var combinedErr error
 	if len(errs) > 0 {
-		combinedErr = fmt.Errorf("gateway list errors: %v", errs)
+		combinedErr = fmt.Errorf("gateway list errors: %w", errors.Join(errs...))
 	}
 
 	return &v1alpha1.GatewayList{
@@ -185,7 +186,7 @@ func (m *MultiClusterClient) ListHTTPRoutes(ctx context.Context) (*v1alpha1.HTTP
 
 	var combinedErr error
 	if len(errs) > 0 {
-		combinedErr = fmt.Errorf("httproute list errors: %v", errs)
+		combinedErr = fmt.Errorf("httproute list errors: %w", errors.Join(errs...))
 	}
 
 	return &v1alpha1.HTTPRouteList{


### PR DESCRIPTION
## Summary

Addresses Copilot review comments from PRs #4157, #4158, #4159:

- **server.go**: Remove `ContentLength != 0` guard that skipped validation for chunked transfers. Now decodes `r.Body` when present, tolerates `io.EOF` for empty bodies. Returns JSON (not plain text) on `/predictions/analyze` 400 errors.
- **sse.go**: Fix comment — namespace is always included in cache key, not conditionally.
- **gateway.go**: Use `errors.Join()` instead of `fmt.Errorf("%v", errs)` for unwrappable error chains.