### PR TITLE
fix: add Netlify redirect for YouTube playlist API

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -75,6 +75,12 @@
   to = "/.netlify/functions/analytics-dashboard"
   status = 200
 
+# YouTube playlist API — proxy to Netlify Function
+[[redirects]]
+  from = "/api/youtube/playlist"
+  to = "/.netlify/functions/youtube-playlist"
+  status = 200
+
 # Analytics dashboard page — serve static HTML
 [[redirects]]
   from = "/analytics"


### PR DESCRIPTION
## Summary
- Adds missing Netlify redirect for `/api/youtube/playlist` -> Netlify Function
- Without this, the SPA catch-all `/* -> /index.html` intercepts the API call
- Follow-up to #4469

## Test plan
- [ ] After deploy, `curl https://console.kubestellar.io/api/youtube/playlist` returns JSON (not HTML)