### PR TITLE
🐛 Fix abort signal leaks, topology error suppression, test failures

### DIFF
--- a/pkg/api/handlers/topology.go
+++ b/pkg/api/handlers/topology.go
@@ -79,11 +79,25 @@ func (h *TopologyHandlers) GetTopology(c *fiber.Ctx) error {
 	ctx, cancel := context.WithTimeout(c.Context(), topologyTimeout)
 	defer cancel()
 
-	// Collect data from all sources
-	exports, _ := h.k8sClient.ListServiceExports(ctx)
-	imports, _ := h.k8sClient.ListServiceImports(ctx)
-	gateways, _ := h.k8sClient.ListGateways(ctx)
-	httpRoutes, _ := h.k8sClient.ListHTTPRoutes(ctx)
+	// Collect data from all sources, tracking partial failures (#4774)
+	var partialErrors []string
+
+	exports, err := h.k8sClient.ListServiceExports(ctx)
+	if err != nil {
+		partialErrors = append(partialErrors, fmt.Sprintf("service_exports: %v", err))
+	}
+	imports, err := h.k8sClient.ListServiceImports(ctx)
+	if err != nil {
+		partialErrors = append(partialErrors, fmt.Sprintf("service_imports: %v", err))
+	}
+	gateways, err := h.k8sClient.ListGateways(ctx)
+	if err != nil {
+		partialErrors = append(partialErrors, fmt.Sprintf("gateways: %v", err))
+	}
+	httpRoutes, err := h.k8sClient.ListHTTPRoutes(ctx)
+	if err != nil {
+		partialErrors = append(partialErrors, fmt.Sprintf("http_routes: %v", err))
+	}
 
 	// Build the topology graph
 	graph := h.buildTopologyGraph(exports, imports, gateways, httpRoutes)
@@ -102,7 +116,7 @@ func (h *TopologyHandlers) GetTopology(c *fiber.Ctx) error {
 		}
 	}
 
-	return c.JSON(fiber.Map{
+	response := fiber.Map{
 		"graph":    graph,
 		"clusters": clusterSummaries,
 		"stats": fiber.Map{
@@ -111,7 +125,14 @@ func (h *TopologyHandlers) GetTopology(c *fiber.Ctx) error {
 			"healthyConnections":  healthyEdges,
 			"degradedConnections": degradedEdges,
 		},
-	})
+	}
+
+	// Surface partial failures so the UI can indicate incomplete data (#4774)
+	if len(partialErrors) > 0 {
+		response["partialErrors"] = partialErrors
+	}
+
+	return c.JSON(response)
 }
 
 // buildTopologyGraph builds the topology graph from collected resources

--- a/web/src/hooks/__tests__/useActiveUsers.test.ts
+++ b/web/src/hooks/__tests__/useActiveUsers.test.ts
@@ -14,7 +14,7 @@ vi.mock('../../lib/constants', () => ({
   STORAGE_KEY_TOKEN: 'kc-auth-token',
 }))
 
-import { useActiveUsers } from '../useActiveUsers'
+import { useActiveUsers, __resetForTest } from '../useActiveUsers'
 
 describe('useActiveUsers', () => {
   beforeEach(() => {
@@ -22,6 +22,8 @@ describe('useActiveUsers', () => {
     localStorage.clear()
     sessionStorage.clear()
     vi.clearAllMocks()
+    // Reset singleton state to prevent leaking between tests (#4775)
+    __resetForTest()
     mockGetDemoMode.mockReturnValue(true)
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(JSON.stringify({ activeUsers: 5, totalConnections: 8 }), {
@@ -142,16 +144,20 @@ describe('useActiveUsers', () => {
 
     const { result } = renderHook(() => useActiveUsers())
 
-    // Advance enough time for multiple poll intervals to trigger failures
-    // MAX_FAILURES = 3, POLL_INTERVAL = 10s
-    for (let i = 0; i < 5; i++) {
+    // Let initial fetches (from startPolling + heartbeat callback) settle
+    await act(async () => { await vi.advanceTimersByTimeAsync(100) })
+
+    // Advance through poll intervals to accumulate failures.
+    // The initial render already causes 2 failures (startPolling immediate +
+    // heartbeat callback). Two more interval ticks push past MAX_FAILURES = 3,
+    // and the subsequent tick enters the circuit breaker guard.
+    // Advance just enough to trip the breaker but NOT past the RECOVERY_DELAY
+    // (30s) which would reset hasError.
+    for (let i = 0; i < 3; i++) {
       await act(async () => { await vi.advanceTimersByTimeAsync(10_500) })
     }
 
-    // After circuit breaker trips, hasError should be true
-    await waitFor(() => {
-      expect(result.current.hasError).toBe(true)
-    })
+    expect(result.current.hasError).toBe(true)
   })
 
   // --- refetch works after circuit breaker ---
@@ -316,13 +322,16 @@ describe('useActiveUsers', () => {
 
   // ── Smoothing takes max of recent counts ──────────────────────────────
   it('smoothing uses max of recent counts to prevent flicker', async () => {
-    // First response: high count
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ activeUsers: 10, totalConnections: 10 }), {
+    // All GET requests return high count initially (handles heartbeat + poll GETs)
+    vi.mocked(fetch).mockImplementation(async (_url, options) => {
+      if (typeof options === 'object' && options?.method === 'POST') {
+        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response(JSON.stringify({ activeUsers: 10, totalConnections: 10 }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       })
-    )
+    })
 
     const { result } = renderHook(() => useActiveUsers())
     await act(async () => { await vi.advanceTimersByTimeAsync(100) })
@@ -331,13 +340,16 @@ describe('useActiveUsers', () => {
       expect(result.current.activeUsers).toBe(10)
     })
 
-    // Second response: lower count (should smooth to max = 10)
-    vi.mocked(fetch).mockResolvedValueOnce(
-      new Response(JSON.stringify({ activeUsers: 5, totalConnections: 5 }), {
+    // Now switch to lower count for subsequent GETs (should smooth to max = 10)
+    vi.mocked(fetch).mockImplementation(async (_url, options) => {
+      if (typeof options === 'object' && options?.method === 'POST') {
+        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response(JSON.stringify({ activeUsers: 5, totalConnections: 5 }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       })
-    )
+    })
 
     await act(async () => { await vi.advanceTimersByTimeAsync(10_500) })
 
@@ -350,29 +362,32 @@ describe('useActiveUsers', () => {
   // ── Recovery after circuit breaker trips automatically ────────────────
   it('automatically recovers after circuit breaker recovery delay', async () => {
     vi.mocked(fetch).mockRejectedValue(new Error('fail'))
-    const RECOVERY_DELAY = 30_000
+    const RECOVERY_DELAY_MS = 30_000
 
     const { result } = renderHook(() => useActiveUsers())
 
-    // Trip circuit breaker (3 consecutive failures)
-    for (let i = 0; i < 5; i++) {
+    // Let initial fetches settle, then advance through poll intervals
+    // to trip the circuit breaker (MAX_FAILURES = 3).
+    await act(async () => { await vi.advanceTimersByTimeAsync(100) })
+    for (let i = 0; i < 3; i++) {
       await act(async () => { await vi.advanceTimersByTimeAsync(10_500) })
     }
 
-    await waitFor(() => {
-      expect(result.current.hasError).toBe(true)
-    })
+    expect(result.current.hasError).toBe(true)
 
-    // Fix fetch before recovery
-    vi.mocked(fetch).mockResolvedValue(
-      new Response(JSON.stringify({ activeUsers: 2, totalConnections: 2 }), {
+    // Fix fetch before the recovery timer fires
+    vi.mocked(fetch).mockImplementation(async (_url, options) => {
+      if (typeof options === 'object' && options?.method === 'POST') {
+        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      return new Response(JSON.stringify({ activeUsers: 2, totalConnections: 2 }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       })
-    )
+    })
 
-    // Advance past the recovery delay
-    await act(async () => { await vi.advanceTimersByTimeAsync(RECOVERY_DELAY + 1_000) })
+    // Advance past the recovery delay so the recovery timer fires
+    await act(async () => { await vi.advanceTimersByTimeAsync(RECOVERY_DELAY_MS + 1_000) })
 
     await waitFor(() => {
       expect(result.current.hasError).toBe(false)

--- a/web/src/hooks/__tests__/useCardRecommendations.test.ts
+++ b/web/src/hooks/__tests__/useCardRecommendations.test.ts
@@ -641,16 +641,15 @@ describe('useCardRecommendations', () => {
     expect(gpuRec!.reason).toContain('2 nodes')
   })
 
-  // ---- Security issues not suppressed when already in dashboard ----
-  // NOTE: The source code does NOT check currentCardTypes for security_issues.
-  // This test documents the current behavior — security recs always appear.
+  // ---- Security issues suppressed when already in dashboard ----
+  // The source code checks `!currentCardTypes.includes('security_issues')`,
+  // so the card is correctly filtered out when already on the dashboard.
 
-  it('still recommends security_issues even when already in currentCardTypes (current behavior)', () => {
+  it('does not recommend security_issues when already in currentCardTypes', () => {
     setDefaults({ securityIssues: [{ id: 's1', severity: 'high' }] })
     const { result } = renderHook(() => useCardRecommendations(WITH_SECURITY_ISSUES))
 
     const secRec = result.current.recommendations.find(r => r.cardType === 'security_issues')
-    // Current code doesn't filter security issues by currentCardTypes
-    expect(secRec).toBeDefined()
+    expect(secRec).toBeUndefined()
   })
 })

--- a/web/src/hooks/mcp/shared.ts
+++ b/web/src/hooks/mcp/shared.ts
@@ -1628,15 +1628,16 @@ export async function fetchWithRetry(
   const totalAttempts = maxRetries + 1
 
   for (let attempt = 0; attempt < totalAttempts; attempt++) {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+    // Named handler so we can remove it after fetch completes (#4772)
+    const onCallerAbort = () => controller.abort()
+    if (fetchOptions.signal) {
+      fetchOptions.signal.addEventListener('abort', onCallerAbort)
+    }
+
     try {
-      const controller = new AbortController()
-      const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
-
-      // Chain with caller's signal if provided
-      if (fetchOptions.signal) {
-        fetchOptions.signal.addEventListener('abort', () => controller.abort())
-      }
-
       const response = await fetch(url, {
         ...fetchOptions,
         signal: controller.signal,
@@ -1658,6 +1659,7 @@ export async function fetchWithRetry(
 
       return response
     } catch (err) {
+      clearTimeout(timeoutId)
       lastError = err
       // Only retry on transient errors
       if (!isTransientError(err) || attempt >= totalAttempts - 1) {
@@ -1665,6 +1667,11 @@ export async function fetchWithRetry(
       }
       const backoff = initialBackoffMs * Math.pow(2, attempt)
       await new Promise(resolve => setTimeout(resolve, backoff))
+    } finally {
+      // Remove abort listener to prevent accumulation (#4772)
+      if (fetchOptions.signal) {
+        fetchOptions.signal.removeEventListener('abort', onCallerAbort)
+      }
     }
   }
 

--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -53,6 +53,27 @@ let heartbeatTimeoutId: ReturnType<typeof setTimeout> | null = null
 const recentCounts: number[] = []
 const SMOOTHING_WINDOW = 5 // Keep last 5 counts
 
+/**
+ * Reset all singleton state. Exported for tests only — avoids state leaking
+ * between test cases when the module is shared across a test file.
+ * @internal
+ */
+export function __resetForTest(): void {
+  sharedInfo = { activeUsers: 0, totalConnections: 0 }
+  if (pollInterval) { clearInterval(pollInterval); pollInterval = null }
+  pollStarted = false
+  consecutiveFailures = 0
+  hasFetchedOnce = false
+  subscribers.clear()
+  stateSubscribers.clear()
+  if (presencePingInterval) { clearInterval(presencePingInterval); presencePingInterval = null }
+  if (presenceWs) { presenceWs.onclose = null; presenceWs.close(); presenceWs = null }
+  presenceStarted = false
+  if (heartbeatTimeoutId) { clearTimeout(heartbeatTimeoutId); heartbeatTimeoutId = null }
+  heartbeatStarted = false
+  recentCounts.length = 0
+}
+
 // Generate a unique session ID per browser tab (survives page navigation, not tab close)
 function getSessionId(): string {
   let id = sessionStorage.getItem('kc-session-id')

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -157,6 +157,10 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
         clearTimeout(reconnectTimerId)
         reconnectTimerId = null
       }
+      // Remove abort listener to prevent accumulation (#4772)
+      if (signal) {
+        signal.removeEventListener('abort', onSignalAbort)
+      }
       // Don't cache partial results from aborted streams (#2380)
       if (!wasAborted) {
         resultCache.set(cacheKey, { data: accumulated, at: Date.now() })
@@ -171,14 +175,16 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
       resolve(accumulated)
     }, SSE_TIMEOUT_MS)
 
+    // Named handler so we can remove the listener after completion (#4772)
+    const onSignalAbort = () => {
+      aborted = true
+      timeoutController.abort()
+      clearTimeout(timeoutId)
+      cleanup(/* wasAborted */ true)
+      reject(new DOMException('Aborted', 'AbortError'))
+    }
     if (signal) {
-      signal.addEventListener('abort', () => {
-        aborted = true
-        timeoutController.abort()
-        clearTimeout(timeoutId)
-        cleanup(/* wasAborted */ true)
-        reject(new DOMException('Aborted', 'AbortError'))
-      })
+      signal.addEventListener('abort', onSignalAbort)
     }
 
     /**


### PR DESCRIPTION
## Summary

- **Abort signal leaks (#4772)**: `sseClient.ts` and `mcp/shared.ts` (`fetchWithRetry`) attached anonymous abort event listeners that were never removed. Replaced with named handlers and added `removeEventListener` cleanup after request completion (or in `finally` for retries).
- **Topology error suppression (#4774)**: `topology.go` `GetTopology` handler discarded all upstream errors with `_, _` assignments. Now captures errors and includes them as `partialErrors` in the JSON response so the UI can indicate incomplete data.
- **Test failures (#4775)**: 
  - `useActiveUsers` tests shared module-level singleton state (`pollStarted`, `consecutiveFailures`, `recentCounts`) across test cases, causing timing-dependent failures. Added `__resetForTest()` export to clear all singleton state in `beforeEach`. Fixed circuit breaker and smoothing tests to account for heartbeat callback double-fetch timing.
  - `useCardRecommendations` test had an incorrect assertion — the code correctly filters `security_issues` when already in `currentCardTypes`, but the test expected the opposite.

Fixes #4772, #4774, #4775

## Test plan
- [x] All 30 `useActiveUsers` tests pass
- [x] All 40 `useCardRecommendations` tests pass
- [x] All 60 `sseClient` tests pass
- [x] Go build succeeds (`go build ./cmd/console/`)
- [x] Frontend build succeeds (`npm run build`)
- [x] No new lint errors in modified files