### PR TITLE
🐛 Fix stale chunk errors after deploy + AI Missions navbar button

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -13,6 +13,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <title>KubeStellar Console</title>
+    <!-- Build version stamp — used by stale-HTML detection to force reload after deploys -->
+    <meta name="app-build-id" content="__COMMIT_HASH__" />
     <style>
       /* Inline app shell — visible before JS loads */
       #app-shell{display:flex;align-items:center;justify-content:center;min-height:100vh;flex-direction:column;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:#a1a1aa}

--- a/web/src/components/ChunkErrorBoundary.tsx
+++ b/web/src/components/ChunkErrorBoundary.tsx
@@ -4,8 +4,8 @@ import i18next from 'i18next'
 import { emitError, emitChunkReloadRecoveryFailed, markErrorReported } from '../lib/analytics'
 import { isChunkLoadError, CHUNK_RELOAD_TS_KEY } from '../lib/chunkErrors'
 
-// Reload throttle interval in milliseconds to prevent infinite reload loops
-const RELOAD_THROTTLE_MS = 30_000 // 30 seconds
+/** Reload throttle interval in milliseconds to prevent infinite reload loops */
+const RELOAD_THROTTLE_MS = 5_000 // 5 seconds — fast enough for back-to-back deploys
 
 interface Props {
   children: ReactNode

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, lazy, Suspense } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { Sun, Moon, Monitor, Menu, X, MoreVertical, ExternalLink } from 'lucide-react'
+import { Sun, Moon, Monitor, Menu, X, MoreVertical, ExternalLink, Sparkles } from 'lucide-react'
 import { useAuth } from '../../../lib/auth'
 import { useSidebarConfig } from '../../../hooks/useSidebarConfig'
 import { useTheme } from '../../../hooks/useTheme'
@@ -23,6 +23,7 @@ const SearchDropdown = lazy(() =>
 const AgentSelector = lazy(() =>
   import('../../agent/AgentSelector').then(m => ({ default: m.AgentSelector }))
 )
+import { useMissions } from '../../../hooks/useMissions'
 import { TokenUsageWidget } from './TokenUsageWidget'
 import { ClusterFilterPanel } from './ClusterFilterPanel'
 import { AgentStatusIndicator } from './AgentStatusIndicator'
@@ -46,6 +47,10 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
   const { isMobile } = useMobile()
   const { t } = useTranslation()
   const branding = useBranding()
+  const { missions, isSidebarOpen, openSidebar } = useMissions()
+  const missionsNeedingAttention = missions.filter(m =>
+    m.status === 'waiting_input' || m.status === 'failed'
+  ).length
 
   // Close mobile more menu on route change
   useEffect(() => {
@@ -127,6 +132,24 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
           {/* Update Indicator */}
           <UpdateIndicator />
 
+          {/* AI Missions — opens the mission sidebar */}
+          {!isSidebarOpen && (
+            <button
+              onClick={openSidebar}
+              className="relative flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors bg-purple-500/10 hover:bg-purple-500/20 text-purple-400 border border-purple-500/20"
+              aria-label={t('missionSidebar.openAIMissions')}
+              title={t('missionSidebar.openAIMissions')}
+            >
+              <Sparkles className="w-4 h-4" />
+              <span>{t('missionSidebar.aiMissions')}</span>
+              {missionsNeedingAttention > 0 && (
+                <span className="absolute -top-1.5 -right-1.5 flex items-center justify-center w-5 h-5 text-[10px] font-bold bg-purple-500 text-white rounded-full animate-pulse">
+                  {missionsNeedingAttention}
+                </span>
+              )}
+            </button>
+          )}
+
           {/* Visit Streak */}
           <StreakBadge />
 
@@ -205,7 +228,24 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
                     <div className="border-t border-border mx-3 my-1" />
                   </div>
 
-                  {/* Items hidden at <lg (1024px): update, token usage, feature request, tour */}
+                  {/* Items hidden at <lg (1024px): AI missions, update, token usage, feature request, tour */}
+                  {!isSidebarOpen && (
+                    <div className="px-3 py-2">
+                      <button
+                        onClick={() => { openSidebar(); setShowMobileMore(false) }}
+                        className="relative flex items-center gap-2 w-full px-3 py-2 text-sm font-medium rounded-lg transition-colors bg-purple-500/10 hover:bg-purple-500/20 text-purple-400"
+                        aria-label={t('missionSidebar.openAIMissions')}
+                      >
+                        <Sparkles className="w-4 h-4" />
+                        <span>{t('missionSidebar.aiMissions')}</span>
+                        {missionsNeedingAttention > 0 && (
+                          <span className="flex items-center justify-center w-5 h-5 text-[10px] font-bold bg-purple-500 text-white rounded-full animate-pulse">
+                            {missionsNeedingAttention}
+                          </span>
+                        )}
+                      </button>
+                    </div>
+                  )}
                   <div className="px-3 py-2">
                     <UpdateIndicator />
                   </div>

--- a/web/src/lib/__tests__/analytics.test.ts
+++ b/web/src/lib/__tests__/analytics.test.ts
@@ -2006,7 +2006,7 @@ describe('tryChunkReloadRecovery — reload throttle', () => {
 
   it('triggers reload when no recent reload exists', () => {
     const CHUNK_RELOAD_TS_KEY = 'chunk-reload-ts'
-    const GLOBAL_RELOAD_THROTTLE_MS = 30000
+    const GLOBAL_RELOAD_THROTTLE_MS = 5000
     const msg = 'Failed to fetch dynamically imported module /assets/foo.js'
 
     // Simulate isChunkLoadMessage
@@ -2025,8 +2025,8 @@ describe('tryChunkReloadRecovery — reload throttle', () => {
 
   it('skips reload when recent reload is within throttle window', () => {
     const CHUNK_RELOAD_TS_KEY = 'chunk-reload-ts'
-    const GLOBAL_RELOAD_THROTTLE_MS = 30000
-    const recentTs = String(Date.now() - 5000) // 5s ago — within throttle
+    const GLOBAL_RELOAD_THROTTLE_MS = 5000
+    const recentTs = String(Date.now() - 2000) // 2s ago — within throttle
 
     sessionStorage.setItem(CHUNK_RELOAD_TS_KEY, recentTs)
 
@@ -2043,8 +2043,8 @@ describe('tryChunkReloadRecovery — reload throttle', () => {
 
   it('allows reload when last reload exceeds throttle window', () => {
     const CHUNK_RELOAD_TS_KEY = 'chunk-reload-ts'
-    const GLOBAL_RELOAD_THROTTLE_MS = 30000
-    const oldTs = String(Date.now() - GLOBAL_RELOAD_THROTTLE_MS - 1000) // 31s ago
+    const GLOBAL_RELOAD_THROTTLE_MS = 5000
+    const oldTs = String(Date.now() - GLOBAL_RELOAD_THROTTLE_MS - 1000) // 6s ago
 
     sessionStorage.setItem(CHUNK_RELOAD_TS_KEY, oldTs)
 

--- a/web/src/lib/__tests__/chunkErrors.test.ts
+++ b/web/src/lib/__tests__/chunkErrors.test.ts
@@ -41,6 +41,18 @@ describe('isChunkLoadMessage', () => {
     expect(isChunkLoadMessage('Export "Foo" not found in module — chunk may be stale')).toBe(true)
   })
 
+  it('detects generic "Failed to fetch"', () => {
+    expect(isChunkLoadMessage('Failed to fetch')).toBe(true)
+  })
+
+  it('detects Firefox NetworkError for missing chunks', () => {
+    expect(isChunkLoadMessage('NetworkError when attempting to fetch resource')).toBe(true)
+  })
+
+  it('detects "Unexpected token \'<\'" from HTML returned for missing chunk', () => {
+    expect(isChunkLoadMessage("Unexpected token '<'")).toBe(true)
+  })
+
   it('returns false for unrelated errors', () => {
     expect(isChunkLoadMessage('TypeError: Cannot read properties of null')).toBe(false)
     expect(isChunkLoadMessage('')).toBe(false)

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1042,7 +1042,8 @@ function checkChunkReloadRecovery() {
 }
 
 // Reload throttle interval — must match ChunkErrorBoundary to prevent loops
-const GLOBAL_RELOAD_THROTTLE_MS = 30_000 // 30 seconds
+/** Global throttle for chunk-error auto-reload — 5s is fast enough for back-to-back deploys */
+const GLOBAL_RELOAD_THROTTLE_MS = 5_000
 
 /**
  * If the error message indicates a stale-chunk failure, auto-reload once

--- a/web/src/lib/chunkErrors.ts
+++ b/web/src/lib/chunkErrors.ts
@@ -33,6 +33,12 @@ export function isChunkLoadMessage(msg: string): boolean {
     // Safari/WebKit uses this message for failed dynamic import()
     msg.includes('Importing a module script failed') ||
     // safeLazy() throws this when a named export is missing from a stale chunk
-    msg.includes('chunk may be stale')
+    msg.includes('chunk may be stale') ||
+    // Generic fetch failure — often occurs when a chunk 404s on the CDN
+    msg.includes('Failed to fetch') ||
+    // Network error variant seen in Firefox for missing chunks
+    msg.includes('NetworkError when attempting to fetch resource') ||
+    // Chrome: TypeError when dynamic import() receives a non-JS response (e.g. 404 HTML)
+    msg.includes("Unexpected token '<'")
   )
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -30,7 +30,8 @@ import { prefetchTopDashboards } from './lib/dashboardVisits'
 // Vite fires `vite:preloadError` before React error boundaries see the error.
 // Auto-reload once to pick up fresh HTML with correct chunk references.
 const CHUNK_RELOAD_KEY = 'chunk-reload-ts'
-const CHUNK_RELOAD_COOLDOWN_MS = 30_000
+/** Cooldown between auto-reloads to prevent infinite reload loops on persistent errors */
+const CHUNK_RELOAD_COOLDOWN_MS = 5_000
 window.addEventListener('vite:preloadError', (event) => {
   const lastReload = sessionStorage.getItem(CHUNK_RELOAD_KEY)
   const now = Date.now()
@@ -41,6 +42,56 @@ window.addEventListener('vite:preloadError', (event) => {
     window.location.reload()
   }
 })
+
+// ── Proactive stale-HTML detection ───────────────────────────────────────
+// On visibility change (user returns to tab) or periodic interval, fetch
+// index.html and compare the app-build-id <meta> tag. If the server has a
+// newer build, reload immediately to pick up correct chunk references.
+const STALE_CHECK_INTERVAL_MS = 120_000 // check every 2 minutes
+const STALE_CHECK_KEY = 'stale-check-ts'
+
+function getLocalBuildId(): string | null {
+  const meta = document.querySelector('meta[name="app-build-id"]')
+  return meta?.getAttribute('content') ?? null
+}
+
+async function checkForStaleHtml(): Promise<void> {
+  // Throttle: at most once per interval
+  const lastCheck = sessionStorage.getItem(STALE_CHECK_KEY)
+  const now = Date.now()
+  if (lastCheck && now - parseInt(lastCheck) < STALE_CHECK_INTERVAL_MS) return
+  sessionStorage.setItem(STALE_CHECK_KEY, String(now))
+
+  const localId = getLocalBuildId()
+  if (!localId) return // dev mode or missing meta — skip
+
+  try {
+    const resp = await fetch('/?_stale_check=' + now, {
+      cache: 'no-store',
+      headers: { Accept: 'text/html' },
+    })
+    if (!resp.ok) return
+    const html = await resp.text()
+    const match = html.match(/meta\s+name="app-build-id"\s+content="([^"]+)"/)
+    if (match && match[1] !== localId) {
+      // Server has a newer build — force reload
+      sessionStorage.setItem(CHUNK_RELOAD_KEY, String(now))
+      window.location.reload()
+    }
+  } catch {
+    // Network error — skip silently
+  }
+}
+
+// Check when user returns to the tab (common scenario: deploy happened while tab was backgrounded)
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    checkForStaleHtml()
+  }
+})
+
+// Also check on a periodic interval for long-lived tabs
+setInterval(checkForStaleHtml, STALE_CHECK_INTERVAL_MS)
 
 // Suppress recharts dimension warnings (these occur when charts render before container is sized)
 const originalWarn = console.warn

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -59,6 +59,14 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
+    // Inject build commit hash into the HTML <meta name="app-build-id"> tag
+    // so the stale-HTML detection script can compare against the server.
+    {
+      name: 'inject-build-id',
+      transformIndexHtml(html) {
+        return html.replace('__COMMIT_HASH__', process.env.VITE_COMMIT_HASH || getGitCommitHash())
+      },
+    },
     // Pre-compress assets at build time — avoids chunked encoding on slow networks
     compression({ algorithm: 'gzip', exclude: [/\.(br)$/], threshold: 1024 }),
     compression({ algorithm: 'brotliCompress', exclude: [/\.(gz)$/], threshold: 1024 }),


### PR DESCRIPTION
## Summary

- **#4313 — Stale chunk errors**: Reduced auto-reload cooldown from 30s to 5s, expanded error pattern matching to cover `Failed to fetch`, Firefox `NetworkError`, and `Unexpected token '<'` (HTML returned for missing chunks). Added proactive stale-HTML detection via `app-build-id` meta tag + visibility/interval checks that auto-reload when the server has a newer build.
- **#4287 — AI Missions accessibility**: Added a prominent "AI Missions" button with Sparkles icon to the navbar (visible at lg+ breakpoints) that opens the missions sidebar. Includes attention badge for missions needing input. Also added to the overflow menu for narrower viewports. Button auto-hides when sidebar is already open.

Fixes #4313, Fixes #4287

## Changes

| File | What changed |
|------|-------------|
| `web/index.html` | Added `<meta name="app-build-id">` tag for stale-HTML detection |
| `web/vite.config.ts` | Added `inject-build-id` plugin to replace placeholder with commit hash at build time |
| `web/src/main.tsx` | Reduced cooldown to 5s, added proactive stale-HTML detection (visibility change + 2min interval) |
| `web/src/lib/chunkErrors.ts` | Added 3 new error patterns: `Failed to fetch`, `NetworkError`, `Unexpected token '<'` |
| `web/src/lib/analytics.ts` | Reduced `GLOBAL_RELOAD_THROTTLE_MS` from 30s to 5s |
| `web/src/components/ChunkErrorBoundary.tsx` | Reduced `RELOAD_THROTTLE_MS` from 30s to 5s |
| `web/src/components/layout/navbar/Navbar.tsx` | Added AI Missions button (desktop + overflow menu) |
| `web/src/lib/__tests__/chunkErrors.test.ts` | Added tests for new error patterns |
| `web/src/lib/__tests__/analytics.test.ts` | Updated throttle values in tests to match 5s |

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Chunk error tests pass (`vitest run chunkErrors.test.ts`)
- [ ] AI Missions button visible in navbar at lg+ breakpoints
- [ ] Clicking button opens missions sidebar
- [ ] Button disappears when sidebar is open, reappears when closed
- [ ] Attention badge shows count when missions need input
- [ ] Button appears in overflow menu on narrow viewports
- [ ] Stale-HTML detection reloads when tab is re-focused after a deploy