### PR TITLE
🐛 Address Copilot comments: tour a11y, GPU threshold scope, coverage workflow

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -59,7 +59,7 @@ jobs:
   # Merge shards and update badge
   merge-coverage:
     needs: test-shard
-    if: always() && github.repository == 'kubestellar/console'
+    if: "!cancelled() && needs.test-shard.result == 'success' && github.repository == 'kubestellar/console'"
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -154,6 +154,8 @@ let nodesCache: NodeData[] = []
 let nodesCacheTimestamp = 0
 let nodesFetchInProgress = false
 const NODES_CACHE_TTL = 30000 // 30 seconds
+/** Cluster-level GPU allocation threshold — flag when >80% of a cluster's GPUs are allocated */
+const GPU_CLUSTER_EXHAUSTION_THRESHOLD = 0.8
 const nodesSubscribers = new Set<(nodes: NodeData[]) => void>()
 
 function notifyNodesSubscribers() {
@@ -420,9 +422,8 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
       }
     })
 
-    // 3. Cluster-level GPU exhaustion — only flag when 80%+ of a cluster's
+    // 3. Cluster-level GPU exhaustion — only flag when >80% of a cluster's
     // total GPUs are allocated. Individual nodes at 100% is normal utilization.
-    const GPU_CLUSTER_EXHAUSTION_THRESHOLD = 0.8
     const filteredGpuNodes = isAllClustersSelected
       ? gpuNodes
       : gpuNodes.filter(n => selectedClusters.includes(n.cluster))
@@ -453,7 +454,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
           source: 'heuristic',
         })
       } else if (gpus.total > 0 && gpus.allocated / gpus.total > GPU_CLUSTER_EXHAUSTION_THRESHOLD) {
-        // Flag cluster-level near-exhaustion (80%+ allocated)
+        // Flag cluster-level near-exhaustion (>80% allocated)
         const pct = Math.round((gpus.allocated / gpus.total) * 100)
         risks.push({
           id: generatePredictionId('gpu-exhaustion', cluster, cluster),

--- a/web/src/components/onboarding/Tour.tsx
+++ b/web/src/components/onboarding/Tour.tsx
@@ -457,6 +457,7 @@ export function TourTrigger() {
       icon={<LogoWithStar className="w-5 h-5" />}
       className={cn(!hasCompletedTour && 'animate-pulse')}
       title="Take a tour"
+      aria-label="Take a tour"
     >
       {!hasCompletedTour && <span className="hidden xl:inline">Take the tour</span>}
     </Button>


### PR DESCRIPTION
Addresses comments from PRs #4172, #4185: tour button aria-label, hoisted GPU constant with fixed comments, coverage merge-job only runs on shard success.