### PR TITLE
Fix: Card: Deployment Issues (deployment_issues)

### DIFF
--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+	appsv1 "k8s.io/api/apps/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -3361,17 +3362,25 @@ func (m *MultiClusterClient) FindDeploymentIssues(ctx context.Context, contextNa
 
 		// Check if not all replicas are ready
 		if deploy.Status.ReadyReplicas < desiredReplicas {
-			// Check conditions for more details
+			// Check conditions for more details. Progressing=False
+			// (ProgressDeadlineExceeded) is the more severe/specific condition
+			// and must take precedence over Available=False regardless of slice
+			// order (#4470). Use a two-pass scan: look for Progressing=False
+			// first, then fall back to Available=False.
 			for _, condition := range deploy.Status.Conditions {
-				if condition.Type == "Available" && condition.Status == "False" {
-					reason = "Unavailable"
-					message = condition.Message
-					break
-				}
-				if condition.Type == "Progressing" && condition.Status == "False" {
+				if condition.Type == appsv1.DeploymentProgressing && condition.Status == corev1.ConditionFalse {
 					reason = "ProgressDeadlineExceeded"
 					message = condition.Message
 					break
+				}
+			}
+			if reason == "" {
+				for _, condition := range deploy.Status.Conditions {
+					if condition.Type == appsv1.DeploymentAvailable && condition.Status == corev1.ConditionFalse {
+						reason = "Unavailable"
+						message = condition.Message
+						break
+					}
 				}
 			}
 
@@ -3420,14 +3429,12 @@ func (m *MultiClusterClient) GetDeployments(ctx context.Context, contextName, na
 		status := "running"
 		if deploy.Status.ReadyReplicas < desired {
 			status = "deploying"
-			// Check if stuck/failed
+			// Only mark as failed when Progressing=False (ProgressDeadlineExceeded).
+			// Available=False alone is a transient state during normal rolling updates
+			// and should remain "deploying", not "failed", to avoid false positives
+			// that contradict live drilldown data (#4470).
 			for _, condition := range deploy.Status.Conditions {
-				if condition.Type == "Progressing" && condition.Status == "False" {
-					status = "failed"
-					break
-				}
-				if condition.Type == "Available" && condition.Status == "False" &&
-					deploy.Status.ObservedGeneration >= deploy.Generation {
+				if condition.Type == appsv1.DeploymentProgressing && condition.Status == corev1.ConditionFalse {
 					status = "failed"
 					break
 				}

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -588,6 +588,129 @@ func TestGetDeploymentsNilReplicas(t *testing.T) {
 	}
 }
 
+// TestGetDeploymentsAvailableFalseNotFailed verifies that a deployment with
+// Available=False but without Progressing=False is reported as "deploying",
+// not "failed" (#4470). Available=False alone is a transient state during
+// normal rolling updates and should not be treated as a hard failure.
+func TestGetDeploymentsAvailableFalseNotFailed(t *testing.T) {
+	m, _ := NewMultiClusterClient("")
+
+	replicas := int32(3)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "rolling-dep",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-5 * time.Minute)},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "nginx"}}},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas: 2, // still rolling out
+			Conditions: []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionFalse, Message: "not all replicas available"},
+				{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "ReplicaSetUpdated"},
+			},
+		},
+	}
+
+	fakeCS := k8sfake.NewSimpleClientset(dep)
+	m.clients["c1"] = fakeCS
+
+	deps, err := m.GetDeployments(context.Background(), "c1", "default")
+	if err != nil {
+		t.Fatalf("GetDeployments failed: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("Expected 1 deployment, got %d", len(deps))
+	}
+	if deps[0].Status != "deploying" {
+		t.Errorf("Expected 'deploying' status for Available=False+Progressing=True, got %q", deps[0].Status)
+	}
+}
+
+// TestGetDeploymentsProgressingFalseFailed verifies that a deployment with
+// Progressing=False is reported as "failed" (#4470).
+func TestGetDeploymentsProgressingFalseFailed(t *testing.T) {
+	m, _ := NewMultiClusterClient("")
+
+	replicas := int32(3)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "stuck-dep",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-30 * time.Minute)},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Image: "bad-image"}}},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas: 0,
+			Conditions: []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionFalse, Reason: "ProgressDeadlineExceeded"},
+				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionFalse, Message: "unavailable"},
+			},
+		},
+	}
+
+	fakeCS := k8sfake.NewSimpleClientset(dep)
+	m.clients["c1"] = fakeCS
+
+	deps, err := m.GetDeployments(context.Background(), "c1", "default")
+	if err != nil {
+		t.Fatalf("GetDeployments failed: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("Expected 1 deployment, got %d", len(deps))
+	}
+	if deps[0].Status != "failed" {
+		t.Errorf("Expected 'failed' status for Progressing=False, got %q", deps[0].Status)
+	}
+}
+
+// TestFindDeploymentIssuesProgressDeadlineExceeded verifies that Progressing=False
+// takes precedence over Available=False when determining the issue reason (#4470).
+func TestFindDeploymentIssuesProgressDeadlineExceeded(t *testing.T) {
+	m, _ := NewMultiClusterClient("")
+
+	replicas := int32(3)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stuck-dep",
+			Namespace: "default",
+		},
+		Spec: appsv1.DeploymentSpec{Replicas: &replicas},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas: 0,
+			Conditions: []appsv1.DeploymentCondition{
+				// Available=False comes first in the slice (old code would pick this)
+				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionFalse, Message: "unavailable"},
+				{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionFalse, Reason: "ProgressDeadlineExceeded", Message: "deadline exceeded"},
+			},
+		},
+	}
+
+	fakeCS := k8sfake.NewSimpleClientset(dep)
+	m.clients["c1"] = fakeCS
+
+	issues, err := m.FindDeploymentIssues(context.Background(), "c1", "default")
+	if err != nil {
+		t.Fatalf("FindDeploymentIssues failed: %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("Expected 1 issue, got %d", len(issues))
+	}
+	if issues[0].Reason != "ProgressDeadlineExceeded" {
+		t.Errorf("Expected reason 'ProgressDeadlineExceeded', got %q", issues[0].Reason)
+	}
+}
+
 func TestGetServices(t *testing.T) {
 	m, _ := NewMultiClusterClient("")
 


### PR DESCRIPTION
> **Adding or modifying a card/dashboard?** Read the [Card Development Guide](.github/CARD_DEVELOPMENT_GUIDE.md) first — it covers required patterns, common pitfalls, and the full file checklist.

> **New CNCF project card?** New cards go in [kubestellar/console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo. PRs adding new cards here will be redirected.

> **Use a coding agent.** This repo is primarily developed with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (Opus 4.5/4.6). It knows all codebase patterns (isDemoData, useCardLoadingState, locale strings, DCO). Manual PRs that miss required patterns will be sent back.

### 📌 Fixes

---

### 📝 Summary of Changes

Corrects how the backend derives Deployment "failed" vs "deploying" states so the Deployment Issues card doesn't report failures that contradict the drilldown/live rollout data.

---

### Changes Made

- [x] Fixed `GetDeployments` rollout status logic to only mark a deployment as `failed` when `Progressing=False` (instead of treating `Available=False` as a hard failure)
- [x] Fixed `FindDeploymentIssues` condition evaluation to use a **two-pass scan** — first pass exclusively checks for `Progressing=False`; second pass only checks `Available=False` if no `Progressing=False` was found, ensuring correct precedence regardless of condition slice order
- [x] Replaced all raw string literals (`"Progressing"`, `"Available"`, `"False"`, `"True"`) in `pkg/k8s/client.go` with typed Kubernetes API constants (`appsv1.DeploymentProgressing`, `appsv1.DeploymentAvailable`, `corev1.ConditionFalse`) for consistency and correctness
- [x] Added `appsv1 "k8s.io/api/apps/v1"` import to `pkg/k8s/client.go`
- [x] Updated all test condition type/status string literals in `pkg/k8s/client_test.go` to use `appsv1.DeploymentAvailable`, `appsv1.DeploymentProgressing`, `corev1.ConditionFalse`, and `corev1.ConditionTrue` constants
- [x] Added unit tests covering `Available=False` not triggering "failed", `Progressing=False` triggering "failed", and `Progressing=False` taking precedence over `Available=False` when the latter appears first in the conditions slice

---

### Checklist

Please ensure the following before submitting your PR:

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [ ] New cards target [console-marketplace](https://github.com/kubestellar/console-marketplace), not this repo
- [ ] isDemoData is wired correctly (cards show Demo badge when using demo data)
- [x] I have written unit tests for the changes (if applicable)
- [x] I have tested the changes locally and ensured they work as expected
- [x] All commits are signed with DCO (`git commit -s`)

---

### Screenshots or Logs (if applicable)

All 7 deployment-related tests pass:
```
--- PASS: TestFindDeploymentIssues (0.00s)
--- PASS: TestFindDeploymentIssuesNilReplicas (0.00s)
--- PASS: TestGetDeployments (0.00s)
--- PASS: TestGetDeploymentsNilReplicas (0.00s)
--- PASS: TestGetDeploymentsAvailableFalseNotFailed (0.00s)
--- PASS: TestGetDeploymentsProgressingFalseFailed (0.00s)
--- PASS: TestFindDeploymentIssuesProgressDeadlineExceeded (0.00s)
```

---

### 👀 Reviewer Notes

The key bug fixed in `FindDeploymentIssues`: the original single-loop would break on the first `Available=False` match, silently shadowing a `Progressing=False` condition appearing later in the slice. The two-pass approach guarantees `Progressing=False` (progress deadline exceeded) always takes priority over `Available=False` (transient unavailability during rolling updates).