### PR TITLE
fix: cluster dropdown overlaps Selected Payload section

### DIFF
--- a/web/src/components/mission-control/FixerDefinitionPanel.tsx
+++ b/web/src/components/mission-control/FixerDefinitionPanel.tsx
@@ -941,7 +941,7 @@ function TargetClusterSelector({
   const isAllSelected = selected.length === 0 || selected.length === clusters.length
 
   return (
-    <div ref={ref} className="relative z-10">
+    <div ref={ref} className="relative z-20">
       <label className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
         Target Clusters
       </label>


### PR DESCRIPTION
## Summary
- Target cluster dropdown's parent stacking context (`z-10`) was too low, causing the absolute dropdown to render behind sibling content ("Selected Payload" grid)
- Bumped to `z-20` so the dropdown sits above the payload section

## Test plan
- [ ] Open a mission in the Fixer Definition Panel
- [ ] Click the "All clusters (click to scope)" trigger
- [ ] Verify dropdown fully covers/overlays the "Selected Payload" section below without overlap