### PR TITLE
fix: passthrough YouTube thumbnail images in MSW demo mode

### DIFF
--- a/web/src/components/layout/navbar/LearnDropdown.tsx
+++ b/web/src/components/layout/navbar/LearnDropdown.tsx
@@ -121,7 +121,7 @@ export function LearnDropdown() {
                       src={getYouTubeThumbnailUrl(video.id)}
                       alt={video.title}
                       className="w-full h-full object-cover"
-                      onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }}
+                      loading="lazy"
                     />
                     <div className="absolute inset-0 flex items-center justify-center bg-black/20 group-hover:bg-black/40 transition-colors">
                       <Play className="w-5 h-5 text-white/70 fill-white/70 group-hover:text-white group-hover:fill-white transition-colors" />

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -205,6 +205,7 @@ export const handlers = [
   http.all('https://api.dicebear.com/*', () => passthrough()),
   http.all('https://fonts.gstatic.com/*', () => passthrough()),
   http.all('https://fonts.googleapis.com/*', () => passthrough()),
+  http.all('https://img.youtube.com/*', () => passthrough()),
 
   // ── Auth refresh (OAuth token exchange) ────────────────────────────
   // Mock the /auth/refresh endpoint used by AuthCallback and silent token refresh


### PR DESCRIPTION
## Summary
- MSW was intercepting `img.youtube.com` requests, causing YouTube video thumbnails to fail loading in the Learn dropdown
- Add `http.all('https://img.youtube.com/*', () => passthrough())` alongside existing external resource passthroughs
- Remove aggressive `onError` handler that hid the `<img>` element on failure

## Root cause
MSW (Mock Service Worker) intercepts ALL network requests in demo mode. External resources like fonts and avatars already had passthrough rules, but `img.youtube.com` was missing.

## Test plan
- [ ] Open Learn dropdown on console.kubestellar.io — YouTube thumbnails should render
- [ ] Hover over thumbnail shows play icon overlay