### PR TITLE
🐛 Fix marketplace install and add mission history pagination

### DIFF
--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -74,6 +74,7 @@ import { useCardGridNavigation } from '../../hooks/useCardGridNavigation'
 import { useModalState } from '../../lib/modals'
 import { setAutoRefreshPaused } from '../../lib/cache'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
+import { STORAGE_KEY_MAIN_DASHBOARD_CARDS } from '../../lib/constants/storage'
 
 // Lazy-load modal components — only shown on explicit user action,
 // so deferring their chunk until first use reduces the initial dashboard bundle.
@@ -89,8 +90,8 @@ interface CachedDashboard {
 let dashboardCache: CachedDashboard | null = null
 // CACHE_TTL removed — dashboard always does background refresh
 
-// Storage key and default cards for the main dashboard
-const DASHBOARD_STORAGE_KEY = 'kubestellar-main-dashboard-cards'
+// Use the shared storage key for the main dashboard
+const DASHBOARD_STORAGE_KEY = STORAGE_KEY_MAIN_DASHBOARD_CARDS
 
 // Default cards loaded from centralized config
 const DEFAULT_DASHBOARD_CARDS: Card[] = getDefaultCardsForDashboard('main')

--- a/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionSidebar.tsx
@@ -77,6 +77,10 @@ export function MissionSidebar() {
   const [collapsedMissions, setCollapsedMissions] = useState<Set<string>>(new Set())
   const [fontSize, setFontSize] = useState<FontSize>('base')
 
+  /** Number of missions rendered per page in the history list (#4778) */
+  const MISSIONS_PAGE_SIZE = 20
+  const [visibleMissionCount, setVisibleMissionCount] = useState(MISSIONS_PAGE_SIZE)
+
   // Resizable sidebar width (desktop non-fullscreen only)
   const [sidebarWidth, setSidebarWidth] = useState(loadSavedWidth)
   const [isResizing, setIsResizing] = useState(false)
@@ -299,6 +303,11 @@ export function MissionSidebar() {
   // Mission list search filter (#3944)
   const [missionSearchQuery, setMissionSearchQuery] = useState('')
 
+  // Reset pagination when search query changes (#4778)
+  useEffect(() => {
+    setVisibleMissionCount(MISSIONS_PAGE_SIZE)
+  }, [missionSearchQuery])
+
   // Split missions into saved (library) and active, applying search filter
   const matchesSearch = useCallback((m: Mission) => {
     if (!missionSearchQuery.trim()) return true
@@ -309,6 +318,10 @@ export function MissionSidebar() {
   const activeMissions = missions
     .filter(m => m.status !== 'saved' && matchesSearch(m))
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+
+  /** Paginated slice of active missions for rendering (#4778) */
+  const visibleActiveMissions = activeMissions.slice(0, visibleMissionCount)
+  const hasMoreMissions = activeMissions.length > visibleMissionCount
 
   const handleImportMission = useCallback((mission: MissionExport) => {
     const missionType = mission.missionClass === 'install' ? 'deploy' as const
@@ -1010,7 +1023,7 @@ export function MissionSidebar() {
             </div>
           )}
 
-          {/* Active missions section */}
+          {/* Active missions section — paginated for performance (#4778) */}
           {activeMissions.length > 0 && (
             <>
               {savedMissions.length > 0 && (
@@ -1019,7 +1032,7 @@ export function MissionSidebar() {
                   <span className="text-2xs bg-secondary px-1.5 py-0.5 rounded-full">{activeMissions.length}</span>
                 </div>
               )}
-              {[...activeMissions].map((mission) => (
+              {visibleActiveMissions.map((mission) => (
                 <MissionListItem
                   key={mission.id}
                   mission={mission}
@@ -1045,6 +1058,18 @@ export function MissionSidebar() {
                   onToggleCollapse={() => toggleMissionCollapse(mission.id)}
                 />
               ))}
+              {/* Load More button — renders remaining missions incrementally */}
+              {hasMoreMissions && (
+                <button
+                  onClick={() => setVisibleMissionCount(prev => prev + MISSIONS_PAGE_SIZE)}
+                  className="w-full py-2 text-xs font-medium text-primary hover:bg-primary/10 rounded-lg transition-colors"
+                >
+                  {t('missionSidebar.loadMore', {
+                    defaultValue: 'Load more ({{remaining}} remaining)',
+                    remaining: activeMissions.length - visibleMissionCount,
+                  })}
+                </button>
+              )}
             </>
           )}
 

--- a/web/src/hooks/useMarketplace.ts
+++ b/web/src/hooks/useMarketplace.ts
@@ -4,6 +4,8 @@ import { addCustomTheme, removeCustomTheme } from '../lib/themes'
 import { emitMarketplaceInstall, emitMarketplaceRemove, emitMarketplaceInstallFailed } from '../lib/analytics'
 import { FETCH_EXTERNAL_TIMEOUT_MS } from '../lib/constants/network'
 import { isCardTypeRegistered } from '../components/cards/cardRegistry'
+import { STORAGE_KEY_MAIN_DASHBOARD_CARDS } from '../lib/constants/storage'
+import { getDefaultCardSize } from '../components/dashboard/dashboardUtils'
 
 const REGISTRY_URL = 'https://raw.githubusercontent.com/kubestellar/console-marketplace/main/registry.json'
 const CACHE_KEY = 'kc-marketplace-registry'
@@ -246,7 +248,28 @@ export function useMarketplace() {
     const json = await response.json()
 
     if (item.type === 'card-preset') {
-      // Dispatch event for the active dashboard to pick up
+      // Persist card directly to the main dashboard localStorage so it
+      // survives navigation. Previously this only dispatched a CustomEvent
+      // that was lost if the Dashboard component wasn't mounted (#4780).
+      const { card_type, config, title } = json as { card_type?: string; config?: Record<string, unknown>; title?: string }
+      if (card_type) {
+        const size = getDefaultCardSize(card_type)
+        const newCard = {
+          id: `mp-${Date.now()}`,
+          card_type,
+          config: config || {},
+          title,
+          position: { x: 0, y: 0, ...size },
+        }
+        try {
+          const raw = localStorage.getItem(STORAGE_KEY_MAIN_DASHBOARD_CARDS)
+          const existing = raw ? JSON.parse(raw) : []
+          const cards = Array.isArray(existing) ? existing : []
+          cards.unshift(newCard)
+          localStorage.setItem(STORAGE_KEY_MAIN_DASHBOARD_CARDS, JSON.stringify(cards))
+        } catch { /* localStorage unavailable — card will appear on next dashboard load */ }
+      }
+      // Also dispatch event so a mounted Dashboard picks up changes immediately
       window.dispatchEvent(new CustomEvent('kc-add-card-from-marketplace', { detail: json }))
       markInstalled(item.id, { installedAt: new Date().toISOString(), type: 'card-preset' })
       emitMarketplaceInstall(item.type, item.name)

--- a/web/src/lib/constants/storage.ts
+++ b/web/src/lib/constants/storage.ts
@@ -39,6 +39,9 @@ export const STORAGE_KEY_TOUR_COMPLETED = 'kubestellar-console-tour-completed'
 export const STORAGE_KEY_ANALYTICS_OPT_OUT = 'kc-analytics-opt-out'
 export const STORAGE_KEY_ANONYMOUS_USER_ID = 'kc-anonymous-user-id'
 
+// ── Dashboard persistence ─────────────────────────────────────────────
+export const STORAGE_KEY_MAIN_DASHBOARD_CARDS = 'kubestellar-main-dashboard-cards'
+
 // ── UI state persistence ───────────────────────────────────────────────
 export const STORAGE_KEY_CLUSTER_LAYOUT = 'kubestellar-cluster-layout-mode'
 export const STORAGE_KEY_NAV_HISTORY = 'kubestellar-nav-history'


### PR DESCRIPTION
## Summary

- **Marketplace Install (#4780):** The "Install" button for card presets dispatched a `CustomEvent` that only `DashboardCards` listened for. When the user was on the Marketplace page (Dashboard not mounted), the event was lost and the card silently never appeared. Now `installItem` directly persists the card to the main dashboard `localStorage`, so it is available when the user navigates back to the dashboard. The event dispatch is retained for the case where the dashboard is already mounted.

- **Mission History Pagination (#4778):** The active missions list rendered all missions at once, causing UI lag with 200+ entries. Now renders the first 20 missions and shows a "Load more" button that incrementally adds 20 per click. The visible count resets when the search query changes.

- Centralizes the main dashboard storage key (`kubestellar-main-dashboard-cards`) into `storage.ts` to avoid string duplication across modules.

## Test plan

- [ ] Go to Marketplace, install a card preset, navigate to the main dashboard — the card should appear
- [ ] Install a theme from Marketplace, go to Settings > Theme — the theme should be listed
- [ ] With 20+ missions in history, verify only the first 20 render initially with a "Load more" button
- [ ] Click "Load more" — next batch of missions appears
- [ ] Search missions — pagination resets to first page of results

Fixes #4778, #4780