### PR TITLE
🐛 Fix pin icon overlap and search bar visibility

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -20,7 +20,7 @@ import { useBackendHealth } from '../../hooks/useBackendHealth'
 import { useDeepLink } from '../../hooks/useDeepLink'
 import { cn } from '../../lib/cn'
 import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
-import { NAVBAR_HEIGHT_PX, BANNER_HEIGHT_PX } from '../../lib/constants/ui'
+import { NAVBAR_HEIGHT_PX, BANNER_HEIGHT_PX, SIDEBAR_CONTROLS_OFFSET_PX } from '../../lib/constants/ui'
 import { CLOSE_ANIMATION_MS, UI_FEEDBACK_TIMEOUT_MS, TOAST_DISMISS_MS } from '../../lib/constants/network'
 import { TourOverlay, TourPrompt } from '../onboarding/Tour'
 import { TourProvider } from '../../hooks/useTour'
@@ -496,7 +496,10 @@ export function Layout({ children }: LayoutProps) {
         </PageErrorBoundary>
         <main
           id="main-content"
-          style={{ marginLeft: sidebarWidthPx, marginRight: 'var(--mission-sidebar-width, 0px)' }}
+          style={{
+            marginLeft: isMobile ? 0 : sidebarWidthPx + SIDEBAR_CONTROLS_OFFSET_PX,
+            marginRight: 'var(--mission-sidebar-width, 0px)',
+          }}
           className="relative flex-1 p-4 pb-24 md:p-6 md:pb-28 transition-[margin] duration-300 overflow-y-auto scroll-enhanced min-w-0"
         >
           <NavigationProgress />

--- a/web/src/components/layout/navbar/Navbar.tsx
+++ b/web/src/components/layout/navbar/Navbar.tsx
@@ -109,9 +109,10 @@ export function Navbar({ topOffset = 0 }: NavbarProps) {
         </a>
       </div>
 
-      {/* Search - hidden on small mobile; min-w-0 + overflow-hidden prevent
-           overlap when the right-side AI Mission button is visible (#4409) */}
-      <div className="hidden sm:block flex-1 min-w-0 max-w-md mx-4 overflow-hidden">
+      {/* Search - hidden on small mobile; min-w-0 prevents layout overflow
+           when the right-side AI Mission button is visible (#4409).
+           min-w-[120px] ensures the input stays usable at narrow widths (#4955). */}
+      <div className="hidden sm:flex flex-1 min-w-[120px] max-w-md mx-4">
         <Suspense fallback={null}><SearchDropdown /></Suspense>
       </div>
 

--- a/web/src/components/layout/navbar/SearchDropdown.tsx
+++ b/web/src/components/layout/navbar/SearchDropdown.tsx
@@ -375,7 +375,7 @@ export function SearchDropdown() {
   }, [selectedIndex])
 
   return (
-    <div data-tour="search" className="flex-1 max-w-md mx-8" ref={searchRef}>
+    <div data-tour="search" className="flex-1 min-w-0" ref={searchRef}>
       <div className="relative">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
         <input

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -66,3 +66,5 @@ export const NAVBAR_HEIGHT_PX = 64
 export const BANNER_HEIGHT_PX = 36
 /** Height of the green dev-mode indicator bar in pixels (h-5 = 20px) */
 export const DEV_BAR_HEIGHT_PX = 20
+/** Width reserved for the sidebar collapse/pin floating controls (p-1.5 + icon + gap) */
+export const SIDEBAR_CONTROLS_OFFSET_PX = 36


### PR DESCRIPTION
## Summary

- **Pin overlap (#4954):** The sidebar's floating collapse/pin controls were positioned at `left: sidebarWidth + 4px`, overlapping the main content area which starts at `marginLeft: sidebarWidth`. Added a `SIDEBAR_CONTROLS_OFFSET_PX` (36px) constant and applied it to the main content's left margin so dashboard titles and content are pushed past the floating controls.

- **Search bar not visible (#4955):** The navbar search container had `overflow-hidden` which clipped the search results dropdown panel. It also had a redundant `max-w-md mx-8` inside the inner SearchDropdown wrapper, compressing the input at narrower viewports. Fixed by removing `overflow-hidden`, removing the redundant width constraints, and adding `min-w-[120px]` to ensure the search input stays usable.

## Changes

| File | Change |
|------|--------|
| `web/src/lib/constants/ui.ts` | Add `SIDEBAR_CONTROLS_OFFSET_PX = 36` constant |
| `web/src/components/layout/Layout.tsx` | Add controls offset to main content `marginLeft` |
| `web/src/components/layout/navbar/Navbar.tsx` | Remove `overflow-hidden`, add `min-w-[120px]` |
| `web/src/components/layout/navbar/SearchDropdown.tsx` | Remove redundant `max-w-md mx-8` |

Fixes #4954, #4955

## Test plan

- [ ] Verify sidebar pin/collapse buttons no longer overlap the "Dashboard" title text
- [ ] Verify search bar is visible and accepts text input at various viewport widths
- [ ] Verify search results dropdown appears correctly below the search input (not clipped)
- [ ] Verify layout looks correct on mobile (controls offset not applied on mobile)
- [ ] Verify sidebar collapse/expand still works correctly