### PR TITLE
fix: cache hooks test timeout in clearAllStorage tests

### DIFF
--- a/web/src/lib/cache/__tests__/hooks.test.ts
+++ b/web/src/lib/cache/__tests__/hooks.test.ts
@@ -71,11 +71,19 @@ function makeObjectStore(): IDBObjectStore {
 }
 
 function makeTransaction(): IDBTransaction {
-  return {
+  const tx = {
     objectStore() {
       return makeObjectStore()
     },
-  } as unknown as IDBTransaction
+    oncomplete: null as ((ev: Event) => void) | null,
+    onerror: null as ((ev: Event) => void) | null,
+    error: null as DOMException | null,
+  }
+  // Fire oncomplete on next microtask so clearAllStorage's promise resolves
+  queueMicrotask(() => {
+    tx.oncomplete?.({} as Event)
+  })
+  return tx as unknown as IDBTransaction
 }
 
 function makeFakeDB(): IDBDatabase {


### PR DESCRIPTION
## Summary
- Fixed 4 tests in `src/lib/cache/__tests__/hooks.test.ts` that were timing out at 5s in coverage-hourly shard 12
- Root cause: IndexedDB mock's `makeTransaction()` didn't support `oncomplete`/`onerror` callbacks
- `clearAllStorage()` awaits `transaction.oncomplete` in a Promise that never resolved

## Fix
Added `oncomplete`/`onerror` to the mock transaction and fire `oncomplete` on next microtask, matching real IndexedDB behavior.

## Tests fixed
- `removes kubestellar- prefixed keys from localStorage`
- `removes kc_ prefixed keys from localStorage`
- `removes ksc_ prefixed keys from localStorage`
- `handles empty localStorage gracefully`

## Other nightly failures investigated
- **consistency-test Phase 5**: Already clean on latest main (fixed by recent commit)
- **gosec G402 InsecureSkipVerify**: `#nosec` annotation works correctly locally (Nosec: 1, Issues: 0) — likely stale CI cache
- **unit-test worker crash**: OOM in CI runner, not a code issue

## Test plan
- [ ] All 42 cache hooks tests pass locally
- [ ] Coverage-hourly shard 12 passes