### PR TITLE
🐛 Fix Auto-QA issues: button patterns and missing test coverage

### DIFF
--- a/web/src/components/clusters/add-cluster/__tests__/CommandLineTab.test.tsx
+++ b/web/src/components/clusters/add-cluster/__tests__/CommandLineTab.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * CommandLineTab component smoke tests
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
+vi.mock('../../../../lib/clipboard', () => ({
+  copyToClipboard: vi.fn(),
+}))
+
+import { CommandLineTab } from '../CommandLineTab'
+
+describe('CommandLineTab', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<CommandLineTab cloudCLIs={[]} />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/clusters/add-cluster/__tests__/ImportTab.test.tsx
+++ b/web/src/components/clusters/add-cluster/__tests__/ImportTab.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * ImportTab component smoke tests
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { createRef } from 'react'
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
+import { ImportTab } from '../ImportTab'
+
+describe('ImportTab', () => {
+  it('renders without crashing', () => {
+    const fileInputRef = createRef<HTMLInputElement>()
+    const { container } = render(
+      <ImportTab
+        kubeconfigYaml=""
+        setKubeconfigYaml={vi.fn()}
+        importState="idle"
+        setImportState={vi.fn()}
+        previewContexts={[]}
+        setPreviewContexts={vi.fn()}
+        errorMessage=""
+        setErrorMessage={vi.fn()}
+        importedCount={0}
+        fileInputRef={fileInputRef as React.RefObject<HTMLInputElement>}
+        handleFileUpload={vi.fn()}
+        handlePreview={vi.fn()}
+        handleImport={vi.fn()}
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/deployments/__tests__/Deployments.test.tsx
+++ b/web/src/components/deployments/__tests__/Deployments.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Deployments component smoke tests
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
+vi.mock('../../../hooks/useMCP', () => ({
+  useClusters: () => ({
+    clusters: [], isLoading: false, isRefreshing: false,
+    lastUpdated: null, refetch: vi.fn(), error: null,
+  }),
+}))
+
+vi.mock('../../../hooks/useCachedData', () => ({
+  useCachedDeployments: () => ({
+    deployments: [], isLoading: false, isRefreshing: false,
+    lastRefresh: null, refetch: vi.fn(), error: null,
+  }),
+  useCachedDeploymentIssues: () => ({
+    issues: [], refetch: vi.fn(), error: null,
+  }),
+  useCachedPodIssues: () => ({
+    issues: [], error: null,
+  }),
+}))
+
+vi.mock('../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({
+    selectedClusters: [], isAllClustersSelected: true,
+  }),
+}))
+
+vi.mock('../../../hooks/useDrillDown', () => ({
+  useDrillDownActions: () => ({
+    drillToAllDeployments: vi.fn(), drillToAllPods: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../hooks/useUniversalStats', () => ({
+  useUniversalStats: () => ({ getStatValue: vi.fn() }),
+  createMergedStatValueGetter: () => vi.fn(),
+}))
+
+vi.mock('../../../config/dashboards', () => ({
+  getDefaultCards: () => [],
+  deploymentsDashboardConfig: { storageKey: 'test-deployments-key' },
+}))
+
+vi.mock('../../../lib/dashboards/migrateStorageKey', () => ({
+  migrateStorageKey: vi.fn(),
+}))
+
+vi.mock('../../../lib/dashboards/DashboardPage', () => ({
+  DashboardPage: ({ children }: { children?: React.ReactNode }) => <div data-testid="dashboard-page">{children}</div>,
+}))
+
+/** Timeout for importing heavy modules */
+const IMPORT_TIMEOUT_MS = 30000
+
+describe('Deployments', () => {
+  it('exports Deployments component', async () => {
+    const mod = await import('../Deployments')
+    expect(mod.Deployments).toBeDefined()
+  }, IMPORT_TIMEOUT_MS)
+})

--- a/web/src/components/helm/__tests__/HelmReleases.test.tsx
+++ b/web/src/components/helm/__tests__/HelmReleases.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * HelmReleases component smoke tests
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
+vi.mock('../../../hooks/useMCP', () => ({
+  useClusters: () => ({
+    clusters: [], isLoading: false, isRefreshing: false,
+    lastUpdated: null, refetch: vi.fn(), error: null,
+  }),
+}))
+
+vi.mock('../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({
+    selectedClusters: [], isAllClustersSelected: true,
+  }),
+}))
+
+vi.mock('../../../hooks/useDrillDown', () => ({
+  useDrillDownActions: () => ({
+    drillToAllHelm: vi.fn(), drillToAllClusters: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../hooks/useUniversalStats', () => ({
+  useUniversalStats: () => ({ getStatValue: vi.fn() }),
+  createMergedStatValueGetter: () => vi.fn(),
+}))
+
+vi.mock('../../../config/dashboards', () => ({
+  getDefaultCards: () => [],
+}))
+
+vi.mock('../../../lib/dashboards/DashboardPage', () => ({
+  DashboardPage: ({ children }: { children?: React.ReactNode }) => <div data-testid="dashboard-page">{children}</div>,
+}))
+
+/** Timeout for importing heavy modules */
+const IMPORT_TIMEOUT_MS = 30000
+
+describe('HelmReleases', () => {
+  it('exports HelmReleases component', async () => {
+    const mod = await import('../HelmReleases')
+    expect(mod.HelmReleases).toBeDefined()
+  }, IMPORT_TIMEOUT_MS)
+})

--- a/web/src/components/history/__tests__/CardHistory.test.tsx
+++ b/web/src/components/history/__tests__/CardHistory.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * CardHistory component smoke tests
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
+vi.mock('../../../hooks/useCardHistory', () => ({
+  useCardHistory: () => ({
+    entries: [],
+    clearHistory: vi.fn(),
+    removeEntry: vi.fn(),
+    restoreCard: vi.fn(),
+  }),
+}))
+
+import { CardHistory } from '../CardHistory'
+
+describe('CardHistory', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<CardHistory onRestoreCard={vi.fn()} />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/onboarding/Onboarding.tsx
+++ b/web/src/components/onboarding/Onboarding.tsx
@@ -7,6 +7,7 @@ import { ROUTES } from '../../config/routes'
 import { STORAGE_KEY_TOKEN, DEMO_TOKEN_VALUE, STORAGE_KEY_ONBOARDING_RESPONSES, STORAGE_KEY_ONBOARDED } from '../../lib/constants'
 import { safeGetItem, safeSetItem, safeSetJSON } from '../../lib/utils/localStorage'
 import { useTranslation } from 'react-i18next'
+import { Button } from '../ui/Button'
 
 interface Question {
   key: string
@@ -216,22 +217,22 @@ export function Onboarding() {
                   </div>
                   <span className="flex-1 text-foreground">{option}</span>
                   <div className="flex gap-1">
-                    <button
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       onClick={() => handleRankMove(index, 'up')}
                       disabled={index === 0}
-                      className="p-1.5 rounded hover:bg-purple-500/20 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                      icon={<ArrowUp className="w-4 h-4 text-muted-foreground" aria-hidden="true" />}
                       aria-label={`Move ${option} up`}
-                    >
-                      <ArrowUp className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
-                    </button>
-                    <button
+                    />
+                    <Button
+                      variant="ghost"
+                      size="sm"
                       onClick={() => handleRankMove(index, 'down')}
                       disabled={index === getRankedOrder().length - 1}
-                      className="p-1.5 rounded hover:bg-purple-500/20 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                      icon={<ArrowDown className="w-4 h-4 text-muted-foreground" aria-hidden="true" />}
                       aria-label={`Move ${option} down`}
-                    >
-                      <ArrowDown className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
-                    </button>
+                    />
                   </div>
                 </div>
               ))}
@@ -261,42 +262,37 @@ export function Onboarding() {
 
           {/* Navigation */}
           <div className="flex items-center justify-between mt-8">
-            <button
+            <Button
+              variant="ghost"
+              size="lg"
               onClick={handleBack}
               disabled={currentStep === 0}
-              className="flex items-center gap-2 px-4 py-2 text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              icon={<ChevronLeft className="w-4 h-4" />}
             >
-              <ChevronLeft className="w-4 h-4" />
               Back
-            </button>
+            </Button>
 
             {isLastStep ? (
-              <button
+              <Button
+                variant="primary"
+                size="lg"
                 onClick={handleComplete}
                 disabled={!canProceed || isSubmitting}
-                className="btn-primary flex items-center gap-2 disabled:opacity-50"
+                loading={isSubmitting}
+                iconRight={!isSubmitting ? <Check className="w-4 h-4" /> : undefined}
               >
-                {isSubmitting ? (
-                  <>
-                    <div className="spinner w-4 h-4" />
-                    Creating dashboard...
-                  </>
-                ) : (
-                  <>
-                    Complete Setup
-                    <Check className="w-4 h-4" />
-                  </>
-                )}
-              </button>
+                {isSubmitting ? 'Creating dashboard...' : 'Complete Setup'}
+              </Button>
             ) : (
-              <button
+              <Button
+                variant="primary"
+                size="lg"
                 onClick={handleNext}
                 disabled={!canProceed}
-                className="btn-primary flex items-center gap-2 disabled:opacity-50"
+                iconRight={<ChevronRight className="w-4 h-4" />}
               >
                 Continue
-                <ChevronRight className="w-4 h-4" />
-              </button>
+              </Button>
             )}
           </div>
         </div>

--- a/web/src/components/onboarding/Tour.tsx
+++ b/web/src/components/onboarding/Tour.tsx
@@ -5,6 +5,7 @@ import { cn } from '../../lib/cn'
 import { useTranslation } from 'react-i18next'
 import { TOOLTIP_POSITION_DELAY_MS } from '../../lib/constants/network'
 import { LogoWithStar } from '../ui/LogoWithStar'
+import { Button } from '../ui/Button'
 
 interface TooltipPosition {
   top?: number
@@ -378,13 +379,13 @@ export function TourOverlay() {
             </div>
             <h3 className="font-semibold text-foreground">{currentStep.title}</h3>
           </div>
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={skipTour}
-            className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground"
+            icon={<X className="w-4 h-4" aria-hidden="true" />}
             aria-label="Skip tour"
-          >
-            <X className="w-4 h-4" aria-hidden="true" />
-          </button>
+          />
         </div>
 
         {/* Content */}
@@ -412,27 +413,22 @@ export function TourOverlay() {
           {/* Navigation */}
           <div className="flex items-center gap-2">
             {currentStepIndex > 0 && (
-              <button
+              <Button
+                variant="ghost"
+                size="sm"
                 onClick={prevStep}
-                className="p-1.5 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+                icon={<ChevronLeft className="w-4 h-4" aria-hidden="true" />}
                 aria-label="Previous step"
-              >
-                <ChevronLeft className="w-4 h-4" aria-hidden="true" />
-              </button>
+              />
             )}
-            <button
+            <Button
+              variant="accent"
+              size="md"
               onClick={nextStep}
-              className="px-3 py-1.5 rounded-lg bg-purple-500 hover:bg-purple-600 text-foreground text-sm font-medium transition-colors flex items-center gap-1"
+              iconRight={currentStepIndex < totalSteps - 1 ? <ChevronRight className="w-4 h-4" /> : undefined}
             >
-              {currentStepIndex === totalSteps - 1 ? (
-                'Finish'
-              ) : (
-                <>
-                  Next
-                  <ChevronRight className="w-4 h-4" />
-                </>
-              )}
-            </button>
+              {currentStepIndex === totalSteps - 1 ? 'Finish' : 'Next'}
+            </Button>
           </div>
         </div>
 
@@ -454,19 +450,16 @@ export function TourTrigger() {
   const { startTour, hasCompletedTour } = useTour()
 
   return (
-    <button
+    <Button
+      variant={hasCompletedTour ? 'ghost' : 'accent'}
+      size="md"
       onClick={startTour}
-      className={cn(
-        'flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors',
-        hasCompletedTour
-          ? 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'
-          : 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 animate-pulse'
-      )}
+      icon={<LogoWithStar className="w-5 h-5" />}
+      className={cn(!hasCompletedTour && 'animate-pulse')}
       title="Take a tour"
     >
-      <LogoWithStar className="w-5 h-5" />
       {!hasCompletedTour && <span className="hidden xl:inline">Take the tour</span>}
-    </button>
+    </Button>
   )
 }
 

--- a/web/src/components/onboarding/__tests__/Onboarding.test.tsx
+++ b/web/src/components/onboarding/__tests__/Onboarding.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * Onboarding component smoke tests
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}))
+
+vi.mock('../../../lib/api', () => ({
+  api: { post: vi.fn() },
+}))
+
+vi.mock('../../../lib/auth', () => ({
+  useAuth: () => ({ user: { github_login: 'test' }, isAuthenticated: true }),
+}))
+
+/** Timeout for importing heavy modules */
+const IMPORT_TIMEOUT_MS = 30000
+
+describe('Onboarding', () => {
+  it('exports Onboarding component', async () => {
+    const mod = await import('../Onboarding')
+    expect(mod.Onboarding).toBeDefined()
+  }, IMPORT_TIMEOUT_MS)
+})

--- a/web/src/components/onboarding/__tests__/Tour.test.tsx
+++ b/web/src/components/onboarding/__tests__/Tour.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Tour component smoke tests
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
+vi.mock('../../../hooks/useTour', () => ({
+  useTour: () => ({
+    isActive: false,
+    currentStep: null,
+    currentStepIndex: 0,
+    totalSteps: 0,
+    nextStep: vi.fn(),
+    prevStep: vi.fn(),
+    skipTour: vi.fn(),
+    startTour: vi.fn(),
+    hasCompletedTour: false,
+  }),
+}))
+
+import { TourTrigger, TourPrompt } from '../Tour'
+
+describe('TourTrigger', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<TourTrigger />)
+    expect(container).toBeTruthy()
+  })
+})
+
+describe('TourPrompt', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<TourPrompt />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/rewards/__tests__/GitHubInvite.test.tsx
+++ b/web/src/components/rewards/__tests__/GitHubInvite.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * GitHubInvite component smoke tests
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
+vi.mock('../../../hooks/useRewards', () => ({
+  useRewards: () => ({
+    totalCoins: 0,
+    awardCoins: vi.fn(),
+    getActionCount: () => 0,
+  }),
+}))
+
+vi.mock('../../../lib/modals/useModalNavigation', () => ({
+  useModalNavigation: vi.fn(),
+  useModalFocusTrap: vi.fn(),
+}))
+
+import { GitHubInviteButton } from '../GitHubInvite'
+
+describe('GitHubInviteButton', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<GitHubInviteButton onClick={vi.fn()} />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/rewards/__tests__/LinkedInShare.test.tsx
+++ b/web/src/components/rewards/__tests__/LinkedInShare.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * LinkedInShare component smoke tests
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+  emitLinkedInShare: vi.fn(),
+}))
+
+vi.mock('../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
+vi.mock('../../../hooks/useRewards', () => ({
+  useRewards: () => ({
+    totalCoins: 0,
+    awardCoins: vi.fn(),
+    getActionCount: () => 0,
+  }),
+}))
+
+vi.mock('../../../lib/modals/useModalNavigation', () => ({
+  useModalNavigation: vi.fn(),
+  useModalFocusTrap: vi.fn(),
+}))
+
+import { LinkedInShareButton, LinkedInShareCard } from '../LinkedInShare'
+
+describe('LinkedInShareButton', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<LinkedInShareButton />)
+    expect(container).toBeTruthy()
+  })
+})
+
+describe('LinkedInShareCard', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<LinkedInShareCard />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/rewards/__tests__/RewardsPanel.test.tsx
+++ b/web/src/components/rewards/__tests__/RewardsPanel.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * RewardsPanel component smoke tests
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+  emitLinkedInShare: vi.fn(),
+}))
+
+vi.mock('../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
+vi.mock('../../../hooks/useRewards', () => ({
+  useRewards: () => ({
+    totalCoins: 0,
+    earnedAchievements: [],
+    recentEvents: [],
+    hasEarnedAction: () => false,
+    getActionCount: () => 0,
+    githubRewards: [],
+    githubPoints: 0,
+    refreshGitHubRewards: vi.fn(),
+  }),
+  REWARD_ACTIONS: [],
+  ACHIEVEMENTS: [],
+}))
+
+/** Timeout for importing heavy modules */
+const IMPORT_TIMEOUT_MS = 30000
+
+describe('RewardsPanel', () => {
+  it('exports RewardsPanel component', async () => {
+    const mod = await import('../RewardsPanel')
+    expect(mod.RewardsPanel).toBeDefined()
+  }, IMPORT_TIMEOUT_MS)
+})

--- a/web/src/components/settings/sections/__tests__/SlackNotificationSettings.test.tsx
+++ b/web/src/components/settings/sections/__tests__/SlackNotificationSettings.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * SlackNotificationSettings component smoke tests
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }),
+}))
+
+vi.mock('../../../../lib/demoMode', () => ({
+  isDemoMode: () => true, getDemoMode: () => true, isNetlifyDeployment: false,
+  isDemoModeForced: false, canToggleDemoMode: () => true, setDemoMode: vi.fn(),
+  toggleDemoMode: vi.fn(), subscribeDemoMode: () => () => {},
+  isDemoToken: () => true, hasRealToken: () => false, setDemoToken: vi.fn(),
+  isFeatureEnabled: () => true,
+}))
+
+vi.mock('../../../../hooks/useDemoMode', () => ({
+  getDemoMode: () => true, default: () => true,
+  useDemoMode: () => ({ isDemoMode: true, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  hasRealToken: () => false, isDemoModeForced: false, isNetlifyDeployment: false,
+  canToggleDemoMode: () => true, isDemoToken: () => true, setDemoToken: vi.fn(),
+  setGlobalDemoMode: vi.fn(),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitNavigate: vi.fn(), emitLogin: vi.fn(), emitEvent: vi.fn(), analyticsReady: Promise.resolve(),
+  emitAddCardModalOpened: vi.fn(), emitCardExpanded: vi.fn(), emitCardRefreshed: vi.fn(),
+}))
+
+vi.mock('../../../../hooks/useTokenUsage', () => ({
+  useTokenUsage: () => ({ usage: { total: 0, remaining: 0, used: 0 }, isLoading: false }),
+  tokenUsageTracker: { getUsage: () => ({ total: 0, remaining: 0, used: 0 }), trackRequest: vi.fn(), getSettings: () => ({ enabled: false }) },
+}))
+
+import { SlackNotificationSettings } from '../SlackNotificationSettings'
+
+describe('SlackNotificationSettings', () => {
+  it('renders without crashing', () => {
+    const { container } = render(
+      <SlackNotificationSettings
+        config={{
+          slackEnabled: false,
+          slackWebhookUrl: '',
+          slackChannel: '',
+          emailEnabled: false,
+          emailRecipients: '',
+          emailSmtpHost: '',
+          emailSmtpPort: 587,
+          emailFrom: '',
+          webhookEnabled: false,
+          webhookUrl: '',
+          webhookHeaders: {},
+          minSeverity: 'warning',
+          quietHoursEnabled: false,
+          quietHoursStart: '22:00',
+          quietHoursEnd: '08:00',
+          browserEnabled: false,
+        }}
+        updateConfig={vi.fn()}
+        testResult={null}
+        setTestResult={vi.fn()}
+        testNotification={vi.fn().mockResolvedValue({})}
+        isLoading={false}
+      />
+    )
+    expect(container).toBeTruthy()
+  })
+})

--- a/web/src/components/terminal/__tests__/PodExecTerminal.test.tsx
+++ b/web/src/components/terminal/__tests__/PodExecTerminal.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * PodExecTerminal component smoke tests
+ *
+ * PodExecTerminal depends on @xterm/xterm which requires a real DOM,
+ * so we verify the export exists rather than attempting a full render.
+ */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../../hooks/useExecSession', () => ({
+  useExecSession: () => ({
+    status: 'disconnected' as const,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    sendInput: vi.fn(),
+    sendResize: vi.fn(),
+    error: null,
+  }),
+}))
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    open: vi.fn(),
+    write: vi.fn(),
+    dispose: vi.fn(),
+    onData: vi.fn(),
+    onResize: vi.fn(),
+    loadAddon: vi.fn(),
+  })),
+}))
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({
+    fit: vi.fn(),
+    dispose: vi.fn(),
+  })),
+}))
+
+/** Timeout for importing heavy modules */
+const IMPORT_TIMEOUT_MS = 30000
+
+describe('PodExecTerminal', () => {
+  it('exports PodExecTerminal component', async () => {
+    const mod = await import('../PodExecTerminal')
+    expect(mod.PodExecTerminal).toBeDefined()
+  }, IMPORT_TIMEOUT_MS)
+})


### PR DESCRIPTION
## Summary
- **#4164 (Inconsistent patterns)**: Replaced raw `<button>` elements in `Tour.tsx` (4 buttons) and `Onboarding.tsx` (4 buttons) with the shared `Button` component for consistent styling and behavior
- **#4168 (Missing test coverage)**: Added smoke tests for 12 untested components: Tour, Onboarding, CardHistory, HelmReleases, Deployments, RewardsPanel, GitHubInvite, LinkedInShare, CommandLineTab, ImportTab, PodExecTerminal, SlackNotificationSettings
- **#4162 (ROADMAP.md)**: False positive — the ROADMAP.md already contains all required sections (Near-Term, Mid-Term, Long-Term, Non-Goals). Will close with comment.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 14 new tests pass (`npx vitest run`)
- [ ] CI build/lint pass

Closes #4164
Closes #4168