### PR TITLE
fix: exclude localhost dev traffic from GA4 error monitor

### DIFF
--- a/.github/workflows/ga4-error-monitor.yml
+++ b/.github/workflows/ga4-error-monitor.yml
@@ -114,9 +114,22 @@ jobs:
                 ],
                 metrics: [{ name: 'eventCount' }],
                 dimensionFilter: {
-                  filter: {
-                    fieldName: 'eventName',
-                    stringFilter: { value: 'ksc_error' },
+                  andGroup: {
+                    expressions: [
+                      {
+                        filter: {
+                          fieldName: 'eventName',
+                          stringFilter: { value: 'ksc_error' },
+                        },
+                      },
+                      {
+                        // Exclude localhost / dev traffic — only monitor production
+                        filter: {
+                          fieldName: 'hostname',
+                          stringFilter: { value: 'console.kubestellar.io' },
+                        },
+                      },
+                    ],
                   },
                 },
                 orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],
@@ -159,9 +172,21 @@ jobs:
                   ],
                   metrics: [{ name: 'eventCount' }],
                   dimensionFilter: {
-                    filter: {
-                      fieldName: 'eventName',
-                      stringFilter: { value: 'ksc_error' },
+                    andGroup: {
+                      expressions: [
+                        {
+                          filter: {
+                            fieldName: 'eventName',
+                            stringFilter: { value: 'ksc_error' },
+                          },
+                        },
+                        {
+                          filter: {
+                            fieldName: 'hostname',
+                            stringFilter: { value: 'console.kubestellar.io' },
+                          },
+                        },
+                      ],
                     },
                   },
                   orderBys: [{ metric: { metricName: 'eventCount' }, desc: true }],


### PR DESCRIPTION
## Summary
- GA4 error monitor was creating issues for Vite HMR errors originating from `localhost` dev servers
- Today: 1,699 "send was called before connect" errors — all from `localhost`, zero from `console.kubestellar.io`
- Added `hostname = console.kubestellar.io` filter to both GA4 queries so only production errors trigger issue creation

## Root cause
The Vite HMR client throws "send was called before connect" when the dev server WebSocket connection drops. This is expected dev-mode behavior (not a bug), but the GA4 error monitor couldn't distinguish it from production errors.

## Test plan
- [ ] Trigger workflow manually: `gh workflow run ga4-error-monitor.yml`
- [ ] Verify it reports 0 errors (no production errors currently)
- [ ] Verify localhost errors are excluded from results