### PR TITLE
✨ Implement Mission Control dry-run mode

### DIFF
--- a/web/src/components/mission-control/LaunchSequence.tsx
+++ b/web/src/components/mission-control/LaunchSequence.tsx
@@ -111,13 +111,15 @@ export function LaunchSequence({
           project.kbPath ? [project.kbPath] : undefined,
         )
 
+        const dryRunPrefix = state.isDryRun ? '[DRY RUN] ' : ''
         const clusterContext = `\n\n**Target cluster:** ${clusterName}`
         const missionId = startMission({
-          title: `Install ${project.displayName}`,
-          description: `Automated install of ${project.displayName} as part of Mission Control deployment`,
+          title: `${dryRunPrefix}Install ${project.displayName}`,
+          description: `${state.isDryRun ? 'Dry-run validation' : 'Automated install'} of ${project.displayName} as part of Mission Control deployment`,
           type: 'deploy',
           cluster: clusterName,
           initialPrompt: prompt + clusterContext,
+          dryRun: state.isDryRun,
         })
 
         // Update with missionId
@@ -279,9 +281,9 @@ export function LaunchSequence({
         <h2 className="text-2xl font-bold">
           {allComplete
             ? allSuccess
-              ? 'Mission Complete!'
-              : 'Mission Completed with Issues'
-            : 'Launch Sequence In Progress'}
+              ? state.isDryRun ? 'Dry Run Complete!' : 'Mission Complete!'
+              : state.isDryRun ? 'Dry Run Completed with Issues' : 'Mission Completed with Issues'
+            : state.isDryRun ? 'Dry Run In Progress' : 'Launch Sequence In Progress'}
         </h2>
         <p className="text-sm text-muted-foreground mt-1">
           {allComplete

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -131,7 +131,14 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
                 <Rocket className="w-5 h-5" />
               </div>
               <div>
-                <h1 className="text-lg font-semibold">Mission Control</h1>
+                <div className="flex items-center gap-2">
+                  <h1 className="text-lg font-semibold">Mission Control</h1>
+                  {state.isDryRun && (
+                    <span className="px-2 py-0.5 text-2xs font-bold uppercase tracking-wider rounded bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
+                      DRY RUN
+                    </span>
+                  )}
+                </div>
                 <p className="text-xs text-muted-foreground">
                   Multi-Cluster Solutions Orchestrator
                 </p>
@@ -336,7 +343,10 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
                     <Button
                       variant="primary"
                       size="sm"
-                      onClick={() => mc.setPhase('launching')}
+                      onClick={() => {
+                        mc.setDryRun(false)
+                        mc.setPhase('launching')
+                      }}
                       className="bg-gradient-to-r from-violet-600 to-indigo-600 hover:from-violet-500 hover:to-indigo-500 text-white border-0 shadow-lg shadow-violet-500/25"
                       icon={<Rocket className="w-4 h-4" />}
                     >
@@ -345,7 +355,10 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
                     <Button
                       variant="secondary"
                       size="sm"
-                      onClick={() => showToast('Dry run mode is not yet available', 'info')}
+                      onClick={() => {
+                        mc.setDryRun(true)
+                        mc.setPhase('launching')
+                      }}
                       icon={<FlaskConical className="w-3.5 h-3.5" />}
                       title="Run against live clusters without deploying — report only"
                     >

--- a/web/src/components/mission-control/types.ts
+++ b/web/src/components/mission-control/types.ts
@@ -118,6 +118,8 @@ export interface MissionControlState {
   overlay: OverlayMode
   /** Whether to deploy all at once or phased */
   deployMode: 'phased' | 'yolo'
+  /** Whether to use server-side dry-run (no actual resource creation) */
+  isDryRun?: boolean
   /** AI planning mission ID (for the hidden conversation) */
   planningMissionId?: string
   /** Whether AI is currently streaming a response */

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -76,6 +76,7 @@ function makeInitialState(persisted?: Partial<MissionControlState> | null): Miss
     phases: persisted?.phases ?? [],
     overlay: persisted?.overlay ?? 'architecture',
     deployMode: persisted?.deployMode ?? 'phased',
+    isDryRun: persisted?.isDryRun ?? false,
     planningMissionId: persisted?.planningMissionId,
     aiStreaming: false,
     launchProgress: persisted?.launchProgress ?? [],
@@ -525,6 +526,10 @@ Order phases by dependency — prerequisites first. Each phase completes before 
     setState((prev) => ({ ...prev, deployMode }))
   }, [])
 
+  const setDryRun = useCallback((isDryRun: boolean) => {
+    setState((prev) => ({ ...prev, isDryRun }))
+  }, [])
+
   // ---------------------------------------------------------------------------
   // Launch
   // ---------------------------------------------------------------------------
@@ -753,6 +758,7 @@ Order phases by dependency — prerequisites first. Each phase completes before 
     setPhase,
     setOverlay,
     setDeployMode,
+    setDryRun,
     // Launch
     updateLaunchProgress,
     setGroundControlDashboardId,

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -118,6 +118,8 @@ interface StartMissionParams {
   cluster?: string
   initialPrompt: string
   context?: Record<string, unknown>
+  /** When true, injects --dry-run=server instructions into the prompt */
+  dryRun?: boolean
 }
 
 interface SaveMissionParams {
@@ -1019,6 +1021,19 @@ Install the console locally with the KubeStellar Console agent to use AI mission
       } else {
         enhancedPrompt = `Target clusters: ${clusterList.join(', ')}\nIMPORTANT: Perform the following on each cluster using their respective kubectl contexts.\n\n${enhancedPrompt}`
       }
+    }
+
+    // Inject dry-run instructions for server-side validation without actual changes
+    if (params.dryRun) {
+      enhancedPrompt += '\n\nCRITICAL — DRY RUN MODE:\n' +
+        'This is a DRY RUN deployment. You MUST NOT create, modify, or delete any actual resources.\n' +
+        'For every kubectl apply, create, or delete command, append --dry-run=server to perform server-side validation only.\n' +
+        'For every helm install or helm upgrade command, append --dry-run to simulate without installing.\n' +
+        'Report what WOULD be deployed, including:\n' +
+        '- Resources that would be created (with their kinds, names, and namespaces)\n' +
+        '- Any validation errors the server returns\n' +
+        '- Any missing prerequisites (CRDs, namespaces, RBAC)\n' +
+        'Conclude with a summary: "DRY RUN COMPLETE — N resources validated, M errors found."\n'
     }
 
     // Remind the agent that it runs in a non-interactive terminal (no stdin).


### PR DESCRIPTION
## Summary
- Wire the existing stub "Dry Run" button in Flight Plan to perform server-side validation (--dry-run=server) without creating actual resources
- Add `isDryRun` to `MissionControlState`, inject dry-run instructions into mission prompts, show `[DRY RUN]` prefix on mission titles and yellow badge in header
- Uses `--dry-run=server` (not `=client`) for server-side validation that catches missing CRDs, RBAC denials, and quota violations
- 5 files changed, 46 insertions, fully backward-compatible (optional field defaults to false)

## Test plan
- [x] `npm run build` passes
- [x] No new lint errors introduced
- [ ] Ignore Playwright failures in CI (per project convention)
- [ ] Manual test: Open Mission Control → Flight Plan → click "Dry Run" → verify `[DRY RUN]` prefix in mission titles and `--dry-run=server` in agent commands