### PR TITLE
fix: passthrough YouTube playlist API in demo mode

### DIFF
--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -630,6 +630,11 @@ export const handlers = [
     return HttpResponse.json({ success: true })
   }),
 
+  // ── Passthrough for Netlify Functions that work in demo mode ─────
+  // These endpoints are backed by Netlify Functions and return real data
+  // even in demo mode — let them through to the actual backend.
+  http.get('/api/youtube/playlist', () => passthrough()),
+
   // ── Catch-all for unmocked API routes ────────────────────────────
   // On Netlify, unhandled /api/* and /health requests fall through to the SPA
   // catch-all which returns index.html (200 OK, text/html). Code calling


### PR DESCRIPTION
## Summary
- MSW catch-all was blocking `/api/youtube/playlist` in demo mode (returning 503)
- Add `passthrough()` for this endpoint since it's backed by a Netlify Function that works independently of the backend
- This is why the Learn dropdown still showed "Coming soon" after #4469 and #4472

## Test plan
- [ ] On console.kubestellar.io, open Learn dropdown — should show uploaded YouTube videos instead of "Coming soon"