### PR TITLE
🐛 Fix DOMPurify install, test failures, CLI validation

### DIFF
--- a/pkg/agent/provider_antigravity.go
+++ b/pkg/agent/provider_antigravity.go
@@ -80,8 +80,26 @@ func (a *AntigravityProvider) Refresh() {
 // Handshake verifies that the Antigravity CLI is installed and can respond.
 // It returns a structured result with prerequisites and actionable errors.
 func (a *AntigravityProvider) Handshake(ctx context.Context) *HandshakeResult {
-	// Re-detect CLI in case the user installed it after the server started.
-	a.detectCLI()
+	// If a cliPath is already configured, validate it exists on disk.
+	// Otherwise, re-detect CLI in case the user installed it after the server started.
+	if a.cliPath != "" {
+		if _, err := os.Stat(a.cliPath); err != nil {
+			return &HandshakeResult{
+				Ready:   false,
+				State:   "failed",
+				Message: fmt.Sprintf("Configured CLI path does not exist: %s", a.cliPath),
+				CliPath: a.cliPath,
+				Prerequisites: []string{
+					fmt.Sprintf("Verify the CLI exists at %s", a.cliPath),
+					"Install the Antigravity CLI (npm install -g @anthropic-ai/antigravity or download from the project page)",
+					"Ensure the 'antigravity' binary is in your PATH",
+					"Restart kc-agent after installing",
+				},
+			}
+		}
+	} else {
+		a.detectCLI()
+	}
 
 	if a.cliPath == "" {
 		return &HandshakeResult{

--- a/pkg/api/handlers/user.go
+++ b/pkg/api/handlers/user.go
@@ -44,7 +44,7 @@ func (h *UserHandler) UpdateCurrentUser(c *fiber.Ctx) error {
 	// Only allow updating certain fields
 	var updates struct {
 		Email   string `json:"email"`
-		SlackID string `json:"slack_id"`
+		SlackID string `json:"slackId"`
 	}
 	if err := c.BodyParser(&updates); err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "Invalid request body")

--- a/pkg/k8s/workload_scaling_test.go
+++ b/pkg/k8s/workload_scaling_test.go
@@ -67,12 +67,26 @@ func TestScaleWorkload(t *testing.T) {
 }
 
 func TestDeleteWorkload(t *testing.T) {
+	deployObj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "dep1",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+			},
+		},
+	}
+
 	scheme := runtime.NewScheme()
 	gvrMap := map[schema.GroupVersionResource]string{
 		{Group: "apps", Version: "v1", Resource: "deployments"}: "DeploymentList",
 	}
 
-	fakeDyn := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrMap)
+	fakeDyn := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrMap, deployObj)
 
 	m, _ := NewMultiClusterClient("")
 	m.dynamicClients["c1"] = fakeDyn

--- a/web/public/mockServiceWorker.js
+++ b/web/public/mockServiceWorker.js
@@ -1,4 +1,4 @@
- 
+/* eslint-disable */
 /* tslint:disable */
 
 /**


### PR DESCRIPTION
## Summary
- **#4630**: Install `dompurify` and `@types/dompurify` packages — build was failing due to missing module
- **#4634**: Seed the fake dynamic client with a Deployment object in `TestDeleteWorkload` so it can actually find and delete the workload
- **#4635**: Fix JSON tag mismatch in `UpdateCurrentUser` handler — the `updates` struct used `json:"slack_id"` but the API sends `"slackId"` (camelCase), so SlackID was never parsed from the request body
- **#4637**: Validate configured CLI path exists on disk in `Handshake()` instead of blindly calling `detectCLI()` which searches PATH and overrides an invalid configured path with a found one

## Test plan
- [x] `npm run build` passes (DOMPurify resolved)
- [x] `go build ./cmd/console/` passes
- [x] `go test -run TestDeleteWorkload` passes
- [x] `go test -run TestUpdateCurrentUser_Success` passes
- [x] `go test -run TestAntigravityProvider_Handshake_InvalidPath` passes

Fixes #4630, #4634, #4635, #4637