### PR TITLE
🐛 Screenshots as compressed comments + GHA processing

### DIFF
--- a/.github/workflows/process-screenshots.yml
+++ b/.github/workflows/process-screenshots.yml
@@ -1,113 +1,101 @@
 name: Process Issue Screenshots
 
-# When a new issue is created with embedded base64 screenshots, this workflow
-# decodes them, commits the images to .github/screenshots/, and replaces the
-# base64 blocks in the issue body with rendered markdown images.
+# When a screenshot comment is added to an issue (base64 data URI in a
+# collapsible block), this workflow decodes it, commits the image to
+# .github/screenshots/, and replaces the comment with a rendered image.
 #
-# This avoids requiring end users' PATs to have push access to the repo.
-# The workflow's GITHUB_TOKEN has write access automatically.
+# Screenshots are added as separate comments (not in the issue body) to
+# avoid GitHub's 65K character body limit. Each comment contains a
+# <!-- screenshot-base64:N --> marker that this workflow looks for.
+#
+# The workflow's GITHUB_TOKEN has write access — no user PAT push access needed.
 
 on:
-  issues:
-    types: [opened]
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: write
   issues: write
 
 jobs:
-  process-screenshots:
-    # Only run if the issue body contains our base64 screenshot marker
-    if: contains(github.event.issue.body, '<!-- screenshot-base64:')
+  process-screenshot:
+    # Only run on issue comments (not PR comments) with our marker
+    if: >
+      !github.event.issue.pull_request &&
+      contains(github.event.comment.body, '<!-- screenshot-base64:')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Process base64 screenshots
+      - name: Process screenshot comment
         uses: actions/github-script@v7
         with:
           script: |
             const issueNumber = context.issue.number;
-            let body = context.payload.issue.body;
+            const commentId = context.payload.comment.id;
+            const body = context.payload.comment.body;
 
-            // Find all screenshot-base64 markers
-            const markerRegex = /<!-- screenshot-base64:(\d+) -->\n<details>\n<summary>Screenshot \d+ \(processing\.\.\.\)<\/summary>\n\n```\n(data:image\/[^;]+;base64,[A-Za-z0-9+/=\n]+)\n```\n\n<\/details>/g;
+            // Extract the screenshot marker and data URI
+            const markerRegex = /<!-- screenshot-base64:(\d+) -->\n<details>\n<summary>Screenshot \d+ \(processing\.\.\.\)<\/summary>\n\n```\n(data:image\/[^;]+;base64,[A-Za-z0-9+/=\s]+)\n```\n\n<\/details>/;
+            const match = markerRegex.exec(body);
 
-            let match;
-            const screenshots = [];
-            while ((match = markerRegex.exec(body)) !== null) {
-              screenshots.push({
-                fullMatch: match[0],
-                index: parseInt(match[1]),
-                dataUri: match[2].replace(/\n/g, ''),
-              });
-            }
-
-            if (screenshots.length === 0) {
-              console.log('No base64 screenshots found in issue body');
+            if (!match) {
+              console.log('No base64 screenshot found in comment');
               return;
             }
 
-            console.log(`Found ${screenshots.length} screenshot(s) to process`);
+            const index = parseInt(match[1]);
+            const dataUri = match[2].replace(/\s/g, '');
 
-            // Extract issue ID from body for folder naming
-            const idMatch = body.match(/Console Request ID:\*\* ([a-f0-9-]+)/);
+            console.log(`Processing screenshot ${index} from comment ${commentId}`);
+
+            // Extract issue request ID from the issue body for folder naming
+            const issueBody = context.payload.issue.body || '';
+            const idMatch = issueBody.match(/Console Request ID:\*\* ([a-f0-9-]+)/);
             const requestId = idMatch ? idMatch[1] : `issue-${issueNumber}`;
 
-            let updatedBody = body;
+            try {
+              // Parse data URI
+              const [header, b64Content] = dataUri.split(',');
+              const extMatch = header.match(/image\/(\w+)/);
+              const ext = extMatch ? extMatch[1].replace('jpeg', 'jpg') : 'png';
 
-            for (const ss of screenshots) {
-              try {
-                // Parse data URI
-                const [header, b64Content] = ss.dataUri.split(',');
-                const extMatch = header.match(/image\/(\w+)/);
-                const ext = extMatch ? extMatch[1].replace('jpeg', 'jpg') : 'png';
+              // Commit the image to the repo
+              const filePath = `.github/screenshots/${requestId}/screenshot-${index}.${ext}`;
+              console.log(`Uploading ${filePath}...`);
 
-                // Decode base64 to verify it's valid
-                const content = b64Content;
-
-                // Commit the image to the repo
-                const filePath = `.github/screenshots/${requestId}/screenshot-${ss.index}.${ext}`;
-                console.log(`Uploading ${filePath}...`);
-
-                const { data } = await github.rest.repos.createOrUpdateFileContents({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  path: filePath,
-                  message: `Add screenshot ${ss.index} for issue #${issueNumber}`,
-                  content: content,
-                  committer: {
-                    name: 'github-actions[bot]',
-                    email: '41898282+github-actions[bot]@users.noreply.github.com',
-                  },
-                });
-
-                const downloadUrl = data.content.download_url;
-                console.log(`Uploaded: ${downloadUrl}`);
-
-                // Replace the base64 block with a rendered image
-                updatedBody = updatedBody.replace(
-                  ss.fullMatch,
-                  `![Screenshot ${ss.index}](${downloadUrl})`
-                );
-              } catch (err) {
-                console.error(`Failed to process screenshot ${ss.index}:`, err.message);
-                // Replace with error message instead of leaving base64 blob
-                updatedBody = updatedBody.replace(
-                  ss.fullMatch,
-                  `> ⚠️ Screenshot ${ss.index} could not be processed: ${err.message}`
-                );
-              }
-            }
-
-            // Update the issue body with rendered images
-            if (updatedBody !== body) {
-              await github.rest.issues.update({
+              const { data } = await github.rest.repos.createOrUpdateFileContents({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: issueNumber,
-                body: updatedBody,
+                path: filePath,
+                message: `Add screenshot ${index} for issue #${issueNumber}`,
+                content: b64Content,
+                committer: {
+                  name: 'github-actions[bot]',
+                  email: '41898282+github-actions[bot]@users.noreply.github.com',
+                },
               });
-              console.log(`Issue #${issueNumber} updated with ${screenshots.length} rendered screenshot(s)`);
+
+              const downloadUrl = data.content.download_url;
+              console.log(`Uploaded: ${downloadUrl}`);
+
+              // Replace the comment with a rendered image
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+                body: `![Screenshot ${index}](${downloadUrl})`,
+              });
+
+              console.log(`Comment ${commentId} updated with rendered screenshot`);
+            } catch (err) {
+              console.error(`Failed to process screenshot ${index}:`, err.message);
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+                body: `> ⚠️ Screenshot ${index} could not be processed: ${err.message}`,
+              });
             }

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -1565,34 +1565,23 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 		repoLabel = "Console Documentation"
 	}
 
-	// Embed screenshots as base64 in the issue body inside collapsible blocks.
-	// A GitHub Actions workflow (process-screenshots.yml) watches for new issues
-	// with these markers, decodes the base64, commits the images to the repo
-	// (using the workflow's GITHUB_TOKEN which has write access), and replaces
-	// the base64 blocks with rendered markdown images. This avoids requiring
-	// the user's PAT to have push access to the repo.
-	screenshotMarkdown := ""
+	// Validate screenshots upfront so we can report accurate counts.
+	// Screenshots are NOT embedded in the issue body (GitHub limits bodies to
+	// 65,536 chars and base64 screenshots easily exceed that). Instead, they
+	// are added as separate comments after issue creation. A GitHub Actions
+	// workflow (process-screenshots.yml) then decodes the base64, commits
+	// images to the repo, and replaces the comment with a rendered image.
+	var validScreenshots []string
 	var ssResult screenshotUploadResult
-	if len(screenshots) > 0 {
-		var blocks []string
-		for i, dataURI := range screenshots {
-			// Validate the data URI format
-			parts := strings.SplitN(dataURI, ",", 2)
-			if len(parts) != 2 {
-				ssResult.Failed++
-				log.Printf("[Feedback] Screenshot %d: invalid data URI format", i+1)
-				continue
-			}
-			ssResult.Uploaded++
-			// Wrap in a collapsible <details> block with a machine-readable marker
-			// that the GHA workflow can find and process.
-			blocks = append(blocks, fmt.Sprintf(
-				"<!-- screenshot-base64:%d -->\n<details>\n<summary>Screenshot %d (processing...)</summary>\n\n```\n%s\n```\n\n</details>",
-				i+1, i+1, dataURI))
+	for i, dataURI := range screenshots {
+		parts := strings.SplitN(dataURI, ",", 2)
+		if len(parts) != 2 {
+			ssResult.Failed++
+			log.Printf("[Feedback] Screenshot %d: invalid data URI format", i+1)
+			continue
 		}
-		if len(blocks) > 0 {
-			screenshotMarkdown = "\n\n## Screenshots\n\n" + strings.Join(blocks, "\n\n")
-		}
+		validScreenshots = append(validScreenshots, dataURI)
+		ssResult.Uploaded++
 	}
 
 	issueBody := fmt.Sprintf(`## User Request
@@ -1604,11 +1593,11 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 
 ## Description
 
-%s%s
+%s
 
 ---
 *This issue was automatically created from the KubeStellar Console.*
-`, request.RequestType, repoLabel, user.GitHubLogin, request.ID.String(), request.Description, screenshotMarkdown)
+`, request.RequestType, repoLabel, user.GitHubLogin, request.ID.String(), request.Description)
 
 	// First attempt: create issue with labels
 	number, htmlURL, err := h.postGitHubIssue(repoOwner, repoName, request.Title, issueBody, labels)
@@ -1618,6 +1607,20 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 		// so maintainers can triage and label it manually.
 		log.Printf("[Feedback] Label permission denied on %s/%s, retrying without labels", repoOwner, repoName)
 		number, htmlURL, err = h.postGitHubIssue(repoOwner, repoName, request.Title, issueBody, nil)
+	}
+
+	// Add screenshots as separate comments (one per screenshot) so they
+	// don't blow up the 65K issue body limit. Each comment contains a
+	// base64 data URI in a collapsible <details> block with a marker
+	// that the process-screenshots GHA workflow can find and process.
+	if err == nil && len(validScreenshots) > 0 {
+		for i, dataURI := range validScreenshots {
+			commentBody := fmt.Sprintf(
+				"<!-- screenshot-base64:%d -->\n<details>\n<summary>Screenshot %d (processing...)</summary>\n\n```\n%s\n```\n\n</details>",
+				i+1, i+1, dataURI)
+			h.addIssueComment(number, commentBody, repoName)
+		}
+		log.Printf("[Feedback] Added %d screenshot comment(s) to issue #%d", len(validScreenshots), number)
 	}
 
 	return number, htmlURL, ssResult, err

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -18,6 +18,7 @@ import { useRewards } from '../../hooks/useRewards'
 import { BACKEND_DEFAULT_URL, STORAGE_KEY_TOKEN, DEMO_TOKEN_VALUE, FETCH_DEFAULT_TIMEOUT_MS, COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
 import { FEEDBACK_UPLOAD_TIMEOUT_MS } from '../../lib/constants/network'
 import { GITHUB_TOKEN_CREATE_URL, GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS } from '../../lib/constants/github-token'
+import { compressScreenshot } from '../../lib/imageCompression'
 import { emitLinkedInShare } from '../../lib/analytics'
 import { isDemoModeForced } from '../../lib/demoMode'
 import { useToast } from '../ui/Toast'
@@ -337,9 +338,14 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
       return
     }
 
-    // Collect base64 data URIs for screenshots so the backend can upload
-    // them to GitHub and embed them directly in the created issue.
-    const screenshotDataURIs = screenshots.map(s => s.preview)
+    // Compress screenshots to fit within GitHub's 65K comment limit.
+    // Images are embedded as base64 in issue comments and processed into
+    // rendered images by a GitHub Actions workflow.
+    const screenshotDataURIs: string[] = []
+    for (const s of screenshots) {
+      const compressed = await compressScreenshot(s.preview)
+      if (compressed) screenshotDataURIs.push(compressed)
+    }
 
     try {
       const hasScreenshots = screenshotDataURIs.length > 0

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -21,7 +21,7 @@ import { emitFeedbackSubmitted, emitLinkedInShare, emitScreenshotAttached, emitS
 import { useBranding } from '../../hooks/useBranding'
 import { FETCH_DEFAULT_TIMEOUT_MS, COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
 import { FEEDBACK_UPLOAD_TIMEOUT_MS } from '../../lib/constants/network'
-// github-token constants no longer needed here — screenshots are embedded as base64
+import { compressScreenshot } from '../../lib/imageCompression'
 import { useFeatureRequests } from '../../hooks/useFeatureRequests'
 import { useAuth } from '../../lib/auth'
 
@@ -167,9 +167,14 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
     setSubmitError(null)
 
     try {
-      // Collect base64 data URIs for any attached screenshots so the
-      // backend can upload them to GitHub and embed them in the issue.
-      const screenshotDataURIs = screenshots.map(s => s.preview)
+      // Compress screenshots to fit within GitHub's 65K issue body limit.
+      // Images are embedded as base64 and processed into rendered images
+      // by a GitHub Actions workflow after the issue is created.
+      const screenshotDataURIs: string[] = []
+      for (const s of screenshots) {
+        const compressed = await compressScreenshot(s.preview)
+        if (compressed) screenshotDataURIs.push(compressed)
+      }
 
       // Submit via backend API — creates GitHub issue directly using the
       // server-side token. No GitHub login required from the user.

--- a/web/src/lib/constants/github-token.ts
+++ b/web/src/lib/constants/github-token.ts
@@ -5,10 +5,11 @@
  * and backend log messages. Keep this in sync if requirements change.
  */
 
-/** Fine-grained PAT permissions required for end-user feedback features */
+/** Fine-grained PAT permissions required for end-user feedback features.
+ *  Note: Contents scope is NOT needed — screenshots are added as issue
+ *  comments and processed into images by a GitHub Actions workflow. */
 export const GITHUB_TOKEN_FINE_GRAINED_PERMISSIONS = [
-  { scope: 'Issues: Read and write', reason: 'create and manage GitHub issues' },
-  { scope: 'Contents: Read and write', reason: 'upload screenshots to issues' },
+  { scope: 'Issues: Read and write', reason: 'create issues, add comments, and attach screenshots' },
 ] as const
 
 /** Classic PAT scope required (covers all of the above) */

--- a/web/src/lib/imageCompression.ts
+++ b/web/src/lib/imageCompression.ts
@@ -1,0 +1,91 @@
+/**
+ * Compress an image data URI to fit within GitHub's issue body limit.
+ *
+ * Screenshots are embedded as base64 in issue bodies and processed into
+ * rendered images by a GitHub Actions workflow. GitHub limits issue bodies
+ * to 65,536 characters, so we compress images to JPEG and resize if needed.
+ *
+ * Target: ~30KB per screenshot (~40K base64 chars), leaving room for
+ * the issue template and multiple screenshots.
+ */
+
+/** Maximum base64 characters per screenshot to stay within GitHub's 65K body limit */
+const MAX_B64_CHARS_PER_SCREENSHOT = 40_000
+
+/** Maximum pixel dimension (width or height) after resize */
+const MAX_DIMENSION_PX = 1024
+
+/** JPEG quality for compression (0-1) */
+const JPEG_QUALITY = 0.6
+
+/** Lower JPEG quality for retry if first pass is still too large */
+const JPEG_QUALITY_LOW = 0.3
+
+/** Maximum dimension for aggressive retry */
+const MAX_DIMENSION_LOW_PX = 640
+
+/**
+ * Compress an image data URI to a JPEG data URI that fits within the
+ * base64 character budget for GitHub issue embedding.
+ *
+ * Returns the compressed data URI, or null if compression fails.
+ */
+export async function compressScreenshot(dataUri: string): Promise<string | null> {
+  try {
+    // First pass: resize to MAX_DIMENSION_PX, JPEG at normal quality
+    let result = await resizeAndCompress(dataUri, MAX_DIMENSION_PX, JPEG_QUALITY)
+    if (result && getBase64Length(result) <= MAX_B64_CHARS_PER_SCREENSHOT) {
+      return result
+    }
+
+    // Second pass: more aggressive — smaller size, lower quality
+    result = await resizeAndCompress(dataUri, MAX_DIMENSION_LOW_PX, JPEG_QUALITY_LOW)
+    if (result && getBase64Length(result) <= MAX_B64_CHARS_PER_SCREENSHOT) {
+      return result
+    }
+
+    // Still too large — give up
+    console.warn('[Screenshot] Image too large even after aggressive compression')
+    return null
+  } catch (err) {
+    console.error('[Screenshot] Compression failed:', err)
+    return null
+  }
+}
+
+/** Get the length of the base64 portion of a data URI */
+function getBase64Length(dataUri: string): number {
+  const commaIdx = dataUri.indexOf(',')
+  return commaIdx >= 0 ? dataUri.length - commaIdx - 1 : dataUri.length
+}
+
+/** Resize image to fit within maxDim and compress to JPEG */
+function resizeAndCompress(dataUri: string, maxDim: number, quality: number): Promise<string | null> {
+  return new Promise((resolve) => {
+    const img = new Image()
+    img.onload = () => {
+      let { width, height } = img
+
+      // Scale down if either dimension exceeds max
+      if (width > maxDim || height > maxDim) {
+        const scale = maxDim / Math.max(width, height)
+        width = Math.round(width * scale)
+        height = Math.round(height * scale)
+      }
+
+      const canvas = document.createElement('canvas')
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) {
+        resolve(null)
+        return
+      }
+
+      ctx.drawImage(img, 0, 0, width, height)
+      resolve(canvas.toDataURL('image/jpeg', quality))
+    }
+    img.onerror = () => resolve(null)
+    img.src = dataUri
+  })
+}


### PR DESCRIPTION
## Summary

Fixes the 422 "body is too long" error from #4220. Base64 screenshots easily exceed GitHub's 65K issue body limit.

### New approach

1. **Frontend compresses** screenshots (JPEG, max 1024px, quality 60%) → ~30KB per image
2. **Backend adds screenshots as separate issue comments** — one per screenshot, each with a `<!-- screenshot-base64:N -->` marker. Issue body stays clean and small.
3. **GHA workflow** (`process-screenshots.yml`) triggers on `issue_comment.created`, decodes base64, commits image to `.github/screenshots/`, replaces the comment with `![Screenshot](url)`

### Token permissions simplified

Since screenshots go via issue comments (not Contents API), the token no longer needs `Contents: Read and write`. Updated `github-token.ts` constants — only `Issues: Read and write` is needed for fine-grained PATs.

### Files changed

- `pkg/api/handlers/feedback.go` — screenshots as comments instead of in body
- `.github/workflows/process-screenshots.yml` — triggers on `issue_comment` instead of `issues.opened`
- `web/src/lib/imageCompression.ts` — new: client-side JPEG compression
- `web/src/components/feedback/*.tsx` — use compression, updated messages
- `web/src/lib/constants/github-token.ts` — removed Contents permission requirement

## Test plan

- [ ] Submit feedback with screenshot → issue created, screenshot added as comment with `<details>` block
- [ ] GHA workflow triggers on the comment → replaces with rendered image
- [ ] Large screenshot (>200KB) compressed to fit in 65K comment limit
- [ ] Multiple screenshots → each gets its own comment
- [ ] Classic PAT with `repo` scope only — works without Contents permission