### PR TITLE
🐛 Wire missing isRefreshing/isFailed in 14 cards + fix memory leak

### DIFF
--- a/web/src/components/cards/ClusterChangelog.tsx
+++ b/web/src/components/cards/ClusterChangelog.tsx
@@ -16,10 +16,11 @@ type TimeRange = '1h' | '6h' | '24h' | '7d'
 
 export function ClusterChangelog() {
   const { t } = useTranslation('cards')
-  const { events, isLoading, isDemoFallback, isFailed, consecutiveFailures, refetch } = useCachedEvents(undefined, undefined, { limit: 200 })
+  const { events, isLoading, isRefreshing, isDemoFallback, isFailed, consecutiveFailures, refetch } = useCachedEvents(undefined, undefined, { limit: 200 })
   const [timeRange, setTimeRange] = useState<TimeRange>('24h')
   const { showSkeleton } = useCardLoadingState({
     isLoading,
+    isRefreshing,
     hasAnyData: events.length > 0,
     isDemoData: isDemoFallback,
     isFailed,

--- a/web/src/components/cards/DeploymentStatus.tsx
+++ b/web/src/components/cards/DeploymentStatus.tsx
@@ -73,6 +73,7 @@ export function DeploymentStatus() {
   const {
     deployments: allDeployments,
     isLoading: hookLoading,
+    isRefreshing,
     isDemoFallback,
     isFailed,
     consecutiveFailures,
@@ -81,6 +82,7 @@ export function DeploymentStatus() {
   // Report data state to CardWrapper for failure badge rendering
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: hookLoading,
+    isRefreshing,
     isDemoData: isDemoFallback,
     hasAnyData: allDeployments.length > 0,
     isFailed,

--- a/web/src/components/cards/GPUNamespaceAllocations.tsx
+++ b/web/src/components/cards/GPUNamespaceAllocations.tsx
@@ -52,8 +52,8 @@ const NAMESPACE_SORT_COMPARATORS: Record<SortByOption, (a: NamespaceGPUAllocatio
 
 export function GPUNamespaceAllocations({ config: _config }: GPUNamespaceAllocationsProps) {
   const { t } = useTranslation(['cards', 'common'])
-  const { nodes: gpuNodes, isLoading: gpuLoading, isRefreshing: gpuRefreshing, isDemoFallback: gpuNodesDemoFallback } = useCachedGPUNodes()
-  const { pods: allPods, isLoading: podsLoading, isDemoFallback: podsDemoFallback } = useCachedAllPods()
+  const { nodes: gpuNodes, isLoading: gpuLoading, isRefreshing: gpuRefreshing, isDemoFallback: gpuNodesDemoFallback, isFailed: gpuFailed, consecutiveFailures: gpuFailures } = useCachedGPUNodes()
+  const { pods: allPods, isLoading: podsLoading, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedAllPods()
   const { drillToGPUNamespace } = useDrillDownActions()
 
   // Combine all isDemoFallback values from cached hooks
@@ -67,6 +67,8 @@ export function GPUNamespaceAllocations({ config: _config }: GPUNamespaceAllocat
     isRefreshing: gpuRefreshing,
     hasAnyData: hasData,
     isDemoData,
+    isFailed: gpuFailed || podsFailed,
+    consecutiveFailures: Math.max(gpuFailures, podsFailures),
   })
 
   // Compute per-namespace GPU allocations

--- a/web/src/components/cards/GPUStatus.tsx
+++ b/web/src/components/cards/GPUStatus.tsx
@@ -41,6 +41,8 @@ export function GPUStatus({ config }: GPUStatusProps) {
     isLoading: hookLoading,
     isDemoFallback,
     isRefreshing,
+    isFailed,
+    consecutiveFailures,
     lastRefresh,
   } = useCachedGPUNodes(cluster)
   const { drillToCluster } = useDrillDownActions()
@@ -51,6 +53,8 @@ export function GPUStatus({ config }: GPUStatusProps) {
     isRefreshing,
     hasAnyData: rawNodes.length > 0,
     isDemoData: isDemoMode || isDemoFallback,
+    isFailed,
+    consecutiveFailures,
     lastRefresh,
   })
 

--- a/web/src/components/cards/GPUWorkloads.tsx
+++ b/web/src/components/cards/GPUWorkloads.tsx
@@ -64,9 +64,12 @@ export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
   const {
     nodes: gpuNodes,
     isLoading: gpuLoading,
+    isRefreshing: gpuRefreshing,
     isDemoFallback: gpuNodesDemoFallback,
+    isFailed: gpuFailed,
+    consecutiveFailures: gpuFailures,
   } = useCachedGPUNodes()
-  const { pods: allPods, isLoading: podsLoading, isDemoFallback: podsDemoFallback } = useCachedAllPods()
+  const { pods: allPods, isLoading: podsLoading, isRefreshing: podsRefreshing, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedAllPods()
   useClusters() // Keep hook for cache warming
   const { drillToPod } = useDrillDownActions()
 
@@ -80,8 +83,11 @@ export function GPUWorkloads({ config: _config }: GPUWorkloadsProps) {
   const hasData = gpuNodes.length > 0 || allPods.length > 0
   useCardLoadingState({
     isLoading: (gpuLoading || podsLoading) && !hasData,
+    isRefreshing: gpuRefreshing || podsRefreshing,
     hasAnyData: hasData,
     isDemoData,
+    isFailed: gpuFailed || podsFailed,
+    consecutiveFailures: Math.max(gpuFailures, podsFailures),
   })
 
   // Pre-filter pods to only GPU workloads (domain-specific logic before hook)

--- a/web/src/components/cards/HelmHistory.tsx
+++ b/web/src/components/cards/HelmHistory.tsx
@@ -134,6 +134,7 @@ export function HelmHistory({ config }: HelmHistoryProps) {
   // Note: Consider "hasAnyData" true when no release selected - we want to show selectors, not empty state
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: historyLoading,
+    isRefreshing: historyRefreshing,
     hasAnyData: rawHistory.length > 0 || !selectedRelease,
     isFailed,
     consecutiveFailures,

--- a/web/src/components/cards/HelmValuesDiff.tsx
+++ b/web/src/components/cards/HelmValuesDiff.tsx
@@ -54,7 +54,7 @@ const SORT_OPTIONS = [
 
 export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   const { t } = useTranslation()
-  const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed: clustersFailed, consecutiveFailures: clustersFailures } = useClusters()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || '')
   const [selectedRelease, setSelectedRelease] = useState<string>(config?.release || '')
   const { drillToHelm } = useDrillDownActions()
@@ -131,14 +131,6 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   // Fetch ALL Helm releases from all clusters once (not per-cluster)
   const { releases: allHelmReleases, isLoading: releasesLoading, isDemoFallback: isDemoData } = useCachedHelmReleases()
 
-  // Report state to CardWrapper for refresh animation
-  const hasClusterData = allClusters.length > 0
-  useCardLoadingState({
-    isLoading: clustersLoading && !hasClusterData,
-    hasAnyData: hasClusterData,
-    isDemoData,
-  })
-
   // Auto-select first cluster and release in demo mode
   useEffect(() => {
     if (isDemoData && allHelmReleases.length > 0 && allClusters.length > 0) {
@@ -174,6 +166,17 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
     selectedRelease || undefined,
     selectedReleaseNamespace
   )
+
+  // Report state to CardWrapper for refresh animation
+  const hasClusterData = allClusters.length > 0
+  useCardLoadingState({
+    isLoading: clustersLoading && !hasClusterData,
+    isRefreshing: clustersRefreshing || valuesRefreshing,
+    hasAnyData: hasClusterData,
+    isDemoData,
+    isFailed: clustersFailed,
+    consecutiveFailures: clustersFailures,
+  })
   // Cached hook doesn't return format; values are always JSON objects
   const format = 'json' as string
 

--- a/web/src/components/cards/ISO27001Audit.tsx
+++ b/web/src/components/cards/ISO27001Audit.tsx
@@ -101,6 +101,7 @@ export function ISO27001Audit({ config }: ISO27001AuditProps) {
   const {
     findings: cachedFindings,
     isLoading: cachedLoading,
+    isRefreshing: cachedRefreshing,
     isDemoFallback,
     isFailed: cachedFailed,
     consecutiveFailures: cachedFailures,
@@ -113,6 +114,7 @@ export function ISO27001Audit({ config }: ISO27001AuditProps) {
     [useDemoData, cachedFindings]
   )
   const isLoading = useDemoData ? false : cachedLoading
+  const isRefreshing = useDemoData ? false : cachedRefreshing
   const isFailed = useDemoData ? false : cachedFailed
   const consecutiveFailures = useDemoData ? 0 : cachedFailures
 
@@ -120,6 +122,7 @@ export function ISO27001Audit({ config }: ISO27001AuditProps) {
   const hasData = rawFindings.length > 0
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isLoading && !hasData,
+    isRefreshing,
     isDemoData: isDemoMode || isDemoFallback,
     hasAnyData: hasData,
     isFailed,

--- a/web/src/components/cards/NamespaceEvents.tsx
+++ b/web/src/components/cards/NamespaceEvents.tsx
@@ -45,8 +45,8 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
     SORT_OPTIONS_KEYS.map(opt => ({ value: opt.value, label: String(t(opt.labelKey)) })),
     [t]
   )
-  const { isLoading: clustersLoading, isRefreshing: clustersRefreshing } = useClusters()
-  const { events: allEvents, isLoading: eventsLoading, isRefreshing: eventsRefreshing, isDemoFallback: eventsDemoFallback } = useCachedWarningEvents()
+  const { isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed: clustersFailed, consecutiveFailures: clustersFailures } = useClusters()
+  const { events: allEvents, isLoading: eventsLoading, isRefreshing: eventsRefreshing, isDemoFallback: eventsDemoFallback, isFailed: eventsFailed, consecutiveFailures: eventsFailures } = useCachedWarningEvents()
   const { drillToEvents } = useDrillDownActions()
   const { isDemoMode } = useDemoMode()
 
@@ -59,6 +59,8 @@ export function NamespaceEvents({ config }: NamespaceEventsProps) {
     isRefreshing: clustersRefreshing || eventsRefreshing,
     hasAnyData: hasData,
     isDemoData: eventsDemoFallback || isDemoMode,
+    isFailed: clustersFailed || eventsFailed,
+    consecutiveFailures: Math.max(clustersFailures, eventsFailures),
   })
 
   // Use cascading selection hook for cluster -> namespace

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -338,7 +338,7 @@ function QuotaModal({
 export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { isDemoMode } = useDemoMode()
-  const { deduplicatedClusters: allClusters, isLoading: clustersLoading } = useClusters()
+  const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed: clustersFailed, consecutiveFailures: clustersFailures } = useClusters()
   const [selectedCluster, setSelectedCluster] = useState<string>(config?.cluster || 'all')
   const [selectedNamespace, setSelectedNamespace] = useState<string>(config?.namespace || 'all')
   const [activeTab, setActiveTab] = useState<TabKey>('quotas')
@@ -372,8 +372,11 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading: isInitialLoading || isFetchingData,
+    isRefreshing: clustersRefreshing,
     hasAnyData: allClusters.length > 0 || resourceQuotas.length > 0 || limitRanges.length > 0,
     isDemoData: isDemoMode || isDemoFallback,
+    isFailed: clustersFailed,
+    consecutiveFailures: clustersFailures,
   })
 
   // Handle save quota

--- a/web/src/components/cards/ResourceMarshall.tsx
+++ b/web/src/components/cards/ResourceMarshall.tsx
@@ -40,7 +40,7 @@ function groupDependencies(deps: ResolvedDependency[]) {
 
 export function ResourceMarshall() {
   const { t } = useTranslation()
-  const { deduplicatedClusters: clusters, isLoading } = useClusters()
+  const { deduplicatedClusters: clusters, isLoading, isRefreshing: clustersRefreshing, isFailed: clustersFailed, consecutiveFailures: clustersFailures } = useClusters()
   const { isDemoMode: demoMode } = useDemoMode()
 
   const [selectedCluster, setSelectedCluster] = useState<string>('')
@@ -54,8 +54,11 @@ export function ResourceMarshall() {
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
+    isRefreshing: clustersRefreshing,
     hasAnyData: clusters.length > 0,
     isDemoData: demoMode || isDemoFallback,
+    isFailed: clustersFailed,
+    consecutiveFailures: clustersFailures,
   })
 
   // Fetch workloads only when both cluster and namespace are selected.

--- a/web/src/components/cards/buildpacks-status/BuildpacksStatus.tsx
+++ b/web/src/components/cards/buildpacks-status/BuildpacksStatus.tsx
@@ -84,6 +84,7 @@ export function BuildpacksStatus({ config }: BuildpacksStatusProps) {
   const {
     images: allImages,
     isLoading,
+    isRefreshing,
     isFailed,
     consecutiveFailures,
     error,
@@ -98,6 +99,7 @@ export function BuildpacksStatus({ config }: BuildpacksStatusProps) {
 
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading || isLoading,
+    isRefreshing,
     hasAnyData: allImages.length > 0,
     isFailed,
     consecutiveFailures,

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -224,8 +224,8 @@ function generatePredictionId(type: string, name: string, cluster?: string): str
 export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { startMission, missions } = useMissions()
-  const { nodes: gpuNodes, isLoading, isDemoFallback: gpuDemoFallback } = useCachedGPUNodes()
-  const { issues: podIssues, isDemoFallback: podsDemoFallback } = useCachedPodIssues()
+  const { nodes: gpuNodes, isLoading, isRefreshing: gpuRefreshing, isDemoFallback: gpuDemoFallback, isFailed: gpuFailed, consecutiveFailures: gpuFailures } = useCachedGPUNodes()
+  const { issues: podIssues, isRefreshing: podsRefreshing, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedPodIssues()
   const { deduplicatedClusters: clusters } = useClusters()
   const { selectedClusters, isAllClustersSelected, customFilter } = useGlobalFilters()
   const { drillToCluster, drillToNode } = useDrillDownActions()
@@ -250,8 +250,11 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
   // Consider both GPU nodes AND local nodes cache for hasAnyData
   useCardLoadingState({
     isLoading: isLoading && nodesLoading,
+    isRefreshing: gpuRefreshing || podsRefreshing,
     hasAnyData: gpuNodes.length > 0 || nodesCache.length > 0 || allNodes.length > 0,
     isDemoData: isDemoMode || gpuDemoFallback || podsDemoFallback,
+    isFailed: gpuFailed || podsFailed,
+    consecutiveFailures: Math.max(gpuFailures, podsFailures),
   })
 
   // Subscribe to cache updates and fetch nodes

--- a/web/src/components/cards/workload-detection/LLMModels.tsx
+++ b/web/src/components/cards/workload-detection/LLMModels.tsx
@@ -33,7 +33,7 @@ export function LLMModels({ config: _config }: LLMModelsProps) {
   const gpuClusterNames = useMemo(() => new Set(gpuNodes.map(n => n.cluster)), [gpuNodes])
   const llmdClusters = useLLMdClusters(deduplicatedClusters, gpuClusterNames)
 
-  const { models, isLoading, isRefreshing, lastRefresh, isDemoFallback } = useCachedLLMdModels(llmdClusters)
+  const { models, isLoading, isRefreshing, isFailed, consecutiveFailures, lastRefresh, isDemoFallback } = useCachedLLMdModels(llmdClusters)
 
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const hasData = models.length > 0
@@ -42,6 +42,8 @@ export function LLMModels({ config: _config }: LLMModelsProps) {
     isRefreshing,
     hasAnyData: hasData,
     isDemoData: isDemoFallback,
+    isFailed,
+    consecutiveFailures,
   })
 
   const {

--- a/web/src/components/missions/UnstructuredFilePreview.tsx
+++ b/web/src/components/missions/UnstructuredFilePreview.tsx
@@ -7,7 +7,7 @@
  * combining with matched console-kb install missions.
  */
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useRef, useEffect } from 'react'
 import {
   ArrowLeft,
   FileCode,
@@ -61,6 +61,14 @@ export function UnstructuredFilePreview({
 }: UnstructuredFilePreviewProps) {
   const [showFullContent, setShowFullContent] = useState(false)
   const [copied, setCopied] = useState(false)
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Clear copy feedback timer on unmount to prevent memory leak
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+    }
+  }, [])
 
   const lines = content.split('\n')
   const isTruncated = lines.length > MAX_PREVIEW_LINES && !showFullContent
@@ -73,8 +81,9 @@ export function UnstructuredFilePreview({
   const handleCopy = useCallback(async () => {
     await copyToClipboard(content)
     setCopied(true)
+    if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
     const COPY_FEEDBACK_MS = 2_000
-    setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
+    copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS)
   }, [content])
 
   return (

--- a/web/src/test/card-loading-standard.test.ts
+++ b/web/src/test/card-loading-standard.test.ts
@@ -89,18 +89,17 @@ const KNOWN_VIOLATIONS: Record<string, Set<string>> = {
   // ── bare isLoading violations ──
   'AppStatus.tsx': new Set(['bare-isLoading']),
   'cloudevents_status/useCloudEventsStatus.ts': new Set(['bare-isLoading']),
-  'ClusterChangelog.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
+  'ClusterChangelog.tsx': new Set(['bare-isLoading']),
   'ClusterDropZone.tsx': new Set(['bare-isLoading']),
   'ClusterNetwork.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
   'console-missions/ConsoleHealthCheckCard.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
   'console-missions/ConsoleIssuesCard.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
   'console-missions/ConsoleKubeconfigAuditCard.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
-  'console-missions/ConsoleOfflineDetectionCard.tsx': new Set(['missing-isRefreshing']),
   'coredns_status/CoreDNSStatus.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
   'CRDHealth.tsx': new Set(['bare-isLoading']),
   'crio_status/useCrioStatus.ts': new Set(['bare-isLoading']),
   'crossplane-status/CrossplaneManagedResources.tsx': new Set(['bare-isLoading']),
-  'DeploymentStatus.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
+  'DeploymentStatus.tsx': new Set(['bare-isLoading']),
   'EtcdStatus.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
   'EventsTimeline.tsx': new Set(['bare-isLoading']),
   'EventStream.tsx': new Set(['bare-isLoading']),
@@ -108,12 +107,9 @@ const KNOWN_VIOLATIONS: Record<string, Set<string>> = {
   'fluentd_status/useFluentdStatus.ts': new Set(['bare-isLoading']),
   'GatewayStatus.tsx': new Set(['bare-isLoading']),
   'GPUStatus.tsx': new Set(['bare-isLoading']),
-  'GPUWorkloads.tsx': new Set(['missing-isRefreshing']),
-  'HelmHistory.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
+  'HelmHistory.tsx': new Set(['bare-isLoading']),
   'HelmReleaseStatus.tsx': new Set(['missing-isRefreshing']),
-  'HelmValuesDiff.tsx': new Set(['missing-isRefreshing']),
   'insights/CrossClusterEventCorrelation.tsx': new Set(['missing-isRefreshing']),
-  'ISO27001Audit.tsx': new Set(['missing-isRefreshing']),
   'kagenti/KagentiAgentDiscovery.tsx': new Set(['bare-isLoading']),
   'kagenti/KagentiAgentFleet.tsx': new Set(['bare-isLoading']),
   'kagenti/KagentiBuildPipeline.tsx': new Set(['bare-isLoading']),
@@ -127,7 +123,6 @@ const KNOWN_VIOLATIONS: Record<string, Set<string>> = {
   'lima_status/useLimaStatus.ts': new Set(['bare-isLoading']),
   'llmd/NightlyE2EStatus.tsx': new Set(['bare-isLoading']),
   'NamespaceMonitor.tsx': new Set(['bare-isLoading']),
-  'NamespaceQuotas.tsx': new Set(['missing-isRefreshing']),
   'NamespaceRBAC.tsx': new Set(['missing-isRefreshing']),
   'NetworkOverview.tsx': new Set(['bare-isLoading']),
   'NetworkPolicyCoverage.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
@@ -138,7 +133,7 @@ const KNOWN_VIOLATIONS: Record<string, Set<string>> = {
   'PredictiveHealth.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
   'RBACExplorer.tsx': new Set(['bare-isLoading']),
   'RecommendedPolicies.tsx': new Set(['missing-isRefreshing']),
-  'ResourceMarshall.tsx': new Set(['bare-isLoading', 'missing-isRefreshing']),
+  'ResourceMarshall.tsx': new Set(['bare-isLoading']),
   'ServiceExports.tsx': new Set(['bare-isLoading']),
   'ServiceImports.tsx': new Set(['bare-isLoading']),
   'strimzi_status/useStrimziStatus.ts': new Set(['bare-isLoading']),
@@ -146,7 +141,6 @@ const KNOWN_VIOLATIONS: Record<string, Set<string>> = {
   'UserManagement.tsx': new Set(['missing-isRefreshing']),
   'weather/Weather.tsx': new Set(['bare-isLoading']),
   'WorkloadDeployment.tsx': new Set(['missing-isRefreshing']),
-  'buildpacks-status/BuildpacksStatus.tsx': new Set(['missing-isRefreshing']),
 }
 
 /**
@@ -161,27 +155,18 @@ const KNOWN_FAILURE_VIOLATIONS: Record<string, Set<string>> = {
   'ClusterLocations.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'ClusterNetwork.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'console-missions/ConsoleKubeconfigAuditCard.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'console-missions/ConsoleOfflineDetectionCard.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'FleetComplianceHeatmap.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'GPUNamespaceAllocations.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'GPUStatus.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'GPUWorkloads.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'HelmValuesDiff.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'insights/CrossClusterEventCorrelation.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'Kubectl.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'KustomizationStatus.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'Missions.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'NamespaceEvents.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'NamespaceMonitor.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'NamespaceQuotas.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'NamespaceRBAC.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'OPAPolicies.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'OverlayComparison.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'RecommendedPolicies.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'ResourceMarshall.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'ResourceTrend.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
   'ResourceUsage.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
-  'workload-detection/LLMModels.tsx': new Set(['missing-isFailed', 'missing-consecutiveFailures']),
 }
 
 /** Check if a violation is known (grandfathered in) */
@@ -411,7 +396,7 @@ describe('Card Loading State Gold Standard', () => {
       // This number MUST ONLY DECREASE. If you fix a card, remove it from
       // KNOWN_VIOLATIONS and decrease this count. If this test fails because
       // the count dropped, that's great — update the expected count!
-      const EXPECTED_KNOWN_VIOLATION_COUNT = 75
+      const EXPECTED_KNOWN_VIOLATION_COUNT = 65
       expect(totalKnown).toBeLessThanOrEqual(EXPECTED_KNOWN_VIOLATION_COUNT)
     })
 
@@ -422,7 +407,7 @@ describe('Card Loading State Gold Standard', () => {
       }
 
       // Separate ratchet for isRefreshing violations. MUST ONLY DECREASE.
-      const EXPECTED_REFRESH_VIOLATION_COUNT = 27
+      const EXPECTED_REFRESH_VIOLATION_COUNT = 17
       expect(refreshCount).toBeLessThanOrEqual(EXPECTED_REFRESH_VIOLATION_COUNT)
     })
 
@@ -434,7 +419,7 @@ describe('Card Loading State Gold Standard', () => {
 
       // Separate ratchet for failure-wiring violations. MUST ONLY DECREASE.
       // Each card entry has 2 violations (missing-isFailed + missing-consecutiveFailures).
-      const EXPECTED_FAILURE_VIOLATION_COUNT = 52
+      const EXPECTED_FAILURE_VIOLATION_COUNT = 34
       expect(failureCount).toBeLessThanOrEqual(EXPECTED_FAILURE_VIOLATION_COUNT)
     })
   })


### PR DESCRIPTION
## Summary

- Wire missing `isRefreshing`, `isFailed`, and `consecutiveFailures` from data hooks to `useCardLoadingState()` in 14 cards — enables refresh spinners and failure badges that were previously missing
- Fix memory leak in `UnstructuredFilePreview`: store `setTimeout` in `useRef` and clear on unmount
- Update `card-loading-standard` test: remove fixed cards from `KNOWN_VIOLATIONS` and `KNOWN_FAILURE_VIOLATIONS`, lower ratchet baselines (75->65 total, 27->17 refresh, 52->34 failure)

## Cards Fixed

| Card | isRefreshing | isFailed | consecutiveFailures |
|------|:---:|:---:|:---:|
| DeploymentStatus | + | | |
| ClusterChangelog | + | | |
| HelmHistory | + (wired existing) | | |
| ISO27001Audit | + | | |
| GPUWorkloads | + | + | + |
| HelmValuesDiff | + (wired existing) | + | + |
| NamespaceQuotas | + | + | + |
| ResourceMarshall | + | + | + |
| BuildpacksStatus | + | | |
| ConsoleOfflineDetectionCard | + | + | + |
| GPUNamespaceAllocations | | + | + |
| GPUStatus | | + | + |
| LLMModels | | + | + |
| NamespaceEvents | | + | + |

## Test plan

- [x] `npm run build` passes
- [x] `npx vitest run src/test/card-loading-standard.test.ts` — 646/646 tests pass
- [ ] Visual: cards show refresh spinner during background revalidation
- [ ] Visual: cards show failure badge after consecutive fetch failures

Fixes #4507, #4509, #4510, #4512, #4517, #4518, #4519, #4520, #4521, #4522, #4523, #4524, #4525, #4526, #4561, #4563, #4566