### PR TITLE
🐛 Wire isRefreshing in HelmReleaseStatus card

### DIFF
--- a/web/src/components/cards/HelmReleaseStatus.tsx
+++ b/web/src/components/cards/HelmReleaseStatus.tsx
@@ -55,6 +55,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
   const {
     releases: allHelmReleases,
     isLoading: releasesLoading,
+    isRefreshing,
     isFailed,
     consecutiveFailures,
     isDemoFallback: isDemoData,
@@ -63,6 +64,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
   // Report loading state to CardWrapper for skeleton/refresh behavior
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading || releasesLoading,
+    isRefreshing,
     hasAnyData: allHelmReleases.length > 0,
     isFailed,
     consecutiveFailures,

--- a/web/src/test/card-loading-standard.test.ts
+++ b/web/src/test/card-loading-standard.test.ts
@@ -108,7 +108,6 @@ const KNOWN_VIOLATIONS: Record<string, Set<string>> = {
   'GatewayStatus.tsx': new Set(['bare-isLoading']),
   'GPUStatus.tsx': new Set(['bare-isLoading']),
   'HelmHistory.tsx': new Set(['bare-isLoading']),
-  'HelmReleaseStatus.tsx': new Set(['missing-isRefreshing']),
   'insights/CrossClusterEventCorrelation.tsx': new Set(['missing-isRefreshing']),
   'kagenti/KagentiAgentDiscovery.tsx': new Set(['bare-isLoading']),
   'kagenti/KagentiAgentFleet.tsx': new Set(['bare-isLoading']),


### PR DESCRIPTION
## Summary
- Destructure `isRefreshing` from `useCachedHelmReleases()` and pass it to `useCardLoadingState()` so the refresh spinner animates during background data fetches
- Remove the `missing-isRefreshing` known-violation entry for `HelmReleaseStatus.tsx` from the card-loading-standard test

Fixes #4826

## Test plan
- [ ] Verify build passes (`npm run build`)
- [ ] Verify `HelmReleaseStatus.tsx` has no lint errors
- [ ] Confirm refresh spinner animates on the Helm Release Status card during background fetches