### PR TITLE
🐛 Add query parameter validation to MCP endpoints

### DIFF
--- a/pkg/api/handlers/mcp_cluster.go
+++ b/pkg/api/handlers/mcp_cluster.go
@@ -72,6 +72,9 @@ func (h *MCPHandlers) ListClusters(c *fiber.Ctx) error {
 // GetClusterHealth returns health for a specific cluster
 func (h *MCPHandlers) GetClusterHealth(c *fiber.Ctx) error {
 	cluster := c.Params("cluster")
+	if err := mcpValidateName("cluster", cluster); err != nil {
+		return err
+	}
 
 	// Demo mode: return demo data immediately
 	if isDemoMode(c) {
@@ -132,6 +135,9 @@ func (h *MCPHandlers) GetNodes(c *fiber.Ctx) error {
 	}
 
 	cluster := c.Query("cluster")
+	if err := mcpValidateName("cluster", cluster); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
@@ -198,6 +204,13 @@ func (h *MCPHandlers) GetEvents(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 	limit := c.QueryInt("limit", 50)
+
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+	if err := mcpValidatePositiveInt("limit", limit, mcpMaxEventLimit); err != nil {
+		return err
+	}
 
 	// Try MCP bridge first
 	if h.bridge != nil {
@@ -298,6 +311,13 @@ func (h *MCPHandlers) GetWarningEvents(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	limit := c.QueryInt("limit", 50)
 
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+	if err := mcpValidatePositiveInt("limit", limit, mcpMaxEventLimit); err != nil {
+		return err
+	}
+
 	// Try MCP bridge first
 	if h.bridge != nil {
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -392,6 +412,10 @@ func (h *MCPHandlers) CheckSecurityIssues(c *fiber.Ctx) error {
 
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
+
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	// Fall back to direct k8s client
 	if h.k8sClient != nil {

--- a/pkg/api/handlers/mcp_resources.go
+++ b/pkg/api/handlers/mcp_resources.go
@@ -24,6 +24,9 @@ func (h *MCPHandlers) GetGPUNodes(c *fiber.Ctx) error {
 	}
 
 	cluster := c.Query("cluster")
+	if err := mcpValidateName("cluster", cluster); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
@@ -84,6 +87,9 @@ func (h *MCPHandlers) GetGPUNodeHealth(c *fiber.Ctx) error {
 	}
 
 	cluster := c.Query("cluster")
+	if err := mcpValidateName("cluster", cluster); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		if cluster == "" {
@@ -145,6 +151,9 @@ func (h *MCPHandlers) GetGPUHealthCronJobStatus(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	if cluster == "" {
 		return c.Status(400).JSON(fiber.Map{"error": "cluster parameter is required"})
+	}
+	if err := mcpValidateName("cluster", cluster); err != nil {
+		return err
 	}
 
 	if h.k8sClient == nil {
@@ -236,6 +245,9 @@ func (h *MCPHandlers) GetGPUHealthCronJobResults(c *fiber.Ctx) error {
 	if cluster == "" {
 		return c.Status(400).JSON(fiber.Map{"error": "cluster parameter is required"})
 	}
+	if err := mcpValidateName("cluster", cluster); err != nil {
+		return err
+	}
 
 	if h.k8sClient == nil {
 		return c.Status(503).JSON(fiber.Map{"error": "No cluster access"})
@@ -259,6 +271,9 @@ func (h *MCPHandlers) GetNVIDIAOperatorStatus(c *fiber.Ctx) error {
 	}
 
 	cluster := c.Query("cluster")
+	if err := mcpValidateName("cluster", cluster); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
@@ -318,6 +333,10 @@ func (h *MCPHandlers) GetConfigMaps(c *fiber.Ctx) error {
 
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
+
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		if cluster == "" {
@@ -380,6 +399,10 @@ func (h *MCPHandlers) GetSecrets(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	if h.k8sClient != nil {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
@@ -440,6 +463,10 @@ func (h *MCPHandlers) GetServiceAccounts(c *fiber.Ctx) error {
 
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
+
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		if cluster == "" {
@@ -502,6 +529,10 @@ func (h *MCPHandlers) GetPVCs(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	if h.k8sClient != nil {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
@@ -561,6 +592,9 @@ func (h *MCPHandlers) GetPVs(c *fiber.Ctx) error {
 	}
 
 	cluster := c.Query("cluster")
+	if err := mcpValidateName("cluster", cluster); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		if cluster == "" {
@@ -623,6 +657,10 @@ func (h *MCPHandlers) GetResourceQuotas(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	if h.k8sClient != nil {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
@@ -683,6 +721,10 @@ func (h *MCPHandlers) GetLimitRanges(c *fiber.Ctx) error {
 
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
+
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		if cluster == "" {
@@ -754,6 +796,12 @@ func (h *MCPHandlers) CreateOrUpdateResourceQuota(c *fiber.Ctx) error {
 	if req.Cluster == "" || req.Name == "" || req.Namespace == "" {
 		return c.Status(400).JSON(fiber.Map{"error": "cluster, name, and namespace are required"})
 	}
+	if err := mcpValidateClusterAndNamespace(req.Cluster, req.Namespace); err != nil {
+		return err
+	}
+	if err := mcpValidateName("name", req.Name); err != nil {
+		return err
+	}
 
 	if len(req.Hard) == 0 {
 		return c.Status(400).JSON(fiber.Map{"error": "At least one resource limit is required in 'hard'"})
@@ -799,6 +847,12 @@ func (h *MCPHandlers) DeleteResourceQuota(c *fiber.Ctx) error {
 	if cluster == "" || namespace == "" || name == "" {
 		return c.Status(400).JSON(fiber.Map{"error": "cluster, namespace, and name are required"})
 	}
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+	if err := mcpValidateName("name", name); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -830,6 +884,18 @@ func (h *MCPHandlers) GetPodLogs(c *fiber.Ctx) error {
 
 	if cluster == "" || namespace == "" || pod == "" {
 		return c.Status(400).JSON(fiber.Map{"error": "cluster, namespace, and pod are required"})
+	}
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+	if err := mcpValidateName("pod", pod); err != nil {
+		return err
+	}
+	if err := mcpValidateName("container", container); err != nil {
+		return err
+	}
+	if err := mcpValidatePositiveInt("tail", tailLines, mcpMaxTailLines); err != nil {
+		return err
 	}
 
 	if h.k8sClient != nil {
@@ -1025,6 +1091,9 @@ func (h *MCPHandlers) GetFlatcarNodes(c *fiber.Ctx) error {
 	}
 
 	cluster := c.Query("cluster")
+	if err := mcpValidateName("cluster", cluster); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		// No cluster specified → query all healthy clusters in parallel
@@ -1084,6 +1153,10 @@ func (h *MCPHandlers) GetIngresses(c *fiber.Ctx) error {
 
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
+
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		if cluster == "" {
@@ -1145,6 +1218,10 @@ func (h *MCPHandlers) GetNetworkPolicies(c *fiber.Ctx) error {
 
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
+
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		if cluster == "" {

--- a/pkg/api/handlers/mcp_validate.go
+++ b/pkg/api/handlers/mcp_validate.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// mcpNamePattern matches valid Kubernetes resource names (RFC 1123 DNS subdomain).
+// Must be lowercase alphanumeric, may contain '-' and '.', max 253 characters.
+var mcpNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9.\-]*[a-z0-9])?$`)
+
+// mcpMaxNameLen is the maximum length for a Kubernetes DNS subdomain name.
+const mcpMaxNameLen = 253
+
+// mcpMaxLabelSelectorLen is the maximum length allowed for a label selector string
+// to prevent excessively large queries.
+const mcpMaxLabelSelectorLen = 1024
+
+// mcpMaxEventLimit is the maximum number of events a client may request.
+const mcpMaxEventLimit = 1000
+
+// mcpMaxTailLines is the maximum number of log tail lines a client may request.
+const mcpMaxTailLines = 10000
+
+// mcpAllowedWorkloadTypes enumerates the valid values for the "type" query parameter
+// on the /api/mcp/workloads endpoint.
+var mcpAllowedWorkloadTypes = map[string]bool{
+	"":            true, // empty means "all types"
+	"Deployment":  true,
+	"StatefulSet": true,
+	"DaemonSet":   true,
+}
+
+// mcpValidateName checks that a non-empty string is a valid Kubernetes name.
+// Empty values are allowed (they mean "all" in most contexts). Returns an
+// HTTP 400 fiber error with the parameter name in the message when invalid.
+func mcpValidateName(param, value string) error {
+	if value == "" {
+		return nil
+	}
+	if len(value) > mcpMaxNameLen {
+		return fiber.NewError(fiber.StatusBadRequest,
+			fmt.Sprintf("invalid %s: exceeds maximum length of %d characters", param, mcpMaxNameLen))
+	}
+	if !mcpNamePattern.MatchString(value) {
+		return fiber.NewError(fiber.StatusBadRequest,
+			fmt.Sprintf("invalid %s: must consist of lowercase alphanumeric characters, '-', or '.'", param))
+	}
+	return nil
+}
+
+// mcpValidateLabelSelector checks that a label selector string is reasonably
+// well-formed and not excessively long.
+func mcpValidateLabelSelector(value string) error {
+	if value == "" {
+		return nil
+	}
+	if len(value) > mcpMaxLabelSelectorLen {
+		return fiber.NewError(fiber.StatusBadRequest,
+			fmt.Sprintf("invalid labelSelector: exceeds maximum length of %d characters", mcpMaxLabelSelectorLen))
+	}
+	// Reject obviously malicious characters (newlines, semicolons, backticks)
+	if strings.ContainsAny(value, ";\n\r`") {
+		return fiber.NewError(fiber.StatusBadRequest,
+			"invalid labelSelector: contains disallowed characters")
+	}
+	return nil
+}
+
+// mcpValidatePositiveInt checks that an integer query parameter falls within
+// [0, max]. Negative values are rejected. Zero is treated as "use default".
+func mcpValidatePositiveInt(param string, value, max int) error {
+	if value < 0 {
+		return fiber.NewError(fiber.StatusBadRequest,
+			fmt.Sprintf("invalid %s: must be a positive integer", param))
+	}
+	if value > max {
+		return fiber.NewError(fiber.StatusBadRequest,
+			fmt.Sprintf("invalid %s: exceeds maximum of %d", param, max))
+	}
+	return nil
+}
+
+// mcpValidateWorkloadType checks that a workload type filter is one of the
+// recognised values ("Deployment", "StatefulSet", "DaemonSet", or empty).
+func mcpValidateWorkloadType(value string) error {
+	if !mcpAllowedWorkloadTypes[value] {
+		return fiber.NewError(fiber.StatusBadRequest,
+			"invalid type: must be one of Deployment, StatefulSet, DaemonSet")
+	}
+	return nil
+}
+
+// mcpValidateClusterAndNamespace is a convenience helper that validates both the
+// cluster and namespace query parameters in a single call.
+func mcpValidateClusterAndNamespace(cluster, namespace string) error {
+	if err := mcpValidateName("cluster", cluster); err != nil {
+		return err
+	}
+	return mcpValidateName("namespace", namespace)
+}

--- a/pkg/api/handlers/mcp_validate_test.go
+++ b/pkg/api/handlers/mcp_validate_test.go
@@ -1,0 +1,181 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPValidation_InvalidClusterNameRejects(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/pods", handler.GetPods)
+
+	// Special characters in cluster name should be rejected
+	req, err := http.NewRequest("GET", "/api/mcp/pods?cluster=my%3Bcluster", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "invalid cluster")
+}
+
+func TestMCPValidation_InvalidNamespaceRejects(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/pods", handler.GetPods)
+
+	// Namespace with uppercase letters should be rejected
+	req, err := http.NewRequest("GET", "/api/mcp/pods?namespace=INVALID", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "invalid namespace")
+}
+
+func TestMCPValidation_ValidClusterAccepted(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/pods", handler.GetPods)
+
+	// Valid k8s name should work normally
+	req, err := http.NewRequest("GET", "/api/mcp/pods?cluster=test-cluster", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestMCPValidation_EmptyParamsAccepted(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/pods", handler.GetPods)
+
+	// No cluster/namespace params (query all) should work
+	req, err := http.NewRequest("GET", "/api/mcp/pods", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestMCPValidation_InvalidWorkloadTypeRejects(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/workloads", handler.GetWorkloads)
+
+	req, err := http.NewRequest("GET", "/api/mcp/workloads?type=InvalidType", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "invalid type")
+}
+
+func TestMCPValidation_ValidWorkloadTypeAccepted(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/workloads", handler.GetWorkloads)
+
+	for _, wt := range []string{"", "Deployment", "StatefulSet", "DaemonSet"} {
+		url := "/api/mcp/workloads"
+		if wt != "" {
+			url += "?type=" + wt
+		}
+		req, err := http.NewRequest("GET", url, nil)
+		require.NoError(t, err)
+
+		resp, err := env.App.Test(req, 5000)
+		require.NoError(t, err)
+		assert.NotEqual(t, http.StatusBadRequest, resp.StatusCode,
+			"workload type %q should be accepted", wt)
+	}
+}
+
+func TestMCPValidation_InvalidLabelSelectorRejects(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/pods", handler.GetPods)
+
+	// Semicolons should be rejected
+	req, err := http.NewRequest("GET", "/api/mcp/pods?labelSelector=app%3Dfoo%3Bbar", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "invalid labelSelector")
+}
+
+func TestMCPValidation_EventsLimitTooHighRejects(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/events", handler.GetEvents)
+
+	req, err := http.NewRequest("GET", "/api/mcp/events?limit=99999", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "invalid limit")
+}
+
+func TestMCPValidation_DemoModeBypassesValidation(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/pods", handler.GetPods)
+
+	// Even with invalid params, demo mode should succeed (validation runs after demo check)
+	req, err := http.NewRequest("GET", "/api/mcp/pods?cluster=INVALID", nil)
+	require.NoError(t, err)
+	req.Header.Set("X-Demo-Mode", "true")
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var payload map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
+	assert.Equal(t, "demo", payload["source"])
+}
+
+func TestMCPValidation_ClusterWithDotsAccepted(t *testing.T) {
+	env := setupTestEnv(t)
+	handler := NewMCPHandlers(nil, env.K8sClient)
+	env.App.Get("/api/mcp/nodes", handler.GetNodes)
+
+	// Cluster names with dots (e.g. "api.cluster.example.com") should be valid
+	req, err := http.NewRequest("GET", "/api/mcp/nodes?cluster=api.cluster.example.com", nil)
+	require.NoError(t, err)
+
+	resp, err := env.App.Test(req, 5000)
+	require.NoError(t, err)
+	// Should not be 400 — the cluster may not exist but validation should pass
+	assert.NotEqual(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/pkg/api/handlers/mcp_workloads.go
+++ b/pkg/api/handlers/mcp_workloads.go
@@ -22,6 +22,13 @@ func (h *MCPHandlers) GetPods(c *fiber.Ctx) error {
 	namespace := c.Query("namespace")
 	labelSelector := c.Query("labelSelector")
 
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+	if err := mcpValidateLabelSelector(labelSelector); err != nil {
+		return err
+	}
+
 	// Try MCP bridge first for its richer functionality
 	if h.bridge != nil {
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -100,6 +107,10 @@ func (h *MCPHandlers) FindPodIssues(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	// Try MCP bridge first
 	if h.bridge != nil {
 		ctx, cancel := context.WithTimeout(c.Context(), mcpDefaultTimeout)
@@ -175,6 +186,10 @@ func (h *MCPHandlers) FindDeploymentIssues(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	// Fall back to direct k8s client
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
@@ -237,6 +252,10 @@ func (h *MCPHandlers) GetDeployments(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	if h.k8sClient != nil {
 		// If no cluster specified, query all clusters in parallel
 		if cluster == "" {
@@ -297,6 +316,10 @@ func (h *MCPHandlers) GetServices(c *fiber.Ctx) error {
 
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
+
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		if cluster == "" {
@@ -359,6 +382,10 @@ func (h *MCPHandlers) GetJobs(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	if h.k8sClient != nil {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
@@ -419,6 +446,10 @@ func (h *MCPHandlers) GetHPAs(c *fiber.Ctx) error {
 
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
+
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		if cluster == "" {
@@ -481,6 +512,10 @@ func (h *MCPHandlers) GetReplicaSets(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	if h.k8sClient != nil {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
@@ -541,6 +576,10 @@ func (h *MCPHandlers) GetStatefulSets(c *fiber.Ctx) error {
 
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
+
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		if cluster == "" {
@@ -603,6 +642,10 @@ func (h *MCPHandlers) GetDaemonSets(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+
 	if h.k8sClient != nil {
 		if cluster == "" {
 			clusters, _, err := h.k8sClient.HealthyClusters(c.Context())
@@ -663,6 +706,10 @@ func (h *MCPHandlers) GetCronJobs(c *fiber.Ctx) error {
 
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
+
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
 
 	if h.k8sClient != nil {
 		if cluster == "" {
@@ -730,6 +777,13 @@ func (h *MCPHandlers) GetWorkloads(c *fiber.Ctx) error {
 	cluster := c.Query("cluster")
 	namespace := c.Query("namespace")
 	workloadType := c.Query("type")
+
+	if err := mcpValidateClusterAndNamespace(cluster, namespace); err != nil {
+		return err
+	}
+	if err := mcpValidateWorkloadType(workloadType); err != nil {
+		return err
+	}
 
 	ctx, cancel := context.WithTimeout(c.Context(), maxResponseDeadline)
 	defer cancel()


### PR DESCRIPTION
## Summary
- Adds strict validation for `cluster`, `namespace`, `labelSelector`, `limit`, `tail`, and `type` query parameters across all MCP API handlers
- Invalid or malformed values now return HTTP 400 with descriptive error messages instead of being silently passed to backend logic
- Validation covers ~30 MCP endpoints across `mcp_cluster.go`, `mcp_workloads.go`, and `mcp_resources.go`

## Details
New file `mcp_validate.go` provides reusable validation functions:
- **`mcpValidateName`** — RFC 1123 DNS subdomain check (lowercase alphanumeric, `-`, `.`, max 253 chars)
- **`mcpValidateLabelSelector`** — length cap and dangerous character rejection
- **`mcpValidatePositiveInt`** — bounds checking for `limit` and `tail` parameters
- **`mcpValidateWorkloadType`** — allowlist of `Deployment`, `StatefulSet`, `DaemonSet`

Demo mode requests bypass validation (checked first in each handler).

## Test plan
- [x] 10 new tests in `mcp_validate_test.go` covering invalid cluster, namespace, workload type, label selector, limit overflow, demo mode bypass, and valid inputs
- [x] All pre-existing handler tests pass (except 1 pre-existing unrelated failure in `TestMCPGetPods_NetworkErrorReturnsUnavailable`)
- [x] `go build ./cmd/console/` succeeds
- [x] `go vet ./pkg/api/handlers/` clean

Fixes #4789