### PR TITLE
Fix profile dropdown clipped on narrow viewports

### DIFF
--- a/web/src/components/layout/UserProfileDropdown.tsx
+++ b/web/src/components/layout/UserProfileDropdown.tsx
@@ -147,7 +147,7 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
 
       {/* Dropdown menu */}
       {isOpen && (
-        <div className="absolute right-0 top-full mt-2 w-72 bg-card border border-border rounded-xl shadow-2xl overflow-hidden z-50">
+        <div className="absolute right-0 top-full mt-2 w-72 max-w-[calc(100vw-1rem)] bg-card border border-border rounded-xl shadow-2xl overflow-hidden z-50">
           {/* Header with avatar and name */}
           <div className="p-4 bg-secondary border-b border-border">
             <div className="flex items-center gap-3">
@@ -171,15 +171,15 @@ export function UserProfileDropdown({ user, onLogout, onPreferences }: UserProfi
 
           {/* User details section */}
           <div className="p-3 space-y-2 border-b border-border">
-            <div className="flex items-center gap-3 px-2 py-1.5 text-sm">
-              <Mail className="w-4 h-4 text-muted-foreground" />
-              <span className="text-muted-foreground">{t('profile.email')}</span>
+            <div className="flex items-center gap-3 px-2 py-1.5 text-sm min-w-0">
+              <Mail className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+              <span className="text-muted-foreground flex-shrink-0">{t('profile.email')}</span>
               <span className="text-foreground truncate">{user.email || t('profile.notSet')}</span>
             </div>
-            <div className="flex items-center gap-3 px-2 py-1.5 text-sm">
-              <MessageSquare className="w-4 h-4 text-muted-foreground" />
-              <span className="text-muted-foreground">{t('profile.slack')}</span>
-              <span className="text-foreground">{user.slackId || t('profile.notConnected')}</span>
+            <div className="flex items-center gap-3 px-2 py-1.5 text-sm min-w-0">
+              <MessageSquare className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+              <span className="text-muted-foreground flex-shrink-0">{t('profile.slack')}</span>
+              <span className="text-foreground truncate">{user.slackId || t('profile.notConnected')}</span>
             </div>
             <div className="flex items-center gap-3 px-2 py-1.5 text-sm">
               <Shield className="w-4 h-4 text-muted-foreground" />


### PR DESCRIPTION
## Summary

- Add `max-w-[calc(100vw-1rem)]` to the profile dropdown container so it stays within the viewport width on smaller screens/resolutions
- Add `min-w-0`, `flex-shrink-0`, and `truncate` to email/slack rows so long values don't push the dropdown wider

Reported by a contributor who noticed the dropdown's right edge (Feedback +Coin, Share on LinkedIn +20 badges) getting clipped by the browser viewport.

## Test plan

- [ ] `npm run build` passes
- [ ] Open profile dropdown on a narrow browser window — dropdown stays within viewport
- [ ] Long email addresses truncate properly instead of overflowing