### PR TITLE
🐛 Fix 15 Go backend security audit findings

### DIFF
--- a/pkg/agent/prediction_metrics.go
+++ b/pkg/agent/prediction_metrics.go
@@ -84,15 +84,48 @@ func RecordPrediction(predType, severity, source, provider string) {
 	predictionsTotal.WithLabelValues(predType, severity, source, provider).Inc()
 }
 
+// allowedCategories is the set of valid prediction categories for Prometheus labels.
+// Values outside this set are mapped to "other" to prevent unbounded cardinality.
+var allowedCategories = map[string]bool{
+	"performance": true,
+	"security":    true,
+	"cost":        true,
+	"reliability": true,
+	"scaling":     true,
+	"networking":  true,
+	"storage":     true,
+	"config":      true,
+	"other":       true,
+}
+
+// allowedSeverities is the set of valid prediction severities for Prometheus labels.
+var allowedSeverities = map[string]bool{
+	"critical": true,
+	"high":     true,
+	"medium":   true,
+	"low":      true,
+	"info":     true,
+}
+
+// sanitizeLabel returns the label value if it is in the allowed set, otherwise "other".
+func sanitizeLabel(value string, allowed map[string]bool) string {
+	if allowed[value] {
+		return value
+	}
+	return "other"
+}
+
 // SetActivePredictions updates the gauge of active predictions
 func SetActivePredictions(predictions []AIPrediction) {
 	// Reset all gauges
 	predictionsActive.Reset()
 
-	// Count by type, severity, source
+	// Count by type, severity, source — sanitize labels to prevent unbounded cardinality
 	counts := make(map[string]float64)
 	for _, p := range predictions {
-		key := p.Category + "|" + p.Severity + "|ai"
+		category := sanitizeLabel(p.Category, allowedCategories)
+		severity := sanitizeLabel(p.Severity, allowedSeverities)
+		key := category + "|" + severity + "|ai"
 		counts[key]++
 	}
 

--- a/pkg/agent/provider_antigravity.go
+++ b/pkg/agent/provider_antigravity.go
@@ -194,6 +194,10 @@ func (a *AntigravityProvider) StreamChat(ctx context.Context, req *ChatRequest, 
 		}
 	}
 
+	if scanErr := scanner.Err(); scanErr != nil {
+		slog.Error("[Antigravity] scanner error reading stdout", "error", scanErr)
+	}
+
 	if err := cmd.Wait(); err != nil {
 		slog.Error("[Antigravity] command finished with error", "error", err)
 	}

--- a/pkg/agent/provider_bob.go
+++ b/pkg/agent/provider_bob.go
@@ -313,7 +313,9 @@ func (b *BobProvider) StreamChat(ctx context.Context, req *ChatRequest, onChunk 
 	}
 
 	// Send the complete response as a single chunk
-	onChunk(resp.Content)
+	if onChunk != nil {
+		onChunk(resp.Content)
+	}
 
 	return resp, nil
 }

--- a/pkg/agent/provider_gemini.go
+++ b/pkg/agent/provider_gemini.go
@@ -80,13 +80,14 @@ func (g *GeminiProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatRespo
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/%s:generateContent?key=%s", geminiAPIBaseURL, g.model, GetConfigManager().GetAPIKey("gemini"))
+	url := fmt.Sprintf("%s/%s:generateContent", geminiAPIBaseURL, g.model)
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-goog-api-key", GetConfigManager().GetAPIKey("gemini"))
 
 	resp, err := g.client.Do(httpReq)
 	if err != nil {
@@ -159,13 +160,14 @@ func (g *GeminiProvider) StreamChat(ctx context.Context, req *ChatRequest, onChu
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	url := fmt.Sprintf("%s/%s:streamGenerateContent?key=%s&alt=sse", geminiAPIBaseURL, g.model, GetConfigManager().GetAPIKey("gemini"))
+	url := fmt.Sprintf("%s/%s:streamGenerateContent?alt=sse", geminiAPIBaseURL, g.model)
 	httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
 	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-goog-api-key", GetConfigManager().GetAPIKey("gemini"))
 
 	resp, err := g.client.Do(httpReq)
 	if err != nil {

--- a/pkg/agent/provider_geminicli.go
+++ b/pkg/agent/provider_geminicli.go
@@ -123,6 +123,10 @@ func (g *GeminiCLIProvider) StreamChat(ctx context.Context, req *ChatRequest, on
 		}
 	}
 
+	if scanErr := scanner.Err(); scanErr != nil {
+		slog.Error("[GeminiCLI] scanner error reading stdout", "error", scanErr)
+	}
+
 	if err := cmd.Wait(); err != nil {
 		slog.Error("[GeminiCLI] command finished with error", "error", err)
 	}

--- a/pkg/agent/provider_ghcopilot.go
+++ b/pkg/agent/provider_ghcopilot.go
@@ -104,6 +104,10 @@ func (g *GHCopilotProvider) StreamChat(ctx context.Context, req *ChatRequest, on
 		}
 	}
 
+	if scanErr := scanner.Err(); scanErr != nil {
+		slog.Error("[GHCopilot] scanner error reading stdout", "error", scanErr)
+	}
+
 	if err := cmd.Wait(); err != nil {
 		slog.Error("[GHCopilot] command finished with error", "error", err)
 	}

--- a/pkg/agent/server_operations.go
+++ b/pkg/agent/server_operations.go
@@ -520,11 +520,11 @@ func validateOpenAIKey(ctx context.Context, apiKey string) (bool, error) {
 
 // validateGeminiKey tests a Google Gemini API key
 func validateGeminiKey(ctx context.Context, apiKey string) (bool, error) {
-	url := fmt.Sprintf("%s?key=%s", geminiAPIBaseURL, apiKey)
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", geminiAPIBaseURL, nil)
 	if err != nil {
 		return false, err
 	}
+	req.Header.Set("x-goog-api-key", apiKey)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/pkg/api/handlers/custom_resources.go
+++ b/pkg/api/handlers/custom_resources.go
@@ -56,6 +56,17 @@ func (h *MCPHandlers) GetCustomResources(c *fiber.Ctx) error {
 		return c.JSON(CustomResourceResponse{Items: []CustomResourceItem{}, IsDemoData: false})
 	}
 
+	// Validate GVR parameters against Kubernetes naming conventions
+	if !isValidK8sName(group) {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid group parameter — must match DNS subdomain format"})
+	}
+	if !isValidK8sVersion(version) {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid version parameter — must be alphanumeric (e.g. v1, v1beta1)"})
+	}
+	if !isValidK8sName(resource) {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid resource parameter — must match DNS label format"})
+	}
+
 	if h.k8sClient == nil {
 		return c.Status(503).JSON(CustomResourceResponse{Items: []CustomResourceItem{}, IsDemoData: true})
 	}

--- a/pkg/api/handlers/exec.go
+++ b/pkg/api/handlers/exec.go
@@ -20,6 +20,10 @@ import (
 // execAuthDeadline is how long the client has to send an auth message after connecting.
 const execAuthDeadline = 5 * time.Second
 
+// execMaxStdinBytes is the maximum allowed size of a single stdin message.
+// Messages exceeding this limit are silently dropped to prevent memory exhaustion.
+const execMaxStdinBytes = 1 * 1024 * 1024 // 1 MB
+
 // ExecHandlers handles pod exec API endpoints
 type ExecHandlers struct {
 	k8sClient *k8s.MultiClusterClient
@@ -294,6 +298,10 @@ func (h *ExecHandlers) HandleExec(c *websocket.Conn) {
 
 			switch m.Type {
 			case "stdin":
+				if len(m.Data) > execMaxStdinBytes {
+					slog.Warn("[Exec] dropping oversized stdin message", "bytes", len(m.Data), "limit", execMaxStdinBytes)
+					continue
+				}
 				select {
 				case stdinCh <- []byte(m.Data):
 				default:

--- a/pkg/api/handlers/mcp_resources.go
+++ b/pkg/api/handlers/mcp_resources.go
@@ -193,6 +193,18 @@ func (h *MCPHandlers) InstallGPUHealthCronJob(c *fiber.Ctx) error {
 		return c.Status(400).JSON(fiber.Map{"error": "cluster is required"})
 	}
 
+	// Validate cron schedule format (5-field standard cron expression)
+	if body.Schedule != "" && !isValidCronSchedule(body.Schedule) {
+		return c.Status(400).JSON(fiber.Map{"error": "invalid cron schedule format — expected 5-field cron expression (e.g. '*/15 * * * *')"})
+	}
+
+	// Validate tier range
+	const minTier = 1
+	const maxTier = 3
+	if body.Tier < minTier || body.Tier > maxTier {
+		return c.Status(400).JSON(fiber.Map{"error": fmt.Sprintf("tier must be between %d and %d", minTier, maxTier)})
+	}
+
 	ctx, cancel := context.WithTimeout(c.Context(), mcpExtendedTimeout)
 	defer cancel()
 

--- a/pkg/api/handlers/validation.go
+++ b/pkg/api/handlers/validation.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"regexp"
+	"strings"
+)
+
+// cronFieldCount is the number of fields in a standard cron expression.
+const cronFieldCount = 5
+
+// cronFieldPattern matches a single cron field (digits, *, /, -, comma).
+var cronFieldPattern = regexp.MustCompile(`^[\d\*,/\-]+$`)
+
+// k8sNamePattern matches valid Kubernetes DNS subdomain names and plural resource names.
+// Allows lowercase alphanumeric, dots, and hyphens (e.g. "apps", "keda.sh", "v1beta1").
+var k8sNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9.\-]*[a-z0-9]$|^[a-z0-9]$`)
+
+// k8sVersionPattern matches Kubernetes API versions (e.g. "v1", "v1beta1", "v2alpha1").
+var k8sVersionPattern = regexp.MustCompile(`^v[0-9]+([a-z]+[0-9]+)?$`)
+
+// maxCronFieldLen is the maximum length of a single cron field to prevent abuse.
+const maxCronFieldLen = 64
+
+// isValidCronSchedule validates a 5-field cron expression.
+// It does not validate semantic correctness (e.g. day 32), only structural format.
+func isValidCronSchedule(schedule string) bool {
+	fields := strings.Fields(schedule)
+	if len(fields) != cronFieldCount {
+		return false
+	}
+	for _, f := range fields {
+		if len(f) > maxCronFieldLen {
+			return false
+		}
+		if !cronFieldPattern.MatchString(f) {
+			return false
+		}
+	}
+	return true
+}
+
+// isValidK8sName validates a Kubernetes-style DNS name (group or resource).
+// Uses maxK8sNameLen (253) defined in gitops.go.
+func isValidK8sName(name string) bool {
+	if len(name) > maxK8sNameLen {
+		return false
+	}
+	return k8sNamePattern.MatchString(name)
+}
+
+// isValidK8sVersion validates a Kubernetes API version string.
+func isValidK8sVersion(version string) bool {
+	if len(version) > maxK8sNameLen {
+		return false
+	}
+	return k8sVersionPattern.MatchString(version)
+}

--- a/pkg/api/handlers/websocket.go
+++ b/pkg/api/handlers/websocket.go
@@ -20,6 +20,9 @@ const (
 	// Connections that exceed this without sending a ping are closed to prevent DoS via
 	// exhausted file descriptors.
 	wsIdleTimeout = 90 * time.Second
+	// wsMaxBroadcastBytes is the maximum serialized size of a single broadcast message.
+	// Messages exceeding this limit are dropped to prevent memory spikes.
+	wsMaxBroadcastBytes = 1 * 1024 * 1024 // 1 MB
 )
 
 // Message represents a WebSocket message
@@ -148,6 +151,11 @@ func (h *Hub) Broadcast(userID uuid.UUID, msg Message) {
 		return
 	}
 
+	if len(data) > wsMaxBroadcastBytes {
+		slog.Warn("[WebSocket] dropping oversized broadcast message", "user", userID, "type", msg.Type, "bytes", len(data), "limit", wsMaxBroadcastBytes)
+		return
+	}
+
 	select {
 	case h.broadcast <- broadcastMessage{userID: userID, data: data}:
 		// Message queued successfully
@@ -230,6 +238,11 @@ func (h *Hub) BroadcastAll(msg Message) {
 	data, err := json.Marshal(msg)
 	if err != nil {
 		slog.Error("[WebSocket] failed to marshal message", "error", err)
+		return
+	}
+
+	if len(data) > wsMaxBroadcastBytes {
+		slog.Warn("[WebSocket] dropping oversized broadcast-all message", "type", msg.Type, "bytes", len(data), "limit", wsMaxBroadcastBytes)
 		return
 	}
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1035,6 +1035,13 @@ func preCompressedStatic(root string) fiber.Handler {
 		}
 		filePath := filepath.Join(root, p)
 
+		// Security: prevent path traversal — ensure resolved path stays within root
+		absRoot, _ := filepath.Abs(root)
+		absFile, _ := filepath.Abs(filePath)
+		if !strings.HasPrefix(absFile, absRoot+string(filepath.Separator)) && absFile != absRoot {
+			return c.Next()
+		}
+
 		// Only serve actual static files
 		info, err := os.Stat(filePath)
 		if err != nil || info.IsDir() {

--- a/pkg/mcp/bridge.go
+++ b/pkg/mcp/bridge.go
@@ -506,7 +506,7 @@ func (b *Bridge) parseClustersResult(result *CallToolResult) ([]ClusterInfo, err
 	for _, content := range result.Content {
 		if content.Type == "text" {
 			if err := json.Unmarshal([]byte(content.Text), &clusters); err != nil {
-				// Try to extract from formatted text
+				slog.Warn("[MCP] failed to parse clusters JSON — returning empty result", "error", err)
 				return b.parseClustersFromText(content.Text), nil
 			}
 		}
@@ -553,6 +553,7 @@ func (b *Bridge) parsePodsResult(result *CallToolResult) ([]PodInfo, error) {
 	for _, content := range result.Content {
 		if content.Type == "text" {
 			if err := json.Unmarshal([]byte(content.Text), &pods); err != nil {
+				slog.Warn("[MCP] failed to parse pods JSON — returning empty result", "error", err)
 				return []PodInfo{}, nil
 			}
 		}
@@ -572,6 +573,7 @@ func (b *Bridge) parsePodIssuesResult(result *CallToolResult) ([]PodIssue, error
 	for _, content := range result.Content {
 		if content.Type == "text" {
 			if err := json.Unmarshal([]byte(content.Text), &issues); err != nil {
+				slog.Warn("[MCP] failed to parse pod issues JSON — returning empty result", "error", err)
 				return []PodIssue{}, nil
 			}
 		}
@@ -591,6 +593,7 @@ func (b *Bridge) parseEventsResult(result *CallToolResult) ([]Event, error) {
 	for _, content := range result.Content {
 		if content.Type == "text" {
 			if err := json.Unmarshal([]byte(content.Text), &events); err != nil {
+				slog.Warn("[MCP] failed to parse events JSON — returning empty result", "error", err)
 				return []Event{}, nil
 			}
 		}

--- a/pkg/settings/crypto.go
+++ b/pkg/settings/crypto.go
@@ -45,11 +45,35 @@ func ensureKeyFile(path string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to generate key: %w", err)
 	}
 
-	// Write hex-encoded key with secure permissions
+	// Atomic write: write to a temp file then rename to prevent races
+	// when multiple processes start simultaneously.
 	encoded := hex.EncodeToString(key)
-	if err := os.WriteFile(path, []byte(encoded), keyFileMode); err != nil {
-		return nil, fmt.Errorf("failed to write keyfile %s: %w", path, err)
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(encoded), keyFileMode); err != nil {
+		return nil, fmt.Errorf("failed to write temp keyfile %s: %w", tmpPath, err)
 	}
+
+	// Use os.Link + os.Remove for atomic creation (fails if target already exists on most filesystems).
+	// If another process already created the key file, use theirs instead of overwriting.
+	if linkErr := os.Link(tmpPath, path); linkErr != nil {
+		// Another process beat us — remove our temp file and read theirs
+		os.Remove(tmpPath)
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil, fmt.Errorf("failed to read keyfile after race: %w", readErr)
+		}
+		existingKey, decErr := hex.DecodeString(string(data))
+		if decErr != nil {
+			return nil, fmt.Errorf("corrupt keyfile %s after race: %w", path, decErr)
+		}
+		if len(existingKey) != keyBytes {
+			return nil, fmt.Errorf("keyfile %s has wrong length after race: got %d, want %d", path, len(existingKey), keyBytes)
+		}
+		return existingKey, nil
+	}
+
+	// Our file won the race — clean up the temp file
+	os.Remove(tmpPath)
 
 	return key, nil
 }

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -27,6 +27,32 @@ const (
 	sqliteDefaultConnMaxIdleTime = 2 * time.Minute
 )
 
+// parseUUID parses a UUID string, logging a warning if malformed instead of
+// silently returning the zero UUID. This prevents data misattribution when
+// the database contains corrupted UUID strings.
+func parseUUID(s string, field string) uuid.UUID {
+	id, err := uuid.Parse(s)
+	if err != nil {
+		slog.Warn("[Store] malformed UUID in database — using zero UUID", "field", field, "value", s, "error", err)
+	}
+	return id
+}
+
+// maxSQLLimit is the maximum allowed value for SQL LIMIT parameters.
+// This provides defense-in-depth against unbounded queries from internal callers.
+const maxSQLLimit = 1000
+
+// clampLimit ensures a SQL LIMIT parameter is within safe bounds (1 to maxSQLLimit).
+func clampLimit(limit int) int {
+	if limit < 1 {
+		return 1
+	}
+	if limit > maxSQLLimit {
+		return maxSQLLimit
+	}
+	return limit
+}
+
 // getEnvInt reads an integer from the environment, falling back to defaultVal.
 func getEnvInt(key string, defaultVal int) int {
 	if v := os.Getenv(key); v != "" {
@@ -285,7 +311,7 @@ func (s *SQLiteStore) scanUser(row *sql.Row) (*models.User, error) {
 		return nil, err
 	}
 
-	u.ID, _ = uuid.Parse(idStr)
+	u.ID = parseUUID(idStr, "user.ID")
 	u.Onboarded = onboarded == 1
 	if email.Valid {
 		u.Email = email.String
@@ -352,7 +378,7 @@ func (s *SQLiteStore) ListUsers() ([]models.User, error) {
 			return nil, err
 		}
 
-		u.ID, _ = uuid.Parse(idStr)
+		u.ID = parseUUID(idStr, "u.ID")
 		u.Onboarded = onboarded == 1
 		if email.Valid {
 			u.Email = email.String
@@ -452,8 +478,8 @@ func (s *SQLiteStore) GetOnboardingResponses(userID uuid.UUID) ([]models.Onboard
 		if err := rows.Scan(&idStr, &userIDStr, &r.QuestionKey, &r.Answer, &r.CreatedAt); err != nil {
 			return nil, err
 		}
-		r.ID, _ = uuid.Parse(idStr)
-		r.UserID, _ = uuid.Parse(userIDStr)
+		r.ID = parseUUID(idStr, "r.ID")
+		r.UserID = parseUUID(userIDStr, "r.UserID")
 		responses = append(responses, r)
 	}
 	return responses, rows.Err()
@@ -509,8 +535,8 @@ func (s *SQLiteStore) scanDashboard(row *sql.Row) (*models.Dashboard, error) {
 		return nil, err
 	}
 
-	d.ID, _ = uuid.Parse(idStr)
-	d.UserID, _ = uuid.Parse(userIDStr)
+	d.ID = parseUUID(idStr, "d.ID")
+	d.UserID = parseUUID(userIDStr, "d.UserID")
 	d.IsDefault = isDefault == 1
 	if layout.Valid {
 		d.Layout = json.RawMessage(layout.String)
@@ -533,8 +559,8 @@ func (s *SQLiteStore) scanDashboardRow(rows *sql.Rows) (*models.Dashboard, error
 		return nil, err
 	}
 
-	d.ID, _ = uuid.Parse(idStr)
-	d.UserID, _ = uuid.Parse(userIDStr)
+	d.ID = parseUUID(idStr, "d.ID")
+	d.UserID = parseUUID(userIDStr, "d.UserID")
 	d.IsDefault = isDefault == 1
 	if layout.Valid {
 		d.Layout = json.RawMessage(layout.String)
@@ -622,14 +648,15 @@ func (s *SQLiteStore) scanCard(row *sql.Row) (*models.Card, error) {
 		return nil, err
 	}
 
-	c.ID, _ = uuid.Parse(idStr)
-	c.DashboardID, _ = uuid.Parse(dashboardIDStr)
+	c.ID = parseUUID(idStr, "c.ID")
+	c.DashboardID = parseUUID(dashboardIDStr, "c.DashboardID")
 	c.CardType = models.CardType(cardType)
 	if config.Valid {
 		c.Config = json.RawMessage(config.String)
 	}
 	if err := json.Unmarshal([]byte(positionStr), &c.Position); err != nil {
-		slog.Error("[Store] failed to unmarshal card position — card will use zero position", "cardID", idStr, "error", err)
+		// Log only that the position was corrupt — omit raw content to prevent information disclosure
+		slog.Warn("[Store] corrupt card position data — card will use zero position", "cardID", idStr)
 	}
 	if lastSummary.Valid {
 		c.LastSummary = lastSummary.String
@@ -652,14 +679,15 @@ func (s *SQLiteStore) scanCardRow(rows *sql.Rows) (*models.Card, error) {
 		return nil, err
 	}
 
-	c.ID, _ = uuid.Parse(idStr)
-	c.DashboardID, _ = uuid.Parse(dashboardIDStr)
+	c.ID = parseUUID(idStr, "c.ID")
+	c.DashboardID = parseUUID(dashboardIDStr, "c.DashboardID")
 	c.CardType = models.CardType(cardType)
 	if config.Valid {
 		c.Config = json.RawMessage(config.String)
 	}
 	if err := json.Unmarshal([]byte(positionStr), &c.Position); err != nil {
-		slog.Error("[Store] failed to unmarshal card position — card will use zero position", "cardID", idStr, "error", err)
+		// Log only that the position was corrupt — omit raw content to prevent information disclosure
+		slog.Warn("[Store] corrupt card position data — card will use zero position", "cardID", idStr)
 	}
 	if lastSummary.Valid {
 		c.LastSummary = lastSummary.String
@@ -742,6 +770,7 @@ func (s *SQLiteStore) AddCardHistory(history *models.CardHistory) error {
 }
 
 func (s *SQLiteStore) GetUserCardHistory(userID uuid.UUID, limit int) ([]models.CardHistory, error) {
+	limit = clampLimit(limit)
 	rows, err := s.db.Query(`SELECT id, user_id, original_card_id, card_type, config, swapped_out_at, reason FROM card_history WHERE user_id = ? ORDER BY swapped_out_at DESC LIMIT ?`, userID.String(), limit)
 	if err != nil {
 		return nil, err
@@ -759,11 +788,11 @@ func (s *SQLiteStore) GetUserCardHistory(userID uuid.UUID, limit int) ([]models.
 			return nil, err
 		}
 
-		h.ID, _ = uuid.Parse(idStr)
-		h.UserID, _ = uuid.Parse(userIDStr)
+		h.ID = parseUUID(idStr, "h.ID")
+		h.UserID = parseUUID(userIDStr, "h.UserID")
 		h.CardType = models.CardType(cardType)
 		if origCardID.Valid {
-			id, _ := uuid.Parse(origCardID.String)
+			id := parseUUID(origCardID.String, "id")
 			h.OriginalCardID = &id
 		}
 		if config.Valid {
@@ -833,9 +862,9 @@ func (s *SQLiteStore) scanPendingSwap(row *sql.Row) (*models.PendingSwap, error)
 		return nil, err
 	}
 
-	swap.ID, _ = uuid.Parse(idStr)
-	swap.UserID, _ = uuid.Parse(userIDStr)
-	swap.CardID, _ = uuid.Parse(cardIDStr)
+	swap.ID = parseUUID(idStr, "swap.ID")
+	swap.UserID = parseUUID(userIDStr, "swap.UserID")
+	swap.CardID = parseUUID(cardIDStr, "swap.CardID")
 	swap.NewCardType = models.CardType(newCardType)
 	swap.Status = models.SwapStatus(status)
 	if config.Valid {
@@ -857,9 +886,9 @@ func (s *SQLiteStore) scanPendingSwapRow(rows *sql.Rows) (*models.PendingSwap, e
 		return nil, err
 	}
 
-	swap.ID, _ = uuid.Parse(idStr)
-	swap.UserID, _ = uuid.Parse(userIDStr)
-	swap.CardID, _ = uuid.Parse(cardIDStr)
+	swap.ID = parseUUID(idStr, "swap.ID")
+	swap.UserID = parseUUID(userIDStr, "swap.UserID")
+	swap.CardID = parseUUID(cardIDStr, "swap.CardID")
 	swap.NewCardType = models.CardType(newCardType)
 	swap.Status = models.SwapStatus(status)
 	if config.Valid {
@@ -944,11 +973,11 @@ func (s *SQLiteStore) GetRecentEvents(userID uuid.UUID, since time.Duration) ([]
 			return nil, err
 		}
 
-		e.ID, _ = uuid.Parse(idStr)
-		e.UserID, _ = uuid.Parse(userIDStr)
+		e.ID = parseUUID(idStr, "e.ID")
+		e.UserID = parseUUID(userIDStr, "e.UserID")
 		e.EventType = models.EventType(eventType)
 		if cardID.Valid {
-			id, _ := uuid.Parse(cardID.String)
+			id := parseUUID(cardID.String, "id")
 			e.CardID = &id
 		}
 		if metadata.Valid {
@@ -1045,8 +1074,8 @@ func (s *SQLiteStore) scanFeatureRequest(row *sql.Row) (*models.FeatureRequest, 
 		return nil, err
 	}
 
-	r.ID, _ = uuid.Parse(idStr)
-	r.UserID, _ = uuid.Parse(userIDStr)
+	r.ID = parseUUID(idStr, "r.ID")
+	r.UserID = parseUUID(userIDStr, "r.UserID")
 	r.RequestType = models.RequestType(requestType)
 	r.Status = models.RequestStatus(status)
 	if issueNumber.Valid {
@@ -1089,8 +1118,8 @@ func (s *SQLiteStore) scanFeatureRequestRow(rows *sql.Rows) (*models.FeatureRequ
 		return nil, err
 	}
 
-	r.ID, _ = uuid.Parse(idStr)
-	r.UserID, _ = uuid.Parse(userIDStr)
+	r.ID = parseUUID(idStr, "r.ID")
+	r.UserID = parseUUID(userIDStr, "r.UserID")
 	r.RequestType = models.RequestType(requestType)
 	r.Status = models.RequestStatus(status)
 	if issueNumber.Valid {
@@ -1201,9 +1230,9 @@ func (s *SQLiteStore) GetPRFeedback(featureRequestID uuid.UUID) ([]models.PRFeed
 			return nil, err
 		}
 
-		f.ID, _ = uuid.Parse(idStr)
-		f.FeatureRequestID, _ = uuid.Parse(requestIDStr)
-		f.UserID, _ = uuid.Parse(userIDStr)
+		f.ID = parseUUID(idStr, "f.ID")
+		f.FeatureRequestID = parseUUID(requestIDStr, "f.FeatureRequestID")
+		f.UserID = parseUUID(userIDStr, "f.UserID")
 		f.FeedbackType = models.FeedbackType(feedbackType)
 		if comment.Valid {
 			f.Comment = comment.String
@@ -1253,12 +1282,12 @@ func (s *SQLiteStore) GetUserNotifications(userID uuid.UUID, limit int) ([]model
 			return nil, err
 		}
 
-		n.ID, _ = uuid.Parse(idStr)
-		n.UserID, _ = uuid.Parse(userIDStr)
+		n.ID = parseUUID(idStr, "n.ID")
+		n.UserID = parseUUID(userIDStr, "n.UserID")
 		n.NotificationType = models.NotificationType(notificationType)
 		n.Read = read == 1
 		if featureRequestID.Valid {
-			id, _ := uuid.Parse(featureRequestID.String)
+			id := parseUUID(featureRequestID.String, "id")
 			n.FeatureRequestID = &id
 		}
 		notifications = append(notifications, n)
@@ -1397,8 +1426,8 @@ func (s *SQLiteStore) scanGPUReservation(row *sql.Row) (*models.GPUReservation, 
 		return nil, err
 	}
 
-	r.ID, _ = uuid.Parse(idStr)
-	r.UserID, _ = uuid.Parse(userIDStr)
+	r.ID = parseUUID(idStr, "r.ID")
+	r.UserID = parseUUID(userIDStr, "r.UserID")
 	r.Status = models.ReservationStatus(status)
 	r.QuotaEnforced = quotaEnforced == 1
 	if updatedAt.Valid {
@@ -1421,8 +1450,8 @@ func (s *SQLiteStore) scanGPUReservationRow(rows *sql.Rows) (*models.GPUReservat
 		return nil, err
 	}
 
-	r.ID, _ = uuid.Parse(idStr)
-	r.UserID, _ = uuid.Parse(userIDStr)
+	r.ID = parseUUID(idStr, "r.ID")
+	r.UserID = parseUUID(userIDStr, "r.UserID")
 	r.Status = models.ReservationStatus(status)
 	r.QuotaEnforced = quotaEnforced == 1
 	if updatedAt.Valid {


### PR DESCRIPTION
## Summary

Addresses 15 security issues identified during a Go backend audit:

- **API key exposure** (#5011): Gemini API key moved from URL query params to `x-goog-api-key` header in `provider_gemini.go` and `server_operations.go`
- **Missing scanner error check** (#5012): Added `scanner.Err()` after `bufio.Scanner` loops in `provider_geminicli.go`, `provider_ghcopilot.go`, `provider_antigravity.go`
- **Nil callback dereference** (#5013): Added nil check before `onChunk()` in `BobProvider.StreamChat`
- **Unbounded Prometheus cardinality** (#5014): AI prediction labels now sanitized against allowed sets in `prediction_metrics.go`
- **Path traversal** (#5015): Static file serving now validates resolved path stays within root directory
- **Unvalidated cron schedule** (#5016): Cron schedule validated against 5-field format before K8s API call
- **Missing GVR validation** (#5017): Group/version/resource params validated against K8s naming conventions
- **Unsafe UUID parsing** (#5018): `parseUUID()` helper logs warnings instead of silently producing zero UUIDs
- **Race condition in key file creation** (#5019): Atomic file creation via `link+rename` prevents key overwrites
- **Silent data loss in MCP bridge** (#5021): Warning logs added when JSON parsing fails in fallback paths
- **Unbounded WebSocket broadcast size** (#5022): 1MB max message size enforced in `Broadcast` and `BroadcastAll`
- **Unbounded SQL LIMIT** (#5023): Defense-in-depth clamping (1-1000) in `GetUserCardHistory`
- **Information disclosure** (#5024): Raw error details removed from card position unmarshal logs
- **Unbounded exec stdin size** (#5025): 1MB max stdin message size in pod exec WebSocket
- **Missing tier bounds** (#5026): Tier field validated (1-3) in GPU health CronJob endpoint

## Test plan

- [ ] `go build ./cmd/console/` passes
- [ ] `go vet ./...` passes
- [ ] Verify Gemini chat/streaming still works (API key now in header)
- [ ] Verify static file serving works normally (path traversal guard)
- [ ] Verify GPU health CronJob install with valid tier (1-3) and invalid tier (0, 4)
- [ ] Verify custom resources endpoint with valid and malformed GVR params

Fixes #5011, #5012, #5013, #5014, #5015, #5016, #5017, #5018, #5019, #5021, #5022, #5023, #5024, #5025, #5026