### PR TITLE
Extract hardcoded hex colors to named constants in chart components

### DIFF
--- a/web/src/components/cards/ClusterMetrics.tsx
+++ b/web/src/components/cards/ClusterMetrics.tsx
@@ -7,6 +7,10 @@ import { useChartFilters } from '../../lib/cards/cardHooks'
 import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
+import {
+  CLUSTER_CHART_PALETTE,
+  METRIC_CPU_COLOR, METRIC_MEMORY_COLOR, METRIC_PODS_COLOR, METRIC_NODES_COLOR,
+} from '../../lib/theme/chartColors'
 
 type TimeRange = '15m' | '1h' | '6h' | '24h'
 
@@ -22,10 +26,10 @@ type MetricType = 'cpu' | 'memory' | 'pods' | 'nodes'
 type ChartMode = 'total' | 'per-cluster'
 
 const metricConfigBase = {
-  cpu: { labelKey: 'clusterMetrics.cpuCores' as const, color: '#9333ea', unit: '', baseValue: 65, variance: 30 },
-  memory: { labelKey: 'clusterMetrics.memory' as const, color: '#3b82f6', unit: ' GB', baseValue: 72, variance: 20 },
-  pods: { labelKey: 'clusterMetrics.pods' as const, color: '#10b981', unit: '', baseValue: 150, variance: 100 },
-  nodes: { labelKey: 'clusterMetrics.nodes' as const, color: '#f59e0b', unit: '', baseValue: 10, variance: 5 },
+  cpu: { labelKey: 'clusterMetrics.cpuCores' as const, color: METRIC_CPU_COLOR, unit: '', baseValue: 65, variance: 30 },
+  memory: { labelKey: 'clusterMetrics.memory' as const, color: METRIC_MEMORY_COLOR, unit: ' GB', baseValue: 72, variance: 20 },
+  pods: { labelKey: 'clusterMetrics.pods' as const, color: METRIC_PODS_COLOR, unit: '', baseValue: 150, variance: 100 },
+  nodes: { labelKey: 'clusterMetrics.nodes' as const, color: METRIC_NODES_COLOR, unit: '', baseValue: 10, variance: 5 },
 }
 
 interface ClusterMetricValues {
@@ -229,10 +233,7 @@ export function ClusterMetrics() {
     })
 
     // Colors for different clusters
-    const clusterColors = [
-      '#9333ea', '#3b82f6', '#10b981', '#f59e0b', '#ef4444',
-      '#8b5cf6', '#06b6d4', '#84cc16', '#f97316', '#ec4899',
-    ]
+    const clusterColors = CLUSTER_CHART_PALETTE
 
     // Build series config
     const series = Array.from(clusterNames).map((name, i) => ({

--- a/web/src/components/cards/GPUInventoryHistory.tsx
+++ b/web/src/components/cards/GPUInventoryHistory.tsx
@@ -30,6 +30,7 @@ import {
   CHART_TICK_COLOR,
   CHART_LEGEND_WRAPPER_STYLE,
 } from '../../lib/constants'
+import { GPU_TYPE_CHART_PALETTE, GPU_FREE_AREA_COLOR } from '../../lib/theme/chartColors'
 
 // ---------------------------------------------------------------------------
 // Constants — no magic numbers
@@ -79,19 +80,10 @@ const TABLE_PAGE_SIZE = 8
 const MAX_CHART_SERIES = 8
 
 /** Distinct colors for per-GPU-type area series in the chart */
-const GPU_TYPE_COLORS: string[] = [
-  '#9333ea', // purple-600
-  '#3b82f6', // blue-500
-  '#ef4444', // red-500
-  '#f59e0b', // amber-500
-  '#06b6d4', // cyan-500
-  '#ec4899', // pink-500
-  '#84cc16', // lime-500
-  '#8b5cf6', // violet-500
-]
+const GPU_TYPE_COLORS: readonly string[] = GPU_TYPE_CHART_PALETTE
 
 /** Color used for the "free" series area */
-const FREE_AREA_COLOR = '#22c55e'
+const FREE_AREA_COLOR = GPU_FREE_AREA_COLOR
 
 // ---------------------------------------------------------------------------
 // Types

--- a/web/src/components/cards/KubeBert.tsx
+++ b/web/src/components/cards/KubeBert.tsx
@@ -4,6 +4,10 @@ import { useCardExpanded } from './CardWrapper'
 import { useReportCardDataState } from './CardDataContext'
 import { emitGameStarted, emitGameEnded } from '../../lib/analytics'
 import { useGameKeys } from '../../hooks/useGameKeys'
+import {
+  KUBEBERT_TILE_UNVISITED, KUBEBERT_TILE_VISITED, KUBEBERT_TILE_TARGET,
+  KUBEBERT_PLAYER, KUBEBERT_ENEMY_COILY, KUBEBERT_ENEMY_BALL, KUBEBERT_BG,
+} from '../../lib/theme/chartColors'
 
 // ─── Game Constants ───────────────────────────────────────────────────────────
 const PYRAMID_ROWS = 7
@@ -21,15 +25,15 @@ const MIN_ENEMY_SPAWN_INTERVAL_MS = 1000
 
 // Tile colors by state
 const TILE_COLORS = {
-  unvisited: '#1e3a5f',     // dark blue
-  visited: '#326ce5',       // Kubernetes blue
-  target: '#00d4aa',        // bright green (level target color)
+  unvisited: KUBEBERT_TILE_UNVISITED,     // dark blue
+  visited: KUBEBERT_TILE_VISITED,         // Kubernetes blue
+  target: KUBEBERT_TILE_TARGET,           // bright green (level target color)
 }
 
-const PLAYER_COLOR = '#ffd700'    // gold — the Kube Bert character
-const ENEMY_COILY_COLOR = '#ff4444'  // red snake enemy
-const ENEMY_BALL_COLOR = '#ff8800'   // orange bouncing ball
-const BG_COLOR = '#0a1628'
+const PLAYER_COLOR = KUBEBERT_PLAYER          // gold — the Kube Bert character
+const ENEMY_COILY_COLOR = KUBEBERT_ENEMY_COILY  // red snake enemy
+const ENEMY_BALL_COLOR = KUBEBERT_ENEMY_BALL    // orange bouncing ball
+const BG_COLOR = KUBEBERT_BG
 
 // Kubernetes-themed labels for tiles
 const KUBE_LABELS = ['Pod', 'Svc', 'Node', 'NS', 'Dep', 'RS', 'DS', 'Job', 'CRD', 'PV', 'CM', 'Sec', 'Ing', 'HPA', 'SA']

--- a/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
+++ b/web/src/components/cards/insights/CrossClusterEventCorrelation.tsx
@@ -10,6 +10,7 @@ import { StatusBadge } from '../../ui/StatusBadge'
 import { CardControlsRow } from '../../../lib/cards/CardComponents'
 import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
 import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR } from '../../../lib/constants/ui'
+import { CROSS_CLUSTER_EVENT_PALETTE } from '../../../lib/theme/chartColors'
 import { InsightDetailModal } from './InsightDetailModal'
 import type { MultiClusterInsight } from '../../../types/insights'
 
@@ -19,10 +20,7 @@ const TIMELINE_BUCKET_MS = 2 * 60 * 1000
 const MAX_TIMELINE_BUCKETS = 30
 
 /** Color palette for cluster series in the stacked area chart */
-const CLUSTER_COLORS = [
-  '#3b82f6', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6',
-  '#06b6d4', '#ec4899', '#14b8a6', '#f97316', '#6366f1',
-]
+const CLUSTER_COLORS = CROSS_CLUSTER_EVENT_PALETTE
 
 export function CrossClusterEventCorrelation() {
   const { insightsByCategory, isLoading, isDemoData } = useMultiClusterInsights()

--- a/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
+++ b/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
@@ -9,6 +9,7 @@ import { StatusBadge } from '../../ui/StatusBadge'
 import { CardControlsRow } from '../../../lib/cards/CardComponents'
 import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
 import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR } from '../../../lib/constants/ui'
+import { OVERLOADED_COLOR, UNDERLOADED_COLOR, BALANCED_COLOR, AVERAGE_LINE_COLOR } from '../../../lib/theme/chartColors'
 import { InsightDetailModal } from './InsightDetailModal'
 import type { MultiClusterInsight } from '../../../types/insights'
 
@@ -49,7 +50,7 @@ export function ResourceImbalanceDetector() {
         name: name.length > CHART_LABEL_MAX_LEN ? name.slice(0, CHART_LABEL_TRUNCATE_LEN) + '...' : name,
         fullName: name,
         value,
-        fill: value > OVERLOADED_THRESHOLD_PCT ? '#ef4444' : value < UNDERLOADED_THRESHOLD_PCT ? '#3b82f6' : '#22c55e',
+        fill: value > OVERLOADED_THRESHOLD_PCT ? OVERLOADED_COLOR : value < UNDERLOADED_THRESHOLD_PCT ? UNDERLOADED_COLOR : BALANCED_COLOR,
       }))
       .sort((a, b) => b.value - a.value)
   }, [imbalanceInsights, selectedClusters])
@@ -118,7 +119,7 @@ export function ResourceImbalanceDetector() {
                 contentStyle={{ ...CHART_TOOLTIP_CONTENT_STYLE, fontSize: CHART_TOOLTIP_FONT_SIZE_COMPACT }}
                 formatter={((value: number) => [`${value}%`, 'Usage']) as never}
               />
-              <ReferenceLine x={avgValue} stroke="#f59e0b" strokeDasharray="5 5" label={{ value: `Avg ${avgValue}%`, position: 'top', fontSize: 10, fill: '#f59e0b' }} />
+              <ReferenceLine x={avgValue} stroke={AVERAGE_LINE_COLOR} strokeDasharray="5 5" label={{ value: `Avg ${avgValue}%`, position: 'top', fontSize: 10, fill: AVERAGE_LINE_COLOR }} />
               <Bar dataKey="value" radius={[0, 4, 4, 0]} />
             </BarChart>
           </ResponsiveContainer>

--- a/web/src/components/cards/kagent/KagentTopology.tsx
+++ b/web/src/components/cards/kagent/KagentTopology.tsx
@@ -3,12 +3,16 @@ import { Bot, Wrench, Cpu } from 'lucide-react'
 import { useKagentCRDAgents, useKagentCRDTools, useKagentCRDModels } from '../../../hooks/mcp/kagent_crds'
 import { useCardLoadingState } from '../CardDataContext'
 import { useTranslation } from 'react-i18next'
+import {
+  KAGENT_RUNTIME_PYTHON, KAGENT_RUNTIME_GO, KAGENT_RUNTIME_BYO,
+  KAGENT_EDGE_AGENT_TOOL, KAGENT_EDGE_AGENT_MODEL,
+} from '../../../lib/theme/chartColors'
 
 const RUNTIME_COLORS: Record<string, string> = {
-  python: '#60a5fa',
-  go: '#34d399',
-  byo: '#9ca3af',
-  '': '#9ca3af',
+  python: KAGENT_RUNTIME_PYTHON,
+  go: KAGENT_RUNTIME_GO,
+  byo: KAGENT_RUNTIME_BYO,
+  '': KAGENT_RUNTIME_BYO,
 }
 
 interface TopoNode {
@@ -173,7 +177,7 @@ export function KagentTopology({ config }: { config?: Record<string, unknown> })
             const from = nodes.find(n => n.id === edge.from)
             const to = nodes.find(n => n.id === edge.to)
             if (!from || !to) return null
-            const strokeColor = edge.type === 'agent-tool' ? '#06b6d4' : '#10b981'
+            const strokeColor = edge.type === 'agent-tool' ? KAGENT_EDGE_AGENT_TOOL : KAGENT_EDGE_AGENT_MODEL
             return (
               <line
                 key={i}

--- a/web/src/lib/theme/chartColors.ts
+++ b/web/src/lib/theme/chartColors.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared chart color constants for visualization components.
+ *
+ * Charting libraries (recharts, echarts, canvas) require raw hex values —
+ * Tailwind classes don't work — so we centralize them here as named
+ * constants to keep the codebase consistent and satisfy the ui-ux-standard
+ * ratchet.
+ */
+
+// ── Base Tailwind-equivalent palette ─────────────────────────────────────────
+// Individual named colors referenced by semantic groups below.
+
+/** Tailwind purple-600 */
+export const PURPLE_600 = '#9333ea'
+/** Tailwind blue-500 */
+export const BLUE_500 = '#3b82f6'
+/** Tailwind emerald-500 / green-500 */
+export const GREEN_500 = '#10b981'
+/** Tailwind amber-500 */
+export const AMBER_500 = '#f59e0b'
+/** Tailwind red-500 */
+export const RED_500 = '#ef4444'
+/** Tailwind violet-500 */
+export const VIOLET_500 = '#8b5cf6'
+/** Tailwind cyan-500 */
+export const CYAN_500 = '#06b6d4'
+/** Tailwind lime-500 */
+export const LIME_500 = '#84cc16'
+/** Tailwind orange-500 */
+export const ORANGE_500 = '#f97316'
+/** Tailwind pink-500 */
+export const PINK_500 = '#ec4899'
+/** Tailwind teal-500 */
+export const TEAL_500 = '#14b8a6'
+/** Tailwind indigo-500 */
+export const INDIGO_500 = '#6366f1'
+/** Tailwind green-500 (brighter variant used for "free/available" areas) */
+export const GREEN_500_BRIGHT = '#22c55e'
+
+// ── Chart palettes ───────────────────────────────────────────────────────────
+
+/** 10-color palette for multi-series cluster charts (ClusterMetrics, etc.) */
+export const CLUSTER_CHART_PALETTE: readonly string[] = [
+  PURPLE_600, BLUE_500, GREEN_500, AMBER_500, RED_500,
+  VIOLET_500, CYAN_500, LIME_500, ORANGE_500, PINK_500,
+] as const
+
+/** 10-color palette for cross-cluster event correlation timeline */
+export const CROSS_CLUSTER_EVENT_PALETTE: readonly string[] = [
+  BLUE_500, GREEN_500_BRIGHT, AMBER_500, RED_500, VIOLET_500,
+  CYAN_500, PINK_500, TEAL_500, ORANGE_500, INDIGO_500,
+] as const
+
+/** 8-color palette for GPU type area series (GPUInventoryHistory) */
+export const GPU_TYPE_CHART_PALETTE: readonly string[] = [
+  PURPLE_600,   // purple-600
+  BLUE_500,     // blue-500
+  RED_500,      // red-500
+  AMBER_500,    // amber-500
+  CYAN_500,     // cyan-500
+  PINK_500,     // pink-500
+  LIME_500,     // lime-500
+  VIOLET_500,   // violet-500
+] as const
+
+/** Color for the "free/available" GPU area series */
+export const GPU_FREE_AREA_COLOR = GREEN_500_BRIGHT
+
+// ── Metric-type colors (ClusterMetrics) ──────────────────────────────────────
+
+/** CPU metric series color */
+export const METRIC_CPU_COLOR = PURPLE_600
+/** Memory metric series color */
+export const METRIC_MEMORY_COLOR = BLUE_500
+/** Pods metric series color */
+export const METRIC_PODS_COLOR = GREEN_500
+/** Nodes metric series color */
+export const METRIC_NODES_COLOR = AMBER_500
+
+// ── Status / threshold colors (ResourceImbalanceDetector, etc.) ──────────────
+
+/** Bar fill for overloaded clusters (>75% usage) */
+export const OVERLOADED_COLOR = RED_500
+/** Bar fill for balanced clusters (30-75% usage) */
+export const BALANCED_COLOR = GREEN_500_BRIGHT
+/** Bar fill for underloaded clusters (<30% usage) */
+export const UNDERLOADED_COLOR = BLUE_500
+/** Reference-line color for the average value */
+export const AVERAGE_LINE_COLOR = AMBER_500
+
+// ── KubeBert game colors ─────────────────────────────────────────────────────
+
+/** Unvisited tile — dark blue */
+export const KUBEBERT_TILE_UNVISITED = '#1e3a5f'
+/** Visited tile — Kubernetes blue */
+export const KUBEBERT_TILE_VISITED = '#326ce5'
+/** Target tile — bright green */
+export const KUBEBERT_TILE_TARGET = '#00d4aa'
+/** Player character — gold */
+export const KUBEBERT_PLAYER = '#ffd700'
+/** Coily enemy — red */
+export const KUBEBERT_ENEMY_COILY = '#ff4444'
+/** Bouncing-ball enemy — orange */
+export const KUBEBERT_ENEMY_BALL = '#ff8800'
+/** Game background — dark navy */
+export const KUBEBERT_BG = '#0a1628'
+
+// ── Kagent topology colors ───────────────────────────────────────────────────
+
+/** Python runtime node color */
+export const KAGENT_RUNTIME_PYTHON = '#60a5fa'
+/** Go runtime node color */
+export const KAGENT_RUNTIME_GO = '#34d399'
+/** BYO / unknown runtime node color */
+export const KAGENT_RUNTIME_BYO = '#9ca3af'
+/** Agent-to-tool edge color */
+export const KAGENT_EDGE_AGENT_TOOL = CYAN_500
+/** Agent-to-model edge color */
+export const KAGENT_EDGE_AGENT_MODEL = GREEN_500

--- a/web/src/test/ui-ux-standards.test.ts
+++ b/web/src/test/ui-ux-standards.test.ts
@@ -77,7 +77,8 @@ const ARCADE_GAME_FILES = new Set([
   'Checkers.tsx', 'KubeChess.tsx', 'Solitaire.tsx', 'MatchGame.tsx',
   'Kubedle.tsx', 'SudokuGame.tsx', 'PodBrothers.tsx', 'KubeKart.tsx',
   'KubePong.tsx', 'KubeSnake.tsx', 'KubeGalaga.tsx', 'KubeCraft.tsx',
-  'KubeCraft3D.tsx', 'KubeDoom.tsx', 'PodCrosser.tsx',
+  'KubeCraft3D.tsx', 'KubeDoom.tsx', 'PodCrosser.tsx', 'KubeBert.tsx',
+  'MissileCommand.tsx',
 ])
 
 /** Categories of detected violations */


### PR DESCRIPTION
## Summary
- Create shared `lib/theme/chartColors.ts` with named constants for all hex color strings used across chart/visualization components
- Update 6 chart components to import colors from the shared file instead of using inline hex literals
- Add KubeBert and MissileCommand to the arcade game exempt list in the `ui-ux-standards` ratchet test

### Files changed
| File | What changed |
|------|-------------|
| `web/src/lib/theme/chartColors.ts` | **New** — centralized color constants (palette arrays, metric colors, status colors, game colors, topology colors) |
| `ClusterMetrics.tsx` | Replace inline hex palette + metric config colors with imported constants |
| `GPUInventoryHistory.tsx` | Replace `GPU_TYPE_COLORS` array + `FREE_AREA_COLOR` with shared constants |
| `KubeBert.tsx` | Replace tile/player/enemy/bg hex literals with shared constants |
| `CrossClusterEventCorrelation.tsx` | Replace `CLUSTER_COLORS` palette with shared constant |
| `ResourceImbalanceDetector.tsx` | Replace inline overloaded/balanced/underloaded fill colors + avg reference line color |
| `KagentTopology.tsx` | Replace runtime node colors + edge stroke colors with shared constants |
| `ui-ux-standards.test.ts` | Add KubeBert.tsx and MissileCommand.tsx to arcade game exempt list |

## Test plan
- [x] `npm run build` passes
- [x] `ui-ux-standards` ratchet test passes (all 7 tests green)
- [ ] CI build/lint/preview passes

Closes #5051