### PR TITLE
test: nightly mission deep link health check

### DIFF
--- a/.github/workflows/nightly-dashboard-health.yml
+++ b/.github/workflows/nightly-dashboard-health.yml
@@ -65,6 +65,7 @@ jobs:
           set +e
           npx playwright test \
             e2e/nightly/dashboard-health.spec.ts \
+            e2e/nightly/mission-deeplink.spec.ts \
             -c e2e/nightly/nightly.config.ts \
             --reporter=list,json 2>&1 | tee /tmp/test-output.txt
           TEST_EXIT=$?

--- a/web/e2e/nightly/mission-deeplink.spec.ts
+++ b/web/e2e/nightly/mission-deeplink.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Nightly Mission Deep Link Health Check
+ *
+ * Validates that mission landing pages (/missions/:id) load correctly
+ * in demo mode. These pages fetch mission data from the console-kb via
+ * /api/missions/file — if MSW intercepts the request (missing passthrough
+ * rule), the page shows "Mission not found" instead of the mission content.
+ *
+ * This test catches the class of bug fixed in PR #4587 where the MSW
+ * catch-all returned 503 for /api/missions/* endpoints.
+ *
+ * Run locally:
+ *   npx playwright test e2e/nightly/mission-deeplink.spec.ts \
+ *     -c e2e/nightly/nightly.config.ts
+ */
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/** Time to wait for the mission content to load (ms) */
+const MISSION_LOAD_TIMEOUT_MS = 15_000
+
+/** Sample of well-known mission slugs to test (covering different prefixes) */
+const MISSION_SLUGS = [
+  'install-drasi',
+  'install-karmada',
+  'install-argo-cd',
+] as const
+
+/** Number of slugs from the index to sample (in addition to the well-known ones) */
+const INDEX_SAMPLE_SIZE = 3
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Mission Deep Links', () => {
+  for (const slug of MISSION_SLUGS) {
+    test(`/missions/${slug} loads mission content`, async ({ page }) => {
+      await page.goto(`/missions/${slug}`, { waitUntil: 'networkidle' })
+
+      // The "Mission not found" error text should NOT be visible
+      const notFoundText = page.getByText('Mission not found')
+      await expect(notFoundText).not.toBeVisible({ timeout: MISSION_LOAD_TIMEOUT_MS })
+
+      // The mission title or step content should be visible
+      // MissionLandingPage renders steps in a list — at least one step should exist
+      const stepElements = page.locator('[data-testid="mission-step"], .mission-step, h3, h2')
+      const pageText = await page.textContent('body')
+      const hasContent = (pageText?.length ?? 0) > 200
+
+      // Either we find structured step elements or the page has substantial content
+      expect(hasContent).toBe(true)
+    })
+  }
+
+  test('random missions from index resolve correctly', async ({ page }) => {
+    // Fetch the missions index to get real paths
+    const response = await page.request.get('/api/missions/file?path=fixes/index.json')
+
+    // If the index itself fails, that's also a passthrough bug
+    expect(response.ok(), 'missions index should be accessible').toBe(true)
+
+    const index = await response.json() as { missions?: Array<{ path: string; title?: string }> }
+    const missions = (index.missions ?? []).filter((m) =>
+      m.path.startsWith('fixes/cncf-install/') && m.path.endsWith('.json'),
+    )
+
+    // Pick random missions to test
+    const shuffled = missions.sort(() => Math.random() - 0.5)
+    const sample = shuffled.slice(0, INDEX_SAMPLE_SIZE)
+
+    for (const entry of sample) {
+      // Extract slug from path: "fixes/cncf-install/install-foo.json" → "install-foo"
+      const slug = entry.path.split('/').pop()?.replace('.json', '') ?? ''
+
+      await test.step(`/missions/${slug}`, async () => {
+        await page.goto(`/missions/${slug}`, { waitUntil: 'networkidle' })
+
+        const notFoundText = page.getByText('Mission not found')
+        await expect(notFoundText).not.toBeVisible({ timeout: MISSION_LOAD_TIMEOUT_MS })
+      })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a Playwright nightly spec that validates `/missions/:id` deep links load correctly in demo mode
- Tests 3 well-known slugs (`install-drasi`, `install-karmada`, `install-argo-cd`) plus 3 random samples from the console-kb index
- Asserts "Mission not found" is NOT visible — catches MSW passthrough regressions like PR #4587

## Why
PR #4587 fixed a bug where all 186+ mission deep links were broken on production because MSW intercepted `/api/missions/*` requests. This went undetected because no nightly test covered the mission landing page in demo mode.

## Test plan
- [ ] CI build passes
- [ ] Run locally: `cd web && npx playwright test e2e/nightly/mission-deeplink.spec.ts -c e2e/nightly/nightly.config.ts`