### PR TITLE
🌱 Add nupurshivani as maintainer and security contact

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,3 +5,4 @@
 | Andy Anderson | [@clubanderson](https://github.com/clubanderson) | IBM | [clubanderson](https://www.linkedin.com/in/clubanderson) |
 | Mike Spreitzer | [@MikeSpreitzer](https://github.com/MikeSpreitzer) | IBM | [mike-spreitzer](https://www.linkedin.com/in/mike-spreitzer/) |
 | Eeshaan Sawant | [@eeshaanSA](https://github.com/eeshaanSA) | ONLYOFFICE | [sawanteeshaan](https://www.linkedin.com/in/sawanteeshaan/) |
+| Nupur Shivani | [@nupurshivani](https://github.com/nupurshivani) | Innovaccer | [nupurshivani](https://www.linkedin.com/in/nupurshivani/) |

--- a/OWNERS
+++ b/OWNERS
@@ -2,8 +2,10 @@ approvers:
   - clubanderson
   - eeshaanSA
   - MikeSpreitzer
+  - nupurshivani
 
 reviewers:
   - clubanderson
   - eeshaanSA
   - MikeSpreitzer
+  - nupurshivani

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -12,4 +12,5 @@ TO [kubestellar-security-announce@googlegroups.com](mailto:kubestellar-security-
 clubanderson<br/>
 eeshaanSA<br/>
 MikeSpreitzer<br/>
+nupurshivani<br/>
 <!--security-contacts-end-->


### PR DESCRIPTION
## Summary
- Adds [Nupur Shivani](https://github.com/nupurshivani) ([LinkedIn](https://www.linkedin.com/in/nupurshivani/)) to `OWNERS` as approver and reviewer
- Adds `nupurshivani` to `SECURITY_CONTACTS`
- Adds entry to `MAINTAINERS.md` (Innovaccer)
- Expands maintainer base toward CNCF incubation requirement (≥3 maintainers from ≥2 organizations)

Ref: #4072

@nupurshivani — Please review and approve this PR to confirm your acceptance as a maintainer and security contact for KubeStellar Console. 🙏

## Test plan
- [ ] Verify `OWNERS` file has correct YAML syntax
- [ ] Verify `SECURITY_CONTACTS` renders correctly
- [ ] Verify `MAINTAINERS.md` table renders correctly