### PR TITLE
🐛 Fix WS logout, MCP validation, refresh, dynamic card fallback

### DIFF
--- a/pkg/api/handlers/auth.go
+++ b/pkg/api/handlers/auth.go
@@ -128,6 +128,12 @@ type AuthConfig struct {
 	SkipOnboarding bool   // Skip onboarding questionnaire for new users
 }
 
+// SessionDisconnecter is the subset of Hub needed to close WebSocket sessions
+// on logout. Defined as an interface to avoid a circular dependency.
+type SessionDisconnecter interface {
+	DisconnectUser(userID uuid.UUID)
+}
+
 // AuthHandler handles authentication
 type AuthHandler struct {
 	store          store.Store
@@ -141,6 +147,7 @@ type AuthHandler struct {
 	githubToken    string
 	devMode        bool
 	skipOnboarding bool
+	wsHub          SessionDisconnecter // optional — set via SetHub to disconnect WS sessions on logout
 }
 
 // NewAuthHandler creates a new auth handler
@@ -197,6 +204,12 @@ func NewAuthHandler(s store.Store, cfg AuthConfig) *AuthHandler {
 		devMode:        cfg.DevMode,
 		skipOnboarding: cfg.SkipOnboarding,
 	}
+}
+
+// SetHub wires the WebSocket hub into the auth handler so that logout
+// can disconnect all active WebSocket sessions for the user (#4906).
+func (h *AuthHandler) SetHub(hub SessionDisconnecter) {
+	h.wsHub = hub
 }
 
 const (
@@ -494,7 +507,14 @@ func (h *AuthHandler) Logout(c *fiber.Ctx) error {
 	// Clear the HttpOnly cookie so the browser stops sending it
 	h.clearJWTCookie(c)
 
-	slog.Info("[Auth] token revoked", "user", claims.GitHubLogin, "jti", claims.ID)
+	// Disconnect all active WebSocket connections for this user (#4906).
+	// This ensures that already-established WebSocket sessions cannot continue
+	// to receive data after the token is revoked.
+	if h.wsHub != nil && claims.UserID != uuid.Nil {
+		h.wsHub.DisconnectUser(claims.UserID)
+	}
+
+	slog.Info("[Auth] token revoked, WS sessions closed", "user", claims.GitHubLogin, "jti", claims.ID)
 	return c.JSON(fiber.Map{"success": true, "message": "Token revoked"})
 }
 

--- a/pkg/api/handlers/mcp.go
+++ b/pkg/api/handlers/mcp.go
@@ -69,16 +69,29 @@ var sanitizedErrorMessages = map[string]string{
 func handleK8sError(c *fiber.Ctx, err error) error {
 	errType := k8s.ClassifyError(err.Error())
 	switch errType {
+	case "not_found":
+		// Invalid or non-existent cluster — return 404 with consistent error format (#4907, #4908)
+		slog.Info("[MCP] cluster not found", "errorType", errType, "error", err)
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"clusterStatus": "not_found",
+			"errorType":     errType,
+			"errorMessage":  "Cluster not found — verify the cluster name exists in your kubeconfig",
+		})
 	case "network", "auth", "timeout", "certificate":
+		// Cluster exists but is unreachable — return 503 with consistent error format (#4908)
 		slog.Info("[MCP] cluster unavailable", "errorType", errType, "error", err)
-		return c.JSON(fiber.Map{
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
 			"clusterStatus": "unavailable",
 			"errorType":     errType,
 			"errorMessage":  sanitizedErrorMessages[errType],
 		})
 	default:
 		slog.Error("[MCP] internal error", "error", err)
-		return c.Status(500).JSON(fiber.Map{"error": "internal server error"})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"clusterStatus": "error",
+			"errorType":     "internal",
+			"errorMessage":  "An internal error occurred",
+		})
 	}
 }
 

--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -174,6 +174,23 @@ func (h *Hub) GetTotalConnectionsCount() int {
 	return len(h.clients)
 }
 
+// DisconnectUser closes all WebSocket connections belonging to the given user.
+// Called by the logout handler to enforce session invalidation (#4906).
+func (h *Hub) DisconnectUser(userID uuid.UUID) {
+	h.mu.RLock()
+	clients := make([]*Client, len(h.userIndex[userID]))
+	copy(clients, h.userIndex[userID])
+	h.mu.RUnlock()
+
+	for _, client := range clients {
+		// Send a close message so the client knows the session was terminated.
+		_ = client.conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "session invalidated"))
+		client.conn.Close()
+	}
+	slog.Info("[WebSocket] disconnected all connections for user", "user", userID, "count", len(clients))
+}
+
 // RecordDemoSession records a heartbeat from a demo mode session
 func (h *Hub) RecordDemoSession(sessionID string) {
 	h.mu.Lock()

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -519,6 +519,8 @@ func (s *Server) setupRoutes() {
 			return c.Status(429).JSON(fiber.Map{"error": "too many requests, try again later"})
 		},
 	})
+	// Wire WebSocket hub into auth handler so logout disconnects WS sessions (#4906)
+	auth.SetHub(s.hub)
 	s.app.Get("/auth/github", authLimiter, auth.GitHubLogin)
 	s.app.Get("/auth/github/callback", authLimiter, auth.GitHubCallback)
 	s.app.Post("/auth/refresh", authLimiter, auth.RefreshToken)

--- a/pkg/k8s/client_health.go
+++ b/pkg/k8s/client_health.go
@@ -61,6 +61,14 @@ func classifyError(errMsg string) string {
 		return "certificate"
 	}
 
+	// Not-found errors — cluster context does not exist in kubeconfig (#4907)
+	if strings.Contains(lowerMsg, "not found") ||
+		strings.Contains(lowerMsg, "does not exist") ||
+		strings.Contains(lowerMsg, "no configuration") ||
+		strings.Contains(lowerMsg, "not exist") {
+		return "not_found"
+	}
+
 	return "unknown"
 }
 

--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -22,20 +22,36 @@ import { useTranslation } from 'react-i18next'
  * Registered as `dynamic_card` in CARD_COMPONENTS.
  * config.dynamicCardId determines which definition to render.
  */
-export function DynamicCard({ config = {} }: CardComponentProps) {
-  const dynamicCardId = (config?.dynamicCardId as string) || ''
+export function DynamicCard({ config }: CardComponentProps) {
+  // Guard against undefined/null config to prevent crashes (#4910)
+  const safeConfig = config ?? {}
+  const dynamicCardId = (typeof safeConfig.dynamicCardId === 'string' ? safeConfig.dynamicCardId : '') || ''
   const definition = getDynamicCard(dynamicCardId)
 
   // Report demo state: dynamic cards depend on the agent for live API data
   const { shouldUseDemoData } = useCardDemoState({ requires: 'agent' })
   useReportCardDataState({ isDemoData: shouldUseDemoData, isFailed: false, consecutiveFailures: 0 })
 
+  if (!dynamicCardId) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center p-4 text-center">
+        <AlertTriangle className="w-8 h-8 text-yellow-400 mb-2" />
+        <p className="text-sm text-muted-foreground">
+          Missing card configuration.
+        </p>
+        <p className="text-xs text-muted-foreground/70 mt-1">
+          No dynamicCardId was provided in the card config.
+        </p>
+      </div>
+    )
+  }
+
   if (!definition) {
     return (
       <div className="h-full flex flex-col items-center justify-center p-4 text-center">
         <AlertTriangle className="w-8 h-8 text-yellow-400 mb-2" />
         <p className="text-sm text-muted-foreground">
-          Dynamic card "{dynamicCardId}" not found.
+          Dynamic card &quot;{dynamicCardId}&quot; not found.
         </p>
         <p className="text-xs text-muted-foreground/70 mt-1">
           The card definition may have been deleted or not loaded yet.
@@ -49,7 +65,7 @@ export function DynamicCard({ config = {} }: CardComponentProps) {
       {definition.tier === 'tier1' && definition.cardDefinition ? (
         <Tier1CardRuntime definition={definition} cardDefinition={definition.cardDefinition} />
       ) : definition.tier === 'tier2' && definition.sourceCode ? (
-        <Tier2CardRuntime definition={definition} config={config} />
+        <Tier2CardRuntime definition={definition} config={safeConfig} />
       ) : (
         <div className="h-full flex flex-col items-center justify-center p-4 text-center">
           <AlertTriangle className="w-8 h-8 text-yellow-400 mb-2" />
@@ -77,13 +93,20 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
   const [apiLoading, setApiLoading] = useState(false)
   const [apiError, setApiError] = useState<string | null>(null)
 
-  const data = cardDefinition.dataSource === 'static'
-    ? (cardDefinition.staticData || [])
-    : apiData
+  // Compute validation flags up front (before hooks) to keep hook call order stable (#4910)
+  const isInvalidConfig = !cardDefinition || typeof cardDefinition !== 'object'
+  const isMissingEndpoint = !isInvalidConfig && cardDefinition?.dataSource === 'api' && !cardDefinition?.apiEndpoint
+
+  const data = isInvalidConfig
+    ? []
+    : (cardDefinition?.dataSource === 'static'
+        ? (cardDefinition?.staticData || [])
+        : apiData)
 
   // Fetch API data if needed
   useEffect(() => {
-    if (cardDefinition.dataSource !== 'api' || !cardDefinition.apiEndpoint) return
+    if (isInvalidConfig || isMissingEndpoint) return
+    if (cardDefinition?.dataSource !== 'api' || !cardDefinition?.apiEndpoint) return
 
     let cancelled = false
     setApiLoading(true)
@@ -109,10 +132,10 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
       })
 
     return () => { cancelled = true }
-  }, [cardDefinition.dataSource, cardDefinition.apiEndpoint])
+  }, [isInvalidConfig, isMissingEndpoint, cardDefinition?.dataSource, cardDefinition?.apiEndpoint])
 
   // useCardData for search/pagination
-  const searchFields = (cardDefinition.searchFields || []) as (keyof Record<string, unknown>)[]
+  const searchFields = ((cardDefinition?.searchFields || []) as (keyof Record<string, unknown>)[])
   const {
     items,
     totalItems,
@@ -133,8 +156,31 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
       defaultDirection: 'asc',
       comparators: {},
     },
-    defaultLimit: cardDefinition.defaultLimit || 5,
+    defaultLimit: cardDefinition?.defaultLimit || 5,
   })
+
+  // Validation-based early returns — placed after all hooks to respect Rules of Hooks (#4910)
+  if (isInvalidConfig) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center p-4 text-center">
+        <AlertTriangle className="w-6 h-6 text-yellow-400 mb-2" />
+        <p className="text-sm text-yellow-400">Invalid card configuration</p>
+        <p className="text-xs text-muted-foreground mt-1">The card definition is missing or malformed.</p>
+      </div>
+    )
+  }
+
+  if (isMissingEndpoint) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center p-4 text-center">
+        <AlertTriangle className="w-6 h-6 text-yellow-400 mb-2" />
+        <p className="text-sm text-yellow-400">Missing API endpoint</p>
+        <p className="text-xs text-muted-foreground mt-1">
+          This card is configured to use API data but no apiEndpoint is specified.
+        </p>
+      </div>
+    )
+  }
 
   if (apiLoading) {
     return (
@@ -287,7 +333,9 @@ export interface Tier2Props {
   config?: Record<string, unknown>
 }
 
-export function Tier2CardRuntime({ definition, config = {} }: Tier2Props) {
+export function Tier2CardRuntime({ definition, config }: Tier2Props) {
+  // Guard against undefined config (#4910)
+  const safeConfig = config ?? {}
   const [CardComponent, setCardComponent] = useState<CardComponent | null>(null)
   const [compiling, setCompiling] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -372,5 +420,5 @@ export function Tier2CardRuntime({ definition, config = {} }: Tier2Props) {
     )
   }
 
-  return <CardComponent config={config} />
+  return <CardComponent config={safeConfig} />
 }

--- a/web/src/hooks/useRefreshIndicator.ts
+++ b/web/src/hooks/useRefreshIndicator.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef } from 'react'
+import { triggerAllRefetches } from '../lib/modeTransition'
 
 // Minimum time to show the refresh indicator on user-triggered refreshes.
 // Kept short for snappy feedback without causing visible flicker.
@@ -22,7 +23,12 @@ export function useRefreshIndicator(refetchFn: () => void, _resetKey?: string) {
       clearTimeout(timerRef.current)
     }
 
+    // Call the primary refetch function (e.g., cluster data)
     refetchFn()
+
+    // Also trigger all registered cache refetches so individual card data
+    // hooks (useCachedPods, useCachedDeployments, etc.) reload their data (#4909).
+    triggerAllRefetches()
 
     timerRef.current = setTimeout(() => {
       setShowIndicator(false)


### PR DESCRIPTION
## Summary

- **#4906**: Close all WebSocket connections for a user on logout — previously WS sessions remained active after token revocation
- **#4907**: Non-existent cluster names now return 404 instead of 500 — added `not_found` error classification in k8s error classifier
- **#4908**: Standardized MCP error response format — all failure types now return consistent `{clusterStatus, errorType, errorMessage}` JSON with proper HTTP status codes (404/503/500)
- **#4909**: Dashboard refresh button now triggers all registered cache refetches via `triggerAllRefetches()`, not just cluster data
- **#4910**: DynamicCard hardened against invalid/missing config — guards for undefined config, missing dynamicCardId, malformed cardDefinition, and missing apiEndpoint

## Changed files

- `pkg/api/handlers/websocket.go` — Added `Hub.DisconnectUser()` method
- `pkg/api/handlers/auth.go` — Added `SessionDisconnecter` interface, `SetHub()`, WS disconnect on logout
- `pkg/api/server.go` — Wire Hub into AuthHandler
- `pkg/api/handlers/mcp.go` — Consistent error responses with proper status codes
- `pkg/k8s/client_health.go` — Added `not_found` error classification
- `web/src/hooks/useRefreshIndicator.ts` — Call `triggerAllRefetches()` on manual refresh
- `web/src/components/cards/DynamicCard.tsx` — Config validation with fallback UI

## Test plan

- [ ] Login, open WS connection, logout — verify WS is disconnected (check browser devtools Network tab)
- [ ] Call `GET /api/mcp/pods?cluster=does-not-exist-xyz` — verify 404 with consistent error body
- [ ] Call `GET /api/mcp/pods` with unreachable cluster — verify 503 with same error format
- [ ] Click dashboard refresh button — verify all cards reload data (not just cluster list)
- [ ] Add a DynamicCard with missing config/apiEndpoint — verify fallback UI instead of crash

Fixes #4906, #4907, #4908, #4909, #4910