### PR TITLE
🐛 Fix DOM nesting violations causing React warnings

### DIFF
--- a/web/src/components/PageErrorBoundary.tsx
+++ b/web/src/components/PageErrorBoundary.tsx
@@ -69,16 +69,16 @@ export class PageErrorBoundary extends Component<Props, State> {
           <h2 className="text-lg font-semibold text-foreground mb-2">
             {i18next.t('common:pageError.title', 'This page encountered an error')}
           </h2>
-          <p className="text-sm text-muted-foreground mb-2 max-w-md">
+          <div className="text-sm text-muted-foreground mb-2 max-w-md">
             {i18next.t(
               'common:pageError.description',
               'Something went wrong while rendering this page. You can try again, go back to the dashboard, or reload.',
             )}
-          </p>
+          </div>
           {this.state.error && (
-            <p className="text-xs text-muted-foreground/70 font-mono mb-6 break-all max-w-lg">
+            <div className="text-xs text-muted-foreground/70 font-mono mb-6 break-all max-w-lg">
               {this.state.error.message}
-            </p>
+            </div>
           )}
           <div className="flex items-center gap-3">
             <button

--- a/web/src/components/alerts/AlertDetail.tsx
+++ b/web/src/components/alerts/AlertDetail.tsx
@@ -150,7 +150,7 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
       <div className="p-4 space-y-4">
         {/* Message */}
         <div>
-          <p className="text-sm text-foreground">{alert.message}</p>
+          <div className="text-sm text-foreground">{alert.message}</div>
         </div>
 
         {/* Meta Info */}
@@ -225,14 +225,14 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
               {alert.aiDiagnosis.summary && (
                 <div>
                   <span className="text-xs text-muted-foreground">{t('alerts.summary')}</span>
-                  <p className="text-sm text-foreground mt-1">{alert.aiDiagnosis.summary}</p>
+                  <div className="text-sm text-foreground mt-1">{alert.aiDiagnosis.summary}</div>
                 </div>
               )}
 
               {alert.aiDiagnosis.rootCause && (
                 <div>
                   <span className="text-xs text-muted-foreground">{t('alerts.rootCause')}</span>
-                  <p className="text-sm text-foreground mt-1">{alert.aiDiagnosis.rootCause}</p>
+                  <div className="text-sm text-foreground mt-1">{alert.aiDiagnosis.rootCause}</div>
                 </div>
               )}
 
@@ -261,9 +261,9 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
               )}
             </div>
           ) : (
-            <p className="text-sm text-muted-foreground">
+            <div className="text-sm text-muted-foreground">
               {t('alerts.noDiagnosisYet')}
-            </p>
+            </div>
           )}
         </div>
 
@@ -289,9 +289,9 @@ export function AlertDetail({ alert, onClose }: AlertDetailProps) {
               ))}
             </div>
             {slackSent && (
-              <p className="text-xs text-green-400 mt-2">
+              <div className="text-xs text-green-400 mt-2">
                 {t('alerts.slackSent')}
-              </p>
+              </div>
             )}
           </div>
         )}

--- a/web/src/components/alerts/AlertRuleEditor.tsx
+++ b/web/src/components/alerts/AlertRuleEditor.tsx
@@ -218,7 +218,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
                 }`}
               />
               {errors.name && (
-                <p className="text-xs text-red-400 mt-1">{errors.name}</p>
+                <span className="block text-xs text-red-400 mt-1">{errors.name}</span>
               )}
             </div>
 
@@ -326,7 +326,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
                   <span className="text-sm text-muted-foreground">%</span>
                 </div>
                 {errors.threshold && (
-                  <p className="text-xs text-red-400 mt-1">{errors.threshold}</p>
+                  <span className="block text-xs text-red-400 mt-1">{errors.threshold}</span>
                 )}
               </div>
             )}
@@ -391,7 +391,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
                       <span className="text-sm text-muted-foreground">°F</span>
                     </div>
                     {errors.temperatureThreshold && (
-                      <p className="text-xs text-red-400 mt-1">{errors.temperatureThreshold}</p>
+                      <span className="block text-xs text-red-400 mt-1">{errors.temperatureThreshold}</span>
                     )}
                   </div>
                 )}
@@ -415,7 +415,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
                       <span className="text-sm text-muted-foreground">mph</span>
                     </div>
                     {errors.windSpeedThreshold && (
-                      <p className="text-xs text-red-400 mt-1">{errors.windSpeedThreshold}</p>
+                      <span className="block text-xs text-red-400 mt-1">{errors.windSpeedThreshold}</span>
                     )}
                   </div>
                 )}

--- a/web/src/components/history/CardHistory.tsx
+++ b/web/src/components/history/CardHistory.tsx
@@ -99,9 +99,9 @@ export function CardHistory({ onRestoreCard }: CardHistoryProps) {
             <History className="w-6 h-6 text-purple-400" />
             Card History
           </h1>
-          <p className="text-muted-foreground">
+          <div className="text-muted-foreground">
             Track changes to your dashboard cards
-          </p>
+          </div>
         </div>
         {history.length > 0 && (
           <button
@@ -144,11 +144,11 @@ export function CardHistory({ onRestoreCard }: CardHistoryProps) {
       {filteredHistory.length === 0 ? (
         <div className="flex flex-col items-center justify-center h-64 rounded-lg border border-dashed border-border">
           <History className="w-12 h-12 text-muted-foreground/50 mb-4" />
-          <p className="text-muted-foreground text-center">
+          <div className="text-muted-foreground text-center">
             {filter === 'all'
               ? 'No card history yet. Changes to dashboard cards will appear here.'
               : `No ${filter} cards in history.`}
-          </p>
+          </div>
         </div>
       ) : (
         <div className="space-y-3">
@@ -172,7 +172,7 @@ export function CardHistory({ onRestoreCard }: CardHistoryProps) {
                 </div>
 
                 {/* Action description */}
-                <p className="text-sm text-muted-foreground">
+                <div className="text-sm text-muted-foreground">
                   {entry.action === 'replaced' && entry.previousCardType && (
                     <>
                       <span className="text-foreground/80">{formatCardType(entry.previousCardType)}</span>
@@ -189,7 +189,7 @@ export function CardHistory({ onRestoreCard }: CardHistoryProps) {
                   {entry.action === 'configured' && (
                     <>{t('history.configurationUpdated')}</>
                   )}
-                </p>
+                </div>
 
                 {/* Dashboard and timestamp */}
                 <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">

--- a/web/src/components/onboarding/Onboarding.tsx
+++ b/web/src/components/onboarding/Onboarding.tsx
@@ -196,7 +196,7 @@ export function Onboarding() {
         <div className="glass rounded-2xl p-8 animate-fade-in-up">
           <h2 className="text-2xl font-bold text-foreground mb-2">{currentQuestion.question}</h2>
           {currentQuestion.description && (
-            <p className="text-muted-foreground mb-6">{currentQuestion.description}</p>
+            <div className="text-muted-foreground mb-6">{currentQuestion.description}</div>
           )}
 
           {/* Options - Single select or Ranked Choice */}

--- a/web/src/components/onboarding/Tour.tsx
+++ b/web/src/components/onboarding/Tour.tsx
@@ -387,7 +387,7 @@ export function TourOverlay() {
         </div>
 
         {/* Content */}
-        <p className="text-sm text-muted-foreground mb-4">{currentStep.content}</p>
+        <div className="text-sm text-muted-foreground mb-4">{currentStep.content}</div>
 
         {/* Footer */}
         <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary

- Replace `<p>` tags with `<div>` or `<span>` in 6 components where they could contain block-level content (SVG icons, conditional renders), eliminating React DOM nesting warnings
- Files fixed: `CardHistory.tsx`, `PageErrorBoundary.tsx`, `Tour.tsx`, `Onboarding.tsx`, `AlertRuleEditor.tsx`, `AlertDetail.tsx`
- No visual changes -- only semantic HTML corrections using the same Tailwind classes

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` shows no new errors (pre-existing count unchanged)
- [ ] Verify no visual regressions on affected pages (Card History, Alerts, Onboarding, error states)
- [ ] Confirm React DOM nesting warnings are gone from browser console

Fixes #5095