### PR TITLE
🐛 Fix cache clearing, session state, key corruption, animation consistency

### DIFF
--- a/web/src/lib/cache/hooks.ts
+++ b/web/src/lib/cache/hooks.ts
@@ -40,6 +40,23 @@ export function useLocalPreference<T>(
     return defaultValue
   })
 
+  // Re-read from localStorage when the key changes at runtime to avoid writing
+  // stale data from a previous key into the new one (#4971).
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(storageKey)
+      if (stored !== null) {
+        setValue(JSON.parse(stored) as T)
+      } else {
+        setValue(defaultValue)
+      }
+    } catch {
+      setValue(defaultValue)
+    }
+    // Only re-run when the storage key actually changes (key prop swap)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey])
+
   // Persist to localStorage when value changes
   useEffect(() => {
     try {
@@ -332,14 +349,19 @@ export async function getStorageStats(): Promise<{
  * Clear all cached data (both IndexedDB and localStorage)
  */
 export async function clearAllStorage(): Promise<void> {
-  // Clear IndexedDB
+  // Clear IndexedDB — await transaction completion so callers can rely on
+  // the store being empty when the promise resolves (#4972)
   try {
     const db = await openDatabase()
-    const transaction = db.transaction(STORE_NAME, 'readwrite')
-    const store = transaction.objectStore(STORE_NAME)
-    store.clear()
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction(STORE_NAME, 'readwrite')
+      const store = transaction.objectStore(STORE_NAME)
+      store.clear()
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(transaction.error)
+    })
   } catch {
-    // Ignore
+    // Ignore — best-effort clear
   }
 
   // Clear kubestellar localStorage

--- a/web/src/lib/cache/index.ts
+++ b/web/src/lib/cache/index.ts
@@ -97,6 +97,25 @@ function ssRead<T>(key: string): { data: T; timestamp: number } | null {
   }
 }
 
+/**
+ * Remove ALL sessionStorage snapshots with the kcc: prefix.
+ * Called during cache clearing to prevent stale data rehydration (#4967, #4970).
+ */
+function clearSessionSnapshots(): void {
+  try {
+    const keysToRemove: string[] = []
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const key = sessionStorage.key(i)
+      if (key?.startsWith(SS_PREFIX)) {
+        keysToRemove.push(key)
+      }
+    }
+    keysToRemove.forEach(k => sessionStorage.removeItem(k))
+  } catch {
+    // sessionStorage may be unavailable in some contexts
+  }
+}
+
 /** Base backoff multiplier for consecutive failures */
 const FAILURE_BACKOFF_MULTIPLIER = 2
 
@@ -519,7 +538,8 @@ export function isSQLiteWorkerActive(): boolean {
  * 1. Wipe the persistent backend (SQLite / IndexedDB) so no old entries
  *    can be reloaded on future page loads or storage-load cycles.
  * 2. Clear the preloaded metadata map (failure counters, etc.).
- * 3. Reset every in-memory CacheStore to its initial (empty) state WITHOUT
+ * 3. Clear sessionStorage snapshots (kcc:*) so stale data cannot rehydrate.
+ * 4. Reset every in-memory CacheStore to its initial (empty) state WITHOUT
  *    reloading from storage (the storage was just cleared).
  */
 function clearAllInMemoryCaches(): void {
@@ -531,7 +551,10 @@ function clearAllInMemoryCaches(): void {
   // 2. Clear metadata
   preloadedMetaMap.clear()
 
-  // 3. Reset every in-memory store WITHOUT reloading from (now-empty) storage
+  // 3. Clear sessionStorage snapshots so next mount cannot rehydrate stale data (#4967)
+  clearSessionSnapshots()
+
+  // 4. Reset every in-memory store WITHOUT reloading from (now-empty) storage
   for (const store of cacheRegistry.values()) {
     (store as CacheStore<unknown>).resetForModeTransition()
   }
@@ -934,7 +957,7 @@ class CacheStore<T> {
         // After MAX_FAILURES, isFailed triggers failure state instead of skeleton.
         isLoading: !hasData && !reachedMaxFailures,
         isRefreshing: false,
-        error: null,
+        error: errorMessage,
         isFailed: hasData ? false : reachedMaxFailures,
         consecutiveFailures: hasData ? 0 : newFailures,
       })
@@ -946,6 +969,8 @@ class CacheStore<T> {
   // Clear cache
   async clear(): Promise<void> {
     await cacheStorage.delete(this.key)
+    // Remove sessionStorage snapshot so re-creating the store cannot rehydrate stale data (#4969)
+    try { sessionStorage.removeItem(SS_PREFIX + this.key) } catch { /* ignore */ }
     preloadedMetaMap.delete(this.key)
     if (workerRpc) {
       workerRpc.setMeta(this.key, { consecutiveFailures: 0 })
@@ -1273,6 +1298,9 @@ export async function clearAllCaches(): Promise<void> {
 
   // Clear preloaded metadata
   preloadedMetaMap.clear()
+
+  // Clear sessionStorage snapshots so stale data cannot rehydrate (#4970)
+  clearSessionSnapshots()
 
   // Clear any remaining localStorage metadata (fallback/legacy)
   const keysToRemove: string[] = []


### PR DESCRIPTION
## Summary
- **#4967, #4969, #4970**: Clear sessionStorage snapshots (`kcc:*`) during mode transitions, single-key `clear()`, and `clearAllCaches()` to prevent stale data rehydration after cache clearing
- **#4968**: Expose `errorMessage` to callers on fetch failure — previously `error` was set to `null` in the catch block, so consumers of `useCache` could never display the last fetch error
- **#4971**: Re-read from localStorage when `useLocalPreference` key changes at runtime — previously the hook initialized state only once, so changing the key prop would carry stale data into the new key
- **#4972**: Await IndexedDB transaction completion in `clearAllStorage()` — previously `store.clear()` was called without awaiting the transaction, so callers could continue before IndexedDB was actually cleared
- **#4974**: Verified all RefreshCw icons across 50+ components — `animate-spin` is already correctly tied to loading state throughout the codebase; remaining unanimated instances are decorative status icons (e.g., "Revision:", "Channel:", "Status:") or one-shot action buttons (error boundary reload/retry)

Fixes #4967, #4968, #4969, #4970, #4971, #4972, #4974

## Test plan
- [ ] Toggle demo mode on/off and verify no stale data rehydrates from sessionStorage
- [ ] Clear a single cache key and verify its sessionStorage snapshot is removed
- [ ] Use `clearAllCaches()` and confirm all `kcc:*` sessionStorage entries are gone
- [ ] Trigger a fetch failure and verify `error` is non-null in the `useCache` result
- [ ] Change a `useLocalPreference` key at runtime (e.g., switch card filter keys) and verify the value updates correctly
- [ ] Call `clearAllStorage()` and confirm the returned promise resolves only after IndexedDB is cleared