### PR TITLE
🐛 Fix start-dev.sh port mismatch with frontend proxy

### DIFF
--- a/start-dev.sh
+++ b/start-dev.sh
@@ -141,6 +141,9 @@ fi
 
 export DEV_MODE=${DEV_MODE:-true}
 export FRONTEND_URL=${FRONTEND_URL:-http://localhost:5174}
+# Tell Vite proxy to target port 8080 where the backend actually listens.
+# Without this, the proxy defaults to 8081 (used when a TLS watchdog sits on 8080).
+export BACKEND_LISTEN_PORT=${BACKEND_LISTEN_PORT:-8080}
 
 # Kill any existing project instances on required ports
 for p in 8080 5174 8585; do


### PR DESCRIPTION
## Summary
- `start-dev.sh` starts the backend on port 8080, but the Vite dev server proxy defaults `BACKEND_LISTEN_PORT` to `8081` (for TLS watchdog setups where port 8080 is occupied by the watchdog)
- This causes all frontend API requests to be proxied to port 8081 where nothing is listening, resulting in "Backend API is currently unavailable"
- Fix: export `BACKEND_LISTEN_PORT=8080` in `start-dev.sh` before starting the frontend so the Vite proxy targets the correct port

Fixes #4707

## Test plan
- [ ] Run `./start-dev.sh` from project root
- [ ] Open `http://localhost:5174` — backend should be detected as available
- [ ] Verify API requests (e.g. `/health`, `/api/*`) are proxied to port 8080