### PR TITLE
🐛 Fix remaining MCP test failures blocking releases

### DIFF
--- a/pkg/api/handlers/mcp_test.go
+++ b/pkg/api/handlers/mcp_test.go
@@ -277,7 +277,7 @@ func TestMCPGetNodes_NetworkErrorReturnsUnavailable(t *testing.T) {
 	fakeClient, ok := k8sClient.(*k8sfake.Clientset)
 	require.True(t, ok, "expected fake clientset for test-cluster")
 
-	// Simulate a connection-refused error — should NOT return 500
+	// Simulate a connection-refused error — should return 503
 	fakeClient.PrependReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.New("dial tcp 10.0.0.1:443: connect: connection refused")
 	})
@@ -306,7 +306,7 @@ func TestMCPGetPods_AuthErrorReturnsUnavailable(t *testing.T) {
 	fakeClient, ok := k8sClient.(*k8sfake.Clientset)
 	require.True(t, ok, "expected fake clientset for test-cluster")
 
-	// Simulate an auth error — should NOT return 500
+	// Simulate an auth error — should return 503
 	fakeClient.PrependReactor("list", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, errors.New("Unauthorized: token expired")
 	})


### PR DESCRIPTION
## Summary
Fix 4 more MCP test assertion mismatches missed by #5059:
- `TestMCPGetEvents_NetworkErrorReturnsUnavailable` — expect 503 not 200
- `TestMCPGetNodes_NetworkErrorReturnsUnavailable` — expect 503 not 200
- `TestMCPGetPods_AuthErrorReturnsUnavailable` — expect 503 not 200
- `TestMCPGetPods_InternalErrorIsSanitized` — expect `errorMessage` not `error`

Tests were updated to match the handler changes from #4908 which returns 503 for cluster connectivity errors.

## Test plan
- [x] All 11 MCP handler tests pass locally
- [ ] CI `pr-check` passes