### PR TITLE
🐛 Fix WebSocket race, nil-pointer crash, shutdown panic

### DIFF
--- a/pkg/agent/device_tracker.go
+++ b/pkg/agent/device_tracker.go
@@ -119,6 +119,12 @@ func (t *DeviceTracker) runLoop() {
 }
 
 func (t *DeviceTracker) scanDevices() {
+	// Guard against nil client — k8s client initialisation may have failed
+	// at startup, leaving DeviceTracker running with a nil reference.
+	if t.k8sClient == nil {
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), deviceTrackerTimeout)
 	defer cancel()
 

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -2280,8 +2280,9 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 	defer conn.Close()
 
+	wsc := &wsClient{}
 	s.clientsMux.Lock()
-	s.clients[conn] = &wsClient{}
+	s.clients[conn] = wsc
 	s.clientsMux.Unlock()
 
 	defer func() {
@@ -2292,8 +2293,11 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("Client connected: %s (origin: %s)", conn.RemoteAddr(), r.Header.Get("Origin"))
 
-	// writeMu protects concurrent WebSocket writes from goroutine-based handlers
-	var writeMu sync.Mutex
+	// writeMu is the single per-connection mutex shared by broadcasts
+	// (prediction_worker) and request/stream handlers. Using the same
+	// mutex prevents concurrent gorilla/websocket writes that would
+	// panic or corrupt connection state.
+	writeMu := &wsc.writeMu
 	// closed is set when the read loop exits; goroutines check it before writing
 	var closed atomic.Bool
 
@@ -2351,11 +2355,11 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 						log.Printf("[Chat] recovered from panic in streaming handler: %v", r)
 					}
 				}()
-				s.handleChatMessageStreaming(conn, m, fa, &writeMu, &closed)
+				s.handleChatMessageStreaming(conn, m, fa, writeMu, &closed)
 			}(msg, forceAgent)
 		} else if msg.Type == protocol.TypeCancelChat {
 			// Cancel an in-progress chat by session ID
-			s.handleCancelChat(conn, msg, &writeMu)
+			s.handleCancelChat(conn, msg, writeMu)
 		} else if msg.Type == protocol.TypeKubectl {
 			// Handle kubectl messages concurrently so one slow cluster
 			// doesn't block the entire WebSocket message loop.

--- a/pkg/api/gpu_utilization_worker.go
+++ b/pkg/api/gpu_utilization_worker.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -29,6 +30,7 @@ type GPUUtilizationWorker struct {
 	k8sClient *k8s.MultiClusterClient
 	interval  time.Duration
 	stopCh    chan struct{}
+	stopOnce  sync.Once // protects stopCh from double-close panic
 }
 
 // NewGPUUtilizationWorker creates a new GPU utilization worker
@@ -72,9 +74,12 @@ func (w *GPUUtilizationWorker) Start() {
 	log.Printf("GPU utilization worker started (interval: %v)", w.interval)
 }
 
-// Stop signals the worker to stop
+// Stop signals the worker to stop. It is safe to call multiple times;
+// only the first call actually closes the stop channel.
 func (w *GPUUtilizationWorker) Stop() {
-	close(w.stopCh)
+	w.stopOnce.Do(func() {
+		close(w.stopCh)
+	})
 }
 
 // collectUtilization queries active reservations and records utilization snapshots

--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -45,8 +45,9 @@ type Hub struct {
 	unregister   chan *Client
 	mu           sync.RWMutex
 	done         chan struct{}
-	jwtSecret    string // JWT secret for WebSocket auth
-	devMode      bool   // when true, demo-token bypass is allowed
+	closeOnce    sync.Once // protects done channel from double-close panic
+	jwtSecret    string    // JWT secret for WebSocket auth
+	devMode      bool      // when true, demo-token bypass is allowed
 }
 
 type broadcastMessage struct {
@@ -128,9 +129,12 @@ func (h *Hub) Run() {
 	}
 }
 
-// Close shuts down the hub
+// Close shuts down the hub. It is safe to call multiple times;
+// only the first call actually closes the done channel.
 func (h *Hub) Close() {
-	close(h.done)
+	h.closeOnce.Do(func() {
+		close(h.done)
+	})
 }
 
 // Broadcast sends a message to all clients of a user.


### PR DESCRIPTION
## Summary

Fixes three crash-path bugs in the Go backend:

- **WebSocket concurrent-write race (#4260)**: The agent server used separate mutexes for broadcasts (`wsClient.writeMu`) and request/stream handlers (a local `writeMu`), allowing concurrent writes on the same `*websocket.Conn`. Now the handler loop reuses `wsClient.writeMu` so all writes are serialized through a single per-connection mutex.
- **Nil-pointer crash in DeviceTracker (#4261)**: `scanDevices()` called `t.k8sClient.ListClusters()` without a nil check. When k8s client init fails at startup the server continues with a nil client but still starts DeviceTracker, causing a nil-pointer dereference. Added a nil guard.
- **Shutdown panic on double-close (#4279)**: `Hub.Close()` and `GPUUtilizationWorker.Stop()` close channels unconditionally. A second call to `Shutdown()` panics with "close of closed channel". Protected both with `sync.Once`.

Fixes #4260, Fixes #4261, Fixes #4279

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/api/handlers/... ./pkg/agent/... -run "DeviceTracker|Hub|GPUUtil|WebSocket"` passes
- [ ] CI build and lint pass