### PR TITLE
🔔 Expand workflow health monitoring to all critical workflows

### DIFF
--- a/.github/workflows/workflow-failure-issue.yml
+++ b/.github/workflows/workflow-failure-issue.yml
@@ -3,13 +3,25 @@ name: Open Issue on Workflow Failure
 on:
   workflow_run:
     workflows:
+      # Release pipeline
       - "Release"
+      - "Build and Deploy KC"
+      # Nightly health checks
       - "Nightly Compliance & Perf"
       - "Nightly Test Suite"
+      - "Nightly Dashboard Health"
+      - "Nightly gh-aw Version Check"
+      - "Playwright Cross-Browser (Nightly)"
+      - "Card Loading Standard"
+      - "Startup Smoke Tests"
+      # Scheduled quality gates
       - "Auto-QA Agent"
       - "Auto-QA Tuner"
       - "Nil Safety"
+      - "GA4 Error Monitor"
+      # Weekly reviews
       - "OpenSSF Scorecard"
+      - "Weekly Coverage Review"
     types:
       - completed
 
@@ -21,7 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.event == 'schedule'
+      (github.event.workflow_run.event == 'schedule' ||
+       github.event.workflow_run.event == 'workflow_dispatch' ||
+       github.event.workflow_run.name == 'Build and Deploy KC')
     steps:
       - name: Check for existing open issue
         id: check
@@ -30,7 +44,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
         run: |
           LABEL="workflow-failure"
-          SEARCH_TITLE="Scheduled workflow failure: ${WORKFLOW_NAME}"
+          SEARCH_TITLE="Workflow failure: ${WORKFLOW_NAME}"
 
           # Search for an existing open issue with matching title and label
           EXISTING=$(gh issue list \
@@ -90,12 +104,12 @@ jobs:
         run: |
           gh issue create \
             --repo "${{ github.repository }}" \
-            --title "Scheduled workflow failure: ${WORKFLOW_NAME}" \
+            --title "Workflow failure: ${WORKFLOW_NAME}" \
             --label "workflow-failure,bug" \
             --body "$(cat <<EOF
-          ## Scheduled Workflow Failure
+          ## Workflow Failure
 
-          The **${WORKFLOW_NAME}** workflow failed during a scheduled run.
+          The **${WORKFLOW_NAME}** workflow failed.
 
           | Detail | Value |
           |--------|-------|


### PR DESCRIPTION
## Summary
Expand the workflow failure monitor from 7 to 15 workflows. Auto-creates a GitHub issue with `workflow-failure` label when any critical workflow fails. Deduplicates — adds a comment to existing open issues instead of creating duplicates.

### Newly monitored
- Build and Deploy KC
- Nightly Dashboard Health
- Nightly gh-aw Version Check
- Playwright Cross-Browser (Nightly)
- Card Loading Standard
- Startup Smoke Tests
- GA4 Error Monitor
- Weekly Coverage Review

### Also fixed
- Triggers on `workflow_dispatch` failures (not just `schedule`) — catches manual re-runs
- Triggers on deploy failures regardless of event type
- Updated issue titles from "Scheduled workflow failure" to "Workflow failure"

## Why
The release workflow failed silently for 5 days (Apr 1-6) because only 7 of 15+ critical workflows were monitored. This ensures no critical workflow can fail without visibility.

## Test plan
- [ ] Workflow YAML is valid
- [ ] Next workflow failure creates an issue automatically