### PR TITLE
🐛 Fix dismiss button not actually dismissing card recommendations

### DIFF
--- a/web/src/components/dashboard/CardRecommendations.tsx
+++ b/web/src/components/dashboard/CardRecommendations.tsx
@@ -136,8 +136,9 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
     setExpandedRec(null)
   }
 
-  const handleDismiss = (e: React.MouseEvent) => {
+  const handleDismiss = (e: React.MouseEvent, rec: CardRecommendation) => {
     e.stopPropagation()
+    dismissRecommendation(rec.id)
     setExpandedRec(null)
   }
 
@@ -242,7 +243,7 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
                           variant="secondary"
                           size="sm"
                           icon={<X className="w-3 h-3" />}
-                          onClick={handleDismiss}
+                          onClick={(e) => handleDismiss(e, rec)}
                           title={t('dashboard.recommendations.dismiss')}
                         />
                       </div>
@@ -374,7 +375,7 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
                         variant="secondary"
                         size="sm"
                         icon={<X className="w-3 h-3" />}
-                        onClick={handleDismiss}
+                        onClick={(e) => handleDismiss(e, rec)}
                         title={t('dashboard.recommendations.dismiss')}
                       />
                     </div>


### PR DESCRIPTION
## Summary

- Fixed `handleDismiss` in `CardRecommendations.tsx` to actually call `dismissRecommendation(rec.id)` before closing the dropdown
- Updated the handler signature to accept the `CardRecommendation` object, matching the pattern used by `handleSnooze`
- Updated both call sites (minimized and expanded views) to pass the recommendation to the handler

## What was wrong

The `handleDismiss` function only called `setExpandedRec(null)` to close the dropdown, but never called `dismissRecommendation()`. This meant clicking "Dismiss" would close the dropdown, but the recommendation chip would immediately reappear since it was never actually dismissed.

## What was changed

**File:** `web/src/components/dashboard/CardRecommendations.tsx`

- `handleDismiss` now accepts a `CardRecommendation` parameter and calls `dismissRecommendation(rec.id)` before closing the dropdown
- Both dismiss button `onClick` handlers updated from `onClick={handleDismiss}` to `onClick={(e) => handleDismiss(e, rec)}`

## Test plan

- [ ] Navigate to Dashboard and wait for "Recommended Cards" row
- [ ] Click a recommendation chip to expand its dropdown
- [ ] Click the X (Dismiss) button
- [ ] Verify the recommendation is permanently removed (not just the dropdown closing)
- [ ] Verify snooze button still works correctly
- [ ] Verify "Add Card" button still works correctly

Fixes #4227