### PR TITLE
🐛 Fix compliance filters, URLs, error handling, MCP bridge panic

### DIFF
--- a/pkg/agent/update_checker.go
+++ b/pkg/agent/update_checker.go
@@ -23,8 +23,9 @@ const (
 	releaseCheckInterval   = 60 * time.Minute
 	healthCheckRetries     = 15
 	healthCheckDelay       = 2 * time.Second
-	githubMainRefURL       = "https://api.github.com/repos/kubestellar/console/git/ref/heads/main"
-	githubReleasesURL      = "https://api.github.com/repos/kubestellar/console/releases"
+	// defaultGitHubRepo is the fallback GitHub owner/repo used when
+	// GITHUB_REPO is not set. Override via env var for forks or GHE.
+	defaultGitHubRepo = "kubestellar/console"
 
 	// Timeouts for each build step — prevents updates from hanging indefinitely
 	gitPullTimeout       = 2 * time.Minute
@@ -39,6 +40,25 @@ const (
 	// Max lines of build output to include in error messages sent to the frontend
 	buildOutputTailLines = 20
 )
+
+// githubRepo returns the GitHub owner/repo slug, preferring the GITHUB_REPO
+// environment variable so forks and GHE instances work out-of-the-box.
+func githubRepo() string {
+	if v := os.Getenv("GITHUB_REPO"); v != "" {
+		return v
+	}
+	return defaultGitHubRepo
+}
+
+// githubMainRefURL builds the GitHub API URL for the main branch ref.
+func githubMainRefURL() string {
+	return fmt.Sprintf("https://api.github.com/repos/%s/git/ref/heads/main", githubRepo())
+}
+
+// githubReleasesURL builds the GitHub API URL for releases.
+func githubReleasesURL() string {
+	return fmt.Sprintf("https://api.github.com/repos/%s/releases", githubRepo())
+}
 
 // UpdateChecker periodically checks for updates and applies them.
 type UpdateChecker struct {
@@ -1086,7 +1106,7 @@ func gitFetchLatestSHA(repoPath string) (string, error) {
 func fetchLatestMainSHAFromGitHub() (string, error) {
 	const githubAPITimeout = 10 * time.Second
 	client := &http.Client{Timeout: githubAPITimeout}
-	resp, err := client.Get(githubMainRefURL)
+	resp, err := client.Get(githubMainRefURL())
 	if err != nil {
 		return "", err
 	}
@@ -1105,7 +1125,7 @@ func fetchLatestMainSHAFromGitHub() (string, error) {
 
 func fetchGitHubReleases() ([]githubReleaseInfo, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(githubReleasesURL)
+	resp, err := client.Get(githubReleasesURL())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -297,7 +297,10 @@ func (h *AuthHandler) devModeLogin(c *fiber.Ctx) error {
 		user.GitHubLogin = devLogin
 		user.Email = devEmail
 		user.AvatarURL = avatarURL
-		h.store.UpdateUser(user)
+		if err := h.store.UpdateUser(user); err != nil {
+			slog.Warn("[Auth] failed to update dev user", "user", devLogin, "error", err)
+			return c.Redirect(h.frontendURL+"/login?error=db_error", fiber.StatusTemporaryRedirect)
+		}
 	}
 
 	// Update last login
@@ -429,7 +432,10 @@ func (h *AuthHandler) GitHubCallback(c *fiber.Ctx) error {
 		user.GitHubLogin = ghUser.Login
 		user.Email = ghUser.Email
 		user.AvatarURL = ghUser.AvatarURL
-		h.store.UpdateUser(user)
+		if err := h.store.UpdateUser(user); err != nil {
+			slog.Warn("[Auth] failed to update user", "user", ghUser.Login, "error", err)
+			return h.oauthErrorRedirect(c, "db_error", "")
+		}
 	}
 
 	// Update last login

--- a/pkg/api/handlers/custom_resources.go
+++ b/pkg/api/handlers/custom_resources.go
@@ -141,7 +141,10 @@ func (h *MCPHandlers) listCR(
 	}
 
 	content := ul.UnstructuredContent()
-	rawItems, _ := content["items"].([]interface{})
+	rawItems, ok := content["items"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected type for items field in %s response", gvr.Resource)
+	}
 	items := make([]CustomResourceItem, 0, len(rawItems))
 
 	for _, raw := range rawItems {

--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -247,14 +247,18 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 
 	if err := conn.ReadJSON(&authMsg); err != nil {
 		slog.Error("[WebSocket] SECURITY: failed to read auth message", "error", err)
-		conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "authentication required"}})
+		if wErr := conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "authentication required"}}); wErr != nil {
+			slog.Error("[WebSocket] failed to send auth error", "error", wErr)
+		}
 		conn.Close()
 		return
 	}
 
 	if authMsg.Type != "auth" || authMsg.Token == "" {
 		slog.Warn("SECURITY: Invalid or missing auth message")
-		conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "authentication required"}})
+		if wErr := conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "authentication required"}}); wErr != nil {
+			slog.Error("[WebSocket] failed to send auth error", "error", wErr)
+		}
 		conn.Close()
 		return
 	}
@@ -268,14 +272,18 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 		slog.Info("Demo-mode WebSocket connection for presence tracking (dev mode)")
 	} else if authMsg.Token == "demo-token" && !h.devMode {
 		slog.Warn("SECURITY: Rejected demo-token WebSocket connection (dev mode not enabled)")
-		conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "demo-token not allowed in production"}})
+		if wErr := conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "demo-token not allowed in production"}}); wErr != nil {
+			slog.Error("[WebSocket] failed to send rejection error", "error", wErr)
+		}
 		conn.Close()
 		return
 	} else if h.jwtSecret != "" {
 		claims, err := middleware.ValidateJWT(authMsg.Token, h.jwtSecret)
 		if err != nil {
 			slog.Warn("[WebSocket] SECURITY: rejected invalid token", "error", err)
-			conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "invalid token"}})
+			if wErr := conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "invalid token"}}); wErr != nil {
+				slog.Error("[WebSocket] failed to send token error", "error", wErr)
+			}
 			conn.Close()
 			return
 		}
@@ -291,13 +299,19 @@ func (h *Hub) HandleConnection(conn *websocket.Conn) {
 
 	if !authenticated {
 		slog.Error("SECURITY: WebSocket authentication failed")
-		conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "authentication failed"}})
+		if wErr := conn.WriteJSON(Message{Type: "error", Data: map[string]string{"message": "authentication failed"}}); wErr != nil {
+			slog.Error("[WebSocket] failed to send auth failure", "error", wErr)
+		}
 		conn.Close()
 		return
 	}
 
 	// Send authentication success message
-	conn.WriteJSON(Message{Type: "authenticated", Data: map[string]string{"status": "connected"}})
+	if err := conn.WriteJSON(Message{Type: "authenticated", Data: map[string]string{"status": "connected"}}); err != nil {
+		slog.Error("[WebSocket] failed to send auth success", "error", err)
+		conn.Close()
+		return
+	}
 
 	// Set idle read deadline — reset on every received message or pong.
 	// This prevents idle connections from holding OS file descriptors forever

--- a/pkg/mcp/bridge.go
+++ b/pkg/mcp/bridge.go
@@ -495,6 +495,9 @@ func (b *Bridge) CallDeployTool(ctx context.Context, name string, args map[strin
 
 func (b *Bridge) parseClustersResult(result *CallToolResult) ([]ClusterInfo, error) {
 	if result.IsError {
+		if len(result.Content) == 0 {
+			return nil, fmt.Errorf("tool returned error with empty content")
+		}
 		return nil, fmt.Errorf("tool error: %s", result.Content[0].Text)
 	}
 
@@ -519,6 +522,9 @@ func (b *Bridge) parseClustersFromText(text string) []ClusterInfo {
 
 func (b *Bridge) parseHealthResult(result *CallToolResult) (*ClusterHealth, error) {
 	if result.IsError {
+		if len(result.Content) == 0 {
+			return nil, fmt.Errorf("tool returned error with empty content")
+		}
 		return nil, fmt.Errorf("tool error: %s", result.Content[0].Text)
 	}
 
@@ -537,6 +543,9 @@ func (b *Bridge) parseHealthResult(result *CallToolResult) (*ClusterHealth, erro
 
 func (b *Bridge) parsePodsResult(result *CallToolResult) ([]PodInfo, error) {
 	if result.IsError {
+		if len(result.Content) == 0 {
+			return nil, fmt.Errorf("tool returned error with empty content")
+		}
 		return nil, fmt.Errorf("tool error: %s", result.Content[0].Text)
 	}
 
@@ -553,6 +562,9 @@ func (b *Bridge) parsePodsResult(result *CallToolResult) ([]PodInfo, error) {
 
 func (b *Bridge) parsePodIssuesResult(result *CallToolResult) ([]PodIssue, error) {
 	if result.IsError {
+		if len(result.Content) == 0 {
+			return nil, fmt.Errorf("tool returned error with empty content")
+		}
 		return nil, fmt.Errorf("tool error: %s", result.Content[0].Text)
 	}
 
@@ -569,6 +581,9 @@ func (b *Bridge) parsePodIssuesResult(result *CallToolResult) ([]PodIssue, error
 
 func (b *Bridge) parseEventsResult(result *CallToolResult) ([]Event, error) {
 	if result.IsError {
+		if len(result.Content) == 0 {
+			return nil, fmt.Errorf("tool returned error with empty content")
+		}
 		return nil, fmt.Errorf("tool error: %s", result.Content[0].Text)
 	}
 

--- a/web/src/components/compliance/Compliance.tsx
+++ b/web/src/components/compliance/Compliance.tsx
@@ -48,28 +48,46 @@ export function Compliance() {
   )
   const reachableClusters = filteredClusters.filter(c => c.reachable !== false)
 
-  // Aggregate real data across clusters
+  // Build the set of cluster names that pass the global filter, so we can
+  // scope tool aggregates to exactly those clusters (#4714, #4722).
+  const filteredClusterNames = useMemo(
+    () => new Set(filteredClusters.map(c => c.name)),
+    [filteredClusters]
+  )
+
+  // Aggregate real data across *filtered* clusters only
   const realData = useMemo(() => {
-    // Kyverno aggregates
-    const kyvernoStatuses = Object.values(kyverno.statuses).filter(s => s.installed)
+    // Kyverno aggregates — scoped to filtered clusters
+    const kyvernoStatuses = Object.values(kyverno.statuses)
+      .filter(s => s.installed && filteredClusterNames.has(s.cluster))
     const kyvernoInstalled = kyvernoStatuses.length > 0
     const kyvernoViolations = kyvernoStatuses.reduce((sum, s) => sum + s.totalViolations, 0)
     const kyvernoPolicies = kyvernoStatuses.reduce((sum, s) => sum + s.totalPolicies, 0)
 
-    // Kubescape aggregates
-    const kubescapeInstalled = kubescape.installed
-    const kubescapeScore = kubescape.aggregated.overallScore
-    const kubescapeFrameworks = kubescape.aggregated.frameworks || []
-    const kubescapeTotalControls = kubescape.aggregated.totalControls
-    const kubescapePassedControls = kubescape.aggregated.passedControls
-    const kubescapeFailedControls = kubescape.aggregated.failedControls
+    // Kubescape aggregates — scoped to filtered clusters
+    const kubescapeStatuses = Object.values(kubescape.statuses)
+      .filter(s => s.installed && filteredClusterNames.has(s.cluster))
+    const kubescapeInstalled = kubescapeStatuses.length > 0
+    const kubescapeTotalControls = kubescapeStatuses.reduce((sum, s) => sum + s.totalControls, 0)
+    const kubescapePassedControls = kubescapeStatuses.reduce((sum, s) => sum + s.passedControls, 0)
+    const kubescapeFailedControls = kubescapeStatuses.reduce((sum, s) => sum + s.failedControls, 0)
+    const kubescapeScore = kubescapeTotalControls > 0
+      ? Math.round((kubescapePassedControls / kubescapeTotalControls) * 100)
+      : 0
+    const kubescapeFrameworks = kubescapeStatuses.length > 0
+      ? (kubescapeStatuses[0]?.frameworks || [])
+      : []
 
-    // Trivy aggregates
-    const trivyInstalled = trivy.installed
-    const trivyVulns = trivy.aggregated.critical + trivy.aggregated.high +
-      trivy.aggregated.medium + trivy.aggregated.low + trivy.aggregated.unknown
-    const trivyCritical = trivy.aggregated.critical
-    const trivyHigh = trivy.aggregated.high
+    // Trivy aggregates — scoped to filtered clusters
+    const trivyStatuses = Object.values(trivy.statuses)
+      .filter(s => s.installed && filteredClusterNames.has(s.cluster))
+    const trivyInstalled = trivyStatuses.length > 0
+    const trivyCritical = trivyStatuses.reduce((sum, s) => sum + s.vulnerabilities.critical, 0)
+    const trivyHigh = trivyStatuses.reduce((sum, s) => sum + s.vulnerabilities.high, 0)
+    const trivyMedium = trivyStatuses.reduce((sum, s) => sum + s.vulnerabilities.medium, 0)
+    const trivyLow = trivyStatuses.reduce((sum, s) => sum + s.vulnerabilities.low, 0)
+    const trivyUnknown = trivyStatuses.reduce((sum, s) => sum + s.vulnerabilities.unknown, 0)
+    const trivyVulns = trivyCritical + trivyHigh + trivyMedium + trivyLow + trivyUnknown
 
     // Any tool installed = we have some real data
     const hasAnyRealData = kyvernoInstalled || kubescapeInstalled || trivyInstalled
@@ -93,7 +111,6 @@ export function Compliance() {
     }
     if (trivyInstalled) {
       // Trivy reports count towards total checks
-      const trivyStatuses = Object.values(trivy.statuses).filter(s => s.installed)
       const totalReports = trivyStatuses.reduce((sum, s) => sum + s.totalReports, 0)
       const reportsWithCritical = trivyCritical + trivyHigh
       totalChecks += totalReports
@@ -127,7 +144,7 @@ export function Compliance() {
       failing,
       warning: Math.max(0, totalChecks - passing - failing),
     }
-  }, [kyverno.statuses, kubescape.installed, kubescape.aggregated, trivy.installed, trivy.aggregated, trivy.statuses])
+  }, [kyverno.statuses, kubescape.statuses, trivy.statuses, filteredClusterNames])
 
   // Only show demo/mock data when the user is explicitly in demo mode.
   // When connected to a live cluster without compliance tools, show zeros — not fake numbers.


### PR DESCRIPTION
## Summary

- **Compliance Stats Overview & Score widgets** now scope aggregates to the globally-filtered cluster set instead of using all-cluster totals (fixes #4714, #4722)
- **update_checker.go**: Replace hardcoded GitHub API URLs with configurable `GITHUB_REPO` env var, defaulting to `kubestellar/console` (fixes #4718)
- **auth.go**: Check and handle `UpdateUser` errors in `devModeLogin` and `GitHubCallback` instead of silently discarding them (fixes #4724)
- **websocket.go**: Check `WriteJSON` return errors in WebSocket auth flow and clean up connections on write failure (fixes #4725)
- **custom_resources.go**: Check type assertion result for `items` field and return descriptive error on failure (fixes #4726)
- **bridge.go**: Add bounds check on `result.Content` before accessing index 0 in all MCP bridge parse methods to prevent index-out-of-bounds panic (fixes #4728)

Fixes #4714, #4718, #4722, #4724, #4725, #4726, #4728

## Test plan

- [ ] Open Compliance dashboard, select a single cluster via global filter, verify Stats Overview and Score widget values reflect only that cluster
- [ ] Set `GITHUB_REPO=myorg/myfork` env var and verify update checker hits the correct API URLs
- [ ] Trigger `UpdateUser` DB failure and verify auth returns error redirect instead of proceeding silently
- [ ] Disconnect WebSocket client mid-auth and verify server logs write error and cleans up
- [ ] Test custom resources endpoint with malformed API response — should return error instead of empty list
- [ ] Configure MCP tool that returns empty Content array — should return error instead of panicking
- [ ] Go build and web build pass with no regressions