### PR TITLE
🐛 Fix active-users HTML parse errors on Netlify

### DIFF
--- a/web/src/hooks/__tests__/useActiveUsers.test.ts
+++ b/web/src/hooks/__tests__/useActiveUsers.test.ts
@@ -20,7 +20,10 @@ describe('useActiveUsers', () => {
     localStorage.clear()
     vi.clearAllMocks()
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({ activeUsers: 5, totalConnections: 8 }), { status: 200 })
+      new Response(JSON.stringify({ activeUsers: 5, totalConnections: 8 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
     )
   })
 
@@ -160,7 +163,10 @@ describe('useActiveUsers', () => {
 
     // Now fix fetch and refetch
     vi.mocked(fetch).mockResolvedValue(
-      new Response(JSON.stringify({ activeUsers: 3, totalConnections: 5 }), { status: 200 })
+      new Response(JSON.stringify({ activeUsers: 3, totalConnections: 5 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
     )
 
     act(() => { result.current.refetch() })
@@ -175,7 +181,10 @@ describe('useActiveUsers', () => {
   // --- Updates counts when API returns new data ---
   it('updates active user counts when API returns new data', async () => {
     vi.mocked(fetch).mockResolvedValue(
-      new Response(JSON.stringify({ activeUsers: 10, totalConnections: 15 }), { status: 200 })
+      new Response(JSON.stringify({ activeUsers: 10, totalConnections: 15 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
     )
 
     const { result } = renderHook(() => useActiveUsers())
@@ -185,6 +194,22 @@ describe('useActiveUsers', () => {
       expect(result.current.activeUsers).toBe(10)
       expect(result.current.totalConnections).toBe(10) // smoothed to same value since smoothing uses max
     })
+  })
+
+  // --- Handles HTML fallback response (Netlify SPA catch-all) ---
+  it('handles HTML response without SyntaxError (Netlify SPA fallback)', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('<!doctype html><html><body>SPA</body></html>', {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      })
+    )
+
+    const { result } = renderHook(() => useActiveUsers())
+    await act(async () => { await vi.advanceTimersByTimeAsync(100) })
+
+    // Should not crash or throw SyntaxError — gracefully treated as error
+    expect(typeof result.current.activeUsers).toBe('number')
   })
 
   // --- Handles invalid JSON gracefully ---

--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -15,6 +15,18 @@ const RECOVERY_DELAY = 30_000 // Retry after circuit breaker trips
 /** Timeout for fetch() call to the active-users endpoint */
 const ACTIVE_USERS_FETCH_TIMEOUT_MS = 5_000
 
+/**
+ * Guard against non-JSON responses (e.g. Netlify SPA catch-all returning index.html).
+ * On Netlify without a Go backend, API calls can fall through to the `/* -> /index.html`
+ * redirect if MSW hasn't registered yet or the Netlify Function fails. The response
+ * has status 200 but content-type text/html, causing `response.json()` to throw
+ * `SyntaxError: Unexpected token '<'`. Checking content-type prevents the parse attempt.
+ */
+function isJsonResponse(resp: Response): boolean {
+  const ct = resp.headers.get('content-type') || ''
+  return ct.includes('application/json')
+}
+
 // Singleton state to share across all hook instances
 let sharedInfo: ActiveUsersInfo = {
   activeUsers: 0,
@@ -177,6 +189,10 @@ async function fetchActiveUsers() {
   try {
     const resp = await fetch('/api/active-users', { signal: AbortSignal.timeout(ACTIVE_USERS_FETCH_TIMEOUT_MS) })
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+    // Guard: if the response is HTML (e.g. Netlify SPA catch-all returning
+    // index.html because MSW hasn't intercepted yet), skip JSON parsing
+    // entirely to avoid SyntaxError: Unexpected token '<' console noise.
+    if (!isJsonResponse(resp)) throw new Error('Non-JSON response (likely HTML fallback)')
     // Use .catch() on .json() to prevent Firefox from firing unhandledrejection
     // before the outer try/catch processes the rejection (microtask timing issue).
     const data = await resp.json().catch(() => null) as ActiveUsersInfo | null


### PR DESCRIPTION
## Summary

On `console.kubestellar.io` (Netlify), `/api/active-users` falls through to the SPA catch-all redirect during MSW startup, returning `index.html` as a 200 response. The hook tries to parse this as JSON → `SyntaxError: Unexpected token '<'` every minute in the console.

### Fix

Added `isJsonResponse()` guard that checks `content-type` header before attempting `res.json()`. Non-JSON responses (HTML fallback) are treated as errors without parse attempt.

## Test plan

- [x] Build passes with all post-build checks green
- [ ] Verify no more `Unexpected token '<'` errors on console.kubestellar.io