### PR TITLE
🐛 Actionable token permission guidance with GitHub + Settings links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,11 @@ SKIP_ONBOARDING=false
 VITE_GEOCODING_API_URL=https://geocoding-api.open-meteo.com/v1/search
 
 # Feature request / AI automation settings (optional)
-# GitHub PAT for programmatic issue creation (needs 'repo' scope)
-# Get from: https://github.com/settings/tokens
+# GitHub PAT for programmatic issue creation and screenshot uploads.
+# Classic PAT: needs 'repo' scope (https://github.com/settings/tokens)
+# Fine-grained PAT: needs 'Issues: Read and write' + 'Contents: Read and write'
+#   (https://github.com/settings/personal-access-tokens/new)
+# Without 'Contents' permission, issues are created but screenshots silently fail.
 FEEDBACK_GITHUB_TOKEN=
 # Repository where issues will be created
 FEEDBACK_REPO_OWNER=kubestellar

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -66,7 +66,9 @@ type FeedbackConfig struct {
 // NewFeedbackHandler creates a new feedback handler
 func NewFeedbackHandler(s store.Store, cfg FeedbackConfig) *FeedbackHandler {
 	if cfg.GitHubToken == "" {
-		log.Printf("[Feedback] WARNING: FEEDBACK_GITHUB_TOKEN is not set — issue submission will be disabled. Add FEEDBACK_GITHUB_TOKEN=<your-pat> to your .env file (requires repo scope).")
+		log.Printf("[Feedback] WARNING: FEEDBACK_GITHUB_TOKEN is not set — issue submission will be disabled. " +
+			"Add FEEDBACK_GITHUB_TOKEN=<your-pat> to your .env file. " +
+			"Classic PAT: needs 'repo' scope. Fine-grained PAT: needs 'Issues' + 'Contents' read/write permissions.")
 	}
 	return &FeedbackHandler{
 		store:         s,
@@ -120,7 +122,9 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 
 	// Reject early if GitHub issue creation is not configured
 	if h.getEffectiveToken() == "" || h.repoOwner == "" || h.repoName == "" {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "Issue submission is not available: FEEDBACK_GITHUB_TOKEN is not configured. Add FEEDBACK_GITHUB_TOKEN=<your-pat> to your .env file (requires a GitHub personal access token with repo scope).")
+		return fiber.NewError(fiber.StatusServiceUnavailable, "Issue submission is not available: FEEDBACK_GITHUB_TOKEN is not configured. "+
+			"Add FEEDBACK_GITHUB_TOKEN=<your-pat> to your .env file. "+
+			"Classic PAT: needs 'repo' scope. Fine-grained PAT: needs 'Issues' + 'Contents' read/write permissions.")
 	}
 
 	// Determine target repo — default to console if not specified or invalid

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -1257,14 +1257,25 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
               {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (success.screenshotsUploaded ?? 0) === 0 && (
                 <div className="mt-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
                   <p className="text-xs text-yellow-400 font-medium">
-                    Screenshot could not be uploaded. The issue was created without it. Check that the GitHub token has &quot;Contents: Read and write&quot; permission.
+                    Screenshot could not be uploaded — the issue was created without it.
+                    The token needs <em>Contents: Read and write</em> permission (fine-grained PAT) or <em>repo</em> scope (classic PAT).
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    <a href="https://github.com/settings/personal-access-tokens" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Update token on GitHub</a>
+                    {' · '}
+                    <button type="button" onClick={() => { window.location.href = '/settings' }} className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Console Settings</button>
                   </p>
                 </div>
               )}
               {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (success.screenshotsUploaded ?? 0) > 0 && (
                 <div className="mt-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
                   <p className="text-xs text-yellow-400 font-medium">
-                    {success.screenshotsUploaded} of {screenshots.length} screenshots uploaded. {success.screenshotsFailed} failed — check GitHub token permissions.
+                    {success.screenshotsUploaded} of {screenshots.length} screenshots uploaded. {success.screenshotsFailed} failed — token may need <em>Contents: Read and write</em> permission.
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    <a href="https://github.com/settings/personal-access-tokens" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Update token on GitHub</a>
+                    {' · '}
+                    <button type="button" onClick={() => { window.location.href = '/settings' }} className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Console Settings</button>
                   </p>
                 </div>
               )}
@@ -1282,16 +1293,22 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
                       </p>
                       <p className="text-muted-foreground text-xs">
                         The <code className="px-1 py-0.5 rounded bg-secondary text-foreground text-2xs">FEEDBACK_GITHUB_TOKEN</code> is
-                        not set. Issue submission requires a GitHub personal access token with <em>repo</em> scope.
-                        Add it to your <code className="px-1 py-0.5 rounded bg-secondary text-foreground text-2xs">.env</code> file or
-                        configure it in{' '}
+                        not set. Issue submission requires a GitHub personal access token with these permissions:
+                      </p>
+                      <ul className="text-muted-foreground text-xs list-disc ml-4 mt-1 space-y-0.5">
+                        <li><em>Issues: Read and write</em> — to create GitHub issues</li>
+                        <li><em>Contents: Read and write</em> — to upload screenshots</li>
+                      </ul>
+                      <p className="text-muted-foreground text-xs mt-1.5">
+                        <a href="https://github.com/settings/personal-access-tokens/new" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Create token on GitHub</a>
+                        {' · '}
                         <button
                           type="button"
                           onClick={() => { window.location.href = '/settings' }}
                           className="text-purple-400 hover:text-purple-300 underline underline-offset-2"
                         >
-                          Settings
-                        </button>.
+                          Console Settings
+                        </button>
                       </p>
                     </div>
                   </div>

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -383,14 +383,25 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
               {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (success.screenshotsUploaded ?? 0) === 0 && (
                 <div className="mb-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
                   <p className="text-xs text-yellow-400 font-medium">
-                    Screenshot could not be uploaded. The issue was created without it. Check that the GitHub token has &quot;Contents: Read and write&quot; permission.
+                    Screenshot could not be uploaded — the issue was created without it.
+                    The token needs <em>Contents: Read and write</em> permission (fine-grained PAT) or <em>repo</em> scope (classic PAT).
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    <a href="https://github.com/settings/personal-access-tokens" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Update token on GitHub</a>
+                    {' · '}
+                    <button type="button" onClick={() => { window.location.href = '/settings' }} className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Console Settings</button>
                   </p>
                 </div>
               )}
               {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (success.screenshotsUploaded ?? 0) > 0 && (
                 <div className="mb-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
                   <p className="text-xs text-yellow-400 font-medium">
-                    {success.screenshotsUploaded} of {screenshots.length} screenshots uploaded. {success.screenshotsFailed} failed — check GitHub token permissions.
+                    {success.screenshotsUploaded} of {screenshots.length} screenshots uploaded. {success.screenshotsFailed} failed — token may need <em>Contents: Read and write</em> permission.
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    <a href="https://github.com/settings/personal-access-tokens" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Update token on GitHub</a>
+                    {' · '}
+                    <button type="button" onClick={() => { window.location.href = '/settings' }} className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Console Settings</button>
                   </p>
                 </div>
               )}


### PR DESCRIPTION
## Summary

Follow-up to #4226. When screenshot uploads fail or the feedback token is missing, users had no clear guidance on what to do. Now:

- **Missing token banner**: Lists the exact permissions needed (Issues + Contents read/write for fine-grained PATs, repo scope for classic PATs) with links to [Create token on GitHub](https://github.com/settings/personal-access-tokens/new) and Console Settings
- **Screenshot upload failure warnings**: Explain which permission is missing and link to [Update token on GitHub](https://github.com/settings/personal-access-tokens) and Console Settings
- **`.env.example`**: Documents both classic and fine-grained PAT requirements
- **Backend logs**: Startup warning and 503 error now specify both token types

## Test plan

- [ ] Remove `FEEDBACK_GITHUB_TOKEN` → missing token banner shows permission list + both links
- [ ] Use a token without Contents permission → submit with screenshot → yellow warning shows with both links
- [ ] Click "Create token on GitHub" link → opens GitHub fine-grained PAT page in new tab
- [ ] Click "Console Settings" link → navigates to /settings