### PR TITLE
🐛 Fix JWT URL leakage and token query-param spoofing

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -256,8 +256,11 @@ func (s *Server) checkOrigin(r *http.Request) bool {
 // Tokens are accepted via the Authorization header for HTTP requests.
 // For WebSocket upgrades, tokens are also accepted via the ?token= query
 // parameter since browsers cannot set custom headers on WebSocket handshakes.
-// Query parameter tokens are restricted to Upgrade requests only to keep
-// secrets out of server logs, browser history, and proxy access logs (#3895).
+// Query parameter tokens are restricted to genuine WebSocket upgrade requests
+// to keep secrets out of server logs, browser history, and proxy access logs
+// (#3895). To prevent spoofed Upgrade headers from enabling the query-param
+// fallback (#4264), we verify all three headers that browsers always send for
+// real WebSocket handshakes: Upgrade, Connection, and Sec-WebSocket-Key.
 func (s *Server) validateToken(r *http.Request) bool {
 	// If no token configured, skip token validation
 	if s.agentToken == "" {
@@ -273,15 +276,50 @@ func (s *Server) validateToken(r *http.Request) bool {
 		}
 	}
 
-	// Fall back to query parameter ONLY for WebSocket upgrade requests
-	// (browsers cannot set custom headers on WebSocket handshakes)
-	if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+	// Fall back to query parameter ONLY for genuine WebSocket upgrade requests.
+	// Browsers always send all three headers; a plain HTTP client spoofing just
+	// the Upgrade header will be missing Connection and/or Sec-WebSocket-Key.
+	if isRealWebSocketUpgrade(r) {
 		if queryToken := r.URL.Query().Get("token"); queryToken != "" {
 			return queryToken == s.agentToken
 		}
 	}
 
 	return false
+}
+
+// isRealWebSocketUpgrade returns true only when the request carries all
+// three headers that a browser sends for a genuine WebSocket handshake:
+//   - Upgrade: websocket
+//   - Connection: upgrade  (the value list must include "upgrade")
+//   - Sec-WebSocket-Key: <non-empty>
+//
+// A plain HTTP client can easily set the Upgrade header alone; requiring
+// all three makes spoofing significantly harder (#4264).
+func isRealWebSocketUpgrade(r *http.Request) bool {
+	if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		return false
+	}
+
+	// Connection header may contain a comma-separated list (e.g. "keep-alive, Upgrade").
+	hasConnectionUpgrade := false
+	for _, v := range strings.Split(r.Header.Get("Connection"), ",") {
+		if strings.EqualFold(strings.TrimSpace(v), "upgrade") {
+			hasConnectionUpgrade = true
+			break
+		}
+	}
+	if !hasConnectionUpgrade {
+		return false
+	}
+
+	// Sec-WebSocket-Key is a base64-encoded 16-byte nonce that browsers
+	// always include. Its absence is a strong signal of a non-browser client.
+	if r.Header.Get("Sec-WebSocket-Key") == "" {
+		return false
+	}
+
+	return true
 }
 
 // Start starts the agent server

--- a/pkg/agent/server_test.go
+++ b/pkg/agent/server_test.go
@@ -601,12 +601,14 @@ func TestServer_SettingsAll(t *testing.T) {
 
 func TestServer_ValidateToken(t *testing.T) {
 	tests := []struct {
-		name           string
-		agentToken     string // configured token
-		authHeader     string
-		queryToken     string
-		upgradeHeader  string // set to "websocket" for WebSocket upgrade requests
-		expectResult   bool
+		name              string
+		agentToken        string // configured token
+		authHeader        string
+		queryToken        string
+		upgradeHeader     string // set to "websocket" for WebSocket upgrade requests
+		connectionHeader  string // "upgrade" for real WebSocket handshakes
+		secWebSocketKey   string // base64 nonce sent by browsers
+		expectResult      bool
 	}{
 		{
 			name:         "No token configured - skip validation",
@@ -630,12 +632,14 @@ func TestServer_ValidateToken(t *testing.T) {
 			expectResult: false,
 		},
 		{
-			name:          "Valid query parameter token on WebSocket upgrade",
-			agentToken:    "secret123",
-			authHeader:    "",
-			queryToken:    "secret123",
-			upgradeHeader: "websocket",
-			expectResult:  true,
+			name:             "Valid query parameter token on genuine WebSocket upgrade",
+			agentToken:       "secret123",
+			authHeader:       "",
+			queryToken:       "secret123",
+			upgradeHeader:    "websocket",
+			connectionHeader: "Upgrade",
+			secWebSocketKey:  "dGhlIHNhbXBsZSBub25jZQ==",
+			expectResult:     true,
 		},
 		{
 			name:         "Query parameter token rejected on non-upgrade request",
@@ -645,12 +649,14 @@ func TestServer_ValidateToken(t *testing.T) {
 			expectResult: false, // query tokens only accepted for WebSocket upgrades
 		},
 		{
-			name:          "Invalid query parameter token on WebSocket upgrade",
-			agentToken:    "secret123",
-			authHeader:    "",
-			queryToken:    "wrongtoken",
-			upgradeHeader: "websocket",
-			expectResult:  false,
+			name:             "Invalid query parameter token on WebSocket upgrade",
+			agentToken:       "secret123",
+			authHeader:       "",
+			queryToken:       "wrongtoken",
+			upgradeHeader:    "websocket",
+			connectionHeader: "Upgrade",
+			secWebSocketKey:  "dGhlIHNhbXBsZSBub25jZQ==",
+			expectResult:     false,
 		},
 		{
 			name:         "Missing token when required",
@@ -665,6 +671,37 @@ func TestServer_ValidateToken(t *testing.T) {
 			authHeader:   "Basic secret123",
 			queryToken:   "",
 			expectResult: false,
+		},
+		{
+			// #4264: spoofed Upgrade header without Connection header
+			name:          "Spoofed Upgrade header only - missing Connection",
+			agentToken:    "secret123",
+			authHeader:    "",
+			queryToken:    "secret123",
+			upgradeHeader: "websocket",
+			// connectionHeader deliberately empty
+			secWebSocketKey: "dGhlIHNhbXBsZSBub25jZQ==",
+			expectResult:    false,
+		},
+		{
+			// #4264: spoofed Upgrade+Connection but missing Sec-WebSocket-Key
+			name:             "Spoofed Upgrade+Connection - missing Sec-WebSocket-Key",
+			agentToken:       "secret123",
+			authHeader:       "",
+			queryToken:       "secret123",
+			upgradeHeader:    "websocket",
+			connectionHeader: "Upgrade",
+			// secWebSocketKey deliberately empty
+			expectResult: false,
+		},
+		{
+			// #4264: only Upgrade header, nothing else
+			name:          "Spoofed Upgrade header alone",
+			agentToken:    "secret123",
+			authHeader:    "",
+			queryToken:    "secret123",
+			upgradeHeader: "websocket",
+			expectResult:  false,
 		},
 	}
 
@@ -684,6 +721,12 @@ func TestServer_ValidateToken(t *testing.T) {
 			}
 			if tt.upgradeHeader != "" {
 				req.Header.Set("Upgrade", tt.upgradeHeader)
+			}
+			if tt.connectionHeader != "" {
+				req.Header.Set("Connection", tt.connectionHeader)
+			}
+			if tt.secWebSocketKey != "" {
+				req.Header.Set("Sec-WebSocket-Key", tt.secWebSocketKey)
 			}
 
 			result := server.validateToken(req)

--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -301,12 +301,13 @@ func (h *AuthHandler) devModeLogin(c *fiber.Ctx) error {
 		return c.Redirect(h.frontendURL+"/login?error=jwt_failed", fiber.StatusTemporaryRedirect)
 	}
 
-	// Set HttpOnly cookie (primary auth) and pass token in URL (migration fallback)
+	// Set HttpOnly cookie (primary auth) — the token is NOT passed in the URL
+	// to prevent leakage via browser history, Referer headers, and server logs (#4278).
+	// The frontend reads the token from the cookie via POST /auth/refresh.
 	h.setJWTCookie(c, jwtToken)
 
-	// Redirect to frontend with token
 	c.Set("Cache-Control", "no-store")
-	redirectURL := fmt.Sprintf("%s/auth/callback?token=%s&onboarded=%t", h.frontendURL, jwtToken, user.Onboarded)
+	redirectURL := fmt.Sprintf("%s/auth/callback?onboarded=%t", h.frontendURL, user.Onboarded)
 	return c.Redirect(redirectURL, fiber.StatusTemporaryRedirect)
 }
 
@@ -433,12 +434,13 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 		return h.oauthErrorRedirect(c, "jwt_failed", "")
 	}
 
-	// Set HttpOnly cookie (primary auth) and pass token in URL (migration fallback)
+	// Set HttpOnly cookie (primary auth) — the token is NOT passed in the URL
+	// to prevent leakage via browser history, Referer headers, and server logs (#4278).
+	// The frontend reads the token from the cookie via POST /auth/refresh.
 	h.setJWTCookie(c, jwtToken)
 
-	// Redirect to frontend with token
 	c.Set("Cache-Control", "no-store")
-	redirectURL := fmt.Sprintf("%s/auth/callback?token=%s&onboarded=%t", h.frontendURL, jwtToken, user.Onboarded)
+	redirectURL := fmt.Sprintf("%s/auth/callback?onboarded=%t", h.frontendURL, user.Onboarded)
 	return c.Redirect(redirectURL, fiber.StatusTemporaryRedirect)
 }
 
@@ -484,19 +486,31 @@ func (h *AuthHandler) Logout(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"success": true, "message": "Token revoked"})
 }
 
-// RefreshToken refreshes the JWT token
+// RefreshToken refreshes the JWT token.
+// Token resolution order: Authorization header -> HttpOnly cookie.
+// The cookie fallback is required for the OAuth callback flow where the
+// frontend has no token in localStorage yet — it was set as an HttpOnly
+// cookie by the backend redirect (#4278).
 func (h *AuthHandler) RefreshToken(c *fiber.Ctx) error {
-	// Get current user from context
+	var tokenString string
+
+	// Prefer Authorization header (existing callers send this)
 	authHeader := c.Get("Authorization")
-	if authHeader == "" {
+	if authHeader != "" {
+		if len(authHeader) < bearerPrefixLen || !strings.HasPrefix(authHeader, bearerPrefix) {
+			return fiber.NewError(fiber.StatusUnauthorized, "Invalid authorization format")
+		}
+		tokenString = authHeader[bearerPrefixLen:]
+	}
+
+	// Fallback: read from HttpOnly cookie (OAuth callback flow)
+	if tokenString == "" {
+		tokenString = c.Cookies(jwtCookieName)
+	}
+
+	if tokenString == "" {
 		return fiber.NewError(fiber.StatusUnauthorized, "Missing authorization")
 	}
-
-	if len(authHeader) < bearerPrefixLen || !strings.HasPrefix(authHeader, bearerPrefix) {
-		return fiber.NewError(fiber.StatusUnauthorized, "Invalid authorization format")
-	}
-
-	tokenString := authHeader[bearerPrefixLen:]
 	token, err := jwt.ParseWithClaims(tokenString, &middleware.UserClaims{}, func(token *jwt.Token) (interface{}, error) {
 		return []byte(h.jwtSecret), nil
 	})

--- a/pkg/api/handlers/auth_test.go
+++ b/pkg/api/handlers/auth_test.go
@@ -48,7 +48,8 @@ func TestDevModeLogin(t *testing.T) {
 		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 
 		loc, _ := resp.Location()
-		assert.Contains(t, loc.String(), "token=")
+		// Token must NOT appear in the redirect URL (#4278 — prevent JWT leakage)
+		assert.NotContains(t, loc.String(), "token=")
 		assert.Contains(t, loc.String(), "onboarded=true") // Dev user is auto-onboarded
 	})
 
@@ -71,7 +72,8 @@ func TestDevModeLogin(t *testing.T) {
 		assert.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
 
 		loc, _ := resp.Location()
-		assert.Contains(t, loc.String(), "token=")
+		// Token must NOT appear in the redirect URL (#4278 — prevent JWT leakage)
+		assert.NotContains(t, loc.String(), "token=")
 		assert.Contains(t, loc.String(), "onboarded=false")
 	})
 }

--- a/web/src/components/auth/AuthCallback.tsx
+++ b/web/src/components/auth/AuthCallback.tsx
@@ -8,6 +8,12 @@ import { useToast } from '../ui/Toast'
 import { safeGetItem, safeRemoveItem } from '../../lib/utils/localStorage'
 import { emitGitHubConnected } from '../../lib/analytics'
 
+/** Timeout (ms) for the /auth/refresh call that exchanges the HttpOnly cookie for a token. */
+const AUTH_REFRESH_TIMEOUT_MS = 5_000
+
+/** Short delay (ms) before navigating after a partial failure. */
+const NAVIGATE_AFTER_ERROR_DELAY_MS = 500
+
 export function AuthCallback() {
   const { t } = useTranslation('common')
   const navigate = useNavigate()
@@ -22,7 +28,6 @@ export function AuthCallback() {
     if (hasProcessed.current) return
     hasProcessed.current = true
 
-    const token = searchParams.get('token')
     const error = searchParams.get('error')
 
     if (error) {
@@ -30,38 +35,55 @@ export function AuthCallback() {
       return
     }
 
-    if (token) {
-      setToken(token, true)
-      emitGitHubConnected()
-      setStatus(t('authCallback.fetchingUserInfo'))
+    // The backend sets the JWT in an HttpOnly cookie during the OAuth redirect.
+    // We call POST /auth/refresh (which reads that cookie) to obtain the token
+    // for localStorage, avoiding JWT exposure in the URL (#4278).
+    const onboarded = searchParams.get('onboarded') === 'true'
 
-      // Check for a return-to URL saved by ProtectedRoute (deep-link through OAuth),
-      // then fall back to the last visited dashboard route, then '/'.
-      const RETURN_TO_KEY = 'kubestellar-return-to'
-      const returnTo = safeGetItem(RETURN_TO_KEY)
-      if (returnTo) safeRemoveItem(RETURN_TO_KEY)
-      const destination = returnTo || getLastRoute() || ROUTES.HOME
+    // Check for a return-to URL saved by ProtectedRoute (deep-link through OAuth),
+    // then fall back to the last visited dashboard route, then '/'.
+    const RETURN_TO_KEY = 'kubestellar-return-to'
+    const returnTo = safeGetItem(RETURN_TO_KEY)
+    if (returnTo) safeRemoveItem(RETURN_TO_KEY)
+    const destination = returnTo || getLastRoute() || ROUTES.HOME
 
-      // Add timeout to prevent hanging forever
-      const timeoutId = setTimeout(() => {
-        navigate(destination)
-      }, 5000)
+    setStatus(t('authCallback.fetchingUserInfo'))
 
-      refreshUser(token).then(() => {
+    // Exchange the HttpOnly cookie for a token via /auth/refresh
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), AUTH_REFRESH_TIMEOUT_MS)
+
+    fetch('/auth/refresh', {
+      method: 'POST',
+      credentials: 'same-origin', // send the HttpOnly cookie
+      signal: controller.signal,
+    })
+      .then((res) => {
         clearTimeout(timeoutId)
+        if (!res.ok) throw new Error(`refresh failed: ${res.status}`)
+        return res.json()
+      })
+      .then((data: { token?: string; onboarded?: boolean }) => {
+        const token = data.token
+        if (!token) throw new Error('No token in refresh response')
+
+        const isOnboarded = data.onboarded ?? onboarded
+        setToken(token, isOnboarded)
+        emitGitHubConnected()
+
+        return refreshUser(token)
+      })
+      .then(() => {
         navigate(destination)
-      }).catch((_err) => {
+      })
+      .catch((_err) => {
         clearTimeout(timeoutId)
         showToast(t('authCallback.failedToFetchUser'), 'warning')
-        // Still try to proceed if we have a token
         setStatus(t('authCallback.completingSignIn'))
         setTimeout(() => {
           navigate(destination)
-        }, 500)
+        }, NAVIGATE_AFTER_ERROR_DELAY_MS)
       })
-    } else {
-      navigate(ROUTES.LOGIN)
-    }
   }, [searchParams, setToken, refreshUser, navigate, showToast])
 
   return (


### PR DESCRIPTION
## Summary

- **Fix #4278**: Remove JWT from OAuth redirect URL query string. The token was being embedded as `?token=...` in the redirect URL, leaking it via browser history, Referer headers, and server logs. Now the token is only set as an HttpOnly cookie, and the frontend `AuthCallback` component calls `POST /auth/refresh` (which reads the cookie) to obtain the token for localStorage.
- **Fix #4264**: Tighten the WebSocket upgrade check in `validateToken` to require all three headers that browsers send for genuine WebSocket handshakes (`Upgrade: websocket`, `Connection: upgrade`, and `Sec-WebSocket-Key`), preventing spoofed Upgrade headers from enabling the `?token=` query-param fallback.

Fixes #4278
Fixes #4264

## Changes

### Backend (`pkg/api/handlers/auth.go`)
- Removed `token=` from both `GitHubCallback` and `devModeLogin` redirect URLs
- Updated `RefreshToken` to also accept JWT from the HttpOnly cookie (fallback for the OAuth callback flow where the frontend has no token in localStorage yet)

### Frontend (`web/src/components/auth/AuthCallback.tsx`)
- Replaced reading token from URL with a `POST /auth/refresh` call that reads the HttpOnly cookie
- Added named constants for timeout values (no magic numbers)

### Agent (`pkg/agent/server.go`)
- Added `isRealWebSocketUpgrade()` helper that checks for all three browser WebSocket handshake headers
- Updated `validateToken` to use the stricter check

### Tests
- Updated `server_test.go`: added 3 new test cases for spoofed header scenarios, updated existing WebSocket test to include all required headers
- Updated `auth_test.go`: assertions now verify token is NOT in redirect URLs

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/... -run TestServer_ValidateToken` passes (12 cases including 3 new spoofing tests)
- [x] `go test ./pkg/api/handlers/... -run TestDevModeLogin` passes (redirect URL no longer contains token)
- [x] `go test ./pkg/api/handlers/... -run TestRefreshToken` passes
- [x] `npm run build` passes
- [ ] Manual: OAuth login flow works (token retrieved via cookie + refresh endpoint)
- [ ] Manual: WebSocket connections still work with proper headers