### PR TITLE
🐛 Fix card shadows, Trestle flicker, duplicate cancel text

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -406,12 +406,6 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
               {t('missionChat.terminateSession', { defaultValue: 'Terminate Session' })}
             </button>
           )}
-          {mission.status === 'cancelling' && (
-            <span className="flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium bg-orange-500/15 text-orange-400 border border-orange-500/30 rounded-lg">
-              <Loader2 className="w-3.5 h-3.5 animate-spin" />
-              Cancelling...
-            </span>
-          )}
           <div className={cn('flex items-center gap-1', config.color)}>
             <StatusIcon className={cn('w-4 h-4', (mission.status === 'running' || mission.status === 'cancelling') && 'animate-spin')} />
             <span className="text-xs">{config.label}</span>

--- a/web/src/hooks/useTrestle.ts
+++ b/web/src/hooks/useTrestle.ts
@@ -438,19 +438,16 @@ export function useTrestle() {
       return
     }
 
-    // Real mode: check all clusters with bounded concurrency, stream results progressively
+    // Real mode: check all clusters with bounded concurrency.
+    // Buffer results and apply a single state update at the end to prevent
+    // the card from flickering through intermediate states (#4266).
     const allStatuses: Record<string, TrestleClusterStatus> = {}
+    let checked = 0
 
     const tasks = (clusterNames || []).map(cluster => async () => {
       const status = await fetchSingleCluster(cluster)
       allStatuses[cluster] = status
-      if (mountedRef.current) {
-        // Stream each result immediately — card re-renders progressively
-        setStatuses(prev => ({ ...prev, [cluster]: status }))
-        setClustersChecked(prev => prev + 1)
-        // Clear initial loading after first result arrives
-        setIsLoading(false)
-      }
+      checked++
     })
 
     await settledWithConcurrency(tasks)
@@ -468,6 +465,8 @@ export function useTrestle() {
         setStatuses(demoStatuses)
         setClustersChecked(demoNames.length)
       } else {
+        setStatuses(allStatuses)
+        setClustersChecked(checked)
         saveToCache(allStatuses)
       }
       setIsLoading(false)

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -242,6 +242,13 @@
     0 3px 6px 0 rgba(0, 0, 0, 0.7);
 }
 
+/* Light mode: softer card shadows (#4254) */
+.light .glass {
+  box-shadow:
+    0 1px 3px 0 rgba(0, 0, 0, 0.08),
+    0 1px 2px -1px rgba(0, 0, 0, 0.06);
+}
+
 /* Card hover effects - uses theme shadow */
 .card-hover {
   @apply transition-all duration-300;


### PR DESCRIPTION
## Summary

- **#4254 — Card shadows too strong in light mode**: Added `.light .glass` CSS override with subtle box-shadow values. The dark-mode `.glass` class uses heavy inset/outer shadows (`rgba(0,0,0,0.85)`) that look harsh in light mode. The override uses gentle `0.08`/`0.06` opacity shadows.
- **#4266 — Compliance Trestle card flickers during loading**: Changed `useTrestle` hook to buffer all cluster check results and apply a single state update at the end, instead of streaming per-cluster results that caused the card to re-render with intermediate values (scores jumping, profiles appearing one by one).
- **#4286 — Duplicate cancelling text in AI missions side panel**: Removed the "Cancelling..." badge from the MissionChat header. The status was shown in three places simultaneously: header badge, status icon label ("Cancelling..." from STATUS_CONFIG), and input area replacement ("Cancelling mission..."). Now only the status icon and input area show the cancelling state.

Fixes #4254
Fixes #4266
Fixes #4286

## Test plan

- [ ] Switch to light mode and verify card shadows are subtle, not heavy black
- [ ] Open the Compliance Trestle card and verify it loads without flickering through intermediate score values
- [ ] Start an AI mission, click cancel, and verify only one "Cancelling" indicator appears (in the input area)