### PR TITLE
Fix React 19 TypeScript build errors

### DIFF
--- a/web/src/components/dashboard/customizer/sections/TemplateGallerySection.tsx
+++ b/web/src/components/dashboard/customizer/sections/TemplateGallerySection.tsx
@@ -40,7 +40,7 @@ export function TemplateGallerySection({ onReplaceWithTemplate, onAddTemplate, d
   const [selectedCategory, setSelectedCategory] = useState<string>('all')
   const [searchText, setSearchText] = useState('')
   const [appliedTemplate, setAppliedTemplate] = useState<string | null>(null)
-  const appliedTimerRef = useRef<ReturnType<typeof setTimeout>>()
+  const appliedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   useEffect(() => () => { if (appliedTimerRef.current) clearTimeout(appliedTimerRef.current) }, [])
 
   const filteredTemplates = DASHBOARD_TEMPLATES.filter(tpl => {

--- a/web/src/components/layout/SidebarCustomizer.tsx
+++ b/web/src/components/layout/SidebarCustomizer.tsx
@@ -263,7 +263,7 @@ export function SidebarCustomizer({ isOpen, onClose, embedded = false }: Sidebar
   const [pendingChanges, setPendingChanges] = useState<{ proposed: ReturnType<typeof previewGenerateFromBehavior>['proposed']; changes: string[] } | null>(null)
 
   // Timer ref for auto-dismiss — prevents memory leak on unmount
-  const dismissTimerRef = useRef<ReturnType<typeof setTimeout>>()
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   useEffect(() => () => { if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current) }, [])
 
   const handleGenerateFromBehavior = async () => {


### PR DESCRIPTION
## Summary

- Build on main is broken after the Dashboard Studio merge (#4365)
- Two files call `useRef()` with zero arguments, which is invalid in `@types/react` v19 (the 0-argument overload was removed)
- Fix: pass explicit `undefined` as the initial value to `useRef<ReturnType<typeof setTimeout> | undefined>(undefined)`

**Files fixed:**
- `src/components/dashboard/customizer/sections/TemplateGallerySection.tsx` (line 43)
- `src/components/layout/SidebarCustomizer.tsx` (line 266)

## Test plan

- [x] `npm run build` passes cleanly
- [x] No new lint errors introduced
- [x] Verified the same 324 pre-existing lint errors exist on main