### PR TITLE
🐛 Fix search interference, update errors, MCP install, health indicators, single-cluster

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -332,7 +332,11 @@ if [ -n "$MCP_MISSING" ]; then
     echo ""
     echo "  Note: $MCP_MISSING not found on PATH."
     echo "  MCP tools (Kubernetes ops and deploy) will be unavailable."
-    echo "  To install, follow Step 1 of the Quick Start guide:"
+    echo ""
+    echo "  Quick install via Homebrew:"
+    echo "    brew install kubestellar/tap/kubestellar-ops kubestellar/tap/kubestellar-deploy"
+    echo ""
+    echo "  Or follow the full Quick Start guide:"
     echo "    https://kubestellar.io/docs/console/overview/quick-start#step-1-install-kubestellar-mcp-tools"
     echo ""
 fi

--- a/web/src/components/alerts/AlertRuleEditor.tsx
+++ b/web/src/components/alerts/AlertRuleEditor.tsx
@@ -44,7 +44,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
     { value: 'warning', label: t('alerts.severityOptions.warning'), color: 'bg-orange-500' },
     { value: 'info', label: t('alerts.severityOptions.info'), color: 'bg-blue-500' },
   ]
-  const { clusters } = useClusters()
+  const { deduplicatedClusters: clusters } = useClusters()
 
   // Form state
   const [name, setName] = useState(rule?.name || '')

--- a/web/src/components/gpu/GPUDashboardTab.tsx
+++ b/web/src/components/gpu/GPUDashboardTab.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Plus,
@@ -15,6 +16,8 @@ import {
   SortableContext,
   rectSortingStrategy,
 } from '@dnd-kit/sortable'
+import { useClusters } from '../../hooks/useMCP'
+import { StatusIndicator } from '../charts/StatusIndicator'
 
 export interface GPUDashboardTabProps {
   dashboardCards: GpuDashCard[]
@@ -42,9 +45,34 @@ export function GPUDashboardTab({
   onShowAddCardModal,
 }: GPUDashboardTabProps) {
   const { t } = useTranslation(['cards', 'common'])
+  const { deduplicatedClusters: clusters } = useClusters()
+
+  const clusterHealth = useMemo(() => {
+    const all = clusters || []
+    const connected = all.filter(c => c.reachable !== false)
+    const disconnected = all.filter(c => c.reachable === false)
+    return { total: all.length, connected: connected.length, disconnected: disconnected.length }
+  }, [clusters])
 
   return (
     <div className="space-y-4">
+      {/* Cluster health summary */}
+      {clusterHealth.total > 0 && (
+        <div className="flex items-center gap-4 p-3 rounded-lg bg-secondary/30 border border-border">
+          <span className="text-sm font-medium text-foreground">Cluster Health</span>
+          <div className="flex items-center gap-1.5">
+            <StatusIndicator status="healthy" size="sm" />
+            <span className="text-sm text-foreground">{clusterHealth.connected} connected</span>
+          </div>
+          {clusterHealth.disconnected > 0 && (
+            <div className="flex items-center gap-1.5">
+              <StatusIndicator status="error" size="sm" />
+              <span className="text-sm text-red-400">{clusterHealth.disconnected} disconnected</span>
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">
           {t('gpuReservations.dashboard.customizable')}

--- a/web/src/components/missions/MissionBrowser.tsx
+++ b/web/src/components/missions/MissionBrowser.tsx
@@ -518,9 +518,20 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
   // Filtered installer & fixer lists
   // ============================================================================
 
-  // Effective search: local tab search overrides global search
+  // Effective search: local tab search takes priority; clear global fallback when user types locally
   const effectiveInstallerSearch = installerSearch || searchQuery
   const effectiveFixerSearch = fixerSearch || searchQuery
+
+  /** When user types in a tab-specific search, clear the global search so it does not interfere */
+  const handleInstallerSearchChange = useCallback((value: string) => {
+    setInstallerSearch(value)
+    if (value && searchQuery) setSearchQuery('')
+  }, [searchQuery])
+
+  const handleFixerSearchChange = useCallback((value: string) => {
+    setFixerSearch(value)
+    if (value && searchQuery) setSearchQuery('')
+  }, [searchQuery])
 
   // AND search: each space-separated term must match somewhere in the mission
   const andMatch = (text: string, query: string) => {
@@ -1362,10 +1373,11 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
             </div>
           )}
 
-          {/* Active filter summary */}
-          {activeFilterCount > 0 && (
+          {/* Active filter summary — always show count when recommendations are loaded */}
+          {recommendations.length > 0 && (
             <div className="text-[11px] text-muted-foreground">
-              Showing {filteredRecommendations.length} of {recommendations.length} recommendations
+              Showing {filteredRecommendations.length} of {recommendations.length} missions
+              {activeFilterCount > 0 && ' (filtered)'}
             </div>
           )}
         </div>
@@ -1835,11 +1847,17 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                     <input
                       type="text"
                       value={installerSearch}
-                      onChange={(e) => setInstallerSearch(e.target.value)}
+                      onChange={(e) => handleInstallerSearchChange(e.target.value)}
                       placeholder="Search installers…"
                       className="w-full pl-10 pr-4 py-1.5 bg-secondary border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
                     />
                   </div>
+                  {!installerSearch && searchQuery && (
+                    <span className="text-xs text-purple-400 flex items-center gap-1">
+                      <Filter className="w-3 h-3" />
+                      Filtered by global search: &quot;{searchQuery}&quot;
+                    </span>
+                  )}
                   <select
                     value={installerCategoryFilter}
                     onChange={(e) => setInstallerCategoryFilter(e.target.value)}
@@ -1920,11 +1938,17 @@ export function MissionBrowser({ isOpen, onClose, onImport, initialMission }: Mi
                     <input
                       type="text"
                       value={fixerSearch}
-                      onChange={(e) => setFixerSearch(e.target.value)}
+                      onChange={(e) => handleFixerSearchChange(e.target.value)}
                       placeholder="Search fixes…"
                       className="w-full pl-10 pr-4 py-1.5 bg-secondary border border-border rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-purple-500/40"
                     />
                   </div>
+                  {!fixerSearch && searchQuery && (
+                    <span className="text-xs text-purple-400 flex items-center gap-1">
+                      <Filter className="w-3 h-3" />
+                      Filtered by global search: &quot;{searchQuery}&quot;
+                    </span>
+                  )}
                   <select
                     value={fixerTypeFilter}
                     onChange={(e) => setFixerTypeFilter(e.target.value)}

--- a/web/src/components/pods/Pods.tsx
+++ b/web/src/components/pods/Pods.tsx
@@ -23,7 +23,7 @@ const DEFAULT_POD_CARDS = getDefaultCards('pods')
 export function Pods() {
   // Use cached hooks for stale-while-revalidate pattern
   const { issues: podIssues, isLoading: podIssuesLoading, isRefreshing: podIssuesRefreshing, lastRefresh: podIssuesLastRefresh, refetch: refetchPodIssues } = useCachedPodIssues()
-  const { clusters, isLoading: clustersLoading, refetch: refetchClusters } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading, refetch: refetchClusters } = useClusters()
 
   // Derive lastUpdated from cache timestamp
   const lastUpdated = podIssuesLastRefresh ? new Date(podIssuesLastRefresh) : null

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -676,7 +676,15 @@ export function UpdateSettings() {
             <span className="text-sm text-muted-foreground">{formatLastChecked()}</span>
           </div>
         </div>
-        {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
+        {error && (
+          <div className="mt-3 p-3 rounded-lg bg-red-500/10 border border-red-500/20">
+            <p className="text-sm text-red-400 font-medium">{t('settings.updates.errorChecking')}</p>
+            <p className="text-xs text-red-400/80 mt-1">{error}</p>
+            <p className="text-xs text-muted-foreground mt-2">
+              Try clicking &quot;Check Now&quot; to retry, or verify that kc-agent is running and network is available.
+            </p>
+          </div>
+        )}
       </div>
 
       {/* Recent Commits (developer channel) — hidden during update */}


### PR DESCRIPTION
## Summary

- **#4513 Single-cluster assumption**: Use `deduplicatedClusters` in `Pods.tsx` and `AlertRuleEditor.tsx` to prevent double-counting when multiple kubeconfig contexts point to the same physical cluster
- **#4559 Global search interferes with tab search**: Clear global `searchQuery` when user types in tab-specific search fields in MissionBrowser; add a visible "filtered by global search" indicator
- **#4560 No pagination in mission browser**: Show "Showing X of Y missions" count in recommended tab unconditionally (not just when filters are active)
- **#4555 Error checking updates**: Display actual error message inline in UpdateSettings with retry guidance, instead of generic "Error checking updates"
- **#4554 Broken MCP servers install**: Add `brew install kubestellar/tap/kubestellar-ops kubestellar/tap/kubestellar-deploy` command in `start.sh` MCP binary warning
- **#4515 Dashboard missing health indicators**: Add cluster health summary (connected/disconnected count) to GPUDashboardTab

Fixes #4513, #4515, #4554, #4555, #4559, #4560

## Test plan

- [ ] Verify pods dashboard does not double-count pods when multiple kubeconfig contexts exist for same cluster
- [ ] Verify alert rule editor cluster list is deduplicated
- [ ] Verify typing in installer/fixer tab search clears global search bar
- [ ] Verify "filtered by global search" indicator shows when global search is active on installer/fixer tabs
- [ ] Verify "Showing X of Y missions" appears in recommended tab
- [ ] Verify UpdateSettings shows actual error text with retry guidance on version check failure
- [ ] Verify `start.sh` shows brew install command when MCP binaries are missing
- [ ] Verify GPU Dashboard tab shows cluster health summary with connected/disconnected counts