### PR TITLE
Fix: Govuln timeout path is reported as clean scan textually

### DIFF
--- a/scripts/dependency-audit-test.sh
+++ b/scripts/dependency-audit-test.sh
@@ -148,7 +148,19 @@ if command -v go &>/dev/null; then
     GO_VULNS=$(grep -c "^Vulnerability #" "$GOVULN_OUTPUT" 2>/dev/null | head -1 | tr -d '[:space:]' || true)
     GO_VULNS="${GO_VULNS:-0}"
 
-    if [ "$GO_VULNS" -eq 0 ] 2>/dev/null; then
+    if [ "$GO_STATUS" = "skip" ] && [ "$GO_VULNS" -gt 0 ] 2>/dev/null; then
+      # Timed out but partial vulnerability output was captured — surface it and fail
+      echo -e "  ${RED}❌ ${GO_VULNS} vulnerability/ies found (scan timed out; results may be incomplete)${NC}"
+      grep -A 2 "^Vulnerability #" "$GOVULN_OUTPUT" 2>/dev/null | head -15 | while IFS= read -r line; do
+        echo -e "    ${DIM}${line}${NC}"
+      done
+      GO_STATUS="fail"
+    elif [ "$GO_STATUS" = "skip" ]; then
+      : # timeout warning already printed above; do not claim a clean scan
+    elif [ "$GO_VULNS" -eq 0 ] 2>/dev/null && [ "$GOVULN_EXIT" -ne 0 ] 2>/dev/null; then
+      echo -e "  ${YELLOW}⚠️  govulncheck failed with exit code ${GOVULN_EXIT} — skipping Go vulnerability result${NC}"
+      GO_STATUS="skip"
+    elif [ "$GO_VULNS" -eq 0 ] 2>/dev/null; then
       echo -e "  ${GREEN}✓ No vulnerabilities found${NC}"
     else
       echo -e "  ${RED}❌ ${GO_VULNS} vulnerability/ies found${NC}"


### PR DESCRIPTION
Fixes misleading govulncheck reporting in `scripts/dependency-audit-test.sh` so the timeout/skip path and tool-error paths no longer claim a clean scan, and partial vulnerabilities captured before a timeout are surfaced rather than silently ignored.

---

### 📝 Summary of Changes

- Suppress "✓ No vulnerabilities found" when the Go scan status is `skip` (timeout) with no partial output
- Surface any partial vulnerability output captured before a timeout: report count + details and set `GO_STATUS="fail"` instead of silently ignoring them
- Handle non-timeout non-zero govulncheck exit codes (e.g. analysis errors): print a warning and set `GO_STATUS="skip"` so the scan is not incorrectly reported as clean on tool failure

---

### Changes Made

- [x] Added guard: when `GO_STATUS=skip` and partial `Vulnerability #` entries were captured before timeout, report them and set `GO_STATUS=fail`
- [x] Preserved existing behaviour: timeout with no partial vulns keeps only the timeout warning (no false clean-scan message)
- [x] Added new `elif` branch: zero vulns + non-zero `GOVULN_EXIT` prints a tool-failure warning and sets `GO_STATUS=skip`

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [ ] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

_Shell script change only — no UI screenshots applicable._

---

### 👀 Reviewer Notes

All changes are confined to `scripts/dependency-audit-test.sh`. The bash syntax was validated with `bash -n`. No frontend build or lint changes were needed.