### PR TITLE
✨ Add multi-project selection: filter dashboard by projects

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { BrandingProvider, useBranding } from './hooks/useBranding'
 import { DrillDownProvider } from './hooks/useDrillDown'
 import { DashboardProvider, useDashboardContext } from './hooks/useDashboardContext'
 import { GlobalFiltersProvider } from './hooks/useGlobalFilters'
+import { ProjectFilterProvider } from './hooks/useProjectFilter'
 import { MissionProvider } from './hooks/useMissions'
 import { CardEventProvider } from './lib/cardEvents'
 import { ToastProvider } from './components/ui/Toast'
@@ -475,6 +476,7 @@ function FullDashboardApp() {
     <UnifiedDemoProvider>
       <RewardsProvider>
       <ToastProvider>
+      <ProjectFilterProvider>
       <GlobalFiltersProvider>
       <MissionProvider>
       <CardEventProvider>
@@ -566,6 +568,7 @@ function FullDashboardApp() {
       </CardEventProvider>
       </MissionProvider>
       </GlobalFiltersProvider>
+      </ProjectFilterProvider>
       </ToastProvider>
       </RewardsProvider>
     </UnifiedDemoProvider>

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -25,6 +25,7 @@ const AgentSelector = lazy(() =>
 )
 import { useMissions } from '../../../hooks/useMissions'
 import { TokenUsageWidget } from './TokenUsageWidget'
+import { ProjectSelector } from './ProjectSelector'
 import { ClusterFilterPanel } from './ClusterFilterPanel'
 import { AgentStatusIndicator } from './AgentStatusIndicator'
 import { UpdateIndicator } from './UpdateIndicator'
@@ -119,7 +120,8 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
       <div className="flex items-center gap-1 md:gap-3 shrink-0">
         {/* Core desktop items: md+ (768px) */}
         <div className="hidden md:flex items-center gap-2">
-          {/* Global Filters (includes Clear Filters button) */}
+          {/* Project + Cluster Filters */}
+          <ProjectSelector />
           <ClusterFilterPanel />
 
           {/* Agent Status + Selector — status (Demo/AI pill) on left, selector on right */}

--- a/web/src/components/layout/navbar/ProjectSelector.tsx
+++ b/web/src/components/layout/navbar/ProjectSelector.tsx
@@ -1,0 +1,292 @@
+/**
+ * ProjectSelector — a multi-select dropdown in the navbar that lets users
+ * filter the entire dashboard by one or more projects.
+ *
+ * Projects are user-defined cluster groupings managed via useProjectFilter.
+ */
+
+import { useState, useRef, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { FolderKanban, Check, Plus, Trash2, ChevronDown } from 'lucide-react'
+import { useProjectFilter } from '../../../hooks/useProjectFilter'
+import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
+import { ALL_PROJECTS_ID, isBuiltInProject } from '../../../lib/projects'
+import { cn } from '../../../lib/cn'
+
+/** Maximum visible project items before the list scrolls */
+const MAX_VISIBLE_ITEMS = 8
+/** Line height (px) per project item used for max-height calculation */
+const ITEM_HEIGHT_PX = 36
+
+export function ProjectSelector() {
+  const { t } = useTranslation()
+  const {
+    projects,
+    selectedProjectIds,
+    toggleProject,
+    setSelectedProjectIds,
+    isAllSelected,
+    isProjectFiltered,
+    addProject,
+    deleteProject,
+  } = useProjectFilter()
+
+  const { availableClusters } = useGlobalFilters()
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [showCreateForm, setShowCreateForm] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [newClusters, setNewClusters] = useState<string[]>([])
+  const [newColor, setNewColor] = useState('#8B5CF6') // purple default
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  // Close on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  // Count of selected user projects (excludes "All")
+  const activeCount = isAllSelected ? 0 : selectedProjectIds.length
+  // User-defined projects only (no built-ins except All)
+  const userProjects = projects.filter(p => !isBuiltInProject(p.id))
+
+  const handleCreate = () => {
+    if (!newName.trim() || newClusters.length === 0) return
+    addProject({
+      name: newName.trim(),
+      clusters: newClusters,
+      namespaces: [],
+      color: newColor,
+    })
+    setNewName('')
+    setNewClusters([])
+    setShowCreateForm(false)
+  }
+
+  const handleCancel = () => {
+    setShowCreateForm(false)
+    setNewName('')
+    setNewClusters([])
+  }
+
+  const label = isAllSelected
+    ? t('projects.allProjects', 'All Projects')
+    : activeCount === 1
+      ? projects.find(p => p.id === selectedProjectIds[0])?.name ?? 'Project'
+      : `${activeCount} Projects`
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      {/* Trigger button */}
+      <button
+        onClick={() => setIsOpen(prev => !prev)}
+        className={cn(
+          'flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors',
+          isProjectFiltered
+            ? 'bg-purple-500/20 text-purple-400'
+            : 'bg-secondary/50 text-muted-foreground hover:text-foreground',
+        )}
+        title={isProjectFiltered ? `Filtering by: ${label}` : 'Select projects to filter dashboard'}
+      >
+        <FolderKanban className="w-4 h-4" />
+        <span className="hidden sm:inline max-w-[120px] truncate">{label}</span>
+        {isProjectFiltered && (
+          <span className="flex items-center justify-center min-w-[18px] h-[18px] px-1 text-[10px] font-bold bg-purple-500 text-white rounded-full">
+            {activeCount}
+          </span>
+        )}
+        <ChevronDown className={cn('w-3 h-3 transition-transform', isOpen && 'rotate-180')} />
+      </button>
+
+      {/* Dropdown panel */}
+      {isOpen && (
+        <div className="absolute top-full right-0 mt-2 w-72 bg-card border border-border rounded-lg shadow-xl z-50 overflow-hidden">
+          {/* Header with "All" toggle */}
+          <div className="px-3 py-2 border-b border-border flex items-center justify-between">
+            <span className="text-sm font-medium text-foreground">
+              {t('projects.title', 'Projects')}
+            </span>
+            <button
+              onClick={() => setSelectedProjectIds([ALL_PROJECTS_ID])}
+              className={cn(
+                'text-xs px-2 py-0.5 rounded transition-colors',
+                isAllSelected
+                  ? 'bg-purple-500/20 text-purple-400'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {t('projects.showAll', 'Show All')}
+            </button>
+          </div>
+
+          {/* Project list */}
+          <div
+            className="overflow-y-auto"
+            style={{ maxHeight: MAX_VISIBLE_ITEMS * ITEM_HEIGHT_PX }}
+          >
+            {userProjects.length === 0 ? (
+              <div className="px-3 py-4 text-xs text-muted-foreground text-center">
+                {t('projects.noProjects', 'No projects defined. Create one below.')}
+              </div>
+            ) : (
+              userProjects.map(proj => {
+                const isSelected =
+                  !isAllSelected && selectedProjectIds.includes(proj.id)
+                return (
+                  <div
+                    key={proj.id}
+                    className="flex items-center gap-2 px-3 py-1.5 hover:bg-secondary/40 transition-colors group"
+                  >
+                    <button
+                      onClick={() => toggleProject(proj.id)}
+                      className="flex-1 flex items-center gap-2 text-left min-w-0"
+                    >
+                      {/* Checkbox */}
+                      <div
+                        className={cn(
+                          'w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 transition-colors',
+                          isSelected
+                            ? 'bg-purple-500 border-purple-500'
+                            : 'border-muted-foreground',
+                        )}
+                      >
+                        {isSelected && <Check className="w-3 h-3 text-white" />}
+                      </div>
+                      {/* Color dot */}
+                      {proj.color && (
+                        <span
+                          className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                          style={{ backgroundColor: proj.color }}
+                        />
+                      )}
+                      {/* Name + cluster count */}
+                      <span className="text-sm truncate text-foreground">
+                        {proj.name}
+                      </span>
+                      <span className="text-xs text-muted-foreground flex-shrink-0">
+                        ({proj.clusters.length})
+                      </span>
+                    </button>
+
+                    {/* Delete */}
+                    <button
+                      onClick={() => deleteProject(proj.id)}
+                      className="p-1 text-muted-foreground hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all flex-shrink-0"
+                      title={t('projects.delete', 'Delete project')}
+                    >
+                      <Trash2 className="w-3 h-3" />
+                    </button>
+                  </div>
+                )
+              })
+            )}
+          </div>
+
+          {/* Create form / button */}
+          <div className="border-t border-border p-3">
+            {showCreateForm ? (
+              <div className="space-y-2">
+                {/* Project name */}
+                <input
+                  type="text"
+                  value={newName}
+                  onChange={e => setNewName(e.target.value)}
+                  placeholder={t('projects.namePlaceholder', 'Project name...')}
+                  className="w-full px-2 py-1.5 text-sm bg-secondary/50 border border-border rounded text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500"
+                  autoFocus
+                />
+
+                {/* Colour picker */}
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground">Color:</span>
+                  {['#8B5CF6', '#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#EC4899'].map(c => (
+                    <button
+                      key={c}
+                      onClick={() => setNewColor(c)}
+                      className={cn(
+                        'w-5 h-5 rounded-full border-2 transition-all',
+                        newColor === c ? 'border-foreground scale-110' : 'border-transparent',
+                      )}
+                      style={{ backgroundColor: c }}
+                    />
+                  ))}
+                </div>
+
+                {/* Cluster multi-select */}
+                <div className="text-xs text-muted-foreground">
+                  {t('projects.selectClusters', 'Select clusters:')}
+                </div>
+                <div className="max-h-32 overflow-y-auto space-y-1">
+                  {(availableClusters || []).map(cluster => {
+                    const checked = newClusters.includes(cluster)
+                    return (
+                      <button
+                        key={cluster}
+                        onClick={() => {
+                          if (checked) {
+                            setNewClusters(prev => prev.filter(c => c !== cluster))
+                          } else {
+                            setNewClusters(prev => [...prev, cluster])
+                          }
+                        }}
+                        className={cn(
+                          'w-full flex items-center gap-2 px-2 py-1 rounded text-left text-xs transition-colors',
+                          checked
+                            ? 'bg-purple-500/20 text-purple-400'
+                            : 'text-muted-foreground hover:bg-secondary/50',
+                        )}
+                      >
+                        <div
+                          className={cn(
+                            'w-3 h-3 rounded border flex items-center justify-center flex-shrink-0',
+                            checked
+                              ? 'bg-purple-500 border-purple-500'
+                              : 'border-muted-foreground',
+                          )}
+                        >
+                          {checked && <Check className="w-2 h-2 text-white" />}
+                        </div>
+                        <span className="truncate">{cluster}</span>
+                      </button>
+                    )
+                  })}
+                </div>
+
+                {/* Actions */}
+                <div className="flex gap-2 pt-1">
+                  <button
+                    onClick={handleCreate}
+                    disabled={!newName.trim() || newClusters.length === 0}
+                    className="flex-1 px-2 py-1 text-xs font-medium bg-purple-500 text-white rounded hover:bg-purple-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {t('projects.create', 'Create')}
+                  </button>
+                  <button
+                    onClick={handleCancel}
+                    className="px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    {t('projects.cancel', 'Cancel')}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                onClick={() => setShowCreateForm(true)}
+                className="w-full flex items-center justify-center gap-2 px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground bg-secondary/30 hover:bg-secondary/50 rounded transition-colors"
+              >
+                <Plus className="w-3 h-3" />
+                {t('projects.createProject', 'Create Project')}
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/hooks/useProjectFilter.tsx
+++ b/web/src/hooks/useProjectFilter.tsx
@@ -1,0 +1,286 @@
+/**
+ * Project filter context — lets users scope the entire dashboard to one or
+ * more "projects" (named cluster groupings).
+ *
+ * Provider should wrap the tree above GlobalFiltersProvider so that the
+ * global cluster list can be narrowed by the active project selection.
+ */
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  type ReactNode,
+} from 'react'
+import {
+  ALL_PROJECTS_ID,
+  MAX_USER_PROJECTS,
+  PROJECTS_STORAGE_KEY,
+  SELECTED_PROJECTS_STORAGE_KEY,
+  isBuiltInProject,
+  getBuiltInProjects,
+  type Project,
+} from '../lib/projects'
+
+// ---------------------------------------------------------------------------
+// Context shape
+// ---------------------------------------------------------------------------
+
+interface ProjectFilterContextType {
+  /** All available projects (built-in + user-defined) */
+  projects: Project[]
+
+  /** IDs of the currently active projects. [ALL_PROJECTS_ID] = no filter */
+  selectedProjectIds: string[]
+
+  /** Replace the full selection */
+  setSelectedProjectIds: (ids: string[]) => void
+
+  /** Toggle a single project on/off */
+  toggleProject: (id: string) => void
+
+  /** True when "All Projects" is the only selection (= no filtering) */
+  isAllSelected: boolean
+
+  /** True when any project filter is active (not "All") */
+  isProjectFiltered: boolean
+
+  /** Convenience — set of cluster names visible under the current selection */
+  visibleClusters: Set<string>
+
+  /** Check if a given cluster name passes the project filter */
+  isClusterVisible: (cluster: string) => boolean
+
+  /** Check if a given namespace passes the project filter */
+  isNamespaceVisible: (namespace: string) => boolean
+
+  // CRUD for user-defined projects
+  addProject: (project: Omit<Project, 'id'>) => void
+  updateProject: (id: string, updates: Partial<Omit<Project, 'id'>>) => void
+  deleteProject: (id: string) => void
+}
+
+const ProjectFilterContext = createContext<ProjectFilterContextType | null>(null)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateProjectId(): string {
+  return `proj-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+function loadFromStorage<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key)
+    if (raw) return JSON.parse(raw) as T
+  } catch {
+    // corrupt data — fall through
+  }
+  return fallback
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export function ProjectFilterProvider({ children }: { children: ReactNode }) {
+  // ---- user-defined projects (persisted) --------------------------------
+  const [userProjects, setUserProjects] = useState<Project[]>(() =>
+    loadFromStorage<Project[]>(PROJECTS_STORAGE_KEY, []),
+  )
+
+  // ---- selected project IDs (persisted) ---------------------------------
+  const [selectedProjectIds, setSelectedProjectIdsState] = useState<string[]>(() =>
+    loadFromStorage<string[]>(SELECTED_PROJECTS_STORAGE_KEY, [ALL_PROJECTS_ID]),
+  )
+
+  // Persist on change
+  useEffect(() => {
+    localStorage.setItem(PROJECTS_STORAGE_KEY, JSON.stringify(userProjects))
+  }, [userProjects])
+
+  useEffect(() => {
+    localStorage.setItem(SELECTED_PROJECTS_STORAGE_KEY, JSON.stringify(selectedProjectIds))
+  }, [selectedProjectIds])
+
+  // ---- combined list (built-in + user) -----------------------------------
+  const projects = useMemo<Project[]>(
+    () => [...getBuiltInProjects(), ...userProjects],
+    [userProjects],
+  )
+
+  // ---- derived booleans ---------------------------------------------------
+  const isAllSelected = useMemo(
+    () =>
+      selectedProjectIds.length === 0 ||
+      selectedProjectIds.includes(ALL_PROJECTS_ID),
+    [selectedProjectIds],
+  )
+
+  const isProjectFiltered = !isAllSelected
+
+  // ---- visible clusters ---------------------------------------------------
+  const visibleClusters = useMemo<Set<string>>(() => {
+    if (isAllSelected) return new Set<string>() // empty = "show everything"
+    const set = new Set<string>()
+    for (const id of selectedProjectIds) {
+      const proj = projects.find(p => p.id === id)
+      if (proj) {
+        for (const c of proj.clusters) set.add(c)
+      }
+    }
+    return set
+  }, [isAllSelected, selectedProjectIds, projects])
+
+  // ---- visible namespaces -------------------------------------------------
+  const visibleNamespaces = useMemo<Set<string>>(() => {
+    if (isAllSelected) return new Set<string>()
+    const set = new Set<string>()
+    for (const id of selectedProjectIds) {
+      const proj = projects.find(p => p.id === id)
+      if (proj) {
+        for (const ns of (proj.namespaces || [])) set.add(ns)
+      }
+    }
+    return set
+  }, [isAllSelected, selectedProjectIds, projects])
+
+  // ---- filter helpers -----------------------------------------------------
+  const isClusterVisible = useCallback(
+    (cluster: string): boolean => {
+      if (isAllSelected) return true
+      return visibleClusters.has(cluster)
+    },
+    [isAllSelected, visibleClusters],
+  )
+
+  const isNamespaceVisible = useCallback(
+    (namespace: string): boolean => {
+      if (isAllSelected) return true
+      // If no selected project defines namespace filters, all namespaces pass
+      if (visibleNamespaces.size === 0) return true
+      return visibleNamespaces.has(namespace)
+    },
+    [isAllSelected, visibleNamespaces],
+  )
+
+  // ---- selection actions --------------------------------------------------
+  const setSelectedProjectIds = useCallback((ids: string[]) => {
+    // If empty or "All" included, normalise to just [ALL_PROJECTS_ID]
+    if (ids.length === 0 || ids.includes(ALL_PROJECTS_ID)) {
+      setSelectedProjectIdsState([ALL_PROJECTS_ID])
+    } else {
+      setSelectedProjectIdsState(ids)
+    }
+  }, [])
+
+  const toggleProject = useCallback(
+    (id: string) => {
+      if (id === ALL_PROJECTS_ID) {
+        // Clicking "All" always resets to show everything
+        setSelectedProjectIdsState([ALL_PROJECTS_ID])
+        return
+      }
+      setSelectedProjectIdsState(prev => {
+        // If currently "All", switch to just this one project
+        if (prev.includes(ALL_PROJECTS_ID) || prev.length === 0) {
+          return [id]
+        }
+        if (prev.includes(id)) {
+          const next = prev.filter(p => p !== id)
+          // If nothing left, revert to "All"
+          return next.length === 0 ? [ALL_PROJECTS_ID] : next
+        }
+        return [...prev, id]
+      })
+    },
+    [],
+  )
+
+  // ---- CRUD ---------------------------------------------------------------
+  const addProject = useCallback(
+    (project: Omit<Project, 'id'>) => {
+      if (userProjects.length >= MAX_USER_PROJECTS) return
+      const newProject: Project = { ...project, id: generateProjectId() }
+      setUserProjects(prev => [...prev, newProject])
+    },
+    [userProjects.length],
+  )
+
+  const updateProject = useCallback(
+    (id: string, updates: Partial<Omit<Project, 'id'>>) => {
+      if (isBuiltInProject(id)) return // cannot edit built-ins
+      setUserProjects(prev =>
+        prev.map(p => (p.id === id ? { ...p, ...updates } : p)),
+      )
+    },
+    [],
+  )
+
+  const deleteProject = useCallback(
+    (id: string) => {
+      if (isBuiltInProject(id)) return
+      setUserProjects(prev => prev.filter(p => p.id !== id))
+      // If the deleted project was selected, remove it from selection
+      setSelectedProjectIdsState(prev => {
+        const next = prev.filter(p => p !== id)
+        return next.length === 0 ? [ALL_PROJECTS_ID] : next
+      })
+    },
+    [],
+  )
+
+  // ---- context value -------------------------------------------------------
+  const value = useMemo<ProjectFilterContextType>(
+    () => ({
+      projects,
+      selectedProjectIds,
+      setSelectedProjectIds,
+      toggleProject,
+      isAllSelected,
+      isProjectFiltered,
+      visibleClusters,
+      isClusterVisible,
+      isNamespaceVisible,
+      addProject,
+      updateProject,
+      deleteProject,
+    }),
+    [
+      projects,
+      selectedProjectIds,
+      setSelectedProjectIds,
+      toggleProject,
+      isAllSelected,
+      isProjectFiltered,
+      visibleClusters,
+      isClusterVisible,
+      isNamespaceVisible,
+      addProject,
+      updateProject,
+      deleteProject,
+    ],
+  )
+
+  return (
+    <ProjectFilterContext.Provider value={value}>
+      {children}
+    </ProjectFilterContext.Provider>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Consumer hook
+// ---------------------------------------------------------------------------
+
+export function useProjectFilter() {
+  const ctx = useContext(ProjectFilterContext)
+  if (!ctx) {
+    throw new Error('useProjectFilter must be used within a ProjectFilterProvider')
+  }
+  return ctx
+}

--- a/web/src/lib/projects.ts
+++ b/web/src/lib/projects.ts
@@ -1,0 +1,67 @@
+/**
+ * Project definitions for multi-project selection.
+ *
+ * A "project" groups clusters (and optionally namespaces) so users can scope
+ * the dashboard to a subset of their infrastructure.  Projects are persisted
+ * in localStorage and surfaced via the useProjectFilter context.
+ */
+
+/** Built-in project ID that represents "all clusters, no filtering" */
+export const ALL_PROJECTS_ID = '__all__'
+
+/** Built-in project ID for clusters not assigned to any user project */
+export const DEFAULT_PROJECT_ID = '__default__'
+
+/** Minimum length for a user-defined project name */
+export const PROJECT_NAME_MIN_LENGTH = 1
+
+/** Maximum number of user-defined projects (excludes built-ins) */
+export const MAX_USER_PROJECTS = 50
+
+/**
+ * A project groups a set of clusters (and optionally namespaces) under a
+ * user-chosen name.  The console uses these to filter every dashboard card.
+ */
+export interface Project {
+  /** Unique identifier (auto-generated for user projects) */
+  id: string
+  /** Human-readable display name */
+  name: string
+  /** Cluster names that belong to this project */
+  clusters: string[]
+  /** Optional namespace filter — empty means all namespaces */
+  namespaces: string[]
+  /** Optional label selector for dynamic cluster matching */
+  labels?: Record<string, string>
+  /** Badge colour shown in the project selector */
+  color?: string
+}
+
+/** Returns the two built-in projects (All, Default) */
+export function getBuiltInProjects(): Project[] {
+  return [
+    {
+      id: ALL_PROJECTS_ID,
+      name: 'All Projects',
+      clusters: [],
+      namespaces: [],
+    },
+    {
+      id: DEFAULT_PROJECT_ID,
+      name: 'Default',
+      clusters: [],
+      namespaces: [],
+    },
+  ]
+}
+
+/** localStorage key for persisted project definitions */
+export const PROJECTS_STORAGE_KEY = 'projects:definitions'
+
+/** localStorage key for the currently selected project IDs */
+export const SELECTED_PROJECTS_STORAGE_KEY = 'projects:selected'
+
+/** Type guard — true for the two built-in IDs */
+export function isBuiltInProject(id: string): boolean {
+  return id === ALL_PROJECTS_ID || id === DEFAULT_PROJECT_ID
+}


### PR DESCRIPTION
- [x] Apply i18n to multi-select label in ProjectSelector.tsx
- [x] Add aria-labels to color picker buttons in ProjectSelector.tsx
- [x] Wire ProjectFilterProvider → GlobalFiltersProvider to narrow cluster scope
- [x] Remove "Default" built-in project (no logic to populate it)
- [x] Normalize selectedProjectIds when projects change (drop unknown IDs via useMemo)
- [x] Add 31 unit tests for useProjectFilter state machine (localStorage hydration, add/delete/update, toggle, normalization)