### PR TITLE
feat: auto-populate Learn dropdown from YouTube playlist

### DIFF
--- a/pkg/api/handlers/youtube.go
+++ b/pkg/api/handlers/youtube.go
@@ -1,0 +1,145 @@
+package handlers
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// YouTubePlaylistHandler fetches videos from a YouTube playlist RSS feed
+// and returns them as JSON. Results are cached to avoid hitting YouTube
+// on every request.
+
+const (
+	// playlistID is the KubeStellar Console tutorials playlist.
+	playlistID = "PL1ALKGr_qZKc-xehA_8iUCdiKsCo6p6nD"
+
+	// playlistCacheTTL controls how long playlist results are cached.
+	playlistCacheTTL = 1 * time.Hour
+
+	// playlistFetchTimeout is the HTTP timeout for fetching the RSS feed.
+	playlistFetchTimeout = 10 * time.Second
+)
+
+// PlaylistVideo is the JSON shape returned to the frontend.
+type PlaylistVideo struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+	Published   string `json:"published,omitempty"`
+}
+
+// youtubeAtomFeed represents the YouTube RSS/Atom feed XML structure.
+type youtubeAtomFeed struct {
+	XMLName xml.Name          `xml:"feed"`
+	Entries []youtubeAtomEntry `xml:"entry"`
+}
+
+type youtubeAtomEntry struct {
+	Title     string `xml:"title"`
+	Published string `xml:"published"`
+	VideoID   string `xml:"http://www.youtube.com/xml/schemas/2015 videoId"`
+	Group     struct {
+		Description string `xml:"http://search.yahoo.com/mrss/ description"`
+	} `xml:"http://search.yahoo.com/mrss/ group"`
+}
+
+type playlistCache struct {
+	mu        sync.RWMutex
+	videos    []PlaylistVideo
+	fetchedAt time.Time
+}
+
+var cache = &playlistCache{}
+
+func fetchPlaylistFromYouTube() ([]PlaylistVideo, error) {
+	url := fmt.Sprintf("https://www.youtube.com/feeds/videos.xml?playlist_id=%s", playlistID)
+
+	client := &http.Client{Timeout: playlistFetchTimeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch playlist feed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("YouTube returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read feed body: %w", err)
+	}
+
+	var feed youtubeAtomFeed
+	if err := xml.Unmarshal(body, &feed); err != nil {
+		return nil, fmt.Errorf("failed to parse feed XML: %w", err)
+	}
+
+	videos := make([]PlaylistVideo, 0, len(feed.Entries))
+	for _, entry := range feed.Entries {
+		videos = append(videos, PlaylistVideo{
+			ID:          entry.VideoID,
+			Title:       entry.Title,
+			Description: entry.Group.Description,
+			Published:   entry.Published,
+		})
+	}
+
+	return videos, nil
+}
+
+func getPlaylistVideos() ([]PlaylistVideo, error) {
+	cache.mu.RLock()
+	if time.Since(cache.fetchedAt) < playlistCacheTTL && cache.videos != nil {
+		videos := cache.videos
+		cache.mu.RUnlock()
+		return videos, nil
+	}
+	cache.mu.RUnlock()
+
+	videos, err := fetchPlaylistFromYouTube()
+	if err != nil {
+		// Return stale cache if available
+		cache.mu.RLock()
+		if cache.videos != nil {
+			stale := cache.videos
+			cache.mu.RUnlock()
+			return stale, nil
+		}
+		cache.mu.RUnlock()
+		return nil, err
+	}
+
+	cache.mu.Lock()
+	cache.videos = videos
+	cache.fetchedAt = time.Now()
+	cache.mu.Unlock()
+
+	return videos, nil
+}
+
+// YouTubePlaylistHandler returns the videos in the KubeStellar Console
+// YouTube playlist as JSON. Public endpoint — no auth required.
+func YouTubePlaylistHandler(c *fiber.Ctx) error {
+	videos, err := getPlaylistVideos()
+	if err != nil {
+		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
+			"error":  "failed to fetch playlist",
+			"detail": err.Error(),
+		})
+	}
+
+	return c.JSON(fiber.Map{
+		"videos":     videos,
+		"playlistId": playlistID,
+		"playlistUrl": fmt.Sprintf(
+			"https://www.youtube.com/playlist?list=%s", playlistID,
+		),
+	})
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -582,6 +582,9 @@ func (s *Server) setupRoutes() {
 	// Dev mode only affects things like frontend URLs and default users,
 	// NOT authentication requirements
 
+	// YouTube playlist (public — proxies to YouTube RSS feed, cached 1h)
+	s.app.Get("/api/youtube/playlist", handlers.YouTubePlaylistHandler)
+
 	// Mission knowledge base browse/file (public — proxies to public GitHub repo)
 	missions := handlers.NewMissionsHandler()
 	missions.RegisterPublicRoutes(s.app.Group("/api/missions"))

--- a/web/netlify/functions/youtube-playlist.mts
+++ b/web/netlify/functions/youtube-playlist.mts
@@ -1,0 +1,107 @@
+/**
+ * Netlify Function: YouTube Playlist
+ *
+ * Fetches videos from the KubeStellar Console YouTube playlist RSS feed
+ * and returns them as JSON. Equivalent to the Go backend's
+ * YouTubePlaylistHandler for Netlify deployments.
+ */
+
+const PLAYLIST_ID = "PL1ALKGr_qZKc-xehA_8iUCdiKsCo6p6nD";
+const FEED_URL = `https://www.youtube.com/feeds/videos.xml?playlist_id=${PLAYLIST_ID}`;
+const ALLOWED_ORIGINS = [
+  "https://console.kubestellar.io",
+  "https://console-deploy-preview.kubestellar.io",
+];
+
+function corsOrigin(origin: string | null): string {
+  if (!origin) return ALLOWED_ORIGINS[0];
+  if (ALLOWED_ORIGINS.some((o) => origin.startsWith(o) || origin.endsWith(".kubestellar.io"))) {
+    return origin;
+  }
+  return ALLOWED_ORIGINS[0];
+}
+
+interface PlaylistVideo {
+  id: string;
+  title: string;
+  description?: string;
+  published?: string;
+}
+
+function parseAtomFeed(xml: string): PlaylistVideo[] {
+  const videos: PlaylistVideo[] = [];
+
+  // Simple XML parsing without a library — extract <entry> blocks
+  const entryRegex = /<entry>([\s\S]*?)<\/entry>/g;
+  let match;
+
+  while ((match = entryRegex.exec(xml)) !== null) {
+    const entry = match[1];
+
+    const videoId = entry.match(/<yt:videoId>([^<]+)<\/yt:videoId>/)?.[1] ?? "";
+    const title = entry.match(/<title>([^<]+)<\/title>/)?.[1] ?? "";
+    const description = entry.match(/<media:description>([^<]*)<\/media:description>/)?.[1] ?? "";
+    const published = entry.match(/<published>([^<]+)<\/published>/)?.[1] ?? "";
+
+    if (videoId) {
+      videos.push({
+        id: videoId,
+        title,
+        description: description || undefined,
+        published: published || undefined,
+      });
+    }
+  }
+
+  return videos;
+}
+
+export default async (req: Request) => {
+  const origin = req.headers.get("origin");
+  const headers: Record<string, string> = {
+    "Access-Control-Allow-Origin": corsOrigin(origin),
+    "Content-Type": "application/json",
+    "Cache-Control": "public, max-age=3600",
+  };
+
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: { ...headers, "Access-Control-Allow-Methods": "GET, OPTIONS" },
+    });
+  }
+
+  try {
+    const resp = await fetch(FEED_URL, {
+      headers: { "User-Agent": "KubeStellar-Console/1.0" },
+    });
+
+    if (!resp.ok) {
+      return new Response(
+        JSON.stringify({ error: "YouTube returned " + resp.status }),
+        { status: 502, headers }
+      );
+    }
+
+    const xml = await resp.text();
+    const videos = parseAtomFeed(xml);
+
+    return new Response(
+      JSON.stringify({
+        videos,
+        playlistId: PLAYLIST_ID,
+        playlistUrl: `https://www.youtube.com/playlist?list=${PLAYLIST_ID}`,
+      }),
+      { status: 200, headers }
+    );
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch playlist", detail: String(err) }),
+      { status: 502, headers }
+    );
+  }
+};
+
+export const config = {
+  path: "/api/youtube/playlist",
+};

--- a/web/src/components/layout/navbar/LearnDropdown.tsx
+++ b/web/src/components/layout/navbar/LearnDropdown.tsx
@@ -1,29 +1,29 @@
 import { useRef, useEffect } from 'react'
 import { useModalState } from '../../../lib/modals'
 import { useLocation } from 'react-router-dom'
-import { BookOpen, Play, ExternalLink, GraduationCap, Video } from 'lucide-react'
+import { BookOpen, Play, ExternalLink, GraduationCap, Video, Loader2 } from 'lucide-react'
 import { useTour } from '../../../hooks/useTour'
 import { LogoWithStar } from '../../ui/LogoWithStar'
 import {
-  LEARNING_VIDEOS,
-  YOUTUBE_PLAYLIST_URL,
   getYouTubeThumbnailUrl,
   getYouTubeWatchUrl,
 } from '../../../config/learningVideos'
+import { usePlaylistVideos } from '../../../hooks/usePlaylistVideos'
 import { cn } from '../../../lib/cn'
-
-const RESOURCES = [
-  { label: 'Documentation', href: 'https://console-docs.kubestellar.io', description: 'Console docs and guides' },
-  { label: 'Getting Started', href: 'https://kubestellar.io/docs/console/overview/introduction', description: 'Quick start guide' },
-  { label: 'Blog', href: 'https://kubestellar.io/blog', description: 'News and updates' },
-  { label: 'YouTube Channel', href: YOUTUBE_PLAYLIST_URL, description: 'Video tutorials playlist' },
-]
 
 export function LearnDropdown() {
   const { isOpen, close, toggle } = useModalState()
   const dropdownRef = useRef<HTMLDivElement>(null)
   const { startTour, hasCompletedTour } = useTour()
   const location = useLocation()
+  const { videos, playlistUrl, loading } = usePlaylistVideos()
+
+  const RESOURCES = [
+    { label: 'Documentation', href: 'https://console-docs.kubestellar.io', description: 'Console docs and guides' },
+    { label: 'Getting Started', href: 'https://kubestellar.io/docs/console/overview/introduction', description: 'Quick start guide' },
+    { label: 'Blog', href: 'https://kubestellar.io/blog', description: 'News and updates' },
+    { label: 'YouTube Channel', href: playlistUrl, description: 'Video tutorials playlist' },
+  ]
 
   // Close on route change
   useEffect(() => {
@@ -102,9 +102,13 @@ export function LearnDropdown() {
             </div>
           </div>
 
-          {LEARNING_VIDEOS.length > 0 ? (
+          {loading ? (
+            <div className="px-4 py-4 flex items-center justify-center">
+              <Loader2 className="w-4 h-4 text-muted-foreground animate-spin" />
+            </div>
+          ) : videos.length > 0 ? (
             <div className="px-2 pb-2 max-h-48 overflow-y-auto">
-              {LEARNING_VIDEOS.map(video => (
+              {videos.map(video => (
                 <a
                   key={video.id}
                   href={getYouTubeWatchUrl(video.id)}
@@ -136,7 +140,7 @@ export function LearnDropdown() {
               <GraduationCap className="w-8 h-8 text-muted-foreground/40 mb-2" />
               <div className="text-xs text-muted-foreground">Coming soon</div>
               <a
-                href={YOUTUBE_PLAYLIST_URL}
+                href={playlistUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-xs text-primary hover:underline mt-1"

--- a/web/src/config/__tests__/learningVideos.test.ts
+++ b/web/src/config/__tests__/learningVideos.test.ts
@@ -3,24 +3,10 @@
  */
 import { describe, it, expect } from 'vitest'
 import {
-  LEARNING_VIDEOS,
   getYouTubeThumbnailUrl,
   getYouTubeWatchUrl,
   YOUTUBE_PLAYLIST_URL,
 } from '../learningVideos'
-
-describe('LEARNING_VIDEOS', () => {
-  it('is an array', () => {
-    expect(Array.isArray(LEARNING_VIDEOS)).toBe(true)
-  })
-
-  it('each video has id and title when array is populated', () => {
-    LEARNING_VIDEOS.forEach(video => {
-      expect(video.id).toBeTruthy()
-      expect(video.title).toBeTruthy()
-    })
-  })
-})
 
 describe('YouTube URL helpers', () => {
   it('getYouTubeThumbnailUrl returns valid URL', () => {

--- a/web/src/config/learningVideos.ts
+++ b/web/src/config/learningVideos.ts
@@ -1,20 +1,10 @@
 /**
- * YouTube video tutorials for the Learn dropdown.
+ * YouTube video tutorial helpers.
  *
- * Add entries here as videos are published to the playlist.
- * Thumbnails and watch URLs are derived from the video ID automatically.
+ * Videos are fetched dynamically from the YouTube playlist via
+ * /api/youtube/playlist (see usePlaylistVideos hook).
+ * These helpers generate thumbnail and watch URLs from a video ID.
  */
-
-export interface LearningVideo {
-  id: string       // YouTube video ID (the ?v= parameter)
-  title: string
-  description?: string
-}
-
-/** Videos from the KubeStellar Console playlist */
-export const LEARNING_VIDEOS: LearningVideo[] = [
-  // Populated as videos are added to the playlist
-]
 
 export const getYouTubeThumbnailUrl = (videoId: string) =>
   `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`

--- a/web/src/hooks/usePlaylistVideos.ts
+++ b/web/src/hooks/usePlaylistVideos.ts
@@ -1,0 +1,90 @@
+import { useState, useEffect } from 'react'
+
+export interface PlaylistVideo {
+  id: string
+  title: string
+  description?: string
+  published?: string
+}
+
+interface PlaylistResponse {
+  videos: PlaylistVideo[]
+  playlistId: string
+  playlistUrl: string
+}
+
+const CACHE_KEY = 'ks-playlist-cache'
+const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
+
+interface CacheEntry {
+  videos: PlaylistVideo[]
+  playlistUrl: string
+  timestamp: number
+}
+
+function readCache(): CacheEntry | null {
+  try {
+    const raw = sessionStorage.getItem(CACHE_KEY)
+    if (!raw) return null
+    const entry: CacheEntry = JSON.parse(raw)
+    if (Date.now() - entry.timestamp > CACHE_TTL_MS) return null
+    return entry
+  } catch {
+    return null
+  }
+}
+
+function writeCache(videos: PlaylistVideo[], playlistUrl: string): void {
+  try {
+    const entry: CacheEntry = { videos, playlistUrl, timestamp: Date.now() }
+    sessionStorage.setItem(CACHE_KEY, JSON.stringify(entry))
+  } catch {
+    // sessionStorage not available — ignore
+  }
+}
+
+/**
+ * Fetches videos from the KubeStellar Console YouTube playlist.
+ * Uses the backend proxy (/api/youtube/playlist) to avoid CORS issues.
+ * Results are cached in sessionStorage for 1 hour.
+ */
+export function usePlaylistVideos() {
+  const [videos, setVideos] = useState<PlaylistVideo[]>([])
+  const [playlistUrl, setPlaylistUrl] = useState(
+    'https://www.youtube.com/playlist?list=PL1ALKGr_qZKc-xehA_8iUCdiKsCo6p6nD'
+  )
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const cached = readCache()
+    if (cached) {
+      setVideos(cached.videos)
+      setPlaylistUrl(cached.playlistUrl)
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+
+    async function fetchPlaylist() {
+      try {
+        const resp = await fetch('/api/youtube/playlist')
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+        const data: PlaylistResponse = await resp.json()
+        if (cancelled) return
+        setVideos(data.videos || [])
+        setPlaylistUrl(data.playlistUrl)
+        writeCache(data.videos || [], data.playlistUrl)
+      } catch {
+        // Silently fail — the UI shows "Coming soon" when videos is empty
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    fetchPlaylist()
+    return () => { cancelled = true }
+  }, [])
+
+  return { videos, playlistUrl, loading }
+}


### PR DESCRIPTION
## Summary
- Videos uploaded to the [KubeStellar Console YouTube playlist](https://www.youtube.com/playlist?list=PL1ALKGr_qZKc-xehA_8iUCdiKsCo6p6nD) now appear automatically in the Learn dropdown — no code changes needed
- Replaces the static `LEARNING_VIDEOS` array with a live RSS feed fetch
- Backend proxy avoids CORS issues (Go endpoint for local, Netlify Function for production)
- Results cached for 1 hour (server-side and sessionStorage)

## Changes
- **`pkg/api/handlers/youtube.go`** — Go handler that fetches/parses YouTube playlist RSS feed, returns JSON, caches 1h
- **`pkg/api/server.go`** — Register public `/api/youtube/playlist` route
- **`web/netlify/functions/youtube-playlist.mts`** — Netlify Function equivalent for production
- **`web/src/hooks/usePlaylistVideos.ts`** — React hook with sessionStorage caching
- **`web/src/components/layout/navbar/LearnDropdown.tsx`** — Use hook instead of static array, add loading state
- **`web/src/config/learningVideos.ts`** — Remove static array, keep URL helpers

## Test plan
- [ ] Upload a video to the YouTube playlist
- [ ] Verify it appears in the Learn dropdown within ~1 hour (or after clearing sessionStorage)
- [ ] Verify "Coming soon" still shows when playlist is empty
- [ ] Verify loading spinner shows briefly on first load
- [ ] Verify Netlify preview works (Function serves the API)