### PR TITLE
✨ Fix Go backend: delete workload, error handling, race conditions

### DIFF
--- a/pkg/agent/protocol/messages.go
+++ b/pkg/agent/protocol/messages.go
@@ -98,13 +98,16 @@ type KubectlRequest struct {
 	Context   string   `json:"context,omitempty"`
 	Namespace string   `json:"namespace,omitempty"`
 	Args      []string `json:"args"`
+	Confirmed bool     `json:"confirmed,omitempty"` // must be true for destructive commands
 }
 
 // KubectlResponse is the response from kubectl commands
 type KubectlResponse struct {
-	Output   string `json:"output"`
-	ExitCode int    `json:"exitCode"`
-	Error    string `json:"error,omitempty"`
+	Output               string `json:"output"`
+	ExitCode             int    `json:"exitCode"`
+	Error                string `json:"error,omitempty"`
+	RequiresConfirmation bool   `json:"requiresConfirmation,omitempty"` // true when user must confirm
+	Command              string `json:"command,omitempty"`              // the command requiring confirmation
 }
 
 // ClaudeRequest is the payload for Claude Code requests

--- a/pkg/agent/provider_cline.go
+++ b/pkg/agent/provider_cline.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -52,7 +51,7 @@ func (c *ClineProvider) Capabilities() ProviderCapability { return CapabilityCha
 
 func (c *ClineProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
 	if !GetConfigManager().HasAPIKey("cline") {
-		return &ChatResponse{Content: fmt.Sprintf("Cline is detected but no API key is configured. Set CLINE_API_KEY to enable chat."), Agent: c.Name(), Done: true}, nil
+		return &ChatResponse{Content: "Cline is detected but no API key is configured. Set CLINE_API_KEY to enable chat.", Agent: c.Name(), Done: true}, nil
 	}
 	return chatViaOpenAICompatible(ctx, req, "cline", "https://api.cline.bot/v1/chat/completions", c.Name())
 }

--- a/pkg/agent/provider_continue.go
+++ b/pkg/agent/provider_continue.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -56,7 +55,7 @@ func (c *ContinueProvider) Capabilities() ProviderCapability { return Capability
 
 func (c *ContinueProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
 	if !GetConfigManager().HasAPIKey("continue") {
-		return &ChatResponse{Content: fmt.Sprintf("Continue is detected but no API key is configured. Set CONTINUE_API_KEY to enable chat."), Agent: c.Name(), Done: true}, nil
+		return &ChatResponse{Content: "Continue is detected but no API key is configured. Set CONTINUE_API_KEY to enable chat.", Agent: c.Name(), Done: true}, nil
 	}
 	return chatViaOpenAICompatible(ctx, req, "continue", "https://api.continue.dev/v1/chat/completions", c.Name())
 }

--- a/pkg/agent/provider_cursor.go
+++ b/pkg/agent/provider_cursor.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -59,7 +58,7 @@ func (c *CursorProvider) Capabilities() ProviderCapability {
 func (c *CursorProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
 	if !GetConfigManager().HasAPIKey("cursor") {
 		return &ChatResponse{
-			Content: fmt.Sprintf("Cursor is detected but no API key is configured. Set CURSOR_API_KEY to enable chat via Cursor's API."),
+			Content: "Cursor is detected but no API key is configured. Set CURSOR_API_KEY to enable chat via Cursor's API.",
 			Agent:   c.Name(),
 			Done:    true,
 		}, nil

--- a/pkg/agent/provider_jetbrains.go
+++ b/pkg/agent/provider_jetbrains.go
@@ -74,7 +74,7 @@ func (j *JetBrainsProvider) Capabilities() ProviderCapability { return Capabilit
 
 func (j *JetBrainsProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
 	if !GetConfigManager().HasAPIKey("jetbrains") {
-		return &ChatResponse{Content: fmt.Sprintf("JetBrains IDE is detected but no API key is configured. Set JETBRAINS_API_KEY to enable chat."), Agent: j.Name(), Done: true}, nil
+		return &ChatResponse{Content: "JetBrains IDE is detected but no API key is configured. Set JETBRAINS_API_KEY to enable chat.", Agent: j.Name(), Done: true}, nil
 	}
 	return chatViaOpenAICompatible(ctx, req, "jetbrains", "https://api.jetbrains.ai/v1/chat/completions", j.Name())
 }

--- a/pkg/agent/provider_raycast.go
+++ b/pkg/agent/provider_raycast.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"runtime"
 )
@@ -40,7 +39,7 @@ func (r *RaycastProvider) Capabilities() ProviderCapability { return CapabilityC
 
 func (r *RaycastProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
 	if !GetConfigManager().HasAPIKey("raycast") {
-		return &ChatResponse{Content: fmt.Sprintf("Raycast is detected but no API key is configured. Set RAYCAST_API_KEY to enable chat."), Agent: r.Name(), Done: true}, nil
+		return &ChatResponse{Content: "Raycast is detected but no API key is configured. Set RAYCAST_API_KEY to enable chat.", Agent: r.Name(), Done: true}, nil
 	}
 	return chatViaOpenAICompatible(ctx, req, "raycast", "https://api.raycast.com/v1/chat/completions", r.Name())
 }

--- a/pkg/agent/provider_vscode.go
+++ b/pkg/agent/provider_vscode.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -54,7 +53,7 @@ func (v *VSCodeProvider) Capabilities() ProviderCapability { return CapabilityCh
 
 func (v *VSCodeProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
 	if !GetConfigManager().HasAPIKey("vscode") {
-		return &ChatResponse{Content: fmt.Sprintf("VS Code is detected but no API key is configured. Set VSCODE_API_KEY to enable chat."), Agent: v.Name(), Done: true}, nil
+		return &ChatResponse{Content: "VS Code is detected but no API key is configured. Set VSCODE_API_KEY to enable chat.", Agent: v.Name(), Done: true}, nil
 	}
 	return chatViaOpenAICompatible(ctx, req, "vscode", "https://api.github.com/copilot/chat/completions", v.Name())
 }

--- a/pkg/agent/provider_windsurf.go
+++ b/pkg/agent/provider_windsurf.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -54,7 +53,7 @@ func (w *WindsurfProvider) Capabilities() ProviderCapability { return Capability
 
 func (w *WindsurfProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
 	if !GetConfigManager().HasAPIKey("windsurf") {
-		return &ChatResponse{Content: fmt.Sprintf("Windsurf is detected but no API key is configured. Set CODEIUM_API_KEY to enable chat."), Agent: w.Name(), Done: true}, nil
+		return &ChatResponse{Content: "Windsurf is detected but no API key is configured. Set CODEIUM_API_KEY to enable chat.", Agent: w.Name(), Done: true}, nil
 	}
 	return chatViaOpenAICompatible(ctx, req, "windsurf", "https://api.codeium.com/v1/chat/completions", w.Name())
 }

--- a/pkg/agent/provider_zed.go
+++ b/pkg/agent/provider_zed.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
@@ -49,7 +48,7 @@ func (z *ZedProvider) Capabilities() ProviderCapability { return CapabilityChat 
 
 func (z *ZedProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
 	if !GetConfigManager().HasAPIKey("zed") {
-		return &ChatResponse{Content: fmt.Sprintf("Zed is detected but no API key is configured. Set ZED_API_KEY to enable chat."), Agent: z.Name(), Done: true}, nil
+		return &ChatResponse{Content: "Zed is detected but no API key is configured. Set ZED_API_KEY to enable chat.", Agent: z.Name(), Done: true}, nil
 	}
 	return chatViaOpenAICompatible(ctx, req, "zed", "https://api.zed.dev/v1/chat/completions", z.Name())
 }

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -2488,6 +2488,37 @@ func (s *Server) handleClustersMessage(msg protocol.Message) protocol.Message {
 	}
 }
 
+// destructiveKubectlVerbs are kubectl subcommands that modify or destroy resources
+// and require explicit user confirmation before execution.
+var destructiveKubectlVerbs = map[string]bool{
+	"delete":  true,
+	"drain":   true,
+	"cordon":  true,
+	"taint":   true,
+	"replace": true,
+}
+
+// isDestructiveKubectlCommand checks whether the given kubectl args contain a
+// destructive verb that requires user confirmation before execution.
+func isDestructiveKubectlCommand(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	verb := strings.ToLower(args[0])
+	if destructiveKubectlVerbs[verb] {
+		return true
+	}
+	// "replace --force" is destructive even though plain "replace" is blocked
+	if verb == "replace" {
+		for _, a := range args[1:] {
+			if a == "--force" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (s *Server) handleKubectlMessage(msg protocol.Message) protocol.Message {
 	// Parse payload
 	payloadBytes, err := json.Marshal(msg.Payload)
@@ -2498,6 +2529,19 @@ func (s *Server) handleKubectlMessage(msg protocol.Message) protocol.Message {
 	var req protocol.KubectlRequest
 	if err := json.Unmarshal(payloadBytes, &req); err != nil {
 		return s.errorResponse(msg.ID, "invalid_payload", "Invalid kubectl request format")
+	}
+
+	// Check for destructive commands that require confirmation
+	if isDestructiveKubectlCommand(req.Args) && !req.Confirmed {
+		return protocol.Message{
+			ID:   msg.ID,
+			Type: protocol.TypeResult,
+			Payload: protocol.KubectlResponse{
+				RequiresConfirmation: true,
+				Command:              "kubectl " + strings.Join(req.Args, " "),
+				ExitCode:             0,
+			},
+		}
 	}
 
 	// Execute kubectl

--- a/pkg/k8s/argocd.go
+++ b/pkg/k8s/argocd.go
@@ -2,14 +2,28 @@ package k8s
 
 import (
 	"context"
+	"log"
+	"strings"
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/kubestellar/console/pkg/api/v1alpha1"
 )
+
+// isNoMatchError returns true when the error indicates that a CRD/resource type
+// is not registered on the cluster (e.g., "no matches for kind X in version Y").
+// This happens when ArgoCD CRDs are not installed.
+func isNoMatchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "no matches for") || strings.Contains(msg, "the server could not find the requested resource")
+}
 
 // ISO 8601 layouts used by ArgoCD for timestamp fields
 var argoTimestampLayouts = []string{
@@ -39,7 +53,8 @@ func (m *MultiClusterClient) ListArgoApplications(ctx context.Context) (*v1alpha
 
 			clusterApps, err := m.ListArgoApplicationsForCluster(ctx, cluster, "")
 			if err != nil {
-				return // CRD not installed or cluster unreachable — skip silently
+				log.Printf("[argocd] Error listing applications on cluster %s: %v", cluster, err)
+				return
 			}
 
 			mu.Lock()
@@ -72,8 +87,13 @@ func (m *MultiClusterClient) ListArgoApplicationsForCluster(ctx context.Context,
 	}
 
 	if err != nil {
-		// ArgoCD CRDs might not be installed — return empty list instead of error
-		return []v1alpha1.ArgoApplication{}, nil
+		if apierrors.IsNotFound(err) || isNoMatchError(err) {
+			// ArgoCD CRDs not installed — return empty list silently
+			return []v1alpha1.ArgoApplication{}, nil
+		}
+		// Real error (auth, network, RBAC) — log and propagate
+		log.Printf("[argocd] Error listing applications on cluster %s: %v", contextName, err)
+		return nil, err
 	}
 
 	return m.parseArgoApplicationsFromList(list, contextName)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -4377,6 +4377,9 @@ func (m *MultiClusterClient) EnsureNamespaceExists(ctx context.Context, contextN
 	if err == nil {
 		return nil // already exists
 	}
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to check namespace %s: %w", namespace, err)
+	}
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -4387,7 +4390,7 @@ func (m *MultiClusterClient) EnsureNamespaceExists(ctx context.Context, contextN
 		},
 	}
 	_, err = client.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
-	if err != nil && strings.Contains(err.Error(), "already exists") {
+	if err != nil && errors.IsAlreadyExists(err) {
 		return nil
 	}
 	return err

--- a/pkg/k8s/workload.go
+++ b/pkg/k8s/workload.go
@@ -610,6 +610,9 @@ func (m *MultiClusterClient) ensureNamespace(
 	if err == nil {
 		return nil // already exists
 	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to check namespace %s: %w", namespace, err)
+	}
 	nsObj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "v1",
@@ -628,7 +631,7 @@ func (m *MultiClusterClient) ensureNamespace(
 		nsObj.SetLabels(labels)
 	}
 	_, err = client.Resource(gvrNamespaces).Create(ctx, nsObj, metav1.CreateOptions{})
-	if err != nil && strings.Contains(err.Error(), "already exists") {
+	if err != nil && apierrors.IsAlreadyExists(err) {
 		return nil
 	}
 	return err
@@ -680,7 +683,7 @@ func applyDependencies(
 				result.Action = "updated"
 				log.Printf("[deploy] Updated %s %s", dep.Kind, dep.Name)
 			}
-		} else {
+		} else if apierrors.IsNotFound(err) {
 			// Resource doesn't exist — create
 			_, err = resource.Create(ctx, objCopy, metav1.CreateOptions{})
 			if err != nil {
@@ -690,6 +693,10 @@ func applyDependencies(
 				result.Action = "created"
 				log.Printf("[deploy] Created %s %s", dep.Kind, dep.Name)
 			}
+		} else {
+			// Real error (network, RBAC, etc.) — do not assume resource is missing
+			result.Action = "failed"
+			log.Printf("[deploy] Failed to check %s %s: %v", dep.Kind, dep.Name, err)
 		}
 
 		results = append(results, result)
@@ -923,10 +930,47 @@ func (m *MultiClusterClient) ScaleWorkload(ctx context.Context, namespace, name 
 	}, nil
 }
 
-// DeleteWorkload deletes a workload from a cluster
+// DeleteWorkload deletes a workload from a cluster by trying Deployment, StatefulSet,
+// and DaemonSet in order. Returns nil if the resource was deleted or not found.
 func (m *MultiClusterClient) DeleteWorkload(ctx context.Context, cluster, namespace, name string) error {
-	// Placeholder for delete implementation
-	return nil
+	dynamicClient, err := m.GetDynamicClient(cluster)
+	if err != nil {
+		return fmt.Errorf("failed to get dynamic client for %s: %w", cluster, err)
+	}
+
+	gvrs := []struct {
+		gvr  schema.GroupVersionResource
+		kind string
+	}{
+		{gvrDeployments, "Deployment"},
+		{gvrStatefulSets, "StatefulSet"},
+		{gvrDaemonSets, "DaemonSet"},
+	}
+
+	deletePolicy := metav1.DeletePropagationForeground
+	deleteOpts := metav1.DeleteOptions{PropagationPolicy: &deletePolicy}
+
+	for _, g := range gvrs {
+		_, getErr := dynamicClient.Resource(g.gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				continue // not this kind, try next
+			}
+			return fmt.Errorf("failed to check %s %s/%s on cluster %s: %w", g.kind, namespace, name, cluster, getErr)
+		}
+
+		// Found the resource — delete it
+		if err := dynamicClient.Resource(g.gvr).Namespace(namespace).Delete(ctx, name, deleteOpts); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil // deleted between Get and Delete — success
+			}
+			return fmt.Errorf("failed to delete %s %s/%s on cluster %s: %w", g.kind, namespace, name, cluster, err)
+		}
+		log.Printf("[delete] Deleted %s %s/%s from cluster %s", g.kind, namespace, name, cluster)
+		return nil
+	}
+
+	return fmt.Errorf("workload %s/%s not found in cluster %s (tried Deployment, StatefulSet, DaemonSet)", namespace, name, cluster)
 }
 
 // GetClusterCapabilities returns the capabilities of all clusters

--- a/web/src/lib/kubectlProxy.ts
+++ b/web/src/lib/kubectlProxy.ts
@@ -31,12 +31,15 @@ interface KubectlRequest {
   context?: string
   namespace?: string
   args: string[]
+  confirmed?: boolean
 }
 
 interface KubectlResponse {
   output: string
   exitCode: number
   error?: string
+  requiresConfirmation?: boolean
+  command?: string
 }
 
 interface PendingRequest {


### PR DESCRIPTION
## Summary

- **#4381**: Remove unnecessary `fmt.Sprintf` calls in `pkg/agent` (8 provider files)
- **#4385**: Fix `DeleteWorkload` no-op — implement actual resource deletion (tries Deployment, StatefulSet, DaemonSet with foreground propagation)
- **#4386**: Distinguish CRD-not-found from real errors in ArgoCD listing (log non-404 errors, silently skip only NotFound/no-match)
- **#4387**: Only create resources on 404 NotFound, not on any GET failure in dependency apply path
- **#4389**: Use `apierrors.IsAlreadyExists()` / `apierrors.IsNotFound()` instead of fragile `strings.Contains(err.Error(), "already exists")` for namespace creation (both `workload.go` and `client.go`)
- **#4396**: Require confirmation before executing destructive kubectl commands (delete, drain, cordon, taint, replace) in AI missions — adds `Confirmed` field to `KubectlRequest` and `RequiresConfirmation` to `KubectlResponse`

Fixes #4381, #4385, #4386, #4387, #4389, #4396

## Test plan

- [x] `go build ./cmd/console/` compiles
- [x] `go build ./cmd/kc-agent/` compiles
- [x] `go vet` passes on all modified packages
- [x] `npm run build` passes (frontend type changes are backward-compatible)
- [ ] DeleteWorkload actually deletes resources (Deployment/StatefulSet/DaemonSet)
- [ ] ArgoCD listing logs real errors, silently skips 404s / no-match errors
- [ ] Dependency apply only creates on 404, returns error on RBAC/network failures
- [ ] Namespace creation handles AlreadyExists via typed error check
- [ ] Destructive kubectl commands return `requiresConfirmation: true` without `confirmed: true`