### PR TITLE
🐛 Fix missing useCardLoadingState params across 3 cards

### DIFF
--- a/web/src/components/cards/AdmissionWebhooks.tsx
+++ b/web/src/components/cards/AdmissionWebhooks.tsx
@@ -8,10 +8,11 @@ import { CardSkeleton } from '../../lib/cards/CardComponents'
 export function AdmissionWebhooks() {
   const { t } = useTranslation('cards')
   const [tab, setTab] = useState<'all' | 'mutating' | 'validating'>('all')
-  const { webhooks, isLoading, isDemoData, isFailed, consecutiveFailures, lastRefresh } = useAdmissionWebhooks()
+  const { webhooks, isLoading, isRefreshing, isDemoData, isFailed, consecutiveFailures, lastRefresh } = useAdmissionWebhooks()
   const hasData = webhooks.length > 0
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isLoading && !hasData,
+    isRefreshing,
     hasAnyData: hasData,
     isDemoData,
     isFailed,

--- a/web/src/components/cards/EtcdStatus.tsx
+++ b/web/src/components/cards/EtcdStatus.tsx
@@ -39,9 +39,10 @@ function isManagedCluster(allPods: PodInfo[], cluster: string): boolean {
 export function EtcdStatus() {
   const { t } = useTranslation('cards')
   // Fetch from all namespaces so we catch etcd pods outside kube-system
-  const { pods, isLoading, isDemoFallback, isFailed, consecutiveFailures } = useCachedPods()
+  const { pods, isLoading, isRefreshing, isDemoFallback, isFailed, consecutiveFailures } = useCachedPods()
   const { showSkeleton } = useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: pods.length > 0,
     isDemoData: isDemoFallback,
     isFailed,

--- a/web/src/components/cards/QuotaHeatmap.tsx
+++ b/web/src/components/cards/QuotaHeatmap.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCachedPods } from '../../hooks/useCachedData'
+import { useCardLoadingState } from './CardDataContext'
 
 interface NamespaceUsage {
   namespace: string
@@ -11,8 +12,18 @@ interface NamespaceUsage {
 
 export function QuotaHeatmap() {
   const { t } = useTranslation('cards')
-  const { pods, isLoading } = useCachedPods(undefined, undefined, { limit: 500 })
+  const { pods, isLoading, isRefreshing, isDemoFallback, isFailed, consecutiveFailures } = useCachedPods(undefined, undefined, { limit: 500 })
   const [selectedNs, setSelectedNs] = useState<string | null>(null)
+
+  const hasData = pods.length > 0
+  const { showSkeleton } = useCardLoadingState({
+    isLoading: isLoading && !hasData,
+    isRefreshing,
+    hasAnyData: hasData,
+    isDemoData: isDemoFallback,
+    isFailed,
+    consecutiveFailures,
+  })
 
   const namespaceData = useMemo(() => {
     const map = new Map<string, NamespaceUsage>()
@@ -32,7 +43,7 @@ export function QuotaHeatmap() {
 
   const maxPods = useMemo(() => Math.max(1, ...namespaceData.map(d => d.podCount)), [namespaceData])
 
-  if (isLoading && pods.length === 0) {
+  if (showSkeleton) {
     return (
       <div className="grid grid-cols-6 gap-1 p-1">
         {Array.from({ length: 24 }).map((_, i) => (

--- a/web/src/hooks/useAdmissionWebhooks.ts
+++ b/web/src/hooks/useAdmissionWebhooks.ts
@@ -131,6 +131,7 @@ export interface UseAdmissionWebhooksResult {
   webhooks: WebhookData[]
   isDemoData: boolean
   isLoading: boolean
+  isRefreshing: boolean
   isFailed: boolean
   consecutiveFailures: number
   lastRefresh: number | null
@@ -144,6 +145,7 @@ export function useAdmissionWebhooks(): UseAdmissionWebhooksResult {
   const [webhooks, setWebhooks] = useState<WebhookData[]>(cachedData.current?.data || [])
   const [isDemoData, setIsDemoData] = useState(cachedData.current?.isDemoData ?? true)
   const [isLoading, setIsLoading] = useState(!cachedData.current)
+  const [isRefreshing, setIsRefreshing] = useState(false)
   const [consecutiveFailures, setConsecutiveFailures] = useState(0)
   const [lastRefresh, setLastRefresh] = useState<number | null>(
     cachedData.current?.timestamp || null
@@ -153,6 +155,9 @@ export function useAdmissionWebhooks(): UseAdmissionWebhooksResult {
   const refetch = useCallback(async (silent = false) => {
     if (!silent && !initialLoadDone.current) {
       setIsLoading(true)
+    }
+    if (silent) {
+      setIsRefreshing(true)
     }
 
     try {
@@ -194,6 +199,7 @@ export function useAdmissionWebhooks(): UseAdmissionWebhooksResult {
       saveToCache(demoWebhooks, true)
     } finally {
       setIsLoading(false)
+      setIsRefreshing(false)
     }
   }, [clusters])
 
@@ -219,6 +225,7 @@ export function useAdmissionWebhooks(): UseAdmissionWebhooksResult {
     webhooks,
     isDemoData,
     isLoading: isLoading || clustersLoading,
+    isRefreshing,
     isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
     consecutiveFailures,
     lastRefresh,


### PR DESCRIPTION
## Summary

- **EtcdStatus**: Add missing `isRefreshing` to `useCachedPods()` destructuring and `useCardLoadingState` call — the refresh icon in the CardWrapper header never animated during background data updates.
- **AdmissionWebhooks**: Add `isRefreshing` state tracking to the `useAdmissionWebhooks` hook (interface, state, set/clear in refetch) and pass it through to `useCardLoadingState` — same refresh icon animation bug.
- **QuotaHeatmap**: Add `useCardLoadingState` call entirely (was completely missing), replacing the hand-rolled `isLoading && pods.length === 0` check with `showSkeleton`. Wire up `isRefreshing`, `isDemoFallback`, `isFailed`, and `consecutiveFailures` — card was disconnected from the CardWrapper state system (no demo badge, no yellow outline, no refresh icon, no failure badge).

**Note**: Issues #4314, #4307, #4303, and #4300 reference WarningEvents, NodeConditions, DNSHealth, and NetworkPolicyCoverage respectively. These cards already have the correct wiring on `main` — the fixes were likely applied in prior PRs. Only 3 cards (EtcdStatus, AdmissionWebhooks, QuotaHeatmap) still needed fixes.

Fixes #4322, Fixes #4310, Fixes #4305

## Test plan

- [ ] Open dashboard with EtcdStatus card visible, trigger background refresh — verify CardWrapper header refresh icon animates
- [ ] Open dashboard with AdmissionWebhooks card visible, trigger background refresh — verify refresh icon animates
- [ ] Open dashboard with QuotaHeatmap card in demo mode — verify Demo badge and yellow outline appear
- [ ] Simulate API failure for QuotaHeatmap — verify failure badge appears on the card
- [ ] Build passes (`npm run build`)
- [ ] Lint passes on changed files