### PR TITLE
🐛 Use safe localStorage wrappers in settings + remove emoji PR convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,6 @@ Starts backend on `:8080` and frontend on `:5174` with a mock `dev-user` account
 ## Commit Conventions
 
 - Sign all commits with DCO: `git commit -s`
-- Emoji prefix: `✨` feature | `🐛` bug fix | `📖` docs | `⚠️` breaking | `🌱` other
 
 ## Getting Help
 

--- a/web/src/components/settings/sections/GitHubTokenSection.tsx
+++ b/web/src/components/settings/sections/GitHubTokenSection.tsx
@@ -6,6 +6,7 @@ import { emitGitHubTokenConfigured, emitGitHubTokenRemoved, emitConversionStep }
 import { UI_FEEDBACK_TIMEOUT_MS, SCROLL_COMPLETE_MS } from '../../../lib/constants/network'
 import { GITHUB_TOKEN_CREATE_URL, GITHUB_TOKEN_CLASSIC_URL } from '../../../lib/constants/github-token'
 import { ConfirmDialog } from '../../../lib/modals'
+import { safeGetItem, safeSetItem, safeRemoveItem } from '../../../lib/utils/localStorage'
 
 interface GitHubTokenSectionProps {
   forceVersionCheck: () => void
@@ -26,7 +27,7 @@ const DEEP_LINK_RENDER_DELAY_MS = 300
 
 /** Build JWT auth headers for backend proxy requests */
 function authHeaders(): Record<string, string> {
-  const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+  const token = safeGetItem(STORAGE_KEY_TOKEN)
   return token ? { Authorization: `Bearer ${token}` } : {}
 }
 
@@ -46,7 +47,7 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
   useEffect(() => {
     const loadToken = async () => {
       // Skip if user explicitly dismissed the env token
-      if (localStorage.getItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED) === 'true') {
+      if (safeGetItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED) === 'true') {
         setIsInitializing(false)
         return
       }
@@ -60,7 +61,7 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
           const data = await response.json() as { hasToken: boolean; source: string }
           if (data.hasToken) {
             const source = data.source || TOKEN_SOURCE_SETTINGS
-            localStorage.setItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE, source)
+            safeSetItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE, source)
             window.dispatchEvent(new CustomEvent('kubestellar-settings-changed'))
             setHasToken(true)
             setTokenSource(source)
@@ -181,9 +182,11 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
       const isValid = await validateViaProxy()
 
       if (isValid) {
-        localStorage.setItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE, TOKEN_SOURCE_SETTINGS)
+        if (!safeSetItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE, TOKEN_SOURCE_SETTINGS)) {
+          console.warn('Token saved to backend but localStorage write failed — settings may not persist')
+        }
         // Clear any previous env-token dismissal
-        localStorage.removeItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED)
+        safeRemoveItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED)
         window.dispatchEvent(new CustomEvent('kubestellar-settings-changed'))
         setHasToken(true)
         setTokenSource(TOKEN_SOURCE_SETTINGS)
@@ -216,9 +219,9 @@ export function GitHubTokenSection({ forceVersionCheck }: GitHubTokenSectionProp
       // Best-effort — clear local state regardless
     }
 
-    localStorage.removeItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE)
+    safeRemoveItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_SOURCE)
     if (isEnvToken) {
-      localStorage.setItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED, 'true')
+      safeSetItem(STORAGE_KEY_FEEDBACK_GITHUB_TOKEN_DISMISSED, 'true')
     }
     setHasToken(false)
     setTokenSource(null)

--- a/web/src/components/settings/sections/ProfileSection.tsx
+++ b/web/src/components/settings/sections/ProfileSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Save, User, Loader2, AlertCircle, RefreshCw } from 'lucide-react'
 import { STORAGE_KEY_TOKEN, FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
+import { safeGetItem } from '../../../lib/utils/localStorage'
 
 interface ProfileSectionProps {
   initialEmail: string
@@ -34,7 +35,7 @@ export function ProfileSection({ initialEmail, initialSlackId, refreshUser, isLo
     setIsSaving(true)
     setError(null)
     try {
-      const token = localStorage.getItem(STORAGE_KEY_TOKEN)
+      const token = safeGetItem(STORAGE_KEY_TOKEN)
       const response = await fetch('/api/me', {
         method: 'PUT',
         headers: {


### PR DESCRIPTION
## Summary

- Migrate `GitHubTokenSection` and `ProfileSection` to safe localStorage utilities (`safeGetItem`/`safeSetItem`/`safeRemoveItem`)
- Check `safeSetItem` return value on the critical token-save path and log a warning when localStorage persistence fails
- Remove emoji prefix convention from CONTRIBUTING.md (not enforced by CI, creates noise in Copilot PRs)

Supersedes #4377 with fixes for silent failure concerns identified in review.

## Test plan

- [ ] `npm run build` passes
- [ ] `npm run lint` passes (no new warnings)
- [ ] Save a GitHub token in settings — verify it persists across page reload
- [ ] Clear a GitHub token — verify it's removed on reload