### PR TITLE
✨ List specific failing tests in Coverage Suite issues + fix remaining assertions

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -53,10 +53,56 @@ jobs:
         run: npm ci
 
       - name: Run shard ${{ matrix.shard }}/${{ env.TOTAL_SHARDS }} with coverage
+        id: test
         working-directory: web
         env:
           NODE_OPTIONS: '--max-old-space-size=4096'
-        run: npx vitest run --coverage --coverage.reportOnFailure --shard=${{ matrix.shard }}/${{ env.TOTAL_SHARDS }}
+        run: |
+          npx vitest run --coverage --coverage.reportOnFailure \
+            --reporter=default --reporter=json \
+            --outputFile.json=test-results.json \
+            --shard=${{ matrix.shard }}/${{ env.TOTAL_SHARDS }} || true
+
+          # Extract failed test names for the issue body
+          if [ -f test-results.json ]; then
+            node -e "
+              const r = require('./test-results.json');
+              const failed = [];
+              for (const suite of r.testResults || []) {
+                for (const t of suite.assertionResults || []) {
+                  if (t.status === 'failed') {
+                    const file = suite.name.replace(/.*\/web\//, '');
+                    failed.push(file + ' > ' + t.fullName);
+                  }
+                }
+                // Also flag suites that failed to load (0 assertions = parse error)
+                if (suite.status === 'failed' && (!suite.assertionResults || suite.assertionResults.length === 0)) {
+                  const file = suite.name.replace(/.*\/web\//, '');
+                  failed.push(file + ' (failed to load)');
+                }
+              }
+              require('fs').writeFileSync('failed-tests.txt', failed.join('\n'));
+              if (failed.length > 0) {
+                console.log('Failed tests in shard ${{ matrix.shard }}:');
+                failed.forEach(f => console.log('  ❌ ' + f));
+                process.exit(1);
+              } else {
+                console.log('All tests passed in shard ${{ matrix.shard }}');
+              }
+            "
+          else
+            echo "No test results JSON found"
+            exit 1
+          fi
+
+      - name: Upload failed test list
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-tests-${{ matrix.shard }}
+          path: web/failed-tests.txt
+          if-no-files-found: ignore
+          retention-days: 1
 
       - name: Upload shard coverage
         if: always()
@@ -103,6 +149,50 @@ jobs:
         with:
           pattern: coverage-shard-*
           path: /tmp/shards
+
+      - name: Download failed test artifacts
+        if: always()
+        uses: actions/download-artifact@v4
+        with:
+          pattern: failed-tests-*
+          path: /tmp/failed-tests
+
+      - name: Collect failed test lists from all shards
+        id: failures
+        run: |
+          FAILED=""
+          for dir in /tmp/failed-tests/failed-tests-*; do
+            if [ -f "$dir/failed-tests.txt" ]; then
+              content=$(cat "$dir/failed-tests.txt")
+              if [ -n "$content" ]; then
+                FAILED="${FAILED}${content}"$'\n'
+              fi
+            fi
+          done
+
+          # Deduplicate and count
+          if [ -n "$FAILED" ]; then
+            UNIQUE=$(echo "$FAILED" | sort -u | grep -v '^$')
+            COUNT=$(echo "$UNIQUE" | wc -l | tr -d ' ')
+            echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
+
+            # Store as multiline output (truncate at 30 to keep issue readable)
+            DISPLAY=$(echo "$UNIQUE" | head -30)
+            REMAINING=$((COUNT - 30))
+            if [ "$REMAINING" -gt 0 ]; then
+              DISPLAY="${DISPLAY}"$'\n'"_...and ${REMAINING} more_"
+            fi
+            # Use delimiter for multiline
+            EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+            echo "list<<${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+            echo "$DISPLAY" >> "$GITHUB_OUTPUT"
+            echo "${EOF_MARKER}" >> "$GITHUB_OUTPUT"
+
+            echo "::warning::${COUNT} test(s) failed across shards"
+          else
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "list=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Merge coverage and generate summary
         id: cov
@@ -279,6 +369,9 @@ jobs:
       - name: Open issue for test failures
         if: needs.test-shard.result == 'failure'
         uses: actions/github-script@v7
+        env:
+          FAILED_TESTS: ${{ steps.failures.outputs.list }}
+          FAILED_COUNT: ${{ steps.failures.outputs.count }}
         with:
           github-token: ${{ secrets.GIST_TOKEN }}
           script: |
@@ -286,6 +379,8 @@ jobs:
             const sha = context.sha;
             const shortSha = sha.substring(0, 7);
             const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${sha}`;
+            const failedTests = process.env.FAILED_TESTS || '';
+            const failedCount = parseInt(process.env.FAILED_COUNT) || 0;
 
             // Find the PR that introduced this commit
             let prInfo = '';
@@ -311,6 +406,19 @@ jobs:
               prInfo,
             ].filter(Boolean).join('\n');
 
+            // Build the failing tests section
+            let failedSection = '';
+            if (failedTests.trim()) {
+              const lines = failedTests.trim().split('\n').map(l => `- \`${l}\``).join('\n');
+              failedSection = [
+                `### Failing tests (${failedCount})`,
+                ``,
+                lines,
+              ].join('\n');
+            } else {
+              failedSection = `### Failing tests\n\n_Could not extract test names. Check the [run logs](${runUrl})._`;
+            }
+
             // Check if there's already an open test-failure issue to avoid duplicates
             const ISSUE_LABEL = 'test-failure';
             const existing = await github.rest.issues.listForRepo({
@@ -322,38 +430,41 @@ jobs:
             });
 
             if (existing.data.length > 0) {
-              // Add a comment to the existing issue with blame info
+              // Add a comment to the existing issue with blame info + failing tests
               const issue = existing.data[0];
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 body: [
-                  `Coverage Suite run [#${context.runNumber}](${runUrl}) also had test failures.`,
+                  `Coverage Suite run [#${context.runNumber}](${runUrl}) — **${failedCount} test(s) failed**`,
                   ``,
                   blameSection,
+                  ``,
+                  failedSection,
                 ].join('\n'),
               });
               console.log(`Commented on existing issue #${issue.number}`);
             } else {
-              // Create a new issue with blame info
+              // Create a new issue with blame info + failing tests
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: `🐛 Test failures in Coverage Suite run #${context.runNumber}`,
+                title: `🐛 ${failedCount} test failure(s) in Coverage Suite run #${context.runNumber}`,
                 body: [
                   `## Test Failures Detected`,
                   ``,
-                  `One or more test shards failed in the [Coverage Suite run #${context.runNumber}](${runUrl}).`,
+                  `**${failedCount} test(s)** failed in the [Coverage Suite run #${context.runNumber}](${runUrl}).`,
                   ``,
                   blameSection,
+                  ``,
+                  failedSection,
                   ``,
                   `Coverage was still merged and the badge updated (currently **${{ steps.cov.outputs.pct }}%**), but the failing tests need attention.`,
                   ``,
                   `### Action needed`,
-                  `1. Check the [run logs](${runUrl}) for failing test files`,
-                  `2. Determine if failures are test updates needed or potential regressions`,
-                  `3. Fix and close this issue`,
+                  `1. For each failing test, determine if it's a **test update needed** or a **potential regression**`,
+                  `2. Fix and close this issue`,
                   ``,
                   `_Auto-generated by Coverage Suite workflow_`,
                 ].join('\n'),

--- a/web/src/components/auth/AuthCallback.test.tsx
+++ b/web/src/components/auth/AuthCallback.test.tsx
@@ -24,6 +24,17 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
 }))
 
+vi.mock('../../lib/utils/localStorage', () => ({
+  safeGetItem: vi.fn(() => null),
+  safeRemoveItem: vi.fn(),
+}))
+
+// Mock fetch to prevent real /auth/refresh request from hanging in jsdom.
+// Return a pending promise so the effect stays in the loading state
+// (i.e., status stays 'authCallback.fetchingUserInfo' and doesn't advance
+// to the .catch handler's 'authCallback.completingSignIn').
+vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})))
+
 import { AuthCallback } from './AuthCallback'
 
 describe('AuthCallback Component', () => {

--- a/web/src/contexts/AlertsContext.test.tsx
+++ b/web/src/contexts/AlertsContext.test.tsx
@@ -82,7 +82,10 @@ beforeEach(() => {
   localStorage.clear()
   vi.useRealTimers()
   vi.clearAllMocks()
+  // Re-initialize hoisted mocks after restoreAllMocks clears their implementations
+  mockStartMission.mockReturnValue('mock-mission-id')
   mockUseDemoMode.mockReturnValue({ isDemoMode: false })
+  mockSendNotificationWithDeepLink.mockImplementation(() => {})
   // Re-stub globals after restoreAllMocks clears them
   vi.stubGlobal('Notification', { permission: 'granted', requestPermission: vi.fn() })
   vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))

--- a/web/src/contexts/__tests__/AlertsContext.test.tsx
+++ b/web/src/contexts/__tests__/AlertsContext.test.tsx
@@ -4337,7 +4337,9 @@ describe('AlertsContext — wave 2 deep coverage', () => {
     }
 
     const { result } = renderHook(() => useAlertsContext(), { wrapper })
+    // Allow lazy component to resolve and onData to fire
     await act(async () => { vi.advanceTimersByTime(0) })
+    await flushTimers()
 
     expect(result.current.dataError).toBe('MCP connection failed')
     expect(result.current.isLoadingData).toBe(false)

--- a/web/src/hooks/__tests__/useSidebarConfig.test.ts
+++ b/web/src/hooks/__tests__/useSidebarConfig.test.ts
@@ -1,23 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
-// Pin React across vi.resetModules() calls — the mock factory caches the real
-// module on first invocation so every fresh import gets the SAME React instance.
-// Without this, renderHook (which uses the original React) and hooks from fresh
-// modules would use different React instances, causing "Invalid hook call".
-const { reactCache, jsxCache } = vi.hoisted(() => ({
-  reactCache: { mod: null as unknown },
-  jsxCache: { mod: null as unknown },
-}))
-vi.mock('react', async (importOriginal) => {
-  if (!reactCache.mod) reactCache.mod = await importOriginal()
-  return reactCache.mod
-})
-vi.mock('react/jsx-runtime', async (importOriginal) => {
-  if (!jsxCache.mod) jsxCache.mod = await importOriginal()
-  return jsxCache.mod
-})
-
 vi.mock('../useDemoMode', () => ({
   useDemoMode: vi.fn(() => ({ isDemoMode: true })),
 }))
@@ -516,9 +499,15 @@ describe('useSidebarConfig — expanded coverage', () => {
   beforeEach(() => {
     localStorage.clear()
     vi.clearAllMocks()
+    // Mock fetch so fetchEnabledDashboards (called by useSidebarConfig hook)
+    // doesn't hang waiting for a real /health request
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      json: async () => ({ enabled_dashboards: [] }),
+    }))
   })
 
   afterEach(() => {
+    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 


### PR DESCRIPTION
## Summary
- Coverage Suite issues now list the **exact failing test names** instead of just linking to run logs
- Each shard exports test results as JSON, extracts failed test names, uploads as artifact
- The merge-coverage job collects all failures and includes them in the issue body
- Also fixes 4 remaining test assertion failures

## Example issue format
```
### Failing tests (3)

- `src/hooks/__tests__/useActiveUsers.test.ts > useActiveUsers > creates session ID`
- `src/lib/cache/__tests__/cache.test.ts > cache module > demoWhenEmpty > shows demoData`
- `src/hooks/__tests__/useAIPredictions.test.ts (failed to load)`
```

## Test plan
- [ ] Valid YAML (verified locally)
- [ ] Next Coverage Suite run creates issue with test names listed