### PR TITLE
feat: split auto-qa adoption psychology into specific actionable issues

### DIFF
--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -3272,124 +3272,111 @@ jobs:
         continue-on-error: true
         run: |
           echo "Scanning for adoption & engagement psychology opportunities..."
-          ISSUES=""
+          TOTAL=0
 
           # ── 1. Variable Reward / Surprise & Delight ──
-          # Look for pages that always show the same static content with
-          # no dynamic highlights, tips, or rotating recommendations.
           STATIC_PAGES=""
           for page_dir in src/components/dashboard src/components/clusters src/components/deploy src/components/compliance src/components/ai-ml src/components/arcade; do
             if [ -d "$page_dir" ]; then
               PAGE_NAME=$(basename "$page_dir")
-              # Check if page has any dynamic tip/highlight/recommendation/surprise element
-              HAS_DYNAMIC=$(grep -rlE "tip(s)?[Oo]f[Tt]he[Dd]ay|didYouKnow|randomTip|spotlight|featured|shuffle|random|rotate.*suggestion|surprise" "$page_dir" 2>/dev/null | head -1 || true)
+              HAS_DYNAMIC=$(grep -rlE "RotatingTip|tip(s)?[Oo]f[Tt]he[Dd]ay|didYouKnow|randomTip|spotlight|featured|shuffle|random|rotate.*suggestion|surprise" "$page_dir" 2>/dev/null | head -1 || true)
               if [ -z "$HAS_DYNAMIC" ]; then
                 STATIC_PAGES="${STATIC_PAGES}  - \`${PAGE_NAME}\`: no variable-reward elements (tips, spotlights, rotating highlights)\n"
               fi
             fi
           done
           if [ -n "$STATIC_PAGES" ]; then
-            ISSUES="${ISSUES}### Missing Variable Rewards (Surprise & Delight)\nThese pages show the same content every visit — adding rotating tips, \"did you know\" facts, or spotlight features would create curiosity and repeat engagement:\n${STATIC_PAGES}\n**Psychology:** Variable ratio reinforcement (slot machine effect) keeps users coming back because they never know what they'll discover next.\n\n"
-          fi
-
-          # ── 2. Progress & Completion Loops ──
-          # Check if there are progress indicators, streaks, or completion
-          # tracking beyond basic onboarding.
-          HAS_STREAK=$(grep -rl "streak\|consecutive.*day\|login.*count\|daily.*reward\|visit.*count" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -1 || true)
-          HAS_PROGRESS_BEYOND_TOUR=$(grep -rlE "progress[Bb]ar|completionPercent|mastery|level[Uu]p|achievement|badge[s]?[Ee]arned|xp\b|experience.*point" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v "tour\|welcome\|getting-started\|onboard" | head -1 || true)
-          HAS_COMPLETION=$(grep -rl "checklist\|setup.*complete\|profile.*complete\|configuration.*score" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -1 || true)
-
-          PROGRESS_GAPS=""
-          if [ -z "$HAS_STREAK" ]; then
-            PROGRESS_GAPS="${PROGRESS_GAPS}  - **No streak/consistency tracking**: Users have no reason to return daily. A \"3-day streak\" badge or activity heatmap creates commitment loops.\n"
-          fi
-          if [ -z "$HAS_PROGRESS_BEYOND_TOUR" ]; then
-            PROGRESS_GAPS="${PROGRESS_GAPS}  - **No mastery/progression system**: Beyond onboarding, users have no sense of progression. A skills tree, exploration percentage, or feature mastery meter would drive deeper engagement.\n"
-          fi
-          if [ -z "$HAS_COMPLETION" ]; then
-            PROGRESS_GAPS="${PROGRESS_GAPS}  - **No setup completeness score**: Users don't know how much of the platform they've configured. A \"Your console is 60% set up\" prompt creates the Zeigarnik effect — the urge to complete unfinished tasks.\n"
-          fi
-          if [ -n "$PROGRESS_GAPS" ]; then
-            ISSUES="${ISSUES}### Missing Progress & Completion Loops\n${PROGRESS_GAPS}\n**Psychology:** The endowed progress effect and Zeigarnik effect drive users to complete sequences they've started. Instagram's activity status and GitHub's contribution graph use this.\n\n"
-          fi
-
-          # ── 3. Social Proof & Community Signals ──
-          # Check for community/social proof elements.
-          HAS_SOCIAL=$(grep -rlE "other.*users|popular|trending|most.*used|community|adopted.*by|used.*by.*teams|star[s]?.*count|fork[s]?.*count" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -1 || true)
-          HAS_ACTIVITY_FEED=$(grep -rlE "activity.*feed|recent.*activity|live.*feed|event.*stream|what.*others" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -1 || true)
-
-          SOCIAL_GAPS=""
-          if [ -z "$HAS_SOCIAL" ]; then
-            SOCIAL_GAPS="${SOCIAL_GAPS}  - **No social proof signals**: Show \"Used by N teams\" or \"Most popular card this week\" to validate user choices and drive feature discovery.\n"
-          fi
-          if [ -z "$HAS_ACTIVITY_FEED" ]; then
-            SOCIAL_GAPS="${SOCIAL_GAPS}  - **No activity feed**: A lightweight \"Recent activity\" or \"What's happening\" panel creates FOMO and shows the platform is alive.\n"
-          fi
-          if [ -n "$SOCIAL_GAPS" ]; then
-            ISSUES="${ISSUES}### Missing Social Proof & Community Signals\n${SOCIAL_GAPS}\n**Psychology:** Social proof (Cialdini) — people follow what others do. Reddit's upvotes, GitHub's stars, and LinkedIn's \"N people viewed your profile\" all leverage this.\n\n"
-          fi
-
-          # ── 4. Curiosity Gaps & Discovery Triggers ──
-          # Check for elements that tease undiscovered features.
-          HAS_TEASER=$(grep -rlE "unlock|discover|hidden|sneak.*peek|coming.*soon|preview|try.*new|new.*feature|beta.*badge|explore.*more|see.*what" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -3 || true)
-          HAS_EASTER_EGG=$(grep -rlE "easter.*egg|secret|konami|hidden.*feature|surprise.*mode" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -1 || true)
-
-          CURIOSITY_GAPS=""
-          if [ -z "$HAS_TEASER" ]; then
-            CURIOSITY_GAPS="${CURIOSITY_GAPS}  - **No feature teasers**: Partially revealed features (\"Unlock AI insights by connecting a cluster\") create information gaps that users feel compelled to close.\n"
-          fi
-          if [ -z "$HAS_EASTER_EGG" ]; then
-            CURIOSITY_GAPS="${CURIOSITY_GAPS}  - **No easter eggs or discovery moments**: Hidden features that users stumble upon create word-of-mouth sharing and delight. Even small ones (Konami code, hidden theme) build cult following.\n"
-          fi
-          if [ -n "$CURIOSITY_GAPS" ]; then
-            ISSUES="${ISSUES}### Missing Curiosity Gaps & Discovery Triggers\n${CURIOSITY_GAPS}\n**Psychology:** The information gap theory (Loewenstein) — curiosity is the gap between what we know and what we want to know. Facebook's notification badges and Reddit's \"N new comments\" exploit this.\n\n"
-          fi
-
-          # ── 5. Personalization & Investment ──
-          # Check if users can invest effort that makes the product
-          # more valuable to them over time (IKEA effect).
-          HAS_CUSTOMIZATION=$(grep -rlE "custom.*layout|user.*preference|personali[sz]|my.*dashboard|favorite|bookmark|pin|saved.*view" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -1 || true)
-          HAS_STORED_VALUE=$(grep -rlE "history|recent.*search|saved.*filter|custom.*card|user.*config|workspace" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -1 || true)
-
-          INVEST_GAPS=""
-          if [ -z "$HAS_CUSTOMIZATION" ]; then
-            INVEST_GAPS="${INVEST_GAPS}  - **No deep customization**: Users who invest effort customizing a tool feel ownership (IKEA effect) and are less likely to churn.\n"
-          fi
-          if [ -z "$HAS_STORED_VALUE" ]; then
-            INVEST_GAPS="${INVEST_GAPS}  - **No stored value accumulation**: Search history, saved filters, and custom views create switching costs. The more a user invests, the harder it is to leave.\n"
-          fi
-          if [ -n "$INVEST_GAPS" ]; then
-            ISSUES="${ISSUES}### Missing Investment & Stored Value\n${INVEST_GAPS}\n**Psychology:** The IKEA effect and sunk cost — users value things they've built. Pinterest boards, Spotify playlists, and Reddit karma all create investment that prevents churn.\n\n"
-          fi
-
-          # ── 6. Trigger & Notification Hooks ──
-          # Check for re-engagement triggers.
-          HAS_REENGAGEMENT=$(grep -rlE "notification|remind|alert.*config|digest|email.*pref|push.*notif|webhook.*user|come.*back" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -1 || true)
-          HAS_IDLE_PROMPT=$(grep -rlE "idle|inactive|welcome.*back|time.*since|last.*visit|miss.*you|catch.*up" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -1 || true)
-
-          TRIGGER_GAPS=""
-          if [ -z "$HAS_REENGAGEMENT" ]; then
-            TRIGGER_GAPS="${TRIGGER_GAPS}  - **No re-engagement triggers**: No notification preferences, digest settings, or alert configurations to bring users back.\n"
-          fi
-          if [ -z "$HAS_IDLE_PROMPT" ]; then
-            TRIGGER_GAPS="${TRIGGER_GAPS}  - **No welcome-back experience**: Users who return after absence see no acknowledgment or catch-up summary. A \"While you were away...\" panel drives re-engagement.\n"
-          fi
-          if [ -n "$TRIGGER_GAPS" ]; then
-            ISSUES="${ISSUES}### Missing Re-engagement Triggers\n${TRIGGER_GAPS}\n**Psychology:** Fogg's behavior model — behavior requires trigger + motivation + ability. External triggers (notifications, digests) bring users back; internal triggers form through habit loops.\n\n"
-          fi
-
-          # ── Emit results ──
-          if [ -n "$ISSUES" ]; then
-            # Count total suggestions
-            SUGGESTION_COUNT=$(echo -e "$ISSUES" | grep -c "^###" || echo "0")
-            echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "count=$SUGGESTION_COUNT" >> "$GITHUB_OUTPUT"
-            printf "%b" "$ISSUES" > /tmp/focus-adoption-psychology.txt
-            echo "Found $SUGGESTION_COUNT adoption psychology opportunities"
+            TOTAL=$((TOTAL + 1))
+            echo "adopt_variable_rewards=true" >> "$GITHUB_OUTPUT"
+            printf "%b" "These pages show the same content every visit — adding rotating tips, \"did you know\" facts, or spotlight features would create curiosity and repeat engagement:\n${STATIC_PAGES}\n**Psychology:** Variable ratio reinforcement (slot machine effect) keeps users coming back because they never know what they'll discover next." > /tmp/adopt-variable-rewards.txt
           else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "No adoption psychology gaps detected — engagement patterns look solid"
+            echo "adopt_variable_rewards=false" >> "$GITHUB_OUTPUT"
           fi
+
+          # ── 2. Streak / Consistency Tracking ──
+          HAS_STREAK=$(grep -rl "streak\|consecutive.*day\|login.*count\|daily.*reward\|visit.*count" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -1 || true)
+          if [ -z "$HAS_STREAK" ]; then
+            TOTAL=$((TOTAL + 1))
+            echo "adopt_streak=true" >> "$GITHUB_OUTPUT"
+            printf "%b" "Users have no reason to return daily. A \"3-day streak\" badge or activity heatmap creates commitment loops.\n\n**Implementation ideas:**\n- Track consecutive login days in localStorage\n- Show a streak counter in the sidebar or header\n- Fire \`ksc_streak_day\` GA4 event (already wired but unused)\n- Add a \"flame\" icon that grows with streak length\n\n**Psychology:** The endowed progress effect — users who see progress (even artificial) are more likely to continue." > /tmp/adopt-streak.txt
+          else
+            echo "adopt_streak=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # ── 3. Mastery / Progression System ──
+          HAS_PROGRESS_BEYOND_TOUR=$(grep -rlE "progress[Bb]ar|completionPercent|mastery|level[Uu]p|achievement|badge[s]?[Ee]arned|xp\b|experience.*point" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v "tour\|welcome\|getting-started\|onboard" | head -1 || true)
+          if [ -z "$HAS_PROGRESS_BEYOND_TOUR" ]; then
+            TOTAL=$((TOTAL + 1))
+            echo "adopt_mastery=true" >> "$GITHUB_OUTPUT"
+            printf "%b" "Beyond onboarding, users have no sense of progression through the console.\n\n**Implementation ideas:**\n- \"Explorer\" percentage — track which dashboards/features the user has visited\n- Feature discovery badges (\"You found the Arcade!\")\n- Skill tree for Kubernetes operations (cluster management → GitOps → AI missions)\n- Show \"You've explored 40%% of the console\" in settings or profile\n\n**Psychology:** The Zeigarnik effect — people remember and feel compelled to complete unfinished tasks." > /tmp/adopt-mastery.txt
+          else
+            echo "adopt_mastery=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # ── 4. Setup Completeness Score ──
+          HAS_COMPLETION=$(grep -rl "checklist\|setup.*complete\|profile.*complete\|configuration.*score" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -1 || true)
+          if [ -z "$HAS_COMPLETION" ]; then
+            TOTAL=$((TOTAL + 1))
+            echo "adopt_completeness=true" >> "$GITHUB_OUTPUT"
+            printf "%b" "Users don't know how much of the platform they've configured.\n\n**Implementation ideas:**\n- \"Your console is 60%% set up\" progress bar on the home dashboard\n- Checklist: Connect cluster → Configure OAuth → Enable AI → Customize dashboards\n- Each completed step fills the progress bar and fires a GA4 conversion event\n- Gray out remaining steps with \"Complete this to unlock...\" teasers\n\n**Psychology:** The endowed progress effect — a 60%% complete bar is harder to abandon than a 0%% one." > /tmp/adopt-completeness.txt
+          else
+            echo "adopt_completeness=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # ── 5. Social Proof Signals ──
+          HAS_SOCIAL=$(grep -rlE "other.*users|popular|trending|most.*used|community|adopted.*by|used.*by.*teams|star[s]?.*count|fork[s]?.*count" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -1 || true)
+          if [ -z "$HAS_SOCIAL" ]; then
+            TOTAL=$((TOTAL + 1))
+            echo "adopt_social_proof=true" >> "$GITHUB_OUTPUT"
+            printf "%b" "No signals showing that other users are actively using the console.\n\n**Implementation ideas:**\n- \"Most popular card this week\" badge on the Add Card modal\n- \"Used by N teams\" on the marketplace cards (pull from GA4 install events)\n- \"N users online\" indicator already exists — make it more prominent\n- Show GitHub star count on the About/Settings page\n\n**Psychology:** Social proof (Cialdini) — people follow what others do. GitHub's star counts and npm's download badges leverage this." > /tmp/adopt-social-proof.txt
+          else
+            echo "adopt_social_proof=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # ── 6. Activity Feed ──
+          HAS_ACTIVITY_FEED=$(grep -rlE "activity.*feed|recent.*activity|live.*feed|event.*stream|what.*others" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -1 || true)
+          if [ -z "$HAS_ACTIVITY_FEED" ]; then
+            TOTAL=$((TOTAL + 1))
+            echo "adopt_activity_feed=true" >> "$GITHUB_OUTPUT"
+            printf "%b" "No lightweight activity feed showing recent platform events.\n\n**Implementation ideas:**\n- \"What's happening\" sidebar card: recent deployments, alerts resolved, missions completed\n- Feed items link to the relevant dashboard for deeper investigation\n- Show anonymized activity from other users (\"Someone deployed nginx to prod-us-east\")\n- Update in real time via the existing WebSocket connection\n\n**Psychology:** FOMO and social presence — an alive-looking platform retains users better than a static one." > /tmp/adopt-activity-feed.txt
+          else
+            echo "adopt_activity_feed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # ── 7. Feature Teasers & Discovery ──
+          HAS_TEASER=$(grep -rlE "unlock|discover|hidden|sneak.*peek|coming.*soon|preview|try.*new|new.*feature|beta.*badge|explore.*more|see.*what" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | grep -v node_modules | head -3 || true)
+          if [ -z "$HAS_TEASER" ]; then
+            TOTAL=$((TOTAL + 1))
+            echo "adopt_feature_teasers=true" >> "$GITHUB_OUTPUT"
+            printf "%b" "No feature teasers that create curiosity about undiscovered capabilities.\n\n**Implementation ideas:**\n- \"Unlock AI insights by connecting a cluster\" prompt on demo mode\n- \"New\" badge on recently added sidebar items (auto-expires after 7 days)\n- \"Did you know you can...\" interstitials after completing a task\n- Blurred preview of premium/advanced features with \"Connect agent to enable\"\n\n**Psychology:** Information gap theory (Loewenstein) — curiosity is the gap between what we know and what we want to know." > /tmp/adopt-feature-teasers.txt
+          else
+            echo "adopt_feature_teasers=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # ── 8. Easter Eggs ──
+          HAS_EASTER_EGG=$(grep -rlE "easter.*egg|secret|konami|hidden.*feature|surprise.*mode" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -1 || true)
+          if [ -z "$HAS_EASTER_EGG" ]; then
+            TOTAL=$((TOTAL + 1))
+            echo "adopt_easter_eggs=true" >> "$GITHUB_OUTPUT"
+            printf "%b" "No easter eggs or hidden discovery moments that create delight and word-of-mouth.\n\n**Implementation ideas:**\n- Konami code (↑↑↓↓←→←→BA) triggers a fun animation or secret theme\n- Click the logo 7 times to reveal a hidden credits page\n- Type \"kubectl\" in the search bar to get a CLI-style response\n- Hidden game in the Arcade dashboard (already has games — add a secret one)\n\n**Psychology:** Surprise and delight create emotional peaks that users share with others, driving organic word-of-mouth growth." > /tmp/adopt-easter-eggs.txt
+          else
+            echo "adopt_easter_eggs=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # ── 9. Welcome-Back Experience ──
+          HAS_IDLE_PROMPT=$(grep -rlE "idle|inactive|welcome.*back|time.*since|last.*visit|miss.*you|catch.*up" src/ --include="*.tsx" --include="*.ts" 2>/dev/null | head -1 || true)
+          if [ -z "$HAS_IDLE_PROMPT" ]; then
+            TOTAL=$((TOTAL + 1))
+            echo "adopt_welcome_back=true" >> "$GITHUB_OUTPUT"
+            printf "%b" "Users who return after absence see no acknowledgment or catch-up summary.\n\n**Implementation ideas:**\n- \"While you were away...\" card on the home dashboard (N alerts resolved, N deployments, N new features)\n- Track last visit timestamp in localStorage\n- Show a brief changelog digest if the console version changed since last visit\n- Personalized greeting: \"Welcome back, Andy — 3 alerts fired since Tuesday\"\n\n**Psychology:** Fogg's behavior model — triggers bring users back. A personalized summary creates internal motivation to check in regularly." > /tmp/adopt-welcome-back.txt
+          else
+            echo "adopt_welcome_back=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # ── Emit summary ──
+          echo "found=$( [ $TOTAL -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+          echo "count=$TOTAL" >> "$GITHUB_OUTPUT"
+          echo "Found $TOTAL adoption psychology opportunities"
 
       # ── Ensure Labels Exist ────────────────────────────────────────
 
@@ -3526,9 +3513,16 @@ jobs:
           FOCUS_ARIA_GAPS: ${{ steps.focus_aria_gaps.outputs.found }}
           FOCUS_MODAL_SAFETY: ${{ steps.focus_modal_safety.outputs.found }}
           FOCUS_EVENT_PARITY: ${{ steps.focus_event_parity.outputs.found }}
-          # Adoption psychology
-          FOCUS_ADOPTION: ${{ steps.focus_adoption_psychology.outputs.found }}
-          FOCUS_ADOPTION_COUNT: ${{ steps.focus_adoption_psychology.outputs.count }}
+          # Adoption psychology — individual findings
+          ADOPT_VARIABLE_REWARDS: ${{ steps.focus_adoption_psychology.outputs.adopt_variable_rewards }}
+          ADOPT_STREAK: ${{ steps.focus_adoption_psychology.outputs.adopt_streak }}
+          ADOPT_MASTERY: ${{ steps.focus_adoption_psychology.outputs.adopt_mastery }}
+          ADOPT_COMPLETENESS: ${{ steps.focus_adoption_psychology.outputs.adopt_completeness }}
+          ADOPT_SOCIAL_PROOF: ${{ steps.focus_adoption_psychology.outputs.adopt_social_proof }}
+          ADOPT_ACTIVITY_FEED: ${{ steps.focus_adoption_psychology.outputs.adopt_activity_feed }}
+          ADOPT_FEATURE_TEASERS: ${{ steps.focus_adoption_psychology.outputs.adopt_feature_teasers }}
+          ADOPT_EASTER_EGGS: ${{ steps.focus_adoption_psychology.outputs.adopt_easter_eggs }}
+          ADOPT_WELCOME_BACK: ${{ steps.focus_adoption_psychology.outputs.adopt_welcome_back }}
           # A11y focus
           FOCUS_COLOR_CONTRAST: ${{ steps.focus_color_contrast.outputs.found }}
           # Performance focus (additional)
@@ -4497,32 +4491,43 @@ jobs:
               });
             }
 
-            // Adoption & Engagement Psychology (every run)
-            if (process.env.FOCUS_ADOPTION === 'true') {
-              const count = process.env.FOCUS_ADOPTION_COUNT || '?';
-              checks.push({
-                title: `${prefix} ${count} adoption & engagement psychology opportunities found`,
-                body: [
-                  `## Auto-QA [Adoption]: Engagement Psychology Audit`,
-                  '',
-                  `**Detected:** ${now} | **Focus:** Adoption Psychology | **Commit:** \`${sha}\` | **Run:** [View](${runUrl})`,
-                  '',
-                  readOutput('/tmp/focus-adoption-psychology.txt'),
-                  '',
-                  '### Implementation Guidance',
-                  '- Pick **one** suggestion and implement it as a small, self-contained UX improvement',
-                  '- Measure impact via GA4 events (add `ksc_` tracking for the new engagement feature)',
-                  '- Prefer lightweight implementations — a "did you know" tooltip is better than a full gamification system',
-                  '- Reference: Nir Eyal\'s Hook Model (Trigger → Action → Variable Reward → Investment)',
-                  ...(prGuidance ? ['', `> **PR Guidance:** ${prGuidance}`] : []),
-                  '',
-                  '---',
-                  `*This issue was automatically created by the [Auto-QA workflow](${runUrl}) during **Adoption Psychology** analysis.*`,
-                  '*Labels `help wanted` enable contributors to pick this up.*',
-                ].join('\n'),
-                labels: ['enhancement', 'help wanted', 'auto-qa', 'triage/accepted', 'auto-qa:adoption'],
-                bonus: true,  // bypass maxIssues cap — adoption issues are always created
-              });
+            // Adoption & Engagement Psychology — individual issues per finding
+            const adoptionFindings = [
+              { env: 'ADOPT_VARIABLE_REWARDS', file: '/tmp/adopt-variable-rewards.txt', title: 'Add variable rewards (rotating tips/spotlights) to static dashboards' },
+              { env: 'ADOPT_STREAK', file: '/tmp/adopt-streak.txt', title: 'Add streak/consistency tracking for daily return engagement' },
+              { env: 'ADOPT_MASTERY', file: '/tmp/adopt-mastery.txt', title: 'Add feature mastery/exploration progression system' },
+              { env: 'ADOPT_COMPLETENESS', file: '/tmp/adopt-completeness.txt', title: 'Add setup completeness score with progress bar' },
+              { env: 'ADOPT_SOCIAL_PROOF', file: '/tmp/adopt-social-proof.txt', title: 'Add social proof signals (popular cards, team usage counts)' },
+              { env: 'ADOPT_ACTIVITY_FEED', file: '/tmp/adopt-activity-feed.txt', title: 'Add lightweight activity feed showing recent platform events' },
+              { env: 'ADOPT_FEATURE_TEASERS', file: '/tmp/adopt-feature-teasers.txt', title: 'Add feature teasers and discovery prompts for hidden capabilities' },
+              { env: 'ADOPT_EASTER_EGGS', file: '/tmp/adopt-easter-eggs.txt', title: 'Add easter eggs and hidden discovery moments' },
+              { env: 'ADOPT_WELCOME_BACK', file: '/tmp/adopt-welcome-back.txt', title: 'Add welcome-back experience for returning users' },
+            ];
+            for (const finding of adoptionFindings) {
+              if (process.env[finding.env] === 'true') {
+                checks.push({
+                  title: `${prefix} ${finding.title}`,
+                  body: [
+                    `## Auto-QA [Adoption]: ${finding.title}`,
+                    '',
+                    `**Detected:** ${now} | **Focus:** Adoption Psychology | **Commit:** \`${sha}\` | **Run:** [View](${runUrl})`,
+                    '',
+                    readOutput(finding.file),
+                    '',
+                    '### Implementation Guidance',
+                    '- Implement as a small, self-contained UX improvement (target: 1 PR, <200 lines)',
+                    '- Add `ksc_` GA4 event tracking for the new engagement feature',
+                    '- Prefer lightweight implementations over complex systems',
+                    ...(prGuidance ? ['', `> **PR Guidance:** ${prGuidance}`] : []),
+                    '',
+                    '---',
+                    `*This issue was automatically created by the [Auto-QA workflow](${runUrl}) during **Adoption Psychology** analysis.*`,
+                    '*Labels `help wanted` enable contributors to pick this up.*',
+                  ].join('\n'),
+                  labels: ['enhancement', 'help wanted', 'auto-qa', 'triage/accepted', 'auto-qa:adoption'],
+                  bonus: true,  // bypass maxIssues cap — adoption issues are always created
+                });
+              }
             }
 
             // ── Apply tuning: filter blocked categories, prioritize boosted ──


### PR DESCRIPTION
## Summary
Replaces the single combined "[Auto-QA] N adoption psychology opportunities found" issue with **9 individual, actionable issues** — each with a specific title, detailed implementation ideas, and psychology context.

## Before
One issue: "[Auto-QA] 1 adoption & engagement psychology opportunities found" — gets deduplicated every run, never creates new issues.

## After
Up to 9 specific issues, each independently tracked:
- `Add streak/consistency tracking for daily return engagement`
- `Add feature mastery/exploration progression system`
- `Add setup completeness score with progress bar`
- `Add social proof signals (popular cards, team usage counts)`
- `Add lightweight activity feed showing recent platform events`
- `Add feature teasers and discovery prompts for hidden capabilities`
- `Add easter eggs and hidden discovery moments`
- `Add welcome-back experience for returning users`
- `Add variable rewards (rotating tips/spotlights) to static dashboards`

Each issue includes implementation ideas and psychology references. Dedup works per-title so closing one doesn't suppress the others.

Also updated the variable rewards scan to detect the `RotatingTip` component (from PR #4646).

## Test plan
- [ ] Trigger workflow manually: `gh workflow run auto-qa.yml`
- [ ] Verify individual issues are created (not one combined issue)
- [ ] Verify dedup works — re-running doesn't create duplicates