### PR TITLE
refactor: convert 609 fmt.Sprintf+slog calls to structured fields

### DIFF
--- a/cmd/console/main.go
+++ b/cmd/console/main.go
@@ -50,7 +50,7 @@ func main() {
 			BackendPort: *backendPort,
 		}
 		if err := runWatchdog(cfg); err != nil {
-			slog.Error(fmt.Sprintf("Watchdog error: %v", err))
+			slog.Error("watchdog error", "error", err)
 			os.Exit(1)
 		}
 		return
@@ -79,7 +79,7 @@ func main() {
 	// page, then initializes services (DB, k8s, MCP, etc.) in the background.
 	server, err := api.NewServer(cfg)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to create server: %v", err))
+		slog.Error("failed to create server", "error", err)
 		os.Exit(1)
 	}
 
@@ -91,14 +91,14 @@ func main() {
 
 		slog.Info("Shutting down...")
 		if err := server.Shutdown(); err != nil {
-			slog.Error(fmt.Sprintf("Shutdown error: %v", err))
+			slog.Error("shutdown error", "error", err)
 		}
 		os.Exit(0)
 	}()
 
 	// Block until shutdown (HTTP listener runs in background from NewServer)
 	if err := server.Start(); err != nil {
-		slog.Error(fmt.Sprintf("Server error: %v", err))
+		slog.Error("server error", "error", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/console/watchdog.go
+++ b/cmd/console/watchdog.go
@@ -49,7 +49,7 @@ type WatchdogConfig struct {
 func runWatchdog(cfg WatchdogConfig) error {
 	// Write PID file so startup-oauth.sh can detect us
 	if err := writePidFile(watchdogPidFile); err != nil {
-		slog.Warn(fmt.Sprintf("[Watchdog] Warning: could not write PID file: %v", err))
+		slog.Warn("[Watchdog] could not write PID file", "error", err)
 	}
 	defer os.Remove(watchdogPidFile)
 
@@ -95,7 +95,7 @@ func runWatchdog(cfg WatchdogConfig) error {
 			strings.Contains(errMsg, "client disconnected") ||
 			strings.Contains(errMsg, "write: broken pipe")
 		if isClientGone {
-			slog.Info(fmt.Sprintf("[Watchdog] Client disconnected (backend still healthy): %v", err))
+			slog.Info("[Watchdog] client disconnected (backend still healthy)", "error", err)
 			return
 		}
 
@@ -103,13 +103,13 @@ func runWatchdog(cfg WatchdogConfig) error {
 		isTimeout := strings.Contains(errMsg, "timeout awaiting response headers") ||
 			strings.Contains(errMsg, "context deadline exceeded")
 		if isTimeout {
-			slog.Info(fmt.Sprintf("[Watchdog] Proxy timeout (backend still healthy): %v", err))
+			slog.Info("[Watchdog] proxy timeout (backend still healthy)", "error", err)
 			http.Error(w, "Gateway Timeout", http.StatusGatewayTimeout)
 			return
 		}
 
 		// Hard connection failure — backend is genuinely down.
-		slog.Error(fmt.Sprintf("[Watchdog] Proxy error (backend down): %v", err))
+		slog.Error("[Watchdog] proxy error (backend down)", "error", err)
 		atomic.StoreInt32(&backendHealthy, 0)
 		serveFallback(w, r)
 	}
@@ -190,7 +190,7 @@ func runWatchdog(cfg WatchdogConfig) error {
 		srv.Shutdown(shutdownCtx)
 	}()
 
-	slog.Info(fmt.Sprintf("[Watchdog] Listening on %s, proxying to %s", addr, backendURL.String()))
+	slog.Info("[Watchdog] listening", "addr", addr, "backend", backendURL.String())
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("watchdog listen error: %w", err)
 	}

--- a/cmd/kc-agent/main.go
+++ b/cmd/kc-agent/main.go
@@ -59,7 +59,7 @@ KubeStellar Console - Local Agent v%s
 		AllowedOrigins: origins,
 	})
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to create server: %v", err))
+		slog.Error("failed to create server", "error", err)
 		os.Exit(1)
 	}
 
@@ -72,7 +72,7 @@ KubeStellar Console - Local Agent v%s
 	}()
 
 	if err := server.Start(); err != nil {
-		slog.Error(fmt.Sprintf("Server error: %v", err))
+		slog.Error("server error", "error", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/agent/device_tracker.go
+++ b/pkg/agent/device_tracker.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -133,7 +132,7 @@ func (t *DeviceTracker) scanDevices() {
 	if err != nil {
 		if !t.loggedClusterError {
 			t.loggedClusterError = true
-			slog.Info(fmt.Sprintf("[DeviceTracker] Cluster data unavailable (will retry silently): %v", err))
+			slog.Info("[DeviceTracker] cluster data unavailable (will retry silently)", "error", err)
 		}
 		return
 	}
@@ -357,8 +356,7 @@ func (t *DeviceTracker) checkForDrop(key, nodeName, cluster, deviceType string, 
 	}
 	t.alerts[alertKey] = alert
 
-	slog.Info(fmt.Sprintf("[DeviceTracker] ALERT: %s on %s/%s dropped from %d to %d",
-		deviceType, cluster, nodeName, maxCount, currentCount))
+	slog.Info("[DeviceTracker] ALERT: device count dropped", "device", deviceType, "cluster", cluster, "node", nodeName, "previous", maxCount, "current", currentCount)
 
 	return alert
 }
@@ -401,8 +399,7 @@ func (t *DeviceTracker) checkForBoolDrop(key, nodeName, cluster, deviceType stri
 	}
 	t.alerts[alertKey] = alert
 
-	slog.Info(fmt.Sprintf("[DeviceTracker] ALERT: %s on %s/%s is no longer available",
-		deviceType, cluster, nodeName))
+	slog.Info("[DeviceTracker] ALERT: capability no longer available", "device", deviceType, "cluster", cluster, "node", nodeName)
 
 	return alert
 }

--- a/pkg/agent/insight_worker.go
+++ b/pkg/agent/insight_worker.go
@@ -131,7 +131,7 @@ func (w *InsightWorker) Enrich(req InsightEnrichmentRequest) (*InsightEnrichment
 	// Try to get AI enrichments from a connected provider
 	enrichments, provider, err := w.callAIProvider(needsEnrichment)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[InsightWorker] AI enrichment failed: %v", err))
+		slog.Error("[InsightWorker] AI enrichment failed", "error", err)
 		// Fall back to rule-based enrichments
 		enrichments = w.generateRuleBasedEnrichments(needsEnrichment)
 		provider = "rules"
@@ -188,7 +188,7 @@ func (w *InsightWorker) callAIProvider(insights []InsightSummary) ([]AIInsightEn
 
 		resp, err := provider.Chat(ctx, req)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[InsightWorker] Provider %s failed: %v", name, err))
+			slog.Error("[InsightWorker] provider failed", "provider", name, "error", err)
 			continue
 		}
 		if resp == nil {
@@ -197,7 +197,7 @@ func (w *InsightWorker) callAIProvider(insights []InsightSummary) ([]AIInsightEn
 
 		enrichments, err := parseEnrichmentResponse(resp.Content, insights)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[InsightWorker] Failed to parse response from %s: %v", name, err))
+			slog.Error("[InsightWorker] failed to parse response", "provider", name, "error", err)
 			continue
 		}
 

--- a/pkg/agent/kagenti.go
+++ b/pkg/agent/kagenti.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
@@ -139,7 +138,7 @@ func (s *Server) handleKagentiAgents(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching agents: %v", err))
+		slog.Info("error fetching agents", "error", err)
 		json.NewEncoder(w).Encode(map[string]any{"agents": []any{}, "error": "internal server error"})
 		return
 	}
@@ -216,7 +215,7 @@ func (s *Server) handleKagentiBuilds(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching builds: %v", err))
+		slog.Info("error fetching builds", "error", err)
 		json.NewEncoder(w).Encode(map[string]any{"builds": []any{}, "error": "internal server error"})
 		return
 	}
@@ -288,7 +287,7 @@ func (s *Server) handleKagentiCards(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching cards: %v", err))
+		slog.Info("error fetching cards", "error", err)
 		json.NewEncoder(w).Encode(map[string]any{"cards": []any{}, "error": "internal server error"})
 		return
 	}
@@ -352,7 +351,7 @@ func (s *Server) handleKagentiTools(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching tools: %v", err))
+		slog.Info("error fetching tools", "error", err)
 		json.NewEncoder(w).Encode(map[string]any{"tools": []any{}, "error": "internal server error"})
 		return
 	}
@@ -419,7 +418,7 @@ func (s *Server) handleKagentiSummary(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching kagenti summary: %v", err))
+		slog.Info("error fetching kagenti summary", "error", err)
 		json.NewEncoder(w).Encode(map[string]any{
 			"agentCount": 0, "readyAgents": 0, "buildCount": 0,
 			"activeBuilds": 0, "toolCount": 0, "cardCount": 0,

--- a/pkg/agent/metrics_history.go
+++ b/pkg/agent/metrics_history.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -143,7 +142,7 @@ func (mh *MetricsHistory) CaptureNow() error {
 func (mh *MetricsHistory) runLoop(interval time.Duration) {
 	// Capture initial snapshot
 	if err := mh.captureSnapshot(); err != nil {
-		slog.Error(fmt.Sprintf("[MetricsHistory] Error capturing initial snapshot: %v", err))
+		slog.Error("[MetricsHistory] error capturing initial snapshot", "error", err)
 	}
 
 	ticker := time.NewTicker(interval)
@@ -153,7 +152,7 @@ func (mh *MetricsHistory) runLoop(interval time.Duration) {
 		select {
 		case <-ticker.C:
 			if err := mh.captureSnapshot(); err != nil {
-				slog.Error(fmt.Sprintf("[MetricsHistory] Error capturing snapshot: %v", err))
+				slog.Error("[MetricsHistory] error capturing snapshot", "error", err)
 			}
 		case <-mh.stopCh:
 			slog.Info("[MetricsHistory] Stopping")
@@ -180,7 +179,7 @@ func (mh *MetricsHistory) captureSnapshot() error {
 	if err != nil {
 		if !mh.loggedClusterError {
 			mh.loggedClusterError = true
-			slog.Info(fmt.Sprintf("[MetricsHistory] Cluster data unavailable (will retry silently): %v", err))
+			slog.Info("[MetricsHistory] cluster data unavailable (will retry silently)", "error", err)
 		}
 	} else {
 		for _, h := range healthList {
@@ -263,8 +262,7 @@ func (mh *MetricsHistory) captureSnapshot() error {
 	// Persist to disk
 	go mh.saveToDisk()
 
-	slog.Info(fmt.Sprintf("[MetricsHistory] Captured snapshot: %d clusters, %d pod issues, %d GPU nodes",
-		len(snapshot.Clusters), len(snapshot.PodIssues), len(snapshot.GPUNodes)))
+	slog.Info("[MetricsHistory] captured snapshot", "clusters", len(snapshot.Clusters), "podIssues", len(snapshot.PodIssues), "gpuNodes", len(snapshot.GPUNodes))
 
 	return nil
 }
@@ -276,19 +274,19 @@ func (mh *MetricsHistory) saveToDisk() {
 	mh.mu.RUnlock()
 
 	if err != nil {
-		slog.Error(fmt.Sprintf("[MetricsHistory] Error marshaling history: %v", err))
+		slog.Error("[MetricsHistory] error marshaling history", "error", err)
 		return
 	}
 
 	// Ensure directory exists
 	if err := os.MkdirAll(mh.dataDir, metricsDirMode); err != nil {
-		slog.Error(fmt.Sprintf("[MetricsHistory] Error creating data dir: %v", err))
+		slog.Error("[MetricsHistory] error creating data dir", "error", err)
 		return
 	}
 
 	filePath := filepath.Join(mh.dataDir, metricsHistoryFile)
 	if err := os.WriteFile(filePath, data, metricsFileMode); err != nil {
-		slog.Error(fmt.Sprintf("[MetricsHistory] Error writing history file: %v", err))
+		slog.Error("[MetricsHistory] error writing history file", "error", err)
 	}
 }
 
@@ -299,14 +297,14 @@ func (mh *MetricsHistory) loadFromDisk() {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			slog.Error(fmt.Sprintf("[MetricsHistory] Error reading history file: %v", err))
+			slog.Error("[MetricsHistory] error reading history file", "error", err)
 		}
 		return
 	}
 
 	var snapshots []MetricsSnapshot
 	if err := json.Unmarshal(data, &snapshots); err != nil {
-		slog.Error(fmt.Sprintf("[MetricsHistory] Error parsing history file: %v", err))
+		slog.Error("[MetricsHistory] error parsing history file", "error", err)
 		return
 	}
 
@@ -324,7 +322,7 @@ func (mh *MetricsHistory) loadFromDisk() {
 	mh.snapshots = filtered
 	mh.mu.Unlock()
 
-	slog.Info(fmt.Sprintf("[MetricsHistory] Loaded %d snapshots from disk", len(filtered)))
+	slog.Info("[MetricsHistory] loaded snapshots from disk", "count", len(filtered))
 }
 
 // GetTrendContext returns formatted history for AI prompt

--- a/pkg/agent/prediction_worker.go
+++ b/pkg/agent/prediction_worker.go
@@ -117,8 +117,7 @@ func (w *PredictionWorker) UpdateSettings(settings PredictionSettings) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.settings = settings
-	slog.Info(fmt.Sprintf("[PredictionWorker] Settings updated: interval=%dm, minConfidence=%d%%, aiEnabled=%v",
-		settings.Interval, settings.MinConfidence, settings.AIEnabled))
+	slog.Info("[PredictionWorker] settings updated", "interval", settings.Interval, "minConfidence", settings.MinConfidence, "aiEnabled", settings.AIEnabled)
 }
 
 // GetSettings returns current settings
@@ -230,7 +229,7 @@ func (w *PredictionWorker) runAnalysis(specificProviders []string) {
 	if err != nil {
 		if !w.loggedClusterError {
 			w.loggedClusterError = true
-			slog.Info(fmt.Sprintf("[PredictionWorker] Cluster data unavailable (will retry silently): %v", err))
+			slog.Info("[PredictionWorker] cluster data unavailable (will retry silently)", "error", err)
 		}
 		return
 	}
@@ -267,7 +266,7 @@ func (w *PredictionWorker) runAnalysis(specificProviders []string) {
 
 		predictions, err := w.analyzeWithProvider(ctx, provider, prompt)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[PredictionWorker] Error with provider %s: %v", providerName, err))
+			slog.Error("[PredictionWorker] provider error", "provider", providerName, "error", err)
 			continue
 		}
 
@@ -301,7 +300,7 @@ func (w *PredictionWorker) runAnalysis(specificProviders []string) {
 	w.lastRun = time.Now()
 	w.mu.Unlock()
 
-	slog.Info(fmt.Sprintf("[PredictionWorker] Analysis complete: %d predictions from %v", len(filtered), usedProviders))
+	slog.Info("[PredictionWorker] analysis complete", "predictions", len(filtered), "providers", usedProviders)
 
 	// Broadcast to WebSocket clients
 	if w.broadcast != nil {
@@ -401,16 +400,16 @@ func (w *PredictionWorker) gatherClusterData(ctx context.Context) (*ClusterAnaly
 	// Get pod issues from healthy clusters only
 	clusters, err := w.k8sClient.ListClusters(ctx)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[PredictionWorker] Error listing clusters: %v", err))
+		slog.Error("[PredictionWorker] error listing clusters", "error", err)
 	} else {
 		for _, cluster := range clusters {
 			if !healthyClusterSet[cluster.Name] {
-				slog.Info(fmt.Sprintf("[PredictionWorker] Skipping offline cluster: %s", cluster.Name))
+				slog.Info("[PredictionWorker] skipping offline cluster", "cluster", cluster.Name)
 				continue
 			}
 			pods, err := w.k8sClient.FindPodIssues(ctx, cluster.Context, "")
 			if err != nil {
-				slog.Error(fmt.Sprintf("[PredictionWorker] Error getting pod issues for %s: %v", cluster.Name, err))
+				slog.Error("[PredictionWorker] error getting pod issues", "cluster", cluster.Name, "error", err)
 				continue
 			}
 			for _, p := range pods {
@@ -430,7 +429,7 @@ func (w *PredictionWorker) gatherClusterData(ctx context.Context) (*ClusterAnaly
 		var fallbackErr error
 		clusters, fallbackErr = w.k8sClient.ListClusters(ctx)
 		if fallbackErr != nil {
-			slog.Error(fmt.Sprintf("[PredictionWorker] Fallback ListClusters for GPU nodes failed: %v", fallbackErr))
+			slog.Error("[PredictionWorker] fallback ListClusters for GPU nodes failed", "error", fallbackErr)
 		}
 	}
 	for _, cluster := range clusters {
@@ -439,7 +438,7 @@ func (w *PredictionWorker) gatherClusterData(ctx context.Context) (*ClusterAnaly
 		}
 		gpuNodes, err := w.k8sClient.GetGPUNodes(ctx, cluster.Context)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[PredictionWorker] Error getting GPU nodes for %s: %v", cluster.Name, err))
+			slog.Error("[PredictionWorker] error getting GPU nodes", "cluster", cluster.Name, "error", err)
 			continue
 		}
 		for _, g := range gpuNodes {
@@ -459,7 +458,7 @@ func (w *PredictionWorker) gatherClusterData(ctx context.Context) (*ClusterAnaly
 		}
 		nodes, err := w.k8sClient.GetNodes(ctx, cluster.Context)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[PredictionWorker] Error getting nodes for %s: %v", cluster.Name, err))
+			slog.Error("[PredictionWorker] error getting nodes", "cluster", cluster.Name, "error", err)
 			continue
 		}
 		for _, n := range nodes {
@@ -494,7 +493,7 @@ func (w *PredictionWorker) buildAnalysisPrompt(data *ClusterAnalysisData) string
 
 	dataJSON, err := json.MarshalIndent(filteredData, "", "  ")
 	if err != nil {
-		slog.Error(fmt.Sprintf("[PredictionWorker] Failed to marshal filtered data: %v", err))
+		slog.Error("[PredictionWorker] failed to marshal filtered data", "error", err)
 		return ""
 	}
 
@@ -683,7 +682,7 @@ func (s *Server) BroadcastToClients(msgType string, payload interface{}) {
 
 	data, err := json.Marshal(message)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[Server] Error marshaling broadcast message: %v", err))
+		slog.Error("[Server] error marshaling broadcast message", "error", err)
 		return
 	}
 
@@ -706,7 +705,7 @@ func (s *Server) BroadcastToClients(msgType string, payload interface{}) {
 		c.wsc.writeMu.Lock()
 		c.conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout))
 		if err := c.conn.WriteMessage(websocket.TextMessage, data); err != nil {
-			slog.Error(fmt.Sprintf("[Server] Error broadcasting to client %s: %v", c.conn.RemoteAddr(), err))
+			slog.Error("[Server] error broadcasting to client", "client", c.conn.RemoteAddr(), "error", err)
 			dead = append(dead, c.conn)
 		}
 		c.conn.SetWriteDeadline(time.Time{}) // clear for normal writes
@@ -721,6 +720,6 @@ func (s *Server) BroadcastToClients(msgType string, payload interface{}) {
 			conn.Close()
 		}
 		s.clientsMux.Unlock()
-		slog.Info(fmt.Sprintf("[Server] Removed %d dead client(s) during broadcast", len(dead)))
+		slog.Info("[Server] removed dead clients during broadcast", "count", len(dead))
 	}
 }

--- a/pkg/agent/prometheus.go
+++ b/pkg/agent/prometheus.go
@@ -110,6 +110,6 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 	// Stream the raw Prometheus response back to the caller
 	w.WriteHeader(resp.StatusCode)
 	if _, copyErr := io.Copy(w, resp.Body); copyErr != nil {
-		slog.Error(fmt.Sprintf("failed to stream Prometheus response: %v", copyErr))
+		slog.Error("failed to stream Prometheus response", "error", copyErr)
 	}
 }

--- a/pkg/agent/provider_antigravity.go
+++ b/pkg/agent/provider_antigravity.go
@@ -102,7 +102,7 @@ func (a *AntigravityProvider) Handshake(ctx context.Context) *HandshakeResult {
 
 	out, err := exec.CommandContext(checkCtx, a.cliPath, "--version").CombinedOutput()
 	if err != nil {
-		slog.Error(fmt.Sprintf("[Antigravity] Handshake failed: %v (output: %s)", err, string(out)))
+		slog.Error("[Antigravity] handshake failed", "error", err, "output", string(out))
 		return &HandshakeResult{
 			Ready:   false,
 			State:   "failed",
@@ -177,7 +177,7 @@ func (a *AntigravityProvider) StreamChat(ctx context.Context, req *ChatRequest, 
 	}
 
 	if err := cmd.Wait(); err != nil {
-		slog.Error(fmt.Sprintf("[Antigravity] Command finished with error: %v", err))
+		slog.Error("[Antigravity] command finished with error", "error", err)
 	}
 
 	return &ChatResponse{

--- a/pkg/agent/provider_bob.go
+++ b/pkg/agent/provider_bob.go
@@ -84,7 +84,7 @@ func (b *BobProvider) detectCLI() {
 		for _, p := range commonPaths {
 			if _, statErr := os.Stat(p); statErr == nil {
 				path = p
-				slog.Info(fmt.Sprintf("Found Bob CLI at: %s", p))
+				slog.Info("found Bob CLI", "path", p)
 				break
 			}
 		}
@@ -93,7 +93,7 @@ func (b *BobProvider) detectCLI() {
 			return
 		}
 	} else {
-		slog.Info(fmt.Sprintf("Found Bob CLI in PATH: %s", path))
+		slog.Info("found Bob CLI in PATH", "path", path)
 	}
 	b.cliPath = path
 
@@ -105,9 +105,9 @@ func (b *BobProvider) detectCLI() {
 	output, err := cmd.Output()
 	if err == nil {
 		b.version = strings.TrimSpace(string(output))
-		slog.Info(fmt.Sprintf("Bob CLI version: %s", b.version))
+		slog.Info("Bob CLI version detected", "version", b.version)
 	} else {
-		slog.Info(fmt.Sprintf("Could not get Bob CLI version: %v", err))
+		slog.Info("could not get Bob CLI version", "error", err)
 	}
 }
 

--- a/pkg/agent/provider_claudecode.go
+++ b/pkg/agent/provider_claudecode.go
@@ -98,7 +98,7 @@ func (c *ClaudeCodeProvider) detectCLI() {
 		for _, p := range commonPaths {
 			if _, statErr := os.Stat(p); statErr == nil {
 				path = p
-				slog.Info(fmt.Sprintf("Found Claude Code CLI at: %s", p))
+				slog.Info("found Claude Code CLI", "path", p)
 				break
 			}
 		}
@@ -107,7 +107,7 @@ func (c *ClaudeCodeProvider) detectCLI() {
 			return
 		}
 	} else {
-		slog.Info(fmt.Sprintf("Found Claude Code CLI in PATH: %s", path))
+		slog.Info("found Claude Code CLI in PATH", "path", path)
 	}
 	c.cliPath = path
 
@@ -120,9 +120,9 @@ func (c *ClaudeCodeProvider) detectCLI() {
 	output, err := cmd.Output()
 	if err == nil {
 		c.version = strings.TrimSpace(string(output))
-		slog.Info(fmt.Sprintf("Claude Code CLI version: %s", c.version))
+		slog.Info("Claude Code CLI version detected", "version", c.version)
 	} else {
-		slog.Info(fmt.Sprintf("Could not get Claude Code CLI version: %v", err))
+		slog.Info("could not get Claude Code CLI version", "error", err)
 	}
 }
 
@@ -319,7 +319,7 @@ func (c *ClaudeCodeProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 
 		var event claudeCodeStreamEvent
 		if err := json.Unmarshal([]byte(line), &event); err != nil {
-			slog.Error(fmt.Sprintf("Warning: failed to parse stream event: %v (line: %s)", err, truncateString(line, 100)))
+			slog.Error("failed to parse stream event", "error", err, "line", truncateString(line, 100))
 			continue
 		}
 
@@ -331,7 +331,7 @@ func (c *ClaudeCodeProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 		case "tool_use":
 			// Tool is being called
 			lastToolName = event.Tool
-			slog.Info(fmt.Sprintf("[Claude Code] Tool use: %s", event.Tool))
+			slog.Info("[Claude Code] tool use", "tool", event.Tool)
 			if onProgress != nil {
 				onProgress(StreamEvent{
 					Type:  "tool_use",
@@ -347,7 +347,7 @@ func (c *ClaudeCodeProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 			if event.Tool != "" && lastToolName == "" {
 				lastToolName = event.Tool
 			}
-			slog.Info(fmt.Sprintf("[Claude Code] Tool result: %s (%d bytes)", event.Tool, len(event.Output)))
+			slog.Info("[Claude Code] tool result", "tool", event.Tool, "bytes", len(event.Output))
 			if onProgress != nil {
 				onProgress(StreamEvent{
 					Type:   "tool_result",
@@ -361,14 +361,14 @@ func (c *ClaudeCodeProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 			// The "user" event wraps tool results in the stream-json format
 			if event.ToolUseResult != nil && event.ToolUseResult.Stdout != "" {
 				lastToolOutput = event.ToolUseResult.Stdout
-				slog.Info(fmt.Sprintf("[Claude Code] Captured tool output (%d bytes)", len(lastToolOutput)))
+				slog.Info("[Claude Code] captured tool output", "bytes", len(lastToolOutput))
 			}
 			// Also check message content for tool results
 			if event.Message != nil {
 				for _, content := range event.Message.Content {
 					if content.Type == "tool_result" && content.Content != "" {
 						lastToolOutput = content.Content
-						slog.Info(fmt.Sprintf("[Claude Code] Captured tool result from message (%d bytes)", len(lastToolOutput)))
+						slog.Info("[Claude Code] captured tool result from message", "bytes", len(lastToolOutput))
 					}
 				}
 			}
@@ -417,7 +417,7 @@ func (c *ClaudeCodeProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 	}
 
 	if err := scanner.Err(); err != nil {
-		slog.Error(fmt.Sprintf("Warning: scanner error: %v", err))
+		slog.Error("scanner error", "error", err)
 	}
 
 	// Wait for command to complete

--- a/pkg/agent/provider_codex.go
+++ b/pkg/agent/provider_codex.go
@@ -128,7 +128,7 @@ func (c *CodexProvider) StreamChat(ctx context.Context, req *ChatRequest, onChun
 	}
 
 	if err := cmd.Wait(); err != nil {
-		slog.Error(fmt.Sprintf("[Codex] Command finished with error: %v", err))
+		slog.Error("[Codex] command finished with error", "error", err)
 	}
 
 	return &ChatResponse{

--- a/pkg/agent/provider_copilotcli.go
+++ b/pkg/agent/provider_copilotcli.go
@@ -106,7 +106,7 @@ func (c *CopilotCLIProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 	}
 
 	prompt := buildPromptWithHistoryGeneric(req)
-	slog.Info(fmt.Sprintf("[CopilotCLI] Starting with prompt length=%d", len(prompt)))
+	slog.Info("[CopilotCLI] starting", "promptLength", len(prompt))
 
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
 		var cancel context.CancelFunc
@@ -145,7 +145,7 @@ func (c *CopilotCLIProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start copilot CLI: %w", err)
 	}
-	slog.Info(fmt.Sprintf("[CopilotCLI] Process started (PID=%d)", cmd.Process.Pid))
+	slog.Info("[CopilotCLI] process started", "pid", cmd.Process.Pid)
 
 	// Capture stderr in background for diagnostics
 	var stderrContent strings.Builder
@@ -173,18 +173,18 @@ func (c *CopilotCLIProvider) StreamChatWithProgress(ctx context.Context, req *Ch
 	}
 
 	if scanErr := scanner.Err(); scanErr != nil {
-		slog.Error(fmt.Sprintf("[CopilotCLI] Scanner error: %v", scanErr))
+		slog.Error("[CopilotCLI] scanner error", "error", scanErr)
 	}
 
 	waitErr := cmd.Wait()
 	if waitErr != nil {
-		slog.Error(fmt.Sprintf("[CopilotCLI] Command finished with error: %v", waitErr))
+		slog.Error("[CopilotCLI] command finished with error", "error", waitErr)
 		if se := stderrContent.String(); se != "" {
-			slog.Info(fmt.Sprintf("[CopilotCLI] stderr: %s", se))
+			slog.Info("[CopilotCLI] stderr output", "stderr", se)
 		}
 	}
 
-	slog.Info(fmt.Sprintf("[CopilotCLI] Completed: %d lines, %d bytes", lineCount, fullResponse.Len()))
+	slog.Info("[CopilotCLI] completed", "lines", lineCount, "bytes", fullResponse.Len())
 
 	content := fullResponse.String()
 

--- a/pkg/agent/provider_geminicli.go
+++ b/pkg/agent/provider_geminicli.go
@@ -124,7 +124,7 @@ func (g *GeminiCLIProvider) StreamChat(ctx context.Context, req *ChatRequest, on
 	}
 
 	if err := cmd.Wait(); err != nil {
-		slog.Error(fmt.Sprintf("[GeminiCLI] Command finished with error: %v", err))
+		slog.Error("[GeminiCLI] command finished with error", "error", err)
 	}
 
 	return &ChatResponse{

--- a/pkg/agent/provider_ghcopilot.go
+++ b/pkg/agent/provider_ghcopilot.go
@@ -105,7 +105,7 @@ func (g *GHCopilotProvider) StreamChat(ctx context.Context, req *ChatRequest, on
 	}
 
 	if err := cmd.Wait(); err != nil {
-		slog.Error(fmt.Sprintf("[GHCopilot] Command finished with error: %v", err))
+		slog.Error("[GHCopilot] command finished with error", "error", err)
 	}
 
 	return &ChatResponse{

--- a/pkg/agent/provider_goose.go
+++ b/pkg/agent/provider_goose.go
@@ -137,7 +137,7 @@ func (g *GooseProvider) StreamChat(ctx context.Context, req *ChatRequest, onChun
 	go func() {
 		defer close(stderrDone)
 		if _, copyErr := io.Copy(&stderrBuf, stderr); copyErr != nil {
-			slog.Error(fmt.Sprintf("[Goose] Error reading stderr: %v", copyErr))
+			slog.Error("[Goose] error reading stderr", "error", copyErr)
 		}
 	}()
 
@@ -153,7 +153,7 @@ func (g *GooseProvider) StreamChat(ctx context.Context, req *ChatRequest, onChun
 		}
 	}
 	if scanErr := scanner.Err(); scanErr != nil {
-		slog.Error(fmt.Sprintf("[Goose] Scanner error: %v", scanErr))
+		slog.Error("[Goose] scanner error", "error", scanErr)
 	}
 
 	// Wait for stderr drain before calling cmd.Wait.
@@ -167,7 +167,7 @@ func (g *GooseProvider) StreamChat(ctx context.Context, req *ChatRequest, onChun
 			}
 			return nil, fmt.Errorf("goose exited with error: %w", waitErr)
 		}
-		slog.Error(fmt.Sprintf("[Goose] Command finished with error: %v", waitErr))
+		slog.Error("[Goose] command finished with error", "error", waitErr)
 	}
 
 	return &ChatResponse{

--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -133,13 +133,13 @@ func NewServer(cfg Config) (*Server, error) {
 	// Initialize k8s client for rich cluster data queries
 	k8sClient, err := k8s.NewMultiClusterClient(cfg.Kubeconfig)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Warning: failed to initialize k8s client: %v", err))
+		slog.Error("failed to initialize k8s client", "error", err)
 		// Don't fail - kubectl functionality still works
 	}
 
 	// Initialize AI providers
 	if err := InitializeProviders(); err != nil {
-		slog.Warn(fmt.Sprintf("Warning: %v", err))
+		slog.Warn("provider initialization issue", "error", err)
 		// Don't fail - kubectl functionality still works without AI
 	}
 
@@ -166,7 +166,7 @@ func NewServer(cfg Config) (*Server, error) {
 
 	// Log non-default origins so users can verify their configuration
 	if len(allowedOrigins) > len(defaultAllowedOrigins) {
-		slog.Info(fmt.Sprintf("Custom allowed origins: %v", allowedOrigins[len(defaultAllowedOrigins):]))
+		slog.Info("custom allowed origins configured", "origins", allowedOrigins[len(defaultAllowedOrigins):])
 	}
 
 	// Optional shared secret for authentication
@@ -244,7 +244,7 @@ func (s *Server) checkOrigin(r *http.Request) bool {
 		}
 	}
 
-	slog.Warn(fmt.Sprintf("SECURITY: Rejected WebSocket connection from unauthorized origin: %s", origin))
+	slog.Warn("SECURITY: rejected WebSocket connection from unauthorized origin", "origin", origin)
 	return false
 }
 
@@ -460,9 +460,9 @@ func (s *Server) Start() error {
 	})
 
 	addr := fmt.Sprintf("127.0.0.1:%d", s.config.Port)
-	slog.Info(fmt.Sprintf("KC Agent v%s starting on %s", Version, addr))
-	slog.Info(fmt.Sprintf("Health: http://%s/health", addr))
-	slog.Info(fmt.Sprintf("WebSocket: ws://%s/ws", addr))
+	slog.Info("KC Agent starting", "version", Version, "addr", addr)
+	slog.Info("health endpoint available", "url", "http://"+addr+"/health")
+	slog.Info("WebSocket endpoint available", "url", "ws://"+addr+"/ws")
 
 	// Validate all configured API keys on startup (run in background to not delay startup)
 	go s.ValidateAllKeys()
@@ -477,10 +477,10 @@ func (s *Server) Start() error {
 				Clusters: clusters,
 				Current:  current,
 			})
-			slog.Info(fmt.Sprintf("[Server] Broadcasted %d clusters to clients", len(clusters)))
+			slog.Info("[Server] broadcasted clusters to clients", "count", len(clusters))
 		})
 		if err := s.k8sClient.StartWatching(); err != nil {
-			slog.Error(fmt.Sprintf("Warning: failed to start kubeconfig watcher: %v", err))
+			slog.Error("failed to start kubeconfig watcher", "error", err)
 		}
 	}
 
@@ -509,7 +509,7 @@ func (s *Server) Start() error {
 				channel = "stable"
 			}
 			s.updateChecker.Configure(true, channel)
-			slog.Info(fmt.Sprintf("Auto-update started (channel=%s)", channel))
+			slog.Info("auto-update started", "channel", channel)
 		}
 	}
 
@@ -627,7 +627,7 @@ func (s *Server) handleProviderCheck(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	result := hp.Handshake(ctx)
-	slog.Info(fmt.Sprintf("[ProviderCheck] %s: state=%s ready=%v msg=%s", providerName, result.State, result.Ready, result.Message))
+	slog.Info("[ProviderCheck] result", "provider", providerName, "state", result.State, "ready", result.Ready, "message", result.Message)
 
 	json.NewEncoder(w).Encode(protocol.ProviderCheckResponse{
 		Provider:      providerName,

--- a/pkg/agent/server_ai.go
+++ b/pkg/agent/server_ai.go
@@ -40,7 +40,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	conn, err := s.upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		slog.Error(fmt.Sprintf("WebSocket upgrade failed: %v", err))
+		slog.Error("WebSocket upgrade failed", "error", err)
 		return
 	}
 	defer conn.Close()
@@ -56,7 +56,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		s.clientsMux.Unlock()
 	}()
 
-	slog.Info(fmt.Sprintf("Client connected: %s (origin: %s)", conn.RemoteAddr(), r.Header.Get("Origin")))
+	slog.Info("client connected", "addr", conn.RemoteAddr(), "origin", r.Header.Get("Origin"))
 
 	// writeMu is the single per-connection mutex shared by broadcasts
 	// (prediction_worker) and request/stream handlers. Using the same
@@ -101,7 +101,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		var msg protocol.Message
 		if err := conn.ReadJSON(&msg); err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				slog.Error(fmt.Sprintf("WebSocket error: %v", err))
+				slog.Error("WebSocket error", "error", err)
 			}
 			break
 		}
@@ -117,7 +117,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			go func(m protocol.Message, fa string) {
 				defer func() {
 					if r := recover(); r != nil {
-						slog.Info(fmt.Sprintf("[Chat] recovered from panic in streaming handler: %v", r))
+						slog.Info("[Chat] recovered from panic in streaming handler", "panic", r)
 					}
 				}()
 				s.handleChatMessageStreaming(conn, m, fa, writeMu, &closed)
@@ -131,7 +131,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			go func(m protocol.Message) {
 				defer func() {
 					if r := recover(); r != nil {
-						slog.Info(fmt.Sprintf("[Kubectl] recovered from panic in message handler: %v", r))
+						slog.Info("[Kubectl] recovered from panic in message handler", "panic", r)
 					}
 				}()
 				response := s.handleMessage(m)
@@ -141,7 +141,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 				writeMu.Lock()
 				defer writeMu.Unlock()
 				if err := conn.WriteJSON(response); err != nil {
-					slog.Error(fmt.Sprintf("Write error: %v", err))
+					slog.Error("write error", "error", err)
 				}
 			}(msg)
 		} else {
@@ -150,7 +150,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			err := conn.WriteJSON(response)
 			writeMu.Unlock()
 			if err != nil {
-				slog.Error(fmt.Sprintf("Write error: %v", err))
+				slog.Error("write error", "error", err)
 				break
 			}
 		}
@@ -158,7 +158,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	closed.Store(true)
 	close(stopPing) // signal pinger goroutine to exit
 
-	slog.Info(fmt.Sprintf("Client disconnected: %s", conn.RemoteAddr()))
+	slog.Info("client disconnected", "addr", conn.RemoteAddr())
 }
 
 // handleMessage processes incoming messages (non-streaming)
@@ -352,15 +352,14 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 	// Smart agent routing: if the prompt suggests command execution, prefer tool-capable agents
 	// Also check conversation history for tool execution context
 	needsTools := s.promptNeedsToolExecution(req.Prompt)
-	slog.Info(fmt.Sprintf("[Chat] Smart routing: prompt=%q, needsTools=%v, currentAgent=%q, isToolCapable=%v",
-		truncateString(req.Prompt, 50), needsTools, agentName, s.isToolCapableAgent(agentName)))
+	slog.Info("[Chat] smart routing", "prompt", truncateString(req.Prompt, 50), "needsTools", needsTools, "currentAgent", agentName, "isToolCapable", s.isToolCapableAgent(agentName))
 
 	if !needsTools && len(req.History) > 0 {
 		// Check if any message in history suggests tool execution was requested
 		for _, h := range req.History {
 			if s.promptNeedsToolExecution(h.Content) {
 				needsTools = true
-				slog.Info(fmt.Sprintf("[Chat] History contains tool execution request: %q", truncateString(h.Content, 50)))
+				slog.Info("[Chat] history contains tool execution request", "content", truncateString(h.Content, 50))
 				break
 			}
 		}
@@ -369,28 +368,27 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 	if needsTools && !s.isToolCapableAgent(agentName) {
 		// Try mixed-mode: use thinking agent + CLI execution agent
 		if toolAgent := s.findToolCapableAgent(); toolAgent != "" {
-			slog.Info(fmt.Sprintf("[Chat] Mixed-mode: thinking=%s, execution=%s", agentName, toolAgent))
+			slog.Info("[Chat] mixed-mode routing", "thinking", agentName, "execution", toolAgent)
 			s.handleMixedModeChat(ctx, conn, msg, req, agentName, toolAgent, req.SessionID, writeMu, closed)
 			return
 		}
-		slog.Info(fmt.Sprintf("[Chat] No tool-capable agent available, keeping %s (best-effort)", agentName))
+		slog.Info("[Chat] no tool-capable agent available, keeping current (best-effort)", "agent", agentName)
 	}
 
-	slog.Info(fmt.Sprintf("[Chat] Final agent selection: requested=%q, forceAgent=%q, selected=%q, sessionID=%q",
-		req.Agent, forceAgent, agentName, req.SessionID))
+	slog.Info("[Chat] final agent selection", "requested", req.Agent, "forceAgent", forceAgent, "selected", agentName, "sessionID", req.SessionID)
 
 	// Get the provider
 	provider, err := s.registry.Get(agentName)
 	if err != nil {
 		// Try default agent
-		slog.Info(fmt.Sprintf("[Chat] Agent %q not found, trying default", agentName))
+		slog.Info("[Chat] agent not found, trying default", "agent", agentName)
 		provider, err = s.registry.GetDefault()
 		if err != nil {
 			safeWrite(ctx, s.errorResponse(msg.ID, "no_agent", "No AI agent available. Please configure an API key"))
 			return
 		}
 		agentName = provider.Name()
-		slog.Info(fmt.Sprintf("[Chat] Using default agent: %s", agentName))
+		slog.Info("[Chat] using default agent", "agent", agentName)
 	}
 
 	if !provider.IsAvailable() {
@@ -475,15 +473,15 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 			if ctx.Err() != nil {
 				// Distinguish timeout from user-initiated cancel (#2375)
 				if ctx.Err() == context.DeadlineExceeded {
-					slog.Info(fmt.Sprintf("[Chat] Session %s timed out after %v", req.SessionID, missionExecutionTimeout))
+					slog.Info("[Chat] session timed out", "sessionID", req.SessionID, "timeout", missionExecutionTimeout)
 					safeWrite(context.Background(), s.errorResponse(msg.ID, "mission_timeout",
 						fmt.Sprintf("Mission timed out after %d minutes. The AI provider did not respond in time. You can retry or try a simpler prompt.", int(missionExecutionTimeout.Minutes()))))
 					return
 				}
-				slog.Info(fmt.Sprintf("[Chat] Session %s cancelled", req.SessionID))
+				slog.Info("[Chat] session cancelled", "sessionID", req.SessionID)
 				return
 			}
-			slog.Error(fmt.Sprintf("[Chat] streaming execution error for %s: %v", agentName, err))
+			slog.Error("[Chat] streaming execution error", "agent", agentName, "error", err)
 			code, msg2 := classifyProviderError(err)
 			safeWrite(ctx, s.errorResponse(msg.ID, code, msg2))
 			return
@@ -500,15 +498,15 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 			if ctx.Err() != nil {
 				// Distinguish timeout from user-initiated cancel (#2375)
 				if ctx.Err() == context.DeadlineExceeded {
-					slog.Info(fmt.Sprintf("[Chat] Session %s timed out after %v", req.SessionID, missionExecutionTimeout))
+					slog.Info("[Chat] session timed out", "sessionID", req.SessionID, "timeout", missionExecutionTimeout)
 					safeWrite(context.Background(), s.errorResponse(msg.ID, "mission_timeout",
 						fmt.Sprintf("Mission timed out after %d minutes. The AI provider did not respond in time. You can retry or try a simpler prompt.", int(missionExecutionTimeout.Minutes()))))
 					return
 				}
-				slog.Info(fmt.Sprintf("[Chat] Session %s cancelled", req.SessionID))
+				slog.Info("[Chat] session cancelled", "sessionID", req.SessionID)
 				return
 			}
-			slog.Error(fmt.Sprintf("[Chat] execution error for %s: %v", agentName, err))
+			slog.Error("[Chat] execution error", "agent", agentName, "error", err)
 			code, msg2 := classifyProviderError(err)
 			safeWrite(ctx, s.errorResponse(msg.ID, code, msg2))
 			return
@@ -518,12 +516,12 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 	// Don't send result if cancelled
 	if ctx.Err() != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			slog.Info(fmt.Sprintf("[Chat] Session %s timed out after completion", req.SessionID))
+			slog.Info("[Chat] session timed out after completion", "sessionID", req.SessionID)
 			safeWrite(context.Background(), s.errorResponse(msg.ID, "mission_timeout",
 				fmt.Sprintf("Mission timed out after %d minutes. The AI provider did not respond in time. You can retry or try a simpler prompt.", int(missionExecutionTimeout.Minutes()))))
 			return
 		}
-		slog.Info(fmt.Sprintf("[Chat] Session %s cancelled after completion", req.SessionID))
+		slog.Info("[Chat] session cancelled after completion", "sessionID", req.SessionID)
 		return
 	}
 
@@ -570,14 +568,14 @@ func (s *Server) handleChatMessageStreaming(conn *websocket.Conn, msg protocol.M
 func (s *Server) handleCancelChat(conn *websocket.Conn, msg protocol.Message, writeMu *sync.Mutex) {
 	payloadBytes, err := json.Marshal(msg.Payload)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[Chat] Failed to marshal cancel chat payload: %v", err))
+		slog.Error("[Chat] failed to marshal cancel chat payload", "error", err)
 		return
 	}
 	var req struct {
 		SessionID string `json:"sessionId"`
 	}
 	if err := json.Unmarshal(payloadBytes, &req); err != nil {
-		slog.Error(fmt.Sprintf("[Chat] Failed to unmarshal cancel chat request: %v", err))
+		slog.Error("[Chat] failed to unmarshal cancel chat request", "error", err)
 		return
 	}
 
@@ -587,9 +585,9 @@ func (s *Server) handleCancelChat(conn *websocket.Conn, msg protocol.Message, wr
 
 	if ok {
 		cancelFn()
-		slog.Info(fmt.Sprintf("[Chat] Cancelled chat for session %s", req.SessionID))
+		slog.Info("[Chat] cancelled chat", "sessionID", req.SessionID)
 	} else {
-		slog.Info(fmt.Sprintf("[Chat] No active chat to cancel for session %s", req.SessionID))
+		slog.Info("[Chat] no active chat to cancel", "sessionID", req.SessionID)
 	}
 
 	writeMu.Lock()
@@ -643,9 +641,9 @@ func (s *Server) handleCancelChatHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if ok {
 		cancelFn()
-		slog.Info(fmt.Sprintf("[Chat] Cancelled chat via HTTP for session %s", req.SessionID))
+		slog.Info("[Chat] cancelled chat via HTTP", "sessionID", req.SessionID)
 	} else {
-		slog.Info(fmt.Sprintf("[Chat] No active chat to cancel via HTTP for session %s", req.SessionID))
+		slog.Info("[Chat] no active chat to cancel via HTTP", "sessionID", req.SessionID)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -727,7 +725,7 @@ func (s *Server) handleChatMessage(msg protocol.Message, forceAgent string) prot
 
 	resp, err := provider.Chat(context.Background(), chatReq)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[Chat] execution error for %s: %v", agentName, err))
+		slog.Error("[Chat] execution error", "agent", agentName, "error", err)
 		return s.errorResponse(msg.ID, "execution_error", fmt.Sprintf("Failed to execute %s", agentName))
 	}
 
@@ -816,11 +814,11 @@ func (s *Server) handleSelectAgentMessage(msg protocol.Message) protocol.Message
 	// For now, update the default agent
 	previousAgent := s.registry.GetDefaultName()
 	if err := s.registry.SetDefault(req.Agent); err != nil {
-		slog.Error(fmt.Sprintf("set default agent error: %v", err))
+		slog.Error("set default agent error", "error", err)
 		return s.errorResponse(msg.ID, "invalid_agent", "invalid agent selection")
 	}
 
-	slog.Info(fmt.Sprintf("Agent selected: %s (was: %s)", req.Agent, previousAgent))
+	slog.Info("agent selected", "agent", req.Agent, "previous", previousAgent)
 
 	return protocol.Message{
 		ID:   msg.ID,
@@ -934,10 +932,10 @@ User request: %s`, req.Prompt)
 	thinkingResp, err := thinkingProvider.Chat(ctx, &thinkingReq)
 	if err != nil {
 		if ctx.Err() != nil {
-			slog.Info(fmt.Sprintf("[MixedMode] Session %s cancelled", sessionID))
+			slog.Info("[MixedMode] session cancelled", "sessionID", sessionID)
 			return
 		}
-		slog.Error(fmt.Sprintf("[MixedMode] Thinking agent error: %v", err))
+		slog.Error("[MixedMode] thinking agent error", "error", err)
 		safeWrite(s.errorResponse(msg.ID, "mixed_mode_error", fmt.Sprintf("Thinking agent error: %v", err)))
 		return
 	}
@@ -1008,10 +1006,10 @@ User request: %s`, req.Prompt)
 	execResp, err := execProvider.Chat(ctx, &execReq)
 	if err != nil {
 		if ctx.Err() != nil {
-			slog.Info(fmt.Sprintf("[MixedMode] Session %s cancelled during execution", sessionID))
+			slog.Info("[MixedMode] session cancelled during execution", "sessionID", sessionID)
 			return
 		}
-		slog.Error(fmt.Sprintf("[MixedMode] Execution agent error: %v", err))
+		slog.Error("[MixedMode] execution agent error", "error", err)
 		execContent = fmt.Sprintf("Execution Error: %v", err)
 		safeWrite(protocol.Message{
 			ID:   msg.ID,
@@ -1064,10 +1062,10 @@ Command output:
 	analysisResp, err := thinkingProvider.Chat(ctx, &analysisReq)
 	if err != nil {
 		if ctx.Err() != nil {
-			slog.Info(fmt.Sprintf("[MixedMode] Session %s cancelled during analysis", sessionID))
+			slog.Info("[MixedMode] session cancelled during analysis", "sessionID", sessionID)
 			return
 		}
-		slog.Error(fmt.Sprintf("[MixedMode] Analysis error: %v", err))
+		slog.Error("[MixedMode] analysis error", "error", err)
 	} else if analysisResp != nil {
 		safeWrite(protocol.Message{
 			ID:   msg.ID,
@@ -1264,7 +1262,7 @@ func (s *Server) loadTokenUsage() {
 
 	var usage tokenUsageData
 	if err := json.Unmarshal(data, &usage); err != nil {
-		slog.Warn(fmt.Sprintf("Warning: could not parse token usage file: %v", err))
+		slog.Warn("could not parse token usage file", "error", err)
 		return
 	}
 
@@ -1277,7 +1275,7 @@ func (s *Server) loadTokenUsage() {
 		s.todayTokensIn = usage.InputIn
 		s.todayTokensOut = usage.OutputOut
 		s.todayDate = today
-		slog.Info(fmt.Sprintf("Loaded token usage: %d input, %d output tokens for today", usage.InputIn, usage.OutputOut))
+		slog.Info("loaded token usage", "inputTokens", usage.InputIn, "outputTokens", usage.OutputOut)
 	}
 }
 
@@ -1298,7 +1296,7 @@ func (s *Server) saveTokenUsage() {
 
 	path := getTokenUsagePath()
 	if err := os.WriteFile(path, data, agentFileMode); err != nil {
-		slog.Warn(fmt.Sprintf("Warning: could not save token usage: %v", err))
+		slog.Warn("could not save token usage", "error", err)
 	}
 }
 

--- a/pkg/agent/server_http.go
+++ b/pkg/agent/server_http.go
@@ -74,7 +74,7 @@ func (s *Server) handleGPUNodesHTTP(w http.ResponseWriter, r *http.Request) {
 	if cluster != "" {
 		nodes, err := s.k8sClient.GetGPUNodes(ctx, cluster)
 		if err != nil {
-			slog.Info(fmt.Sprintf("error fetching nodes: %v", err))
+			slog.Info("error fetching nodes", "error", err)
 			json.NewEncoder(w).Encode(map[string]interface{}{"nodes": []interface{}{}, "error": "internal server error"})
 			return
 		}
@@ -83,7 +83,7 @@ func (s *Server) handleGPUNodesHTTP(w http.ResponseWriter, r *http.Request) {
 		// Query all clusters
 		clusters, err := s.k8sClient.ListClusters(ctx)
 		if err != nil {
-			slog.Info(fmt.Sprintf("error fetching nodes: %v", err))
+			slog.Info("error fetching nodes", "error", err)
 			json.NewEncoder(w).Encode(map[string]interface{}{"nodes": []interface{}{}, "error": "internal server error"})
 			return
 		}
@@ -96,7 +96,7 @@ func (s *Server) handleGPUNodesHTTP(w http.ResponseWriter, r *http.Request) {
 				defer wg.Done()
 				defer func() {
 					if r := recover(); r != nil {
-						slog.Info(fmt.Sprintf("[GPUNodes] recovered from panic for cluster %s: %v", clusterName, r))
+						slog.Info("[GPUNodes] recovered from panic", "cluster", clusterName, "panic", r)
 					}
 				}()
 				clusterCtx, clusterCancel := context.WithTimeout(ctx, agentDefaultTimeout)
@@ -145,7 +145,7 @@ func (s *Server) handleNodesHTTP(w http.ResponseWriter, r *http.Request) {
 		// Query specific cluster
 		nodes, err := s.k8sClient.GetNodes(ctx, cluster)
 		if err != nil {
-			slog.Info(fmt.Sprintf("error fetching nodes: %v", err))
+			slog.Info("error fetching nodes", "error", err)
 			json.NewEncoder(w).Encode(map[string]interface{}{"nodes": []interface{}{}, "error": "internal server error"})
 			return
 		}
@@ -154,7 +154,7 @@ func (s *Server) handleNodesHTTP(w http.ResponseWriter, r *http.Request) {
 		// Query all clusters
 		clusters, err := s.k8sClient.ListClusters(ctx)
 		if err != nil {
-			slog.Info(fmt.Sprintf("error fetching nodes: %v", err))
+			slog.Info("error fetching nodes", "error", err)
 			json.NewEncoder(w).Encode(map[string]interface{}{"nodes": []interface{}{}, "error": "internal server error"})
 			return
 		}
@@ -168,7 +168,7 @@ func (s *Server) handleNodesHTTP(w http.ResponseWriter, r *http.Request) {
 				defer wg.Done()
 				defer func() {
 					if r := recover(); r != nil {
-						slog.Info(fmt.Sprintf("[Nodes] recovered from panic for cluster %s: %v", clusterName, r))
+						slog.Info("[Nodes] recovered from panic", "cluster", clusterName, "panic", r)
 					}
 				}()
 				clusterCtx, clusterCancel := context.WithTimeout(ctx, agentDefaultTimeout)
@@ -232,7 +232,7 @@ func (s *Server) handleEventsHTTP(w http.ResponseWriter, r *http.Request) {
 	// Get events from the cluster
 	events, err := s.k8sClient.GetEvents(ctx, cluster, namespace, limit)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching events: %v", err))
+		slog.Info("error fetching events", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"events": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -277,7 +277,7 @@ func (s *Server) handleNamespacesHTTP(w http.ResponseWriter, r *http.Request) {
 
 	namespaces, err := s.k8sClient.ListNamespacesWithDetails(ctx, cluster)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching namespaces: %v", err))
+		slog.Info("error fetching namespaces", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"namespaces": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -317,7 +317,7 @@ func (s *Server) handleDeploymentsHTTP(w http.ResponseWriter, r *http.Request) {
 
 	deployments, err := s.k8sClient.GetDeployments(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching deployments: %v", err))
+		slog.Info("error fetching deployments", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"deployments": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -347,7 +347,7 @@ func (s *Server) handleReplicaSetsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	replicasets, err := s.k8sClient.GetReplicaSets(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching replicasets: %v", err))
+		slog.Info("error fetching replicasets", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"replicasets": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -376,7 +376,7 @@ func (s *Server) handleStatefulSetsHTTP(w http.ResponseWriter, r *http.Request) 
 	defer cancel()
 	statefulsets, err := s.k8sClient.GetStatefulSets(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching statefulsets: %v", err))
+		slog.Info("error fetching statefulsets", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"statefulsets": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -405,7 +405,7 @@ func (s *Server) handleDaemonSetsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	daemonsets, err := s.k8sClient.GetDaemonSets(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching daemonsets: %v", err))
+		slog.Info("error fetching daemonsets", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"daemonsets": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -434,7 +434,7 @@ func (s *Server) handleCronJobsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	cronjobs, err := s.k8sClient.GetCronJobs(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching cronjobs: %v", err))
+		slog.Info("error fetching cronjobs", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"cronjobs": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -463,7 +463,7 @@ func (s *Server) handleIngressesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	ingresses, err := s.k8sClient.GetIngresses(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching ingresses: %v", err))
+		slog.Info("error fetching ingresses", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"ingresses": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -492,7 +492,7 @@ func (s *Server) handleNetworkPoliciesHTTP(w http.ResponseWriter, r *http.Reques
 	defer cancel()
 	policies, err := s.k8sClient.GetNetworkPolicies(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching networkpolicies: %v", err))
+		slog.Info("error fetching networkpolicies", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"networkpolicies": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -521,7 +521,7 @@ func (s *Server) handleServicesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	services, err := s.k8sClient.GetServices(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching services: %v", err))
+		slog.Info("error fetching services", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"services": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -550,7 +550,7 @@ func (s *Server) handleConfigMapsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	configmaps, err := s.k8sClient.GetConfigMaps(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching configmaps: %v", err))
+		slog.Info("error fetching configmaps", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"configmaps": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -586,7 +586,7 @@ func (s *Server) handleSecretsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	secrets, err := s.k8sClient.GetSecrets(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching secrets: %v", err))
+		slog.Info("error fetching secrets", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"secrets": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -615,7 +615,7 @@ func (s *Server) handleServiceAccountsHTTP(w http.ResponseWriter, r *http.Reques
 	defer cancel()
 	serviceaccounts, err := s.k8sClient.GetServiceAccounts(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching serviceaccounts: %v", err))
+		slog.Info("error fetching serviceaccounts", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"serviceaccounts": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -644,7 +644,7 @@ func (s *Server) handleJobsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	jobs, err := s.k8sClient.GetJobs(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching jobs: %v", err))
+		slog.Info("error fetching jobs", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"jobs": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -673,7 +673,7 @@ func (s *Server) handleHPAsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	hpas, err := s.k8sClient.GetHPAs(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching hpas: %v", err))
+		slog.Info("error fetching hpas", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"hpas": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -702,7 +702,7 @@ func (s *Server) handlePVCsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	pvcs, err := s.k8sClient.GetPVCs(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching pvcs: %v", err))
+		slog.Info("error fetching pvcs", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"pvcs": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -731,7 +731,7 @@ func (s *Server) handleRolesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	roles, err := s.k8sClient.ListRoles(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching roles: %v", err))
+		slog.Info("error fetching roles", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"roles": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -760,7 +760,7 @@ func (s *Server) handleRoleBindingsHTTP(w http.ResponseWriter, r *http.Request) 
 	defer cancel()
 	bindings, err := s.k8sClient.ListRoleBindings(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching rolebindings: %v", err))
+		slog.Info("error fetching rolebindings", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"rolebindings": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -789,7 +789,7 @@ func (s *Server) handleResourceQuotasHTTP(w http.ResponseWriter, r *http.Request
 	defer cancel()
 	quotas, err := s.k8sClient.GetResourceQuotas(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching resourcequotas: %v", err))
+		slog.Info("error fetching resourcequotas", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"resourcequotas": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -818,7 +818,7 @@ func (s *Server) handleLimitRangesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	ranges, err := s.k8sClient.GetLimitRanges(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching limitranges: %v", err))
+		slog.Info("error fetching limitranges", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"limitranges": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -857,7 +857,7 @@ func (s *Server) handleResolveDepsHTTP(w http.ResponseWriter, r *http.Request) {
 
 	kind, bundle, err := s.k8sClient.ResolveWorkloadDependencies(ctx, cluster, namespace, name)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error resolving dependencies for %s/%s in %s: %v", namespace, name, cluster, err))
+		slog.Info("error resolving dependencies", "namespace", namespace, "name", name, "cluster", cluster, "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"workload":     name,
 			"kind":         "Deployment",
@@ -973,7 +973,7 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.k8sClient.ScaleWorkload(ctx, namespace, name, []string{cluster}, replicas)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error scaling %s/%s in %s: %v", namespace, name, cluster, err))
+		slog.Info("error scaling resource", "namespace", namespace, "name", name, "cluster", cluster, "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"success": false,
 			"error":   err.Error(),
@@ -1023,7 +1023,7 @@ func (s *Server) handlePodsHTTP(w http.ResponseWriter, r *http.Request) {
 
 	pods, err := s.k8sClient.GetPods(ctx, cluster, namespace)
 	if err != nil {
-		slog.Info(fmt.Sprintf("error fetching pods: %v", err))
+		slog.Info("error fetching pods", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"pods": []interface{}{}, "error": "internal server error"})
 		return
 	}
@@ -1065,7 +1065,7 @@ func (s *Server) handleClusterHealthHTTP(w http.ResponseWriter, r *http.Request)
 
 	health, err := s.k8sClient.GetClusterHealth(ctx, cluster)
 	if err != nil {
-		slog.Error(fmt.Sprintf("request error: %v", err))
+		slog.Error("request error", "error", err)
 		json.NewEncoder(w).Encode(map[string]interface{}{"error": "internal server error"})
 		return
 	}
@@ -1117,7 +1117,7 @@ func (s *Server) handleRestartBackend(w http.ResponseWriter, r *http.Request) {
 	killed := s.killBackendProcess()
 
 	if err := s.startBackendProcess(); err != nil {
-		slog.Error(fmt.Sprintf("[RestartBackend] Failed to start backend: %v", err))
+		slog.Error("[RestartBackend] failed to start backend", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"success": false,
@@ -1130,7 +1130,7 @@ func (s *Server) handleRestartBackend(w http.ResponseWriter, r *http.Request) {
 	time.Sleep(stabilizationDelay)
 	healthy := s.checkBackendHealth()
 
-	slog.Info(fmt.Sprintf("[RestartBackend] Backend restarted (killed=%v, healthy=%v)", killed, healthy))
+	slog.Info("[RestartBackend] backend restarted", "killed", killed, "healthy", healthy)
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"success": true,
 		"killed":  killed,
@@ -1186,7 +1186,7 @@ func (s *Server) startBackendProcess() error {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Info(fmt.Sprintf("[Backend] recovered from panic in process reaper: %v", r))
+				slog.Info("[Backend] recovered from panic in process reaper", "panic", r)
 			}
 		}()
 		cmd.Wait()
@@ -1392,13 +1392,13 @@ func (s *Server) handleRenameContextHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := s.kubectl.RenameContext(req.OldName, req.NewName); err != nil {
-		slog.Error(fmt.Sprintf("rename context error: %v", err))
+		slog.Error("rename context error", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "rename_failed", Message: "failed to rename context"})
 		return
 	}
 
-	slog.Info(fmt.Sprintf("Renamed context: %s -> %s", req.OldName, req.NewName))
+	slog.Info("renamed context", "from", req.OldName, "to", req.NewName)
 	json.NewEncoder(w).Encode(protocol.RenameContextResponse{Success: true, OldName: req.OldName, NewName: req.NewName})
 }
 
@@ -1462,7 +1462,7 @@ func (s *Server) handleKubeconfigPreviewHTTP(w http.ResponseWriter, r *http.Requ
 
 	entries, err := s.kubectl.PreviewKubeconfig(req.Kubeconfig)
 	if err != nil {
-		slog.Error(fmt.Sprintf("kubeconfig preview error: %v", err))
+		slog.Error("kubeconfig preview error", "error", err)
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "preview_failed", Message: "invalid kubeconfig"})
 		return
@@ -1513,13 +1513,13 @@ func (s *Server) handleKubeconfigImportHTTP(w http.ResponseWriter, r *http.Reque
 
 	added, skipped, err := s.kubectl.ImportKubeconfig(req.Kubeconfig)
 	if err != nil {
-		slog.Error(fmt.Sprintf("kubeconfig import error: %v", err))
+		slog.Error("kubeconfig import error", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(kubeconfigImportResponse{Success: false, Error: "failed to import kubeconfig"})
 		return
 	}
 
-	slog.Info(fmt.Sprintf("Kubeconfig import: added %d contexts, skipped %d", len(added), len(skipped)))
+	slog.Info("kubeconfig import complete", "added", len(added), "skipped", len(skipped))
 	json.NewEncoder(w).Encode(kubeconfigImportResponse{Success: true, Added: added, Skipped: skipped})
 }
 
@@ -1564,13 +1564,13 @@ func (s *Server) handleKubeconfigAddHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := s.kubectl.AddCluster(req); err != nil {
-		slog.Error(fmt.Sprintf("add cluster error: %v", err))
+		slog.Error("add cluster error", "error", err)
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(kubeconfigAddResponse{Success: false, Error: "failed to add cluster"})
 		return
 	}
 
-	slog.Info(fmt.Sprintf("Added cluster via form: context=%s cluster=%s", req.ContextName, req.ClusterName))
+	slog.Info("added cluster via form", "context", req.ContextName, "cluster", req.ClusterName)
 	json.NewEncoder(w).Encode(kubeconfigAddResponse{Success: true})
 }
 
@@ -1610,7 +1610,7 @@ func (s *Server) handleKubeconfigTestHTTP(w http.ResponseWriter, r *http.Request
 
 	result, err := s.kubectl.TestClusterConnection(req)
 	if err != nil {
-		slog.Error(fmt.Sprintf("test connection error: %v", err))
+		slog.Error("test connection error", "error", err)
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(TestConnectionResult{Reachable: false, Error: "connection test failed"})
 		return

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -97,7 +97,7 @@ func (s *Server) handleSettingsKeyByProvider(w http.ResponseWriter, r *http.Requ
 	}
 
 	if err := cm.RemoveAPIKey(provider); err != nil {
-		slog.Error(fmt.Sprintf("delete API key error: %v", err))
+		slog.Error("delete API key error", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "delete_failed", Message: "failed to delete API key"})
 		return
@@ -109,7 +109,7 @@ func (s *Server) handleSettingsKeyByProvider(w http.ResponseWriter, r *http.Requ
 	// Refresh provider availability
 	s.refreshProviderAvailability()
 
-	slog.Info(fmt.Sprintf("API key removed for provider: %s", provider))
+	slog.Info("API key removed", "provider", provider)
 	json.NewEncoder(w).Encode(map[string]bool{"success": true})
 }
 
@@ -141,7 +141,7 @@ func (s *Server) handleSettingsAll(w http.ResponseWriter, r *http.Request) {
 	case "GET":
 		all, err := sm.GetAll()
 		if err != nil {
-			slog.Error(fmt.Sprintf("[settings] GetAll error: %v", err))
+			slog.Error("[settings] GetAll error", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "settings_load_failed", Message: "Failed to load settings"})
 			return
@@ -165,7 +165,7 @@ func (s *Server) handleSettingsAll(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err := sm.SaveAll(&all); err != nil {
-			slog.Error(fmt.Sprintf("[settings] SaveAll error: %v", err))
+			slog.Error("[settings] SaveAll error", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "settings_save_failed", Message: "Failed to save settings"})
 			return
@@ -211,7 +211,7 @@ func (s *Server) handleSettingsExport(w http.ResponseWriter, r *http.Request) {
 	sm := settings.GetSettingsManager()
 	data, err := sm.ExportEncrypted()
 	if err != nil {
-		slog.Error(fmt.Sprintf("[settings] Export error: %v", err))
+		slog.Error("[settings] export error", "error", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "export_failed", Message: "Failed to export settings"})
@@ -261,7 +261,7 @@ func (s *Server) handleSettingsImport(w http.ResponseWriter, r *http.Request) {
 
 	sm := settings.GetSettingsManager()
 	if err := sm.ImportEncrypted(body); err != nil {
-		slog.Error(fmt.Sprintf("[settings] Import error: %v", err))
+		slog.Error("[settings] import error", "error", err)
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "import_failed", Message: "failed to import settings"})
 		return
@@ -308,7 +308,7 @@ func (s *Server) handleGetKeysStatus(w http.ResponseWriter, r *http.Request) {
 			// Cache the validity for IsAvailable() checks
 			cm.SetKeyValidity(p.name, valid)
 			if err != nil {
-				slog.Error(fmt.Sprintf("API key validation error for %s: %v", p.name, err))
+				slog.Error("API key validation error", "provider", p.name, "error", err)
 				status.Error = "validation failed"
 			}
 		}
@@ -348,7 +348,7 @@ func (s *Server) handleSetKey(w http.ResponseWriter, r *http.Request) {
 	if !valid {
 		w.WriteHeader(http.StatusBadRequest)
 		if validationErr != nil {
-			slog.Error(fmt.Sprintf("API key validation error: %v", validationErr))
+			slog.Error("API key validation error", "error", validationErr)
 		}
 		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "invalid_key", Message: "Invalid API key"})
 		return
@@ -358,7 +358,7 @@ func (s *Server) handleSetKey(w http.ResponseWriter, r *http.Request) {
 
 	// Save the key
 	if err := cm.SetAPIKey(req.Provider, req.APIKey); err != nil {
-		slog.Error(fmt.Sprintf("save API key error: %v", err))
+		slog.Error("save API key error", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(protocol.ErrorPayload{Code: "save_failed", Message: "failed to save API key"})
 		return
@@ -370,14 +370,14 @@ func (s *Server) handleSetKey(w http.ResponseWriter, r *http.Request) {
 	// Save model if provided
 	if req.Model != "" {
 		if err := cm.SetModel(req.Provider, req.Model); err != nil {
-			slog.Error(fmt.Sprintf("Warning: failed to save model preference: %v", err))
+			slog.Error("failed to save model preference", "error", err)
 		}
 	}
 
 	// Refresh provider availability
 	s.refreshProviderAvailability()
 
-	slog.Info(fmt.Sprintf("API key configured for provider: %s", req.Provider))
+	slog.Info("API key configured", "provider", req.Provider)
 	json.NewEncoder(w).Encode(map[string]any{
 		"success":  true,
 		"provider": req.Provider,
@@ -442,18 +442,18 @@ func (s *Server) ValidateAllKeys() {
 				continue // Already validated
 			}
 			// Validate the key
-			slog.Info(fmt.Sprintf("Validating %s API key...", provider))
+			slog.Info("validating API key", "provider", provider)
 			valid, err := s.validateAPIKey(provider)
 			if err != nil {
 				// Network or other error - don't cache, will try again later
-				slog.Error(fmt.Sprintf("Warning: %s API key validation error (will retry): %v", provider, err))
+				slog.Error("API key validation error (will retry)", "provider", provider, "error", err)
 			} else {
 				// Cache the validity result
 				cm.SetKeyValidity(provider, valid)
 				if valid {
-					slog.Info(fmt.Sprintf("%s API key is valid", provider))
+					slog.Info("API key is valid", "provider", provider)
 				} else {
-					slog.Warn(fmt.Sprintf("Warning: %s API key is INVALID", provider))
+					slog.Warn("API key is INVALID", "provider", provider)
 				}
 			}
 		}
@@ -609,7 +609,7 @@ func (s *Server) handleProvidersHealth(w http.ResponseWriter, r *http.Request) {
 			defer wg.Done()
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Info(fmt.Sprintf("[ProviderHealth] recovered from panic checking %s: %v", providerID, r))
+					slog.Info("[ProviderHealth] recovered from panic checking provider", "provider", providerID, "panic", r)
 				}
 			}()
 			status := checkStatuspageHealth(client, url)
@@ -626,7 +626,7 @@ func (s *Server) handleProvidersHealth(w http.ResponseWriter, r *http.Request) {
 			defer wg.Done()
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Info(fmt.Sprintf("[ProviderHealth] recovered from panic pinging %s: %v", providerID, r))
+					slog.Info("[ProviderHealth] recovered from panic pinging provider", "provider", providerID, "panic", r)
 				}
 			}()
 			status := checkPingHealth(client, url)
@@ -772,7 +772,7 @@ func (s *Server) handlePredictionsAnalyze(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := s.predictionWorker.TriggerAnalysis(req.Providers); err != nil {
-		slog.Error(fmt.Sprintf("prediction analysis error: %v", err))
+		slog.Error("prediction analysis error", "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -823,7 +823,7 @@ func (s *Server) handlePredictionsFeedback(w http.ResponseWriter, r *http.Reques
 
 	// For now, just acknowledge - feedback is stored client-side
 	// In the future, this could store to a database for model improvement
-	slog.Info(fmt.Sprintf("[Predictions] Feedback received: %s = %s", req.PredictionID, req.Feedback))
+	slog.Info("[Predictions] feedback received", "predictionID", req.PredictionID, "feedback", req.Feedback)
 
 	json.NewEncoder(w).Encode(map[string]string{
 		"status": "recorded",
@@ -1040,7 +1040,7 @@ func (s *Server) sendNativeNotification(alerts []DeviceAlert) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Info(fmt.Sprintf("[DeviceTracker] recovered from panic in notification: %v", r))
+				slog.Info("[DeviceTracker] recovered from panic in notification", "panic", r)
 			}
 		}()
 
@@ -1054,7 +1054,7 @@ func (s *Server) sendNativeNotification(alerts []DeviceAlert) {
 				"-sender", "com.google.Chrome",
 			)
 			if err := cmd.Run(); err != nil {
-				slog.Error(fmt.Sprintf("[DeviceTracker] terminal-notifier failed: %v, falling back to osascript", err))
+				slog.Error("[DeviceTracker] terminal-notifier failed, falling back to osascript", "error", err)
 			} else {
 				return
 			}
@@ -1065,7 +1065,7 @@ func (s *Server) sendNativeNotification(alerts []DeviceAlert) {
 			message, title)
 		cmd := exec.Command("osascript", "-e", script)
 		if err := cmd.Run(); err != nil {
-			slog.Error(fmt.Sprintf("[DeviceTracker] Failed to send notification: %v", err))
+			slog.Error("[DeviceTracker] failed to send notification", "error", err)
 		}
 	}()
 }
@@ -1195,11 +1195,11 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Info(fmt.Sprintf("[LocalClusters] recovered from panic creating cluster %s: %v", req.Name, r))
+					slog.Info("[LocalClusters] recovered from panic creating cluster", "cluster", req.Name, "panic", r)
 				}
 			}()
 			if err := s.localClusters.CreateCluster(req.Tool, req.Name); err != nil {
-				slog.Error(fmt.Sprintf("[LocalClusters] Failed to create cluster %s with %s: %v", req.Name, req.Tool, err))
+				slog.Error("[LocalClusters] failed to create cluster", "cluster", req.Name, "tool", req.Tool, "error", err)
 				errMsg := sanitizeClusterError(err)
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 					"tool":     req.Tool,
@@ -1215,7 +1215,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 					"error": errMsg,
 				})
 			} else {
-				slog.Info(fmt.Sprintf("[LocalClusters] Created cluster %s with %s", req.Name, req.Tool))
+				slog.Info("[LocalClusters] created cluster", "cluster", req.Name, "tool", req.Tool)
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 					"tool":     req.Tool,
 					"name":     req.Name,
@@ -1252,11 +1252,11 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Info(fmt.Sprintf("[LocalClusters] recovered from panic deleting cluster %s: %v", name, r))
+					slog.Info("[LocalClusters] recovered from panic deleting cluster", "cluster", name, "panic", r)
 				}
 			}()
 			if err := s.localClusters.DeleteCluster(tool, name); err != nil {
-				slog.Error(fmt.Sprintf("[LocalClusters] Failed to delete cluster %s: %v", name, err))
+				slog.Error("[LocalClusters] failed to delete cluster", "cluster", name, "error", err)
 				errMsg := sanitizeClusterError(err)
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 					"tool":     tool,
@@ -1272,7 +1272,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 					"error": errMsg,
 				})
 			} else {
-				slog.Info(fmt.Sprintf("[LocalClusters] Deleted cluster %s", name))
+				slog.Info("[LocalClusters] deleted cluster", "cluster", name)
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 					"tool":     tool,
 					"name":     name,
@@ -1342,7 +1342,7 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Info(fmt.Sprintf("[LocalClusters] recovered from panic during %s of cluster %s: %v", req.Action, req.Name, r))
+				slog.Info("[LocalClusters] recovered from panic during lifecycle action", "action", req.Action, "cluster", req.Name, "panic", r)
 			}
 		}()
 
@@ -1360,7 +1360,7 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 		}
 
 		if err != nil {
-			slog.Error(fmt.Sprintf("[LocalClusters] Failed to %s cluster %s: %v", req.Action, req.Name, err))
+			slog.Error("[LocalClusters] lifecycle action failed", "action", req.Action, "cluster", req.Name, "error", err)
 			errMsg := sanitizeClusterError(err)
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     req.Tool,
@@ -1370,7 +1370,7 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 				"progress": 0,
 			})
 		} else {
-			slog.Info(fmt.Sprintf("[LocalClusters] %s cluster %s completed", req.Action, req.Name))
+			slog.Info("[LocalClusters] lifecycle action completed", "action", req.Action, "cluster", req.Name)
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     req.Tool,
 				"name":     req.Name,
@@ -1406,7 +1406,7 @@ func (s *Server) handleVClusterList(w http.ResponseWriter, r *http.Request) {
 
 	instances, err := s.localClusters.ListVClusters()
 	if err != nil {
-		slog.Error(fmt.Sprintf("[vCluster] Failed to list vclusters: %v", err))
+		slog.Error("[vCluster] failed to list vclusters", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -1453,11 +1453,11 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Info(fmt.Sprintf("[vCluster] recovered from panic creating vcluster %s: %v", req.Name, r))
+				slog.Info("[vCluster] recovered from panic creating vcluster", "name", req.Name, "panic", r)
 			}
 		}()
 		if err := s.localClusters.CreateVCluster(req.Name, req.Namespace); err != nil {
-			slog.Error(fmt.Sprintf("[vCluster] Failed to create vcluster %s: %v", req.Name, err))
+			slog.Error("[vCluster] failed to create vcluster", "name", req.Name, "error", err)
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     "vcluster",
 				"name":     req.Name,
@@ -1466,7 +1466,7 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 				"progress": progressFailed,
 			})
 		} else {
-			slog.Info(fmt.Sprintf("[vCluster] Created vcluster %s in namespace %s", req.Name, req.Namespace))
+			slog.Info("[vCluster] created vcluster", "name", req.Name, "namespace", req.Namespace)
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     "vcluster",
 				"name":     req.Name,
@@ -1519,12 +1519,12 @@ func (s *Server) handleVClusterConnect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.localClusters.ConnectVCluster(req.Name, req.Namespace); err != nil {
-		slog.Error(fmt.Sprintf("[vCluster] Failed to connect to vcluster %s: %v", req.Name, err))
+		slog.Error("[vCluster] failed to connect to vcluster", "name", req.Name, "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	slog.Info(fmt.Sprintf("[vCluster] Connected to vcluster %s in namespace %s", req.Name, req.Namespace))
+	slog.Info("[vCluster] connected to vcluster", "name", req.Name, "namespace", req.Namespace)
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"status":    "connected",
 		"name":      req.Name,
@@ -1567,12 +1567,12 @@ func (s *Server) handleVClusterDisconnect(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := s.localClusters.DisconnectVCluster(req.Name, req.Namespace); err != nil {
-		slog.Error(fmt.Sprintf("[vCluster] Failed to disconnect from vcluster %s: %v", req.Name, err))
+		slog.Error("[vCluster] failed to disconnect from vcluster", "name", req.Name, "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	slog.Info(fmt.Sprintf("[vCluster] Disconnected from vcluster %s", req.Name))
+	slog.Info("[vCluster] disconnected from vcluster", "name", req.Name)
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"status":    "disconnected",
 		"name":      req.Name,
@@ -1618,11 +1618,11 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Info(fmt.Sprintf("[vCluster] recovered from panic deleting vcluster %s: %v", req.Name, r))
+				slog.Info("[vCluster] recovered from panic deleting vcluster", "name", req.Name, "panic", r)
 			}
 		}()
 		if err := s.localClusters.DeleteVCluster(req.Name, req.Namespace); err != nil {
-			slog.Error(fmt.Sprintf("[vCluster] Failed to delete vcluster %s: %v", req.Name, err))
+			slog.Error("[vCluster] failed to delete vcluster", "name", req.Name, "error", err)
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     "vcluster",
 				"name":     req.Name,
@@ -1631,7 +1631,7 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 				"progress": progressFailed,
 			})
 		} else {
-			slog.Info(fmt.Sprintf("[vCluster] Deleted vcluster %s from namespace %s", req.Name, req.Namespace))
+			slog.Info("[vCluster] deleted vcluster", "name", req.Name, "namespace", req.Namespace)
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     "vcluster",
 				"name":     req.Name,
@@ -1687,7 +1687,7 @@ func (s *Server) handleInsightsEnrich(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := s.insightWorker.Enrich(req)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[insights] enrichment error: %v", err))
+		slog.Error("[insights] enrichment error", "error", err)
 		// Return empty enrichments on error, not HTTP error
 		json.NewEncoder(w).Encode(InsightEnrichmentResponse{
 			Enrichments: []AIInsightEnrichment{},

--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -196,7 +196,7 @@ func (uc *UpdateChecker) Status() AutoUpdateStatusResponse {
 			resp.LatestSHA = sha
 			resp.HasUpdate = sha != resp.CurrentSHA && resp.CurrentSHA != ""
 		} else {
-			slog.Error(fmt.Sprintf("[AutoUpdate] Failed to fetch latest SHA: %v", err))
+			slog.Error("[AutoUpdate] failed to fetch latest SHA", "error", err)
 		}
 	}
 
@@ -217,7 +217,7 @@ func (uc *UpdateChecker) TriggerNow(channelOverride string) bool {
 			defer atomic.StoreInt32(&uc.updating, 0)
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Error(fmt.Sprintf("[AutoUpdate] PANIC recovered in update goroutine: %v", r))
+					slog.Error("[AutoUpdate] PANIC recovered in update goroutine", "panic", r)
 				}
 			}()
 
@@ -237,7 +237,7 @@ func (uc *UpdateChecker) TriggerNow(channelOverride string) bool {
 			defer atomic.StoreInt32(&uc.updating, 0)
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Error(fmt.Sprintf("[AutoUpdate] PANIC recovered in update goroutine: %v", r))
+					slog.Error("[AutoUpdate] PANIC recovered in update goroutine", "panic", r)
 				}
 			}()
 			uc.checkAndUpdate()
@@ -315,7 +315,7 @@ func (uc *UpdateChecker) checkDeveloperChannel() {
 
 	latestSHA, err := fetchLatestMainSHAWithRepo(repoPath)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] Failed to check main SHA: %v", err))
+		slog.Error("[AutoUpdate] failed to check main SHA", "error", err)
 		return
 	}
 
@@ -328,7 +328,7 @@ func (uc *UpdateChecker) checkDeveloperChannel() {
 	}
 
 	if latestSHA == currentSHA || currentSHA == "" {
-		slog.Info(fmt.Sprintf("[AutoUpdate] Already up to date (%s), no update needed", short(currentSHA)))
+		slog.Info("[AutoUpdate] already up to date, no update needed", "sha", short(currentSHA))
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:   "done",
 			Message:  "Already up to date — no changes on main",
@@ -337,7 +337,7 @@ func (uc *UpdateChecker) checkDeveloperChannel() {
 		return
 	}
 
-	slog.Info(fmt.Sprintf("[AutoUpdate] New commit on main: %s -> %s", short(currentSHA), short(latestSHA)))
+	slog.Info("[AutoUpdate] new commit on main", "from", short(currentSHA), "to", short(latestSHA))
 	uc.executeDeveloperUpdate(latestSHA)
 }
 
@@ -349,10 +349,10 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 
 	start := time.Now()
 	total := devUpdateTotalSteps
-	slog.Info(fmt.Sprintf("[AutoUpdate] === Starting update: %s -> %s ===", short(previousSHA), short(newSHA)))
+	slog.Info("[AutoUpdate] starting update", "from", short(previousSHA), "to", short(newSHA))
 
 	// Step 1/7: Git pull
-	slog.Info(fmt.Sprintf("[AutoUpdate] Step 1/%d: git pull --rebase origin main", total))
+	slog.Info("[AutoUpdate] step progress", "step", 1, "total", total, "description", "git pull --rebase origin main")
 	uc.broadcast("update_progress", UpdateProgressPayload{
 		Status:     "pulling",
 		Message:    fmt.Sprintf("Pulling %s from main...", short(newSHA)),
@@ -362,7 +362,7 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 	})
 
 	if err := runGitPullWithTimeout(repoPath, gitPullTimeout); err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] FAILED at step 1 (git pull) after %s: %v", time.Since(start), err))
+		slog.Error("[AutoUpdate] FAILED at step 1 (git pull)", "elapsed", time.Since(start), "error", err)
 		uc.recordError(fmt.Sprintf("git pull failed: %v", err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:  "failed",
@@ -371,11 +371,11 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 		})
 		return
 	}
-	slog.Info(fmt.Sprintf("[AutoUpdate] Step 1/%d complete (git pull) in %s", total, time.Since(start)))
+	slog.Info("[AutoUpdate] step complete", "step", 1, "total", total, "description", "git pull", "elapsed", time.Since(start))
 
 	// Step 2/7: npm install (with automatic cache recovery)
 	webDir := repoPath + "/web"
-	slog.Info(fmt.Sprintf("[AutoUpdate] Step 2/%d: npm install", total))
+	slog.Info("[AutoUpdate] step progress", "step", 2, "total", total, "description", "npm install")
 	uc.broadcast("update_progress", UpdateProgressPayload{
 		Status:     "building",
 		Message:    "Installing npm dependencies...",
@@ -386,7 +386,7 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 
 	stepStart := time.Now()
 	if err := uc.resilientNpmInstall(webDir, 2, total, npmInstallTimeout); err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] FAILED at step 2 (npm install) after %s: %v", time.Since(start), err))
+		slog.Error("[AutoUpdate] FAILED at step 2 (npm install)", "elapsed", time.Since(start), "error", err)
 		uc.recordError(fmt.Sprintf("npm install failed: %v", err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:  "failed",
@@ -395,14 +395,14 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 		})
 		rollbackGit(repoPath, previousSHA)
 		if rbErr := rebuildFrontend(repoPath); rbErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] WARNING: rollback rebuildFrontend failed: %v", rbErr))
+			slog.Error("[AutoUpdate] rollback rebuildFrontend failed", "error", rbErr)
 		}
 		return
 	}
-	slog.Info(fmt.Sprintf("[AutoUpdate] Step 2/%d complete (npm install) in %s", total, time.Since(stepStart)))
+	slog.Info("[AutoUpdate] step complete", "step", 2, "total", total, "description", "npm install", "elapsed", time.Since(stepStart))
 
 	// Step 3/7: Frontend build (Vite)
-	slog.Info(fmt.Sprintf("[AutoUpdate] Step 3/%d: npm run build", total))
+	slog.Info("[AutoUpdate] step progress", "step", 3, "total", total, "description", "npm run build")
 	uc.broadcast("update_progress", UpdateProgressPayload{
 		Status:     "building",
 		Message:    "Building frontend with Vite...",
@@ -415,7 +415,7 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 	res := uc.runBuildCmd(frontendBuildTimeout, "Building frontend with Vite", 3, total, 30,
 		"npm", []string{"run", "build"}, webDir, nil)
 	if res.err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] FAILED at step 3 (frontend build) after %s: %v", time.Since(start), res.err))
+		slog.Error("[AutoUpdate] FAILED at step 3 (frontend build)", "elapsed", time.Since(start), "error", res.err)
 		uc.recordError(fmt.Sprintf("frontend build failed: %v", res.err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:  "failed",
@@ -424,14 +424,14 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 		})
 		rollbackGit(repoPath, previousSHA)
 		if rbErr := rebuildFrontend(repoPath); rbErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] WARNING: rollback rebuildFrontend failed: %v", rbErr))
+			slog.Error("[AutoUpdate] rollback rebuildFrontend failed", "error", rbErr)
 		}
 		return
 	}
-	slog.Info(fmt.Sprintf("[AutoUpdate] Step 3/%d complete (frontend build) in %s", total, time.Since(stepStart)))
+	slog.Info("[AutoUpdate] step complete", "step", 3, "total", total, "description", "frontend build", "elapsed", time.Since(stepStart))
 
 	// Step 4/7: Build console binary
-	slog.Info(fmt.Sprintf("[AutoUpdate] Step 4/%d: go build ./cmd/console", total))
+	slog.Info("[AutoUpdate] step progress", "step", 4, "total", total, "description", "go build ./cmd/console")
 	uc.broadcast("update_progress", UpdateProgressPayload{
 		Status:     "building",
 		Message:    "Building console binary...",
@@ -452,7 +452,7 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 		"go", []string{"build", "-o", consoleTmp, "./cmd/console"}, repoPath, []string{"GOWORK=off"})
 	if res.err != nil {
 		os.Remove(consoleTmp) // clean up partial build
-		slog.Error(fmt.Sprintf("[AutoUpdate] FAILED at step 4 (console build) after %s: %v", time.Since(start), res.err))
+		slog.Error("[AutoUpdate] FAILED at step 4 (console build)", "elapsed", time.Since(start), "error", res.err)
 		uc.recordError(fmt.Sprintf("go build console failed: %v", res.err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:  "failed",
@@ -461,21 +461,21 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 		})
 		rollbackGit(repoPath, previousSHA)
 		if rbErr := rebuildFrontend(repoPath); rbErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] WARNING: rollback rebuildFrontend failed: %v", rbErr))
+			slog.Error("[AutoUpdate] rollback rebuildFrontend failed", "error", rbErr)
 		}
 		if rbErr := rebuildGoBinaries(repoPath); rbErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] WARNING: rollback rebuildGoBinaries failed: %v", rbErr))
+			slog.Error("[AutoUpdate] rollback rebuildGoBinaries failed", "error", rbErr)
 		}
 		return
 	}
 	if err := os.Rename(consoleTmp, consolePath); err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] Failed to move console binary: %v", err))
+		slog.Error("[AutoUpdate] failed to move console binary", "error", err)
 		os.Remove(consoleTmp)
 	}
-	slog.Info(fmt.Sprintf("[AutoUpdate] Step 4/%d complete (console binary) in %s", total, time.Since(stepStart)))
+	slog.Info("[AutoUpdate] step complete", "step", 4, "total", total, "description", "console binary", "elapsed", time.Since(stepStart))
 
 	// Step 5/7: Build kc-agent binary
-	slog.Info(fmt.Sprintf("[AutoUpdate] Step 5/%d: go build ./cmd/kc-agent", total))
+	slog.Info("[AutoUpdate] step progress", "step", 5, "total", total, "description", "go build ./cmd/kc-agent")
 	uc.broadcast("update_progress", UpdateProgressPayload{
 		Status:     "building",
 		Message:    "Building kc-agent binary...",
@@ -495,7 +495,7 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 		"go", []string{"build", "-o", agentTmp, "./cmd/kc-agent"}, repoPath, []string{"GOWORK=off"})
 	if res.err != nil {
 		os.Remove(agentTmp) // clean up partial build
-		slog.Error(fmt.Sprintf("[AutoUpdate] FAILED at step 5 (kc-agent build) after %s: %v", time.Since(start), res.err))
+		slog.Error("[AutoUpdate] FAILED at step 5 (kc-agent build)", "elapsed", time.Since(start), "error", res.err)
 		uc.recordError(fmt.Sprintf("go build kc-agent failed: %v", res.err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:  "failed",
@@ -504,21 +504,21 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 		})
 		rollbackGit(repoPath, previousSHA)
 		if rbErr := rebuildFrontend(repoPath); rbErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] WARNING: rollback rebuildFrontend failed: %v", rbErr))
+			slog.Error("[AutoUpdate] rollback rebuildFrontend failed", "error", rbErr)
 		}
 		if rbErr := rebuildGoBinaries(repoPath); rbErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] WARNING: rollback rebuildGoBinaries failed: %v", rbErr))
+			slog.Error("[AutoUpdate] rollback rebuildGoBinaries failed", "error", rbErr)
 		}
 		return
 	}
 	if err := os.Rename(agentTmp, agentPath); err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] Failed to move kc-agent binary: %v", err))
+		slog.Error("[AutoUpdate] failed to move kc-agent binary", "error", err)
 		os.Remove(agentTmp)
 	}
-	slog.Info(fmt.Sprintf("[AutoUpdate] Step 5/%d complete (kc-agent binary) in %s", total, time.Since(stepStart)))
+	slog.Info("[AutoUpdate] step complete", "step", 5, "total", total, "description", "kc-agent binary", "elapsed", time.Since(stepStart))
 
 	// Step 6/7: Stopping services
-	slog.Info(fmt.Sprintf("[AutoUpdate] Step 6/%d: preparing restart", total))
+	slog.Info("[AutoUpdate] step progress", "step", 6, "total", total, "description", "preparing restart")
 	uc.broadcast("update_progress", UpdateProgressPayload{
 		Status:     "restarting",
 		Message:    "Stopping current services...",
@@ -533,10 +533,10 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 	uc.lastUpdateError = ""
 	uc.mu.Unlock()
 
-	slog.Info(fmt.Sprintf("[AutoUpdate] === Build complete: %s -> %s (total: %s), restarting... ===", short(previousSHA), short(newSHA), time.Since(start)))
+	slog.Info("[AutoUpdate] build complete, restarting", "from", short(previousSHA), "to", short(newSHA), "elapsed", time.Since(start))
 
 	// Step 7/7: Restart via startup-oauth.sh
-	slog.Info(fmt.Sprintf("[AutoUpdate] Step 7/%d: restart via startup-oauth.sh", total))
+	slog.Info("[AutoUpdate] step progress", "step", 7, "total", total, "description", "restart via startup-oauth.sh")
 	uc.broadcast("update_progress", UpdateProgressPayload{
 		Status:     "restarting",
 		Message:    "Restarting via startup-oauth.sh...",
@@ -558,7 +558,7 @@ func (uc *UpdateChecker) executeDeveloperUpdate(newSHA string) {
 func (uc *UpdateChecker) restartViaStartupScript(repoPath string) {
 	scriptPath := repoPath + "/startup-oauth.sh"
 	if _, err := os.Stat(scriptPath); err != nil {
-		slog.Info(fmt.Sprintf("[AutoUpdate] startup-oauth.sh not found at %s, falling back to exec", scriptPath))
+		slog.Info("[AutoUpdate] startup-oauth.sh not found, falling back to exec", "path", scriptPath)
 		uc.selfUpdateFallback(repoPath)
 		return
 	}
@@ -569,7 +569,7 @@ func (uc *UpdateChecker) restartViaStartupScript(repoPath string) {
 	logPath := repoPath + "/data/auto-update-restart.log"
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
-		slog.Info(fmt.Sprintf("[AutoUpdate] Cannot create restart log at %s: %v", logPath, err))
+		slog.Info("[AutoUpdate] cannot create restart log", "path", logPath, "error", err)
 		logFile = nil
 	}
 
@@ -583,7 +583,7 @@ func (uc *UpdateChecker) restartViaStartupScript(repoPath string) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err := cmd.Start(); err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] Failed to spawn startup-oauth.sh: %v", err))
+		slog.Error("[AutoUpdate] failed to spawn startup-oauth.sh", "error", err)
 		if logFile != nil {
 			logFile.Close()
 		}
@@ -591,7 +591,7 @@ func (uc *UpdateChecker) restartViaStartupScript(repoPath string) {
 		return
 	}
 
-	slog.Info(fmt.Sprintf("[AutoUpdate] startup-oauth.sh spawned (pid %d), log: %s, exiting for restart...", cmd.Process.Pid, logPath))
+	slog.Info("[AutoUpdate] startup-oauth.sh spawned, exiting for restart", "pid", cmd.Process.Pid, "log", logPath)
 
 	// Give the script a moment to start before we exit
 	time.Sleep(1 * time.Second)
@@ -613,7 +613,7 @@ func (uc *UpdateChecker) restartViaStartupScript(repoPath string) {
 func (uc *UpdateChecker) selfUpdateFallback(repoPath string) {
 	currentBinary, err := os.Executable()
 	if err != nil {
-		slog.Info(fmt.Sprintf("[AutoUpdate] Cannot determine kc-agent binary path: %v", err))
+		slog.Info("[AutoUpdate] cannot determine kc-agent binary path", "error", err)
 		return
 	}
 
@@ -622,12 +622,12 @@ func (uc *UpdateChecker) selfUpdateFallback(repoPath string) {
 	// Kill and restart backend using the pre-built binary
 	uc.killBackend()
 	if err := uc.restartBackend(); err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] Backend restart failed: %v", err))
+		slog.Error("[AutoUpdate] backend restart failed", "error", err)
 	}
 
 	// Re-exec with the same args — replaces this process atomically
 	if err := syscall.Exec(currentBinary, os.Args, os.Environ()); err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] exec into new kc-agent failed: %v", err))
+		slog.Error("[AutoUpdate] exec into new kc-agent failed", "error", err)
 	}
 	// If exec succeeds, this line is never reached
 }
@@ -645,7 +645,7 @@ func (uc *UpdateChecker) checkReleaseChannel(channel string) {
 
 	releases, err := fetchGitHubReleases()
 	if err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] Failed to fetch releases: %v", err))
+		slog.Error("[AutoUpdate] failed to fetch releases", "error", err)
 		return
 	}
 
@@ -658,7 +658,7 @@ func (uc *UpdateChecker) checkReleaseChannel(channel string) {
 	}
 
 	if latest == nil || latest.TagName == currentVersion {
-		slog.Info(fmt.Sprintf("[AutoUpdate] Already on latest %s release (%s)", channel, currentVersion))
+		slog.Info("[AutoUpdate] already on latest release", "channel", channel, "version", currentVersion)
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:   "done",
 			Message:  fmt.Sprintf("Already up to date — running latest %s release", channel),
@@ -667,7 +667,7 @@ func (uc *UpdateChecker) checkReleaseChannel(channel string) {
 		return
 	}
 
-	slog.Info(fmt.Sprintf("[AutoUpdate] New release available: %s -> %s", currentVersion, latest.TagName))
+	slog.Info("[AutoUpdate] new release available", "current", currentVersion, "latest", latest.TagName)
 
 	switch installMethod {
 	case "binary":
@@ -761,7 +761,7 @@ func (uc *UpdateChecker) executeBinaryUpdate(release *githubReleaseInfo) {
 	if err := os.Rename(stagingDir+"/console", consolePath); err != nil {
 		// Attempt to restore the backup before returning
 		if rbErr := os.Rename(consolePath+".backup", consolePath); rbErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] WARNING: backup restore failed after rename error: %v", rbErr))
+			slog.Error("[AutoUpdate] backup restore failed after rename error", "error", rbErr)
 		}
 		uc.recordError(fmt.Sprintf("replace rename failed: %v", err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
@@ -777,7 +777,7 @@ func (uc *UpdateChecker) executeBinaryUpdate(release *githubReleaseInfo) {
 	if err := os.Chmod(consolePath, fileModeBinary); err != nil {
 		// Attempt to restore the backup before returning
 		if rbErr := os.Rename(consolePath+".backup", consolePath); rbErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] WARNING: backup restore failed after chmod error: %v", rbErr))
+			slog.Error("[AutoUpdate] backup restore failed after chmod error", "error", rbErr)
 		}
 		uc.recordError(fmt.Sprintf("chmod failed: %v", err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
@@ -798,7 +798,7 @@ func (uc *UpdateChecker) executeBinaryUpdate(release *githubReleaseInfo) {
 	if err := uc.restartBackend(); err != nil {
 		// Rollback
 		if rbErr := os.Rename(consolePath+".backup", consolePath); rbErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] WARNING: backup restore failed after restart error: %v", rbErr))
+			slog.Error("[AutoUpdate] backup restore failed after restart error", "error", rbErr)
 		}
 		uc.recordError(fmt.Sprintf("restart failed: %v", err))
 		uc.broadcast("update_progress", UpdateProgressPayload{
@@ -811,11 +811,11 @@ func (uc *UpdateChecker) executeBinaryUpdate(release *githubReleaseInfo) {
 
 	if !waitForBackendHealth() {
 		if rbErr := os.Rename(consolePath+".backup", consolePath); rbErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] WARNING: backup restore failed after health check failure: %v", rbErr))
+			slog.Error("[AutoUpdate] backup restore failed after health check failure", "error", rbErr)
 		}
 		uc.killBackend()
 		if rbErr := uc.restartBackend(); rbErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] WARNING: rollback restartBackend failed: %v", rbErr))
+			slog.Error("[AutoUpdate] rollback restartBackend failed", "error", rbErr)
 		}
 		uc.recordError("new version failed health check")
 		uc.broadcast("update_progress", UpdateProgressPayload{
@@ -836,7 +836,7 @@ func (uc *UpdateChecker) executeBinaryUpdate(release *githubReleaseInfo) {
 	uc.lastUpdateError = ""
 	uc.mu.Unlock()
 
-	slog.Info(fmt.Sprintf("[AutoUpdate] Binary updated to %s", release.TagName))
+	slog.Info("[AutoUpdate] binary updated", "version", release.TagName)
 	uc.broadcast("update_progress", UpdateProgressPayload{
 		Status:   "done",
 		Message:  fmt.Sprintf("Updated to %s", release.TagName),
@@ -917,7 +917,7 @@ func (uc *UpdateChecker) executeDevReleaseUpdate(release *githubReleaseInfo) {
 	uc.lastUpdateError = ""
 	uc.mu.Unlock()
 
-	slog.Info(fmt.Sprintf("[AutoUpdate] Build complete for %s, restarting via startup-oauth.sh...", release.TagName))
+	slog.Info("[AutoUpdate] build complete, restarting via startup-oauth.sh", "version", release.TagName)
 	uc.restartViaStartupScript(repoPath)
 }
 
@@ -926,7 +926,7 @@ func (uc *UpdateChecker) recordError(msg string) {
 	uc.lastUpdateError = msg
 	uc.lastUpdateTime = time.Now()
 	uc.mu.Unlock()
-	slog.Error(fmt.Sprintf("[AutoUpdate] Error: %s", msg))
+	slog.Error("[AutoUpdate] error", "message", msg)
 }
 
 // --- npm install with resilience ---
@@ -954,7 +954,7 @@ func (uc *UpdateChecker) resilientNpmInstall(webDir string, step, totalSteps int
 		}
 
 		// Broadcast retry status
-		slog.Error(fmt.Sprintf("[AutoUpdate] npm install failed (attempt %d/%d), cleaning cache...", attempt, npmInstallMaxRetries))
+		slog.Error("[AutoUpdate] npm install failed, cleaning cache", "attempt", attempt, "maxRetries", npmInstallMaxRetries)
 		uc.broadcast("update_progress", UpdateProgressPayload{
 			Status:     "building",
 			Message:    fmt.Sprintf("npm install failed — cleaning cache (attempt %d/%d)...", attempt, npmInstallMaxRetries),
@@ -968,7 +968,7 @@ func (uc *UpdateChecker) resilientNpmInstall(webDir string, step, totalSteps int
 		cacheClean.Stdout = os.Stdout
 		cacheClean.Stderr = os.Stderr
 		if cleanErr := cacheClean.Run(); cleanErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] npm cache clean also failed: %v (user may need: sudo chown -R $(id -u):$(id -g) ~/.npm)", cleanErr))
+			slog.Error("[AutoUpdate] npm cache clean also failed (user may need: sudo chown -R $(id -u):$(id -g) ~/.npm)", "error", cleanErr)
 		}
 
 		// On 2nd+ attempt, remove node_modules for a completely clean install
@@ -1051,7 +1051,7 @@ func fetchLatestMainSHAWithRepo(repoPath string) (string, error) {
 		if err == nil {
 			return sha, nil
 		}
-		slog.Error(fmt.Sprintf("[AutoUpdate] git fetch failed (%v), falling back to GitHub API", err))
+		slog.Error("[AutoUpdate] git fetch failed, falling back to GitHub API", "error", err)
 	}
 
 	// Fallback: GitHub API (unauthenticated, 60 req/hour rate limit)
@@ -1171,7 +1171,7 @@ func gitStash(repoPath string) bool {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] git stash failed: %v", err))
+		slog.Error("[AutoUpdate] git stash failed", "error", err)
 		return false
 	}
 	return true
@@ -1185,7 +1185,7 @@ func gitStashPop(repoPath string) {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] git stash pop failed (changes saved in stash): %v", err))
+		slog.Error("[AutoUpdate] git stash pop failed (changes saved in stash)", "error", err)
 	}
 }
 
@@ -1205,12 +1205,12 @@ func rebuildFrontend(repoPath string) error {
 		if npmErr = npmInstall.Run(); npmErr == nil {
 			break
 		}
-		slog.Error(fmt.Sprintf("[AutoUpdate] rebuildFrontend: npm install failed (attempt %d/%d), cleaning cache...", attempt, npmInstallMaxRetries))
+		slog.Error("[AutoUpdate] rebuildFrontend: npm install failed, cleaning cache", "attempt", attempt, "maxRetries", npmInstallMaxRetries)
 		cacheClean := exec.Command("npm", "cache", "clean", "--force")
 		cacheClean.Stdout = os.Stdout
 		cacheClean.Stderr = os.Stderr
 		if cleanErr := cacheClean.Run(); cleanErr != nil {
-			slog.Error(fmt.Sprintf("[AutoUpdate] WARNING: npm cache clean failed: %v", cleanErr))
+			slog.Error("[AutoUpdate] npm cache clean failed", "error", cleanErr)
 		}
 		if attempt >= 2 {
 			os.RemoveAll(webDir + "/node_modules")
@@ -1270,7 +1270,7 @@ func rollbackGit(repoPath, sha string) {
 	cmd := exec.Command("git", "reset", "--hard", sha)
 	cmd.Dir = repoPath
 	if err := cmd.Run(); err != nil {
-		slog.Error(fmt.Sprintf("[AutoUpdate] Rollback to %s failed: %v", short(sha), err))
+		slog.Error("[AutoUpdate] rollback failed", "sha", short(sha), "error", err)
 	}
 }
 

--- a/pkg/api/gpu_utilization_worker.go
+++ b/pkg/api/gpu_utilization_worker.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"strconv"
@@ -72,7 +71,7 @@ func (w *GPUUtilizationWorker) Start() {
 			}
 		}
 	}()
-	slog.Info(fmt.Sprintf("GPU utilization worker started (interval: %v)", w.interval))
+	slog.Info("GPU utilization worker started", "interval", w.interval)
 }
 
 // Stop signals the worker to stop. It is safe to call multiple times;
@@ -91,7 +90,7 @@ func (w *GPUUtilizationWorker) collectUtilization() {
 
 	reservations, err := w.store.ListActiveGPUReservations()
 	if err != nil {
-		slog.Error(fmt.Sprintf("GPU utilization worker: failed to list active reservations: %v", err))
+		slog.Error("GPU utilization worker: failed to list active reservations", "error", err)
 		return
 	}
 
@@ -115,14 +114,14 @@ func (w *GPUUtilizationWorker) collectForReservation(ctx context.Context, reserv
 	// Get pods in this namespace/cluster
 	pods, err := w.k8sClient.GetPods(ctx, cluster, namespace)
 	if err != nil {
-		slog.Error(fmt.Sprintf("GPU utilization worker: failed to get pods for %s/%s: %v", cluster, namespace, err))
+		slog.Error("GPU utilization worker: failed to get pods", "cluster", cluster, "namespace", namespace, "error", err)
 		return
 	}
 
 	// Get GPU nodes for this cluster to know which nodes have GPUs
 	gpuNodes, err := w.k8sClient.GetGPUNodes(ctx, cluster)
 	if err != nil {
-		slog.Error(fmt.Sprintf("GPU utilization worker: failed to get GPU nodes for %s: %v", cluster, err))
+		slog.Error("GPU utilization worker: failed to get GPU nodes", "cluster", cluster, "error", err)
 		return
 	}
 
@@ -174,7 +173,7 @@ func (w *GPUUtilizationWorker) collectForReservation(ctx context.Context, reserv
 	}
 
 	if err := w.store.InsertUtilizationSnapshot(snapshot); err != nil {
-		slog.Error(fmt.Sprintf("GPU utilization worker: failed to insert snapshot for reservation %s: %v", reservation.ID, err))
+		slog.Error("GPU utilization worker: failed to insert snapshot", "reservation", reservation.ID, "error", err)
 	}
 }
 
@@ -183,10 +182,10 @@ func (w *GPUUtilizationWorker) cleanupOldSnapshots() {
 	cutoff := time.Now().AddDate(0, 0, -snapshotRetentionDays)
 	deleted, err := w.store.DeleteOldUtilizationSnapshots(cutoff)
 	if err != nil {
-		slog.Error(fmt.Sprintf("GPU utilization worker: failed to cleanup old snapshots: %v", err))
+		slog.Error("GPU utilization worker: failed to cleanup old snapshots", "error", err)
 		return
 	}
 	if deleted > 0 {
-		slog.Info(fmt.Sprintf("GPU utilization worker: cleaned up %d old snapshots", deleted))
+		slog.Info("GPU utilization worker: cleaned up old snapshots", "deleted", deleted)
 	}
 }

--- a/pkg/api/handlers/analytics_proxy.go
+++ b/pkg/api/handlers/analytics_proxy.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"bytes"
 	"encoding/base64"
-	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -72,7 +71,7 @@ func GA4ScriptProxy(c *fiber.Ctx) error {
 	target := "https://www.googletagmanager.com/gtag/js?" + qs
 	resp, err := analyticsClient.Get(target)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[GA4] Failed to fetch gtag.js: %v", err))
+		slog.Error("[GA4] failed to fetch gtag.js", "error", err)
 		return c.SendStatus(fiber.StatusBadGateway)
 	}
 	defer resp.Body.Close()
@@ -276,7 +275,7 @@ func UmamiScriptProxy(c *fiber.Ctx) error {
 	target := umamiUpstreamBase + "/ksc"
 	resp, err := analyticsClient.Get(target)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[Umami] Failed to fetch tracking script: %v", err))
+		slog.Error("[Umami] failed to fetch tracking script", "error", err)
 		return c.SendStatus(fiber.StatusBadGateway)
 	}
 	defer resp.Body.Close()

--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -175,7 +175,7 @@ func NewAuthHandler(s store.Store, cfg AuthConfig) *AuthHandler {
 	}
 
 	if ghURL != "https://github.com" {
-		slog.Info(fmt.Sprintf("GitHub Enterprise: OAuth via %s, API via %s", ghURL, apiBase))
+		slog.Info("[Auth] GitHub Enterprise configured", "oauthURL", ghURL, "apiBase", apiBase)
 	}
 
 	return &AuthHandler{
@@ -366,7 +366,7 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 	// or the OAuth app is misconfigured (e.g., suspended, wrong callback URL).
 	if ghError := c.Query("error"); ghError != "" {
 		ghDescription := c.Query("error_description", ghError)
-		slog.Error(fmt.Sprintf("[Auth] GitHub returned error: %s — %s", ghError, ghDescription))
+		slog.Error("[Auth] GitHub returned error", "error", ghError, "description", ghDescription)
 		if ghError == "access_denied" {
 			return h.oauthErrorRedirect(c, "access_denied", ghDescription)
 		}
@@ -392,14 +392,14 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 	token, err := h.oauthConfig.Exchange(ctx, code)
 	if err != nil {
 		errCode, detail := classifyExchangeError(err)
-		slog.Error(fmt.Sprintf("[Auth] Token exchange failed (%s): %v", errCode, err))
+		slog.Error("[Auth] token exchange failed", "code", errCode, "error", err)
 		return h.oauthErrorRedirect(c, errCode, detail)
 	}
 
 	// Get user info from GitHub
 	ghUser, err := h.getGitHubUser(token.AccessToken)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[Auth] Failed to get GitHub user: %v", err))
+		slog.Error("[Auth] failed to get GitHub user", "error", err)
 		detail := err.Error()
 		return h.oauthErrorRedirect(c, "user_fetch_failed", detail)
 	}
@@ -407,7 +407,7 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 	// Find or create user
 	user, err := h.store.GetUserByGitHubID(fmt.Sprintf("%d", ghUser.ID))
 	if err != nil {
-		slog.Error(fmt.Sprintf("[Auth] Database error getting user: %v", err))
+		slog.Error("[Auth] database error getting user", "error", err)
 		return h.oauthErrorRedirect(c, "db_error", "")
 	}
 
@@ -421,7 +421,7 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 			Onboarded:   h.skipOnboarding, // Skip questionnaire if SKIP_ONBOARDING=true
 		}
 		if err := h.store.CreateUser(user); err != nil {
-			slog.Error(fmt.Sprintf("[Auth] Failed to create user: %v", err))
+			slog.Error("[Auth] failed to create user", "error", err)
 			return h.oauthErrorRedirect(c, "create_user_failed", "")
 		}
 	} else {
@@ -438,7 +438,7 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 	// Generate JWT
 	jwtToken, err := h.generateJWT(user)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[Auth] JWT generation failed: %v", err))
+		slog.Error("[Auth] JWT generation failed", "error", err)
 		return h.oauthErrorRedirect(c, "jwt_failed", "")
 	}
 
@@ -488,7 +488,7 @@ func (h *AuthHandler) Logout(c *fiber.Ctx) error {
 	// Clear the HttpOnly cookie so the browser stops sending it
 	h.clearJWTCookie(c)
 
-	slog.Info(fmt.Sprintf("[Auth] Token revoked for user %s (jti: %s)", claims.GitHubLogin, claims.ID))
+	slog.Info("[Auth] token revoked", "user", claims.GitHubLogin, "jti", claims.ID)
 	return c.JSON(fiber.Map{"success": true, "message": "Token revoked"})
 }
 

--- a/pkg/api/handlers/benchmarks.go
+++ b/pkg/api/handlers/benchmarks.go
@@ -429,7 +429,7 @@ func (h *BenchmarkHandlers) driveGetWithRetry(url string) (*http.Response, error
 	for attempt := 0; attempt <= driveMaxRetries; attempt++ {
 		if attempt > 0 {
 			backoff := driveRetryBaseDelay * time.Duration(1<<(attempt-1))
-			slog.Info(fmt.Sprintf("[benchmarks] Retrying after %v (attempt %d/%d)", backoff, attempt, driveMaxRetries))
+			slog.Info("[benchmarks] retrying", "backoff", backoff, "attempt", attempt, "maxRetries", driveMaxRetries)
 			time.Sleep(backoff)
 		}
 		resp, err := h.driveGet(url)
@@ -480,7 +480,7 @@ func (h *BenchmarkHandlers) GetReports(c *fiber.Ctx) error {
 	// Fetch from Google Drive
 	reports, parseFailures, err := h.fetchAllReports(cutoff)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[benchmarks] Google Drive fetch error: %v", err))
+		slog.Error("[benchmarks] Google Drive fetch error", "error", err)
 		h.cache.mu.RLock()
 		stale := h.cache.reports
 		h.cache.mu.RUnlock()
@@ -491,7 +491,7 @@ func (h *BenchmarkHandlers) GetReports(c *fiber.Ctx) error {
 	}
 
 	h.cache.set(reports, since)
-	slog.Info(fmt.Sprintf("[benchmarks] Fetched %d reports from Google Drive (since=%s, parseFailures=%d)", len(reports), since, parseFailures))
+	slog.Info("[benchmarks] fetched reports from Google Drive", "count", len(reports), "since", since, "parseFailures", parseFailures)
 	resp := fiber.Map{"reports": reports, "source": "live"}
 	if parseFailures > 0 {
 		resp["parse_failures"] = parseFailures
@@ -557,12 +557,12 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 			}
 			batch, err := json.Marshal(pendingBatch)
 			if err != nil {
-				slog.Error(fmt.Sprintf("[benchmarks] Failed to marshal batch: %v", err))
+				slog.Error("[benchmarks] failed to marshal batch", "error", err)
 				return
 			}
 			fmt.Fprintf(w, "event: batch\ndata: %s\n\n", batch)
 			w.Flush()
-			slog.Info(fmt.Sprintf("[benchmarks] Flushed batch of %d (total: %d)", len(pendingBatch), totalSent))
+			slog.Info("[benchmarks] flushed batch", "batchSize", len(pendingBatch), "totalSent", totalSent)
 			pendingBatch = pendingBatch[:0]
 		}
 
@@ -589,7 +589,7 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 
 		topLevel, err := h.listDriveFolder(h.folderID)
 		if err != nil {
-			slog.Info(fmt.Sprintf("error listing drive folder: %v", err))
+			slog.Info("[benchmarks] error listing drive folder", "error", err)
 			fmt.Fprintf(w, "event: error\ndata: {\"error\":\"failed to fetch benchmark data\"}\n\n")
 			w.Flush()
 			return
@@ -609,7 +609,7 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 		}
 
 		if skippedFolders > 0 {
-			slog.Info(fmt.Sprintf("[benchmarks] Skipped %d experiment folders older than %s", skippedFolders, since))
+			slog.Info("[benchmarks] skipped old experiment folders", "skipped", skippedFolders, "since", since)
 		}
 		fmt.Fprintf(w, "event: progress\ndata: {\"status\":\"fetching\",\"experiments\":%d,\"total\":0,\"skipped\":%d}\n\n", len(experiments), skippedFolders)
 		w.Flush()
@@ -617,7 +617,7 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 		for _, item := range experiments {
 			runFolders, err := h.listDriveFolder(item.ID)
 			if err != nil {
-				slog.Error(fmt.Sprintf("[benchmarks] Error listing experiment %q: %v", item.Name, err))
+				slog.Error("[benchmarks] error listing experiment", "experiment", item.Name, "error", err)
 				continue
 			}
 			for _, runItem := range runFolders {
@@ -639,7 +639,7 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 				})
 				totalParseFailures += failures
 				if err != nil {
-					slog.Error(fmt.Sprintf("[benchmarks] Error in %q/%q: %v", item.Name, runItem.Name, err))
+					slog.Error("[benchmarks] error in experiment run", "experiment", item.Name, "run", runItem.Name, "error", err)
 					continue
 				}
 				// Flush any remaining reports after each run folder for timely delivery
@@ -647,7 +647,7 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 					flushBatch()
 				}
 				if len(reports) > 0 {
-					slog.Info(fmt.Sprintf("[benchmarks] Streamed %d from %q/%q (total: %d)", len(reports), item.Name, runItem.Name, totalSent))
+					slog.Info("[benchmarks] streamed reports", "count", len(reports), "experiment", item.Name, "run", runItem.Name, "totalSent", totalSent)
 				}
 			}
 		}
@@ -656,7 +656,7 @@ func (h *BenchmarkHandlers) StreamReports(c *fiber.Ctx) error {
 		flushBatch()
 
 		h.cache.set(allReports, since)
-		slog.Info(fmt.Sprintf("[benchmarks] Stream complete: %d total reports, %d folders skipped, %d parse failures (since=%s)", totalSent, skippedFolders, totalParseFailures, since))
+		slog.Info("[benchmarks] stream complete", "totalSent", totalSent, "skipped", skippedFolders, "parseFailures", totalParseFailures, "since", since)
 		fmt.Fprintf(w, "event: done\ndata: {\"total\":%d,\"source\":\"live\",\"parse_failures\":%d}\n\n", totalSent, totalParseFailures)
 		w.Flush()
 	})
@@ -697,7 +697,7 @@ func (h *BenchmarkHandlers) fetchAllReports(cutoff time.Time) ([]BenchmarkReport
 		}
 		runFolders, err := h.listDriveFolder(item.ID)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[benchmarks] Error listing experiment %q: %v", item.Name, err))
+			slog.Error("[benchmarks] error listing experiment", "experiment", item.Name, "error", err)
 			continue
 		}
 		for _, runItem := range runFolders {
@@ -709,7 +709,7 @@ func (h *BenchmarkHandlers) fetchAllReports(cutoff time.Time) ([]BenchmarkReport
 			}
 			reports, failures, err := h.fetchRunFolder(runItem.ID, item.Name, runItem.Name)
 			if err != nil {
-				slog.Error(fmt.Sprintf("[benchmarks] Error in %q/%q: %v", item.Name, runItem.Name, err))
+				slog.Error("[benchmarks] error in experiment run", "experiment", item.Name, "run", runItem.Name, "error", err)
 				continue
 			}
 			allReports = append(allReports, reports...)
@@ -757,7 +757,7 @@ func (h *BenchmarkHandlers) fetchRunFolder(folderID, experimentName, runName str
 		}
 		resultFolders, err := h.listDriveFolder(sub.ID)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[benchmarks] Error listing results in %q/%q: %v", experimentName, runName, err))
+			slog.Error("[benchmarks] error listing results", "experiment", experimentName, "run", runName, "error", err)
 			continue
 		}
 		for _, rf := range resultFolders {
@@ -804,12 +804,12 @@ func (h *BenchmarkHandlers) collectBenchmarkFiles(folderID, experimentName, runN
 func (h *BenchmarkHandlers) downloadAndParseReport(f driveFile, experimentName, runName string) (BenchmarkReport, error) {
 	data, err := h.downloadDriveFile(f.ID)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[benchmarks] Error downloading %q: %v", f.Name, err))
+		slog.Error("[benchmarks] error downloading file", "file", f.Name, "error", err)
 		return BenchmarkReport{}, err
 	}
 	var raw rawV1Report
 	if err := yaml.Unmarshal(data, &raw); err != nil {
-		slog.Error(fmt.Sprintf("[benchmarks] Error parsing %q: %v", f.Name, err))
+		slog.Error("[benchmarks] error parsing file", "file", f.Name, "error", err)
 		return BenchmarkReport{}, err
 	}
 	return adaptV1ToV2(raw, experimentName, runName, f.CreatedTime), nil
@@ -933,9 +933,11 @@ func adaptV1ToV2(raw rawV1Report, experimentName, runName, fileCreatedTime strin
 	if inputRate > 0 {
 		agg.Throughput.InputTokenRate = scalarToStats(inputRate, "tokens/s")
 	} else if inputRate < 0 {
-		slog.Warn(fmt.Sprintf("[benchmarks] WARNING: negative derived input_token_rate (%.2f) for %s/%s stage %d — total=%.2f output=%.2f; skipping field",
-			inputRate, experimentName, runName, raw.Scenario.Load.Metadata.Stage,
-			raw.Metrics.Throughput.TotalTokensPerSec, raw.Metrics.Throughput.OutputTokensPerSec))
+		slog.Warn("[benchmarks] negative derived input_token_rate, skipping field",
+			"inputRate", inputRate, "experiment", experimentName, "run", runName,
+			"stage", raw.Scenario.Load.Metadata.Stage,
+			"totalTokensPerSec", raw.Metrics.Throughput.TotalTokensPerSec,
+			"outputTokensPerSec", raw.Metrics.Throughput.OutputTokensPerSec)
 	}
 
 	// Results — requests

--- a/pkg/api/handlers/card_proxy.go
+++ b/pkg/api/handlers/card_proxy.go
@@ -80,7 +80,7 @@ var blockedCIDRs = func() []*net.IPNet {
 		_, ipnet, err := net.ParseCIDR(cidr)
 		if err != nil {
 			// Hardcoded CIDRs must always parse — a failure here is a programming error.
-			slog.Error(fmt.Sprintf("[CardProxy] FATAL: failed to parse blocked CIDR %q: %v", cidr, err))
+			slog.Error("[CardProxy] failed to parse blocked CIDR", "cidr", cidr, "error", err)
 			os.Exit(1)
 		}
 		nets = append(nets, ipnet)
@@ -163,7 +163,7 @@ func (h *CardProxyHandler) Proxy(c *fiber.Ctx) error {
 	// so the proxy request is cancelled if the client disconnects.
 	req, err := http.NewRequestWithContext(c.Context(), http.MethodGet, rawURL, nil)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[CardProxy] Failed to build request for %s: %v", host, err))
+		slog.Error("[CardProxy] failed to build request", "host", host, "error", err)
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
 			"error": "Failed to create proxy request",
 		})
@@ -174,7 +174,7 @@ func (h *CardProxyHandler) Proxy(c *fiber.Ctx) error {
 	// Execute request
 	resp, err := cardProxyClient.Do(req)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[CardProxy] Request failed for %s: %v", host, err))
+		slog.Error("[CardProxy] request failed", "host", host, "error", err)
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
 			"error": "External request failed",
 		})
@@ -184,7 +184,7 @@ func (h *CardProxyHandler) Proxy(c *fiber.Ctx) error {
 	// Detect redirects and return a helpful error instead of an opaque 3xx
 	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
 		location := resp.Header.Get("Location")
-		slog.Info(fmt.Sprintf("[CardProxy] Redirect from %s (status %d, location=%s)", host, resp.StatusCode, location))
+		slog.Info("[CardProxy] redirect detected", "host", host, "status", resp.StatusCode, "location", location)
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
 			"error": fmt.Sprintf("External API returned a redirect (%d). Update the URL to the final destination.", resp.StatusCode),
 		})
@@ -194,20 +194,20 @@ func (h *CardProxyHandler) Proxy(c *fiber.Ctx) error {
 	limitedReader := io.LimitReader(resp.Body, cardProxyMaxResponseBytes+1)
 	body, err := io.ReadAll(limitedReader)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[CardProxy] Failed to read response body from %s: %v", host, err))
+		slog.Error("[CardProxy] failed to read response body", "host", host, "error", err)
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
 			"error": "Failed to read external response",
 		})
 	}
 	if len(body) > cardProxyMaxResponseBytes {
-		slog.Info(fmt.Sprintf("[CardProxy] Response too large from %s: %d bytes", host, len(body)))
+		slog.Info("[CardProxy] response too large", "host", host, "bytes", len(body))
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
 			"error": "Response too large (max 5 MB)",
 		})
 	}
 
 	// Log successful proxy requests for audit trail
-	slog.Info(fmt.Sprintf("[CardProxy] %s -> %s (status=%d, size=%d bytes)", c.IP(), host, resp.StatusCode, len(body)))
+	slog.Info("[CardProxy] proxied request", "clientIP", c.IP(), "host", host, "status", resp.StatusCode, "bytes", len(body))
 
 	// Forward Content-Type
 	if ct := resp.Header.Get("Content-Type"); ct != "" {

--- a/pkg/api/handlers/console_persistence.go
+++ b/pkg/api/handlers/console_persistence.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -91,7 +90,7 @@ func (h *ConsolePersistenceHandlers) StartWatcher(ctx context.Context) error {
 
 	activeCluster, err := h.persistenceStore.GetActiveCluster(ctx)
 	if err != nil {
-		slog.Info(fmt.Sprintf("[ConsolePersistence] Cannot start watcher: %v", err))
+		slog.Info("[ConsolePersistence] cannot start watcher", "error", err)
 		return err
 	}
 
@@ -147,7 +146,7 @@ func (h *ConsolePersistenceHandlers) UpdateConfig(c *fiber.Ctx) error {
 	}
 
 	if err := h.persistenceStore.UpdateConfig(config); err != nil {
-		slog.Info(fmt.Sprintf("bad request: %v", err))
+		slog.Info("[ConsolePersistence] bad request", "error", err)
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 
@@ -159,7 +158,7 @@ func (h *ConsolePersistenceHandlers) UpdateConfig(c *fiber.Ctx) error {
 	h.StopWatcher()
 	if config.Enabled {
 		if err := h.StartWatcher(c.Context()); err != nil {
-			slog.Error(fmt.Sprintf("[ConsolePersistence] Failed to start watcher: %v", err))
+			slog.Error("[ConsolePersistence] failed to start watcher", "error", err)
 		}
 	}
 
@@ -182,7 +181,7 @@ func (h *ConsolePersistenceHandlers) GetStatus(c *fiber.Ctx) error {
 func (h *ConsolePersistenceHandlers) ListManagedWorkloads(c *fiber.Ctx) error {
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -191,7 +190,7 @@ func (h *ConsolePersistenceHandlers) ListManagedWorkloads(c *fiber.Ctx) error {
 
 	workloads, err := persistence.ListManagedWorkloads(c.Context(), namespace)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -205,7 +204,7 @@ func (h *ConsolePersistenceHandlers) GetManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -214,7 +213,7 @@ func (h *ConsolePersistenceHandlers) GetManagedWorkload(c *fiber.Ctx) error {
 
 	workload, err := persistence.GetManagedWorkload(c.Context(), namespace, name)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -231,7 +230,7 @@ func (h *ConsolePersistenceHandlers) CreateManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -250,7 +249,7 @@ func (h *ConsolePersistenceHandlers) CreateManagedWorkload(c *fiber.Ctx) error {
 
 	created, err := persistence.CreateManagedWorkload(c.Context(), &workload)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -269,7 +268,7 @@ func (h *ConsolePersistenceHandlers) UpdateManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -282,7 +281,7 @@ func (h *ConsolePersistenceHandlers) UpdateManagedWorkload(c *fiber.Ctx) error {
 
 	updated, err := persistence.UpdateManagedWorkload(c.Context(), &workload)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -296,7 +295,7 @@ func (h *ConsolePersistenceHandlers) DeleteManagedWorkload(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -304,7 +303,7 @@ func (h *ConsolePersistenceHandlers) DeleteManagedWorkload(c *fiber.Ctx) error {
 	persistence := k8s.NewConsolePersistence(client)
 
 	if err := persistence.DeleteManagedWorkload(c.Context(), namespace, name); err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -320,7 +319,7 @@ func (h *ConsolePersistenceHandlers) DeleteManagedWorkload(c *fiber.Ctx) error {
 func (h *ConsolePersistenceHandlers) ListClusterGroups(c *fiber.Ctx) error {
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -329,7 +328,7 @@ func (h *ConsolePersistenceHandlers) ListClusterGroups(c *fiber.Ctx) error {
 
 	groups, err := persistence.ListClusterGroups(c.Context(), namespace)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -343,7 +342,7 @@ func (h *ConsolePersistenceHandlers) GetClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -352,7 +351,7 @@ func (h *ConsolePersistenceHandlers) GetClusterGroup(c *fiber.Ctx) error {
 
 	group, err := persistence.GetClusterGroup(c.Context(), namespace, name)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -369,7 +368,7 @@ func (h *ConsolePersistenceHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -394,7 +393,7 @@ func (h *ConsolePersistenceHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 
 	created, err := persistence.CreateClusterGroup(c.Context(), &group)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -413,7 +412,7 @@ func (h *ConsolePersistenceHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -432,7 +431,7 @@ func (h *ConsolePersistenceHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 
 	updated, err := persistence.UpdateClusterGroup(c.Context(), &group)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -446,7 +445,7 @@ func (h *ConsolePersistenceHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -454,7 +453,7 @@ func (h *ConsolePersistenceHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 	persistence := k8s.NewConsolePersistence(client)
 
 	if err := persistence.DeleteClusterGroup(c.Context(), namespace, name); err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -567,7 +566,7 @@ func (h *ConsolePersistenceHandlers) clusterMatchesFilter(cluster k8s.ClusterInf
 		// in the original issue but are not yet present in the ClusterInfo or
 		// ClusterHealth data models. Until those fields are added, filters on
 		// them intentionally return false so they do not silently match all clusters.
-		slog.Info(fmt.Sprintf("clusterMatchesFilter: unsupported filter field %q, skipping cluster %q", filter.Field, cluster.Name))
+		slog.Info("[ConsolePersistence] unsupported filter field, skipping cluster", "field", filter.Field, "cluster", cluster.Name)
 		return false
 	}
 }
@@ -605,7 +604,7 @@ func clusterFilterNeedsNodes(filters []v1alpha1.ClusterFilter) bool {
 func (h *ConsolePersistenceHandlers) ListWorkloadDeployments(c *fiber.Ctx) error {
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -614,7 +613,7 @@ func (h *ConsolePersistenceHandlers) ListWorkloadDeployments(c *fiber.Ctx) error
 
 	deployments, err := persistence.ListWorkloadDeployments(c.Context(), namespace)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -628,7 +627,7 @@ func (h *ConsolePersistenceHandlers) GetWorkloadDeployment(c *fiber.Ctx) error {
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -637,7 +636,7 @@ func (h *ConsolePersistenceHandlers) GetWorkloadDeployment(c *fiber.Ctx) error {
 
 	deployment, err := persistence.GetWorkloadDeployment(c.Context(), namespace, name)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -654,7 +653,7 @@ func (h *ConsolePersistenceHandlers) CreateWorkloadDeployment(c *fiber.Ctx) erro
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -678,7 +677,7 @@ func (h *ConsolePersistenceHandlers) CreateWorkloadDeployment(c *fiber.Ctx) erro
 
 	created, err := persistence.CreateWorkloadDeployment(c.Context(), &deployment)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -700,7 +699,7 @@ func (h *ConsolePersistenceHandlers) UpdateWorkloadDeploymentStatus(c *fiber.Ctx
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -710,7 +709,7 @@ func (h *ConsolePersistenceHandlers) UpdateWorkloadDeploymentStatus(c *fiber.Ctx
 	// Get existing deployment
 	deployment, err := persistence.GetWorkloadDeployment(c.Context(), namespace, name)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -719,7 +718,7 @@ func (h *ConsolePersistenceHandlers) UpdateWorkloadDeploymentStatus(c *fiber.Ctx
 
 	updated, err := persistence.UpdateWorkloadDeploymentStatus(c.Context(), deployment)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -733,7 +732,7 @@ func (h *ConsolePersistenceHandlers) DeleteWorkloadDeployment(c *fiber.Ctx) erro
 
 	client, _, err := h.persistenceStore.GetActiveClient(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("service unavailable: %v", err))
+		slog.Info("[ConsolePersistence] service unavailable", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -741,7 +740,7 @@ func (h *ConsolePersistenceHandlers) DeleteWorkloadDeployment(c *fiber.Ctx) erro
 	persistence := k8s.NewConsolePersistence(client)
 
 	if err := persistence.DeleteWorkloadDeployment(c.Context(), namespace, name); err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[ConsolePersistence] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -751,7 +750,7 @@ func (h *ConsolePersistenceHandlers) DeleteWorkloadDeployment(c *fiber.Ctx) erro
 // reconcileDeployment handles the actual deployment of workloads to clusters
 // This is called when a WorkloadDeployment CR is created
 func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd *v1alpha1.WorkloadDeployment) {
-	slog.Info(fmt.Sprintf("[ConsolePersistence] Reconciling deployment %s/%s", wd.Namespace, wd.Name))
+	slog.Info("[ConsolePersistence] reconciling deployment", "namespace", wd.Namespace, "name", wd.Name)
 
 	// TODO: Implement deployment logic
 	// 1. Get the ManagedWorkload referenced by workloadRef
@@ -762,7 +761,7 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 	// For now, just update status to show it's being processed
 	client, _, err := h.persistenceStore.GetActiveClient(ctx)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[ConsolePersistence] Failed to get client for reconciliation: %v", err))
+		slog.Error("[ConsolePersistence] failed to get client for reconciliation", "error", err)
 		return
 	}
 
@@ -771,7 +770,7 @@ func (h *ConsolePersistenceHandlers) reconcileDeployment(ctx context.Context, wd
 	// Update status to InProgress
 	wd.Status.Phase = "InProgress"
 	if _, err := persistence.UpdateWorkloadDeploymentStatus(ctx, wd); err != nil {
-		slog.Error(fmt.Sprintf("[ConsolePersistence] Failed to update deployment status: %v", err))
+		slog.Error("[ConsolePersistence] failed to update deployment status", "error", err)
 	}
 }
 

--- a/pkg/api/handlers/custom_resources.go
+++ b/pkg/api/handlers/custom_resources.go
@@ -66,7 +66,7 @@ func (h *MCPHandlers) GetCustomResources(c *fiber.Ctx) error {
 	if cluster != "" {
 		items, err := h.listCR(c.Context(), cluster, namespace, gvr)
 		if err != nil {
-			slog.Info(fmt.Sprintf("custom-resources: cluster %s: %v", cluster, err))
+			slog.Info("custom-resources: cluster error", "cluster", cluster, "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": fmt.Sprintf("failed to list %s: %v", resource, err)})
 		}
 		return c.JSON(CustomResourceResponse{Items: items, IsDemoData: false})
@@ -75,7 +75,7 @@ func (h *MCPHandlers) GetCustomResources(c *fiber.Ctx) error {
 	// Fan-out across all healthy clusters
 	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		slog.Info(fmt.Sprintf("custom-resources: HealthyClusters: %v", err))
+		slog.Info("custom-resources: HealthyClusters failed", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 

--- a/pkg/api/handlers/exec.go
+++ b/pkg/api/handlers/exec.go
@@ -136,7 +136,7 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 
 	var authMsg execAuthMessage
 	if err := c.ReadJSON(&authMsg); err != nil {
-		slog.Error(fmt.Sprintf("SECURITY: exec: failed to read auth message: %v", err))
+		slog.Error("[Exec] SECURITY: failed to read auth message", "error", err)
 		writeError(c, "authentication required")
 		return
 	}
@@ -162,12 +162,12 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 
 	claims, err := middleware.ValidateJWT(authMsg.Token, h.jwtSecret)
 	if err != nil {
-		slog.Warn(fmt.Sprintf("SECURITY: exec: rejected invalid token: %v", err))
+		slog.Warn("[Exec] SECURITY: rejected invalid token", "error", err)
 		writeError(c, "invalid token")
 		return
 	}
 
-	slog.Info(fmt.Sprintf("exec: authenticated user %s for pod exec", claims.GitHubLogin))
+	slog.Info("[Exec] authenticated user for pod exec", "user", claims.GitHubLogin)
 
 	// Clear read deadline after successful auth
 	c.SetReadDeadline(time.Time{})
@@ -180,7 +180,7 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 	// Read the init message
 	_, msg, err := c.ReadMessage()
 	if err != nil {
-		slog.Error(fmt.Sprintf("exec: failed to read init message: %v", err))
+		slog.Error("[Exec] failed to read init message", "error", err)
 		return
 	}
 
@@ -329,7 +329,7 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 	exitCode := 0
 	if execErr != nil {
 		exitCode = 1
-		slog.Error(fmt.Sprintf("exec: stream ended with error: %v", execErr))
+		slog.Error("[Exec] stream ended with error", "error", execErr)
 	}
 
 	exitMsg, _ := json.Marshal(execMessage{Type: "exit", ExitCode: exitCode})

--- a/pkg/api/handlers/feedback.go
+++ b/pkg/api/handlers/feedback.go
@@ -159,7 +159,7 @@ func (h *FeedbackHandler) CreateFeatureRequest(c *fiber.Ctx) error {
 	// Create GitHub issue (route to the correct repo)
 	issueNumber, _, ssResult, err := h.createGitHubIssueInRepo(request, user, h.repoOwner, targetRepoName, input.Screenshots)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to create GitHub issue: %v", err))
+		slog.Error("[Feedback] failed to create GitHub issue", "error", err)
 		// Clean up the orphaned database record
 		h.store.CloseFeatureRequest(request.ID, false)
 		return fiber.NewError(fiber.StatusBadGateway, fmt.Sprintf("Failed to create GitHub issue: %v", err))
@@ -287,7 +287,7 @@ func (h *FeedbackHandler) ListAllFeatureRequests(c *fiber.Ctx) error {
 	// Fetch issues created by the logged-in user from GitHub
 	issues, err := h.fetchGitHubIssues(currentGitHubLogin)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to fetch GitHub issues: %v", err))
+		slog.Error("[Feedback] failed to fetch GitHub issues", "error", err)
 		// Fall back to local database if GitHub fetch fails
 		return h.listLocalFeatureRequests(c, userID)
 	}
@@ -907,7 +907,7 @@ func (h *FeedbackHandler) closeGitHubIssue(issueNumber int, repoName string) {
 	payload := map[string]string{"state": "closed"}
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to marshal close issue payload: %v", err))
+		slog.Error("[Feedback] failed to marshal close issue payload", "error", err)
 		return
 	}
 
@@ -916,7 +916,7 @@ func (h *FeedbackHandler) closeGitHubIssue(issueNumber int, repoName string) {
 
 	req, err := http.NewRequest("PATCH", url, bytes.NewBuffer(jsonData))
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to create close issue request: %v", err))
+		slog.Error("[Feedback] failed to create close issue request", "error", err)
 		return
 	}
 
@@ -927,7 +927,7 @@ func (h *FeedbackHandler) closeGitHubIssue(issueNumber int, repoName string) {
 	client := &http.Client{Timeout: githubAPITimeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to close GitHub issue: %v", err))
+		slog.Error("[Feedback] failed to close GitHub issue", "error", err)
 		return
 	}
 	defer resp.Body.Close()
@@ -937,7 +937,7 @@ func (h *FeedbackHandler) closeGitHubIssue(issueNumber int, repoName string) {
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}
-		slog.Info(fmt.Sprintf("GitHub API returned %d when closing issue: %s", resp.StatusCode, string(body)))
+		slog.Info("[Feedback] GitHub API error closing issue", "status", resp.StatusCode, "body", string(body))
 	}
 }
 
@@ -946,7 +946,7 @@ func (h *FeedbackHandler) addIssueComment(issueNumber int, comment string, repoN
 	payload := map[string]string{"body": comment}
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to marshal issue comment payload: %v", err))
+		slog.Error("[Feedback] failed to marshal issue comment payload", "error", err)
 		return
 	}
 
@@ -955,7 +955,7 @@ func (h *FeedbackHandler) addIssueComment(issueNumber int, comment string, repoN
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to create issue comment request: %v", err))
+		slog.Error("[Feedback] failed to create issue comment request", "error", err)
 		return
 	}
 
@@ -966,7 +966,7 @@ func (h *FeedbackHandler) addIssueComment(issueNumber int, comment string, repoN
 	client := &http.Client{Timeout: githubAPITimeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to add issue comment: %v", err))
+		slog.Error("[Feedback] failed to add issue comment", "error", err)
 		return
 	}
 	defer resp.Body.Close()
@@ -976,7 +976,7 @@ func (h *FeedbackHandler) addIssueComment(issueNumber int, comment string, repoN
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}
-		slog.Info(fmt.Sprintf("GitHub API returned %d when adding comment: %s", resp.StatusCode, string(body)))
+		slog.Info("[Feedback] GitHub API error adding comment", "status", resp.StatusCode, "body", string(body))
 	}
 }
 
@@ -1182,7 +1182,7 @@ func (h *FeedbackHandler) handleIssueEvent(payload map[string]interface{}) error
 	issueNumber := int(numF)
 	issueURL, _ := issue["html_url"].(string)
 
-	slog.Info(fmt.Sprintf("[Webhook] Issue #%d %s", issueNumber, action))
+	slog.Info("[Webhook] issue event", "issue", issueNumber, "action", action)
 
 	// Handle label events — track pipeline progression
 	if action == "labeled" {
@@ -1202,7 +1202,7 @@ func (h *FeedbackHandler) handleIssueEvent(payload map[string]interface{}) error
 		if info, ok := pipelineLabels[labelName]; ok {
 			request := h.findFeatureRequest(issueNumber)
 			if request == nil {
-				slog.Info(fmt.Sprintf("[Webhook] No DB record for issue #%d, skipping label update", issueNumber))
+				slog.Info("[Webhook] no DB record, skipping label update", "issue", issueNumber)
 				return nil
 			}
 
@@ -1222,7 +1222,7 @@ func (h *FeedbackHandler) handleIssueEvent(payload map[string]interface{}) error
 		if labelName == "ai-fix-requested" {
 			request := h.findFeatureRequest(issueNumber)
 			if request == nil {
-				slog.Info(fmt.Sprintf("[Webhook] No DB record for issue #%d, skipping ai-fix-requested", issueNumber))
+				slog.Info("[Webhook] no DB record, skipping ai-fix-requested", "issue", issueNumber)
 			}
 			return nil
 		}
@@ -1230,7 +1230,7 @@ func (h *FeedbackHandler) handleIssueEvent(payload map[string]interface{}) error
 
 	// Handle issue opened — only log, don't auto-create DB records
 	if action == "opened" {
-		slog.Info(fmt.Sprintf("[Webhook] Issue #%d opened, no DB record auto-created (GitHub is source of truth)", issueNumber))
+		slog.Info("[Webhook] issue opened, no DB record auto-created (GitHub is source of truth)", "issue", issueNumber)
 	}
 
 	// Handle issue closed
@@ -1246,7 +1246,7 @@ func (h *FeedbackHandler) handleAIProcessingComplete(issueNumber int, issueURL s
 	// Find feature request by issue number
 	request, err := h.store.GetFeatureRequestByIssueNumber(issueNumber)
 	if err != nil || request == nil {
-		slog.Info(fmt.Sprintf("[Webhook] Feature request not found for issue #%d", issueNumber))
+		slog.Info("[Webhook] feature request not found", "issue", issueNumber)
 		return nil
 	}
 
@@ -1400,7 +1400,7 @@ func (h *FeedbackHandler) handlePREvent(payload map[string]interface{}) error {
 		var err error
 		request, err = h.store.GetFeatureRequest(requestID)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[Webhook] Error getting feature request %s: %v", requestID, err))
+			slog.Error("[Webhook] error getting feature request", "requestID", requestID, "error", err)
 		}
 	}
 
@@ -1412,7 +1412,7 @@ func (h *FeedbackHandler) handlePREvent(payload map[string]interface{}) error {
 			request, err = h.store.GetFeatureRequestByIssueNumber(issueNum)
 			if err == nil && request != nil {
 				requestID = request.ID
-				slog.Info(fmt.Sprintf("[Webhook] PR #%d linked to feature request via issue #%d", prNumber, issueNum))
+				slog.Info("[Webhook] PR linked to feature request via issue", "pr", prNumber, "issue", issueNum)
 				break
 			}
 		}
@@ -1433,7 +1433,7 @@ func (h *FeedbackHandler) handlePREvent(payload map[string]interface{}) error {
 			// Not linked to any feature request and not AI-generated, ignore
 			return nil
 		}
-		slog.Info(fmt.Sprintf("[Webhook] PR #%d has ai-generated label but no linked feature request", prNumber))
+		slog.Info("[Webhook] PR has ai-generated label but no linked feature request", "pr", prNumber)
 		return nil
 	}
 
@@ -1465,7 +1465,7 @@ func (h *FeedbackHandler) handlePREvent(payload map[string]interface{}) error {
 		}
 	}
 
-	slog.Info(fmt.Sprintf("[Webhook] PR #%d %s for request %s", prNumber, action, requestID))
+	slog.Info("[Webhook] PR event processed", "pr", prNumber, "action", action, "requestID", requestID)
 	return nil
 }
 
@@ -1498,18 +1498,18 @@ func (h *FeedbackHandler) handleDeploymentStatus(payload map[string]interface{})
 		return nil
 	}
 
-	slog.Info(fmt.Sprintf("[Webhook] Deployment success for PR #%d: %s", prNumber, targetURL))
+	slog.Info("[Webhook] deployment success", "pr", prNumber, "targetURL", targetURL)
 
 	// Find feature request by PR number and update preview URL
 	request, err := h.store.GetFeatureRequestByPRNumber(prNumber)
 	if err != nil || request == nil {
-		slog.Info(fmt.Sprintf("[Webhook] No feature request found for PR #%d", prNumber))
+		slog.Info("[Webhook] no feature request found for PR", "pr", prNumber)
 		return nil
 	}
 
 	// Update preview URL
 	if err := h.store.UpdateFeatureRequestPreview(request.ID, targetURL); err != nil {
-		slog.Error(fmt.Sprintf("[Webhook] Failed to update preview URL: %v", err))
+		slog.Error("[Webhook] failed to update preview URL", "error", err)
 		return err
 	}
 
@@ -1519,7 +1519,7 @@ func (h *FeedbackHandler) handleDeploymentStatus(payload map[string]interface{})
 		fmt.Sprintf("A preview for '%s' is now available.", request.Title),
 		targetURL)
 
-	slog.Info(fmt.Sprintf("[Webhook] Updated preview URL for request %s: %s", request.ID, targetURL))
+	slog.Info("[Webhook] updated preview URL", "requestID", request.ID, "targetURL", targetURL)
 	return nil
 }
 
@@ -1577,7 +1577,7 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 		parts := strings.SplitN(dataURI, ",", 2)
 		if len(parts) != 2 {
 			ssResult.Failed++
-			slog.Info(fmt.Sprintf("[Feedback] Screenshot %d: invalid data URI format", i+1))
+			slog.Info("[Feedback] screenshot has invalid data URI format", "index", i+1)
 			continue
 		}
 		validScreenshots = append(validScreenshots, dataURI)
@@ -1605,7 +1605,7 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 		// The token lacks permission to create/apply labels on this repo.
 		// Retry without labels — the issue body includes the request type
 		// so maintainers can triage and label it manually.
-		slog.Info(fmt.Sprintf("[Feedback] Label permission denied on %s/%s, retrying without labels", repoOwner, repoName))
+		slog.Info("[Feedback] label permission denied, retrying without labels", "repo", repoOwner+"/"+repoName)
 		number, htmlURL, err = h.postGitHubIssue(repoOwner, repoName, request.Title, issueBody, nil)
 	}
 
@@ -1620,7 +1620,7 @@ func (h *FeedbackHandler) createGitHubIssueInRepo(request *models.FeatureRequest
 				i+1, i+1, dataURI)
 			h.addIssueComment(number, commentBody, repoName)
 		}
-		slog.Info(fmt.Sprintf("[Feedback] Added %d screenshot comment(s) to issue #%d", len(validScreenshots), number))
+		slog.Info("[Feedback] added screenshot comments to issue", "count", len(validScreenshots), "issue", number)
 	}
 
 	return number, htmlURL, ssResult, err
@@ -1799,7 +1799,7 @@ func (h *FeedbackHandler) addPRComment(request *models.FeatureRequest, feedback 
 	payload := map[string]string{"body": commentBody}
 	jsonData, err := json.Marshal(payload)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to marshal PR comment payload: %v", err))
+		slog.Error("[Feedback] failed to marshal PR comment payload", "error", err)
 		return
 	}
 
@@ -1808,7 +1808,7 @@ func (h *FeedbackHandler) addPRComment(request *models.FeatureRequest, feedback 
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to create PR comment request: %v", err))
+		slog.Error("[Feedback] failed to create PR comment request", "error", err)
 		return
 	}
 
@@ -1819,7 +1819,7 @@ func (h *FeedbackHandler) addPRComment(request *models.FeatureRequest, feedback 
 	client := &http.Client{Timeout: githubAPITimeout}
 	resp, err := client.Do(req)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to add PR comment: %v", err))
+		slog.Error("[Feedback] failed to add PR comment", "error", err)
 		return
 	}
 	defer resp.Body.Close()
@@ -1829,7 +1829,7 @@ func (h *FeedbackHandler) addPRComment(request *models.FeatureRequest, feedback 
 		if readErr != nil {
 			body = []byte("(failed to read response body)")
 		}
-		slog.Info(fmt.Sprintf("GitHub API returned %d when adding PR comment: %s", resp.StatusCode, string(body)))
+		slog.Info("[Feedback] GitHub API error adding PR comment", "status", resp.StatusCode, "body", string(body))
 	}
 }
 
@@ -1857,7 +1857,7 @@ func (h *FeedbackHandler) createNotification(userID uuid.UUID, requestID *uuid.U
 		ActionURL:        actionURL,
 	}
 	if err := h.store.CreateNotification(notification); err != nil {
-		slog.Error(fmt.Sprintf("Failed to create notification: %v", err))
+		slog.Error("[Feedback] failed to create notification", "error", err)
 	}
 }
 
@@ -1941,9 +1941,8 @@ func LoadFeedbackConfig() FeedbackConfig {
 	}
 	for envVar, defaultVal := range feedbackEnvVars {
 		if os.Getenv(envVar) == "" {
-			slog.Warn(fmt.Sprintf("WARNING: %s is not set, using default %q — "+
-				"set this env var for fork/enterprise deployments to avoid "+
-				"routing feedback to the upstream repository", envVar, defaultVal))
+			slog.Warn("[Feedback] env var not set, using default — set this for fork/enterprise deployments",
+				"envVar", envVar, "default", defaultVal)
 		}
 	}
 

--- a/pkg/api/handlers/gateway.go
+++ b/pkg/api/handlers/gateway.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -59,7 +58,7 @@ func (h *GatewayHandlers) ListGateways(c *fiber.Ctx) error {
 	if err != nil {
 		// If we got partial results alongside errors, log and return what we have
 		if list != nil && len(list.Items) > 0 {
-			slog.Info(fmt.Sprintf("partial gateway list failure: %v", err))
+			slog.Info("partial gateway list failure", "error", err)
 			return c.JSON(list)
 		}
 		return handleK8sError(c, err)
@@ -100,7 +99,7 @@ func (h *GatewayHandlers) ListHTTPRoutes(c *fiber.Ctx) error {
 	if err != nil {
 		// If we got partial results alongside errors, log and return what we have
 		if list != nil && len(list.Items) > 0 {
-			slog.Info(fmt.Sprintf("partial httproute list failure: %v", err))
+			slog.Info("partial httproute list failure", "error", err)
 			return c.JSON(list)
 		}
 		return handleK8sError(c, err)

--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -132,7 +131,7 @@ func (h *GitHubProxyHandler) Proxy(c *fiber.Ctx) error {
 	// Security: only allow specific GitHub API prefixes (see allowedGitHubPrefixes)
 	apiPath := "/" + path
 	if !isAllowedGitHubPath(apiPath) {
-		slog.Info(fmt.Sprintf("[GitHubProxy] Blocked disallowed path: %s", apiPath))
+		slog.Info("[GitHubProxy] blocked disallowed path", "path", apiPath)
 		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
 			"error": "GitHub API path not allowed",
 		})
@@ -168,7 +167,7 @@ func (h *GitHubProxyHandler) Proxy(c *fiber.Ctx) error {
 	// Execute request
 	resp, err := githubProxyClient.Do(req)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[GitHubProxy] Request failed for %s: %v", apiPath, err))
+		slog.Error("[GitHubProxy] request failed", "path", apiPath, "error", err)
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
 			"error": "GitHub API request failed",
 		})
@@ -238,7 +237,7 @@ func (h *GitHubProxyHandler) SaveToken(c *fiber.Ctx) error {
 	all.FeedbackGitHubToken = body.Token
 	all.FeedbackGitHubTokenSource = settings.GitHubTokenSourceSettings
 	if err := sm.SaveAll(all); err != nil {
-		slog.Error(fmt.Sprintf("[GitHubProxy] Failed to save token: %v", err))
+		slog.Error("[GitHubProxy] failed to save token", "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Failed to save token",
 		})

--- a/pkg/api/handlers/gitops.go
+++ b/pkg/api/handlers/gitops.go
@@ -186,7 +186,7 @@ func (h *GitOpsHandlers) ListHelmReleases(c *fiber.Ctx) error {
 
 		clusters, _, err := h.k8sClient.HealthyClusters(hcCtx)
 		if err != nil {
-			slog.Info(fmt.Sprintf("error listing healthy clusters for releases: %v", err))
+			slog.Info("[GitOps] error listing healthy clusters for releases", "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "releases": []HelmRelease{}})
 		}
 
@@ -242,13 +242,13 @@ func (h *GitOpsHandlers) getHelmReleasesForCluster(ctx context.Context, cluster 
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		slog.Error(fmt.Sprintf("helm ls failed for cluster %s: %v, stderr: %s", cluster, err, stderr.String()))
+		slog.Error("[GitOps] helm ls failed", "cluster", cluster, "error", err, "stderr", stderr.String())
 		return []HelmRelease{}
 	}
 
 	releases := make([]HelmRelease, 0)
 	if err := json.Unmarshal(stdout.Bytes(), &releases); err != nil {
-		slog.Error(fmt.Sprintf("failed to parse helm ls output for cluster %s: %v", cluster, err))
+		slog.Error("[GitOps] failed to parse helm ls output", "cluster", cluster, "error", err)
 		return []HelmRelease{}
 	}
 
@@ -277,7 +277,7 @@ func (h *GitOpsHandlers) ListKustomizations(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			slog.Info(fmt.Sprintf("error listing healthy clusters for kustomizations: %v", err))
+			slog.Info("[GitOps] error listing healthy clusters for kustomizations", "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "kustomizations": []Kustomization{}})
 		}
 
@@ -332,7 +332,7 @@ func (h *GitOpsHandlers) getKustomizationsForCluster(ctx context.Context, cluste
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		slog.Error(fmt.Sprintf("kubectl get kustomizations failed for cluster %s: %v, stderr: %s", cluster, err, stderr.String()))
+		slog.Error("[GitOps] kubectl get kustomizations failed", "cluster", cluster, "error", err, "stderr", stderr.String())
 		return []Kustomization{}
 	}
 
@@ -361,7 +361,7 @@ func (h *GitOpsHandlers) getKustomizationsForCluster(ctx context.Context, cluste
 	}
 
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
-		slog.Error(fmt.Sprintf("failed to parse kustomizations for cluster %s: %v", cluster, err))
+		slog.Error("[GitOps] failed to parse kustomizations", "cluster", cluster, "error", err)
 		return []Kustomization{}
 	}
 
@@ -451,7 +451,7 @@ func (h *GitOpsHandlers) ListOperators(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			slog.Info(fmt.Sprintf("error listing healthy clusters for operators: %v", err))
+			slog.Info("[GitOps] error listing healthy clusters for operators", "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "operators": []Operator{}})
 		}
 
@@ -608,7 +608,7 @@ func (h *GitOpsHandlers) getOperatorsForCluster(ctx context.Context, cluster str
 		}
 		// Retry once for transient errors (HTTP/2 stream errors, connection resets)
 		if ctx.Err() == nil {
-			slog.Error(fmt.Sprintf("Retrying operator fetch for cluster %s after transient error", cluster))
+			slog.Error("[GitOps] retrying operator fetch after transient error", "cluster", cluster)
 			time.Sleep(gitopsRetryDelay)
 			operators, err = h.fetchOperatorsFromCluster(ctx, cluster)
 		}
@@ -650,9 +650,9 @@ func (h *GitOpsHandlers) fetchOperatorsFromCluster(ctx context.Context, cluster 
 	if err := cmd.Run(); err != nil {
 		stderrStr := stderr.String()
 		if ctx.Err() == nil {
-			slog.Error(fmt.Sprintf("kubectl get csv failed for cluster %s: %v, stderr: %s", cluster, err, stderrStr))
+			slog.Error("[GitOps] kubectl get csv failed", "cluster", cluster, "error", err, "stderr", stderrStr)
 		} else {
-			slog.Info(fmt.Sprintf("kubectl get csv timed out for cluster %s", cluster))
+			slog.Info("[GitOps] kubectl get csv timed out", "cluster", cluster)
 		}
 		// "doesn't have a resource type" = cluster lacks OLM — permanent, safe to cache
 		if strings.Contains(stderrStr, "doesn't have a resource type") {
@@ -679,7 +679,7 @@ func (h *GitOpsHandlers) fetchOperatorsFromCluster(ctx context.Context, cluster 
 	}
 
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
-		slog.Error(fmt.Sprintf("failed to parse operators JSON for cluster %s: %v", cluster, err))
+		slog.Error("[GitOps] failed to parse operators JSON", "cluster", cluster, "error", err)
 		return nil, err
 	}
 
@@ -716,7 +716,7 @@ func (h *GitOpsHandlers) ListOperatorSubscriptions(c *fiber.Ctx) error {
 	if h.k8sClient != nil {
 		clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 		if err != nil {
-			slog.Info(fmt.Sprintf("error listing healthy clusters for subscriptions: %v", err))
+			slog.Info("[GitOps] error listing healthy clusters for subscriptions", "error", err)
 			return c.Status(500).JSON(fiber.Map{"error": "internal server error", "subscriptions": []OperatorSubscription{}})
 		}
 
@@ -848,7 +848,7 @@ func (h *GitOpsHandlers) getSubscriptionsForCluster(ctx context.Context, cluster
 
 	if err := cmd.Run(); err != nil {
 		if ctx.Err() == nil {
-			slog.Error(fmt.Sprintf("kubectl get subscriptions failed for cluster %s: %v", cluster, err))
+			slog.Error("[GitOps] kubectl get subscriptions failed", "cluster", cluster, "error", err)
 		}
 		return []OperatorSubscription{}
 	}
@@ -1005,7 +1005,7 @@ func (h *GitOpsHandlers) DetectDrift(c *fiber.Ctx) error {
 		if err == nil {
 			return c.JSON(result)
 		}
-		slog.Error(fmt.Sprintf("MCP detect_drift failed, falling back to kubectl: %v", err))
+		slog.Error("[GitOps] MCP detect_drift failed, falling back to kubectl", "error", err)
 	}
 
 	// Fall back to kubectl diff
@@ -1176,7 +1176,7 @@ func (h *GitOpsHandlers) Sync(c *fiber.Ctx) error {
 		if err == nil {
 			return c.JSON(result)
 		}
-		slog.Error(fmt.Sprintf("MCP sync failed, falling back to kubectl: %v", err))
+		slog.Error("[GitOps] MCP sync failed, falling back to kubectl", "error", err)
 	}
 
 	// Fall back to kubectl apply
@@ -1496,19 +1496,19 @@ func isKustomizeDir(path string) bool {
 func cleanupTempDir(dir string) {
 	// Only remove directories that match our expected pattern
 	if !strings.HasPrefix(dir, gitOpsTempDirPrefix) {
-		slog.Warn(fmt.Sprintf("SECURITY: Refused to delete directory outside gitops temp prefix: %s", dir))
+		slog.Warn("[GitOps] SECURITY: refused to delete directory outside gitops temp prefix", "dir", dir)
 		return
 	}
 
 	// Additional validation: ensure no path traversal
 	if strings.Contains(dir, "..") {
-		slog.Warn(fmt.Sprintf("SECURITY: Refused to delete directory with path traversal: %s", dir))
+		slog.Warn("[GitOps] SECURITY: refused to delete directory with path traversal", "dir", dir)
 		return
 	}
 
 	// Use os.RemoveAll instead of shell command for safety
 	if err := os.RemoveAll(dir); err != nil {
-		slog.Error(fmt.Sprintf("Warning: Failed to cleanup temp directory %s: %v", dir, err))
+		slog.Error("[GitOps] failed to cleanup temp directory", "dir", dir, "error", err)
 	}
 }
 
@@ -1719,13 +1719,13 @@ func (h *GitOpsHandlers) ListHelmHistory(c *fiber.Ctx) error {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		slog.Error(fmt.Sprintf("helm history failed for release %s: %v, stderr: %s", release, err, stderr.String()))
+		slog.Error("[GitOps] helm history failed", "release", release, "error", err, "stderr", stderr.String())
 		return c.JSON(fiber.Map{"history": []HelmHistoryEntry{}, "error": stderr.String()})
 	}
 
 	history := make([]HelmHistoryEntry, 0)
 	if err := json.Unmarshal(stdout.Bytes(), &history); err != nil {
-		slog.Error(fmt.Sprintf("failed to parse helm history output for release %s: %v", release, err))
+		slog.Error("[GitOps] failed to parse helm history output", "release", release, "error", err)
 		return c.JSON(fiber.Map{"history": []HelmHistoryEntry{}, "error": "failed to parse history"})
 	}
 
@@ -1773,7 +1773,7 @@ func (h *GitOpsHandlers) GetHelmValues(c *fiber.Ctx) error {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		slog.Error(fmt.Sprintf("helm get values failed for release %s: %v, stderr: %s", release, err, stderr.String()))
+		slog.Error("[GitOps] helm get values failed", "release", release, "error", err, "stderr", stderr.String())
 		return c.JSON(fiber.Map{"values": map[string]interface{}{}, "error": stderr.String()})
 	}
 
@@ -1869,17 +1869,17 @@ func (h *GitOpsHandlers) RollbackHelmRelease(c *fiber.Ctx) error {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	slog.Info(fmt.Sprintf("helm rollback: %s to revision %d in %s/%s", req.Release, req.Revision, req.Cluster, req.Namespace))
+	slog.Info("[GitOps] helm rollback", "release", req.Release, "revision", req.Revision, "cluster", req.Cluster, "namespace", req.Namespace)
 
 	if err := cmd.Run(); err != nil {
-		slog.Error(fmt.Sprintf("helm rollback failed for %s: %v, stderr: %s", req.Release, err, stderr.String()))
+		slog.Error("[GitOps] helm rollback failed", "release", req.Release, "error", err, "stderr", stderr.String())
 		return c.Status(500).JSON(fiber.Map{
 			"error":  "rollback failed",
 			"detail": stderr.String(),
 		})
 	}
 
-	slog.Info(fmt.Sprintf("helm rollback succeeded: %s to revision %d", req.Release, req.Revision))
+	slog.Info("[GitOps] helm rollback succeeded", "release", req.Release, "revision", req.Revision)
 	return c.JSON(fiber.Map{
 		"success": true,
 		"message": fmt.Sprintf("Rolled back %s to revision %d", req.Release, req.Revision),
@@ -1918,17 +1918,17 @@ func (h *GitOpsHandlers) UninstallHelmRelease(c *fiber.Ctx) error {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	slog.Info(fmt.Sprintf("helm uninstall: %s in %s/%s", req.Release, req.Cluster, req.Namespace))
+	slog.Info("[GitOps] helm uninstall", "release", req.Release, "cluster", req.Cluster, "namespace", req.Namespace)
 
 	if err := cmd.Run(); err != nil {
-		slog.Error(fmt.Sprintf("helm uninstall failed for %s: %v, stderr: %s", req.Release, err, stderr.String()))
+		slog.Error("[GitOps] helm uninstall failed", "release", req.Release, "error", err, "stderr", stderr.String())
 		return c.Status(500).JSON(fiber.Map{
 			"error":  "uninstall failed",
 			"detail": stderr.String(),
 		})
 	}
 
-	slog.Info(fmt.Sprintf("helm uninstall succeeded: %s", req.Release))
+	slog.Info("[GitOps] helm uninstall succeeded", "release", req.Release)
 	return c.JSON(fiber.Map{
 		"success": true,
 		"message": fmt.Sprintf("Uninstalled release %s", req.Release),
@@ -2000,17 +2000,17 @@ func (h *GitOpsHandlers) UpgradeHelmRelease(c *fiber.Ctx) error {
 		cmd.Stderr = &stderr
 	}
 
-	slog.Info(fmt.Sprintf("helm upgrade: %s with chart %s in %s/%s", req.Release, req.Chart, req.Cluster, req.Namespace))
+	slog.Info("[GitOps] helm upgrade", "release", req.Release, "chart", req.Chart, "cluster", req.Cluster, "namespace", req.Namespace)
 
 	if err := cmd.Run(); err != nil {
-		slog.Error(fmt.Sprintf("helm upgrade failed for %s: %v, stderr: %s", req.Release, err, stderr.String()))
+		slog.Error("[GitOps] helm upgrade failed", "release", req.Release, "error", err, "stderr", stderr.String())
 		return c.Status(500).JSON(fiber.Map{
 			"error":  "upgrade failed",
 			"detail": stderr.String(),
 		})
 	}
 
-	slog.Info(fmt.Sprintf("helm upgrade succeeded: %s", req.Release))
+	slog.Info("[GitOps] helm upgrade succeeded", "release", req.Release)
 	return c.JSON(fiber.Map{
 		"success": true,
 		"message": fmt.Sprintf("Upgraded release %s", req.Release),
@@ -2211,7 +2211,7 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": err.Error(), "success": false})
 	}
 
-	slog.Info(fmt.Sprintf("[ArgoCD] Triggering sync for %s/%s on cluster %s", namespace, req.AppName, req.Cluster))
+	slog.Info("[ArgoCD] triggering sync", "namespace", namespace, "app", req.AppName, "cluster", req.Cluster)
 
 	// Strategy 1: Try ArgoCD REST API if auth token is configured
 	argoToken := os.Getenv("ARGOCD_AUTH_TOKEN")
@@ -2249,9 +2249,9 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 							"method":  "api",
 						})
 					}
-					slog.Info(fmt.Sprintf("[ArgoCD] API sync returned status %d, falling back", resp.StatusCode))
+					slog.Info("[ArgoCD] API sync returned error status, falling back", "status", resp.StatusCode)
 				} else {
-					slog.Error(fmt.Sprintf("[ArgoCD] API sync failed: %v, falling back", err))
+					slog.Error("[ArgoCD] API sync failed, falling back", "error", err)
 				}
 			}
 		}
@@ -2266,7 +2266,7 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 		)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			slog.Error(fmt.Sprintf("[ArgoCD] CLI sync failed: %v, output: %s, falling back to Annotation Patching", err, string(output)))
+			slog.Error("[ArgoCD] CLI sync failed, falling back to annotation patching", "error", err, "output", string(output))
 		} else {
 			return c.JSON(fiber.Map{
 				"success": true,
@@ -2338,7 +2338,7 @@ func (h *GitOpsHandlers) TriggerArgoSync(c *fiber.Ctx) error {
 func (h *GitOpsHandlers) discoverArgoServerURL(ctx context.Context, cluster string) string {
 	clientset, err := h.k8sClient.GetClient(cluster)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[ArgoCD] Server discovery failed: cannot get client for cluster %s: %v", cluster, err))
+		slog.Error("[ArgoCD] server discovery failed: cannot get client", "cluster", cluster, "error", err)
 		return ""
 	}
 
@@ -2351,11 +2351,11 @@ func (h *GitOpsHandlers) discoverArgoServerURL(ctx context.Context, cluster stri
 				// Use cluster-internal DNS: <service>.<namespace>.svc
 				return fmt.Sprintf("https://%s.%s.svc:%d", svc.Name, svc.Namespace, svc.Spec.Ports[0].Port)
 			} else {
-				slog.Warn(fmt.Sprintf("[ArgoCD] Server discovery warning: argocd-server service found in %s but has no ports", ns))
+				slog.Warn("[ArgoCD] server discovery: argocd-server service has no ports", "namespace", ns)
 			}
 		}
 	}
-	slog.Info(fmt.Sprintf("[ArgoCD] Server discovery empty: argocd-server service not found in cluster %s", cluster))
+	slog.Info("[ArgoCD] server discovery: argocd-server service not found", "cluster", cluster)
 	return ""
 }
 

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -61,14 +60,14 @@ func handleK8sError(c *fiber.Ctx, err error) error {
 	errType := k8s.ClassifyError(err.Error())
 	switch errType {
 	case "network", "auth", "timeout", "certificate":
-		slog.Info(fmt.Sprintf("cluster unavailable (%s): %v", errType, err))
+		slog.Info("[MCP] cluster unavailable", "errorType", errType, "error", err)
 		return c.JSON(fiber.Map{
 			"clusterStatus": "unavailable",
 			"errorType":     errType,
 			"errorMessage":  err.Error(),
 		})
 	default:
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[MCP] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 }

--- a/pkg/api/handlers/mcp_cluster.go
+++ b/pkg/api/handlers/mcp_cluster.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"sort"
 	"sync"
@@ -28,7 +27,7 @@ func (h *MCPHandlers) ListClusters(c *fiber.Ctx) error {
 		if err == nil && len(clusters) > 0 {
 			return c.JSON(fiber.Map{"clusters": clusters, "source": "mcp"})
 		}
-		slog.Error(fmt.Sprintf("MCP bridge ListClusters failed, falling back to k8s client: %v", err))
+		slog.Error("[MCP] bridge ListClusters failed, falling back to k8s client", "error", err)
 	}
 
 	// Fall back to direct k8s client
@@ -88,7 +87,7 @@ func (h *MCPHandlers) GetClusterHealth(c *fiber.Ctx) error {
 		if err == nil {
 			return c.JSON(health)
 		}
-		slog.Error(fmt.Sprintf("MCP bridge GetClusterHealth failed, falling back: %v", err))
+		slog.Error("[MCP] bridge GetClusterHealth failed, falling back", "error", err)
 	}
 
 	// Fall back to direct k8s client
@@ -206,7 +205,7 @@ func (h *MCPHandlers) GetEvents(c *fiber.Ctx) error {
 		if err == nil {
 			return c.JSON(fiber.Map{"events": events, "source": "mcp"})
 		}
-		slog.Error(fmt.Sprintf("MCP bridge GetEvents failed, falling back: %v", err))
+		slog.Error("[MCP] bridge GetEvents failed, falling back", "error", err)
 	}
 
 	// Fall back to direct k8s client
@@ -302,7 +301,7 @@ func (h *MCPHandlers) GetWarningEvents(c *fiber.Ctx) error {
 		if err == nil {
 			return c.JSON(fiber.Map{"events": events, "source": "mcp"})
 		}
-		slog.Error(fmt.Sprintf("MCP bridge GetWarningEvents failed, falling back: %v", err))
+		slog.Error("[MCP] bridge GetWarningEvents failed, falling back", "error", err)
 	}
 
 	// Fall back to direct k8s client

--- a/pkg/api/handlers/mcp_resources.go
+++ b/pkg/api/handlers/mcp_resources.go
@@ -766,7 +766,7 @@ func (h *MCPHandlers) CreateOrUpdateResourceQuota(c *fiber.Ctx) error {
 		// Auto-create namespace if requested (used by GPU reservation flow)
 		if req.EnsureNamespace {
 			if err := h.k8sClient.EnsureNamespaceExists(ctx, req.Cluster, req.Namespace); err != nil {
-				slog.Error(fmt.Sprintf("failed to create namespace: %v", err))
+				slog.Error("[MCP] failed to create namespace", "error", err)
 				return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 			}
 		}
@@ -954,7 +954,7 @@ func validateToolName(name string, allowedTools map[string]bool) error {
 	// Check if tool is in allowlist
 	allowed, exists := allowedTools[name]
 	if !exists || !allowed {
-		slog.Warn(fmt.Sprintf("SECURITY: Blocked attempt to call unauthorized tool: %s", name))
+		slog.Warn("[MCP] SECURITY: blocked unauthorized tool call", "tool", name)
 		return fiber.NewError(fiber.StatusForbidden, "tool not allowed: "+name)
 	}
 
@@ -1261,7 +1261,7 @@ func (h *MCPHandlers) GetPodNetworkStats(c *fiber.Ctx) error {
 
 	clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error listing healthy clusters for network stats: %v", err))
+		slog.Error("[MCP] internal error listing healthy clusters for network stats", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -1282,7 +1282,7 @@ func (h *MCPHandlers) GetPodNetworkStats(c *fiber.Ctx) error {
 
 			client, clientErr := h.k8sClient.GetClient(clusterName)
 			if clientErr != nil {
-				slog.Info(fmt.Sprintf("network stats: cannot get client for %s: %v", clusterName, clientErr))
+				slog.Info("[MCP] network stats: cannot get client", "cluster", clusterName, "error", clientErr)
 				return
 			}
 
@@ -1299,7 +1299,7 @@ func (h *MCPHandlers) GetPodNetworkStats(c *fiber.Ctx) error {
 							continue
 						}
 					}
-					slog.Info(fmt.Sprintf("network stats: list pods (app=%s) on %s: %v", label, clusterName, listErr))
+					slog.Info("[MCP] network stats: list pods failed", "app", label, "cluster", clusterName, "error", listErr)
 					continue
 				}
 
@@ -1382,7 +1382,7 @@ func fetchPodInterfaceStats(
 
 	var summary kubeletStatsSummary
 	if jsonErr := json.Unmarshal(raw, &summary); jsonErr != nil {
-		slog.Error(fmt.Sprintf("network stats: failed to parse kubelet summary from node %s: %v", nodeName, jsonErr))
+		slog.Error("[MCP] network stats: failed to parse kubelet summary", "node", nodeName, "error", jsonErr)
 		return nil
 	}
 

--- a/pkg/api/handlers/mcp_workloads.go
+++ b/pkg/api/handlers/mcp_workloads.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"sync"
 
@@ -32,7 +31,7 @@ func (h *MCPHandlers) GetPods(c *fiber.Ctx) error {
 		if err == nil {
 			return c.JSON(fiber.Map{"pods": pods, "source": "mcp"})
 		}
-		slog.Error(fmt.Sprintf("MCP bridge GetPods failed, falling back: %v", err))
+		slog.Error("[MCP] bridge GetPods failed, falling back", "error", err)
 	}
 
 	// Fall back to direct k8s client
@@ -107,7 +106,7 @@ func (h *MCPHandlers) FindPodIssues(c *fiber.Ctx) error {
 		if err == nil {
 			return c.JSON(fiber.Map{"issues": issues, "source": "mcp"})
 		}
-		slog.Error(fmt.Sprintf("MCP bridge FindPodIssues failed, falling back: %v", err))
+		slog.Error("[MCP] bridge FindPodIssues failed, falling back", "error", err)
 	}
 
 	// Fall back to direct k8s client
@@ -734,7 +733,7 @@ func (h *MCPHandlers) GetWorkloads(c *fiber.Ctx) error {
 
 	list, err := h.k8sClient.ListWorkloads(ctx, cluster, namespace, workloadType)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[MCP] internal error listing workloads", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 

--- a/pkg/api/handlers/mcs.go
+++ b/pkg/api/handlers/mcs.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -208,7 +207,7 @@ func (h *MCSHandlers) CreateServiceExport(c *fiber.Ctx) error {
 
 	var req CreateServiceExportRequest
 	if err := c.BodyParser(&req); err != nil {
-		slog.Info(fmt.Sprintf("invalid request body: %v", err))
+		slog.Info("[MCS] invalid request body", "error", err)
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 
@@ -228,7 +227,7 @@ func (h *MCSHandlers) CreateServiceExport(c *fiber.Ctx) error {
 
 	// Create the ServiceExport
 	if err := h.k8sClient.CreateServiceExport(ctx, req.Cluster, req.Namespace, req.ServiceName); err != nil {
-		slog.Error(fmt.Sprintf("failed to create serviceexport: %v", err))
+		slog.Error("[MCS] failed to create serviceexport", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -255,7 +254,7 @@ func (h *MCSHandlers) DeleteServiceExport(c *fiber.Ctx) error {
 	defer cancel()
 
 	if err := h.k8sClient.DeleteServiceExport(ctx, cluster, namespace, name); err != nil {
-		slog.Error(fmt.Sprintf("failed to delete serviceexport: %v", err))
+		slog.Error("[MCS] failed to delete serviceexport", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 

--- a/pkg/api/handlers/missions.go
+++ b/pkg/api/handlers/missions.go
@@ -218,7 +218,7 @@ func (h *MissionsHandler) githubGet(url string, clientToken string) (*http.Respo
 	// If auth failed (401/403) or got 404 with a token (raw.githubusercontent returns 404 for bad tokens),
 	// retry without auth — the target repo is public
 	if hasToken && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound) {
-		slog.Info(fmt.Sprintf("[missions] GitHub token returned %d for %s — retrying without auth (token may be expired)", resp.StatusCode, url))
+		slog.Info("[missions] GitHub token returned error, retrying without auth", "status", resp.StatusCode, "url", url)
 		resp.Body.Close()
 		retryReq, err := http.NewRequest("GET", url, nil)
 		if err != nil {
@@ -230,7 +230,7 @@ func (h *MissionsHandler) githubGet(url string, clientToken string) (*http.Respo
 			return nil, err
 		}
 		if retryResp.StatusCode == http.StatusForbidden || retryResp.StatusCode == http.StatusTooManyRequests {
-			slog.Error(fmt.Sprintf("[missions] Unauthenticated retry also failed (%d) for %s — likely rate-limited (check GITHUB_TOKEN in .env)", retryResp.StatusCode, url))
+			slog.Error("[missions] unauthenticated retry also failed, likely rate-limited", "status", retryResp.StatusCode, "url", url)
 		}
 		return retryResp, nil
 	}
@@ -256,7 +256,7 @@ func (h *MissionsHandler) BrowseConsoleKB(c *fiber.Ctx) error {
 
 	// Check fresh cache first
 	if cached := h.cache.get(cacheKey, missionsCacheTTL); cached != nil {
-		slog.Info(fmt.Sprintf("[missions] Cache HIT (browse) path=%q", path))
+		slog.Info("[missions] cache HIT (browse)", "path", path)
 		c.Set("Content-Type", cached.contentType)
 		c.Set("X-Cache", "HIT")
 		return c.Status(cached.statusCode).Send(cached.body)
@@ -268,7 +268,7 @@ func (h *MissionsHandler) BrowseConsoleKB(c *fiber.Ctx) error {
 	if err != nil {
 		// Upstream failed — try stale cache
 		if stale := h.cache.getStale(cacheKey, missionsCacheStaleTTL); stale != nil {
-			slog.Error(fmt.Sprintf("[missions] Upstream error, serving STALE cache (browse) path=%q err=%v", path, err))
+			slog.Error("[missions] upstream error, serving stale cache (browse)", "path", path, "error", err)
 			c.Set("Content-Type", stale.contentType)
 			c.Set("X-Cache", "STALE")
 			return c.Status(stale.statusCode).Send(stale.body)
@@ -286,7 +286,7 @@ func (h *MissionsHandler) BrowseConsoleKB(c *fiber.Ctx) error {
 	// Rate-limited — serve stale cache if available
 	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
 		if stale := h.cache.getStale(cacheKey, missionsCacheStaleTTL); stale != nil {
-			slog.Info(fmt.Sprintf("[missions] Rate-limited (%d), serving STALE cache (browse) path=%q", resp.StatusCode, path))
+			slog.Info("[missions] rate-limited, serving stale cache (browse)", "status", resp.StatusCode, "path", path)
 			c.Set("Content-Type", stale.contentType)
 			c.Set("X-Cache", "STALE")
 			return c.Status(stale.statusCode).Send(stale.body)
@@ -350,7 +350,7 @@ func (h *MissionsHandler) BrowseConsoleKB(c *fiber.Ctx) error {
 			statusCode:  http.StatusOK,
 			fetchedAt:   time.Now(),
 		})
-		slog.Info(fmt.Sprintf("[missions] Cache MISS → stored (browse) path=%q", path))
+		slog.Info("[missions] cache MISS, stored (browse)", "path", path)
 	}
 
 	c.Set("X-Cache", "MISS")
@@ -385,7 +385,7 @@ func (h *MissionsHandler) GetMissionFile(c *fiber.Ctx) error {
 
 	// Check fresh cache first
 	if cached := h.cache.get(cacheKey, missionsCacheTTL); cached != nil {
-		slog.Info(fmt.Sprintf("[missions] Cache HIT (file) ref=%q path=%q", ref, path))
+		slog.Info("[missions] cache HIT (file)", "ref", ref, "path", path)
 		c.Set("Content-Type", cached.contentType)
 		c.Set("X-Cache", "HIT")
 		return c.Status(cached.statusCode).Send(cached.body)
@@ -397,7 +397,7 @@ func (h *MissionsHandler) GetMissionFile(c *fiber.Ctx) error {
 	if err != nil {
 		// Upstream failed — try stale cache
 		if stale := h.cache.getStale(cacheKey, missionsCacheStaleTTL); stale != nil {
-			slog.Error(fmt.Sprintf("[missions] Upstream error, serving STALE cache (file) ref=%q path=%q err=%v", ref, path, err))
+			slog.Error("[missions] upstream error, serving stale cache (file)", "ref", ref, "path", path, "error", err)
 			c.Set("Content-Type", stale.contentType)
 			c.Set("X-Cache", "STALE")
 			return c.Status(stale.statusCode).Send(stale.body)
@@ -415,7 +415,7 @@ func (h *MissionsHandler) GetMissionFile(c *fiber.Ctx) error {
 	// Rate-limited — serve stale cache if available
 	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
 		if stale := h.cache.getStale(cacheKey, missionsCacheStaleTTL); stale != nil {
-			slog.Info(fmt.Sprintf("[missions] Rate-limited (%d), serving STALE cache (file) ref=%q path=%q", resp.StatusCode, ref, path))
+			slog.Info("[missions] rate-limited, serving stale cache (file)", "status", resp.StatusCode, "ref", ref, "path", path)
 			c.Set("Content-Type", stale.contentType)
 			c.Set("X-Cache", "STALE")
 			return c.Status(stale.statusCode).Send(stale.body)
@@ -441,7 +441,7 @@ func (h *MissionsHandler) GetMissionFile(c *fiber.Ctx) error {
 		statusCode:  http.StatusOK,
 		fetchedAt:   time.Now(),
 	})
-	slog.Info(fmt.Sprintf("[missions] Cache MISS → stored (file) ref=%q path=%q (%d bytes)", ref, path, len(body)))
+	slog.Info("[missions] cache MISS, stored (file)", "ref", ref, "path", path, "bytes", len(body))
 
 	c.Set("Content-Type", "text/plain")
 	c.Set("X-Cache", "MISS")
@@ -636,8 +636,8 @@ func (h *MissionsHandler) ShareToGitHub(c *fiber.Ctx) error {
 
 		// If this is not the last attempt, wait before retrying
 		if attempt < forkHeadSHAMaxRetries-1 {
-			slog.Info(fmt.Sprintf("[missions] Fork HEAD SHA not yet available (attempt %d/%d, status %d) — retrying in %v",
-				attempt+1, forkHeadSHAMaxRetries, mainRefResp.StatusCode, backoff))
+			slog.Info("[missions] fork HEAD SHA not yet available, retrying",
+				"attempt", attempt+1, "maxRetries", forkHeadSHAMaxRetries, "status", mainRefResp.StatusCode, "backoff", backoff)
 			time.Sleep(backoff)
 			backoff *= forkHeadSHABackoffMultiplier
 		}

--- a/pkg/api/handlers/namespaces.go
+++ b/pkg/api/handlers/namespaces.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -47,7 +46,7 @@ func (h *NamespaceHandler) ListNamespaces(c *fiber.Ctx) error {
 
 	namespaces, err := h.k8sClient.ListNamespacesWithDetails(ctx, cluster)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to list namespaces: %v", err))
+		slog.Error("[Namespaces] failed to list namespaces", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -87,7 +86,7 @@ func (h *NamespaceHandler) CreateNamespace(c *fiber.Ctx) error {
 
 	ns, err := h.k8sClient.CreateNamespace(ctx, req.Cluster, req.Name, req.Labels)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to create namespace: %v", err))
+		slog.Error("[Namespaces] failed to create namespace", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -126,7 +125,7 @@ func (h *NamespaceHandler) DeleteNamespace(c *fiber.Ctx) error {
 	}
 
 	if err := h.k8sClient.DeleteNamespace(ctx, cluster, name); err != nil {
-		slog.Error(fmt.Sprintf("failed to delete namespace: %v", err))
+		slog.Error("[Namespaces] failed to delete namespace", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -150,7 +149,7 @@ func (h *NamespaceHandler) GetNamespaceAccess(c *fiber.Ctx) error {
 
 	bindings, err := h.k8sClient.ListRoleBindings(ctx, cluster, name)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to list role bindings: %v", err))
+		slog.Error("[Namespaces] failed to list role bindings", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -219,7 +218,7 @@ func (h *NamespaceHandler) GrantNamespaceAccess(c *fiber.Ctx) error {
 
 	bindingName, err := h.k8sClient.GrantNamespaceAccess(ctx, req.Cluster, namespace, req)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to grant access: %v", err))
+		slog.Error("[Namespaces] failed to grant access", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -260,7 +259,7 @@ func (h *NamespaceHandler) RevokeNamespaceAccess(c *fiber.Ctx) error {
 	}
 
 	if err := h.k8sClient.DeleteRoleBinding(ctx, cluster, namespace, bindingName, false); err != nil {
-		slog.Error(fmt.Sprintf("failed to revoke access: %v", err))
+		slog.Error("[Namespaces] failed to revoke access", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 

--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -731,7 +731,7 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 
 	req, err := http.NewRequest("GET", jobsURL, nil)
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[NightlyE2E] internal error", "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
@@ -741,7 +741,7 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 
 	resp, err := h.httpClient.Do(req)
 	if err != nil {
-		slog.Info(fmt.Sprintf("bad gateway: %v", err))
+		slog.Info("[NightlyE2E] bad gateway", "error", err)
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{"error": "bad gateway"})
 	}
 	defer resp.Body.Close()
@@ -764,7 +764,7 @@ func (h *NightlyE2EHandler) GetRunLogs(c *fiber.Ctx) error {
 		} `json:"jobs"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&jobData); err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[NightlyE2E] internal error", "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 

--- a/pkg/api/handlers/notifications.go
+++ b/pkg/api/handlers/notifications.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/gofiber/fiber/v2"
@@ -53,7 +52,7 @@ func (h *NotificationHandler) TestNotification(c *fiber.Ctx) error {
 
 	err := h.service.TestNotifier(req.Type, req.Config)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Notification test failed: %v", err))
+		slog.Error("[Notifications] test failed", "error", err)
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error":   "Notification test failed",
 			"message": "notification test failed",
@@ -79,7 +78,7 @@ func (h *NotificationHandler) SendAlertNotification(c *fiber.Ctx) error {
 	// Send alert to specified channels
 	err := h.service.SendAlertToChannels(req.Alert, req.Channels)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to send alert notification: %v", err))
+		slog.Error("[Notifications] failed to send alert", "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error":   "Failed to send notification",
 			"message": "failed to send notification",

--- a/pkg/api/handlers/onboarding.go
+++ b/pkg/api/handlers/onboarding.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
 	"log/slog"
 
 	"github.com/gofiber/fiber/v2"
@@ -164,7 +163,7 @@ func generateDefaultCards(responses []models.OnboardingResponse) []models.Card {
 		// Add config for GPU filtering
 		gpuConfig, err := json.Marshal(map[string]string{"resource_type": "gpu"})
 		if err != nil {
-			slog.Error(fmt.Sprintf("Failed to marshal GPU config: %v", err))
+			slog.Error("[Onboarding] failed to marshal GPU config", "error", err)
 			gpuConfig = []byte(`{"resource_type":"gpu"}`)
 		}
 		cards = append(cards, models.Card{

--- a/pkg/api/handlers/rbac.go
+++ b/pkg/api/handlers/rbac.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"time"
 
@@ -179,7 +178,7 @@ func (h *RBACHandler) ListK8sServiceAccounts(c *fiber.Ctx) error {
 		// Get SAs from specific cluster
 		sas, err := h.k8sClient.ListServiceAccounts(ctx, cluster, namespace)
 		if err != nil {
-			slog.Error(fmt.Sprintf("failed to list service accounts: %v", err))
+			slog.Error("[RBAC] failed to list service accounts", "error", err)
 			return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 		}
 		return c.JSON(sas)
@@ -327,7 +326,7 @@ func (h *RBACHandler) CreateServiceAccount(c *fiber.Ctx) error {
 
 	sa, err := h.k8sClient.CreateServiceAccount(ctx, req.Cluster, req.Namespace, req.Name)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to create service account: %v", err))
+		slog.Error("[RBAC] failed to create service account", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -359,7 +358,7 @@ func (h *RBACHandler) CreateRoleBinding(c *fiber.Ctx) error {
 	}
 
 	if err := h.k8sClient.CreateRoleBinding(ctx, req); err != nil {
-		slog.Error(fmt.Sprintf("failed to create role binding: %v", err))
+		slog.Error("[RBAC] failed to create role binding", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -405,7 +404,7 @@ func (h *RBACHandler) ListOpenShiftUsers(c *fiber.Ctx) error {
 
 	users, err := h.k8sClient.ListOpenShiftUsers(ctx, cluster)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to list openshift users: %v", err))
+		slog.Error("[RBAC] failed to list openshift users", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -423,7 +422,7 @@ func (h *RBACHandler) GetPermissionsSummary(c *fiber.Ctx) error {
 
 	summaries, err := h.k8sClient.GetAllPermissionsSummaries(ctx)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to get permissions summary: %v", err))
+		slog.Error("[RBAC] failed to get permissions summary", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 
@@ -467,7 +466,7 @@ func (h *RBACHandler) CheckCanI(c *fiber.Ctx) error {
 
 	result, err := h.k8sClient.CheckCanI(ctx, req.Cluster, req)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to check permission: %v", err))
+		slog.Error("[RBAC] failed to check permission", "error", err)
 		return fiber.NewError(fiber.StatusInternalServerError, "internal server error")
 	}
 

--- a/pkg/api/handlers/rewards.go
+++ b/pkg/api/handlers/rewards.go
@@ -112,7 +112,7 @@ func (h *RewardsHandler) GetGitHubRewards(c *fiber.Ctx) error {
 	// Cache miss — fetch from GitHub
 	resp, err := h.fetchUserRewards(githubLogin, token)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[rewards] Failed to fetch GitHub rewards for %s: %v", githubLogin, err))
+		slog.Error("[rewards] failed to fetch GitHub rewards", "user", githubLogin, "error", err)
 
 		// Return stale cache if available
 		h.mu.RLock()
@@ -156,7 +156,7 @@ func (h *RewardsHandler) fetchUserRewards(login, token string) (*GitHubRewardsRe
 	// 1. Fetch issues authored by user
 	issues, err := h.searchItems(login, "issue", token)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[rewards] Warning: failed to search issues for %s: %v", login, err))
+		slog.Error("[rewards] failed to search issues", "user", login, "error", err)
 		fetchErr = fmt.Errorf("issue search failed: %w", err)
 	} else {
 		for _, item := range issues {
@@ -168,7 +168,7 @@ func (h *RewardsHandler) fetchUserRewards(login, token string) (*GitHubRewardsRe
 	// 2. Fetch PRs authored by user
 	prs, err := h.searchItems(login, "pr", token)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[rewards] Warning: failed to search PRs for %s: %v", login, err))
+		slog.Error("[rewards] failed to search PRs", "user", login, "error", err)
 		fetchErr = fmt.Errorf("PR search failed: %w", err)
 	} else {
 		for _, item := range prs {

--- a/pkg/api/handlers/self_upgrade.go
+++ b/pkg/api/handlers/self_upgrade.go
@@ -133,7 +133,7 @@ func (h *SelfUpgradeHandler) canPatchDeployment(ctx context.Context, client kube
 	}
 	result, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, review, metav1.CreateOptions{})
 	if err != nil {
-		slog.Error(fmt.Sprintf("[self-upgrade] RBAC check failed: %v", err))
+		slog.Error("[self-upgrade] RBAC check failed", "error", err)
 		return false
 	}
 	return result.Status.Allowed
@@ -269,7 +269,7 @@ func (h *SelfUpgradeHandler) TriggerUpgrade(c *fiber.Ctx) error {
 	}
 	newImage := repo + ":" + req.ImageTag
 
-	slog.Info(fmt.Sprintf("[self-upgrade] Upgrading %s/%s: %s → %s", namespace, dep.Name, currentImage, newImage))
+	slog.Info("[self-upgrade] upgrading deployment", "namespace", namespace, "deployment", dep.Name, "from", currentImage, "to", newImage)
 
 	// Broadcast progress to all WebSocket clients
 	h.hub.BroadcastAll(Message{
@@ -306,7 +306,7 @@ func (h *SelfUpgradeHandler) TriggerUpgrade(c *fiber.Ctx) error {
 		metav1.PatchOptions{},
 	)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[self-upgrade] Patch failed: %v", err))
+		slog.Error("[self-upgrade] patch failed", "error", err)
 		h.hub.BroadcastAll(Message{
 			Type: "update_progress",
 			Data: map[string]any{

--- a/pkg/api/handlers/settings.go
+++ b/pkg/api/handlers/settings.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"log/slog"
 
 	"github.com/gofiber/fiber/v2"
@@ -33,7 +32,7 @@ func (h *SettingsHandler) GetSettings(c *fiber.Ctx) error {
 
 	all, err := h.manager.GetAll()
 	if err != nil {
-		slog.Error(fmt.Sprintf("[settings] GetAll error: %v", err))
+		slog.Error("[settings] GetAll error", "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Failed to load settings",
 		})
@@ -59,7 +58,7 @@ func (h *SettingsHandler) SaveSettings(c *fiber.Ctx) error {
 	}
 
 	if err := h.manager.SaveAll(&all); err != nil {
-		slog.Error(fmt.Sprintf("[settings] SaveAll error: %v", err))
+		slog.Error("[settings] SaveAll error", "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Failed to save settings",
 		})
@@ -83,7 +82,7 @@ func (h *SettingsHandler) ExportSettings(c *fiber.Ctx) error {
 
 	data, err := h.manager.ExportEncrypted()
 	if err != nil {
-		slog.Error(fmt.Sprintf("[settings] Export error: %v", err))
+		slog.Error("[settings] Export error", "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
 			"error": "Failed to export settings",
 		})
@@ -112,7 +111,7 @@ func (h *SettingsHandler) ImportSettings(c *fiber.Ctx) error {
 	}
 
 	if err := h.manager.ImportEncrypted(body); err != nil {
-		slog.Error(fmt.Sprintf("[settings] Import error: %v", err))
+		slog.Error("[settings] Import error", "error", err)
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error":   "Failed to import settings",
 			"message": "invalid settings data",

--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -29,7 +29,7 @@ type sseClusterStreamConfig struct {
 func writeSSEEvent(w *bufio.Writer, eventName string, data interface{}) {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[SSE] marshal error: %v", err))
+		slog.Error("[SSE] marshal error", "error", err)
 		return
 	}
 	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventName, jsonData)
@@ -129,7 +129,7 @@ func streamClusters(
 ) error {
 	healthy, offline, err := h.k8sClient.HealthyClusters(c.Context())
 	if err != nil {
-		slog.Error(fmt.Sprintf("internal error: %v", err))
+		slog.Error("[SSE] internal error", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 
@@ -200,7 +200,7 @@ func streamClusters(
 				elapsed := time.Since(start)
 
 				if fetchErr != nil {
-					slog.Error(fmt.Sprintf("[SSE] cluster %s fetch failed (%v): %v", clusterName, elapsed, fetchErr))
+					slog.Error("[SSE] cluster fetch failed", "cluster", clusterName, "elapsed", elapsed, "error", fetchErr)
 					if elapsed > 5*time.Second {
 						h.k8sClient.MarkSlow(clusterName)
 					}
@@ -239,7 +239,7 @@ func streamClusters(
 		case <-done:
 			// All healthy clusters finished
 		case <-streamCtx.Done():
-			slog.Info(fmt.Sprintf("[SSE] stream context done, sending partial results: %v", streamCtx.Err()))
+			slog.Info("[SSE] stream context done, sending partial results", "error", streamCtx.Err())
 			// Cancel all in-flight goroutines immediately.
 			streamCancel()
 		}

--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -88,7 +87,7 @@ func (h *Hub) Run() {
 			h.clients[client] = true
 			h.userIndex[client.userID] = append(h.userIndex[client.userID], client)
 			h.mu.Unlock()
-			slog.Info(fmt.Sprintf("WebSocket client connected: %s", client.userID))
+			slog.Info("[WebSocket] client connected", "user", client.userID)
 
 		case client := <-h.unregister:
 			h.mu.Lock()
@@ -109,7 +108,7 @@ func (h *Hub) Run() {
 				}
 			}
 			h.mu.Unlock()
-			slog.Info(fmt.Sprintf("WebSocket client disconnected: %s", client.userID))
+			slog.Info("[WebSocket] client disconnected", "user", client.userID)
 
 		case msg := <-h.broadcast:
 			h.mu.RLock()
@@ -145,7 +144,7 @@ func (h *Hub) Close() {
 func (h *Hub) Broadcast(userID uuid.UUID, msg Message) {
 	data, err := json.Marshal(msg)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to marshal message: %v", err))
+		slog.Error("[WebSocket] failed to marshal message", "error", err)
 		return
 	}
 
@@ -154,10 +153,10 @@ func (h *Hub) Broadcast(userID uuid.UUID, msg Message) {
 		// Message queued successfully
 	case <-h.done:
 		// Hub is shut down; discard the message
-		slog.Info(fmt.Sprintf("Hub closed, dropping broadcast for user %s", userID))
+		slog.Info("[WebSocket] hub closed, dropping broadcast", "user", userID)
 	default:
 		// Broadcast buffer is full; drop the message to avoid blocking the sender
-		slog.Info(fmt.Sprintf("Broadcast buffer full, dropping message for user %s (type: %s)", userID, msg.Type))
+		slog.Info("[WebSocket] broadcast buffer full, dropping message", "user", userID, "type", msg.Type)
 	}
 }
 
@@ -206,14 +205,14 @@ func (h *Hub) BroadcastAll(msg Message) {
 	// Check if the hub has been shut down before doing any work
 	select {
 	case <-h.done:
-		slog.Info(fmt.Sprintf("Hub closed, dropping broadcast-all (type: %s)", msg.Type))
+		slog.Info("[WebSocket] hub closed, dropping broadcast-all", "type", msg.Type)
 		return
 	default:
 	}
 
 	data, err := json.Marshal(msg)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to marshal message: %v", err))
+		slog.Error("[WebSocket] failed to marshal message", "error", err)
 		return
 	}
 
@@ -247,7 +246,7 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 	}
 
 	if err := conn.ReadJSON(&authMsg); err != nil {
-		slog.Error(fmt.Sprintf("SECURITY: Failed to read auth message: %v", err))
+		slog.Error("[WebSocket] SECURITY: failed to read auth message", "error", err)
 		conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "authentication required"}})
 		conn.Close()
 		return
@@ -275,14 +274,14 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 	} else if h.jwtSecret != "" {
 		claims, err := middleware.ValidateJWT(authMsg.Token, h.jwtSecret)
 		if err != nil {
-			slog.Warn(fmt.Sprintf("SECURITY: Rejected WebSocket - invalid token: %v", err))
+			slog.Warn("[WebSocket] SECURITY: rejected invalid token", "error", err)
 			conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "invalid token"}})
 			conn.Close()
 			return
 		}
 		userID = claims.UserID
 		authenticated = true
-		slog.Info(fmt.Sprintf("Authenticated WebSocket connection for user: %s", claims.GitHubLogin))
+		slog.Info("[WebSocket] authenticated connection", "user", claims.GitHubLogin)
 	} else {
 		// No JWT secret configured - accept connection anyway for dev compatibility
 		userID = uuid.Nil
@@ -336,7 +335,7 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 					return
 				}
 				if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
-					slog.Error(fmt.Sprintf("WebSocket write error: %v", err))
+					slog.Error("[WebSocket] write error", "error", err)
 					return
 				}
 			case <-pingTicker.C:
@@ -357,7 +356,7 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 		_, message, err := conn.ReadMessage()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				slog.Error(fmt.Sprintf("WebSocket error: %v", err))
+				slog.Error("[WebSocket] unexpected close error", "error", err)
 			}
 			break
 		}
@@ -377,7 +376,7 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 			select {
 			case client.send <- []byte(`{"type":"pong"}`):
 			default:
-				slog.Info(fmt.Sprintf("[WebSocket] Dropping pong for client %s: send channel full", client.userID))
+				slog.Info("[WebSocket] dropping pong, send channel full", "user", client.userID)
 			}
 		}
 	}

--- a/pkg/api/handlers/workloads.go
+++ b/pkg/api/handlers/workloads.go
@@ -125,7 +125,7 @@ func (h *WorkloadHandlers) DeployWorkload(c *fiber.Ctx) error {
 
 	var req DeployRequest
 	if err := c.BodyParser(&req); err != nil {
-		slog.Info(fmt.Sprintf("invalid request body: %v", err))
+		slog.Info("[Workloads] invalid request body", "error", err)
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 
@@ -179,7 +179,7 @@ func (h *WorkloadHandlers) ResolveDependencies(c *fiber.Ctx) error {
 	workloadKind, bundle, err := h.k8sClient.ResolveWorkloadDependencies(ctx, cluster, namespace, name)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			slog.Info(fmt.Sprintf("not found: %v", err))
+			slog.Info("[Workloads] not found", "error", err)
 			return c.Status(404).JSON(fiber.Map{"error": "not found"})
 		}
 		return handleK8sError(c, err)
@@ -236,7 +236,7 @@ func (h *WorkloadHandlers) MonitorWorkload(c *fiber.Ctx) error {
 	result, err := h.k8sClient.MonitorWorkload(ctx, cluster, namespace, name)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			slog.Info(fmt.Sprintf("not found: %v", err))
+			slog.Info("[Workloads] not found", "error", err)
 			return c.Status(404).JSON(fiber.Map{"error": "not found"})
 		}
 		return handleK8sError(c, err)
@@ -372,7 +372,7 @@ func (h *WorkloadHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 
 	var group ClusterGroup
 	if err := c.BodyParser(&group); err != nil {
-		slog.Info(fmt.Sprintf("invalid request body: %v", err))
+		slog.Info("[Workloads] invalid request body", "error", err)
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 	if group.Name == "" {
@@ -400,7 +400,7 @@ func (h *WorkloadHandlers) CreateClusterGroup(c *fiber.Ctx) error {
 			if err := h.k8sClient.LabelClusterNodes(ctx, cluster, map[string]string{
 				"kubestellar.io/group": group.Name,
 			}); err != nil {
-				slog.Error(fmt.Sprintf("failed to label cluster %s: %v", cluster, err))
+				slog.Error("[Workloads] failed to label cluster", "cluster", cluster, "error", err)
 				labelErrors = append(labelErrors, fmt.Sprintf("cluster %s: %v", cluster, err))
 			}
 		}
@@ -432,7 +432,7 @@ func (h *WorkloadHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 
 	var group ClusterGroup
 	if err := c.BodyParser(&group); err != nil {
-		slog.Info(fmt.Sprintf("invalid request body: %v", err))
+		slog.Info("[Workloads] invalid request body", "error", err)
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 	group.Name = name
@@ -459,7 +459,7 @@ func (h *WorkloadHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 		for _, cluster := range oldGroup.Clusters {
 			if !newSet[cluster] {
 				if err := h.k8sClient.RemoveClusterNodeLabels(ctx, cluster, []string{"kubestellar.io/group"}); err != nil {
-					slog.Error(fmt.Sprintf("failed to remove label from cluster %s: %v", cluster, err))
+					slog.Error("[Workloads] failed to remove label from cluster", "cluster", cluster, "error", err)
 					labelErrors = append(labelErrors, fmt.Sprintf("cluster %s: %v", cluster, err))
 				}
 			}
@@ -469,7 +469,7 @@ func (h *WorkloadHandlers) UpdateClusterGroup(c *fiber.Ctx) error {
 				if err := h.k8sClient.LabelClusterNodes(ctx, cluster, map[string]string{
 					"kubestellar.io/group": group.Name,
 				}); err != nil {
-					slog.Error(fmt.Sprintf("failed to label cluster %s: %v", cluster, err))
+					slog.Error("[Workloads] failed to label cluster", "cluster", cluster, "error", err)
 					labelErrors = append(labelErrors, fmt.Sprintf("cluster %s: %v", cluster, err))
 				}
 			}
@@ -513,7 +513,7 @@ func (h *WorkloadHandlers) DeleteClusterGroup(c *fiber.Ctx) error {
 		var labelErrors []string
 		for _, cluster := range group.Clusters {
 			if err := h.k8sClient.RemoveClusterNodeLabels(ctx, cluster, []string{"kubestellar.io/group"}); err != nil {
-				slog.Error(fmt.Sprintf("failed to remove label from cluster %s: %v", cluster, err))
+				slog.Error("[Workloads] failed to remove label from cluster", "cluster", cluster, "error", err)
 				labelErrors = append(labelErrors, fmt.Sprintf("cluster %s: %v", cluster, err))
 			}
 		}
@@ -566,7 +566,7 @@ func (h *WorkloadHandlers) EvaluateClusterQuery(c *fiber.Ctx) error {
 
 	var query ClusterGroupQuery
 	if err := c.BodyParser(&query); err != nil {
-		slog.Info(fmt.Sprintf("invalid query: %v", err))
+		slog.Info("[Workloads] invalid query", "error", err)
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 
@@ -578,7 +578,7 @@ func (h *WorkloadHandlers) EvaluateClusterQuery(c *fiber.Ctx) error {
 	// We only want one result per unique server URL.
 	dedupClusters, _, err := h.k8sClient.HealthyClusters(ctx)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to list clusters: %v", err))
+		slog.Error("[Workloads] failed to list clusters", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 	primaryNames := make(map[string]bool, len(dedupClusters))
@@ -589,7 +589,7 @@ func (h *WorkloadHandlers) EvaluateClusterQuery(c *fiber.Ctx) error {
 	// Get all cluster health data and keep only deduplicated entries
 	allHealth, err := h.k8sClient.GetAllClusterHealth(ctx)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to get cluster health: %v", err))
+		slog.Error("[Workloads] failed to get cluster health", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 	healthData := make([]k8s.ClusterHealth, 0, len(dedupClusters))
@@ -830,7 +830,7 @@ func (h *WorkloadHandlers) GenerateClusterQuery(c *fiber.Ctx) error {
 	registry := agent.GetRegistry()
 	provider, err := registry.GetDefault()
 	if err != nil {
-		slog.Info(fmt.Sprintf("no ai provider available: %v", err))
+		slog.Info("[Workloads] no AI provider available", "error", err)
 		return c.Status(503).JSON(fiber.Map{"error": "service unavailable"})
 	}
 
@@ -877,7 +877,7 @@ If the user's request doesn't need label selectors, omit the labelSelector field
 
 	resp, err := provider.Chat(aiCtx, chatReq)
 	if err != nil {
-		slog.Error(fmt.Sprintf("ai query generation failed: %v", err))
+		slog.Error("[Workloads] AI query generation failed", "error", err)
 		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
 	}
 	if resp == nil {
@@ -898,7 +898,7 @@ If the user's request doesn't need label selectors, omit the labelSelector field
 		Query         ClusterGroupQuery `json:"query"`
 	}
 	if err := json.Unmarshal([]byte(content), &result); err != nil {
-		slog.Info(fmt.Sprintf("could not parse AI response as structured query: %v", err))
+		slog.Info("[Workloads] could not parse AI response as structured query", "error", err)
 		return c.JSON(fiber.Map{
 			"raw":   resp.Content,
 			"error": "could not parse AI response as structured query",
@@ -947,7 +947,7 @@ func (h *WorkloadHandlers) ScaleWorkload(c *fiber.Ctx) error {
 
 	var req ScaleRequest
 	if err := c.BodyParser(&req); err != nil {
-		slog.Info(fmt.Sprintf("invalid request body: %v", err))
+		slog.Info("[Workloads] invalid request body", "error", err)
 		return c.Status(400).JSON(fiber.Map{"error": "invalid request"})
 	}
 

--- a/pkg/api/middleware/auth.go
+++ b/pkg/api/middleware/auth.go
@@ -94,7 +94,7 @@ func (c *revokedTokenCache) Revoke(jti string, expiresAt time.Time) {
 	// Write-through to persistent store (best-effort; log on failure).
 	if store != nil {
 		if err := store.RevokeToken(jti, expiresAt); err != nil {
-			slog.Error(fmt.Sprintf("[Auth] failed to persist token revocation for jti %s: %v", jti, err))
+			slog.Error("[Auth] failed to persist token revocation", "jti", jti, "error", err)
 		}
 	}
 }
@@ -114,7 +114,7 @@ func (c *revokedTokenCache) IsRevoked(jti string) bool {
 	if store != nil {
 		revoked, err := store.IsTokenRevoked(jti)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[Auth] failed to check token revocation for jti %s: %v", jti, err))
+			slog.Error("[Auth] failed to check token revocation", "jti", jti, "error", err)
 			return false
 		}
 		if revoked {
@@ -156,9 +156,9 @@ func (c *revokedTokenCache) cleanup() {
 	// Also prune expired rows from the persistent store.
 	if store != nil {
 		if n, err := store.CleanupExpiredTokens(); err != nil {
-			slog.Error(fmt.Sprintf("[Auth] failed to cleanup expired tokens: %v", err))
+			slog.Error("[Auth] failed to cleanup expired tokens", "error", err)
 		} else if n > 0 {
-			slog.Info(fmt.Sprintf("[Auth] cleaned up %d expired revoked tokens from store", n))
+			slog.Info("[Auth] cleaned up expired revoked tokens", "count", n)
 		}
 	}
 }
@@ -187,7 +187,7 @@ func JWTAuth(secret string) fiber.Handler {
 		if authHeader != "" {
 			tokenString = strings.TrimPrefix(authHeader, "Bearer ")
 			if tokenString == authHeader {
-				slog.Info(fmt.Sprintf("[Auth] Invalid authorization format for %s", c.Path()))
+				slog.Info("[Auth] invalid authorization format", "path", c.Path())
 				return fiber.NewError(fiber.StatusUnauthorized, "Invalid authorization format")
 			}
 		}
@@ -204,31 +204,31 @@ func JWTAuth(secret string) fiber.Handler {
 		}
 
 		if tokenString == "" {
-			slog.Info(fmt.Sprintf("[Auth] Missing authorization for %s", c.Path()))
+			slog.Info("[Auth] missing authorization", "path", c.Path())
 			return fiber.NewError(fiber.StatusUnauthorized, "Missing authorization")
 		}
 
 		token, err := ParseJWT(tokenString, secret)
 
 		if err != nil {
-			slog.Error(fmt.Sprintf("[Auth] Token parse error for %s: %v", c.Path(), err))
+			slog.Error("[Auth] token parse error", "path", c.Path(), "error", err)
 			return fiber.NewError(fiber.StatusUnauthorized, "Invalid token")
 		}
 
 		if !token.Valid {
-			slog.Info(fmt.Sprintf("[Auth] Invalid token for %s", c.Path()))
+			slog.Info("[Auth] invalid token", "path", c.Path())
 			return fiber.NewError(fiber.StatusUnauthorized, "Invalid token")
 		}
 
 		claims, ok := token.Claims.(*UserClaims)
 		if !ok {
-			slog.Info(fmt.Sprintf("[Auth] Invalid token claims for %s", c.Path()))
+			slog.Info("[Auth] invalid token claims", "path", c.Path())
 			return fiber.NewError(fiber.StatusUnauthorized, "Invalid token claims")
 		}
 
 		// Check if token has been revoked (server-side logout)
 		if claims.ID != "" && IsTokenRevoked(claims.ID) {
-			slog.Info(fmt.Sprintf("[Auth] Revoked token used for %s", c.Path()))
+			slog.Info("[Auth] revoked token used", "path", c.Path())
 			return fiber.NewError(fiber.StatusUnauthorized, "Token has been revoked")
 		}
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -277,16 +277,16 @@ func NewServer(cfg Config) (*Server, error) {
 	persistenceConfigPath := filepath.Join(filepath.Dir(cfg.DatabasePath), "persistence.json")
 	persistenceStore := store.NewPersistenceStore(persistenceConfigPath)
 	if err := persistenceStore.Load(); err != nil {
-		slog.Error(fmt.Sprintf("Warning: Failed to load persistence config: %v", err))
+		slog.Error("[Server] failed to load persistence config", "error", err)
 	}
 	slog.Info("Persistence store initialized")
 
 	// Initialize persistent settings manager
 	settingsManager := settings.GetSettingsManager()
 	if err := settingsManager.MigrateFromConfigYaml(agent.GetConfigManager()); err != nil {
-		slog.Error(fmt.Sprintf("Warning: Failed to migrate settings from config.yaml: %v", err))
+		slog.Error("[Server] failed to migrate settings from config.yaml", "error", err)
 	}
-	slog.Info(fmt.Sprintf("Settings manager initialized (%s)", settingsManager.GetSettingsPath()))
+	slog.Info("[Server] settings manager initialized", "path", settingsManager.GetSettingsPath())
 
 	server := &Server{
 		app:                 app,
@@ -329,9 +329,9 @@ func startLoadingServer(addr string) *http.Server {
 
 	srv := &http.Server{Addr: addr, Handler: mux}
 	go func() {
-		slog.Info(fmt.Sprintf("Loading page available on %s", addr))
+		slog.Info("[Server] loading page available", "addr", addr)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error(fmt.Sprintf("Loading server error: %v", err))
+			slog.Error("[Server] loading server error", "error", err)
 		}
 	}()
 	// Give the listener time to bind
@@ -1145,11 +1145,11 @@ func (s *Server) Start() error {
 		// Wait for the OS to fully release the port instead of a fixed sleep.
 		// The previous 50ms sleep was insufficient on some systems.
 		if err := waitForPortRelease(listenPort, portReleaseTimeout); err != nil {
-			slog.Warn(fmt.Sprintf("Warning: port %d may not be fully released: %v", listenPort, err))
+			slog.Warn("[Server] port may not be fully released", "port", listenPort, "error", err)
 		}
 	}
 
-	slog.Info(fmt.Sprintf("Starting server on %s (dev=%v)", addr, s.config.DevMode))
+	slog.Info("[Server] starting", "addr", addr, "devMode", s.config.DevMode)
 	return s.app.Listen(addr)
 }
 
@@ -1192,7 +1192,7 @@ func (s *Server) Shutdown() error {
 	}
 	if s.bridge != nil {
 		if err := s.bridge.Stop(); err != nil {
-			slog.Error(fmt.Sprintf("Warning: MCP bridge shutdown error: %v", err))
+			slog.Error("[Server] MCP bridge shutdown error", "error", err)
 		}
 	}
 	if err := s.store.Close(); err != nil {
@@ -1225,7 +1225,7 @@ func LoadConfigFromEnv() Config {
 	var backendPort int
 	if p := os.Getenv("BACKEND_PORT"); p != "" {
 		if v, err := strconv.Atoi(p); err != nil {
-			slog.Warn(fmt.Sprintf("WARNING: invalid BACKEND_PORT %q, ignoring: %v", p, err))
+			slog.Warn("[Server] invalid BACKEND_PORT, ignoring", "value", p, "error", err)
 		} else {
 			backendPort = v
 		}
@@ -1326,9 +1326,8 @@ func warnDefaultEnvVars(vars map[string]string) {
 	for _, envVar := range keys {
 		defaultVal := vars[envVar]
 		if os.Getenv(envVar) == "" {
-			slog.Warn(fmt.Sprintf("WARNING: %s is not set, using default %q — "+
-				"set this env var for fork/enterprise deployments to avoid "+
-				"routing actions to the upstream repository", envVar, defaultVal))
+			slog.Warn("[Server] env var not set, using default — set this for fork/enterprise deployments",
+				"envVar", envVar, "default", defaultVal)
 		}
 	}
 }
@@ -1343,7 +1342,7 @@ func generateDevSecret() string {
 	if _, err := rand.Read(b); err != nil {
 		// crypto/rand.Read should never fail on supported platforms;
 		// if it does, fall back to a logged warning and a best-effort value.
-		slog.Error(fmt.Sprintf("WARNING: crypto/rand.Read failed: %v — using fallback", err))
+		slog.Error("[Server] crypto/rand.Read failed, using fallback", "error", err)
 		return fmt.Sprintf("dev-fallback-%d", b)
 	}
 	return hex.EncodeToString(b)

--- a/pkg/k8s/argocd.go
+++ b/pkg/k8s/argocd.go
@@ -54,7 +54,7 @@ func (m *MultiClusterClient) ListArgoApplications(ctx context.Context) (*v1alpha
 
 			clusterApps, err := m.ListArgoApplicationsForCluster(ctx, cluster, "")
 			if err != nil {
-				slog.Error(fmt.Sprintf("[argocd] Error listing applications on cluster %s: %v", cluster, err))
+				slog.Error("[argocd] error listing applications", "cluster", cluster, "error", err)
 				return
 			}
 
@@ -93,7 +93,7 @@ func (m *MultiClusterClient) ListArgoApplicationsForCluster(ctx context.Context,
 			return []v1alpha1.ArgoApplication{}, nil
 		}
 		// Real error (auth, network, RBAC) — log and propagate
-		slog.Error(fmt.Sprintf("[argocd] Error listing applications on cluster %s: %v", contextName, err))
+		slog.Error("[argocd] error listing applications", "cluster", contextName, "error", err)
 		return nil, err
 	}
 
@@ -208,7 +208,7 @@ func (m *MultiClusterClient) ListArgoApplicationSets(ctx context.Context) (*v1al
 
 			clusterAppSets, err := m.ListArgoApplicationSetsForCluster(ctx, cluster)
 			if err != nil {
-				slog.Info(fmt.Sprintf("[ArgoCD] Skipping cluster %s for ApplicationSets: %v", cluster, err))
+				slog.Info("[ArgoCD] skipping cluster for ApplicationSets", "cluster", cluster, "error", err)
 				return // CRD not installed or cluster unreachable — skip silently
 			}
 

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -655,7 +655,7 @@ func NewMultiClusterClient(kubeconfig string) (*MultiClusterClient, error) {
 			slog.Info("Using in-cluster config (no kubeconfig file found)")
 			client.inClusterConfig = inClusterConfig
 			client.inClusterName = detectInClusterName(inClusterConfig)
-			slog.Info(fmt.Sprintf("Detected in-cluster name: %s", client.inClusterName))
+			slog.Info("detected in-cluster name", "name", client.inClusterName)
 		}
 	}
 
@@ -773,11 +773,11 @@ func (m *MultiClusterClient) StartWatching() error {
 	// Also watch the directory (for editors that do atomic saves)
 	dir := filepath.Dir(m.kubeconfig)
 	if err := watcher.Add(dir); err != nil {
-		slog.Warn(fmt.Sprintf("Warning: could not watch kubeconfig directory: %v", err))
+		slog.Warn("could not watch kubeconfig directory", "error", err)
 	}
 
 	go m.watchLoop()
-	slog.Info(fmt.Sprintf("Watching kubeconfig for changes: %s", m.kubeconfig))
+	slog.Info("watching kubeconfig for changes", "path", m.kubeconfig)
 	return nil
 }
 
@@ -787,7 +787,7 @@ func (m *MultiClusterClient) StartWatching() error {
 func (m *MultiClusterClient) reloadAndNotify() {
 	slog.Info("Kubeconfig changed, reloading...")
 	if err := m.LoadConfig(); err != nil {
-		slog.Info(fmt.Sprintf("Error reloading kubeconfig: %v", err))
+		slog.Error("error reloading kubeconfig", "error", err)
 		return
 	}
 	slog.Info("Kubeconfig reloaded successfully")
@@ -797,7 +797,7 @@ func (m *MultiClusterClient) reloadAndNotify() {
 	if m.watcher != nil {
 		_ = m.watcher.Remove(m.kubeconfig)
 		if err := m.watcher.Add(m.kubeconfig); err != nil {
-			slog.Warn(fmt.Sprintf("Warning: could not re-watch kubeconfig file: %v", err))
+			slog.Warn("could not re-watch kubeconfig file", "error", err)
 		}
 	}
 
@@ -856,7 +856,7 @@ func (m *MultiClusterClient) watchLoop() {
 			if !ok {
 				return
 			}
-			slog.Error(fmt.Sprintf("Kubeconfig watcher error: %v", err))
+			slog.Error("kubeconfig watcher error", "error", err)
 		case <-pollTicker.C:
 			// Polling fallback: detect changes that fsnotify missed
 			info, err := os.Stat(m.kubeconfig)
@@ -1033,11 +1033,11 @@ func (m *MultiClusterClient) WarmupHealthCache() {
 
 	clusters, err := m.DeduplicatedClusters(ctx)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[Warmup] failed to list clusters: %v", err))
+		slog.Error("[Warmup] failed to list clusters", "error", err)
 		return
 	}
 
-	slog.Info(fmt.Sprintf("[Warmup] probing %d clusters for reachability...", len(clusters)))
+	slog.Info("[Warmup] probing clusters for reachability", "clusterCount", len(clusters))
 	var wg sync.WaitGroup
 	for _, cl := range clusters {
 		wg.Add(1)
@@ -1061,9 +1061,9 @@ func (m *MultiClusterClient) WarmupHealthCache() {
 				m.cacheTime[ctxName] = time.Now()
 				m.mu.Unlock()
 				if errType == "auth" {
-					slog.Info(fmt.Sprintf("[Warmup] %s: auth failure — run credential refresh (e.g. tsh kube login) to restore access", name))
+					slog.Info("[Warmup] auth failure — run credential refresh to restore access", "cluster", name)
 				} else {
-					slog.Error(fmt.Sprintf("[Warmup] %s: unreachable (client error)", name))
+					slog.Error("[Warmup] unreachable (client error)", "cluster", name)
 				}
 				return
 			}
@@ -1083,9 +1083,9 @@ func (m *MultiClusterClient) WarmupHealthCache() {
 				m.cacheTime[ctxName] = time.Now()
 				m.mu.Unlock()
 				if errType == "auth" {
-					slog.Info(fmt.Sprintf("[Warmup] %s: auth failure (will cache for %v to avoid exec-plugin spam)", name, authFailureCacheTTL))
+					slog.Info("[Warmup] auth failure (will cache to avoid exec-plugin spam)", "cluster", name, "cacheTTL", authFailureCacheTTL)
 				} else {
-					slog.Info(fmt.Sprintf("[Warmup] %s: unreachable (%v)", name, listErr))
+					slog.Info("[Warmup] unreachable", "cluster", name, "error", listErr)
 				}
 			} else {
 				m.mu.Lock()
@@ -1097,7 +1097,7 @@ func (m *MultiClusterClient) WarmupHealthCache() {
 				}
 				m.cacheTime[ctxName] = time.Now()
 				m.mu.Unlock()
-				slog.Info(fmt.Sprintf("[Warmup] %s: reachable", name))
+				slog.Info("[Warmup] reachable", "cluster", name)
 			}
 		}(cl.Name, cl.Context)
 	}
@@ -1123,7 +1123,7 @@ func (m *MultiClusterClient) WarmupHealthCache() {
 		}
 	}
 	m.mu.RUnlock()
-	slog.Info(fmt.Sprintf("[Warmup] done: %d reachable, %d unreachable", reachable, unreachable))
+	slog.Info("[Warmup] done", "reachable", reachable, "unreachable", unreachable)
 }
 
 // HealthyClusters returns deduplicated clusters split into two lists:
@@ -1157,7 +1157,7 @@ func (m *MultiClusterClient) MarkSlow(clusterName string) {
 	m.mu.Lock()
 	m.slowClusters[clusterName] = time.Now()
 	m.mu.Unlock()
-	slog.Info(fmt.Sprintf("[Slow] cluster %s marked as slow (reduced timeout for %v)", clusterName, slowClusterTTL))
+	slog.Info("[Slow] cluster marked as slow", "cluster", clusterName, "duration", slowClusterTTL)
 }
 
 // IsSlow returns true if the cluster was recently marked as slow.

--- a/pkg/k8s/client_gpu.go
+++ b/pkg/k8s/client_gpu.go
@@ -593,9 +593,9 @@ func (m *MultiClusterClient) GetGPUHealthCronJobStatus(ctx context.Context, cont
 		// Auto-reconcile: update CronJob if version is outdated and user has permissions
 		if status.UpdateAvailable && status.CanInstall {
 			if reconcileErr := m.InstallGPUHealthCronJob(ctx, contextName, ns, cj.Spec.Schedule, status.Tier); reconcileErr != nil {
-				slog.Error(fmt.Sprintf("[GPUHealthCronJob] Auto-reconcile failed for %s: %v", contextName, reconcileErr))
+				slog.Error("[GPUHealthCronJob] auto-reconcile failed", "cluster", contextName, "error", reconcileErr)
 			} else {
-				slog.Info(fmt.Sprintf("[GPUHealthCronJob] Auto-reconciled %s to script version %d", contextName, gpuHealthScriptVersion))
+				slog.Info("[GPUHealthCronJob] auto-reconciled to latest version", "cluster", contextName, "version", gpuHealthScriptVersion)
 				status.Version = gpuHealthScriptVersion
 				status.UpdateAvailable = false
 			}
@@ -657,7 +657,7 @@ func readGPUHealthResults(ctx context.Context, client kubernetes.Interface, name
 		Nodes []GPUHealthCheckResult `json:"nodes"`
 	}
 	if jsonErr := json.Unmarshal([]byte(resultsJSON), &wrapper); jsonErr != nil {
-		slog.Error(fmt.Sprintf("[GPUHealthCronJob] Failed to parse ConfigMap results: %v", jsonErr))
+		slog.Error("[GPUHealthCronJob] failed to parse ConfigMap results", "error", jsonErr)
 		return nil
 	}
 	return wrapper.Nodes
@@ -842,7 +842,7 @@ func (m *MultiClusterClient) InstallGPUHealthCronJob(ctx context.Context, contex
 		}
 	}
 
-	slog.Info(fmt.Sprintf("[GPUHealthCronJob] Installed on cluster %s in namespace %s (schedule=%s, tier=%d, version=%d)", contextName, namespace, schedule, tier, gpuHealthScriptVersion))
+	slog.Info("[GPUHealthCronJob] installed", "cluster", contextName, "namespace", namespace, "schedule", schedule, "tier", tier, "version", gpuHealthScriptVersion)
 	return nil
 }
 
@@ -1170,32 +1170,32 @@ func (m *MultiClusterClient) UninstallGPUHealthCronJob(ctx context.Context, cont
 
 	// Delete results ConfigMap
 	if delErr := client.CoreV1().ConfigMaps(namespace).Delete(ctx, gpuHealthConfigMapName, metav1.DeleteOptions{}); delErr != nil && !errors.IsNotFound(delErr) {
-		slog.Warn(fmt.Sprintf("[GPUHealthCronJob] Warning: could not delete results ConfigMap: %v", delErr))
+		slog.Warn("[GPUHealthCronJob] could not delete results ConfigMap", "error", delErr)
 	}
 
 	// Delete associated Jobs
 	if delErr := client.BatchV1().Jobs(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
 		LabelSelector: "app=" + gpuHealthCronJobName,
 	}); delErr != nil {
-		slog.Warn(fmt.Sprintf("[GPUHealthCronJob] Warning: could not clean up jobs: %v", delErr))
+		slog.Warn("[GPUHealthCronJob] could not clean up jobs", "error", delErr)
 	}
 
 	// Delete ClusterRoleBinding
 	if delErr := client.RbacV1().ClusterRoleBindings().Delete(ctx, gpuHealthClusterRoleBinding, metav1.DeleteOptions{}); delErr != nil && !errors.IsNotFound(delErr) {
-		slog.Warn(fmt.Sprintf("[GPUHealthCronJob] Warning: could not delete ClusterRoleBinding: %v", delErr))
+		slog.Warn("[GPUHealthCronJob] could not delete ClusterRoleBinding", "error", delErr)
 	}
 
 	// Delete ClusterRole
 	if delErr := client.RbacV1().ClusterRoles().Delete(ctx, gpuHealthClusterRole, metav1.DeleteOptions{}); delErr != nil && !errors.IsNotFound(delErr) {
-		slog.Warn(fmt.Sprintf("[GPUHealthCronJob] Warning: could not delete ClusterRole: %v", delErr))
+		slog.Warn("[GPUHealthCronJob] could not delete ClusterRole", "error", delErr)
 	}
 
 	// Delete ServiceAccount
 	if delErr := client.CoreV1().ServiceAccounts(namespace).Delete(ctx, gpuHealthServiceAccount, metav1.DeleteOptions{}); delErr != nil && !errors.IsNotFound(delErr) {
-		slog.Warn(fmt.Sprintf("[GPUHealthCronJob] Warning: could not delete ServiceAccount: %v", delErr))
+		slog.Warn("[GPUHealthCronJob] could not delete ServiceAccount", "error", delErr)
 	}
 
-	slog.Info(fmt.Sprintf("[GPUHealthCronJob] Uninstalled from cluster %s namespace %s", contextName, namespace))
+	slog.Info("[GPUHealthCronJob] uninstalled", "cluster", contextName, "namespace", namespace)
 	return nil
 }
 

--- a/pkg/k8s/console_watcher.go
+++ b/pkg/k8s/console_watcher.go
@@ -62,7 +62,7 @@ func (w *ConsoleWatcher) Start(ctx context.Context) error {
 	w.started = true
 	w.mu.Unlock()
 
-	slog.Info(fmt.Sprintf("[ConsoleWatcher] Starting watch on namespace %s", w.namespace))
+	slog.Info("[ConsoleWatcher] starting watch", "namespace", w.namespace)
 
 	// Start watchers for each resource type
 	gvrs := []struct {
@@ -93,7 +93,7 @@ func (w *ConsoleWatcher) Stop() {
 	close(w.stopCh)
 
 	for gvr, watcher := range w.watchers {
-		slog.Info(fmt.Sprintf("[ConsoleWatcher] Stopping watch for %s", gvr.Resource))
+		slog.Info("[ConsoleWatcher] stopping watch", "resource", gvr.Resource)
 		watcher.Stop()
 	}
 
@@ -118,7 +118,7 @@ func (w *ConsoleWatcher) watchResource(ctx context.Context, gvr schema.GroupVers
 
 		err := w.doWatch(ctx, gvr, resourceType)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[ConsoleWatcher] Watch error for %s: %v, retrying in %v", resourceType, err, backoff))
+			slog.Error("[ConsoleWatcher] watch error, retrying", "resourceType", resourceType, "error", err, "retryIn", backoff)
 
 			timer := time.NewTimer(backoff)
 			select {
@@ -145,7 +145,7 @@ func (w *ConsoleWatcher) watchResource(ctx context.Context, gvr schema.GroupVers
 
 // doWatch performs the actual watch operation
 func (w *ConsoleWatcher) doWatch(ctx context.Context, gvr schema.GroupVersionResource, resourceType string) error {
-	slog.Info(fmt.Sprintf("[ConsoleWatcher] Starting watch for %s in namespace %s", resourceType, w.namespace))
+	slog.Info("[ConsoleWatcher] starting watch for resource", "resourceType", resourceType, "namespace", w.namespace)
 
 	watcher, err := w.client.Resource(gvr).Namespace(w.namespace).Watch(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -175,7 +175,7 @@ func (w *ConsoleWatcher) doWatch(ctx context.Context, gvr schema.GroupVersionRes
 			}
 
 			if err := w.handleEvent(event, resourceType); err != nil {
-				slog.Error(fmt.Sprintf("[ConsoleWatcher] Error handling %s event: %v", resourceType, err))
+				slog.Error("[ConsoleWatcher] error handling event", "resourceType", resourceType, "error", err)
 			}
 		}
 	}
@@ -229,7 +229,7 @@ func (w *ConsoleWatcher) handleEvent(event watch.Event, resourceType string) err
 		Resource:     resource,
 	}
 
-	slog.Info(fmt.Sprintf("[ConsoleWatcher] %s %s: %s/%s", eventType, resourceType, u.GetNamespace(), u.GetName()))
+	slog.Info("[ConsoleWatcher] resource event", "eventType", eventType, "resourceType", resourceType, "namespace", u.GetNamespace(), "name", u.GetName())
 
 	// Call handler
 	if w.handler != nil {

--- a/pkg/k8s/workload.go
+++ b/pkg/k8s/workload.go
@@ -85,7 +85,7 @@ func (m *MultiClusterClient) ListWorkloads(ctx context.Context, cluster, namespa
 	var mu sync.Mutex
 	workloads := make([]v1alpha1.Workload, 0)
 
-	slog.Info(fmt.Sprintf("[ListWorkloads] Listing workloads across %d clusters: %v", len(clusterNames), clusterNames))
+	slog.Info("[ListWorkloads] listing workloads", "clusterCount", len(clusterNames), "clusters", clusterNames)
 	for _, clusterName := range clusterNames {
 		wg.Add(1)
 		go func(c string) {
@@ -93,10 +93,10 @@ func (m *MultiClusterClient) ListWorkloads(ctx context.Context, cluster, namespa
 
 			clusterWorkloads, err := m.ListWorkloadsForCluster(ctx, c, namespace, workloadType)
 			if err != nil {
-				slog.Error(fmt.Sprintf("[ListWorkloads] Error listing workloads for cluster %q: %v", c, err))
+				slog.Error("[ListWorkloads] error listing workloads for cluster", "cluster", c, "error", err)
 				return
 			}
-			slog.Info(fmt.Sprintf("[ListWorkloads] Found %d workloads in cluster %q", len(clusterWorkloads), c))
+			slog.Info("[ListWorkloads] found workloads in cluster", "count", len(clusterWorkloads), "cluster", c)
 
 			mu.Lock()
 			workloads = append(workloads, clusterWorkloads...)
@@ -130,7 +130,7 @@ func (m *MultiClusterClient) ListWorkloadsForCluster(ctx context.Context, contex
 			deployments, err = dynamicClient.Resource(gvrDeployments).Namespace(namespace).List(ctx, metav1.ListOptions{})
 		}
 		if err != nil {
-			slog.Error(fmt.Sprintf("[ListWorkloadsForCluster] %s: error listing deployments: %v", contextName, err))
+			slog.Error("[ListWorkloadsForCluster] error listing deployments", "cluster", contextName, "error", err)
 		} else {
 			parsed := m.parseDeploymentsAsWorkloads(deployments, contextName)
 			workloads = append(workloads, parsed...)
@@ -146,7 +146,7 @@ func (m *MultiClusterClient) ListWorkloadsForCluster(ctx context.Context, contex
 			statefulsets, err = dynamicClient.Resource(gvrStatefulSets).Namespace(namespace).List(ctx, metav1.ListOptions{})
 		}
 		if err != nil {
-			slog.Error(fmt.Sprintf("[ListWorkloadsForCluster] %s: error listing statefulsets: %v", contextName, err))
+			slog.Error("[ListWorkloadsForCluster] error listing statefulsets", "cluster", contextName, "error", err)
 		} else {
 			parsed := m.parseStatefulSetsAsWorkloads(statefulsets, contextName)
 			workloads = append(workloads, parsed...)
@@ -162,7 +162,7 @@ func (m *MultiClusterClient) ListWorkloadsForCluster(ctx context.Context, contex
 			daemonsets, err = dynamicClient.Resource(gvrDaemonSets).Namespace(namespace).List(ctx, metav1.ListOptions{})
 		}
 		if err != nil {
-			slog.Error(fmt.Sprintf("[ListWorkloadsForCluster] %s: error listing daemonsets: %v", contextName, err))
+			slog.Error("[ListWorkloadsForCluster] error listing daemonsets", "cluster", contextName, "error", err)
 		} else {
 			parsed := m.parseDaemonSetsAsWorkloads(daemonsets, contextName)
 			workloads = append(workloads, parsed...)
@@ -472,12 +472,12 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 	// 2. Resolve dependencies (ConfigMaps, Secrets, SA, RBAC, PVCs, Services, Ingress, NetworkPolicy, HPA, PDB)
 	bundle, err := m.ResolveDependencies(ctx, sourceCluster, namespace, sourceObj, opts)
 	if err != nil {
-		slog.Error(fmt.Sprintf("[deploy] Warning: dependency resolution failed: %v", err))
+		slog.Warn("[deploy] dependency resolution failed", "error", err)
 		bundle = &DependencyBundle{Workload: sourceObj}
 	}
 	if len(bundle.Warnings) > 0 {
 		for _, w := range bundle.Warnings {
-			slog.Info(fmt.Sprintf("[deploy] %s", w))
+			slog.Info("[deploy] dependency warning", "warning", w)
 		}
 	}
 
@@ -519,7 +519,7 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 			// 4a. Ensure namespace exists on target
 			nsErr := m.ensureNamespace(clusterCtx, targetClient, namespace, opts)
 			if nsErr != nil {
-				slog.Error(fmt.Sprintf("[deploy] Warning: namespace ensure failed on %s: %v", targetCluster, nsErr))
+				slog.Warn("[deploy] namespace ensure failed", "cluster", targetCluster, "error", nsErr)
 			}
 
 			// 4b. Apply dependencies in order before the workload
@@ -670,7 +670,7 @@ func applyDependencies(
 				// Not managed by console — skip to avoid overwriting user resources
 				result.Action = "skipped"
 				results = append(results, result)
-				slog.Info(fmt.Sprintf("[deploy] Skipped %s %s (not console-managed)", dep.Kind, dep.Name))
+				slog.Info("[deploy] skipped (not console-managed)", "kind", dep.Kind, "name", dep.Name)
 				continue
 			}
 			// Console-managed — update
@@ -678,25 +678,25 @@ func applyDependencies(
 			_, err = resource.Update(ctx, objCopy, metav1.UpdateOptions{})
 			if err != nil {
 				result.Action = "failed"
-				slog.Error(fmt.Sprintf("[deploy] Failed to update %s %s: %v", dep.Kind, dep.Name, err))
+				slog.Error("[deploy] failed to update dependency", "kind", dep.Kind, "name", dep.Name, "error", err)
 			} else {
 				result.Action = "updated"
-				slog.Info(fmt.Sprintf("[deploy] Updated %s %s", dep.Kind, dep.Name))
+				slog.Info("[deploy] updated dependency", "kind", dep.Kind, "name", dep.Name)
 			}
 		} else if apierrors.IsNotFound(err) {
 			// Resource doesn't exist — create
 			_, err = resource.Create(ctx, objCopy, metav1.CreateOptions{})
 			if err != nil {
 				result.Action = "failed"
-				slog.Error(fmt.Sprintf("[deploy] Failed to create %s %s: %v", dep.Kind, dep.Name, err))
+				slog.Error("[deploy] failed to create dependency", "kind", dep.Kind, "name", dep.Name, "error", err)
 			} else {
 				result.Action = "created"
-				slog.Info(fmt.Sprintf("[deploy] Created %s %s", dep.Kind, dep.Name))
+				slog.Info("[deploy] created dependency", "kind", dep.Kind, "name", dep.Name)
 			}
 		} else {
 			// Real error (network, RBAC, etc.) — do not assume resource is missing
 			result.Action = "failed"
-			slog.Error(fmt.Sprintf("[deploy] Failed to check %s %s: %v", dep.Kind, dep.Name, err))
+			slog.Error("[deploy] failed to check dependency", "kind", dep.Kind, "name", dep.Name, "error", err)
 		}
 
 		results = append(results, result)
@@ -966,7 +966,7 @@ func (m *MultiClusterClient) DeleteWorkload(ctx context.Context, cluster, namesp
 			}
 			return fmt.Errorf("failed to delete %s %s/%s on cluster %s: %w", g.kind, namespace, name, cluster, err)
 		}
-		slog.Info(fmt.Sprintf("[delete] Deleted %s %s/%s from cluster %s", g.kind, namespace, name, cluster))
+		slog.Info("[delete] deleted workload", "kind", g.kind, "namespace", namespace, "name", name, "cluster", cluster)
 		return nil
 	}
 

--- a/pkg/mcp/bridge.go
+++ b/pkg/mcp/bridge.go
@@ -116,7 +116,7 @@ func (b *Bridge) Start(ctx context.Context) error {
 	// Start kubestellar-ops if path is configured and binary exists
 	if b.config.KubestellarOpsPath != "" {
 		if _, err := exec.LookPath(b.config.KubestellarOpsPath); err != nil {
-			slog.Info(fmt.Sprintf("kubestellar-ops binary not found on PATH (%q) — MCP ops tools will be unavailable. Install via: brew install kubestellar/tap/kubestellar-ops", b.config.KubestellarOpsPath))
+			slog.Info("kubestellar-ops binary not found on PATH — MCP ops tools will be unavailable", "path", b.config.KubestellarOpsPath, "install", "brew install kubestellar/tap/kubestellar-ops")
 		} else {
 			wg.Add(1)
 			go func() {
@@ -131,7 +131,7 @@ func (b *Bridge) Start(ctx context.Context) error {
 	// Start kubestellar-deploy if path is configured and binary exists
 	if b.config.KubestellarDeployPath != "" {
 		if _, err := exec.LookPath(b.config.KubestellarDeployPath); err != nil {
-			slog.Info(fmt.Sprintf("kubestellar-deploy binary not found on PATH (%q) — MCP deploy tools will be unavailable. Install via: brew install kubestellar/tap/kubestellar-deploy", b.config.KubestellarDeployPath))
+			slog.Info("kubestellar-deploy binary not found on PATH — MCP deploy tools will be unavailable", "path", b.config.KubestellarDeployPath, "install", "brew install kubestellar/tap/kubestellar-deploy")
 		} else {
 			wg.Add(1)
 			go func() {
@@ -146,7 +146,7 @@ func (b *Bridge) Start(ctx context.Context) error {
 	// Start inspektor-gadget if path is configured and binary exists
 	if b.config.InspektorGadgetPath != "" {
 		if _, err := exec.LookPath(b.config.InspektorGadgetPath); err != nil {
-			slog.Info(fmt.Sprintf("inspektor-gadget MCP binary not found on PATH (%q) — Gadget tools will be unavailable.", b.config.InspektorGadgetPath))
+			slog.Info("inspektor-gadget MCP binary not found on PATH — Gadget tools will be unavailable", "path", b.config.InspektorGadgetPath)
 		} else {
 			wg.Add(1)
 			go func() {

--- a/pkg/notifications/service.go
+++ b/pkg/notifications/service.go
@@ -22,7 +22,7 @@ func NewService() *Service {
 func (s *Service) RegisterSlackNotifier(id, webhookURL, channel string) {
 	if webhookURL != "" {
 		s.notifiers[fmt.Sprintf("slack:%s", id)] = NewSlackNotifier(webhookURL, channel)
-		slog.Info(fmt.Sprintf("Registered Slack notifier: %s", id))
+		slog.Info("registered Slack notifier", "id", id)
 	}
 }
 
@@ -30,7 +30,7 @@ func (s *Service) RegisterSlackNotifier(id, webhookURL, channel string) {
 func (s *Service) RegisterPagerDutyNotifier(id, routingKey string) {
 	if routingKey != "" {
 		s.notifiers[fmt.Sprintf("pagerduty:%s", id)] = NewPagerDutyNotifier(routingKey)
-		slog.Info(fmt.Sprintf("Registered PagerDuty notifier: %s", id))
+		slog.Info("registered PagerDuty notifier", "id", id)
 	}
 }
 
@@ -38,7 +38,7 @@ func (s *Service) RegisterPagerDutyNotifier(id, routingKey string) {
 func (s *Service) RegisterOpsGenieNotifier(id, apiKey string) {
 	if apiKey != "" {
 		s.notifiers[fmt.Sprintf("opsgenie:%s", id)] = NewOpsGenieNotifier(apiKey)
-		slog.Info(fmt.Sprintf("Registered OpsGenie notifier: %s", id))
+		slog.Info("registered OpsGenie notifier", "id", id)
 	}
 }
 
@@ -50,7 +50,7 @@ func (s *Service) RegisterEmailNotifier(id, smtpHost string, smtpPort int, usern
 			recipients[i] = strings.TrimSpace(r)
 		}
 		s.notifiers[fmt.Sprintf("email:%s", id)] = NewEmailNotifier(smtpHost, smtpPort, username, password, from, recipients)
-		slog.Info(fmt.Sprintf("Registered Email notifier: %s", id))
+		slog.Info("registered Email notifier", "id", id)
 	}
 }
 
@@ -65,10 +65,10 @@ func (s *Service) SendAlert(alert Alert) error {
 	for id, notifier := range s.notifiers {
 		if err := notifier.Send(alert); err != nil {
 			errMsg := fmt.Sprintf("failed to send notification via %s: %v", id, err)
-			slog.Info(errMsg)
+			slog.Error("failed to send notification", "notifier", id, "error", err)
 			errors = append(errors, errMsg)
 		} else {
-			slog.Info(fmt.Sprintf("Successfully sent alert notification via %s", id))
+			slog.Info("sent alert notification", "notifier", id)
 		}
 	}
 
@@ -135,10 +135,10 @@ func (s *Service) SendAlertToChannels(alert Alert, channels []NotificationChanne
 		if notifier != nil {
 			if err := notifier.Send(alert); err != nil {
 				errMsg := fmt.Sprintf("failed to send notification via %s channel %s: %v", channel.Type, channelID, err)
-				slog.Info(errMsg)
+				slog.Error("failed to send notification", "channelType", channel.Type, "channelID", channelID, "error", err)
 				errors = append(errors, errMsg)
 			} else {
-				slog.Info(fmt.Sprintf("Successfully sent alert notification via %s channel %s", channel.Type, channelID))
+				slog.Info("sent alert notification", "channelType", channel.Type, "channelID", channelID)
 			}
 		}
 	}

--- a/pkg/settings/manager.go
+++ b/pkg/settings/manager.go
@@ -53,7 +53,7 @@ func GetSettingsManager() *SettingsManager {
 			keyPath:      filepath.Join(kcDir, keyFileName),
 		}
 		if err := globalSettingsManager.init(); err != nil {
-			slog.Error(fmt.Sprintf("[settings] initialization error: %v", err))
+			slog.Error("[settings] initialization error", "error", err)
 			// Ensure settings is never nil even when init fails
 			globalSettingsManager.settings = DefaultSettings()
 		}
@@ -166,7 +166,7 @@ func (sm *SettingsManager) GetAll() (*AllSettings, error) {
 		sm.mu.Lock()
 		sm.migrateLegacyGitHubToken()
 		if err := sm.saveLocked(); err != nil {
-			slog.Error(fmt.Sprintf("[settings] failed to persist legacy token migration: %v", err))
+			slog.Error("[settings] failed to persist legacy token migration", "error", err)
 		}
 		sm.mu.Unlock()
 	}
@@ -201,11 +201,11 @@ func (sm *SettingsManager) GetAll() (*AllSettings, error) {
 	if sm.settings.Encrypted.APIKeys != nil {
 		plaintext, err := decrypt(sm.key, sm.settings.Encrypted.APIKeys)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[settings] failed to decrypt API keys: %v", err))
+			slog.Error("[settings] failed to decrypt API keys", "error", err)
 		} else if plaintext != nil {
 			var keys map[string]APIKeyEntry
 			if err := json.Unmarshal(plaintext, &keys); err != nil {
-				slog.Error(fmt.Sprintf("[settings] failed to parse decrypted API keys: %v", err))
+				slog.Error("[settings] failed to parse decrypted API keys", "error", err)
 			} else {
 				all.APIKeys = keys
 			}
@@ -216,7 +216,7 @@ func (sm *SettingsManager) GetAll() (*AllSettings, error) {
 	if sm.settings.Encrypted.FeedbackGitHubToken != nil {
 		plaintext, err := decrypt(sm.key, sm.settings.Encrypted.FeedbackGitHubToken)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[settings] failed to decrypt GitHub token: %v", err))
+			slog.Error("[settings] failed to decrypt GitHub token", "error", err)
 		} else if plaintext != nil {
 			all.FeedbackGitHubToken = string(plaintext)
 			all.FeedbackGitHubTokenSource = GitHubTokenSourceSettings
@@ -236,11 +236,11 @@ func (sm *SettingsManager) GetAll() (*AllSettings, error) {
 	if sm.settings.Encrypted.Notifications != nil {
 		plaintext, err := decrypt(sm.key, sm.settings.Encrypted.Notifications)
 		if err != nil {
-			slog.Error(fmt.Sprintf("[settings] failed to decrypt notifications: %v", err))
+			slog.Error("[settings] failed to decrypt notifications", "error", err)
 		} else if plaintext != nil {
 			var notif NotificationSecrets
 			if err := json.Unmarshal(plaintext, &notif); err != nil {
-				slog.Error(fmt.Sprintf("[settings] failed to parse decrypted notifications: %v", err))
+				slog.Error("[settings] failed to parse decrypted notifications", "error", err)
 			} else {
 				all.Notifications = notif
 			}
@@ -362,7 +362,7 @@ func (sm *SettingsManager) MigrateFromConfigYaml(cp ConfigProvider) error {
 	}
 	sm.settings.Encrypted.APIKeys = enc
 
-	slog.Info(fmt.Sprintf("[settings] migrated %d API key(s) from config.yaml", len(keys)))
+	slog.Info("[settings] migrated API keys from config.yaml", "count", len(keys))
 	return sm.saveLocked()
 }
 

--- a/pkg/store/persistence_config.go
+++ b/pkg/store/persistence_config.go
@@ -163,8 +163,7 @@ func (p *PersistenceStore) Save() error {
 		return fmt.Errorf("failed to write persistence config: %w", err)
 	}
 
-	slog.Info(fmt.Sprintf("[PersistenceStore] Config saved: enabled=%v, primary=%s, secondary=%s",
-		p.config.Enabled, p.config.PrimaryCluster, p.config.SecondaryCluster))
+	slog.Info("[PersistenceStore] config saved", "enabled", p.config.Enabled, "primary", p.config.PrimaryCluster, "secondary", p.config.SecondaryCluster)
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Converts all 609 instances of `slog.Info/Warn/Error(fmt.Sprintf(...))` to use slog's native key-value structured fields across 62 Go files. This was the last remaining finding from the comprehensive code review.

**Before:**
```go
slog.Error(fmt.Sprintf("[K8s] cluster %s health check failed: %v", name, err))
slog.Info(fmt.Sprintf("[AutoUpdate] Step %d/%d: %s", step, total, desc))
```

**After:**
```go
slog.Error("[K8s] cluster health check failed", "cluster", name, "error", err)
slog.Info("[AutoUpdate] step progress", "step", step, "total", total, "description", desc)
```

### Why
- Enables machine-readable structured JSON log output for aggregation tools (ELK, Datadog, Grafana Loki)
- Removes unnecessary `fmt.Sprintf` string formatting overhead (slog evaluates lazily)
- Log fields are now individually queryable/filterable
- Removed unused `fmt` imports from 18 files

### Scope
- 62 files modified, 609 conversions
- No logic changes — purely logging format migration
- Removed 18 unused `fmt` imports

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All tests pass (store, notifications, mcp, models, middleware, settings)
- [x] Zero remaining `fmt.Sprintf` + `slog` instances: `grep -rn 'fmt.Sprintf' pkg/ cmd/ --include="*.go" | grep -v _test.go | grep 'slog\.' | wc -l` → 0