### PR TITLE
fix: Learn dropdown blinks open and immediately closes

### DIFF
--- a/web/src/lib/modals/useModalNavigation.ts
+++ b/web/src/lib/modals/useModalNavigation.ts
@@ -243,8 +243,8 @@ export interface UseModalStateResult {
 
 export function useModalState(initialOpen = false): UseModalStateResult {
   const [isOpen, setIsOpen] = useState(initialOpen)
-  const open = () => setIsOpen(true)
-  const close = () => setIsOpen(false)
-  const toggle = () => setIsOpen(prev => !prev)
+  const open = useCallback(() => setIsOpen(true), [])
+  const close = useCallback(() => setIsOpen(false), [])
+  const toggle = useCallback(() => setIsOpen(prev => !prev), [])
   return { isOpen, open, close, toggle }
 }


### PR DESCRIPTION
## Summary
- **Root cause**: `useModalState` returned `open`/`close`/`toggle` as plain arrow functions — new references every render. `LearnDropdown`'s route-change effect had `close` in its dependency array, so it fired on every re-render, immediately closing the dropdown after `toggle()` opened it.
- **Fix**: Wrap all three callbacks with `useCallback` so their references are stable across renders. This is a one-line-per-callback change in the shared `useModalState` hook.
- All 25 existing tests pass, build and lint clean.

## Test plan
- [ ] Click the Learn (book) icon in the navbar — dropdown should open and stay open
- [ ] Click it again — dropdown should close
- [ ] Click outside the dropdown — should close
- [ ] Press Escape while dropdown is open — should close
- [ ] Navigate to a different page — dropdown should close
- [ ] Verify other dropdowns using `useModalState` still work (search, cluster filter, agent selector)