### PR TITLE
fix: dynamic card config crash and GitHubActivity magic number

### DIFF
--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react'
 import { GitPullRequest, GitBranch, Star, Users, Package, TrendingUp, AlertCircle, Clock, CheckCircle, XCircle, GitMerge, Settings, X, Plus, Check } from 'lucide-react'
 import { FETCH_EXTERNAL_TIMEOUT_MS } from '../../lib/constants'
+import { POLL_INTERVAL_SLOW_MS } from '../../lib/constants/network'
 import { Button } from '../ui/Button'
 import { Skeleton } from '../ui/Skeleton'
 import { useDemoMode } from '../../hooks/useDemoMode'
@@ -434,7 +435,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
     fetchGitHubData().catch(() => { /* errors handled inside fetchGitHubData */ })
     // Auto-refresh every 60 seconds (bypasses cache for fresh data) — skip in demo mode
     if (!isDemoMode) {
-      const interval = setInterval(() => fetchGitHubData(true).catch(() => { /* errors handled inside fetchGitHubData */ }), 60_000)
+      const interval = setInterval(() => fetchGitHubData(true).catch(() => { /* errors handled inside fetchGitHubData */ }), POLL_INTERVAL_SLOW_MS)
       return () => clearInterval(interval)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/lib/dynamic-cards/compiler.ts
+++ b/web/src/lib/dynamic-cards/compiler.ts
@@ -1,5 +1,5 @@
 import type { CompileResult, DynamicComponentResult } from './types'
-import type { ComponentType } from 'react'
+import { createElement, type ComponentType } from 'react'
 import type { CardComponentProps } from '../../components/cards/cardRegistry'
 import { getDynamicScope } from './scope'
 
@@ -95,7 +95,13 @@ export function createCardComponent(compiledCode: string): DynamicComponentResul
       }
     }
 
-    return { component, error: null, cleanup: timerCleanup }
+    // Wrap the compiled component to guarantee config is always an object.
+    // User-written card code may destructure config (e.g. `const { filter } = config`)
+    // which throws if config is undefined (the prop is optional in CardComponentProps).
+    const SafeComponent: ComponentType<CardComponentProps> = (props) =>
+      createElement(component, { ...props, config: props.config ?? {} })
+
+    return { component: SafeComponent, error: null, cleanup: timerCleanup }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     return { component: null, error: `Runtime error: ${message}` }


### PR DESCRIPTION
## Summary

Two remaining GA4 error fixes from the code review:

1. **Dynamic card config crash** (~9 `ksc_error` events/week on `/alerts`): User-written card code that destructures `config` (e.g. `const { filter } = config`) crashes when `config` is `undefined` because `CardComponentProps.config` is optional. Wraps compiled dynamic components to guarantee `config` is always an object via `props.config ?? {}`.

2. **GitHubActivity magic number**: Replace hardcoded `60_000` polling interval with `POLL_INTERVAL_SLOW_MS` from network constants for consistency with zero-magic-numbers policy.

## Test plan
- [x] `npm run build` passes
- [x] Monitor GA4 — expect `/alerts` `ksc_error` events to drop to ~0