### PR TITLE
🐛 Wire missing isRefreshing in 7 cards

### DIFF
--- a/web/src/components/cards/ClusterFocus.tsx
+++ b/web/src/components/cards/ClusterFocus.tsx
@@ -19,9 +19,9 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
   const { t } = useTranslation(['cards', 'common'])
   const selectedCluster = config?.cluster
   const { deduplicatedClusters: allClusters, isLoading: clustersLoading, isRefreshing: clustersRefreshing, isFailed, consecutiveFailures } = useClusters()
-  const { nodes: gpuNodes, isDemoFallback: gpuDemoFallback } = useCachedGPUNodes()
-  const { issues: podIssues, isDemoFallback: podsDemoFallback } = useCachedPodIssues(selectedCluster)
-  const { issues: deploymentIssues, isDemoFallback: deployDemoFallback } = useCachedDeploymentIssues(selectedCluster)
+  const { nodes: gpuNodes, isDemoFallback: gpuDemoFallback, isRefreshing: gpuRefreshing } = useCachedGPUNodes()
+  const { issues: podIssues, isDemoFallback: podsDemoFallback, isRefreshing: podsRefreshing } = useCachedPodIssues(selectedCluster)
+  const { issues: deploymentIssues, isDemoFallback: deployDemoFallback, isRefreshing: deploymentsRefreshing } = useCachedDeploymentIssues(selectedCluster)
   const { drillToCluster, drillToPod, drillToDeployment } = useDrillDownActions()
   const [internalCluster, setInternalCluster] = useState<string>('')
   const { isDemoMode } = useDemoMode()
@@ -30,7 +30,7 @@ export function ClusterFocus({ config }: ClusterFocusProps) {
   const hasData = allClusters.length > 0
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: clustersLoading && !hasData,
-    isRefreshing: clustersRefreshing,
+    isRefreshing: clustersRefreshing || gpuRefreshing || podsRefreshing || deploymentsRefreshing,
     hasAnyData: hasData,
     isDemoData: isDemoMode || gpuDemoFallback || podsDemoFallback || deployDemoFallback,
     isFailed,

--- a/web/src/components/cards/ClusterHealth.tsx
+++ b/web/src/components/cards/ClusterHealth.tsx
@@ -88,7 +88,7 @@ export function ClusterHealth() {
     error,
     lastRefresh,
   } = useClusters()
-  const { nodes: gpuNodes, isDemoFallback } = useCachedGPUNodes()
+  const { nodes: gpuNodes, isDemoFallback, isRefreshing: gpuRefreshing } = useCachedGPUNodes()
   const { selectedClusters, isAllClustersSelected } = useGlobalFilters()
   const { isMobile } = useMobile()
   const { isDemoMode } = useDemoMode()
@@ -143,7 +143,7 @@ export function ClusterHealth() {
   const hasData = rawClusters.length > 0
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: isLoadingHook && !hasData,
-    isRefreshing,
+    isRefreshing: isRefreshing || gpuRefreshing,
     hasAnyData: hasData,
     isFailed: !!error && !hasData,
     consecutiveFailures: error ? 1 : 0,

--- a/web/src/components/cards/GPUNamespaceAllocations.tsx
+++ b/web/src/components/cards/GPUNamespaceAllocations.tsx
@@ -53,7 +53,7 @@ const NAMESPACE_SORT_COMPARATORS: Record<SortByOption, (a: NamespaceGPUAllocatio
 export function GPUNamespaceAllocations({ config: _config }: GPUNamespaceAllocationsProps) {
   const { t } = useTranslation(['cards', 'common'])
   const { nodes: gpuNodes, isLoading: gpuLoading, isRefreshing: gpuRefreshing, isDemoFallback: gpuNodesDemoFallback, isFailed: gpuFailed, consecutiveFailures: gpuFailures } = useCachedGPUNodes()
-  const { pods: allPods, isLoading: podsLoading, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedAllPods()
+  const { pods: allPods, isLoading: podsLoading, isRefreshing: podsRefreshing, isDemoFallback: podsDemoFallback, isFailed: podsFailed, consecutiveFailures: podsFailures } = useCachedAllPods()
   const { drillToGPUNamespace } = useDrillDownActions()
 
   // Combine all isDemoFallback values from cached hooks
@@ -64,7 +64,7 @@ export function GPUNamespaceAllocations({ config: _config }: GPUNamespaceAllocat
   const hasData = gpuNodes.length > 0 || allPods.length > 0
   useCardLoadingState({
     isLoading: (gpuLoading || podsLoading) && !hasData,
-    isRefreshing: gpuRefreshing,
+    isRefreshing: gpuRefreshing || podsRefreshing,
     hasAnyData: hasData,
     isDemoData,
     isFailed: gpuFailed || podsFailed,

--- a/web/src/components/cards/HelmHistory.tsx
+++ b/web/src/components/cards/HelmHistory.tsx
@@ -90,7 +90,7 @@ export function HelmHistory({ config }: HelmHistoryProps) {
   }, [globalSelectedClusters, isAllClustersSelected])
 
   // Fetch ALL Helm releases from all clusters once (not per-cluster)
-  const { releases: allHelmReleases, isLoading: releasesLoading, isDemoFallback: isDemoData } = useCachedHelmReleases()
+  const { releases: allHelmReleases, isLoading: releasesLoading, isRefreshing: releasesRefreshing, isDemoFallback: isDemoData } = useCachedHelmReleases()
 
   // Auto-select cluster and release in demo mode so card shows data immediately
   useEffect(() => {
@@ -134,7 +134,7 @@ export function HelmHistory({ config }: HelmHistoryProps) {
   // Note: Consider "hasAnyData" true when no release selected - we want to show selectors, not empty state
   const { showSkeleton, showEmptyState } = useCardLoadingState({
     isLoading: historyLoading,
-    isRefreshing: historyRefreshing,
+    isRefreshing: historyRefreshing || releasesRefreshing,
     hasAnyData: rawHistory.length > 0 || !selectedRelease,
     isFailed,
     consecutiveFailures,

--- a/web/src/components/cards/HelmValuesDiff.tsx
+++ b/web/src/components/cards/HelmValuesDiff.tsx
@@ -129,7 +129,7 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   }, [globalSelectedClusters, isAllClustersSelected])
 
   // Fetch ALL Helm releases from all clusters once (not per-cluster)
-  const { releases: allHelmReleases, isLoading: releasesLoading, isDemoFallback: isDemoData } = useCachedHelmReleases()
+  const { releases: allHelmReleases, isLoading: releasesLoading, isRefreshing: releasesRefreshing, isDemoFallback: isDemoData } = useCachedHelmReleases()
 
   // Auto-select first cluster and release in demo mode
   useEffect(() => {
@@ -171,7 +171,7 @@ export function HelmValuesDiff({ config }: HelmValuesDiffProps) {
   const hasClusterData = allClusters.length > 0
   useCardLoadingState({
     isLoading: clustersLoading && !hasClusterData,
-    isRefreshing: clustersRefreshing || valuesRefreshing,
+    isRefreshing: clustersRefreshing || releasesRefreshing || valuesRefreshing,
     hasAnyData: hasClusterData,
     isDemoData,
     isFailed: clustersFailed,

--- a/web/src/components/cards/NamespaceMonitor.tsx
+++ b/web/src/components/cards/NamespaceMonitor.tsx
@@ -133,13 +133,13 @@ export function NamespaceMonitor({ config: _config }: CardComponentProps) {
 
   // Fetch data for selected cluster
   const { namespaces, isDemoFallback: namespacesDemoFallback, isRefreshing: namespacesRefreshing } = useCachedNamespaces(selectedCluster || undefined)
-  const { deployments, isDemoFallback: deploymentsDemoFallback } = useCachedDeployments(selectedCluster || undefined)
-  const { services, isDemoFallback: servicesDemoFallback } = useCachedServices(selectedCluster || undefined)
-  const { pvcs, isDemoFallback: pvcsDemoFallback } = useCachedPVCs(selectedCluster || undefined)
-  const { pods, isDemoFallback: podsDemoFallback } = useCachedPods(selectedCluster || undefined, undefined, { limit: 500 })
-  const { configmaps, isDemoFallback: configmapsDemoFallback } = useCachedConfigMaps(selectedCluster || undefined)
-  const { secrets, isDemoFallback: secretsDemoFallback } = useCachedSecrets(selectedCluster || undefined)
-  const { jobs, isDemoFallback: jobsDemoFallback } = useCachedJobs(selectedCluster || undefined)
+  const { deployments, isDemoFallback: deploymentsDemoFallback, isRefreshing: deploymentsRefreshing } = useCachedDeployments(selectedCluster || undefined)
+  const { services, isDemoFallback: servicesDemoFallback, isRefreshing: servicesRefreshing } = useCachedServices(selectedCluster || undefined)
+  const { pvcs, isDemoFallback: pvcsDemoFallback, isRefreshing: pvcsRefreshing } = useCachedPVCs(selectedCluster || undefined)
+  const { pods, isDemoFallback: podsDemoFallback, isRefreshing: podsRefreshing } = useCachedPods(selectedCluster || undefined, undefined, { limit: 500 })
+  const { configmaps, isDemoFallback: configmapsDemoFallback, isRefreshing: configmapsRefreshing } = useCachedConfigMaps(selectedCluster || undefined)
+  const { secrets, isDemoFallback: secretsDemoFallback, isRefreshing: secretsRefreshing } = useCachedSecrets(selectedCluster || undefined)
+  const { jobs, isDemoFallback: jobsDemoFallback, isRefreshing: jobsRefreshing } = useCachedJobs(selectedCluster || undefined)
 
   // Combine all isDemoFallback values from cached hooks
   const isDemoData = namespacesDemoFallback || deploymentsDemoFallback || servicesDemoFallback ||
@@ -148,7 +148,7 @@ export function NamespaceMonitor({ config: _config }: CardComponentProps) {
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading,
-    isRefreshing: namespacesRefreshing,
+    isRefreshing: namespacesRefreshing || deploymentsRefreshing || servicesRefreshing || pvcsRefreshing || podsRefreshing || configmapsRefreshing || secretsRefreshing || jobsRefreshing,
     hasAnyData: clusters.length > 0,
     isDemoData: isDemoMode || isDemoData,
   })

--- a/web/src/components/cards/NamespaceQuotas.tsx
+++ b/web/src/components/cards/NamespaceQuotas.tsx
@@ -350,7 +350,7 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
   const [deleteConfirm, setDeleteConfirm] = useState<{ cluster: string; namespace: string; name: string } | null>(null)
 
   // Fetch namespaces for the selected cluster (only when specific cluster selected)
-  const { namespaces, isDemoFallback } = useCachedNamespaces(selectedCluster !== 'all' ? selectedCluster : undefined)
+  const { namespaces, isDemoFallback, isRefreshing: namespacesRefreshing } = useCachedNamespaces(selectedCluster !== 'all' ? selectedCluster : undefined)
 
   // Filter clusters based on global filter (useCardData handles global filtering internally)
   const clusters = allClusters
@@ -372,7 +372,7 @@ export function NamespaceQuotas({ config }: NamespaceQuotasProps) {
   // Report loading state to CardWrapper for skeleton/refresh behavior
   useCardLoadingState({
     isLoading: isInitialLoading || isFetchingData,
-    isRefreshing: clustersRefreshing,
+    isRefreshing: clustersRefreshing || namespacesRefreshing,
     hasAnyData: allClusters.length > 0 || resourceQuotas.length > 0 || limitRanges.length > 0,
     isDemoData: isDemoMode || isDemoFallback,
     isFailed: clustersFailed,


### PR DESCRIPTION
## Summary
- Destructure `isRefreshing` from all `useCached*` hooks and OR them together in `useCardLoadingState()` so the refresh spinner animates for every background data source, not just the first hook.
- **NamespaceMonitor**: 7 of 8 hooks were missing `isRefreshing` (#4839)
- **ClusterFocus**: 3 `useCached*` hooks were missing `isRefreshing` (#4840)
- **ClusterHealth**: `useCachedGPUNodes` was missing `isRefreshing` (#4843)
- **HelmHistory**: `useCachedHelmReleases` was missing `isRefreshing` (#4846)
- **HelmValuesDiff**: `useCachedHelmReleases` was missing `isRefreshing` (#4847)
- **GPUNamespaceAllocations**: `useCachedAllPods` was missing `isRefreshing` (#4850)
- **NamespaceQuotas**: `useCachedNamespaces` was missing `isRefreshing` (#4853)

Fixes #4839, #4840, #4843, #4846, #4847, #4850, #4853

## Test plan
- [x] `npm run build` passes
- [x] `card-loading-standard.test.ts` passes (646/646)
- [ ] Verify refresh spinner animates on each card when background data updates