### PR TITLE
🐛 Fix coverage: every 2 hours, never cancel

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -5,12 +5,12 @@ name: Hourly Coverage Suite
 
 on:
   schedule:
-    - cron: '15 * * * *'  # Every hour at :15
+    - cron: '15 */2 * * *'  # Every 2 hours at :15 (run takes ~25 min)
   workflow_dispatch:
 
 concurrency:
   group: coverage-hourly
-  cancel-in-progress: true
+  cancel-in-progress: false  # Never cancel — let runs complete
 
 permissions:
   contents: read


### PR DESCRIPTION
Hourly cron cancelled the previous run at 25 min (just before completion). Changed to every 2 hours with cancel-in-progress: false.