### PR TITLE
🐛 Fix dev startup scripts to handle stale port processes

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -4,38 +4,10 @@
 set -e
 
 PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$PROJECT_DIR"
 
-# Safely kill a project process on a port. Unrelated processes are warned and
-# left running to avoid disrupting non-project services.
-kill_project_port() {
-    local port="$1"
-    local pids
-    pids=$(lsof -ti ":${port}" 2>/dev/null || true)
-    [ -z "$pids" ] && return 0
-
-    local to_kill=()
-    for pid in $pids; do
-        local cmd
-        cmd=$(ps -p "$pid" -o args= 2>/dev/null || true)
-        if echo "$cmd" | grep -qF "$PROJECT_DIR" \
-           || echo "$cmd" | grep -q "cmd/console" \
-           || echo "$cmd" | grep -q "kc-agent"; then
-            to_kill+=("$pid")
-            echo -e "${YELLOW}Stopping project process on port ${port} (PID ${pid})...${NC}"
-            kill -TERM "$pid" 2>/dev/null || true
-        else
-            echo -e "${YELLOW}Warning: Port ${port} is in use by an unrelated process (PID ${pid}: ${cmd:-unknown}). Skipping.${NC}"
-        fi
-    done
-
-    [ ${#to_kill[@]} -eq 0 ] && return 0
-    sleep 2
-
-    # Fall back to SIGKILL for project processes that did not exit gracefully
-    for pid in "${to_kill[@]}"; do
-        kill -9 "$pid" 2>/dev/null || true
-    done
-}
+# Load shared port cleanup utilities (kill_project_port, verify_port_free)
+source "$PROJECT_DIR/scripts/port-cleanup.sh"
 
 # Colors
 RED='\033[0;31m'
@@ -88,6 +60,13 @@ echo ""
 # Clear project processes on required ports; unrelated services are left running
 kill_project_port "$PORT"
 kill_project_port 5174
+
+# Verify all required ports are free before proceeding
+for p in $PORT 5174; do
+    if ! verify_port_free "$p"; then
+        exit 1
+    fi
+done
 
 # Function to cleanup on exit
 cleanup() {

--- a/scripts/port-cleanup.sh
+++ b/scripts/port-cleanup.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# KubeStellar Console — Shared Port Cleanup Utilities
+#
+# Provides kill_project_port() and verify_port_free() for all startup scripts.
+# Source this file: source "$(dirname "$0")/scripts/port-cleanup.sh"
+#
+# kill_project_port <port> [tcp_state]
+#   Finds processes on the given port, kills project-owned ones (matching
+#   SCRIPT_DIR, cmd/console, or kc-agent), and warns about unrelated ones.
+#
+# verify_port_free <port>
+#   Returns 0 if the port is available, 1 if still occupied (prints error).
+
+# Maximum seconds to wait for a process to exit after SIGTERM
+GRACEFUL_SHUTDOWN_WAIT_SECS=3
+
+# Safely kill a project process on a port. Unrelated processes are warned and
+# left running to avoid disrupting non-project services. An optional second
+# argument restricts lsof to a TCP state (e.g. "TCP:LISTEN") so watchdog
+# outgoing connections are not matched.
+kill_project_port() {
+    local port="$1"
+    local tcp_state="${2:-}"
+    local pids
+
+    if [ -n "$tcp_state" ]; then
+        pids=$(lsof -ti ":${port}" -s "${tcp_state}" 2>/dev/null || true)
+    else
+        pids=$(lsof -ti ":${port}" 2>/dev/null || true)
+    fi
+    [ -z "$pids" ] && return 0
+
+    local to_kill=()
+    for pid in $pids; do
+        local cmd
+        cmd=$(ps -p "$pid" -o args= 2>/dev/null || true)
+        # Match project processes by script directory, Go binary path, or agent name
+        if echo "$cmd" | grep -qF "${SCRIPT_DIR:-__no_match__}" \
+           || echo "$cmd" | grep -q "cmd/console" \
+           || echo "$cmd" | grep -q "kc-agent" \
+           || echo "$cmd" | grep -q "kubestellar.*console"; then
+            to_kill+=("$pid")
+            echo -e "${YELLOW:-}Stopping stale project process on port ${port} (PID ${pid})...${NC:-}"
+            kill -TERM "$pid" 2>/dev/null || true
+        else
+            echo -e "${YELLOW:-}Warning: Port ${port} is in use by an unrelated process (PID ${pid}: ${cmd:-unknown}). Skipping.${NC:-}"
+        fi
+    done
+
+    [ ${#to_kill[@]} -eq 0 ] && return 0
+
+    # Wait for graceful shutdown before resorting to SIGKILL
+    local waited=0
+    while [ $waited -lt $GRACEFUL_SHUTDOWN_WAIT_SECS ]; do
+        local all_exited=true
+        for pid in "${to_kill[@]}"; do
+            if kill -0 "$pid" 2>/dev/null; then
+                all_exited=false
+                break
+            fi
+        done
+        if [ "$all_exited" = true ]; then
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    # Fall back to SIGKILL for project processes that did not exit gracefully
+    for pid in "${to_kill[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            echo -e "${YELLOW:-}Force-killing stale process on port ${port} (PID ${pid})...${NC:-}"
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    done
+
+    # Brief wait for SIGKILL to take effect
+    sleep 1
+}
+
+# Verify a port is free after cleanup. Returns 0 if free, 1 if occupied.
+# Prints an actionable error message when the port is blocked.
+verify_port_free() {
+    local port="$1"
+    local tcp_state="${2:-}"
+    local pids
+
+    if [ -n "$tcp_state" ]; then
+        pids=$(lsof -ti ":${port}" -s "${tcp_state}" 2>/dev/null || true)
+    else
+        pids=$(lsof -ti ":${port}" 2>/dev/null || true)
+    fi
+
+    if [ -n "$pids" ]; then
+        echo -e "${RED:-}Error: Port ${port} is still in use after cleanup.${NC:-}"
+        for pid in $pids; do
+            local cmd
+            cmd=$(ps -p "$pid" -o args= 2>/dev/null || true)
+            echo -e "${RED:-}  PID ${pid}: ${cmd:-unknown}${NC:-}"
+        done
+        echo -e "${RED:-}Manually stop the process(es) above, then try again:${NC:-}"
+        echo -e "${RED:-}  kill ${pids}${NC:-}"
+        return 1
+    fi
+    return 0
+}

--- a/scripts/prod.sh
+++ b/scripts/prod.sh
@@ -7,37 +7,8 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_DIR="$( dirname "$SCRIPT_DIR" )"
 
-# Safely kill a project process on a port. Unrelated processes are warned and
-# left running to avoid disrupting non-project services.
-kill_project_port() {
-    local port="$1"
-    local pids
-    pids=$(lsof -ti ":${port}" 2>/dev/null || true)
-    [ -z "$pids" ] && return 0
-
-    local to_kill=()
-    for pid in $pids; do
-        local cmd
-        cmd=$(ps -p "$pid" -o args= 2>/dev/null || true)
-        if echo "$cmd" | grep -qF "$PROJECT_DIR" \
-           || echo "$cmd" | grep -q "cmd/console" \
-           || echo "$cmd" | grep -q "kc-agent"; then
-            to_kill+=("$pid")
-            echo -e "${YELLOW}Stopping project process on port ${port} (PID ${pid})...${NC}"
-            kill -TERM "$pid" 2>/dev/null || true
-        else
-            echo -e "${YELLOW}Warning: Port ${port} is in use by an unrelated process (PID ${pid}: ${cmd:-unknown}). Skipping.${NC}"
-        fi
-    done
-
-    [ ${#to_kill[@]} -eq 0 ] && return 0
-    sleep 2
-
-    # Fall back to SIGKILL for project processes that did not exit gracefully
-    for pid in "${to_kill[@]}"; do
-        kill -9 "$pid" 2>/dev/null || true
-    done
-}
+# Load shared port cleanup utilities (kill_project_port, verify_port_free)
+source "$PROJECT_DIR/scripts/port-cleanup.sh"
 
 # Colors
 RED='\033[0;31m'
@@ -95,6 +66,13 @@ echo ""
 # Clear project processes on required ports; unrelated services are left running
 for p in $PORT 5174; do
     kill_project_port "$p"
+done
+
+# Verify all required ports are free before proceeding
+for p in $PORT 5174; do
+    if ! verify_port_free "$p"; then
+        exit 1
+    fi
 done
 
 # Cleanup on exit

--- a/scripts/startup-smoke-test.sh
+++ b/scripts/startup-smoke-test.sh
@@ -15,6 +15,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 PROJECT_DIR="$(pwd)"
+SCRIPT_DIR="$PROJECT_DIR"
+
+# Load shared port cleanup utilities (kill_project_port, verify_port_free)
+source "$PROJECT_DIR/scripts/port-cleanup.sh"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -32,36 +36,6 @@ fi
 
 PIDS_TO_KILL=()
 ENV_BACKUP_FILE=""
-
-# Kill a process on a port only if it belongs to this project. Unrelated
-# processes are warned and left running to avoid disrupting local services.
-kill_project_port() {
-    local port="$1"
-    local pids
-    pids=$(lsof -ti ":${port}" 2>/dev/null || true)
-    [ -z "$pids" ] && return 0
-
-    local to_kill=()
-    for pid in $pids; do
-        local cmd
-        cmd=$(ps -p "$pid" -o args= 2>/dev/null || true)
-        if echo "$cmd" | grep -qF "$PROJECT_DIR" \
-           || echo "$cmd" | grep -q "cmd/console" \
-           || echo "$cmd" | grep -q "kc-agent"; then
-            to_kill+=("$pid")
-            kill "$pid" 2>/dev/null || true
-        else
-            echo -e "${DIM}  Skipping unrelated process on port ${port} (PID ${pid}: ${cmd:-unknown})${NC}"
-        fi
-    done
-
-    [ ${#to_kill[@]} -eq 0 ] && return 0
-    sleep 1
-
-    for pid in "${to_kill[@]}"; do
-        kill -9 "$pid" 2>/dev/null || true
-    done
-}
 
 cleanup() {
   echo -e "\n${DIM}Cleaning up...${NC}"

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -83,38 +83,8 @@ fi
 
 cd "$SCRIPT_DIR"
 
-# Safely kill a process on a port only if it belongs to this project.
-# Unrelated processes (e.g., local databases, other dev servers) are warned
-# and left running to avoid disrupting non-project services.
-kill_project_port() {
-    local port="$1"
-    local pids
-    pids=$(lsof -ti ":${port}" 2>/dev/null || true)
-    [ -z "$pids" ] && return 0
-
-    local to_kill=()
-    for pid in $pids; do
-        local cmd
-        cmd=$(ps -p "$pid" -o args= 2>/dev/null || true)
-        if echo "$cmd" | grep -qF "$SCRIPT_DIR" \
-           || echo "$cmd" | grep -q "cmd/console" \
-           || echo "$cmd" | grep -q "kc-agent"; then
-            to_kill+=("$pid")
-            echo "Stopping project process on port ${port} (PID ${pid})..."
-            kill -TERM "$pid" 2>/dev/null || true
-        else
-            echo "Warning: Port ${port} is in use by an unrelated process (PID ${pid}: ${cmd:-unknown}). Skipping."
-        fi
-    done
-
-    [ ${#to_kill[@]} -eq 0 ] && return 0
-    sleep 2
-
-    # Fall back to SIGKILL for project processes that did not exit gracefully
-    for pid in "${to_kill[@]}"; do
-        kill -9 "$pid" 2>/dev/null || true
-    done
-}
+# Load shared port cleanup utilities (kill_project_port, verify_port_free)
+source "$SCRIPT_DIR/scripts/port-cleanup.sh"
 
 # Load .env file if it exists (overrides any existing env vars)
 if [ -f .env ]; then
@@ -148,6 +118,13 @@ export BACKEND_LISTEN_PORT=${BACKEND_LISTEN_PORT:-8080}
 # Kill any existing project instances on required ports
 for p in 8080 5174 8585; do
     kill_project_port "$p"
+done
+
+# Verify all required ports are free before proceeding
+for p in 8080 5174 8585; do
+    if ! verify_port_free "$p"; then
+        exit 1
+    fi
 done
 
 echo "Starting KubeStellar Console (dev mode)..."

--- a/start.sh
+++ b/start.sh
@@ -201,14 +201,46 @@ if ! download_binary "kc-agent" "$VERSION" "$PLATFORM"; then
     echo "  (kc-agent is optional — local cluster features will be limited)"
 fi
 
-# Kill any existing console instance on the console port
-EXISTING_PID=$(lsof -ti :"$PORT" 2>/dev/null || true)
-if [ -n "$EXISTING_PID" ]; then
-    echo "Killing existing process on port $PORT (PID: $EXISTING_PID)..."
-    kill -TERM "$EXISTING_PID" 2>/dev/null || true
+# Kill any existing console instance on the console port.
+# Only kill processes that look like they belong to this project to avoid
+# disrupting unrelated services (e.g., a database on the same port).
+EXISTING_PIDS=$(lsof -ti :"$PORT" 2>/dev/null || true)
+if [ -n "$EXISTING_PIDS" ]; then
+    for epid in $EXISTING_PIDS; do
+        ECMD=$(ps -p "$epid" -o args= 2>/dev/null || true)
+        if echo "$ECMD" | grep -q "console" \
+           || echo "$ECMD" | grep -q "kubestellar"; then
+            echo "Stopping stale console process on port $PORT (PID: $epid)..."
+            kill -TERM "$epid" 2>/dev/null || true
+        else
+            echo "Warning: Port $PORT is in use by an unrelated process (PID $epid: ${ECMD:-unknown}). Skipping."
+        fi
+    done
+    # Wait for graceful shutdown then force-kill any remaining project processes
     sleep 2
-    # Fall back to SIGKILL if process did not exit gracefully
-    kill -9 "$EXISTING_PID" 2>/dev/null || true
+    for epid in $EXISTING_PIDS; do
+        if kill -0 "$epid" 2>/dev/null; then
+            ECMD=$(ps -p "$epid" -o args= 2>/dev/null || true)
+            if echo "$ECMD" | grep -q "console" \
+               || echo "$ECMD" | grep -q "kubestellar"; then
+                echo "Force-killing stale process on port $PORT (PID: $epid)..."
+                kill -9 "$epid" 2>/dev/null || true
+            fi
+        fi
+    done
+fi
+
+# Verify the port is free before starting
+REMAINING_PID=$(lsof -ti :"$PORT" 2>/dev/null || true)
+if [ -n "$REMAINING_PID" ]; then
+    echo "Error: Port $PORT is still in use after cleanup."
+    for rpid in $REMAINING_PID; do
+        RCMD=$(ps -p "$rpid" -o args= 2>/dev/null || true)
+        echo "  PID $rpid: ${RCMD:-unknown}"
+    done
+    echo "Manually stop the process(es) above, then try again:"
+    echo "  kill $REMAINING_PID"
+    exit 1
 fi
 # Note: kc-agent on port 8585 is managed via PID file — not force-killed here
 

--- a/startup-demo.sh
+++ b/startup-demo.sh
@@ -10,37 +10,8 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# Safely kill a project process on a port. Unrelated processes are warned and
-# left running to avoid disrupting non-project services.
-kill_project_port() {
-    local port="$1"
-    local pids
-    pids=$(lsof -ti ":${port}" 2>/dev/null || true)
-    [ -z "$pids" ] && return 0
-
-    local to_kill=()
-    for pid in $pids; do
-        local cmd
-        cmd=$(ps -p "$pid" -o args= 2>/dev/null || true)
-        if echo "$cmd" | grep -qF "$SCRIPT_DIR" \
-           || echo "$cmd" | grep -q "cmd/console" \
-           || echo "$cmd" | grep -q "kc-agent"; then
-            to_kill+=("$pid")
-            echo -e "${YELLOW}Stopping project process on port ${port} (PID ${pid})...${NC}"
-            kill -TERM "$pid" 2>/dev/null || true
-        else
-            echo -e "${YELLOW}Warning: Port ${port} is in use by an unrelated process (PID ${pid}: ${cmd:-unknown}). Skipping.${NC}"
-        fi
-    done
-
-    [ ${#to_kill[@]} -eq 0 ] && return 0
-    sleep 2
-
-    # Fall back to SIGKILL for project processes that did not exit gracefully
-    for pid in "${to_kill[@]}"; do
-        kill -9 "$pid" 2>/dev/null || true
-    done
-}
+# Load shared port cleanup utilities (kill_project_port, verify_port_free)
+source "$SCRIPT_DIR/scripts/port-cleanup.sh"
 
 # Colors
 RED='\033[0;31m'
@@ -64,6 +35,13 @@ mkdir -p ./data
 # Port cleanup — only kill project processes; unrelated services are left running
 for p in 8080 5174; do
     kill_project_port "$p"
+done
+
+# Verify all required ports are free before proceeding
+for p in 8080 5174; do
+    if ! verify_port_free "$p"; then
+        exit 1
+    fi
 done
 
 # Cleanup on exit

--- a/startup-oauth.sh
+++ b/startup-oauth.sh
@@ -115,43 +115,8 @@ fi
 
 cd "$SCRIPT_DIR"
 
-# Safely kill a project process on a port. Unrelated processes are warned and
-# left running. An optional second argument restricts lsof to a TCP state
-# (e.g. "TCP:LISTEN") so watchdog outgoing connections are not matched.
-kill_project_port() {
-    local port="$1"
-    local tcp_state="${2:-}"
-    local pids
-    if [ -n "$tcp_state" ]; then
-        pids=$(lsof -ti ":${port}" -s "${tcp_state}" 2>/dev/null || true)
-    else
-        pids=$(lsof -ti ":${port}" 2>/dev/null || true)
-    fi
-    [ -z "$pids" ] && return 0
-
-    local to_kill=()
-    for pid in $pids; do
-        local cmd
-        cmd=$(ps -p "$pid" -o args= 2>/dev/null || true)
-        if echo "$cmd" | grep -qF "$SCRIPT_DIR" \
-           || echo "$cmd" | grep -q "cmd/console" \
-           || echo "$cmd" | grep -q "kc-agent"; then
-            to_kill+=("$pid")
-            echo -e "${YELLOW}Stopping project process on port ${port} (PID ${pid})...${NC}"
-            kill -TERM "$pid" 2>/dev/null || true
-        else
-            echo -e "${YELLOW}Warning: Port ${port} is in use by an unrelated process (PID ${pid}: ${cmd:-unknown}). Skipping.${NC}"
-        fi
-    done
-
-    [ ${#to_kill[@]} -eq 0 ] && return 0
-    sleep 2
-
-    # Fall back to SIGKILL for project processes that did not exit gracefully
-    for pid in "${to_kill[@]}"; do
-        kill -9 "$pid" 2>/dev/null || true
-    done
-}
+# Load shared port cleanup utilities (kill_project_port, verify_port_free)
+source "$SCRIPT_DIR/scripts/port-cleanup.sh"
 
 # Colors
 RED='\033[0;31m'
@@ -295,6 +260,13 @@ fi
 if [ "$USE_DEV_SERVER" = true ]; then PORTS_TO_CLEAN="$PORTS_TO_CLEAN 5174"; fi
 for p in $PORTS_TO_CLEAN; do
     kill_project_port "$p" "TCP:LISTEN"
+done
+
+# Verify all required ports are free before proceeding
+for p in $PORTS_TO_CLEAN; do
+    if ! verify_port_free "$p" "TCP:LISTEN"; then
+        exit 1
+    fi
 done
 
 # Cleanup on exit


### PR DESCRIPTION
## Summary
- Extracts the duplicated `kill_project_port()` function (copied 7 times across startup scripts) into a shared `scripts/port-cleanup.sh` helper
- Adds `verify_port_free()` that fails fast with an actionable error when a port cannot be freed, instead of silently proceeding to a confusing startup failure
- Improves graceful shutdown: polls for process exit before falling back to SIGKILL
- Makes `start.sh` (curl bootstrap) use project-aware cleanup instead of blindly killing any process on the port
- All 7 startup scripts now use the shared helper

## Test plan
- [ ] Run `./start-dev.sh`, interrupt with Ctrl+C, run again -- should auto-clean stale processes
- [ ] Start a non-project process on port 8080, run `./start-dev.sh` -- should warn and exit with clear error
- [ ] Run `./startup-oauth.sh` after a stale session -- should clean up and start cleanly
- [ ] Run `./startup-demo.sh` after a stale session -- should clean up and start cleanly
- [ ] Verify `bash -n` passes on all modified scripts (syntax check)

Fixes #4902