### PR TITLE
🐛 Fix frontend: centralization, state management, consistency test, filter glow

### DIFF
--- a/scripts/consistency-test.sh
+++ b/scripts/consistency-test.sh
@@ -454,6 +454,7 @@ phase6() {
     'src/components/cards/Missions.tsx'  # Date.now() for demo mission timestamps, not cache TTL
     'src/App.tsx'  # Date.now() for page view analytics duration, not cache TTL
     'src/hooks/useSelfUpgrade.ts'  # Date.now() for restart polling elapsed, not cache TTL
+    'src/components/cards/workload-monitor/gitHubCIUtils.ts'  # Date.now() for formatTimeAgo display, not cache TTL
   )
 
   # Find files that implement caching with TTL: have localStorage AND Date.now() - (subtraction

--- a/web/src/components/cards/workload-monitor/gitHubCIUtils.ts
+++ b/web/src/components/cards/workload-monitor/gitHubCIUtils.ts
@@ -31,5 +31,9 @@ export function loadRepos(): string[] {
 
 /** Persists the repo list to localStorage. */
 export function saveRepos(repos: string[]) {
-  localStorage.setItem(REPOS_STORAGE_KEY, JSON.stringify(repos))
+  try {
+    localStorage.setItem(REPOS_STORAGE_KEY, JSON.stringify(repos))
+  } catch {
+    // Silently ignore storage errors (e.g. private browsing, quota exceeded)
+  }
 }

--- a/web/src/components/layout/navbar/ClusterFilterPanel.tsx
+++ b/web/src/components/layout/navbar/ClusterFilterPanel.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Search, Server, Activity, Filter, Check, AlertTriangle, Save, X, Trash2, WifiOff } from 'lucide-react'
 import { AlertCircle, CheckCircle2 } from 'lucide-react'
 import { useGlobalFilters, SEVERITY_LEVELS, SEVERITY_CONFIG, STATUS_LEVELS, STATUS_CONFIG } from '../../../hooks/useGlobalFilters'
+import { useModalState } from '../../../lib/modals'
 import { cn } from '../../../lib/cn'
 
 /** Color palette for saved filter sets */
@@ -109,8 +110,8 @@ export function ClusterFilterPanel() {
     activeFilterSetId,
   } = useGlobalFilters()
 
-  const [showDropdown, setShowDropdown] = useState(false)
-  const [showSaveForm, setShowSaveForm] = useState(false)
+  const { isOpen: showDropdown, close: closeDropdown, toggle: toggleDropdown } = useModalState()
+  const { isOpen: showSaveForm, open: openSaveForm, close: closeSaveForm } = useModalState()
   const [newName, setNewName] = useState('')
   const [newColor, setNewColor] = useState(FILTER_SET_COLORS[0])
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -139,19 +140,19 @@ export function ClusterFilterPanel() {
     saveCurrentFilters(newName.trim(), newColor)
     setNewName('')
     setNewColor(FILTER_SET_COLORS[0])
-    setShowSaveForm(false)
+    closeSaveForm()
   }
 
   // Close dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setShowDropdown(false)
+        closeDropdown()
       }
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
+  }, [closeDropdown])
 
   // Get active filter set for the indicator
   const activeSet = activeFilterSetId
@@ -160,14 +161,15 @@ export function ClusterFilterPanel() {
 
   return (
     <>
-      {/* Filter icon button */}
-      <div className="relative" ref={dropdownRef}>
+      {/* Filter icon button — isolate creates a stacking context to prevent
+           the glow shadow from bleeding into adjacent header controls (#4380) */}
+      <div className="relative isolate" ref={dropdownRef}>
         <button
-          onClick={() => setShowDropdown(!showDropdown)}
+          onClick={() => toggleDropdown()}
           className={cn(
             'relative flex items-center justify-center w-8 h-8 rounded-lg transition-colors',
             isFiltered
-              ? 'bg-purple-500/20 text-purple-400 shadow-[0_0_8px_rgba(139,92,246,0.3)]'
+              ? 'bg-purple-500/20 text-purple-400 shadow-[0_0_6px_rgba(139,92,246,0.2)]'
               : 'bg-secondary/50 text-muted-foreground hover:text-foreground'
           )}
           title={isFiltered ? 'Filters active - click to modify' : 'No filters - click to filter'}
@@ -415,7 +417,7 @@ export function ClusterFilterPanel() {
                       {t('common:filters.save', 'Save')}
                     </button>
                     <button
-                      onClick={() => { setShowSaveForm(false); setNewName('') }}
+                      onClick={() => { closeSaveForm(); setNewName('') }}
                       className="px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
                     >
                       {t('common:filters.cancel', 'Cancel')}
@@ -424,7 +426,7 @@ export function ClusterFilterPanel() {
                 </div>
               ) : (
                 <button
-                  onClick={() => setShowSaveForm(true)}
+                  onClick={() => openSaveForm()}
                   disabled={!isFiltered}
                   className="w-full flex items-center justify-center gap-2 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground bg-secondary/30 hover:bg-secondary/50 rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                 >

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -13,6 +13,7 @@ import {
 import { cn } from '../../lib/cn'
 import { api } from '../../lib/api'
 import { useAuth } from '../../lib/auth'
+import { FETCH_EXTERNAL_TIMEOUT_MS } from '../../lib/constants/network'
 import { matchMissionsToCluster } from '../../lib/missions/matcher'
 import { useClusterContext } from '../../hooks/useClusterContext'
 import {
@@ -747,7 +748,9 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
           if (ghFile.content && ghFile.encoding === 'base64') {
             content = atob(ghFile.content.replace(/\n/g, ''))
           } else if (ghFile.download_url) {
-            const rawResp = await fetch(ghFile.download_url)
+            const rawResp = await fetch(ghFile.download_url, {
+              signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS),
+            })
             content = await rawResp.text()
           } else {
             content = JSON.stringify(ghFile)

--- a/web/src/components/ui/CollapsibleSection.tsx
+++ b/web/src/components/ui/CollapsibleSection.tsx
@@ -1,6 +1,7 @@
-import { useState, ReactNode } from 'react'
+import { ReactNode } from 'react'
 import { ChevronDown, ChevronRight } from 'lucide-react'
 import { Button } from './Button'
+import { useModalState } from '../../lib/modals'
 
 interface CollapsibleSectionProps {
   title: string
@@ -17,14 +18,14 @@ export function CollapsibleSection({
   badge,
   className = '',
 }: CollapsibleSectionProps) {
-  const [isOpen, setIsOpen] = useState(defaultOpen)
+  const { isOpen, toggle } = useModalState(defaultOpen)
 
   return (
     <div className={className}>
       <Button
         variant="ghost"
         size="md"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={toggle}
         className="w-full justify-start px-2 py-2 font-medium text-foreground"
         fullWidth
         icon={isOpen ? (

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -48,6 +48,8 @@ window.addEventListener('vite:preloadError', (event) => {
 // index.html and compare the app-build-id <meta> tag. If the server has a
 // newer build, reload immediately to pick up correct chunk references.
 const STALE_CHECK_INTERVAL_MS = 120_000 // check every 2 minutes
+/** Timeout for the stale-HTML fetch — keep short to avoid blocking tab restore */
+const STALE_CHECK_FETCH_TIMEOUT_MS = 5_000
 const STALE_CHECK_KEY = 'stale-check-ts'
 
 function getLocalBuildId(): string | null {
@@ -69,6 +71,7 @@ async function checkForStaleHtml(): Promise<void> {
     const resp = await fetch('/?_stale_check=' + now, {
       cache: 'no-store',
       headers: { Accept: 'text/html' },
+      signal: AbortSignal.timeout(STALE_CHECK_FETCH_TIMEOUT_MS),
     })
     if (!resp.ok) return
     const html = await resp.text()


### PR DESCRIPTION
## Summary

- **#4367**: Migrate `CollapsibleSection` and `ClusterFilterPanel` to use `useModalState` hook instead of raw `useState(false)` for modal/toggle state
- **#4376**: Wrap `saveRepos()` localStorage call in try-catch for private browsing safety
- **#4378**: Fix nightly consistency test regression — add `AbortSignal.timeout()` to 2 unguarded `fetch()` calls (`main.tsx` stale-HTML check, `MissionBrowser.tsx` GitHub download); exclude `gitHubCIUtils.ts` from Phase 6 false positive (uses `Date.now()` for display formatting, not cache TTL)
- **#4380**: Fix filter icon glow bleeding into adjacent header controls — add `isolate` class to create stacking context and reduce shadow spread from 8px/0.3 to 6px/0.2

Fixes #4367, #4376, #4378, #4380

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes (no new warnings on changed files)
- [x] Consistency test passes: `bash scripts/consistency-test.sh` (0 errors, was 2)
- [ ] Filter icon glow no longer bleeds into adjacent controls (visual check)
- [ ] CollapsibleSection toggle behavior unchanged
- [ ] ClusterFilterPanel open/close/save behavior unchanged