### PR TITLE
🐛 Fix 5 bugs: Falco demo, screenshot preview, deployment mismatch, ArgoCD demo, cluster reachability

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -190,6 +192,8 @@ type ClusterHealth struct {
 	// PVC metrics
 	PVCCount      int `json:"pvcCount,omitempty"`      // Total PVC count
 	PVCBoundCount int `json:"pvcBoundCount,omitempty"` // Bound PVC count
+	// External reachability — TCP probe to the API server URL from this host (#4202)
+	ExternallyReachable *bool `json:"externallyReachable,omitempty"`
 	// Issues and timing
 	Issues    []string `json:"issues,omitempty"`
 	CheckedAt string   `json:"checkedAt,omitempty"`
@@ -1537,6 +1541,22 @@ func (m *MultiClusterClient) GetClusterHealth(ctx context.Context, contextName s
 		health.PVCBoundCount = prevCached.PVCBoundCount
 	}
 
+	// Populate the API server URL from the REST config for the frontend to display.
+	// Also run an external TCP probe to distinguish internal-only vs external reachability (#4202).
+	if health.Reachable {
+		m.mu.RLock()
+		cfg := m.configs[contextName]
+		m.mu.RUnlock()
+		if cfg != nil && cfg.Host != "" {
+			health.APIServer = cfg.Host
+			reachable := probeAPIServer(cfg.Host)
+			health.ExternallyReachable = &reachable
+			if !reachable {
+				health.Issues = append(health.Issues, "API server externally unreachable (TCP probe failed)")
+			}
+		}
+	}
+
 	// Only cache successful results — don't cache failures (timeout, context canceled)
 	// so the next request retries immediately instead of serving stale errors
 	if health.Reachable {
@@ -1547,6 +1567,39 @@ func (m *MultiClusterClient) GetClusterHealth(ctx context.Context, contextName s
 	}
 
 	return health, nil
+}
+
+// probeAPIServer performs a lightweight TCP dial to the API server URL to verify
+// external reachability. The kc-agent can reach clusters via internal networking
+// or VPN, but users/CI runners may not be able to (#4202).
+func probeAPIServer(host string) bool {
+	// Parse the URL to extract host:port.
+	// rest.Config.Host can be a bare "host:port" or a full URL "https://host:port".
+	addr := host
+	if strings.Contains(host, "://") {
+		parsed, err := url.Parse(host)
+		if err != nil {
+			return false
+		}
+		port := parsed.Port()
+		if port == "" {
+			if parsed.Scheme == "https" {
+				port = "443"
+			} else {
+				port = "80"
+			}
+		}
+		addr = net.JoinHostPort(parsed.Hostname(), port)
+	} else if !strings.Contains(host, ":") {
+		addr = net.JoinHostPort(host, "443")
+	}
+
+	conn, err := net.DialTimeout("tcp", addr, clusterProbeTimeout)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
 }
 
 // GetPods returns pods for a namespace/cluster

--- a/web/src/components/cards/ArgoCDApplications.tsx
+++ b/web/src/components/cards/ArgoCDApplications.tsx
@@ -226,19 +226,21 @@ function ArgoCDApplicationsInternal({ config }: ArgoCDApplicationsProps) {
         </div>
       </div>
 
-      {/* Integration notice */}
-      <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-orange-500/10 border border-orange-500/20 text-xs">
-        <AlertCircle className="w-4 h-4 text-orange-400 flex-shrink-0 mt-0.5" />
-        <div>
-          <p className="text-orange-400 font-medium">{t('argoCDApplications.argocdIntegration')}</p>
-          <p className="text-muted-foreground">
-            {t('argoCDApplications.installArgoCD')}{' '}
-            <a href="https://argo-cd.readthedocs.io/en/stable/getting_started/" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline inline-block py-2">
-              {t('argoCDApplications.installGuide')}
-            </a>
-          </p>
+      {/* Integration notice — only shown in demo/fallback mode (#4201) */}
+      {isDemoData && (
+        <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-orange-500/10 border border-orange-500/20 text-xs">
+          <AlertCircle className="w-4 h-4 text-orange-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-orange-400 font-medium">{t('argoCDApplications.argocdIntegration')}</p>
+            <p className="text-muted-foreground">
+              {t('argoCDApplications.installArgoCD')}{' '}
+              <a href="https://argo-cd.readthedocs.io/en/stable/getting_started/" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline inline-block py-2">
+                {t('argoCDApplications.installGuide')}
+              </a>
+            </p>
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Local Search */}
       <CardSearchInput

--- a/web/src/components/cards/ArgoCDHealth.tsx
+++ b/web/src/components/cards/ArgoCDHealth.tsx
@@ -93,19 +93,21 @@ export function ArgoCDHealth({ config: _config }: ArgoCDHealthProps) {
         </div>
       </div>
 
-      {/* Integration notice */}
-      <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-orange-500/10 border border-orange-500/20 text-xs">
-        <AlertCircle className="w-4 h-4 text-orange-400 flex-shrink-0 mt-0.5" />
-        <div>
-          <p className="text-orange-400 font-medium">{t('argoCDHealth.argocdIntegration')}</p>
-          <p className="text-muted-foreground">
-            {t('argoCDHealth.installArgoCD')}{' '}
-            <a href="https://argo-cd.readthedocs.io/en/stable/getting_started/" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline inline-block py-2">
-              {t('argoCDHealth.installGuide')}
-            </a>
-          </p>
+      {/* Integration notice — only shown in demo/fallback mode (#4201) */}
+      {isDemoData && (
+        <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-orange-500/10 border border-orange-500/20 text-xs">
+          <AlertCircle className="w-4 h-4 text-orange-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-orange-400 font-medium">{t('argoCDHealth.argocdIntegration')}</p>
+            <p className="text-muted-foreground">
+              {t('argoCDHealth.installArgoCD')}{' '}
+              <a href="https://argo-cd.readthedocs.io/en/stable/getting_started/" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline inline-block py-2">
+                {t('argoCDHealth.installGuide')}
+              </a>
+            </p>
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Health gauge */}
       <div className="flex items-center justify-center gap-4 mb-4 p-4 rounded-lg bg-secondary/30">

--- a/web/src/components/cards/ArgoCDSyncStatus.tsx
+++ b/web/src/components/cards/ArgoCDSyncStatus.tsx
@@ -112,19 +112,21 @@ export function ArgoCDSyncStatus({ config: _config }: ArgoCDSyncStatusProps) {
         </div>
       </div>
 
-      {/* Integration notice */}
-      <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-orange-500/10 border border-orange-500/20 text-xs">
-        <AlertCircle className="w-4 h-4 text-orange-400 flex-shrink-0 mt-0.5" />
-        <div>
-          <p className="text-orange-400 font-medium">{t('argoCDSyncStatus.argocdIntegration')}</p>
-          <p className="text-muted-foreground">
-            {t('argoCDSyncStatus.installArgoCD')}{' '}
-            <a href="https://argo-cd.readthedocs.io/en/stable/getting_started/" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline inline-block py-2">
-              {t('argoCDSyncStatus.installGuide')}
-            </a>
-          </p>
+      {/* Integration notice — only shown in demo/fallback mode (#4201) */}
+      {isDemoData && (
+        <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-orange-500/10 border border-orange-500/20 text-xs">
+          <AlertCircle className="w-4 h-4 text-orange-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-orange-400 font-medium">{t('argoCDSyncStatus.argocdIntegration')}</p>
+            <p className="text-muted-foreground">
+              {t('argoCDSyncStatus.installArgoCD')}{' '}
+              <a href="https://argo-cd.readthedocs.io/en/stable/getting_started/" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline inline-block py-2">
+                {t('argoCDSyncStatus.installGuide')}
+              </a>
+            </p>
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Donut chart placeholder */}
       <div className="flex justify-center mb-4">

--- a/web/src/components/cards/ClusterHealth.tsx
+++ b/web/src/components/cards/ClusterHealth.tsx
@@ -352,6 +352,16 @@ export function ClusterHealth() {
                   <CloudProviderIcon provider={provider} size={14} />
                 </span>
                 <span className="text-sm text-foreground truncate">{cluster.name}</span>
+                {/* Warn when cluster is internally reachable but API server is externally unreachable (#4202) */}
+                {!clusterUnreachable && !clusterLoading && cluster.externallyReachable === false && (
+                  <span
+                    className="flex items-center gap-0.5 text-2xs px-1.5 py-0.5 rounded bg-yellow-500/15 text-yellow-400 border border-yellow-500/20 shrink-0"
+                    title="API server externally unreachable — cluster healthy internally but external access may be blocked"
+                  >
+                    <WifiOff className="w-3 h-3" />
+                    <span className="hidden sm:inline">ext. unreachable</span>
+                  </span>
+                )}
                 {consoleUrl && (
                   <a
                     href={consoleUrl}

--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -11,6 +11,7 @@ import { AlertTriangle, AlertCircle, Shield, ExternalLink, Info, Loader2, Chevro
 import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
+import { useDemoMode } from '../../hooks/useDemoMode'
 import { useTrivy } from '../../hooks/useTrivy'
 import { useKubescape } from '../../hooks/useKubescape'
 import { useKyverno } from '../../hooks/useKyverno'
@@ -97,36 +98,55 @@ Please help me install one or both of these tools:
 
 Please install at least one tool and verify it is producing scan results.`
 
-// ── Falco (still static — no hook yet) ──────────────────────────────────
+// ── Falco (static demo data — no live hook yet) ───────────────────────
 
 export function FalcoAlerts({ config: _config }: CardConfig) {
-  useCardLoadingState({ isLoading: false, hasAnyData: true, isDemoData: true })
+  const { isDemoMode } = useDemoMode()
+
+  // Falco has no live data hook yet so isDemoData is always true.
+  // However, we still gate the demo content on isDemoMode so the card
+  // correctly shows an empty / install-prompt state when a real agent
+  // is connected but Falco is not installed.
+  const showDemo = isDemoMode
+  useCardLoadingState({ isLoading: false, hasAnyData: showDemo, isDemoData: showDemo })
+
   const demoAlerts = [
     { severity: 'critical', message: 'Container escape attempt detected', time: '2m ago' },
     { severity: 'warning', message: 'Privileged pod spawned', time: '15m ago' },
     { severity: 'info', message: 'Shell spawned in container', time: '1h ago' },
   ]
 
-  return (
-    <div className="space-y-3">
-      <div className="flex items-start gap-2 p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 text-xs">
-        <AlertCircle className="w-4 h-4 text-purple-400 flex-shrink-0 mt-0.5" />
-        <div>
-          <p className="text-purple-400 font-medium">Falco Integration</p>
-          <p className="text-muted-foreground">
-            Install Falco for runtime security monitoring.{' '}
-            <a
-              href="https://falco.org/docs/install-operate/installation/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-purple-400 hover:underline"
-            >
-              Install guide →
-            </a>
-          </p>
+  if (!showDemo) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-start gap-2 p-2 rounded-lg bg-purple-500/10 border border-purple-500/20 text-xs">
+          <AlertCircle className="w-4 h-4 text-purple-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-purple-400 font-medium">Falco Integration</p>
+            <p className="text-muted-foreground">
+              Install Falco for runtime security monitoring.{' '}
+              <a
+                href="https://falco.org/docs/install-operate/installation/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-purple-400 hover:underline"
+              >
+                Install guide &rarr;
+              </a>
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-col items-center justify-center py-4 text-muted-foreground text-sm">
+          <Shield className="w-6 h-6 mb-2 text-purple-400/50" />
+          <p>No Falco alerts available</p>
+          <p className="text-xs mt-1">Install Falco to see runtime security alerts</p>
         </div>
       </div>
+    )
+  }
 
+  return (
+    <div className="space-y-3">
       <div className="space-y-2">
         {demoAlerts.map((alert, i) => (
           <div

--- a/web/src/components/drilldown/views/DeploymentDrillDown.tsx
+++ b/web/src/components/drilldown/views/DeploymentDrillDown.tsx
@@ -113,8 +113,12 @@ export function DeploymentDrillDown({ data }: Props) {
   const [scaleError, setScaleError] = useState<string | null>(null)
   const { checkPermission } = useCanI()
 
-  const reason = data.reason as string
-  const message = data.message as string
+  // Track reason/message from the initial click payload but reconcile with
+  // live data: if the live fetch shows the deployment is now healthy
+  // (readyReplicas === replicas), clear stale failure reason/message to
+  // prevent the contradictory "Healthy + DeploymentFailed" display (#4200).
+  const [liveReason, setLiveReason] = useState<string | undefined>(data.reason as string | undefined)
+  const [liveMessage, setLiveMessage] = useState<string | undefined>(data.message as string | undefined)
 
   // Helper to run kubectl commands
   const runKubectl = (args: string[]): Promise<string> => {
@@ -166,9 +170,32 @@ export function DeploymentDrillDown({ data }: Props) {
       const output = await runKubectl(['get', 'deployment', deploymentName, '-n', namespace, '-o', 'json'])
       if (output) {
         const deploy = JSON.parse(output)
-        setReplicas(deploy.spec?.replicas || 0)
-        setReadyReplicas(deploy.status?.readyReplicas || 0)
+        const liveReplicas = deploy.spec?.replicas || 0
+        const liveReady = deploy.status?.readyReplicas || 0
+        setReplicas(liveReplicas)
+        setReadyReplicas(liveReady)
         setLabels(deploy.metadata?.labels || {})
+
+        // Reconcile reason/message with live state (#4200):
+        // If live data shows healthy, clear the stale failure reason/message.
+        // If still unhealthy, derive reason from deployment conditions.
+        if (liveReady === liveReplicas && liveReplicas > 0) {
+          setLiveReason(undefined)
+          setLiveMessage(undefined)
+        } else {
+          // Extract current condition from the deployment status
+          const conditions = (deploy.status?.conditions || []) as Array<{ type: string; status: string; reason?: string; message?: string }>
+          const failedCondition = conditions.find(
+            (c: { type: string; status: string }) =>
+              (c.type === 'Available' && c.status === 'False') ||
+              (c.type === 'Progressing' && c.status === 'False') ||
+              (c.type === 'ReplicaFailure' && c.status === 'True')
+          )
+          if (failedCondition) {
+            setLiveReason(failedCondition.reason || liveReason)
+            setLiveMessage(failedCondition.message || liveMessage)
+          }
+        }
 
         // Get ReplicaSets using the deployment's actual selector (matchLabels + matchExpressions)
         const rsSelector = buildLabelSelector(
@@ -415,7 +442,7 @@ export function DeploymentDrillDown({ data }: Props) {
                     <div className="text-lg font-semibold text-foreground">
                       {isHealthy ? 'Healthy' : 'Degraded'}
                     </div>
-                    {reason && <div className="text-sm text-muted-foreground">{reason}</div>}
+                    {liveReason && <div className="text-sm text-muted-foreground">{liveReason}</div>}
                   </div>
                 </div>
                 <div className="flex items-center gap-4">
@@ -431,8 +458,8 @@ export function DeploymentDrillDown({ data }: Props) {
                   </div>
                 </div>
               </div>
-              {message && (
-                <div className="mt-3 p-2 rounded bg-card/50 text-sm text-muted-foreground">{message}</div>
+              {liveMessage && (
+                <div className="mt-3 p-2 rounded bg-card/50 text-sm text-muted-foreground">{liveMessage}</div>
               )}
             </div>
 

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -129,8 +129,10 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
   const [isDragOver, setIsDragOver] = useState(false)
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null)
   const [isPreviewFullscreen, setIsPreviewFullscreen] = useState(false)
+  const [previewImageSrc, setPreviewImageSrc] = useState<string | null>(null)
   const screenshotInputRef = useRef<HTMLInputElement>(null)
   const fullscreenOverlayRef = useRef<HTMLDivElement>(null)
+  const screenshotPreviewRef = useRef<HTMLDivElement>(null)
 
   // Close fullscreen preview on Escape key
   const handleFullscreenKeyDown = useCallback((e: KeyboardEvent) => {
@@ -1457,6 +1459,15 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
                           <div className="absolute inset-0 flex items-center justify-center gap-1 opacity-0 group-hover:opacity-100 bg-black/60 rounded-lg transition-opacity">
                             <button
                               type="button"
+                              onClick={e => { e.stopPropagation(); setPreviewImageSrc(s.preview) }}
+                              className="p-1.5 rounded-md bg-secondary/80 text-foreground hover:bg-secondary transition-colors"
+                              title="Preview screenshot"
+                              aria-label="Preview screenshot"
+                            >
+                              <Eye className="w-3.5 h-3.5" />
+                            </button>
+                            <button
+                              type="button"
                               onClick={e => { e.stopPropagation(); void copyScreenshotToClipboard(s.preview, i) }}
                               className="p-1.5 rounded-md bg-secondary/80 text-foreground hover:bg-secondary transition-colors"
                               title="Copy to clipboard"
@@ -1623,6 +1634,51 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
               <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
                 {description}
               </ReactMarkdown>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Screenshot image preview overlay */}
+      {previewImageSrc && (
+        <div
+          ref={screenshotPreviewRef}
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === screenshotPreviewRef.current) {
+              setPreviewImageSrc(null)
+            }
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              setPreviewImageSrc(null)
+            }
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Screenshot preview"
+        >
+          <div className="relative max-w-[90vw] max-h-[85vh] bg-background border border-border rounded-xl shadow-2xl flex flex-col">
+            <div className="flex items-center justify-between px-5 py-3 border-b border-border">
+              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <Maximize2 className="w-4 h-4" />
+                Screenshot Preview
+              </div>
+              <button
+                type="button"
+                onClick={() => setPreviewImageSrc(null)}
+                className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary/80 transition-colors"
+                aria-label="Close screenshot preview"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+            <div className="flex-1 overflow-auto p-4 flex items-center justify-center">
+              <img
+                src={previewImageSrc}
+                alt="Screenshot preview"
+                className="max-w-full max-h-[75vh] object-contain rounded-lg"
+              />
             </div>
           </div>
         </div>

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1115,6 +1115,8 @@ async function processClusterHealth(cluster: ClusterInfo): Promise<void> {
           // healthy: true means all nodes are ready; false means some aren't ready but cluster is reachable
           healthy: hasValidData ? health.healthy : false,
           reachable: true,  // We definitely reached the cluster if we have data
+          // External reachability probe result (#4202)
+          externallyReachable: health.externallyReachable,
           nodeCount: health.nodeCount,
           podCount: health.podCount,
           cpuCores: health.cpuCores,

--- a/web/src/hooks/mcp/types.ts
+++ b/web/src/hooks/mcp/types.ts
@@ -32,6 +32,9 @@ export interface ClusterInfo {
   authMethod?: 'exec' | 'token' | 'certificate' | 'auth-provider' | 'unknown'
   // Reachability fields (from health check)
   reachable?: boolean
+  /** External TCP probe result — false when the API server is internally reachable
+   *  but not reachable from outside (e.g. external network outage) (#4202). */
+  externallyReachable?: boolean
   lastSeen?: string
   errorType?: 'timeout' | 'auth' | 'network' | 'certificate' | 'unknown'
   errorMessage?: string
@@ -77,6 +80,9 @@ export interface ClusterHealth {
   issues?: string[]
   // Fields for reachability
   reachable?: boolean
+  /** External TCP probe result — false when the API server is internally reachable
+   *  but not reachable from outside (e.g. external network outage) (#4202). */
+  externallyReachable?: boolean
   lastSeen?: string
   errorType?: 'timeout' | 'auth' | 'network' | 'certificate' | 'unknown'
   errorMessage?: string

--- a/web/src/hooks/useArgoCD.ts
+++ b/web/src/hooks/useArgoCD.ts
@@ -368,19 +368,21 @@ export function useArgoCDApplications(): UseArgoCDApplicationsResult {
       // Try real API first
       const result = await fetchArgoApplications()
 
-      if (!result.isDemoData && (result.items || []).length > 0) {
-        // Real data from ArgoCD
-        setApplications(result.items)
+      if (!result.isDemoData) {
+        // Real data from ArgoCD — use it even if empty (ArgoCD installed
+        // but no applications deployed yet).  Previously an empty list
+        // was treated as "no ArgoCD" which triggered mock fallback (#4201).
+        setApplications(result.items || [])
         setIsDemoData(false)
         setError(null)
         setConsecutiveFailures(0)
         setLastRefresh(Date.now())
         initialLoadDone.current = true
-        saveToCache(APPS_CACHE_KEY, result.items, false)
+        saveToCache(APPS_CACHE_KEY, result.items || [], false)
         return
       }
 
-      // API returned but no real data (ArgoCD not installed) — fall through to mock
+      // API explicitly indicated demo data — fall through to mock
       throw new Error('No ArgoCD data available')
     } catch {
       // API failed or returned demo indicator — fall back to mock data
@@ -493,18 +495,18 @@ export function useArgoCDHealth(): UseArgoCDHealthResult {
       const result = await fetchArgoHealth()
 
       if (!result.isDemoData) {
-        const total = result.stats.healthy + result.stats.degraded +
-          result.stats.progressing + result.stats.missing + result.stats.unknown
-        if (total > 0) {
-          setStats(result.stats)
-          setIsDemoData(false)
-          setError(null)
-          setConsecutiveFailures(0)
-          setLastRefresh(Date.now())
-          initialLoadDone.current = true
-          saveToCache(HEALTH_CACHE_KEY, result.stats, false)
-          return
-        }
+        // Real data from ArgoCD — use it even if totals are zero
+        // (ArgoCD installed but no applications yet).  Previously a
+        // zero total was treated as "no ArgoCD" which triggered mock
+        // fallback even when ArgoCD was running (#4201).
+        setStats(result.stats)
+        setIsDemoData(false)
+        setError(null)
+        setConsecutiveFailures(0)
+        setLastRefresh(Date.now())
+        initialLoadDone.current = true
+        saveToCache(HEALTH_CACHE_KEY, result.stats, false)
+        return
       }
 
       // No real data — fall through to mock
@@ -671,17 +673,15 @@ export function useArgoCDSyncStatus(localClusterFilter: string[] = []): UseArgoC
       const result = await fetchArgoSync()
 
       if (!result.isDemoData) {
-        const total = result.stats.synced + result.stats.outOfSync + result.stats.unknown
-        if (total > 0) {
-          setStats(result.stats)
-          setIsDemoData(false)
-          setError(null)
-          setConsecutiveFailures(0)
-          setLastRefresh(Date.now())
-          initialLoadDone.current = true
-          saveToCache(SYNC_CACHE_KEY, result.stats, false)
-          return
-        }
+        // Real data from ArgoCD — use it even if totals are zero (#4201).
+        setStats(result.stats)
+        setIsDemoData(false)
+        setError(null)
+        setConsecutiveFailures(0)
+        setLastRefresh(Date.now())
+        initialLoadDone.current = true
+        saveToCache(SYNC_CACHE_KEY, result.stats, false)
+        return
       }
 
       // No real data — fall through to mock


### PR DESCRIPTION
## Summary

Fixes 5 bug issues in a single batch:

- **#4198 - Falco Alerts shows demo data even when local agent is running**: FalcoAlerts now gates demo content on `isDemoMode` instead of always showing hardcoded demo alerts with `isDemoData: true`. When not in demo mode, shows install prompt and empty state.

- **#4199 - Add image preview button to feedback screenshot thumbnails**: Added Eye/preview button to screenshot thumbnails in the feedback modal. Clicking opens a fullscreen image overlay with the screenshot at full resolution. Overlay is dismissible via Escape key, close button, or backdrop click. Reuses existing `Maximize2` and `Eye` icons already imported.

- **#4200 - Deployment status mismatch between list and drilldown**: DeploymentDrillDown now reconciles `reason`/`message` with live kubectl data after fetching. When the live fetch shows the deployment is healthy (`readyReplicas === replicas`), stale failure `reason`/`message` from the click payload is cleared. When still unhealthy, reason is derived from the deployment's actual conditions.

- **#4201 - ArgoCD cards show Demo mode even when ArgoCD is deployed**: ArgoCD hooks (`useArgoCDApplications`, `useArgoCDHealth`, `useArgoCDSyncStatus`) no longer force mock fallback when the API returns empty items or zero totals with `isDemoData=false`. Previously, an empty result from a running ArgoCD was treated as "no ArgoCD" and triggered demo data. Integration banner in all three ArgoCD cards is now conditional on `isDemoData`.

- **#4202 - Console shows cluster as reachable when API server is externally unreachable**: Added external TCP probe (`probeAPIServer`) in the Go backend's `GetClusterHealth`. New `externallyReachable` field on `ClusterHealth` distinguishes internal vs external reachability. The ClusterHealth card shows a yellow "ext. unreachable" warning badge when the cluster is internally healthy but the API server TCP probe fails.

## Files changed

- `pkg/k8s/client.go` - External reachability TCP probe + new field
- `web/src/hooks/useArgoCD.ts` - Fix aggressive mock fallback
- `web/src/hooks/mcp/types.ts` - Add externallyReachable to types
- `web/src/hooks/mcp/shared.ts` - Pass through externallyReachable
- `web/src/components/cards/ComplianceCards.tsx` - FalcoAlerts demo gating
- `web/src/components/cards/ArgoCDApplications.tsx` - Conditional banner
- `web/src/components/cards/ArgoCDHealth.tsx` - Conditional banner
- `web/src/components/cards/ArgoCDSyncStatus.tsx` - Conditional banner
- `web/src/components/cards/ClusterHealth.tsx` - External unreachable badge
- `web/src/components/drilldown/views/DeploymentDrillDown.tsx` - Status reconciliation
- `web/src/components/feedback/FeatureRequestModal.tsx` - Screenshot preview

## Test plan

- [ ] Verify FalcoAlerts shows demo data only in demo mode, shows empty state otherwise
- [ ] Verify screenshot preview button appears on thumbnails in feedback modal
- [ ] Verify screenshot preview overlay opens/closes correctly (Escape, close button, backdrop)
- [ ] Verify deployment drilldown clears stale failure reason when live data shows healthy
- [ ] Verify ArgoCD cards show live data (not demo) when ArgoCD API returns isDemoData: false
- [ ] Verify ArgoCD integration banner is hidden when live data is available
- [ ] Verify ClusterHealth shows ext. unreachable badge when API server probe fails
- [ ] TypeScript builds cleanly (npx tsc --noEmit)
- [ ] Go builds cleanly (go build ./...)

Closes #4198, closes #4199, closes #4200, closes #4201, closes #4202