### PR TITLE
📖 Fix data-at-rest claim in security self-assessment

### DIFF
--- a/docs/security/SELF-ASSESSMENT.md
+++ b/docs/security/SELF-ASSESSMENT.md
@@ -150,11 +150,11 @@ The security response team (listed in [SECURITY_CONTACTS](../../SECURITY_CONTACT
 
 ### Data Storage Summary
 
-The following table details all data persisted by KubeStellar Console, both server-side and client-side:
+The following table provides a high-level summary of data persisted by KubeStellar Console, both server-side and client-side:
 
 | Storage | Type | What is Stored | Location | Retention |
 |---------|------|----------------|----------|-----------|
-| **Backend SQLite** | Relational DB | User accounts, dashboard layouts, card configurations, GPU utilization snapshots, revoked JWT tokens, user analytics events, feature requests | Server: `/data/console.db` | Indefinite |
+| **Backend SQLite** | Relational DB | User accounts, dashboard layouts, card configurations, GPU utilization snapshots, revoked JWT tokens, user analytics events, feature requests | Server default: `./data/console.db` (or `DATABASE_PATH`); Helm default: `/app/data/console.db` | Mixed: user/configuration data retained until deleted; GPU utilization snapshots cleaned up after 90 days; revoked JWT tokens deleted after `expires_at` |
 | **Metrics History** | JSON file | Rolling cluster metrics (CPU/memory %, node counts, pod issues, GPU allocation per node) | kc-agent host: `~/.kc/metrics_history.json` | 7 days |
 | **Frontend SQLite (OPFS)** | Browser DB | Cached Kubernetes resource data (pods, deployments, services) for performance | Browser OPFS: `/kc-cache.sqlite3` | Until browser cache cleared |
 | **Frontend IndexedDB** | Browser DB | Same as OPFS (fallback when OPFS unavailable) | Browser IndexedDB: `kc_cache` | Until browser cache cleared |
@@ -165,7 +165,7 @@ The following table details all data persisted by KubeStellar Console, both serv
 
 - Raw Kubernetes resource data (pods, deployments, services) is **not** stored server-side — it is fetched on-demand and cached only in browser storage and a 15-second in-memory server cache.
 - Kubernetes **credentials** never leave the user's machine — the kc-agent proxies requests locally.
-- The backend SQLite database stores user preferences and dashboard configuration, plus GPU utilization snapshots for historical trend analysis.
+- The backend SQLite database stores server-side application data such as user accounts, dashboards/cards/configuration, feature requests, and GPU utilization snapshots for historical trend analysis.
 - The kc-agent's metrics history file (`~/.kc/metrics_history.json`) stores 7 days of aggregated cluster health metrics on the user's local machine for AI-assisted trend analysis.
 
 ### Known Issues and Areas for Improvement


### PR DESCRIPTION
### 📌 Fixes

---

### 📝 Summary of Changes

- Fixes misleading Non-Goals bullet that claimed Console does "not store cluster data at rest (except user preferences in local SQLite)"
- Replaces with accurate statement that raw K8s resource data is not stored server-side, with link to new Data Storage Summary
- Adds **Data Storage Summary** table to the Appendix documenting all 6 persistence layers (backend SQLite, metrics history JSON, OPFS SQLite, IndexedDB, localStorage, in-memory SSE cache)
- Corrects Backend SQLite location from `/data/console.db` to `./data/console.db` (or `DATABASE_PATH`); Helm default `/app/data/console.db`
- Corrects Backend SQLite retention from `Indefinite` to mixed policy (user/config data: until deleted; GPU snapshots: 90 days; revoked JWT tokens: deleted after `expires_at`)
- Rewords table intro from "details all data persisted" to "provides a high-level summary" to avoid implying exhaustiveness
- Updates "Key points" bullet to explicitly name server-side objects (user accounts, dashboards/cards/configuration, feature requests, GPU utilization snapshots) instead of the misleading "user preferences"

This matters because the self-assessment is referenced in the <a href="https://github.com/cncf/toc/pull/2106">CNCF TOC sandbox application</a> — accuracy is critical for TAG-Security review.

---

### Changes Made

- [x] Corrected misleading Non-Goals bullet about data at rest in `docs/security/SELF-ASSESSMENT.md`
- [x] Added Data Storage Summary table to the Appendix
- [x] Fixed Backend SQLite location and retention fields to reflect actual defaults and mixed retention policy
- [x] Reworded table intro to clarify it is a high-level summary, not exhaustive
- [x] Updated "Key points" bullet to name server-side stored objects explicitly

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

_Documentation-only change — no screenshots applicable._

---

### 👀 Reviewer Notes

Cross-reference the Data Storage Summary table against:
- `pkg/store/sqlite.go` — backend SQLite schema and cleanup jobs
- `pkg/agent/metrics_history.go` — 7-day rolling metrics history
- `web/src/lib/cache/` — OPFS/IndexedDB browser cache layer
- `deploy/helm/kubestellar-console/values.yaml` — Helm `DATABASE_PATH` default (`/app/data/console.db`)