### PR TITLE
🐛 Fix brew install command — remove invalid --head flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Opens at [localhost:8080](http://localhost:8080). Deploy into a cluster with [`d
 **kc-agent** connects [console.kubestellar.io](https://console.kubestellar.io) to your local clusters:
 
 ```bash
-brew tap kubestellar/tap && brew install --head kc-agent   # macOS
+brew tap kubestellar/tap && brew install kc-agent   # macOS
 go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent  # Linux (Go 1.24+)
 ```
 

--- a/web/src/components/agent/AgentSetupDialog.tsx
+++ b/web/src/components/agent/AgentSetupDialog.tsx
@@ -24,7 +24,7 @@ export function AgentSetupDialog() {
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const copiedLinuxTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
-  const macOSInstallCommand = 'brew tap kubestellar/tap && brew install --head kc-agent && kc-agent'
+  const macOSInstallCommand = 'brew tap kubestellar/tap && brew install kc-agent && kc-agent'
   const linuxBuildCommand = 'git clone https://github.com/kubestellar/console.git && cd console && go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent'
 
   useEffect(() => {

--- a/web/src/components/setup/InClusterAgentDialog.tsx
+++ b/web/src/components/setup/InClusterAgentDialog.tsx
@@ -11,7 +11,7 @@ interface InClusterAgentDialogProps {
   onClose: () => void
 }
 
-const BREW_INSTALL_CMD = 'brew tap kubestellar/tap && brew install --head kc-agent && kc-agent'
+const BREW_INSTALL_CMD = 'brew tap kubestellar/tap && brew install kc-agent && kc-agent'
 const BUILD_FROM_SOURCE_CMD = 'git clone https://github.com/kubestellar/console.git && cd console && go build -o bin/kc-agent ./cmd/kc-agent && ./bin/kc-agent'
 const DOCS_URL = 'https://console-docs.kubestellar.io'
 

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -469,7 +469,7 @@ export function useLocalAgent() {
     steps: [
       {
         title: 'Install via Homebrew (macOS / WSL)',
-        command: 'brew tap kubestellar/tap && brew install --head kc-agent && kc-agent',
+        command: 'brew tap kubestellar/tap && brew install kc-agent && kc-agent',
       },
       {
         title: 'Build from source (Linux / WSL — recommended)',
@@ -477,7 +477,7 @@ export function useLocalAgent() {
       },
       {
         title: 'Install via Linuxbrew (Linux / WSL — alternative)',
-        command: '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap kubestellar/tap && brew install --head kc-agent && kc-agent',
+        command: '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" && brew tap kubestellar/tap && brew install kc-agent && kc-agent',
       },
     ],
     benefits: [

--- a/web/src/locales/de/common.json
+++ b/web/src/locales/de/common.json
@@ -2790,7 +2790,7 @@
     "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
     "linuxInstructions": "Linux / WSL installation instructions",
     "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -2949,7 +2949,7 @@
     "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
     "linuxInstructions": "Linux / WSL installation instructions",
     "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+ only:",
-    "linuxBrewAlternative": "Alternative: install Homebrew for Linux / WSL first (https://docs.brew.sh/Homebrew-on-Linux), then: brew tap kubestellar/tap && brew install --head kc-agent"
+    "linuxBrewAlternative": "Alternative: install Homebrew for Linux / WSL first (https://docs.brew.sh/Homebrew-on-Linux), then: brew tap kubestellar/tap && brew install kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/es/common.json
+++ b/web/src/locales/es/common.json
@@ -2790,7 +2790,7 @@
     "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
     "linuxInstructions": "Linux / WSL installation instructions",
     "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/fr/common.json
+++ b/web/src/locales/fr/common.json
@@ -2790,7 +2790,7 @@
     "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
     "linuxInstructions": "Linux / WSL installation instructions",
     "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/hi/common.json
+++ b/web/src/locales/hi/common.json
@@ -2790,7 +2790,7 @@
     "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
     "linuxInstructions": "Linux / WSL installation instructions",
     "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/it/common.json
+++ b/web/src/locales/it/common.json
@@ -2790,7 +2790,7 @@
     "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
     "linuxInstructions": "Linux / WSL installation instructions",
     "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/ja/common.json
+++ b/web/src/locales/ja/common.json
@@ -2790,7 +2790,7 @@
     "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
     "linuxInstructions": "Linux / WSL installation instructions",
     "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/pt/common.json
+++ b/web/src/locales/pt/common.json
@@ -2790,7 +2790,7 @@
     "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
     "linuxInstructions": "Linux / WSL installation instructions",
     "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/locales/zh/common.json
+++ b/web/src/locales/zh/common.json
@@ -2790,7 +2790,7 @@
     "quickInstallMacOS": "Quick Install — macOS / WSL (Homebrew)",
     "linuxInstructions": "Linux / WSL installation instructions",
     "linuxBuildDesc": "Build from source (recommended for Linux / WSL). Requires Go 1.24+:",
-    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install --head kc-agent"
+    "linuxBrewAlternative": "Alternatively, use Linuxbrew (Linux / WSL): brew tap kubestellar/tap && brew install kc-agent"
   },
   "agentStatus": {
     "connectingToAgent": "Connecting to local agent...",

--- a/web/src/pages/FromHeadlamp.tsx
+++ b/web/src/pages/FromHeadlamp.tsx
@@ -147,7 +147,7 @@ const CLUSTER_INGRESS_STEPS: InstallStep[] = [
     step: 3,
     title: 'Connect the kc-agent',
     commands: [
-      'brew tap kubestellar/tap && brew install --head kc-agent',
+      'brew tap kubestellar/tap && brew install kc-agent',
       'KC_ALLOWED_ORIGINS=https://console.example.com kc-agent',
     ],
     note: 'The kc-agent bridges your browser to your Kubernetes clusters via the in-cluster console. Set KC_ALLOWED_ORIGINS to your console\'s URL so the agent accepts cross-origin requests.',

--- a/web/src/pages/FromLens.tsx
+++ b/web/src/pages/FromLens.tsx
@@ -144,7 +144,7 @@ const CLUSTER_INGRESS_STEPS: InstallStep[] = [
     step: 3,
     title: 'Connect the kc-agent',
     commands: [
-      'brew tap kubestellar/tap && brew install --head kc-agent',
+      'brew tap kubestellar/tap && brew install kc-agent',
       'KC_ALLOWED_ORIGINS=https://console.example.com kc-agent',
     ],
     note: 'The kc-agent bridges your browser to your Kubernetes clusters via the in-cluster console. Set KC_ALLOWED_ORIGINS to your console\'s URL so the agent accepts cross-origin requests.',


### PR DESCRIPTION
## Summary
- Removed the `--head` flag from all `brew install --head kc-agent` commands across the codebase (16 occurrences in 15 files)
- The kc-agent Homebrew formula is GoReleaser-generated and has no `head` block, so `--head` causes installation to fail
- Fixed in: README, component files, hooks, page files, and all 9 locale JSON files

## Test plan
- [x] Verified no remaining `--head` occurrences via grep
- [x] `npm run build` passes
- [ ] Manually verify `brew tap kubestellar/tap && brew install kc-agent` works on macOS