### PR TITLE
🐛 Fix false 'screenshot uploaded' message when upload fails

### DIFF
--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -153,7 +153,7 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 	}
 
 	// Create GitHub issue (route to the correct repo)
-	issueNumber, _, err := h.createGitHubIssueInRepo(request, user, h.repoOwner, targetRepoName, input.Screenshots)
+	issueNumber, _, ssResult, err := h.createGitHubIssueInRepo(request, user, h.repoOwner, targetRepoName, input.Screenshots)
 	if err != nil {
 		log.Printf("Failed to create GitHub issue: %v", err)
 		// Clean up the orphaned database record
@@ -181,7 +181,18 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 	}
 	h.store.CreateNotification(notification)
 
-	return c.Status(fiber.StatusCreated).JSON(request)
+	// Return the request with screenshot upload status so the frontend can
+	// display an accurate message instead of always claiming success.
+	type createResponse struct {
+		*models.FeatureRequest
+		ScreenshotsUploaded int `json:"screenshots_uploaded"`
+		ScreenshotsFailed   int `json:"screenshots_failed"`
+	}
+	return c.Status(fiber.StatusCreated).JSON(createResponse{
+		FeatureRequest:      request,
+		ScreenshotsUploaded: ssResult.Uploaded,
+		ScreenshotsFailed:   ssResult.Failed,
+	})
 }
 
 // ListFeatureRequests returns the user's feature requests
@@ -1515,7 +1526,14 @@ func (h *FeedbackHandler) handleDeploymentStatus(payload map[string]interface{})
 // If the initial request with labels fails due to insufficient label permissions
 // (HTTP 403 on the "label" resource), the function retries without labels so
 // the issue is still created. Labels can be added later by a maintainer.
-func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest, user *models.User, repoOwner, repoName string, screenshots []string) (int, string, error) {
+// screenshotUploadResult tracks the outcome of screenshot uploads so the
+// frontend can display an accurate status message instead of assuming success.
+type screenshotUploadResult struct {
+	Uploaded int `json:"screenshots_uploaded"`
+	Failed   int `json:"screenshots_failed"`
+}
+
+func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest, user *models.User, repoOwner, repoName string, screenshots []string) (int, string, screenshotUploadResult, error) {
 	// Determine labels based on request type and target repo
 	var labels []string
 	isDocs := request.TargetRepo == models.TargetRepoDocs
@@ -1545,14 +1563,21 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 
 	// Upload screenshots to GitHub and build markdown image references
 	screenshotMarkdown := ""
+	var ssResult screenshotUploadResult
 	if len(screenshots) > 0 {
 		var imageLines []string
 		for i, dataURI := range screenshots {
 			url, err := h.uploadScreenshotToGitHub(repoOwner, repoName, request.ID.String(), i, dataURI)
 			if err != nil {
+				ssResult.Failed++
 				log.Printf("[Feedback] Failed to upload screenshot %d: %v", i+1, err)
+				if strings.Contains(err.Error(), "404") {
+					log.Printf("[Feedback] Hint: a 404 from the GitHub Contents API usually means the token lacks 'Contents: Read and write' permission. "+
+						"Ensure FEEDBACK_GITHUB_TOKEN has this scope for %s/%s.", repoOwner, repoName)
+				}
 				continue
 			}
+			ssResult.Uploaded++
 			imageLines = append(imageLines, fmt.Sprintf("![Screenshot %d](%s)", i+1, url))
 		}
 		if len(imageLines) > 0 {
@@ -1585,7 +1610,7 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 		number, htmlURL, err = h.postGitHubIssue(repoOwner, repoName, request.Title, issueBody, nil)
 	}
 
-	return number, htmlURL, err
+	return number, htmlURL, ssResult, err
 }
 
 // postGitHubIssue sends a POST request to the GitHub Issues API.

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -115,7 +115,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
   const [description, setDescription] = useState('')
   const [descriptionTab, setDescriptionTab] = useState<'write' | 'preview'>('write')
   const [error, setError] = useState<string | null>(null)
-  const [success, setSuccess] = useState<{ issueUrl?: string } | null>(null)
+  const [success, setSuccess] = useState<{ issueUrl?: string; screenshotsUploaded?: number; screenshotsFailed?: number } | null>(null)
   const [confirmClose, setConfirmClose] = useState<string | null>(null) // request ID to confirm close
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
   const [actionLoading, setActionLoading] = useState<string | null>(null) // request ID being acted on
@@ -349,7 +349,11 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
         target_repo: targetRepo,
         ...(hasScreenshots && { screenshots: screenshotDataURIs }),
       }, hasScreenshots ? { timeout: FEEDBACK_UPLOAD_TIMEOUT_MS } : undefined)
-      setSuccess({ issueUrl: result.github_issue_url })
+      setSuccess({
+        issueUrl: result.github_issue_url,
+        screenshotsUploaded: result.screenshots_uploaded,
+        screenshotsFailed: result.screenshots_failed,
+      })
       // Keep the success state visible for 5s so users can read the confirmation and open the issue before switching to the Updates tab
       setTimeout(() => {
         setDescription('')
@@ -1240,13 +1244,27 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
                 </button>
               </div>
 
-              {/* Screenshot upload confirmation */}
-              {screenshots.length > 0 && (
+              {/* Screenshot upload status — show based on actual backend result */}
+              {screenshots.length > 0 && success && (success.screenshotsUploaded ?? 0) > 0 && (
                 <div className="mt-4 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
                   <p className="text-xs text-green-400 font-medium">
-                    {screenshots.length === 1
+                    {(success.screenshotsUploaded ?? 0) === 1
                       ? 'Screenshot uploaded and attached to the issue.'
-                      : `${screenshots.length} screenshots uploaded and attached to the issue.`}
+                      : `${success.screenshotsUploaded} screenshots uploaded and attached to the issue.`}
+                  </p>
+                </div>
+              )}
+              {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (success.screenshotsUploaded ?? 0) === 0 && (
+                <div className="mt-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+                  <p className="text-xs text-yellow-400 font-medium">
+                    Screenshot could not be uploaded. The issue was created without it. Check that the GitHub token has &quot;Contents: Read and write&quot; permission.
+                  </p>
+                </div>
+              )}
+              {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (success.screenshotsUploaded ?? 0) > 0 && (
+                <div className="mt-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+                  <p className="text-xs text-yellow-400 font-medium">
+                    {success.screenshotsUploaded} of {screenshots.length} screenshots uploaded. {success.screenshotsFailed} failed — check GitHub token permissions.
                   </p>
                 </div>
               )}

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -50,7 +50,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [success, setSuccess] = useState<{ issueUrl?: string } | null>(null)
+  const [success, setSuccess] = useState<{ issueUrl?: string; screenshotsUploaded?: number; screenshotsFailed?: number } | null>(null)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const { awardCoins } = useRewards()
   const [screenshots, setScreenshots] = useState<{ file: File; preview: string }[]>([])
@@ -221,7 +221,11 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
 
       // Clear draft on successful submit
       localStorage.removeItem(DRAFT_KEY)
-      setSuccess({ issueUrl: result.github_issue_url })
+      setSuccess({
+        issueUrl: result.github_issue_url,
+        screenshotsUploaded: result.screenshots_uploaded,
+        screenshotsFailed: result.screenshots_failed,
+      })
     } catch (err) {
       console.error('[Screenshot] Failed to submit feedback:', err)
       if (err instanceof Error) {
@@ -366,13 +370,27 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                 </a>
               )}
 
-              {/* Screenshot confirmation */}
-              {screenshots.length > 0 && (
+              {/* Screenshot upload status — show based on actual backend result */}
+              {screenshots.length > 0 && success && (success.screenshotsUploaded ?? 0) > 0 && (
                 <div className="mb-4 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
                   <p className="text-xs text-green-400 font-medium">
-                    {screenshots.length === 1
+                    {(success.screenshotsUploaded ?? 0) === 1
                       ? 'Screenshot uploaded and attached to the issue.'
-                      : `${screenshots.length} screenshots uploaded and attached to the issue.`}
+                      : `${success.screenshotsUploaded} screenshots uploaded and attached to the issue.`}
+                  </p>
+                </div>
+              )}
+              {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (success.screenshotsUploaded ?? 0) === 0 && (
+                <div className="mb-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+                  <p className="text-xs text-yellow-400 font-medium">
+                    Screenshot could not be uploaded. The issue was created without it. Check that the GitHub token has &quot;Contents: Read and write&quot; permission.
+                  </p>
+                </div>
+              )}
+              {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (success.screenshotsUploaded ?? 0) > 0 && (
+                <div className="mb-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+                  <p className="text-xs text-yellow-400 font-medium">
+                    {success.screenshotsUploaded} of {screenshots.length} screenshots uploaded. {success.screenshotsFailed} failed — check GitHub token permissions.
                   </p>
                 </div>
               )}

--- a/web/src/hooks/useFeatureRequests.ts
+++ b/web/src/hooks/useFeatureRequests.ts
@@ -41,6 +41,10 @@ export interface FeatureRequest {
   closed_by_user?: boolean
   created_at: string
   updated_at?: string
+  /** Number of screenshots successfully uploaded to GitHub (only in create response) */
+  screenshots_uploaded?: number
+  /** Number of screenshots that failed to upload (only in create response) */
+  screenshots_failed?: number
 }
 
 /** Check if a request has been triaged (accepted for review) */


### PR DESCRIPTION
## Summary

Fixes #4220

- **Backend**: `createGitHubIssueInRepo` now returns `screenshots_uploaded` and `screenshots_failed` counts in the create response. When upload fails with 404, logs a hint that the GitHub token likely needs `Contents: Read and write` permission.
- **Frontend**: Both `FeatureRequestModal` and `FeedbackModal` now use the backend response to display accurate screenshot status — green banner for success, yellow warning when uploads fail (with guidance to check token permissions). Previously, the UI always showed "Screenshot uploaded" based on local state regardless of backend result.

**Root cause**: The GitHub Contents API returns 404 when the token lacks `Contents: Read and write` permission (fine-grained PATs) or `repo`/`public_repo` scope (classic PATs). The Issues API works with just `Issues: Read and write`, so issue creation succeeds while screenshot upload silently fails.

## Test plan

- [ ] Submit feedback with a screenshot using a token that has Issues + Contents write permissions → green "Screenshot uploaded" banner
- [ ] Submit feedback with a screenshot using a token that only has Issues write (no Contents) → yellow warning banner saying upload failed
- [ ] Submit feedback without screenshots → no screenshot banner shown
- [ ] Check backend logs for the helpful hint message when 404 occurs