### PR TITLE
✨ Fix console errors, stale data, drill-down, group form, CRD stats, node repair

### DIFF
--- a/web/src/components/cards/CRDHealth.tsx
+++ b/web/src/components/cards/CRDHealth.tsx
@@ -242,7 +242,7 @@ export function CRDHealth({ config: _config }: CRDHealthProps) {
           {/* Summary */}
           <div className="grid grid-cols-4 gap-2 mb-4">
             <div className="p-2 rounded-lg bg-cyan-500/10 text-center">
-              <span className="text-lg font-bold text-cyan-400">{totalItems}</span>
+              <span className="text-lg font-bold text-cyan-400">{statsSource.length}</span>
               <p className="text-xs text-muted-foreground">{t('crdHealth.crds')}</p>
             </div>
             <div className="p-2 rounded-lg bg-green-500/10 text-center">

--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -100,7 +100,7 @@ export function ClusterDetailModal({ clusterName, clusterUser, onClose, onRename
   const { nodes: clusterNodes, isLoading: nodesLoading } = useNodes(clusterName)
   const { stats: namespaceStats, isLoading: nsLoading } = useNamespaceStats(clusterName)
   const { deployments: clusterDeployments } = useDeployments(clusterName)
-  const { drillToPod } = useDrillDownActions()
+  const { drillToPod, drillToDeployment } = useDrillDownActions()
   const { startMission } = useMissions()
 
   // Get cached cluster info for distribution detection (lastUpdated via parent refresh cycle)
@@ -689,6 +689,15 @@ After I approve, help me execute the repairs step by step.`,
               {clusterDeploymentIssues.slice(0, 3).map((issue, i) => (
                 <div
                   key={`dep-${i}`}
+                  onClick={() => {
+                    drillToDeployment(clusterName, issue.namespace, issue.name, {
+                      replicas: issue.replicas,
+                      readyReplicas: issue.readyReplicas,
+                      reason: issue.reason,
+                      message: issue.message,
+                    })
+                    onClose()
+                  }}
                   className="p-3 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
                 >
                   <div className="flex items-center justify-between">

--- a/web/src/components/clusters/ClusterGroupsSection.tsx
+++ b/web/src/components/clusters/ClusterGroupsSection.tsx
@@ -36,9 +36,28 @@ export function ClusterGroupsSection({
   const [newGroupName, setNewGroupName] = useState('')
   const [newGroupClusters, setNewGroupClusters] = useState<string[]>([])
 
-  // Only render when there are groups or the form is showing
+  // When no groups exist and form is not showing, render just the New Group button
   if (clusterGroups.length === 0 && !showGroupForm) {
-    return null
+    return (
+      <div className="mb-6">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+            <FolderOpen className="w-4 h-4" />
+            <span>Cluster Groups (0)</span>
+          </div>
+          <button
+            onClick={() => {
+              setShowGroupForm(true)
+              setShowGroups(true)
+            }}
+            className="flex items-center gap-1 text-xs text-primary hover:text-primary/80 transition-colors"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            New Group
+          </button>
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/web/src/components/clusters/NodeDetailPanel.tsx
+++ b/web/src/components/clusters/NodeDetailPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { X, Server, ChevronDown, ChevronUp, Wrench } from 'lucide-react'
+import { X, Server, ChevronDown, ChevronUp, Wrench, CheckCircle } from 'lucide-react'
 import { NodeInfo } from '../../hooks/useMCP'
 import { ConditionBadges, hasConditionIssues, getConditionIssuesSummary } from '../shared/ConditionBadges'
 import { useMissions } from '../../hooks/useMissions'
@@ -182,20 +182,21 @@ Please proceed step by step and ask for confirmation before making any changes.`
           </div>
         )}
 
-        {/* Repair button - always visible, disabled when no issues */}
-        <button
-          onClick={handleRepair}
-          disabled={!hasIssues}
-          className={cn(
-            'mt-2 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors w-full justify-center',
-            hasIssues
-              ? 'bg-orange-500/20 text-orange-400 hover:bg-orange-500/30 cursor-pointer'
-              : 'bg-secondary/30 text-muted-foreground cursor-not-allowed'
-          )}
-        >
-          <Wrench className="w-3.5 h-3.5" />
-          Repair
-        </button>
+        {/* Repair button - only shown when node has issues */}
+        {hasIssues ? (
+          <button
+            onClick={handleRepair}
+            className="mt-2 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors w-full justify-center bg-orange-500/20 text-orange-400 hover:bg-orange-500/30 cursor-pointer"
+          >
+            <Wrench className="w-3.5 h-3.5" />
+            Repair
+          </button>
+        ) : (
+          <div className="mt-2 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium w-full justify-center bg-green-500/10 text-green-400">
+            <CheckCircle className="w-3.5 h-3.5" />
+            Healthy
+          </div>
+        )}
       </div>
     </div>
   )

--- a/web/src/components/drilldown/views/CRDDrillDown.tsx
+++ b/web/src/components/drilldown/views/CRDDrillDown.tsx
@@ -162,8 +162,8 @@ export function CRDDrillDown({ data }: Props) {
           if (msg.id === requestId && msg.payload?.output) {
             output = msg.payload.output
           }
-        } catch (e) {
-          console.error('Failed to parse WebSocket message:', e)
+        } catch {
+          // Non-critical: malformed WS message; resolve with whatever output we have
         }
         clearTimeout(timeout)
         ws.close()

--- a/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
+++ b/web/src/components/drilldown/views/MultiClusterSummaryDrillDown.tsx
@@ -5,6 +5,7 @@ import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import type { DrillDownViewType } from '../../../hooks/useDrillDown'
 import { useCachedNodes } from '../../../hooks/useCachedData'
 import { useTranslation } from 'react-i18next'
+import { formatRelativeTime } from '../../../lib/formatters'
 
 interface MultiClusterSummaryDrillDownProps {
   data: Record<string, unknown>
@@ -175,8 +176,11 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
   const { nodes: rawCachedNodes, lastRefresh: nodesLastRefresh } = useCachedNodes()
   // Guard against undefined to prevent crashes when APIs return 404/500/empty
   const cachedNodes = rawCachedNodes || []
-  // Freshness tracking: lastUpdated (from nodesLastRefresh) available if needed for display
-  void nodesLastRefresh
+  // Convert epoch ms to ISO string for the freshness indicator
+  const nodesDataAge = useMemo(() => {
+    if (!nodesLastRefresh) return null
+    return new Date(nodesLastRefresh).toISOString()
+  }, [nodesLastRefresh])
   const [searchQuery, setSearchQuery] = useState('')
   const [statusFilter, setStatusFilter] = useState<string>('all')
   const [clusterFilter, setClusterFilter] = useState<string>('all')
@@ -433,6 +437,15 @@ export function MultiClusterSummaryDrillDown({ data, viewType }: MultiClusterSum
 
   return (
     <div className="space-y-6">
+      {/* Freshness indicator for cached data */}
+      {nodesDataAge && (
+        <div className="flex justify-end">
+          <span className="text-2xs text-muted-foreground" title={new Date(nodesLastRefresh!).toLocaleString()}>
+            Updated {formatRelativeTime(nodesDataAge)}
+          </span>
+        </div>
+      )}
+
       {/* Summary Stats */}
       <div className="grid grid-cols-3 gap-4">
         <div className="glass rounded-lg p-4">

--- a/web/src/components/drilldown/views/NodeDrillDown.tsx
+++ b/web/src/components/drilldown/views/NodeDrillDown.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { copyToClipboard } from '../../../lib/clipboard'
 import { useCachedNodes } from '../../../hooks/useCachedData'
+import { formatRelativeTime } from '../../../lib/formatters'
 
 interface Props {
   data: Record<string, unknown>
@@ -34,7 +35,11 @@ export function NodeDrillDown({ data }: Props) {
   // Fetch node data from cache to fill in missing fields (#3028)
   // lastRefresh tracks when node data was last updated (freshness: lastUpdated shown in parent via CardWrapper)
   const { nodes, isLoading: isLoadingNodes, isFailed: isNodesFailed, lastRefresh: nodeLastRefresh } = useCachedNodes(cluster || undefined)
-  void nodeLastRefresh // freshness timestamp available if needed for display
+  // Format lastRefresh as a relative time string for the freshness indicator
+  const nodeDataAge = useMemo(() => {
+    if (!nodeLastRefresh) return null
+    return new Date(nodeLastRefresh).toISOString()
+  }, [nodeLastRefresh])
 
   // Look up this specific node from the cached data
   const cachedNode = useMemo(() => {
@@ -130,7 +135,14 @@ Start by checking node events and conditions.`,
 
       {/* Node Info */}
       <div className="p-4 rounded-lg bg-card/50 border border-border">
-        <h3 className="text-lg font-semibold text-foreground mb-4">Node: {nodeName}</h3>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold text-foreground">Node: {nodeName}</h3>
+          {nodeDataAge && (
+            <span className="text-2xs text-muted-foreground" title={new Date(nodeLastRefresh!).toLocaleString()}>
+              Updated {formatRelativeTime(nodeDataAge)}
+            </span>
+          )}
+        </div>
 
         {/* Loading indicator while resolving node data */}
         {isResolvingNode && (


### PR DESCRIPTION
## Summary
- **#4436**: Remove noisy `console.error` for non-critical WebSocket parse failures in CRDDrillDown
- **#4438**: Add freshness indicators ("Updated Xm ago") to NodeDrillDown and MultiClusterSummaryDrillDown cached data
- **#4444**: Make deployment issue rows clickable in ClusterDetailModal (drillToDeployment + close modal)
- **#4446**: Show "New Group" button even when no cluster groups exist and the form is closed
- **#4447**: Fix CRD stats summary grid to use `statsSource.length` (pre-pagination filtered count) instead of `totalItems` (which diverges from healthyCount + unhealthyCount)
- **#4448**: Hide node repair button on healthy nodes; show a "Healthy" indicator instead

Fixes #4436, #4438, #4444, #4446, #4447, #4448

## Test plan
- [ ] `npm run build` passes
- [ ] Click deployment issue row in ClusterDetailModal — should drill down and close modal
- [ ] Open Clusters page with no groups — "New Group" button should be visible
- [ ] CRD Health card: summary grid total matches healthy + unhealthy count
- [ ] Node detail panel: no repair button on healthy nodes, shows green "Healthy" badge
- [ ] NodeDrillDown and MultiClusterSummaryDrillDown show "Updated Xm ago" timestamp