### PR TITLE
🐛 Fix 11 Mission Control and Dashboard UX bugs

### DIFF
--- a/web/src/components/dashboard/CardRecommendations.tsx
+++ b/web/src/components/dashboard/CardRecommendations.tsx
@@ -55,8 +55,9 @@ export function CardRecommendations({ currentCardTypes, onAddCard }: Props) {
           if (countdownRef.current) clearInterval(countdownRef.current)
           countdownRef.current = null
           setMinimized(true)
-          // Persist collapse so the expanded panel never comes back
-          safeSetItem(STORAGE_KEY_RECS_COLLAPSED, 'true')
+          // Timer-initiated collapse: do NOT persist to localStorage.
+          // Only user-initiated minimize (explicit click) persists state.
+          // This allows the panel to re-expand on next session/page load.
           return AUTO_COLLAPSE_SECONDS
         }
         return prev - 1

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -150,7 +150,7 @@ export function Dashboard() {
   const { showIndicator, triggerRefresh } = useRefreshIndicator(refetch)
   const isRefreshing = dataRefreshing || showIndicator
   const isFetching = isClustersLoading || isRefreshing || showIndicator
-  const { drillToAllClusters, drillToAllPods } = useDrillDownActions()
+  const { drillToAllClusters, drillToAllPods, drillToAllNodes } = useDrillDownActions()
 
   // Reset hook for dashboard
   const { reset, isCustomized } = useDashboardReset({
@@ -198,6 +198,7 @@ export function Dashboard() {
   const unhealthyClusters = (clusters || []).filter(c => !c.healthy).length
   const totalPods = (clusters || []).reduce((sum, c) => sum + (c.podCount || 0), 0)
   const totalNamespaces = (clusters || []).reduce((sum, c) => sum + (c.namespaces?.length || 0), 0)
+  const totalNodes = (clusters || []).reduce((sum, c) => sum + (c.nodeCount || 0), 0)
 
   // Dashboard-specific stats value getter
   const getDashboardStatValue = useCallback((blockId: string): StatBlockValue => {
@@ -212,12 +213,14 @@ export function Dashboard() {
         return { value: unhealthyClusters, sublabel: 'unhealthy', onClick: () => drillToAllClusters('unhealthy'), isClickable: unhealthyClusters > 0 }
       case 'namespaces':
         return { value: totalNamespaces, sublabel: 'namespaces', onClick: () => navigate(ROUTES.NAMESPACES), isClickable: totalNamespaces > 0 }
+      case 'nodes':
+        return { value: totalNodes, sublabel: 'total nodes', onClick: () => drillToAllNodes(), isClickable: totalNodes > 0 }
       case 'pods':
         return { value: totalPods, sublabel: 'pods', onClick: () => drillToAllPods(), isClickable: totalPods > 0 }
       default:
         return { value: '-' }
     }
-  }, [clusters, healthyClusters, unhealthyClusters, totalNamespaces, totalPods, drillToAllClusters, drillToAllPods, navigate])
+  }, [clusters, healthyClusters, unhealthyClusters, totalNamespaces, totalNodes, totalPods, drillToAllClusters, drillToAllNodes, drillToAllPods, navigate])
 
   // Merged getter: dashboard-specific values first, then universal fallback
   const getStatValue = useCallback(

--- a/web/src/components/dashboard/GettingStartedBanner.tsx
+++ b/web/src/components/dashboard/GettingStartedBanner.tsx
@@ -20,6 +20,7 @@ import {
 import { emitGettingStartedShown, emitGettingStartedActioned, emitTipShown } from '../../lib/analytics'
 import { DASHBOARD_CONFIGS } from '../../config/dashboards/index'
 import { getRandomTip } from '../../lib/tips'
+import { useLocalAgent } from '../../hooks/useLocalAgent'
 
 const DASHBOARD_COUNT = Object.keys(DASHBOARD_CONFIGS).length
 
@@ -55,7 +56,12 @@ export function GettingStartedBanner({
     () => safeGetItem(STORAGE_KEY_HINTS_SUPPRESSED) === 'true'
   )
 
-  if (hintsSuppressed || dismissed) return null
+  // Suppress Getting Started banner when agent is connected —
+  // PostConnectBanner takes priority to avoid showing two banners at once (#4558)
+  const { status: agentStatus } = useLocalAgent()
+  const isAgentConnected = agentStatus === 'connected'
+
+  if (hintsSuppressed || dismissed || isAgentConnected) return null
 
   const handleDismiss = () => {
     setDismissed(true)

--- a/web/src/components/dashboard/MissionSuggestions.tsx
+++ b/web/src/components/dashboard/MissionSuggestions.tsx
@@ -70,8 +70,9 @@ export function MissionSuggestions() {
           if (countdownRef.current) clearInterval(countdownRef.current)
           countdownRef.current = null
           setMinimized(true)
-          // Persist collapse so the expanded panel never comes back
-          safeSetItem(STORAGE_KEY_MISSIONS_COLLAPSED, 'true')
+          // Timer-initiated collapse: do NOT persist to localStorage.
+          // Only user-initiated minimize (explicit click) persists state.
+          // This allows the panel to re-expand on next session/page load.
           return AUTO_COLLAPSE_SECONDS
         }
         return prev - 1

--- a/web/src/components/drilldown/views/ResourcesDrillDown.tsx
+++ b/web/src/components/drilldown/views/ResourcesDrillDown.tsx
@@ -280,13 +280,20 @@ export function ResourcesDrillDown({ data: _data }: Props) {
     const totalMemoryGB = clusters.reduce((sum, c) => sum + (c.memoryGB || 0), 0)
     const totalMemoryRequestsGB = clusters.reduce((sum, c) => sum + (c.memoryRequestsGB || 0), 0)
 
+    /** CPU utilization percentage across all clusters */
+    const cpuPercent = totalCPUs > 0 ? Math.round((totalCPURequests / totalCPUs) * 100) : 0
+    /** Memory utilization percentage across all clusters */
+    const memoryPercent = totalMemoryGB > 0 ? Math.round((totalMemoryRequestsGB / totalMemoryGB) * 100) : 0
+
     return {
       cpus: totalCPUs,
       cpuRequests: totalCPURequests,
+      cpuPercent,
       nodes: totalNodes,
       pods: totalPods,
       memoryGB: totalMemoryGB,
       memoryRequestsGB: totalMemoryRequestsGB,
+      memoryPercent,
     }
   }, [clusters])
 
@@ -348,6 +355,9 @@ export function ResourcesDrillDown({ data: _data }: Props) {
             <span className="text-xs text-muted-foreground">CPU Capacity</span>
           </div>
           <div className="text-xl font-bold text-foreground">{totals.cpus.toLocaleString()} cores</div>
+          <div className="text-2xs text-muted-foreground mt-0.5">
+            {totals.cpuPercent}% utilized ({totals.cpuRequests.toLocaleString()} requested)
+          </div>
         </div>
 
         <div className="p-3 rounded-lg bg-card/50 border border-border min-w-[120px]">
@@ -359,6 +369,9 @@ export function ResourcesDrillDown({ data: _data }: Props) {
             {totals.memoryGB >= 1000
               ? `${(totals.memoryGB / 1024).toFixed(1)} TB`
               : `${Math.round(totals.memoryGB)} GB`}
+          </div>
+          <div className="text-2xs text-muted-foreground mt-0.5">
+            {totals.memoryPercent}% utilized ({formatMemory(totals.memoryRequestsGB)} requested)
           </div>
         </div>
 
@@ -455,6 +468,14 @@ export function ResourcesDrillDown({ data: _data }: Props) {
                       nodeCount: cluster.nodeCount,
                       podCount: cluster.podCount,
                       cpuCores: cluster.cpuCores,
+                      memoryGB: cluster.memoryGB,
+                      cpuRequestsCores: cluster.cpuRequestsCores,
+                      cpuUsageCores: cluster.cpuUsageCores,
+                      memoryRequestsGB: cluster.memoryRequestsGB,
+                      memoryUsageGB: cluster.memoryUsageGB,
+                      storageGB: cluster.storageGB,
+                      metricsAvailable: cluster.metricsAvailable,
+                      origin: 'resources',
                     })}
                   />
                 )

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -1023,20 +1023,20 @@ export function MissionSidebar() {
                   mission={mission}
                   isActive={false}
                   onClick={() => {
+                    // Always show the mission's chat first (#4549)
+                    setActiveMission(mission.id)
+                    // Also open Mission Control dialog for planning missions
                     if (mission.title === 'Mission Control Planning') {
                       setShowMissionControl(true)
-                    } else {
-                      setActiveMission(mission.id)
                     }
                   }}
                   onDismiss={() => dismissMission(mission.id)}
                   onTerminate={() => cancelMission(mission.id)}
                   onExpand={() => {
+                    setActiveMission(mission.id)
+                    setFullScreen(true)
                     if (mission.title === 'Mission Control Planning') {
                       setShowMissionControl(true)
-                    } else {
-                      setActiveMission(mission.id)
-                      setFullScreen(true)
                     }
                   }}
                   isCollapsed={collapsedMissions.has(mission.id)}

--- a/web/src/components/layout/navbar/StreakBadge.tsx
+++ b/web/src/components/layout/navbar/StreakBadge.tsx
@@ -8,6 +8,7 @@
 
 import { useTranslation } from 'react-i18next'
 import { useVisitStreak } from '../../../hooks/useVisitStreak'
+import { useAuth } from '../../../lib/auth'
 
 /** Minimum streak to display the badge — showing "1" is meaningless */
 const MIN_DISPLAY_STREAK = 2
@@ -15,8 +16,11 @@ const MIN_DISPLAY_STREAK = 2
 export function StreakBadge() {
   const { t } = useTranslation()
   const { streak } = useVisitStreak()
+  const { isAuthenticated } = useAuth()
 
-  if (streak < MIN_DISPLAY_STREAK) return null
+  // Hide badge until authentication is confirmed to prevent flash
+  // before OAuth redirect when session has expired (#4541)
+  if (!isAuthenticated || streak < MIN_DISPLAY_STREAK) return null
 
   return (
     <span

--- a/web/src/components/mission-control/ClusterAssignmentPanel.tsx
+++ b/web/src/components/mission-control/ClusterAssignmentPanel.tsx
@@ -50,8 +50,13 @@ export function ClusterAssignmentPanel({
   const [excludedClusters, setExcludedClusters] = useState<Set<string>>(new Set())
   const [showClusterPicker, setShowClusterPicker] = useState(false)
 
-  // Healthy clusters only
-  const allHealthyClusters = clusters.filter((c) => c.healthy !== false && c.reachable !== false)
+  // Healthy clusters only — sort by name for stable ordering when toggling projects (#4548)
+  const allHealthyClusters = useMemo(
+    () => clusters
+      .filter((c) => c.healthy !== false && c.reachable !== false)
+      .sort((a, b) => a.name.localeCompare(b.name)),
+    [clusters]
+  )
   // Active clusters = healthy minus excluded
   const healthyClusters = useMemo(
     () => allHealthyClusters.filter((c) => !excludedClusters.has(c.name)),

--- a/web/src/components/mission-control/FixerDefinitionPanel.tsx
+++ b/web/src/components/mission-control/FixerDefinitionPanel.tsx
@@ -956,7 +956,7 @@ function TargetClusterSelector({
   const isAllSelected = selected.length === 0 || selected.length === clusters.length
 
   return (
-    <div ref={ref} className="relative">
+    <div ref={ref} className="relative z-10">
       <label className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
         Target Clusters
       </label>

--- a/web/src/components/mission-control/LaunchSequence.tsx
+++ b/web/src/components/mission-control/LaunchSequence.tsx
@@ -27,6 +27,8 @@ interface LaunchSequenceProps {
   state: MissionControlState
   onUpdateProgress: (progress: PhaseProgress[]) => void
   onComplete: (dashboardId?: string) => void
+  /** Close the Mission Control dialog entirely */
+  onClose?: () => void
 }
 
 const STATUS_ICONS: Record<string, React.ReactNode> = {
@@ -41,6 +43,7 @@ export function LaunchSequence({
   state,
   onUpdateProgress,
   onComplete,
+  onClose,
 }: LaunchSequenceProps) {
   const { startMission, missions } = useMissions()
   const [isStarted, setIsStarted] = useState(false)
@@ -379,7 +382,7 @@ export function LaunchSequence({
           animate={{ opacity: 1, y: 0 }}
           className="flex justify-center gap-3 pt-4"
         >
-          <Button variant="secondary" size="sm" onClick={() => onComplete()}>
+          <Button variant="secondary" size="sm" onClick={() => onClose ? onClose() : onComplete()}>
             Close
           </Button>
         </motion.div>

--- a/web/src/components/mission-control/MissionControlDialog.tsx
+++ b/web/src/components/mission-control/MissionControlDialog.tsx
@@ -319,6 +319,7 @@ export function MissionControlDialog({ open, onClose }: MissionControlDialogProp
                         if (dashboardId) mc.setGroundControlDashboardId(dashboardId)
                         mc.setPhase('complete')
                       }}
+                      onClose={onClose}
                     />
                   </PhaseWrapper>
                 )}

--- a/web/src/components/mission-control/useMissionControl.ts
+++ b/web/src/components/mission-control/useMissionControl.ts
@@ -274,9 +274,19 @@ export function useMissionControl() {
     setState((prev) => ({ ...prev, targetClusters }))
   }, [])
 
+  // Use refs for the latest state to avoid stale closures in askAIForSuggestions.
+  // Without this, the first click on "Suggest" can be a no-op because the callback
+  // captures a stale planningMissionId or targetClusters from a previous render (#4547).
+  const stateRef = useRef(state)
+  const helmReleasesRef = useRef(helmReleases)
+  useEffect(() => { stateRef.current = state }, [state])
+  useEffect(() => { helmReleasesRef.current = helmReleases }, [helmReleases])
+
   const askAIForSuggestions = useCallback(
     (description: string, existingProjects: PayloadProject[] = []) => {
-      let missionId = state.planningMissionId
+      const currentState = stateRef.current
+      const currentHelmReleases = helmReleasesRef.current
+      let missionId = currentState.planningMissionId
 
       const existingContext =
         existingProjects.length > 0
@@ -284,15 +294,15 @@ export function useMissionControl() {
           : ''
 
       // Scope AI analysis to selected target clusters (if any)
-      const clusterScope = state.targetClusters.length > 0
-        ? `\n\nIMPORTANT — The user has scoped this mission to these specific clusters ONLY: ${JSON.stringify(state.targetClusters)}. Do NOT analyze or suggest deployments for clusters outside this list.`
+      const clusterScope = currentState.targetClusters.length > 0
+        ? `\n\nIMPORTANT — The user has scoped this mission to these specific clusters ONLY: ${JSON.stringify(currentState.targetClusters)}. Do NOT analyze or suggest deployments for clusters outside this list.`
         : ''
 
       // Include helm release info so AI knows what's already installed
       // Filter to target clusters if scoped
-      const scopedReleases = state.targetClusters.length > 0
-        ? (helmReleases || []).filter(r => r.cluster && state.targetClusters.includes(r.cluster))
-        : helmReleases
+      const scopedReleases = currentState.targetClusters.length > 0
+        ? (currentHelmReleases || []).filter(r => r.cluster && currentState.targetClusters.includes(r.cluster))
+        : currentHelmReleases
       const helmContext = scopedReleases?.length
         ? `\n\nIMPORTANT — Cluster inspection results (helm releases already installed across clusters):\n${JSON.stringify(scopedReleases.map(r => ({ name: r.name, chart: r.chart, namespace: r.namespace, status: r.status, cluster: r.cluster })), null, 2)}\n\nFor each suggested project, check if it is already installed on the clusters. Include a "Cluster Inspection Summary" table in your analysis showing which components are Running vs Not installed on each cluster.`
         : ''
@@ -352,7 +362,7 @@ Include real CNCF projects only. Consider dependencies between projects.`
         setState((prev) => ({ ...prev, aiStreaming: true }))
       }
     },
-    [state.planningMissionId, startMission, sendMessage, helmReleases]
+    [startMission, sendMessage]
   )
 
   const addProject = useCallback((project: PayloadProject) => {

--- a/web/src/components/ui/RotatingTip.tsx
+++ b/web/src/components/ui/RotatingTip.tsx
@@ -62,7 +62,7 @@ export function RotatingTip({ page }: RotatingTipProps) {
   if (!tip) return null
 
   return (
-    <div role="status" aria-label="Page tip" className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-purple-500/10 border border-purple-500/20 text-xs text-purple-300">
+    <div role="status" aria-label="Page tip" className="hidden sm:flex items-center gap-2 px-3 py-1.5 rounded-lg bg-purple-500/10 border border-purple-500/20 text-xs text-purple-300">
       <Lightbulb className="w-3.5 h-3.5 flex-shrink-0 text-purple-400" aria-hidden="true" />
       <span><span className="font-medium">Tip:</span> {tip}</span>
     </div>


### PR DESCRIPTION
## Summary

Batch fix for 11 user-reported bugs across Mission Control wizard and Dashboard UX.

### Mission Control fixes
- **#4543** — Target Clusters dropdown no longer overlaps payload grid (z-index stacking fix)
- **#4544** — Close button on dry run/launch completion now actually closes the dialog
- **#4547** — Suggest button works on first click (fixed stale closure in askAIForSuggestions)
- **#4548** — Cluster cards stay in stable order when toggling projects in Chart Your Course
- **#4549** — Clicking a Mission Control mission opens its chat history AND the MC dialog

### Dashboard/UX fixes
- **#4546** — Resource Usage drilldown now shows utilization percentages and passes resource context
- **#4556** — Nodes stat block has dashboard-specific click handler (was missing `case 'nodes'`)
- **#4557** — Auto-collapse timer no longer permanently persists; only explicit minimize does
- **#4558** — Getting Started banner suppressed when agent is connected (PostConnect takes priority)
- **#4541** — Streak badge hidden until auth confirmed (prevents flash before OAuth redirect)
- **#4565** — RotatingTip hidden on mobile (`hidden sm:flex`) to prevent UI overlap

## Test plan
- [ ] Open Mission Control, type a description, click Suggest — should work on first click
- [ ] In Chart Your Course, toggle project assignments — cluster cards should not reorder
- [ ] After dry run completes, click Close — dialog should dismiss
- [ ] Click a "Mission Control Planning" mission in sidebar — should show its chat
- [ ] Check Nodes stat block on dashboard — should be clickable and drill to all-nodes view
- [ ] Expand Recommended Actions, wait 20s for auto-collapse, refresh — should re-expand
- [ ] Connect agent — Getting Started banner should disappear, only Post-Connect shows
- [ ] Resize browser to mobile width — RotatingTip should be hidden
- [ ] Resource Usage card drilldown — should show CPU/Memory utilization percentages

Fixes #4543, #4544, #4547, #4548, #4549, #4546, #4556, #4557, #4558, #4541, #4565