### PR TITLE
Fix: Issues in rbac_test.go

### DIFF
--- a/pkg/api/handlers/rbac_test.go
+++ b/pkg/api/handlers/rbac_test.go
@@ -45,14 +45,15 @@ func (s *rbacTestStore) UpdateUserRole(userID uuid.UUID, role string) error {
 
 func TestRBACUpdateUserRole_ForbiddenForNonAdmin(t *testing.T) {
 	env := setupTestEnv(t)
-	adminUser := &models.User{
+	// Fix 4: variable renamed to reflect its actual viewer role
+	nonAdminUser := &models.User{
 		ID:   testAdminUserID,
-		Role: string(models.UserRoleViewer),
+		Role: models.UserRoleViewer, // Fix 1: use enum type directly, not string cast
 	}
 
 	store := &rbacTestStore{
 		users: map[uuid.UUID]*models.User{
-			testAdminUserID: adminUser,
+			testAdminUserID: nonAdminUser,
 		},
 	}
 
@@ -68,7 +69,11 @@ func TestRBACUpdateUserRole_ForbiddenForNonAdmin(t *testing.T) {
 
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
+	defer resp.Body.Close() // Fix 5: close response body
 	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	// Fix 2: verify no state mutation occurred despite the forbidden response
+	assert.Equal(t, uuid.Nil, store.updatedUserID)
+	assert.Empty(t, store.updatedRole)
 }
 
 func TestRBACUpdateUserRole_Success(t *testing.T) {
@@ -76,7 +81,7 @@ func TestRBACUpdateUserRole_Success(t *testing.T) {
 	targetUserID := uuid.New()
 	adminUser := &models.User{
 		ID:   testAdminUserID,
-		Role: string(models.UserRoleAdmin),
+		Role: models.UserRoleAdmin, // Fix 1: use enum type directly, not string cast
 	}
 
 	store := &rbacTestStore{
@@ -97,6 +102,7 @@ func TestRBACUpdateUserRole_Success(t *testing.T) {
 
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
+	defer resp.Body.Close() // Fix 5: close response body
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, targetUserID, store.updatedUserID)
 	assert.Equal(t, string(models.UserRoleEditor), store.updatedRole)
@@ -106,7 +112,7 @@ func TestRBACListConsoleUsers_Success(t *testing.T) {
 	env := setupTestEnv(t)
 	adminUser := &models.User{
 		ID:   testAdminUserID,
-		Role: string(models.UserRoleAdmin),
+		Role: models.UserRoleAdmin, // Fix 1: use enum type directly, not string cast
 	}
 
 	store := &rbacTestStore{
@@ -114,8 +120,8 @@ func TestRBACListConsoleUsers_Success(t *testing.T) {
 			testAdminUserID: adminUser,
 		},
 		listUsers: []models.User{
-			{ID: testAdminUserID, GitHubLogin: "admin", Role: string(models.UserRoleAdmin)},
-			{ID: uuid.New(), GitHubLogin: "dev1", Role: string(models.UserRoleEditor)},
+			{ID: testAdminUserID, GitHubLogin: "admin", Role: models.UserRoleAdmin},   // Fix 1: use enum type directly
+			{ID: uuid.New(), GitHubLogin: "dev1", Role: models.UserRoleEditor},        // Fix 1: use enum type directly
 		},
 	}
 
@@ -127,10 +133,17 @@ func TestRBACListConsoleUsers_Success(t *testing.T) {
 
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
+	defer resp.Body.Close() // Fix 5: close response body
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 	var users []models.User
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&users))
 	assert.Len(t, users, 2)
-	assert.Equal(t, "admin", users[0].GitHubLogin)
+
+	// Fix 3: use order-agnostic check without depending on slice position
+	logins := make([]string, len(users))
+	for i, u := range users {
+		logins[i] = u.GitHubLogin
+	}
+	assert.ElementsMatch(t, []string{"admin", "dev1"}, logins)
 }


### PR DESCRIPTION
> **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.

> **New CNCF project card?** New cards go in [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo. PRs adding new cards here will be redirected.

> **Use a coding agent.** This repo is primarily developed with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Opus 4.5/4.6). It knows all codebase patterns (isDemoData, useCardLoadingState, locale strings, DCO). Manual PRs that miss required patterns will be sent back.

---

### 📝 Summary of Changes

Fixes test issues in `pkg/api/handlers/rbac_test.go` by aligning role types with the `models.UserRole` enum, strengthening RBAC-related assertions, improving resource hygiene, and ensuring the list-users test verifies the full expected set of users in an order-independent manner.

---

### Changes Made

- [x] Replace incorrect `string(models.UserRoleX)` assignments to `models.User.Role` with the enum type directly
- [x] Close HTTP response bodies in RBAC handler tests to avoid resource leaks
- [x] Improve assertions for forbidden role updates to reduce brittleness
- [x] Strengthen list-users test to assert the full expected set (`"admin"` and `"dev1"`) using `assert.ElementsMatch` instead of only checking that `"admin"` is present — prevents the test from passing when wrong users are returned

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [x] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

All RBAC tests pass:

```
=== RUN   TestRBACUpdateUserRole_ForbiddenForNonAdmin
--- PASS: TestRBACUpdateUserRole_ForbiddenForNonAdmin (0.00s)
=== RUN   TestRBACUpdateUserRole_Success
--- PASS: TestRBACUpdateUserRole_Success (0.00s)
=== RUN   TestRBACListConsoleUsers_Success
--- PASS: TestRBACListConsoleUsers_Success (0.00s)
PASS
ok      github.com/kubestellar/console/pkg/api/handlers 0.013s
```

---

### 👀 Reviewer Notes

Changes are confined to `rbac_test.go` test code only — no production logic was modified.