### PR TITLE
🐛 Fix 6 persistent test failures blocking coverage

### DIFF
--- a/web/src/components/alerts/AlertRuleEditor.test.tsx
+++ b/web/src/components/alerts/AlertRuleEditor.test.tsx
@@ -6,7 +6,7 @@ import '../../test/utils/setupMocks'
 
 vi.mock('../../hooks/useMCP', () => ({
   useClusters: () => ({
-    clusters: [{ name: 'test-cluster', context: 'test-ctx' }],
+    deduplicatedClusters: [{ name: 'test-cluster', context: 'test-ctx', reachable: true }],
   }),
 }))
 

--- a/web/src/config/__tests__/learningVideos.test.ts
+++ b/web/src/config/__tests__/learningVideos.test.ts
@@ -11,7 +11,7 @@ import {
 describe('YouTube URL helpers', () => {
   it('getYouTubeThumbnailUrl returns valid URL', () => {
     const url = getYouTubeThumbnailUrl('abc123')
-    expect(url).toBe('https://img.youtube.com/vi/abc123/mqdefault.jpg')
+    expect(url).toBe('/api/youtube/thumbnail/abc123')
   })
 
   it('getYouTubeWatchUrl returns valid URL', () => {

--- a/web/src/lib/modals/__tests__/BaseModal.test.tsx
+++ b/web/src/lib/modals/__tests__/BaseModal.test.tsx
@@ -181,6 +181,7 @@ describe('BaseModal.Content', () => {
   })
 
   it('removes padding when noPadding is true', () => {
+    render(
       <BaseModal isOpen={true} onClose={vi.fn()}>
         <BaseModal.Content noPadding={true}>
           <p>No padding</p>

--- a/web/src/lib/modals/__tests__/ConfirmDialog.test.tsx
+++ b/web/src/lib/modals/__tests__/ConfirmDialog.test.tsx
@@ -79,12 +79,13 @@ describe('ConfirmDialog', () => {
   })
 
   it('renders with danger variant by default', () => {
-    // Danger variant uses red color classes
+    render(<ConfirmDialog {...defaultProps} />)
     const confirmBtn = screen.getByText('Confirm').closest('button')
     expect(confirmBtn?.className).toContain('red')
   })
 
   it('renders with warning variant', () => {
+    render(
       <ConfirmDialog {...defaultProps} variant="warning" />
     )
     const confirmBtn = screen.getByText('Confirm').closest('button')
@@ -92,6 +93,7 @@ describe('ConfirmDialog', () => {
   })
 
   it('renders with info variant', () => {
+    render(
       <ConfirmDialog {...defaultProps} variant="info" />
     )
     const confirmBtn = screen.getByText('Confirm').closest('button')


### PR DESCRIPTION
## Summary
- **learningVideos.test.ts**: Updated `getYouTubeThumbnailUrl` assertion to match the API proxy route (`/api/youtube/thumbnail/...`) instead of the old direct YouTube URL
- **AlertRuleEditor.test.tsx**: Updated `useClusters` mock to return `deduplicatedClusters` instead of `clusters` (changed in PR #4582)
- **BaseModal.test.tsx**: Added missing `render()` call in the `noPadding` test case (parse error at line 189)
- **ConfirmDialog.test.tsx**: Added missing `render()` calls in `warning` and `info` variant test cases (parse errors at lines 89/95)

## Test plan
- [x] All 4 test files pass individually (39 tests total)
- [x] No changes to source components -- only test mocks and assertions updated