### PR TITLE
🐛 Add null guards for toLowerCase in PVC, Kyverno, GPU search

### DIFF
--- a/web/src/components/cards/KyvernoPolicies.tsx
+++ b/web/src/components/cards/KyvernoPolicies.tsx
@@ -66,12 +66,12 @@ function KyvernoPoliciesInternal({ config: _config }: KyvernoPoliciesProps) {
     if (!localSearch.trim()) return allPolicies
     const query = localSearch.toLowerCase()
     return allPolicies.filter(policy =>
-      policy.name.toLowerCase().includes(query) ||
-      policy.category.toLowerCase().includes(query) ||
-      policy.description.toLowerCase().includes(query) ||
-      policy.status.toLowerCase().includes(query) ||
-      policy.kind.toLowerCase().includes(query) ||
-      policy.cluster.toLowerCase().includes(query)
+      (policy.name ?? '').toLowerCase().includes(query) ||
+      (policy.category ?? '').toLowerCase().includes(query) ||
+      (policy.description ?? '').toLowerCase().includes(query) ||
+      (policy.status ?? '').toLowerCase().includes(query) ||
+      (policy.kind ?? '').toLowerCase().includes(query) ||
+      (policy.cluster ?? '').toLowerCase().includes(query)
     )
   }, [localSearch, allPolicies])
 

--- a/web/src/components/cards/PVCStatus.tsx
+++ b/web/src/components/cards/PVCStatus.tsx
@@ -42,14 +42,14 @@ function parseCapacity(capacity?: string): number {
 }
 
 const PVC_SORT_COMPARATORS = {
-  status: (a: PVC, b: PVC) => (STATUS_ORDER[a.status.toLowerCase()] ?? 1) - (STATUS_ORDER[b.status.toLowerCase()] ?? 1),
+  status: (a: PVC, b: PVC) => (STATUS_ORDER[(a.status ?? '').toLowerCase()] ?? 1) - (STATUS_ORDER[(b.status ?? '').toLowerCase()] ?? 1),
   name: commonComparators.string<PVC>('name'),
   capacity: (a: PVC, b: PVC) => parseCapacity(b.capacity) - parseCapacity(a.capacity),
   age: (a: PVC, b: PVC) => (a.age || '').localeCompare(b.age || ''),
 }
 
 function getStatusIcon(status: string) {
-  switch (status.toLowerCase()) {
+  switch ((status ?? '').toLowerCase()) {
     case 'bound':
       return <CheckCircle className="w-3 h-3 text-green-400" />
     case 'pending':
@@ -60,7 +60,7 @@ function getStatusIcon(status: string) {
 }
 
 function getStatusColor(status: string) {
-  switch (status.toLowerCase()) {
+  switch ((status ?? '').toLowerCase()) {
     case 'bound':
       return 'text-green-400'
     case 'pending':

--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -197,11 +197,11 @@ export function GPUReservations() {
     if (searchTerm.trim()) {
       const term = searchTerm.trim().toLowerCase()
       filtered = filtered.filter(r =>
-        r.title.toLowerCase().includes(term) ||
-        r.namespace.toLowerCase().includes(term) ||
-        r.user_name.toLowerCase().includes(term) ||
-        r.cluster.toLowerCase().includes(term) ||
-        r.status.toLowerCase().includes(term) ||
+        (r.title ?? '').toLowerCase().includes(term) ||
+        (r.namespace ?? '').toLowerCase().includes(term) ||
+        (r.user_name ?? '').toLowerCase().includes(term) ||
+        (r.cluster ?? '').toLowerCase().includes(term) ||
+        (r.status ?? '').toLowerCase().includes(term) ||
         (r.gpu_type && r.gpu_type.toLowerCase().includes(term)) ||
         (r.description && r.description.toLowerCase().includes(term)) ||
         (r.notes && r.notes.toLowerCase().includes(term))


### PR DESCRIPTION
## Summary
- Guard `.toLowerCase()` on raw API fields with `?? ''` fallback in PVCStatus, KyvernoPolicies, and GPUReservations
- Prevents card crashes when API returns null/undefined for status or other string fields

Fixes #5090, fixes #5091

## Test plan
- [x] `npm run build` passes
- [ ] CI build + DCO pass