### PR TITLE
fix: mission deep links broken on production (demo mode)

### DIFF
--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -636,6 +636,8 @@ export const handlers = [
   // even in demo mode — let them through to the actual backend.
   http.get('/api/youtube/playlist', () => passthrough()),
   http.get('/api/youtube/thumbnail/*', () => passthrough()),
+  http.get('/api/missions/file', () => passthrough()),
+  http.get('/api/missions/browse', () => passthrough()),
 
   // ── Catch-all for unmocked API routes ────────────────────────────
   // On Netlify, unhandled /api/* and /health requests fall through to the SPA


### PR DESCRIPTION
## Summary
- MSW catch-all handler was intercepting `/api/missions/*` requests with 503 "not available in demo mode" on the Netlify production site
- All 186+ mission deep links (e.g., `/missions/install-drasi`) were broken — users saw "Mission not found"
- Added passthrough rules for `/api/missions/file` and `/api/missions/browse` endpoints so they reach the real Netlify Functions

## Root cause
The MSW handlers have a catch-all `http.all('/api/*', ...)` that returns 503 for any unhandled API route in demo mode. YouTube endpoints had passthrough rules but the missions endpoints did not.

This was never caught because mission landing pages are tested against the Go backend locally (no MSW), and MSW only activates on Netlify (`VITE_DEMO_MODE=true`).

## Test plan
- [ ] Deploy to Netlify preview
- [ ] Open `/missions/install-drasi` — should show the mission content instead of "Mission not found"
- [ ] Open `/missions/install-karmada` — same
- [ ] Verify "Browse all missions" still works

Reported by: https://github.com/drasi-project/drasi-platform/issues/400#issuecomment-4185198545