### PR TITLE
🐛 Sort mission list by last activity — most recent first

### DIFF
--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -304,7 +304,9 @@ export function MissionSidebar() {
     return m.title.toLowerCase().includes(q) || m.description.toLowerCase().includes(q)
   }, [missionSearchQuery])
   const savedMissions = missions.filter(m => m.status === 'saved' && matchesSearch(m))
-  const activeMissions = missions.filter(m => m.status !== 'saved' && matchesSearch(m))
+  const activeMissions = missions
+    .filter(m => m.status !== 'saved' && matchesSearch(m))
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
 
   const handleImportMission = useCallback((mission: MissionExport) => {
     const missionType = mission.missionClass === 'install' ? 'deploy' as const


### PR DESCRIPTION
## Summary

- Sort the active mission list by `updatedAt` descending so recently-used missions appear at the top
- Matches standard chat-app UX where the most recently interacted-with conversation rises to the top
- Saved (library) missions are unaffected — only the active missions list is sorted

Fixes #4494

## Test plan
- [ ] `npm run build` passes
- [ ] Create multiple missions, interact with an older one, verify it moves to the top of the list
- [ ] New missions still appear at the top
- [ ] Search filtering still works correctly with the new sort order