### PR TITLE
🐛 Fix blank card empty state and persist collapse/expand state

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -515,14 +515,31 @@ export function CardWrapper({
   const collapseKey = cardId || `${cardType}-default`
   const { isCollapsed: hookCollapsed, setCollapsed: hookSetCollapsed } = useCardCollapse(collapseKey)
 
+  // Check if this card has a previously-saved collapse state in localStorage.
+  // When the user explicitly collapsed a card, we should respect that immediately
+  // on page navigation (no delay) to prevent a flash of expanded state (#4895).
+  const hasSavedCollapseState = useMemo(() => {
+    try {
+      const stored = localStorage.getItem('kubestellar-collapsed-cards')
+      if (!stored) return false
+      const ids: string[] = JSON.parse(stored)
+      return ids.includes(collapseKey)
+    } catch {
+      return false
+    }
+  }, [collapseKey])
+
   // Track whether initial data load has completed AND content has been visible
-  const [hasCompletedInitialLoad, setHasCompletedInitialLoad] = useState(checkIsDemoMode)
-  const [collapseDelayPassed, setCollapseDelayPassed] = useState(checkIsDemoMode)
+  // Skip the delay entirely if the card has a saved collapsed state — the user
+  // explicitly collapsed it, so we should respect that immediately across navigations.
+  const [hasCompletedInitialLoad, setHasCompletedInitialLoad] = useState(checkIsDemoMode || hasSavedCollapseState)
+  const [collapseDelayPassed, setCollapseDelayPassed] = useState(checkIsDemoMode || hasSavedCollapseState)
 
   // Allow external control to override hook state
   // IMPORTANT: Don't collapse until initial data load is complete AND a brief delay has passed
   // This prevents the jarring sequence of: skeleton → collapse → show data
   // Cards stay expanded showing content briefly, then respect collapsed state
+  // Exception: if the card has a saved collapse state, apply it immediately (#4895)
   const savedCollapsedState = externalCollapsed ?? hookCollapsed
   const isCollapsed = (hasCompletedInitialLoad && collapseDelayPassed) ? savedCollapsedState : false
   const setCollapsed = useCallback((collapsed: boolean) => {
@@ -1116,11 +1133,38 @@ export function CardWrapper({
                         )}
                       </div>
                     )}
+                    {/* Fallback empty state: when a card finishes loading but has no data,
+                    show a helpful empty state instead of a blank card (#4894).
+                    This catches cards that don't implement their own showEmptyState check.
+                    Conditions: child reported state, not loading, no data, and timeout hasn't fired. */}
+                    {childDataState && !childDataState.isLoading && !childDataState.hasData && !cardLoadingTimedOut && (
+                      <div className="h-full flex flex-col items-center justify-center p-4 text-center" data-card-empty-state="true">
+                        <div className="w-12 h-12 rounded-full bg-secondary flex items-center justify-center mb-3">
+                          <Info className="w-6 h-6 text-muted-foreground" />
+                        </div>
+                        <p className="text-sm font-medium text-foreground mb-1">
+                          {t('cardWrapper.noDataTitle')}
+                        </p>
+                        <p className="text-xs text-muted-foreground mb-3 max-w-xs">
+                          {t('cardWrapper.noDataMessage')}
+                        </p>
+                        {onRefresh && (
+                          <button
+                            onClick={onRefresh}
+                            className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md bg-secondary hover:bg-secondary/80 text-foreground transition-colors"
+                          >
+                            <RefreshCw className="w-3 h-3" />
+                            {t('cardWrapper.loadingTimedOutRetry')}
+                          </button>
+                        )}
+                      </div>
+                    )}
                     {/* ALWAYS render children so they can report their data state via useCardLoadingState.
-                    Hide visually when skeleton is showing or loading timed out, but keep mounted so useLayoutEffect runs.
+                    Hide visually when skeleton is showing, loading timed out, or empty state is shown,
+                    but keep mounted so useLayoutEffect runs.
                     This prevents the deadlock where CardWrapper waits for hasData but children never mount.
                     Suspense catches lazy() chunk loading so it doesn't bubble up to Layout and blank the whole page. */}
-                    <div className={(shouldShowSkeleton || (cardLoadingTimedOut && !childDataState?.hasData)) ? 'hidden' : 'contents'}>
+                    <div className={(shouldShowSkeleton || (cardLoadingTimedOut && !childDataState?.hasData) || (childDataState && !childDataState.isLoading && !childDataState.hasData && !cardLoadingTimedOut)) ? 'hidden' : 'contents'}>
                       <DynamicCardErrorBoundary cardId={cardId || cardType}>
                         <Suspense fallback={<CardSkeleton type={effectiveSkeletonType} rows={skeletonRows || 3} showHeader={false} />}>
                           {children}

--- a/web/src/locales/de/cards.json
+++ b/web/src/locales/de/cards.json
@@ -576,7 +576,9 @@
     "snoozeTooltip": "Delay this swap for 1 hour",
     "swapNowTooltip": "Swap to the new card immediately",
     "keepThisTooltip": "Cancel the swap and keep this card",
-    "cardInfo": "Card information"
+    "cardInfo": "Card information",
+    "noDataTitle": "No data available",
+    "noDataMessage": "This card has no data to display. Data may become available when the data source is connected."
   },
   "github": {
     "pullRequests": "Pull Requests",

--- a/web/src/locales/en/cards.json
+++ b/web/src/locales/en/cards.json
@@ -591,7 +591,9 @@
     "snoozeTooltip": "Delay this swap for 1 hour",
     "swapNowTooltip": "Swap to the new card immediately",
     "keepThisTooltip": "Cancel the swap and keep this card",
-    "cardInfo": "Card information"
+    "cardInfo": "Card information",
+    "noDataTitle": "No data available",
+    "noDataMessage": "This card has no data to display. Data may become available when the data source is connected."
   },
   "github": {
     "pullRequests": "Pull Requests",

--- a/web/src/locales/es/cards.json
+++ b/web/src/locales/es/cards.json
@@ -576,7 +576,9 @@
     "snoozeTooltip": "Delay this swap for 1 hour",
     "swapNowTooltip": "Swap to the new card immediately",
     "keepThisTooltip": "Cancel the swap and keep this card",
-    "cardInfo": "Card information"
+    "cardInfo": "Card information",
+    "noDataTitle": "No data available",
+    "noDataMessage": "This card has no data to display. Data may become available when the data source is connected."
   },
   "github": {
     "pullRequests": "Pull Requests",

--- a/web/src/locales/fr/cards.json
+++ b/web/src/locales/fr/cards.json
@@ -576,7 +576,9 @@
     "snoozeTooltip": "Delay this swap for 1 hour",
     "swapNowTooltip": "Swap to the new card immediately",
     "keepThisTooltip": "Cancel the swap and keep this card",
-    "cardInfo": "Card information"
+    "cardInfo": "Card information",
+    "noDataTitle": "No data available",
+    "noDataMessage": "This card has no data to display. Data may become available when the data source is connected."
   },
   "github": {
     "pullRequests": "Pull Requests",

--- a/web/src/locales/hi/cards.json
+++ b/web/src/locales/hi/cards.json
@@ -576,7 +576,9 @@
     "snoozeTooltip": "Delay this swap for 1 hour",
     "swapNowTooltip": "Swap to the new card immediately",
     "keepThisTooltip": "Cancel the swap and keep this card",
-    "cardInfo": "Card information"
+    "cardInfo": "Card information",
+    "noDataTitle": "No data available",
+    "noDataMessage": "This card has no data to display. Data may become available when the data source is connected."
   },
   "github": {
     "pullRequests": "Pull Requests",

--- a/web/src/locales/it/cards.json
+++ b/web/src/locales/it/cards.json
@@ -576,7 +576,9 @@
     "snoozeTooltip": "Delay this swap for 1 hour",
     "swapNowTooltip": "Swap to the new card immediately",
     "keepThisTooltip": "Cancel the swap and keep this card",
-    "cardInfo": "Card information"
+    "cardInfo": "Card information",
+    "noDataTitle": "No data available",
+    "noDataMessage": "This card has no data to display. Data may become available when the data source is connected."
   },
   "github": {
     "pullRequests": "Pull Requests",

--- a/web/src/locales/ja/cards.json
+++ b/web/src/locales/ja/cards.json
@@ -576,7 +576,9 @@
     "snoozeTooltip": "Delay this swap for 1 hour",
     "swapNowTooltip": "Swap to the new card immediately",
     "keepThisTooltip": "Cancel the swap and keep this card",
-    "cardInfo": "Card information"
+    "cardInfo": "Card information",
+    "noDataTitle": "No data available",
+    "noDataMessage": "This card has no data to display. Data may become available when the data source is connected."
   },
   "github": {
     "pullRequests": "Pull Requests",

--- a/web/src/locales/pt/cards.json
+++ b/web/src/locales/pt/cards.json
@@ -576,7 +576,9 @@
     "snoozeTooltip": "Delay this swap for 1 hour",
     "swapNowTooltip": "Swap to the new card immediately",
     "keepThisTooltip": "Cancel the swap and keep this card",
-    "cardInfo": "Card information"
+    "cardInfo": "Card information",
+    "noDataTitle": "No data available",
+    "noDataMessage": "This card has no data to display. Data may become available when the data source is connected."
   },
   "github": {
     "pullRequests": "Pull Requests",

--- a/web/src/locales/zh/cards.json
+++ b/web/src/locales/zh/cards.json
@@ -576,7 +576,9 @@
     "snoozeTooltip": "Delay this swap for 1 hour",
     "swapNowTooltip": "Swap to the new card immediately",
     "keepThisTooltip": "Cancel the swap and keep this card",
-    "cardInfo": "Card information"
+    "cardInfo": "Card information",
+    "noDataTitle": "No data available",
+    "noDataMessage": "This card has no data to display. Data may become available when the data source is connected."
   },
   "github": {
     "pullRequests": "Pull Requests",


### PR DESCRIPTION
## Summary

- **#4894 — Blank cards when data is empty:** CardWrapper now renders a fallback empty state (icon, "No data available" message, retry button) when a card finishes loading but reports no data. This catches cards that don't implement their own `showEmptyState` check. Children remain mounted (hidden) so they resume when data arrives.

- **#4895 — Collapse state lost on navigation:** When a card has a saved collapse state in localStorage (user explicitly collapsed it), the delay mechanism that prevents skeleton-then-collapse jank on first load is now skipped. The collapsed state applies immediately on route changes, eliminating the flash of expanded content.

## Changes

- `CardWrapper.tsx`: Added `hasSavedCollapseState` memo that reads localStorage to detect previously-collapsed cards. When found, `hasCompletedInitialLoad` and `collapseDelayPassed` start as `true`, applying the saved state instantly. Added fallback empty state UI when `childDataState` reports no data and no loading.
- All 9 locale `cards.json` files: Added `cardWrapper.noDataTitle` and `cardWrapper.noDataMessage` translation keys.

## Test plan

- [ ] Collapse a card, navigate away, return — card should remain collapsed
- [ ] Refresh the page with a collapsed card — card should load collapsed without flash
- [ ] Return `[]` from an API endpoint — card should show "No data available" instead of blank
- [ ] Cards that implement their own `showEmptyState` should still use their custom empty state (children render, CardWrapper fallback is hidden via `hidden` class)
- [ ] Click "Retry" on the empty state — should trigger refresh

Fixes #4894, #4895