### PR TITLE
🐛 Fix infinite re-render loop crashing all cards

### DIFF
--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -570,10 +570,11 @@ export function CardWrapper({
   const menuButtonRef = useRef<HTMLButtonElement>(null)
 
   // Report callback for CardDataContext (childDataState is declared earlier for refresh animation)
-  const reportCallback = (state: CardDataState) => {
+  // Must be useCallback — CardDataContext children use this in useLayoutEffect deps
+  const reportCallback = useCallback((state: CardDataState) => {
     setChildDataState(state)
-  }
-  const reportCtx = { report: reportCallback }
+  }, [])
+  const reportCtx = useMemo(() => ({ report: reportCallback }), [reportCallback])
 
   // Merge child-reported state with props — child reports take priority when present
   const effectiveIsFailed = isFailed || childDataState?.isFailed || cardLoadingTimedOut


### PR DESCRIPTION
## CRITICAL — All cards crash with React error #185

The Dashboard Studio merge (#4365) introduced `reportCallback` and `reportCtx` in CardWrapper without `useCallback`/`useMemo`. These create new references every render, causing `useLayoutEffect` in `CardDataContext` to re-fire infinitely.

**Fix:** Wrap `reportCallback` in `useCallback` and `reportCtx` in `useMemo`.

## Test plan
- [x] Cards render without crashes locally