### PR TITLE
🐛 Add error boundary tests and harden DynamicCard TSX execution

### DIFF
--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -348,39 +348,47 @@ export function Tier2CardRuntime({ definition, config }: Tier2Props) {
       setCompiling(true)
       setError(null)
 
-      const source = definition.sourceCode
-      if (!source) {
-        setError('No source code provided.')
-        setCompiling(false)
-        return
-      }
-
-      // Check for cached compiled code
-      let code = definition.compiledCode
-      if (!code) {
-        const result = await compileCardCode(source)
-        if (cancelled) return
-        if (result.error) {
-          setError(result.error)
+      try {
+        const source = definition.sourceCode
+        if (!source) {
+          setError('No source code provided.')
           setCompiling(false)
           return
         }
-        code = result.code!
-      }
 
-      // Create component from compiled code
-      const componentResult = createCardComponent(code)
-      if (cancelled) return
+        // Check for cached compiled code
+        let code = definition.compiledCode
+        if (!code) {
+          const result = await compileCardCode(source)
+          if (cancelled) return
+          if (result.error) {
+            setError(result.error)
+            setCompiling(false)
+            return
+          }
+          code = result.code!
+        }
 
-      if (componentResult.error) {
-        setError(componentResult.error)
+        // Create component from compiled code
+        const componentResult = createCardComponent(code)
+        if (cancelled) return
+
+        if (componentResult.error) {
+          setError(componentResult.error)
+          setCompiling(false)
+          return
+        }
+
+        cleanupRef.current = componentResult.cleanup
+        setCardComponent(() => componentResult.component)
         setCompiling(false)
-        return
+      } catch (err) {
+        if (cancelled) return
+        const message = err instanceof Error ? err.message : String(err)
+        console.error(`[DynamicCard] Unexpected compile error:`, err)
+        setError(`Unexpected error: ${message}`)
+        setCompiling(false)
       }
-
-      cleanupRef.current = componentResult.cleanup
-      setCardComponent(() => componentResult.component)
-      setCompiling(false)
     }
 
     compile()

--- a/web/src/components/cards/__tests__/DynamicCardErrorBoundary.test.tsx
+++ b/web/src/components/cards/__tests__/DynamicCardErrorBoundary.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DynamicCardErrorBoundary } from '../DynamicCardErrorBoundary'
+
+// Suppress console.error from React error boundaries during tests
+const originalConsoleError = console.error
+beforeEach(() => {
+  console.error = vi.fn()
+})
+
+// Restore after all tests
+afterAll(() => {
+  console.error = originalConsoleError
+})
+
+vi.mock('../../../lib/analytics', () => ({
+  emitError: vi.fn(),
+  markErrorReported: vi.fn(),
+}))
+
+vi.mock('../../../lib/chunkErrors', () => ({
+  isChunkLoadError: () => false,
+}))
+
+/** Component that always throws during render */
+function CrashingComponent(): JSX.Element {
+  throw new Error('TSX execution crash')
+}
+
+/** Component that renders successfully */
+function HealthyComponent() {
+  return <div data-testid="healthy">Healthy card content</div>
+}
+
+describe('DynamicCardErrorBoundary', () => {
+  it('renders children when no error occurs', () => {
+    render(
+      <DynamicCardErrorBoundary cardId="test-card">
+        <HealthyComponent />
+      </DynamicCardErrorBoundary>,
+    )
+    expect(screen.getByTestId('healthy')).toBeTruthy()
+    expect(screen.getByText('Healthy card content')).toBeTruthy()
+  })
+
+  it('catches render errors and shows recovery UI instead of crashing', () => {
+    render(
+      <DynamicCardErrorBoundary cardId="bad-card">
+        <CrashingComponent />
+      </DynamicCardErrorBoundary>,
+    )
+    expect(screen.getByText('Card Render Error')).toBeTruthy()
+    expect(screen.getByText('TSX execution crash')).toBeTruthy()
+  })
+
+  it('does not crash the parent when a child throws', () => {
+    const { container } = render(
+      <div data-testid="parent">
+        <DynamicCardErrorBoundary cardId="bad-card">
+          <CrashingComponent />
+        </DynamicCardErrorBoundary>
+      </div>,
+    )
+    // Parent remains intact
+    expect(container.querySelector('[data-testid="parent"]')).toBeTruthy()
+    // Error UI is rendered inside the boundary
+    expect(screen.getByText('Card Render Error')).toBeTruthy()
+  })
+
+  it('shows retry button with attempt count', () => {
+    render(
+      <DynamicCardErrorBoundary cardId="retry-card">
+        <CrashingComponent />
+      </DynamicCardErrorBoundary>,
+    )
+    const retryButton = screen.getByRole('button', { name: /retry/i })
+    expect(retryButton).toBeTruthy()
+    expect(retryButton.textContent).toContain('3')
+  })
+
+  it('decrements retry count on each failed retry attempt', () => {
+    render(
+      <DynamicCardErrorBoundary cardId="retry-card">
+        <CrashingComponent />
+      </DynamicCardErrorBoundary>,
+    )
+    // First error: retryCount=0, retriesLeft=3
+    expect(screen.getByText(/3 left/)).toBeTruthy()
+
+    // Click retry — component re-renders, crashes again, retryCount becomes 1
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(screen.getByText(/2 left/)).toBeTruthy()
+
+    // Click retry again — retryCount becomes 2
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    expect(screen.getByText(/1 left/)).toBeTruthy()
+  })
+
+  it('shows reload message after all retries are exhausted', () => {
+    render(
+      <DynamicCardErrorBoundary cardId="exhaust-card">
+        <CrashingComponent />
+      </DynamicCardErrorBoundary>,
+    )
+
+    // Exhaust all 3 retries
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }))
+
+    // Retry button should be gone, replaced by reload message
+    expect(screen.queryByRole('button', { name: /retry/i })).toBeNull()
+    expect(screen.getByText('Reload the page to try again.')).toBeTruthy()
+  })
+
+  it('calls onError callback when an error is caught', () => {
+    const onError = vi.fn()
+    render(
+      <DynamicCardErrorBoundary cardId="callback-card" onError={onError}>
+        <CrashingComponent />
+      </DynamicCardErrorBoundary>,
+    )
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'TSX execution crash' }),
+      expect.objectContaining({ componentStack: expect.any(String) }),
+    )
+  })
+
+  it('isolates errors between sibling boundaries', () => {
+    render(
+      <div>
+        <DynamicCardErrorBoundary cardId="good-card">
+          <HealthyComponent />
+        </DynamicCardErrorBoundary>
+        <DynamicCardErrorBoundary cardId="bad-card">
+          <CrashingComponent />
+        </DynamicCardErrorBoundary>
+      </div>,
+    )
+    // Good card still renders
+    expect(screen.getByTestId('healthy')).toBeTruthy()
+    // Bad card shows error UI
+    expect(screen.getByText('Card Render Error')).toBeTruthy()
+  })
+
+  it('emits analytics error when a crash occurs', async () => {
+    const { emitError, markErrorReported } = await import('../../../lib/analytics')
+    render(
+      <DynamicCardErrorBoundary cardId="analytics-card">
+        <CrashingComponent />
+      </DynamicCardErrorBoundary>,
+    )
+    expect(markErrorReported).toHaveBeenCalledWith('TSX execution crash')
+    expect(emitError).toHaveBeenCalledWith(
+      'card_render',
+      '[analytics-card] TSX execution crash',
+      'analytics-card',
+    )
+  })
+})

--- a/web/src/lib/dynamic-cards/scope.ts
+++ b/web/src/lib/dynamic-cards/scope.ts
@@ -64,7 +64,11 @@ export function createTimerScope() {
     }
     const id = window.setTimeout((...a: unknown[]) => {
       activeTimers.delete(id)
-      ;(callback as (...a: unknown[]) => void)(...a)
+      try {
+        ;(callback as (...a: unknown[]) => void)(...a)
+      } catch (err) {
+        console.error('[DynamicCard] Uncaught error in setTimeout callback:', err)
+      }
     }, sanitizeDelay(delay), ...args)
     return trackTimer(id)
   }
@@ -82,7 +86,14 @@ export function createTimerScope() {
       throw new Error(`Timer limit exceeded (max ${MAX_ACTIVE_TIMERS} concurrent timers per card)`)
     }
     const clamped = Math.max(sanitizeDelay(delay), MIN_INTERVAL_MS)
-    const id = window.setInterval(callback as (...a: unknown[]) => void, clamped, ...args)
+    const wrappedCallback = (...a: unknown[]) => {
+      try {
+        ;(callback as (...a: unknown[]) => void)(...a)
+      } catch (err) {
+        console.error('[DynamicCard] Uncaught error in setInterval callback:', err)
+      }
+    }
+    const id = window.setInterval(wrappedCallback, clamped, ...args)
     return trackTimer(id)
   }
 


### PR DESCRIPTION
## Summary
- Wraps the Tier 2 `compile()` async function with a top-level try/catch to prevent unhandled promise rejections from crashing the dashboard
- Adds try/catch around sandboxed `setTimeout`/`setInterval` callbacks in the dynamic card scope so uncaught errors in timer code are logged instead of propagating to the global error handler
- Adds 9 tests for `DynamicCardErrorBoundary` covering render crash isolation, retry mechanism, exhaustion, sibling independence, analytics emission, and onError callback

## Test plan
- [x] `npm run build` passes
- [x] All 9 new DynamicCardErrorBoundary tests pass
- [x] All 13 existing compiler tests pass
- [ ] CI build/lint/preview pass

Fixes #4916