### PR TITLE
🐛 Fix 15 Go backend issues: mutex, scanner, type safety, SSE, cache, permissions

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -162,31 +162,37 @@ func (cm *ConfigManager) GetModel(provider, defaultModel string) string {
 
 // SetAPIKey stores an API key for a provider
 func (cm *ConfigManager) SetAPIKey(provider, apiKey string) error {
-	cm.mu.Lock()
-	agentConfig := cm.config.Agents[provider]
-	agentConfig.APIKey = apiKey
-	cm.config.Agents[provider] = agentConfig
-	cm.mu.Unlock()
+	func() {
+		cm.mu.Lock()
+		defer cm.mu.Unlock()
+		agentConfig := cm.config.Agents[provider]
+		agentConfig.APIKey = apiKey
+		cm.config.Agents[provider] = agentConfig
+	}()
 
 	return cm.Save()
 }
 
 // SetModel stores a model preference for a provider
 func (cm *ConfigManager) SetModel(provider, model string) error {
-	cm.mu.Lock()
-	agentConfig := cm.config.Agents[provider]
-	agentConfig.Model = model
-	cm.config.Agents[provider] = agentConfig
-	cm.mu.Unlock()
+	func() {
+		cm.mu.Lock()
+		defer cm.mu.Unlock()
+		agentConfig := cm.config.Agents[provider]
+		agentConfig.Model = model
+		cm.config.Agents[provider] = agentConfig
+	}()
 
 	return cm.Save()
 }
 
 // RemoveAPIKey removes the API key for a provider
 func (cm *ConfigManager) RemoveAPIKey(provider string) error {
-	cm.mu.Lock()
-	delete(cm.config.Agents, provider)
-	cm.mu.Unlock()
+	func() {
+		cm.mu.Lock()
+		defer cm.mu.Unlock()
+		delete(cm.config.Agents, provider)
+	}()
 
 	return cm.Save()
 }
@@ -248,9 +254,11 @@ func (cm *ConfigManager) GetDefaultAgent() string {
 
 // SetDefaultAgent sets the default agent
 func (cm *ConfigManager) SetDefaultAgent(agent string) error {
-	cm.mu.Lock()
-	cm.config.DefaultAgent = agent
-	cm.mu.Unlock()
+	func() {
+		cm.mu.Lock()
+		defer cm.mu.Unlock()
+		cm.config.DefaultAgent = agent
+	}()
 
 	return cm.Save()
 }

--- a/pkg/agent/insight_worker.go
+++ b/pkg/agent/insight_worker.go
@@ -229,8 +229,12 @@ func buildInsightEnrichmentPrompt(insights []InsightSummary) string {
 		b.WriteString(fmt.Sprintf("Severity: %s\n", insight.Severity))
 		b.WriteString(fmt.Sprintf("Affected Clusters: %s\n", strings.Join(insight.AffectedClusters, ", ")))
 		if len(insight.Metrics) > 0 {
-			metricsJSON, _ := json.Marshal(insight.Metrics)
-			b.WriteString(fmt.Sprintf("Metrics: %s\n", string(metricsJSON)))
+			metricsJSON, err := json.Marshal(insight.Metrics)
+			if err != nil {
+				slog.Warn("[InsightWorker] failed to marshal metrics, omitting from prompt", "insightID", insight.ID, "error", err)
+			} else {
+				b.WriteString(fmt.Sprintf("Metrics: %s\n", string(metricsJSON)))
+			}
 		}
 		b.WriteString("\n")
 	}

--- a/pkg/agent/kagent_crds.go
+++ b/pkg/agent/kagent_crds.go
@@ -123,6 +123,7 @@ func (s *Server) handleKagentCRDAgents(w http.ResponseWriter, r *http.Request) {
 	cluster := r.URL.Query().Get("cluster")
 	namespace := r.URL.Query().Get("namespace")
 	if cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]any{"agents": []any{}, "error": "cluster parameter required"})
 		return
 	}
@@ -133,6 +134,7 @@ func (s *Server) handleKagentCRDAgents(w http.ResponseWriter, r *http.Request) {
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
 		slog.Info("error fetching kagent agents for cluster request")
+		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"agents": []any{}, "error": "internal server error"})
 		return
 	}
@@ -151,8 +153,14 @@ func (s *Server) handleKagentCRDAgents(w http.ResponseWriter, r *http.Request) {
 
 	agents := make([]kagentCRDAgent, 0, len(list.Items))
 	for _, item := range list.Items {
-		specMap, _ := item.Object["spec"].(map[string]any)
-		statusMap, _ := item.Object["status"].(map[string]any)
+		specMap, ok := item.Object["spec"].(map[string]any)
+		if !ok {
+			specMap = nil
+		}
+		statusMap, ok := item.Object["status"].(map[string]any)
+		if !ok {
+			statusMap = nil
+		}
 
 		a := kagentCRDAgent{
 			Name:      item.GetName(),
@@ -213,6 +221,7 @@ func (s *Server) handleKagentCRDTools(w http.ResponseWriter, r *http.Request) {
 	cluster := r.URL.Query().Get("cluster")
 	namespace := r.URL.Query().Get("namespace")
 	if cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]any{"tools": []any{}, "error": "cluster parameter required"})
 		return
 	}
@@ -223,6 +232,7 @@ func (s *Server) handleKagentCRDTools(w http.ResponseWriter, r *http.Request) {
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
 		slog.Info("error fetching kagent tools for cluster request")
+		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"tools": []any{}, "error": "internal server error"})
 		return
 	}
@@ -238,8 +248,14 @@ func (s *Server) handleKagentCRDTools(w http.ResponseWriter, r *http.Request) {
 	}
 	if err == nil {
 		for _, item := range tsList.Items {
-			specMap, _ := item.Object["spec"].(map[string]any)
-			statusMap, _ := item.Object["status"].(map[string]any)
+			specMap, ok := item.Object["spec"].(map[string]any)
+			if !ok {
+				specMap = nil
+			}
+			statusMap, ok := item.Object["status"].(map[string]any)
+			if !ok {
+				statusMap = nil
+			}
 
 			t := kagentCRDTool{
 				Name:      item.GetName(),
@@ -267,8 +283,14 @@ func (s *Server) handleKagentCRDTools(w http.ResponseWriter, r *http.Request) {
 	}
 	if err == nil {
 		for _, item := range rmsList.Items {
-			specMap, _ := item.Object["spec"].(map[string]any)
-			statusMap, _ := item.Object["status"].(map[string]any)
+			specMap, ok := item.Object["spec"].(map[string]any)
+			if !ok {
+				specMap = nil
+			}
+			statusMap, ok := item.Object["status"].(map[string]any)
+			if !ok {
+				statusMap = nil
+			}
 
 			t := kagentCRDTool{
 				Name:      item.GetName(),
@@ -327,6 +349,7 @@ func (s *Server) handleKagentCRDModels(w http.ResponseWriter, r *http.Request) {
 	cluster := r.URL.Query().Get("cluster")
 	namespace := r.URL.Query().Get("namespace")
 	if cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]any{"models": []any{}, "error": "cluster parameter required"})
 		return
 	}
@@ -337,6 +360,7 @@ func (s *Server) handleKagentCRDModels(w http.ResponseWriter, r *http.Request) {
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
 		slog.Info("error fetching kagent models for cluster request")
+		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"models": []any{}, "error": "internal server error"})
 		return
 	}
@@ -352,7 +376,10 @@ func (s *Server) handleKagentCRDModels(w http.ResponseWriter, r *http.Request) {
 	}
 	if err == nil {
 		for _, item := range mcList.Items {
-			specMap, _ := item.Object["spec"].(map[string]any)
+			specMap, ok := item.Object["spec"].(map[string]any)
+			if !ok {
+				specMap = nil
+			}
 
 			m := kagentCRDModel{
 				Name:      item.GetName(),
@@ -377,8 +404,14 @@ func (s *Server) handleKagentCRDModels(w http.ResponseWriter, r *http.Request) {
 	}
 	if err == nil {
 		for _, item := range mpcList.Items {
-			specMap, _ := item.Object["spec"].(map[string]any)
-			statusMap, _ := item.Object["status"].(map[string]any)
+			specMap, ok := item.Object["spec"].(map[string]any)
+			if !ok {
+				specMap = nil
+			}
+			statusMap, ok := item.Object["status"].(map[string]any)
+			if !ok {
+				statusMap = nil
+			}
 
 			m := kagentCRDModel{
 				Name:      item.GetName(),
@@ -437,6 +470,7 @@ func (s *Server) handleKagentCRDMemories(w http.ResponseWriter, r *http.Request)
 	cluster := r.URL.Query().Get("cluster")
 	namespace := r.URL.Query().Get("namespace")
 	if cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]any{"memories": []any{}, "error": "cluster parameter required"})
 		return
 	}
@@ -447,6 +481,7 @@ func (s *Server) handleKagentCRDMemories(w http.ResponseWriter, r *http.Request)
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
 		slog.Info("error fetching kagent memories for cluster request")
+		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{"memories": []any{}, "error": "internal server error"})
 		return
 	}
@@ -464,7 +499,10 @@ func (s *Server) handleKagentCRDMemories(w http.ResponseWriter, r *http.Request)
 
 	memories := make([]kagentCRDMemory, 0, len(list.Items))
 	for _, item := range list.Items {
-		specMap, _ := item.Object["spec"].(map[string]any)
+		specMap, ok := item.Object["spec"].(map[string]any)
+		if !ok {
+			specMap = nil
+		}
 
 		m := kagentCRDMemory{
 			Name:      item.GetName(),
@@ -500,6 +538,7 @@ func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) 
 
 	cluster := r.URL.Query().Get("cluster")
 	if cluster == "" {
+		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]any{"error": "cluster parameter required"})
 		return
 	}
@@ -510,6 +549,7 @@ func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) 
 	dynClient, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
 		slog.Info("error fetching kagent CRD summary for cluster request")
+		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]any{
 			"agentCount": 0, "toolServerCount": 0, "remoteMCPServerCount": 0,
 			"modelConfigCount": 0, "modelProviderConfigCount": 0, "memoryCount": 0,
@@ -542,8 +582,8 @@ func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) 
 	if mcList, err := dynClient.Resource(modelConfigGVR).List(ctx, metav1.ListOptions{}); err == nil {
 		modelConfigCount = len(mcList.Items)
 		for _, item := range mcList.Items {
-			specMap, _ := item.Object["spec"].(map[string]any)
-			if specMap != nil {
+			specMap, ok := item.Object["spec"].(map[string]any)
+			if ok && specMap != nil {
 				provider := nestedString(specMap, "provider")
 				if provider != "" {
 					byProvider[provider]++
@@ -556,8 +596,8 @@ func (s *Server) handleKagentCRDSummary(w http.ResponseWriter, r *http.Request) 
 	if mpcList, err := dynClient.Resource(modelProviderConfigGVR).List(ctx, metav1.ListOptions{}); err == nil {
 		modelProviderConfigCount = len(mpcList.Items)
 		for _, item := range mpcList.Items {
-			specMap, _ := item.Object["spec"].(map[string]any)
-			if specMap != nil {
+			specMap, ok := item.Object["spec"].(map[string]any)
+			if ok && specMap != nil {
 				provider := nestedString(specMap, "provider")
 				if provider != "" {
 					byProvider[provider]++

--- a/pkg/agent/provider_helpers.go
+++ b/pkg/agent/provider_helpers.go
@@ -37,6 +37,10 @@ func buildPromptWithHistoryGeneric(req *ChatRequest) string {
 			sb.WriteString("Assistant: ")
 		case "system":
 			sb.WriteString("System: ")
+		default:
+			// Use a generic label for unknown roles (e.g., "tool", "function")
+			// so the prompt formatting remains correct.
+			sb.WriteString("Unknown: ")
 		}
 		sb.WriteString(msg.Content)
 		sb.WriteString("\n\n")

--- a/pkg/agent/provider_openai_compat.go
+++ b/pkg/agent/provider_openai_compat.go
@@ -15,6 +15,9 @@ import (
 func chatViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKey, endpoint, agentName string) (*ChatResponse, error) {
 	cm := GetConfigManager()
 	apiKey := cm.GetAPIKey(providerKey)
+	if apiKey == "" {
+		return nil, fmt.Errorf("API key not configured for provider %s", providerKey)
+	}
 	model := cm.GetModel(providerKey, "")
 
 	messages := buildOpenAIMessages(req)
@@ -87,6 +90,9 @@ func chatViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKey,
 func streamViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKey, endpoint, agentName string, onChunk func(chunk string)) (*ChatResponse, error) {
 	cm := GetConfigManager()
 	apiKey := cm.GetAPIKey(providerKey)
+	if apiKey == "" {
+		return nil, fmt.Errorf("API key not configured for provider %s", providerKey)
+	}
 	model := cm.GetModel(providerKey, "")
 
 	messages := buildOpenAIMessages(req)
@@ -168,6 +174,10 @@ func streamViaOpenAICompatible(ctx context.Context, req *ChatRequest, providerKe
 				TotalTokens:  chunk.Usage.TotalTokens,
 			}
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("stream read error: %w", err)
 	}
 
 	return &ChatResponse{

--- a/pkg/api/handlers/analytics_proxy.go
+++ b/pkg/api/handlers/analytics_proxy.go
@@ -55,15 +55,16 @@ var gtagCache struct {
 func GA4ScriptProxy(c *fiber.Ctx) error {
 	qs := string(c.Context().QueryArgs().QueryString())
 
-	// Check cache
+	// Check cache — copy the body slice under lock to prevent TOCTOU races
 	gtagCache.RLock()
 	if gtagCache.body != nil && gtagCache.queryString == qs && time.Since(gtagCache.fetchedAt) < gtagCacheTTL {
-		body := gtagCache.body
+		bodyCopy := make([]byte, len(gtagCache.body))
+		copy(bodyCopy, gtagCache.body)
 		ct := gtagCache.contentType
 		gtagCache.RUnlock()
 		c.Set("Content-Type", ct)
 		c.Set("Cache-Control", "public, max-age=3600")
-		return c.Send(body)
+		return c.Send(bodyCopy)
 	}
 	gtagCache.RUnlock()
 
@@ -259,15 +260,16 @@ var umamiScriptCache struct {
 // console's own domain. The script is cached server-side to avoid
 // re-fetching on every page load.
 func UmamiScriptProxy(c *fiber.Ctx) error {
-	// Check cache
+	// Check cache — copy the body slice under lock to prevent TOCTOU races
 	umamiScriptCache.RLock()
 	if umamiScriptCache.body != nil && time.Since(umamiScriptCache.fetchedAt) < umamiScriptCacheTTL {
-		body := umamiScriptCache.body
+		bodyCopy := make([]byte, len(umamiScriptCache.body))
+		copy(bodyCopy, umamiScriptCache.body)
 		ct := umamiScriptCache.contentType
 		umamiScriptCache.RUnlock()
 		c.Set("Content-Type", ct)
 		c.Set("Cache-Control", "public, max-age=3600")
-		return c.Send(body)
+		return c.Send(bodyCopy)
 	}
 	umamiScriptCache.RUnlock()
 

--- a/pkg/api/handlers/github_proxy.go
+++ b/pkg/api/handlers/github_proxy.go
@@ -143,8 +143,9 @@ func (h *GitHubProxyHandler) Proxy(c *fiber.Ctx) error {
 		targetURL += "?" + string(qs)
 	}
 
-	// Create proxied request
-	req, err := http.NewRequest(http.MethodGet, targetURL, nil)
+	// Create proxied request with context propagation so cancellation
+	// from client disconnect stops the upstream call.
+	req, err := http.NewRequestWithContext(c.Context(), http.MethodGet, targetURL, nil)
 	if err != nil {
 		return c.Status(fiber.StatusBadGateway).JSON(fiber.Map{
 			"error": "Failed to create proxy request",

--- a/pkg/api/handlers/kagent_proxy.go
+++ b/pkg/api/handlers/kagent_proxy.go
@@ -91,6 +91,13 @@ func (h *KagentProxyHandler) Chat(c *fiber.Ctx) error {
 			w.Flush()
 		}
 
+		if err := scanner.Err(); err != nil {
+			// Stream was interrupted — send error event instead of [DONE]
+			fmt.Fprintf(w, "data: {\"error\": \"stream interrupted\"}\n\n")
+			w.Flush()
+			return
+		}
+
 		fmt.Fprintf(w, "data: [DONE]\n\n")
 		w.Flush()
 	})

--- a/pkg/api/handlers/kagenti_provider_proxy.go
+++ b/pkg/api/handlers/kagenti_provider_proxy.go
@@ -91,6 +91,13 @@ func (h *KagentiProviderProxyHandler) Chat(c *fiber.Ctx) error {
 			w.Flush()
 		}
 
+		if err := scanner.Err(); err != nil {
+			// Stream was interrupted — send error event instead of [DONE]
+			fmt.Fprintf(w, "data: {\"error\": \"stream interrupted\"}\n\n")
+			w.Flush()
+			return
+		}
+
 		fmt.Fprintf(w, "data: [DONE]\n\n")
 		w.Flush()
 	})

--- a/pkg/api/handlers/nightly_e2e.go
+++ b/pkg/api/handlers/nightly_e2e.go
@@ -169,6 +169,9 @@ func isAllowedRepo(repo string) bool {
 
 // NewNightlyE2EHandler creates a handler using the given GitHub token for API access.
 // It pre-warms the cache in the background so the first request returns instantly.
+// prewarmTimeout is the maximum time allowed for the background cache prewarm.
+const prewarmTimeout = 30 * time.Second
+
 func NewNightlyE2EHandler(githubToken string) *NightlyE2EHandler {
 	h := &NightlyE2EHandler{
 		githubToken: githubToken,
@@ -182,10 +185,31 @@ func NewNightlyE2EHandler(githubToken string) *NightlyE2EHandler {
 }
 
 func (h *NightlyE2EHandler) prewarm() {
-	resp, err := h.fetchAll()
-	if err != nil {
+	// Use a timeout to prevent this goroutine from blocking indefinitely
+	// if the GitHub API is slow or unreachable.
+	timer := time.NewTimer(prewarmTimeout)
+	defer timer.Stop()
+
+	done := make(chan struct{})
+	var resp *NightlyE2EResponse
+	var fetchErr error
+
+	go func() {
+		resp, fetchErr = h.fetchAll()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if fetchErr != nil {
+			slog.Error("[NightlyE2E] prewarm failed", "error", fetchErr)
+			return
+		}
+	case <-timer.C:
+		slog.Error("[NightlyE2E] prewarm timed out", "timeout", prewarmTimeout)
 		return
 	}
+
 	ttl := nightlyCacheIdleTTL
 	if hasInProgressRuns(resp.Guides) {
 		ttl = nightlyCacheActiveTTL

--- a/pkg/api/handlers/sse.go
+++ b/pkg/api/handlers/sse.go
@@ -26,14 +26,20 @@ type sseClusterStreamConfig struct {
 }
 
 // writeSSEEvent writes one SSE event to the buffered writer and flushes.
-func writeSSEEvent(w *bufio.Writer, eventName string, data interface{}) {
+// Returns an error if the write or flush fails (e.g., client disconnected).
+func writeSSEEvent(w *bufio.Writer, eventName string, data interface{}) error {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
 		slog.Error("[SSE] marshal error", "error", err)
-		return
+		return fmt.Errorf("marshal: %w", err)
 	}
-	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventName, jsonData)
-	w.Flush()
+	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventName, jsonData); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("flush: %w", err)
+	}
+	return nil
 }
 
 // sseOverallDeadline is the maximum wall-clock time an SSE stream stays open.

--- a/pkg/notifications/opsgenie.go
+++ b/pkg/notifications/opsgenie.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -106,7 +107,11 @@ func (o *OpsGenieNotifier) createAlert(alert Alert, alias string) error {
 	if err != nil {
 		return fmt.Errorf("failed to send opsgenie notification: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		// Drain the body so the underlying TCP connection can be reused.
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusCreated {
 		return fmt.Errorf("opsgenie API returned status %d", resp.StatusCode)
@@ -139,7 +144,11 @@ func (o *OpsGenieNotifier) closeAlert(alias string) error {
 	if err != nil {
 		return fmt.Errorf("failed to send opsgenie close: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		// Drain the body so the underlying TCP connection can be reused.
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("opsgenie close API returned status %d", resp.StatusCode)

--- a/pkg/notifications/pagerduty.go
+++ b/pkg/notifications/pagerduty.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -125,7 +126,11 @@ func (p *PagerDutyNotifier) sendEvent(event pagerdutyEvent) error {
 	if err != nil {
 		return fmt.Errorf("failed to send pagerduty notification: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		// Drain the body so the underlying TCP connection can be reused.
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusAccepted {
 		return fmt.Errorf("pagerduty API returned status %d", resp.StatusCode)

--- a/pkg/notifications/slack.go
+++ b/pkg/notifications/slack.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -155,7 +156,11 @@ func (s *SlackNotifier) sendSlackMessage(msg slackMessage) error {
 	if err != nil {
 		return fmt.Errorf("failed to send slack notification: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		// Drain the body so the underlying TCP connection can be reused.
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("slack API returned status %d", resp.StatusCode)

--- a/pkg/store/persistence_config.go
+++ b/pkg/store/persistence_config.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	configDirMode  = 0755
-	configFileMode = 0644
+	configDirMode  = 0700 // Owner read/write/execute only
+	configFileMode = 0600 // Owner read/write only — prevents other users from reading cluster config
 )
 
 // PersistenceConfig holds the configuration for CRD-based persistence

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -382,8 +382,19 @@ func (s *SQLiteStore) DeleteUser(id uuid.UUID) error {
 	return err
 }
 
-// UpdateUserRole updates only the user's role
+// validUserRoles is the set of allowed role values for user accounts.
+var validUserRoles = map[string]bool{
+	"admin":  true,
+	"editor": true,
+	"viewer": true,
+}
+
+// UpdateUserRole updates only the user's role after validating it against
+// the allowed set (admin, editor, viewer).
 func (s *SQLiteStore) UpdateUserRole(userID uuid.UUID, role string) error {
+	if !validUserRoles[role] {
+		return fmt.Errorf("invalid role %q: must be one of admin, editor, viewer", role)
+	}
 	_, err := s.db.Exec(`UPDATE users SET role = ? WHERE id = ?`, role, userID.String())
 	return err
 }


### PR DESCRIPTION
## Summary

Fixes 15 small Go backend bugs across the codebase:

- **Mutex safety**: Use `defer` for mutex unlock in ConfigManager methods to prevent deadlocks on panic (#4793)
- **Scanner errors**: Check `scanner.Err()` after streaming loops in OpenAI-compat provider and SSE proxies (#4794, #4800)
- **JSON marshal**: Handle marshal error in InsightWorker enrichment prompt instead of injecting corrupt data (#4795)
- **Role switch**: Add `default` case for unknown message roles in prompt builder (#4796)
- **HTTP status codes**: Set proper 400/500 status codes for error responses in kagent CRD handlers (#4797)
- **API key validation**: Reject empty API keys early with a clear error instead of sending "Bearer " (#4798)
- **Type assertions**: Use two-value form for K8s unstructured object type assertions (#4799)
- **SSE write errors**: Return errors from `writeSSEEvent` so callers can detect client disconnects (#4801)
- **Cache race**: Copy cached body slice under lock to prevent TOCTOU race in analytics proxy (#4802)
- **Context propagation**: Use `NewRequestWithContext` in GitHub proxy to cancel upstream on client disconnect (#4803)
- **Goroutine leak**: Add timeout and error logging to nightly E2E prewarm goroutine (#4804)
- **Role validation**: Validate role string against allowed set (admin/editor/viewer) in `UpdateUserRole` (#4805)
- **File permissions**: Tighten persistence config file permissions from 0644 to 0600 (#4806)
- **Connection reuse**: Drain HTTP response bodies before close in Slack/PagerDuty/OpsGenie notification clients (#4807)

Fixes #4793, #4794, #4795, #4796, #4797, #4798, #4799, #4800, #4801, #4802, #4803, #4804, #4805, #4806, #4807

## Test plan

- [x] `go build ./cmd/console/` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/store/...` passes (including UpdateUserRole tests)
- [x] `go test ./pkg/agent/...` passes
- [x] `go test ./pkg/notifications/...` passes
- [x] Pre-existing `TestDeleteWorkload` failure confirmed on main (not caused by this PR)