### PR TITLE
🐛 Fix GA4 error tracking — send error_code dimension

### DIFF
--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1002,6 +1002,7 @@ function wasAlreadyReported(msg: string): boolean {
 
 export function emitError(category: string, detail: string, cardId?: string) {
   send('ksc_error', {
+    error_code: category,
     error_category: category,
     error_detail: detail.slice(0, ERROR_DETAIL_MAX_LEN),
     error_page: window.location.pathname,


### PR DESCRIPTION
## Summary
The `ksc_error` event was sending `error_category` but GA4 only has `error_code` registered as a custom dimension. All 46 errors today showed up with empty `error_code`, making them impossible to debug from analytics.

Now sends `error_code` (mapped from category) so the registered GA4 dimension is populated. Categories include: `card_render`, `runtime`, `chunk_load`, `unhandled_rejection`, `uncaught_render`, `page_render`.

## Context
Today's GA4 showed 46 errors (45 from 1 user in India on `/clusters` and `/`, 1 from Azerbaijan on `/ai-ml`) — all with blank `error_code`. After this fix, future errors will be categorized in GA4 reports.

The 45 errors from India are likely stale-bundle related (14 `ksc_chunk_reload_recovery` events from the same user on `/clusters`) — expected after today's many deploys (React 19, compiler, memo cleanup).

## Test plan
- [x] `npm run build` passes