### PR TITLE
Fix remaining TS errors in tsconfig.json and vite.config.ts

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -16,6 +16,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -63,13 +63,13 @@ export default defineConfig(({ mode }) => ({
     // so the stale-HTML detection script can compare against the server.
     {
       name: 'inject-build-id',
-      transformIndexHtml(html) {
+      transformIndexHtml(html: string) {
         return html.replace('__COMMIT_HASH__', process.env.VITE_COMMIT_HASH || getGitCommitHash())
       },
     },
     // Pre-compress assets at build time — avoids chunked encoding on slow networks
-    compression({ algorithm: 'gzip', exclude: [/\.(br)$/], threshold: 1024 }),
-    compression({ algorithm: 'brotliCompress', exclude: [/\.(gz)$/], threshold: 1024 }),
+    compression({ algorithms: ['gzip'], exclude: [/\.(br)$/], threshold: 1024 }),
+    compression({ algorithms: ['brotliCompress'], exclude: [/\.(gz)$/], threshold: 1024 }),
     // Enable Istanbul instrumentation for E2E coverage
     isE2ECoverage &&
       istanbul({


### PR DESCRIPTION
## Summary

Fixes the last 4 VS Code TypeScript errors:
- `tsconfig.json`: Silence `baseUrl` deprecation warning with `ignoreDeprecations: "5.0"`
- `vite.config.ts:66`: Add `string` type to `html` parameter in `transformIndexHtml`
- `vite.config.ts:71-72`: Use `algorithms: ['gzip']` array instead of deprecated `algorithm: 'gzip'` string (vite-plugin-compression2 API change)

## Test plan
- [ ] `npm run build` passes
- [ ] Gzip + brotli compressed assets still generated in dist/
- [ ] VS Code shows 0 errors in tsconfig.json and vite.config.ts