### PR TITLE
🐛 Embed screenshots as base64 in issues; GHA processes into images

### DIFF
--- a/.github/workflows/process-screenshots.yml
+++ b/.github/workflows/process-screenshots.yml
@@ -1,0 +1,113 @@
+name: Process Issue Screenshots
+
+# When a new issue is created with embedded base64 screenshots, this workflow
+# decodes them, commits the images to .github/screenshots/, and replaces the
+# base64 blocks in the issue body with rendered markdown images.
+#
+# This avoids requiring end users' PATs to have push access to the repo.
+# The workflow's GITHUB_TOKEN has write access automatically.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  process-screenshots:
+    # Only run if the issue body contains our base64 screenshot marker
+    if: contains(github.event.issue.body, '<!-- screenshot-base64:')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Process base64 screenshots
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueNumber = context.issue.number;
+            let body = context.payload.issue.body;
+
+            // Find all screenshot-base64 markers
+            const markerRegex = /<!-- screenshot-base64:(\d+) -->\n<details>\n<summary>Screenshot \d+ \(processing\.\.\.\)<\/summary>\n\n```\n(data:image\/[^;]+;base64,[A-Za-z0-9+/=\n]+)\n```\n\n<\/details>/g;
+
+            let match;
+            const screenshots = [];
+            while ((match = markerRegex.exec(body)) !== null) {
+              screenshots.push({
+                fullMatch: match[0],
+                index: parseInt(match[1]),
+                dataUri: match[2].replace(/\n/g, ''),
+              });
+            }
+
+            if (screenshots.length === 0) {
+              console.log('No base64 screenshots found in issue body');
+              return;
+            }
+
+            console.log(`Found ${screenshots.length} screenshot(s) to process`);
+
+            // Extract issue ID from body for folder naming
+            const idMatch = body.match(/Console Request ID:\*\* ([a-f0-9-]+)/);
+            const requestId = idMatch ? idMatch[1] : `issue-${issueNumber}`;
+
+            let updatedBody = body;
+
+            for (const ss of screenshots) {
+              try {
+                // Parse data URI
+                const [header, b64Content] = ss.dataUri.split(',');
+                const extMatch = header.match(/image\/(\w+)/);
+                const ext = extMatch ? extMatch[1].replace('jpeg', 'jpg') : 'png';
+
+                // Decode base64 to verify it's valid
+                const content = b64Content;
+
+                // Commit the image to the repo
+                const filePath = `.github/screenshots/${requestId}/screenshot-${ss.index}.${ext}`;
+                console.log(`Uploading ${filePath}...`);
+
+                const { data } = await github.rest.repos.createOrUpdateFileContents({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: filePath,
+                  message: `Add screenshot ${ss.index} for issue #${issueNumber}`,
+                  content: content,
+                  committer: {
+                    name: 'github-actions[bot]',
+                    email: '41898282+github-actions[bot]@users.noreply.github.com',
+                  },
+                });
+
+                const downloadUrl = data.content.download_url;
+                console.log(`Uploaded: ${downloadUrl}`);
+
+                // Replace the base64 block with a rendered image
+                updatedBody = updatedBody.replace(
+                  ss.fullMatch,
+                  `![Screenshot ${ss.index}](${downloadUrl})`
+                );
+              } catch (err) {
+                console.error(`Failed to process screenshot ${ss.index}:`, err.message);
+                // Replace with error message instead of leaving base64 blob
+                updatedBody = updatedBody.replace(
+                  ss.fullMatch,
+                  `> ⚠️ Screenshot ${ss.index} could not be processed: ${err.message}`
+                );
+              }
+            }
+
+            // Update the issue body with rendered images
+            if (updatedBody !== body) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: updatedBody,
+              });
+              console.log(`Issue #${issueNumber} updated with ${screenshots.length} rendered screenshot(s)`);
+            }

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -1565,27 +1565,33 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 		repoLabel = "Console Documentation"
 	}
 
-	// Upload screenshots to GitHub and build markdown image references
+	// Embed screenshots as base64 in the issue body inside collapsible blocks.
+	// A GitHub Actions workflow (process-screenshots.yml) watches for new issues
+	// with these markers, decodes the base64, commits the images to the repo
+	// (using the workflow's GITHUB_TOKEN which has write access), and replaces
+	// the base64 blocks with rendered markdown images. This avoids requiring
+	// the user's PAT to have push access to the repo.
 	screenshotMarkdown := ""
 	var ssResult screenshotUploadResult
 	if len(screenshots) > 0 {
-		var imageLines []string
+		var blocks []string
 		for i, dataURI := range screenshots {
-			url, err := h.uploadScreenshotToGitHub(repoOwner, repoName, request.ID.String(), i, dataURI)
-			if err != nil {
+			// Validate the data URI format
+			parts := strings.SplitN(dataURI, ",", 2)
+			if len(parts) != 2 {
 				ssResult.Failed++
-				log.Printf("[Feedback] Failed to upload screenshot %d: %v", i+1, err)
-				if strings.Contains(err.Error(), "404") {
-					log.Printf("[Feedback] Hint: a 404 from the GitHub Contents API usually means the token lacks 'Contents: Read and write' permission. "+
-						"Ensure FEEDBACK_GITHUB_TOKEN has this scope for %s/%s.", repoOwner, repoName)
-				}
+				log.Printf("[Feedback] Screenshot %d: invalid data URI format", i+1)
 				continue
 			}
 			ssResult.Uploaded++
-			imageLines = append(imageLines, fmt.Sprintf("![Screenshot %d](%s)", i+1, url))
+			// Wrap in a collapsible <details> block with a machine-readable marker
+			// that the GHA workflow can find and process.
+			blocks = append(blocks, fmt.Sprintf(
+				"<!-- screenshot-base64:%d -->\n<details>\n<summary>Screenshot %d (processing...)</summary>\n\n```\n%s\n```\n\n</details>",
+				i+1, i+1, dataURI))
 		}
-		if len(imageLines) > 0 {
-			screenshotMarkdown = "\n\n## Screenshots\n\n" + strings.Join(imageLines, "\n\n")
+		if len(blocks) > 0 {
+			screenshotMarkdown = "\n\n## Screenshots\n\n" + strings.Join(blocks, "\n\n")
 		}
 	}
 

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -17,7 +17,7 @@ import { useAuth } from '../../lib/auth'
 import { useRewards } from '../../hooks/useRewards'
 import { BACKEND_DEFAULT_URL, STORAGE_KEY_TOKEN, DEMO_TOKEN_VALUE, FETCH_DEFAULT_TIMEOUT_MS, COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
 import { FEEDBACK_UPLOAD_TIMEOUT_MS } from '../../lib/constants/network'
-import { GITHUB_TOKEN_MANAGE_URL, GITHUB_TOKEN_CREATE_URL, GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS, GITHUB_TOKEN_CLASSIC_SCOPE } from '../../lib/constants/github-token'
+import { GITHUB_TOKEN_CREATE_URL, GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS } from '../../lib/constants/github-token'
 import { emitLinkedInShare } from '../../lib/analytics'
 import { isDemoModeForced } from '../../lib/demoMode'
 import { useToast } from '../ui/Toast'
@@ -1245,41 +1245,28 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
                 </button>
               </div>
 
-              {/* Screenshot upload status — show based on actual backend result */}
+              {/* Screenshot status — screenshots are embedded as base64 in the issue body
+                  and processed into images by a GitHub Actions workflow */}
               {screenshots.length > 0 && success && (success.screenshotsUploaded ?? 0) > 0 && (
                 <div className="mt-4 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
                   <p className="text-xs text-green-400 font-medium">
                     {(success.screenshotsUploaded ?? 0) === 1
-                      ? 'Screenshot uploaded and attached to the issue.'
-                      : `${success.screenshotsUploaded} screenshots uploaded and attached to the issue.`}
+                      ? 'Screenshot attached to the issue. It will render as an image shortly.'
+                      : `${success.screenshotsUploaded} screenshots attached to the issue. They will render as images shortly.`}
                   </p>
                 </div>
               )}
-              {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (success.screenshotsUploaded ?? 0) === 0 && (
+              {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (
                 <div className="mt-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
                   <p className="text-xs text-yellow-400 font-medium">
-                    Screenshot could not be uploaded — the issue was created without it.
-                    The token needs <em>{GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS[1].scope}</em> permission (fine-grained PAT) or <em>{GITHUB_TOKEN_CLASSIC_SCOPE}</em> scope (classic PAT).
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    <a href={GITHUB_TOKEN_MANAGE_URL} target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Update token on GitHub</a>
-                    {' · '}
-                    <button type="button" onClick={() => { window.location.href = '/settings#github-token' }} className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Console Settings</button>
+                    {success.screenshotsFailed === 1
+                      ? 'Screenshot could not be attached — invalid image format.'
+                      : `${success.screenshotsFailed} screenshots could not be attached — invalid image format.`}
                   </p>
                 </div>
               )}
-              {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (success.screenshotsUploaded ?? 0) > 0 && (
-                <div className="mt-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
-                  <p className="text-xs text-yellow-400 font-medium">
-                    {success.screenshotsUploaded} of {screenshots.length} screenshots uploaded. {success.screenshotsFailed} failed — token may need <em>{GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS[1].scope}</em> permission.
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    <a href={GITHUB_TOKEN_MANAGE_URL} target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Update token on GitHub</a>
-                    {' · '}
-                    <button type="button" onClick={() => { window.location.href = '/settings#github-token' }} className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Console Settings</button>
-                  </p>
-                </div>
-              )}
+              {/* Token permission warnings removed — screenshots are now embedded as base64,
+                  no push access needed. GHA workflow processes them into images. */}
             </div>
           ) : (
             <form id="feedback-form" onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0 overflow-hidden">

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -21,7 +21,7 @@ import { emitFeedbackSubmitted, emitLinkedInShare, emitScreenshotAttached, emitS
 import { useBranding } from '../../hooks/useBranding'
 import { FETCH_DEFAULT_TIMEOUT_MS, COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
 import { FEEDBACK_UPLOAD_TIMEOUT_MS } from '../../lib/constants/network'
-import { GITHUB_TOKEN_MANAGE_URL, GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS, GITHUB_TOKEN_CLASSIC_SCOPE } from '../../lib/constants/github-token'
+// github-token constants no longer needed here — screenshots are embedded as base64
 import { useFeatureRequests } from '../../hooks/useFeatureRequests'
 import { useAuth } from '../../lib/auth'
 
@@ -337,38 +337,22 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                 </a>
               )}
 
-              {/* Screenshot upload status — show based on actual backend result */}
+              {/* Screenshot status — embedded as base64 in issue body, processed by GHA */}
               {screenshots.length > 0 && success && (success.screenshotsUploaded ?? 0) > 0 && (
                 <div className="mb-4 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
                   <p className="text-xs text-green-400 font-medium">
                     {(success.screenshotsUploaded ?? 0) === 1
-                      ? 'Screenshot uploaded and attached to the issue.'
-                      : `${success.screenshotsUploaded} screenshots uploaded and attached to the issue.`}
+                      ? 'Screenshot attached to the issue. It will render as an image shortly.'
+                      : `${success.screenshotsUploaded} screenshots attached to the issue. They will render as images shortly.`}
                   </p>
                 </div>
               )}
-              {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (success.screenshotsUploaded ?? 0) === 0 && (
+              {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (
                 <div className="mb-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
                   <p className="text-xs text-yellow-400 font-medium">
-                    Screenshot could not be uploaded — the issue was created without it.
-                    The token needs <em>{GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS[1].scope}</em> permission (fine-grained PAT) or <em>{GITHUB_TOKEN_CLASSIC_SCOPE}</em> scope (classic PAT).
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    <a href={GITHUB_TOKEN_MANAGE_URL} target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Update token on GitHub</a>
-                    {' · '}
-                    <button type="button" onClick={() => { window.location.href = '/settings#github-token' }} className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Console Settings</button>
-                  </p>
-                </div>
-              )}
-              {screenshots.length > 0 && success && (success.screenshotsFailed ?? 0) > 0 && (success.screenshotsUploaded ?? 0) > 0 && (
-                <div className="mb-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
-                  <p className="text-xs text-yellow-400 font-medium">
-                    {success.screenshotsUploaded} of {screenshots.length} screenshots uploaded. {success.screenshotsFailed} failed — token may need <em>{GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS[1].scope}</em> permission.
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    <a href={GITHUB_TOKEN_MANAGE_URL} target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Update token on GitHub</a>
-                    {' · '}
-                    <button type="button" onClick={() => { window.location.href = '/settings#github-token' }} className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Console Settings</button>
+                    {success.screenshotsFailed === 1
+                      ? 'Screenshot could not be attached — invalid image format.'
+                      : `${success.screenshotsFailed} screenshots could not be attached — invalid image format.`}
                   </p>
                 </div>
               )}


### PR DESCRIPTION
## Summary

Fixes #4220 — screenshot uploads never worked for non-org-members because the Contents API requires push access to the repo.

### Root cause
The backend uploaded screenshots via `PUT /repos/{owner}/{repo}/contents/` which requires **write/push access**. Any user without org membership (i.e., every localhost user) got a 404. This was never a token scope issue — it was a fundamental permissions issue.

### New approach (two-step)

1. **Backend** embeds screenshots as base64 data URIs in the issue body inside collapsible `<details>` blocks with machine-readable markers:
   ```
   <!-- screenshot-base64:1 -->
   <details><summary>Screenshot 1 (processing...)</summary>
   data:image/png;base64,iVBOR...
   </details>
   ```
   No push access needed — just Issues write permission.

2. **GHA workflow** (`process-screenshots.yml`) triggers on `issues.opened`:
   - Finds `<!-- screenshot-base64:N -->` markers
   - Decodes base64, commits images to `.github/screenshots/` using the workflow's `GITHUB_TOKEN` (which has write access)
   - Replaces base64 blocks with rendered `![Screenshot](url)` markdown
   - Updates the issue body

### Other changes
- Frontend messages: "will render as an image shortly" instead of "uploaded and attached"
- Token permission warnings for Contents scope removed (no longer needed)
- `uploadScreenshotToGitHub` function retained but no longer called from the issue creation path

## Test plan

- [ ] Submit feedback with screenshot on localhost (non-org-member token) → issue created with base64 `<details>` block
- [ ] GHA workflow triggers on the new issue → base64 replaced with rendered image
- [ ] Submit without screenshot → no `<details>` blocks, no workflow trigger
- [ ] Invalid image format → yellow warning "invalid image format"
- [ ] Multiple screenshots → each gets its own numbered marker and is processed