### PR TITLE
🐛 Fix error states, abort controllers, unmount safety

### DIFF
--- a/web/src/components/cards/DeploymentIssues.tsx
+++ b/web/src/components/cards/DeploymentIssues.tsx
@@ -132,6 +132,17 @@ function DeploymentIssuesInternal({ config }: DeploymentIssuesProps) {
     return <CardSkeleton type="list" rows={3} showHeader rowHeight={100} />
   }
 
+  if (isFailed && !hookLoading && rawIssues.length === 0) {
+    return (
+      <CardEmptyState
+        icon={AlertTriangle}
+        title={t('deploymentIssues.failedToLoad', 'Failed to load deployment data')}
+        message={error || t('deploymentIssues.apiUnavailable', 'Deployment API is unavailable')}
+        variant="error"
+      />
+    )
+  }
+
   if (issues.length === 0 && rawIssues.length === 0) {
     return (
       <CardEmptyState

--- a/web/src/components/cards/GitHubActivity.tsx
+++ b/web/src/components/cards/GitHubActivity.tsx
@@ -1,6 +1,5 @@
 import { useState, useMemo, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react'
 import { GitPullRequest, GitBranch, Star, Users, Package, TrendingUp, AlertCircle, Clock, CheckCircle, XCircle, GitMerge, Settings, X, Plus, Check } from 'lucide-react'
-import { FETCH_EXTERNAL_TIMEOUT_MS } from '../../lib/constants'
 import { POLL_INTERVAL_SLOW_MS } from '../../lib/constants/network'
 import { Button } from '../ui/Button'
 import { Skeleton } from '../ui/Skeleton'
@@ -253,10 +252,11 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
   // Token is injected server-side by the GitHub proxy — no client-side token needed
   const reposKey = useMemo(() => repos.join(','), [repos])
 
-  const fetchGitHubData = async (isManualRefresh = false) => {
+  const fetchGitHubData = useCallback(async (isManualRefresh = false, signal?: AbortSignal) => {
     if (isDemoMode) {
       const targetRepo = repos[0] || DEFAULT_REPO
       const demo = getDemoGitHubData(targetRepo)
+      if (signal?.aborted) return
       setRepoInfo(demo.repoInfo)
       setPRs(demo.prs)
       setIssues(demo.issues)
@@ -290,6 +290,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
       const cached = getCachedData(targetRepo)
       // Use cached data only if it has valid PR data (not empty from old buggy cache)
       if (cached && cached.prs && cached.prs.length > 0) {
+        if (signal?.aborted) return
         setRepoInfo(cached.repoInfo)
         setPRs(cached.prs)
         setIssues(cached.issues)
@@ -315,21 +316,24 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
       const headers: HeadersInit = {
         'Accept': 'application/vnd.github.v3+json',
       }
+      // Use the provided signal for all fetch calls to support cancellation
+      const fetchOptions = { headers, signal }
 
       // Fetch repository info
-      const repoResponse = await fetch(`/api/github/repos/${targetRepo}`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
+      const repoResponse = await fetch(`/api/github/repos/${targetRepo}`, fetchOptions)
       if (!repoResponse.ok) throw new Error(`Failed to fetch repo: ${repoResponse.statusText}`)
       // Use .catch() directly on .json() to prevent Firefox from firing unhandledrejection
       // before the outer try/catch processes the rejection (Firefox-specific microtask timing).
       const repoData = await repoResponse.json().catch(() => null)
       if (!repoData) throw new Error('Failed to parse GitHub repo response: invalid JSON')
+      if (signal?.aborted) return
       setRepoInfo(repoData)
 
       // Fetch open PRs and closed/merged PRs separately to ensure we get merged PRs
       // For active repos, all "recently updated" PRs might be open ones
       const [openPRsResponse, closedPRsResponse] = await Promise.all([
-        fetch(`/api/github/repos/${targetRepo}/pulls?state=open&per_page=50&sort=updated`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }),
-        fetch(`/api/github/repos/${targetRepo}/pulls?state=closed&per_page=50&sort=updated`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
+        fetch(`/api/github/repos/${targetRepo}/pulls?state=open&per_page=50&sort=updated`, fetchOptions),
+        fetch(`/api/github/repos/${targetRepo}/pulls?state=closed&per_page=50&sort=updated`, fetchOptions)
       ])
 
       if (!openPRsResponse.ok) throw new Error(`Failed to fetch open PRs: ${openPRsResponse.statusText}`)
@@ -344,13 +348,14 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
         .sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime())
         .slice(0, 100) // Keep top 100 for display
 
+      if (signal?.aborted) return
       setPRs(allPRs)
       setOpenPRCount(openPRsData.length)
 
       // Fetch open Issues count and recent issues
       const [openIssuesResponse, recentIssuesResponse] = await Promise.all([
-        fetch(`/api/github/repos/${targetRepo}/issues?state=open&per_page=1`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) }),
-        fetch(`/api/github/repos/${targetRepo}/issues?state=all&per_page=50&sort=updated`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
+        fetch(`/api/github/repos/${targetRepo}/issues?state=open&per_page=1`, fetchOptions),
+        fetch(`/api/github/repos/${targetRepo}/issues?state=all&per_page=50&sort=updated`, fetchOptions)
       ])
 
       // Get open issue count from Link header or response body
@@ -364,6 +369,7 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
           const openIssues = await openIssuesResponse.json().catch(() => null)
           calculatedOpenIssueCount = (openIssues || []).filter((i: GitHubIssue & { pull_request?: unknown }) => !i.pull_request).length
         }
+        if (signal?.aborted) return
         setOpenIssueCount(calculatedOpenIssueCount)
       }
 
@@ -371,20 +377,23 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
       const issuesData: GitHubIssue[] = await recentIssuesResponse.json().catch(() => null) ?? []
       // Filter out pull requests (they come with issues endpoint but have pull_request field)
       const filteredIssues = issuesData.filter((issue: GitHubIssue & { pull_request?: unknown }) => !issue.pull_request)
+      if (signal?.aborted) return
       setIssues(filteredIssues)
 
       // Fetch Releases
-      const releasesResponse = await fetch(`/api/github/repos/${targetRepo}/releases?per_page=10`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
+      const releasesResponse = await fetch(`/api/github/repos/${targetRepo}/releases?per_page=10`, fetchOptions)
       if (!releasesResponse.ok) throw new Error(`Failed to fetch releases: ${releasesResponse.statusText}`)
       const releasesData = await releasesResponse.json().catch(() => null)
       if (!releasesData) throw new Error('Failed to parse GitHub releases response: invalid JSON')
+      if (signal?.aborted) return
       setReleases(releasesData)
 
       // Fetch Contributors
-      const contributorsResponse = await fetch(`/api/github/repos/${targetRepo}/contributors?per_page=20`, { headers, signal: AbortSignal.timeout(FETCH_EXTERNAL_TIMEOUT_MS) })
+      const contributorsResponse = await fetch(`/api/github/repos/${targetRepo}/contributors?per_page=20`, fetchOptions)
       if (!contributorsResponse.ok) throw new Error(`Failed to fetch contributors: ${contributorsResponse.statusText}`)
       const contributorsData = await contributorsResponse.json().catch(() => null)
       if (!contributorsData) throw new Error('Failed to parse GitHub contributors response: invalid JSON')
+      if (signal?.aborted) return
       setContributors(contributorsData)
 
       // Cache the fetched data using the calculated counts
@@ -400,6 +409,10 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
 
       setLastRefresh(new Date())
     } catch (err) {
+      // Abort errors are expected during cleanup — do not treat as failures
+      if (err instanceof DOMException && err.name === 'AbortError') return
+      if (signal?.aborted) return
+
       const errorMessage = err instanceof Error ? err.message : 'Failed to fetch GitHub data'
       console.error('GitHub API error:', err)
 
@@ -426,20 +439,27 @@ function useGitHubActivity(config?: GitHubActivityConfig) {
 
       setError(errorMessage)
     } finally {
-      setIsLoading(false)
-      setIsRefreshing(false)
+      if (!signal?.aborted) {
+        setIsLoading(false)
+        setIsRefreshing(false)
+      }
     }
-  }
+  }, [isDemoMode, repos, org])
 
   useEffect(() => {
-    fetchGitHubData().catch(() => { /* errors handled inside fetchGitHubData */ })
+    const controller = new AbortController()
+    fetchGitHubData(false, controller.signal).catch(() => { /* errors handled inside fetchGitHubData */ })
     // Auto-refresh every 60 seconds (bypasses cache for fresh data) — skip in demo mode
+    let interval: ReturnType<typeof setInterval> | undefined
     if (!isDemoMode) {
-      const interval = setInterval(() => fetchGitHubData(true).catch(() => { /* errors handled inside fetchGitHubData */ }), POLL_INTERVAL_SLOW_MS)
-      return () => clearInterval(interval)
+      interval = setInterval(() => fetchGitHubData(true, controller.signal).catch(() => { /* errors handled inside fetchGitHubData */ }), POLL_INTERVAL_SLOW_MS)
+    }
+    return () => {
+      controller.abort()
+      if (interval) clearInterval(interval)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reposKey, org, isDemoMode])
+  }, [reposKey, org, isDemoMode, fetchGitHubData])
 
   return {
     prs,

--- a/web/src/components/cards/HardwareHealthCard.tsx
+++ b/web/src/components/cards/HardwareHealthCard.tsx
@@ -335,19 +335,27 @@ export function HardwareHealthCard() {
     setLocalClusterFilter([])
   }
 
+  // Track clear-alert error for user feedback
+  const [clearAlertError, setClearAlertError] = useState<string | null>(null)
+
   // Clear an alert (after power cycle) — triggers refetch to update cached data
   const clearAlert = async (alertId: string) => {
+    setClearAlertError(null)
     try {
-      await fetch(`${LOCAL_AGENT_HTTP_URL}/devices/alerts/clear`, {
+      const response = await fetch(`${LOCAL_AGENT_HTTP_URL}/devices/alerts/clear`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ alertId }),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
+      if (!response.ok) {
+        setClearAlertError(`Failed to clear alert (${response.status})`)
+        return
+      }
       // Refetch to update cached data (the cleared alert won't be in the response)
       refetch()
     } catch {
-      // Silently fail
+      setClearAlertError('Failed to clear alert — agent is unreachable')
     }
   }
 
@@ -430,8 +438,23 @@ export function HardwareHealthCard() {
     }
   }, [currentPage, currentTotalPages])
 
+  /** Auto-dismiss delay for alert clear error messages */
+  const CLEAR_ERROR_DISMISS_MS = 5000
+  useEffect(() => {
+    if (!clearAlertError) return
+    const timer = setTimeout(() => setClearAlertError(null), CLEAR_ERROR_DISMISS_MS)
+    return () => clearTimeout(timer)
+  }, [clearAlertError])
+
   return (
     <div className="h-full flex flex-col">
+      {/* Clear alert error feedback */}
+      {clearAlertError && (
+        <div className="mb-2 p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 text-xs flex items-center gap-2">
+          <XCircle className="w-4 h-4 flex-shrink-0" />
+          <span>{clearAlertError}</span>
+        </div>
+      )}
       {/* Status Summary */}
       <div className="grid grid-cols-3 gap-2 mb-4">
         <div className={cn(

--- a/web/src/components/cards/OPAPolicies.tsx
+++ b/web/src/components/cards/OPAPolicies.tsx
@@ -198,14 +198,17 @@ function OPAPoliciesInternal({ config: _config }: OPAPoliciesProps) {
   const [agentClusters, setAgentClusters] = useState<{ name: string; healthy?: boolean }[]>([])
   useEffect(() => {
     if (shouldUseDemoData) return
-    fetch(`${LOCAL_AGENT_HTTP_URL}/clusters`)
+    const controller = new AbortController()
+    fetch(`${LOCAL_AGENT_HTTP_URL}/clusters`, { signal: controller.signal })
       .then(res => res.json())
       .then(data => {
+        if (controller.signal.aborted) return
         if (data.clusters) {
           setAgentClusters(data.clusters.map((c: { name: string }) => ({ name: c.name, healthy: true })))
         }
       })
-      .catch(() => { /* agent not available */ })
+      .catch(() => { /* agent not available or request aborted */ })
+    return () => controller.abort()
   }, [shouldUseDemoData])
 
   // Use agent clusters if shared state is empty - memoize for stability

--- a/web/src/components/cards/PodIssues.tsx
+++ b/web/src/components/cards/PodIssues.tsx
@@ -1,4 +1,4 @@
-import { MemoryStick, ImageOff, Clock, RefreshCw, CheckCircle } from 'lucide-react'
+import { MemoryStick, ImageOff, Clock, RefreshCw, CheckCircle, AlertTriangle } from 'lucide-react'
 import { useCachedPodIssues } from '../../hooks/useCachedData'
 import type { PodIssue } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
@@ -108,6 +108,17 @@ export function PodIssues() {
 
   if (showSkeleton) {
     return <CardSkeleton type="list" rows={3} showHeader rowHeight={80} />
+  }
+
+  if (isFailed && !hookLoading && rawIssues.length === 0) {
+    return (
+      <CardEmptyState
+        icon={AlertTriangle}
+        title="Failed to load pod data"
+        message={error || 'Pod API is unavailable'}
+        variant="error"
+      />
+    )
   }
 
   if (issues.length === 0 && rawIssues.length === 0) {

--- a/web/src/components/cards/SecurityIssues.tsx
+++ b/web/src/components/cards/SecurityIssues.tsx
@@ -226,6 +226,20 @@ function SecurityIssuesInternal({ config }: SecurityIssuesProps) {
     )
   }
 
+  if (isFailed && !isLoading && issues.length === 0) {
+    return (
+      <div className="h-full flex flex-col">
+        <div className="flex-1 flex flex-col items-center justify-center text-center">
+          <div className="w-12 h-12 rounded-full bg-red-500/10 flex items-center justify-center mb-3" title={t('securityIssues.failedToLoad', 'Failed to load security scan')}>
+            <AlertTriangle className="w-6 h-6 text-red-400" />
+          </div>
+          <p className="text-foreground font-medium">{t('securityIssues.failedToLoad', 'Failed to load security scan')}</p>
+          <p className="text-sm text-muted-foreground">{error || t('securityIssues.apiUnavailable', 'Security scan API is unavailable')}</p>
+        </div>
+      </div>
+    )
+  }
+
   if (showEmptyState || (!isLoading && issues.length === 0)) {
     return (
       <div className="h-full flex flex-col">

--- a/web/src/components/data-compliance/DataCompliance.tsx
+++ b/web/src/components/data-compliance/DataCompliance.tsx
@@ -22,7 +22,7 @@ export function DataCompliance() {
   const { isLoading: clustersLoading, refetch, lastUpdated, isRefreshing: dataRefreshing, error } = useClusters()
   useGlobalFilters() // Keep hook for potential future use
   const { getStatValue: getUniversalStatValue } = useUniversalStats()
-  const { posture, scores, isLoading: complianceLoading, isDemoData, isRefreshing: complianceRefreshing } = useDataCompliance()
+  const { posture, scores, isLoading: complianceLoading, isDemoData, isRefreshing: complianceRefreshing, failedClusters } = useDataCompliance()
 
   const isLoading = clustersLoading || complianceLoading
   const isRefreshing = dataRefreshing || complianceRefreshing
@@ -109,6 +109,20 @@ export function DataCompliance() {
           <div>
             <div className="font-medium">Failed to load cluster data</div>
             <div className="text-sm text-muted-foreground">{error}</div>
+          </div>
+        </div>
+      )}
+      {/* Partial cluster failure warning */}
+      {failedClusters.length > 0 && !error && (
+        <div className="mb-4 p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-yellow-400 flex items-center gap-2">
+          <AlertTriangle className="w-5 h-5" />
+          <div>
+            <div className="font-medium">
+              Data from {failedClusters.length}/{posture.totalClusters} clusters unavailable
+            </div>
+            <div className="text-sm text-muted-foreground">
+              Unreachable: {(failedClusters || []).join(', ')}
+            </div>
           </div>
         </div>
       )}

--- a/web/src/hooks/useDataCompliance.ts
+++ b/web/src/hooks/useDataCompliance.ts
@@ -218,6 +218,7 @@ export function useDataCompliance() {
   const [isLoading, setIsLoading] = useState(!cachedSnapshot)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [failedClusters, setFailedClusters] = useState<string[]>([])
   const [isUsingDemoData, setIsUsingDemoData] = useState(!cachedSnapshot)
   const fetchInProgress = useRef(false)
   const initialLoadDone = useRef(!!cachedSnapshot)
@@ -260,17 +261,22 @@ export function useDataCompliance() {
         reachableClusters: clusters.length,
       }
 
+      const clusterFailures: string[] = []
       const tasks = clusters.map(cluster => async () => {
-        const data = await fetchClusterCompliance(cluster.name)
-        aggregated.totalSecrets += data.secrets.total
-        aggregated.opaqueSecrets += data.secrets.opaque
-        aggregated.tlsSecrets += data.secrets.tls
-        aggregated.saTokenSecrets += data.secrets.saToken
-        aggregated.dockerSecrets += data.secrets.docker
-        aggregated.rbacPolicies += data.roles
-        aggregated.roleBindings += data.roleBindings
-        aggregated.clusterAdminBindings += data.clusterAdminBindings
-        aggregated.totalNamespaces += data.namespaces
+        try {
+          const data = await fetchClusterCompliance(cluster.name)
+          aggregated.totalSecrets += data.secrets.total
+          aggregated.opaqueSecrets += data.secrets.opaque
+          aggregated.tlsSecrets += data.secrets.tls
+          aggregated.saTokenSecrets += data.secrets.saToken
+          aggregated.dockerSecrets += data.secrets.docker
+          aggregated.rbacPolicies += data.roles
+          aggregated.roleBindings += data.roleBindings
+          aggregated.clusterAdminBindings += data.clusterAdminBindings
+          aggregated.totalNamespaces += data.namespaces
+        } catch {
+          clusterFailures.push(cluster.name)
+        }
       })
 
       await settledWithConcurrency(tasks)
@@ -278,7 +284,12 @@ export function useDataCompliance() {
       setPosture(aggregated)
       saveToCache(aggregated)
       setIsUsingDemoData(false)
-      setError(null)
+      setFailedClusters(clusterFailures)
+      if (clusterFailures.length > 0) {
+        setError(`Data from ${clusterFailures.length}/${clusters.length} clusters unavailable`)
+      } else {
+        setError(null)
+      }
       initialLoadDone.current = true
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch compliance data')
@@ -296,6 +307,7 @@ export function useDataCompliance() {
       setIsLoading(false)
       setIsUsingDemoData(true)
       setError(null)
+      setFailedClusters([])
       initialLoadDone.current = true
       return
     }
@@ -315,6 +327,7 @@ export function useDataCompliance() {
       setIsLoading(true)
       setIsUsingDemoData(true)
       setError(null)
+      setFailedClusters([])
       initialLoadDone.current = false
     })
 
@@ -367,6 +380,7 @@ export function useDataCompliance() {
     isLoading,
     isRefreshing,
     error,
+    failedClusters,
     isDemoData: isUsingDemoData,
     refetch: () => refetch(false),
   }

--- a/web/src/lib/cards/CardComponents.tsx
+++ b/web/src/lib/cards/CardComponents.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useRef, useState, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom'
-import { LucideIcon, CheckCircle, AlertTriangle, Info, Search, Filter, ChevronDown, ChevronRight, Server, Stethoscope, Wrench } from 'lucide-react'
+import { LucideIcon, CheckCircle, AlertTriangle, Info, Search, Filter, ChevronDown, ChevronRight, Server, Stethoscope, Wrench, XCircle } from 'lucide-react'
 import { useMissions } from '../../hooks/useMissions'
 import { useApiKeyCheck, ApiKeyPromptModal } from '../../components/cards/console-missions/shared'
 import { Skeleton } from '../../components/ui/Skeleton'
@@ -93,7 +93,7 @@ export interface CardEmptyStateProps {
   /** Secondary message */
   message?: string
   /** Variant determines color scheme */
-  variant?: 'success' | 'info' | 'warning' | 'neutral'
+  variant?: 'success' | 'info' | 'warning' | 'error' | 'neutral'
   /** Optional action button */
   action?: {
     label: string
@@ -116,6 +116,11 @@ const emptyStateVariants = {
     iconBg: 'bg-yellow-500/10',
     iconColor: 'text-yellow-400',
     icon: AlertTriangle,
+  },
+  error: {
+    iconBg: 'bg-red-500/10',
+    iconColor: 'text-red-400',
+    icon: XCircle,
   },
   neutral: {
     iconBg: 'bg-secondary',


### PR DESCRIPTION
## Summary
- **SecurityIssues** (#4965): Show error state when `isFailed` is true instead of false green "No security issues" all-clear
- **PodIssues** (#4966): Show error state when `isFailed` is true instead of false "All pods healthy" message
- **DeploymentIssues** (#4973): Show error state when `isFailed` is true instead of false "All healthy" message
- **DataCompliance** (#4976): Track per-cluster fetch failures and display a yellow warning banner ("Data from N/M clusters unavailable") when some clusters fail
- **HardwareHealthCard** (#4977): Show auto-dismissing error feedback when clear-alert API fails, replacing the `// Silently fail` catch block
- **GitHubActivity** (#4979): Add `AbortController` with `signal` passed through all fetch calls; check `signal.aborted` before every `setState` call; proper cleanup on unmount/dependency change
- **OPAPolicies** (#4980): Add `AbortController` to agent clusters fetch with cleanup return in `useEffect`

Also adds `error` variant to `CardEmptyState` component (used by PodIssues and DeploymentIssues).

## Test plan
- [ ] Disconnect agent API, verify SecurityIssues/PodIssues/DeploymentIssues show error state (not false healthy)
- [ ] With multiple clusters, make one unreachable — verify DataCompliance shows yellow warning with cluster names
- [ ] Click "Clear alert" on HardwareHealth while agent is down — verify error banner appears and auto-dismisses
- [ ] Navigate away from GitHubActivity mid-fetch — verify no console warnings about unmounted setState
- [ ] Toggle demo mode rapidly on OPAPolicies — verify no stale state updates

Fixes #4965, #4966, #4973, #4976, #4977, #4979, #4980