### PR TITLE
🔄 Migrate useContext to use() pattern

### DIFF
--- a/web/src/components/cards/CardDataContext.tsx
+++ b/web/src/components/cards/CardDataContext.tsx
@@ -39,7 +39,7 @@
  * ```
  */
 
-import { createContext, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { createContext, use, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { isAgentUnavailable } from '../../hooks/useLocalAgent'
 import { isInClusterMode } from '../../hooks/useBackendHealth'
@@ -82,7 +82,7 @@ export const ForceLiveContext = createContext<boolean>(false)
 
 /** Hook for card components to check if they should bypass demo mode */
 export function useForceLive(): boolean {
-  return useContext(ForceLiveContext)
+  return use(ForceLiveContext)
 }
 
 /**
@@ -92,7 +92,7 @@ export function useForceLive(): boolean {
  */
 export function useReportCardDataState(state: CardDataState) {
   const { isFailed, consecutiveFailures, errorMessage, isLoading, isRefreshing, hasData, isDemoData, lastUpdated } = state
-  const ctx = useContext(CardDataReportContext)
+  const ctx = use(CardDataReportContext)
   // useLayoutEffect runs synchronously before paint, ensuring cached data
   // is reported before CardWrapper decides to show skeleton
   useLayoutEffect(() => {

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState, useEffect, useCallback, useRef, useMemo, createContext, useContext, ComponentType, Suspense, lazy } from 'react'
+import { ReactNode, useState, useEffect, useCallback, useRef, useMemo, createContext, use, ComponentType, Suspense, lazy } from 'react'
 import { createPortal } from 'react-dom'
 import {
   Maximize2, MoreVertical, Clock, Settings, Trash2, RefreshCw, MoveHorizontal, ChevronRight, ChevronDown, Info, Download, Link2, Bug, AlertTriangle, Sparkles, X,
@@ -115,7 +115,7 @@ const CardExpandedContext = createContext<CardExpandedContextType>({
 
 /** Hook for child components to know if their parent card is expanded and get container size */
 export function useCardExpanded() {
-  return useContext(CardExpandedContext)
+  return use(CardExpandedContext)
 }
 
 // Context to expose cardType to descendant shared components (CardControls,
@@ -125,7 +125,7 @@ const CardTypeContext = createContext<string>('')
 
 /** Hook for shared UI components to read the cardType of their parent CardWrapper */
 export function useCardType() {
-  return useContext(CardTypeContext)
+  return use(CardTypeContext)
 }
 
 // Note: Lazy mounting and eager mount scheduling have been removed.

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, useEffect, useRef, ReactNode } from 'react'
+import { createContext, use, useState, useCallback, useEffect, useRef, ReactNode } from 'react'
 import { X, Check, AlertTriangle, Info } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { Button } from './Button'
@@ -18,7 +18,7 @@ interface ToastContextValue {
 const ToastContext = createContext<ToastContextValue | null>(null)
 
 export function useToast() {
-  const context = useContext(ToastContext)
+  const context = use(ToastContext)
   if (!context) {
     throw new Error('useToast must be used within a ToastProvider')
   }

--- a/web/src/contexts/AlertsContext.tsx
+++ b/web/src/contexts/AlertsContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense, type ReactNode } from 'react'
+import { createContext, use, useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense, type ReactNode } from 'react'
 import { settledWithConcurrency } from '../lib/utils/concurrency'
 import { useMissions } from '../hooks/useMissions'
 import { useDemoMode } from '../hooks/useDemoMode'
@@ -1769,7 +1769,7 @@ Please provide:
 }
 
 export function useAlertsContext() {
-  const context = useContext(AlertsContext)
+  const context = use(AlertsContext)
   if (!context) {
     throw new Error('useAlertsContext must be used within an AlertsProvider')
   }

--- a/web/src/contexts/StackContext.tsx
+++ b/web/src/contexts/StackContext.tsx
@@ -6,7 +6,7 @@
  *
  * When demo mode is enabled, provides fake demo stacks instead of live data.
  */
-import React, { createContext, useContext, useState, useEffect, useMemo, useCallback } from 'react'
+import React, { createContext, use, useState, useEffect, useMemo, useCallback } from 'react'
 import { useStackDiscovery, type LLMdStack, type LLMdStackComponent } from '../hooks/useStackDiscovery'
 import { useDemoMode } from '../hooks/useDemoMode'
 import { useClusters } from '../hooks/mcp/clusters'
@@ -289,7 +289,7 @@ export function StackProvider({ children }: StackProviderProps) {
 }
 
 export function useStack() {
-  const context = useContext(StackContext)
+  const context = use(StackContext)
   if (!context) {
     throw new Error('useStack must be used within a StackProvider')
   }
@@ -298,5 +298,5 @@ export function useStack() {
 
 // Hook to check if we're inside a StackProvider
 export function useOptionalStack(): StackContextType | null {
-  return useContext(StackContext)
+  return use(StackContext)
 }

--- a/web/src/hooks/useAlerts.ts
+++ b/web/src/hooks/useAlerts.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useContext } from 'react'
+import { useState, useEffect, useCallback, use } from 'react'
 import { AlertsContext } from '../contexts/AlertsContext'
 import type {
   Alert,
@@ -59,7 +59,7 @@ const _emptyAlertRule: AlertRule = {
 
 // Hook for managing alert rules - uses shared context
 export function useAlertRules() {
-  const context = useContext(AlertsContext)
+  const context = use(AlertsContext)
   if (!context) {
     return {
       rules: [] as AlertRule[],
@@ -115,7 +115,7 @@ export function useSlackWebhooks() {
 
 // Hook for managing alerts - uses shared context
 export function useAlerts() {
-  const context = useContext(AlertsContext)
+  const context = use(AlertsContext)
   if (!context) {
     return {
       alerts: [] as Alert[],

--- a/web/src/hooks/useBranding.tsx
+++ b/web/src/hooks/useBranding.tsx
@@ -6,7 +6,7 @@
  * (KubeStellar values) if the endpoint is unavailable or returns no branding.
  */
 
-import { createContext, useContext, useState, useEffect, type ReactNode } from 'react'
+import { createContext, use, useState, useEffect, type ReactNode } from 'react'
 import { DEFAULT_BRANDING, mergeBranding, type BrandingConfig } from '../lib/branding'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { updateAnalyticsIds } from '../lib/analytics'
@@ -15,7 +15,7 @@ const BrandingContext = createContext<BrandingConfig>(DEFAULT_BRANDING)
 
 /** Access the current branding configuration */
 export function useBranding(): BrandingConfig {
-  return useContext(BrandingContext)
+  return use(BrandingContext)
 }
 
 interface BrandingProviderProps {

--- a/web/src/hooks/useClusterFilter.tsx
+++ b/web/src/hooks/useClusterFilter.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
+import { createContext, use, useState, useEffect, useCallback, ReactNode } from 'react'
 import { useClusters } from './useMCP'
 
 interface ClusterFilterContextType {
@@ -100,7 +100,7 @@ export function ClusterFilterProvider({ children }: { children: ReactNode }) {
 }
 
 export function useClusterFilter() {
-  const context = useContext(ClusterFilterContext)
+  const context = use(ClusterFilterContext)
   if (!context) {
     throw new Error('useClusterFilter must be used within a ClusterFilterProvider')
   }

--- a/web/src/hooks/useDashboardContext.tsx
+++ b/web/src/hooks/useDashboardContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, ReactNode } from 'react'
+import { createContext, use, useState, useCallback, ReactNode } from 'react'
 import { useDashboardHealth, type DashboardHealthInfo } from './useDashboardHealth'
 
 // Card to be restored from history
@@ -94,7 +94,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 }
 
 export function useDashboardContext() {
-  const context = useContext(DashboardContext)
+  const context = use(DashboardContext)
   if (!context) {
     throw new Error('useDashboardContext must be used within a DashboardProvider')
   }
@@ -104,5 +104,5 @@ export function useDashboardContext() {
 // Optional hook that doesn't throw if used outside provider
 // Useful for components that might be rendered outside the dashboard
 export function useDashboardContextOptional() {
-  return useContext(DashboardContext)
+  return use(DashboardContext)
 }

--- a/web/src/hooks/useDrillDown.tsx
+++ b/web/src/hooks/useDrillDown.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, ReactNode } from 'react'
+import { createContext, use, useState, useCallback, ReactNode } from 'react'
 import { emitDrillDownOpened, emitDrillDownClosed } from '../lib/analytics'
 
 // Types for drill-down navigation
@@ -168,7 +168,7 @@ export function DrillDownProvider({ children }: { children: ReactNode }) {
 }
 
 export function useDrillDown() {
-  const context = useContext(DrillDownContext)
+  const context = use(DrillDownContext)
   if (!context) {
     throw new Error('useDrillDown must be used within a DrillDownProvider')
   }
@@ -285,7 +285,7 @@ const _noopState: DrillDownState = { isOpen: false, stack: [], currentView: null
 
 // Helper hook to create drill-down actions
 export function useDrillDownActions() {
-  const context = useContext(DrillDownContext)
+  const context = use(DrillDownContext)
   const state = context?.state ?? _noopState
   const open = context?.open ?? _noopOpen
   const push = context?.push ?? _noopPush

--- a/web/src/hooks/useGlobalFilters.tsx
+++ b/web/src/hooks/useGlobalFilters.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, useMemo, ReactNode } from 'react'
+import { createContext, use, useState, useEffect, useCallback, useMemo, ReactNode } from 'react'
 // Import directly from mcp/clusters to avoid pulling in the full MCP barrel
 // (~254 KB). Only clusters.ts + shared.ts are needed here.
 import { useClusters } from './mcp/clusters'
@@ -663,7 +663,7 @@ export function GlobalFiltersProvider({ children }: { children: ReactNode }) {
 }
 
 export function useGlobalFilters() {
-  const context = useContext(GlobalFiltersContext)
+  const context = use(GlobalFiltersContext)
   if (!context) {
     throw new Error('useGlobalFilters must be used within a GlobalFiltersProvider')
   }

--- a/web/src/hooks/useMissions.tsx
+++ b/web/src/hooks/useMissions.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useCallback, useRef, useEffect, ReactNode } from 'react'
+import { createContext, use, useState, useCallback, useRef, useEffect, ReactNode } from 'react'
 import type { AgentInfo, AgentsListPayload, AgentSelectedPayload, ChatStreamPayload } from '../types/agent'
 import { AgentCapabilityToolExec } from '../types/agent'
 import { getDemoMode } from './useDemoMode'
@@ -1942,7 +1942,7 @@ const MISSIONS_FALLBACK: MissionContextValue = {
 }
 
 export function useMissions() {
-  const context = useContext(MissionContext)
+  const context = use(MissionContext)
   if (!context) {
     if (import.meta.env.DEV) {
       console.warn('useMissions was called outside MissionProvider — returning safe fallback')

--- a/web/src/hooks/useRewards.tsx
+++ b/web/src/hooks/useRewards.tsx
@@ -3,7 +3,7 @@
  * Tracks user coins, achievements, and reward events
  */
 
-import { createContext, useContext, useState, useEffect, useCallback, ReactNode, useMemo } from 'react'
+import { createContext, use, useState, useEffect, useCallback, ReactNode, useMemo } from 'react'
 import { useAuth } from '../lib/auth'
 import {
   RewardActionType,
@@ -274,7 +274,7 @@ const REWARDS_FALLBACK: RewardsContextType = {
 }
 
 export function useRewards() {
-  const context = useContext(RewardsContext)
+  const context = use(RewardsContext)
   if (!context) {
     if (import.meta.env.DEV) {
       console.warn('useRewards was called outside RewardsProvider — returning safe fallback')

--- a/web/src/hooks/useTheme.tsx
+++ b/web/src/hooks/useTheme.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, createContext, useContext } from 'react'
+import { useState, useEffect, useCallback, useMemo, createContext, use } from 'react'
 import { Theme, themes, getAllThemes, getThemeById, getDefaultTheme } from '../lib/themes'
 import { emitThemeChanged } from '../lib/analytics'
 import { GOOGLE_FONTS_API_URL } from '../config/externalApis'
@@ -287,7 +287,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 }
 
 export function useTheme(): ThemeContextValue {
-  const context = useContext(ThemeContext)
+  const context = use(ThemeContext)
   if (!context) {
     // Fallback for when used outside provider (backwards compatibility)
     const defaultTheme = getDefaultTheme()

--- a/web/src/hooks/useTour.tsx
+++ b/web/src/hooks/useTour.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
+import { createContext, use, useState, useEffect, useCallback, ReactNode } from 'react'
 import { useMobile } from './useMobile'
 import { SETTINGS_CHANGED_EVENT, SETTINGS_RESTORED_EVENT } from '../lib/settingsSync'
 import { emitTourStarted, emitTourCompleted, emitTourSkipped } from '../lib/analytics'
@@ -210,7 +210,7 @@ const TOUR_FALLBACK: TourContextValue = {
 }
 
 export function useTour() {
-  const context = useContext(TourContext)
+  const context = use(TourContext)
   if (!context) {
     if (import.meta.env.DEV) {
       console.warn('useTour was called outside TourProvider — returning safe fallback')

--- a/web/src/hooks/useVersionCheck.tsx
+++ b/web/src/hooks/useVersionCheck.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, createContext, useContext, type ReactNode } from 'react'
+import { useState, useEffect, useCallback, useMemo, createContext, use, type ReactNode } from 'react'
 import type {
   UpdateChannel,
   ReleaseType,
@@ -866,7 +866,7 @@ export function VersionCheckProvider({ children }: { children: ReactNode }) {
  * Public hook — reads from the shared VersionCheckProvider context.
  */
 export function useVersionCheck(): VersionCheckValue {
-  const ctx = useContext(VersionCheckContext)
+  const ctx = use(VersionCheckContext)
   if (!ctx) {
     throw new Error('useVersionCheck must be used within a <VersionCheckProvider>')
   }

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
+import { createContext, use, useState, useEffect, useCallback, ReactNode } from 'react'
 import { checkOAuthConfigured } from './api'
 import { dashboardSync } from './dashboards/dashboardSync'
 import { clearPermissionsCache } from '../hooks/usePermissions'
@@ -456,7 +456,7 @@ const AUTH_FALLBACK: AuthContextType = {
 }
 
 export function useAuth() {
-  const context = useContext(AuthContext)
+  const context = use(AuthContext)
   if (!context) {
     if (import.meta.env.DEV) {
       console.warn('useAuth was called outside AuthProvider — returning safe fallback')

--- a/web/src/lib/cardEvents.tsx
+++ b/web/src/lib/cardEvents.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useRef, useCallback, type ReactNode } from 'react'
+import { createContext, use, useRef, useCallback, type ReactNode } from 'react'
 
 // ============================================================================
 // Card Event Types
@@ -115,7 +115,7 @@ export function CardEventProvider({ children }: { children: ReactNode }) {
 // ============================================================================
 
 export function useCardEvents(): CardEventBus {
-  const ctx = useContext(CardEventContext)
+  const ctx = use(CardEventContext)
   if (!ctx) {
     // Return no-op bus when used outside provider (graceful degradation)
     return {

--- a/web/src/lib/unified/demo/UnifiedDemoContext.ts
+++ b/web/src/lib/unified/demo/UnifiedDemoContext.ts
@@ -5,7 +5,7 @@
  * Components use this context to access demo data and skeleton states.
  */
 
-import { createContext, useContext } from 'react'
+import { createContext, use } from 'react'
 import type { UnifiedDemoContextValue, DemoDataState } from './types'
 
 /**
@@ -55,7 +55,7 @@ export const UnifiedDemoContext = createContext<UnifiedDemoContextValue>(default
  * @returns The demo context value
  */
 export function useUnifiedDemoContext(): UnifiedDemoContextValue {
-  return useContext(UnifiedDemoContext)
+  return use(UnifiedDemoContext)
 }
 
 /**
@@ -63,7 +63,7 @@ export function useUnifiedDemoContext(): UnifiedDemoContextValue {
  * @returns Whether demo mode is on
  */
 export function useIsDemoMode(): boolean {
-  const { isDemoMode } = useContext(UnifiedDemoContext)
+  const { isDemoMode } = use(UnifiedDemoContext)
   return isDemoMode
 }
 
@@ -72,7 +72,7 @@ export function useIsDemoMode(): boolean {
  * @returns Whether mode is switching
  */
 export function useIsModeSwitching(): boolean {
-  const { isModeSwitching } = useContext(UnifiedDemoContext)
+  const { isModeSwitching } = use(UnifiedDemoContext)
   return isModeSwitching
 }
 
@@ -82,6 +82,6 @@ export function useIsModeSwitching(): boolean {
  * @returns Current mode version
  */
 export function useModeVersion(): number {
-  const { modeVersion } = useContext(UnifiedDemoContext)
+  const { modeVersion } = use(UnifiedDemoContext)
   return modeVersion
 }


### PR DESCRIPTION
## Summary

- Replace all `useContext(SomeContext)` calls with `use(SomeContext)` across 19 files (React 19 pattern)
- Update imports: remove `useContext` from react imports, add `use`
- No changes to context creation (`createContext`) or provider components
- All existing null checks and error throws preserved

Closes #5044

## Files Changed (19)

**Hooks:** `useAlerts`, `useBranding`, `useClusterFilter`, `useDashboardContext`, `useDrillDown`, `useGlobalFilters`, `useMissions`, `useRewards`, `useTheme`, `useTour`, `useVersionCheck`

**Contexts:** `AlertsContext`, `StackContext`

**Components:** `CardDataContext`, `CardWrapper`, `Toast`

**Lib:** `auth`, `cardEvents`, `UnifiedDemoContext`

## Test plan

- [x] TypeScript compilation passes (`tsc -b`)
- [x] Vite production build passes (`npm run build`)
- [x] Post-build safety checks pass
- [ ] CI build/lint passes