### PR TITLE
🐛 Add null-safety for Helm status and vulnerability data

### DIFF
--- a/web/src/components/cards/ComplianceCards.tsx
+++ b/web/src/components/cards/ComplianceCards.tsx
@@ -188,11 +188,13 @@ export function TrivyScan({ config: _config }: CardConfig) {
     const agg = { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 }
     for (const [name, s] of Object.entries(statuses)) {
       if (!s.installed || !selectedClusters.includes(name)) continue
-      agg.critical += s.vulnerabilities.critical
-      agg.high += s.vulnerabilities.high
-      agg.medium += s.vulnerabilities.medium
-      agg.low += s.vulnerabilities.low
-      agg.unknown += s.vulnerabilities.unknown
+      const vuln = s.vulnerabilities
+      if (!vuln) continue
+      agg.critical += vuln.critical
+      agg.high += vuln.high
+      agg.medium += vuln.medium
+      agg.low += vuln.low
+      agg.unknown += vuln.unknown
     }
     return agg
   }, [statuses, aggregated, selectedClusters])
@@ -314,8 +316,8 @@ Please proceed step by step.`,
         <div className="flex flex-wrap gap-1">
           {Object.values(statuses).filter(s => s.installed).map(s => (
             <button key={s.cluster} onClick={() => setModalCluster(s.cluster)} className="cursor-pointer">
-              <StatusBadge color={s.vulnerabilities.critical > 0 ? 'red' : 'green'} size="xs">
-                {s.cluster}: {s.vulnerabilities.critical}C/{s.vulnerabilities.high}H
+              <StatusBadge color={(s.vulnerabilities?.critical ?? 0) > 0 ? 'red' : 'green'} size="xs">
+                {s.cluster}: {s.vulnerabilities?.critical ?? 0}C/{s.vulnerabilities?.high ?? 0}H
               </StatusBadge>
             </button>
           ))}

--- a/web/src/components/cards/ComplianceDrift.tsx
+++ b/web/src/components/cards/ComplianceDrift.tsx
@@ -117,7 +117,7 @@ export function ComplianceDrift({ config: _config }: CardConfig) {
     const trivyEntries = Object.entries(trivyStatuses || {})
       .filter(([name, s]) => s.installed && shouldInclude(name))
     if (trivyEntries.length >= MIN_CLUSTERS_FOR_DRIFT) {
-      const values = trivyEntries.map(([, s]) => s.vulnerabilities.critical + s.vulnerabilities.high)
+      const values = trivyEntries.map(([, s]) => (s.vulnerabilities?.critical ?? 0) + (s.vulnerabilities?.high ?? 0))
       const { mean, stdDev } = stats(values)
       if (stdDev > 0) {
         trivyEntries.forEach(([cluster], i) => {

--- a/web/src/components/cards/FleetComplianceHeatmap.tsx
+++ b/web/src/components/cards/FleetComplianceHeatmap.tsx
@@ -264,13 +264,14 @@ export function FleetComplianceHeatmap({ config: _config }: CardConfig) {
       } else if (ts.totalReports === 0) {
         trivyCell = { status: 'warning', label: 'No reports', tooltip: 'Trivy installed but no vulnerability reports generated' }
       } else {
-        const critHigh = ts.vulnerabilities.critical + ts.vulnerabilities.high
+        const vuln = ts.vulnerabilities ?? { critical: 0, high: 0, medium: 0, low: 0 }
+        const critHigh = vuln.critical + vuln.high
         const status: CellStatus = critHigh >= VULN_CRITICAL_THRESHOLD ? 'critical'
           : critHigh >= VULN_WARNING_THRESHOLD ? 'warning' : 'good'
         trivyCell = {
           status,
           label: `${critHigh} crit/high`,
-          tooltip: `C:${ts.vulnerabilities.critical} H:${ts.vulnerabilities.high} M:${ts.vulnerabilities.medium} L:${ts.vulnerabilities.low}`,
+          tooltip: `C:${vuln.critical} H:${vuln.high} M:${vuln.medium} L:${vuln.low}`,
         }
       }
 

--- a/web/src/components/cards/HelmReleaseStatus.tsx
+++ b/web/src/components/cards/HelmReleaseStatus.tsx
@@ -85,7 +85,7 @@ export function HelmReleaseStatus({ config }: HelmReleaseStatusProps) {
         chart: chartName,
         version: chartVersion,
         appVersion: r.app_version || '',
-        status: r.status.toLowerCase() as 'deployed' | 'failed' | 'pending' | 'superseded' | 'uninstalling',
+        status: (r.status?.toLowerCase() ?? 'unknown') as 'deployed' | 'failed' | 'pending' | 'superseded' | 'uninstalling',
         updated: r.updated,
         revision: parseInt(r.revision) || 1,
         cluster: r.cluster,


### PR DESCRIPTION
## Summary
- Guard `r.status.toLowerCase()` in HelmReleaseStatus with optional chaining and fallback to `'unknown'`
- Guard `s.vulnerabilities` accesses in ComplianceCards, ComplianceDrift, and FleetComplianceHeatmap with null checks and `?? 0` fallbacks
- Prevents card crashes when API returns null status or stale cached data lacks vulnerability fields

Fixes #5086, fixes #5087

## Test plan
- [x] `npm run build` passes
- [ ] CI build + DCO pass