### PR TITLE
✨ Add ArgoCD ApplicationSet integration with security fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,17 @@ GEMINI_MODEL=
 DEFAULT_AGENT=
 
 # ===========================================
+# ArgoCD Integration (optional)
+# ===========================================
+# Auth token for ArgoCD REST API sync (bypasses CLI and annotation fallback)
+# Generate via: argocd account generate-token --account admin
+# If not set, sync falls back to argocd CLI or annotation patching
+ARGOCD_AUTH_TOKEN=
+# WARNING: Setting this to "true" disables TLS certificate verification for
+# ArgoCD API calls. Only use in dev/test environments with self-signed certs.
+ARGOCD_TLS_INSECURE=
+
+# ===========================================
 # GA4 Analytics — Anti-spam proxy
 # ===========================================
 # The frontend uses a DECOY Measurement ID (visible in source code).

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -59,6 +59,7 @@ The Auto-QA workflow uses this file to verify component consistency.
 | KustomizationStatus | web/src/components/cards/KustomizationStatus.tsx | `kustomization_status` |
 | OverlayComparison | web/src/components/cards/OverlayComparison.tsx | `overlay_comparison` |
 | ArgoCDApplications | web/src/components/cards/ArgoCDApplications.tsx | `argocd_applications` |
+| ArgoCDApplicationSets | web/src/components/cards/ArgoCDApplicationSets.tsx | `argocd_applicationsets` |
 | ArgoCDSyncStatus | web/src/components/cards/ArgoCDSyncStatus.tsx | `argocd_sync_status` |
 | ArgoCDHealth | web/src/components/cards/ArgoCDHealth.tsx | `argocd_health` |
 | UserManagement | web/src/components/cards/UserManagement.tsx | `user_management` |

--- a/docs/integrations/argocd.md
+++ b/docs/integrations/argocd.md
@@ -1,0 +1,79 @@
+# KubeStellar Console: ArgoCD Integration Guide
+
+The KubeStellar Console integrates with ArgoCD to provide fleet-wide visibility and management of your GitOps deployments. This integration allows you to:
+- Discover and monitor ArgoCD **Applications** across all your managed clusters.
+- Discover and monitor ArgoCD **ApplicationSets** that define fleet-wide deployment generators.
+- View real-time synchronization status and component health.
+- Trigger on-demand syncs directly from the dashboard.
+
+## Prerequisites
+
+- One or more Kubernetes clusters monitored by the KubeStellar Console.
+- ArgoCD deployed on those clusters (typically in the `argocd` or `gitops` namespace).
+- KubeStellar Console installed and running.
+
+## Authentication & Setup Options
+
+The KubeStellar Console uses a tiered approach to interact with ArgoCD, specifically for triggering synchronizations. You can choose the setup method that best fits your environment.
+
+### Option 1: REST API via Auth Token (Recommended for Production)
+The most robust method connects directly to the ArgoCD API Server.
+
+1. Generate an admin token from your ArgoCD instance:
+   ```bash
+   argocd account generate-token --account admin
+   ```
+2. Open your KubeStellar Console's `.env` or `.env.local` file.
+3. Set the `ARGOCD_AUTH_TOKEN` variable:
+   ```env
+   # ===========================================
+   # ArgoCD Integration
+   # ===========================================
+   ARGOCD_AUTH_TOKEN=eyJhbGciOiJ...
+   ```
+4. Restart the console backend. The console will automatically discover the ArgoCD Server service in the target cluster and use this token to trigger REST API operations.
+
+### Option 2: Local CLI Integration (Recommended for Local Dev)
+If the ArgoCD CLI is installed on the same machine/container running the KubeStellar Console, the console will detect it and use it.
+
+1. Install the `argocd` CLI tool (ensure it is available in the `$PATH`).
+2. Log in to ArgoCD locally.
+3. No environment variables are required.
+
+### Option 3: Kubernetes API Patching (Fallback)
+If neither a token nor the CLI is available, the Console falls back to patching the Kubernetes Custom Resources directly using your current K8s context.
+
+1. The console will add the annotation `argocd.argoproj.io/refresh: hard` to the target `Application` CRD.
+2. **Requirements**: The Role/ClusterRole associated with the KubeStellar Console must have `patch` permissions on `applications.argoproj.io`.
+
+## How to View and Add Cards in the UI
+
+The ArgoCD integrations are provided as dynamic cards that can be added to any of your dashboards in the Console.
+
+1. Navigate to your main overview dashboard at `http://localhost:8080/` (or your specific hosted Console URL).
+2. Alternatively, you can add them to a specific cluster's dashboard by navigating to `http://localhost:8080/cluster/<cluster-name>`.
+3. Click the **Add Card** (or **+**) button at the top right of the dashboard.
+4. In the component catalog, scroll down to the **ArgoCD** category.
+5. Select from the available views to add them to your board:
+   - **ArgoCD Applications**: View individual applications, sync status, and click to sync.
+   - **ArgoCD ApplicationSets**: Monitor fleet-wide generator templates and the number of applications they manage.
+   - **ArgoCD Sync Status**: High-level donut chart visualization of synchronization states.
+   - **ArgoCD Health**: High-level status overview of application health.
+
+## Developer API Endpoints
+
+If you are developing against the console, the backend exposes the following new API endpoints specifically for the ArgoCD integration. These require authentication headers if accessed externally:
+
+| Method | Endpoint | Description |
+| :--- | :--- | :--- |
+| `GET` | `/api/gitops/argocd/applications` | Returns all discovered ArgoCD Applications across clusters. |
+| `GET` | `/api/gitops/argocd/applicationsets` | Returns all discovered ArgoCD ApplicationSets across clusters. |
+| `GET` | `/api/gitops/argocd/status` | Returns a detection health-check summary indicating if ArgoCD was found per cluster. |
+| `GET` | `/api/gitops/argocd/health` | Returns an aggregated summary of application health states. |
+| `GET` | `/api/gitops/argocd/sync` | Returns an aggregated summary of synchronization states. |
+| `POST` | `/api/gitops/argocd/sync` | Triggers a hard sync for a specific application. Requires `{name, namespace, cluster}` body. |
+
+## Troubleshooting
+
+- **Cards show "Demo Data" or "Integration Notice"**: The console did not find any Application or ApplicationSet CRDs in your clusters. Ensure ArgoCD is installed in the clusters the console is bound to.
+- **"Failed to trigger sync"**: Your authentication token might be expired, or the console lacks RBAC permissions to patch standard CRDs in the ArgoCD namespace. Check the console logs for specific `TriggerArgoSync` errors.

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -4,9 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -2161,7 +2164,7 @@ func (h *GitOpsHandlers) GetArgoSyncSummary(c *fiber.Ctx) error {
 }
 
 // TriggerArgoSync triggers a sync operation for an ArgoCD Application.
-// This is a best-effort operation that patches the Application's operation field.
+// Tries ArgoCD REST API first (if ARGOCD_AUTH_TOKEN is set), then CLI, then annotation patching.
 // POST /api/gitops/argocd/sync
 func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 	if h.k8sClient == nil {
@@ -2189,16 +2192,63 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 			"success": false,
 		})
 	}
+	
+	if err := validateK8sName(req.AppName, "appName"); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": err.Error(), "success": false})
+	}
+	if err := validateK8sName(req.Cluster, "cluster"); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": err.Error(), "success": false})
+	}
 
 	// Default namespace for ArgoCD applications
 	namespace := req.Namespace
 	if namespace == "" {
 		namespace = "argocd"
+	} else if err := validateK8sName(namespace, "namespace"); err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": err.Error(), "success": false})
 	}
 
 	log.Printf("[ArgoCD] Triggering sync for %s/%s on cluster %s", namespace, req.AppName, req.Cluster)
 
-	// Use argocd CLI if available, otherwise try kubectl annotation refresh
+	// Strategy 1: Try ArgoCD REST API if auth token is configured
+	argoToken := os.Getenv("ARGOCD_AUTH_TOKEN")
+	if argoToken != "" {
+		argoServerURL := h.discoverArgoServerURL(c.Context(), req.Cluster)
+		if argoServerURL != "" {
+			syncURL := fmt.Sprintf("%s/api/v1/applications/%s/sync", argoServerURL, url.PathEscape(req.AppName))
+			syncBody := []byte(`{"prune":true}`)
+
+			httpReq, err := http.NewRequestWithContext(c.Context(), "POST", syncURL, bytes.NewReader(syncBody))
+			if err == nil {
+				httpReq.Header.Set("Authorization", "Bearer "+argoToken)
+				httpReq.Header.Set("Content-Type", "application/json")
+
+				skipVerify := os.Getenv("ARGOCD_TLS_INSECURE") == "true"
+				client := &http.Client{
+					Timeout: argocdQueryTimeout,
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
+					},
+				}
+				resp, err := client.Do(httpReq)
+				if err == nil {
+					defer resp.Body.Close()
+					if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+						return c.JSON(fiber.Map{
+							"success": true,
+							"message": "Sync triggered via ArgoCD REST API",
+							"method":  "api",
+						})
+					}
+					log.Printf("[ArgoCD] API sync returned status %d, falling back", resp.StatusCode)
+				} else {
+					log.Printf("[ArgoCD] API sync failed: %v, falling back", err)
+				}
+			}
+		}
+	}
+
+	// Strategy 2: Use argocd CLI if available
 	if _, err := exec.LookPath("argocd"); err == nil {
 		cmd := exec.CommandContext(c.Context(), "argocd", "app", "sync", req.AppName,
 			"--namespace", namespace,
@@ -2207,19 +2257,17 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 		)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			log.Printf("[ArgoCD] CLI sync failed: %v, output: %s", err, string(output))
-			return c.Status(500).JSON(fiber.Map{
-				"error":   fmt.Sprintf("ArgoCD sync failed: %v", err),
-				"success": false,
+			log.Printf("[ArgoCD] CLI sync failed: %v, output: %s, falling back to Annotation Patching", err, string(output))
+		} else {
+			return c.JSON(fiber.Map{
+				"success": true,
+				"message": "Sync triggered via ArgoCD CLI",
+				"method":  "cli",
 			})
 		}
-		return c.JSON(fiber.Map{
-			"success": true,
-			"message": "Sync triggered via ArgoCD CLI",
-		})
 	}
 
-	// Fallback: annotate the Application to trigger a refresh
+	// Strategy 3: Fallback — annotate the Application to trigger a refresh
 	dynamicClient, err := h.k8sClient.GetDynamicClient(req.Cluster)
 	if err != nil {
 		return c.Status(500).JSON(fiber.Map{
@@ -2273,5 +2321,126 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{
 		"success": true,
 		"message": "Sync triggered via Application resource annotation",
+		"method":  "annotation",
 	})
 }
+
+// discoverArgoServerURL discovers the ArgoCD API server URL via K8s Service lookup
+func (h *GitOpsHandlers) discoverArgoServerURL(ctx context.Context, cluster string) string {
+	clientset, err := h.k8sClient.GetClient(cluster)
+	if err != nil {
+		log.Printf("[ArgoCD] Server discovery failed: cannot get client for cluster %s: %v", cluster, err)
+		return ""
+	}
+
+	// Look for the argocd-server service in common namespaces
+	namespaces := []string{"argocd", "argo-cd", "gitops"}
+	for _, ns := range namespaces {
+		svc, err := clientset.CoreV1().Services(ns).Get(ctx, "argocd-server", metav1.GetOptions{})
+		if err == nil {
+			if len(svc.Spec.Ports) > 0 {
+				// Use cluster-internal DNS: <service>.<namespace>.svc
+				return fmt.Sprintf("https://%s.%s.svc:%d", svc.Name, svc.Namespace, svc.Spec.Ports[0].Port)
+			} else {
+				log.Printf("[ArgoCD] Server discovery warning: argocd-server service found in %s but has no ports", ns)
+			}
+		}
+	}
+	log.Printf("[ArgoCD] Server discovery empty: argocd-server service not found in cluster %s", cluster)
+	return ""
+}
+
+// ListArgoApplicationSets returns all ArgoCD ApplicationSet resources across all clusters.
+// GET /api/gitops/argocd/applicationsets
+// Query params: ?cluster=<name> (optional, filter by cluster)
+func (h *GitOpsHandlers) ListArgoApplicationSets(c *fiber.Ctx) error {
+	if h.k8sClient == nil {
+		return c.Status(503).JSON(fiber.Map{
+			"error":      "Kubernetes client not configured",
+			"isDemoData": true,
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), argocdQueryTimeout)
+	defer cancel()
+
+	appSetList, err := h.k8sClient.ListArgoApplicationSets(ctx)
+	if err != nil {
+		return c.Status(500).JSON(fiber.Map{
+			"error":      fmt.Sprintf("Failed to list ArgoCD ApplicationSets: %v", err),
+			"isDemoData": true,
+		})
+	}
+
+	// Optional cluster filter
+	clusterFilter := c.Query("cluster")
+	if clusterFilter != "" {
+		filtered := make([]v1alpha1.ArgoApplicationSet, 0)
+		for _, appSet := range appSetList.Items {
+			if appSet.Cluster == clusterFilter {
+				filtered = append(filtered, appSet)
+			}
+		}
+		return c.JSON(fiber.Map{
+			"items":      filtered,
+			"totalCount": len(filtered),
+			"isDemoData": false,
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"items":      appSetList.Items,
+		"totalCount": appSetList.TotalCount,
+		"isDemoData": false,
+	})
+}
+
+// GetArgoStatus reports whether ArgoCD is detected on any connected cluster.
+// GET /api/gitops/argocd/status
+func (h *GitOpsHandlers) GetArgoStatus(c *fiber.Ctx) error {
+	if h.k8sClient == nil {
+		return c.JSON(fiber.Map{
+			"detected": false,
+			"clusters": []interface{}{},
+		})
+	}
+
+	ctx, cancel := context.WithTimeout(c.Context(), argocdQueryTimeout)
+	defer cancel()
+
+	// Check for Application CRDs
+	appList, _ := h.k8sClient.ListArgoApplications(ctx)
+	appSetList, _ := h.k8sClient.ListArgoApplicationSets(ctx)
+
+	// Build per-cluster detection
+	clusterMap := make(map[string]*v1alpha1.ArgoClusterStatus)
+
+	if appList != nil {
+		for _, app := range appList.Items {
+			if _, ok := clusterMap[app.Cluster]; !ok {
+				clusterMap[app.Cluster] = &v1alpha1.ArgoClusterStatus{Name: app.Cluster}
+			}
+			clusterMap[app.Cluster].HasApplications = true
+		}
+	}
+
+	if appSetList != nil {
+		for _, appSet := range appSetList.Items {
+			if _, ok := clusterMap[appSet.Cluster]; !ok {
+				clusterMap[appSet.Cluster] = &v1alpha1.ArgoClusterStatus{Name: appSet.Cluster}
+			}
+			clusterMap[appSet.Cluster].HasApplicationSets = true
+		}
+	}
+
+	clusters := make([]v1alpha1.ArgoClusterStatus, 0, len(clusterMap))
+	for _, cs := range clusterMap {
+		clusters = append(clusters, *cs)
+	}
+
+	return c.JSON(fiber.Map{
+		"detected": len(clusters) > 0,
+		"clusters": clusters,
+	})
+}
+

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -811,8 +811,10 @@ func (s *Server) setupRoutes() {
 	api.Post("/self-upgrade/trigger", selfUpgradeHandler.TriggerUpgrade)
 	// ArgoCD routes (Application CRD discovery and sync)
 	api.Get("/gitops/argocd/applications", gitopsHandlers.ListArgoApplications)
+	api.Get("/gitops/argocd/applicationsets", gitopsHandlers.ListArgoApplicationSets)
 	api.Get("/gitops/argocd/health", gitopsHandlers.GetArgoHealthSummary)
 	api.Get("/gitops/argocd/sync", gitopsHandlers.GetArgoSyncSummary)
+	api.Get("/gitops/argocd/status", gitopsHandlers.GetArgoStatus)
 	api.Post("/gitops/argocd/sync", gitopsHandlers.TriggerArgoSync)
 	// Frontend compatibility alias
 	api.Get("/mcp/operator-subscriptions", gitopsHandlers.ListOperatorSubscriptions)

--- a/pkg/api/v1alpha1/argocd_types.go
+++ b/pkg/api/v1alpha1/argocd_types.go
@@ -16,6 +16,13 @@ var (
 		Version:  "v1alpha1",
 		Resource: "applications",
 	}
+
+	// ArgoApplicationSetGVR is the GroupVersionResource for ArgoCD ApplicationSet (v1alpha1)
+	ArgoApplicationSetGVR = schema.GroupVersionResource{
+		Group:    "argoproj.io",
+		Version:  "v1alpha1",
+		Resource: "applicationsets",
+	}
 )
 
 // ArgoApplication represents an ArgoCD Application resource
@@ -42,6 +49,24 @@ type ArgoApplicationList struct {
 	TotalCount int               `json:"totalCount"`
 }
 
+// ArgoApplicationSet represents an ArgoCD ApplicationSet resource
+type ArgoApplicationSet struct {
+	Name       string   `json:"name"`
+	Namespace  string   `json:"namespace"`
+	Cluster    string   `json:"cluster"`
+	Generators []string `json:"generators"` // e.g. ["list", "cluster", "git", "matrix"]
+	Template   string   `json:"template"`   // Template application name
+	SyncPolicy string   `json:"syncPolicy"` // "Automated", "Manual", or ""
+	Status     string   `json:"status"`     // Overall status from conditions
+	AppCount   int      `json:"appCount"`   // Number of applications generated
+}
+
+// ArgoApplicationSetList is a list of ArgoCD ApplicationSets
+type ArgoApplicationSetList struct {
+	Items      []ArgoApplicationSet `json:"items"`
+	TotalCount int                  `json:"totalCount"`
+}
+
 // ArgoHealthSummary aggregates health status counts across applications
 type ArgoHealthSummary struct {
 	Healthy     int `json:"healthy"`
@@ -63,6 +88,19 @@ type ArgoSyncRequest struct {
 	AppName   string `json:"appName"`
 	Namespace string `json:"namespace"`
 	Cluster   string `json:"cluster"`
+}
+
+// ArgoStatusResponse reports ArgoCD detection status per cluster
+type ArgoStatusResponse struct {
+	Detected bool                `json:"detected"`
+	Clusters []ArgoClusterStatus `json:"clusters"`
+}
+
+// ArgoClusterStatus reports ArgoCD presence on a single cluster
+type ArgoClusterStatus struct {
+	Name              string `json:"name"`
+	HasApplications   bool   `json:"hasApplications"`
+	HasApplicationSets bool  `json:"hasApplicationSets"`
 }
 
 // TimeSinceArgo returns a human-readable duration since the given time

--- a/pkg/k8s/argocd.go
+++ b/pkg/k8s/argocd.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"sync"
@@ -185,3 +186,173 @@ func parseArgoTimeAgo(timeStr string) string {
 	// If we can't parse the timestamp, return the raw string
 	return timeStr
 }
+
+// ListArgoApplicationSets lists all ArgoCD ApplicationSet resources across all clusters.
+// If ArgoCD CRDs are not installed on a cluster, that cluster is silently skipped.
+func (m *MultiClusterClient) ListArgoApplicationSets(ctx context.Context) (*v1alpha1.ArgoApplicationSetList, error) {
+	m.mu.RLock()
+	clusters := make([]string, 0, len(m.clients))
+	for name := range m.clients {
+		clusters = append(clusters, name)
+	}
+	m.mu.RUnlock()
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	appSets := make([]v1alpha1.ArgoApplicationSet, 0)
+
+	for _, clusterName := range clusters {
+		wg.Add(1)
+		go func(cluster string) {
+			defer wg.Done()
+
+			clusterAppSets, err := m.ListArgoApplicationSetsForCluster(ctx, cluster)
+			if err != nil {
+				log.Printf("[ArgoCD] Skipping cluster %s for ApplicationSets: %v", cluster, err)
+				return // CRD not installed or cluster unreachable — skip silently
+			}
+
+			mu.Lock()
+			appSets = append(appSets, clusterAppSets...)
+			mu.Unlock()
+		}(clusterName)
+	}
+
+	wg.Wait()
+
+	return &v1alpha1.ArgoApplicationSetList{
+		Items:      appSets,
+		TotalCount: len(appSets),
+	}, nil
+}
+
+// ListArgoApplicationSetsForCluster lists ArgoCD ApplicationSet resources in a specific cluster.
+// Returns an empty list (not an error) if ArgoCD CRDs are not installed.
+func (m *MultiClusterClient) ListArgoApplicationSetsForCluster(ctx context.Context, contextName string) ([]v1alpha1.ArgoApplicationSet, error) {
+	dynamicClient, err := m.GetDynamicClient(contextName)
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := dynamicClient.Resource(v1alpha1.ArgoApplicationSetGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) || isNoMatchError(err) {
+			// ArgoCD CRDs not installed — return empty list silently
+			return []v1alpha1.ArgoApplicationSet{}, nil
+		}
+		// Real error (auth, network, RBAC) — log and propagate
+		return nil, fmt.Errorf("failed to list ApplicationSets on cluster %s: %w", contextName, err)
+	}
+
+	return m.parseArgoApplicationSetsFromList(list, contextName), nil
+}
+
+// parseArgoApplicationSetsFromList parses ArgoCD ApplicationSets from an unstructured list
+func (m *MultiClusterClient) parseArgoApplicationSetsFromList(list interface{}, contextName string) []v1alpha1.ArgoApplicationSet {
+	appSets := make([]v1alpha1.ArgoApplicationSet, 0)
+
+	uList, ok := list.(*unstructured.UnstructuredList)
+	if !ok {
+		return appSets
+	}
+
+	for i := range uList.Items {
+		item := &uList.Items[i]
+		content := item.UnstructuredContent()
+
+		appSet := v1alpha1.ArgoApplicationSet{
+			Name:      item.GetName(),
+			Namespace: item.GetNamespace(),
+			Cluster:   contextName,
+			Status:    "Unknown",
+		}
+
+		// Parse spec.generators — extract generator type names
+		if spec, found, _ := unstructuredNestedMap(content, "spec"); found {
+			if generators, ok := spec["generators"].([]interface{}); ok {
+				appSet.Generators = parseGeneratorTypes(generators)
+			}
+
+			// Parse spec.template.metadata.name for the template app name
+			if tmpl, tmplFound, _ := unstructuredNestedMap(spec, "template"); tmplFound {
+				if meta, metaFound, _ := unstructuredNestedMap(tmpl, "metadata"); metaFound {
+					if name, ok := meta["name"].(string); ok {
+						appSet.Template = name
+					}
+				}
+			}
+
+			// Parse spec.syncPolicy logic correctly
+			appSet.SyncPolicy = "Manual"
+			if tmpl, tmplFound, _ := unstructuredNestedMap(spec, "template"); tmplFound {
+				if tmplSpec, tsFound, _ := unstructuredNestedMap(tmpl, "spec"); tsFound {
+					if sp, spFound, _ := unstructuredNestedMap(tmplSpec, "syncPolicy"); spFound {
+						if _, hasAuto := sp["automated"]; hasAuto {
+							appSet.SyncPolicy = "Automated"
+						}
+					}
+				}
+			}
+		}
+
+		// Parse status.conditions for overall status
+		if status, found, _ := unstructuredNestedMap(content, "status"); found {
+			if conditions, ok := status["conditions"].([]interface{}); ok {
+				appSet.Status = parseAppSetConditionStatus(conditions)
+			}
+			// Parse status.applicationStatus for app count
+			if appStatuses, ok := status["applicationStatus"].([]interface{}); ok {
+				appSet.AppCount = len(appStatuses)
+			}
+		}
+
+		appSets = append(appSets, appSet)
+	}
+
+	return appSets
+}
+
+// parseGeneratorTypes extracts generator type names from the generators array
+func parseGeneratorTypes(generators []interface{}) []string {
+	types := make([]string, 0, len(generators))
+	knownTypes := []string{"list", "clusters", "cluster", "git", "matrix", "merge", "scmProvider", "pullRequest", "clusterDecisionResource"}
+
+	for _, gen := range generators {
+		genMap, ok := gen.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, t := range knownTypes {
+			if _, exists := genMap[t]; exists {
+				types = append(types, t)
+				break
+			}
+		}
+	}
+
+	if len(types) == 0 {
+		types = append(types, "unknown")
+	}
+	return types
+}
+
+// parseAppSetConditionStatus returns a human-readable status from ApplicationSet conditions
+func parseAppSetConditionStatus(conditions []interface{}) string {
+	for _, cond := range conditions {
+		condMap, ok := cond.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := condMap["type"].(string)
+		condStatus, _ := condMap["status"].(string)
+
+		if condType == "ErrorOccurred" && condStatus == "True" {
+			return "Error"
+		}
+		if condType == "ResourcesUpToDate" && condStatus == "True" {
+			return "Healthy"
+		}
+	}
+	return "Progressing"
+}
+

--- a/web/src/components/cards/ArgoCDApplicationSets.tsx
+++ b/web/src/components/cards/ArgoCDApplicationSets.tsx
@@ -1,0 +1,325 @@
+import { useMemo } from 'react'
+import { CheckCircle, XCircle, RefreshCw, AlertTriangle, ExternalLink, AlertCircle, Layers, GitBranch } from 'lucide-react'
+import { ClusterBadge } from '../ui/ClusterBadge'
+import { Skeleton } from '../ui/Skeleton'
+import { useArgoApplicationSets, type ArgoApplicationSet } from '../../hooks/useArgoCD'
+import { StatusBadge } from '../ui/StatusBadge'
+import { useCardLoadingState } from './CardDataContext'
+import { useCardData, commonComparators, type SortDirection } from '../../lib/cards/cardHooks'
+import {
+  CardSearchInput,
+  CardControlsRow,
+  CardPaginationFooter,
+} from '../../lib/cards/CardComponents'
+import { DynamicCardErrorBoundary } from './DynamicCardErrorBoundary'
+import { useTranslation } from 'react-i18next'
+
+interface ArgoCDApplicationSetsProps {
+  config?: {
+    cluster?: string
+  }
+}
+
+type SortByOption = 'status' | 'name' | 'namespace' | 'appCount'
+
+const SORT_OPTIONS_KEYS: ReadonlyArray<{ value: SortByOption; label: string }> = [
+  { value: 'status', label: 'Status' },
+  { value: 'name', label: 'Name' },
+  { value: 'namespace', label: 'Namespace' },
+  { value: 'appCount', label: 'App Count' },
+]
+
+const statusConfig: Record<string, { icon: typeof CheckCircle; color: string; bg: string }> = {
+  Healthy: { icon: CheckCircle, color: 'text-green-400', bg: 'bg-green-500/20' },
+  Progressing: { icon: RefreshCw, color: 'text-blue-400', bg: 'bg-blue-500/20' },
+  Error: { icon: XCircle, color: 'text-red-400', bg: 'bg-red-500/20' },
+  Unknown: { icon: AlertTriangle, color: 'text-muted-foreground', bg: 'bg-gray-500/20 dark:bg-gray-400/20' },
+}
+
+const statusOrder: Record<string, number> = { Error: 0, Unknown: 1, Progressing: 2, Healthy: 3 }
+
+const APPSET_SORT_COMPARATORS = {
+  status: (a: ArgoApplicationSet, b: ArgoApplicationSet) => (statusOrder[a.status] ?? 5) - (statusOrder[b.status] ?? 5),
+  name: commonComparators.string<ArgoApplicationSet>('name'),
+  namespace: commonComparators.string<ArgoApplicationSet>('namespace'),
+  appCount: (a: ArgoApplicationSet, b: ArgoApplicationSet) => b.appCount - a.appCount,
+}
+
+function ArgoCDApplicationSetsInternal({ config }: ArgoCDApplicationSetsProps) {
+  const { t } = useTranslation('cards')
+  const {
+    applicationSets: allAppSets,
+    isLoading,
+    isRefreshing,
+    isFailed,
+    consecutiveFailures,
+    isDemoData,
+  } = useArgoApplicationSets()
+
+  // Report loading state to CardWrapper
+  const hasData = allAppSets.length > 0
+  const { showSkeleton, showEmptyState } = useCardLoadingState({
+    isLoading: isLoading && !hasData,
+    isRefreshing,
+    hasAnyData: hasData,
+    isFailed,
+    consecutiveFailures,
+    isDemoData,
+  })
+
+  // Pre-filter by config
+  const preFiltered = useMemo(() => {
+    let filtered = allAppSets
+    if (config?.cluster) filtered = filtered.filter(a => a.cluster === config.cluster)
+    return filtered
+  }, [allAppSets, config])
+
+  // useCardData for search/cluster filter/sort/pagination
+  const {
+    items: appSets,
+    totalItems,
+    currentPage,
+    totalPages,
+    itemsPerPage,
+    goToPage,
+    needsPagination,
+    setItemsPerPage,
+    filters: {
+      search: searchQuery,
+      setSearch: setSearchQuery,
+      localClusterFilter,
+      toggleClusterFilter,
+      clearClusterFilter,
+      availableClusters,
+      showClusterFilter,
+      setShowClusterFilter,
+      clusterFilterRef,
+    },
+    sorting: {
+      sortBy,
+      setSortBy,
+      sortDirection,
+      setSortDirection,
+    },
+    containerRef,
+    containerStyle,
+  } = useCardData<ArgoApplicationSet, SortByOption>(preFiltered, {
+    filter: {
+      searchFields: ['name', 'namespace', 'cluster', 'template'],
+      clusterField: 'cluster',
+      storageKey: 'argocd-applicationsets',
+    },
+    sort: {
+      defaultField: 'status',
+      defaultDirection: 'asc' as SortDirection,
+      comparators: APPSET_SORT_COMPARATORS,
+    },
+    defaultLimit: 5,
+  })
+
+  // Stats
+  const stats = useMemo(() => ({
+    healthy: preFiltered.filter(a => a.status === 'Healthy').length,
+    progressing: preFiltered.filter(a => a.status === 'Progressing').length,
+    error: preFiltered.filter(a => a.status === 'Error').length,
+    totalApps: preFiltered.reduce((sum, a) => sum + a.appCount, 0),
+  }), [preFiltered])
+
+  if (showSkeleton) {
+    return (
+      <div className="h-full flex flex-col min-h-card">
+        <div className="flex items-center justify-between mb-4">
+          <Skeleton variant="text" width={150} height={20} />
+          <Skeleton variant="rounded" width={80} height={28} />
+        </div>
+        <div className="space-y-2">
+          <Skeleton variant="rounded" height={60} />
+          <Skeleton variant="rounded" height={60} />
+          <Skeleton variant="rounded" height={60} />
+        </div>
+      </div>
+    )
+  }
+
+  if (showEmptyState) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground">
+        <Layers className="w-8 h-8 mb-2 opacity-50" />
+        <p className="text-sm">{t('argoCDApplicationSets.noApplicationSets', 'No ApplicationSets found')}</p>
+        <p className="text-xs mt-1">{t('argoCDApplicationSets.deployWithArgoCD', 'Deploy ApplicationSets with ArgoCD to manage fleet-wide deployments')}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full flex flex-col min-h-card content-loaded">
+      {/* Header with controls */}
+      <div className="flex items-center justify-between mb-3 flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <StatusBadge color="purple">
+            {totalItems} AppSet{totalItems !== 1 ? 's' : ''}
+          </StatusBadge>
+          <StatusBadge color="blue">
+            {stats.totalApps} generated app{stats.totalApps !== 1 ? 's' : ''}
+          </StatusBadge>
+        </div>
+        <div className="flex items-center gap-2">
+          <CardControlsRow
+            clusterIndicator={localClusterFilter.length > 0 ? {
+              selectedCount: localClusterFilter.length,
+              totalCount: availableClusters.length,
+            } : undefined}
+            clusterFilter={{
+              availableClusters,
+              selectedClusters: localClusterFilter,
+              onToggle: toggleClusterFilter,
+              onClear: clearClusterFilter,
+              isOpen: showClusterFilter,
+              setIsOpen: setShowClusterFilter,
+              containerRef: clusterFilterRef,
+              minClusters: 1,
+            }}
+            cardControls={{
+              limit: itemsPerPage,
+              onLimitChange: setItemsPerPage,
+              sortBy,
+              sortOptions: SORT_OPTIONS_KEYS.map(o => ({ ...o })),
+              onSortChange: (v) => setSortBy(v as SortByOption),
+              sortDirection,
+              onSortDirectionChange: setSortDirection,
+            }}
+            extra={
+              <a
+                href="https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="p-1 hover:bg-secondary rounded transition-colors text-muted-foreground hover:text-purple-400"
+                title="ArgoCD ApplicationSet documentation"
+              >
+                <ExternalLink className="w-4 h-4" />
+              </a>
+            }
+            className="mb-0"
+          />
+        </div>
+      </div>
+
+      {/* Integration notice — only shown in demo/fallback mode */}
+      {isDemoData && (
+        <div className="flex items-start gap-2 p-2 mb-3 rounded-lg bg-purple-500/10 border border-purple-500/20 text-xs">
+          <AlertCircle className="w-4 h-4 text-purple-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-purple-400 font-medium">{t('argoCDApplicationSets.demoNotice', 'ArgoCD ApplicationSet Integration')}</p>
+            <p className="text-muted-foreground">
+              {t('argoCDApplicationSets.installGuide', 'Install or configure ArgoCD with ApplicationSet controller.')}{' '}
+              <a href="https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:underline inline-block py-2">
+                Setup Guide →
+              </a>
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Local Search */}
+      <CardSearchInput
+        value={searchQuery}
+        onChange={setSearchQuery}
+        placeholder="Search ApplicationSets..."
+        className="mb-3"
+      />
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-2 mb-3">
+        <div className="text-center p-2 rounded-lg bg-green-500/10">
+          <p className="text-lg font-bold text-green-400">{stats.healthy}</p>
+          <p className="text-xs text-muted-foreground">Healthy</p>
+        </div>
+        <div className="text-center p-2 rounded-lg bg-blue-500/10">
+          <p className="text-lg font-bold text-blue-400">{stats.progressing}</p>
+          <p className="text-xs text-muted-foreground">Progressing</p>
+        </div>
+        <div className="text-center p-2 rounded-lg bg-red-500/10">
+          <p className="text-lg font-bold text-red-400">{stats.error}</p>
+          <p className="text-xs text-muted-foreground">Error</p>
+        </div>
+      </div>
+
+      {/* ApplicationSet list */}
+      <div ref={containerRef} className="flex-1 space-y-2 overflow-y-auto min-h-card-content" style={containerStyle}>
+        {appSets.length === 0 ? (
+          <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+            No matching ApplicationSets
+          </div>
+        ) : (
+          appSets.map((appSet, idx) => {
+            const statusCfg = statusConfig[appSet.status] || statusConfig.Unknown
+            const StatusIcon = statusCfg.icon
+
+            return (
+              <div
+                key={`${appSet.cluster}-${appSet.namespace}-${appSet.name}-${idx}`}
+                className="p-3 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors group"
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center gap-2">
+                    <Layers className="w-4 h-4 text-purple-400" />
+                    <span className="text-sm font-medium text-foreground">{appSet.name}</span>
+                    <span className={`text-xs px-1.5 py-0.5 rounded ${statusCfg.bg} ${statusCfg.color}`}>
+                      <StatusIcon className="w-3 h-3 inline mr-1" />
+                      {appSet.status}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-xs px-1.5 py-0.5 rounded bg-purple-500/20 text-purple-400">
+                      {appSet.appCount} app{appSet.appCount !== 1 ? 's' : ''}
+                    </span>
+                    <span className={`text-xs px-1.5 py-0.5 rounded ${
+                      appSet.syncPolicy === 'Automated'
+                        ? 'bg-green-500/20 text-green-400'
+                        : 'bg-yellow-500/20 text-yellow-400'
+                    }`}>
+                      {appSet.syncPolicy || 'Manual'}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <div className="flex items-center gap-2">
+                    <ClusterBadge cluster={appSet.cluster} size="sm" />
+                    <span>/{appSet.namespace}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <GitBranch className="w-3 h-3" />
+                    <span>{(appSet.generators || []).join(', ')}</span>
+                  </div>
+                </div>
+                {appSet.template && (
+                  <div className="mt-1 text-xs text-muted-foreground truncate">
+                    Template: <span className="text-foreground/70">{appSet.template}</span>
+                  </div>
+                )}
+              </div>
+            )
+          })
+        )}
+      </div>
+
+      {/* Pagination */}
+      <CardPaginationFooter
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={totalItems}
+        itemsPerPage={typeof itemsPerPage === 'number' ? itemsPerPage : totalItems}
+        onPageChange={goToPage}
+        needsPagination={needsPagination}
+      />
+    </div>
+  )
+}
+
+export function ArgoCDApplicationSets(props: ArgoCDApplicationSetsProps) {
+  return (
+    <DynamicCardErrorBoundary cardId="ArgoCDApplicationSets">
+      <ArgoCDApplicationSetsInternal {...props} />
+    </DynamicCardErrorBoundary>
+  )
+}

--- a/web/src/components/cards/cardMetadata.ts
+++ b/web/src/components/cards/cardMetadata.ts
@@ -90,6 +90,7 @@ export const CARD_TITLES: Record<string, string> = {
 
   // ArgoCD cards
   argocd_applications: 'ArgoCD Applications',
+  argocd_applicationsets: 'ArgoCD ApplicationSets',
   argocd_sync_status: 'ArgoCD Sync Status',
   argocd_health: 'ArgoCD Health',
 
@@ -375,6 +376,7 @@ export const CARD_DESCRIPTIONS: Record<string, string> = {
   overlay_comparison: 'Compare Kustomize overlays across environments.',
   chart_versions: 'Available Helm chart versions and update status.',
   argocd_applications: 'ArgoCD application inventory and sync status.',
+  argocd_applicationsets: 'ArgoCD ApplicationSets manage fleet-wide deployments using generators to produce Applications across clusters.',
   argocd_sync_status: 'Sync status of ArgoCD-managed applications.',
   argocd_health: 'Health of ArgoCD applications and components.',
   gpu_overview: 'Summary of GPU resources across all clusters. Use this to see how many GPUs are available, allocated, and idle across your fleet — essential for AI/ML workload planning.',

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -78,6 +78,7 @@ const ChartVersions = safeLazy(() => _deployBundle, 'ChartVersions')
 const KustomizationStatus = safeLazy(() => _deployBundle, 'KustomizationStatus')
 const OverlayComparison = safeLazy(() => _deployBundle, 'OverlayComparison')
 const ArgoCDApplications = safeLazy(() => _deployBundle, 'ArgoCDApplications')
+const ArgoCDApplicationSets = safeLazy(() => _deployBundle, 'ArgoCDApplicationSets')
 const ArgoCDSyncStatus = safeLazy(() => _deployBundle, 'ArgoCDSyncStatus')
 const ArgoCDHealth = safeLazy(() => _deployBundle, 'ArgoCDHealth')
 const UserManagement = safeLazy(() => import('./UserManagement'), 'UserManagement')
@@ -372,6 +373,7 @@ const RAW_CARD_COMPONENTS: Record<string, CardComponent> = {
   overlay_comparison: OverlayComparison,
   // ArgoCD cards
   argocd_applications: ArgoCDApplications,
+  argocd_applicationsets: ArgoCDApplicationSets,
   argocd_sync_status: ArgoCDSyncStatus,
   argocd_health: ArgoCDHealth,
   // User management
@@ -824,6 +826,7 @@ const CARD_CHUNK_PRELOADERS: Record<string, () => Promise<unknown>> = {
   kustomization_status: () => import('./deploy-bundle'),
   overlay_comparison: () => import('./deploy-bundle'),
   argocd_applications: () => import('./deploy-bundle'),
+  argocd_applicationsets: () => import('./deploy-bundle'),
   argocd_sync_status: () => import('./deploy-bundle'),
   argocd_health: () => import('./deploy-bundle'),
   // active_alerts — preloader registered via unified descriptor system
@@ -1333,6 +1336,7 @@ export const CARD_DEFAULT_WIDTHS: Record<string, number> = {
   namespace_monitor: 8,
   gitops_drift: 6,
   argocd_applications: 6,
+  argocd_applicationsets: 6,
   argocd_sync_status: 6,
   kustomization_status: 6,
   pvc_status: 6,

--- a/web/src/components/cards/deploy-bundle.ts
+++ b/web/src/components/cards/deploy-bundle.ts
@@ -19,6 +19,7 @@ export { ResourceMarshall } from './ResourceMarshall'
 // GitOps & ArgoCD
 export { GitOpsDrift } from './GitOpsDrift'
 export { ArgoCDApplications } from './ArgoCDApplications'
+export { ArgoCDApplicationSets } from './ArgoCDApplicationSets'
 export { ArgoCDSyncStatus } from './ArgoCDSyncStatus'
 export { ArgoCDHealth } from './ArgoCDHealth'
 

--- a/web/src/components/dashboard/AddCardModal.tsx
+++ b/web/src/components/dashboard/AddCardModal.tsx
@@ -150,6 +150,7 @@ const CARD_CATALOG = {
   ],
   'ArgoCD': [
     { type: 'argocd_applications', title: 'ArgoCD Applications', description: 'ArgoCD app status', visualization: 'status' },
+    { type: 'argocd_applicationsets', title: 'ArgoCD ApplicationSets', description: 'Fleet-wide deployments using generators', visualization: 'table' },
     { type: 'argocd_sync_status', title: 'ArgoCD Sync Status', description: 'Sync state of applications', visualization: 'donut' },
     { type: 'argocd_health', title: 'ArgoCD Health', description: 'Application health overview', visualization: 'status' },
   ],

--- a/web/src/hooks/useArgoCD.ts
+++ b/web/src/hooks/useArgoCD.ts
@@ -742,3 +742,228 @@ export function useArgoCDSyncStatus(localClusterFilter: string[] = []): UseArgoC
     refetch: () => refetch(false),
   }
 }
+
+// ============================================================================
+// Types: ApplicationSets
+// ============================================================================
+
+export interface ArgoApplicationSet {
+  name: string
+  namespace: string
+  cluster: string
+  generators: string[]  // e.g. ["list", "cluster", "git", "matrix"]
+  template: string      // Template application name
+  syncPolicy: string    // "Automated", "Manual", or ""
+  status: string        // "Healthy", "Progressing", "Error", "Unknown"
+  appCount: number      // Number of applications generated
+}
+
+// ============================================================================
+// API Fetch: ApplicationSets
+// ============================================================================
+
+async function fetchArgoApplicationSets(): Promise<{ items: ArgoApplicationSet[]; isDemoData: boolean }> {
+  const ctrl = new AbortController()
+  const tid = setTimeout(() => ctrl.abort(), FETCH_DEFAULT_TIMEOUT_MS)
+  try {
+    const res = await fetch('/api/gitops/argocd/applicationsets', {
+      signal: ctrl.signal,
+      headers: authHeaders(),
+    })
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}))
+      if (body.isDemoData) {
+        return { items: [], isDemoData: true }
+      }
+      throw new Error(`API ${res.status}: ${body.error || res.statusText}`)
+    }
+    const data = await res.json()
+    return {
+      items: (data.items || []) as ArgoApplicationSet[],
+      isDemoData: data.isDemoData === true,
+    }
+  } finally {
+    clearTimeout(tid)
+  }
+}
+
+// ============================================================================
+// Mock Data: ApplicationSets
+// ============================================================================
+
+function getMockArgoApplicationSets(clusters: string[]): ArgoApplicationSet[] {
+  const appSets: ArgoApplicationSet[] = []
+
+  const templates = [
+    {
+      name: 'platform-services',
+      generators: ['clusters'],
+      template: '{{name}}-platform',
+      syncPolicy: 'Automated',
+      status: 'Healthy',
+      appCount: 5,
+    },
+    {
+      name: 'microservices-fleet',
+      generators: ['git'],
+      template: '{{path.basename}}',
+      syncPolicy: 'Automated',
+      status: 'Healthy',
+      appCount: 12,
+    },
+    {
+      name: 'monitoring-stack',
+      generators: ['list'],
+      template: 'monitoring-{{name}}',
+      syncPolicy: 'Manual',
+      status: 'Progressing',
+      appCount: 3,
+    },
+    {
+      name: 'multi-region-apps',
+      generators: ['matrix'],
+      template: '{{cluster}}-{{app}}',
+      syncPolicy: 'Automated',
+      status: 'Error',
+      appCount: 8,
+    },
+  ]
+
+  ;(clusters || []).forEach((cluster, idx) => {
+    // Distribute templates across clusters
+    const startIdx = idx % 2 === 0 ? 0 : 2
+    const endIdx = startIdx + 2
+    templates.slice(startIdx, endIdx).forEach((tmpl) => {
+      appSets.push({
+        ...tmpl,
+        namespace: 'argocd',
+        cluster,
+      })
+    })
+  })
+
+  return appSets
+}
+
+// ============================================================================
+// Hook: useArgoApplicationSets
+// ============================================================================
+
+const APPSET_CACHE_KEY = 'kc-argocd-appsets-cache'
+
+interface UseArgoApplicationSetsResult {
+  applicationSets: ArgoApplicationSet[]
+  isDemoData: boolean
+  isLoading: boolean
+  isRefreshing: boolean
+  error: string | null
+  isFailed: boolean
+  consecutiveFailures: number
+  lastRefresh: number | null
+  refetch: () => Promise<void>
+}
+
+export function useArgoApplicationSets(): UseArgoApplicationSetsResult {
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading } = useClusters()
+
+  // Initialize from cache
+  const cachedData = useRef(loadFromCache<ArgoApplicationSet[]>(APPSET_CACHE_KEY))
+  const [applicationSets, setApplicationSets] = useState<ArgoApplicationSet[]>(
+    cachedData.current?.data || []
+  )
+  const [isDemoData, setIsDemoData] = useState(cachedData.current?.isDemoData ?? true)
+  const [isLoading, setIsLoading] = useState(!cachedData.current)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [consecutiveFailures, setConsecutiveFailures] = useState(0)
+  const [lastRefresh, setLastRefresh] = useState<number | null>(
+    cachedData.current?.timestamp || null
+  )
+  const initialLoadDone = useRef(!!cachedData.current)
+
+  const clusterNames = useMemo(
+    () => (clusters || []).map(c => c.name),
+    [clusters]
+  )
+
+  const refetch = useCallback(async (silent = false) => {
+    if (clusterNames.length === 0) {
+      setIsLoading(false)
+      return
+    }
+
+    if (!silent) {
+      setIsRefreshing(true)
+      if (!initialLoadDone.current) {
+        setIsLoading(true)
+      }
+    }
+
+    try {
+      // Try real API first
+      const result = await fetchArgoApplicationSets()
+
+      if (!result.isDemoData) {
+        setApplicationSets(result.items || [])
+        setIsDemoData(false)
+        setError(null)
+        setConsecutiveFailures(0)
+        setLastRefresh(Date.now())
+        initialLoadDone.current = true
+        saveToCache(APPSET_CACHE_KEY, result.items || [], false)
+        return
+      }
+
+      // API explicitly indicated demo data — fall through to mock
+      throw new Error('No ArgoCD ApplicationSet data available')
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : 'Failed to fetch ApplicationSets'
+      console.error('[ArgoCD] ApplicationSets fetch failed:', errorMsg)
+      setError(errorMsg)
+      setConsecutiveFailures(prev => prev + 1)
+      // Only fall back to demo data if this is likely "not installed" (not a transient error)
+      if (consecutiveFailures >= FAILURE_THRESHOLD) {
+        const appSets = getMockArgoApplicationSets(clusterNames)
+        setApplicationSets(appSets)
+        setIsDemoData(true)
+      }
+      setLastRefresh(Date.now())
+      initialLoadDone.current = true
+    } finally {
+      setIsLoading(false)
+      setIsRefreshing(false)
+    }
+  }, [clusterNames, consecutiveFailures])
+
+  // Initial load
+  useEffect(() => {
+    if (!clustersLoading && clusterNames.length > 0) {
+      refetch()
+    } else if (!clustersLoading) {
+      setIsLoading(false)
+    }
+  }, [clustersLoading, clusterNames.length]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-refresh
+  useEffect(() => {
+    if (applicationSets.length === 0) return
+
+    const interval = setInterval(() => {
+      refetch(true)
+    }, REFRESH_INTERVAL_MS)
+
+    return () => clearInterval(interval)
+  }, [applicationSets.length, refetch])
+
+  return {
+    applicationSets,
+    isDemoData,
+    isLoading: isLoading || clustersLoading,
+    isRefreshing,
+    error,
+    isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
+    consecutiveFailures,
+    lastRefresh,
+    refetch: () => refetch(false),
+  }
+}


### PR DESCRIPTION
- [x] Fix stale `consecutiveFailures` in `useArgoCD.ts` - compute `nextFailures` locally before using for threshold check
- [x] Cache mock ApplicationSet data to `APPSET_CACHE_KEY` with `isDemoData: true` on demo fallback
- [x] Add `argoCDApplicationSets` i18n namespace to `web/src/locales/en/cards.json`
- [x] Use `t('argoCDApplicationSets.*')` in `ArgoCDApplicationSets.tsx` for search placeholder, status labels (Healthy/Progressing/Error), and no-match text
- [x] Fix `discoverArgoServerURL` to prefer port named `https` or port 443 over first port (avoids `https://:80`)
- [x] Fix `GetArgoStatus` to return 503 + error message instead of silently discarding `ListArgoApplications`/`ListArgoApplicationSets` errors
- [x] Fix docs: `{name, namespace, cluster}` → `{appName, namespace, cluster}` in `docs/integrations/argocd.md`
- [x] Build and lint validation (Go + frontend both pass)