### PR TITLE
🐛 Wire Stats Overview to global cluster filter

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, Suspense } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef, Suspense } from 'react'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import {
   DndContext,
@@ -73,6 +73,7 @@ import { DashboardHealthIndicator } from './DashboardHealthIndicator'
 import { useCardGridNavigation } from '../../hooks/useCardGridNavigation'
 import { useModalState } from '../../lib/modals'
 import { setAutoRefreshPaused } from '../../lib/cache'
+import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 
 // Lazy-load modal components — only shown on explicit user action,
 // so deferring their chunk until first use reduces the initial dashboard bundle.
@@ -181,6 +182,9 @@ export function Dashboard() {
   // Universal stats for cross-dashboard stat blocks
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
 
+  // Global cluster filter — stats should reflect only selected clusters
+  const { selectedClusters: globalSelectedClusters, isAllClustersSelected } = useGlobalFilters()
+
   // Inter-card event bus for cross-card deploy
   const publishCardEvent = useCardPublish()
   const { mutate: deployWorkload } = useDeployWorkload()
@@ -194,18 +198,26 @@ export function Dashboard() {
     groupName: string
   } | null>(null)
 
-  // Stats calculations for StatsOverview
-  const healthyClusters = (clusters || []).filter(c => c.healthy).length
-  const unhealthyClusters = (clusters || []).filter(c => !c.healthy).length
-  const totalPods = (clusters || []).reduce((sum, c) => sum + (c.podCount || 0), 0)
-  const totalNamespaces = (clusters || []).reduce((sum, c) => sum + (c.namespaces?.length || 0), 0)
-  const totalNodes = (clusters || []).reduce((sum, c) => sum + (c.nodeCount || 0), 0)
+  // Apply global cluster filter before computing stats so the overview
+  // reflects only the user's current cluster selection.
+  const filteredClusters = useMemo(() => {
+    const all = clusters || []
+    if (isAllClustersSelected) return all
+    return all.filter(c => globalSelectedClusters.includes(c.name))
+  }, [clusters, globalSelectedClusters, isAllClustersSelected])
+
+  // Stats calculations for StatsOverview (scoped to filtered clusters)
+  const healthyClusters = filteredClusters.filter(c => c.healthy).length
+  const unhealthyClusters = filteredClusters.filter(c => !c.healthy).length
+  const totalPods = filteredClusters.reduce((sum, c) => sum + (c.podCount || 0), 0)
+  const totalNamespaces = filteredClusters.reduce((sum, c) => sum + (c.namespaces?.length || 0), 0)
+  const totalNodes = filteredClusters.reduce((sum, c) => sum + (c.nodeCount || 0), 0)
 
   // Dashboard-specific stats value getter
   const getDashboardStatValue = useCallback((blockId: string): StatBlockValue => {
     switch (blockId) {
       case 'clusters':
-        return { value: clusters.length, sublabel: 'total clusters', onClick: () => drillToAllClusters(), isClickable: clusters.length > 0 }
+        return { value: filteredClusters.length, sublabel: 'total clusters', onClick: () => drillToAllClusters(), isClickable: filteredClusters.length > 0 }
       case 'healthy':
         return { value: healthyClusters, sublabel: 'healthy', onClick: () => drillToAllClusters('healthy'), isClickable: healthyClusters > 0 }
       case 'warnings':
@@ -221,7 +233,7 @@ export function Dashboard() {
       default:
         return { value: '-' }
     }
-  }, [clusters, healthyClusters, unhealthyClusters, totalNamespaces, totalNodes, totalPods, drillToAllClusters, drillToAllNodes, drillToAllPods, navigate])
+  }, [filteredClusters, healthyClusters, unhealthyClusters, totalNamespaces, totalNodes, totalPods, drillToAllClusters, drillToAllNodes, drillToAllPods, navigate])
 
   // Merged getter: dashboard-specific values first, then universal fallback
   const getStatValue = useCallback(

--- a/web/src/components/dashboard/__tests__/Dashboard.test.tsx
+++ b/web/src/components/dashboard/__tests__/Dashboard.test.tsx
@@ -174,6 +174,16 @@ vi.mock('../../../hooks/useRefreshIndicator', () => ({
 }))
 vi.mock('../../../hooks/useDemoMode', () => ({ getDemoMode: () => false }))
 
+const mockGlobalFilters = {
+  selectedClusters: [] as string[],
+  isAllClustersSelected: true,
+  customFilter: '',
+  filterByCluster: <T,>(items: T[]) => items,
+}
+vi.mock('../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => mockGlobalFilters,
+}))
+
 // Mock child components as minimal stubs
 vi.mock('../DashboardDropZone', () => ({ DashboardDropZone: () => <div data-testid="drop-zone" /> }))
 vi.mock('../CardRecommendations', () => ({ CardRecommendations: () => <div data-testid="card-recs" /> }))
@@ -203,8 +213,12 @@ vi.mock('../WelcomeCard', () => ({ WelcomeCard: () => <div data-testid="welcome-
 vi.mock('../../shared/DashboardHeader', () => ({
   DashboardHeader: ({ title }: { title: string }) => <div data-testid="dashboard-header">{title}</div>,
 }))
+let capturedGetStatValue: ((blockId: string) => { value: unknown }) | null = null
 vi.mock('../../ui/StatsOverview', () => ({
-  StatsOverview: () => <div data-testid="stats-overview" />,
+  StatsOverview: ({ getStatValue }: { getStatValue: (id: string) => { value: unknown } }) => {
+    capturedGetStatValue = getStatValue
+    return <div data-testid="stats-overview" />
+  },
   StatBlockValue: {},
 }))
 vi.mock('../dashboardUtils', () => ({
@@ -247,6 +261,10 @@ describe('Dashboard', () => {
     mockSafeGetJSON.mockReturnValue(null)
     mockLocation.pathname = '/'
     mockLocation.key = 'test-key'
+    capturedGetStatValue = null
+    // Reset global filter to default (all clusters)
+    mockGlobalFilters.selectedClusters = []
+    mockGlobalFilters.isAllClustersSelected = true
 
     // Return empty dashboards to avoid recursive API calls
     mockApiGet.mockResolvedValue({ data: [] })
@@ -337,5 +355,45 @@ describe('Dashboard', () => {
   it('shows drop zone component', () => {
     render(<Dashboard />)
     expect(screen.getByTestId('drop-zone')).toBeInTheDocument()
+  })
+
+  describe('global cluster filter', () => {
+    it('shows all-cluster totals when no filter is applied', () => {
+      // Default: isAllClustersSelected = true
+      mockGlobalFilters.selectedClusters = []
+      mockGlobalFilters.isAllClustersSelected = true
+      render(<Dashboard />)
+      expect(capturedGetStatValue).toBeTruthy()
+      // Both clusters counted (prod + staging)
+      expect(capturedGetStatValue!('clusters').value).toBe(2)
+      // 50 + 20 = 70 total pods
+      expect(capturedGetStatValue!('pods').value).toBe(70)
+      // 3 + 1 = 4 nodes
+      expect(capturedGetStatValue!('nodes').value).toBe(4)
+    })
+
+    it('scopes stats to selected clusters when global filter is active', () => {
+      // Filter to only 'prod' cluster
+      mockGlobalFilters.selectedClusters = ['prod']
+      mockGlobalFilters.isAllClustersSelected = false
+      render(<Dashboard />)
+      expect(capturedGetStatValue).toBeTruthy()
+      // Only prod counted
+      expect(capturedGetStatValue!('clusters').value).toBe(1)
+      expect(capturedGetStatValue!('healthy').value).toBe(1)
+      expect(capturedGetStatValue!('errors').value).toBe(0)
+      expect(capturedGetStatValue!('pods').value).toBe(50)
+      expect(capturedGetStatValue!('nodes').value).toBe(3)
+    })
+
+    it('shows zero stats when filter selects no matching clusters', () => {
+      mockGlobalFilters.selectedClusters = ['nonexistent']
+      mockGlobalFilters.isAllClustersSelected = false
+      render(<Dashboard />)
+      expect(capturedGetStatValue).toBeTruthy()
+      expect(capturedGetStatValue!('clusters').value).toBe(0)
+      expect(capturedGetStatValue!('pods').value).toBe(0)
+      expect(capturedGetStatValue!('nodes').value).toBe(0)
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Dashboard Stats Overview now respects the global cluster filter instead of always showing all-cluster aggregates
- When users select specific clusters in the filter panel, stats (cluster count, healthy/unhealthy, pods, nodes, namespaces) are scoped to that selection
- When no filter is applied, behavior is unchanged (shows global totals)

## Changes
- **`Dashboard.tsx`**: Import `useGlobalFilters`, filter `clusters` via `useMemo` before computing stats, update `getDashboardStatValue` to use `filteredClusters`
- **`Dashboard.test.tsx`**: Add `useGlobalFilters` mock + 3 new tests covering all-clusters, single-cluster filter, and no-match filter scenarios

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes on changed files
- [x] 16/16 tests pass (13 existing + 3 new filter tests)
- [ ] Manual: Open Dashboard, verify stats show global totals
- [ ] Manual: Select a single cluster in global filter, verify stats update to reflect only that cluster
- [ ] Manual: Clear filter, verify stats revert to global totals

Fixes #4676