### PR TITLE
🐛 Fix Auto-QA batch 2: route constants + Copilot 404 handling

### DIFF
--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -4661,9 +4661,15 @@ jobs:
                   ? ' — CONSOLE_AUTO PAT may be expired (check repo secrets)'
                   : e.status === 403
                   ? ' — token may lack repo scope or Copilot agent is not enabled'
+                  : e.status === 404
+                  ? ' — Copilot coding agent may not be enabled for this repo (check GitHub Copilot settings)'
                   : '';
                 core.warning(`Could not assign Copilot to #${issue.number}: ${e.message}${hint}`);
-                rejections.push({ issueNumber: issue.number, status: e.status || 'unknown', message: e.message });
+                // Only track as rejection if it's a rate-limit or auth issue (429/401/403).
+                // 404 means the Copilot agent endpoint doesn't exist — not a rate limit problem.
+                if (e.status !== 404) {
+                  rejections.push({ issueNumber: issue.number, status: e.status || 'unknown', message: e.message });
+                }
               }
               if (!check.bonus) {
                 created++;

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, Suspense, lazy, useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useLocation } from 'react-router-dom'
+import { ROUTES } from '../../config/routes'
 import { Box, Wifi, WifiOff, X, Settings, Rocket, RotateCcw, Check, Loader2, RefreshCw, Plug } from 'lucide-react'
 import { Button } from '../ui/Button'
 import { Navbar } from './navbar/index'
@@ -461,7 +462,7 @@ export function Layout({ children }: LayoutProps) {
             </div>
             <div className="flex items-center gap-2 shrink-0">
               <Link
-                to="/settings"
+                to={ROUTES.SETTINGS}
                 className="flex items-center gap-1 text-xs px-2 py-0.5 bg-orange-500/20 hover:bg-orange-500/30 text-orange-400 rounded transition-colors whitespace-nowrap"
               >
                 <Settings className="w-3 h-3" />

--- a/web/src/components/modals/sections/AIActionBar.tsx
+++ b/web/src/components/modals/sections/AIActionBar.tsx
@@ -1,5 +1,6 @@
 import { Bot, Settings } from 'lucide-react'
 import { Link } from 'react-router-dom'
+import { ROUTES } from '../../../config/routes'
 import { useMissions } from '../../../hooks/useMissions'
 import type { AIAction, ResourceContext } from '../types/modal.types'
 import { useTranslation } from 'react-i18next'
@@ -108,7 +109,7 @@ export function AIActionBar({
 
         {!isAgentConnected && (
           <Link
-            to="/settings"
+            to={ROUTES.SETTINGS}
             className="flex items-center gap-1 text-xs text-yellow-400 hover:text-yellow-300 transition-colors"
             title="Configure AI agent"
           >
@@ -150,7 +151,7 @@ export function AIActionBar({
       {!isAgentConnected && (
         <p className="mt-2 text-xs text-muted-foreground">
           Connect the local agent to enable AI features.{' '}
-          <Link to="/settings" className="text-purple-400 hover:text-purple-300">
+          <Link to={ROUTES.SETTINGS} className="text-purple-400 hover:text-purple-300">
             Configure →
           </Link>
         </p>

--- a/web/src/pages/FeatureKagent.tsx
+++ b/web/src/pages/FeatureKagent.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { Link } from 'react-router-dom'
+import { ROUTES } from '../config/routes'
 import {
   ArrowRight,
   ExternalLink,
@@ -114,7 +115,7 @@ export function FeatureKagent() {
           </p>
           <div className="flex items-center justify-center gap-4">
             <Link
-              to="/settings"
+              to={ROUTES.SETTINGS}
               className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-purple-500 text-white font-medium hover:bg-purple-600 transition-colors"
             >
               Configure in Settings
@@ -178,7 +179,7 @@ export function FeatureKagent() {
       <section className="max-w-4xl mx-auto px-6 py-16 text-center">
         <div className="flex items-center justify-center gap-4 flex-wrap">
           <Link
-            to="/settings"
+            to={ROUTES.SETTINGS}
             className="inline-flex items-center gap-2 px-8 py-4 rounded-lg bg-purple-500 text-white font-medium text-lg hover:bg-purple-600 transition-colors"
           >
             <Sparkles className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- **#4191 (Navigation)**: Replace hardcoded `"/settings"` link paths with `ROUTES.SETTINGS` constant in `FeatureKagent.tsx`, `AIActionBar.tsx`, and `Layout.tsx`. Other findings (external link attributes, back navigation, route constants file) are false positives — the codebase already has all of these.
- **#4193 (Efficiency)**: Close as false positive — all `import *` findings are in test files only (not production-bundled, tree-shaking is irrelevant). The inline style/arrow function counts are generic without actionable specifics.
- **#4195 (Copilot assignment)**: Add 404-specific error hint in auto-qa workflow and skip creating diagnostic issues for 404 errors (which indicate Copilot agent isn't enabled, not a rate limit problem).

Closes #4191, closes #4193, closes #4195

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Lint clean on changed files (pre-existing errors in Layout.tsx unrelated to this change)