### PR TITLE
🐛 Fix shared dropdownRef across .map() in suggestions/recommendations

### DIFF
--- a/web/src/components/dashboard/CardRecommendations.tsx
+++ b/web/src/components/dashboard/CardRecommendations.tsx
@@ -40,7 +40,6 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
     safeGetItem(STORAGE_KEY_RECS_COLLAPSED) === 'true'
   )
   const [countdown, setCountdown] = useState(AUTO_COLLAPSE_SECONDS)
-  const dropdownRef = useRef<HTMLDivElement>(null)
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const analyticsEmittedRef = useRef(false)
 
@@ -96,8 +95,9 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
     if (!expandedRec) return
 
     const handleClickOutside = (e: MouseEvent) => {
-      // Check if click is outside the dropdown content
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+      // Use the currently expanded ID to find the correct dropdown element
+      const activeDropdown = document.getElementById(`rec-dropdown-${expandedRec}`)
+      if (activeDropdown && !activeDropdown.contains(e.target as Node)) {
         setExpandedRec(null)
       }
     }
@@ -199,7 +199,6 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
                 {/* Inline dropdown — appears below the chip without expanding the panel */}
                 {isExpanded && (
                   <div
-                    ref={dropdownRef}
                     id={`rec-dropdown-${rec.id}`}
                     role="menu"
                     className="absolute top-full left-0 mt-1 z-50 w-72 rounded-lg border border-border/50 bg-card shadow-xl"
@@ -327,7 +326,7 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
               {/* Expanded dropdown */}
               {isExpanded && (
                 <div
-                  ref={dropdownRef}
+                  id={`rec-dropdown-${rec.id}`}
                   role="menu"
                   className="absolute top-full left-0 mt-1 z-50 w-72 rounded-lg border border-border/50 bg-card shadow-xl"
                   onKeyDown={(e) => {

--- a/web/src/components/dashboard/MissionSuggestions.tsx
+++ b/web/src/components/dashboard/MissionSuggestions.tsx
@@ -49,7 +49,6 @@ export function MissionSuggestions() {
   const [processingId, setProcessingId] = useState<string | null>(null)
   const [minimized, setMinimized] = useState(true)
   const [countdown, setCountdown] = useState(AUTO_COLLAPSE_SECONDS)
-  const dropdownRef = useRef<HTMLDivElement>(null)
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const analyticsEmittedRef = useRef(false)
 
@@ -119,8 +118,9 @@ export function MissionSuggestions() {
     if (!expandedId) return
 
     const handleClickOutside = (e: MouseEvent) => {
-      // Check if click is outside the dropdown content
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+      // Use the currently expanded ID to find the correct dropdown element
+      const activeDropdown = document.getElementById(`mission-dropdown-${expandedId}`)
+      if (activeDropdown && !activeDropdown.contains(e.target as Node)) {
         setExpandedId(null)
       }
     }
@@ -262,7 +262,7 @@ export function MissionSuggestions() {
                 {/* Inline dropdown — appears below the chip without expanding the panel */}
                 {isExpanded && (
                   <div
-                    ref={dropdownRef}
+                    id={`mission-dropdown-${suggestion.id}`}
                     role="menu"
                     className="absolute top-full left-0 mt-1 z-50 w-72 rounded-lg border border-border/50 bg-card shadow-xl"
                     style={{ isolation: 'isolate' }}
@@ -416,7 +416,7 @@ export function MissionSuggestions() {
               {/* Expanded dropdown */}
               {isExpanded && (
                 <div
-                  ref={dropdownRef}
+                  id={`mission-dropdown-${suggestion.id}`}
                   role="menu"
                   className="absolute top-full left-0 mt-1 z-50 w-72 rounded-lg border border-border/50 bg-card shadow-xl"
                   style={{ isolation: 'isolate' }}


### PR DESCRIPTION
## Summary

- Fixes the shared `dropdownRef` bug in `MissionSuggestions.tsx` and `CardRecommendations.tsx` where a single `useRef` was assigned inside `.map()` loops, causing it to always point to the last rendered dropdown element
- Replaced `ref={dropdownRef}` with `id`-based lookup (`document.getElementById`) using the currently expanded item ID, ensuring click-outside detection always references the correct active dropdown

Fixes #4232

## Changes

- **MissionSuggestions.tsx**: Removed `dropdownRef`, added `id={mission-dropdown-${suggestion.id}}` to dropdown divs, updated click-outside handler to use `document.getElementById(`mission-dropdown-${expandedId}`)`
- **CardRecommendations.tsx**: Removed `dropdownRef`, added `id={rec-dropdown-${rec.id}}` to the expanded-panel dropdown div (minimized view already had it), updated click-outside handler to use `document.getElementById(`rec-dropdown-${expandedRec}`)`

## Test plan

- [ ] Open Dashboard with multiple Recommended Actions chips visible
- [ ] Expand a chip that is NOT the last in the list
- [ ] Click inside the dropdown (e.g., on description text) — should NOT close
- [ ] Click outside the dropdown — should close
- [ ] Repeat for Recommended Cards chips
- [ ] Verify Escape key still closes dropdowns
- [ ] Verify keyboard navigation (ArrowDown/ArrowUp) still works within dropdowns