### PR TITLE
🐛 Fix Welcome page stats/SEO and MaintenanceWindows validation

### DIFF
--- a/web/src/components/cards/MaintenanceWindows.tsx
+++ b/web/src/components/cards/MaintenanceWindows.tsx
@@ -29,6 +29,7 @@ export function MaintenanceWindows() {
   const { t } = useTranslation()
   const [windows, setWindows] = useState<MaintenanceWindow[]>(loadWindows)
   const [showForm, setShowForm] = useState(false)
+  const [timeError, setTimeError] = useState('')
   const [formData, setFormData] = useState({
     cluster: '',
     description: '',
@@ -54,6 +55,11 @@ export function MaintenanceWindows() {
 
   const handleAdd = useCallback(() => {
     if (!formData.cluster || !formData.startTime || !formData.endTime) return
+    if (new Date(formData.endTime) <= new Date(formData.startTime)) {
+      setTimeError('End time must be after start time')
+      return
+    }
+    setTimeError('')
     const newWindow: MaintenanceWindow = {
       id: `mw-${Date.now()}`,
       ...formData,
@@ -90,7 +96,7 @@ export function MaintenanceWindows() {
       <div className="flex items-center justify-between">
         <span className="text-xs text-muted-foreground">{displayWindows.filter(w => w.status !== 'completed').length} upcoming</span>
         <button
-          onClick={() => setShowForm(!showForm)}
+          onClick={() => { setShowForm(!showForm); setTimeError('') }}
           className="text-xs px-2 py-0.5 rounded bg-primary/10 text-primary hover:bg-primary/20 transition-colors"
         >
           {showForm ? 'Cancel' : '+ Schedule'}
@@ -127,6 +133,9 @@ export function MaintenanceWindows() {
               className="flex-1 px-2 py-1 text-xs rounded bg-background border border-border/50 focus:outline-none focus:ring-1 focus:ring-primary"
             />
           </div>
+          {timeError && (
+            <p className="text-xs text-red-400">{timeError}</p>
+          )}
           <div className="flex items-center justify-between">
             <select
               value={formData.type}

--- a/web/src/hooks/useSidebarConfig.ts
+++ b/web/src/hooks/useSidebarConfig.ts
@@ -48,7 +48,7 @@ function subscribe(listener: () => void): () => void {
 }
 
 // Core dashboards shown in sidebar by default (reduced from 28 to 9 to cut clutter)
-const DEFAULT_PRIMARY_NAV: SidebarItem[] = [
+export const DEFAULT_PRIMARY_NAV: SidebarItem[] = [
   { id: 'dashboard', name: 'Dashboard', icon: 'LayoutDashboard', href: '/', type: 'link', order: 0 },
   { id: 'clusters', name: 'My Clusters', icon: 'Server', href: '/clusters', type: 'link', order: 1 },
   { id: 'cluster-admin', name: 'Cluster Admin', icon: 'ShieldAlert', href: '/cluster-admin', type: 'link', order: 2 },

--- a/web/src/pages/Welcome.tsx
+++ b/web/src/pages/Welcome.tsx
@@ -13,15 +13,33 @@ import {
   Play,
 } from 'lucide-react'
 import { emitWelcomeViewed, emitWelcomeActioned } from '../lib/analytics'
+import { getRegisteredCardTypes } from '../components/cards/cardRegistry'
+import { DEFAULT_PRIMARY_NAV, DISCOVERABLE_DASHBOARDS } from '../hooks/useSidebarConfig'
+
+/* ------------------------------------------------------------------ */
+/*  SEO / meta constants                                               */
+/* ------------------------------------------------------------------ */
+
+const PAGE_TITLE = 'KubeStellar Console — Open Source Kubernetes Dashboard'
+const META_DESCRIPTION =
+  'AI-powered, multi-cluster Kubernetes dashboard with GPU visibility, cost analytics, security compliance, and GitOps — all open source, no sign-up required.'
 
 /* ------------------------------------------------------------------ */
 /*  Hero stats — social proof for conference audiences                 */
+/*  Card and dashboard counts are derived from the actual registries   */
+/*  so they stay in sync as the codebase evolves.                      */
 /* ------------------------------------------------------------------ */
+
+/** Total unique dashboards = default sidebar + discoverable dashboards */
+const TOTAL_DASHBOARDS = new Set([
+  ...DEFAULT_PRIMARY_NAV.map(d => d.id),
+  ...DISCOVERABLE_DASHBOARDS.map(d => d.id),
+]).size
 
 const HERO_STATS = [
   { value: '250+', label: 'CNCF tools' },
-  { value: '32', label: 'Dashboards' },
-  { value: '241', label: 'Cards' },
+  { value: String(TOTAL_DASHBOARDS), label: 'Dashboards' },
+  { value: String(getRegisteredCardTypes().length), label: 'Cards' },
   { value: '0', label: 'Paywalls' },
 ]
 
@@ -98,6 +116,16 @@ export function Welcome() {
   const ref = searchParams.get('ref') || 'direct'
 
   useEffect(() => {
+    document.title = PAGE_TITLE
+    const metaDesc = document.querySelector('meta[name="description"]')
+    if (metaDesc) {
+      metaDesc.setAttribute('content', META_DESCRIPTION)
+    } else {
+      const meta = document.createElement('meta')
+      meta.name = 'description'
+      meta.content = META_DESCRIPTION
+      document.head.appendChild(meta)
+    }
     emitWelcomeViewed(ref)
   }, [ref])
 


### PR DESCRIPTION
## Summary

- **#4415**: Derive hero stats (Cards, Dashboards) dynamically from `cardRegistry` and `useSidebarConfig` so they stay in sync as the codebase evolves
- **#4416**: Set `document.title` and inject `<meta name="description">` on the Welcome page for SEO and social sharing previews
- **#4417**: Validate `endTime > startTime` in MaintenanceWindows form with inline error message; clear error when form is toggled

Fixes #4415, #4416, #4417

## Test plan
- [ ] `npm run build` passes
- [ ] Welcome page hero stats reflect actual card/dashboard counts from registries
- [ ] Sharing `/welcome` URL in Slack/social shows descriptive title and description
- [ ] MaintenanceWindows form rejects endTime <= startTime with red error text
- [ ] Error clears when form is cancelled and reopened