### PR TITLE
🐛 fix(layout): remove unused `children` prop that breaks production build

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -90,7 +90,7 @@ interface LayoutProps {
   children?: ReactNode
 }
 
-export function Layout({ children }: LayoutProps) {
+export function Layout(_props: LayoutProps) {
   const { t } = useTranslation()
   const { config } = useSidebarConfig()
   const { isMobile } = useMobile()


### PR DESCRIPTION
## Problem

The [Layout](cci:1://file:///Users/mrhapile/kubestellar/console/web/src/components/layout/Layout.tsx:92:0-606:1) component destructures `children` from props but never
uses it — child routes are rendered via React Router's `<Outlet />`.

TypeScript's `noUnusedLocals` / `noUnusedParameters` flags this as
**TS6133**, which causes `tsc -b` (and therefore `vite build`) to
fail with:

src/components/layout/Layout.tsx:93:24 - error TS6133: 'children' is declared but its value is never read.


This blocks all production builds (`./startup-oauth.sh`, CI, Netlify).

## Fix

Changed `{ children }` → `_props` in the function signature. The
underscore prefix tells TypeScript the parameter is intentionally
unused while preserving the [LayoutProps](cci:2://file:///Users/mrhapile/kubestellar/console/web/src/components/layout/Layout.tsx:88:0-90:1) type contract.

## Testing

- `npx tsc -b` exits cleanly (exit code 0)
- `./startup-oauth.sh` completes the full build and serves on :8080