### PR TITLE
🐛 Fix Nodes stat block to use client-side navigation instead of hard refresh

### DIFF
--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useCallback } from 'react'
-import { useSearchParams, useLocation } from 'react-router-dom'
+import { useSearchParams, useLocation, useNavigate } from 'react-router-dom'
 import { AlertTriangle, ChevronRight, ChevronDown, Server, Scissors } from 'lucide-react'
 import { useClusters, useGPUNodes, useNVIDIAOperators, refreshSingleCluster } from '../../hooks/useMCP'
 import { ClusterDetailModal } from './ClusterDetailModal'
@@ -72,6 +72,7 @@ export function Clusters() {
   } = useGlobalFilters()
   const [searchParams, setSearchParams] = useSearchParams()
   const location = useLocation()
+  const navigate = useNavigate()
   const [selectedCluster, setSelectedCluster] = useState<string | null>(null)
 
   // Read filter from URL, default to 'all'
@@ -219,28 +220,28 @@ export function Clusters() {
         return {
           value: hasData ? stats.totalNodes : '-',
           sublabel: 'total nodes',
-          onClick: () => { emitClusterStatsDrillDown('nodes'); window.location.href = '/compute' },
+          onClick: () => { emitClusterStatsDrillDown('nodes'); navigate('/compute') },
           isClickable: hasData,
         }
       case 'cpus':
         return {
           value: hasData ? stats.totalCPUs : '-',
           sublabel: 'cores allocatable',
-          onClick: () => { emitClusterStatsDrillDown('cpu'); window.location.href = '/compute' },
+          onClick: () => { emitClusterStatsDrillDown('cpu'); navigate('/compute') },
           isClickable: hasData,
         }
       case 'memory':
         return {
           value: hasData ? formatMemoryStat(stats.totalMemoryGB) : '-',
           sublabel: 'allocatable',
-          onClick: () => { emitClusterStatsDrillDown('memory'); window.location.href = '/compute' },
+          onClick: () => { emitClusterStatsDrillDown('memory'); navigate('/compute') },
           isClickable: hasData,
         }
       case 'storage':
         return {
           value: hasData ? formatMemoryStat(stats.totalStorageGB) : '-',
           sublabel: 'storage',
-          onClick: () => { emitClusterStatsDrillDown('storage'); window.location.href = '/storage' },
+          onClick: () => { emitClusterStatsDrillDown('storage'); navigate('/storage') },
           isClickable: hasData,
         }
       case 'gpus':
@@ -254,13 +255,13 @@ export function Clusters() {
         return {
           value: hasData ? stats.totalPods : '-',
           sublabel: 'running pods',
-          onClick: () => { emitClusterStatsDrillDown('pods'); window.location.href = '/workloads' },
+          onClick: () => { emitClusterStatsDrillDown('pods'); navigate('/workloads') },
           isClickable: hasData,
         }
       default:
         return { value: '-', sublabel: '' }
     }
-  }, [stats, setFilter, openGPUModal])
+  }, [stats, setFilter, openGPUModal, navigate])
 
   const getStatValue = useCallback(
     (blockId: string) => createMergedStatValueGetter(getDashboardStatValue, getUniversalStatValue)(blockId),


### PR DESCRIPTION
## Summary
- Replaced `window.location.href` with React Router's `navigate()` in all stat block click handlers (Nodes, CPUs, Memory, Storage, Pods) on the My Clusters dashboard
- This eliminates the full page reload when clicking stat blocks, providing smooth client-side navigation to Compute, Storage, and Workloads pages

Fixes #4961

## Test plan
- [ ] Click the Nodes stat block on My Clusters dashboard — should navigate to /compute without a page refresh
- [ ] Click CPUs, Memory stat blocks — should navigate to /compute client-side
- [ ] Click Storage stat block — should navigate to /storage client-side
- [ ] Click Pods stat block — should navigate to /workloads client-side
- [ ] Verify browser back/forward buttons work correctly after navigation