### PR TITLE
🐛 Fix hook lifecycle, heartbeat cleanup, state reset bugs

### DIFF
--- a/web/src/hooks/__tests__/useDashboardCards.test.ts
+++ b/web/src/hooks/__tests__/useDashboardCards.test.ts
@@ -320,10 +320,9 @@ describe('useDashboardCards', () => {
       })
 
       expect(result.current.cards).toEqual(DEFAULT_CARDS)
-      // Note: resetToDefaults calls localStorage.removeItem, but the useEffect
-      // that watches `cards` re-persists the defaultCards immediately after.
-      // The net effect is that localStorage contains the default cards again.
-      expect(readStoredCards()).toEqual(DEFAULT_CARDS)
+      // resetToDefaults removes the localStorage key and skips the persistence
+      // effect so the key stays removed (fixes #4686 — reset no longer undone)
+      expect(localStorage.getItem(TEST_STORAGE_KEY)).toBeNull()
     })
 
     it('restores to empty array when no defaultCards were provided', () => {
@@ -341,16 +340,34 @@ describe('useDashboardCards', () => {
 
       expect(result.current.cards).toEqual([])
     })
+
+    it('does not re-persist defaults after reset (fixes #4686)', () => {
+      const { result } = renderHook(() =>
+        useDashboardCards({ storageKey: TEST_STORAGE_KEY, defaultCards: DEFAULT_CARDS }),
+      )
+
+      // Customize, then reset
+      act(() => {
+        result.current.addCard('extra')
+      })
+      act(() => {
+        result.current.resetToDefaults()
+      })
+
+      // The persistence effect should have been skipped — key stays removed
+      expect(localStorage.getItem(TEST_STORAGE_KEY)).toBeNull()
+
+      // isCustomized should return false since the key is gone
+      expect(result.current.isCustomized()).toBe(false)
+    })
   })
 
   // ── isCustomized ────────────────────────────────────────────────────────
 
   describe('isCustomized', () => {
-    it('returns false before any mutation persists', () => {
-      // localStorage is empty at this point — but the useEffect that persists
-      // defaultCards fires asynchronously. The useState initializer sets cards
-      // to defaultCards, and the useEffect writes them. After render, isCustomized
-      // will reflect whether localStorage has been written.
+    it('returns false when stored cards match defaults (fixes #4687)', () => {
+      // The useEffect persists defaultCards to localStorage on first render.
+      // isCustomized now compares content, not just key existence.
       localStorage.removeItem(TEST_STORAGE_KEY)
 
       const { result } = renderHook(() =>
@@ -358,8 +375,8 @@ describe('useDashboardCards', () => {
       )
 
       // After the first render, the useEffect persists cards to localStorage,
-      // so isCustomized should return true (localStorage key now exists).
-      expect(result.current.isCustomized()).toBe(true)
+      // but since the stored content matches defaultCards, isCustomized returns false.
+      expect(result.current.isCustomized()).toBe(false)
     })
 
     it('returns true when cards have been modified', () => {
@@ -367,12 +384,11 @@ describe('useDashboardCards', () => {
         useDashboardCards({ storageKey: TEST_STORAGE_KEY, defaultCards: DEFAULT_CARDS }),
       )
 
-      // After initial render + useEffect, localStorage has the default cards
-      // so isCustomized returns true (key exists).
       act(() => {
         result.current.addCard('extra')
       })
 
+      // After adding a card, stored content differs from defaults
       expect(result.current.isCustomized()).toBe(true)
     })
 
@@ -380,16 +396,31 @@ describe('useDashboardCards', () => {
       // Manually ensure the key is absent
       localStorage.removeItem(TEST_STORAGE_KEY)
 
+      // Use a fresh render to avoid persistence effect writing the key
       const { result } = renderHook(() =>
         useDashboardCards({ storageKey: TEST_STORAGE_KEY, defaultCards: DEFAULT_CARDS }),
       )
 
-      // Before useEffect fires, call isCustomized synchronously
-      // This checks only whether the localStorage key exists —
-      // the hook's useEffect will set it, but isCustomized is just a
-      // wrapper around localStorage.getItem !== null.
-      // After renderHook, the effect has already fired, so the key exists.
+      // After renderHook, the effect persists defaults. Since content matches
+      // defaults, isCustomized returns false.
+      expect(result.current.isCustomized()).toBe(false)
+    })
+
+    it('returns false after resetToDefaults even if key gets re-written', () => {
+      const { result } = renderHook(() =>
+        useDashboardCards({ storageKey: TEST_STORAGE_KEY, defaultCards: DEFAULT_CARDS }),
+      )
+
+      // Customize, then reset
+      act(() => {
+        result.current.addCard('extra')
+      })
       expect(result.current.isCustomized()).toBe(true)
+
+      act(() => {
+        result.current.resetToDefaults()
+      })
+      expect(result.current.isCustomized()).toBe(false)
     })
   })
 

--- a/web/src/hooks/useAIPredictions.ts
+++ b/web/src/hooks/useAIPredictions.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import type {
   AIPrediction,
   AIPredictionsResponse,
@@ -14,7 +14,7 @@ import { LOCAL_AGENT_WS_URL, LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS, AI_PREDICTION_TIMEOUT_MS, WS_RECONNECT_DELAY_MS, UI_FEEDBACK_TIMEOUT_MS, RETRY_DELAY_MS } from '../lib/constants/network'
 
 const AGENT_HTTP_URL = LOCAL_AGENT_HTTP_URL
-const POLL_INTERVAL = 30000 // Poll every 30 seconds as fallback
+const POLL_INTERVAL_MS = 30_000 // Poll every 30 seconds as fallback
 
 // Demo mode predictions
 const DEMO_AI_PREDICTIONS: AIPrediction[] = [
@@ -52,6 +52,8 @@ let providers: string[] = []
 let isStale = false
 let wsConnected = false
 let ws: WebSocket | null = null
+let singletonPollInterval: ReturnType<typeof setInterval> | null = null
+let wsReconnectTimeout: ReturnType<typeof setTimeout> | null = null
 const subscribers = new Set<() => void>()
 
 // Notify all subscribers
@@ -123,6 +125,7 @@ async function fetchAIPredictions(): Promise<void> {
       // Endpoint not implemented yet, use empty predictions
       aiPredictions = []
       isStale = true
+      notifySubscribers()
     } else {
       reportAgentDataError('/predictions/ai', `HTTP ${response.status}`)
     }
@@ -181,8 +184,10 @@ function connectWebSocket(): void {
     ws.onclose = () => {
       wsConnected = false
       ws = null
-      // Reconnect after delay
-      setTimeout(connectWebSocket, WS_RECONNECT_DELAY_MS)
+      // Only reconnect if there are still active subscribers
+      if (subscribers.size > 0) {
+        wsReconnectTimeout = setTimeout(connectWebSocket, WS_RECONNECT_DELAY_MS)
+      }
     }
 
     ws.onerror = () => {
@@ -230,6 +235,31 @@ async function triggerAnalysis(specificProviders?: string[]): Promise<boolean> {
   }
 }
 
+/** Start singleton polling — only starts once regardless of how many hook instances exist */
+function startSingletonPolling() {
+  if (singletonPollInterval) return
+  fetchAIPredictions()
+  singletonPollInterval = setInterval(fetchAIPredictions, POLL_INTERVAL_MS)
+}
+
+/** Stop all singleton resources when the last subscriber unmounts */
+function stopSingleton() {
+  if (singletonPollInterval) {
+    clearInterval(singletonPollInterval)
+    singletonPollInterval = null
+  }
+  if (wsReconnectTimeout) {
+    clearTimeout(wsReconnectTimeout)
+    wsReconnectTimeout = null
+  }
+  if (ws) {
+    ws.onclose = null // Prevent reconnect from onclose handler
+    ws.close()
+    ws = null
+    wsConnected = false
+  }
+}
+
 /**
  * Hook to access AI predictions
  */
@@ -241,7 +271,6 @@ export function useAIPredictions() {
   const [isAnalyzing, setIsAnalyzing] = useState(false)
   const [stale, setStale] = useState(isStale)
   const [activeProviders, setActiveProviders] = useState<string[]>(providers)
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   // Subscribe to state updates
   useEffect(() => {
@@ -255,19 +284,15 @@ export function useAIPredictions() {
     subscribers.add(handleUpdate)
     handleUpdate() // Get initial state
 
-    // Start WebSocket connection
+    // Start WebSocket and polling only when first subscriber mounts
     connectWebSocket()
-
-    // Initial fetch
-    fetchAIPredictions()
-
-    // Set up polling as fallback
-    pollRef.current = setInterval(fetchAIPredictions, POLL_INTERVAL)
+    startSingletonPolling()
 
     return () => {
       subscribers.delete(handleUpdate)
-      if (pollRef.current) {
-        clearInterval(pollRef.current)
+      // Tear down singleton resources when last subscriber unmounts
+      if (subscribers.size === 0) {
+        stopSingleton()
       }
     }
   }, [])

--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -47,6 +47,7 @@ let presencePingInterval: ReturnType<typeof setInterval> | null = null
 
 // Netlify heartbeat state (serverless mode)
 let heartbeatStarted = false
+let heartbeatTimeoutId: ReturnType<typeof setTimeout> | null = null
 
 // Smoothing for unstable Netlify Blobs counts (eventual consistency causes fluctuations)
 const recentCounts: number[] = []
@@ -91,12 +92,35 @@ function startHeartbeat() {
   // Subsequent heartbeats with jitter to spread them out
   function scheduleNextHeartbeat() {
     const jitter = Math.random() * HEARTBEAT_JITTER
-    setTimeout(() => {
+    heartbeatTimeoutId = setTimeout(() => {
       sendHeartbeat()
       scheduleNextHeartbeat()
     }, HEARTBEAT_INTERVAL + jitter)
   }
   scheduleNextHeartbeat()
+}
+
+// Stop heartbeat timer chain
+function stopHeartbeat() {
+  if (heartbeatTimeoutId) {
+    clearTimeout(heartbeatTimeoutId)
+    heartbeatTimeoutId = null
+  }
+  heartbeatStarted = false
+}
+
+// Tear down presence WebSocket connection
+function stopPresenceConnection() {
+  if (presencePingInterval) {
+    clearInterval(presencePingInterval)
+    presencePingInterval = null
+  }
+  if (presenceWs) {
+    presenceWs.onclose = null // Prevent reconnect from onclose handler
+    presenceWs.close()
+    presenceWs = null
+  }
+  presenceStarted = false
 }
 
 // Start WebSocket presence connection (backend mode)
@@ -306,11 +330,15 @@ export function useActiveUsers() {
       window.removeEventListener('kc-demo-mode-change', handleDemoChange)
       document.removeEventListener('visibilitychange', handleVisibility)
 
-      // Stop polling when no subscribers remain to prevent leaked intervals
-      if (subscribers.size === 0 && pollInterval) {
-        clearInterval(pollInterval)
-        pollInterval = null
-        pollStarted = false
+      // Stop all singleton resources when no subscribers remain
+      if (subscribers.size === 0) {
+        if (pollInterval) {
+          clearInterval(pollInterval)
+          pollInterval = null
+          pollStarted = false
+        }
+        stopHeartbeat()
+        stopPresenceConnection()
       }
     }
   }, [])

--- a/web/src/hooks/useDashboardCards.ts
+++ b/web/src/hooks/useDashboardCards.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 
 export interface DashboardCard {
   id: string
@@ -17,6 +17,9 @@ interface UseDashboardCardsOptions {
 
 export function useDashboardCards({ storageKey, defaultCards = [], defaultCollapsed = false }: UseDashboardCardsOptions) {
   const collapsedKey = `${storageKey}:collapsed`
+
+  // Track whether a reset just happened so the persistence effect can skip one cycle
+  const skipPersistRef = useRef(false)
 
   const [cards, setCards] = useState<DashboardCard[]>(() => {
     try {
@@ -47,8 +50,12 @@ export function useDashboardCards({ storageKey, defaultCards = [], defaultCollap
     setIsCollapsed(prev => !prev)
   }, [])
 
-  // Save to localStorage when cards change
+  // Save to localStorage when cards change — skip if resetToDefaults just fired
   useEffect(() => {
+    if (skipPersistRef.current) {
+      skipPersistRef.current = false
+      return
+    }
     localStorage.setItem(storageKey, JSON.stringify(cards))
   }, [cards, storageKey])
 
@@ -82,13 +89,23 @@ export function useDashboardCards({ storageKey, defaultCards = [], defaultCollap
   }, [])
 
   const resetToDefaults = useCallback(() => {
+    skipPersistRef.current = true
     setCards(defaultCards)
     localStorage.removeItem(storageKey)
   }, [defaultCards, storageKey])
 
   const isCustomized = useCallback(() => {
-    return localStorage.getItem(storageKey) !== null
-  }, [storageKey])
+    const stored = localStorage.getItem(storageKey)
+    if (stored === null) return false
+    // Compare actual content to defaults — key existence alone is not sufficient
+    // because the persistence effect may have re-written the default state
+    try {
+      const parsed = JSON.parse(stored)
+      return JSON.stringify(parsed) !== JSON.stringify(defaultCards)
+    } catch {
+      return false
+    }
+  }, [storageKey, defaultCards])
 
   return {
     cards,

--- a/web/src/hooks/useWorkloads.ts
+++ b/web/src/hooks/useWorkloads.ts
@@ -269,8 +269,12 @@ export function useClusterCapabilities(enabled = true) {
   const [isLoading, setIsLoading] = useState(enabled)
   const [error, setError] = useState<Error | null>(null)
 
+  // Use a ref to always have the latest enabled value, avoiding stale closures
+  const enabledRef = useRef(enabled)
+  enabledRef.current = enabled
+
   const fetchData = useCallback(async () => {
-    if (!enabled) return
+    if (!enabledRef.current) return
     setIsLoading(true)
     setError(null)
 
@@ -286,7 +290,7 @@ export function useClusterCapabilities(enabled = true) {
     } finally {
       setIsLoading(false)
     }
-  }, [enabled])
+  }, [])
 
   useEffect(() => {
     if (!enabled) {


### PR DESCRIPTION
## Summary
- **useAIPredictions**: Singleton polling (one interval for all instances), subscriber-aware WebSocket reconnect, notify on 404 path, full teardown on last unmount
- **useActiveUsers**: Store heartbeat timeout ID and clear on last unmount, tear down presence WebSocket and ping interval when no subscribers remain
- **useClusterCapabilities**: Use ref for `enabled` flag to prevent stale closure when toggling from false to true
- **useDashboardCards**: Skip persistence effect after `resetToDefaults` so the storage key stays removed; `isCustomized` now compares content to defaults instead of only checking key existence

## Test plan
- [x] Build passes (`npm run build`)
- [x] All tests pass for modified hooks (69 dashboard+workloads, 45 AI predictions)
- [x] Lint clean on modified files (pre-existing lint error in useActiveUsers unchanged)
- [x] Updated useDashboardCards tests to verify new reset/isCustomized behavior

Fixes #4686, #4687, #4689, #4690, #4691, #4692, #4693, #4695, #4696