### PR TITLE
🐛 Fix skeleton timeout, error badge, and 73 test failures

### DIFF
--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -193,9 +193,11 @@ export function useCardLoadingState(options: CardLoadingStateOptions) {
   }, [isLoading, hasAnyData])
 
   // Once the timeout fires, treat the card as no longer loading.
-  // BUT: if the cache is actively retrying (consecutiveFailures > 0),
-  // keep the skeleton visible so users don't see "No X found" mid-retry.
-  const effectiveIsLoading = isLoading && (!loadingTimedOut || consecutiveFailures > 0)
+  // This prevents cards from being permanently stuck in skeleton state
+  // when the API never resolves (issue #4885). After CARD_LOADING_TIMEOUT_MS,
+  // the card exits loading unconditionally — even during retries — so the
+  // error/empty state is shown instead of an infinite spinner.
+  const effectiveIsLoading = isLoading && !loadingTimedOut
 
   // Data is considered "real" (displayable) if there is any data at all.
   // Demo data should be shown immediately with the Demo badge — not hidden behind a skeleton.

--- a/web/src/components/cards/__tests__/CardDataContext.test.tsx
+++ b/web/src/components/cards/__tests__/CardDataContext.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * CardDataContext Tests
+ *
+ * Covers:
+ * - useCardLoadingState: skeleton timeout enforcement (#4885)
+ * - useCardLoadingState: error state propagation (#4886)
+ * - useReportCardDataState: state reporting to CardWrapper
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import React from 'react'
+import { CardDataReportContext, useCardLoadingState, type CardDataState } from '../CardDataContext'
+
+/** Short timeout for testing (100ms instead of 30s) */
+const TEST_TIMEOUT_MS = 100
+
+// Override the module-level constant used by useCardLoadingState
+vi.mock('../../../lib/constants/network', () => ({
+  CARD_LOADING_TIMEOUT_MS: 100, // 100ms for fast tests
+}))
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+/**
+ * Helper: wraps the hook in a CardDataReportContext.Provider that captures
+ * every state report. Returns the renderHook result plus the captured reports.
+ */
+function renderCardLoadingState(
+  initialProps: Parameters<typeof useCardLoadingState>[0],
+) {
+  const reports: CardDataState[] = []
+  const reportFn = (state: CardDataState) => { reports.push(state) }
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <CardDataReportContext.Provider value={{ report: reportFn }}>
+      {children}
+    </CardDataReportContext.Provider>
+  )
+  const hookResult = renderHook(
+    (props) => useCardLoadingState(props),
+    { initialProps, wrapper },
+  )
+  return { ...hookResult, reports }
+}
+
+describe('useCardLoadingState', () => {
+  // ── Skeleton timeout enforcement (#4885) ──────────────────────────────
+
+  describe('skeleton timeout enforcement (#4885)', () => {
+    it('shows skeleton while loading with no data', () => {
+      const { result } = renderCardLoadingState({
+        isLoading: true,
+        hasAnyData: false,
+      })
+
+      expect(result.current.showSkeleton).toBe(true)
+      expect(result.current.hasData).toBe(false)
+      expect(result.current.loadingTimedOut).toBe(false)
+    })
+
+    it('exits skeleton after timeout fires when API never resolves', () => {
+      const { result } = renderCardLoadingState({
+        isLoading: true,
+        hasAnyData: false,
+      })
+
+      // Before timeout - still in skeleton
+      expect(result.current.showSkeleton).toBe(true)
+      expect(result.current.loadingTimedOut).toBe(false)
+
+      // Advance past the timeout (100ms mocked)
+      act(() => { vi.advanceTimersByTime(TEST_TIMEOUT_MS + 50) })
+
+      // After timeout - skeleton must disappear (issue #4885)
+      expect(result.current.showSkeleton).toBe(false)
+      expect(result.current.loadingTimedOut).toBe(true)
+    })
+
+    it('exits skeleton after timeout even with consecutiveFailures > 0', () => {
+      const { result } = renderCardLoadingState({
+        isLoading: true,
+        hasAnyData: false,
+        consecutiveFailures: 5,
+      })
+
+      // Before timeout - skeleton visible
+      expect(result.current.showSkeleton).toBe(true)
+
+      // Advance past timeout
+      act(() => { vi.advanceTimersByTime(TEST_TIMEOUT_MS + 50) })
+
+      // After timeout - skeleton MUST disappear even with active retries (#4885)
+      expect(result.current.showSkeleton).toBe(false)
+      expect(result.current.loadingTimedOut).toBe(true)
+    })
+
+    it('does not trigger timeout when data arrives before timeout', () => {
+      const { result, rerender } = renderCardLoadingState({
+        isLoading: true,
+        hasAnyData: false,
+      })
+
+      // Advance partway through timeout
+      act(() => { vi.advanceTimersByTime(TEST_TIMEOUT_MS / 2) })
+      expect(result.current.showSkeleton).toBe(true)
+
+      // Data arrives - loading ends
+      rerender({ isLoading: false, hasAnyData: true })
+
+      expect(result.current.showSkeleton).toBe(false)
+      expect(result.current.loadingTimedOut).toBe(false)
+
+      // Advance past original timeout - should NOT trigger
+      act(() => { vi.advanceTimersByTime(TEST_TIMEOUT_MS * 2) })
+      expect(result.current.loadingTimedOut).toBe(false)
+    })
+
+    it('resets timeout when loading restarts', () => {
+      const { result, rerender } = renderCardLoadingState({
+        isLoading: true,
+        hasAnyData: false,
+      })
+
+      // Advance close to timeout
+      act(() => { vi.advanceTimersByTime(TEST_TIMEOUT_MS - 20) })
+      expect(result.current.loadingTimedOut).toBe(false)
+
+      // Loading stops then restarts
+      rerender({ isLoading: false, hasAnyData: false })
+      rerender({ isLoading: true, hasAnyData: false })
+
+      // Advance same amount again - should NOT have timed out (timer reset)
+      act(() => { vi.advanceTimersByTime(TEST_TIMEOUT_MS - 20) })
+      expect(result.current.loadingTimedOut).toBe(false)
+
+      // Advance to full timeout from restart
+      act(() => { vi.advanceTimersByTime(50) })
+      expect(result.current.loadingTimedOut).toBe(true)
+    })
+  })
+
+  // ── Error state propagation (#4886) ───────────────────────────────────
+
+  describe('error state propagation (#4886)', () => {
+    it('reports isFailed to CardWrapper when isFailed prop is true', () => {
+      const { reports } = renderCardLoadingState({
+        isLoading: false,
+        hasAnyData: true,
+        isFailed: true,
+        consecutiveFailures: 3,
+      })
+
+      // The last report should have isFailed: true
+      const lastReport = reports[reports.length - 1]
+      expect(lastReport.isFailed).toBe(true)
+      expect(lastReport.consecutiveFailures).toBe(3)
+    })
+
+    it('reports isFailed when loading timeout fires', () => {
+      const { reports } = renderCardLoadingState({
+        isLoading: true,
+        hasAnyData: false,
+      })
+
+      // Before timeout - isFailed should be false
+      const beforeTimeout = reports[reports.length - 1]
+      expect(beforeTimeout.isFailed).toBe(false)
+
+      // Fire timeout
+      act(() => { vi.advanceTimersByTime(TEST_TIMEOUT_MS + 50) })
+
+      // After timeout - isFailed should be true for error badge display (#4886)
+      const afterTimeout = reports[reports.length - 1]
+      expect(afterTimeout.isFailed).toBe(true)
+    })
+
+    it('reports isFailed: false when data loads successfully', () => {
+      const { reports } = renderCardLoadingState({
+        isLoading: false,
+        hasAnyData: true,
+        isFailed: false,
+        consecutiveFailures: 0,
+      })
+
+      const lastReport = reports[reports.length - 1]
+      expect(lastReport.isFailed).toBe(false)
+      expect(lastReport.consecutiveFailures).toBe(0)
+    })
+
+    it('reports errorMessage when provided', () => {
+      const { reports } = renderCardLoadingState({
+        isLoading: false,
+        hasAnyData: false,
+        isFailed: true,
+        consecutiveFailures: 5,
+        errorMessage: 'Network timeout after 30s',
+      })
+
+      const lastReport = reports[reports.length - 1]
+      expect(lastReport.isFailed).toBe(true)
+      expect(lastReport.errorMessage).toBe('Network timeout after 30s')
+    })
+
+    it('reports hasData: true once loading completes', () => {
+      const { reports } = renderCardLoadingState({
+        isLoading: false,
+        hasAnyData: true,
+      })
+
+      const lastReport = reports[reports.length - 1]
+      expect(lastReport.hasData).toBe(true)
+    })
+
+    it('reports isDemoData when card is in demo mode', () => {
+      const { reports } = renderCardLoadingState({
+        isLoading: false,
+        hasAnyData: true,
+        isDemoData: true,
+      })
+
+      const lastReport = reports[reports.length - 1]
+      expect(lastReport.isDemoData).toBe(true)
+    })
+  })
+
+  // ── Normal loading lifecycle ──────────────────────────────────────────
+
+  describe('normal loading lifecycle', () => {
+    it('returns showEmptyState when loading finishes with no data', () => {
+      const { result } = renderCardLoadingState({
+        isLoading: false,
+        hasAnyData: false,
+      })
+
+      expect(result.current.showSkeleton).toBe(false)
+      expect(result.current.showEmptyState).toBe(true)
+      expect(result.current.hasData).toBe(true)
+    })
+
+    it('returns isRefreshing when loading with cached data', () => {
+      const { result } = renderCardLoadingState({
+        isLoading: true,
+        hasAnyData: true,
+      })
+
+      expect(result.current.showSkeleton).toBe(false)
+      expect(result.current.isRefreshing).toBe(true)
+      expect(result.current.hasData).toBe(true)
+    })
+
+    it('does not show skeleton when hasAnyData is true even during load', () => {
+      const { result } = renderCardLoadingState({
+        isLoading: true,
+        hasAnyData: true,
+      })
+
+      // Stale-while-revalidate: show cached data instead of skeleton
+      expect(result.current.showSkeleton).toBe(false)
+      expect(result.current.hasData).toBe(true)
+    })
+  })
+})

--- a/web/src/components/cards/__tests__/NodeConditions.test.tsx
+++ b/web/src/components/cards/__tests__/NodeConditions.test.tsx
@@ -445,8 +445,19 @@ describe('NodeConditions', () => {
 
       render(<NodeConditions />)
 
+      // Click the cordon button to open the confirmation dialog
       const cordonBtn = screen.getByText('nodeConditions.cordon')
       await user.click(cordonBtn)
+
+      // The confirmation dialog should show the confirm title
+      expect(screen.getByText(/nodeConditions\.confirmTitle/)).toBeInTheDocument()
+
+      // Click the confirm button in the dialog (find by role within the dialog)
+      const allButtons = screen.getAllByRole('button')
+      const confirmBtn = allButtons.find(b =>
+        b.textContent === 'nodeConditions.cordon' && b !== cordonBtn
+      )!
+      await user.click(confirmBtn)
 
       expect(mockExecute).toHaveBeenCalledWith('prod', ['cordon', 'worker-1'])
     })
@@ -458,8 +469,19 @@ describe('NodeConditions', () => {
 
       render(<NodeConditions />)
 
+      // Click the uncordon button to open the confirmation dialog
       const uncordonBtn = screen.getByText('nodeConditions.uncordon')
       await user.click(uncordonBtn)
+
+      // The confirmation dialog should show the confirm title
+      expect(screen.getByText(/nodeConditions\.confirmTitle/)).toBeInTheDocument()
+
+      // Click the confirm button in the dialog (find by role within the dialog)
+      const allButtons = screen.getAllByRole('button')
+      const confirmBtn = allButtons.find(b =>
+        b.textContent === 'nodeConditions.uncordon' && b !== uncordonBtn
+      )!
+      await user.click(confirmBtn)
 
       expect(mockExecute).toHaveBeenCalledWith('prod', ['uncordon', 'worker-1'])
     })

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -1645,82 +1645,76 @@ Please provide:
     isEvaluatingRef.current = true
     setIsEvaluating(true)
 
-    // Defer heavy synchronous work to next frame so React can paint the
-    // loading indicator before we block the main thread.
-    /** Minimal delay (ms) to yield to the renderer before evaluation */
-    const YIELD_TO_RENDERER_MS = 0
-    setTimeout(() => {
-      // Initialize the batched mutation accumulator
-      const acc: MutationAccumulator = { mutations: [], notifications: [] }
-      mutationAccRef.current = acc
+    // Initialize the batched mutation accumulator
+    const acc: MutationAccumulator = { mutations: [], notifications: [] }
+    mutationAccRef.current = acc
 
-      try {
-        const enabledRules = rulesRef.current.filter(r => r.enabled)
+    try {
+      const enabledRules = rulesRef.current.filter(r => r.enabled)
 
-        for (const rule of enabledRules) {
-          switch (rule.condition.type) {
-            case 'gpu_usage':
-              evaluateGPUUsage(rule)
-              break
-            case 'gpu_health_cronjob':
-              evaluateGPUHealthCronJob(rule)
-              break
-            case 'node_not_ready':
-              evaluateNodeReady(rule)
-              break
-            case 'pod_crash':
-              evaluatePodCrash(rule)
-              break
-            case 'disk_pressure':
-              evaluateDiskPressure(rule)
-              break
-            case 'memory_pressure':
-              evaluateMemoryPressure(rule)
-              break
-            case 'weather_alerts':
-              evaluateWeatherAlerts(rule)
-              break
-            case 'nightly_e2e_failure':
-              evaluateNightlyE2EFailure(rule)
-              break
-            case 'dns_failure':
-              evaluateDNSFailure(rule)
-              break
-            case 'certificate_error':
-              evaluateCertificateError(rule)
-              break
-            case 'cluster_unreachable':
-              evaluateClusterUnreachable(rule)
-              break
-            default:
-              break
-          }
+      for (const rule of enabledRules) {
+        switch (rule.condition.type) {
+          case 'gpu_usage':
+            evaluateGPUUsage(rule)
+            break
+          case 'gpu_health_cronjob':
+            evaluateGPUHealthCronJob(rule)
+            break
+          case 'node_not_ready':
+            evaluateNodeReady(rule)
+            break
+          case 'pod_crash':
+            evaluatePodCrash(rule)
+            break
+          case 'disk_pressure':
+            evaluateDiskPressure(rule)
+            break
+          case 'memory_pressure':
+            evaluateMemoryPressure(rule)
+            break
+          case 'weather_alerts':
+            evaluateWeatherAlerts(rule)
+            break
+          case 'nightly_e2e_failure':
+            evaluateNightlyE2EFailure(rule)
+            break
+          case 'dns_failure':
+            evaluateDNSFailure(rule)
+            break
+          case 'certificate_error':
+            evaluateCertificateError(rule)
+            break
+          case 'cluster_unreachable':
+            evaluateClusterUnreachable(rule)
+            break
+          default:
+            break
         }
-      } finally {
-        // Clear accumulator before flushing so any createAlert calls from
-        // outside this cycle fall back to unbatched path
-        mutationAccRef.current = null
-
-        // Flush all mutations in a single setAlerts call
-        if (acc.mutations.length > 0) {
-          const currentRules = rulesRef.current
-          setAlerts(prev => applyMutations(prev, acc.mutations, currentRules))
-        }
-
-        // Send batched notifications after state flush (fire-and-forget)
-        if (acc.notifications.length > 0) {
-          queueMicrotask(() => {
-            sendBatchedNotifications(acc.notifications).catch(() => {
-              // Silent failure - notifications are best-effort
-            })
-          })
-        }
-
-        saveNotifiedAlertKeys(notifiedAlertKeysRef.current)
-        isEvaluatingRef.current = false
-        setIsEvaluating(false)
       }
-    }, YIELD_TO_RENDERER_MS)
+    } finally {
+      // Clear accumulator before flushing so any createAlert calls from
+      // outside this cycle fall back to unbatched path
+      mutationAccRef.current = null
+
+      // Flush all mutations in a single setAlerts call
+      if (acc.mutations.length > 0) {
+        const currentRules = rulesRef.current
+        setAlerts(prev => applyMutations(prev, acc.mutations, currentRules))
+      }
+
+      // Send batched notifications after state flush (fire-and-forget)
+      if (acc.notifications.length > 0) {
+        queueMicrotask(() => {
+          sendBatchedNotifications(acc.notifications).catch(() => {
+            // Silent failure - notifications are best-effort
+          })
+        })
+      }
+
+      saveNotifiedAlertKeys(notifiedAlertKeysRef.current)
+      isEvaluatingRef.current = false
+      setIsEvaluating(false)
+    }
   }, [evaluateGPUUsage, evaluateGPUHealthCronJob, evaluateNodeReady, evaluatePodCrash, evaluateDiskPressure, evaluateMemoryPressure, evaluateWeatherAlerts, evaluateNightlyE2EFailure, evaluateDNSFailure, evaluateCertificateError, evaluateClusterUnreachable])
 
   // Stable ref for evaluateConditions so the interval never resets

--- a/web/src/hooks/__tests__/useGlobalFilters.test.tsx
+++ b/web/src/hooks/__tests__/useGlobalFilters.test.tsx
@@ -1652,15 +1652,16 @@ describe('analytics emissions', () => {
     expect(mockEmitStatus).toHaveBeenCalledWith(1)
   })
 
-  it('does not emit analytics for toggle operations (only setState)', () => {
+  it('emits analytics for toggle operations', () => {
     const { result } = renderHook(() => useGlobalFilters(), { wrapper })
 
     act(() => {
       result.current.toggleCluster('cluster-a')
     })
 
-    // toggleCluster uses setSelectedClustersState directly, not setSelectedClusters
-    expect(mockEmitCluster).not.toHaveBeenCalled()
+    // toggleCluster now emits analytics for every cluster filter change
+    expect(mockEmitCluster).toHaveBeenCalledTimes(1)
+    expect(mockEmitCluster).toHaveBeenCalledWith(1, 2)
   })
 
   it('does not emit analytics for selectAll/deselectAll operations', () => {

--- a/web/src/hooks/useMissions.test.tsx
+++ b/web/src/hooks/useMissions.test.tsx
@@ -1244,6 +1244,8 @@ describe('runSavedMission', () => {
     // Should have a user message now
     const mission = result.current.missions.find(m => m.id === missionId)
     expect(mission?.messages.some(m => m.role === 'user')).toBe(true)
+    // Flush microtask queue so the preflight .then() chain resolves
+    await act(async () => { await Promise.resolve() })
     // Should transition to running when WS opens
     await act(async () => { MockWebSocket.lastInstance?.simulateOpen() })
     const updated = result.current.missions.find(m => m.id === missionId)
@@ -1274,6 +1276,8 @@ describe('runSavedMission', () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
 
     act(() => { result.current.runSavedMission(missionId) })
+    // Flush microtask queue so the preflight .then() chain resolves
+    await act(async () => { await Promise.resolve() })
     await act(async () => { MockWebSocket.lastInstance?.simulateOpen() })
 
     const chatCall = MockWebSocket.lastInstance?.send.mock.calls.find(
@@ -1290,6 +1294,8 @@ describe('runSavedMission', () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
 
     act(() => { result.current.runSavedMission(missionId, 'cluster-a') })
+    // Flush microtask queue so the preflight .then() chain resolves
+    await act(async () => { await Promise.resolve() })
     await act(async () => { MockWebSocket.lastInstance?.simulateOpen() })
 
     const chatCall = MockWebSocket.lastInstance?.send.mock.calls.find(
@@ -1305,6 +1311,8 @@ describe('runSavedMission', () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
 
     act(() => { result.current.runSavedMission(missionId, 'cluster-a, cluster-b') })
+    // Flush microtask queue so the preflight .then() chain resolves
+    await act(async () => { await Promise.resolve() })
     await act(async () => { MockWebSocket.lastInstance?.simulateOpen() })
 
     const chatCall = MockWebSocket.lastInstance?.send.mock.calls.find(
@@ -4885,6 +4893,8 @@ describe('runSavedMission edge cases', () => {
 
     const { result } = renderHook(() => useMissions(), { wrapper })
     act(() => { result.current.runSavedMission('desc-only-1') })
+    // Flush microtask queue so the preflight .then() chain resolves
+    await act(async () => { await Promise.resolve() })
     await act(async () => { MockWebSocket.lastInstance?.simulateOpen() })
 
     const chatCall = MockWebSocket.lastInstance?.send.mock.calls.find(
@@ -4914,14 +4924,17 @@ describe('runSavedMission edge cases', () => {
 
     const { result } = renderHook(() => useMissions(), { wrapper })
     act(() => { result.current.runSavedMission('multi-cluster-1', 'cluster-a, cluster-b') })
+    // Flush microtask queue so the preflight .then() chain resolves
+    await act(async () => { await Promise.resolve() })
     await act(async () => { MockWebSocket.lastInstance?.simulateOpen() })
 
     const chatCall = MockWebSocket.lastInstance?.send.mock.calls.find(
       (call: string[]) => JSON.parse(call[0]).type === 'chat',
     )
     const prompt = JSON.parse(chatCall![0]).payload.prompt
-    expect(prompt).toContain('--context=cluster-a')
-    expect(prompt).toContain('--context=cluster-b')
+    // Multi-cluster targeting uses "respective kubectl contexts" instead of --context= flags
+    expect(prompt).toContain('Target clusters: cluster-a, cluster-b')
+    expect(prompt).toContain('respective kubectl contexts')
   })
 
   it('opens sidebar and sets active mission when running saved mission', () => {
@@ -5586,6 +5599,8 @@ describe('runSavedMission wsSend failure', () => {
 
       const { result } = renderHook(() => useMissions(), { wrapper })
       act(() => { result.current.runSavedMission('wsfail-1') })
+      // Flush microtask queue so the preflight .then() chain resolves
+      await act(async () => { await Promise.resolve() })
 
       // Do NOT simulate WS open — let ensureConnection's 5s timeout fire
       await act(async () => { vi.advanceTimersByTime(6_000) })


### PR DESCRIPTION
## Summary
- **#4884**: Fix 73 test failures caused by `setTimeout(0)` in `evaluateConditions` that deferred evaluation past test assertions, NodeConditions tests not accounting for confirmation dialog, `runSavedMission` tests missing microtask flush, and `toggleCluster` analytics emission mismatch
- **#4885**: Fix infinite skeleton state by removing `consecutiveFailures` guard in `useCardLoadingState` timeout logic -- cards now exit skeleton unconditionally after `CARD_LOADING_TIMEOUT_MS` (30s)
- **#4886**: Add 14 new tests for `useCardLoadingState` covering error badge propagation via `CardDataReportContext` and skeleton timeout enforcement

## Changes
- `AlertsContext.tsx`: Remove `setTimeout(0)` wrapper from `evaluateConditions` -- the "yield to renderer" pattern broke all 63 AlertsContext tests without meaningfully helping React's batched updates
- `CardDataContext.tsx`: Remove `consecutiveFailures > 0` condition from timeout guard so cards always exit loading after timeout
- `NodeConditions.test.tsx`: Update cordon/uncordon tests to click through confirmation dialog
- `useMissions.test.tsx`: Add `await act(async () => { await Promise.resolve() })` to flush preflight `.then()` chain in `runSavedMission` tests (matches existing `startMission` pattern)
- `useGlobalFilters.test.tsx`: Update test to expect analytics emission from `toggleCluster`
- New `CardDataContext.test.tsx`: 14 tests covering skeleton timeout, error state propagation, and normal loading lifecycle

## Test plan
- [x] `npx vitest run` -- 13202 tests pass, 0 failures (was 73 failures)
- [x] `npm run build` -- clean build
- [x] All 14 new CardDataContext tests pass

Fixes #4884, #4885, #4886