### PR TITLE
fix: proxy YouTube thumbnails to bypass MSW in demo mode

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -81,6 +81,12 @@
   to = "/.netlify/functions/youtube-playlist"
   status = 200
 
+# YouTube thumbnail proxy — serves thumbnails through our origin to avoid MSW blocking
+[[redirects]]
+  from = "/api/youtube/thumbnail/*"
+  to = "/.netlify/functions/youtube-thumbnail"
+  status = 200
+
 # Analytics dashboard page — serve static HTML
 [[redirects]]
   from = "/analytics"

--- a/pkg/api/handlers/youtube.go
+++ b/pkg/api/handlers/youtube.go
@@ -143,3 +143,38 @@ func YouTubePlaylistHandler(c *fiber.Ctx) error {
 		),
 	})
 }
+
+// YouTubeThumbnailProxy proxies a YouTube video thumbnail image through
+// the backend, avoiding MSW/CORS issues in demo mode.
+// Route: GET /api/youtube/thumbnail/:id
+func YouTubeThumbnailProxy(c *fiber.Ctx) error {
+	videoID := c.Params("id")
+	if videoID == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "missing video id"})
+	}
+
+	// Only allow alphanumeric, hyphens, and underscores (YouTube video IDs)
+	for _, ch := range videoID {
+		if !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '-' || ch == '_') {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid video id"})
+		}
+	}
+
+	url := fmt.Sprintf("https://img.youtube.com/vi/%s/mqdefault.jpg", videoID)
+
+	client := &http.Client{Timeout: playlistFetchTimeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return c.Status(fiber.StatusBadGateway).SendString("failed to fetch thumbnail")
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return c.Status(fiber.StatusBadGateway).SendString("failed to read thumbnail")
+	}
+
+	c.Set("Content-Type", "image/jpeg")
+	c.Set("Cache-Control", "public, max-age=86400")
+	return c.Send(body)
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -587,6 +587,7 @@ func (s *Server) setupRoutes() {
 
 	// YouTube playlist (public — proxies to YouTube RSS feed, cached 1h)
 	s.app.Get("/api/youtube/playlist", handlers.YouTubePlaylistHandler)
+	s.app.Get("/api/youtube/thumbnail/:id", handlers.YouTubeThumbnailProxy)
 
 	// Mission knowledge base browse/file (public — proxies to public GitHub repo)
 	missions := handlers.NewMissionsHandler()

--- a/web/netlify/functions/youtube-thumbnail.mts
+++ b/web/netlify/functions/youtube-thumbnail.mts
@@ -1,0 +1,41 @@
+/**
+ * Netlify Function: YouTube Thumbnail Proxy
+ *
+ * Proxies YouTube video thumbnails through the backend to avoid
+ * MSW service worker blocking external image requests in demo mode.
+ */
+
+export default async (req: Request) => {
+  const url = new URL(req.url);
+  const videoId = url.pathname.split("/").pop() || "";
+
+  if (!videoId || !/^[\w-]+$/.test(videoId)) {
+    return new Response("invalid video id", { status: 400 });
+  }
+
+  try {
+    const resp = await fetch(
+      `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
+    );
+
+    if (!resp.ok) {
+      return new Response("thumbnail not found", { status: 404 });
+    }
+
+    const body = await resp.arrayBuffer();
+
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "Content-Type": "image/jpeg",
+        "Cache-Control": "public, max-age=86400",
+      },
+    });
+  } catch {
+    return new Response("failed to fetch thumbnail", { status: 502 });
+  }
+};
+
+export const config = {
+  path: "/api/youtube/thumbnail/*",
+};

--- a/web/src/config/learningVideos.ts
+++ b/web/src/config/learningVideos.ts
@@ -7,7 +7,7 @@
  */
 
 export const getYouTubeThumbnailUrl = (videoId: string) =>
-  `https://img.youtube.com/vi/${videoId}/mqdefault.jpg`
+  `/api/youtube/thumbnail/${videoId}`
 
 export const getYouTubeWatchUrl = (videoId: string) =>
   `https://www.youtube.com/watch?v=${videoId}`

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -635,6 +635,7 @@ export const handlers = [
   // These endpoints are backed by Netlify Functions and return real data
   // even in demo mode — let them through to the actual backend.
   http.get('/api/youtube/playlist', () => passthrough()),
+  http.get('/api/youtube/thumbnail/*', () => passthrough()),
 
   // ── Catch-all for unmocked API routes ────────────────────────────
   // On Netlify, unhandled /api/* and /health requests fall through to the SPA


### PR DESCRIPTION
## Summary
MSW service worker blocks `img.youtube.com` image requests in demo mode, causing broken thumbnails in the Learn dropdown. This proxies thumbnails through our own API origin.

- Go: `GET /api/youtube/thumbnail/:id` proxies to `img.youtube.com`
- Netlify: `youtube-thumbnail.mts` does the same for production
- Frontend: `getYouTubeThumbnailUrl()` now returns `/api/youtube/thumbnail/{id}` (same-origin)
- MSW passthrough added for the proxy route

## Test plan
- [ ] Open Learn dropdown — video thumbnails should display correctly
- [ ] Thumbnail shows a still frame from the video (YouTube auto-generated)