### PR TITLE
Fix: Secret scan can report PASS even when scanner execution fails

### DIFF
--- a/scripts/secret-scan-test.sh
+++ b/scripts/secret-scan-test.sh
@@ -16,6 +16,7 @@
 # Exit code:
 #   0 — no secrets found
 #   1 — secrets detected
+#   2+ — scanner execution error (missing binary, crash, bad config, etc.)
 
 set -euo pipefail
 
@@ -54,11 +55,17 @@ echo ""
 if ! command -v gitleaks &>/dev/null; then
   echo -e "${YELLOW}Installing gitleaks...${NC}"
   if command -v brew &>/dev/null; then
-    brew install gitleaks 2>/dev/null
+    brew install gitleaks
   elif command -v go &>/dev/null; then
-    go install github.com/gitleaks/gitleaks/v8@latest 2>/dev/null
+    go install github.com/gitleaks/gitleaks/v8@latest
+    # go install places binaries in GOPATH/bin which may not be on PATH
+    export PATH="$(go env GOPATH)/bin:$PATH"
   else
     echo -e "${RED}ERROR: Cannot install gitleaks — install manually: brew install gitleaks${NC}"
+    exit 1
+  fi
+  if ! command -v gitleaks &>/dev/null; then
+    echo -e "${RED}ERROR: gitleaks installation failed — binary not found after install${NC}"
     exit 1
   fi
 fi
@@ -68,7 +75,8 @@ fi
 # ============================================================================
 
 GITLEAKS_CONFIG=$(mktemp)
-trap 'rm -f "$GITLEAKS_CONFIG"' EXIT
+GITLEAKS_STDERR=$(mktemp)
+trap 'rm -f "$GITLEAKS_CONFIG" "$GITLEAKS_STDERR"' EXIT
 
 cat > "$GITLEAKS_CONFIG" << 'TOML'
 title = "KubeStellar Console gitleaks config"
@@ -123,7 +131,7 @@ if [ -n "$SCAN_GIT_HISTORY" ]; then
     --config="$GITLEAKS_CONFIG" \
     --report-format=json \
     --report-path="$REPORT_JSON" \
-    --verbose 2>/dev/null || GITLEAKS_EXIT=$?
+    --verbose 2>"$GITLEAKS_STDERR" || GITLEAKS_EXIT=$?
 else
   echo -e "${DIM}Scanning working tree...${NC}"
   gitleaks detect \
@@ -131,7 +139,17 @@ else
     --report-format=json \
     --report-path="$REPORT_JSON" \
     --no-git \
-    --verbose 2>/dev/null || GITLEAKS_EXIT=$?
+    --verbose 2>"$GITLEAKS_STDERR" || GITLEAKS_EXIT=$?
+fi
+
+# Exit code 1 means leaks were found (expected); exit code >1 means execution error
+if [ "$GITLEAKS_EXIT" -gt 1 ]; then
+  echo -e "${RED}ERROR: gitleaks failed to execute (exit code ${GITLEAKS_EXIT})${NC}"
+  if [ -s "$GITLEAKS_STDERR" ]; then
+    echo -e "${RED}Scanner output:${NC}"
+    cat "$GITLEAKS_STDERR" >&2
+  fi
+  exit "$GITLEAKS_EXIT"
 fi
 
 echo ""


### PR DESCRIPTION
> **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.

> **New CNCF project card?** New cards go in [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo. PRs adding new cards here will be redirected.

> **Use a coding agent.** This repo is primarily developed with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Opus 4.5/4.6). It knows all codebase patterns (isDemoData, useCardLoadingState, locale strings, DCO). Manual PRs that miss required patterns will be sent back.

### 📌 Fixes

---

### 📝 Summary of Changes

Fixes the `scripts/secret-scan-test.sh` helper so it no longer reports a "PASS" when `gitleaks` fails to execute (missing binary, crash, bad config, etc.), addressing false negatives in the console repo's secret scanning workflow.

- Ensures `gitleaks` installation is verified by re-checking `command -v gitleaks` after install
- Captures `gitleaks` stderr to a temp file and fails the script when `gitleaks` exits with a code > 1 (execution error)
- Propagates the actual `$GITLEAKS_EXIT` code on execution error (instead of hardcoded `1`), making scanner execution failures distinguishable from "secrets detected" (exit code 1) — consistent with the documented `2+` exit code in the script header
- Exports `$(go env GOPATH)/bin` into `$PATH` after `go install` so the post-install `command -v gitleaks` check can locate the freshly-installed binary even when `GOPATH/bin` is not already on `PATH`
- Updates script header documentation to document the `2+` exit code for scanner execution errors

---

### Changes Made

- [x] Fixed `scripts/secret-scan-test.sh` to fail when `gitleaks` exits with code > 1 (execution error)
- [x] Fixed exit code propagation: execution-error path now exits with `$GITLEAKS_EXIT` (≥2) instead of hardcoded `1`
- [x] Fixed `go install` PATH issue: `GOPATH/bin` is exported to `$PATH` immediately after `go install` so the binary is findable
- [x] Updated script header to document exit code `2+` for scanner execution errors

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

Exit code behavior after fix:
- `0` — no secrets found
- `1` — secrets detected
- `2+` — scanner execution error (missing binary, crash, bad config, etc.)

---

### 👀 Reviewer Notes

Changes are limited to `scripts/secret-scan-test.sh`. No frontend or backend code is affected.