### PR TITLE
🐛 Defer URL.revokeObjectURL to prevent corrupted downloads

### DIFF
--- a/web/src/components/cards/Kubectl.tsx
+++ b/web/src/components/cards/Kubectl.tsx
@@ -10,6 +10,7 @@ import { useCardLoadingState } from './CardDataContext'
 import { useTranslation } from 'react-i18next'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { copyToClipboard } from '../../lib/clipboard'
+import { safeRevokeObjectURL } from '../../lib/download'
 
 interface CommandHistoryItem {
   id: string
@@ -432,7 +433,7 @@ data:
     a.href = url
     a.download = 'manifest.yaml'
     a.click()
-    URL.revokeObjectURL(url)
+    safeRevokeObjectURL(url)
   }, [yamlContent])
 
   // Handle keyboard shortcuts

--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -23,6 +23,7 @@ import { CSS } from '@dnd-kit/utilities'
 import { useTranslation } from 'react-i18next'
 import { api, BackendUnavailableError, UnauthenticatedError } from '../../lib/api'
 import { useDashboards, Dashboard } from '../../hooks/useDashboards'
+import { safeRevokeObjectURL } from '../../lib/download'
 import { useClusters } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useSidebarConfig } from '../../hooks/useSidebarConfig'
@@ -696,7 +697,7 @@ export function CustomDashboard() {
             a.href = url
             a.download = `${(dashboard?.name || 'dashboard').replace(/\s+/g, '-').toLowerCase()}.json`
             a.click()
-            URL.revokeObjectURL(url)
+            safeRevokeObjectURL(url)
             showToast('Dashboard exported', 'success')
           } catch {
             showToast('Failed to export dashboard', 'error')

--- a/web/src/components/dashboard/Dashboard.tsx
+++ b/web/src/components/dashboard/Dashboard.tsx
@@ -23,6 +23,7 @@ import {
 } from '@dnd-kit/sortable'
 import { useTranslation } from 'react-i18next'
 import { api, BackendUnavailableError, UnauthenticatedError } from '../../lib/api'
+import { safeRevokeObjectURL } from '../../lib/download'
 import { emitCardAdded, emitCardRemoved, emitCardDragged, emitCardConfigured } from '../../lib/analytics'
 import { useDashboards } from '../../hooks/useDashboards'
 import { useClusters } from '../../hooks/useMCP'
@@ -1155,7 +1156,7 @@ export function Dashboard() {
             a.href = url
             a.download = `${(dashboard.name || 'dashboard').replace(/\s+/g, '-').toLowerCase()}.json`
             a.click()
-            URL.revokeObjectURL(url)
+            safeRevokeObjectURL(url)
             showToast('Dashboard exported', 'success')
           } catch {
             showToast('Failed to export dashboard', 'error')

--- a/web/src/components/drilldown/RemediationConsole.tsx
+++ b/web/src/components/drilldown/RemediationConsole.tsx
@@ -7,6 +7,7 @@ import { AI_THINKING_DELAY_MS, FOCUS_DELAY_MS } from '../../lib/constants/networ
 import { authFetch } from '../../lib/api'
 import { useTranslation } from 'react-i18next'
 import { copyToClipboard } from '../../lib/clipboard'
+import { safeRevokeObjectURL } from '../../lib/download'
 
 interface LogEntry {
   id: string
@@ -383,7 +384,7 @@ Labels:       app=${resourceName.split('-')[0]}
     a.href = url
     a.download = `remediation-${resourceName}-${Date.now()}.log`
     a.click()
-    URL.revokeObjectURL(url)
+    safeRevokeObjectURL(url)
   }
 
   if (!isOpen) return null

--- a/web/src/components/drilldown/views/YAMLDrillDown.tsx
+++ b/web/src/components/drilldown/views/YAMLDrillDown.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { emitDataExported } from '../../../lib/analytics'
 import { copyToClipboard } from '../../../lib/clipboard'
+import { safeRevokeObjectURL } from '../../../lib/download'
 
 interface Props {
   data: Record<string, unknown>
@@ -80,7 +81,7 @@ export function YAMLDrillDown({ data }: Props) {
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
-    URL.revokeObjectURL(url)
+    safeRevokeObjectURL(url)
     emitDataExported('yaml_download', resourceType)
   }
 

--- a/web/src/components/layout/mission-sidebar/MissionChat.tsx
+++ b/web/src/components/layout/mission-sidebar/MissionChat.tsx
@@ -38,6 +38,7 @@ import { STATUS_CONFIG, TYPE_ICONS } from './types'
 import type { FontSize } from './types'
 import { TypingIndicator } from './TypingIndicator'
 import { MemoizedMessage } from './MemoizedMessage'
+import { safeRevokeObjectURL } from '../../../lib/download'
 
 export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' as FontSize, onToggleFullScreen }: { mission: Mission; isFullScreen?: boolean; fontSize?: FontSize; onToggleFullScreen?: () => void }) {
   const { t } = useTranslation('common')
@@ -173,7 +174,7 @@ export function MissionChat({ mission, isFullScreen = false, fontSize = 'base' a
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
-    URL.revokeObjectURL(url)
+    safeRevokeObjectURL(url)
   }, [mission])
 
   // Check if user is at bottom of scroll container

--- a/web/src/components/missions/ShareMissionDialog.tsx
+++ b/web/src/components/missions/ShareMissionDialog.tsx
@@ -23,6 +23,7 @@ import { fullScan } from '../../lib/missions/scanner/index'
 import { cn } from '../../lib/cn'
 import { UI_FEEDBACK_TIMEOUT_MS } from '../../lib/constants/network'
 import { copyToClipboard } from '../../lib/clipboard'
+import { safeRevokeObjectURL } from '../../lib/download'
 
 interface ShareMissionDialogProps {
   resolution: Resolution
@@ -146,7 +147,7 @@ export function ShareMissionDialog({ resolution, isOpen, onClose }: ShareMission
         a.href = url
         a.download = `${mission.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 60)}.json`
         a.click()
-        URL.revokeObjectURL(url)
+        safeRevokeObjectURL(url)
         break
       }
       case 'clipboard':
@@ -163,7 +164,7 @@ export function ShareMissionDialog({ resolution, isOpen, onClose }: ShareMission
         yamlAnchor.href = yamlUrl
         yamlAnchor.download = `${mission.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 60)}.yaml`
         yamlAnchor.click()
-        URL.revokeObjectURL(yamlUrl)
+        safeRevokeObjectURL(yamlUrl)
         break
       }
     }

--- a/web/src/components/widgets/WidgetExportModal.tsx
+++ b/web/src/components/widgets/WidgetExportModal.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../lib/widgets/widgetRegistry'
 import { generateWidget, getWidgetFilename, type WidgetConfig } from '../../lib/widgets/codeGenerator'
 import { copyToClipboard } from '../../lib/clipboard'
+import { safeRevokeObjectURL } from '../../lib/download'
 
 interface WidgetExportModalProps {
   isOpen: boolean
@@ -113,7 +114,7 @@ export function WidgetExportModal({ isOpen, onClose, cardType, mode: _mode = 'pi
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
-    URL.revokeObjectURL(url)
+    safeRevokeObjectURL(url)
     setIsLoading(false)
     emitWidgetDownloaded('uebersicht')
   }

--- a/web/src/hooks/__tests__/usePersistedSettings.test.ts
+++ b/web/src/hooks/__tests__/usePersistedSettings.test.ts
@@ -485,6 +485,8 @@ describe('usePersistedSettings', () => {
       expect.objectContaining({ method: 'POST' }),
     )
     expect(mockClick).toHaveBeenCalled()
+    // safeRevokeObjectURL defers via setTimeout — advance timers to trigger it
+    await vi.advanceTimersByTimeAsync(200)
     expect(mockRevokeObjectURL).toHaveBeenCalled()
 
     mockAppendChild.mockRestore()

--- a/web/src/hooks/usePersistedSettings.ts
+++ b/web/src/hooks/usePersistedSettings.ts
@@ -10,6 +10,7 @@ import {
 import { LOCAL_AGENT_HTTP_URL } from '../lib/constants'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { isNetlifyDeployment } from '../lib/demoMode'
+import { safeRevokeObjectURL } from '../lib/download'
 
 const DEBOUNCE_MS = 1000
 const RETRY_DELAY_MS = 3000
@@ -117,7 +118,7 @@ export function usePersistedSettings() {
       document.body.appendChild(a)
       a.click()
       document.body.removeChild(a)
-      URL.revokeObjectURL(url)
+      safeRevokeObjectURL(url)
     } catch (err) {
       console.error('[settings] export failed:', err)
       throw err

--- a/web/src/lib/download.ts
+++ b/web/src/lib/download.ts
@@ -1,0 +1,15 @@
+/**
+ * Delay in ms before revoking a blob Object URL after triggering a download.
+ * Browsers (especially Firefox) may still need the URL reference while the
+ * download action spins up on the main thread.  Revoking synchronously can
+ * produce a corrupted or empty file.
+ */
+const REVOKE_OBJECT_URL_DELAY_MS = 100
+
+/**
+ * Safely revoke a blob Object URL after a short delay so the browser can
+ * finish initiating the download.
+ */
+export function safeRevokeObjectURL(url: string): void {
+  setTimeout(() => URL.revokeObjectURL(url), REVOKE_OBJECT_URL_DELAY_MS)
+}


### PR DESCRIPTION
## Summary
- Add `safeRevokeObjectURL()` helper that wraps `URL.revokeObjectURL` in a 100ms `setTimeout`
- Replace all 10 synchronous `URL.revokeObjectURL` calls across 9 files with the safe version
- Prevents corrupted/empty file downloads on Firefox or throttled devices where the browser hasn't finished initiating the download before the Object URL is revoked

Fixes #5077

## Files changed
- **New:** `web/src/lib/download.ts` — `safeRevokeObjectURL` helper
- `Dashboard.tsx`, `CustomDashboard.tsx`, `Kubectl.tsx`, `WidgetExportModal.tsx`, `RemediationConsole.tsx`, `YAMLDrillDown.tsx`, `ShareMissionDialog.tsx`, `MissionChat.tsx`, `usePersistedSettings.ts`
- `usePersistedSettings.test.ts` — advance fake timers before asserting revoke was called

## Test plan
- [x] `npm run build` passes
- [x] `usePersistedSettings.test.ts` — 28/28 pass
- [ ] CI build + DCO pass