### PR TITLE
🐛 Fix 5 remaining Go test failures blocking nightly/weekly releases

### DIFF
--- a/pkg/agent/provider_antigravity_test.go
+++ b/pkg/agent/provider_antigravity_test.go
@@ -7,6 +7,9 @@ import (
 )
 
 func TestAntigravityProvider_Handshake_NotInstalled(t *testing.T) {
+	// Override PATH so detectCLI() cannot find a real CLI binary.
+	t.Setenv("PATH", t.TempDir())
+
 	p := &AntigravityProvider{} // No cliPath set
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -159,7 +159,9 @@ func TestMCPGetPods_InternalErrorIsSanitized(t *testing.T) {
 
 	var payload map[string]interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
-	assert.Equal(t, "internal server error", payload["error"])
+	assert.Equal(t, "error", payload["clusterStatus"])
+	assert.Equal(t, "internal", payload["errorType"])
+	assert.Equal(t, "An internal error occurred", payload["errorMessage"])
 }
 
 func TestMCPGetPods_NetworkErrorReturnsUnavailable(t *testing.T) {
@@ -256,7 +258,7 @@ func TestMCPGetEvents_NetworkErrorReturnsUnavailable(t *testing.T) {
 
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "network errors should return 200, not 500")
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, "network errors should return 503")
 
 	var payload map[string]interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
@@ -285,7 +287,7 @@ func TestMCPGetNodes_NetworkErrorReturnsUnavailable(t *testing.T) {
 
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "network errors should return 200, not 500")
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, "network errors should return 503")
 
 	var payload map[string]interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
@@ -314,7 +316,7 @@ func TestMCPGetPods_AuthErrorReturnsUnavailable(t *testing.T) {
 
 	resp, err := env.App.Test(req, 5000)
 	require.NoError(t, err)
-	assert.Equal(t, http.StatusOK, resp.StatusCode, "auth errors should return 200, not 500")
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode, "auth errors should return 503")
 
 	var payload map[string]interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))


### PR DESCRIPTION
## Summary

- **TestMCPGetPods_InternalErrorIsSanitized**: Updated assertion to match the structured error response format (`clusterStatus`/`errorType`/`errorMessage`) instead of the old flat `"error"` field
- **TestMCPGetEvents_NetworkErrorReturnsUnavailable**: Changed expected status from 200 to 503 to match `handleK8sError` behavior
- **TestMCPGetNodes_NetworkErrorReturnsUnavailable**: Changed expected status from 200 to 503 to match `handleK8sError` behavior
- **TestMCPGetPods_AuthErrorReturnsUnavailable**: Changed expected status from 200 to 503 to match `handleK8sError` behavior
- **TestAntigravityProvider_Handshake_NotInstalled**: Override `PATH` with `t.Setenv` so `detectCLI()` cannot discover a real CLI binary on the test machine

These tests have been failing since the `handleK8sError` refactor that changed network/auth/internal errors from HTTP 200 to proper HTTP status codes (503/500) with structured JSON payloads. This is a follow-up to #5059 which fixed the first batch of 4 test failures.

## Test plan

- [x] All 9 Go test packages pass (`go test ./...`)
- [x] `go vet` clean
- [x] No new dependencies added