### PR TITLE
🐛 Run coverage merge even if some shards fail

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -59,7 +59,7 @@ jobs:
   # Merge shards and update badge
   merge-coverage:
     needs: test-shard
-    if: github.repository == 'kubestellar/console'
+    if: always() && github.repository == 'kubestellar/console'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
Merge job was skipped because shard 3 got cancelled. Added always() so partial coverage still updates the badge.