### PR TITLE
🐛 Guard against undefined config in dynamic card rendering (#4312)

### DIFF
--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -22,7 +22,7 @@ import { useTranslation } from 'react-i18next'
  * Registered as `dynamic_card` in CARD_COMPONENTS.
  * config.dynamicCardId determines which definition to render.
  */
-export function DynamicCard({ config }: CardComponentProps) {
+export function DynamicCard({ config = {} }: CardComponentProps) {
   const { t: _t } = useTranslation()
   const dynamicCardId = (config?.dynamicCardId as string) || ''
   const definition = getDynamicCard(dynamicCardId)
@@ -288,7 +288,7 @@ export interface Tier2Props {
   config?: Record<string, unknown>
 }
 
-export function Tier2CardRuntime({ definition, config }: Tier2Props) {
+export function Tier2CardRuntime({ definition, config = {} }: Tier2Props) {
   const [CardComponent, setCardComponent] = useState<CardComponent | null>(null)
   const [compiling, setCompiling] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/web/src/components/clusters/components/SortableClusterCard.tsx
+++ b/web/src/components/clusters/components/SortableClusterCard.tsx
@@ -77,7 +77,7 @@ export const SortableClusterCard = memo(function SortableClusterCard({
         }
       >
         {CardComponent ? (
-          <CardComponent config={card.config} />
+          <CardComponent config={card.config ?? {}} />
         ) : (
           <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
             <AlertTriangle className="w-6 h-6 text-yellow-500" />

--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -175,7 +175,7 @@ function SortableCard({ card, onConfigure, onRemove, onWidthChange, isDragging, 
         onRefresh={onRefresh}
         lastUpdated={lastUpdated}
       >
-        <CardComponent config={card.config} />
+        <CardComponent config={card.config ?? {}} />
       </CardWrapper>
     </div>
   )
@@ -196,7 +196,7 @@ function DragPreviewCard({ card }: { card: Card }) {
         title={card.title || formatCardTitle(card.card_type)}
         cardWidth={card.position?.w || 4}
       >
-        {CardComponent ? <CardComponent config={card.config} /> : null}
+        {CardComponent ? <CardComponent config={card.config ?? {}} /> : null}
       </CardWrapper>
     </div>
   )

--- a/web/src/components/dashboard/DashboardCards.tsx
+++ b/web/src/components/dashboard/DashboardCards.tsx
@@ -177,7 +177,7 @@ export function DashboardCards({
                     isLive={LIVE_DATA_CARDS.has(card.card_type)}
                   >
                     {CardComponent ? (
-                      <CardComponent config={card.config} />
+                      <CardComponent config={card.config ?? {}} />
                     ) : (
                       <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
                         <AlertTriangle className="w-6 h-6 text-yellow-500" />

--- a/web/src/components/dashboard/SharedSortableCard.tsx
+++ b/web/src/components/dashboard/SharedSortableCard.tsx
@@ -116,7 +116,7 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
         }
       >
         {CardComponent ? (
-          <CardComponent config={card.config} />
+          <CardComponent config={card.config ?? {}} />
         ) : (
           <div className="flex items-center justify-center h-full text-muted-foreground">
             <p>Card type: {card.card_type}</p>

--- a/web/src/lib/cards/cardHooks.ts
+++ b/web/src/lib/cards/cardHooks.ts
@@ -94,7 +94,9 @@ export function useCardFilters<T>(
   items: T[],
   config: FilterConfig<T>
 ): UseCardFiltersResult<T> {
-  const { searchFields, clusterField, statusField, customPredicate, storageKey } = config
+  // Guard against undefined config — dynamic/custom cards may pass undefined at runtime
+  const safeConfig = config ?? ({} as FilterConfig<T>)
+  const { searchFields, clusterField, statusField, customPredicate, storageKey } = safeConfig
   const {
     filterByCluster,
     filterByStatus,
@@ -206,7 +208,7 @@ export function useCardFilters<T>(
       const query = globalCustomFilter.toLowerCase()
       result = result.filter(item => {
         // Check searchFields
-        for (const field of searchFields) {
+        for (const field of (searchFields || [])) {
           const value = item[field]
           if (value && String(value).toLowerCase().includes(query)) {
             return true
@@ -225,7 +227,7 @@ export function useCardFilters<T>(
       const query = search.toLowerCase()
       result = result.filter(item => {
         // Check searchFields
-        for (const field of searchFields) {
+        for (const field of (searchFields || [])) {
           const value = item[field]
           if (value && String(value).toLowerCase().includes(query)) {
             return true
@@ -292,16 +294,18 @@ export function useCardSort<T, S extends string>(
   items: T[],
   config: SortConfig<T, S>
 ): UseCardSortResult<T, S> {
-  const { defaultField, defaultDirection, comparators } = config
+  // Guard against undefined config — dynamic/custom cards may pass undefined at runtime
+  const safeConfig = config ?? ({} as SortConfig<T, S>)
+  const { defaultField, defaultDirection, comparators } = safeConfig
   const [sortBy, setSortBy] = useState<S>(defaultField)
-  const [sortDirection, setSortDirection] = useState<SortDirection>(defaultDirection)
+  const [sortDirection, setSortDirection] = useState<SortDirection>(defaultDirection ?? 'asc')
 
   const toggleSortDirection = useCallback(() => {
     setSortDirection(prev => (prev === 'asc' ? 'desc' : 'asc'))
   }, [])
 
   const sorted = useMemo(() => {
-    const comparator = comparators[sortBy]
+    const comparator = comparators?.[sortBy]
     if (!comparator) return items
 
     const sortedItems = [...items].sort((a, b) => {
@@ -357,7 +361,9 @@ export function useCardData<T, S extends string = string>(
   items: T[],
   config: CardDataConfig<T, S>
 ): UseCardDataResult<T, S> {
-  const { filter: filterConfig, sort: sortConfig, defaultLimit = 5 } = config
+  // Guard against undefined config — dynamic/custom cards may pass undefined at runtime
+  const safeConfig = config ?? ({} as CardDataConfig<T, S>)
+  const { filter: filterConfig, sort: sortConfig, defaultLimit = 5 } = safeConfig
   const [itemsPerPage, setItemsPerPage] = useState<number | 'unlimited'>(defaultLimit)
   const [currentPage, setCurrentPage] = useState(1)
 

--- a/web/src/lib/dashboards/DashboardComponents.tsx
+++ b/web/src/lib/dashboards/DashboardComponents.tsx
@@ -103,7 +103,7 @@ export const SortableDashboardCard = memo(function SortableDashboardCard({
         }
       >
         {CardComponent ? (
-          <CardComponent config={card.config} />
+          <CardComponent config={card.config ?? {}} />
         ) : (
           <div className="flex flex-col items-center justify-center h-full gap-2 text-muted-foreground p-4">
             <AlertTriangle className="w-6 h-6 text-yellow-500" />


### PR DESCRIPTION
## Summary
- Custom/dynamic Tier 2 cards crash with `Cannot destructure property 'filter' of 'config' as it is undefined` when `card.config` is undefined (18 GA4 error events in 24 hours)
- Adds default `config = {}` in `DynamicCard` and `Tier2CardRuntime` destructuring
- Adds `?? {}` fallback in all 6 call sites that pass `card.config` to card components (`SharedSortableCard`, `DashboardCards`, `CustomDashboard`, `DashboardComponents`, `SortableClusterCard`)
- Guards `useCardData`, `useCardFilters`, and `useCardSort` against undefined config with safe defaults, optional chaining on `comparators`, and `|| []` on `searchFields` iteration

Fixes #4312

## Test plan
- [ ] Create a new Tier 2 custom card via Card Factory and verify it renders without crashing
- [ ] Verify existing dashboard cards still render correctly
- [ ] Verify cards with no config (newly added, preview mode) don't crash