### PR TITLE
feat: GA4 tracking for mission landing page errors

### DIFF
--- a/web/src/components/missions/MissionLandingPage.tsx
+++ b/web/src/components/missions/MissionLandingPage.tsx
@@ -18,6 +18,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { validateMissionExport } from '../../lib/missions/types'
 import type { MissionExport, MissionStep } from '../../lib/missions/types'
 import { getHomeBrowseMissionsRoute } from '../../config/routes'
+import { emitMissionError, emitPageView } from '../../lib/analytics'
 
 // ============================================================================
 // Constants
@@ -278,15 +279,19 @@ export function MissionLandingPage() {
   useEffect(() => {
     if (!missionId) {
       setError('No mission specified')
+      emitMissionError('unknown', 'no_mission_specified')
       setLoading(false)
       return
     }
+
+    emitPageView(`/missions/${missionId}`)
 
     fetchMissionBySlug(missionId).then((result) => {
       if (result) {
         setMission(result.mission)
       } else {
         setError('Mission not found')
+        emitMissionError(missionId, 'mission_not_found')
       }
       setLoading(false)
     })


### PR DESCRIPTION
## Summary
- Emit `ksc_mission_error` GA4 event when a `/missions/:id` deep link fails to load
- Emit `page_view` for successful mission landing page loads
- Uses existing `emitMissionError` and `emitPageView` from analytics.ts

## Why
The MSW passthrough bug (PR #4587) broke all 186+ mission deep links for months without detection. This GA4 event creates a signal in analytics — any spike in `ksc_mission_error` with `error_code: mission_not_found` indicates broken mission links.

## Test plan
- [ ] Build passes
- [ ] Navigate to `/missions/install-drasi` — no error event fired
- [ ] Navigate to `/missions/nonexistent-slug` — `ksc_mission_error` event fired with `mission_not_found`