### PR TITLE
🐛 URGENT: Fix production crash from bare console.* stripping

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -47,19 +47,15 @@ export default defineConfig(({ mode }) => ({
     __DEV_MODE__: process.env.VITE_DEV_MODE !== undefined
       ? JSON.stringify(process.env.VITE_DEV_MODE === 'true')
       : JSON.stringify(mode === 'development'),
-    // Strip console/debugger in production (replaces terser drop_console).
-    // Both globalThis.console.* and console.* forms are needed — Vite's
-    // define does literal text replacement, so "console.debug" won't match
-    // a rule for "globalThis.console.debug" and vice-versa.
+    // Strip console calls in production (replaces terser drop_console).
+    // IMPORTANT: Only use globalThis.console.* — bare "console.log" does
+    // literal text replacement that hits vendor/dependency code too,
+    // turning their console.log(...) into undefined(...) which crashes.
     ...(mode === 'production' ? {
       'globalThis.console.log': 'undefined',
       'globalThis.console.info': 'undefined',
       'globalThis.console.debug': 'undefined',
       'globalThis.console.trace': 'undefined',
-      'console.log': 'undefined',
-      'console.info': 'undefined',
-      'console.debug': 'undefined',
-      'console.trace': 'undefined',
     } : {}),
   },
   plugins: [


### PR DESCRIPTION
## PRODUCTION IS DOWN

PR #4239 added bare `console.log`/`console.debug` to Vite's `define` config. Vite's define does **literal text replacement** — it replaced `console.log(...)` with `undefined(...)` inside vendor dependencies (Tailwind Merge, etc.), causing:

```
TypeError: (void 0) is not a function
  at bA (vendor-Dj3uwf9i.js:4724:194)
```

This crashes the entire app on `console.kubestellar.io` — blank page, React never mounts.

### Fix

Remove bare `console.*` forms from Vite define. Only use `globalThis.console.*` which is specific enough to target our code without hitting vendor code.

### Verified

- `grep -c "void 0(" dist/assets/vendor-*.js` returns **0** after fix (was crashing before)
- Build passes