### PR TITLE
🐛 Fix path traversal, CORS, WS logout, SSE recovery, lazy fallback, padding

### DIFF
--- a/pkg/agent/server.go
+++ b/pkg/agent/server.go
@@ -446,11 +446,14 @@ func (s *Server) Start() error {
 	// WebSocket endpoint
 	mux.HandleFunc("/ws", s.handleWebSocket)
 
-	// CORS preflight - includes Private Network Access header for browser security
+	// CORS preflight - uses isAllowedOrigin() instead of wildcard to restrict access
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		origin := r.Header.Get("Origin")
+		if s.isAllowedOrigin(origin) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+		}
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 		w.Header().Set("Access-Control-Allow-Private-Network", "true")
 		if r.Method == "OPTIONS" {
 			w.WriteHeader(http.StatusOK)

--- a/pkg/api/handlers/self_upgrade.go
+++ b/pkg/api/handlers/self_upgrade.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -19,6 +20,14 @@ import (
 
 	k8sclient "github.com/kubestellar/console/pkg/k8s"
 )
+
+// imageTagMaxLen is the maximum allowed length for an image tag to prevent abuse.
+const imageTagMaxLen = 128
+
+// validImageTagRe enforces a strict pattern for Docker/OCI image tags:
+// alphanumeric, dots, hyphens, plus signs, and underscores only — no slashes,
+// colons, at-signs, or path-traversal sequences.
+var validImageTagRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._+\-]{0,127}$`)
 
 // Self-upgrade timeout for Kubernetes API calls
 const selfUpgradeTimeout = 30 * time.Second
@@ -207,10 +216,11 @@ func (h *SelfUpgradeHandler) TriggerUpgrade(c *fiber.Ctx) error {
 		})
 	}
 
-	// Validate image tag format (prevent injection)
-	if strings.ContainsAny(req.ImageTag, " \t\n\"'\\{}") {
+	// Validate image tag: strict regex rejects path traversal (../, /), at-signs (@),
+	// colons (:), and any other characters that could alter the image reference.
+	if len(req.ImageTag) > imageTagMaxLen || !validImageTagRe.MatchString(req.ImageTag) {
 		return c.Status(fiber.StatusBadRequest).JSON(SelfUpgradeTriggerResponse{
-			Error: "invalid imageTag format",
+			Error: "invalid imageTag format — must be alphanumeric with dots, hyphens, or underscores only",
 		})
 	}
 

--- a/web/src/components/cards/cardRegistry.ts
+++ b/web/src/components/cards/cardRegistry.ts
@@ -1495,6 +1495,13 @@ export function getCardComponent(cardType: string): CardComponent | undefined {
     return CARD_COMPONENTS['dynamic_card']
   }
 
+  // Log a warning so missing/misspelled card types are surfaced in the console
+  // instead of silently disappearing (#4932).
+  console.warn(
+    `[cardRegistry] Unknown card type "${cardType}" — no component registered. ` +
+    'Check for typos in the dashboard config or register the card in cardRegistry.ts.',
+  )
+
   return undefined
 }
 

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -944,7 +944,7 @@ export function Dashboard() {
 
   if (isLoading && localCards.length === 0) {
     return (
-      <div className="pt-16">
+      <div className="pt-4">
         {/* Header skeleton */}
         <div className="flex items-center justify-between mb-6">
           <div>
@@ -980,7 +980,7 @@ export function Dashboard() {
   }
 
   return (
-    <div data-testid="dashboard-page" className="pt-16">
+    <div data-testid="dashboard-page" className="pt-4">
       {/* Header */}
       <DashboardHeader
         title={t('dashboard.title')}

--- a/web/src/components/dashboard/SharedSortableCard.tsx
+++ b/web/src/components/dashboard/SharedSortableCard.tsx
@@ -88,6 +88,19 @@ export const SortableCard = memo(function SortableCard({ card, onConfigure, onRe
 
   const CardComponent = CARD_COMPONENTS[card.card_type]
 
+  // Render a visible fallback for missing/misspelled card types (#4932)
+  if (!CardComponent) {
+    return (
+      <div
+        ref={(el) => { setNodeRef(el); registerRef?.(el) }}
+        style={style}
+        className="glass rounded-lg p-4 flex items-center justify-center text-muted-foreground text-sm border border-dashed border-warning/40"
+      >
+        Unknown card type: <code className="ml-1 font-mono text-warning">{card.card_type}</code>
+      </div>
+    )
+  }
+
   return (
     <div
       ref={(el) => { setNodeRef(el); registerRef?.(el) }}

--- a/web/src/hooks/useActiveUsers.ts
+++ b/web/src/hooks/useActiveUsers.ts
@@ -2,6 +2,16 @@ import { useState, useEffect, useCallback } from 'react'
 import { getDemoMode, isDemoModeForced } from './useDemoMode'
 import { STORAGE_KEY_TOKEN } from '../lib/constants'
 
+/**
+ * Disconnect the presence WebSocket and stop the heartbeat.
+ * MUST be called during logout to prevent stale auth tokens from being
+ * transmitted on a persistent connection after the user signs out (#4936).
+ */
+export function disconnectPresence(): void {
+  stopPresenceConnection()
+  stopHeartbeat()
+}
+
 export interface ActiveUsersInfo {
   activeUsers: number
   totalConnections: number

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState, useEffect, useCallback, ReactNode 
 import { checkOAuthConfigured } from './api'
 import { dashboardSync } from './dashboards/dashboardSync'
 import { clearPermissionsCache } from '../hooks/usePermissions'
+import { disconnectPresence } from '../hooks/useActiveUsers'
 import { clearSSECache } from './sseClient'
 import { STORAGE_KEY_TOKEN, DEMO_TOKEN_VALUE, STORAGE_KEY_DEMO_MODE, STORAGE_KEY_ONBOARDED, STORAGE_KEY_USER_CACHE, FETCH_DEFAULT_TIMEOUT_MS } from './constants'
 import { emitLogin, emitLogout, setAnalyticsUserId, setAnalyticsUserProperties, emitConversionStep, emitDeveloperSession } from './analytics'
@@ -179,6 +180,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     clearPermissionsCache()
     // Clear SSE result cache to prevent stale data from previous session (#4712)
     clearSSECache()
+    // Disconnect presence WebSocket to stop transmitting stale auth tokens (#4936)
+    disconnectPresence()
   }, [])
 
   const setDemoMode = useCallback(() => {

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -815,18 +815,53 @@ class CacheStore<T> {
       // The fetch() completion below sets isLoading: false.
       // This lets CardWrapper show partial data + refresh spinner while
       // more clusters are still streaming in via SSE.
+      //
+      // Throttle progress updates to avoid overwhelming React with rapid-fire
+      // re-renders when multiple clusters respond within the same tick (#4935).
+      // Each update creates a new state object reference so useSyncExternalStore
+      // triggers a synchronous re-render.
+      /** Minimum interval (ms) between progress-driven re-renders */
+      const PROGRESS_THROTTLE_MS = 100
+      let lastProgressTs = 0
+      let pendingProgress: T | null = null
+      let progressTimerId: ReturnType<typeof setTimeout> | null = null
+
+      const flushProgress = () => {
+        if (pendingProgress === null) return
+        if (this.resetVersion !== fetchVersion) return
+        this.setState({ data: pendingProgress })
+        pendingProgress = null
+        lastProgressTs = Date.now()
+      }
+
       const onProgress = progressiveFetcher ? (partialData: T) => {
         if (this.resetVersion !== fetchVersion) return  // stale — ignore
         // Skip empty progress updates — don't wipe cached data with []
         if (isEquivalentToInitial(partialData, this.initialData)) return
-        this.setState({
-          data: partialData,
-        })
+
+        const now = Date.now()
+        pendingProgress = partialData
+
+        if (now - lastProgressTs >= PROGRESS_THROTTLE_MS) {
+          // Enough time has passed — flush immediately
+          if (progressTimerId) { clearTimeout(progressTimerId); progressTimerId = null }
+          flushProgress()
+        } else if (!progressTimerId) {
+          // Schedule a flush at the end of the throttle window
+          const remaining = PROGRESS_THROTTLE_MS - (now - lastProgressTs)
+          progressTimerId = setTimeout(() => {
+            progressTimerId = null
+            flushProgress()
+          }, remaining)
+        }
       } : undefined
 
       const newData = progressiveFetcher && onProgress
         ? await progressiveFetcher(onProgress)
         : await fetcher()
+
+      // Flush any pending throttled progress update before processing final data
+      if (progressTimerId) { clearTimeout(progressTimerId); progressTimerId = null }
 
       // If a reset happened during fetch, discard stale results
       if (this.resetVersion !== fetchVersion) {

--- a/web/src/lib/safeLazy.ts
+++ b/web/src/lib/safeLazy.ts
@@ -1,5 +1,10 @@
 import { lazy, type ComponentType } from 'react'
 
+/** Maximum number of retry attempts before giving up on a failed dynamic import */
+const LAZY_IMPORT_MAX_RETRIES = 2
+/** Base delay in ms between retry attempts (doubles each retry via exponential backoff) */
+const LAZY_IMPORT_RETRY_BASE_MS = 1_000
+
 /**
  * Safe wrapper around React.lazy() for named exports.
  *
@@ -8,35 +13,56 @@ import { lazy, type ComponentType } from 'react'
  * and React receives `{ default: undefined }`, causing "Cannot read properties of
  * undefined" errors.
  *
- * This helper throws a descriptive error that triggers the ChunkErrorBoundary's
- * auto-reload recovery instead of silently crashing.
+ * This helper:
+ * 1. Throws a descriptive error that triggers the ChunkErrorBoundary's
+ *    auto-reload recovery instead of silently crashing.
+ * 2. Retries the import with exponential backoff on network/chunk errors (#4933)
+ *    so transient failures don't crash the app.
  */
 export function safeLazy<T extends Record<string, unknown>>(
   importFn: () => Promise<T>,
   exportName: keyof T & string,
 ): ReturnType<typeof lazy> {
-  return lazy(() =>
-    importFn().then((m) => {
-      // When an eagerly-loaded bundle uses .catch(() => undefined) to suppress
-      // unhandled rejections, a stale-chunk failure resolves the promise to
-      // undefined instead of rejecting it. Without this guard, accessing
-      // m[exportName] throws a generic TypeError that isChunkLoadMessage()
-      // does not recognise, so ChunkErrorBoundary never triggers auto-reload.
-      if (!m) {
-        throw new Error(
-          'Module failed to load — chunk may be stale. ' +
-          'Reload the page to get the latest version.',
-        )
-      }
-      const component = m[exportName]
-      if (!component) {
-        throw new Error(
-          `Export "${exportName}" not found in module — chunk may be stale. ` +
-          'Reload the page to get the latest version.',
-        )
-      }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      return { default: component as ComponentType<any> }
-    }),
-  )
+  return lazy(() => {
+    const attemptImport = (retriesLeft: number): Promise<{ default: ComponentType<Record<string, unknown>> }> =>
+      importFn()
+        .then((m) => {
+          // When an eagerly-loaded bundle uses .catch(() => undefined) to suppress
+          // unhandled rejections, a stale-chunk failure resolves the promise to
+          // undefined instead of rejecting it. Without this guard, accessing
+          // m[exportName] throws a generic TypeError that isChunkLoadMessage()
+          // does not recognise, so ChunkErrorBoundary never triggers auto-reload.
+          if (!m) {
+            throw new Error(
+              'Module failed to load — chunk may be stale. ' +
+              'Reload the page to get the latest version.',
+            )
+          }
+          const component = m[exportName]
+          if (!component) {
+            throw new Error(
+              `Export "${exportName}" not found in module — chunk may be stale. ` +
+              'Reload the page to get the latest version.',
+            )
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return { default: component as ComponentType<any> }
+        })
+        .catch((err: Error) => {
+          if (retriesLeft > 0) {
+            const delay = LAZY_IMPORT_RETRY_BASE_MS * Math.pow(2, LAZY_IMPORT_MAX_RETRIES - retriesLeft)
+            console.warn(
+              `[safeLazy] Import failed for "${exportName}" (${retriesLeft} retries left), ` +
+              `retrying in ${delay}ms: ${err.message}`,
+            )
+            return new Promise<{ default: ComponentType<Record<string, unknown>> }>((resolve) =>
+              setTimeout(() => resolve(attemptImport(retriesLeft - 1)), delay),
+            )
+          }
+          // All retries exhausted — re-throw so ChunkErrorBoundary can handle it
+          throw err
+        })
+
+    return attemptImport(LAZY_IMPORT_MAX_RETRIES)
+  })
 }

--- a/web/src/lib/sseClient.ts
+++ b/web/src/lib/sseClient.ts
@@ -148,6 +148,8 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
   const promise = new Promise<T[]>((resolve, reject) => {
     const accumulated: T[] = []
     let aborted = false
+    /** Whether we received a proper "done" event from the server */
+    let receivedDone = false
     /** Timer ID for scheduled reconnect — cleared on unmount/abort */
     let reconnectTimerId: ReturnType<typeof setTimeout> | null = null
 
@@ -237,6 +239,7 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
                 console.error('[SSE] Failed to parse cluster_data:', e)
               }
             } else if (eventType === 'done') {
+              receivedDone = true
               clearTimeout(timeoutId)
               cleanup()
               try {
@@ -252,9 +255,15 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
           const pump = (): Promise<void> =>
             reader.read().then(({ done, value }) => {
               if (done) {
-                // Stream ended — flush remaining buffer
+                // Stream ended without a "done" event — partial data (#4934).
+                // Flush remaining buffer and resolve with what we have.
                 if (sseBuffer.trim()) {
                   parseSSEChunk(sseBuffer + '\n\n', handleEvent)
+                }
+                if (!receivedDone && accumulated.length > 0) {
+                  console.warn(
+                    `[SSE] Stream ended without "done" event — returning ${accumulated.length} partial items`,
+                  )
                 }
                 cleanup()
                 clearTimeout(timeoutId)
@@ -275,15 +284,9 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
             return
           }
 
-          // If we already collected some data, resolve with what we have
-          if (accumulated.length > 0) {
-            clearTimeout(timeoutId)
-            cleanup()
-            resolve(accumulated)
-            return
-          }
-
-          // Retry with exponential backoff if we haven't exceeded attempts
+          // Retry with exponential backoff if we haven't exceeded attempts (#4934).
+          // Even with partial data, a retry can complete the stream from remaining
+          // clusters. Only resolve with partial data when all retries are exhausted.
           const retriesRemaining = SSE_MAX_RECONNECT_ATTEMPTS - attemptNumber
           if (retriesRemaining > 0 && !aborted) {
             const delay = Math.min(
@@ -291,8 +294,8 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
               SSE_RECONNECT_MAX_MS,
             )
             console.warn(
-              `[SSE] Connection failed (attempt ${attemptNumber + 1}/${SSE_MAX_RECONNECT_ATTEMPTS + 1}), ` +
-              `retrying in ${delay}ms: ${err.message}`,
+              `[SSE] Connection failed (attempt ${attemptNumber + 1}/${SSE_MAX_RECONNECT_ATTEMPTS + 1}, ` +
+              `${accumulated.length} items so far), retrying in ${delay}ms: ${err.message}`,
             )
             reconnectTimerId = setTimeout(() => {
               reconnectTimerId = null
@@ -303,7 +306,16 @@ export function fetchSSE<T>(options: SSEFetchOptions<T>): Promise<T[]> {
             return
           }
 
-          // All retries exhausted — clean up and reject
+          // All retries exhausted — resolve with partial data if we have any
+          if (accumulated.length > 0) {
+            console.warn(`[SSE] All retries exhausted — resolving with ${accumulated.length} partial items`)
+            clearTimeout(timeoutId)
+            cleanup()
+            resolve(accumulated)
+            return
+          }
+
+          // No data at all — clean up and reject
           clearTimeout(timeoutId)
           cleanup()
           reject(new Error(`SSE stream error: ${err.message}`))


### PR DESCRIPTION
- [x] `sseClient.ts`: retry on stream-ended-without-done with backoff; add `seenClusters` Set to deduplicate cluster data across retry attempts
- [x] `cache/index.ts`: call `flushProgress()` before clearing the throttle timer
- [x] `SharedSortableCard.tsx`: render unknown card type fallback inside `CardWrapper` so remove/configure actions remain available
- [x] `safeLazy.ts`: type catch param as `unknown`, normalize to `Error`
- [x] `self_upgrade.go`: fix error message to mention "plus signs"
- [x] Build passes, lint clean (pre-existing errors only), CodeQL: 0 alerts
- [ ] Push blocked: `fix/security-ux-sse` was auto-deleted after PR #4950 merged; repo rules prevent re-creating it. Changes committed locally on `fix/review-suggestions-4950` (commit `0ea1deac`)