### PR TITLE
🐛 Fix auth.test.ts duplicate import breaking coverage

### DIFF
--- a/web/src/lib/__tests__/auth.test.ts
+++ b/web/src/lib/__tests__/auth.test.ts
@@ -10,7 +10,6 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { renderHook } from '@testing-library/react'
 
 // ---------------------------------------------------------------------------
 // Mocks — declared before importing the module under test


### PR DESCRIPTION
Duplicate renderHook import caused parse error, preventing shard coverage upload.