### PR TITLE
🐛 Fix mission retry button to re-execute last failed message

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -319,9 +319,9 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
   }
 
   const handleRetryMission = useCallback(() => {
-    // Find the original user prompt (first user message in the conversation)
-    const initialUserMessage = mission.messages.find(m => m.role === 'user')
-    const prompt = initialUserMessage?.content || ''
+    // Find the last user message in the conversation (the one that failed)
+    const lastUserMessage = [...mission.messages].reverse().find(m => m.role === 'user')
+    const prompt = lastUserMessage?.content || ''
     if (!prompt.trim()) return
     sendMessage(mission.id, prompt)
   }, [mission.id, mission.messages, sendMessage])


### PR DESCRIPTION
## Summary
- Fixed the AI Mission retry button which was re-executing the **first** user message in the conversation instead of the **last** (failed) one
- Root cause: `handleRetryMission` used `.find()` (returns first match) instead of finding the last user message
- Changed to `[...messages].reverse().find()` to correctly locate the most recent user message

Fixes #4491

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Start an AI Mission, send multiple messages, trigger a failure, click Retry — verify it retries the last failed message, not the first one