### PR TITLE
🐛 Wire Predictive Health card to global cluster filter

### DIFF
--- a/web/src/components/cards/PredictiveHealth.tsx
+++ b/web/src/components/cards/PredictiveHealth.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useCachedNodes, useCachedPods } from '../../hooks/useCachedData'
+import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useCardLoadingState } from './CardDataContext'
 
@@ -50,14 +51,18 @@ function confidenceFromUsage(usagePct: number): number {
 
 export function PredictiveHealth() {
   const { t } = useTranslation('cards')
-  const { nodes, isLoading: nodesLoading, isDemoFallback: nodesDemoFallback, isFailed: nodesFailed, consecutiveFailures: nodesFailures } = useCachedNodes()
-  const { pods, isLoading: podsLoading, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedPods()
+  const { nodes: allNodes, isLoading: nodesLoading, isDemoFallback: nodesDemoFallback, isFailed: nodesFailed, consecutiveFailures: nodesFailures } = useCachedNodes()
+  const { pods: allPods, isLoading: podsLoading, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedPods()
+  const { filterByCluster } = useGlobalFilters()
   const [expandedId, setExpandedId] = useState<string | null>(null)
+
+  const nodes = useMemo(() => filterByCluster(allNodes), [allNodes, filterByCluster])
+  const pods = useMemo(() => filterByCluster(allPods), [allPods, filterByCluster])
 
   const isLoading = nodesLoading || podsLoading
   const { showSkeleton } = useCardLoadingState({
     isLoading,
-    hasAnyData: nodes.length > 0 || pods.length > 0,
+    hasAnyData: allNodes.length > 0 || allPods.length > 0,
     isDemoData: nodesDemoFallback || podsDemoFallback,
     isFailed: nodesFailed || podsFailed,
     consecutiveFailures: Math.max(nodesFailures, podsFailures),

--- a/web/src/components/cards/__tests__/PredictiveHealth.test.tsx
+++ b/web/src/components/cards/__tests__/PredictiveHealth.test.tsx
@@ -40,6 +40,15 @@ vi.mock('../CardDataContext', () => ({
   useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
 }))
 
+const mockFilterByCluster = vi.fn(<T extends { cluster?: string }>(items: T[]): T[] => items)
+vi.mock('../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({
+    filterByCluster: mockFilterByCluster,
+    selectedClusters: [] as string[],
+    isAllClustersSelected: true,
+  }),
+}))
+
 const mockNodes = vi.fn()
 const mockPods = vi.fn()
 vi.mock('../../../hooks/useCachedData', () => ({
@@ -85,6 +94,69 @@ describe('PredictiveHealth', () => {
     mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
     const { container } = render(<PredictiveHealth />)
     expect(container).toBeTruthy()
+  })
+
+  it('passes nodes and pods through filterByCluster', () => {
+    const testNodes = [
+      { name: 'node-1', cluster: 'cluster-a', conditions: [], unschedulable: false },
+      { name: 'node-2', cluster: 'cluster-b', conditions: [], unschedulable: false },
+    ]
+    const testPods = [
+      { name: 'pod-1', cluster: 'cluster-a', restarts: 0 },
+      { name: 'pod-2', cluster: 'cluster-b', restarts: 0 },
+    ]
+    mockNodes.mockReturnValue({ nodes: testNodes, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: testPods, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+
+    render(<PredictiveHealth />)
+
+    // filterByCluster should be called with both nodes and pods arrays
+    expect(mockFilterByCluster).toHaveBeenCalledWith(testNodes)
+    expect(mockFilterByCluster).toHaveBeenCalledWith(testPods)
+  })
+
+  it('shows only filtered cluster predictions when filter is active', () => {
+    // filterByCluster returns only cluster-a items
+    mockFilterByCluster.mockImplementation(<T extends { cluster?: string }>(items: T[]): T[] =>
+      items.filter(item => item.cluster === 'cluster-a')
+    )
+
+    const testNodes = [
+      { name: 'node-a', cluster: 'cluster-a', conditions: [{ type: 'MemoryPressure', status: 'True' }], unschedulable: false },
+      { name: 'node-b', cluster: 'cluster-b', conditions: [{ type: 'MemoryPressure', status: 'True' }], unschedulable: false },
+    ]
+    const testPods = [
+      { name: 'pod-a', cluster: 'cluster-a', restarts: 0 },
+      { name: 'pod-b', cluster: 'cluster-b', restarts: 0 },
+    ]
+    mockNodes.mockReturnValue({ nodes: testNodes, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: testPods, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+
+    const { container } = render(<PredictiveHealth />)
+
+    // Should only show cluster-a predictions, not cluster-b
+    const text = container.textContent || ''
+    expect(text).not.toContain('cluster-b')
+  })
+
+  it('shows empty state when filter excludes all clusters', () => {
+    // filterByCluster returns nothing
+    mockFilterByCluster.mockImplementation(() => [])
+
+    const testNodes = [
+      { name: 'node-a', cluster: 'cluster-a', conditions: [{ type: 'MemoryPressure', status: 'True' }], unschedulable: false },
+    ]
+    const testPods = [
+      { name: 'pod-a', cluster: 'cluster-a', restarts: 10 },
+    ]
+    mockNodes.mockReturnValue({ nodes: testNodes, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+    mockPods.mockReturnValue({ pods: testPods, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, error: null, lastRefresh: Date.now() })
+
+    const { container } = render(<PredictiveHealth />)
+
+    // With no data after filtering, should show the all-clear / empty state
+    const text = container.textContent || ''
+    expect(text).toContain('predictiveHealth.allClear')
   })
 
 })


### PR DESCRIPTION
## Summary
- Import `useGlobalFilters` and apply `filterByCluster()` to both `nodes` and `pods` data before computing predictions
- When users select specific clusters in the global filter panel, predictions are now scoped to only those clusters
- Clearing the filter reverts to global predictions (existing behavior preserved)

## Test plan
- [x] 3 new tests: passes nodes/pods through filterByCluster, shows only filtered cluster predictions, shows empty state when filter excludes all clusters
- [x] All 8 tests pass
- [x] Build passes
- [x] Lint clean on changed files

Fixes #4679